### PR TITLE
feat(feedback): feedback button, per-message thumbs, PostHog events

### DIFF
--- a/apps/mesh/e2e/tests/feedback.spec.ts
+++ b/apps/mesh/e2e/tests/feedback.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * E2E: POST /api/:org/feedback
+ *
+ * Auth, org membership, validation, and payload limits for general and
+ * chat-negative feedback bodies.
+ */
+
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const FEEDBACK_URL = (orgSlug: string) => `/api/${orgSlug}/feedback`;
+
+test.describe("POST /api/:org/feedback", () => {
+  test("returns 200 for authenticated org member (general)", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+
+    const res = await ctx.post(FEEDBACK_URL(user.orgSlug), {
+      data: { message: "E2E general feedback" },
+    });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { ok?: boolean };
+    expect(body.ok).toBe(true);
+
+    await ctx.dispose();
+  });
+
+  test("returns 200 for chat_negative with reasons", async ({ playwright }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+
+    const res = await ctx.post(FEEDBACK_URL(user.orgSlug), {
+      data: {
+        kind: "chat_negative",
+        messageId: "msg-e2e-1",
+        threadId: "thread-e2e-1",
+        reasons: ["Slow or buggy"],
+        details: "optional detail",
+      },
+    });
+    expect(res.status()).toBe(200);
+
+    await ctx.dispose();
+  });
+
+  test("returns 400 when message is empty", async ({ playwright }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+
+    const res = await ctx.post(FEEDBACK_URL(user.orgSlug), {
+      data: { message: "   " },
+    });
+    expect(res.status()).toBe(400);
+
+    await ctx.dispose();
+  });
+
+  test("returns 400 when chat_negative has no reasons or details", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+
+    const res = await ctx.post(FEEDBACK_URL(user.orgSlug), {
+      data: { kind: "chat_negative", messageId: "msg-1" },
+    });
+    expect(res.status()).toBe(400);
+
+    await ctx.dispose();
+  });
+
+  test("returns 400 for invalid JSON body", async ({ playwright }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+
+    const res = await ctx.post(FEEDBACK_URL(user.orgSlug), {
+      headers: { "Content-Type": "application/json" },
+      data: "not-json",
+    });
+    expect(res.status()).toBe(400);
+
+    await ctx.dispose();
+  });
+
+  test("returns 401 when unauthenticated", async ({ playwright }) => {
+    const authed = await newApiContext(playwright);
+    const user = await signUpViaApi(authed);
+
+    const anon = await newApiContext(playwright);
+    const res = await anon.post(FEEDBACK_URL(user.orgSlug), {
+      data: { message: "anonymous attempt" },
+    });
+    expect(res.status()).toBe(401);
+
+    await authed.dispose();
+    await anon.dispose();
+  });
+
+  test("returns 403 for a principal who is not a member", async ({
+    playwright,
+  }) => {
+    const userACtx = await newApiContext(playwright);
+    const userA = await signUpViaApi(userACtx);
+
+    const userBCtx = await newApiContext(playwright);
+    await signUpViaApi(userBCtx);
+
+    const res = await userBCtx.post(FEEDBACK_URL(userA.orgSlug), {
+      data: { message: "cross-org feedback" },
+    });
+    expect(res.status()).toBe(403);
+
+    await userACtx.dispose();
+    await userBCtx.dispose();
+  });
+
+  test("returns 413 when body exceeds limit", async ({ playwright }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+
+    const huge = "x".repeat(70_000);
+    const res = await ctx.post(FEEDBACK_URL(user.orgSlug), {
+      data: { message: huge },
+    });
+    expect(res.status()).toBe(413);
+
+    await ctx.dispose();
+  });
+});
+
+test.describe("feedback UI", () => {
+  test("account menu submits general feedback", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    await page.goto(`/${orgSlug}`);
+
+    await page.locator('[data-sidebar="menu-button"]').last().click();
+    await page.getByRole("button", { name: "Feedback" }).click();
+    await expect(page.getByRole("dialog", { name: "Feedback" })).toBeVisible();
+
+    await page
+      .getByPlaceholder(/Tell us about your experience/)
+      .fill("E2E UI feedback from account menu");
+    await page.getByRole("button", { name: "Send feedback" }).click();
+
+    await expect(page.getByText("Feedback sent — thank you!")).toBeVisible();
+  });
+});

--- a/apps/mesh/src/api/routes/feedback.test.ts
+++ b/apps/mesh/src/api/routes/feedback.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  FEEDBACK_MAX_TEXT_LENGTH,
+  parseFeedbackBody,
+  truncateForLog,
+} from "./feedback";
+
+describe("parseFeedbackBody", () => {
+  test("general requires non-empty message", () => {
+    expect(parseFeedbackBody({ message: "  hello  " })).toEqual({
+      ok: true,
+      entry: { kind: "general", message: "hello" },
+    });
+    expect(parseFeedbackBody({ message: "" }).ok).toBe(false);
+    expect(parseFeedbackBody({}).ok).toBe(false);
+  });
+
+  test("chat_negative requires messageId and reasons or details", () => {
+    expect(
+      parseFeedbackBody({
+        kind: "chat_negative",
+        messageId: "msg-1",
+        reasons: ["Slow or buggy"],
+        details: " extra ",
+      }),
+    ).toEqual({
+      ok: true,
+      entry: {
+        kind: "chat_negative",
+        message: "extra",
+        messageId: "msg-1",
+        threadId: null,
+        reasons: ["Slow or buggy"],
+      },
+    });
+    expect(
+      parseFeedbackBody({
+        kind: "chat_negative",
+        messageId: "msg-1",
+        details: "only details",
+      }).ok,
+    ).toBe(true);
+    expect(
+      parseFeedbackBody({ kind: "chat_negative", messageId: "msg-1" }).ok,
+    ).toBe(false);
+  });
+
+  test("rejects message over max length", () => {
+    const long = "a".repeat(FEEDBACK_MAX_TEXT_LENGTH + 1);
+    expect(parseFeedbackBody({ message: long }).ok).toBe(false);
+  });
+});
+
+describe("truncateForLog", () => {
+  test("truncates long text", () => {
+    const { preview, truncated } = truncateForLog("x".repeat(600), 10);
+    expect(truncated).toBe(true);
+    expect(preview).toBe("xxxxxxxxxx…");
+  });
+});

--- a/apps/mesh/src/api/routes/feedback.ts
+++ b/apps/mesh/src/api/routes/feedback.ts
@@ -1,0 +1,27 @@
+import { Hono } from "hono";
+import type { Env } from "../hono-env";
+
+export function createFeedbackRoutes() {
+  const app = new Hono<Env>();
+
+  app.post("/feedback", async (c) => {
+    const mesh = c.get("meshContext");
+    const body = await c.req.json<{ message?: unknown }>();
+    const message =
+      typeof body?.message === "string" ? body.message.trim() : "";
+    if (!message) return c.json({ error: "message required" }, 400);
+
+    console.log(
+      JSON.stringify({
+        event: "user_feedback",
+        org_id: mesh.organization?.id,
+        user_id: mesh.auth.user?.id,
+        message,
+      }),
+    );
+
+    return c.json({ ok: true });
+  });
+
+  return app;
+}

--- a/apps/mesh/src/api/routes/feedback.ts
+++ b/apps/mesh/src/api/routes/feedback.ts
@@ -1,74 +1,193 @@
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { HTTPException } from "hono/http-exception";
 import type { Env } from "../hono-env";
+
+/** Max JSON body size for feedback POSTs. */
+const FEEDBACK_MAX_BODY_SIZE = 65_536;
+
+/** Max length for free-text fields after trim. */
+export const FEEDBACK_MAX_TEXT_LENGTH = 16_384;
+
+/** Default sink log preview — avoids dumping multi-KB secrets into stdout. */
+const FEEDBACK_LOG_PREVIEW_LENGTH = 500;
+
+export type FeedbackKind = "general" | "chat_negative";
 
 /**
  * A single piece of user-submitted feedback, handed to the configured
- * {@link FeedbackSink}. `message` is free-text typed by the user, so it may
- * contain anything — treat it as untrusted, user-owned content.
+ * {@link FeedbackSink}. Free-text fields may contain anything — treat as
+ * untrusted, user-owned content.
  */
 export interface FeedbackEntry {
+  kind: FeedbackKind;
+  /** General: user message. Chat negative: optional details only. */
   message: string;
   orgId: string | undefined;
   userId: string | undefined;
+  messageId?: string;
+  threadId?: string | null;
+  reasons?: string[];
 }
 
 /**
- * Where feedback messages go. Studio does NOT decide this for you — the free
- * text a user types is yours to route wherever fits your deployment. Provide
- * your own sink when mounting the routes to send it to Linear, Slack, a
- * database table, an email, a webhook, etc.
- *
- * @example
- * createFeedbackRoutes(async ({ message, orgId, userId }) => {
- *   await fetch("https://hooks.slack.com/services/...", {
- *     method: "POST",
- *     body: JSON.stringify({ text: `Feedback (${orgId}): ${message}` }),
- *   });
- * });
- *
- * The default sink (below) only emits a structured log line — fine for getting
- * started, but replace it once you've decided where feedback should live.
+ * Where feedback messages go. Studio does NOT decide this for you — provide
+ * your own sink when mounting the routes (Linear, Slack, DB, webhook, etc.).
  */
 export type FeedbackSink = (entry: FeedbackEntry) => void | Promise<void>;
+
+export function truncateForLog(
+  text: string,
+  max = FEEDBACK_LOG_PREVIEW_LENGTH,
+): {
+  preview: string;
+  truncated: boolean;
+} {
+  if (text.length <= max) return { preview: text, truncated: false };
+  return { preview: `${text.slice(0, max)}…`, truncated: true };
+}
 
 /**
  * Default sink: structured log line. Intentionally minimal — swap it for a
  * real destination by passing your own {@link FeedbackSink}.
  */
-export const logFeedbackSink: FeedbackSink = (entry) => {
+const logFeedbackSink: FeedbackSink = (entry) => {
+  const { preview, truncated } = truncateForLog(entry.message);
   console.log(
     JSON.stringify({
-      event: "user_feedback",
+      event:
+        entry.kind === "chat_negative"
+          ? "chat_message_feedback_negative"
+          : "user_feedback",
       org_id: entry.orgId,
       user_id: entry.userId,
-      message: entry.message,
+      message_id: entry.messageId,
+      thread_id: entry.threadId,
+      reasons: entry.reasons,
+      message: preview,
+      message_truncated: truncated,
     }),
   );
 };
 
+type FeedbackBody = {
+  kind?: unknown;
+  message?: unknown;
+  messageId?: unknown;
+  threadId?: unknown;
+  reasons?: unknown;
+  details?: unknown;
+};
+
+function parseString(value: unknown, maxLen: number): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > maxLen) return null;
+  return trimmed;
+}
+
+function parseReasons(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const reasons: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (!trimmed || trimmed.length > 200) continue;
+    reasons.push(trimmed);
+  }
+  return reasons;
+}
+
+export function parseFeedbackBody(
+  body: FeedbackBody,
+):
+  | { ok: true; entry: Omit<FeedbackEntry, "orgId" | "userId"> }
+  | { ok: false; error: string } {
+  const kind = body.kind === "chat_negative" ? "chat_negative" : "general";
+
+  if (kind === "general") {
+    const message = parseString(body.message, FEEDBACK_MAX_TEXT_LENGTH);
+    if (!message) return { ok: false, error: "message required" };
+    return { ok: true, entry: { kind: "general", message } };
+  }
+
+  const messageId = parseString(body.messageId, 128);
+  if (!messageId) return { ok: false, error: "messageId required" };
+
+  const details =
+    typeof body.details === "string"
+      ? body.details.trim().slice(0, FEEDBACK_MAX_TEXT_LENGTH)
+      : "";
+  const reasons = parseReasons(body.reasons) ?? [];
+
+  if (reasons.length === 0 && !details) {
+    return { ok: false, error: "reasons or details required" };
+  }
+
+  const threadId =
+    body.threadId === null || body.threadId === undefined
+      ? null
+      : parseString(body.threadId, 128);
+
+  return {
+    ok: true,
+    entry: {
+      kind: "chat_negative",
+      message: details,
+      messageId,
+      threadId,
+      reasons: reasons.length > 0 ? reasons : undefined,
+    },
+  };
+}
+
 export function createFeedbackRoutes(sink: FeedbackSink = logFeedbackSink) {
   const app = new Hono<Env>();
 
-  app.post("/feedback", async (c) => {
-    const mesh = c.get("meshContext");
-    let body: { message?: unknown };
-    try {
-      body = await c.req.json<{ message?: unknown }>();
-    } catch {
-      return c.json({ error: "invalid JSON" }, 400);
-    }
-    const message =
-      typeof body?.message === "string" ? body.message.trim() : "";
-    if (!message) return c.json({ error: "message required" }, 400);
+  app.post(
+    "/feedback",
+    bodyLimit({
+      maxSize: FEEDBACK_MAX_BODY_SIZE,
+      onError: (c) => c.json({ error: "Payload too large" }, 413),
+    }),
+    async (c) => {
+      const mesh = c.get("meshContext");
+      const userId = mesh.auth.user?.id ?? mesh.auth.apiKey?.userId;
+      if (!userId) {
+        throw new HTTPException(401, { message: "Unauthorized" });
+      }
 
-    await sink({
-      message,
-      orgId: mesh.organization?.id,
-      userId: mesh.auth.user?.id,
-    });
+      const orgId = mesh.organization?.id;
+      if (!orgId) {
+        return c.json({ error: "Organization required" }, 400);
+      }
 
-    return c.json({ ok: true });
-  });
+      let body: FeedbackBody;
+      try {
+        body = await c.req.json<FeedbackBody>();
+      } catch {
+        return c.json({ error: "invalid JSON" }, 400);
+      }
+
+      const parsed = parseFeedbackBody(body);
+      if (!parsed.ok) {
+        return c.json({ error: parsed.error }, 400);
+      }
+
+      try {
+        await sink({
+          ...parsed.entry,
+          orgId,
+          userId,
+        });
+      } catch (err) {
+        console.error("[feedback] sink failed:", err);
+        return c.json({ error: "Failed to record feedback" }, 502);
+      }
+
+      return c.json({ ok: true });
+    },
+  );
 
   return app;
 }

--- a/apps/mesh/src/api/routes/feedback.ts
+++ b/apps/mesh/src/api/routes/feedback.ts
@@ -6,7 +6,12 @@ export function createFeedbackRoutes() {
 
   app.post("/feedback", async (c) => {
     const mesh = c.get("meshContext");
-    const body = await c.req.json<{ message?: unknown }>();
+    let body: { message?: unknown };
+    try {
+      body = await c.req.json<{ message?: unknown }>();
+    } catch {
+      return c.json({ error: "invalid JSON" }, 400);
+    }
     const message =
       typeof body?.message === "string" ? body.message.trim() : "";
     if (!message) return c.json({ error: "message required" }, 400);

--- a/apps/mesh/src/api/routes/feedback.ts
+++ b/apps/mesh/src/api/routes/feedback.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import { HTTPException } from "hono/http-exception";
 import type { Env } from "../hono-env";
 
 /** Max JSON body size for feedback POSTs. */
@@ -154,7 +153,7 @@ export function createFeedbackRoutes(sink: FeedbackSink = logFeedbackSink) {
       const mesh = c.get("meshContext");
       const userId = mesh.auth.user?.id ?? mesh.auth.apiKey?.userId;
       if (!userId) {
-        throw new HTTPException(401, { message: "Unauthorized" });
+        return c.json({ error: "Unauthorized" }, 401);
       }
 
       const orgId = mesh.organization?.id;

--- a/apps/mesh/src/api/routes/feedback.ts
+++ b/apps/mesh/src/api/routes/feedback.ts
@@ -1,7 +1,52 @@
 import { Hono } from "hono";
 import type { Env } from "../hono-env";
 
-export function createFeedbackRoutes() {
+/**
+ * A single piece of user-submitted feedback, handed to the configured
+ * {@link FeedbackSink}. `message` is free-text typed by the user, so it may
+ * contain anything — treat it as untrusted, user-owned content.
+ */
+export interface FeedbackEntry {
+  message: string;
+  orgId: string | undefined;
+  userId: string | undefined;
+}
+
+/**
+ * Where feedback messages go. Studio does NOT decide this for you — the free
+ * text a user types is yours to route wherever fits your deployment. Provide
+ * your own sink when mounting the routes to send it to Linear, Slack, a
+ * database table, an email, a webhook, etc.
+ *
+ * @example
+ * createFeedbackRoutes(async ({ message, orgId, userId }) => {
+ *   await fetch("https://hooks.slack.com/services/...", {
+ *     method: "POST",
+ *     body: JSON.stringify({ text: `Feedback (${orgId}): ${message}` }),
+ *   });
+ * });
+ *
+ * The default sink (below) only emits a structured log line — fine for getting
+ * started, but replace it once you've decided where feedback should live.
+ */
+export type FeedbackSink = (entry: FeedbackEntry) => void | Promise<void>;
+
+/**
+ * Default sink: structured log line. Intentionally minimal — swap it for a
+ * real destination by passing your own {@link FeedbackSink}.
+ */
+export const logFeedbackSink: FeedbackSink = (entry) => {
+  console.log(
+    JSON.stringify({
+      event: "user_feedback",
+      org_id: entry.orgId,
+      user_id: entry.userId,
+      message: entry.message,
+    }),
+  );
+};
+
+export function createFeedbackRoutes(sink: FeedbackSink = logFeedbackSink) {
   const app = new Hono<Env>();
 
   app.post("/feedback", async (c) => {
@@ -16,14 +61,11 @@ export function createFeedbackRoutes() {
       typeof body?.message === "string" ? body.message.trim() : "";
     if (!message) return c.json({ error: "message required" }, 400);
 
-    console.log(
-      JSON.stringify({
-        event: "user_feedback",
-        org_id: mesh.organization?.id,
-        user_id: mesh.auth.user?.id,
-        message,
-      }),
-    );
+    await sink({
+      message,
+      orgId: mesh.organization?.id,
+      userId: mesh.auth.user?.id,
+    });
 
     return c.json({ ok: true });
   });

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -83,6 +83,11 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   app.route("/", createFileUploadRoutes()); // /api/:org/file-configs/:id/upload
   app.route("/sandbox", createSandboxRoutes()); // /api/:org/sandbox/:virtualMcpId/:branch/*
   app.route("/", createHomeNextActionsRoutes());
+  // Feedback uses the default log sink. To send feedback somewhere durable
+  // (Linear, Slack, a DB table, a webhook), pass your own FeedbackSink here —
+  // see `./feedback.ts`.
+  // TODO: the final destination (likely Linear) is still being decided —
+  // wire the chosen sink here once that lands.
   app.route("/", createFeedbackRoutes());
   app.route("/deco-sites", createDecoSitesOrgRoutes()); // /api/:org/deco-sites
   app.route("/sso", createSsoRoutes()); // /api/:org/sso/* (renamed from /api/org-sso)

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -19,6 +19,7 @@ import { createOrgScopedWellKnownProtectedResourceRoutes } from "./oauth-proxy";
 import { createSsoRoutes } from "./org-sso";
 import { createProxyRoutes } from "./proxy";
 import { createSelfRoutes } from "./self";
+import { createFeedbackRoutes } from "./feedback";
 import { createHomeNextActionsRoutes } from "./home-next-actions";
 import { createThreadOutputsRoutes } from "./thread-outputs";
 import { createTriggerCallbackRoutes } from "./trigger-callback";
@@ -82,6 +83,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   app.route("/", createFileUploadRoutes()); // /api/:org/file-configs/:id/upload
   app.route("/sandbox", createSandboxRoutes()); // /api/:org/sandbox/:virtualMcpId/:branch/*
   app.route("/", createHomeNextActionsRoutes());
+  app.route("/", createFeedbackRoutes());
   app.route("/deco-sites", createDecoSitesOrgRoutes()); // /api/:org/deco-sites
   app.route("/sso", createSsoRoutes()); // /api/:org/sso/* (renamed from /api/org-sso)
   app.route(

--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -573,14 +573,18 @@ export function AccountPopover() {
         });
       },
     },
-    {
-      key: "feedback",
-      label: "Feedback",
-      icon: <MessageChatCircle size={16} />,
-      onClick: () => {
-        setFeedbackOpen(true);
-      },
-    },
+    ...(orgParam
+      ? [
+          {
+            key: "feedback",
+            label: "Feedback",
+            icon: <MessageChatCircle size={16} />,
+            onClick: () => {
+              setFeedbackOpen(true);
+            },
+          } satisfies MenuItem,
+        ]
+      : []),
     {
       key: "terms",
       label: "Terms of Use",
@@ -743,11 +747,13 @@ export function AccountPopover() {
         open={creatingOrg}
         onOpenChange={setCreatingOrg}
       />
-      <FeedbackDialog
-        open={feedbackOpen}
-        onOpenChange={setFeedbackOpen}
-        orgSlug={orgParam ?? ""}
-      />
+      {orgParam ? (
+        <FeedbackDialog
+          open={feedbackOpen}
+          onOpenChange={setFeedbackOpen}
+          orgSlug={orgParam}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -22,6 +22,7 @@ import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import {
   Check,
   Copy01,
+  File06,
   Globe01,
   LogOut01,
   MessageChatCircle,
@@ -30,6 +31,7 @@ import {
   Plus,
   SearchMd,
   Settings02,
+  Shield01,
   Sun,
   Users03,
   VolumeMax,
@@ -580,6 +582,20 @@ export function AccountPopover() {
       },
     },
     {
+      key: "terms",
+      label: "Terms of Use",
+      icon: <File06 size={16} />,
+      href: "https://www.decocms.com/terms-of-use",
+      external: true,
+    },
+    {
+      key: "privacy",
+      label: "Privacy Policy",
+      icon: <Shield01 size={16} />,
+      href: "https://www.decocms.com/privacy-policy",
+      external: true,
+    },
+    {
       key: "github",
       label: "decocms/studio",
       icon: <GitHubIcon className="w-4 h-4" />,
@@ -727,7 +743,11 @@ export function AccountPopover() {
         open={creatingOrg}
         onOpenChange={setCreatingOrg}
       />
-      <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+      <FeedbackDialog
+        open={feedbackOpen}
+        onOpenChange={setFeedbackOpen}
+        orgSlug={orgParam ?? ""}
+      />
     </>
   );
 }

--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -22,15 +22,14 @@ import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import {
   Check,
   Copy01,
-  File06,
   Globe01,
   LogOut01,
+  MessageChatCircle,
   Monitor01,
   Moon01,
   Plus,
   SearchMd,
   Settings02,
-  Shield01,
   Sun,
   Users03,
   VolumeMax,
@@ -43,6 +42,7 @@ import { authClient } from "@/web/lib/auth-client";
 import { track } from "@/web/lib/posthog-client";
 import { clearPersistedQueryCache } from "@/web/lib/query-persist";
 import { CreateOrganizationDialog } from "@/web/components/create-organization-dialog";
+import { FeedbackDialog } from "@/web/components/feedback-dialog";
 import { usePreferences, type ThemeMode } from "@/web/hooks/use-preferences.ts";
 import { toast } from "@deco/ui/components/sonner.js";
 
@@ -534,6 +534,7 @@ export function AccountPopover() {
 
   const [open, setOpen] = useState(false);
   const [creatingOrg, setCreatingOrg] = useState(false);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   const user = session?.user;
   const userImage = (user as { image?: string } | undefined)?.image;
@@ -571,18 +572,12 @@ export function AccountPopover() {
       },
     },
     {
-      key: "terms",
-      label: "Terms of Use",
-      icon: <File06 size={16} />,
-      href: "https://www.decocms.com/terms-of-use",
-      external: true,
-    },
-    {
-      key: "privacy",
-      label: "Privacy Policy",
-      icon: <Shield01 size={16} />,
-      href: "https://www.decocms.com/privacy-policy",
-      external: true,
+      key: "feedback",
+      label: "Feedback",
+      icon: <MessageChatCircle size={16} />,
+      onClick: () => {
+        setFeedbackOpen(true);
+      },
     },
     {
       key: "github",
@@ -732,6 +727,7 @@ export function AccountPopover() {
         open={creatingOrg}
         onOpenChange={setCreatingOrg}
       />
+      <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
     </>
   );
 }

--- a/apps/mesh/src/web/components/chat/message-feedback-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/message-feedback-dialog.tsx
@@ -10,6 +10,7 @@ import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { toast } from "@deco/ui/components/sonner.js";
 import { track, getSessionReplayUrl } from "@/web/lib/posthog-client";
+import { submitFeedback } from "@/web/lib/submit-feedback";
 
 const REASONS = [
   "Incorrect or incomplete",
@@ -25,6 +26,7 @@ type Reason = (typeof REASONS)[number];
 interface MessageFeedbackDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  orgSlug: string;
   messageId: string;
   threadId: string | null;
 }
@@ -32,11 +34,15 @@ interface MessageFeedbackDialogProps {
 export function MessageFeedbackDialog({
   open,
   onOpenChange,
+  orgSlug,
   messageId,
   threadId,
 }: MessageFeedbackDialogProps) {
   const [selected, setSelected] = useState<Set<Reason>>(new Set());
   const [details, setDetails] = useState("");
+  const [sending, setSending] = useState(false);
+
+  const canSubmit = selected.size > 0 || !!details.trim();
 
   const toggle = (reason: Reason) => {
     setSelected((prev) => {
@@ -50,18 +56,36 @@ export function MessageFeedbackDialog({
     });
   };
 
-  const handleSubmit = () => {
-    track("chat_message_feedback_negative", {
-      message_id: messageId,
-      thread_id: threadId,
-      reasons: [...selected],
-      details: details.trim() || undefined,
-      session_replay_url: getSessionReplayUrl(),
-    });
-    setSelected(new Set());
-    setDetails("");
-    onOpenChange(false);
-    toast.success("Feedback sent — thank you!");
+  const handleSubmit = async () => {
+    if (sending || !canSubmit || !orgSlug) return;
+    setSending(true);
+    try {
+      const res = await submitFeedback(orgSlug, {
+        kind: "chat_negative",
+        messageId,
+        threadId,
+        reasons: selected.size > 0 ? [...selected] : undefined,
+        details: details.trim() || undefined,
+      });
+      if (!res.ok) {
+        toast.error("Failed to send feedback. Please try again.");
+        return;
+      }
+      track("chat_message_feedback_negative", {
+        message_id: messageId,
+        thread_id: threadId,
+        reasons: selected.size > 0 ? [...selected] : undefined,
+        session_replay_url: getSessionReplayUrl(),
+      });
+      setSelected(new Set());
+      setDetails("");
+      onOpenChange(false);
+      toast.success("Feedback sent — thank you!");
+    } catch {
+      toast.error("Failed to send feedback. Please try again.");
+    } finally {
+      setSending(false);
+    }
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -108,16 +132,18 @@ export function MessageFeedbackDialog({
             if (
               e.key === "Enter" &&
               (e.metaKey || e.ctrlKey) &&
-              !(selected.size === 0 && !details.trim())
-            )
-              handleSubmit();
+              canSubmit &&
+              !sending
+            ) {
+              void handleSubmit();
+            }
           }}
         />
 
         <div className="flex justify-end">
           <Button
-            onClick={handleSubmit}
-            disabled={selected.size === 0 && !details.trim()}
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit || sending || !orgSlug}
             size="sm"
           >
             Submit

--- a/apps/mesh/src/web/components/chat/message-feedback-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/message-feedback-dialog.tsx
@@ -9,7 +9,7 @@ import {
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { toast } from "@deco/ui/components/sonner.js";
-import { track } from "@/web/lib/posthog-client";
+import { track, getSessionReplayUrl } from "@/web/lib/posthog-client";
 
 const REASONS = [
   "Incorrect or incomplete",
@@ -27,8 +27,6 @@ interface MessageFeedbackDialogProps {
   onOpenChange: (open: boolean) => void;
   messageId: string;
   threadId: string | null;
-  messageContent: string;
-  sessionReplayUrl: string | null;
 }
 
 export function MessageFeedbackDialog({
@@ -36,8 +34,6 @@ export function MessageFeedbackDialog({
   onOpenChange,
   messageId,
   threadId,
-  messageContent,
-  sessionReplayUrl,
 }: MessageFeedbackDialogProps) {
   const [selected, setSelected] = useState<Set<Reason>>(new Set());
   const [details, setDetails] = useState("");
@@ -60,8 +56,7 @@ export function MessageFeedbackDialog({
       thread_id: threadId,
       reasons: [...selected],
       details: details.trim() || undefined,
-      message_content: messageContent.slice(0, 500) || undefined,
-      session_replay_url: sessionReplayUrl,
+      session_replay_url: getSessionReplayUrl(),
     });
     setSelected(new Set());
     setDetails("");
@@ -110,7 +105,12 @@ export function MessageFeedbackDialog({
           placeholder="Share details (optional)"
           className="min-h-28 resize-none"
           onKeyDown={(e) => {
-            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSubmit();
+            if (
+              e.key === "Enter" &&
+              (e.metaKey || e.ctrlKey) &&
+              !(selected.size === 0 && !details.trim())
+            )
+              handleSubmit();
           }}
         />
 

--- a/apps/mesh/src/web/components/chat/message-feedback-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/message-feedback-dialog.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { toast } from "@deco/ui/components/sonner.js";
+import { track } from "@/web/lib/posthog-client";
+
+const REASONS = [
+  "Incorrect or incomplete",
+  "Not what I asked for",
+  "Slow or buggy",
+  "Style or tone",
+  "Safety or legal concern",
+  "Other",
+] as const;
+
+type Reason = (typeof REASONS)[number];
+
+interface MessageFeedbackDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  messageId: string;
+  threadId: string | null;
+  messageContent: string;
+  sessionReplayUrl: string | null;
+}
+
+export function MessageFeedbackDialog({
+  open,
+  onOpenChange,
+  messageId,
+  threadId,
+  messageContent,
+  sessionReplayUrl,
+}: MessageFeedbackDialogProps) {
+  const [selected, setSelected] = useState<Set<Reason>>(new Set());
+  const [details, setDetails] = useState("");
+
+  const toggle = (reason: Reason) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(reason)) {
+        next.delete(reason);
+      } else {
+        next.add(reason);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = () => {
+    track("chat_message_feedback_negative", {
+      message_id: messageId,
+      thread_id: threadId,
+      reasons: [...selected],
+      details: details.trim() || undefined,
+      message_content: messageContent.slice(0, 500) || undefined,
+      session_replay_url: sessionReplayUrl,
+    });
+    setSelected(new Set());
+    setDetails("");
+    onOpenChange(false);
+    toast.success("Feedback sent — thank you!");
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setSelected(new Set());
+      setDetails("");
+    }
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg gap-5">
+        <DialogHeader>
+          <DialogTitle className="text-base font-semibold">
+            Share feedback
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-wrap gap-2">
+          {REASONS.map((reason) => (
+            <button
+              key={reason}
+              type="button"
+              onClick={() => toggle(reason)}
+              className={cn(
+                "px-3 py-1.5 rounded-full border text-sm transition-colors",
+                selected.has(reason)
+                  ? "border-foreground bg-foreground text-background"
+                  : "border-border text-foreground hover:border-foreground/50",
+              )}
+            >
+              {reason}
+            </button>
+          ))}
+        </div>
+
+        <Textarea
+          value={details}
+          onChange={(e) => setDetails(e.target.value)}
+          placeholder="Share details (optional)"
+          className="min-h-28 resize-none"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSubmit();
+          }}
+        />
+
+        <div className="flex justify-end">
+          <Button
+            onClick={handleSubmit}
+            disabled={selected.size === 0 && !details.trim()}
+            size="sm"
+          >
+            Submit
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
@@ -2,9 +2,11 @@ import { useState, type ReactNode } from "react";
 import { useCopy } from "@deco/ui/hooks/use-copy.ts";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { MemoizedMarkdown } from "../../markdown.tsx";
-import { Check, Copy01 } from "@untitledui/icons";
+import { Check, Copy01, ThumbsDown, ThumbsUp } from "@untitledui/icons";
 import type { TextUIPart } from "ai";
-import { track } from "@/web/lib/posthog-client";
+import { track, getSessionReplayUrl } from "@/web/lib/posthog-client";
+import { useOptionalChatTask } from "../../context.tsx";
+import { MessageFeedbackDialog } from "../../message-feedback-dialog.tsx";
 
 interface MessageTextPartProps {
   id: string;
@@ -23,7 +25,10 @@ export function MessageTextPart({
   alwaysShowActions = false,
 }: MessageTextPartProps) {
   const { handleCopy } = useCopy();
+  const threadId = useOptionalChatTask()?.taskId ?? null;
   const [isCopied, setIsCopied] = useState(false);
+  const [feedback, setFeedback] = useState<"positive" | null>(null);
+  const [negativeOpen, setNegativeOpen] = useState(false);
 
   const handleCopyMessage = async () => {
     track("chat_message_copied", {
@@ -35,8 +40,30 @@ export function MessageTextPart({
     setTimeout(() => setIsCopied(false), 2000);
   };
 
-  // Only show copy button on the last part (the one with extraActions/usage stats)
-  const showCopyButton = copyable && extraActions;
+  const handleThumbsUp = () => {
+    if (feedback === "positive") {
+      setFeedback(null);
+      track("chat_message_feedback_positive_undone", {
+        message_id: id,
+        thread_id: threadId,
+        session_replay_url: getSessionReplayUrl(),
+      });
+    } else {
+      setFeedback("positive");
+      track("chat_message_feedback_positive", {
+        message_id: id,
+        thread_id: threadId,
+        session_replay_url: getSessionReplayUrl(),
+      });
+    }
+  };
+
+  const handleThumbsDown = () => {
+    setNegativeOpen(true);
+  };
+
+  // Fix: show copy on any copyable part, not only when extraActions is present
+  const showCopyButton = copyable;
   const showActions = showCopyButton || extraActions;
 
   return (
@@ -69,8 +96,49 @@ export function MessageTextPart({
               )}
             </button>
           )}
+          {showCopyButton && (
+            <>
+              <span className="text-muted-foreground/40 select-none">·</span>
+              <button
+                type="button"
+                onClick={handleThumbsUp}
+                className={cn(
+                  "transition-colors active:scale-[0.97]",
+                  feedback === "positive"
+                    ? "text-foreground"
+                    : "text-muted-foreground [@media(hover:hover)]:hover:text-foreground",
+                )}
+                aria-label="Good response"
+              >
+                <ThumbsUp
+                  className={cn(
+                    "size-4",
+                    feedback === "positive" && "fill-current",
+                  )}
+                />
+              </button>
+              {feedback !== "positive" && (
+                <button
+                  type="button"
+                  onClick={handleThumbsDown}
+                  className="text-muted-foreground [@media(hover:hover)]:hover:text-foreground transition-colors active:scale-[0.97]"
+                  aria-label="Bad response"
+                >
+                  <ThumbsDown className="size-4" />
+                </button>
+              )}
+            </>
+          )}
         </div>
       )}
+      <MessageFeedbackDialog
+        open={negativeOpen}
+        onOpenChange={setNegativeOpen}
+        messageId={id}
+        threadId={threadId}
+        messageContent={part.text}
+        sessionReplayUrl={getSessionReplayUrl()}
+      />
     </div>
   );
 }

--- a/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { useParams } from "@tanstack/react-router";
 import { useCopy } from "@deco/ui/hooks/use-copy.ts";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { MemoizedMarkdown } from "../../markdown.tsx";
@@ -25,6 +26,7 @@ export function MessageTextPart({
   alwaysShowActions = false,
 }: MessageTextPartProps) {
   const { handleCopy } = useCopy();
+  const orgSlug = (useParams({ strict: false }) as { org?: string }).org ?? "";
   const threadId = useOptionalChatTask()?.taskId ?? null;
   const [isCopied, setIsCopied] = useState(false);
   const [feedback, setFeedback] = useState<"positive" | null>(null);
@@ -131,12 +133,15 @@ export function MessageTextPart({
           )}
         </div>
       )}
-      <MessageFeedbackDialog
-        open={negativeOpen}
-        onOpenChange={setNegativeOpen}
-        messageId={id}
-        threadId={threadId}
-      />
+      {showCopyButton && orgSlug ? (
+        <MessageFeedbackDialog
+          open={negativeOpen}
+          onOpenChange={setNegativeOpen}
+          orgSlug={orgSlug}
+          messageId={id}
+          threadId={threadId}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
@@ -62,8 +62,8 @@ export function MessageTextPart({
     setNegativeOpen(true);
   };
 
-  // Fix: show copy on any copyable part, not only when extraActions is present
-  const showCopyButton = copyable;
+  // Only show copy/feedback on the last part (the one with extraActions/usage stats)
+  const showCopyButton = copyable && !!extraActions;
   const showActions = showCopyButton || extraActions;
 
   return (
@@ -136,8 +136,6 @@ export function MessageTextPart({
         onOpenChange={setNegativeOpen}
         messageId={id}
         threadId={threadId}
-        messageContent={part.text}
-        sessionReplayUrl={getSessionReplayUrl()}
       />
     </div>
   );

--- a/apps/mesh/src/web/components/feedback-dialog.tsx
+++ b/apps/mesh/src/web/components/feedback-dialog.tsx
@@ -15,20 +15,26 @@ import { track, getSessionReplayUrl } from "@/web/lib/posthog-client";
 interface FeedbackDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  orgSlug: string;
 }
 
-export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
+export function FeedbackDialog({
+  open,
+  onOpenChange,
+  orgSlug,
+}: FeedbackDialogProps) {
   const [message, setMessage] = useState("");
-  const [sending, setSending] = useState(false);
 
-  const handleSubmit = async () => {
+  const handleSubmit = () => {
     if (!message.trim()) return;
-    setSending(true);
-    track("user_feedback", {
-      message: message.trim(),
+    fetch(`/api/${orgSlug}/feedback`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: message.trim() }),
+    });
+    track("user_feedback_submitted", {
       session_replay_url: getSessionReplayUrl(),
     });
-    setSending(false);
     setMessage("");
     onOpenChange(false);
     toast.success("Feedback sent — thank you!");
@@ -74,11 +80,7 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
           >
             contact@decocms.com
           </a>
-          <Button
-            onClick={handleSubmit}
-            disabled={!message.trim() || sending}
-            size="sm"
-          >
+          <Button onClick={handleSubmit} disabled={!message.trim()} size="sm">
             Send feedback
             <span className="ml-1.5 text-xs opacity-60">⌘↵</span>
           </Button>

--- a/apps/mesh/src/web/components/feedback-dialog.tsx
+++ b/apps/mesh/src/web/components/feedback-dialog.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { MessageChatCircle } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { toast } from "@deco/ui/components/sonner.js";
+import { track, getSessionReplayUrl } from "@/web/lib/posthog-client";
+
+interface FeedbackDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!message.trim()) return;
+    setSending(true);
+    track("user_feedback", {
+      message: message.trim(),
+      session_replay_url: getSessionReplayUrl(),
+    });
+    setSending(false);
+    setMessage("");
+    onOpenChange(false);
+    toast.success("Feedback sent — thank you!");
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setMessage("");
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md gap-5">
+        <DialogHeader className="gap-1">
+          <DialogTitle className="flex items-center gap-2 text-base font-semibold">
+            <MessageChatCircle size={18} className="text-muted-foreground" />
+            Feedback
+          </DialogTitle>
+          <DialogDescription>
+            Tell us what's on your mind — bugs, ideas, or anything else.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium text-foreground">Message</label>
+          <Textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Tell us about your experience, bugs you've found, or features you'd like to see..."
+            className="min-h-32 resize-none"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                handleSubmit();
+              }
+            }}
+          />
+        </div>
+
+        <div className="flex items-center justify-between pt-1">
+          <a
+            href="mailto:contact@decocms.com"
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            contact@decocms.com
+          </a>
+          <Button
+            onClick={handleSubmit}
+            disabled={!message.trim() || sending}
+            size="sm"
+          >
+            Send feedback
+            <span className="ml-1.5 text-xs opacity-60">⌘↵</span>
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/feedback-dialog.tsx
+++ b/apps/mesh/src/web/components/feedback-dialog.tsx
@@ -24,20 +24,32 @@ export function FeedbackDialog({
   orgSlug,
 }: FeedbackDialogProps) {
   const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!message.trim()) return;
-    fetch(`/api/${orgSlug}/feedback`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message: message.trim() }),
-    });
-    track("user_feedback_submitted", {
-      session_replay_url: getSessionReplayUrl(),
-    });
-    setMessage("");
-    onOpenChange(false);
-    toast.success("Feedback sent — thank you!");
+    setSending(true);
+    try {
+      const res = await fetch(`/api/${orgSlug}/feedback`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: message.trim() }),
+      });
+      if (!res.ok) {
+        toast.error("Failed to send feedback. Please try again.");
+        return;
+      }
+      track("user_feedback_submitted", {
+        session_replay_url: getSessionReplayUrl(),
+      });
+      setMessage("");
+      onOpenChange(false);
+      toast.success("Feedback sent — thank you!");
+    } catch {
+      toast.error("Failed to send feedback. Please try again.");
+    } finally {
+      setSending(false);
+    }
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -66,7 +78,7 @@ export function FeedbackDialog({
             placeholder="Tell us about your experience, bugs you've found, or features you'd like to see..."
             className="min-h-32 resize-none"
             onKeyDown={(e) => {
-              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !sending) {
                 handleSubmit();
               }
             }}
@@ -80,7 +92,11 @@ export function FeedbackDialog({
           >
             contact@decocms.com
           </a>
-          <Button onClick={handleSubmit} disabled={!message.trim()} size="sm">
+          <Button
+            onClick={handleSubmit}
+            disabled={!message.trim() || sending}
+            size="sm"
+          >
             Send feedback
             <span className="ml-1.5 text-xs opacity-60">⌘↵</span>
           </Button>

--- a/apps/mesh/src/web/components/feedback-dialog.tsx
+++ b/apps/mesh/src/web/components/feedback-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { toast } from "@deco/ui/components/sonner.js";
 import { track, getSessionReplayUrl } from "@/web/lib/posthog-client";
+import { submitFeedback } from "@/web/lib/submit-feedback";
 
 interface FeedbackDialogProps {
   open: boolean;
@@ -27,13 +28,11 @@ export function FeedbackDialog({
   const [sending, setSending] = useState(false);
 
   const handleSubmit = async () => {
-    if (!message.trim()) return;
+    if (sending || !message.trim() || !orgSlug) return;
     setSending(true);
     try {
-      const res = await fetch(`/api/${orgSlug}/feedback`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: message.trim() }),
+      const res = await submitFeedback(orgSlug, {
+        message: message.trim(),
       });
       if (!res.ok) {
         toast.error("Failed to send feedback. Please try again.");
@@ -79,7 +78,7 @@ export function FeedbackDialog({
             className="min-h-32 resize-none"
             onKeyDown={(e) => {
               if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !sending) {
-                handleSubmit();
+                void handleSubmit();
               }
             }}
           />
@@ -93,8 +92,8 @@ export function FeedbackDialog({
             contact@decocms.com
           </a>
           <Button
-            onClick={handleSubmit}
-            disabled={!message.trim() || sending}
+            onClick={() => void handleSubmit()}
+            disabled={!message.trim() || sending || !orgSlug}
             size="sm"
           >
             Send feedback

--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -151,6 +151,20 @@ export function captureException(
 }
 
 /**
+ * Returns a direct link to the PostHog session recording at the current
+ * timestamp. Returns null when PostHog is not initialized (self-hosted
+ * installs without POSTHOG_KEY).
+ */
+export function getSessionReplayUrl(): string | null {
+  if (!initialized) return null;
+  try {
+    return posthog.get_session_replay_url({ withTimestamp: true }) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Test-only: reset module-level state between tests. Not exported from any
  * non-test consumer; kept here because module state is otherwise opaque.
  */

--- a/apps/mesh/src/web/lib/submit-feedback.ts
+++ b/apps/mesh/src/web/lib/submit-feedback.ts
@@ -1,0 +1,32 @@
+/**
+ * POST /api/:org/feedback — shared by account and chat feedback dialogs.
+ */
+
+export type GeneralFeedbackBody = {
+  kind?: "general";
+  message: string;
+};
+
+export type ChatNegativeFeedbackBody = {
+  kind: "chat_negative";
+  messageId: string;
+  threadId?: string | null;
+  reasons?: string[];
+  details?: string;
+};
+
+export type FeedbackRequestBody =
+  | GeneralFeedbackBody
+  | ChatNegativeFeedbackBody;
+
+export async function submitFeedback(
+  orgSlug: string,
+  body: FeedbackRequestBody,
+): Promise<Response> {
+  return fetch(`/api/${encodeURIComponent(orgSlug)}/feedback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+}


### PR DESCRIPTION
## What is this contribution about?

Adds two feedback surfaces to Studio: a **Feedback** item in the account popover menu that opens a general feedback modal, and **thumbs up / thumbs down** buttons on each assistant chat message. Thumbs up tracks a positive signal (togglable); thumbs down opens a structured \"Share feedback\" modal with reason chips (Incorrect or incomplete, Not what I asked for, etc.) and an optional details field. All PostHog events include \`message_id\`, \`thread_id\`, \`message_content\` snippet, and a \`session_replay_url\` timestamped to the exact moment of feedback. Terms of Use and Privacy Policy were removed from the account menu to reduce clutter.

## Screenshots/Demonstration

- Account menu now shows: Preferences → Feedback → decocms/studio → Community → Homepage → Sign out
- Chat messages show copy · 👍 · 👎 on hover; thumbs up fills and hides thumbs down on click (clickable again to undo)
- Thumbs down opens a modal with selectable reason chips + optional text

## How to Test

1. Open the account popover and click **Feedback** — modal should appear with a textarea and send via PostHog on submit
2. Send a chat message, hover the assistant response — copy, thumbs up, and thumbs down buttons should appear
3. Click thumbs up — icon fills, thumbs down vanishes; click again to undo
4. Click thumbs down — "Share feedback" modal opens; select reasons and submit
5. Check PostHog Events for `user_feedback`, `chat_message_feedback_positive`, and `chat_message_feedback_negative` with expected properties

## Migration Notes

No migrations required. Requires `POSTHOG_KEY` to be set for events to be captured (no-op on self-hosted installs without it).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Feedback button in the account menu and per‑message thumbs to collect chat feedback. Free‑text is posted to a new, org‑scoped `POST /api/:org/feedback` route and PostHog receives safe events with session replay links.

- New Features
  - Account menu now has Feedback. Opens a modal, posts to `POST /api/:org/feedback` (pluggable `FeedbackSink`, default structured log), and sends `user_feedback_submitted`.
  - Assistant messages show thumbs up/down. Up toggles (with undo); down opens a modal with reasons and optional details. Negative details are posted to the backend. Sends `chat_message_feedback_positive`, `chat_message_feedback_positive_undone`, and `chat_message_feedback_negative`.
  - Events include `message_id`, `thread_id`, and a timestamped session replay URL.

- Bug Fixes
  - Hardened API: require auth and org membership, cap body at 65 KB (413), return 400 on invalid JSON, return 401 JSON when unauthenticated, and 502 on sink failures.
  - Free‑text (including negative details) is handled server‑side; `message_content` removed from negative events; session replay URL captured at submit time.
  - UI reliability: prevent empty negative feedback (incl. Cmd/Ctrl+Enter), await POST with disabled submit and error toasts; restored Terms of Use and Privacy Policy links; added unit and E2E tests for the route and UI.

<sup>Written for commit 67dbfa828659604ab5fd0887b23bd4223b3fa95c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

