### PR TITLE
feat(runtime): expose createTool title via MCP tools/list

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -600,6 +600,7 @@ function ConnectionItemSkeleton() {
 
 interface UITool {
   name: string;
+  title?: string;
   description?: string;
   resourceUri: string;
 }
@@ -658,6 +659,7 @@ function LayoutTabContent({
                 icon?: string | null;
                 tools?: Array<{
                   name: string;
+                  title?: string;
                   description?: string;
                   _meta?: Record<string, unknown>;
                 }> | null;
@@ -667,7 +669,12 @@ function LayoutTabContent({
               const resourceUri = getUIResourceUri(t._meta);
               if (!resourceUri) return [];
               return [
-                { name: t.name, description: t.description, resourceUri },
+                {
+                  name: t.name,
+                  title: t.title,
+                  description: t.description,
+                  resourceUri,
+                },
               ];
             });
             return {
@@ -811,12 +818,15 @@ function LayoutTabContent({
         writeLayout({ defaultMainView: { type: "chat" } });
       }
     } else {
+      const toolTitle = connectionsData
+        .find((c) => c.id === connectionId)
+        ?.uiTools.find((t) => t.name === toolName)?.title;
       writePinned([
         ...pinnedViews,
         {
           connectionId,
           toolName,
-          label: toTitleCase(toolName),
+          label: toolTitle ?? toTitleCase(toolName),
           icon: null,
         },
       ]);
@@ -1034,7 +1044,7 @@ function LayoutTabContent({
                                   value={
                                     pinned && pinnedView
                                       ? pinnedView.label
-                                      : toTitleCase(tool.name)
+                                      : (tool.title ?? toTitleCase(tool.name))
                                   }
                                   onChange={(e) =>
                                     handleLabelChange(

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -63,6 +63,8 @@ export interface Tool<
 > {
   _meta?: Record<string, unknown>;
   id: TId;
+  /** Human-readable name exposed via MCP tools/list `title` */
+  title?: string;
   description?: string;
   annotations?: ToolAnnotations;
   inputSchema: TSchemaIn;
@@ -82,6 +84,7 @@ export interface Tool<
 export type CreatedTool = {
   _meta?: Record<string, unknown>;
   id: string;
+  title?: string;
   description?: string;
   annotations?: ToolAnnotations;
   inputSchema: ZodTypeAny;
@@ -945,6 +948,7 @@ export const createMCPServer = <
         tool.id,
         {
           _meta: tool._meta,
+          title: tool.title,
           description: tool.description,
           annotations: tool.annotations,
           // Pass the full ZodObject (not its `.shape`) so the SDK skips


### PR DESCRIPTION
## Summary
- Add optional `title` to `@decocms/runtime` `createTool` and pass it through MCP `registerTool`, so `tools/list` exposes human-readable names per the MCP spec
- Studio agent Layout reads `tool.title` for pinned view previews and default pin labels (fallback remains `toTitleCase(name)`)
- Bump `@decocms/runtime` to **1.6.3** (patch — backward compatible optional field)

## Usage
```typescript
createTool({
  id: "file_explorer",
  title: "Preview",
  description: "...",
  ...
})
```

## Test plan
- [ ] `bun run --cwd packages/runtime check`
- [ ] Publish `@decocms/runtime@1.6.3` to npm
- [ ] Verify `tools/list` returns `title` for tools that set it
- [ ] In Studio agent Layout, unpinned UI tools show MCP title instead of title-cased id
- [ ] Pinning a tool uses MCP title as default label


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional tool `title` to `@decocms/runtime` and expose it via MCP `tools/list` so tools show human-readable names. Studio agent uses `title` for default pin labels and preview names, with fallback to title-cased IDs.

- **New Features**
  - `createTool` supports `title`; passed through MCP `registerTool` and returned by `tools/list`.
  - Layout reads `tool.title` for pinned view labels and unpinned UI tool previews.

- **Dependencies**
  - Bump `@decocms/runtime` to `1.6.3` (patch).

<sup>Written for commit 5e0a4460f020e626fe301d0ea22125aedb969f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

