### PR TITLE
fix(sections-editor): prevent deco-site forms panel content from being clipped

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1861,7 +1861,7 @@ export function SectionsEditor({
 
       {/* Drill-down: section list OR section form */}
       {isEditing ? (
-        <ScrollArea className="flex-1 min-h-0">
+        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
           {isEditingMultivariateSection && sectionFlagVariants.length > 0 && (
             <>
               <SectionVariantList
@@ -1919,7 +1919,7 @@ export function SectionsEditor({
           </div>
         </ScrollArea>
       ) : isGlobalBlockMode ? (
-        <ScrollArea className="flex-1 min-h-0">
+        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
           <div className="min-w-0 max-w-full overflow-x-hidden p-4">
             {activeSchema && formValue ? (
               <SchemaForm
@@ -1939,7 +1939,7 @@ export function SectionsEditor({
           </div>
         </ScrollArea>
       ) : (
-        <ScrollArea className="flex-1 min-h-0">
+        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
           {/* Variant rule editor (collapsible so users can reclaim space) */}
           {hasMultipleVariants && ruleResolveType !== null && (
             <div


### PR DESCRIPTION
## What is this contribution about?
The deco-site forms panel (sections editor) was hard-clipping content at the panel's right edge — long labels like alert/nav-item text were cut off instead of truncating with an ellipsis. The forms render inside a Radix `ScrollArea` whose `Viewport` wraps children in a `display:table` element that sizes to its widest content, so the existing `min-w-0`/`truncate` styles never actually constrained the fields. This forces that Radix content wrapper to `display:block` on the three sections-editor scroll areas so content respects the viewport width and truncates correctly. It is scoped to these instances rather than the shared `ScrollArea` because another consumer relies on the horizontal content-width behavior.

## Screenshots/Demonstration
Before: array-item/field text overflowed past the resizable panel divider and was clipped. After: text stays within the viewport and truncates with an ellipsis.

## How to Test
1. Open a deco-site page in the sections editor and select a section with long field/array values (e.g. Header → Alerts).
2. Resize the forms panel narrower.
3. Expected: long labels truncate with `…` inside the panel instead of being clipped at the right edge.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clipped content in the deco-site forms panel by forcing the Radix `ScrollArea` viewport wrapper to `display:block` so long labels stay within the panel and truncate with an ellipsis.

- **Bug Fixes**
  - Applied `[&_[data-slot=scroll-area-viewport]>div]:!block` to the three sections-editor `ScrollArea`s.
  - Scoped to these instances to avoid changing shared `ScrollArea` behavior used elsewhere.

<sup>Written for commit b453544393faa9f9a7c194d976c5e1237065f5c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

