### PR TITLE
feat(permissions): gate the settings UI by member capability

### DIFF
--- a/apps/mesh/e2e/tests/settings-capability-gating.spec.ts
+++ b/apps/mesh/e2e/tests/settings-capability-gating.spec.ts
@@ -19,6 +19,11 @@ import { connectDevDb } from "../fixtures/db";
 import { signUpViaApi } from "../fixtures/auth-api";
 import { expect, newApiContext, test } from "../fixtures/test";
 
+// Better Auth's CSRF guard rejects org-endpoint POSTs without an Origin that
+// matches trustedOrigins (keyed off baseURL). The page's own request context
+// doesn't set one, so we pass it explicitly on those calls.
+const ORIGIN = `http://localhost:${process.env.PORT ?? "3000"}`;
+
 test.describe("settings capability gating", () => {
   let db: Client;
 
@@ -64,6 +69,7 @@ test.describe("settings capability gating", () => {
       .context()
       .request.post("/api/auth/organization/accept-invitation", {
         data: { invitationId },
+        headers: { Origin: ORIGIN },
       });
     expect(
       accept.ok(),
@@ -74,6 +80,7 @@ test.describe("settings capability gating", () => {
     // (signup left their own org active).
     await page.context().request.post("/api/auth/organization/set-active", {
       data: { organizationId: orgId },
+      headers: { Origin: ORIGIN },
     });
 
     // Direct-navigating to a management route renders the no-access panel

--- a/apps/mesh/e2e/tests/settings-capability-gating.spec.ts
+++ b/apps/mesh/e2e/tests/settings-capability-gating.spec.ts
@@ -118,4 +118,31 @@ test.describe("settings capability gating", () => {
       0,
     );
   });
+
+  test("a failed capability lookup shows a retryable error, not a denial", async ({
+    page,
+  }) => {
+    const owner = await signUpViaApi(page.context().request);
+
+    // Force the capability lookup to fail for every attempt (incl. retries).
+    await page.route("**/api/auth/custom/my-capabilities/**", (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: "{}",
+      }),
+    );
+
+    await page.goto(`/${owner.orgSlug}/settings/general`);
+
+    // The owner would normally see General. With the lookup failing they get
+    // the retryable error — never the no-access panel, which would be
+    // indistinguishable from a real denial.
+    await expect(page.getByText("Couldn't load your permissions")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("No access to general settings")).toHaveCount(
+      0,
+    );
+  });
 });

--- a/apps/mesh/e2e/tests/settings-capability-gating.spec.ts
+++ b/apps/mesh/e2e/tests/settings-capability-gating.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * E2E: capability-based gating of the settings UI.
+ *
+ * Drives the real browser as a restricted member (built-in "user" role, which
+ * resolves to no gated capabilities) and asserts the gating wired up in the
+ * settings layout + route guards + capability-aware index redirect:
+ *
+ *   - direct-navigating to a management settings route shows the no-access
+ *     panel instead of the page;
+ *   - the /settings index lands a no-management member on Profile (the always-
+ *     accessible fallback), and an owner on General;
+ *
+ * The capability resolution itself is unit + e2e tested at the endpoint
+ * (my-capabilities.spec.ts); this spec covers the UI consuming it.
+ */
+
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+test.describe("settings capability gating", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("a plain member is gated out of management settings", async ({
+    page,
+    playwright,
+  }) => {
+    // Owner of org A (separate API context so it doesn't share the page's
+    // cookies).
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("org A not found after signup");
+
+    // The PAGE becomes a second user (gets their own org), then joins org A as
+    // a built-in "user" — no management capabilities there.
+    const member = await signUpViaApi(page.context().request);
+
+    const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+      data: { organizationId: orgId, email: member.email, role: "user" },
+    });
+    expect(invite.ok()).toBe(true);
+    const inviteJson = (await invite.json()) as {
+      id?: string;
+      invitation?: { id?: string };
+    };
+    const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+    expect(invitationId).toBeTruthy();
+
+    const accept = await page
+      .context()
+      .request.post("/api/auth/organization/accept-invitation", {
+        data: { invitationId },
+      });
+    expect(
+      accept.ok(),
+      `accept-invitation failed: ${await accept.text().catch(() => "")}`,
+    ).toBe(true);
+
+    // Make org A the member's active org so the shell loads it deterministically
+    // (signup left their own org active).
+    await page.context().request.post("/api/auth/organization/set-active", {
+      data: { organizationId: orgId },
+    });
+
+    // Direct-navigating to a management route renders the no-access panel
+    // (the route guard denies) instead of the General settings page.
+    await page.goto(`/${owner.orgSlug}/settings/general`);
+    await expect(page.getByText("No access to general settings")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // The settings index redirects a no-management member to Profile — the
+    // always-accessible fallback — rather than landing them on a denied tab.
+    await page.goto(`/${owner.orgSlug}/settings`);
+    await page.waitForURL((url) => url.pathname.endsWith("/settings/profile"), {
+      timeout: 15_000,
+    });
+
+    // The Members management nav item is filtered out for this member; the
+    // count check (vs. a single-element assertion) avoids strict-mode flakes.
+    await expect(
+      page.getByRole("link", { name: "Members", exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test("the owner reaches management settings normally", async ({ page }) => {
+    const owner = await signUpViaApi(page.context().request);
+
+    // The index sends a privileged user to General (proves org:manage is
+    // granted) — not the Profile fallback — and the page renders without the
+    // no-access panel.
+    await page.goto(`/${owner.orgSlug}/settings`);
+    await page.waitForURL((url) => url.pathname.endsWith("/settings/general"), {
+      timeout: 15_000,
+    });
+    await expect(page.getByText("No access to general settings")).toHaveCount(
+      0,
+    );
+  });
+});

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -1015,10 +1015,15 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       // View automations
       "AUTOMATION_GET",
       "AUTOMATION_LIST",
-      // View AI providers
+      // View AI providers (read-only — every member needs to know which
+      // providers are configured so chat / agents can use them). KEY_LIST
+      // returns metadata only (no secret material); CREDITS is the balance
+      // shown in the chat header.
       "AI_PROVIDERS_LIST",
       "AI_PROVIDERS_LIST_MODELS",
       "AI_PROVIDERS_ACTIVE",
+      "AI_PROVIDER_KEY_LIST",
+      "AI_PROVIDER_CREDITS",
       // Object storage access
       "LIST_OBJECTS",
       "GET_OBJECT_METADATA",

--- a/apps/mesh/src/web/components/access-gate.tsx
+++ b/apps/mesh/src/web/components/access-gate.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+import { Loading01 } from "@untitledui/icons";
+import { NoPermissionState } from "@/web/components/no-permission-state";
+import { CapabilityLoadError } from "@/web/components/capability-load-error";
+
+interface AccessGateProps {
+  /** Whether access is granted (computed by the caller from its own signal). */
+  granted: boolean;
+  loading: boolean;
+  /** True when the capability lookup failed (network/server error). */
+  error: boolean;
+  /** Friendly label of the section, used in the no-permission heading. */
+  area?: string;
+  children: ReactNode;
+}
+
+/**
+ * Shared render for the route guards: a spinner while access resolves, a
+ * retryable error on lookup failure (never a false denial), the no-access panel
+ * when denied, and the children when granted. RequireCapability and
+ * RequirePrivileged differ only in how they compute `granted`, so the rendering
+ * lives here once.
+ */
+export function AccessGate({
+  granted,
+  loading,
+  error,
+  area,
+  children,
+}: AccessGateProps) {
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8">
+        <Loading01 size={20} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <CapabilityLoadError />;
+  }
+
+  if (!granted) {
+    return <NoPermissionState area={area} />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/mesh/src/web/components/capability-load-error.tsx
+++ b/apps/mesh/src/web/components/capability-load-error.tsx
@@ -1,0 +1,40 @@
+import { AlertTriangle } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useQueryClient } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+
+/**
+ * Shown when the capability bitmap can't be loaded (network / server error),
+ * so a transient failure surfaces as a retryable error rather than masquerading
+ * as a no-access denial. "Try again" invalidates the query, which refetches it.
+ */
+export function CapabilityLoadError() {
+  const queryClient = useQueryClient();
+  const { locator } = useProjectContext();
+
+  return (
+    <div className="flex h-full min-h-[60vh] flex-1 flex-col items-center justify-center gap-4 p-6 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <AlertTriangle size={28} />
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-lg font-medium">Couldn't load your permissions</h3>
+        <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+          Something went wrong checking your access. This is usually temporary.
+        </p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() =>
+          queryClient.invalidateQueries({
+            queryKey: KEYS.myCapabilities(locator),
+          })
+        }
+      >
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/no-permission-state.tsx
+++ b/apps/mesh/src/web/components/no-permission-state.tsx
@@ -1,0 +1,43 @@
+import { Lock01 } from "@untitledui/icons";
+import { Link, useParams } from "@tanstack/react-router";
+import { Button } from "@deco/ui/components/button.tsx";
+
+interface NoPermissionStateProps {
+  /** Short label describing the section the user tried to open. */
+  area?: string;
+  /** Optional override for the body copy. */
+  description?: string;
+}
+
+/**
+ * Full-panel empty state shown when a member's role doesn't include a
+ * capability (used by RequireCapability). Offers a way back to the always-
+ * accessible profile page.
+ */
+export function NoPermissionState({
+  area,
+  description,
+}: NoPermissionStateProps) {
+  const { org } = useParams({ from: "/shell/$org" });
+  const title = area ? `No access to ${area}` : "No access";
+  const body =
+    description ??
+    "Your role doesn't include permission for this section. Ask an organization admin to update your role if you need it.";
+
+  return (
+    <div className="flex h-full min-h-[60vh] flex-1 flex-col items-center justify-center gap-4 p-6 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Lock01 size={28} />
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-lg font-medium">{title}</h3>
+        <p className="mx-auto max-w-sm text-sm text-muted-foreground">{body}</p>
+      </div>
+      <Button variant="outline" size="sm" asChild>
+        <Link to="/$org/settings/profile" params={{ org }}>
+          Go to your profile
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/require-capability.tsx
+++ b/apps/mesh/src/web/components/require-capability.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from "react";
-import { Loading01 } from "@untitledui/icons";
 import { useCapability, type CapabilityId } from "@/web/hooks/use-capability";
-import { NoPermissionState } from "@/web/components/no-permission-state";
-import { CapabilityLoadError } from "@/web/components/capability-load-error";
+import { AccessGate } from "@/web/components/access-gate";
 
 interface RequireCapabilityProps {
   capability: CapabilityId;
@@ -13,10 +11,9 @@ interface RequireCapabilityProps {
 
 /**
  * Route-level guard. Renders children only when the current user has the
- * capability, a clean no-permission state otherwise, and a spinner while the
- * capability resolves (so the page doesn't flicker). Because the guarded
- * subtree isn't mounted until access is confirmed, the inner view's data
- * hooks never fire for a denied user.
+ * capability (spinner while resolving, retryable error on lookup failure,
+ * no-access panel when denied). The guarded subtree isn't mounted until access
+ * is confirmed, so the inner view's data hooks never fire for a denied user.
  */
 export function RequireCapability({
   capability,
@@ -24,24 +21,9 @@ export function RequireCapability({
   children,
 }: RequireCapabilityProps) {
   const { granted, loading, error } = useCapability(capability);
-
-  if (loading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Loading01 size={20} className="animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
-
-  // A failed capability lookup must not read as a denial — show a retryable
-  // error instead of locking the user (incl. owners/admins) out.
-  if (error) {
-    return <CapabilityLoadError />;
-  }
-
-  if (!granted) {
-    return <NoPermissionState area={area} />;
-  }
-
-  return <>{children}</>;
+  return (
+    <AccessGate granted={granted} loading={loading} error={error} area={area}>
+      {children}
+    </AccessGate>
+  );
 }

--- a/apps/mesh/src/web/components/require-capability.tsx
+++ b/apps/mesh/src/web/components/require-capability.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { Loading01 } from "@untitledui/icons";
+import { useCapability, type CapabilityId } from "@/web/hooks/use-capability";
+import { NoPermissionState } from "@/web/components/no-permission-state";
+
+interface RequireCapabilityProps {
+  capability: CapabilityId;
+  /** Friendly label of the section, used in the no-permission heading. */
+  area?: string;
+  children: ReactNode;
+}
+
+/**
+ * Route-level guard. Renders children only when the current user has the
+ * capability, a clean no-permission state otherwise, and a spinner while the
+ * capability resolves (so the page doesn't flicker). Because the guarded
+ * subtree isn't mounted until access is confirmed, the inner view's data
+ * hooks never fire for a denied user.
+ */
+export function RequireCapability({
+  capability,
+  area,
+  children,
+}: RequireCapabilityProps) {
+  const { granted, loading } = useCapability(capability);
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8">
+        <Loading01 size={20} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!granted) {
+    return <NoPermissionState area={area} />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/mesh/src/web/components/require-capability.tsx
+++ b/apps/mesh/src/web/components/require-capability.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Loading01 } from "@untitledui/icons";
 import { useCapability, type CapabilityId } from "@/web/hooks/use-capability";
 import { NoPermissionState } from "@/web/components/no-permission-state";
+import { CapabilityLoadError } from "@/web/components/capability-load-error";
 
 interface RequireCapabilityProps {
   capability: CapabilityId;
@@ -22,7 +23,7 @@ export function RequireCapability({
   area,
   children,
 }: RequireCapabilityProps) {
-  const { granted, loading } = useCapability(capability);
+  const { granted, loading, error } = useCapability(capability);
 
   if (loading) {
     return (
@@ -30,6 +31,12 @@ export function RequireCapability({
         <Loading01 size={20} className="animate-spin text-muted-foreground" />
       </div>
     );
+  }
+
+  // A failed capability lookup must not read as a denial — show a retryable
+  // error instead of locking the user (incl. owners/admins) out.
+  if (error) {
+    return <CapabilityLoadError />;
   }
 
   if (!granted) {

--- a/apps/mesh/src/web/components/require-privileged.tsx
+++ b/apps/mesh/src/web/components/require-privileged.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from "react";
-import { Loading01 } from "@untitledui/icons";
 import { useCapabilities } from "@/web/hooks/use-capability";
-import { NoPermissionState } from "@/web/components/no-permission-state";
-import { CapabilityLoadError } from "@/web/components/capability-load-error";
+import { AccessGate } from "@/web/components/access-gate";
 
 interface RequirePrivilegedProps {
   /** Friendly label of the section, used in the no-permission heading. */
@@ -19,22 +17,14 @@ interface RequirePrivilegedProps {
  */
 export function RequirePrivileged({ area, children }: RequirePrivilegedProps) {
   const { isPrivileged, loading, error } = useCapabilities();
-
-  if (loading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Loading01 size={20} className="animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return <CapabilityLoadError />;
-  }
-
-  if (!isPrivileged) {
-    return <NoPermissionState area={area} />;
-  }
-
-  return <>{children}</>;
+  return (
+    <AccessGate
+      granted={isPrivileged}
+      loading={loading}
+      error={error}
+      area={area}
+    >
+      {children}
+    </AccessGate>
+  );
 }

--- a/apps/mesh/src/web/components/require-privileged.tsx
+++ b/apps/mesh/src/web/components/require-privileged.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { Loading01 } from "@untitledui/icons";
+import { useCapabilities } from "@/web/hooks/use-capability";
+import { NoPermissionState } from "@/web/components/no-permission-state";
+import { CapabilityLoadError } from "@/web/components/capability-load-error";
+
+interface RequirePrivilegedProps {
+  /** Friendly label of the section, used in the no-permission heading. */
+  area?: string;
+  children: ReactNode;
+}
+
+/**
+ * Route guard for screens that require a privileged built-in role (owner or
+ * admin) rather than a capability — e.g. role management, which calls Better
+ * Auth role APIs (listRoles/createRole/…) that are owner/admin-only. No custom
+ * role can use those, so gating by a grantable capability would expose a broken
+ * screen; this gates strictly on privilege.
+ */
+export function RequirePrivileged({ area, children }: RequirePrivilegedProps) {
+  const { isPrivileged, loading, error } = useCapabilities();
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8">
+        <Loading01 size={20} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <CapabilityLoadError />;
+  }
+
+  if (!isPrivileged) {
+    return <NoPermissionState area={area} />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/mesh/src/web/hooks/use-capability.ts
+++ b/apps/mesh/src/web/hooks/use-capability.ts
@@ -1,0 +1,118 @@
+/**
+ * useCapability / useCapabilities
+ *
+ * Resolve whether the current user has a given permission capability in the
+ * active org, for proactive UI gating (hide / disable / redirect) so users
+ * don't see actions that would fail at the API.
+ *
+ * Backed by GET /api/auth/custom/my-capabilities/:slug — the server is the
+ * single source of truth. This hook only reads the resolved bitmap; it never
+ * re-derives role logic.
+ */
+
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useQuery } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+
+export type CapabilityId =
+  | "org:manage"
+  | "members:manage"
+  | "connections:manage"
+  | "agents:manage"
+  | "automations:manage"
+  | "monitoring:view"
+  | "secrets:manage"
+  | "file-configs:manage"
+  | "ai-providers:manage"
+  | "tags:manage"
+  | "registry:manage"
+  | "registry:monitor"
+  | "api-keys:manage"
+  | "event-bus:use"
+  | "storage:delete"
+  | "connections:sql";
+
+const BUILTIN_BYPASS_ROLES = new Set(["owner", "admin"]);
+
+interface MyCapabilitiesResponse {
+  role: string | null;
+  capabilities: Record<string, boolean>;
+}
+
+function useMyCapabilities(): {
+  data: MyCapabilitiesResponse | undefined;
+  loading: boolean;
+} {
+  const { org, locator } = useProjectContext();
+
+  const { data, isLoading } = useQuery({
+    queryKey: KEYS.myCapabilities(locator),
+    queryFn: async (): Promise<MyCapabilitiesResponse> => {
+      const res = await fetch(
+        `/api/auth/custom/my-capabilities/${encodeURIComponent(org.slug)}`,
+        { credentials: "include" },
+      );
+      if (!res.ok) {
+        return { role: null, capabilities: {} };
+      }
+      return (await res.json()) as MyCapabilitiesResponse;
+    },
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  return { data, loading: isLoading };
+}
+
+export interface CapabilityResult {
+  granted: boolean;
+  loading: boolean;
+  reason: "loading" | "owner" | "admin" | "role" | "denied";
+}
+
+/**
+ * Whether the current user has the given capability in the active org.
+ */
+export function useCapability(id: CapabilityId): CapabilityResult {
+  const { data, loading } = useMyCapabilities();
+
+  if (loading) {
+    return { granted: false, loading: true, reason: "loading" };
+  }
+
+  const role = data?.role ?? null;
+  if (!role) {
+    return { granted: false, loading: false, reason: "denied" };
+  }
+  if (role === "owner") {
+    return { granted: true, loading: false, reason: "owner" };
+  }
+  if (role === "admin") {
+    return { granted: true, loading: false, reason: "admin" };
+  }
+
+  const granted = data?.capabilities?.[id] === true;
+  return { granted, loading: false, reason: granted ? "role" : "denied" };
+}
+
+/**
+ * The full capability bitmap plus role context, for screens that gate several
+ * things at once. owner/admin already come back all-true from the server.
+ */
+export function useCapabilities(): {
+  capabilities: Record<CapabilityId, boolean>;
+  loading: boolean;
+  isPrivileged: boolean;
+  roleSlug: string | undefined;
+} {
+  const { data, loading } = useMyCapabilities();
+  const role = data?.role ?? undefined;
+  const isPrivileged = role ? BUILTIN_BYPASS_ROLES.has(role) : false;
+
+  return {
+    capabilities: (data?.capabilities ?? {}) as Record<CapabilityId, boolean>,
+    loading,
+    isPrivileged,
+    roleSlug: role,
+  };
+}

--- a/apps/mesh/src/web/hooks/use-capability.ts
+++ b/apps/mesh/src/web/hooks/use-capability.ts
@@ -42,57 +42,72 @@ interface MyCapabilitiesResponse {
 function useMyCapabilities(): {
   data: MyCapabilitiesResponse | undefined;
   loading: boolean;
+  error: boolean;
 } {
   const { org, locator } = useProjectContext();
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: KEYS.myCapabilities(locator),
     queryFn: async (): Promise<MyCapabilitiesResponse> => {
       const res = await fetch(
         `/api/auth/custom/my-capabilities/${encodeURIComponent(org.slug)}`,
         { credentials: "include" },
       );
+      // Throw on failure so it surfaces as an error state — NOT a silent
+      // "denied". Swallowing it would make a transient blip lock owners and
+      // admins out of every gated route, indistinguishable from real denial.
       if (!res.ok) {
-        return { role: null, capabilities: {} };
+        throw new Error(`my-capabilities request failed: ${res.status}`);
       }
       return (await res.json()) as MyCapabilitiesResponse;
     },
     staleTime: 30_000,
-    retry: false,
+    // Ride out transient failures before surfacing an error to the UI.
+    retry: 2,
   });
 
-  return { data, loading: isLoading };
+  return { data, loading: isLoading, error: isError };
 }
 
 export interface CapabilityResult {
   granted: boolean;
   loading: boolean;
-  reason: "loading" | "owner" | "admin" | "role" | "denied";
+  /** True when capabilities couldn't be resolved (network/server error). */
+  error: boolean;
+  reason: "loading" | "error" | "owner" | "admin" | "role" | "denied";
 }
 
 /**
  * Whether the current user has the given capability in the active org.
  */
 export function useCapability(id: CapabilityId): CapabilityResult {
-  const { data, loading } = useMyCapabilities();
+  const { data, loading, error } = useMyCapabilities();
 
   if (loading) {
-    return { granted: false, loading: true, reason: "loading" };
+    return { granted: false, loading: true, error: false, reason: "loading" };
+  }
+  if (error) {
+    return { granted: false, loading: false, error: true, reason: "error" };
   }
 
   const role = data?.role ?? null;
   if (!role) {
-    return { granted: false, loading: false, reason: "denied" };
+    return { granted: false, loading: false, error: false, reason: "denied" };
   }
   if (role === "owner") {
-    return { granted: true, loading: false, reason: "owner" };
+    return { granted: true, loading: false, error: false, reason: "owner" };
   }
   if (role === "admin") {
-    return { granted: true, loading: false, reason: "admin" };
+    return { granted: true, loading: false, error: false, reason: "admin" };
   }
 
   const granted = data?.capabilities?.[id] === true;
-  return { granted, loading: false, reason: granted ? "role" : "denied" };
+  return {
+    granted,
+    loading: false,
+    error: false,
+    reason: granted ? "role" : "denied",
+  };
 }
 
 /**
@@ -102,16 +117,18 @@ export function useCapability(id: CapabilityId): CapabilityResult {
 export function useCapabilities(): {
   capabilities: Record<CapabilityId, boolean>;
   loading: boolean;
+  error: boolean;
   isPrivileged: boolean;
   roleSlug: string | undefined;
 } {
-  const { data, loading } = useMyCapabilities();
+  const { data, loading, error } = useMyCapabilities();
   const role = data?.role ?? undefined;
   const isPrivileged = role ? BUILTIN_BYPASS_ROLES.has(role) : false;
 
   return {
     capabilities: (data?.capabilities ?? {}) as Record<CapabilityId, boolean>,
     loading,
+    error,
     isPrivileged,
     roleSlug: role,
   };

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -263,13 +263,9 @@ const settingsLayout = createRoute({
 const settingsIndexRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/",
-  beforeLoad: ({ params }) => {
-    throw redirect({
-      to: "/$org/settings/general",
-      params: { org: params.org },
-    });
-  },
-  component: () => null,
+  component: lazyRouteComponent(
+    () => import("./routes/orgs/settings/index-redirect.tsx"),
+  ),
 });
 
 // Operations: Connections

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -80,7 +80,7 @@ interface SettingsNavGroup {
 function useSettingsSidebarGroups(): SettingsNavGroup[] {
   const currentProject = useProjectContext().project;
   const enabledPlugins = currentProject.enabledPlugins ?? [];
-  const { capabilities, isPrivileged, loading } = useCapabilities();
+  const { capabilities, isPrivileged, loading, error } = useCapabilities();
 
   const enabledSettingsItems = pluginSettingsSidebarItems
     .filter((item) => enabledPlugins.includes(item.pluginId))
@@ -221,11 +221,12 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
     },
   ];
 
-  // While capabilities load, show every item optimistically (avoids a flicker
-  // for the common privileged case). Once resolved, hide items the member's
-  // role can't open and drop any group left empty. Items without a `requires`
-  // (Profile, plugin items) are always visible.
-  if (loading) {
+  // While capabilities load — or if the lookup errored — show every item
+  // optimistically. This avoids a flicker for the common privileged case and
+  // ensures a transient failure never hides nav from owners/admins. Once
+  // resolved, hide items the member's role can't open and drop any group left
+  // empty. Items without a `requires` (Profile, plugin items) are always shown.
+  if (loading || error) {
     return groups;
   }
   return groups

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -70,6 +70,9 @@ interface SettingsNavItem {
   to: string;
   /** Capability required to see this item. Omitted = visible to every member. */
   requires?: CapabilityId;
+  /** Restrict to privileged built-in roles (owner/admin). For screens backed
+   *  by owner/admin-only APIs (e.g. role management). */
+  privilegedOnly?: boolean;
 }
 
 interface SettingsNavGroup {
@@ -184,7 +187,8 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           label: "Roles",
           icon: <Shield01 size={14} />,
           to: "/$org/settings/roles",
-          requires: "members:manage",
+          // Role management uses owner/admin-only Better Auth APIs.
+          privilegedOnly: true,
         },
         {
           key: "sso",
@@ -232,9 +236,11 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
   return groups
     .map((group) => ({
       ...group,
-      items: group.items.filter(
-        (item) => !item.requires || isPrivileged || capabilities[item.requires],
-      ),
+      items: group.items.filter((item) => {
+        if (item.privilegedOnly) return isPrivileged;
+        if (!item.requires) return true;
+        return isPrivileged || capabilities[item.requires];
+      }),
     }))
     .filter((group) => group.items.length > 0);
 }

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -49,6 +49,7 @@ import {
   HardDrive,
 } from "@untitledui/icons";
 import { useProjectContext } from "@decocms/mesh-sdk";
+import { useCapabilities, type CapabilityId } from "@/web/hooks/use-capability";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { Suspense } from "react";
 import { pluginSettingsSidebarItems } from "@/web/index";
@@ -67,6 +68,8 @@ interface SettingsNavItem {
   label: string;
   icon: React.ReactNode;
   to: string;
+  /** Capability required to see this item. Omitted = visible to every member. */
+  requires?: CapabilityId;
 }
 
 interface SettingsNavGroup {
@@ -77,6 +80,7 @@ interface SettingsNavGroup {
 function useSettingsSidebarGroups(): SettingsNavGroup[] {
   const currentProject = useProjectContext().project;
   const enabledPlugins = currentProject.enabledPlugins ?? [];
+  const { capabilities, isPrivileged, loading } = useCapabilities();
 
   const enabledSettingsItems = pluginSettingsSidebarItems
     .filter((item) => enabledPlugins.includes(item.pluginId))
@@ -91,36 +95,44 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           label: "General",
           icon: <Building02 size={14} />,
           to: "/$org/settings/general",
+          requires: "org:manage",
         },
         {
           key: "brand-context",
           label: "Brand Context",
           icon: <BookOpen01 size={14} />,
           to: "/$org/settings/brand-context",
+          requires: "org:manage",
         },
         {
           key: "ai-providers",
           label: "AI Providers",
           icon: <CpuChip01 size={14} />,
           to: "/$org/settings/ai-providers",
+          requires: "ai-providers:manage",
         },
         {
           key: "secrets",
           label: "Secrets",
           icon: <Key01 size={14} />,
           to: "/$org/settings/secrets",
+          requires: "secrets:manage",
         },
         {
           key: "files",
           label: "Files",
           icon: <HardDrive size={14} />,
           to: "/$org/settings/files",
+          requires: "file-configs:manage",
         },
       ],
     },
     {
       label: "Build",
       items: [
+        // connections + agents map to heavy route components that aren't
+        // capability-guarded yet — gated fully (nav + route + actions) in a
+        // follow-up, so leave them visible here to avoid half-gating.
         {
           key: "connections",
           label: "Connections",
@@ -138,12 +150,14 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           label: "Automations",
           icon: <Zap size={14} />,
           to: "/$org/settings/automations",
+          requires: "automations:manage",
         },
         {
           key: "store",
           label: "Store",
           icon: <PackageCheck size={14} />,
           to: "/$org/settings/store",
+          requires: "registry:manage",
         },
       ],
     },
@@ -151,6 +165,8 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
       label: "Manage",
       items: [
         {
+          // Monitor's route isn't capability-guarded yet (see Build note); gated
+          // fully in the follow-up. Visible to all members for now.
           key: "monitor",
           label: "Monitor",
           icon: <BarChart10 size={14} />,
@@ -161,18 +177,21 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           label: "Members",
           icon: <Users03 size={14} />,
           to: "/$org/settings/members",
+          requires: "members:manage",
         },
         {
           key: "roles",
           label: "Roles",
           icon: <Shield01 size={14} />,
           to: "/$org/settings/roles",
+          requires: "members:manage",
         },
         {
           key: "sso",
           label: "Security",
           icon: <Lock01 size={14} />,
           to: "/$org/settings/sso",
+          requires: "org:manage",
         },
       ],
     },
@@ -184,6 +203,7 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           label: "Plugins",
           icon: <Zap size={14} />,
           to: "/$org/settings/features",
+          requires: "org:manage",
         },
         ...enabledSettingsItems,
       ],
@@ -201,7 +221,21 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
     },
   ];
 
-  return groups;
+  // While capabilities load, show every item optimistically (avoids a flicker
+  // for the common privileged case). Once resolved, hide items the member's
+  // role can't open and drop any group left empty. Items without a `requires`
+  // (Profile, plugin items) are always visible.
+  if (loading) {
+    return groups;
+  }
+  return groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter(
+        (item) => !item.requires || isPrivileged || capabilities[item.requires],
+      ),
+    }))
+    .filter((group) => group.items.length > 0);
 }
 
 export function SettingsSidebar() {

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -29,6 +29,10 @@ export const KEYS = {
   organizationRoles: (locator: ProjectLocator) =>
     [locator, "organization-roles"] as const,
 
+  // Current user's resolved capability bitmap within the active org
+  myCapabilities: (locator: ProjectLocator) =>
+    [locator, "my-capabilities"] as const,
+
   // Connections (scoped by project)
   connections: (locator: ProjectLocator) => [locator, "connections"] as const,
   connectionsByBinding: (locator: ProjectLocator, binding: string) =>

--- a/apps/mesh/src/web/routes/orgs/settings/ai-providers.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/ai-providers.tsx
@@ -1,5 +1,10 @@
 import { OrgAiProvidersPage } from "@/web/views/settings/ai-providers";
+import { RequireCapability } from "@/web/components/require-capability";
 
 export default function AiProvidersRoute() {
-  return <OrgAiProvidersPage />;
+  return (
+    <RequireCapability capability="ai-providers:manage" area="AI providers">
+      <OrgAiProvidersPage />
+    </RequireCapability>
+  );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/automations.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/automations.tsx
@@ -14,8 +14,9 @@ import {
 } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { track } from "@/web/lib/posthog-client";
+import { RequireCapability } from "@/web/components/require-capability";
 
-export default function SettingsAutomationsPage() {
+function SettingsAutomationsPage() {
   const { org } = useProjectContext();
   const { data: automations = [] } = useAutomations(undefined);
   const agents = useVirtualMCPs();
@@ -109,5 +110,13 @@ export default function SettingsAutomationsPage() {
         </Page.Body>
       </Page.Content>
     </Page>
+  );
+}
+
+export default function SettingsAutomationsRoute() {
+  return (
+    <RequireCapability capability="automations:manage" area="automations">
+      <SettingsAutomationsPage />
+    </RequireCapability>
   );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/brand-context.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/brand-context.tsx
@@ -1,5 +1,10 @@
 import { OrgBrandContextPage } from "@/web/views/settings/org-brand-context";
+import { RequireCapability } from "@/web/components/require-capability";
 
 export default function BrandContextRoute() {
-  return <OrgBrandContextPage />;
+  return (
+    <RequireCapability capability="org:manage" area="brand context">
+      <OrgBrandContextPage />
+    </RequireCapability>
+  );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/features.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/features.tsx
@@ -1,5 +1,10 @@
 import { ProjectPluginsPage } from "@/web/views/settings/project-plugins";
+import { RequireCapability } from "@/web/components/require-capability";
 
 export default function FeaturesRoute() {
-  return <ProjectPluginsPage />;
+  return (
+    <RequireCapability capability="org:manage" area="plugins">
+      <ProjectPluginsPage />
+    </RequireCapability>
+  );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/files.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/files.tsx
@@ -1,5 +1,10 @@
 import { OrgFilesPage } from "@/web/views/settings/files";
+import { RequireCapability } from "@/web/components/require-capability";
 
 export default function FilesRoute() {
-  return <OrgFilesPage />;
+  return (
+    <RequireCapability capability="file-configs:manage" area="files">
+      <OrgFilesPage />
+    </RequireCapability>
+  );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/general.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/general.tsx
@@ -1,5 +1,10 @@
 import { OrgGeneralPage } from "@/web/views/settings/org-general";
+import { RequireCapability } from "@/web/components/require-capability";
 
 export default function GeneralRoute() {
-  return <OrgGeneralPage />;
+  return (
+    <RequireCapability capability="org:manage" area="general settings">
+      <OrgGeneralPage />
+    </RequireCapability>
+  );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/index-redirect.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/index-redirect.tsx
@@ -1,15 +1,19 @@
 import { Navigate, useParams } from "@tanstack/react-router";
 import { Loading01 } from "@untitledui/icons";
 import { useCapabilities, type CapabilityId } from "@/web/hooks/use-capability";
+import { CapabilityLoadError } from "@/web/components/capability-load-error";
 
 /**
  * Capability-aware /settings index. Redirects each member to the first
  * settings tab their role can open. Profile is always accessible, so it's the
  * guaranteed fallback — a member never lands on a no-access page.
+ *
+ * The order below covers every capability-gated settings tab, so a member
+ * whose only grant is e.g. Secrets or Files lands there rather than Profile.
  */
 export default function SettingsIndexRedirect() {
   const { org } = useParams({ from: "/shell/$org" });
-  const { capabilities, isPrivileged, loading } = useCapabilities();
+  const { capabilities, isPrivileged, loading, error } = useCapabilities();
 
   if (loading) {
     return (
@@ -17,6 +21,12 @@ export default function SettingsIndexRedirect() {
         <Loading01 size={20} className="animate-spin text-muted-foreground" />
       </div>
     );
+  }
+
+  // Don't fall through to the Profile redirect on a failed lookup — that reads
+  // as "no access". Surface a retryable error instead.
+  if (error) {
+    return <CapabilityLoadError />;
   }
 
   const can = (id: CapabilityId) => isPrivileged || capabilities[id] === true;
@@ -28,6 +38,12 @@ export default function SettingsIndexRedirect() {
     return (
       <Navigate to="/$org/settings/ai-providers" params={{ org }} replace />
     );
+  }
+  if (can("secrets:manage")) {
+    return <Navigate to="/$org/settings/secrets" params={{ org }} replace />;
+  }
+  if (can("file-configs:manage")) {
+    return <Navigate to="/$org/settings/files" params={{ org }} replace />;
   }
   if (can("automations:manage")) {
     return (

--- a/apps/mesh/src/web/routes/orgs/settings/index-redirect.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/index-redirect.tsx
@@ -1,0 +1,47 @@
+import { Navigate, useParams } from "@tanstack/react-router";
+import { Loading01 } from "@untitledui/icons";
+import { useCapabilities, type CapabilityId } from "@/web/hooks/use-capability";
+
+/**
+ * Capability-aware /settings index. Redirects each member to the first
+ * settings tab their role can open. Profile is always accessible, so it's the
+ * guaranteed fallback — a member never lands on a no-access page.
+ */
+export default function SettingsIndexRedirect() {
+  const { org } = useParams({ from: "/shell/$org" });
+  const { capabilities, isPrivileged, loading } = useCapabilities();
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8">
+        <Loading01 size={20} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const can = (id: CapabilityId) => isPrivileged || capabilities[id] === true;
+
+  if (can("org:manage")) {
+    return <Navigate to="/$org/settings/general" params={{ org }} replace />;
+  }
+  if (can("ai-providers:manage")) {
+    return (
+      <Navigate to="/$org/settings/ai-providers" params={{ org }} replace />
+    );
+  }
+  if (can("automations:manage")) {
+    return (
+      <Navigate to="/$org/settings/automations" params={{ org }} replace />
+    );
+  }
+  if (can("registry:manage")) {
+    return <Navigate to="/$org/settings/store" params={{ org }} replace />;
+  }
+  if (can("monitoring:view")) {
+    return <Navigate to="/$org/settings/monitor" params={{ org }} replace />;
+  }
+  if (can("members:manage")) {
+    return <Navigate to="/$org/settings/members" params={{ org }} replace />;
+  }
+  return <Navigate to="/$org/settings/profile" params={{ org }} replace />;
+}

--- a/apps/mesh/src/web/routes/orgs/settings/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/members.tsx
@@ -1,1 +1,10 @@
-export { default } from "@/web/routes/orgs/members";
+import MembersPage from "@/web/routes/orgs/members";
+import { RequireCapability } from "@/web/components/require-capability";
+
+export default function MembersRoute() {
+  return (
+    <RequireCapability capability="members:manage" area="members">
+      <MembersPage />
+    </RequireCapability>
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/settings/registry.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/registry.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react";
 import { Loading01 } from "@untitledui/icons";
+import { RequireCapability } from "@/web/components/require-capability";
 
 const RegistryLayout = lazy(
   () => import("@/web/views/registry/registry-layout"),
@@ -7,14 +8,19 @@ const RegistryLayout = lazy(
 
 export default function SettingsRegistryPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="flex-1 flex items-center justify-center">
-          <Loading01 size={20} className="animate-spin text-muted-foreground" />
-        </div>
-      }
-    >
-      <RegistryLayout />
-    </Suspense>
+    <RequireCapability capability="registry:manage" area="the registry">
+      <Suspense
+        fallback={
+          <div className="flex-1 flex items-center justify-center">
+            <Loading01
+              size={20}
+              className="animate-spin text-muted-foreground"
+            />
+          </div>
+        }
+      >
+        <RegistryLayout />
+      </Suspense>
+    </RequireCapability>
   );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/roles.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/roles.tsx
@@ -47,7 +47,7 @@ import {
   getTargetKey,
   type RoleEditorTarget,
 } from "@/web/views/settings/org-role-detail.tsx";
-import { RequireCapability } from "@/web/components/require-capability";
+import { RequirePrivileged } from "@/web/components/require-privileged";
 
 // ============================================================================
 // Role color helpers
@@ -459,9 +459,11 @@ function RolesPage() {
 }
 
 export default function RolesRoute() {
+  // Role-definition CRUD (listRoles/createRole/…) is owner/admin-only in Better
+  // Auth, so gate on privilege rather than a grantable capability.
   return (
-    <RequireCapability capability="members:manage" area="roles">
+    <RequirePrivileged area="roles">
       <RolesPage />
-    </RequireCapability>
+    </RequirePrivileged>
   );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/roles.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/roles.tsx
@@ -47,6 +47,7 @@ import {
   getTargetKey,
   type RoleEditorTarget,
 } from "@/web/views/settings/org-role-detail.tsx";
+import { RequireCapability } from "@/web/components/require-capability";
 
 // ============================================================================
 // Role color helpers
@@ -426,7 +427,7 @@ function RolesPageContent() {
   );
 }
 
-export default function RolesPage() {
+function RolesPage() {
   return (
     <ErrorBoundary
       fallback={
@@ -454,5 +455,13 @@ export default function RolesPage() {
         <RolesPageContent />
       </Suspense>
     </ErrorBoundary>
+  );
+}
+
+export default function RolesRoute() {
+  return (
+    <RequireCapability capability="members:manage" area="roles">
+      <RolesPage />
+    </RequireCapability>
   );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/secrets.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/secrets.tsx
@@ -1,5 +1,10 @@
 import { OrgSecretsPage } from "@/web/views/settings/secrets";
+import { RequireCapability } from "@/web/components/require-capability";
 
 export default function SecretsRoute() {
-  return <OrgSecretsPage />;
+  return (
+    <RequireCapability capability="secrets:manage" area="secrets">
+      <OrgSecretsPage />
+    </RequireCapability>
+  );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/sso.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/sso.tsx
@@ -1,5 +1,10 @@
 import { OrgSsoPage } from "@/web/views/settings/org-sso";
+import { RequireCapability } from "@/web/components/require-capability";
 
 export default function SsoRoute() {
-  return <OrgSsoPage />;
+  return (
+    <RequireCapability capability="org:manage" area="security">
+      <OrgSsoPage />
+    </RequireCapability>
+  );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/store-registry.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/store-registry.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { Loading01 } from "@untitledui/icons";
+import { RequireCapability } from "@/web/components/require-capability";
 
 const RegistryLayout = lazy(
   () => import("@/web/views/registry/registry-layout"),
@@ -11,16 +12,23 @@ export default function StoreRegistryPage() {
   const { org } = useParams({ from: "/shell/$org" });
 
   return (
-    <Suspense
-      fallback={
-        <div className="h-full flex items-center justify-center">
-          <Loading01 size={20} className="animate-spin text-muted-foreground" />
-        </div>
-      }
-    >
-      <RegistryLayout
-        onBack={() => navigate({ to: "/$org/settings/store", params: { org } })}
-      />
-    </Suspense>
+    <RequireCapability capability="registry:manage" area="the registry">
+      <Suspense
+        fallback={
+          <div className="h-full flex items-center justify-center">
+            <Loading01
+              size={20}
+              className="animate-spin text-muted-foreground"
+            />
+          </div>
+        }
+      >
+        <RegistryLayout
+          onBack={() =>
+            navigate({ to: "/$org/settings/store", params: { org } })
+          }
+        />
+      </Suspense>
+    </RequireCapability>
   );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/store.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/store.tsx
@@ -1,5 +1,10 @@
 import { OrgStorePage } from "@/web/views/settings/org-store";
+import { RequireCapability } from "@/web/components/require-capability";
 
 export default function StoreRoute() {
-  return <OrgStorePage />;
+  return (
+    <RequireCapability capability="registry:manage" area="the store">
+      <OrgStorePage />
+    </RequireCapability>
+  );
 }


### PR DESCRIPTION
## Summary

First slice of capability-based UI gating, built on the `my-capabilities` endpoint from #3601. Members now only see and can open the settings sections their role allows.

### Infrastructure
- **`useCapability` / `useCapabilities`** — read the server-resolved bitmap from `GET /api/auth/custom/my-capabilities/:slug`. The server is the single source of truth; the hook never re-derives role logic. owner/admin short-circuit to granted.
- **`RequireCapability`** route guard + **`NoPermissionState`** empty state. The guard renders a spinner while resolving, the no-access panel when denied, and children when granted — and it sits *outside* each route's data hooks, so a denied user never fires the inner queries.

### Settings gating
- **Sidebar nav** is filtered by each item's required capability (optimistic while capabilities load to avoid flicker; empty groups dropped). Items with no requirement (Profile, plugin items) always show.
- **`/settings` index** is now capability-aware: redirects each member to the first tab their role can open, with **Profile as the guaranteed fallback** so no one lands on a no-access page (previously it always sent everyone to `/general`).
- **Routes guarded:** general, brand-context, ai-providers, secrets, files, store, sso, features, members, roles, automations (each → its capability, e.g. members/roles → `members:manage`).

## Deliberately out of scope
Connections, Agents and Monitor map to large route components with their own in-page actions to gate. To avoid *half*-gating (hiding the nav item while the route stays open via direct URL), they're left fully untouched here and gated end-to-end (nav + route + buttons) in the follow-up PR.

## Testing
The capability **resolution** this relies on is unit- and e2e-tested at the endpoint (#3601). This PR is the UI wiring on top. A UI e2e for the deny path (a restricted member sees fewer nav items / a no-access panel) is a sensible fast-follow — it needs a second authenticated browser session, which I'd add and validate in CI separately.

Typecheck, lint, knip, format all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the Settings UI by member capability so people only see sections they can use. Also enforce owner/admin-only access to Roles, close registry deep-link gaps, let all members see configured AI providers (read-only), and refactor route guards to a shared `AccessGate` for consistent loading/error/denied states.

- **New Features**
  - `useCapability` / `useCapabilities` read the server bitmap from `GET /api/auth/custom/my-capabilities/:slug`; owners/admins auto-granted.
  - Route guards: `RequireCapability` and `RequirePrivileged` with `NoPermissionState` and `CapabilityLoadError`; shared `AccessGate` centralizes loading/error/denied rendering and prevents inner data hooks when denied.
  - Settings sidebar filters items by required capability, hides empty groups, and always shows items without `requires`; the Roles nav item is owner/admin-only.
  - Capability-aware `/settings` index redirects to the first accessible tab (Profile fallback); registry deep-link routes (`/settings/registry`, `/settings/store/registry`) are now guarded.
  - All members can see configured AI providers (read-only) via `AI_PROVIDER_KEY_LIST` and `AI_PROVIDER_CREDITS`; managing providers stays behind `ai-providers:manage`.

- **Bug Fixes**
  - Distinguish capability load failures from denial: the hook throws on failure (with retry), `RequireCapability`/index render a retryable `CapabilityLoadError`, and the sidebar stays fully visible on error.
  - Settings index redirect includes Secrets and Files; e2e covers restricted vs. owner flows and the retryable error path, and sends the Origin header on org POSTs to satisfy CSRF.

<sup>Written for commit a834ac49835f1506024af96344880a8ca7548fe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

