### PR TITLE
fix(chat): use server-stamped started_at for live elapsed timer

### DIFF
--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -38,7 +38,7 @@ import { addUsage, emptyUsageStats } from "@decocms/mesh-sdk";
 import { useOptionalChatStream, useOptionalChatTask } from "../context.tsx";
 import { LiveTimer } from "../../live-timer.tsx";
 import { GridLoader } from "../../grid-loader.tsx";
-import { formatDuration } from "../../../lib/format-time.ts";
+import { formatDuration, toEpochMs } from "../../../lib/format-time.ts";
 
 type ThinkingStage = "planning" | "thinking";
 
@@ -607,19 +607,26 @@ export function MessageAssistant({
   const isSubmitted = status === "submitted";
   const isLoading = isStreaming || isSubmitted;
 
-  // Track when this message's generation started for the live elapsed timer
-  const [startedAt, setStartedAt] = useState<number | null>(() =>
-    isLoading ? Date.now() : null,
-  );
+  // Track when this message's generation started for the live elapsed timer.
+  //
+  // Prefer the server-stamped stream start (`metadata.created_at`, set on the
+  // first stream chunk in run-stream.ts and persisted in thread_messages).
+  // This makes the chronometer survive a page refresh — it resumes counting
+  // from the real start time instead of restarting at 0 on remount.
+  //
+  // Client fallback (`Date.now()`) covers the brief "submitted but no chunks
+  // yet" window where the server hasn't sent a `start` chunk; once that
+  // chunk arrives the server time takes over via the `??` below.
+  const serverStartedAt = toEpochMs(message?.metadata?.created_at);
+  const [clientFallbackStartedAt, setClientFallbackStartedAt] = useState<
+    number | null
+  >(() => (isLoading ? Date.now() : null));
   const [prevIsLoading, setPrevIsLoading] = useState(isLoading);
   if (prevIsLoading !== isLoading) {
     setPrevIsLoading(isLoading);
-    if (isLoading) {
-      setStartedAt(Date.now());
-    } else {
-      setStartedAt(null);
-    }
+    setClientFallbackStartedAt(isLoading ? Date.now() : null);
   }
+  const startedAt = serverStartedAt ?? clientFallbackStartedAt;
 
   // Handle null message or empty parts
   const hasContent = message !== null && message.parts.length > 0;

--- a/apps/mesh/src/web/components/live-timer.tsx
+++ b/apps/mesh/src/web/components/live-timer.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useState } from "react";
-import { formatDuration } from "@/web/lib/format-time";
+import { computeElapsedMs, formatDuration } from "@/web/lib/format-time";
 
 export function LiveTimer({ since }: { since: number }) {
-  const [elapsed, setElapsed] = useState(() => Date.now() - since);
+  // `since` can be a server-stamped timestamp; clamp at 0 so positive
+  // server-vs-client clock skew never renders a negative duration.
+  const [elapsed, setElapsed] = useState(() =>
+    computeElapsedMs(since, Date.now()),
+  );
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- interval required for live elapsed timer
   useEffect(() => {
-    const id = setInterval(() => setElapsed(Date.now() - since), 100);
+    const id = setInterval(
+      () => setElapsed(computeElapsedMs(since, Date.now())),
+      100,
+    );
     return () => clearInterval(id);
   }, [since]);
 

--- a/apps/mesh/src/web/lib/format-time.test.ts
+++ b/apps/mesh/src/web/lib/format-time.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { subSeconds } from "date-fns";
-import { formatDuration, formatTimeAgo, toEpochMs } from "./format-time";
+import {
+  computeElapsedMs,
+  formatDuration,
+  formatTimeAgo,
+  toEpochMs,
+} from "./format-time";
 
 describe("formatTimeAgo", () => {
   test("returns <1m for dates less than 60 seconds ago", () => {
@@ -99,5 +104,25 @@ describe("toEpochMs", () => {
 
   test("returns null for an Invalid Date instance", () => {
     expect(toEpochMs(new Date("invalid"))).toBeNull();
+  });
+});
+
+describe("computeElapsedMs", () => {
+  test("returns positive elapsed when now is after start", () => {
+    expect(computeElapsedMs(1_000, 3_500)).toBe(2_500);
+  });
+
+  test("returns 0 when now equals start", () => {
+    expect(computeElapsedMs(1_000, 1_000)).toBe(0);
+  });
+
+  test("clamps to 0 when start is ahead of now (server clock skew)", () => {
+    // serverStartedAt > Date.now() — e.g. server clock 30s ahead of client.
+    // Without the clamp, the live timer would render "-30.0s".
+    expect(computeElapsedMs(30_000, 0)).toBe(0);
+  });
+
+  test("clamps to 0 for small sub-second skew", () => {
+    expect(computeElapsedMs(1_500, 1_200)).toBe(0);
   });
 });

--- a/apps/mesh/src/web/lib/format-time.test.ts
+++ b/apps/mesh/src/web/lib/format-time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { subSeconds } from "date-fns";
-import { formatDuration, formatTimeAgo } from "./format-time";
+import { formatDuration, formatTimeAgo, toEpochMs } from "./format-time";
 
 describe("formatTimeAgo", () => {
   test("returns <1m for dates less than 60 seconds ago", () => {
@@ -68,5 +68,36 @@ describe("formatDuration", () => {
   test("does not produce 60.0s at minute boundaries", () => {
     expect(formatDuration(119.95)).toBe("2m 0.0s");
     expect(formatDuration(179.96)).toBe("3m 0.0s");
+  });
+});
+
+describe("toEpochMs", () => {
+  test("returns null for undefined", () => {
+    expect(toEpochMs(undefined)).toBeNull();
+  });
+
+  test("returns null for null", () => {
+    expect(toEpochMs(null)).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(toEpochMs("")).toBeNull();
+  });
+
+  test("returns epoch ms for an ISO date string", () => {
+    expect(toEpochMs("2024-01-01T00:00:00.000Z")).toBe(Date.UTC(2024, 0, 1));
+  });
+
+  test("returns getTime() for a Date instance", () => {
+    const d = new Date("2024-06-01T12:34:56.000Z");
+    expect(toEpochMs(d)).toBe(d.getTime());
+  });
+
+  test("returns null for an unparseable string", () => {
+    expect(toEpochMs("not-a-date")).toBeNull();
+  });
+
+  test("returns null for an Invalid Date instance", () => {
+    expect(toEpochMs(new Date("invalid"))).toBeNull();
   });
 });

--- a/apps/mesh/src/web/lib/format-time.ts
+++ b/apps/mesh/src/web/lib/format-time.ts
@@ -29,6 +29,20 @@ export function toEpochMs(
 }
 
 /**
+ * Compute elapsed milliseconds since `start`, clamped at 0.
+ *
+ * The clamp matters when `start` is a server-stamped timestamp (e.g.
+ * `message.metadata.created_at` from the streaming pipeline) and the server
+ * clock is ahead of the client clock — without it, `Date.now() - start`
+ * would be negative and the live elapsed timer would briefly render a
+ * negative duration like "-0.3s" until the client clock catches up.
+ */
+export function computeElapsedMs(start: number, now: number): number {
+  const diff = now - start;
+  return diff > 0 ? diff : 0;
+}
+
+/**
  * Format a duration in seconds into a human-readable string.
  * - Under 60s: "12.3s"
  * - 60s and above: "2m 3.1s"

--- a/apps/mesh/src/web/lib/format-time.ts
+++ b/apps/mesh/src/web/lib/format-time.ts
@@ -13,6 +13,22 @@ export function formatTimeAgo(date: Date): string {
 }
 
 /**
+ * Convert a server-provided timestamp (ISO string, Date, null, or undefined)
+ * into a finite epoch-ms number, or `null` if the value is missing/unparseable.
+ *
+ * Used to lift server-side "started at" timestamps into the live-elapsed-timer
+ * pipeline so the chronometer survives page refreshes instead of restarting
+ * from `Date.now()` on every mount.
+ */
+export function toEpochMs(
+  value: string | Date | null | undefined,
+): number | null {
+  if (value == null || value === "") return null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
  * Format a duration in seconds into a human-readable string.
  * - Under 60s: "12.3s"
  * - 60s and above: "2m 3.1s"


### PR DESCRIPTION
## Summary

- The generating-footer chronometer in `MessageAssistant` was driven by a `Date.now()` snapshot captured in `useState` the moment `isLoading` flipped true. On page refresh the component remounted and the counter restarted at `00:00` instead of continuing from the real stream start time.
- The streaming pipeline already stamps `message.metadata.created_at` on the first `start` chunk in `apps/mesh/src/harnesses/decopilot/run-stream.ts` and persists it in `thread_messages.metadata`, so the value survives reloads via `COLLECTION_THREAD_MESSAGES_LIST`. This PR makes the timer prefer that server-stamped time and keeps a small client `Date.now()` fallback only for the brief submitted-before-first-chunk window.

## Changes

- `apps/mesh/src/web/lib/format-time.ts` — added pure helper `toEpochMs(value: string | Date | null | undefined): number | null` that safely converts server-provided timestamps to epoch ms.
- `apps/mesh/src/web/lib/format-time.test.ts` — 7 new unit tests covering `undefined`, `null`, empty string, ISO string, `Date` instance, unparseable string, Invalid Date.
- `apps/mesh/src/web/components/chat/message/assistant.tsx` — replaced the client-only `startedAt` state with `serverStartedAt ?? clientFallbackStartedAt`, derived from `message.metadata.created_at`.

## Why this works across refreshes

| Scenario | Source of `startedAt` |
|---|---|
| Fresh stream, after `start` chunk | `message.metadata.created_at` (server time) |
| Submitted, no chunks yet | `Date.now()` fallback (timer keeps moving) |
| Page refresh mid-stream | `message.metadata.created_at` reloaded from `thread_messages` — timer resumes from the real start |
| Stream finished | not rendered |

## Test plan

- [x] `bun test apps/mesh/src/web/lib/format-time.test.ts` — 17 pass / 0 fail
- [x] `bun run fmt` — no changes
- [x] `bun run --cwd apps/mesh check` (tsc) — 0 errors
- [x] `bun run lint` — 0 new warnings (4 pre-existing in unrelated files)
- [ ] Manual: start a chat, let the model stream for ~30s, refresh the page mid-stream, confirm the live timer keeps counting from the real start (not 00:00).
- [ ] Manual: confirm the timer still works for a brand-new message that hasn't received the first `start` chunk yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the chat “generating” timer to the server-stamped start time so it doesn’t reset to 00:00 after a page refresh. Clamps the live elapsed value at 0 to avoid negative durations from server/client clock skew; keeps a client timestamp only before the first stream chunk.

- **Bug Fixes**
  - `MessageAssistant`: prefer `message.metadata.created_at` for the live timer; use `Date.now()` only until the first `start` chunk.
  - `LiveTimer`: use `computeElapsedMs` to clamp negative elapsed and prevent “-0.3s” renders.
  - `format-time.ts`: add `toEpochMs` and `computeElapsedMs` helpers with unit tests.

<sup>Written for commit e8c993b13be45a4ab7857041ac63b9a29b9cbe94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

