### PR TITLE
feat(permissions): gate connections, agents, and monitor by capability

### DIFF
--- a/apps/mesh/e2e/tests/connections-agents-monitor-gating.spec.ts
+++ b/apps/mesh/e2e/tests/connections-agents-monitor-gating.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * E2E: capability gating of the Connections, Agents and Monitor surfaces.
+ *
+ * Drives the real browser as a built-in "user" member (no gated capabilities):
+ *   - Monitor is capability-gated (monitoring:view) → no-access panel;
+ *   - Connections + Agents stay viewable (basic-usage), but their create
+ *     affordances are hidden (connections:manage / agents:manage).
+ */
+
+import type { APIRequestContext, Page } from "@playwright/test";
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const ORIGIN = `http://localhost:${process.env.PORT ?? "3000"}`;
+
+/**
+ * Sign the page in as a fresh user, join `orgId` as a built-in "user", and make
+ * it the active org. Returns nothing — the page is left authenticated.
+ */
+async function joinAsUser(
+  page: Page,
+  ownerCtx: APIRequestContext,
+  orgId: string,
+): Promise<void> {
+  const member = await signUpViaApi(page.context().request);
+
+  const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+    data: { organizationId: orgId, email: member.email, role: "user" },
+  });
+  expect(invite.ok()).toBe(true);
+  const inviteJson = (await invite.json()) as {
+    id?: string;
+    invitation?: { id?: string };
+  };
+  const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+
+  const accept = await page
+    .context()
+    .request.post("/api/auth/organization/accept-invitation", {
+      data: { invitationId },
+      headers: { Origin: ORIGIN },
+    });
+  expect(
+    accept.ok(),
+    `accept-invitation failed: ${await accept.text().catch(() => "")}`,
+  ).toBe(true);
+
+  await page.context().request.post("/api/auth/organization/set-active", {
+    data: { organizationId: orgId },
+    headers: { Origin: ORIGIN },
+  });
+}
+
+test.describe("connections / agents / monitor gating", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("a plain member can't manage connections, agents, or view monitoring", async ({
+    page,
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("org not found after signup");
+
+    await joinAsUser(page, ownerCtx, orgId);
+
+    // Monitor is gated by monitoring:view → no-access panel.
+    await page.goto(`/${owner.orgSlug}/settings/monitor`);
+    await expect(page.getByText("No access to monitoring")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Connections page loads (viewing is basic-usage) but the create CTA is
+    // hidden without connections:manage.
+    await page.goto(`/${owner.orgSlug}/settings/connections`);
+    await expect(page.getByPlaceholder("Search for a connection")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Custom Connection" }),
+    ).toHaveCount(0);
+
+    // Agents page loads but the create CTA is hidden without agents:manage.
+    await page.goto(`/${owner.orgSlug}/settings/agents`);
+    await expect(page.getByPlaceholder("Search for an agent...")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Create Agent" }),
+    ).toHaveCount(0);
+
+    await ownerCtx.dispose();
+  });
+
+  test("the owner sees the management affordances", async ({ page }) => {
+    const owner = await signUpViaApi(page.context().request);
+
+    await page.goto(`/${owner.orgSlug}/settings/connections`);
+    await expect(
+      page.getByRole("button", { name: "Custom Connection" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.goto(`/${owner.orgSlug}/settings/monitor`);
+    await expect(page.getByText("No access to monitoring")).toHaveCount(0);
+  });
+});

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -133,9 +133,9 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
     {
       label: "Build",
       items: [
-        // connections + agents map to heavy route components that aren't
-        // capability-guarded yet — gated fully (nav + route + actions) in a
-        // follow-up, so leave them visible here to avoid half-gating.
+        // connections + agents stay visible to every member — viewing them is
+        // basic-usage. The create/update/delete affordances inside those pages
+        // are gated in-page by connections:manage / agents:manage.
         {
           key: "connections",
           label: "Connections",
@@ -168,12 +168,11 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
       label: "Manage",
       items: [
         {
-          // Monitor's route isn't capability-guarded yet (see Build note); gated
-          // fully in the follow-up. Visible to all members for now.
           key: "monitor",
           label: "Monitor",
           icon: <BarChart10 size={14} />,
           to: "/$org/settings/monitor",
+          requires: "monitoring:view",
         },
         {
           key: "members",

--- a/apps/mesh/src/web/routes/agents-list.tsx
+++ b/apps/mesh/src/web/routes/agents-list.tsx
@@ -8,6 +8,7 @@ import {
 } from "@decocms/mesh-sdk";
 import { Page } from "@/web/components/page";
 import { ProjectCard } from "@/web/components/project-card";
+import { useCapability } from "@/web/hooks/use-capability";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import {
@@ -53,6 +54,7 @@ export default function AgentsListPage() {
   } | null>(null);
   const [importDecoOpen, setImportDecoOpen] = useState(false);
   const [githubPickerOpen, setGithubPickerOpen] = useState(false);
+  const { granted: canManageAgents } = useCapability("agents:manage");
 
   const lowerSearch = search.toLowerCase();
 
@@ -100,53 +102,55 @@ export default function AgentsListPage() {
                   }
                 }}
               />
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button size="sm">
-                    <Plus size={14} />
-                    Create Agent
-                  </Button>
-                </DropdownMenuTrigger>
-                <CreateAgentDropdownContent
-                  onCreateFromScratch={() => {
-                    track("agent_create_clicked", {
-                      source: "agents_list",
-                      method: "scratch",
-                    });
-                    createVirtualMCP();
-                  }}
-                  onCreateWebsite={() => {
-                    track("agent_create_clicked", {
-                      source: "agents_list",
-                      method: "website",
-                    });
-                    createFromTemplate(WEBSITE_TEMPLATE);
-                  }}
-                  onCreateHydrogenStore={() => {
-                    track("agent_create_clicked", {
-                      source: "agents_list",
-                      method: "hydrogen",
-                    });
-                    createFromTemplate(HYDROGEN_TEMPLATE);
-                  }}
-                  onImportGitHub={() => {
-                    track("agent_create_clicked", {
-                      source: "agents_list",
-                      method: "github",
-                    });
-                    setGithubPickerOpen(true);
-                  }}
-                  onImportDeco={() => {
-                    track("agent_create_clicked", {
-                      source: "agents_list",
-                      method: "deco",
-                    });
-                    setImportDecoOpen(true);
-                  }}
-                  isCreating={isCreating || isCreatingFromTemplate}
-                  align="end"
-                />
-              </DropdownMenu>
+              {canManageAgents && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button size="sm">
+                      <Plus size={14} />
+                      Create Agent
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <CreateAgentDropdownContent
+                    onCreateFromScratch={() => {
+                      track("agent_create_clicked", {
+                        source: "agents_list",
+                        method: "scratch",
+                      });
+                      createVirtualMCP();
+                    }}
+                    onCreateWebsite={() => {
+                      track("agent_create_clicked", {
+                        source: "agents_list",
+                        method: "website",
+                      });
+                      createFromTemplate(WEBSITE_TEMPLATE);
+                    }}
+                    onCreateHydrogenStore={() => {
+                      track("agent_create_clicked", {
+                        source: "agents_list",
+                        method: "hydrogen",
+                      });
+                      createFromTemplate(HYDROGEN_TEMPLATE);
+                    }}
+                    onImportGitHub={() => {
+                      track("agent_create_clicked", {
+                        source: "agents_list",
+                        method: "github",
+                      });
+                      setGithubPickerOpen(true);
+                    }}
+                    onImportDeco={() => {
+                      track("agent_create_clicked", {
+                        source: "agents_list",
+                        method: "deco",
+                      });
+                      setImportDecoOpen(true);
+                    }}
+                    isCreating={isCreating || isCreatingFromTemplate}
+                    align="end"
+                  />
+                </DropdownMenu>
+              )}
             </div>
           </div>
 
@@ -160,10 +164,13 @@ export default function AgentsListPage() {
                 description={
                   search
                     ? `No agents match "${search}"`
-                    : "Create an agent to get started."
+                    : canManageAgents
+                      ? "Create an agent to get started."
+                      : "Ask an organization admin to create one."
                 }
                 actions={
-                  !search && (
+                  !search &&
+                  canManageAgents && (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button size="sm">
@@ -229,11 +236,14 @@ export default function AgentsListPage() {
                     key={agent.id}
                     project={agent}
                     lastUsedAt={lastUsedMap?.get(agent.id)?.last_used_at}
-                    onDeleteClick={() =>
-                      setDeleteTarget({
-                        id: agent.id,
-                        title: agent.title,
-                      })
+                    onDeleteClick={
+                      canManageAgents
+                        ? () =>
+                            setDeleteTarget({
+                              id: agent.id,
+                              title: agent.title,
+                            })
+                        : undefined
                     }
                   />
                 ))}

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -10,6 +10,7 @@ import { Page } from "@/web/components/page";
 import type { RegistryItem } from "@/web/components/store/types";
 import { DeleteConnectionDialogs } from "@/web/components/delete-connection-dialogs";
 import { useDeleteConnection } from "@/web/hooks/use-delete-connection";
+import { useCapability } from "@/web/hooks/use-capability";
 import { useInfiniteScroll } from "@/web/hooks/use-infinite-scroll";
 import { useLocalStorage } from "@/web/hooks/use-local-storage";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
@@ -274,6 +275,8 @@ function ConnectionGroupCard({
 function BulkActionBar({
   count,
   total,
+  canManage,
+  canManageAgents,
   onSelectAll,
   onDeselectAll,
   onDelete,
@@ -283,6 +286,8 @@ function BulkActionBar({
 }: {
   count: number;
   total: number;
+  canManage: boolean;
+  canManageAgents: boolean;
   onSelectAll: () => void;
   onDeselectAll: () => void;
   onDelete: () => void;
@@ -317,40 +322,46 @@ function BulkActionBar({
             Clear selection
           </Button>
         )}
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 text-xs px-2"
-          onClick={onAddToAgent}
-        >
-          <Plus size={13} />
-          Add to Agent
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 text-xs px-2"
-          onClick={() => onToggleStatus("active")}
-        >
-          Enable
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 text-xs px-2"
-          onClick={() => onToggleStatus("inactive")}
-        >
-          Disable
-        </Button>
-        <Button
-          variant="destructive"
-          size="sm"
-          className="h-7 text-xs px-2"
-          onClick={onDelete}
-        >
-          <Trash01 size={13} />
-          Delete
-        </Button>
+        {canManageAgents && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs px-2"
+            onClick={onAddToAgent}
+          >
+            <Plus size={13} />
+            Add to Agent
+          </Button>
+        )}
+        {canManage && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 text-xs px-2"
+              onClick={() => onToggleStatus("active")}
+            >
+              Enable
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 text-xs px-2"
+              onClick={() => onToggleStatus("inactive")}
+            >
+              Disable
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              className="h-7 text-xs px-2"
+              onClick={onDelete}
+            >
+              <Trash01 size={13} />
+              Delete
+            </Button>
+          </>
+        )}
         <Button
           variant="ghost"
           size="sm"
@@ -519,6 +530,7 @@ function isCommunityItem(item: RegistryItem): boolean {
 
 function CatalogItemCard({
   item,
+  canManage,
   allConnections,
   connectedAppNames,
   connectingItemId,
@@ -526,6 +538,7 @@ function CatalogItemCard({
   onConnect,
 }: {
   item: RegistryItem;
+  canManage: boolean;
   allConnections: ConnectionEntity[];
   connectedAppNames: Set<string>;
   connectingItemId: string | null;
@@ -568,7 +581,11 @@ function CatalogItemCard({
       }
       return;
     }
-    handleConnect();
+    // Connecting installs a connection (connections:manage). Members without it
+    // can browse the catalog but not connect.
+    if (canManage) {
+      handleConnect();
+    }
   };
 
   const handleConnect = () => {
@@ -612,22 +629,24 @@ function CatalogItemCard({
                 Connected
               </span>
             ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 px-3 rounded-lg text-sm font-medium"
-                disabled={connectingItemId !== null}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleConnect();
-                }}
-              >
-                {connectingItemId === item.id ? (
-                  <Loading01 size={14} className="animate-spin" />
-                ) : (
-                  "Connect"
-                )}
-              </Button>
+              canManage && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-3 rounded-lg text-sm font-medium"
+                  disabled={connectingItemId !== null}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleConnect();
+                  }}
+                >
+                  {connectingItemId === item.id ? (
+                    <Loading01 size={14} className="animate-spin" />
+                  ) : (
+                    "Connect"
+                  )}
+                </Button>
+              )
             )}
           </div>
         }
@@ -679,6 +698,8 @@ function ConnectionResults({
   const connections = useConnections(listState);
 
   const deleteConnection = useDeleteConnection();
+  const { granted: canManage } = useCapability("connections:manage");
+  const { granted: canManageAgents } = useCapability("agents:manage");
 
   // Selection / bulk-action state
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -1158,25 +1179,29 @@ function ConnectionResults({
                                 <Eye size={16} />
                                 Open
                               </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  toggleSelect(connection.id);
-                                }}
-                              >
-                                <CheckSquare size={16} />
-                                Select
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                variant="destructive"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  deleteConnection.requestDelete(connection);
-                                }}
-                              >
-                                <Trash01 size={16} />
-                                Delete
-                              </DropdownMenuItem>
+                              {(canManage || canManageAgents) && (
+                                <DropdownMenuItem
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    toggleSelect(connection.id);
+                                  }}
+                                >
+                                  <CheckSquare size={16} />
+                                  Select
+                                </DropdownMenuItem>
+                              )}
+                              {canManage && (
+                                <DropdownMenuItem
+                                  variant="destructive"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    deleteConnection.requestDelete(connection);
+                                  }}
+                                >
+                                  <Trash01 size={16} />
+                                  Delete
+                                </DropdownMenuItem>
+                              )}
                             </DropdownMenuContent>
                           </DropdownMenu>
                         </div>
@@ -1190,6 +1215,7 @@ function ConnectionResults({
                 <CatalogItemCard
                   key={`catalog-${item._registryId}:${item.id}`}
                   item={item}
+                  canManage={canManage}
                   allConnections={connections}
                   connectedAppNames={connectedAppNames}
                   connectingItemId={connectingItemId}
@@ -1228,6 +1254,8 @@ function ConnectionResults({
         <BulkActionBar
           count={selectedIds.size}
           total={filteredConnections.length}
+          canManage={canManage}
+          canManageAgents={canManageAgents}
           onSelectAll={() => {
             setSelectedIds(new Set(filteredConnections.map((c) => c.id)));
           }}
@@ -1252,6 +1280,7 @@ function OrgMcpsContent() {
   const { data: session } = authClient.useSession();
   const { stdioEnabled } = useAuthConfig();
   const isMobile = useIsMobile();
+  const { granted: canManage } = useCapability("connections:manage");
 
   // Consolidated list UI state (search, filters, sorting, view mode)
   const listState = useListState<ConnectionEntity>({
@@ -1519,14 +1548,14 @@ function OrgMcpsContent() {
     }
   };
 
-  const ctaButton = (
+  const ctaButton = canManage ? (
     <div className="flex items-center gap-2">
       <Button variant="outline" onClick={openCreateDialog}>
         <Plus size={14} className="sm:hidden" />
         <span className="hidden sm:inline">Custom Connection</span>
       </Button>
     </div>
-  );
+  ) : null;
 
   return (
     <>

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -1079,7 +1079,9 @@ function ConnectionResults({
               description={
                 listState.search
                   ? `No Connections match "${listState.search}"`
-                  : "Create a connection to get started."
+                  : canManage
+                    ? "Create a connection to get started."
+                    : "Ask an organization admin to add one."
               }
             />
           ) : (
@@ -1351,8 +1353,10 @@ function OrgMcpsContent() {
       registryItems,
     });
 
-  // Create dialog state is derived from search params
-  const isCreating = search.action === "create";
+  // Create dialog state is derived from search params, but gated on capability
+  // so it can't be opened by deep-linking to ?action=create without
+  // connections:manage (the write would fail server-side regardless).
+  const isCreating = canManage && search.action === "create";
 
   const openCreateDialog = () => {
     track("connections_custom_dialog_opened", {

--- a/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
@@ -8,6 +8,7 @@ import { SearchInput } from "@deco/ui/components/search-input.tsx";
 import { Page } from "@/web/components/page";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
+import { RequireCapability } from "@/web/components/require-capability";
 import { MONITORING_CONFIG } from "@/web/components/monitoring/config.ts";
 import type { DateRange } from "@/web/components/monitoring/monitoring-stats-row.tsx";
 import {
@@ -885,101 +886,103 @@ export default function MonitoringDashboard() {
     activeFiltersCount += validPropertyFilters.length;
 
   return (
-    <Page>
-      <ErrorBoundary
-        fallback={
-          <>
-            <Page.Body className="!pb-3">
-              <Page.Title>Monitoring</Page.Title>
-            </Page.Body>
-            <Page.Content>
-              <div className="flex-1 flex items-center justify-center h-full">
-                <EmptyState
-                  title="Failed to load monitoring data"
-                  description="There was an error loading the monitoring data. Please try again."
-                />
-              </div>
-            </Page.Content>
-          </>
-        }
-      >
-        <Suspense
+    <RequireCapability capability="monitoring:view" area="monitoring">
+      <Page>
+        <ErrorBoundary
           fallback={
             <>
               <Page.Body className="!pb-3">
-                <div className="flex flex-col gap-4">
-                  <Page.Title>Monitoring</Page.Title>
-                  <CollectionTabs
-                    tabs={[
-                      { id: "overview", label: "Overview" },
-                      { id: "audit", label: "Audit" },
-                      { id: "threads", label: "Threads" },
-                    ]}
-                    activeTab={tab}
-                    onTabChange={(tabId) =>
-                      updateFilters({
-                        tab: tabId as "overview" | "audit" | "threads",
-                      })
-                    }
+                <Page.Title>Monitoring</Page.Title>
+              </Page.Body>
+              <Page.Content>
+                <div className="flex-1 flex items-center justify-center h-full">
+                  <EmptyState
+                    title="Failed to load monitoring data"
+                    description="There was an error loading the monitoring data. Please try again."
                   />
                 </div>
-              </Page.Body>
-
-              {tab === "threads" ? (
-                <div className="flex-1 flex flex-col overflow-auto md:overflow-hidden">
-                  <MonitoringLogsTable.Skeleton />
-                </div>
-              ) : tab === "audit" ? (
-                <div className="flex-1 flex flex-col overflow-auto md:overflow-hidden">
-                  <MonitoringLogsTable.Skeleton />
-                </div>
-              ) : (
-                <div className="flex-1 flex flex-col overflow-auto">
-                  <OverviewTabSkeleton />
-                </div>
-              )}
+              </Page.Content>
             </>
           }
         >
-          <MonitoringDashboardContent
-            tab={tab}
-            dateRange={dateRange}
-            displayDateRange={displayDateRange}
-            connectionIds={connectionIds}
-            virtualMcpIds={virtualMcpIds}
-            tool={tool}
-            status={status}
-            search={searchQuery}
-            streaming={streaming}
-            hideSystem={hideSystem}
-            activeFiltersCount={activeFiltersCount}
-            from={from}
-            to={to}
-            propertyFilters={propertyFilters}
-            onUpdateFilters={updateFilters}
-            onTimeRangeChange={(range) => {
-              track("monitoring_time_range_changed", {
-                from: range.from,
-                to: range.to,
-              });
-              handleTimeRangeChange(range);
-            }}
-            onStreamingToggle={() => {
-              track("monitoring_live_toggled", { enabled: !streaming });
-              updateFilters({ streaming: !streaming });
-            }}
-            onTabChange={(newTab) => {
-              if (newTab !== tab) {
-                track("monitoring_tab_changed", {
-                  from_tab: tab,
-                  to_tab: newTab,
+          <Suspense
+            fallback={
+              <>
+                <Page.Body className="!pb-3">
+                  <div className="flex flex-col gap-4">
+                    <Page.Title>Monitoring</Page.Title>
+                    <CollectionTabs
+                      tabs={[
+                        { id: "overview", label: "Overview" },
+                        { id: "audit", label: "Audit" },
+                        { id: "threads", label: "Threads" },
+                      ]}
+                      activeTab={tab}
+                      onTabChange={(tabId) =>
+                        updateFilters({
+                          tab: tabId as "overview" | "audit" | "threads",
+                        })
+                      }
+                    />
+                  </div>
+                </Page.Body>
+
+                {tab === "threads" ? (
+                  <div className="flex-1 flex flex-col overflow-auto md:overflow-hidden">
+                    <MonitoringLogsTable.Skeleton />
+                  </div>
+                ) : tab === "audit" ? (
+                  <div className="flex-1 flex flex-col overflow-auto md:overflow-hidden">
+                    <MonitoringLogsTable.Skeleton />
+                  </div>
+                ) : (
+                  <div className="flex-1 flex flex-col overflow-auto">
+                    <OverviewTabSkeleton />
+                  </div>
+                )}
+              </>
+            }
+          >
+            <MonitoringDashboardContent
+              tab={tab}
+              dateRange={dateRange}
+              displayDateRange={displayDateRange}
+              connectionIds={connectionIds}
+              virtualMcpIds={virtualMcpIds}
+              tool={tool}
+              status={status}
+              search={searchQuery}
+              streaming={streaming}
+              hideSystem={hideSystem}
+              activeFiltersCount={activeFiltersCount}
+              from={from}
+              to={to}
+              propertyFilters={propertyFilters}
+              onUpdateFilters={updateFilters}
+              onTimeRangeChange={(range) => {
+                track("monitoring_time_range_changed", {
+                  from: range.from,
+                  to: range.to,
                 });
-              }
-              updateFilters({ tab: newTab });
-            }}
-          />
-        </Suspense>
-      </ErrorBoundary>
-    </Page>
+                handleTimeRangeChange(range);
+              }}
+              onStreamingToggle={() => {
+                track("monitoring_live_toggled", { enabled: !streaming });
+                updateFilters({ streaming: !streaming });
+              }}
+              onTabChange={(newTab) => {
+                if (newTab !== tab) {
+                  track("monitoring_tab_changed", {
+                    from_tab: tab,
+                    to_tab: newTab,
+                  });
+                }
+                updateFilters({ tab: newTab });
+              }}
+            />
+          </Suspense>
+        </ErrorBoundary>
+      </Page>
+    </RequireCapability>
   );
 }


### PR DESCRIPTION
## Summary

Finishes the surfaces deferred from the settings-gating PR (#3609), using existing capabilities. Two patterns, depending on whether *viewing* is privileged:

**Monitor** — viewing *is* the capability, so it's a route guard:
- `RequireCapability("monitoring:view")` wraps the dashboard (denied members never mount its data hooks), and the nav item is gated.

**Connections / Agents** — viewing is basic-usage (members can browse), so only the **write affordances** are hidden:
- *Connections* (`connections:manage`): the "Custom Connection" CTA, catalog **Connect** buttons (and the card click no longer connects), per-row **Delete**, and the bulk **Enable/Disable/Delete** bar. The bulk **Add to Agent** action is gated by `agents:manage`; the row **Select** action only appears when *some* bulk action is available.
- *Agents* (`agents:manage`): the **Create Agent** dropdown (toolbar + empty-state) and per-agent **Delete**. The empty state now tells a member without the capability to "ask an organization admin" instead of dangling a create CTA.

Affordance gating is by hiding (conditional render), consistent with the settings nav — members don't see actions that would 403.

## Out of scope (future)
Chat composer (`chat:image-generation` / `chat:web-search`) and the tasks `threads:view-all` filter need **new** capabilities + backend enforcement, so they stay separate.

## Testing
e2e (`connections-agents-monitor-gating.spec.ts`): a built-in `user` member gets the no-access panel on Monitor and sees no create CTA on Connections/Agents (pages still load — viewing is basic-usage); the owner sees the affordances. Typecheck / lint / knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds capability gating for Monitoring, Connections, and Agents. Monitor now requires `monitoring:view`; Connections/Agents remain browseable but hide management actions without `connections:manage`/`agents:manage`.

- **New Features**
  - Monitoring: route wrapped with `RequireCapability("monitoring:view")`; settings nav item requires `monitoring:view`; denied users see the no‑access panel.
  - Connections: hide "Custom Connection" CTA, catalog "Connect" buttons, per‑row Delete, and bulk Enable/Disable/Delete without `connections:manage`; bulk "Add to Agent" requires `agents:manage`; row "Select" shows only when any bulk action is available; card click no longer connects.
  - Agents: hide "Create Agent" dropdown and per‑agent Delete without `agents:manage`; empty state asks members to contact an org admin.
  - Tests: added e2e `connections-agents-monitor-gating.spec.ts` to verify member vs. owner behavior.

- **Bug Fixes**
  - Connections: empty state is role‑aware; members without `connections:manage` see “Ask an organization admin to add one.”
  - Connections: the create dialog no longer opens via `?action=create` unless `connections:manage` is granted.

<sup>Written for commit 51646a3e266fee7b479891fe4d74c0a4f5e2a788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

