### PR TITLE
fix(add-tile-drawer): update ScrollArea class for improved styling

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -123,7 +123,7 @@ export function AddTileDrawer({ open, onOpenChange }: AddTileDrawerProps) {
             />
           </div>
         </SheetHeader>
-        <ScrollArea className="flex-1 min-h-0">
+        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
           <div className="p-3 flex flex-col gap-4">
             <Suspense fallback={<DrawerListSkeleton />}>
               <DrawerBody search={search} />


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes layout in the Add Tile drawer by updating the `ScrollArea` class to force the viewport child div to display as block. This prevents content collapsing and ensures proper spacing and full-width rendering.

<sup>Written for commit 3523c8f5554820320e203f882e16f1a4eda09f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

