### PR TITLE
fix(sidebar): replace task-group dimming with red-dot filter indicator

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
@@ -37,8 +37,6 @@ export interface TaskGroupProps {
   onToggleOrgPin?: (virtualMcpId: string, pinned: boolean) => void;
   /** Precomputed visible count for this group (avoids O(T) scan per hook). */
   groupVisibleCount?: number;
-  /** When true, the group renders dimmed (used when filters wipe out the body). */
-  dimmed: boolean;
   filters: SidebarFilters;
   /** When set, the group header is draggable for reordering. */
   sortable?: {
@@ -60,7 +58,6 @@ export function TaskGroup({
   isOrgPinned = false,
   canManageOrgPin = false,
   onToggleOrgPin,
-  dimmed,
   filters,
   groupVisibleCount,
   sortable,
@@ -114,7 +111,7 @@ export function TaskGroup({
           isToolCallRuns={isToolCallRuns}
         />
       </span>
-      {!isToolCallRuns && !dimmed && (
+      {!isToolCallRuns && (
         <button
           type="button"
           aria-label="New task in this agent"
@@ -131,7 +128,7 @@ export function TaskGroup({
   );
 
   return (
-    <div className={cn("flex flex-col gap-0.5", dimmed && "opacity-50")}>
+    <div className="flex flex-col gap-0.5">
       {isToolCallRuns ? (
         header
       ) : (

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -313,11 +313,11 @@ export function TaskGroupsList() {
           </ToolbarIconButton>
           <Popover>
             <PopoverTrigger asChild>
-              <ToolbarIconButton
-                aria-label="Filter tasks"
-                active={filtersActive}
-              >
+              <ToolbarIconButton aria-label="Filter tasks">
                 <FilterLines size={16} />
+                {filtersActive && (
+                  <span className="absolute top-0.5 right-0.5 size-2 rounded-full bg-red-500 ring-1 ring-sidebar pointer-events-none" />
+                )}
               </ToolbarIconButton>
             </PopoverTrigger>
             <PopoverContent
@@ -411,9 +411,6 @@ export function TaskGroupsList() {
             onReorder={() => setLocalOrderRevision((n) => n + 1)}
             renderGroup={(group) => ({
               ...buildAgentGroupRenderProps(group),
-              dimmed:
-                filtersActive &&
-                typeFiltered(memberFiltered(group.threads)).length === 0,
             })}
           />
         )}


### PR DESCRIPTION
## What is this contribution about?
When a task filter was active, agent groups with no matching tasks were dimmed to 50% opacity. This sent the wrong signal — empty groups looked disabled even though nothing was actually being hidden (e.g. switching "members" between mine/all dimmed groups that simply had no tasks). This replaces the per-group dimming with a single red dot on the filter icon (matching the existing inbox unread-badge pattern), so an active filter is signalled in one consistent place without changing how the group list reads.

## Screenshots/Demonstration
Before: empty groups rendered at 50% opacity when a filter was active. After: groups render normally and a red dot appears on the filter icon while any filter is active.

## How to Test
1. Open the sidebar task list and apply a filter (e.g. switch members to "All members" or change the type filter).
2. Confirm no agent group is dimmed regardless of whether it has matching tasks.
3. Confirm a red dot appears on the filter icon while a filter is active, and disappears when filters return to default.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced per-group dimming in the sidebar with a red dot on the filter icon to indicate active filters. This prevents empty agent groups from looking disabled and keeps the "New task" action available.

- **Bug Fixes**
  - Removed `dimmed` prop and opacity styling from `TaskGroup`; groups stay fully opaque.
  - Added a red-dot badge to the filter icon when filters are active (replaces toolbar `active` state).
  - Always show the "New task" button, regardless of filters.

<sup>Written for commit 9bb70b1dd8fb807235399bccff22a0112b4eae1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

