### PR TITLE
feat(permissions): round out basic-usage for normal members

### DIFF
--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -1018,22 +1018,38 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       // View AI providers (read-only — every member needs to know which
       // providers are configured so chat / agents can use them). KEY_LIST
       // returns metadata only (no secret material); CREDITS is the balance
-      // shown in the chat header.
+      // shown in the chat header. TOPUP_URL returns a checkout link surfaced
+      // in the chat credits-exhausted banner so any member can self-serve.
       "AI_PROVIDERS_LIST",
       "AI_PROVIDERS_LIST_MODELS",
       "AI_PROVIDERS_ACTIVE",
       "AI_PROVIDER_KEY_LIST",
       "AI_PROVIDER_CREDITS",
+      "AI_PROVIDER_TOPUP_URL",
       // Object storage access
       "LIST_OBJECTS",
       "GET_OBJECT_METADATA",
       "GET_PRESIGNED_URL",
       "PUT_PRESIGNED_URL",
+      // Browse files in a configured bucket (file picker in the sandbox /
+      // content editor). Lists object keys only — no credentials returned.
+      "FILE_OBJECTS_LIST",
       // Sandbox previews
       "SANDBOX_START",
       "SANDBOX_DELETE",
       // Cross-resource discovery / command palette
       "GLOBAL_SEARCH",
+      // App-shell essentials (read-only) — every member hits these on first
+      // paint or in the global chrome:
+      //   SETTINGS_GET → sidebar / plugins / model tiers loaded at shell boot
+      //   USER_GET     → resolve member display ("created by" on agents, etc.);
+      //                  handler scopes to shared-org members, no secrets
+      //   LINK_CURRENT_GET → caller's own desktop-link status (header poll)
+      //   BRAND_CONTEXT_LIST → org branding for the chat empty state
+      "ORGANIZATION_SETTINGS_GET",
+      "USER_GET",
+      "LINK_CURRENT_GET",
+      "BRAND_CONTEXT_LIST",
       // Chat threads — talking to an agent is the most basic usage of the
       // product, so every member can CRUD their OWN threads. Per-thread access
       // is scoped at the handler level (you only see your own threads unless


### PR DESCRIPTION
## Summary

Prerequisite for the planned capstone of removing `"user"` from the `BUILTIN_ROLES` bypass. Today the built-in `user` role bypasses all permission checks, so UI gating only truly bites custom roles. Once `user` is enforced, a normal member gets **only** basic-usage server-side — so basic-usage must cover everything a non-admin legitimately does first.

I traced every non-admin flow (chat, app-shell boot, viewing agents/connections, inbox, tasks, profile/preferences, global search, file picker, credits banner) to its MCP tool calls and found read/essential tools that work **today only via the user-role bypass**. This adds them to the `basic-usage` capability.

### Added tools

| Tool | Flow | Why safe |
|---|---|---|
| `ORGANIZATION_SETTINGS_GET` | App-shell boot (Suspense) + home | `readOnlyHint`; UI config only (sidebar, plugins, model tiers) — no secrets |
| `USER_GET` | "Created by" on agent/automation detail | `readOnlyHint`; handler scopes to shared-org members; returns public profile |
| `LINK_CURRENT_GET` | Header desktop indicator (polled), home, chat | Read; caller's **own** link status |
| `BRAND_CONTEXT_LIST` | Chat no-provider empty state branding | Read; org branding, no secrets |
| `AI_PROVIDER_TOPUP_URL` | Chat credits-exhausted banner "Top up" | Returns a checkout URL; lets any member self-serve credits |
| `FILE_OBJECTS_LIST` | File picker in sandbox/content editor | Lists object keys only — no credentials |

Verified each tool's read-only-ness / output schema before adding. Write/management tools (CREATE/UPDATE/DELETE, provisioning, member/tag management, monitoring) were confirmed to be called only by gated admin UI and were **left gated**.

### Notes

- Runtime-grant model: one-line edit to the `basic-usage` capability, no role-backfill migration (see `BASIC_USAGE_TOOLS` docs in `registry-metadata.ts`).
- The `user`-role enforcement flip itself is a **separate follow-up** — not in this PR.

## Testing

- `bun run check` ✅
- `bun run lint` ✅ (0 warnings, 0 errors)
- `bun run knip` ✅ (no findings)
- `bun run fmt` ✅

No test added: per TESTING.md this is a one-line declarative capability change with no logic to unit-test, and adding a brittle snapshot of the set would not be meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands `basic-usage` permissions to include essential read-only tools normal members use, so enforcing the built-in `user` role won’t break core flows. Covers app shell boot, chat branding and credits, file picker, and user display info.

- **New Features**
  - ORGANIZATION_SETTINGS_GET — app shell config; read-only.
  - USER_GET — member display info; org-scoped; read-only.
  - LINK_CURRENT_GET — your desktop link status; read-only.
  - BRAND_CONTEXT_LIST — org branding for chat empty state; read-only.
  - AI_PROVIDER_TOPUP_URL — checkout URL for self-serve credits.
  - FILE_OBJECTS_LIST — list object keys for the file picker; no secrets.

- **Migration**
  - No data migration; runtime capability update in `apps/mesh/src/tools/registry-metadata.ts`.
  - Admin write/manage tools remain gated. The `user` role enforcement flip will be a follow-up.

<sup>Written for commit b77e0f4340d853904ad70e618dcedf4e298fb0bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

