### PR TITLE
fix(sidebar): eliminate triple-jump CLS when toggling org pin

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -85,9 +85,18 @@ export function TaskGroupsList() {
   const [orgPinOverrides, setOrgPinOverrides] = useState<
     Record<string, boolean>
   >({});
+  const serverOrgPinnedSet = new Set(serverOrgPinnedIds);
+  // Only keep overrides that haven't been confirmed by server data yet.
+  // This prevents the group from jumping back when the override is cleared
+  // before the React Query re-fetch completes.
+  const activeOverrides = Object.fromEntries(
+    Object.entries(orgPinOverrides).filter(
+      ([id, pinned]) => serverOrgPinnedSet.has(id) !== pinned,
+    ),
+  );
   const orgPinnedIds = (() => {
     const set = new Set(serverOrgPinnedIds);
-    for (const [id, pinned] of Object.entries(orgPinOverrides)) {
+    for (const [id, pinned] of Object.entries(activeOverrides)) {
       if (pinned) set.add(id);
       else set.delete(id);
     }
@@ -193,7 +202,7 @@ export function TaskGroupsList() {
 
   const handleToggleOrgPin = async (virtualMcpId: string, pinned: boolean) => {
     if (!canManageOrgPin) return;
-    if (orgPinOverrides[virtualMcpId] !== undefined) return;
+    if (activeOverrides[virtualMcpId] !== undefined) return;
     track("sidebar_group_org_pin_toggled", {
       virtual_mcp_id: virtualMcpId,
       pinned,
@@ -204,14 +213,10 @@ export function TaskGroupsList() {
         id: virtualMcpId,
         data: { pinned },
       });
-      syncOrdersOnOrgPinToggle(orderScope, virtualMcpId, pinned);
-      setLocalOrderRevision((n) => n + 1);
-      setOrgPinOverrides((prev) => {
-        const next = { ...prev };
-        delete next[virtualMcpId];
-        return next;
-      });
+      // Override auto-clears via activeOverrides once serverOrgPinnedIds reflects the change.
+      // No explicit cleanup here to avoid the group jumping back while the re-fetch is in flight.
     } catch {
+      syncOrdersOnOrgPinToggle(orderScope, virtualMcpId, !pinned);
       setOrgPinOverrides((prev) => {
         const next = { ...prev };
         delete next[virtualMcpId];

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -86,14 +86,26 @@ export function TaskGroupsList() {
     Record<string, boolean>
   >({});
   const serverOrgPinnedSet = new Set(serverOrgPinnedIds);
-  // Only keep overrides that haven't been confirmed by server data yet.
-  // This prevents the group from jumping back when the override is cleared
-  // before the React Query re-fetch completes.
-  const activeOverrides = Object.fromEntries(
-    Object.entries(orgPinOverrides).filter(
-      ([id, pinned]) => serverOrgPinnedSet.has(id) !== pinned,
-    ),
-  );
+
+  // Partition overrides into active (server hasn't confirmed yet) vs confirmed.
+  // Confirmed entries are pruned from state so they can't reactivate if server
+  // data fluctuates (cache miss, background refetch, etc.).
+  const activeOverrides: Record<string, boolean> = {};
+  const confirmedKeys: string[] = [];
+  for (const [id, pinned] of Object.entries(orgPinOverrides)) {
+    if (serverOrgPinnedSet.has(id) !== pinned) {
+      activeOverrides[id] = pinned;
+    } else {
+      confirmedKeys.push(id);
+    }
+  }
+  if (confirmedKeys.length > 0) {
+    setOrgPinOverrides((prev) => {
+      const next = { ...prev };
+      for (const k of confirmedKeys) delete next[k];
+      return next;
+    });
+  }
   const orgPinnedIds = (() => {
     const set = new Set(serverOrgPinnedIds);
     for (const [id, pinned] of Object.entries(activeOverrides)) {
@@ -213,8 +225,8 @@ export function TaskGroupsList() {
         id: virtualMcpId,
         data: { pinned },
       });
-      // Override auto-clears via activeOverrides once serverOrgPinnedIds reflects the change.
-      // No explicit cleanup here to avoid the group jumping back while the re-fetch is in flight.
+      // The override is pruned from state automatically on the next render once
+      // serverOrgPinnedIds reflects the change — no explicit cleanup needed here.
     } catch {
       syncOrdersOnOrgPinToggle(orderScope, virtualMcpId, !pinned);
       setOrgPinOverrides((prev) => {


### PR DESCRIPTION
## What is this contribution about?

When pinning or unpinning an agent to/from org, the sidebar group was jumping position three times: once on click (optimistic update moves it to the new section), back when the override was cleared after `mutateAsync` resolved but before React Query's re-fetch completed, then forward again once the re-fetch finished with the confirmed server state.

The fix introduces `activeOverrides` — a derived view of `orgPinOverrides` that automatically discards entries where `serverOrgPinnedIds` has already confirmed the change. The override stays alive until the server catches up, so the group never jumps back mid-flight. On mutation failure, `syncOrdersOnOrgPinToggle` reverts the localStorage order before the override is explicitly cleared.

## Screenshots/Demonstration

> The fix is behavioral — the sidebar group no longer jumps back and forth after pinning/unpinning.

## How to Test

1. Open the sidebar and right-click an agent in the user section → "Pin for all members"
2. Observe: the group moves to the org section once and stays there (no back-and-forth jump)
3. Right-click an org-pinned agent → "Unpin for all members"
4. Observe: the group moves to the user section once and stays there
5. Simulate a slow connection (Network tab → Slow 3G) and repeat — the group should remain stable until the request completes

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar “triple jump” layout shift when pinning/unpinning by keeping the optimistic pin state active until the server confirms, and pruning confirmed overrides to prevent reactivation on refetch.

- **Bug Fixes**
  - Added `activeOverrides` derived from `orgPinOverrides` and `serverOrgPinnedIds`; confirmed entries are removed from state so they can’t reappear on cache misses or background refetches.
  - Used `activeOverrides` to compute `orgPinnedIds` and to block duplicate pin toggles while a change is pending.
  - On success, no explicit cleanup; overrides auto‑prune when server data updates. On failure, revert local order via `syncOrdersOnOrgPinToggle` and clear the override.

<sup>Written for commit ba77322b549e0487eefd090f3f7dab0ade67990d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

