### PR TITLE
fix(sidebar): archive navigates to next thread on same agent

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -19,7 +19,7 @@ import {
   useVirtualMCPActions,
   useVirtualMCPs,
 } from "@decocms/mesh-sdk";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useParams } from "@tanstack/react-router";
 import { authClient } from "@/web/lib/auth-client";
 import {
   useThreadActions,
@@ -100,9 +100,7 @@ export function TaskGroupsList() {
   const { hide } = useThreadActions();
 
   const { setTaskId, createNewTask } = usePanelActions();
-  const navigate = useNavigate();
   const params = useParams({ strict: false }) as {
-    org?: string;
     taskId?: string;
   };
   const activeTaskId = params.taskId ?? null;
@@ -160,14 +158,13 @@ export function TaskGroupsList() {
     const wasActive = task.id === activeTaskId;
     hide(task.id);
     if (!wasActive) return;
-    const next = sortedThreads.find((t) => t.id !== task.id);
+    const next = sortedThreads.find(
+      (t) => t.id !== task.id && t.virtual_mcp_id === task.virtual_mcp_id,
+    );
     if (next) {
       setTaskId(next.id, next.virtual_mcp_id);
-    } else if (params.org) {
-      navigate({
-        to: "/$org",
-        params: { org: params.org },
-      });
+    } else {
+      createNewTask(task.virtual_mcp_id);
     }
   };
 


### PR DESCRIPTION
## What is this contribution about?

When archiving the active thread, the sidebar was jumping to the oldest thread across all agents (the first result of `sortedThreads.find`). It now moves to the most recent other thread on the **same agent**. If no other threads exist for that agent, it falls back to opening a new blank thread instead.

## Screenshots/Demonstration

N/A — behavioral fix, no visual change beyond the navigation target.

## How to Test

1. Open Studio with multiple threads across at least one agent that has 2+ threads.
2. Archive the currently active thread.
3. Expected: the next most recent thread on the **same agent** becomes active (not the oldest thread across all agents).
4. Archive all threads of an agent — expected: a new blank thread opens for that agent.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar archive navigation: archiving the active thread now switches to the most recent other thread on the same agent, instead of the oldest thread across all agents. If no other threads exist for that agent, it opens a new blank thread.

<sup>Written for commit ba8cd10a6d61c6e72c516bc573457a863b43512e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

