### PR TITLE
feat(permissions): let members see configured AI providers (basic-usage)

### DIFF
--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -1015,10 +1015,15 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       // View automations
       "AUTOMATION_GET",
       "AUTOMATION_LIST",
-      // View AI providers
+      // View AI providers (read-only — every member needs to know which
+      // providers are configured so chat / agents can use them). KEY_LIST
+      // returns metadata only (no secret material); CREDITS is the balance
+      // shown in the chat header.
       "AI_PROVIDERS_LIST",
       "AI_PROVIDERS_LIST_MODELS",
       "AI_PROVIDERS_ACTIVE",
+      "AI_PROVIDER_KEY_LIST",
+      "AI_PROVIDER_CREDITS",
       // Object storage access
       "LIST_OBJECTS",
       "GET_OBJECT_METADATA",


### PR DESCRIPTION
## Summary

A non-admin member saw the **"set up an AI provider"** prompt and couldn't use already-configured providers. Root cause: the UI's "is a provider configured?" check (`useAiProviderKeys` → `AI_PROVIDER_KEY_LIST`) wasn't granted to non-admins, so it got an access-denied and concluded no provider existed.

Adds the read-only AI provider tools to **basic-usage**:
- `AI_PROVIDER_KEY_LIST` — returns metadata only (id, providerId, label, preset, createdBy/At); **no secret material**.
- `AI_PROVIDER_CREDITS` — the balance shown in the chat header.

Managing providers (`AI_PROVIDER_KEY_CREATE/DELETE`, OAuth, provisioning, top-up) stays gated behind `ai-providers:manage`.

Runtime grant, no migration.

## Follow-up (not in this PR)

When there genuinely is **no** provider configured and the member **can't** set one up, the screen still shows the "set up a provider" CTA — it should instead say "ask an organization admin." That's UI gating of the setup CTA by `ai-providers:manage`, which belongs with the broader button/CTA gating pass (PR 3b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let non-admin members see configured AI providers and credit balance by adding read-only provider permissions to `basic-usage`. Fixes the false "set up an AI provider" prompt when providers already exist.

- **Bug Fixes**
  - Granted `AI_PROVIDER_KEY_LIST` (metadata only; no secrets) and `AI_PROVIDER_CREDITS` to `basic-usage`.
  - Provider management remains gated behind `ai-providers:manage`; no migration needed.

<sup>Written for commit 9f7d0d8880fb89f718624ae2ebfb865d9c0dc1d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

