### PR TITLE
fix(release-mesh): restore build-docker dependency on publish-npm

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -123,13 +123,22 @@ jobs:
   # GHCR — no digest-export + imagetools merge dance. arm64 is built under
   # QEMU on an amd64 runner; for this Bun image (no heavy native compile) the
   # emulation overhead is small enough to make the simpler topology a win.
-  # Runs in parallel with publish-npm: the Dockerfile installs from the
-  # workspace, never from the npm registry, so it doesn't depend on the npm
-  # publish completing first.
+  # Depends on publish-npm: the Dockerfile installs the *published* package
+  # (`RUN bun add decocms@${MESH_VERSION}` in apps/mesh/Dockerfile), so the
+  # build can only resolve the version AFTER publish-npm has published it and
+  # its "Wait for npm propagation" step confirms availability. Running this in
+  # parallel with publish-npm races the publish and fails with
+  # `No version matching "<v>" found for specifier "decocms"`.
   build-docker:
     name: Build & push Docker (multi-arch)
-    needs: prepare
-    if: needs.prepare.outputs.image-exists == 'false'
+    needs: [prepare, publish-npm]
+    # always() so a skipped publish-npm (version already on npm) still lets the
+    # build run; a failed publish-npm skips it (don't ship an image whose
+    # `bunx @decocms/mesh@X` can't resolve).
+    if: |
+      always() &&
+      needs.prepare.outputs.image-exists == 'false' &&
+      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Studio image builds have been failing since **2.381.2** (commit `65f61fd7f`) and **2.382.0**. The `Release Mesh` workflow's **"Build & push Docker (multi-arch)"** job fails fast (~2.5 min vs ~6–8 min for a good build) with:

```
#13 [linux/amd64 5/6] RUN bun add decocms@2.381.2
error: No version matching "2.381.2" found for specifier "decocms" (but package exists)
```

NPM publish itself **succeeds** — all the versions exist on npm now. This is a **race condition** introduced by #3635 ("parallel npm").

### Root cause

#3635 removed `build-docker`'s `needs: publish-npm`, justified by the assumption that *"the Dockerfile installs from the workspace, never from the npm registry."* **That assumption is false** — `apps/mesh/Dockerfile:28` runs `bun add decocms@${MESH_VERSION}`, installing the *published* npm package. So the build genuinely depends on the publish completing.

The Docker path to `bun add` (apt-get + cached layers) is much shorter than npm's path to "published + propagated" (a 47 MB tarball with provenance signing), so the build reliably loses the race. Timeline of run `26826852902`:

| Time | Event |
|------|-------|
| 14:36:00 | Docker build runs `bun add decocms@2.381.2` → **fails**, not on npm yet |
| 14:37:18 | NPM publish job *finishes* |
| 14:37:25 | publish job's own "Wait for npm propagation" step confirms availability |

### Fix

Restore the pre-#3635 wiring: `build-docker` `needs: [prepare, publish-npm]`, with an `always()`-guarded `if` so a **skipped** publish (version already on npm) still builds, while a **failed** publish skips the build (don't ship an image whose `bunx @decocms/mesh@X` can't resolve — matches the existing `bump-deco-apps-cd` gating). This makes the existing "Wait for npm propagation" step actually gate the consumer.

**Trade-off:** drops the parallelism #3635 wanted (~1–2 min added to the critical path). That optimization was invalid for a Dockerfile that pulls from npm.

## Testing

- Verified via `gh run view` that `publish-npm` succeeds and `build-docker` is the only failing job in runs `26826852902` (2.381.2) and `26826882472` (2.382.0).
- Confirmed `decocms@2.381.2` and `@2.382.0` exist on npm (`npm view`), proving the failure is a publish/build race, not a publish failure.
- `git show d4585bb0f` confirms #3635 changed `needs: [prepare, publish-npm]` → `needs: prepare`; this PR reverts that part to the known-good config.

## Unblock current release

`decocms@2.382.0` is now on npm, so re-running the release for that commit will build the image (publish will be skipped as already-published, and `bun add decocms@2.382.0` now resolves):

```bash
gh workflow run release-mesh.yaml -f ref=<full-SHA-of-2.382.0-bump>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the Release Mesh `build-docker` job’s dependency on `publish-npm` to fix the publish/build race that broke Studio Docker builds. The job now waits for npm publish and propagation (so `bun add decocms@${MESH_VERSION}` resolves), runs when publish is successful or skipped, and is skipped on publish failure.

<sup>Written for commit 28dbad8f97022eacfc2f2c23649a0a875aa48851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

