### PR TITLE
ci(release-mesh): drop ECR push, single multi-arch job, parallel npm

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -26,7 +26,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/mesh
-  ECR_REPO: deco/mesh
 
 jobs:
   prepare:
@@ -109,35 +108,29 @@ jobs:
       - name: Wait for npm propagation
         run: |
           echo "Waiting for npm registry propagation..."
-          for i in $(seq 1 12); do
+          for i in $(seq 1 6); do
             if npm view decocms@${{ needs.prepare.outputs.version }} version >/dev/null 2>&1; then
-              echo "Version available on npm after $((i * 10))s"
+              echo "Version available on npm after $((i * 5))s"
               exit 0
             fi
-            echo "Attempt $i/12 - not yet available, waiting 10s..."
-            sleep 10
+            echo "Attempt $i/6 - not yet available, waiting 5s..."
+            sleep 5
           done
-          echo "Version not available on npm after 120s"
+          echo "Version not available on npm after 30s"
           exit 1
 
+  # Single-job multi-arch build. Pushes the final tagged manifest directly to
+  # GHCR — no digest-export + imagetools merge dance. arm64 is built under
+  # QEMU on an amd64 runner; for this Bun image (no heavy native compile) the
+  # emulation overhead is small enough to make the simpler topology a win.
+  # Runs in parallel with publish-npm: the Dockerfile installs from the
+  # workspace, never from the npm registry, so it doesn't depend on the npm
+  # publish completing first.
   build-docker:
-    name: Build Docker (${{ matrix.platform }})
-    needs: [prepare, publish-npm]
-    if: |
-      always() &&
-      needs.prepare.outputs.image-exists == 'false' &&
-      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped')
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            suffix: amd64
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            suffix: arm64
-    runs-on: ${{ matrix.runner }}
+    name: Build & push Docker (multi-arch)
+    needs: prepare
+    if: needs.prepare.outputs.image-exists == 'false'
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -152,104 +145,39 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::578348582779:role/github-actions-ecr-push-mesh
-          aws-region: sa-east-1
-      - name: Login to Amazon ECR
-        id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
-      - uses: docker/setup-buildx-action@v3
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: ./apps/mesh
-          file: ./apps/mesh/Dockerfile
-          platforms: ${{ matrix.platform }}
-          build-args: |
-            MESH_VERSION=${{ needs.prepare.outputs.version }}
-          outputs: 'type=image,"name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPO }}",push-by-digest=true,name-canonical=true,push=true'
-          cache-from: type=gha,scope=mesh-${{ matrix.suffix }}
-          cache-to: type=gha,mode=max,scope=mesh-${{ matrix.suffix }}
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.suffix }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge-docker:
-    name: Merge multi-arch manifest
-    needs: [prepare, build-docker]
-    if: needs.prepare.outputs.image-exists == 'false'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::578348582779:role/github-actions-ecr-push-mesh
-          aws-region: sa-east-1
-      - name: Login to Amazon ECR
-        id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPO }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{ needs.prepare.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.prepare.outputs.version }}
             type=raw,value=latest
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        env:
-          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          ECR_IMAGE: ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPO }}
-        run: |
-          GHCR_TAGS=$(jq -cr --arg p "$GHCR_IMAGE:" '.tags | map(select(startswith($p))) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          ECR_TAGS=$(jq -cr --arg p "$ECR_IMAGE:" '.tags | map(select(startswith($p))) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          docker buildx imagetools create $GHCR_TAGS \
-            $(printf "$GHCR_IMAGE@sha256:%s " *)
-          docker buildx imagetools create $ECR_TAGS \
-            $(printf "$ECR_IMAGE@sha256:%s " *)
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./apps/mesh
+          file: ./apps/mesh/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MESH_VERSION=${{ needs.prepare.outputs.version }}
+          cache-from: type=gha,scope=mesh
+          cache-to: type=gha,mode=max,scope=mesh
 
   release:
     name: GitHub Release + Deployment
-    needs: [prepare, publish-npm, build-docker, merge-docker]
+    needs: [prepare, publish-npm, build-docker]
     if: |
       always() &&
       (needs.prepare.outputs.version-changed == 'true' || needs.prepare.outputs.image-exists == 'false') &&
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
-      (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') &&
-      (needs.merge-docker.result == 'success' || needs.merge-docker.result == 'skipped')
+      (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -315,15 +243,15 @@ jobs:
   # ---------------------------------------------------------------------------
   bump-deco-apps-cd:
     name: Trigger deco-apps-cd bump
-    needs: [prepare, merge-docker]
+    needs: [prepare, build-docker]
     # Only bump when a VALID image for this version exists: either already
-    # published (image-exists == 'true', so merge-docker is skipped) or just
-    # built and merged. A skipped merge-docker from a failed build must NOT bump.
+    # published (image-exists == 'true', so build-docker is skipped) or just
+    # built. A skipped build-docker from a failed build must NOT bump.
     if: |
       always() &&
       (
         needs.prepare.outputs.image-exists == 'true' ||
-        needs.merge-docker.result == 'success'
+        needs.build-docker.result == 'success'
       )
     runs-on: ubuntu-latest
     # Reuses DEPLOY_REPO_TOKEN — the decobot machine-user PAT already used to

--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -243,12 +243,19 @@ jobs:
   # ---------------------------------------------------------------------------
   bump-deco-apps-cd:
     name: Trigger deco-apps-cd bump
-    needs: [prepare, build-docker]
-    # Only bump when a VALID image for this version exists: either already
-    # published (image-exists == 'true', so build-docker is skipped) or just
-    # built. A skipped build-docker from a failed build must NOT bump.
+    needs: [prepare, publish-npm, build-docker]
+    # Only bump when this release is fully consistent across the artifact pair:
+    #   * a VALID image for this version exists (either already published, so
+    #     build-docker is skipped, or freshly built), AND
+    #   * the npm side didn't fail. publish-npm is gated separately because
+    #     build-docker is now parallel to it — without this clause, an npm
+    #     failure could still ship an image to prod whose `bunx @decocms/mesh@X`
+    #     wouldn't resolve, leaving the two artifacts inconsistent.
+    # A skipped publish-npm (version already on npm) or skipped build-docker
+    # (image already in GHCR) is fine — those mean "nothing to do", not failure.
     if: |
       always() &&
+      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
       (
         needs.prepare.outputs.image-exists == 'true' ||
         needs.build-docker.result == 'success'


### PR DESCRIPTION
## Summary

- Drop ECR push end-to-end — SP cluster was destroyed, argo-deploy-mesh is archived, prod and stg in Oregon pull only from ghcr.io
- Collapse matrix (amd64+arm64) + merge-docker job into a single multi-arch build (buildx + QEMU, push tagged manifest directly to GHCR)
- Run build-docker in parallel with publish-npm (Dockerfile installs from workspace, not the npm registry — no dependency)
- Cut npm-propagation wait from 120s to 30s

Expected wall-clock: ~12-15 min → ~6-8 min per release.

## Test plan

- [ ] Trigger \`workflow_dispatch\` with a no-op (image already exists) to verify the short-circuit path still works
- [ ] Bump apps/mesh/package.json by 1 patch on a test branch, dispatch and verify multi-arch manifest lands in ghcr.io with both amd64 + arm64
- [ ] Confirm \`studio-image-bump\` dispatch fires deco-apps-cd and stg auto-syncs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined the mesh release workflow by dropping ECR pushes, switching to a single multi-arch GHCR build, and running Docker build in parallel with npm publish. Gated the bump trigger on npm success to keep Docker and npm in sync; releases now take ~6–8 min (down from ~12–15).

- **Refactors**
  - Removed ECR push and AWS auth; publish to GHCR only.
  - Replaced per-arch matrix + merge with one multi-arch build (amd64 + arm64 via QEMU) that pushes tagged manifests directly.
  - Ran `build-docker` in parallel with `publish-npm` (Dockerfile builds from workspace, not the registry).
  - Reduced npm propagation wait from 120s to 30s.
  - Updated `release` to depend on the single build job and `bump-deco-apps-cd` to also require `publish-npm` success/skipped to prevent artifact drift.

<sup>Written for commit 414b62bd54e3bdfcaeb1726f903aecb44ed7564a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

