### PR TITLE
refactor(home): enhance loading experience with Suspense and skeleton…

### DIFF
--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -213,15 +213,20 @@ function AgentUITile({
       </button>
       <div className="flex min-h-0 flex-1 gap-3 overflow-hidden">
         <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border">
-          <MCPAppRenderer
-            resourceURI={tile.resourceUri}
-            orgId={org.id}
-            client={client}
-            displayMode="fullscreen"
-            minHeight={tile.minHeight ?? 200}
-            maxHeight={tile.maxHeight ?? 4000}
-            className="h-full"
-          />
+          {/* Inner boundary so the slow resource read only blocks the embedded
+              panel — the tile chrome (agent name, Open chat, prompt chips)
+              renders immediately and stays interactive while the app loads. */}
+          <Suspense fallback={<TilePanelSkeleton />}>
+            <MCPAppRenderer
+              resourceURI={tile.resourceUri}
+              orgId={org.id}
+              client={client}
+              displayMode="fullscreen"
+              minHeight={tile.minHeight ?? 200}
+              maxHeight={tile.maxHeight ?? 4000}
+              className="h-full"
+            />
+          </Suspense>
         </div>
         {promptChips.length > 0 && !isEditMode && tileWidth >= 2 && (
           // Right-side column of action chips. `overflow-hidden` clips
@@ -243,6 +248,18 @@ function AgentUITile({
         )}
       </div>
       {dialog}
+    </div>
+  );
+}
+
+/** Fallback for just the embedded app panel — keeps the tile chrome visible
+ *  while the (potentially slow) resource read is in flight. */
+function TilePanelSkeleton() {
+  return (
+    <div className="flex h-full w-full flex-col gap-2 p-4">
+      <Skeleton className="h-3 w-2/3" />
+      <Skeleton className="h-3 w-1/2" />
+      <Skeleton className="mt-1 h-full w-full rounded-md" />
     </div>
   );
 }

--- a/apps/mesh/src/web/hooks/collections/use-ai-providers.ts
+++ b/apps/mesh/src/web/hooks/collections/use-ai-providers.ts
@@ -18,8 +18,29 @@ import {
 
 export type { AiProviderKey, AiProviderModel, AiProviderInfo };
 import { z } from "zod";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { KEYS } from "../../lib/query-keys";
+
+/**
+ * Query options for the org's AI provider keys. Shared with parallel-prefetch
+ * batches so they warm the exact cache entry useAiProviderKeys reads.
+ */
+export function aiProviderKeysQueryOptions(client: Client, orgId: string) {
+  return {
+    queryKey: KEYS.aiProviderKeys(orgId),
+    staleTime: 60_000,
+    queryFn: async () => {
+      const result = (await client.callTool({
+        name: "AI_PROVIDER_KEY_LIST",
+        arguments: {},
+      })) as {
+        structuredContent?: { keys: AiProviderKey[] };
+      };
+      return result.structuredContent ?? null;
+    },
+  };
+}
 
 // LLM type matching ModelSchema from @decocms/bindings
 export type LLM = z.infer<typeof ModelCollectionEntitySchema>;
@@ -61,19 +82,7 @@ export function useAiProviderKeys() {
     orgSlug: org.slug,
   });
 
-  const { data } = useSuspenseQuery({
-    queryKey: KEYS.aiProviderKeys(org.id),
-    staleTime: 60_000,
-    queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_KEY_LIST",
-        arguments: {},
-      })) as {
-        structuredContent?: { keys: AiProviderKey[] };
-      };
-      return result.structuredContent ?? null;
-    },
-  });
+  const { data } = useSuspenseQuery(aiProviderKeysQueryOptions(client, org.id));
   return data?.keys ?? [];
 }
 

--- a/apps/mesh/src/web/hooks/use-home-next-actions.ts
+++ b/apps/mesh/src/web/hooks/use-home-next-actions.ts
@@ -29,8 +29,13 @@ interface HomeNextActionsResponse {
   tiles?: HomeTileEntry[];
 }
 
-export function useHomeNextActions(orgSlug: string) {
-  const query = useQuery({
+/**
+ * Query options for the home next-actions feed. Shared with parallel-prefetch
+ * batches so the (tile-gating) fetch can start alongside the self tool calls
+ * instead of waiting behind them.
+ */
+export function homeNextActionsQueryOptions(orgSlug: string) {
+  return {
     queryKey: KEYS.homeNextActions(orgSlug),
     queryFn: async (): Promise<HomeNextActionsResponse> => {
       // `no-store`: the endpoint sends `Cache-Control: max-age=10`, so a
@@ -44,8 +49,12 @@ export function useHomeNextActions(orgSlug: string) {
       return (await res.json()) as HomeNextActionsResponse;
     },
     staleTime: 0,
-    refetchOnWindowFocus: "always",
-  });
+    refetchOnWindowFocus: "always" as const,
+  };
+}
+
+export function useHomeNextActions(orgSlug: string) {
+  const query = useQuery(homeNextActionsQueryOptions(orgSlug));
 
   return {
     isLoading: query.isLoading,

--- a/apps/mesh/src/web/hooks/use-organization-settings.ts
+++ b/apps/mesh/src/web/hooks/use-organization-settings.ts
@@ -4,6 +4,7 @@ import {
   useProjectContext,
   WellKnownOrgMCPId,
 } from "@decocms/mesh-sdk";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   useMutation,
   useQuery,
@@ -69,6 +70,33 @@ const EMPTY_SIMPLE_MODE: SimpleModeConfig = {
 };
 
 /**
+ * Query options for the shared org-settings row. Shared by both the suspense
+ * and non-suspense hooks below and by parallel-prefetch batches, so all callers
+ * build the same query key + queryFn and read one cache entry.
+ */
+export function organizationSettingsQueryOptions(
+  client: Client,
+  orgId: string,
+) {
+  return {
+    queryKey: KEYS.organizationSettings(orgId),
+    queryFn: async (): Promise<OrganizationSettings> => {
+      const result = (await client.callTool({
+        name: "ORGANIZATION_SETTINGS_GET",
+        arguments: {},
+      })) as { structuredContent?: OrganizationSettings; isError?: boolean };
+      if (result?.isError) {
+        return { ...EMPTY_SETTINGS, organizationId: orgId };
+      }
+      return (
+        result.structuredContent ?? { ...EMPTY_SETTINGS, organizationId: orgId }
+      );
+    },
+    staleTime: 60_000,
+  };
+}
+
+/**
  * Core query hook over the single shared `organization_settings` row.
  * Callers pass a `select` fn to derive just the slice they care about.
  * Not exported — use a named wrapper (useSimpleMode, useRegistryConfig, …).
@@ -84,23 +112,7 @@ function useOrganizationSettings<T = OrganizationSettings>(
   });
 
   return useQuery({
-    queryKey: KEYS.organizationSettings(org.id),
-    queryFn: async () => {
-      const result = (await client.callTool({
-        name: "ORGANIZATION_SETTINGS_GET",
-        arguments: {},
-      })) as { structuredContent?: OrganizationSettings; isError?: boolean };
-      if (result?.isError) {
-        return { ...EMPTY_SETTINGS, organizationId: org.id };
-      }
-      return (
-        result.structuredContent ?? {
-          ...EMPTY_SETTINGS,
-          organizationId: org.id,
-        }
-      );
-    },
-    staleTime: 60_000,
+    ...organizationSettingsQueryOptions(client, org.id),
     select: select as (data: OrganizationSettings) => T,
   });
 }
@@ -120,22 +132,9 @@ export function useOrganizationSettingsSuspense(
     orgSlug,
   });
 
-  const { data } = useSuspenseQuery({
-    queryKey: KEYS.organizationSettings(orgId),
-    queryFn: async () => {
-      const result = (await client.callTool({
-        name: "ORGANIZATION_SETTINGS_GET",
-        arguments: {},
-      })) as { structuredContent?: OrganizationSettings; isError?: boolean };
-      if (result?.isError) {
-        return { ...EMPTY_SETTINGS, organizationId: orgId };
-      }
-      return (
-        result.structuredContent ?? { ...EMPTY_SETTINGS, organizationId: orgId }
-      );
-    },
-    staleTime: 60_000,
-  });
+  const { data } = useSuspenseQuery(
+    organizationSettingsQueryOptions(client, orgId),
+  );
 
   return data;
 }

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -1,8 +1,12 @@
 import {
   getWellKnownDecopilotVirtualMCP,
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
   useProjectContext,
   useVirtualMCP,
+  virtualMcpItemQueryOptions,
 } from "@decocms/mesh-sdk";
+import { useQuery, useSuspenseQueries } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
 import { Check, LayoutAlt04, Plus, X } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -17,9 +21,14 @@ import {
   useHomeEdit,
 } from "@/web/components/home/home-edit-context";
 import { HomeGrid, useHomeGridStats } from "@/web/components/home/home-grid";
-import { useAiProviderKeys } from "@/web/hooks/collections/use-ai-providers";
+import {
+  aiProviderKeysQueryOptions,
+  useAiProviderKeys,
+} from "@/web/hooks/collections/use-ai-providers";
 import { useCurrentLink } from "@/web/hooks/use-current-link";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
+import { homeNextActionsQueryOptions } from "@/web/hooks/use-home-next-actions";
+import { organizationSettingsQueryOptions } from "@/web/hooks/use-organization-settings";
 import {
   agentHasClonableSource,
   hasLocalCliHarness,
@@ -32,11 +41,34 @@ export function HomePage() {
   const { data: session } = authClient.useSession();
   const { org } = useProjectContext();
   const isMobile = useIsMobile();
-  const allKeys = useAiProviderKeys();
   const link = useCurrentLink();
   const { selectedVirtualMcp } = useChatPrefs();
   const defaultAgent = getWellKnownDecopilotVirtualMCP(org.id);
   const displayAgent = selectedVirtualMcp ?? defaultAgent;
+
+  // Warm the tile-gating home feed in parallel with the self tool calls below.
+  // Plain (non-suspense) query so a flaky feed never blanks the home — it only
+  // starts the fetch early; useHomeGridStats reads the same cache entry.
+  useQuery(homeNextActionsQueryOptions(org.slug));
+
+  // Resolve the self MCP client once, then fire every independent self tool call
+  // in a single parallel batch. Without this, the stacked useSuspenseQuery hooks
+  // below each suspend before the next starts, serializing into a waterfall that
+  // delayed home-next-actions (and thus the tiles) by seconds.
+  const selfClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  useSuspenseQueries({
+    queries: [
+      aiProviderKeysQueryOptions(selfClient, org.id),
+      organizationSettingsQueryOptions(selfClient, org.id),
+      virtualMcpItemQueryOptions(org.id, displayAgent.id, selfClient),
+    ],
+  });
+
+  const allKeys = useAiProviderKeys();
   const fullVm = useVirtualMCP(displayAgent.id);
   const {
     hasDecoKey,

--- a/packages/mesh-sdk/src/hooks/index.ts
+++ b/packages/mesh-sdk/src/hooks/index.ts
@@ -74,6 +74,7 @@ export {
 export {
   useVirtualMCPs,
   useVirtualMCP,
+  virtualMcpItemQueryOptions,
   useVirtualMCPActions,
   useVirtualMCPsLastUsed,
   type VirtualMCPFilter,

--- a/packages/mesh-sdk/src/hooks/use-collections.ts
+++ b/packages/mesh-sdk/src/hooks/use-collections.ts
@@ -182,15 +182,12 @@ function extractPayload<T>(result: unknown): T {
 }
 
 /**
- * Get a single item by ID from a collection
- *
- * @param scopeKey - The scope key (connectionId for connection-scoped, virtualMcpId for virtual-mcp-scoped, etc.)
- * @param collectionName - The name of the collection (e.g., "CONNECTIONS", "AGENT")
- * @param itemId - The ID of the item to fetch (undefined returns null without making an API call)
- * @param client - The MCP client used to call collection tools
- * @returns Suspense query result with the item, or null if itemId is undefined
+ * Query options for a single collection item. Shared between useCollectionItem
+ * and parallel-prefetch batches (useSuspenseQueries) so both build an identical
+ * query key + queryFn — letting a prefetch warm the exact cache entry the hook
+ * later reads.
  */
-export function useCollectionItem<T extends CollectionEntity>(
+export function collectionItemQueryOptions<T extends CollectionEntity>(
   scopeKey: string,
   collectionName: string,
   itemId: string | undefined,
@@ -198,8 +195,7 @@ export function useCollectionItem<T extends CollectionEntity>(
 ) {
   const upperName = collectionName.toUpperCase();
   const getToolName = `COLLECTION_${upperName}_GET`;
-
-  const { data } = useSuspenseQuery({
+  return {
     queryKey: KEYS.collectionItem(
       client,
       scopeKey,
@@ -220,7 +216,18 @@ export function useCollectionItem<T extends CollectionEntity>(
       return extractPayload<CollectionGetOutput<T>>(result);
     },
     staleTime: 60_000,
-  });
+  };
+}
+
+export function useCollectionItem<T extends CollectionEntity>(
+  scopeKey: string,
+  collectionName: string,
+  itemId: string | undefined,
+  client: Client,
+) {
+  const { data } = useSuspenseQuery(
+    collectionItemQueryOptions<T>(scopeKey, collectionName, itemId, client),
+  );
 
   return data?.item ?? null;
 }

--- a/packages/mesh-sdk/src/hooks/use-virtual-mcp.ts
+++ b/packages/mesh-sdk/src/hooks/use-virtual-mcp.ts
@@ -10,12 +10,14 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { VirtualMCPEntity } from "../types/virtual-mcp";
 import { useProjectContext } from "../context";
 import {
+  collectionItemQueryOptions,
   useCollectionActions,
   useCollectionItem,
   useCollectionList,
   type CollectionFilter,
   type UseCollectionListOptions,
 } from "./use-collections";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { useMCPClient } from "./use-mcp-client";
 import { SELF_MCP_ALIAS_ID } from "../lib/constants";
 import { KEYS } from "../lib/query-keys";
@@ -55,6 +57,23 @@ export function useVirtualMCPs(options: UseVirtualMCPsOptions = {}) {
     "VIRTUAL_MCP",
     client,
     options,
+  );
+}
+
+/**
+ * Query options for a single virtual MCP — shared with parallel-prefetch
+ * batches so they warm the exact cache entry useVirtualMCP reads.
+ */
+export function virtualMcpItemQueryOptions(
+  orgId: string,
+  virtualMcpId: string | null | undefined,
+  client: Client,
+) {
+  return collectionItemQueryOptions<VirtualMCPEntity>(
+    orgId,
+    "VIRTUAL_MCP",
+    virtualMcpId ?? undefined,
+    client,
   );
 }
 

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -72,6 +72,7 @@ export {
   // Virtual MCP hooks
   useVirtualMCPs,
   useVirtualMCP,
+  virtualMcpItemQueryOptions,
   useVirtualMCPActions,
   useVirtualMCPsLastUsed,
   type VirtualMCPFilter,


### PR DESCRIPTION
… components

- Wrapped MCPAppRenderer in a Suspense component to improve loading behavior, allowing the tile chrome to remain interactive while the app loads.
- Introduced TilePanelSkeleton as a fallback UI during loading, providing a better user experience.
- Refactored query options in useHomeNextActions, useOrganizationSettings, and useAiProviderKeys to standardize query configurations and improve code reusability.
- Updated HomePage to utilize new query options for better data fetching efficiency.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved Home tile loading with a `Suspense` boundary and skeleton fallback, and parallelized data prefetch to eliminate query waterfalls. Tiles stay interactive while the embedded app panel loads, and home feed/tiles render faster.

- **New Features**
  - Wrapped the embedded app panel in `Suspense` so tile chrome remains interactive.
  - Added `TilePanelSkeleton` as the panel’s loading UI.

- **Refactors**
  - Standardized shared query options for cache reuse and prefetch: `homeNextActionsQueryOptions`, `organizationSettingsQueryOptions`, `aiProviderKeysQueryOptions`, `virtualMcpItemQueryOptions`, and `collectionItemQueryOptions` in `@decocms/mesh-sdk`.
  - Parallelized self MCP tool calls with `useSuspenseQueries` from `@tanstack/react-query`, and warmed the home next-actions feed early with a non-suspense `useQuery`.

<sup>Written for commit dfcc4d86cb4c64ed5c9d86fb88568e5e97d191dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

