### PR TITLE
fix(links): stop MAX_PAYLOAD_EXCEEDED on remote user-sandbox streams

### DIFF
--- a/apps/mesh/src/links/dispatcher.test.ts
+++ b/apps/mesh/src/links/dispatcher.test.ts
@@ -165,4 +165,33 @@ describe("dispatcher", () => {
     const decoded = decodeFrame(new TextDecoder().decode(cancels[0]!.data));
     expect(decoded.type).toBe("cancel");
   });
+
+  test("request publish failure rejects and unsubscribes the inbox exactly once", async () => {
+    const nats = makeFakeNats();
+    let unsubscribes = 0;
+    const origSubscribe = nats.subscribe.bind(nats);
+    (nats as { subscribe: typeof nats.subscribe }).subscribe = (
+      subject,
+      cb,
+    ) => {
+      const off = origSubscribe(subject, cb);
+      return () => {
+        unsubscribes++;
+        off();
+      };
+    };
+    (nats as { publish: typeof nats.publish }).publish = () => {
+      throw new Error("MAX_PAYLOAD_EXCEEDED");
+    };
+    const dispatch = createDispatcher({ nats, requestTimeoutMs: 5_000 });
+    await expect(async () => {
+      for await (const _ of dispatch("user-1", {
+        method: "POST",
+        path: "/_sandbox/x/write",
+        headers: {},
+        body: "x",
+      }));
+    }).toThrow(/MAX_PAYLOAD_EXCEEDED/);
+    expect(unsubscribes).toBe(1); // exactly once — no leak, no double-cleanup
+  });
 });

--- a/apps/mesh/src/links/dispatcher.test.ts
+++ b/apps/mesh/src/links/dispatcher.test.ts
@@ -194,4 +194,28 @@ describe("dispatcher", () => {
     }).toThrow(/MAX_PAYLOAD_EXCEEDED/);
     expect(unsubscribes).toBe(1); // exactly once — no leak, no double-cleanup
   });
+
+  test("request publish failure detaches the abort listener (no stray cancel on later abort)", async () => {
+    const nats = makeFakeNats();
+    const cancels: string[] = [];
+    (nats as { publish: typeof nats.publish }).publish = (subject) => {
+      if (subject.startsWith("links.dispatch.")) {
+        throw new Error("MAX_PAYLOAD_EXCEEDED");
+      }
+      if (subject.startsWith("links.cancel.")) cancels.push(subject);
+    };
+    const ac = new AbortController();
+    const dispatch = createDispatcher({ nats, requestTimeoutMs: 5_000 });
+    await expect(async () => {
+      for await (const _ of dispatch(
+        "user-1",
+        { method: "POST", path: "/_sandbox/x/write", headers: {}, body: "x" },
+        { signal: ac.signal },
+      ));
+    }).toThrow(/MAX_PAYLOAD_EXCEEDED/);
+    // The dispatch already failed and cleaned up; aborting now must not invoke
+    // onAbort (its listener was removed), so no cancel frame is published.
+    ac.abort();
+    expect(cancels).toEqual([]);
+  });
 });

--- a/apps/mesh/src/links/dispatcher.ts
+++ b/apps/mesh/src/links/dispatcher.ts
@@ -106,7 +106,10 @@ export function createDispatcher(deps: CreateDispatcherDeps): DispatchFn {
           wake();
         });
 
+        let cleanedUp = false;
         const cleanup = (): void => {
+          if (cleanedUp) return;
+          cleanedUp = true;
           done = true;
           try {
             unsubscribe();
@@ -126,20 +129,27 @@ export function createDispatcher(deps: CreateDispatcherDeps): DispatchFn {
         };
         opts?.signal?.addEventListener("abort", onAbort, { once: true });
 
-        deps.nats.publish(
-          `links.dispatch.${userSub}`,
-          encoder.encode(
-            encodeFrame({
-              type: "request",
-              reqId,
-              method: req.method,
-              path: req.path,
-              headers: req.headers,
-              ...(req.body !== undefined ? { body: req.body } : {}),
-            }),
-          ),
-          { reply: inbox },
-        );
+        try {
+          deps.nats.publish(
+            `links.dispatch.${userSub}`,
+            encoder.encode(
+              encodeFrame({
+                type: "request",
+                reqId,
+                method: req.method,
+                path: req.path,
+                headers: req.headers,
+                ...(req.body !== undefined ? { body: req.body } : {}),
+              }),
+            ),
+            { reply: inbox },
+          );
+        } catch (err) {
+          // e.g. a request body over max_payload (follow-up F1 will chunk
+          // these). Tear down the inbox subscription before surfacing.
+          cleanup();
+          throw err instanceof Error ? err : new Error(String(err));
+        }
 
         const firstReplyDeadline = Date.now() + timeoutMs;
         let receivedAny = false;

--- a/apps/mesh/src/links/dispatcher.ts
+++ b/apps/mesh/src/links/dispatcher.ts
@@ -146,7 +146,9 @@ export function createDispatcher(deps: CreateDispatcherDeps): DispatchFn {
           );
         } catch (err) {
           // e.g. a request body over max_payload (follow-up F1 will chunk
-          // these). Tear down the inbox subscription before surfacing.
+          // these). This path skips the finally below, so detach the abort
+          // listener and tear down the inbox subscription before surfacing.
+          opts?.signal?.removeEventListener("abort", onAbort);
           cleanup();
           throw err instanceof Error ? err : new Error(String(err));
         }

--- a/apps/mesh/src/links/ws-gateway.test.ts
+++ b/apps/mesh/src/links/ws-gateway.test.ts
@@ -10,6 +10,7 @@ import {
   encodeFrame,
   type DispatchFrame,
 } from "./dispatch-frames";
+import { MAX_PUBLISH_BYTES } from "../nats/payload-chunking";
 
 function makeFakeNatsAdapter() {
   // Records subscribe/publish; doesn't deliver — that's tested in dispatch demux.
@@ -433,5 +434,152 @@ describe("ws-gateway dispatch demux", () => {
     const frameB = decodeFrame(new TextDecoder().decode(repliesB[0]!));
     expect(frameA.type).toBe("error");
     expect(frameB.type).toBe("error");
+  });
+
+  test("splits an oversized chunk frame into ordered sub-chunks that each fit", async () => {
+    const nats = makeFakeNatsAdapter();
+    const inbox = "_INBOX.big";
+    const replies: Uint8Array[] = [];
+    nats.subs.set(inbox, (data) => replies.push(data));
+
+    const { url } = await startGateway({
+      validateBearer: async () => "user-1",
+      natsAdapter: nats,
+    });
+
+    const ws = new WebSocket(url, {
+      headers: { authorization: "Bearer x" },
+    } as unknown as string);
+    await new Promise<void>((r) => ws.addEventListener("open", () => r()));
+    ws.send(
+      encodeFrame({
+        type: "hello",
+        previewPort: 5174,
+        machineId: "m",
+        cliVersion: "1",
+        capabilities: [],
+      }),
+    );
+    for (let i = 0; i < 40; i++) {
+      if (nats.subs.has("links.dispatch.user-1")) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    const dispatchHandler = nats.subs.get("links.dispatch.user-1")!;
+    dispatchHandler(
+      new TextEncoder().encode(
+        encodeFrame({
+          type: "request",
+          reqId: "r-1",
+          method: "GET",
+          path: "/_sandbox/x/read",
+          headers: {},
+        }),
+      ),
+      inbox,
+    );
+
+    // One oversized chunk whose encoded frame exceeds the NATS payload budget.
+    const data = "x".repeat(MAX_PUBLISH_BYTES + 100);
+    ws.send(encodeFrame({ type: "chunk", reqId: "r-1", data }));
+
+    const chunkData = () =>
+      replies
+        .map((b) => decodeFrame(new TextDecoder().decode(b)))
+        .filter(
+          (f): f is Extract<DispatchFrame, { type: "chunk" }> =>
+            f.type === "chunk",
+        );
+    for (let i = 0; i < 80; i++) {
+      if (
+        chunkData()
+          .map((f) => f.data)
+          .join("").length >= data.length
+      ) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+
+    const chunks = chunkData();
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const b of replies) {
+      expect(b.length).toBeLessThanOrEqual(MAX_PUBLISH_BYTES);
+    }
+    expect(chunks.every((f) => f.reqId === "r-1")).toBe(true);
+    expect(chunks.map((f) => f.data).join("")).toBe(data);
+    ws.close();
+  });
+
+  test("a publish that throws becomes a clean error frame (no uncaught throw)", async () => {
+    const nats = makeFakeNatsAdapter();
+    const inbox = "_INBOX.err";
+    const replies: Uint8Array[] = [];
+    nats.subs.set(inbox, (data) => replies.push(data));
+
+    const origPublish = nats.publish.bind(nats);
+    let threw = false;
+    (nats as { publish: typeof nats.publish }).publish = (subject, data) => {
+      let frame: DispatchFrame | null = null;
+      try {
+        frame = decodeFrame(new TextDecoder().decode(data));
+      } catch {
+        /* not a frame */
+      }
+      if (frame?.type === "chunk" && !threw) {
+        threw = true;
+        throw new Error("MAX_PAYLOAD_EXCEEDED");
+      }
+      origPublish(subject, data);
+    };
+
+    const { url } = await startGateway({
+      validateBearer: async () => "user-1",
+      natsAdapter: nats,
+    });
+    const ws = new WebSocket(url, {
+      headers: { authorization: "Bearer x" },
+    } as unknown as string);
+    await new Promise<void>((r) => ws.addEventListener("open", () => r()));
+    ws.send(
+      encodeFrame({
+        type: "hello",
+        previewPort: 5174,
+        machineId: "m",
+        cliVersion: "1",
+        capabilities: [],
+      }),
+    );
+    for (let i = 0; i < 40; i++) {
+      if (nats.subs.has("links.dispatch.user-1")) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    const dispatchHandler = nats.subs.get("links.dispatch.user-1")!;
+    dispatchHandler(
+      new TextEncoder().encode(
+        encodeFrame({
+          type: "request",
+          reqId: "r-1",
+          method: "GET",
+          path: "/_sandbox/x/read",
+          headers: {},
+        }),
+      ),
+      inbox,
+    );
+
+    ws.send(encodeFrame({ type: "chunk", reqId: "r-1", data: "hello" }));
+
+    for (let i = 0; i < 80; i++) {
+      if (replies.length > 0) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(replies.length).toBeGreaterThanOrEqual(1);
+    const frame = decodeFrame(new TextDecoder().decode(replies[0]!));
+    expect(frame.type).toBe("error");
+    if (frame.type === "error") {
+      expect(frame.code).toBe("publish_failed");
+      expect(frame.reqId).toBe("r-1");
+    }
+    ws.close();
   });
 });

--- a/apps/mesh/src/links/ws-gateway.test.ts
+++ b/apps/mesh/src/links/ws-gateway.test.ts
@@ -582,4 +582,80 @@ describe("ws-gateway dispatch demux", () => {
     }
     ws.close();
   });
+
+  test("keeps the inflight entry when even the error frame fails to publish, so close still notifies", async () => {
+    const nats = makeFakeNatsAdapter();
+    const inbox = "_INBOX.dbl";
+    const replies: Uint8Array[] = [];
+    nats.subs.set(inbox, (data) => replies.push(data));
+
+    // While `failInbox` is set, every publish to the reply inbox throws — so
+    // both the chunk publish AND the follow-up error-frame publish fail.
+    let failInbox = true;
+    const origPublish = nats.publish.bind(nats);
+    (nats as { publish: typeof nats.publish }).publish = (subject, data) => {
+      if (subject === inbox && failInbox) {
+        throw new Error("MAX_PAYLOAD_EXCEEDED");
+      }
+      origPublish(subject, data);
+    };
+
+    const { url } = await startGateway({
+      validateBearer: async () => "user-1",
+      natsAdapter: nats,
+    });
+    const ws = new WebSocket(url, {
+      headers: { authorization: "Bearer x" },
+    } as unknown as string);
+    await new Promise<void>((r) => ws.addEventListener("open", () => r()));
+    ws.send(
+      encodeFrame({
+        type: "hello",
+        previewPort: 5174,
+        machineId: "m",
+        cliVersion: "1",
+        capabilities: [],
+      }),
+    );
+    for (let i = 0; i < 40; i++) {
+      if (nats.subs.has("links.dispatch.user-1")) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    const dispatchHandler = nats.subs.get("links.dispatch.user-1")!;
+    dispatchHandler(
+      new TextEncoder().encode(
+        encodeFrame({
+          type: "request",
+          reqId: "r-1",
+          method: "GET",
+          path: "/_sandbox/x/read",
+          headers: {},
+        }),
+      ),
+      inbox,
+    );
+
+    // Chunk publish throws; the error-frame publish throws too → nothing
+    // reaches the inbox and the inflight entry must be retained.
+    ws.send(encodeFrame({ type: "chunk", reqId: "r-1", data: "hello" }));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(replies.length).toBe(0);
+
+    // NATS recovers; closing the socket must now deliver a ws_closed error for
+    // the still-tracked request, proving the entry was not dropped.
+    failInbox = false;
+    ws.close();
+
+    for (let i = 0; i < 80; i++) {
+      if (replies.length > 0) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(replies.length).toBeGreaterThanOrEqual(1);
+    const frame = decodeFrame(new TextDecoder().decode(replies[0]!));
+    expect(frame.type).toBe("error");
+    if (frame.type === "error") {
+      expect(frame.code).toBe("ws_closed");
+      expect(frame.reqId).toBe("r-1");
+    }
+  });
 });

--- a/apps/mesh/src/links/ws-gateway.ts
+++ b/apps/mesh/src/links/ws-gateway.ts
@@ -19,6 +19,7 @@ import {
 } from "./dispatch-frames";
 import type { LinkClaim, LinkClaimRegistry } from "./link-claim-registry";
 import type { Capability } from "./protocol";
+import { MAX_PUBLISH_BYTES, splitChunkData } from "../nats/payload-chunking";
 
 const WS_CLOSE_SUPERSEDED = 4001;
 const WS_CLOSE_POLICY = 1008;
@@ -292,6 +293,59 @@ function onCancelFromNats(
   ws.send(encodeFrame(frame));
 }
 
+/**
+ * Publish a frame to `reply`, splitting an oversized `chunk` into ordered
+ * sub-chunks (same reqId) so each NATS message stays under the payload limit.
+ * The dispatcher yields chunks in order and the consumer concatenates, so no
+ * reassembly is needed. Non-chunk frames (headers/end/error) are small.
+ */
+function publishFrame(
+  ws: ServerWebSocket<WsAttachData>,
+  reply: string,
+  frame: DispatchFrame,
+): void {
+  const nats = ws.data.deps.nats;
+  if (frame.type !== "chunk") {
+    nats.publish(reply, encoder.encode(encodeFrame(frame)));
+    return;
+  }
+  const encoded = encoder.encode(encodeFrame(frame));
+  if (encoded.length <= MAX_PUBLISH_BYTES) {
+    nats.publish(reply, encoded);
+    return;
+  }
+  const overhead = encoder.encode(
+    encodeFrame({ type: "chunk", reqId: frame.reqId, data: "" }),
+  ).length;
+  for (const piece of splitChunkData(frame.data, MAX_PUBLISH_BYTES, overhead)) {
+    nats.publish(
+      reply,
+      encoder.encode(
+        encodeFrame({ type: "chunk", reqId: frame.reqId, data: piece }),
+      ),
+    );
+  }
+}
+
+/** Best-effort clean error frame to a reply inbox. */
+function publishErrorFrame(
+  ws: ServerWebSocket<WsAttachData>,
+  reply: string,
+  reqId: string,
+  message: string,
+): void {
+  try {
+    ws.data.deps.nats.publish(
+      reply,
+      encoder.encode(
+        encodeFrame({ type: "error", reqId, code: "publish_failed", message }),
+      ),
+    );
+  } catch {
+    /* reply inbox unreachable — nothing more we can do */
+  }
+}
+
 async function onAfterHello(
   ws: ServerWebSocket<WsAttachData>,
   frame: DispatchFrame,
@@ -306,7 +360,21 @@ async function onAfterHello(
   const entry = inflight.get(frame.reqId);
   if (!entry) return;
 
-  ws.data.deps.nats.publish(entry.reply, encoder.encode(encodeFrame(frame)));
+  try {
+    publishFrame(ws, entry.reply, frame);
+  } catch (err) {
+    // A NATS publish error (e.g. connection gone) — surface it cleanly to the
+    // waiting dispatcher instead of letting the throw escape the WS handler
+    // and silently break the stream.
+    publishErrorFrame(
+      ws,
+      entry.reply,
+      frame.reqId,
+      err instanceof Error ? err.message : String(err),
+    );
+    inflight.delete(frame.reqId);
+    return;
+  }
 
   if (frame.type === "end" || frame.type === "error") {
     inflight.delete(frame.reqId);

--- a/apps/mesh/src/links/ws-gateway.ts
+++ b/apps/mesh/src/links/ws-gateway.ts
@@ -327,13 +327,15 @@ function publishFrame(
   }
 }
 
-/** Best-effort clean error frame to a reply inbox. */
+/** Best-effort clean error frame to a reply inbox. Returns whether it
+ *  actually published — callers use this to decide if the inflight entry can
+ *  be dropped or must be kept for the close-time fallback. */
 function publishErrorFrame(
   ws: ServerWebSocket<WsAttachData>,
   reply: string,
   reqId: string,
   message: string,
-): void {
+): boolean {
   try {
     ws.data.deps.nats.publish(
       reply,
@@ -341,8 +343,10 @@ function publishErrorFrame(
         encodeFrame({ type: "error", reqId, code: "publish_failed", message }),
       ),
     );
+    return true;
   } catch {
     /* reply inbox unreachable — nothing more we can do */
+    return false;
   }
 }
 
@@ -366,13 +370,17 @@ async function onAfterHello(
     // A NATS publish error (e.g. connection gone) — surface it cleanly to the
     // waiting dispatcher instead of letting the throw escape the WS handler
     // and silently break the stream.
-    publishErrorFrame(
+    const delivered = publishErrorFrame(
       ws,
       entry.reply,
       frame.reqId,
       err instanceof Error ? err.message : String(err),
     );
-    inflight.delete(frame.reqId);
+    // Only drop the inflight entry once the dispatcher has actually been told
+    // the request ended. If even the error frame failed to publish (e.g. NATS
+    // down), keep it so the close handler's ws_closed fallback can still fire —
+    // the dispatcher has no idle timeout once it has received any chunk.
+    if (delivered) inflight.delete(frame.reqId);
     return;
   }
 

--- a/apps/mesh/src/nats/payload-chunking.test.ts
+++ b/apps/mesh/src/nats/payload-chunking.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { MAX_PUBLISH_BYTES, splitChunkData } from "./payload-chunking";
+
+const enc = new TextEncoder();
+const frameBytes = (reqId: string, data: string) =>
+  enc.encode(JSON.stringify({ type: "chunk", reqId, data })).length;
+
+describe("splitChunkData", () => {
+  test("returns the input unchanged when it already fits", () => {
+    const data = "hello world";
+    const overhead = frameBytes("r1", "");
+    expect(splitChunkData(data, MAX_PUBLISH_BYTES, overhead)).toEqual([data]);
+  });
+
+  test("splits oversized data so each piece's frame fits, and concatenation is exact", () => {
+    const data = "x".repeat(MAX_PUBLISH_BYTES * 3 + 1234);
+    const overhead = frameBytes("req-1234", "");
+    const pieces = splitChunkData(data, MAX_PUBLISH_BYTES, overhead);
+    expect(pieces.length).toBeGreaterThan(1);
+    for (const p of pieces) {
+      expect(frameBytes("req-1234", p)).toBeLessThanOrEqual(MAX_PUBLISH_BYTES);
+    }
+    expect(pieces.join("")).toBe(data);
+  });
+
+  test("is safe for JSON-special characters (escaping never overflows the budget)", () => {
+    // Every char escapes to 2 bytes ("\\\"" / "\\\\" / "\\n"); still must fit.
+    const data = '"\\\n'.repeat(MAX_PUBLISH_BYTES); // far larger than one frame
+    const overhead = frameBytes("r", "");
+    const pieces = splitChunkData(data, MAX_PUBLISH_BYTES, overhead);
+    for (const p of pieces) {
+      expect(frameBytes("r", p)).toBeLessThanOrEqual(MAX_PUBLISH_BYTES);
+    }
+    expect(pieces.join("")).toBe(data);
+  });
+
+  test("is safe for multibyte / surrogate-pair content", () => {
+    const data = "😀🎉".repeat(MAX_PUBLISH_BYTES); // 4-byte UTF-8, surrogate pairs
+    const overhead = frameBytes("r", "");
+    const pieces = splitChunkData(data, MAX_PUBLISH_BYTES, overhead);
+    for (const p of pieces) {
+      expect(frameBytes("r", p)).toBeLessThanOrEqual(MAX_PUBLISH_BYTES);
+    }
+    expect(pieces.join("")).toBe(data);
+  });
+
+  test("boundary: every returned piece's frame stays within the budget", () => {
+    const overhead = frameBytes("r", "");
+    const justUnder = "a".repeat(MAX_PUBLISH_BYTES);
+    for (const p of splitChunkData(justUnder, MAX_PUBLISH_BYTES, overhead)) {
+      expect(frameBytes("r", p)).toBeLessThanOrEqual(MAX_PUBLISH_BYTES);
+    }
+  });
+});

--- a/apps/mesh/src/nats/payload-chunking.ts
+++ b/apps/mesh/src/nats/payload-chunking.ts
@@ -7,7 +7,8 @@
  * stream the consumer concatenates, so an oversized `chunk` frame is split
  * into smaller ORDERED chunks (no reassembly needed) before publishing.
  *
- * This module is the single source of truth for the per-message byte budget.
+ * This module is the link transport's source of truth for the per-message byte
+ * budget; decopilot's nats-stream-buffer.ts keeps its own separate copy.
  */
 
 /** Per-message ceiling, under the 1 MiB NATS default to leave headroom for

--- a/apps/mesh/src/nats/payload-chunking.ts
+++ b/apps/mesh/src/nats/payload-chunking.ts
@@ -1,0 +1,53 @@
+/**
+ * Splitting helpers for the link transport's NATS hop.
+ *
+ * NATS rejects any single message larger than the server's `max_payload`
+ * (default 1 MiB) with MAX_PAYLOAD_EXCEEDED, thrown synchronously by the
+ * client. The link response stream is an ordered, single-publisher byte
+ * stream the consumer concatenates, so an oversized `chunk` frame is split
+ * into smaller ORDERED chunks (no reassembly needed) before publishing.
+ *
+ * This module is the single source of truth for the per-message byte budget.
+ */
+
+/** Per-message ceiling, under the 1 MiB NATS default to leave headroom for
+ *  the subject and protocol framing (the server counts payload only). */
+export const MAX_PUBLISH_BYTES = 768 * 1024;
+
+/** Worst-case JSON escaping is 6 bytes per UTF-16 code unit (\u00XX); UTF-8 is
+ *  at most 4. Using 6 as the per-unit upper bound guarantees a piece's encoded
+ *  chunk frame never exceeds the budget without re-encoding per code point. */
+const WORST_CASE_BYTES_PER_UNIT = 6;
+
+/**
+ * Split `data` into ordered substrings such that each, embedded in a
+ * `{type:"chunk",reqId,data}` frame whose envelope is `frameOverheadBytes`,
+ * JSON-encodes to <= `maxBytes`. Concatenating the pieces reproduces `data`
+ * exactly. Avoids splitting a surrogate pair (cosmetic — lone surrogates also
+ * round-trip through JSON, but keeping pairs intact is cleaner).
+ */
+export function splitChunkData(
+  data: string,
+  maxBytes: number,
+  frameOverheadBytes: number,
+): string[] {
+  const budget = maxBytes - frameOverheadBytes;
+  if (budget <= 0) throw new Error("frame overhead exceeds maxBytes");
+  const maxUnits = Math.max(1, Math.floor(budget / WORST_CASE_BYTES_PER_UNIT));
+  if (data.length <= maxUnits) return [data];
+
+  const out: string[] = [];
+  let i = 0;
+  while (i < data.length) {
+    let end = Math.min(i + maxUnits, data.length);
+    if (end < data.length) {
+      const code = data.charCodeAt(end - 1);
+      // High surrogate at the cut edge — back off one unit to keep the pair.
+      if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+    }
+    if (end <= i) end = i + 1; // pathological tiny budget — never stall
+    out.push(data.slice(i, end));
+    i = end;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Running claude-code on a **remote user-sandbox** frequently failed with `Error: MAX_PAYLOAD_EXCEEDED`.

**Root cause:** the desktop/link (`user-desktop`) sandbox provider tunnels daemon traffic over **NATS** (the cluster `agent-sandbox`/docker provider uses HTTP and is unaffected). A single response `chunk` frame carrying large claude-code output — a big tool result, file dump, or `git diff` — can exceed the NATS `max_payload` (1 MiB default, never overridden here). `nc.publish` throws `MAX_PAYLOAD_EXCEEDED` **synchronously** at the WS→NATS republish in `ws-gateway.onAfterHello`, dropping the chunk and breaking the stream.

**Fix:** split an oversized `chunk` frame into **ordered sub-chunks** (same `reqId`) at the NATS publish boundary. The reply inbox is per-request / single-publisher and the dispatcher consumer already concatenates chunks in order, so **no reassembly protocol, group-ids, or buffering is needed**. The split lives entirely on the mesh side — **no daemon/CLI change**, no rollout hazard.

- `apps/mesh/src/nats/payload-chunking.ts` — new single source of truth for the per-message budget (`MAX_PUBLISH_BYTES = 768 KiB`) + an escape-safe, surrogate-safe `splitChunkData`.
- `ws-gateway.onAfterHello` — split oversized `chunk` frames; surface any genuine publish error as a clean `error` frame instead of an uncaught throw.
- `dispatcher.ts` — fix a pre-existing inbox-subscription **leak** when the request publish throws (e.g. a large request body), and make `cleanup` idempotent.

This approach was chosen over a generic in-band fragment/reassemble protocol after a multi-perspective plan review: the reassembler concentrated real Blockers (untrusted-`total` allocation DoS, ~8 GB worst-case memory, live-group eviction corruption on shared subjects, lost-fragment hangs) that the ordered-chunk approach avoids entirely. Rationale + deferred follow-ups are in `docs/superpowers/plans/2026-06-01-nats-payload-fragmentation.md`.

## Out of scope (documented follow-ups)
- **F1** — request-body chunking (large `/_sandbox/write` over the shared `links.dispatch` subject). Currently fails **cleanly** rather than leaking.
- **F2** SSE cross-pod broadcast · **F3** decopilot constant unification · **F4** server `max_payload` bump (stopgap) · **F5** resilience harness for large link streams.

## Test Plan
- [x] `bun test apps/mesh/src/nats apps/mesh/src/links` — 60 pass
- [x] `bun run check` (all workspaces), `bun run lint` (0 errors), `bun run fmt:check`
- [ ] Manual: run claude-code on a remote user-sandbox, trigger large output (big `cat`/`git diff`), confirm no `MAX_PAYLOAD_EXCEEDED` and an intact stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `MAX_PAYLOAD_EXCEEDED` on remote user-sandbox streams by splitting oversized `chunk` frames at the WS→`NATS` hop into ordered sub-chunks. Also surfaces publish failures as clean error frames, keeps inflight state when the error frame can’t be published, and fixes an inbox unsubscribe/abort-listener leak.

- **Bug Fixes**
  - Split oversized response `chunk` frames in `ws-gateway` using `MAX_PUBLISH_BYTES = 768 KiB`; send ordered sub-chunks with the same `reqId` so consumers just concatenate; no daemon/CLI change.
  - Centralize the budget and splitting in `apps/mesh/src/nats/payload-chunking.ts` (`splitChunkData`), safe for JSON escaping and surrogate pairs; guarantees each published frame stays within the limit.
  - Catch `NATS` publish errors and send an `error` frame with `code: "publish_failed"`; only drop inflight once the error frame is delivered. If both the chunk and error publish fail, retain inflight so close emits `ws_closed` instead of hanging.
  - In `dispatcher`, wrap request publish in try/catch, unsubscribe the reply inbox on error, detach the abort listener when publish throws, and make cleanup idempotent.

<sup>Written for commit 1d98f2881d391abc40353c84879cfeadda0486ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

