### PR TITLE
fix(github): publish dialog and header git state after commit

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -12,6 +12,7 @@
  */
 
 import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { streamSSE } from "hono/streaming";
 import { createMiddleware } from "hono/factory";
 import { composeSandboxRef } from "@decocms/sandbox/provider";
@@ -49,6 +50,24 @@ interface VmClaim {
 
 type VmEnv = Env & { Variables: Env["Variables"] & { vmClaim: VmClaim } };
 
+const SANDBOX_BRANCH_NAME = /^[a-zA-Z0-9][a-zA-Z0-9/._-]*$/;
+
+function assertSandboxBranchParam(branch: string): void {
+  if (
+    !branch ||
+    branch.length > 255 ||
+    branch.includes("..") ||
+    branch.startsWith("/") ||
+    branch.endsWith("/") ||
+    branch.endsWith(".lock") ||
+    !SANDBOX_BRANCH_NAME.test(branch)
+  ) {
+    throw new Error(`Invalid branch name: ${branch}`);
+  }
+}
+
+const SUGGEST_COMMIT_MAX_BODY_BYTES = 512 * 1024;
+
 // ---- Shared middleware ------------------------------------------------------
 
 /**
@@ -77,6 +96,13 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
   const branch = c.req.param("branch");
   if (!virtualMcpId || !branch) {
     return c.json({ error: "virtualMcpId and branch are required" }, 400);
+  }
+
+  try {
+    assertSandboxBranchParam(branch);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ error: message }, 400);
   }
 
   const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
@@ -419,35 +445,26 @@ export const createSandboxRoutes = () => {
       map404to410: true,
     }),
   );
-  app.post("/:virtualMcpId/:branch/git/suggest-commit", async (c) => {
-    const runner = requireRunner(c);
-    if (runner instanceof Response) return runner;
+  app.post(
+    "/:virtualMcpId/:branch/git/suggest-commit",
+    bodyLimit({
+      maxSize: SUGGEST_COMMIT_MAX_BODY_BYTES,
+      onError: (c) =>
+        c.json(
+          { error: "Payload too large" },
+          413,
+          SANDBOX_PROXY_CACHE_HEADERS,
+        ),
+    }),
+    async (c) => {
+      const runner = requireRunner(c);
+      if (runner instanceof Response) return runner;
 
-    const { claimName } = c.get("vmClaim");
-    const ctx = c.var.meshContext;
+      const { claimName } = c.get("vmClaim");
+      const ctx = c.var.meshContext;
 
-    let body: { status?: GitStatusLike; diff?: GitDiffLike } = {};
-    try {
-      const text = await c.req.text();
-      if (text.trim()) {
-        body = JSON.parse(text) as {
-          status?: GitStatusLike;
-          diff?: GitDiffLike;
-        };
-      }
-    } catch {
-      return c.json(
-        { error: "Invalid JSON body" },
-        400,
-        SANDBOX_PROXY_CACHE_HEADERS,
-      );
-    }
-
-    try {
-      let status = body.status;
-      let diff = body.diff;
-      if (!status || !diff) {
-        [status, diff] = await Promise.all([
+      try {
+        const [status, diff] = await Promise.all([
           fetchDaemonJson<GitStatusLike>(
             runner,
             claimName,
@@ -461,24 +478,24 @@ export const createSandboxRoutes = () => {
             "GET",
           ),
         ]);
+        const suggestion = await suggestCommitMessageWithLlm(ctx, status, diff);
+        return c.json(suggestion, 200, SANDBOX_PROXY_CACHE_HEADERS);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message === "SANDBOX_GONE") {
+          return c.json(
+            {
+              error:
+                "Sandbox handle is gone. The sandbox needs to be re-provisioned.",
+            },
+            410,
+            SANDBOX_PROXY_CACHE_HEADERS,
+          );
+        }
+        return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
       }
-      const suggestion = await suggestCommitMessageWithLlm(ctx, status, diff);
-      return c.json(suggestion, 200, SANDBOX_PROXY_CACHE_HEADERS);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message === "SANDBOX_GONE") {
-        return c.json(
-          {
-            error:
-              "Sandbox handle is gone. The sandbox needs to be re-provisioned.",
-          },
-          410,
-          SANDBOX_PROXY_CACHE_HEADERS,
-        );
-      }
-      return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
-    }
-  });
+    },
+  );
 
   // -- Preview fetch (CORS proxy) -------------------------------------------
   app.get("/:virtualMcpId/:branch/preview-fetch", async (c) => {

--- a/apps/mesh/src/lib/suggest-commit-message.test.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.test.ts
@@ -18,6 +18,47 @@ describe("suggest-commit-message", () => {
     expect(result.message).toContain("update src/app.tsx");
   });
 
+  test("fallbackCommitSuggestion uses diff paths when working tree is clean", () => {
+    const result = fallbackCommitSuggestion(
+      {
+        modified: [],
+        created: [],
+        deleted: [],
+        not_added: [],
+      },
+      {
+        diffs: {
+          ".deco/blocks/pages-home.json": { from: "{}", to: "{}" },
+        },
+      },
+    );
+
+    expect(result.title).toBe("Update .deco/blocks/pages-home.json");
+    expect(result.body).toContain(".deco/blocks/pages-home.json");
+  });
+
+  test("buildCommitContextSummary includes diff-only paths vs base", () => {
+    const summary = buildCommitContextSummary(
+      {
+        modified: [],
+        created: [],
+        deleted: [],
+        not_added: [],
+      },
+      {
+        diffs: {
+          ".deco/blocks/pages-home.json": {
+            from: "old",
+            to: "new",
+          },
+        },
+      },
+    );
+
+    expect(summary).toContain("Changed: .deco/blocks/pages-home.json");
+    expect(summary).toContain("+ new");
+  });
+
   test("buildCommitContextSummary includes diff snippets", () => {
     const summary = buildCommitContextSummary(
       {

--- a/apps/mesh/src/lib/suggest-commit-message.test.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.test.ts
@@ -61,6 +61,30 @@ describe("suggest-commit-message", () => {
     expect(result.body).toContain(".deco/blocks/pages-home.json");
   });
 
+  test("fallbackCommitSuggestion classifies diff-only add and delete", () => {
+    const added = fallbackCommitSuggestion(
+      {
+        modified: [],
+        created: [],
+        deleted: [],
+        not_added: [],
+      },
+      { diffs: { "routes/new.tsx": { from: null, to: "export {}" } } },
+    );
+    expect(added.message).toContain("add routes/new.tsx");
+
+    const deleted = fallbackCommitSuggestion(
+      {
+        modified: [],
+        created: [],
+        deleted: [],
+        not_added: [],
+      },
+      { diffs: { "routes/old.tsx": { from: "x", to: null } } },
+    );
+    expect(deleted.message).toContain("delete routes/old.tsx");
+  });
+
   test("buildCommitContextSummary includes diff-only paths vs base", () => {
     const summary = buildCommitContextSummary(
       {

--- a/apps/mesh/src/lib/suggest-commit-message.test.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.test.ts
@@ -2,7 +2,31 @@ import { describe, expect, test } from "bun:test";
 import {
   buildCommitContextSummary,
   fallbackCommitSuggestion,
+  parseCommitSuggestionJson,
 } from "./suggest-commit-message";
+
+describe("parseCommitSuggestionJson", () => {
+  test("parses bare JSON", () => {
+    const result = parseCommitSuggestionJson(
+      '{"title":"Add feature","body":"Does the thing"}',
+    );
+    expect(result?.title).toBe("Add feature");
+    expect(result?.body).toBe("Does the thing");
+  });
+
+  test("strips markdown fences", () => {
+    const result = parseCommitSuggestionJson(
+      '```json\n{"title":"Fix bug","body":""}\n```',
+    );
+    expect(result?.title).toBe("Fix bug");
+  });
+
+  test("falls back to first line as title", () => {
+    const result = parseCommitSuggestionJson("Plain title\n\nMore detail");
+    expect(result?.title).toBe("Plain title");
+    expect(result?.body).toBe("More detail");
+  });
+});
 
 describe("suggest-commit-message", () => {
   test("fallbackCommitSuggestion summarizes changed files", () => {

--- a/apps/mesh/src/lib/suggest-commit-message.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.ts
@@ -29,13 +29,27 @@ function isGeneratedNoise(path: string): boolean {
   return /^static\/.*\.css$/.test(path);
 }
 
-function changedPaths(status: GitStatusLike): string[] {
-  return [
+/** Paths from the working tree plus any keys in a base…head diff (committed PR work). */
+function changedPaths(status: GitStatusLike, diff?: GitDiffLike): string[] {
+  const fromStatus = [
     ...status.modified,
     ...status.created,
     ...status.deleted,
     ...status.not_added,
   ].filter((p) => !isGeneratedNoise(p));
+  const fromDiff = diff
+    ? Object.keys(diff.diffs).filter((p) => !isGeneratedNoise(p))
+    : [];
+  return [...new Set([...fromStatus, ...fromDiff])];
+}
+
+function pathChangeLabel(path: string, status: GitStatusLike): string {
+  if (status.created.includes(path) || status.not_added.includes(path)) {
+    return `Added: ${path}`;
+  }
+  if (status.deleted.includes(path)) return `Deleted: ${path}`;
+  if (status.modified.includes(path)) return `Modified: ${path}`;
+  return `Changed: ${path}`;
 }
 
 function changedLines(
@@ -151,13 +165,8 @@ export function buildCommitContextSummary(
   status: GitStatusLike,
   diff: GitDiffLike,
 ): string {
-  const paths = changedPaths(status);
-  const fileLines = [
-    ...status.modified.map((f) => `Modified: ${f}`),
-    ...status.created.map((f) => `Added: ${f}`),
-    ...status.deleted.map((f) => `Deleted: ${f}`),
-    ...status.not_added.map((f) => `Added: ${f}`),
-  ].join("\n");
+  const paths = changedPaths(status, diff);
+  const fileLines = paths.map((p) => pathChangeLabel(p, status)).join("\n");
 
   const snippets = paths
     .map((path) => {
@@ -173,20 +182,23 @@ export function buildCommitContextSummary(
 
 export function fallbackCommitSuggestion(
   status: GitStatusLike,
+  diff?: GitDiffLike,
 ): CommitSuggestion {
-  const all = [
-    ...status.created.map((f) => `add ${f}`),
-    ...status.modified.map((f) => `update ${f}`),
-    ...status.deleted.map((f) => `delete ${f}`),
-    ...status.not_added.map((f) => `add ${f}`),
-  ].filter((f) => !isGeneratedNoise(f.replace(/^(add|update|delete) /, "")));
+  const paths = changedPaths(status, diff);
+  const all = paths.map((f) => {
+    if (status.created.includes(f) || status.not_added.includes(f)) {
+      return `add ${f}`;
+    }
+    if (status.deleted.includes(f)) return `delete ${f}`;
+    return `update ${f}`;
+  });
 
   const label = all.length > 0 ? all[0] : "Update files";
   const extra = all.length > 1 ? ` and ${all.length - 1} more` : "";
   const message = `${label}${extra}`;
   const title = message.charAt(0).toUpperCase() + message.slice(1);
 
-  const bodyPaths = changedPaths(status).slice(0, 5).join(", ");
+  const bodyPaths = paths.slice(0, 5).join(", ");
   return {
     message,
     title,
@@ -227,13 +239,13 @@ export async function suggestCommitMessageWithLlm(
   status: GitStatusLike,
   diff: GitDiffLike,
 ): Promise<CommitSuggestion> {
-  const paths = changedPaths(status);
+  const paths = changedPaths(status, diff);
   if (paths.length === 0) {
     return { title: "No changes", body: "", message: "No changes" };
   }
 
   const orgId = ctx.organization?.id;
-  if (!orgId) return fallbackCommitSuggestion(status);
+  if (!orgId) return fallbackCommitSuggestion(status, diff);
 
   try {
     const tier = await resolveTier(ctx, "fast");
@@ -255,5 +267,5 @@ export async function suggestCommitMessageWithLlm(
     console.warn("[suggest-commit-message] LLM failed, using fallback", err);
   }
 
-  return fallbackCommitSuggestion(status);
+  return fallbackCommitSuggestion(status, diff);
 }

--- a/apps/mesh/src/lib/suggest-commit-message.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.ts
@@ -43,13 +43,39 @@ function changedPaths(status: GitStatusLike, diff?: GitDiffLike): string[] {
   return [...new Set([...fromStatus, ...fromDiff])];
 }
 
-function pathChangeLabel(path: string, status: GitStatusLike): string {
+function pathChangeKind(
+  path: string,
+  status: GitStatusLike,
+  diff?: GitDiffLike,
+): "add" | "delete" | "update" {
   if (status.created.includes(path) || status.not_added.includes(path)) {
-    return `Added: ${path}`;
+    return "add";
   }
-  if (status.deleted.includes(path)) return `Deleted: ${path}`;
-  if (status.modified.includes(path)) return `Modified: ${path}`;
-  return `Changed: ${path}`;
+  if (status.deleted.includes(path)) return "delete";
+  const entry = diff?.diffs[path];
+  if (entry) {
+    if (!entry.from && entry.to) return "add";
+    if (entry.from && !entry.to) return "delete";
+  }
+  if (status.modified.includes(path)) return "update";
+  return "update";
+}
+
+function pathChangeLabel(
+  path: string,
+  status: GitStatusLike,
+  diff?: GitDiffLike,
+): string {
+  switch (pathChangeKind(path, status, diff)) {
+    case "add":
+      return `Added: ${path}`;
+    case "delete":
+      return `Deleted: ${path}`;
+    case "update":
+      return status.modified.includes(path)
+        ? `Modified: ${path}`
+        : `Changed: ${path}`;
+  }
 }
 
 function changedLines(
@@ -166,7 +192,9 @@ export function buildCommitContextSummary(
   diff: GitDiffLike,
 ): string {
   const paths = changedPaths(status, diff);
-  const fileLines = paths.map((p) => pathChangeLabel(p, status)).join("\n");
+  const fileLines = paths
+    .map((p) => pathChangeLabel(p, status, diff))
+    .join("\n");
 
   const snippets = paths
     .map((path) => {
@@ -186,11 +214,8 @@ export function fallbackCommitSuggestion(
 ): CommitSuggestion {
   const paths = changedPaths(status, diff);
   const all = paths.map((f) => {
-    if (status.created.includes(f) || status.not_added.includes(f)) {
-      return `add ${f}`;
-    }
-    if (status.deleted.includes(f)) return `delete ${f}`;
-    return `update ${f}`;
+    const kind = pathChangeKind(f, status, diff);
+    return `${kind} ${f}`;
   });
 
   const label = all.length > 0 ? all[0] : "Update files";

--- a/apps/mesh/src/lib/suggest-commit-message.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.ts
@@ -206,7 +206,9 @@ export function fallbackCommitSuggestion(
   };
 }
 
-function parseCommitSuggestionJson(text: string): CommitSuggestion | null {
+export function parseCommitSuggestionJson(
+  text: string,
+): CommitSuggestion | null {
   const cleaned = text
     .trim()
     .replace(/^```(?:json)?\s*\n?/i, "")

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -65,6 +65,9 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const { currentBranch: branch, setCurrentTaskBranch } = useChatTask();
   const chat = useChatStream();
   const [publishOpen, setPublishOpen] = useState(false);
+  const [publishDialogIntent, setPublishDialogIntent] = useState<
+    "publish" | "open-pr"
+  >("publish");
   const [githubActionPending, setGithubActionPending] = useState(false);
   const debugKeyRef = useRef("");
 
@@ -248,7 +251,11 @@ export function HeaderActions({ virtualMcpId }: Props) {
     if (!action || !githubHeadBranch) return;
     switch (action) {
       case "commit-and-push":
+        setPublishDialogIntent("publish");
+        setPublishOpen(true);
+        return;
       case "create-pr":
+        setPublishDialogIntent("open-pr");
         setPublishOpen(true);
         return;
       case "reopen":
@@ -336,6 +343,12 @@ export function HeaderActions({ virtualMcpId }: Props) {
           owner={githubRepo.owner}
           repo={githubRepo.name}
           previewUrl={previewUrl}
+          dialogIntent={publishDialogIntent}
+          headSha={
+            effectiveBranchMeta.kind === "ready"
+              ? effectiveBranchMeta.headSha
+              : null
+          }
           openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}
           onPublished={switchToFreshBranch}

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -319,6 +319,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
           githubActionPending={githubActionPending}
           onActivate={onActivate}
           prNumber={pr?.number}
+          prBase={pr?.base}
           onSquashMerge={handleSquashMerge}
           onReview={
             pr
@@ -364,6 +365,7 @@ function HeaderButtonRenderer(props: {
   githubActionPending: boolean;
   onActivate: (action: HeaderButton["action"]) => void;
   prNumber?: number;
+  prBase?: string;
   onSquashMerge: (pullNumber: number) => void | Promise<void>;
   onReview?: () => void;
 }) {
@@ -389,6 +391,7 @@ function HeaderButtonRenderer(props: {
       <WithTooltip label={tooltipLabel}>
         <MergeSplitButton
           prNumber={props.prNumber}
+          baseBranch={props.prBase}
           disabled={disabled}
           loading={loading}
           onPublish={() => props.onSquashMerge(props.prNumber!)}

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -386,11 +386,14 @@ function HeaderButtonRenderer(props: {
     ? "Chat is running"
     : (button.tooltip ?? null);
 
-  if (button.action === "merge-split" && props.prNumber != null) {
+  if (
+    button.action === "merge-split" &&
+    props.prNumber != null &&
+    props.prBase != null
+  ) {
     return (
       <WithTooltip label={tooltipLabel}>
         <MergeSplitButton
-          prNumber={props.prNumber}
           baseBranch={props.prBase}
           disabled={disabled}
           loading={loading}

--- a/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
+++ b/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
@@ -10,7 +10,6 @@ import { ChevronDown } from "@untitledui/icons";
 import { publishToBaseLabel } from "./publish-label.ts";
 
 interface Props {
-  prNumber: number;
   /** PR base branch (e.g. main) — controls publish button copy. */
   baseBranch: string;
   disabled: boolean;

--- a/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
+++ b/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
@@ -7,9 +7,12 @@ import {
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { ChevronDown } from "@untitledui/icons";
+import { publishToBaseLabel } from "./publish-label.ts";
 
 interface Props {
   prNumber: number;
+  /** PR base branch (e.g. main) — controls publish button copy. */
+  baseBranch: string;
   disabled: boolean;
   loading?: boolean;
   onPublish: () => void | Promise<void>;
@@ -21,11 +24,13 @@ interface Props {
  * uses the chat agent for a read-only review pass.
  */
 export function MergeSplitButton({
+  baseBranch,
   disabled,
   loading = false,
   onPublish,
   onReview,
 }: Props) {
+  const publishLabel = publishToBaseLabel(baseBranch);
   return (
     <div className="inline-flex items-stretch rounded-md">
       <Button
@@ -36,7 +41,7 @@ export function MergeSplitButton({
         onClick={() => void onPublish()}
       >
         {loading ? <Spinner size="xs" variant="default" /> : null}
-        Publish
+        {publishLabel}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -442,9 +442,22 @@ describe("selectHeaderButton", () => {
         reviews: reviews(),
       }),
     );
-    expect(r.label).toBe("Publish");
+    expect(r.label).toBe("Publish to production");
     expect(r.action).toBe("merge-split");
     expect(r.variant).toBe("success");
+  });
+
+  test("PR open + all clear + base develop → Publish", () => {
+    const r = selectHeaderButton(
+      happyInput({
+        branch: ready({ aheadOfBase: 3, base: "develop" }),
+        pr: pr({ base: "develop" }),
+        checks: [check()],
+        reviews: reviews(),
+      }),
+    );
+    expect(r.label).toBe("Publish");
+    expect(r.action).toBe("merge-split");
   });
 
   test("priority: dirty beats everything else", () => {

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { BranchMeta, LifecycleState } from "@decocms/sandbox/shared";
 import type { ClaimPhase } from "@/web/components/sandbox/hooks/sandbox-events-context";
+import { mergeBranchMetaWithGitStatus } from "./sandbox-git-api.ts";
 import { selectHeaderButton } from "./panel-state";
 import type { CheckRun, PrSummary } from "./use-pr-data";
 import type { PrReviewSignals } from "./use-pr-reviews";
@@ -349,6 +350,37 @@ describe("selectHeaderButton", () => {
     expect(r.variant).toBe("special");
   });
 
+  test("refresh: unknown SSE + git aheadOfBase → Submit for review", () => {
+    const branch = mergeBranchMetaWithGitStatus(
+      { kind: "unknown" },
+      {
+        not_added: [],
+        conflicted: [],
+        created: [],
+        deleted: [],
+        modified: [],
+        renamed: [],
+        files: [],
+        staged: [],
+        ahead: 0,
+        behind: 0,
+        current: "deco/young-trail",
+        tracking: "origin/deco/young-trail",
+        detached: false,
+        aheadOfBase: 2,
+        behindBase: 0,
+        base: "main",
+        headSha: "abc",
+        unpushed: 0,
+      },
+    );
+    const r = selectHeaderButton(
+      happyInput({ branch, pr: null, checks: [], reviews: null }),
+    );
+    expect(r.label).toBe("Submit for review");
+    expect(r.action).toBe("create-pr");
+  });
+
   test("ahead of base + no PR → Submit for review", () => {
     const r = selectHeaderButton(
       happyInput({ branch: ready({ aheadOfBase: 3 }) }),
@@ -445,6 +477,19 @@ describe("selectHeaderButton", () => {
     expect(r.label).toBe("Publish to production");
     expect(r.action).toBe("merge-split");
     expect(r.variant).toBe("success");
+  });
+
+  test("PR open + reviews still loading → Publish to production (main base)", () => {
+    const r = selectHeaderButton(
+      happyInput({
+        branch: ready({ aheadOfBase: 3 }),
+        pr: pr(),
+        checks: [check()],
+        reviews: null,
+      }),
+    );
+    expect(r.label).toBe("Publish to production");
+    expect(r.action).toBe("merge-split");
   });
 
   test("PR open + all clear + base develop → Publish", () => {

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -3,6 +3,7 @@ import type { ClaimPhase } from "@/web/components/sandbox/hooks/sandbox-events-c
 import { CLAIM_PHASE_COPY } from "@/web/components/sandbox/claim-phase-copy";
 import type { CheckRun, PrSummary } from "./use-pr-data.ts";
 import type { PrReviewSignals } from "./use-pr-reviews.ts";
+import { publishToBaseLabel } from "./publish-label.ts";
 import { saveChangesDebug } from "./save-changes-debug.ts";
 
 /**
@@ -293,7 +294,7 @@ export function selectHeaderButton(
     }
 
     return {
-      label: "Publish",
+      label: publishToBaseLabel(pr.base),
       action: "merge-split",
       variant: "success",
       tooltip: `Squash-merge PR #${pr.number} into ${pr.base}`,

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -58,6 +58,8 @@ class PublishFlowError extends Error {
   }
 }
 
+export type PublishDialogIntent = "publish" | "open-pr";
+
 export interface PublishDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -70,6 +72,13 @@ export interface PublishDialogProps {
   owner: string;
   repo: string;
   previewUrl?: string | null;
+  /**
+   * `open-pr` — commits are already on the branch; open a PR from them.
+   * `publish` — commit/push local changes (default).
+   */
+  dialogIntent?: PublishDialogIntent;
+  /** Branch HEAD for base…head diff when `dialogIntent` is `open-pr`. */
+  headSha?: string | null;
   /** When set, the dialog commits to the branch and updates this open PR. */
   openPullRequest?: PrSummary | null;
   /** Called after commit/push or PR open/merge so the header can refresh. */
@@ -110,6 +119,8 @@ function PublishDialogBody({
   owner,
   repo,
   previewUrl,
+  dialogIntent = "publish",
+  headSha = null,
   openPullRequest = null,
   onPullRequestChanged,
   onPublished,
@@ -121,6 +132,9 @@ function PublishDialogBody({
   });
 
   const commitToOpenPr = openPullRequest?.state === "open";
+  /** Header "Save changes" — commit/push only, no new PR / merge. */
+  const isSaveChangesFlow = dialogIntent === "publish";
+  const openPrFromCommits = dialogIntent === "open-pr" && !commitToOpenPr;
 
   const [gitStatus, setGitStatus] = useState<GitStatus | null>(null);
   const [gitDiff, setGitDiff] = useState<GitDiffResult | null>(null);
@@ -151,9 +165,15 @@ function PublishDialogBody({
       setSubmitForReviewError(undefined);
       setSaveChangesError(undefined);
       try {
+        const diffOpts = openPrFromCommits
+          ? {
+              base: baseBranch,
+              ...(headSha ? { headSha } : {}),
+            }
+          : undefined;
         const [status, diff] = await Promise.all([
           fetchGitStatus(orgSlug, virtualMcpId, branch),
-          fetchGitDiff(orgSlug, virtualMcpId, branch),
+          fetchGitDiff(orgSlug, virtualMcpId, branch, diffOpts),
         ]);
         setGitStatus(status);
         setGitDiff(diff);
@@ -204,7 +224,12 @@ function PublishDialogBody({
   const changesCount = countGitChanges(gitStatus);
   const diffCount = gitDiff ? Object.keys(gitDiff.diffs).length : changesCount;
 
-  const canSubmit = !isLoadingGitDiff && hasUnpublishedWork(gitStatus, gitDiff);
+  const hasLocalUnpublished = hasUnpublishedWork(gitStatus, gitDiff);
+  const canSubmit =
+    !isLoadingGitDiff &&
+    (isSaveChangesFlow
+      ? hasLocalUnpublished
+      : hasLocalUnpublished || openPrFromCommits);
   const canPublish = canSubmit && isDecoOnlyDiff(gitDiff);
   const publishDisabledReason =
     canSubmit && !isDecoOnlyDiff(gitDiff)
@@ -253,13 +278,15 @@ function PublishDialogBody({
       const prBody = publishBody.trim() || undefined;
       const message = commitMessage() || prTitle;
 
-      try {
-        await publishGitChanges(orgSlug, virtualMcpId, branch, message);
-      } catch (error) {
-        throw new PublishFlowError(
-          error instanceof Error ? error.message : "Failed to push changes",
-          "push",
-        );
+      if (hasLocalUnpublished) {
+        try {
+          await publishGitChanges(orgSlug, virtualMcpId, branch, message);
+        } catch (error) {
+          throw new PublishFlowError(
+            error instanceof Error ? error.message : "Failed to push changes",
+            "push",
+          );
+        }
       }
 
       try {
@@ -387,7 +414,9 @@ function PublishDialogBody({
       const prBody = publishBody.trim() || undefined;
       const message = commitMessage() || prTitle;
 
-      await publishGitChanges(orgSlug, virtualMcpId, branch, message);
+      if (hasLocalUnpublished) {
+        await publishGitChanges(orgSlug, virtualMcpId, branch, message);
+      }
 
       const pr = await openPullRequestForBranch(githubClient, {
         owner,
@@ -421,12 +450,20 @@ function PublishDialogBody({
         <div className="shrink-0 space-y-3 px-6 pt-5 pb-4">
           <div className="space-y-1">
             <p className="text-xs font-medium text-muted-foreground">
-              {commitToOpenPr ? "Save changes" : "Publish"}
+              {isSaveChangesFlow
+                ? "Save changes"
+                : openPrFromCommits
+                  ? "Submit for review"
+                  : "Publish"}
             </p>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-green-500" />
               {diffCount} {diffCount === 1 ? "change" : "changes"}{" "}
-              {commitToOpenPr ? "to save" : "to publish"}
+              {isSaveChangesFlow
+                ? "to save"
+                : openPrFromCommits
+                  ? "in this PR"
+                  : "to publish"}
             </div>
           </div>
           {discardAllConfirm ? (
@@ -468,7 +505,7 @@ function PublishDialogBody({
                   Changes
                 </TabsTrigger>
               </TabsList>
-              {diffCount > 0 && (
+              {diffCount > 0 && !openPrFromCommits && (
                 <button
                   type="button"
                   className="text-xs text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
@@ -495,7 +532,9 @@ function PublishDialogBody({
               <TabsContent value="description" className="mt-0 px-6 py-5">
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">
-                    <p className="text-sm font-medium">Commit message</p>
+                    <p className="text-sm font-medium">
+                      {openPrFromCommits ? "Pull request" : "Commit message"}
+                    </p>
                     <button
                       type="button"
                       className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
@@ -566,12 +605,13 @@ function PublishDialogBody({
                   </div>
                   <p className="text-xs text-muted-foreground">
                     Branch: <span className="font-mono">{branch}</span>
-                    {commitToOpenPr ? (
+                    {isSaveChangesFlow ? (
                       <>
                         {" · "}
                         <span className="text-foreground/80">
-                          Commits and pushes to update open PR #
-                          {openPullRequest.number}.
+                          {commitToOpenPr
+                            ? `Commits and pushes to update open PR #${openPullRequest.number}.`
+                            : "Commits and pushes to the branch without opening a pull request."}
                         </span>
                       </>
                     ) : (
@@ -616,7 +656,7 @@ function PublishDialogBody({
         </div>
 
         <div className="shrink-0 border-t px-6 py-3">
-          {commitToOpenPr ? (
+          {isSaveChangesFlow ? (
             <>
               <Button
                 type="button"

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -38,6 +38,7 @@ import {
   fetchGitDiff,
   fetchGitStatus,
   fetchSuggestCommitMessage,
+  hasLocalWorkToPush,
   hasUnpublishedWork,
   isDecoOnlyDiff,
   publishGitChanges,
@@ -226,7 +227,9 @@ function PublishDialogBody({
   const changesCount = countGitChanges(gitStatus);
   const diffCount = gitDiff ? Object.keys(gitDiff.diffs).length : changesCount;
 
-  const hasLocalUnpublished = hasUnpublishedWork(gitStatus, gitDiff);
+  const hasLocalUnpublished = openPrFromCommits
+    ? hasLocalWorkToPush(gitStatus)
+    : hasUnpublishedWork(gitStatus, gitDiff);
   const canSubmit =
     !isLoadingGitDiff &&
     (isSaveChangesFlow
@@ -353,7 +356,8 @@ function PublishDialogBody({
         toast.error(msg, {
           action: {
             label: "View PR",
-            onClick: () => window.open(error.pr!.htmlUrl, "_blank", "noopener"),
+            onClick: () =>
+              window.open(error.pr!.htmlUrl, "_blank", "noopener,noreferrer"),
           },
         });
         await onPullRequestChanged?.();
@@ -432,7 +436,8 @@ function PublishDialogBody({
       toast.success(`Submitted pull request #${pr.number} for review`, {
         action: {
           label: "View on GitHub",
-          onClick: () => window.open(pr.htmlUrl, "_blank", "noopener"),
+          onClick: () =>
+            window.open(pr.htmlUrl, "_blank", "noopener,noreferrer"),
         },
       });
       handleOpenChange(false);

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -31,6 +31,7 @@ import {
   type CreatedPullRequest,
 } from "./github-pr-api.ts";
 import type { PrSummary } from "./use-pr-data.ts";
+import { publishToBaseLabel } from "./publish-label.ts";
 import {
   countGitChanges,
   discardGitFiles,
@@ -203,6 +204,7 @@ function PublishDialogBody({
   }
 
   const githubHeadBranch = readGitHeadBranch(gitStatus) ?? branch;
+  const publishLabel = publishToBaseLabel(baseBranch);
 
   const regenerateSuggestion = () => {
     if (!gitStatus || !gitDiff) return;
@@ -454,7 +456,7 @@ function PublishDialogBody({
                 ? "Save changes"
                 : openPrFromCommits
                   ? "Submit for review"
-                  : "Publish"}
+                  : publishLabel}
             </p>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-green-500" />
@@ -620,8 +622,8 @@ function PublishDialogBody({
                         <span className="font-mono">{baseBranch}</span>
                         {" · "}
                         <span className="text-foreground/80">
-                          Submit for review keeps changes on the branch; Publish
-                          squash-merges into {baseBranch}.
+                          Submit for review keeps changes on the branch;{" "}
+                          {publishLabel} squash-merges into {baseBranch}.
                         </span>
                       </>
                     )}
@@ -693,6 +695,7 @@ function PublishDialogBody({
                   Submit for review
                 </Button>
                 <PublishButton
+                  label={publishLabel}
                   canPublish={canPublish}
                   disabledReason={publishDisabledReason}
                   isPublishing={isPublishing}
@@ -717,12 +720,14 @@ function PublishDialogBody({
 }
 
 function PublishButton({
+  label,
   canPublish,
   disabledReason,
   isPublishing,
   isSubmittingForReview,
   onPublish,
 }: {
+  label: string;
   canPublish: boolean;
   disabledReason: string | null;
   isPublishing: boolean;
@@ -738,7 +743,7 @@ function PublishButton({
       disabled={!canPublish || isPublishing || isSubmittingForReview}
     >
       {isPublishing ? <Loading01 className="h-4 w-4 animate-spin" /> : null}
-      Publish
+      {label}
     </Button>
   );
 

--- a/apps/mesh/src/web/components/thread/github/publish-label.test.ts
+++ b/apps/mesh/src/web/components/thread/github/publish-label.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { publishToBaseLabel } from "./publish-label.ts";
+
+describe("publishToBaseLabel", () => {
+  test("main → Publish to production", () => {
+    expect(publishToBaseLabel("main")).toBe("Publish to production");
+    expect(publishToBaseLabel("Main")).toBe("Publish to production");
+  });
+
+  test("other bases → Publish", () => {
+    expect(publishToBaseLabel("develop")).toBe("Publish");
+    expect(publishToBaseLabel("staging")).toBe("Publish");
+  });
+});

--- a/apps/mesh/src/web/components/thread/github/publish-label.test.ts
+++ b/apps/mesh/src/web/components/thread/github/publish-label.test.ts
@@ -7,6 +7,10 @@ describe("publishToBaseLabel", () => {
     expect(publishToBaseLabel("Main")).toBe("Publish to production");
   });
 
+  test("master → Publish to production", () => {
+    expect(publishToBaseLabel("master")).toBe("Publish to production");
+  });
+
   test("other bases → Publish", () => {
     expect(publishToBaseLabel("develop")).toBe("Publish");
     expect(publishToBaseLabel("staging")).toBe("Publish");

--- a/apps/mesh/src/web/components/thread/github/publish-label.ts
+++ b/apps/mesh/src/web/components/thread/github/publish-label.ts
@@ -1,6 +1,8 @@
+const PRODUCTION_BASE_BRANCHES = new Set(["main", "master"]);
+
 /** Squash-merge / publish action label for a target base branch. */
 export function publishToBaseLabel(base: string): string {
-  return base.trim().toLowerCase() === "main"
+  return PRODUCTION_BASE_BRANCHES.has(base.trim().toLowerCase())
     ? "Publish to production"
     : "Publish";
 }

--- a/apps/mesh/src/web/components/thread/github/publish-label.ts
+++ b/apps/mesh/src/web/components/thread/github/publish-label.ts
@@ -1,0 +1,6 @@
+/** Squash-merge / publish action label for a target base branch. */
+export function publishToBaseLabel(base: string): string {
+  return base.trim().toLowerCase() === "main"
+    ? "Publish to production"
+    : "Publish";
+}

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -53,6 +53,34 @@ describe("mergeBranchMetaWithGitStatus", () => {
       expect(merged.unpushed).toBe(2);
     }
   });
+
+  test("unknown SSE meta + git aheadOfBase → ready with commits vs base", () => {
+    const merged = mergeBranchMetaWithGitStatus(
+      { kind: "unknown" },
+      {
+        ...cleanStatus,
+        aheadOfBase: 3,
+        base: "main",
+        headSha: "abc123",
+      },
+    );
+    expect(merged.kind).toBe("ready");
+    if (merged.kind === "ready") {
+      expect(merged.aheadOfBase).toBe(3);
+      expect(merged.base).toBe("main");
+      expect(merged.headSha).toBe("abc123");
+    }
+  });
+
+  test("raises stale SSE aheadOfBase when git status reports more", () => {
+    const merged = mergeBranchMetaWithGitStatus(
+      { ...readyMeta, aheadOfBase: 0 },
+      { ...cleanStatus, aheadOfBase: 2, base: "main" },
+    );
+    if (merged.kind === "ready") {
+      expect(merged.aheadOfBase).toBe(2);
+    }
+  });
 });
 
 describe("hasUnpublishedWork", () => {

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { BranchMeta } from "@decocms/sandbox/shared";
 import {
+  hasLocalWorkToPush,
   hasUnpublishedWork,
   isDecoOnlyDiff,
   mergeBranchMetaWithGitStatus,
@@ -72,6 +73,14 @@ describe("mergeBranchMetaWithGitStatus", () => {
     }
   });
 
+  test("unknown SSE + empty git status stays unknown", () => {
+    const merged = mergeBranchMetaWithGitStatus(
+      { kind: "unknown" },
+      cleanStatus,
+    );
+    expect(merged.kind).toBe("unknown");
+  });
+
   test("raises stale SSE aheadOfBase when git status reports more", () => {
     const merged = mergeBranchMetaWithGitStatus(
       { ...readyMeta, aheadOfBase: 0 },
@@ -83,20 +92,40 @@ describe("mergeBranchMetaWithGitStatus", () => {
   });
 });
 
+describe("hasLocalWorkToPush", () => {
+  test("false when clean tree with only base diff context", () => {
+    expect(hasLocalWorkToPush(cleanStatus)).toBe(false);
+  });
+
+  test("true when ahead of tracking", () => {
+    expect(hasLocalWorkToPush({ ...cleanStatus, ahead: 1 })).toBe(true);
+  });
+});
+
 describe("hasUnpublishedWork", () => {
   test("true when only unpushed commits exist", () => {
     expect(hasUnpublishedWork({ ...cleanStatus, ahead: 1 }, null)).toBe(true);
   });
 
-  test("true when diff has entries", () => {
+  test("true when working-tree diff has entries", () => {
     const diff: GitDiffResult = {
       diffs: { "a.ts": { from: "a", to: "b" } },
     };
     expect(hasUnpublishedWork(cleanStatus, diff)).toBe(true);
   });
 
-  test("false when clean with no unpushed commits", () => {
+  test("false when clean with no unpushed commits and empty diff", () => {
     expect(hasUnpublishedWork(cleanStatus, { diffs: {} })).toBe(false);
+  });
+});
+
+describe("open-pr push gating", () => {
+  test("base diff alone must not imply unpublished work to push", () => {
+    const baseDiff: GitDiffResult = {
+      diffs: { ".deco/blocks/home.json": { from: "{}", to: "{}" } },
+    };
+    expect(hasLocalWorkToPush(cleanStatus)).toBe(false);
+    expect(hasUnpublishedWork(cleanStatus, baseDiff)).toBe(true);
   });
 });
 

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -236,7 +236,7 @@ export function countGitChanges(status: GitStatus | null): number {
 }
 
 /** True when the working tree or index has uncommitted work. */
-function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
+export function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
   if (!status) return false;
   return (
     countGitChanges(status) > 0 ||
@@ -245,15 +245,24 @@ function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
   );
 }
 
-/** True when there is local work to commit or unpushed commits on the branch. */
+/** True when the branch still needs commit and/or push (ignores base…head PR diff). */
+export function hasLocalWorkToPush(
+  status: GitStatus | null | undefined,
+): boolean {
+  if (!status) return false;
+  return (
+    hasGitLocalWork(status) || status.ahead > 0 || (status.unpushed ?? 0) > 0
+  );
+}
+
+/** True when there is local work to commit, unpushed commits, or working-tree diff paths. */
 export function hasUnpublishedWork(
   status: GitStatus | null | undefined,
   diff: GitDiffResult | null | undefined,
 ): boolean {
   if (!status) return false;
   return (
-    hasGitLocalWork(status) ||
-    status.ahead > 0 ||
+    hasLocalWorkToPush(status) ||
     (diff != null && Object.keys(diff.diffs).length > 0)
   );
 }
@@ -271,7 +280,7 @@ function gitStatusAheadOfBase(gitStatus: GitStatus): number {
 }
 
 function gitStatusBehindBase(gitStatus: GitStatus): number {
-  return gitStatus.behindBase ?? gitStatus.behind;
+  return gitStatus.behindBase ?? 0;
 }
 
 export function mergeBranchMetaWithGitStatus(
@@ -297,12 +306,16 @@ export function mergeBranchMetaWithGitStatus(
       unpushed: Math.max(branchMeta.unpushed, unpushed),
       aheadOfBase: Math.max(branchMeta.aheadOfBase, aheadOfBase),
       behindBase:
-        gitStatus.behindBase !== undefined ? behindBase : branchMeta.behindBase,
+        gitStatus.behindBase !== undefined
+          ? Math.max(branchMeta.behindBase, behindBase)
+          : branchMeta.behindBase,
       headSha: headSha || branchMeta.headSha,
     };
   }
 
-  if (!branchName && !gitDirty && aheadOfBase === 0 && unpushed === 0) {
+  // SSE still unknown — only promote when git reports actionable divergence,
+  // not merely because `git status` can read the checked-out branch name.
+  if (!gitDirty && aheadOfBase === 0 && unpushed === 0) {
     return branchMeta;
   }
 

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -236,7 +236,7 @@ export function countGitChanges(status: GitStatus | null): number {
 }
 
 /** True when the working tree or index has uncommitted work. */
-export function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
+function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
   if (!status) return false;
   return (
     countGitChanges(status) > 0 ||

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -20,6 +20,12 @@ export interface GitStatus {
   current: string | null;
   tracking: string | null;
   detached: boolean;
+  base?: string;
+  aheadOfBase?: number;
+  behindBase?: number;
+  headSha?: string;
+  /** Commits on HEAD not on origin/<branch> (from /git/status). */
+  unpushed?: number;
 }
 
 export interface GitDiffEntry {
@@ -256,6 +262,18 @@ export function hasUnpublishedWork(
  * Merge live `/git/status` into SSE `BranchMeta`. The status endpoint is
  * always fresh; branch SSE can lag when the daemon watcher misses a save.
  */
+function gitStatusUnpushed(gitStatus: GitStatus): number {
+  return Math.max(gitStatus.unpushed ?? 0, gitStatus.ahead);
+}
+
+function gitStatusAheadOfBase(gitStatus: GitStatus): number {
+  return gitStatus.aheadOfBase ?? 0;
+}
+
+function gitStatusBehindBase(gitStatus: GitStatus): number {
+  return gitStatus.behindBase ?? gitStatus.behind;
+}
+
 export function mergeBranchMetaWithGitStatus(
   branchMeta: BranchMeta,
   gitStatus: GitStatus | undefined,
@@ -264,26 +282,38 @@ export function mergeBranchMetaWithGitStatus(
 
   const gitDirty = hasGitLocalWork(gitStatus);
   const branchName = readGitHeadBranch(gitStatus);
+  const unpushed = gitStatusUnpushed(gitStatus);
+  const aheadOfBase = gitStatusAheadOfBase(gitStatus);
+  const behindBase = gitStatusBehindBase(gitStatus);
+  const base = gitStatus.base ?? "main";
+  const headSha = gitStatus.headSha ?? "";
 
   if (branchMeta.kind === "ready") {
     return {
       ...branchMeta,
       branch: branchName ?? branchMeta.branch,
+      base: gitStatus.base ?? branchMeta.base,
       workingTreeDirty: gitDirty,
-      unpushed: Math.max(branchMeta.unpushed, gitStatus.ahead),
+      unpushed: Math.max(branchMeta.unpushed, unpushed),
+      aheadOfBase: Math.max(branchMeta.aheadOfBase, aheadOfBase),
+      behindBase:
+        gitStatus.behindBase !== undefined ? behindBase : branchMeta.behindBase,
+      headSha: headSha || branchMeta.headSha,
     };
   }
 
-  if (!branchName && !gitDirty) return branchMeta;
+  if (!branchName && !gitDirty && aheadOfBase === 0 && unpushed === 0) {
+    return branchMeta;
+  }
 
   return {
     kind: "ready",
     branch: branchName ?? "",
-    base: "main",
+    base,
     workingTreeDirty: gitDirty,
-    unpushed: gitStatus.ahead,
-    aheadOfBase: 0,
-    behindBase: gitStatus.behind,
-    headSha: "",
+    unpushed,
+    aheadOfBase,
+    behindBase,
+    headSha,
   };
 }

--- a/packages/sandbox/daemon/git/branch-divergence.ts
+++ b/packages/sandbox/daemon/git/branch-divergence.ts
@@ -9,35 +9,33 @@ export interface BranchDivergenceFields {
   unpushed: number;
 }
 
+export type GitTryRunner = (args: string[]) => string | null;
+
 function gitEnv(repoDir: string): Record<string, string> {
   return { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
 }
 
-function runGit(repoDir: string, args: string[]): string {
-  return git(args, { cwd: repoDir, env: gitEnv(repoDir) });
-}
-
-function tryGit(repoDir: string, args: string[]): string | null {
+function defaultTryGit(repoDir: string, args: string[]): string | null {
   try {
-    return runGit(repoDir, args);
+    return git(args, { cwd: repoDir, env: gitEnv(repoDir) });
   } catch {
     return null;
   }
 }
 
-/** Divergence vs default base branch — same rules as BranchStatusMonitor. */
+/** Divergence vs default base branch — shared by HTTP /git/status and BranchStatusMonitor. */
 export function computeBranchDivergence(
   repoDir: string,
+  tryGit: GitTryRunner = (args) => defaultTryGit(repoDir, args),
 ): BranchDivergenceFields {
   let base =
-    tryGit(repoDir, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]) ??
-    "";
+    tryGit(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]) ?? "";
   if (base.startsWith("origin/")) base = base.slice("origin/".length);
   if (!base) base = "main";
 
-  const branch = tryGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]) ?? "";
+  const branch = tryGit(["rev-parse", "--abbrev-ref", "HEAD"]) ?? "";
   const refExists = (ref: string) =>
-    tryGit(repoDir, ["rev-parse", "--verify", "--quiet", ref]) !== null;
+    tryGit(["rev-parse", "--verify", "--quiet", ref]) !== null;
 
   const branchRef =
     branch && refExists(`origin/${branch}`) ? `origin/${branch}` : "HEAD";
@@ -45,14 +43,14 @@ export function computeBranchDivergence(
   let unpushed = 0;
   if (branch && branchRef === `origin/${branch}`) {
     unpushed = Number(
-      tryGit(repoDir, ["rev-list", "--count", `${branchRef}..HEAD`]) ?? "0",
+      tryGit(["rev-list", "--count", `${branchRef}..HEAD`]) ?? "0",
     );
   }
 
   let aheadOfBase = 0;
   let behindBase = 0;
   if (refExists(`origin/${base}`)) {
-    const lr = tryGit(repoDir, [
+    const lr = tryGit([
       "rev-list",
       "--left-right",
       "--count",
@@ -65,7 +63,7 @@ export function computeBranchDivergence(
     }
   }
 
-  const headSha = tryGit(repoDir, ["rev-parse", branchRef]) ?? "";
+  const headSha = tryGit(["rev-parse", branchRef]) ?? "";
 
   return { base, aheadOfBase, behindBase, headSha, unpushed };
 }

--- a/packages/sandbox/daemon/git/branch-divergence.ts
+++ b/packages/sandbox/daemon/git/branch-divergence.ts
@@ -34,11 +34,15 @@ export function computeBranchDivergence(
   if (!base) base = "main";
 
   const branch = tryGit(["rev-parse", "--abbrev-ref", "HEAD"]) ?? "";
+  if (!branch || branch === "HEAD") {
+    const headSha = tryGit(["rev-parse", "HEAD"]) ?? "";
+    return { base, aheadOfBase: 0, behindBase: 0, headSha, unpushed: 0 };
+  }
+
   const refExists = (ref: string) =>
     tryGit(["rev-parse", "--verify", "--quiet", ref]) !== null;
 
-  const branchRef =
-    branch && refExists(`origin/${branch}`) ? `origin/${branch}` : "HEAD";
+  const branchRef = refExists(`origin/${branch}`) ? `origin/${branch}` : "HEAD";
 
   let unpushed = 0;
   if (branch && branchRef === `origin/${branch}`) {

--- a/packages/sandbox/daemon/git/branch-divergence.ts
+++ b/packages/sandbox/daemon/git/branch-divergence.ts
@@ -1,0 +1,71 @@
+import { git } from "../setup/git";
+
+export interface BranchDivergenceFields {
+  base: string;
+  aheadOfBase: number;
+  behindBase: number;
+  headSha: string;
+  /** Commits on HEAD not on `origin/<current branch>`. */
+  unpushed: number;
+}
+
+function gitEnv(repoDir: string): Record<string, string> {
+  return { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
+}
+
+function runGit(repoDir: string, args: string[]): string {
+  return git(args, { cwd: repoDir, env: gitEnv(repoDir) });
+}
+
+function tryGit(repoDir: string, args: string[]): string | null {
+  try {
+    return runGit(repoDir, args);
+  } catch {
+    return null;
+  }
+}
+
+/** Divergence vs default base branch — same rules as BranchStatusMonitor. */
+export function computeBranchDivergence(
+  repoDir: string,
+): BranchDivergenceFields {
+  let base =
+    tryGit(repoDir, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]) ??
+    "";
+  if (base.startsWith("origin/")) base = base.slice("origin/".length);
+  if (!base) base = "main";
+
+  const branch = tryGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]) ?? "";
+  const refExists = (ref: string) =>
+    tryGit(repoDir, ["rev-parse", "--verify", "--quiet", ref]) !== null;
+
+  const branchRef =
+    branch && refExists(`origin/${branch}`) ? `origin/${branch}` : "HEAD";
+
+  let unpushed = 0;
+  if (branch && branchRef === `origin/${branch}`) {
+    unpushed = Number(
+      tryGit(repoDir, ["rev-list", "--count", `${branchRef}..HEAD`]) ?? "0",
+    );
+  }
+
+  let aheadOfBase = 0;
+  let behindBase = 0;
+  if (refExists(`origin/${base}`)) {
+    const lr = tryGit(repoDir, [
+      "rev-list",
+      "--left-right",
+      "--count",
+      `origin/${base}...${branchRef}`,
+    ]);
+    const m = lr?.match(/^(\d+)\s+(\d+)$/);
+    if (m) {
+      behindBase = Number(m[1]);
+      aheadOfBase = Number(m[2]);
+    }
+  }
+
+  const headSha = tryGit(repoDir, ["rev-parse", branchRef]) ?? "";
+
+  return { base, aheadOfBase, behindBase, headSha, unpushed };
+}

--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { Broadcaster } from "../events/broadcast";
 import type { BranchMeta } from "../events/types";
 import type { Config } from "../types";
+import { computeBranchDivergence } from "./branch-divergence";
 import { gitSync as rawGitSync } from "./git-sync";
 import { parsePorcelainZ } from "./porcelain";
 
@@ -231,15 +232,17 @@ export class BranchStatusMonitor {
   }
 
   private compute(): Extract<BranchMeta, { kind: "ready" }> | null {
-    const run = (args: string[]) => this.runGit(args);
-    const refExists = (ref: string) =>
-      run(["rev-parse", "--verify", "--quiet", ref]).length > 0;
     try {
-      const branch = run(["rev-parse", "--abbrev-ref", "HEAD"]);
+      const branch = this.runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
       if (!branch || branch === "HEAD") return null;
-      let base = run(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
-      if (base.startsWith("origin/")) base = base.slice("origin/".length);
-      if (!base) base = "main";
+
+      const tryGit = (args: string[]) => {
+        const out = this.runGit(args);
+        return out.length > 0 ? out : null;
+      };
+      const { base, unpushed, aheadOfBase, behindBase, headSha } =
+        computeBranchDivergence(this.config.repoDir, tryGit);
+
       const dirtyPaths = this.readDirtyPaths();
       const baseline = this.dirtyBaseline;
       const { dirty, changedPaths } = this.isWorkingTreeDirty(dirtyPaths);
@@ -253,31 +256,7 @@ export class BranchStatusMonitor {
           workingTreeDirty: dirty,
         });
       }
-      const branchRef = refExists(`origin/${branch}`)
-        ? `origin/${branch}`
-        : "HEAD";
-      const unpushed =
-        branchRef === `origin/${branch}`
-          ? Number(
-              run(["rev-list", "--count", `origin/${branch}..HEAD`]) || "0",
-            )
-          : 0;
-      let aheadOfBase = 0;
-      let behindBase = 0;
-      if (refExists(`origin/${base}`)) {
-        const lr = run([
-          "rev-list",
-          "--left-right",
-          "--count",
-          `origin/${base}...${branchRef}`,
-        ]);
-        const m = lr.match(/^(\d+)\s+(\d+)$/);
-        if (m) {
-          behindBase = Number(m[1]);
-          aheadOfBase = Number(m[2]);
-        }
-      }
-      const headSha = run(["rev-parse", branchRef]);
+
       return {
         kind: "ready",
         branch,

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -39,6 +39,42 @@ describe("git routes", () => {
     expect(body.modified).toContain("README.md");
   });
 
+  it("status reports aheadOfBase on a feature branch", async () => {
+    const { appRoot, repoDir } = initRepo();
+    gitSync(["checkout", "-b", "feat/test"], { cwd: repoDir, asUser: false });
+    writeFileSync(join(repoDir, "feature.txt"), "x\n");
+    gitSync(["add", "feature.txt"], { cwd: repoDir, asUser: false });
+    gitSync(["commit", "-m", "feature"], { cwd: repoDir, asUser: false });
+    const mainSha = gitSync(["rev-parse", "main"], {
+      cwd: repoDir,
+      asUser: false,
+    }).trim();
+    gitSync(["update-ref", "refs/remotes/origin/main", mainSha], {
+      cwd: repoDir,
+      asUser: false,
+    });
+    const featureSha = gitSync(["rev-parse", "HEAD"], {
+      cwd: repoDir,
+      asUser: false,
+    }).trim();
+    gitSync(["update-ref", "refs/remotes/origin/feat/test", featureSha], {
+      cwd: repoDir,
+      asUser: false,
+    });
+
+    const handler = makeGitStatusHandler({ appRoot, repoDir });
+    const res = await handler(new Request("http://x/git/status"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      aheadOfBase: number;
+      base: string;
+      current: string | null;
+    };
+    expect(body.current).toBe("feat/test");
+    expect(body.base).toBe("main");
+    expect(body.aheadOfBase).toBeGreaterThan(0);
+  });
+
   it("diff returns before/after content", async () => {
     const { appRoot, repoDir } = initRepo();
     writeFileSync(join(repoDir, "README.md"), "hello world\n");

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -83,7 +83,13 @@ export interface GitDiffResult {
   mergeBaseSha?: string;
 }
 
-function computeStatus(repoDir: string): GitStatusResult {
+/** Porcelain + upstream tracking only — no base-branch divergence (expensive). */
+function computeWorkingTreeStatus(
+  repoDir: string,
+): Omit<
+  GitStatusResult,
+  "base" | "aheadOfBase" | "behindBase" | "headSha" | "unpushed"
+> {
   const porcelain = runGit(repoDir, ["status", "--porcelain=v1", "-z"]);
   const files: GitStatusFile[] = parsePorcelainFiles(porcelain);
 
@@ -131,8 +137,6 @@ function computeStatus(repoDir: string): GitStatusResult {
     }
   }
 
-  const divergence = computeBranchDivergence(repoDir);
-
   return {
     not_added,
     conflicted,
@@ -147,12 +151,13 @@ function computeStatus(repoDir: string): GitStatusResult {
     current: branch,
     tracking,
     detached,
-    base: divergence.base,
-    aheadOfBase: divergence.aheadOfBase,
-    behindBase: divergence.behindBase,
-    headSha: divergence.headSha,
-    unpushed: divergence.unpushed,
   };
+}
+
+function computeStatus(repoDir: string): GitStatusResult {
+  const working = computeWorkingTreeStatus(repoDir);
+  const divergence = computeBranchDivergence(repoDir);
+  return { ...working, ...divergence };
 }
 
 function readWorkingFile(repoDir: string, filePath: string): string | null {
@@ -173,7 +178,7 @@ function readRefFile(
 }
 
 function computeDiff(repoDir: string): GitDiffResult {
-  const status = computeStatus(repoDir);
+  const status = computeWorkingTreeStatus(repoDir);
   const paths = [
     ...new Set(status.files.map((f) => f.path).filter((p) => p.length > 0)),
   ];
@@ -302,7 +307,7 @@ const SKIP_HOOKS_ENV: Record<string, string> = {
   HUSKY: "0",
 };
 
-function changedPathsFromStatus(status: GitStatusResult): string[] {
+function changedPathsFromStatus(status: { files: GitStatusFile[] }): string[] {
   return [
     ...new Set(status.files.map((f) => f.path).filter((p) => p.length > 0)),
   ];
@@ -327,7 +332,7 @@ function publish(deps: GitDeps, message: string): { pushed: boolean } {
     throw new Error("Cannot publish from a detached HEAD");
   }
 
-  const status = computeStatus(repoDir);
+  const status = computeWorkingTreeStatus(repoDir);
   const paths = changedPathsFromStatus(status);
   if (paths.length > 0) {
     runGit(repoDir, ["add", "--", ...paths]);
@@ -364,7 +369,7 @@ function publish(deps: GitDeps, message: string): { pushed: boolean } {
 function discard(deps: GitDeps, filepaths: string[]): void {
   const repoDir = deps.repoDir;
   const validated = filepaths.map((fp) => resolveRepoRelativePath(deps, fp));
-  const status = computeStatus(repoDir);
+  const status = computeWorkingTreeStatus(repoDir);
   const toRestore: string[] = [];
   const toDelete: string[] = [];
 

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -1,6 +1,7 @@
 import fs, { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { computeBranchDivergence } from "../git/branch-divergence";
 import { parsePorcelainFiles } from "../git/porcelain";
 import { rebaseOntoBase } from "../git/rebase-onto-base";
 import {
@@ -59,6 +60,16 @@ export interface GitStatusResult {
   current: string | null;
   tracking: string | null;
   detached: boolean;
+  /** Default branch (e.g. main) from origin/HEAD. */
+  base: string;
+  /** Commits on branch not in origin/<base>. */
+  aheadOfBase: number;
+  /** Commits in origin/<base> not in branch. */
+  behindBase: number;
+  /** Resolved ref for divergence (origin/<branch> or HEAD). */
+  headSha: string;
+  /** Commits on HEAD not in origin/<current branch>. */
+  unpushed: number;
 }
 
 export interface GitDiffEntry {
@@ -120,6 +131,8 @@ function computeStatus(repoDir: string): GitStatusResult {
     }
   }
 
+  const divergence = computeBranchDivergence(repoDir);
+
   return {
     not_added,
     conflicted,
@@ -134,6 +147,11 @@ function computeStatus(repoDir: string): GitStatusResult {
     current: branch,
     tracking,
     detached,
+    base: divergence.base,
+    aheadOfBase: divergence.aheadOfBase,
+    behindBase: divergence.behindBase,
+    headSha: divergence.headSha,
+    unpushed: divergence.unpushed,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Submit for review modal**: When commits are already on the branch (no local dirty state), open the dialog in `open-pr` mode with a base-branch diff so Submit/Publish/Regenerate work instead of showing 0 changes and disabled buttons.
- **Save changes modal**: Footer follows `dialogIntent` from the header (`publish` → single Save changes button; `open-pr` → Submit for review + Publish).
- **Regenerate**: `suggest-commit-message` uses paths from `diff.diffs` when the working tree is clean (fixes "No changes" after commit).
- **Header after refresh**: `/git/status` includes `aheadOfBase`, `behindBase`, `base`, `headSha`, and `unpushed`; `mergeBranchMetaWithGitStatus` no longer synthesizes `aheadOfBase: 0` before SSE, so **Submit for review** stays visible instead of **Up to date**.

## Test plan

- [x] `bun test` on `sandbox-git-api.test.ts`, `panel-state.test.ts`, `suggest-commit-message.test.ts`, `packages/sandbox/daemon/routes/git.test.ts`
- [ ] Commit on branch without PR → header **Submit for review** → modal shows diff vs base, Regenerate fills title/body, Submit works
- [ ] Refresh page with unpushed commits vs base → header still **Submit for review** (not **Up to date**)
- [ ] Local dirty changes → header **Save changes** → modal footer **Save changes**
- [ ] Open PR + local edits → **Save changes** commits/pushes to update PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub publish flow and header state, adds base…head diffs when commits already exist, and labels main/master merges as “Publish to production.” Also hardens push gating, suggest‑commit, and divergence reporting so we never push on base‑only diffs and header state survives refresh.

- **Bug Fixes**
  - Submit for review opens in open‑pr mode for clean trees with a base‑branch diff; Regenerate uses diff paths, and fallback suggestions classify add/delete for diff‑only changes.
  - Header action persists after refresh via real divergence from `/git/status`; SSE stays unknown until git reports dirty/unpushed/ahead; detached HEAD is safely handled.
  - Open‑PR flow only pushes when there’s local work (`hasLocalWorkToPush`); base‑only diffs never trigger a push.
  - Suggest‑commit route validates branch, enforces a 512 KB body limit, and always fetches status+diff on the server.

- **New Features**
  - `/git/status` returns `base`, `aheadOfBase`, `behindBase`, `headSha`, and `unpushed` using shared daemon‑level divergence.
  - Publish dialog supports base…head diffs for PRs from existing commits and shows “Publish to production” across the header, dialog, and merge button.

<sup>Written for commit 505bd4239e087480c05c8f0686d4cf8e7fb68488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

