### PR TITLE
fix(sections-editor): improve union type form display and media field UX

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
+  embeddedUnionBlockId,
   isAutoPreviewBlockKey,
+  isEmbeddedUnionResolveType,
   isManifestSectionResolveType,
   isSavedBlockResolveType,
   parseSavedBlockSchemaTitle,
+  unionRefMatchesValue,
 } from "./block-type-utils";
 import type { LiveMeta } from "./resolve-schema";
 
@@ -55,5 +58,25 @@ describe("block-type-utils", () => {
     );
     expect(isAutoPreviewBlockKey("Header")).toBe(false);
     expect(isAutoPreviewBlockKey("%")).toBe(false);
+  });
+
+  it("isEmbeddedUnionResolveType detects inline module@blockId enums", () => {
+    expect(
+      isEmbeddedUnionResolveType("ZmlsZTovLy9...Carousel.tsx==@ImageBanner"),
+    ).toBe(true);
+    expect(
+      isEmbeddedUnionResolveType("site/sections/Images/Carousel.tsx"),
+    ).toBe(false);
+    expect(isEmbeddedUnionResolveType("Header")).toBe(false);
+  });
+
+  it("unionRefMatchesValue matches embedded union ids by suffix", () => {
+    const ref = "ZmlsZ...Carousel.tsx==@ImageBanner";
+    expect(unionRefMatchesValue(ref, ref)).toBe(true);
+    expect(unionRefMatchesValue(ref, "ImageBanner")).toBe(true);
+    expect(
+      unionRefMatchesValue(ref, "ZmlsZ...Carousel.tsx==@VideoBanner"),
+    ).toBe(false);
+    expect(embeddedUnionBlockId(ref)).toBe("ImageBanner");
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
@@ -12,6 +12,37 @@ export function parseSavedBlockSchemaTitle(
   };
 }
 
+/**
+ * Inline union variants in the same TS module (e.g. `ImageBanner | VideoBanner`
+ * inside `Carousel.tsx`) use schema enum values like
+ * `base64(fileUrl)@ImageBanner`. Those identifiers are for schema
+ * discrimination only — persisting them as `__resolveType` in decofile data
+ * makes deco treat the object as a loadable block and throws DanglingReference.
+ */
+export function isEmbeddedUnionResolveType(resolveType: string): boolean {
+  return resolveType.includes("@");
+}
+
+/** Block name suffix from an embedded union resolve type (`…@ImageBanner`). */
+export function embeddedUnionBlockId(resolveType: string): string | null {
+  const at = resolveType.lastIndexOf("@");
+  if (at < 0 || at === resolveType.length - 1) return null;
+  return resolveType.slice(at + 1);
+}
+
+export function unionRefMatchesValue(
+  refResolveType: string,
+  valueResolveType: string,
+): boolean {
+  if (refResolveType === valueResolveType) return true;
+  const refId = embeddedUnionBlockId(refResolveType);
+  if (!refId) return false;
+  return (
+    valueResolveType === refId ||
+    embeddedUnionBlockId(valueResolveType) === refId
+  );
+}
+
 function getManifestBlockType(
   meta: LiveMeta,
   resolveType: string,

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -73,6 +73,7 @@ export function AnyOfField({
     return (
       <div className="space-y-4">
         <div className="space-y-1.5">
+          <Label htmlFor={path}>{label}</Label>
           <Select value={currentRt} onValueChange={handleRefChange}>
             <SelectTrigger>
               <SelectValue placeholder="Select..." />

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -14,7 +14,7 @@ function detectCurrentType(
   value: unknown,
   refs: Array<{ resolveType: string; schema?: SchemaProperty }>,
 ): string {
-  const fallback = refs.find((r) => r.resolveType)?.resolveType ?? "";
+  const fallback = refs[0]?.resolveType ?? "";
   if (!value || typeof value !== "object" || Array.isArray(value))
     return fallback;
   const obj = value as Record<string, unknown>;
@@ -24,7 +24,8 @@ function detectCurrentType(
     if (match) return match.resolveType;
   }
 
-  // Infer branch by counting matching property keys
+  // Infer branch by counting matching property keys; only prefer a scored
+  // branch when it actually matches something (score > 0).
   let best = fallback;
   let bestScore = -1;
   for (const ref of refs) {
@@ -32,7 +33,7 @@ function detectCurrentType(
     const score = Object.keys(ref.schema.properties).filter(
       (k) => (obj as Record<string, unknown>)[k] !== undefined,
     ).length;
-    if (score > bestScore) {
+    if (score > 0 && score > bestScore) {
       bestScore = score;
       best = ref.resolveType;
     }
@@ -57,11 +58,16 @@ export function AnyOfField({
     const selectedRef = refs.find((r) => r.resolveType === currentRt);
 
     const handleRefChange = (rt: string) => {
+      const targetRef = refs.find((r) => r.resolveType === rt);
+      const allowed = new Set(Object.keys(targetRef?.schema?.properties ?? {}));
       const existing =
         value !== null && typeof value === "object" && !Array.isArray(value)
           ? (value as Record<string, unknown>)
           : {};
-      onChange({ ...existing, __resolveType: rt });
+      const filtered = Object.fromEntries(
+        Object.entries(existing).filter(([k]) => allowed.has(k)),
+      );
+      onChange({ ...filtered, __resolveType: rt });
     };
 
     return (

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Select,
   SelectContent,
@@ -6,9 +7,34 @@ import {
   SelectValue,
 } from "@deco/ui/components/select.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
+import {
+  embeddedUnionBlockId,
+  isEmbeddedUnionResolveType,
+  unionRefMatchesValue,
+} from "../block-type-utils";
 import type { SchemaProperty } from "../resolve-schema";
 import type { FieldProps } from "./field-props";
 import { SchemaForm } from "../schema-form";
+
+function defaultsForSchema(schema?: SchemaProperty): Record<string, unknown> {
+  if (!schema?.properties) return {};
+  const out: Record<string, unknown> = {};
+  for (const [key, prop] of Object.entries(schema.properties)) {
+    if (key.startsWith("__") || key === "@type") continue;
+    if (prop.default !== undefined) {
+      out[key] = prop.default;
+    } else if (prop.type === "boolean") {
+      out[key] = false;
+    } else if (prop.type === "string") {
+      out[key] = "";
+    } else if (prop.type === "number" || prop.type === "integer") {
+      out[key] = 0;
+    } else if (prop.type === "object") {
+      out[key] = {};
+    }
+  }
+  return out;
+}
 
 function detectCurrentType(
   value: unknown,
@@ -20,18 +46,34 @@ function detectCurrentType(
   const obj = value as Record<string, unknown>;
 
   if (typeof obj.__resolveType === "string") {
-    const match = refs.find((r) => r.resolveType === obj.__resolveType);
+    const match = refs.find((r) =>
+      unionRefMatchesValue(r.resolveType, obj.__resolveType as string),
+    );
     if (match) return match.resolveType;
   }
 
-  // Infer branch by counting matching property keys; only prefer a scored
-  // branch when it actually matches something (score > 0).
+  // Prefer branch-specific keys over shared ones (alt, action) so
+  // ImageBanner|VideoBanner items don't always collapse to the first branch.
   let best = fallback;
   let bestScore = -1;
   for (const ref of refs) {
     if (!ref.schema?.properties) continue;
+    const keys = Object.keys(ref.schema.properties).filter(
+      (k) =>
+        !k.startsWith("__") && k !== "@type" && k !== "action" && k !== "alt",
+    );
+    const score = keys.filter((k) => obj[k] !== undefined).length;
+    if (score > 0 && score > bestScore) {
+      bestScore = score;
+      best = ref.resolveType;
+    }
+  }
+  if (bestScore > 0) return best;
+
+  for (const ref of refs) {
+    if (!ref.schema?.properties) continue;
     const score = Object.keys(ref.schema.properties).filter(
-      (k) => (obj as Record<string, unknown>)[k] !== undefined,
+      (k) => obj[k] !== undefined,
     ).length;
     if (score > 0 && score > bestScore) {
       bestScore = score;
@@ -50,14 +92,20 @@ export function AnyOfField({
   breadcrumbPath,
   onBreadcrumbChange,
 }: FieldProps) {
+  const refs = (schema.anyOfRefs ?? []).filter((r) => r.resolveType !== "");
+  const inferredRt =
+    refs.length > 0
+      ? detectCurrentType(value, refs)
+      : (refs[0]?.resolveType ?? "");
+  const [selectedRt, setSelectedRt] = useState(inferredRt);
+
   // ── block-ref mode (anyOfRefs from schema resolution) ─────────────
-  if (schema.anyOfRefs && schema.anyOfRefs.length > 0) {
-    const refs = schema.anyOfRefs.filter((r) => r.resolveType !== "");
-    if (refs.length === 0) return null;
-    const currentRt = detectCurrentType(value, refs);
-    const selectedRef = refs.find((r) => r.resolveType === currentRt);
+  if (refs.length > 0) {
+    const activeRt = selectedRt || inferredRt;
+    const selectedRef = refs.find((r) => r.resolveType === activeRt);
 
     const handleRefChange = (rt: string) => {
+      setSelectedRt(rt);
       const targetRef = refs.find((r) => r.resolveType === rt);
       const allowed = new Set(Object.keys(targetRef?.schema?.properties ?? {}));
       const existing =
@@ -67,21 +115,48 @@ export function AnyOfField({
       const filtered = Object.fromEntries(
         Object.entries(existing).filter(([k]) => allowed.has(k)),
       );
-      onChange({ ...filtered, __resolveType: rt });
+      const next = {
+        ...defaultsForSchema(targetRef?.schema),
+        ...filtered,
+      };
+
+      // Embedded union variants (ImageBanner | VideoBanner in Carousel.tsx)
+      // must not get a persisted __resolveType — deco only expects plain props.
+      if (isEmbeddedUnionResolveType(rt)) {
+        onChange(next);
+        return;
+      }
+      onChange({ ...next, __resolveType: rt });
+    };
+
+    const persistUnionValue = (next: unknown) => {
+      if (
+        !isEmbeddedUnionResolveType(activeRt) ||
+        next === null ||
+        typeof next !== "object" ||
+        Array.isArray(next)
+      ) {
+        onChange(next);
+        return;
+      }
+      const { __resolveType: _, ...rest } = next as Record<string, unknown>;
+      onChange(rest);
     };
 
     return (
       <div className="space-y-4">
         <div className="space-y-1.5">
           <Label htmlFor={path}>{label}</Label>
-          <Select value={currentRt} onValueChange={handleRefChange}>
+          <Select value={activeRt} onValueChange={handleRefChange}>
             <SelectTrigger>
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
               {refs.map((ref) => (
                 <SelectItem key={ref.resolveType} value={ref.resolveType}>
-                  {ref.title}
+                  {ref.title ??
+                    embeddedUnionBlockId(ref.resolveType) ??
+                    ref.resolveType}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -96,7 +171,7 @@ export function AnyOfField({
           <SchemaForm
             schema={selectedRef.schema}
             value={value}
-            onChange={onChange}
+            onChange={persistUnionValue}
             basePath={path}
             breadcrumbPath={breadcrumbPath}
             onBreadcrumbChange={onBreadcrumbChange}
@@ -104,6 +179,10 @@ export function AnyOfField({
         )}
       </div>
     );
+  }
+
+  if (schema.anyOfRefs && schema.anyOfRefs.length > 0) {
+    return null;
   }
 
   // ── Fallback: render a basic text input for unresolved anyOf fields ──

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -6,7 +6,39 @@ import {
   SelectValue,
 } from "@deco/ui/components/select.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
+import type { SchemaProperty } from "../resolve-schema";
 import type { FieldProps } from "./field-props";
+import { SchemaForm } from "../schema-form";
+
+function detectCurrentType(
+  value: unknown,
+  refs: Array<{ resolveType: string; schema?: SchemaProperty }>,
+): string {
+  const fallback = refs.find((r) => r.resolveType)?.resolveType ?? "";
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return fallback;
+  const obj = value as Record<string, unknown>;
+
+  if (typeof obj.__resolveType === "string") {
+    const match = refs.find((r) => r.resolveType === obj.__resolveType);
+    if (match) return match.resolveType;
+  }
+
+  // Infer branch by counting matching property keys
+  let best = fallback;
+  let bestScore = -1;
+  for (const ref of refs) {
+    if (!ref.schema?.properties) continue;
+    const score = Object.keys(ref.schema.properties).filter(
+      (k) => (obj as Record<string, unknown>)[k] !== undefined,
+    ).length;
+    if (score > bestScore) {
+      bestScore = score;
+      best = ref.resolveType;
+    }
+  }
+  return best;
+}
 
 export function AnyOfField({
   schema,
@@ -14,39 +46,54 @@ export function AnyOfField({
   onChange,
   path,
   label,
+  breadcrumbPath,
+  onBreadcrumbChange,
 }: FieldProps) {
   // ── block-ref mode (anyOfRefs from schema resolution) ─────────────
   if (schema.anyOfRefs && schema.anyOfRefs.length > 0) {
-    const refs = schema.anyOfRefs;
-    const currentRt =
-      value !== null &&
-      typeof value === "object" &&
-      !Array.isArray(value) &&
-      typeof (value as Record<string, unknown>).__resolveType === "string"
-        ? ((value as Record<string, unknown>).__resolveType as string)
-        : (refs[0]?.resolveType ?? "");
+    const refs = schema.anyOfRefs.filter((r) => r.resolveType !== "");
+    if (refs.length === 0) return null;
+    const currentRt = detectCurrentType(value, refs);
+    const selectedRef = refs.find((r) => r.resolveType === currentRt);
 
     const handleRefChange = (rt: string) => {
-      onChange({ __resolveType: rt });
+      const existing =
+        value !== null && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>)
+          : {};
+      onChange({ ...existing, __resolveType: rt });
     };
 
     return (
-      <div className="space-y-1.5">
-        <Label htmlFor={path}>{label}</Label>
-        <Select value={currentRt} onValueChange={handleRefChange}>
-          <SelectTrigger>
-            <SelectValue placeholder="Select..." />
-          </SelectTrigger>
-          <SelectContent>
-            {refs.map((ref) => (
-              <SelectItem key={ref.resolveType} value={ref.resolveType}>
-                {ref.title}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {schema.description && (
-          <p className="text-xs text-muted-foreground">{schema.description}</p>
+      <div className="space-y-4">
+        <div className="space-y-1.5">
+          <Select value={currentRt} onValueChange={handleRefChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              {refs.map((ref) => (
+                <SelectItem key={ref.resolveType} value={ref.resolveType}>
+                  {ref.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {schema.description && (
+            <p className="text-xs text-muted-foreground">
+              {schema.description}
+            </p>
+          )}
+        </div>
+        {selectedRef?.schema?.properties && (
+          <SchemaForm
+            schema={selectedRef.schema}
+            value={value}
+            onChange={onChange}
+            basePath={path}
+            breadcrumbPath={breadcrumbPath}
+            onBreadcrumbChange={onBreadcrumbChange}
+          />
         )}
       </div>
     );

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -41,15 +41,17 @@ export function ArrayField({
     const defaultVal =
       itemSchema?.default !== undefined
         ? itemSchema.default
-        : t === "object" || t === "block-ref"
+        : t === "object"
           ? {}
-          : t === "number" || t === "integer"
-            ? 0
-            : t === "boolean"
-              ? false
-              : t === "array"
-                ? []
-                : "";
+          : t === "block-ref"
+            ? { __resolveType: itemSchema?.anyOfRefs?.[0]?.resolveType ?? "" }
+            : t === "number" || t === "integer"
+              ? 0
+              : t === "boolean"
+                ? false
+                : t === "array"
+                  ? []
+                  : "";
     const next = [...items, defaultVal];
     onChange(next);
     const nextIndex = next.length - 1;

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -16,7 +16,7 @@ function getItemLabel(item: unknown, index: number): string {
     return String(item);
   if (item && typeof item === "object" && !Array.isArray(item)) {
     const obj = item as Record<string, unknown>;
-    for (const key of ["name", "label", "title", "text", "href", "id"]) {
+    for (const key of ["name", "label", "title", "alt", "text", "href", "id"]) {
       if (typeof obj[key] === "string" && obj[key]) return obj[key] as string;
     }
   }
@@ -41,7 +41,7 @@ export function ArrayField({
     const defaultVal =
       itemSchema?.default !== undefined
         ? itemSchema.default
-        : t === "object"
+        : t === "object" || t === "block-ref"
           ? {}
           : t === "number" || t === "integer"
             ? 0

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -44,7 +44,12 @@ export function ArrayField({
         : t === "object"
           ? {}
           : t === "block-ref"
-            ? { __resolveType: itemSchema?.anyOfRefs?.[0]?.resolveType ?? "" }
+            ? {
+                __resolveType:
+                  typeof itemSchema?.anyOfRefs?.[0]?.resolveType === "string"
+                    ? itemSchema.anyOfRefs[0].resolveType
+                    : "",
+              }
             : t === "number" || t === "integer"
               ? 0
               : t === "boolean"

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import type { FieldProps } from "./field-props";
 import { SchemaForm, renderField } from "../schema-form";
 
@@ -44,12 +45,13 @@ export function ArrayField({
         : t === "object"
           ? {}
           : t === "block-ref"
-            ? {
-                __resolveType:
-                  typeof itemSchema?.anyOfRefs?.[0]?.resolveType === "string"
-                    ? itemSchema.anyOfRefs[0].resolveType
-                    : "",
-              }
+            ? (() => {
+                const rt = itemSchema?.anyOfRefs?.[0]?.resolveType;
+                if (typeof rt !== "string" || isEmbeddedUnionResolveType(rt)) {
+                  return {};
+                }
+                return { __resolveType: rt };
+              })()
             : t === "number" || t === "integer"
               ? 0
               : t === "boolean"

--- a/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
@@ -101,7 +101,9 @@ export function FileField({
     // bulletproofs against any broken min-w-0 chain above.
     <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2 overflow-hidden">
       <div className="min-w-0 space-y-0.5">
-        <Label htmlFor={path} className="text-muted-foreground">{label}</Label>
+        <Label htmlFor={path} className="text-muted-foreground">
+          {label}
+        </Label>
         {schema.description && (
           <p className="text-xs leading-normal text-muted-foreground">
             {schema.description}

--- a/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
@@ -14,6 +14,15 @@ import { useFilePickerUpload } from "@/web/hooks/use-file-picker";
 import { extractUrl } from "./extract-url";
 import type { FieldProps } from "./field-props";
 
+function ExtBadge({ ext }: { ext: string }) {
+  if (!ext) return null;
+  return (
+    <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
+      {ext}
+    </span>
+  );
+}
+
 function basename(url: string): string {
   try {
     const path = new URL(url).pathname;
@@ -36,6 +45,7 @@ export function FileField({
   path,
   label,
 }: FieldProps) {
+  const isVideo = schema.format === "video-uri";
   const strValue = extractUrl(value);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -122,7 +132,7 @@ export function FileField({
         )}
       >
         {strValue ? (
-          schema.format === "video-uri" ? (
+          isVideo ? (
             <>
               <div className="relative h-40 w-full overflow-hidden bg-black">
                 <video
@@ -137,11 +147,7 @@ export function FileField({
                 <p className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
                   {fileName}
                 </p>
-                {ext && (
-                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
-                    {ext}
-                  </span>
-                )}
+                <ExtBadge ext={ext} />
               </div>
             </>
           ) : (
@@ -155,11 +161,7 @@ export function FileField({
                   {strValue}
                 </p>
               </div>
-              {ext && (
-                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
-                  {ext}
-                </span>
-              )}
+              <ExtBadge ext={ext} />
             </div>
           )
         ) : (
@@ -168,15 +170,11 @@ export function FileField({
             onClick={() => setPickerOpen(true)}
             className="flex w-full flex-col items-center justify-center gap-2 py-8 text-sm text-muted-foreground hover:bg-muted/60 hover:text-foreground"
           >
-            {schema.format === "video-uri" ? (
-              <Film01 size={20} />
-            ) : (
-              <File02 size={20} />
-            )}
+            {isVideo ? <Film01 size={20} /> : <File02 size={20} />}
             <span className="text-sm font-medium">
               {upload.isPending
                 ? "Uploading…"
-                : schema.format === "video-uri"
+                : isVideo
                   ? "Drop a video here or click to browse"
                   : "Drop a file or click to browse"}
             </span>

--- a/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
@@ -68,8 +68,15 @@ export function FileField({
 
   async function handleFiles(files: FileList | File[] | null) {
     if (!files) return;
-    const list = Array.from(files);
+    let list = Array.from(files);
     if (list.length === 0) return;
+    if (isVideo) {
+      list = list.filter((f) => f.type.startsWith("video/"));
+      if (list.length === 0) {
+        toast.error("Please drop a video file (mp4, webm, …).");
+        return;
+      }
+    }
 
     const targetConfigId = resolveTargetConfigId();
     if (!targetConfigId) {

--- a/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { File02, Trash01, Upload01 } from "@untitledui/icons";
+import { File02, Film01, Trash01, Upload01 } from "@untitledui/icons";
 import { toast } from "sonner";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
@@ -101,7 +101,7 @@ export function FileField({
     // bulletproofs against any broken min-w-0 chain above.
     <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2 overflow-hidden">
       <div className="min-w-0 space-y-0.5">
-        <Label htmlFor={path}>{label}</Label>
+        <Label htmlFor={path} className="text-muted-foreground">{label}</Label>
         {schema.description && (
           <p className="text-xs leading-normal text-muted-foreground">
             {schema.description}
@@ -120,33 +120,63 @@ export function FileField({
         )}
       >
         {strValue ? (
-          <div className="flex items-center gap-3 px-3 py-2.5">
-            <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-background">
-              <File02 size={18} className="text-muted-foreground" />
+          schema.format === "video-uri" ? (
+            <>
+              <div className="relative h-40 w-full overflow-hidden bg-black">
+                <video
+                  key={strValue}
+                  src={strValue}
+                  preload="metadata"
+                  className="h-full w-full object-contain"
+                />
+              </div>
+              <div className="flex items-center gap-2 border-t border-border/60 bg-background/50 px-3 py-2">
+                <Film01 size={14} className="shrink-0 text-muted-foreground" />
+                <p className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                  {fileName}
+                </p>
+                {ext && (
+                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
+                    {ext}
+                  </span>
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="flex items-center gap-3 px-3 py-2.5">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-background">
+                <File02 size={18} className="text-muted-foreground" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium">{fileName}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {strValue}
+                </p>
+              </div>
+              {ext && (
+                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
+                  {ext}
+                </span>
+              )}
             </div>
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-medium">{fileName}</p>
-              <p className="truncate text-xs text-muted-foreground">
-                {strValue}
-              </p>
-            </div>
-            {ext && (
-              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
-                {ext}
-              </span>
-            )}
-          </div>
+          )
         ) : (
           <button
             type="button"
             onClick={() => setPickerOpen(true)}
             className="flex w-full flex-col items-center justify-center gap-2 py-8 text-sm text-muted-foreground hover:bg-muted/60 hover:text-foreground"
           >
-            <File02 size={20} />
+            {schema.format === "video-uri" ? (
+              <Film01 size={20} />
+            ) : (
+              <File02 size={20} />
+            )}
             <span className="text-sm font-medium">
               {upload.isPending
                 ? "Uploading…"
-                : "Drop a file or click to browse"}
+                : schema.format === "video-uri"
+                  ? "Drop a video here or click to browse"
+                  : "Drop a file or click to browse"}
             </span>
             <span className="text-xs text-muted-foreground">Up to 100 MB</span>
           </button>

--- a/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
@@ -144,7 +144,7 @@ export function ImageField({
     // against a misbehaving min-w-0 chain.
     <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2 overflow-hidden">
       <div className="min-w-0 space-y-0.5">
-        <Label htmlFor={path}>{label}</Label>
+        <Label htmlFor={path} className="text-muted-foreground">{label}</Label>
         {schema.description && (
           <p className="text-xs leading-normal text-muted-foreground">
             {schema.description}

--- a/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
@@ -144,7 +144,9 @@ export function ImageField({
     // against a misbehaving min-w-0 chain.
     <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2 overflow-hidden">
       <div className="min-w-0 space-y-0.5">
-        <Label htmlFor={path} className="text-muted-foreground">{label}</Label>
+        <Label htmlFor={path} className="text-muted-foreground">
+          {label}
+        </Label>
         {schema.description && (
           <p className="text-xs leading-normal text-muted-foreground">
             {schema.description}

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -27,6 +27,7 @@ export interface SchemaProperty {
     resolveType: string;
     title: string;
     description?: string;
+    schema?: SchemaProperty;
   }>;
 }
 
@@ -128,6 +129,10 @@ export function resolveSchema(
     let resolved = v;
     if (typeof v.$ref === "string") {
       resolved = resolveRef(v.$ref);
+      const refKey = v.$ref.split("/").pop() ?? "";
+      if (refKey === "VideoWidget" && !resolved.format) {
+        resolved = { ...resolved, format: "video-uri" };
+      }
     }
 
     // Extract enum values from anyOf/oneOf const/enum branches
@@ -235,6 +240,7 @@ export function resolveSchema(
                 typeof branch.description === "string"
                   ? branch.description
                   : undefined,
+              schema: buildProperty(branch, depth + 1),
             };
           });
           return {
@@ -256,6 +262,7 @@ export function resolveSchema(
             resolveType: string;
             title: string;
             description?: string;
+            schema?: SchemaProperty;
           }> = [];
           for (const branch of nonNull) {
             const def = resolveRef(branch.$ref as string);
@@ -299,6 +306,7 @@ export function resolveSchema(
                 typeof def.description === "string"
                   ? def.description
                   : undefined,
+              schema: buildProperty(def, depth + 1),
             });
           }
           return {

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -43,6 +43,12 @@ export interface LiveMeta {
 
 type RawSchema = Record<string, unknown>;
 
+// deco.cx convention: VideoWidget schemas don't carry `format` in their
+// JSON Schema definition, so we inject it here so the UI can render a
+// VideoField instead of a generic FileField. If the schema ever gains the
+// `format` field natively this guard becomes a no-op.
+const VIDEO_WIDGET_REF_KEY = "VideoWidget";
+
 /**
  * Resolve the schema for a given __resolveType by searching across ALL
  * block types in the manifest (sections, loaders, matchers, etc.).
@@ -130,7 +136,7 @@ export function resolveSchema(
     if (typeof v.$ref === "string") {
       resolved = resolveRef(v.$ref);
       const refKey = v.$ref.split("/").pop() ?? "";
-      if (refKey === "VideoWidget" && !resolved.format) {
+      if (refKey === VIDEO_WIDGET_REF_KEY && !resolved.format) {
         resolved = { ...resolved, format: "video-uri" };
       }
     }

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -246,7 +246,8 @@ export function resolveSchema(
                 typeof branch.description === "string"
                   ? branch.description
                   : undefined,
-              schema: buildProperty(branch, depth + 1),
+              schema:
+                depth + 1 < 6 ? buildProperty(branch, depth + 1) : undefined,
             };
           });
           return {
@@ -312,7 +313,7 @@ export function resolveSchema(
                 typeof def.description === "string"
                   ? def.description
                   : undefined,
-              schema: buildProperty(def, depth + 1),
+              schema: depth + 1 < 6 ? buildProperty(def, depth + 1) : undefined,
             });
           }
           return {

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -96,7 +96,7 @@ export function renderField(props: FieldProps) {
     return <ImageField key={props.path} {...props} />;
   }
   // file-uri → FileField (filename chip + any-type picker)
-  if (schema.format === "file-uri") {
+  if (schema.format === "file-uri" || schema.format === "video-uri") {
     return <FileField key={props.path} {...props} />;
   }
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -95,7 +95,7 @@ export function renderField(props: FieldProps) {
   if (schema.format === "image-uri") {
     return <ImageField key={props.path} {...props} />;
   }
-  // file-uri → FileField (filename chip + any-type picker)
+  // file-uri / video-uri → FileField (filename chip + picker, video preview)
   if (schema.format === "file-uri" || schema.format === "video-uri") {
     return <FileField key={props.path} {...props} />;
   }

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -27,7 +27,7 @@ import { isLazyResolveType } from "./section-lazy";
 import { arrayMove } from "@dnd-kit/sortable";
 import type { ParsedSection } from "./section-list";
 import { SchemaForm } from "./schema-form";
-import { resolveSchema } from "./resolve-schema";
+import { resolveSchema, type SchemaProperty } from "./resolve-schema";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
 import { PageVariantTabs, VariantTabIcon } from "./page-variant-tabs";
 import { MakeReusableModal } from "./make-reusable-modal";
@@ -73,6 +73,44 @@ import {
 } from "./section-variants";
 
 const AUTOSAVE_DELAY = 700;
+
+function SchemaFormPanel({
+  activeSchema,
+  formValue,
+  formResetKey,
+  onFormChange,
+  onBreadcrumbChange,
+  emptyMessage,
+}: {
+  activeSchema: SchemaProperty | null | undefined;
+  formValue: unknown;
+  formResetKey: number;
+  onFormChange: (v: unknown) => void;
+  onBreadcrumbChange: (path: string[]) => void;
+  emptyMessage: string;
+}) {
+  return (
+    <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
+      <div className="mx-auto max-w-2xl">
+        {activeSchema && formValue ? (
+          <SchemaForm
+            key={formResetKey}
+            schema={activeSchema}
+            value={formValue}
+            onChange={onFormChange}
+            basePath=""
+            breadcrumbPath={[]}
+            onBreadcrumbChange={onBreadcrumbChange}
+          />
+        ) : (
+          <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+            {emptyMessage}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 const VARIANT_TAB_ACTIVE_CLASS =
   "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.22)]";
@@ -1900,47 +1938,25 @@ export function SectionsEditor({
               )}
             </>
           )}
-          <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
-            <div className="mx-auto max-w-2xl">
-              {activeSchema && formValue ? (
-                <SchemaForm
-                  key={formResetKey}
-                  schema={activeSchema}
-                  value={formValue}
-                  onChange={handleFormChange}
-                  basePath=""
-                  breadcrumbPath={[]}
-                  onBreadcrumbChange={setFieldBreadcrumbs}
-                />
-              ) : (
-                <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-                  No editable fields for this variant.
-                </div>
-              )}
-            </div>
-          </div>
+          <SchemaFormPanel
+            activeSchema={activeSchema}
+            formValue={formValue}
+            formResetKey={formResetKey}
+            onFormChange={handleFormChange}
+            onBreadcrumbChange={setFieldBreadcrumbs}
+            emptyMessage="No editable fields for this variant."
+          />
         </ScrollArea>
       ) : isGlobalBlockMode ? (
         <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
-          <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
-            <div className="mx-auto max-w-2xl">
-              {activeSchema && formValue ? (
-                <SchemaForm
-                  key={formResetKey}
-                  schema={activeSchema}
-                  value={formValue}
-                  onChange={handleFormChange}
-                  basePath=""
-                  breadcrumbPath={[]}
-                  onBreadcrumbChange={setFieldBreadcrumbs}
-                />
-              ) : (
-                <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-                  No editable fields for this global block.
-                </div>
-              )}
-            </div>
-          </div>
+          <SchemaFormPanel
+            activeSchema={activeSchema}
+            formValue={formValue}
+            formResetKey={formResetKey}
+            onFormChange={handleFormChange}
+            onBreadcrumbChange={setFieldBreadcrumbs}
+            emptyMessage="No editable fields for this global block."
+          />
         </ScrollArea>
       ) : (
         <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1900,42 +1900,46 @@ export function SectionsEditor({
               )}
             </>
           )}
-          <div className="min-w-0 max-w-full overflow-x-hidden p-4">
-            {activeSchema && formValue ? (
-              <SchemaForm
-                key={formResetKey}
-                schema={activeSchema}
-                value={formValue}
-                onChange={handleFormChange}
-                basePath=""
-                breadcrumbPath={[]}
-                onBreadcrumbChange={setFieldBreadcrumbs}
-              />
-            ) : (
-              <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-                No editable fields for this variant.
-              </div>
-            )}
+          <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
+            <div className="mx-auto max-w-2xl">
+              {activeSchema && formValue ? (
+                <SchemaForm
+                  key={formResetKey}
+                  schema={activeSchema}
+                  value={formValue}
+                  onChange={handleFormChange}
+                  basePath=""
+                  breadcrumbPath={[]}
+                  onBreadcrumbChange={setFieldBreadcrumbs}
+                />
+              ) : (
+                <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+                  No editable fields for this variant.
+                </div>
+              )}
+            </div>
           </div>
         </ScrollArea>
       ) : isGlobalBlockMode ? (
         <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
-          <div className="min-w-0 max-w-full overflow-x-hidden p-4">
-            {activeSchema && formValue ? (
-              <SchemaForm
-                key={formResetKey}
-                schema={activeSchema}
-                value={formValue}
-                onChange={handleFormChange}
-                basePath=""
-                breadcrumbPath={[]}
-                onBreadcrumbChange={setFieldBreadcrumbs}
-              />
-            ) : (
-              <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-                No editable fields for this global block.
-              </div>
-            )}
+          <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
+            <div className="mx-auto max-w-2xl">
+              {activeSchema && formValue ? (
+                <SchemaForm
+                  key={formResetKey}
+                  schema={activeSchema}
+                  value={formValue}
+                  onChange={handleFormChange}
+                  basePath=""
+                  breadcrumbPath={[]}
+                  onBreadcrumbChange={setFieldBreadcrumbs}
+                />
+              ) : (
+                <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+                  No editable fields for this global block.
+                </div>
+              )}
+            </div>
           </div>
         </ScrollArea>
       ) : (


### PR DESCRIPTION
## What is this contribution about?

Fixes several form display issues in the sections editor for union type fields (e.g. `ImageItem | VideoItem` arrays):

- **Array item labels**: Items now use the `alt` field as the display label in the list, so entries show "IMG 1", "VIDEO 1" instead of "Item 1, 2, 3"
- **Union type sub-forms**: `AnyOfField` now renders the selected branch's schema inline below the type selector, with type inference from existing data so items without `__resolveType` still open on the right branch
- **Video src field**: `VideoWidget` refs are annotated with `format: video-uri` so `src` fields render with a drag-and-drop drop zone, film icon, and a first-frame video preview instead of a plain text input
- **Media field labels**: Image and video field labels are now `text-muted-foreground`
- **Form layout**: Form content is constrained to `max-w-2xl` with horizontal padding in the sections editor panel
- **Select crash fix**: Guards against empty `resolveType` values that caused a Select component crash when navigating to certain pages

## Screenshots/Demonstration

Before: array items showed "Item 1, 2, 3", union fields showed only a type dropdown with no sub-fields, video src was a plain text input.

After: items show their `alt` label, selecting ImageItem/VideoItem reveals the relevant fields, video src shows a drop zone with first-frame preview.

## How to Test

1. Open a page with an `ImageGrid` section (e.g. demo-linkedin Home Page)
2. Open the Images array — items should show "IMG 1", "VIDEO 1", "IMAGE 2"
3. Click an item — the type selector (ImageItem/VideoItem) should appear with the correct branch pre-selected and its fields rendered below
4. Click the VideoItem — the Src field should show a drag-and-drop area with a video frame preview
5. Navigate to other pages and confirm no Select crash occurs

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves union-type field UX with inline sub-forms, safer type inference, and better video handling. Adds embedded-union support that avoids persisting schema-internal types to prevent DanglingReference, plus a labeled selector, video-only drag-and-drop, and layout polish.

- **New Features**
  - `AnyOfField` renders the selected branch inline, infers it from data when `__resolveType` is missing, and shows a labeled type selector.
  - `VideoWidget` refs are treated as `video-uri`; video fields show drag-and-drop, a film icon, a first-frame preview, and only accept video files.
  - Array items use `alt` as the list label; image/video field labels use muted text; form content is constrained to `max-w-2xl` with padding.

- **Bug Fixes**
  - Embedded union variants (`module@BlockId`) are detected; the selector tracks state and `__resolveType` is not persisted, preventing DanglingReference and selector snap-back.
  - Inference only selects a union branch when properties match (score > 0).
  - Switching union types strips keys not in the target branch schema to prevent stale data.
  - Block-ref array items default to `{ __resolveType }` only when the default is a non-embedded string; validates it is a string when creating new items.
  - Guard empty/invalid `resolveType` values to prevent Select crashes, and cap `anyOf` schema expansion depth to avoid runaway nesting.

<sup>Written for commit 7e84f9202adfaf16d637815207202e10ceab971c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

