### PR TITLE
Local daemon supervision

### DIFF
--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -7,6 +7,7 @@
  */
 import { tmpdir } from "node:os";
 import { join } from "path";
+import { sleep } from "@decocms/std";
 import type { Subprocess } from "bun";
 import { buildSettings } from "../../settings/pipeline";
 import {
@@ -185,83 +186,79 @@ export async function startDevServer(
   // hits the outer .git, refuses to clone, and the daemon crashes
   // mid-bootstrap. The tmpdir-rooted path keyed by workspace slug also
   // keeps concurrent worktrees from fighting over the same sandboxes dir.
-  const linkChild: Promise<Subprocess | null> = !options.localSandboxProvider
-    ? Promise.resolve(null)
-    : (async (): Promise<Subprocess | null> => {
-        const { ensureLink } = await import("../../services/ensure-services");
-        try {
-          const { info, proc } = await ensureLink({
-            home: settings.dataDir,
-            clusterUrl: serverUrl,
-            linkDataDir,
-            repoRoot,
-            stdio: [
-              "inherit",
-              useInherit ? "inherit" : "pipe",
-              useInherit ? "inherit" : "pipe",
-            ],
-            onSpawn: (proc) => {
-              if (useInherit) return;
-              pipeToLogStore(proc.stdout as ReadableStream<Uint8Array>);
-              pipeToLogStore(proc.stderr as ReadableStream<Uint8Array>);
-            },
-            beforeSpawn: async () => {
-              // Wait for the cluster's HTTP port before spawning the link
-              // daemon so it can immediately reach the WS gateway.
-              await waitForPort(Number(settings.port), { intervalMs: 500 });
-              // Then wait for the cluster's `bootstrapDevLinkSession` to
-              // drop session.json into linkDataDir, since the link CLI's
-              // `ensureSession` errors out (non-TTY auto-spawn) if it's
-              // missing.
-              const sessionPath = join(linkDataDir, "session.json");
-              const deadline = Date.now() + 30_000;
-              while (Date.now() < deadline) {
-                if (await Bun.file(sessionPath).exists()) return;
-                await new Promise((r) => setTimeout(r, 250));
-              }
-              throw new Error(
-                `[dev-link] session.json not minted at ${sessionPath} after 30s — check cluster logs for [dev-link] errors`,
-              );
-            },
-          });
-          // Mark Sandbox ready once the link binary's HTTP server accepts
-          // connections on its port. Fire-and-forget; if the link never
-          // comes up (e.g. no admin user yet for session bootstrap), the
-          // status stays "pending" and the user sees a spinner — useful
-          // signal that something's wrong rather than silent failure.
-          void waitForPort(info.port, { intervalMs: 500 })
-            .then(() => {
-              updateService({
-                name: "Sandbox",
-                status: "ready",
-                port: info.port,
-              });
-            })
-            .catch(() => {
-              /* link never came up — leave status pending as a signal */
-            });
-          return proc;
-        } catch (err) {
-          addLogEntry({
-            method: "",
-            path: "",
-            status: 0,
-            duration: 0,
-            timestamp: new Date(),
-            rawLine: `[link] failed to start: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          });
-          return null;
-        }
+  //
+  // Supervise the daemon for the whole session rather than spawning it once.
+  // The daemon's WS self-heals (cluster-connection reconnects forever); only a
+  // process exit is unrecoverable, and an unsupervised exit silently expires
+  // the NATS link claim (60s TTL) → every user-desktop dispatch 409s with
+  // `user_desktop_link_offline` while the UI still reads "ready". superviseLink
+  // respawns on exit with backoff and drives Sandbox status from real liveness.
+  const linkAbort = new AbortController();
+  const linkSupervisor: Promise<void> = !options.localSandboxProvider
+    ? Promise.resolve()
+    : (async () => {
+        const { superviseLink } = await import(
+          "../../services/ensure-services"
+        );
+        await superviseLink({
+          home: settings.dataDir,
+          clusterUrl: serverUrl,
+          linkDataDir,
+          repoRoot,
+          signal: linkAbort.signal,
+          stdio: [
+            "inherit",
+            useInherit ? "inherit" : "pipe",
+            useInherit ? "inherit" : "pipe",
+          ],
+          onSpawn: (proc) => {
+            if (useInherit) return;
+            pipeToLogStore(proc.stdout as ReadableStream<Uint8Array>);
+            pipeToLogStore(proc.stderr as ReadableStream<Uint8Array>);
+          },
+          beforeSpawn: async () => {
+            // Wait for the cluster's HTTP port before spawning the link
+            // daemon so it can immediately reach the WS gateway.
+            await waitForPort(Number(settings.port), { intervalMs: 500 });
+            // Then wait for the cluster's `bootstrapDevLinkSession` to drop
+            // session.json into linkDataDir, since the link CLI's
+            // `ensureSession` errors out (non-TTY auto-spawn) if it's missing.
+            const sessionPath = join(linkDataDir, "session.json");
+            const deadline = Date.now() + 30_000;
+            while (Date.now() < deadline) {
+              if (await Bun.file(sessionPath).exists()) return;
+              await sleep(250);
+            }
+            throw new Error(
+              `[dev-link] session.json not minted at ${sessionPath} after 30s — check cluster logs for [dev-link] errors`,
+            );
+          },
+          // Drive Sandbox status from real liveness: "ready" when the daemon's
+          // HTTP port answers, "pending" (spinner) while it's down/respawning
+          // so a crash isn't masked by a stale "ready".
+          onReady: (port) =>
+            updateService({ name: "Sandbox", status: "ready", port }),
+          onDown: () =>
+            updateService({ name: "Sandbox", status: "pending", port: 0 }),
+          onLog: (rawLine) =>
+            addLogEntry({
+              method: "",
+              path: "",
+              status: 0,
+              duration: 0,
+              timestamp: new Date(),
+              rawLine,
+            }),
+        });
       })();
 
   const shutdown = async (signal: NodeJS.Signals) => {
-    // Wait for any in-flight link spawn to settle so we don't orphan a
-    // process that gets spawned right after we've torn down everything
-    // else. On a normal shutdown the spawn has long since resolved.
-    await linkChild.catch(() => null);
-    // Stop the link first — it talks to the cluster on shutdown
+    // Stop the supervisor first so it can't respawn the daemon we're about to
+    // tear down, then wait for its loop to settle (it may be mid-spawn). This
+    // also prevents orphaning a process spawned right as we shut down.
+    linkAbort.abort();
+    await linkSupervisor.catch(() => null);
+    // Stop the link next — it talks to the cluster on shutdown
     // (DELETE /api/links/me), so giving it a window before we tear down
     // the API server reduces orphaned registry entries. stopLink reads
     // the state file written by ensureLink, signals the daemon, waits

--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -15,7 +15,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "fs";
-import { sleep } from "@decocms/std";
+import { exponentialBackoffWithJitter, sleep } from "@decocms/std";
 import { chmod, unlink } from "fs/promises";
 import { createRequire } from "module";
 import { createConnection, createServer } from "net";
@@ -867,11 +867,135 @@ async function stopLink(home: string): Promise<void> {
   console.log("Link stopped");
 }
 
+// Respawn policy for a dev-session link daemon. Capped exponential backoff so
+// a daemon that crash-loops on a persistent fault doesn't busy-spin.
+const LINK_RESPAWN_BASE_MS = 500;
+const LINK_RESPAWN_CAP_MS = 30_000;
+// A daemon that stays up at least this long counts as healthy; its next exit
+// resets the backoff streak instead of escalating from a stale count.
+const LINK_HEALTHY_UPTIME_MS = 30_000;
+
+function linkRespawnBackoffMs(attempt: number): number {
+  return exponentialBackoffWithJitter(
+    LINK_RESPAWN_CAP_MS,
+    LINK_RESPAWN_BASE_MS,
+    attempt,
+    2,
+    0.5,
+  );
+}
+
+/** Resolve when the subprocess exits or `signal` aborts, whichever is first. */
+function exitedOrAborted(
+  proc: ReturnType<typeof Bun.spawn>,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void proc.exited.then(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    });
+  });
+}
+
+/** Poll a PID until it dies or `signal` aborts. Used for a reused daemon, where
+ *  we have no `Subprocess` handle to await. */
+async function waitUntilPidDead(
+  pid: number,
+  signal: AbortSignal,
+): Promise<void> {
+  while (!signal.aborted && isProcessAlive(pid)) {
+    await sleep(2_000, { signal }).catch(() => {});
+  }
+}
+
+export interface SuperviseLinkInputs extends EnsureLinkInputs {
+  /** Fired when the daemon's HTTP port is accepting connections. */
+  onReady?: (port: number) => void;
+  /** Fired when the daemon is down and a respawn is pending. */
+  onDown?: () => void;
+  /** Human-facing status lines (spawn failures, crash codes, respawn notices). */
+  onLog?: (line: string) => void;
+  /** Abort to stop supervising (orderly shutdown). */
+  signal: AbortSignal;
+}
+
+/**
+ * Keep the link daemon alive for the lifetime of a dev session.
+ *
+ * `ensureLink` spawns the daemon once and returns; nothing notices if it later
+ * dies. The daemon's *WebSocket* self-heals (cluster-connection.ts reconnects
+ * forever), so the one unrecoverable failure is the process itself exiting —
+ * after which its NATS link claim expires (60s TTL) and every user-desktop
+ * dispatch returns `user_desktop_link_offline` while the dev UI still shows the
+ * sandbox as ready. This loop closes that gap: respawn on unexpected exit with
+ * capped exponential backoff, and surface real liveness via the callbacks.
+ *
+ * Resolves when `signal` aborts (orderly shutdown). The caller is responsible
+ * for stopping the still-running daemon afterward (e.g. via `stopLink`).
+ */
+async function superviseLink(inputs: SuperviseLinkInputs): Promise<void> {
+  let attempt = 0;
+  while (!inputs.signal.aborted) {
+    const startedAt = Date.now();
+    let result: EnsureLinkResult;
+    try {
+      result = await ensureLink(inputs);
+    } catch (err) {
+      inputs.onDown?.();
+      inputs.onLog?.(
+        `[link] daemon failed to start: ${
+          err instanceof Error ? err.message : String(err)
+        } — retrying`,
+      );
+      if (inputs.signal.aborted) return;
+      await sleep(linkRespawnBackoffMs(attempt++), {
+        signal: inputs.signal,
+      }).catch(() => {});
+      continue;
+    }
+
+    // ensureLink already waited for the port on a fresh spawn; a reused daemon
+    // hasn't been probed here. Either way, confirm before declaring ready.
+    void waitForPort(result.info.port)
+      .then(() => inputs.onReady?.(result.info.port))
+      .catch(() => {});
+
+    // Block until the daemon process is gone. Fresh spawn → await the
+    // Subprocess; reused managed daemon (proc === null) → poll its PID.
+    if (result.proc) {
+      await exitedOrAborted(result.proc, inputs.signal);
+    } else if (result.info.pid !== null) {
+      await waitUntilPidDead(result.info.pid, inputs.signal);
+    }
+
+    if (inputs.signal.aborted) return;
+
+    // Unexpected exit. ensureLink's next readState sees the dead PID and clears
+    // it, so the following iteration spawns fresh.
+    inputs.onDown?.();
+    const aliveMs = Date.now() - startedAt;
+    if (aliveMs >= LINK_HEALTHY_UPTIME_MS) attempt = 0;
+    inputs.onLog?.(
+      `[link] daemon exited after ${Math.round(aliveMs / 1000)}s — respawning`,
+    );
+    await sleep(linkRespawnBackoffMs(attempt++), {
+      signal: inputs.signal,
+    }).catch(() => {});
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
-export { ensureLink, stopLink };
+export { ensureLink, stopLink, superviseLink };
 
 function portFromUrl(url: string, fallback: number): number {
   try {

--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -995,7 +995,7 @@ async function superviseLink(inputs: SuperviseLinkInputs): Promise<void> {
 // Public API
 // ---------------------------------------------------------------------------
 
-export { ensureLink, stopLink, superviseLink };
+export { stopLink, superviseLink };
 
 function portFromUrl(url: string, fallback: number): number {
   try {

--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -195,11 +195,16 @@ function probePort(port: number, host = "localhost"): Promise<boolean> {
   });
 }
 
-async function waitForPort(port: number, timeoutMs = 30_000): Promise<void> {
+async function waitForPort(
+  port: number,
+  timeoutMs = 30_000,
+  signal?: AbortSignal,
+): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
+    if (signal?.aborted) throw new Error(`Aborted waiting for port ${port}`);
     if (await probePort(port)) return;
-    await sleep(200);
+    await sleep(200, signal ? { signal } : undefined).catch(() => {});
   }
   throw new Error(`Timed out waiting for port ${port}`);
 }
@@ -962,9 +967,17 @@ async function superviseLink(inputs: SuperviseLinkInputs): Promise<void> {
     }
 
     // ensureLink already waited for the port on a fresh spawn; a reused daemon
-    // hasn't been probed here. Either way, confirm before declaring ready.
-    void waitForPort(result.info.port)
-      .then(() => inputs.onReady?.(result.info.port))
+    // hasn't been probed here. Either way, confirm before declaring ready —
+    // but bind the probe to this daemon instance: cancel it when the daemon
+    // exits or we abort, so a slow/late probe can't emit a stale onReady for a
+    // dead daemon (each respawn gets a new port) or leak across respawns.
+    const readyAbort = new AbortController();
+    const cancelReady = () => readyAbort.abort();
+    inputs.signal.addEventListener("abort", cancelReady, { once: true });
+    void waitForPort(result.info.port, 30_000, readyAbort.signal)
+      .then(() => {
+        if (!readyAbort.signal.aborted) inputs.onReady?.(result.info.port);
+      })
       .catch(() => {});
 
     // Block until the daemon process is gone. Fresh spawn → await the
@@ -974,6 +987,11 @@ async function superviseLink(inputs: SuperviseLinkInputs): Promise<void> {
     } else if (result.info.pid !== null) {
       await waitUntilPidDead(result.info.pid, inputs.signal);
     }
+
+    // Daemon is gone (or we're aborting): stop the readiness probe and drop the
+    // abort listener so iterations don't accumulate listeners on inputs.signal.
+    readyAbort.abort();
+    inputs.signal.removeEventListener("abort", cancelReady);
 
     if (inputs.signal.aborted) return;
 


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the local link daemon alive during dev with a supervisor that auto-respawns on exit and updates Sandbox status from real liveness. This avoids silent link expiry and reduces 409 `user_desktop_link_offline` errors.

- **New Features**
  - Added `superviseLink` with capped exponential backoff (`@decocms/std` `exponentialBackoffWithJitter`).
  - Emits `onReady`, `onDown`, and `onLog` callbacks to reflect daemon health.
  - Waits for cluster port and `session.json` using `@decocms/std` `sleep`.
  - Properly handles reused daemons by probing port and watching PID.
  - Bound readiness probe to the daemon instance via abortable `waitForPort`; cancels on exit to prevent stale “ready” and cleans up listeners.

- **Refactors**
  - Replaced one-shot `ensureLink` spawn in `dev` command with a long-running supervisor.
  - Clean shutdown: abort supervisor first, wait, then stop the link.
  - Updated public API export to `superviseLink` (kept `stopLink`).

<sup>Written for commit 3633317ab9abdd29a993029725d0d8fc65a9848c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

