### PR TITLE
feat(permissions): include own-thread CRUD in basic-usage

### DIFF
--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -1029,6 +1029,16 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "SANDBOX_DELETE",
       // Cross-resource discovery / command palette
       "GLOBAL_SEARCH",
+      // Chat threads — talking to an agent is the most basic usage of the
+      // product, so every member can CRUD their OWN threads. Per-thread access
+      // is scoped at the handler level (you only see your own threads unless
+      // you also hold the threads:view-all capability).
+      "COLLECTION_THREADS_CREATE",
+      "COLLECTION_THREADS_LIST",
+      "COLLECTION_THREADS_GET",
+      "COLLECTION_THREADS_UPDATE",
+      "COLLECTION_THREADS_DELETE",
+      "COLLECTION_THREAD_MESSAGES_LIST",
     ],
   },
   // Organization


### PR DESCRIPTION
## Summary

Talking to an agent is the most basic usage of the product, but the thread tools weren't in **basic-usage** — so a non-admin member got `Access denied to: COLLECTION_THREADS_CREATE` the moment they tried to start a chat.

Adds the own-thread tools to the basic-usage capability:
`COLLECTION_THREADS_CREATE / LIST / GET / UPDATE / DELETE` + `COLLECTION_THREAD_MESSAGES_LIST`.

These are scoped to the member's **own** threads at the handler level — you only see other members' threads if you additionally hold the `threads:view-all` capability — so granting CRUD to everyone is safe.

Granted at runtime via the basic-usage set, so **no role-backfill migration** (the whole point of the runtime model from #3599).

## Testing

Verified the tools resolve into `BASIC_USAGE_TOOLS`; found while manually testing a restricted custom-role member, who could view but not chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables all members to start and manage their own chat threads by adding thread CRUD to basic usage, fixing “Access denied to: `COLLECTION_THREADS_CREATE`” for non-admin users.

- **New Features**
  - Added `COLLECTION_THREADS_CREATE`, `COLLECTION_THREADS_LIST`, `COLLECTION_THREADS_GET`, `COLLECTION_THREADS_UPDATE`, `COLLECTION_THREADS_DELETE`, and `COLLECTION_THREAD_MESSAGES_LIST` to the `basic-usage` capability (granted at runtime; no migration).
  - Access is limited to the member’s own threads; viewing others still requires `threads:view-all`.

<sup>Written for commit bd83c200b0e448e4b6a41324b5c13e6b5034f681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

