### PR TITLE
refactor(home): update agent card titles and descriptions for improve…

### DIFF
--- a/apps/mesh/src/api/routes/home-next-actions.ts
+++ b/apps/mesh/src/api/routes/home-next-actions.ts
@@ -112,13 +112,17 @@ async function defaultHomeAgentNextActions(
             maxHeight: t.maxHeight,
           }));
 
+        // Quick-access agent card (no prompt). The home chip shows the
+        // agent name as the title and its description as the subtitle, so
+        // map the fields that way rather than hoisting the description up
+        // into the title slot.
         const fallback = (): PromptEntry => ({
           agentId: id,
           agentName: virtualMcp.title,
           agentIcon: virtualMcp.icon,
           promptName: "",
-          title: virtualMcp.description || "Start a new chat",
-          description: "",
+          title: virtualMcp.title,
+          description: virtualMcp.description || "Start a new chat",
           hasArguments: false,
         });
 
@@ -261,8 +265,8 @@ export function createHomeNextActionsRoutes() {
         agentName: agent.title,
         agentIcon: agent.icon,
         promptName: "",
-        title: "Start a new chat",
-        description: "",
+        title: agent.title,
+        description: "Start a new chat",
         hasArguments: false,
       });
     }

--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -123,7 +123,7 @@ export function AddTileDrawer({ open, onOpenChange }: AddTileDrawerProps) {
             />
           </div>
         </SheetHeader>
-        <ScrollArea className="flex-1">
+        <ScrollArea className="flex-1 min-h-0">
           <div className="p-3 flex flex-col gap-4">
             <Suspense fallback={<DrawerListSkeleton />}>
               <DrawerBody search={search} />

--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -9,7 +9,7 @@ import { Suspense } from "react";
 import { useMCPClient, useProjectContext } from "@decocms/mesh-sdk";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { ArrowRight, X } from "@untitledui/icons";
+import { ArrowRight } from "@untitledui/icons";
 import { toast } from "sonner";
 import { MCPAppRenderer } from "@/mcp-apps/mcp-app-renderer.tsx";
 import { AgentAvatar } from "@/web/components/agent-icon";
@@ -48,6 +48,13 @@ function tileCandidateId(t: HomeTileEntry): string {
   // Disambiguates multiple tiles pinned to the same agent by including
   // the resource URI — each (agent, resource) pair is its own grid tile.
   return `tile:${t.agentId}:${t.resourceUri}`;
+}
+
+/** Secondary line under the card title. Quick-access agent cards (no
+ *  promptName) put the agent name in the title slot, so their subtitle is
+ *  the agent description; prompt cards keep the owning agent's name. */
+function entrySubtitle(entry: HomePromptEntry): string {
+  return entry.promptName ? entry.agentName : entry.description;
 }
 
 function entryToPrompt(entry: HomePromptEntry): Prompt {
@@ -120,7 +127,7 @@ function PromptTile({
             {entry.title}
           </div>
           <div className="truncate text-xs text-muted-foreground mt-0.5">
-            {entry.agentName}
+            {entrySubtitle(entry)}
           </div>
         </div>
         {!isEditMode && (
@@ -131,70 +138,6 @@ function PromptTile({
           />
         )}
       </button>
-      {dialog}
-    </>
-  );
-}
-
-function PromptChip({
-  entry,
-  isEditMode,
-  onHide,
-}: {
-  entry: HomePromptEntry;
-  isEditMode: boolean;
-  onHide: () => void;
-}) {
-  const { open, dialog, starting } = usePromptEntryAction(entry.agentId);
-
-  return (
-    <>
-      <div className="group/chip relative">
-        <button
-          type="button"
-          onClick={() => !isEditMode && open(entry)}
-          disabled={starting || isEditMode}
-          aria-busy={starting}
-          className={cn(
-            "flex w-full items-center gap-3 rounded-2xl bg-card card-shadow px-3 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            !isEditMode &&
-              "transition-colors hover:bg-accent/40 cursor-pointer",
-            isEditMode && "cursor-default",
-            starting && "opacity-60",
-          )}
-        >
-          <AgentAvatar
-            icon={entry.agentIcon}
-            name={entry.agentName}
-            size="sm+"
-          />
-          <div className="min-w-0 flex-1">
-            <div className="line-clamp-2 text-sm font-medium text-foreground leading-snug">
-              {entry.title}
-            </div>
-            <div className="truncate text-xs text-muted-foreground mt-0.5">
-              {entry.agentName}
-            </div>
-          </div>
-          {!isEditMode && (
-            <ArrowRight
-              size={16}
-              className="shrink-0 text-muted-foreground opacity-0 -translate-x-1 transition-all duration-200 group-hover/chip:opacity-100 group-hover/chip:translate-x-0"
-              aria-hidden
-            />
-          )}
-        </button>
-        {isEditMode && (
-          <button
-            type="button"
-            onClick={onHide}
-            aria-label="Remove tile"
-            className="absolute -top-2 -right-2 flex size-6 items-center justify-center rounded-full bg-background border border-border text-muted-foreground shadow-sm hover:bg-muted hover:text-foreground"
-          >
-            <X size={12} />
-          </button>
-        )}
-      </div>
       {dialog}
     </>
   );
@@ -501,35 +444,10 @@ export function HomeGrid({ isEditMode }: HomeGridProps) {
   const isEmpty = layout.snapshot.visible.length === 0;
   if (isEmpty && !isEditMode) return null;
 
-  // If the visible board is "just prompts" (no agent UI tiles), bypass the
-  // absolute-positioned grid and render content-hugging chips in a wrapping
-  // row — the grid's fixed cells make small tiles look clipped/empty.
-  const visibleHasUITile = layout.snapshot.visible.some((t) => {
-    const cand = candidatesById.get(t.id);
-    return cand?.kind === "tile";
-  });
-
-  if (!visibleHasUITile) {
-    const visiblePrompts = layout.snapshot.visible
-      .map((t) => candidatesById.get(t.id))
-      .filter((c): c is PromptCandidate => c?.kind === "prompt");
-    return (
-      // Same container width / column count as the tile board. Keeps
-      // chip columns aligned with whatever a future agent-UI tile would
-      // occupy, so nothing shifts when the user adds their first tile.
-      <div className="mt-4 grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-        {visiblePrompts.map((c) => (
-          <PromptChip
-            key={c.id}
-            entry={c.data}
-            isEditMode={isEditMode}
-            onHide={() => removeCandidate(c.id)}
-          />
-        ))}
-      </div>
-    );
-  }
-
+  // Everything renders through the same absolute-positioned grid board —
+  // prompts as 1×1 tiles, agent UI as larger tiles. One path means the
+  // edit-mode drag handle + size/remove menu show up consistently, whether
+  // or not the home has an agent-UI tile.
   return (
     <div className="mt-4 flex w-full max-w-7xl flex-col gap-4">
       <TileBoard

--- a/apps/mesh/src/web/components/home/tile-board/tile-board.tsx
+++ b/apps/mesh/src/web/components/home/tile-board/tile-board.tsx
@@ -285,7 +285,7 @@ function BoardTile({
   );
 }
 
-function TileMenu({
+export function TileMenu({
   tile,
   onResize,
   onRemove,

--- a/apps/mesh/src/web/components/home/tile-board/tile-board.tsx
+++ b/apps/mesh/src/web/components/home/tile-board/tile-board.tsx
@@ -285,7 +285,7 @@ function BoardTile({
   );
 }
 
-export function TileMenu({
+function TileMenu({
   tile,
   onResize,
   onRemove,


### PR DESCRIPTION
…d clarity

- Adjusted fallback and prompt tile entries to use agent names as titles and descriptions for quick-access agent cards.
- Enhanced the AddTileDrawer component with a minimum height for better layout consistency.
- Removed unused imports and refactored subtitle logic in the HomeGrid component for cleaner code and improved readability.
- Exported the TileMenu function for better accessibility in other components.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies quick-access agent cards by using the agent name as the title and its description as the subtitle across API and UI. Unifies prompt rendering through the tile grid for a consistent layout and editing experience.

- **Refactors**
  - Quick-access cards: API/UI set title = agent name, subtitle = description; prompt tiles keep the agent name as the subtitle.
  - Unified rendering: removed chip-only path; all prompts render as 1×1 tiles with consistent edit/menu controls; centralized subtitle logic; exported TileMenu.
  - Tooling: added `knip` for dead-code checks.

- **Bug Fixes**
  - AddTileDrawer scroll area now has a min height to prevent layout issues in smaller containers.

<sup>Written for commit 085b3caa678b6d266247b436d562c082f4d64b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

