### PR TITLE
fix(shell): coerce persisted chat panel width to number

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
@@ -25,6 +25,22 @@ import { ChatCenterPanel } from "@/web/layouts/chat-center-panel";
 import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 
+const DEFAULT_CHAT_PANEL_WIDTH = 45;
+
+/** react-resizable-panels requires numeric defaultSize; localStorage may hold strings. */
+function normalizePanelSizePercent(
+  value: unknown,
+  fallback = DEFAULT_CHAT_PANEL_WIDTH,
+): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || n <= 0 || n >= 100) return fallback;
+  return n;
+}
+
+function chatPanelWidthInitializer(existing: number | undefined): number {
+  return normalizePanelSizePercent(existing, DEFAULT_CHAT_PANEL_WIDTH);
+}
+
 function PersistentChatPanel({
   children,
   defaultSize,
@@ -33,12 +49,16 @@ function PersistentChatPanel({
   const [_isPending, startTransition] = useTransition();
   const [storedChatPanelWidth, setChatPanelWidth] = useLocalStorage(
     LOCALSTORAGE_KEYS.decoChatPanelWidth(),
-    45,
+    chatPanelWidthInitializer,
+  );
+  const chatPanelWidth = normalizePanelSizePercent(
+    storedChatPanelWidth,
+    DEFAULT_CHAT_PANEL_WIDTH,
   );
   // Only apply the stored width when both panels are open (non-extreme default).
   // When chat is solo (100) or closed (0), the caller's defaultSize wins.
   const effectiveDefaultSize =
-    defaultSize > 0 && defaultSize < 100 ? storedChatPanelWidth : defaultSize;
+    defaultSize > 0 && defaultSize < 100 ? chatPanelWidth : defaultSize;
   const handleResize = (size: number) =>
     startTransition(() => {
       if (size > 0 && size < 100) setChatPanelWidth(size);
@@ -82,7 +102,11 @@ export function ChatMainPanelGroup({
   const sizes = computeChatMainSizes(chatOpen, mainOpen);
   const [storedChatPanelWidth] = useLocalStorage(
     LOCALSTORAGE_KEYS.decoChatPanelWidth(),
-    45,
+    chatPanelWidthInitializer,
+  );
+  const chatPanelWidth = normalizePanelSizePercent(
+    storedChatPanelWidth,
+    DEFAULT_CHAT_PANEL_WIDTH,
   );
   const panelGroupRef = useRef<ImperativePanelGroupHandle>(null);
 
@@ -92,11 +116,10 @@ export function ChatMainPanelGroup({
     if (!handle) return;
     const s = computeChatMainSizes(chatOpen, mainOpen);
     // When both panels are open, honor the user's persisted chat width.
-    const chatSize = s.chat > 0 && s.chat < 100 ? storedChatPanelWidth : s.chat;
-    const mainSize =
-      s.chat > 0 && s.chat < 100 ? 100 - storedChatPanelWidth : s.main;
+    const chatSize = s.chat > 0 && s.chat < 100 ? chatPanelWidth : s.chat;
+    const mainSize = s.chat > 0 && s.chat < 100 ? 100 - chatPanelWidth : s.main;
     handle.setLayout([chatSize, mainSize]);
-  }, [chatOpen, mainOpen, storedChatPanelWidth]);
+  }, [chatOpen, mainOpen, chatPanelWidth]);
 
   return (
     <ResizablePanelGroup


### PR DESCRIPTION

<img width="260" height="264" alt="Screenshot 2026-06-02 at 15 29 04" src="https://github.com/user-attachments/assets/e1a5718c-3e4a-40ee-a97d-064c6a1ada81" />


## Summary
- Fixes a crash in the agent shell when opening chat/main resizable panels (`defaultSize.toPrecision is not a function`).
- Normalizes the persisted chat panel width from localStorage to a numeric percentage before passing it to `react-resizable-panels`.
- Migrates invalid stored values back to the default width on read.

## Test plan
- [x] Reproduced locally: agent shell crashed when `mesh:decochat:panel-width` was a string
- [ ] Reload agent/chat layout with both panels open — no error boundary crash
- [ ] Drag chat panel divider — width persists and reloads correctly
- [ ] Clear `mesh:decochat:panel-width` in localStorage and confirm default 45% layout still works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the agent shell when opening resizable chat/main panels. We now coerce the persisted chat panel width from localStorage to a number and default invalid values to 45%.

- **Bug Fixes**
  - Sanitize stored width via `normalizePanelSizePercent` and `chatPanelWidthInitializer` to handle strings, NaN, and out-of-range values.
  - Apply the sanitized width only when both panels are open; otherwise respect caller defaults.
  - Ensure `react-resizable-panels` receives a number to avoid `toPrecision` errors.

<sup>Written for commit 1bd85ece4aa2903efd276557ee90e9fe580d446f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

