### PR TITLE
fix(link-daemon): fix SSE dispatch crash on disconnect + add logging

### DIFF
--- a/apps/mesh/src/link-daemon/cluster-connection.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection.ts
@@ -64,13 +64,24 @@ export async function connectToCluster(
     cancellers.set(frame.reqId, () => ac.abort());
 
     const sendErrorFrame = (err: unknown): void => {
+      const message = err instanceof Error ? err.message : String(err);
+      // This boundary was previously silent, which made daemon→cluster
+      // `handler_error` frames invisible in the link log. Log the code +
+      // message + originating request so a `handler_error: …` surfaced in the
+      // cluster (via dispatcher.ts) can be traced back to the exact handler
+      // path that threw on this daemon.
+      console.error(
+        `[cluster-connection] handler_error reqId=${frame.reqId} method=${frame.method} path=${frame.path} name=${
+          err instanceof Error ? err.name : typeof err
+        } message=${message}`,
+      );
       try {
         ws.send(
           encodeFrame({
             type: "error",
             reqId: frame.reqId,
             code: "handler_error",
-            message: err instanceof Error ? err.message : String(err),
+            message,
           }),
         );
       } catch {
@@ -115,6 +126,17 @@ export async function connectToCluster(
 
       try {
         const res = await input.controlHandler.handle(frame);
+        if (res.status >= 400) {
+          console.warn(
+            `[cluster-connection] lifecycle ${frame.method} ${frame.path} → ${res.status}${
+              res.body ? ` body=${res.body.slice(0, 200)}` : ""
+            }`,
+          );
+        } else {
+          console.log(
+            `[cluster-connection] lifecycle ${frame.method} ${frame.path} → ${res.status}`,
+          );
+        }
         ws.send(
           encodeFrame({
             type: "headers",
@@ -155,6 +177,11 @@ export async function connectToCluster(
         // next reconnect. Successive failures within one reconnect cycle
         // still ramp up normally.
         attempt = 0;
+        console.log(
+          `[cluster-connection] ws open → ${input.url} machineId=${input.hello.machineId} previewPort=${input.hello.previewPort} capabilities=${
+            input.hello.capabilities.join(",") || "(none)"
+          }`,
+        );
         ws.send(
           encodeFrame({
             type: "hello",
@@ -176,12 +203,22 @@ export async function connectToCluster(
         let frame: DispatchFrame;
         try {
           frame = decodeFrame(text);
-        } catch {
+        } catch (err) {
+          console.error(
+            `[cluster-connection] failed to decode frame (${text.length} bytes): ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
           return;
         }
         if (frame.type === "request") {
           void handleRequest(ws, frame);
         } else if (frame.type === "cancel") {
+          console.log(
+            `[cluster-connection] cancel reqId=${frame.reqId} active=${cancellers.has(
+              frame.reqId,
+            )}`,
+          );
           cancellers.get(frame.reqId)?.();
         }
       });
@@ -189,13 +226,27 @@ export async function connectToCluster(
       ws.addEventListener("close", (ev) => {
         activeWs = null;
         if (stopped) {
+          console.log(
+            `[cluster-connection] ws closed code=${ev.code} reason="${ev.reason}" — shutting down (no reconnect)`,
+          );
           resolve({ shouldReconnect: false });
           return;
         }
-        resolve({ shouldReconnect: shouldReconnectOnClose(ev.code) });
+        const willReconnect = shouldReconnectOnClose(ev.code);
+        console.warn(
+          `[cluster-connection] ws closed code=${ev.code} reason="${ev.reason}" reconnect=${willReconnect}`,
+        );
+        resolve({ shouldReconnect: willReconnect });
       });
-      ws.addEventListener("error", () => {
-        // close handler picks up
+      ws.addEventListener("error", (ev) => {
+        // The close handler drives the reconnect decision; we log here so a
+        // transient WS error (DNS, TLS, connection refused) stays visible even
+        // when a close event follows immediately after.
+        const detail =
+          (ev as { message?: string }).message ??
+          (ev as { error?: { message?: string } }).error?.message ??
+          "unknown";
+        console.error(`[cluster-connection] ws error: ${detail}`);
       });
     });
   };
@@ -204,8 +255,15 @@ export async function connectToCluster(
     while (!stopped && attempt < maxAttempts) {
       const { shouldReconnect } = await runOnce();
       if (stopped || !shouldReconnect) break;
-      await new Promise((r) => setTimeout(r, computeBackoffMs(attempt)));
+      const backoffMs = computeBackoffMs(attempt);
+      console.log(
+        `[cluster-connection] reconnecting in ${backoffMs}ms (attempt ${attempt})`,
+      );
+      await new Promise((r) => setTimeout(r, backoffMs));
     }
+    console.log(
+      `[cluster-connection] connection loop ended (stopped=${stopped} attempt=${attempt} maxAttempts=${maxAttempts})`,
+    );
     resolveClosed();
   })();
 

--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -225,6 +225,17 @@ export function createControlHandler(deps: ControlHandlerDeps): ControlHandler {
                 };
               }
             }
+          } catch (err) {
+            // Connect succeeded but the upstream body stream broke mid-flight
+            // (e.g. the spawned daemon crashed its SSE writer). Distinct from
+            // the connect-failure log above; this re-throw surfaces as a
+            // `handler_error` frame (see cluster-connection.ts sendErrorFrame).
+            console.error(
+              `[control] proxy ${req.method} ${rest} handle=${handle} port=${port} body stream error: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+            throw err;
           } finally {
             reader.releaseLock();
           }

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -195,8 +195,18 @@ export function createDesktopSandboxProvider(
     const timer = setTimeout(() => ac.abort(), 1500);
     try {
       const res = await fetcher(`${sandboxUrl}/health`, { signal: ac.signal });
+      if (!res.ok) {
+        console.warn(
+          `[user-desktop] probe ${sandboxUrl}/health → ${res.status} (treating as dead)`,
+        );
+      }
       return res.ok;
-    } catch {
+    } catch (err) {
+      console.warn(
+        `[user-desktop] probe ${sandboxUrl}/health failed: ${
+          err instanceof Error ? err.message : String(err)
+        } (treating as dead)`,
+      );
       return false;
     } finally {
       clearTimeout(timer);
@@ -204,6 +214,9 @@ export function createDesktopSandboxProvider(
   };
 
   const evictDead = (state: SandboxState): void => {
+    console.warn(
+      `[user-desktop] evicting dead daemon handle=${state.handle} port=${state.port}`,
+    );
     try {
       state.process.kill("SIGTERM");
     } catch {
@@ -237,8 +250,16 @@ export function createDesktopSandboxProvider(
     const candidates = [...sandboxes.values()]
       .filter((s) => s.activeDispatchCount === 0)
       .sort((a, b) => a.lastUsedAt - b.lastUsedAt);
-    if (candidates.length === 0) return; // every sandbox is pinned
+    if (candidates.length === 0) {
+      console.warn(
+        `[user-desktop] at cap ${sandboxes.size}/${cap} but every sandbox is pinned (active dispatch) — exceeding cap temporarily`,
+      );
+      return; // every sandbox is pinned
+    }
     const victim = candidates[0]!;
+    console.log(
+      `[user-desktop] evicting LRU victim handle=${victim.handle} port=${victim.port} (cap ${cap} reached, size=${sandboxes.size})`,
+    );
     try {
       victim.process.kill("SIGTERM");
     } catch {
@@ -329,8 +350,15 @@ export function createDesktopSandboxProvider(
       spawned.exited.then(() => {
         const current = sandboxes.get(input.handle);
         if (current === state) {
+          console.warn(
+            `[user-desktop] daemon process exited unexpectedly handle=${input.handle} port=${port} — removing from cache`,
+          );
           sandboxes.delete(input.handle);
           emit({ handle: input.handle, phase: "evicted" });
+        } else {
+          console.log(
+            `[user-desktop] daemon process exited handle=${input.handle} port=${port} (already replaced/removed)`,
+          );
         }
       });
     }
@@ -343,6 +371,9 @@ export function createDesktopSandboxProvider(
       const existing = sandboxes.get(input.handle);
       if (existing) {
         if (await probeAlive(existing.sandboxApiUrl)) {
+          console.log(
+            `[user-desktop] cache hit handle=${input.handle} port=${existing.port} (alive)`,
+          );
           existing.lastUsedAt = Date.now();
           return {
             sandboxApiUrl: existing.sandboxApiUrl,
@@ -352,10 +383,18 @@ export function createDesktopSandboxProvider(
         }
         // Cached entry is dead — tear it down before respawning so the new
         // entry's spawn isn't fighting the corpse for the same workdir.
+        console.warn(
+          `[user-desktop] cache stale handle=${input.handle} port=${existing.port} — respawning`,
+        );
         evictDead(existing);
       }
       const pending = inflight.get(input.handle);
-      if (pending) return pending;
+      if (pending) {
+        console.log(
+          `[user-desktop] joining in-flight ensure handle=${input.handle}`,
+        );
+        return pending;
+      }
       const promise = buildEntry(input).finally(() => {
         inflight.delete(input.handle);
       });
@@ -406,7 +445,13 @@ export function createDesktopSandboxProvider(
     },
     async deleteSandbox(handle) {
       const s = sandboxes.get(handle);
-      if (!s) return;
+      if (!s) {
+        console.log(
+          `[user-desktop] delete handle=${handle} (not found, no-op)`,
+        );
+        return;
+      }
+      console.log(`[user-desktop] delete handle=${handle} port=${s.port}`);
       try {
         s.process.kill("SIGTERM");
       } catch {
@@ -416,6 +461,9 @@ export function createDesktopSandboxProvider(
       emit({ handle, phase: "deleted" });
     },
     async shutdown() {
+      console.log(
+        `[user-desktop] shutdown — killing ${sandboxes.size} sandbox(es)`,
+      );
       for (const s of sandboxes.values()) {
         try {
           s.process.kill("SIGTERM");

--- a/packages/sandbox/daemon/routes/dispatch.test.ts
+++ b/packages/sandbox/daemon/routes/dispatch.test.ts
@@ -113,6 +113,77 @@ describe("POST /_sandbox/dispatch", () => {
     expect(res.status).toBe(410);
   });
 
+  it("does not crash with ERR_INVALID_STATE when the consumer cancels mid-stream", async () => {
+    // Repro for the link-daemon crash: a long-lived run whose SSE consumer
+    // (browser → cluster → link WS) disconnects mid-stream. The harness keeps
+    // producing chunks; without a guard the writer enqueues on the now-closed
+    // controller and throws "Controller is already closed", crashing the run
+    // (surfaced as `harness_crashed`) instead of stopping cleanly.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    let settleHarness!: () => void;
+    const harnessDone = new Promise<void>((r) => {
+      settleHarness = r;
+    });
+
+    const errorArgs: unknown[][] = [];
+    const originalConsoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      errorArgs.push(args);
+    };
+
+    try {
+      const deps = makeDeps({
+        lookupHarness: () => ({
+          async *stream() {
+            try {
+              yield { type: "start", id: "m1" } as const;
+              // Pause until the consumer has cancelled, then keep producing —
+              // these post-cancel chunks are what used to crash the writer.
+              await gate;
+              for (let i = 0; i < 25; i++) {
+                yield { type: "text-delta", id: "m1", delta: "x" } as const;
+              }
+            } finally {
+              settleHarness();
+            }
+          },
+        }),
+      });
+
+      const body = JSON.stringify({
+        harnessId: "fake",
+        input: {
+          ...fixtures.FIXTURE_MINIMAL_INPUT,
+          runId: "run-cancel-midstream",
+        },
+      });
+      const res = await handleDispatchRequest(authedDispatch(body), deps);
+      expect(res.status).toBe(200);
+
+      const reader = res.body!.getReader();
+      await reader.read(); // consume the first chunk
+      await reader.cancel(); // simulate consumer disconnect → stream cancel()
+      release(); // let the harness produce more after the consumer is gone
+      await harnessDone; // the generator's `finally` ran → loop fully unwound
+      await Promise.resolve();
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    const crashed = errorArgs.some((args) =>
+      args.some(
+        (a) =>
+          (typeof a === "string" && a.includes("harness crashed")) ||
+          (a instanceof Error &&
+            a.message.includes("Controller is already closed")),
+      ),
+    );
+    expect(crashed).toBe(false);
+  });
+
   it("wraps harness errors as an error SSE event followed by done", async () => {
     const harnessId = "throws";
     const body = JSON.stringify({

--- a/packages/sandbox/daemon/routes/dispatch.ts
+++ b/packages/sandbox/daemon/routes/dispatch.ts
@@ -145,17 +145,30 @@ export async function handleDispatchRequest(
   }
 
   const encoder = new TextEncoder();
+  // Set once the SSE consumer goes away (reader cancel) or the run is
+  // aborted. Guards every `write` so a harness that keeps producing chunks
+  // after the client disconnected can't `enqueue` on a closed controller —
+  // that throws `ERR_INVALID_STATE: Controller is already closed`, which
+  // crashed the run (surfaced as `harness_crashed`) and triggered a cluster
+  // re-dispatch storm instead of a clean stop.
+  let streamClosed = false;
   const sseStream = new ReadableStream<Uint8Array>({
     async start(controller) {
-      const write = (event: DispatchSSEEvent) => {
-        controller.enqueue(
-          encoder.encode(`data: ${JSON.stringify(event)}\n\n`),
-        );
+      const write = (event: DispatchSSEEvent): void => {
+        if (streamClosed || ctrl.signal.aborted) return;
+        try {
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(event)}\n\n`),
+          );
+        } catch {
+          // Consumer disconnected between the guard check and the enqueue.
+          streamClosed = true;
+        }
       };
       let chunkCount = 0;
       try {
         for await (const chunk of harness.stream()) {
-          if (ctrl.signal.aborted) break;
+          if (ctrl.signal.aborted || streamClosed) break;
           chunkCount++;
           write({ type: "ui-message-chunk", chunk });
         }
@@ -175,8 +188,23 @@ export async function handleDispatchRequest(
       } finally {
         write({ type: "done" });
         activeRuns.delete(input.runId);
-        controller.close();
+        if (!streamClosed) {
+          try {
+            controller.close();
+          } catch {
+            // Already closed by a consumer cancel — nothing to do.
+          }
+        }
       }
+    },
+    cancel() {
+      // The SSE consumer (link daemon → cluster reverse-proxy → browser)
+      // disconnected — e.g. the user navigated to another task or the link
+      // WS stream was torn down mid-run. Abort the run so the harness
+      // `for await` loop stops pulling chunks instead of spinning until it
+      // writes to the now-closed controller. Mirrors DELETE /_sandbox/runs/:id.
+      streamClosed = true;
+      ctrl.abort();
     },
   });
 


### PR DESCRIPTION
## What is this contribution about?
The sandbox daemon's `/_sandbox/dispatch` SSE writer was unguarded and the stream had no `cancel()` handler, so when an SSE consumer disconnected mid-run (navigating to another task, or a link-WS reconnect during a long run) the harness kept writing to a closed controller and crashed with `ERR_INVALID_STATE: Controller is already closed` — surfacing as `harness_crashed` and triggering a cluster re-dispatch storm. This guards every write, propagates consumer-cancel to the run's `AbortController`, and guards the final `close()`. It also adds previously-missing logging across the link-daemon connection path — `cluster-connection` WS open/close/error/reconnect plus the silent `handler_error` boundary, the user-desktop sandbox cache/probe/evict/watchdog lifecycle, and `control-handler` body-stream errors — so daemon-side failures are traceable in `link.log`.

## Screenshots/Demonstration
N/A — server/daemon only, no UI changes.

## How to Test
1. `bun test packages/sandbox/daemon/routes/dispatch.test.ts` — the new test `does not crash with ERR_INVALID_STATE when the consumer cancels mid-stream` passes (and fails if the `dispatch.ts` guard is reverted).
2. With `deco link` running, start a long agent run, switch to another task and come back — the run no longer crashes with "Controller is already closed".
3. Inspect `~/deco/link.log` for the new `[cluster-connection]` / `[user-desktop]` lifecycle and error lines.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed) — N/A
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the sandbox daemon’s `/_sandbox/dispatch` SSE stream when the consumer disconnects mid-run. Adds detailed `link-daemon` logging so failures are traceable in `link.log` and avoids `harness_crashed` re-dispatch storms.

- **Bug Fixes**
  - Guard every SSE `enqueue` and the final `close()` in `/_sandbox/dispatch`; stop when the stream closes or the run is aborted.
  - Implement stream `cancel()` to abort the run via `AbortController`.
  - Add a regression test to ensure no `ERR_INVALID_STATE` on mid-stream consumer cancel.

- **New Features**
  - Add `link-daemon` observability: WS open/close/error/reconnect, lifecycle responses, and the `handler_error` boundary in `cluster-connection`.
  - Log cache/probe/evict/spawn/watchdog events in the user-desktop sandbox provider.
  - Log proxy body-stream errors in `control-handler` to surface upstream failures in `link.log`.

<sup>Written for commit b172bcadde067d831d844c0396cc549119db03dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

