### PR TITLE
fix(link-daemon): surface sandbox bring-up failures to chat

### DIFF
--- a/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
@@ -188,6 +188,54 @@ describe("desktop sandbox provider", () => {
     }
   });
 
+  it("throws a marked, user-facing error when the health check fails", async () => {
+    const dataDir = tmpDataDir();
+    try {
+      let portCounter = 31000;
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        spawnDaemon: () => fakeDaemonSpawner(),
+        postConfig: async () => {},
+        waitForHealth: async () => {
+          throw new Error("did not respond on /health within 5s");
+        },
+        pickPort: () => portCounter++,
+      });
+      const err = (await provider
+        .ensureSandbox({ handle: "h1", repo: undefined })
+        .catch((e) => e)) as Error;
+      expect(err.message).toContain("sandbox failed to start");
+      expect(err.message.toLowerCase()).toContain("come online");
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws a marked error identifying the config step on a config timeout", async () => {
+    const dataDir = tmpDataDir();
+    try {
+      let portCounter = 32000;
+      const timeout = new Error("The operation timed out.");
+      timeout.name = "TimeoutError";
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        spawnDaemon: () => fakeDaemonSpawner(),
+        waitForHealth: async () => {},
+        postConfig: async () => {
+          throw timeout;
+        },
+        pickPort: () => portCounter++,
+      });
+      const err = (await provider
+        .ensureSandbox({ handle: "h2", repo: undefined })
+        .catch((e) => e)) as Error;
+      expect(err.message).toContain("sandbox failed to start");
+      expect(err.message.toLowerCase()).toContain("config");
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it("clears the map entry when the daemon process exits unexpectedly", async () => {
     let exitResolver: (() => void) | null = null;
     const exitPromise = new Promise<void>((r) => {

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -161,6 +161,40 @@ export interface DesktopSandboxProviderDeps {
   onEvent?: (event: SandboxEvent) => void;
 }
 
+/**
+ * Wrap a low-level bring-up step error in a user-facing message carrying the
+ * stable `sandbox failed to start:` marker. The chat web layer keys on this
+ * marker (`parseErrorMessage` in the highlight component) to show the real
+ * reason instead of the generic "took longer than expected". The original
+ * error is preserved as `cause` for the daemon log + the `failed` event.
+ */
+function markBringUpFailure(reason: string, cause: unknown): Error {
+  return new Error(`sandbox failed to start: ${reason}`, { cause });
+}
+
+/**
+ * True for runtime timeout aborts — notably the `AbortSignal.timeout()`
+ * `DOMException` ("The operation timed out.") that fires when the spawned
+ * daemon doesn't answer `POST /_sandbox/config` within `CONFIG_TIMEOUT_MS`.
+ */
+function isTimeoutLike(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return (
+    err.name === "TimeoutError" ||
+    /timed out|timeout|operation was aborted|aborted/i.test(err.message)
+  );
+}
+
+/** The original (pre-marker) cause message, for operator-facing logs/events. */
+function bringUpCauseMessage(err: unknown): string {
+  if (err instanceof Error) {
+    const cause = (err as { cause?: unknown }).cause;
+    if (cause instanceof Error && cause.message) return cause.message;
+    return err.message;
+  }
+  return String(err);
+}
+
 export function createDesktopSandboxProvider(
   deps: DesktopSandboxProviderDeps,
 ): DesktopSandboxProvider {
@@ -271,16 +305,29 @@ export function createDesktopSandboxProvider(
       deps.spawnDaemon({ workdir, handle: input.handle, port, daemonToken }),
     );
     try {
-      await deps.waitForHealth(port);
+      try {
+        await deps.waitForHealth(port);
+      } catch (err) {
+        throw markBringUpFailure("the sandbox didn't come online in time", err);
+      }
       console.log(
         `[user-desktop] healthy handle=${input.handle} port=${port} — posting config`,
       );
-      await deps.postConfig(
-        port,
-        devPort,
-        { repo: input.repo, workload: input.workload },
-        daemonToken,
-      );
+      try {
+        await deps.postConfig(
+          port,
+          devPort,
+          { repo: input.repo, workload: input.workload },
+          daemonToken,
+        );
+      } catch (err) {
+        throw markBringUpFailure(
+          isTimeoutLike(err)
+            ? "configuration timed out"
+            : "the sandbox rejected its configuration",
+          err,
+        );
+      }
     } catch (err) {
       console.error(
         `[user-desktop] sandbox bring-up failed handle=${input.handle} port=${port} (killing daemon):`,
@@ -294,7 +341,7 @@ export function createDesktopSandboxProvider(
       emit({
         handle: input.handle,
         phase: "failed",
-        error: err instanceof Error ? err.message : String(err),
+        error: bringUpCauseMessage(err),
       });
       throw err;
     }

--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -15,6 +15,7 @@ import { TodosHighlight } from "./todos";
 import { CollapsibleHighlight } from "./collapsible-highlight";
 import { CreditsExhaustedBanner } from "../credits-exhausted-banner";
 import { useHighlightFlags } from "./use-highlight-count";
+import { parseErrorMessage } from "./parse-error-message";
 import type { UserAskToolPart } from "../types";
 
 // ============================================================================
@@ -28,53 +29,6 @@ const WARNING_DESCRIPTIONS: Record<string, string> = {
   "tool-calls":
     "Response paused after tool execution to prevent infinite loops and save costs. Click continue to keep working.",
 };
-
-// Raw error.message strings can be anything: a clean string, an HTML page
-// from an upstream proxy (Cloudflare 5xx), a JSON blob, a network failure.
-// Classify to pick a human summary + recovery hint; preserve the original
-// payload so devs can still inspect it under "Show technical details".
-function parseErrorMessage(message: string): {
-  summary: string;
-  rawDetails: string | null;
-} {
-  const trimmed = message.trim();
-  const looksLikeHtml =
-    trimmed.startsWith("<") && /<[a-z][\s\S]*>/i.test(trimmed);
-  const isCloudflare =
-    /cloudflare|cf-[a-z-]+|error[\s_-]?code[\s_-]?5\d\d/i.test(trimmed);
-  const isNetwork = /failed to fetch|networkerror|load failed|offline/i.test(
-    trimmed,
-  );
-  const isTimeout = /timeout|timed out|aborted|deadline/i.test(trimmed);
-  const isTooLong = trimmed.length > 240;
-
-  if (isCloudflare || (looksLikeHtml && isTooLong)) {
-    return {
-      summary:
-        "Our servers are having a moment. Try sending again in a few seconds.",
-      rawDetails: message,
-    };
-  }
-  if (isNetwork) {
-    return {
-      summary: "Lost connection. Check your network and try again.",
-      rawDetails: message,
-    };
-  }
-  if (isTimeout) {
-    return {
-      summary: "That took longer than expected. Try again.",
-      rawDetails: message,
-    };
-  }
-  if (looksLikeHtml || isTooLong) {
-    return {
-      summary: "Something unexpected came back from the server. Try again.",
-      rawDetails: message,
-    };
-  }
-  return { summary: message, rawDetails: null };
-}
 
 type StatusHighlightProps =
   | {

--- a/apps/mesh/src/web/components/chat/highlight/parse-error-message.test.ts
+++ b/apps/mesh/src/web/components/chat/highlight/parse-error-message.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { parseErrorMessage } from "./parse-error-message";
+
+describe("parseErrorMessage", () => {
+  test("surfaces sandbox bring-up failures with a specific summary, not the generic timeout text", () => {
+    // Shape the daemon emits (via the `handler_error` frame) on a config timeout.
+    const raw =
+      "handler_error: sandbox failed to start: configuration timed out";
+    const result = parseErrorMessage(raw);
+
+    // Must NOT collapse into the generic timeout bucket even though the
+    // message contains "timed out".
+    expect(result.summary).not.toBe(
+      "That took longer than expected. Try again.",
+    );
+    expect(result.summary.toLowerCase()).toContain("sandbox");
+    expect(result.summary).toContain("configuration timed out");
+    expect(result.rawDetails).toBe(raw);
+  });
+
+  test("uses a generic sandbox summary when no cause clause is present", () => {
+    const result = parseErrorMessage("sandbox failed to start");
+    expect(result.summary.toLowerCase()).toContain("sandbox");
+    expect(result.summary).not.toContain("(");
+    expect(result.rawDetails).toBe("sandbox failed to start");
+  });
+
+  test("still classifies a plain timeout (no sandbox marker) as the generic timeout", () => {
+    const result = parseErrorMessage("handler_error: The operation timed out.");
+    expect(result.summary).toBe("That took longer than expected. Try again.");
+  });
+
+  test("passes through a plain, short error message unchanged", () => {
+    const result = parseErrorMessage("Something broke");
+    expect(result.summary).toBe("Something broke");
+    expect(result.rawDetails).toBeNull();
+  });
+});

--- a/apps/mesh/src/web/components/chat/highlight/parse-error-message.ts
+++ b/apps/mesh/src/web/components/chat/highlight/parse-error-message.ts
@@ -1,0 +1,62 @@
+// Raw error.message strings can be anything: a clean string, an HTML page
+// from an upstream proxy (Cloudflare 5xx), a JSON blob, a network failure.
+// Classify to pick a human summary + recovery hint; preserve the original
+// payload so devs can still inspect it under "Show technical details".
+export function parseErrorMessage(message: string): {
+  summary: string;
+  rawDetails: string | null;
+} {
+  const trimmed = message.trim();
+  const looksLikeHtml =
+    trimmed.startsWith("<") && /<[a-z][\s\S]*>/i.test(trimmed);
+  const isCloudflare =
+    /cloudflare|cf-[a-z-]+|error[\s_-]?code[\s_-]?5\d\d/i.test(trimmed);
+  const isNetwork = /failed to fetch|networkerror|load failed|offline/i.test(
+    trimmed,
+  );
+  const isTimeout = /timeout|timed out|aborted|deadline/i.test(trimmed);
+  const isTooLong = trimmed.length > 240;
+
+  // Sandbox bring-up failures carry the stable `sandbox failed to start:`
+  // marker (set daemon-side in user-desktop-provider). Classify these BEFORE
+  // the generic timeout/HTML branches — the underlying cause often contains
+  // "timed out", which would otherwise collapse into the vague "took longer
+  // than expected" bucket and hide the real reason from the user.
+  const sandboxStart = /sandbox failed to start(?::\s*(.+))?/is.exec(trimmed);
+  if (sandboxStart) {
+    const cause = sandboxStart[1]?.trim().replace(/\.$/, "");
+    return {
+      summary: cause
+        ? `Your sandbox didn't finish starting up (${cause}). Try again.`
+        : "Your sandbox didn't finish starting up. Try again.",
+      rawDetails: message,
+    };
+  }
+
+  if (isCloudflare || (looksLikeHtml && isTooLong)) {
+    return {
+      summary:
+        "Our servers are having a moment. Try sending again in a few seconds.",
+      rawDetails: message,
+    };
+  }
+  if (isNetwork) {
+    return {
+      summary: "Lost connection. Check your network and try again.",
+      rawDetails: message,
+    };
+  }
+  if (isTimeout) {
+    return {
+      summary: "That took longer than expected. Try again.",
+      rawDetails: message,
+    };
+  }
+  if (looksLikeHtml || isTooLong) {
+    return {
+      summary: "Something unexpected came back from the server. Try again.",
+      rawDetails: message,
+    };
+  }
+  return { summary: message, rawDetails: null };
+}


### PR DESCRIPTION
## What is this contribution about?
When a chat runs in a linked local sandbox (`deco link`), a slow bring-up made the daemon throw a bare `"The operation timed out."`, which the chat UI collapsed into the generic *"That took longer than expected."* — hiding the real cause. This tags bring-up failures with a stable `sandbox failed to start:` marker (naming the failing step: health vs. configuration), and classifies that marker in `parseErrorMessage` (extracted from `index.tsx` into its own pure, unit-tested module) so chat now shows *"Your sandbox didn't finish starting up (configuration timed out). Try again."* The original error is preserved as `cause` for the daemon log and the `failed` event, so operator-facing detail is unchanged.

## Screenshots/Demonstration
Error banner headline copy changes from **"That took longer than expected. Try again."** to e.g. **"Your sandbox didn't finish starting up (configuration timed out). Try again."** The full `handler_error: …` text remains under "Show technical details".

## How to Test
1. `bun test apps/mesh/src/link-daemon/user-desktop-provider.test.ts apps/mesh/src/web/components/chat/highlight/parse-error-message.test.ts` — all green.
2. Unit-level: `parseErrorMessage("handler_error: sandbox failed to start: configuration timed out")` returns the sandbox-specific summary, not the generic timeout text; a plain `"...timed out"` still maps to the generic message.
3. Expected outcome: a sandbox config/health bring-up failure surfaces a specific, human reason in the chat error banner.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show specific sandbox start-up failures in chat instead of a generic timeout. The daemon tags bring-up errors, and the web app classifies them to display clear, actionable messages (e.g., "Your sandbox didn't finish starting up (configuration timed out). Try again.").

- **Bug Fixes**
  - Tag daemon bring-up errors with `sandbox failed to start: <reason>` (health vs. configuration); keep the original error as `cause` for logs and the `failed` event.
  - Extracted `parseErrorMessage` into a pure module and updated chat to surface sandbox-specific summaries using the marker.
  - Added unit tests for the desktop provider and error parser.

<sup>Written for commit c49aa40a5a1506436d249c0edc996dd2e0aa8bf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

