### PR TITLE
fix(decopilot): generate chat titles via structured output

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -123,14 +123,12 @@ Git operations live in two layers:
 
 export const TITLE_GENERATOR_PROMPT = `Generate a concise, sentence-case title (3-7 words) that captures the main topic or goal of this session. Use sentence case: capitalize only the first word and proper nouns.
 
-Return JSON with a single "title" field.
-
 Good examples:
-{"title": "Fix login button on mobile"}
-{"title": "Add OAuth authentication"}
-{"title": "Query product catalog data"}
-{"title": "Set up event subscriptions"}
+- Fix login button on mobile
+- Add OAuth authentication
+- Query product catalog data
+- Set up event subscriptions
 
-Bad (too vague): {"title": "Help with task"}
-Bad (too long): {"title": "Investigate and fix the issue where the login button does not respond on mobile devices"}
-Bad (wrong case): {"title": "Fix Login Button On Mobile"}`;
+Bad (too vague): Help with task
+Bad (too long): Investigate and fix the issue where the login button does not respond on mobile devices
+Bad (wrong case): Fix Login Button On Mobile`;

--- a/apps/mesh/src/harnesses/decopilot/title-generator.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.ts
@@ -47,6 +47,9 @@ export function genTitle(config: {
     }, POST_STREAM_GRACE_MS);
   };
 
+  const fallbackTitle =
+    userMessage.split("\n")[0].trim().slice(0, 60) || null;
+
   const promise = (async (): Promise<string | null> => {
     try {
       const result = await generateObject({
@@ -63,8 +66,8 @@ export function genTitle(config: {
         .slice(0, 60) // Max 60 chars
         .trim();
 
-      // Reject empty or all-punctuation strings (e.g. "---", "{}")
-      if (!title || !/\w/.test(title)) return null;
+      // Reject empty or all-punctuation strings — fall back to user message
+      if (!title || !/\w/.test(title)) return fallbackTitle;
 
       return title;
     } catch (error) {
@@ -73,13 +76,13 @@ export function genTitle(config: {
         console.warn(
           "[decopilot:title] Title generation aborted (timeout or parent abort)",
         );
-      } else {
-        console.error(
-          "[decopilot:title] ❌ Failed to generate title:",
-          err.message,
-        );
+        return null;
       }
-      return null;
+      console.error(
+        "[decopilot:title] ❌ Failed to generate title:",
+        err.message,
+      );
+      return fallbackTitle;
     } finally {
       clearTimeout(graceTimeoutId);
       abortSignal.removeEventListener("abort", onParentAbort);

--- a/apps/mesh/src/harnesses/decopilot/title-generator.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.ts
@@ -5,9 +5,14 @@
  */
 
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import { generateText } from "ai";
+import { generateObject } from "ai";
+import { z } from "zod";
 
 import { TITLE_GENERATOR_PROMPT } from "../../api/routes/decopilot/constants";
+
+const TITLE_SCHEMA = z.object({
+  title: z.string().describe("A concise, sentence-case title (3-7 words)"),
+});
 
 /**
  * Generate a short title for the conversation in the background.
@@ -44,44 +49,22 @@ export function genTitle(config: {
 
   const promise = (async (): Promise<string | null> => {
     try {
-      const result = await generateText({
+      const result = await generateObject({
         model,
+        schema: TITLE_SCHEMA,
         system: TITLE_GENERATOR_PROMPT,
         messages: [{ role: "user", content: userMessage }],
-        maxOutputTokens: 60,
         temperature: 0.2,
         abortSignal: titleAbortController.signal,
       });
 
-      // Strip markdown code fences if present, then try JSON parse
-      const cleaned = result.text
-        .trim()
-        .replace(/^```(?:json)?\s*\n?/i, "")
-        .replace(/\n?```\s*$/, "")
-        .trim();
-
-      let title: string;
-
-      try {
-        const parsed = JSON.parse(cleaned);
-        title = typeof parsed.title === "string" ? parsed.title : cleaned;
-      } catch {
-        // Fallback: extract first line and clean up formatting
-        const firstLine = cleaned.split("\n")[0] ?? cleaned;
-        title = firstLine;
-      }
-
-      title = title
-        .replace(/^["']|["']$/g, "") // Remove quotes
-        .replace(/^(Title:|title:)\s*/i, "") // Remove "Title:" prefix
-        .replace(/^```.*$/gm, "") // Remove any remaining fence lines
-        .replace(/[{}[\]]/g, "") // Remove JSON braces/brackets
+      const title = result.object.title
         .replace(/[.!?]$/, "") // Remove trailing punctuation
         .slice(0, 60) // Max 60 chars
         .trim();
 
-      // If cleanup left nothing useful, don't set a broken title
-      if (!title || /^[\s"':{}[\],]+$/.test(title)) return null;
+      // If the model returned nothing useful, don't set a broken title
+      if (!title) return null;
 
       return title;
     } catch (error) {

--- a/apps/mesh/src/harnesses/decopilot/title-generator.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.ts
@@ -51,8 +51,7 @@ export function genTitle(config: {
   // through the same sanitization as the model title, or a static default if
   // the message is empty or has no usable text.
   const fallbackTitle = (() => {
-    const candidate = userMessage
-      .split("\n")[0]
+    const candidate = (userMessage.split("\n")[0] ?? "")
       .replace(/[.!?]$/, "")
       .slice(0, 60)
       .trim();

--- a/apps/mesh/src/harnesses/decopilot/title-generator.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.ts
@@ -14,6 +14,11 @@ const TITLE_SCHEMA = z.object({
   title: z.string().describe("A concise, sentence-case title (3-7 words)"),
 });
 
+// A title is usable only if it contains at least one letter or number in any
+// script. Unicode-aware (\p{L}\p{N}) so non-Latin titles (CJK, Arabic, etc.)
+// aren't rejected the way ASCII-only \w would.
+const hasUsableText = (s: string): boolean => /[\p{L}\p{N}]/u.test(s);
+
 /**
  * Generate a short title for the conversation in the background.
  *
@@ -55,7 +60,7 @@ export function genTitle(config: {
       .replace(/[.!?]$/, "")
       .slice(0, 60)
       .trim();
-    return candidate && /\w/.test(candidate) ? candidate : "New chat";
+    return hasUsableText(candidate) ? candidate : "New chat";
   })();
 
   const promise = (async (): Promise<string | null> => {
@@ -75,7 +80,7 @@ export function genTitle(config: {
         .trim();
 
       // Reject empty or all-punctuation strings — fall back to user message
-      if (!title || !/\w/.test(title)) return fallbackTitle;
+      if (!hasUsableText(title)) return fallbackTitle;
 
       return title;
     } catch (error) {

--- a/apps/mesh/src/harnesses/decopilot/title-generator.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.ts
@@ -47,10 +47,17 @@ export function genTitle(config: {
     }, POST_STREAM_GRACE_MS);
   };
 
-  // Always resolves to a usable title: first line of the user message, or a
-  // static default if the message is empty/whitespace-only.
-  const fallbackTitle =
-    userMessage.split("\n")[0].trim().slice(0, 60) || "New chat";
+  // Always resolves to a usable title: first line of the user message, run
+  // through the same sanitization as the model title, or a static default if
+  // the message is empty or has no usable text.
+  const fallbackTitle = (() => {
+    const candidate = userMessage
+      .split("\n")[0]
+      .replace(/[.!?]$/, "")
+      .slice(0, 60)
+      .trim();
+    return candidate && /\w/.test(candidate) ? candidate : "New chat";
+  })();
 
   const promise = (async (): Promise<string | null> => {
     try {

--- a/apps/mesh/src/harnesses/decopilot/title-generator.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.ts
@@ -63,8 +63,8 @@ export function genTitle(config: {
         .slice(0, 60) // Max 60 chars
         .trim();
 
-      // If the model returned nothing useful, don't set a broken title
-      if (!title) return null;
+      // Reject empty or all-punctuation strings (e.g. "---", "{}")
+      if (!title || !/\w/.test(title)) return null;
 
       return title;
     } catch (error) {

--- a/apps/mesh/src/harnesses/decopilot/title-generator.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.ts
@@ -47,8 +47,10 @@ export function genTitle(config: {
     }, POST_STREAM_GRACE_MS);
   };
 
+  // Always resolves to a usable title: first line of the user message, or a
+  // static default if the message is empty/whitespace-only.
   const fallbackTitle =
-    userMessage.split("\n")[0].trim().slice(0, 60) || null;
+    userMessage.split("\n")[0].trim().slice(0, 60) || "New chat";
 
   const promise = (async (): Promise<string | null> => {
     try {


### PR DESCRIPTION
## What is this contribution about?
Fixes chat title generation, which sometimes produced broken titles like `"title":` or left threads stuck on "New chat". The title generator prompted the model for raw JSON and hand-parsed it — truncated (capped at `maxOutputTokens: 60`) or multi-line JSON broke `JSON.parse`, and the fallback emitted JSON fragments instead of a real title. This replaces `generateText` + manual parsing with `generateObject` and a Zod schema, so the model always returns a valid, complete title.

## How to Test
1. Start a new chat (thread defaults to "New chat").
2. Send a first message describing a task.
3. Expected: the thread title updates to a concise sentence-case title, never a JSON fragment.

## Migration Notes
Not applicable.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat title generation by switching to structured output with `generateObject` and a `zod` schema. Adds a sanitized, Unicode-aware fallback so titles are clean, support non‑Latin scripts, and are always set; null only on abort.

- **Bug Fixes**
  - Replaced `generateText` + manual parsing with `generateObject` from `ai` and a `zod` schema; simplified prompt (removed raw JSON examples) and removed the output token cap.
  - Unified sanitization and fallback: strip trailing punctuation, max 60 chars; Unicode-aware usable-text check (accepts CJK/Arabic/etc.); fallback to sanitized first line or "New chat".
  - Error handling: on failure use the sanitized fallback; return null only on abort; guarded split for `noUncheckedIndexedAccess`.

<sup>Written for commit 6df6e08957e4856cfb7dcc2bfc68e5fcea72c04b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

