### PR TITLE
fix(auth): let owners/admins create capability-scoped custom roles

### DIFF
--- a/apps/mesh/e2e/tests/create-scoped-role.spec.ts
+++ b/apps/mesh/e2e/tests/create-scoped-role.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * E2E: an owner can create a capability-scoped custom role.
+ *
+ * Regression guard for a Better Auth dynamic-AC gotcha: create-role checks that
+ * the creator *holds* every permission they grant, and access-control matches
+ * actions literally — so a built-in owner defined as `self: ["*"]` was reported
+ * as "missing self:SOME_TOOL" and couldn't create any tool-scoped role
+ * (YOU_ARE_NOT_ALLOWED_TO_CREATE_A_ROLE). The built-in roles now enumerate the
+ * full tool list, so an owner can grant any tool.
+ *
+ * The second test exercises the whole chain the role editor relies on:
+ * create a scoped role → assign it to a member → that member's resolved
+ * capabilities reflect exactly the granted tools.
+ */
+
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+// The tools backing the monitoring:view capability (registry-metadata).
+const MONITORING_TOOLS = [
+  "MONITORING_LOG_GET",
+  "MONITORING_LOGS_LIST",
+  "MONITORING_STATS",
+];
+
+async function orgIdForSlug(db: Client, slug: string): Promise<string> {
+  const row = await db.query<{ id: string }>(
+    `SELECT id FROM "organization" WHERE slug = $1`,
+    [slug],
+  );
+  const id = row.rows[0]?.id;
+  if (!id) throw new Error(`org not found for slug ${slug}`);
+  return id;
+}
+
+test.describe("create capability-scoped role", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("an owner can create a role granting specific tools", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ctx);
+    const orgId = await orgIdForSlug(db, owner.orgSlug);
+
+    const res = await ctx.post("/api/auth/organization/create-role", {
+      data: {
+        organizationId: orgId,
+        role: `monitor-${Date.now()}`,
+        permission: { self: MONITORING_TOOLS },
+      },
+    });
+    expect(
+      res.ok(),
+      `create-role failed: ${await res.text().catch(() => "")}`,
+    ).toBe(true);
+
+    await ctx.dispose();
+  });
+
+  test("a scoped role resolves to exactly its capabilities for a member", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgId = await orgIdForSlug(db, owner.orgSlug);
+
+    const roleSlug = `monitor-${Date.now()}`;
+    const createRole = await ownerCtx.post(
+      "/api/auth/organization/create-role",
+      {
+        data: {
+          organizationId: orgId,
+          role: roleSlug,
+          permission: { self: MONITORING_TOOLS },
+        },
+      },
+    );
+    expect(
+      createRole.ok(),
+      `create-role failed: ${await createRole.text().catch(() => "")}`,
+    ).toBe(true);
+
+    // A member, invited and then assigned the scoped role.
+    const memberCtx = await newApiContext(playwright);
+    const member = await signUpViaApi(memberCtx);
+
+    const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+      data: { organizationId: orgId, email: member.email, role: "user" },
+    });
+    expect(invite.ok()).toBe(true);
+    const inviteJson = (await invite.json()) as {
+      id?: string;
+      invitation?: { id?: string };
+    };
+    const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+
+    const accept = await memberCtx.post(
+      "/api/auth/organization/accept-invitation",
+      { data: { invitationId } },
+    );
+    expect(accept.ok()).toBe(true);
+
+    const memberRow = await db.query<{ id: string }>(
+      `SELECT id FROM "member" WHERE "userId" = $1 AND "organizationId" = $2`,
+      [member.userId, orgId],
+    );
+    const memberId = memberRow.rows[0]?.id;
+    if (!memberId) throw new Error("member row not found after accept");
+
+    const assign = await ownerCtx.post(
+      "/api/auth/organization/update-member-role",
+      { data: { organizationId: orgId, memberId, role: [roleSlug] } },
+    );
+    expect(
+      assign.ok(),
+      `update-member-role failed: ${await assign.text().catch(() => "")}`,
+    ).toBe(true);
+
+    // The member's resolved capabilities reflect exactly the granted tools.
+    const res = await memberCtx.get(
+      `/api/auth/custom/my-capabilities/${encodeURIComponent(owner.orgSlug)}`,
+    );
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as {
+      role: string | null;
+      capabilities: Record<string, boolean>;
+    };
+    expect(body.role).toBe(roleSlug);
+    expect(body.capabilities["monitoring:view"]).toBe(true);
+    expect(body.capabilities["members:manage"]).toBe(false);
+
+    await ownerCtx.dispose();
+    await memberCtx.dispose();
+  });
+});

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -99,18 +99,27 @@ const statement = { ...defaultStatements, self: ["*", ...allTools] };
 
 const ac = createAccessControl(statement);
 
+// Built-in roles must enumerate every `self` tool, not just `["*"]`. Better
+// Auth's access-control `authorize()` matches actions literally — `["*"]` only
+// authorizes a request for the literal action "*", NOT specific tools. Runtime
+// checks bypass this for built-in roles, but `create-role` gates a creator on
+// whether they hold each permission they grant; with `self: ["*"]` an owner is
+// reported as "missing self:SOME_TOOL" and can't create a capability-scoped
+// custom role at all. Enumerating the full tool list fixes that.
+const fullSelf = ["*", ...allTools];
+
 const user = ac.newRole({
-  self: ["*"],
+  self: fullSelf,
   ...adminAc.statements,
 }) as Role;
 
 const admin = ac.newRole({
-  self: ["*"],
+  self: fullSelf,
   ...adminAc.statements,
 }) as Role;
 
 const owner = ac.newRole({
-  self: ["*"],
+  self: fullSelf,
   ...adminAc.statements,
 }) as Role;
 

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -99,27 +99,33 @@ const statement = { ...defaultStatements, self: ["*", ...allTools] };
 
 const ac = createAccessControl(statement);
 
-// Built-in roles must enumerate every `self` tool, not just `["*"]`. Better
-// Auth's access-control `authorize()` matches actions literally — `["*"]` only
-// authorizes a request for the literal action "*", NOT specific tools. Runtime
-// checks bypass this for built-in roles, but `create-role` gates a creator on
-// whether they hold each permission they grant; with `self: ["*"]` an owner is
-// reported as "missing self:SOME_TOOL" and can't create a capability-scoped
-// custom role at all. Enumerating the full tool list fixes that.
-const fullSelf = ["*", ...allTools];
+// The role-creating built-in roles (owner/admin) must enumerate every `self`
+// tool, not just `["*"]`. Better Auth's access-control `authorize()` matches
+// actions literally — `["*"]` authorizes only a request for the literal action
+// "*", NOT specific tools. Runtime checks bypass this for built-in roles, but
+// `create-role` gates the *creator* on whether they hold each permission they
+// grant; with `self: ["*"]` an owner is reported as "missing self:SOME_TOOL"
+// and can't create a capability-scoped custom role at all. Enumerating the full
+// tool list fixes that.
+//
+// `user` is intentionally left as-is: it can't create roles
+// (allowedRolesToCreateResources = ADMIN_ROLES), and its `self` is never
+// consulted at runtime (the built-in-role bypass short-circuits first). Giving
+// it the full tool list would only mis-signal that "user" holds full access.
+const creatorSelf = ["*", ...allTools];
 
 const user = ac.newRole({
-  self: fullSelf,
+  self: ["*"],
   ...adminAc.statements,
 }) as Role;
 
 const admin = ac.newRole({
-  self: fullSelf,
+  self: creatorSelf,
   ...adminAc.statements,
 }) as Role;
 
 const owner = ac.newRole({
-  self: fullSelf,
+  self: creatorSelf,
   ...adminAc.statements,
 }) as Role;
 


### PR DESCRIPTION
## The bug

Creating a custom role with specific tool permissions via the role editor fails **even for the org owner**:

```
APIError YOU_ARE_NOT_ALLOWED_TO_CREATE_A_ROLE
missingPermissions: [ "self:MONITORING_LOG_GET", "self:MONITORING_LOGS_LIST", "self:MONITORING_STATS" ]
```

## Root cause

Better Auth's `create-role` gates the creator on whether they *hold* every permission they're granting, via the access-control `authorize()`. That matcher is **literal** (`allowedActions.includes(action)`) — it does **not** treat `["*"]` as a wildcard. Our built-in roles were defined as `self: ["*"]`, so:

- **Runtime** checks work, because `AccessControl` and `boundAuth.hasPermission` both short-circuit built-in owner/admin — `authorize` is never consulted.
- **create-role** *does* consult it, and `["*"].includes("self:MONITORING_LOG_GET")` is `false` → the owner is "missing" the permission → denied. (Unlike `update-member-role`, create-role doesn't pass `allowCreatorAllPermissions`.)

Proven locally:
```
OLD self:["*"]          authorize({self:["MONITORING_STATS"]}) → { success: false }
NEW self:["*",...all]   authorize({self:["MONITORING_STATS"]}) → { success: true }
```

## Fix

Define the built-in roles' `self` as the enumerated tool list (`["*", ...allTools]`, matching the access-control statement) so `authorize` recognizes specific tools. **Runtime behavior is unchanged** — built-in roles still bypass — this only fixes the create-role creator-permission check.

## Testing

E2e (`create-scoped-role.spec.ts`):
- an owner can create a role granting specific tools (was a 403);
- a member assigned that scoped role resolves to exactly its capabilities (`monitoring:view` true, `members:manage` false) — proving create → assign → resolve end to end.

This is a pre-existing bug (since the capability-based role editor shipped), surfaced during manual testing. It blocks creating any tool-scoped custom role, so the capability RBAC feature is unusable without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that blocked owners/admins from creating capability‑scoped custom roles. `admin` and `owner` now enumerate all `self` tools so `create-role` recognizes granted permissions.

- **Bug Fixes**
  - Update built-in `admin` and `owner` roles to `self: ["*", ...allTools]` so `authorize()` doesn’t deny `create-role` when granting specific tools. Keep `user` as `self: ["*"]` since it can’t create roles.
  - Added an e2e for create → assign → resolve. Confirms an owner can create a tool‑scoped role and a member only gets the granted capabilities. Runtime behavior is unchanged.

<sup>Written for commit db07fe6dc85766ffe594265b7b889e976fa84dc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

