### PR TITLE
fix(sidebar): navigate to home when archiving the last thread in an agent

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -19,7 +19,7 @@ import {
   useVirtualMCPActions,
   useVirtualMCPs,
 } from "@decocms/mesh-sdk";
-import { useParams } from "@tanstack/react-router";
+import { useNavigate, useParams } from "@tanstack/react-router";
 import { authClient } from "@/web/lib/auth-client";
 import {
   useThreadActions,
@@ -99,6 +99,7 @@ export function TaskGroupsList() {
   const visibleThreads = filterThreads(allThreads, { hidden: false });
   const { hide } = useThreadActions();
 
+  const navigate = useNavigate();
   const { setTaskId, createNewTask } = usePanelActions();
   const params = useParams({ strict: false }) as {
     taskId?: string;
@@ -164,7 +165,7 @@ export function TaskGroupsList() {
     if (next) {
       setTaskId(next.id, next.virtual_mcp_id);
     } else {
-      createNewTask(task.virtual_mcp_id);
+      navigate({ to: "/$org", params: { org: org.slug } });
     }
   };
 


### PR DESCRIPTION
## What is this contribution about?

When archiving the last thread in an agent, the previous behavior created a new blank thread, making it impossible to reach a state with no threads open in that agent. This fix navigates the user to the org home (`/$org`) instead, allowing a clean empty state.

## Screenshots/Demonstration

> Archive the only thread in an agent — user is now redirected to home instead of a new blank thread being created.

## How to Test

1. Open an agent that has exactly one thread.
2. Archive that thread via the sidebar archive button.
3. Expected outcome: user is navigated to the org home page, not a new blank thread.

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects to the org home (`/$org`) when archiving the only thread in an agent, instead of creating a new blank thread. This enables a clean empty state and avoids auto-creating threads.

<sup>Written for commit cdc338107c7944b7af5446a6389756c9d0bb5b74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

