### PR TITLE
fix(vm-tools): improve error handling for daemon requests

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/index.ts
@@ -175,10 +175,13 @@ async function daemonRequest(
       res.status,
       rawText.slice(0, 2000),
     );
-    throw new Error(
+    const errorMessage =
       (json as { error?: string }).error ??
-        `Daemon ${path} failed (${res.status})`,
-    );
+      `Daemon ${path} failed (${res.status})`;
+    if (res.status === 404 && errorMessage === "sandbox not found") {
+      throw new DaemonUnreachableError(new Error(errorMessage));
+    }
+    throw new Error(errorMessage);
   }
   return json;
 }

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -506,7 +506,7 @@ export class AgentSandboxProvider implements SandboxProvider {
     path: string,
     init: ProxyRequestInit,
   ): Promise<Response> {
-    const rec = await this.getRecord(handle);
+    let rec = await this.getRecord(handle);
 
     // rehydrate failed (port-forward is pod-local); route via in-cluster Service instead.
     if (!rec && this.previewUrlPattern && this.stateStore) {
@@ -518,6 +518,10 @@ export class AgentSandboxProvider implements SandboxProvider {
         const daemonUrl = `http://${adoptedName}.${this.namespace}.svc.cluster.local:${DAEMON_CONTAINER_PORT}`;
         return proxyDaemonRequest(daemonUrl, token, path, init);
       }
+    }
+
+    if (!rec) {
+      rec = await this.resurrectByHandle(handle).catch(() => null);
     }
 
     if (!rec) {

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -520,8 +520,17 @@ export class AgentSandboxProvider implements SandboxProvider {
       }
     }
 
+    // Operator may have evicted the claim+pod (15-min idle TTL) since the record
+    // was cached. Mirror exec()'s requireRecord(): resurrect from the persisted
+    // ensureOpts before giving up, so the agent's request path recovers the same
+    // way exec does instead of surfacing a 404. resurrectByHandle returns null
+    // only for genuine not-found cases (no state-store / no row / row predates
+    // ensureOpts) — those fall through to the 404 below. A real ensure() failure
+    // (K8s/provisioning/bootstrap) THROWS and must propagate: callers already
+    // treat a throw as unreachable, and swallowing it would mislabel a backend
+    // failure as a false 404 "sandbox not found".
     if (!rec) {
-      rec = await this.resurrectByHandle(handle).catch(() => null);
+      rec = await this.resurrectByHandle(handle);
     }
 
     if (!rec) {


### PR DESCRIPTION
- Refactored error handling in daemonRequest function to provide clearer error messages.
- Introduced specific handling for 404 errors when the sandbox is not found, throwing a DaemonUnreachableError.
- Updated AgentSandboxProvider to attempt resurrection of records if not found, enhancing robustness.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves daemon request error handling and sandbox recovery to prevent false 404s. 404 "sandbox not found" now maps to `DaemonUnreachableError`, and the provider resurrects missing sandboxes from persisted options before failing.

- **Bug Fixes**
  - In `vm-tools` daemonRequest, map 404 "sandbox not found" to `DaemonUnreachableError` for clearer retries.
  - In `AgentSandboxProvider`, try `resurrectByHandle` from persisted ensure options before returning 404, and propagate real ensure() failures instead of masking them as 404.

<sup>Written for commit abc8ce2310b06a6dd42a9cec7256240c7c4b1128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

