### PR TITLE
feat(agent-shell-layout): enhance sandbox event stream management

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -61,7 +61,10 @@ import {
 } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity, SandboxMap } from "@decocms/mesh-sdk/types";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { useSandboxStart } from "@/web/components/sandbox/hooks/use-sandbox-start";
+import {
+  useSandboxStart,
+  useIsSandboxStartPending,
+} from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { useStatusSounds } from "../../hooks/use-status-sounds";
 import { authClient } from "@/web/lib/auth-client";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -265,17 +268,20 @@ function VmEventsBridge({
     triggerAutoStart,
   ]);
 
-  // Open the events stream only when a sandbox exists or is about to: a
-  // GitHub-linked agent auto-starts one (effect above), or the sandboxMap
-  // already has an entry for this (user, branch). Without this gate, an
-  // ephemeral decopilot run that never spawns a sandbox would open an events
-  // stream that 404s and reconnects forever (daemon log spam).
+  // Open the events stream only when a sandbox actually exists or a start is
+  // in flight — NOT merely because the agent has a GitHub repo configured.
+  // Gate instead on a registered sandboxMap entry, or an in-flight
+  // SANDBOX_START (covers the booting window; the auto-start above shares this
+  // mutation key, so `useIsSandboxStartPending` observes it).
+  const isStartPending = useIsSandboxStartPending(
+    virtualMcpId,
+    currentBranch ?? undefined,
+  );
   const branchMap =
     userId && currentBranch
       ? parseBranchMap(sandboxMap?.[userId]?.[currentBranch])
       : {};
-  const shouldConnect =
-    hasActiveGithubRepo || Object.keys(branchMap).length > 0;
+  const shouldConnect = Object.keys(branchMap).length > 0 || isStartPending;
 
   return (
     <SandboxEventsProvider


### PR DESCRIPTION
- Added `useIsSandboxStartPending` hook to track sandbox start status.
- Updated logic to open event streams only when a sandbox exists or is in the process of starting, preventing unnecessary connections and log spam.
- Refined conditions for connecting to event streams based on active branch maps and pending sandbox starts.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open sandbox event streams only when a sandbox exists or is actively starting. This prevents 404 reconnect loops and cuts log noise in ephemeral runs.

- **Bug Fixes**
  - Gate connections on branch map entries or a pending start (not on repo config).
  - Added `useIsSandboxStartPending` and wired it to auto-start to cover the boot window.

<sup>Written for commit 8f120d79ccbce02f61fb441ef47be7c3c841ee07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

