### PR TITLE
feat(sections-editor): clearer global section editing + clickable hide toggle

### DIFF
--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -1,6 +1,13 @@
 @import "@deco/ui/styles/global.css";
 @import "@daveyplate/better-auth-ui/css";
 
+@theme {
+  /* Global/reusable section indicator — purple hue 289 */
+  --color-global-section: oklch(0.7278 0.151 289);
+  --color-global-section-fg: oklch(0.45 0.15 289);
+  --color-global-section-fg-dark: oklch(0.78 0.15 289);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -815,7 +815,7 @@ export function PreviewContent() {
                     onClick={() => setPagesOpen((prev) => !prev)}
                   >
                     {activeGlobalSection && (
-                      <span className="shrink-0 inline-flex items-center gap-1 rounded bg-[oklch(0.7278_0.151_289/0.14)] px-1.5 py-0.5 text-[11px] font-medium text-[oklch(0.45_0.15_289)] dark:text-[oklch(0.78_0.15_289)]">
+                      <span className="shrink-0 inline-flex items-center gap-1 rounded bg-global-section/14 px-1.5 py-0.5 text-[11px] font-medium text-global-section-fg dark:text-global-section-fg-dark">
                         <Globe02 size={11} />
                         Global
                       </span>

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -814,6 +814,12 @@ export function PreviewContent() {
                     className="flex h-8 w-full min-w-0 items-center gap-1 rounded-md bg-background px-2 transition-colors duration-200 hover:bg-accent"
                     onClick={() => setPagesOpen((prev) => !prev)}
                   >
+                    {activeGlobalSection && (
+                      <span className="shrink-0 inline-flex items-center gap-1 rounded bg-[oklch(0.7278_0.151_289/0.14)] px-1.5 py-0.5 text-[11px] font-medium text-[oklch(0.45_0.15_289)] dark:text-[oklch(0.78_0.15_289)]">
+                        <Globe02 size={11} />
+                        Global
+                      </span>
+                    )}
                     <span className="min-w-0 flex-1 truncate text-left text-[12px] text-foreground/88">
                       {previewLabel}
                     </span>

--- a/apps/mesh/src/web/components/sections-editor/add-section-modal.tsx
+++ b/apps/mesh/src/web/components/sections-editor/add-section-modal.tsx
@@ -173,7 +173,7 @@ function SectionGalleryCard({
         "group flex flex-col overflow-hidden rounded-lg border bg-card text-left transition-colors",
         "hover:border-primary/40 hover:bg-accent/30",
         entry.isSavedBlock &&
-          "border-[oklch(0.7278_0.151_289/0.35)] hover:bg-[oklch(0.7278_0.151_289/0.08)]",
+          "border-global-section/35 hover:bg-global-section/8",
       )}
     >
       <LazySectionPreview

--- a/apps/mesh/src/web/components/sections-editor/parse-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/parse-sections.ts
@@ -1,5 +1,9 @@
 import { isLazyResolveType } from "./section-lazy";
-import { labelFromResolveType, type RawSection } from "./section-types";
+import {
+  labelFromResolveType,
+  NEVER_MATCHER_RESOLVE_TYPE,
+  type RawSection,
+} from "./section-types";
 
 export interface ParsedSection {
   index: number;
@@ -48,12 +52,10 @@ export function parseSections(
       const mvObj = (isLazy ? innerSection : s) as RawSection;
       const rawVariants = Array.isArray(mvObj?.variants) ? mvObj.variants : [];
 
-      const NEVER_TYPES = ["website/matchers/never.ts"];
       if (
         rawVariants.length === 1 &&
-        NEVER_TYPES.includes(
-          (rawVariants[0]?.rule?.__resolveType as string) ?? "",
-        )
+        ((rawVariants[0]?.rule?.__resolveType as string) ?? "") ===
+          NEVER_MATCHER_RESOLVE_TYPE
       ) {
         const innerValue = (rawVariants[0]?.value ?? {}) as Record<
           string,

--- a/apps/mesh/src/web/components/sections-editor/parse-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/parse-sections.ts
@@ -2,6 +2,8 @@ import { isLazyResolveType } from "./section-lazy";
 import {
   labelFromResolveType,
   NEVER_MATCHER_RESOLVE_TYPE,
+  PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
+  SECTION_MULTIVARIATE_RESOLVE_TYPE,
   type RawSection,
 } from "./section-types";
 
@@ -48,7 +50,10 @@ export function parseSections(
       : undefined;
     const mvRt = isLazy ? (innerSection?.__resolveType ?? "") : rt;
 
-    if (mvRt.includes("flags/multivariate")) {
+    if (
+      mvRt === PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE ||
+      mvRt === SECTION_MULTIVARIATE_RESOLVE_TYPE
+    ) {
       const mvObj = (isLazy ? innerSection : s) as RawSection;
       const rawVariants = Array.isArray(mvObj?.variants) ? mvObj.variants : [];
 

--- a/apps/mesh/src/web/components/sections-editor/section-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-list.tsx
@@ -48,9 +48,9 @@ import { parseSections, type ParsedSection } from "./parse-sections";
 export { parseSections, type ParsedSection, type RawSection };
 
 const GLOBAL_SECTION_ROW_CLASS =
-  "text-[oklch(0.45_0.15_289)] hover:bg-[oklch(0.7278_0.151_289/0.12)] dark:text-[oklch(0.78_0.15_289)] dark:hover:bg-[oklch(0.7278_0.151_289/0.15)]";
+  "text-global-section-fg hover:bg-global-section/12 dark:text-global-section-fg-dark dark:hover:bg-global-section/15";
 const GLOBAL_SECTION_MENU_ITEM_CLASS =
-  "text-[oklch(0.45_0.15_289)] focus:bg-[oklch(0.7278_0.151_289/0.12)] focus:text-[oklch(0.45_0.15_289)] dark:text-[oklch(0.78_0.15_289)] dark:focus:bg-[oklch(0.7278_0.151_289/0.15)] dark:focus:text-[oklch(0.78_0.15_289)] [&_svg]:!text-[oklch(0.7278_0.151_289)]";
+  "text-global-section-fg focus:bg-global-section/12 focus:text-global-section-fg dark:text-global-section-fg-dark dark:focus:bg-global-section/15 dark:focus:text-global-section-fg-dark [&_svg]:!text-global-section";
 
 interface SectionEntry {
   id: string;
@@ -197,6 +197,7 @@ function SortableSectionItem({
             onToggleHidden();
           }}
           onPointerDown={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
         >
           {section.isHidden ? <EyeOff size={14} /> : <Eye size={14} />}
         </Button>

--- a/apps/mesh/src/web/components/sections-editor/section-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-list.tsx
@@ -96,11 +96,6 @@ function SectionRowContent({ section }: { section: ParsedSection }) {
       >
         {section.label}
       </span>
-      {section.isHidden ? (
-        <EyeOff className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-      ) : (
-        <Eye className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60 opacity-0 group-hover:opacity-100" />
-      )}
       {section.isLazy && (
         <Zap className="h-3.5 w-3.5 shrink-0 text-yellow-500" />
       )}
@@ -134,6 +129,7 @@ function SortableSectionItem({
   onDelete,
   onDuplicate,
   onMakeReusable,
+  onToggleHidden,
 }: {
   section: ParsedSection;
   sortableId: string;
@@ -142,6 +138,7 @@ function SortableSectionItem({
   onDelete: () => void;
   onDuplicate: () => void;
   onMakeReusable: () => void;
+  onToggleHidden: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useSortable({
@@ -180,6 +177,30 @@ function SortableSectionItem({
       )}
     >
       <SectionRowContent section={section} />
+
+      {!section.isMultivariate && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={
+            section.isHidden ? `Show ${section.label}` : `Hide ${section.label}`
+          }
+          className={cn(
+            "size-6 shrink-0 transition-opacity",
+            section.isHidden
+              ? "opacity-100"
+              : "opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100",
+          )}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleHidden();
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {section.isHidden ? <EyeOff size={14} /> : <Eye size={14} />}
+        </Button>
+      )}
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -244,6 +265,7 @@ export function SectionList({
   onDelete,
   onDuplicate,
   onMakeReusable,
+  onToggleHidden,
   onAddSection,
   canAddSection = true,
 }: {
@@ -255,6 +277,7 @@ export function SectionList({
   onDelete: (index: number) => void;
   onDuplicate: (index: number) => void;
   onMakeReusable: (index: number) => void;
+  onToggleHidden: (index: number) => void;
   onAddSection: () => void;
   canAddSection?: boolean;
 }) {
@@ -381,6 +404,7 @@ export function SectionList({
                 onDelete={() => onDelete(entry.section.index)}
                 onDuplicate={() => onDuplicate(entry.section.index)}
                 onMakeReusable={() => onMakeReusable(entry.section.index)}
+                onToggleHidden={() => onToggleHidden(entry.section.index)}
               />
             ))}
           </div>

--- a/apps/mesh/src/web/components/sections-editor/section-types.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-types.ts
@@ -12,8 +12,15 @@ export const GLOBAL_SECTION_ICON_COLOR = "oklch(0.7278 0.151 289)";
 
 export const ALWAYS_MATCHER_RESOLVE_TYPE = "website/matchers/always.ts";
 
+/** Matcher that never matches — used to hide a section from the live site. */
+export const NEVER_MATCHER_RESOLVE_TYPE = "website/matchers/never.ts";
+
 export const PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE =
   "website/flags/multivariate.ts";
+
+/** Multivariate wrapper for a single section (used for variants and hiding). */
+export const SECTION_MULTIVARIATE_RESOLVE_TYPE =
+  "website/flags/multivariate/section.ts";
 
 /** Human label from a deco resolve type path or block id. */
 export function labelFromResolveType(rt: string): string {

--- a/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
@@ -4,13 +4,16 @@ import {
   duplicateMultivariateSectionVariant,
   flattenMultivariateSection,
   getMultivariateSectionObject,
+  hideSection,
   isDefaultVariantRule,
   parseSectionFlagVariants,
   pickVariantToKeepIndex,
+  showSection,
   unwrapVariantSectionValue,
   updateMultivariateSectionVariantValue,
   writeVariantSectionValue,
 } from "./section-variants";
+import { parseSections } from "./parse-sections";
 
 describe("section-variants", () => {
   it("getMultivariateSectionObject unwraps lazy multivariate sections", () => {
@@ -244,5 +247,39 @@ describe("section-variants", () => {
         title: "Default",
       },
     });
+  });
+
+  it("hideSection produces a section parsed as hidden", () => {
+    const hidden = hideSection({
+      __resolveType: "site/sections/Hero.tsx",
+      title: "Hero",
+    });
+
+    expect(parseSections([hidden], {})[0]?.isHidden).toBe(true);
+  });
+
+  it("hideSection/showSection round-trips normal, lazy, and saved-block sections", () => {
+    const cases = [
+      { __resolveType: "site/sections/Hero.tsx", title: "Hero" },
+      {
+        __resolveType: "website/sections/Rendering/Lazy.tsx",
+        section: { __resolveType: "site/sections/Hero.tsx", title: "Lazy" },
+      },
+      { __resolveType: "Header" },
+    ];
+
+    for (const original of cases) {
+      const restored = showSection(hideSection(original as never));
+      expect(restored).toEqual(original as never);
+    }
+  });
+
+  it("showSection returns null when there is no hidden value", () => {
+    expect(
+      showSection({
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [],
+      } as never),
+    ).toBeNull();
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
@@ -258,13 +258,18 @@ describe("section-variants", () => {
     expect(parseSections([hidden], {})[0]?.isHidden).toBe(true);
   });
 
-  it("hideSection/showSection round-trips normal, lazy, and saved-block sections", () => {
+  it("hideSection/showSection round-trips normal, lazy-outer, and saved-block sections", () => {
+    // hideSection wraps outside the lazy shell, so the lazy section is stored
+    // verbatim as variants[0].value — showSection extracts it directly without
+    // touching the outerLazy branch.
     const cases = [
       { __resolveType: "site/sections/Hero.tsx", title: "Hero" },
       {
         __resolveType: "website/sections/Rendering/Lazy.tsx",
         section: { __resolveType: "site/sections/Hero.tsx", title: "Lazy" },
       },
+      // saved-block: bare resolve-type key with no "/"; showSection has no
+      // special saved-block logic — it extracts variants[0].value like any section.
       { __resolveType: "Header" },
     ];
 
@@ -274,7 +279,49 @@ describe("section-variants", () => {
     }
   });
 
-  it("showSection returns null when there is no hidden value", () => {
+  it("showSection unwraps a lazy-outer hidden section (outerLazy branch)", () => {
+    // Data shape: lazy(multivariate(never(section))) — the multivariate lives
+    // inside the lazy shell rather than outside. showSection's outerLazy branch
+    // handles this by peering into raw.section before reading variants.
+    const lazyOuter = {
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            value: { __resolveType: "site/sections/Hero.tsx", title: "Inner" },
+            rule: { __resolveType: "website/matchers/never.ts" },
+          },
+        ],
+      },
+    };
+    expect(showSection(lazyOuter as never)).toEqual({
+      __resolveType: "site/sections/Hero.tsx",
+      title: "Inner",
+    });
+  });
+
+  it("showSection returns null when the section is not hidden (no never rule)", () => {
+    expect(
+      showSection({ __resolveType: "site/sections/Hero.tsx" } as never),
+    ).toBeNull();
+  });
+
+  it("showSection returns null when the variant rule is not a never matcher", () => {
+    expect(
+      showSection({
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            value: { __resolveType: "site/sections/Hero.tsx" },
+            rule: { __resolveType: "website/matchers/always.ts" },
+          },
+        ],
+      } as never),
+    ).toBeNull();
+  });
+
+  it("showSection returns null when there are no variants", () => {
     expect(
       showSection({
         __resolveType: "website/flags/multivariate/section.ts",

--- a/apps/mesh/src/web/components/sections-editor/section-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.ts
@@ -31,7 +31,14 @@ export function showSection(raw: RawSection): RawSection | null {
   const variants = mvObj?.variants as
     | Array<Record<string, unknown>>
     | undefined;
-  return (variants?.[0]?.value as RawSection | undefined) ?? null;
+  const first = variants?.[0];
+  const rule = first?.rule as Record<string, unknown> | undefined;
+  if (
+    (rule?.__resolveType as string | undefined) !== NEVER_MATCHER_RESOLVE_TYPE
+  ) {
+    return null;
+  }
+  return (first?.value as RawSection | undefined) ?? null;
 }
 
 export interface SectionFlagVariant {

--- a/apps/mesh/src/web/components/sections-editor/section-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.ts
@@ -1,7 +1,38 @@
 import { isLazyResolveType } from "./section-lazy";
-import type { RawSection } from "./section-types";
+import {
+  NEVER_MATCHER_RESOLVE_TYPE,
+  SECTION_MULTIVARIATE_RESOLVE_TYPE,
+  type RawSection,
+} from "./section-types";
 
 export type { RawSection };
+
+/**
+ * Wrap a section in a multivariate block gated by a `never` matcher so it never
+ * renders on the live site. Parses back as `isHidden`. The original section is
+ * preserved verbatim as the variant value, so {@link showSection} can restore
+ * it exactly — works for normal, lazy, and saved-block sections alike.
+ */
+export function hideSection(raw: RawSection): RawSection {
+  return {
+    __resolveType: SECTION_MULTIVARIATE_RESOLVE_TYPE,
+    variants: [
+      { value: raw, rule: { __resolveType: NEVER_MATCHER_RESOLVE_TYPE } },
+    ],
+  } as RawSection;
+}
+
+/** Unwrap a hidden section back to the section it was hiding, or null. */
+export function showSection(raw: RawSection): RawSection | null {
+  const outerLazy = isLazyResolveType(raw.__resolveType);
+  const mvObj = (outerLazy ? raw.section : raw) as
+    | Record<string, unknown>
+    | undefined;
+  const variants = mvObj?.variants as
+    | Array<Record<string, unknown>>
+    | undefined;
+  return (variants?.[0]?.value as RawSection | undefined) ?? null;
+}
 
 export interface SectionFlagVariant {
   label: string;

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -35,7 +35,11 @@ import { MakeReusableModal } from "./make-reusable-modal";
 import { AddSectionModal } from "./add-section-modal";
 import type { SectionCatalogEntry } from "./section-catalog";
 import { SectionVariantList } from "./section-variant-list";
-import { ALWAYS_MATCHER_RESOLVE_TYPE, type RawSection } from "./section-types";
+import {
+  ALWAYS_MATCHER_RESOLVE_TYPE,
+  labelFromResolveType,
+  type RawSection,
+} from "./section-types";
 import {
   buildMatcherBlockData,
   buildMatcherBlockReference,
@@ -82,17 +86,6 @@ const VARIANT_TAB_ACTIVE_CLASS =
 
 const capitalize = (s: string) =>
   s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
-
-function labelFromResolveType(rt: string): string {
-  const segments = rt.split("/");
-  const filename = segments[segments.length - 1] ?? rt;
-  return (
-    filename
-      .replace(/\.(tsx?|jsx?)$/, "")
-      .replace(/[-_]/g, " ")
-      .replace(/\b\w/g, (c) => c.toUpperCase()) || rt
-  );
-}
 
 /**
  * Render a `start`/`end` ISO-date pair as a compact range — used by deco's
@@ -1793,7 +1786,7 @@ export function SectionsEditor({
             className={cn(
               "border-b px-3 py-2.5",
               showGlobalBanner &&
-                "border-[oklch(0.7278_0.151_289/0.22)] bg-[oklch(0.7278_0.151_289/0.12)] dark:bg-[oklch(0.7278_0.151_289/0.16)]",
+                "border-global-section/22 bg-global-section/12 dark:bg-global-section/16",
             )}
           >
             <div className="flex min-w-0 items-center gap-2 overflow-hidden">
@@ -1843,13 +1836,13 @@ export function SectionsEditor({
                           "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors",
                           isLast
                             ? showGlobalBanner
-                              ? "font-semibold text-[oklch(0.45_0.15_289)] dark:text-[oklch(0.78_0.15_289)]"
+                              ? "font-semibold text-global-section-fg dark:text-global-section-fg-dark"
                               : "font-medium text-foreground"
                             : showGlobalBanner
                               ? "text-foreground/80"
                               : "text-muted-foreground",
                           showGlobalBanner
-                            ? "hover:bg-[oklch(0.7278_0.151_289/0.15)]"
+                            ? "hover:bg-global-section/15"
                             : "hover:bg-accent hover:text-accent-foreground",
                         )}
                       >
@@ -1863,7 +1856,7 @@ export function SectionsEditor({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="shrink-0 cursor-help">
-                      <Globe01 className="size-4 text-[oklch(0.45_0.15_289)] dark:text-[oklch(0.78_0.15_289)]" />
+                      <Globe01 className="size-4 text-global-section-fg dark:text-global-section-fg-dark" />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent side="bottom" className="max-w-[260px]">

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -4,6 +4,7 @@ import {
   ChevronRight,
   ChevronUp,
   Flag01,
+  Globe01,
   Loading01,
 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -65,8 +66,10 @@ import {
   duplicateMultivariateSectionVariant,
   flattenMultivariateSection,
   getMultivariateSectionObject,
+  hideSection,
   parseSectionFlagVariants,
   rebuildSectionWithMultivariate,
+  showSection,
   unwrapVariantSectionValue,
   updateMultivariateSectionVariantRule,
   updateMultivariateSectionVariantValue,
@@ -941,6 +944,26 @@ export function SectionsEditor({
     savePageSections(updatedSections);
   };
 
+  // Hide/show a section via the multivariate+never wrapper (see hideSection /
+  // showSection). Round-trips normal, lazy, and saved-block sections.
+  // Multivariate sections (real variants) are managed through the variant UI.
+  const handleToggleHidden = (index: number) => {
+    if (!activePageKey) return;
+    const rawSection = rawSections[index];
+    const parsed = parsedSections[index];
+    if (!rawSection || !parsed || parsed.isMultivariate) return;
+
+    const next = parsed.isHidden
+      ? showSection(rawSection)
+      : hideSection(rawSection);
+    if (!next) return;
+
+    const updatedSections = [...rawSections];
+    updatedSections[index] = next;
+    if (selectedSectionIndex === index) clearSectionEditing();
+    savePageSections(updatedSections);
+  };
+
   const handleAddSection = (entry: SectionCatalogEntry) => {
     if (!activePageKey) return;
 
@@ -1424,6 +1447,16 @@ export function SectionsEditor({
   const isEditing =
     isEditingSection &&
     (isEditingMultivariateSection || !!(activeSchema && formValue));
+  // A reusable/global section reached from inside a page (purple in the list).
+  // Editing it writes back to the shared block definition, so changes apply
+  // everywhere it's used — surface the same global banner as the dedicated
+  // global-section route.
+  const isEditingSavedBlock =
+    isEditing && !isGlobalBlockMode && selectedParsed?.isSavedBlock === true;
+  const showGlobalBanner = isGlobalBlockMode || isEditingSavedBlock;
+  const globalBannerName = isGlobalBlockMode
+    ? globalBlockName
+    : (selectedParsed?.label ?? "");
   const sectionRuleSchema =
     sectionRuleResolveType && meta
       ? resolveSchema(sectionRuleResolveType, meta)
@@ -1441,6 +1474,13 @@ export function SectionsEditor({
             ...fieldBreadcrumbs,
           ]
       : [];
+  // The global header still needs a crumb at the top level of a directly-opened
+  // global block, where editingBreadcrumbs is empty — fall back to its name.
+  const headerCrumbs = showGlobalBanner
+    ? editingBreadcrumbs.length > 0
+      ? editingBreadcrumbs
+      : [globalBannerName]
+    : editingBreadcrumbs;
   const handleAddPageVariant = () => {
     if (!activePageKey) return;
     const fullPageData = decofile[activePageKey] as Record<string, unknown>;
@@ -1744,76 +1784,104 @@ export function SectionsEditor({
   return (
     <div className="flex h-full min-w-0 w-full flex-col">
       {/* Page header */}
-      <div className="px-3 py-2.5 border-b shrink-0">
-        {isEditing && (!isGlobalBlockMode || fieldBreadcrumbs.length > 0) ? (
-          <div className="flex min-w-0 items-center gap-2 overflow-hidden">
-            {!isGlobalBlockMode && hasMultipleVariants && activeVariant && (
-              <button
-                type="button"
-                onClick={exitSectionEditing}
-                title={`Editing in variant: ${activeVariant.label}`}
-                className={cn(
-                  "shrink-0 inline-flex items-center gap-1 rounded-md h-6 px-1.5 text-xs font-medium cursor-pointer transition-opacity hover:opacity-80",
-                  VARIANT_TAB_ACTIVE_CLASS,
-                )}
-              >
-                <VariantTabIcon
-                  rule={resolveEffectiveMatcherRule(
-                    activeVariant.rule,
-                    decofile ?? {},
-                    meta ?? undefined,
-                  )}
-                  matchers={availableMatchers}
-                />
-                <span className="max-w-[160px] truncate">
-                  {activeVariant.label}
-                </span>
-              </button>
+      <div className="shrink-0">
+        {/* When editing a reusable/global block (opened directly or from inside
+            a page), the breadcrumb bar goes purple with a globe and a note that
+            changes apply everywhere — so it never reads as a local edit. */}
+        {showGlobalBanner || isEditing ? (
+          <div
+            className={cn(
+              "border-b px-3 py-2.5",
+              showGlobalBanner &&
+                "border-[oklch(0.7278_0.151_289/0.22)] bg-[oklch(0.7278_0.151_289/0.12)] dark:bg-[oklch(0.7278_0.151_289/0.16)]",
             )}
-            <nav
-              aria-label="Editing breadcrumb"
-              className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-sm"
-            >
-              {editingBreadcrumbs.map((crumb, index) => {
-                const isLast = index === editingBreadcrumbs.length - 1;
-
-                return (
-                  <span
-                    key={`${crumb}-${index}`}
-                    className="flex min-w-0 items-center gap-1 overflow-hidden"
-                  >
-                    {index > 0 && (
-                      <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" />
+          >
+            <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+              {!isGlobalBlockMode && hasMultipleVariants && activeVariant && (
+                <button
+                  type="button"
+                  onClick={exitSectionEditing}
+                  title={`Editing in variant: ${activeVariant.label}`}
+                  className={cn(
+                    "shrink-0 inline-flex items-center gap-1 rounded-md h-6 px-1.5 text-xs font-medium cursor-pointer transition-opacity hover:opacity-80",
+                    VARIANT_TAB_ACTIVE_CLASS,
+                  )}
+                >
+                  <VariantTabIcon
+                    rule={resolveEffectiveMatcherRule(
+                      activeVariant.rule,
+                      decofile ?? {},
+                      meta ?? undefined,
                     )}
-                    <button
-                      type="button"
-                      onClick={() => handleBreadcrumbClick(index)}
-                      title={crumb}
-                      className={cn(
-                        "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
-                        isLast
-                          ? "font-medium text-foreground"
-                          : "text-muted-foreground",
-                      )}
-                    >
-                      {crumb}
-                    </button>
+                    matchers={availableMatchers}
+                  />
+                  <span className="max-w-[160px] truncate">
+                    {activeVariant.label}
                   </span>
-                );
-              })}
-            </nav>
-          </div>
-        ) : isGlobalBlockMode ? (
-          <div className="space-y-0.5">
-            <div className="text-sm font-medium truncate">
-              {globalBlockName}
+                </button>
+              )}
+              <nav
+                aria-label="Editing breadcrumb"
+                className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-sm"
+              >
+                {headerCrumbs.map((crumb, index) => {
+                  const isLast = index === headerCrumbs.length - 1;
+
+                  return (
+                    <span
+                      key={`${crumb}-${index}`}
+                      className="flex min-w-0 items-center gap-1 overflow-hidden"
+                    >
+                      {index > 0 && (
+                        <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" />
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => handleBreadcrumbClick(index)}
+                        title={crumb}
+                        className={cn(
+                          "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors",
+                          isLast
+                            ? showGlobalBanner
+                              ? "font-semibold text-[oklch(0.45_0.15_289)] dark:text-[oklch(0.78_0.15_289)]"
+                              : "font-medium text-foreground"
+                            : showGlobalBanner
+                              ? "text-foreground/80"
+                              : "text-muted-foreground",
+                          showGlobalBanner
+                            ? "hover:bg-[oklch(0.7278_0.151_289/0.15)]"
+                            : "hover:bg-accent hover:text-accent-foreground",
+                        )}
+                      >
+                        {crumb}
+                      </button>
+                    </span>
+                  );
+                })}
+              </nav>
+              {showGlobalBanner && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="shrink-0 cursor-help">
+                      <Globe01 className="size-4 text-[oklch(0.45_0.15_289)] dark:text-[oklch(0.78_0.15_289)]" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="max-w-[260px]">
+                    A global section is a reusable block shared across your
+                    site. Editing it here updates it everywhere it's used.
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
-            <div className="text-xs text-muted-foreground">
-              Global component
-            </div>
+            {showGlobalBanner && (
+              <p className="mt-1.5 py-1.5 pl-1 text-sm leading-snug text-foreground">
+                This is a global section. Changes apply everywhere this section
+                is used across your site.
+              </p>
+            )}
           </div>
         ) : (
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 border-b px-3 py-2.5">
             <div className="flex-1 min-w-0">
               <PageHeaderInputs
                 pageKey={activePageKey!}
@@ -2005,6 +2073,7 @@ export function SectionsEditor({
               onDelete={handleDeleteSection}
               onDuplicate={handleDuplicateSection}
               onMakeReusable={setMakeReusableIndex}
+              onToggleHidden={handleToggleHidden}
               onAddSection={() => setAddSectionOpen(true)}
               canAddSection={canAddSection}
             />


### PR DESCRIPTION
## What is this contribution about?
Editing a reusable/global section previously gave almost no signal it was global — and when reached from inside a page (the common path) it looked identical to a local edit, so users could change a site-wide block thinking it was page-local. This adds a persistent purple breadcrumb bar (globe icon + tooltip + "this is a global section, changes apply everywhere it's used" note) whenever you edit a reusable block, whether opened directly or from inside a page, with the section name in the global purple and a matching "Global" pill in the preview address bar. It also fixes the section-list eye icon, which was a decorative glyph that opened the section instead of toggling visibility — it's now a real button (like the `…` menu) that hides/shows via the `never`-matcher multivariate wrap, round-tripping normal, lazy, and saved-block sections.

## Screenshots/Demonstration
Purple global-section bar with globe tooltip; eye button on each section row toggles hide/show.

## How to Test
1. Open the CMS sections editor and click a global/reusable section (purple) inside a page — confirm the purple bar, globe tooltip, and "global" messaging appear and persist when drilling into fields.
2. Hover a section row and click the eye icon — it should hide the section (line-through + persistent eye-off) without opening it, and click again to restore.
3. Open a global section directly from the Sections collection — same bar appears; preview address bar shows a "Global" pill.

## Migration Notes
Not applicable.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make global section editing unmistakable and safer, and add a real hide/show toggle in the section list. This prevents accidental global edits and lets users quickly hide sections without opening them.

- **New Features**
  - Persistent purple “Global” banner with globe + tooltip and clear message when editing a reusable section, opened inside a page or directly. Breadcrumbs reflect context (with fallback when opened directly), and the preview address bar shows a “Global” pill.
  - Clickable eye button on each section row to hide/show without opening. Uses a multivariate wrapper with a `never` matcher, suppresses click/keyboard bubbling, hides the control for true multivariate sections, and round‑trips normal, lazy‑outer, and saved‑block sections.

- **Bug Fixes**
  - Hardened hidden parsing and restore: multivariate detection now uses explicit `PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE` and `SECTION_MULTIVARIATE_RESOLVE_TYPE`, and `showSection` validates `NEVER_MATCHER_RESOLVE_TYPE` and returns `null` when not hidden. Added tests for lazy‑outer unwrap and non‑hidden guards.

<sup>Written for commit 763bac0501f714907ca68f993e4b9667b337ed92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

