### PR TITLE
feat(auth): enhance dev link session handling for local mode and user…

### DIFF
--- a/apps/mesh/src/auth/dev-link-session.ts
+++ b/apps/mesh/src/auth/dev-link-session.ts
@@ -25,6 +25,7 @@ import { chmod, mkdir, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getDb } from "@/database";
 import { auth } from "./index";
+import { getLocalAdminUser, isLocalMode } from "./local-mode";
 
 export interface DevLinkSession {
   target: string;
@@ -65,13 +66,29 @@ export async function bootstrapDevLinkSession(
   clusterBaseUrl: string,
 ): Promise<{ path: string; userSub: string } | null> {
   const path = devLinkSessionPath(homeDir);
+
+  // Resolve the user the link should represent. In local mode this is the
+  // seeded admin (the same user the browser auto-logs-in as), pinned by its
+  // stable `<username>@localhost.mesh` email. Pinning to the email — rather
+  // than "most-recently-created user" — prevents a leftover e2e run (which
+  // seeds throwaway `*@playwright.local` users with newer createdAt) from
+  // hijacking the dev link and producing a user_desktop_link_offline mismatch
+  // when dispatch looks the claim up under the browser's userId.
+  const db = getDb().db;
+  const user = isLocalMode()
+    ? await getLocalAdminUser()
+    : await db
+        .selectFrom("user")
+        .select(["id", "email", "name"])
+        .orderBy("createdAt", "desc")
+        .executeTakeFirst();
+  if (!user?.id) return null;
+
   if (existsSync(path)) {
-    // Re-use the existing session file iff its API key still verifies.
-    // If the key was deleted/rotated/expired (e.g. DB wipe, manual
-    // cleanup, expiresIn lapsed) the link daemon fails to register with
-    // an opaque 500 "no session". Verifying up front and re-minting on
-    // failure makes restarts self-healing without the developer having
-    // to manually delete the file.
+    // Re-use the existing session file iff it belongs to the resolved user
+    // *and* its API key still verifies. A user mismatch (stale file from a
+    // prior session/e2e run) or an invalid key (DB wipe, rotation, expiry)
+    // forces a re-mint, making restarts self-healing without manual cleanup.
     try {
       const file = Bun.file(path);
       const json = (await file.json()) as {
@@ -80,11 +97,7 @@ export async function bootstrapDevLinkSession(
       };
       const sub = json.user?.sub;
       const key = json.accessToken;
-      if (
-        typeof sub === "string" &&
-        sub.length > 0 &&
-        typeof key === "string"
-      ) {
+      if (sub === user.id && typeof key === "string") {
         const verified = await auth.api
           .verifyApiKey({ body: { key } })
           .then((r: { valid?: boolean } | null) => r?.valid === true)
@@ -95,17 +108,6 @@ export async function bootstrapDevLinkSession(
       // fall through and re-mint
     }
   }
-
-  const db = getDb().db;
-  // Most-recently-created admin user — local-mode seeds exactly one,
-  // but we don't pin to the local-mode email so a hand-created admin
-  // also works when DECOCMS_LOCAL_MODE is off.
-  const user = await db
-    .selectFrom("user")
-    .select(["id", "email", "name"])
-    .orderBy("createdAt", "desc")
-    .executeTakeFirst();
-  if (!user?.id) return null;
 
   let apiKey: { key?: string } | null = null;
   try {

--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -143,9 +143,15 @@ export function createControlHandler(deps: ControlHandlerDeps): ControlHandler {
       const rest = sm[2] ?? "/";
       const port = deps.provider.proxyPort(handle);
       if (port == null) {
-        console.warn(
-          `[control] handleStream unknown handle=${handle} method=${req.method} rest=${rest} (no spawned sandbox for this handle)`,
-        );
+        // SSE-style endpoints (`/events`, `/idle`) auto-reconnect from the
+        // browser, so a handle with no spawned sandbox would flood the log on
+        // every retry. Stay quiet for those — same rationale as the verbose
+        // gate on the success path below.
+        if (rest !== "/events" && rest !== "/idle") {
+          console.warn(
+            `[control] handleStream unknown handle=${handle} method=${req.method} rest=${rest} (no spawned sandbox for this handle)`,
+          );
+        }
         return (async function* () {
           yield {
             type: "headers" as const,

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -136,10 +136,20 @@ const LOG_EVENT = "log" as const;
 export function SandboxEventsProvider({
   virtualMcpId,
   branch,
+  enabled = true,
   children,
 }: {
   virtualMcpId: string | null;
   branch: string | null;
+  /**
+   * Open the events stream only when a sandbox exists (or is about to) for
+   * this (virtualMcpId, branch). Mounting the provider with `enabled={false}`
+   * keeps the idle context available to consumers without connecting — this
+   * avoids an endless 404/reconnect loop (and daemon log spam) for branches
+   * that never spawn a sandbox, e.g. an ephemeral decopilot run that never
+   * touches a VM tool. Defaults to true to preserve prior behavior.
+   */
+  enabled?: boolean;
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
@@ -183,7 +193,7 @@ export function SandboxEventsProvider({
     setActiveProcesses([]);
     buffers.current.clear();
 
-    if (!virtualMcpId || !branch) return;
+    if (!virtualMcpId || !branch || !enabled) return;
 
     const sseUrl = `/api/${encodeURIComponent(org.slug)}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/events`;
 
@@ -387,7 +397,7 @@ export function SandboxEventsProvider({
       if (reconnectTimer) clearTimeout(reconnectTimer);
       clearSuspendTimer();
     };
-  }, [virtualMcpId, branch, org.slug]);
+  }, [virtualMcpId, branch, org.slug, enabled]);
 
   const value: SandboxEventsValue = {
     phase,

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -265,10 +265,23 @@ function VmEventsBridge({
     triggerAutoStart,
   ]);
 
+  // Open the events stream only when a sandbox exists or is about to: a
+  // GitHub-linked agent auto-starts one (effect above), or the sandboxMap
+  // already has an entry for this (user, branch). Without this gate, an
+  // ephemeral decopilot run that never spawns a sandbox would open an events
+  // stream that 404s and reconnects forever (daemon log spam).
+  const branchMap =
+    userId && currentBranch
+      ? parseBranchMap(sandboxMap?.[userId]?.[currentBranch])
+      : {};
+  const shouldConnect =
+    hasActiveGithubRepo || Object.keys(branchMap).length > 0;
+
   return (
     <SandboxEventsProvider
       virtualMcpId={virtualMcpId}
       branch={currentBranch ?? null}
+      enabled={shouldConnect}
     >
       {children}
     </SandboxEventsProvider>


### PR DESCRIPTION
… verification

- Introduced local admin user retrieval in local mode to ensure correct user representation.
- Improved session file reuse logic to verify both user identity and API key validity, enhancing self-healing capabilities.
- Updated SandboxEventsProvider to conditionally open event streams based on sandbox existence, reducing unnecessary log spam.
- Added a mechanism to prevent endless reconnect loops for branches without active sandboxes.

This update streamlines the development experience and improves error handling in the link daemon and sandbox event management.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves dev link sessions and sandbox event streaming to avoid user mismatches and cut reconnect log spam. In local mode we pin to the seeded admin, and we only open SSE streams when a sandbox exists or is starting.

- **New Features**
  - Dev link session now resolves the correct user: use the seeded local admin in local mode; otherwise use the latest user.
  - Reuse session file only if it matches the resolved user and the API key verifies; otherwise re-mint to self-heal.
  - Add `enabled` gating to SandboxEventsProvider and wire it in the agent shell to connect only when a sandbox exists or will auto-start.
  - Suppress noisy warnings for `/events` and `/idle` when no sandbox is spawned to prevent reconnect log spam.

<sup>Written for commit b47f183656bd9b7760cee2619948104dd232f90f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

