### PR TITLE
fix(sidebar): throttle and dedupe per-group thread list fetches

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/group-show-more-identity.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/group-show-more-identity.ts
@@ -1,0 +1,26 @@
+import type { GroupKind, SidebarFilters } from "./next-page-offset";
+
+/** Stable cache key for per-group sidebar list fetches (probe + pagination). */
+export function groupShowMoreIdentity(
+  orgId: string,
+  kind: GroupKind,
+  key: string,
+  filters: SidebarFilters,
+): string {
+  return [
+    orgId,
+    kind,
+    key,
+    filters.type,
+    filters.member,
+    filters.currentUserId ?? "",
+  ].join("|");
+}
+
+/**
+ * `member: "mine"` omits `created_by` until `currentUserId` is known, then
+ * changes the query. Wait for the session so we do not probe twice (null → id).
+ */
+export function shouldDeferGroupProbe(filters: SidebarFilters): boolean {
+  return filters.member === "mine" && !filters.currentUserId;
+}

--- a/apps/mesh/src/web/components/sidebar/task-groups/group-threads-fetch-dedup.test.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/group-threads-fetch-dedup.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  fetchGroupProbeDeduped,
+  fetchGroupPageDeduped,
+  resetGroupThreadsFetchDedupForTests,
+} from "./group-threads-fetch-dedup";
+import { resetGroupThreadsFetchQueueForTests } from "./group-threads-fetch-queue";
+import { shouldDeferGroupProbe } from "./group-show-more-identity";
+
+afterEach(() => {
+  resetGroupThreadsFetchDedupForTests();
+  resetGroupThreadsFetchQueueForTests();
+});
+
+describe("shouldDeferGroupProbe", () => {
+  it("waits for currentUserId when member is mine", () => {
+    expect(
+      shouldDeferGroupProbe({
+        type: "all",
+        member: "mine",
+        currentUserId: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferGroupProbe({
+        type: "all",
+        member: "mine",
+        currentUserId: "user-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not defer for all members", () => {
+    expect(
+      shouldDeferGroupProbe({
+        type: "all",
+        member: "all",
+        currentUserId: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("fetchGroupProbeDeduped", () => {
+  it("runs the probe fn once for concurrent callers on the same identity", async () => {
+    let calls = 0;
+    const run = async () => {
+      calls++;
+      await Bun.sleep(5);
+      return { serverHasMore: true };
+    };
+
+    const identity = "org|agent|vm-a|all|all|";
+    const [a, b] = await Promise.all([
+      fetchGroupProbeDeduped(identity, run),
+      fetchGroupProbeDeduped(identity, run),
+    ]);
+
+    expect(calls).toBe(1);
+    expect(a).toEqual({ serverHasMore: true });
+    expect(b).toEqual({ serverHasMore: true });
+
+    let callsAfterCache = 0;
+    const cached = await fetchGroupProbeDeduped(identity, async () => {
+      callsAfterCache++;
+      return { serverHasMore: false };
+    });
+    expect(callsAfterCache).toBe(0);
+    expect(cached).toEqual({ serverHasMore: true });
+  });
+});
+
+describe("fetchGroupPageDeduped", () => {
+  it("dedupes in-flight page fetches for the same identity offset and limit", async () => {
+    let calls = 0;
+    const run = async () => {
+      calls++;
+      await Bun.sleep(5);
+      return { items: [] };
+    };
+
+    const identity = "org|agent|vm-a|all|all|user-1";
+    const [a, b] = await Promise.all([
+      fetchGroupPageDeduped(identity, 0, 10, run),
+      fetchGroupPageDeduped(identity, 0, 10, run),
+    ]);
+
+    expect(calls).toBe(1);
+    expect(a).toEqual({ items: [] });
+    expect(b).toEqual({ items: [] });
+  });
+
+  it("does not dedupe different offsets", async () => {
+    let calls = 0;
+    const run = async () => {
+      calls++;
+      return { ok: true };
+    };
+
+    const identity = "org|agent|vm-a|all|all|";
+    await fetchGroupPageDeduped(identity, 0, 10, run);
+    await fetchGroupPageDeduped(identity, 10, 10, run);
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/mesh/src/web/components/sidebar/task-groups/group-threads-fetch-dedup.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/group-threads-fetch-dedup.ts
@@ -1,0 +1,79 @@
+import { enqueueGroupThreadsFetch } from "./group-threads-fetch-queue";
+
+export interface GroupProbeResult {
+  serverHasMore: boolean;
+}
+
+function pageCacheKey(identity: string, offset: number, limit: number): string {
+  return `${identity}|o:${offset}|l:${limit}`;
+}
+
+const probeResultCache = new Map<string, GroupProbeResult>();
+const probeInFlight = new Map<string, Promise<GroupProbeResult>>();
+const pageInFlight = new Map<string, Promise<unknown>>();
+
+/**
+ * One in-flight / cached probe per `identity`. Survives hook remounts and
+ * duplicate expanded groups re-rendering in the same tick.
+ */
+export function fetchGroupProbeDeduped(
+  identity: string,
+  run: () => Promise<GroupProbeResult>,
+): Promise<GroupProbeResult> {
+  const cached = probeResultCache.get(identity);
+  if (cached) return Promise.resolve(cached);
+
+  const existing = probeInFlight.get(identity);
+  if (existing) return existing;
+
+  const promise = enqueueGroupThreadsFetch(run)
+    .then((result) => {
+      probeResultCache.set(identity, result);
+      return result;
+    })
+    .finally(() => {
+      probeInFlight.delete(identity);
+    });
+
+  probeInFlight.set(identity, promise);
+  return promise;
+}
+
+export function getCachedGroupProbe(
+  identity: string,
+): GroupProbeResult | undefined {
+  return probeResultCache.get(identity);
+}
+
+export function isGroupProbeInFlight(identity: string): boolean {
+  return probeInFlight.has(identity);
+}
+
+/**
+ * Dedupes identical `COLLECTION_THREADS_LIST` page fetches (same identity,
+ * offset, limit) while a request is in flight.
+ */
+export function fetchGroupPageDeduped<T>(
+  identity: string,
+  offset: number,
+  limit: number,
+  run: () => Promise<T>,
+): Promise<T> {
+  const key = pageCacheKey(identity, offset, limit);
+  const existing = pageInFlight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+
+  const promise = enqueueGroupThreadsFetch(run).finally(() => {
+    pageInFlight.delete(key);
+  });
+
+  pageInFlight.set(key, promise);
+  return promise;
+}
+
+/** Test-only reset. */
+export function resetGroupThreadsFetchDedupForTests(): void {
+  probeResultCache.clear();
+  probeInFlight.clear();
+  pageInFlight.clear();
+}

--- a/apps/mesh/src/web/components/sidebar/task-groups/group-threads-fetch-queue.test.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/group-threads-fetch-queue.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  enqueueGroupThreadsFetch,
+  resetGroupThreadsFetchQueueForTests,
+} from "./group-threads-fetch-queue";
+
+afterEach(() => {
+  resetGroupThreadsFetchQueueForTests();
+});
+
+describe("enqueueGroupThreadsFetch", () => {
+  it("runs tasks and resolves results", async () => {
+    const value = await enqueueGroupThreadsFetch(async () => 42);
+    expect(value).toBe(42);
+  });
+
+  it("limits concurrent executions to four", async () => {
+    let peak = 0;
+    let active = 0;
+
+    const tasks = Array.from({ length: 8 }, () =>
+      enqueueGroupThreadsFetch(async () => {
+        active++;
+        peak = Math.max(peak, active);
+        await Bun.sleep(0);
+        active--;
+        return 1;
+      }),
+    );
+
+    const results = await Promise.all(tasks);
+    expect(results).toHaveLength(8);
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThan(1);
+  });
+});

--- a/apps/mesh/src/web/components/sidebar/task-groups/group-threads-fetch-queue.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/group-threads-fetch-queue.ts
@@ -1,0 +1,41 @@
+/**
+ * Limits concurrent per-group `COLLECTION_THREADS_LIST` calls so opening many
+ * expanded sidebar groups at once does not exhaust browser connection slots
+ * (`net::ERR_INSUFFICIENT_RESOURCES`).
+ */
+const MAX_CONCURRENT = 4;
+
+let inFlight = 0;
+const waiters: Array<() => void> = [];
+
+function drain(): void {
+  while (inFlight < MAX_CONCURRENT && waiters.length > 0) {
+    const next = waiters.shift();
+    if (next) next();
+  }
+}
+
+export function enqueueGroupThreadsFetch<T>(fn: () => Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const run = () => {
+      inFlight++;
+      void fn()
+        .then(resolve, reject)
+        .finally(() => {
+          inFlight--;
+          drain();
+        });
+    };
+    if (inFlight < MAX_CONCURRENT) {
+      run();
+    } else {
+      waiters.push(run);
+    }
+  });
+}
+
+/** Test-only reset — not exported from the public module surface in production. */
+export function resetGroupThreadsFetchQueueForTests(): void {
+  inFlight = 0;
+  waiters.length = 0;
+}

--- a/apps/mesh/src/web/components/sidebar/task-groups/stable-order.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/stable-order.ts
@@ -31,7 +31,7 @@ function readStoredOrder(key: string): string[] {
     const raw = localStorage.getItem(key);
     const parsed = raw ? (JSON.parse(raw) as unknown) : [];
     return Array.isArray(parsed)
-      ? parsed.filter((v): v is string => typeof v === "string")
+      ? parsed.filter((v): v is string => typeof v === "string" && v.length > 0)
       : [];
   } catch {
     return [];

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
@@ -239,11 +239,12 @@ function AgentExpandedBody({
     virtualMcpId,
     filters,
     groupVisibleCount,
+    true,
   );
-  const { isFetching, loadMore, hasMore } = showMore;
+  const { isFetching, loadMore, hasMore, canAutoLoadFirstPage } = showMore;
 
   const [autoLoaded, setAutoLoaded] = useState(false);
-  if (!autoLoaded && threads.length === 0 && hasMore && !isFetching) {
+  if (!autoLoaded && threads.length === 0 && canAutoLoadFirstPage) {
     setAutoLoaded(true);
     queueMicrotask(() => {
       void loadMore();
@@ -286,19 +287,30 @@ function AgentExpandedBody({
 }
 
 function StatusExpandedBody({
+  status,
   threads,
   activeTaskId,
   onSelectTask,
   onArchiveTask,
-  showMore,
+  filters,
 }: {
+  status: StatusGroupData["status"];
   threads: Task[];
   activeTaskId: string | null;
   onSelectTask: (task: Task) => void;
   onArchiveTask: (task: Task) => void;
-  showMore: ReturnType<typeof useGroupShowMore>;
+  filters: SidebarFilters;
 }) {
-  const { isFetching, loadMore, hasMore } = showMore;
+  const showMore = useGroupShowMore("status", status, filters, undefined, true);
+  const { isFetching, loadMore, hasMore, canAutoLoadFirstPage } = showMore;
+
+  const [autoLoaded, setAutoLoaded] = useState(false);
+  if (!autoLoaded && threads.length === 0 && canAutoLoadFirstPage) {
+    setAutoLoaded(true);
+    queueMicrotask(() => {
+      void loadMore();
+    });
+  }
 
   return (
     <>
@@ -342,19 +354,9 @@ export function StatusGroup({
   const config = STATUS_CONFIG[status];
   const StatusIcon = config.icon;
   const [expanded, setExpanded] = useGroupExpanded(`status-${status}`, false);
-  const showMore = useGroupShowMore("status", status, filters);
 
   function handleToggleExpanded() {
-    const next = !expanded;
-    setExpanded(next);
-    if (
-      next &&
-      threads.length === 0 &&
-      showMore.hasMore &&
-      !showMore.isFetching
-    ) {
-      void showMore.loadMore();
-    }
+    setExpanded(!expanded);
   }
 
   return (
@@ -391,11 +393,12 @@ export function StatusGroup({
       {expanded && (
         <div className="flex flex-col gap-0.5 pb-1 pl-4">
           <StatusExpandedBody
+            status={status}
             threads={threads}
             activeTaskId={activeTaskId}
             onSelectTask={onSelectTask}
             onArchiveTask={onArchiveTask}
-            showMore={showMore}
+            filters={filters}
           />
         </div>
       )}

--- a/apps/mesh/src/web/components/sidebar/task-groups/use-group-expanded.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/use-group-expanded.ts
@@ -12,6 +12,9 @@ export function useGroupExpanded(
   virtualMcpId: string,
   defaultExpanded: boolean,
 ): [boolean, (next: boolean) => void] {
+  if (virtualMcpId.length === 0) {
+    return [false, () => {}];
+  }
   const [expanded, setExpanded] = useLocalStorage<boolean>(
     `${STORAGE_KEY_PREFIX}${virtualMcpId}`,
     defaultExpanded,

--- a/apps/mesh/src/web/components/sidebar/task-groups/use-group-show-more.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/use-group-show-more.ts
@@ -22,6 +22,16 @@ import {
   type GroupKind,
   type SidebarFilters,
 } from "./next-page-offset";
+import {
+  fetchGroupPageDeduped,
+  fetchGroupProbeDeduped,
+  getCachedGroupProbe,
+  isGroupProbeInFlight,
+} from "./group-threads-fetch-dedup";
+import {
+  groupShowMoreIdentity,
+  shouldDeferGroupProbe,
+} from "./group-show-more-identity";
 
 interface ShowMoreState {
   isFetching: boolean;
@@ -29,22 +39,6 @@ interface ShowMoreState {
   identity: string;
   /** Authoritative once probed or after a per-group page fetch. */
   serverHasMore: boolean | null;
-}
-
-function makeIdentity(
-  orgId: string,
-  kind: GroupKind,
-  key: string,
-  filters: SidebarFilters,
-): string {
-  return [
-    orgId,
-    kind,
-    key,
-    filters.type,
-    filters.member,
-    filters.currentUserId ?? "",
-  ].join("|");
 }
 
 function parseListResult(result: unknown): {
@@ -83,6 +77,14 @@ function countNewMatchingItems(
   return count;
 }
 
+function resolveServerHasMoreFromProbe(
+  totalCount: number | undefined,
+  visible: number,
+): boolean {
+  if (totalCount === undefined) return false;
+  return groupHasMoreFromTotal(visible, totalCount);
+}
+
 /**
  * Per-group "Show more" controller. Owns `hasMore`/`isFetching` for one
  * (org, kind, key, filters) tuple.
@@ -93,22 +95,43 @@ export function useGroupShowMore(
   filters: SidebarFilters,
   /** Precomputed visible count for this group (avoids O(T) scan per hook). */
   visibleCount?: number,
+  /**
+   * When false, skips probe/load network calls. Pass `false` while a group is
+   * collapsed so dozens of stored `sidebar.group.expanded.*` keys cannot fan out
+   * MCP requests on mount.
+   */
+  enabled = true,
 ) {
   const { org } = useProjectContext();
-  const identity = makeIdentity(org.id, kind, key, filters);
-  const [state, setState] = useState<ShowMoreState>({
-    isFetching: false,
-    isProbing: false,
-    identity,
-    serverHasMore: null,
+  const identity = groupShowMoreIdentity(org.id, kind, key, filters);
+  const deferProbe = shouldDeferGroupProbe(filters);
+
+  const [state, setState] = useState<ShowMoreState>(() => {
+    const cached = getCachedGroupProbe(identity);
+    return {
+      isFetching: false,
+      isProbing: !cached && isGroupProbeInFlight(identity),
+      identity,
+      serverHasMore: cached?.serverHasMore ?? null,
+    };
   });
+
+  /** Avoid attaching multiple listeners when `serverHasMore` is still null. */
+  const [probeListenerIdentity, setProbeListenerIdentity] = useState<
+    string | null
+  >(null);
+
   if (state.identity !== identity) {
+    const cached = getCachedGroupProbe(identity);
     setState({
       isFetching: false,
-      isProbing: false,
+      isProbing: !cached && isGroupProbeInFlight(identity),
       identity,
-      serverHasMore: null,
+      serverHasMore: cached?.serverHasMore ?? null,
     });
+    if (probeListenerIdentity !== null) {
+      setProbeListenerIdentity(null);
+    }
   }
 
   const manager = useThreadManager();
@@ -127,53 +150,50 @@ export function useGroupShowMore(
   });
 
   if (
+    enabled &&
+    !deferProbe &&
     state.identity === identity &&
     state.serverHasMore === null &&
-    !state.isProbing &&
-    !state.isFetching
+    !state.isFetching &&
+    probeListenerIdentity !== identity
   ) {
     const capturedIdentity = identity;
-    setState((s) =>
-      s.identity === capturedIdentity ? { ...s, isProbing: true } : s,
-    );
-    void (async () => {
-      try {
-        const args = buildShowMoreArgs(kind, key, 0, filters, 1);
-        const result = await client.callTool({
-          name: "COLLECTION_THREADS_LIST",
-          arguments: args as unknown as Record<string, unknown>,
-        });
-        if ((result as { isError?: boolean }).isError) {
-          throw new Error(
-            extractToolErrorMessage(result, "COLLECTION_THREADS_LIST failed"),
-          );
-        }
-        const { totalCount } = parseListResult(result);
-        const visible = nextPageOffset(
-          manager.threads.get(),
-          kind,
-          key,
-          filters,
+    setProbeListenerIdentity(capturedIdentity);
+    if (!getCachedGroupProbe(capturedIdentity)) {
+      setState((s) =>
+        s.identity === capturedIdentity ? { ...s, isProbing: true } : s,
+      );
+    }
+    void fetchGroupProbeDeduped(capturedIdentity, async () => {
+      const args = buildShowMoreArgs(kind, key, 0, filters, 1);
+      const result = await client.callTool({
+        name: "COLLECTION_THREADS_LIST",
+        arguments: args as unknown as Record<string, unknown>,
+      });
+      if ((result as { isError?: boolean }).isError) {
+        throw new Error(
+          extractToolErrorMessage(result, "COLLECTION_THREADS_LIST failed"),
         );
+      }
+      const { totalCount } = parseListResult(result);
+      const visible = nextPageOffset(manager.threads.get(), kind, key, filters);
+      return {
+        serverHasMore: resolveServerHasMoreFromProbe(totalCount, visible),
+      };
+    })
+      .then(({ serverHasMore }) => {
         setState((s) => {
           if (s.identity !== capturedIdentity) return s;
-          return {
-            ...s,
-            isProbing: false,
-            serverHasMore:
-              totalCount === undefined
-                ? false
-                : groupHasMoreFromTotal(visible, totalCount),
-          };
+          return { ...s, isProbing: false, serverHasMore };
         });
-      } catch {
+      })
+      .catch(() => {
         setState((s) =>
           s.identity === capturedIdentity
             ? { ...s, isProbing: false, serverHasMore: false }
             : s,
         );
-      }
-    })();
+      });
   }
 
   async function loadMore(): Promise<void> {
@@ -192,10 +212,16 @@ export function useGroupShowMore(
         GROUP_PAGE_SIZE,
       );
 
-      const result = await client.callTool({
-        name: "COLLECTION_THREADS_LIST",
-        arguments: args as unknown as Record<string, unknown>,
-      });
+      const result = await fetchGroupPageDeduped(
+        capturedIdentity,
+        offset,
+        GROUP_PAGE_SIZE,
+        () =>
+          client.callTool({
+            name: "COLLECTION_THREADS_LIST",
+            arguments: args as unknown as Record<string, unknown>,
+          }),
+      );
 
       if ((result as { isError?: boolean }).isError) {
         throw new Error(
@@ -249,7 +275,17 @@ export function useGroupShowMore(
 
   const isBusy = state.isFetching || state.isProbing;
   const showButton =
-    !isBusy && resolveGroupHasMore(derivedHasMore, state.serverHasMore);
+    enabled &&
+    !deferProbe &&
+    !isBusy &&
+    resolveGroupHasMore(derivedHasMore, state.serverHasMore);
 
-  return { hasMore: showButton, isFetching: isBusy, loadMore };
+  return {
+    hasMore: showButton,
+    isFetching: isBusy,
+    loadMore,
+    /** Safe to auto-fetch the first page after the probe returned `true`. */
+    canAutoLoadFirstPage:
+      enabled && !deferProbe && state.serverHasMore === true && !isBusy,
+  };
 }


### PR DESCRIPTION
## Summary

- Limits concurrent per-group `COLLECTION_THREADS_LIST` calls (max 4) to avoid `net::ERR_INSUFFICIENT_RESOURCES` when many sidebar groups are expanded from localStorage.
- Dedupes probe and in-flight page fetches per group identity; defers "Mine only" probes until `currentUserId` is available (avoids duplicate requests when the session hydrates).
- Only runs status-group pagination when the status section is expanded; auto-loads the first page only after a probe confirms more threads exist.

## Test plan

- [x] `bun test apps/mesh/src/web/components/sidebar/task-groups/`
- [ ] Open org with many `sidebar.group.expanded.*: true` keys — Network should show fewer simultaneous `POST .../mcp/self` calls and no request storm
- [ ] Expand/collapse agent groups — fetches only when expanded
- [ ] "Mine only" filter — single probe per group after session loads (not one before + one after user id)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttles and dedupes per-group `COLLECTION_THREADS_LIST` fetches in the sidebar to prevent request storms and browser resource errors. Fetches run only when groups are expanded; first page auto-loads only after a probe confirms more items.

- **Bug Fixes**
  - Limit concurrent per-group fetches to 4 via a queue to avoid `net::ERR_INSUFFICIENT_RESOURCES`.
  - Dedupe probe and page requests by stable group identity (including offset/limit); cache probe results and reuse in-flight calls.
  - Defer "Mine only" probes until `currentUserId` is present to avoid double requests during session hydration.
  - Status groups paginate only when expanded; first page auto-loads only after the probe returns true.
  - Guard expanded-state hook when `virtualMcpId` is empty; ignore empty strings when reading stored order.
  - Added tests for the queue, dedupe, and defer logic.

<sup>Written for commit 8a0774131a8886b77288ae9f400c39d0425fc03a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

