### PR TITLE
feat(cms): SEO editor with multi-format previews + JSON file viewer

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -253,8 +253,8 @@ function ContentBrowserReady({
   const [activeCollection, setActiveCollection] =
     useState<CollectionId>("pages");
   const [selection, setSelection] = useState<Selection>(null);
-  // Page whose SEO is being edited in the two-pane SEO editor (null = none).
-  const [seoPageKey, setSeoPageKey] = useState<string | null>(null);
+  // Page that should open with the inline SEO form in SectionsEditor.
+  const [openPageSeoKey, setOpenPageSeoKey] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   // Reset search when switching collections (derived-state sync pattern)
   const [prevCollection, setPrevCollection] = useState(activeCollection);
@@ -577,7 +577,7 @@ function ContentBrowserReady({
         onSelect={(id) => {
           setActiveCollection(id);
           setSelection(null);
-          setSeoPageKey(null);
+          setOpenPageSeoKey(null);
         }}
       />
       {activeCollection !== "seo" && (
@@ -592,7 +592,7 @@ function ContentBrowserReady({
           selection={selection}
           onSelect={(next) => {
             setSelection(next);
-            setSeoPageKey(null);
+            setOpenPageSeoKey(null);
           }}
           previewUrl={previewUrl}
           onCreate={() => {
@@ -618,7 +618,7 @@ function ContentBrowserReady({
               key: page.key,
               path: page.path,
             });
-            setSeoPageKey(page.key);
+            setOpenPageSeoKey(page.key);
           }}
           onViewPageJson={(page) => setJsonPageKey(page.key)}
           onDuplicateSection={handleDuplicateSection}
@@ -657,29 +657,6 @@ function ContentBrowserReady({
               meta={meta}
               target={{ kind: "site" }}
               previewBaseUrl={previewUrl}
-            />
-          ) : seoPageKey ? (
-            <SeoEditor
-              key={`seo:${seoPageKey}`}
-              orgSlug={orgSlug}
-              virtualMcpId={virtualMcpId}
-              branch={branch}
-              decofile={decofile}
-              meta={meta}
-              target={{
-                kind: "page",
-                pageKey: seoPageKey,
-                pageName:
-                  pages.find((p) => p.key === seoPageKey)?.name ?? "Page",
-                path: pages.find((p) => p.key === seoPageKey)?.path ?? "/",
-              }}
-              previewBaseUrl={previewUrl}
-              onBack={() => setSeoPageKey(null)}
-              onEditDefaultSeo={() => {
-                setSeoPageKey(null);
-                setSelection(null);
-                setActiveCollection("seo");
-              }}
             />
           ) : selection ? (
             selection.collection === "posts" ? (
@@ -725,7 +702,11 @@ function ContentBrowserReady({
                 activeGlobalBlockKey={
                   selection.collection === "sections" ? selection.key : null
                 }
-                onEditPageSeo={(pageKey) => setSeoPageKey(pageKey)}
+                initialEditSeo={
+                  selection.collection === "pages" &&
+                  openPageSeoKey === selection.key
+                }
+                onExitSeo={() => setOpenPageSeoKey(null)}
               />
             )
           ) : (

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -857,7 +857,10 @@ function CollectionsSidebar({
   onSelect,
 }: {
   active: CollectionId;
-  counts: Record<"pages" | "sections" | "posts" | "authors" | "categories", number>;
+  counts: Record<
+    "pages" | "sections" | "posts" | "authors" | "categories",
+    number
+  >;
   showBlog: boolean;
   onSelect: (id: CollectionId) => void;
 }) {

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -303,7 +303,10 @@ function ContentBrowserReady({
     );
   }
 
-  const counts: Record<"pages" | "sections", number> = {
+  const counts: Record<
+    "pages" | "sections" | "posts" | "authors" | "categories",
+    number
+  > = {
     pages: pages.length,
     sections: globalSections.length,
     posts: allBlogEntries.posts.length,

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy, useState } from "react";
 import {
   AlertCircle,
   BookOpen01,
+  Code01,
   Copy01,
   DotsHorizontal,
   Edit01,
@@ -13,6 +14,7 @@ import {
   Plus,
   SearchLg,
   Tag01,
+  CreditCardSearch,
   Trash01,
   Users01,
 } from "@untitledui/icons";
@@ -103,6 +105,7 @@ import {
   useDeleteBlogBlock,
   useSaveBlogBlock,
 } from "./blog/use-blog-mutations";
+import { PageJsonDialog } from "@/web/components/sections-editor/page-json-dialog";
 
 const PostEditor = lazy(() =>
   import("./blog/post-editor").then((m) => ({ default: m.PostEditor })),
@@ -118,6 +121,12 @@ const SectionsEditor = lazy(() =>
   })),
 );
 
+const SeoEditor = lazy(() =>
+  import("@/web/components/sections-editor/seo-editor").then((m) => ({
+    default: m.SeoEditor,
+  })),
+);
+
 const AddSectionModal = lazy(() =>
   import("@/web/components/sections-editor/add-section-modal").then((m) => ({
     default: m.AddSectionModal,
@@ -126,7 +135,7 @@ const AddSectionModal = lazy(() =>
 
 const VARIANT_GREEN = "oklch(0.65 0.15 160)";
 
-type CollectionId = "pages" | "sections" | BlogKind;
+type CollectionId = "pages" | "sections" | "seo" | BlogKind;
 
 type Selection =
   | { collection: "pages"; key: string; path: string }
@@ -244,6 +253,8 @@ function ContentBrowserReady({
   const [activeCollection, setActiveCollection] =
     useState<CollectionId>("pages");
   const [selection, setSelection] = useState<Selection>(null);
+  // Page whose SEO is being edited in the two-pane SEO editor (null = none).
+  const [seoPageKey, setSeoPageKey] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   // Reset search when switching collections (derived-state sync pattern)
   const [prevCollection, setPrevCollection] = useState(activeCollection);
@@ -258,6 +269,7 @@ function ContentBrowserReady({
   const [addSectionOpen, setAddSectionOpen] = useState(false);
   const [renameSectionKey, setRenameSectionKey] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget>(null);
+  const [jsonPageKey, setJsonPageKey] = useState<string | null>(null);
 
   if (decofileLoading || metaLoading) {
     return (
@@ -291,7 +303,7 @@ function ContentBrowserReady({
     );
   }
 
-  const counts: Record<CollectionId, number> = {
+  const counts: Record<"pages" | "sections", number> = {
     pages: pages.length,
     sections: globalSections.length,
     posts: allBlogEntries.posts.length,
@@ -565,64 +577,112 @@ function ContentBrowserReady({
         onSelect={(id) => {
           setActiveCollection(id);
           setSelection(null);
+          setSeoPageKey(null);
         }}
       />
-      <ItemList
-        activeCollection={activeCollection}
-        pages={pages}
-        sections={globalSections}
-        blogEntries={blogEntries}
-        decofile={decofile}
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-        selection={selection}
-        onSelect={setSelection}
-        previewUrl={previewUrl}
-        onCreate={() => {
-          if (activeCollection === "pages") {
-            openCreatePage();
-          } else if (isBlogKind(activeCollection)) {
-            void handleCreateBlog(activeCollection);
-          } else if (!previewUrl) {
-            toast.error("Start the preview dev server to add sections.");
-          } else {
-            setAddSectionOpen(true);
-          }
-        }}
-        onDuplicatePage={openDuplicatePage}
-        onRenamePage={openRenamePage}
-        onAddPageVariant={handleAddPageVariant}
-        onDeletePage={(page) =>
-          setDeleteTarget({ kind: "page", key: page.key, label: page.name })
-        }
-        onDuplicateSection={handleDuplicateSection}
-        onRenameSection={(s) => setRenameSectionKey(s.key)}
-        onDeleteSection={(s) =>
-          setDeleteTarget({ kind: "section", key: s.key, label: s.name })
-        }
-        onDuplicateBlog={handleDuplicateBlog}
-        onDeleteBlog={(e) =>
-          setDeleteTarget({
-            kind: "blog",
-            blogKind: e.kind,
-            key: e.key,
-            label: e.label,
-          })
-        }
-      />
-      <div className="flex-1 min-w-0">
-        {selection ? (
-          <Suspense
-            fallback={
-              <div className="h-full flex items-center justify-center">
-                <Loading01
-                  size={20}
-                  className="animate-spin text-muted-foreground"
-                />
-              </div>
+      {activeCollection !== "seo" && (
+        <ItemList
+          activeCollection={activeCollection}
+          pages={pages}
+          sections={globalSections}
+          blogEntries={blogEntries}
+          decofile={decofile}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          selection={selection}
+          onSelect={(next) => {
+            setSelection(next);
+            setSeoPageKey(null);
+          }}
+          previewUrl={previewUrl}
+          onCreate={() => {
+            if (activeCollection === "pages") {
+              openCreatePage();
+            } else if (isBlogKind(activeCollection)) {
+              void handleCreateBlog(activeCollection);
+            } else if (!previewUrl) {
+              toast.error("Start the preview dev server to add sections.");
+            } else {
+              setAddSectionOpen(true);
             }
-          >
-            {selection.collection === "posts" ? (
+          }}
+          onDuplicatePage={openDuplicatePage}
+          onRenamePage={openRenamePage}
+          onAddPageVariant={handleAddPageVariant}
+          onDeletePage={(page) =>
+            setDeleteTarget({ kind: "page", key: page.key, label: page.name })
+          }
+          onEditPageSeo={(page) => {
+            setSelection({
+              collection: "pages",
+              key: page.key,
+              path: page.path,
+            });
+            setSeoPageKey(page.key);
+          }}
+          onViewPageJson={(page) => setJsonPageKey(page.key)}
+          onDuplicateSection={handleDuplicateSection}
+          onRenameSection={(s) => setRenameSectionKey(s.key)}
+          onDeleteSection={(s) =>
+            setDeleteTarget({ kind: "section", key: s.key, label: s.name })
+          }
+          onDuplicateBlog={handleDuplicateBlog}
+          onDeleteBlog={(e) =>
+            setDeleteTarget({
+              kind: "blog",
+              blogKind: e.kind,
+              key: e.key,
+              label: e.label,
+            })
+          }
+        />
+      )}
+      <div className="flex-1 min-w-0">
+        <Suspense
+          fallback={
+            <div className="h-full flex items-center justify-center">
+              <Loading01
+                size={20}
+                className="animate-spin text-muted-foreground"
+              />
+            </div>
+          }
+        >
+          {activeCollection === "seo" ? (
+            <SeoEditor
+              orgSlug={orgSlug}
+              virtualMcpId={virtualMcpId}
+              branch={branch}
+              decofile={decofile}
+              meta={meta}
+              target={{ kind: "site" }}
+              previewBaseUrl={previewUrl}
+            />
+          ) : seoPageKey ? (
+            <SeoEditor
+              key={`seo:${seoPageKey}`}
+              orgSlug={orgSlug}
+              virtualMcpId={virtualMcpId}
+              branch={branch}
+              decofile={decofile}
+              meta={meta}
+              target={{
+                kind: "page",
+                pageKey: seoPageKey,
+                pageName:
+                  pages.find((p) => p.key === seoPageKey)?.name ?? "Page",
+                path: pages.find((p) => p.key === seoPageKey)?.path ?? "/",
+              }}
+              previewBaseUrl={previewUrl}
+              onBack={() => setSeoPageKey(null)}
+              onEditDefaultSeo={() => {
+                setSeoPageKey(null);
+                setSelection(null);
+                setActiveCollection("seo");
+              }}
+            />
+          ) : selection ? (
+            selection.collection === "posts" ? (
               <PostEditor
                 key={`post:${selection.key}`}
                 orgSlug={orgSlug}
@@ -665,21 +725,22 @@ function ContentBrowserReady({
                 activeGlobalBlockKey={
                   selection.collection === "sections" ? selection.key : null
                 }
+                onEditPageSeo={(pageKey) => setSeoPageKey(pageKey)}
               />
-            )}
-          </Suspense>
-        ) : (
-          <EmptyMessage
-            title={`Select ${
-              isBlogKind(activeCollection)
-                ? `a ${BLOG_SINGULAR[activeCollection]}`
-                : activeCollection === "pages"
-                  ? "a page"
-                  : "a section"
-            } to edit`}
-            description='Pick an item from the list, or click "+" to create one.'
-          />
-        )}
+            )
+          ) : (
+            <EmptyMessage
+              title={`Select ${
+                isBlogKind(activeCollection)
+                  ? `a ${BLOG_SINGULAR[activeCollection]}`
+                  : activeCollection === "pages"
+                    ? "a page"
+                    : "a section"
+              } to edit`}
+              description='Pick an item from the list, or click "+" to create one.'
+            />
+          )}
+        </Suspense>
       </div>
 
       {/* Page create/duplicate/rename dialog */}
@@ -733,6 +794,18 @@ function ContentBrowserReady({
         </Suspense>
       )}
 
+      {/* Page JSON dialog */}
+      {jsonPageKey && (
+        <PageJsonDialog
+          open={!!jsonPageKey}
+          onOpenChange={(open) => {
+            if (!open) setJsonPageKey(null);
+          }}
+          pageKey={jsonPageKey}
+          decofile={decofile}
+        />
+      )}
+
       {/* Delete confirmation */}
       <AlertDialog
         open={!!deleteTarget}
@@ -784,7 +857,7 @@ function CollectionsSidebar({
   onSelect,
 }: {
   active: CollectionId;
-  counts: Record<CollectionId, number>;
+  counts: Record<"pages" | "sections" | "posts" | "authors" | "categories", number>;
   showBlog: boolean;
   onSelect: (id: CollectionId) => void;
 }) {
@@ -842,6 +915,13 @@ function CollectionsSidebar({
             />
           </>
         )}
+        <CollectionRow
+          id="seo"
+          icon={CreditCardSearch}
+          label="SEO"
+          active={active === "seo"}
+          onSelect={onSelect}
+        />
       </nav>
     </div>
   );
@@ -858,7 +938,7 @@ function CollectionRow({
   id: CollectionId;
   icon: React.ComponentType<{ size?: number; className?: string }>;
   label: string;
-  count: number;
+  count?: number;
   active: boolean;
   onSelect: (id: CollectionId) => void;
 }) {
@@ -875,14 +955,16 @@ function CollectionRow({
     >
       <Icon size={16} className="shrink-0" />
       <span className="flex-1 truncate">{label}</span>
-      <span
-        className={cn(
-          "shrink-0 text-xs tabular-nums",
-          active ? "text-accent-foreground/70" : "text-muted-foreground/70",
-        )}
-      >
-        {count}
-      </span>
+      {count !== undefined && (
+        <span
+          className={cn(
+            "shrink-0 text-xs tabular-nums",
+            active ? "text-accent-foreground/70" : "text-muted-foreground/70",
+          )}
+        >
+          {count}
+        </span>
+      )}
     </button>
   );
 }
@@ -903,6 +985,8 @@ function ItemList({
   onRenamePage,
   onAddPageVariant,
   onDeletePage,
+  onEditPageSeo,
+  onViewPageJson,
   onDuplicateSection,
   onRenameSection,
   onDeleteSection,
@@ -924,6 +1008,8 @@ function ItemList({
   onRenamePage: (page: PageEntry) => void;
   onAddPageVariant: (page: PageEntry) => void;
   onDeletePage: (page: PageEntry) => void;
+  onEditPageSeo: (page: PageEntry) => void;
+  onViewPageJson: (page: PageEntry) => void;
   onDuplicateSection: (section: GlobalSectionEntry) => void;
   onRenameSection: (section: GlobalSectionEntry) => void;
   onDeleteSection: (section: GlobalSectionEntry) => void;
@@ -1035,6 +1121,8 @@ function ItemList({
                         onDuplicate={() => onDuplicatePage(page)}
                         onRename={() => onRenamePage(page)}
                         onAddVariant={() => onAddPageVariant(page)}
+                        onEditSeo={() => onEditPageSeo(page)}
+                        onViewJson={() => onViewPageJson(page)}
                         onDelete={() => onDeletePage(page)}
                       />
                     }
@@ -1211,11 +1299,15 @@ function ItemActions({
   onDuplicate,
   onRename,
   onAddVariant,
+  onEditSeo,
+  onViewJson,
   onDelete,
 }: {
   onDuplicate: () => void;
   onRename?: () => void;
   onAddVariant?: () => void;
+  onEditSeo?: () => void;
+  onViewJson?: () => void;
   onDelete: () => void;
 }) {
   return (
@@ -1252,6 +1344,23 @@ function ItemActions({
               <Flag01 size={14} style={{ color: VARIANT_GREEN }} />
               Add variant
             </DropdownMenuItem>
+          </>
+        )}
+        {(onEditSeo || onViewJson) && (
+          <>
+            <DropdownMenuSeparator />
+            {onEditSeo && (
+              <DropdownMenuItem onClick={onEditSeo}>
+                <CreditCardSearch size={14} />
+                Edit SEO
+              </DropdownMenuItem>
+            )}
+            {onViewJson && (
+              <DropdownMenuItem onClick={onViewJson}>
+                <Code01 size={14} />
+                View JSON
+              </DropdownMenuItem>
+            )}
           </>
         )}
         <DropdownMenuSeparator />

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -3,10 +3,13 @@ import { useState, useRef } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import type { OnMount } from "@monaco-editor/react";
 import {
+  Brackets,
   ChevronDown,
   ChevronRight,
-  File06,
-  FolderClosed,
+  File02,
+  FileCode01,
+  Folder,
+  Image01,
   Loading01,
   SearchSm,
   XClose,
@@ -40,6 +43,12 @@ interface FileExplorerProps {
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
+  /**
+   * When set (or changed), opens this file path in the editor — expanding
+   * ancestor folders, selecting it, and loading its content. Used to deep-link
+   * into a file (e.g. "View JSON" opening a page's `.deco/blocks/<key>.json`).
+   */
+  openPath?: string | null;
 }
 
 function buildApiUrl(
@@ -56,10 +65,49 @@ function toDaemonPath(treePath: string) {
   return treePath.startsWith("/") ? treePath.slice(1) : treePath;
 }
 
+type FileIcon = React.ComponentType<{
+  size?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}>;
+
+/** Warm folder tone — reads well on both light and dark backgrounds. */
+const FOLDER_COLOR = "#d9a441";
+const DEFAULT_FILE_COLOR = "#94a3b8";
+
+/**
+ * Maps a filename to an icon + accent color by extension, so the tree reads at
+ * a glance (blue for TS, amber for JSON, purple for images, …). Colors are
+ * inline (not Tailwind scale tokens) and chosen to work in light and dark.
+ */
+function getFileVisual(name: string): { Icon: FileIcon; color: string } {
+  const n = name.toLowerCase();
+  if (n.endsWith(".tsx") || n.endsWith(".ts"))
+    return { Icon: FileCode01, color: "#3b82f6" };
+  if (
+    n.endsWith(".jsx") ||
+    n.endsWith(".js") ||
+    n.endsWith(".mjs") ||
+    n.endsWith(".cjs")
+  )
+    return { Icon: FileCode01, color: "#d9a441" };
+  if (n.endsWith(".json")) return { Icon: Brackets, color: "#cb9b3f" };
+  if (n.endsWith(".css") || n.endsWith(".scss"))
+    return { Icon: FileCode01, color: "#06b6d4" };
+  if (n.endsWith(".html") || n.endsWith(".xml"))
+    return { Icon: FileCode01, color: "#f97316" };
+  if (/\.(png|jpe?g|gif|webp|avif|ico|svg)$/.test(n))
+    return { Icon: Image01, color: "#a855f7" };
+  if (n.endsWith(".md") || n.endsWith(".mdx"))
+    return { Icon: File02, color: "#64748b" };
+  return { Icon: File02, color: DEFAULT_FILE_COLOR };
+}
+
 export function FileExplorer({
   orgSlug,
   virtualMcpId,
   branch,
+  openPath,
 }: FileExplorerProps) {
   // File tree state
   const [files, setFiles] = useState<string[]>([]);
@@ -94,6 +142,15 @@ export function FileExplorer({
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- one-shot fetch trigger
     loadTreeCalledRef.current = true;
     fetchFileTree();
+  }
+
+  // Deep-link: open the requested file when `openPath` is set or changes.
+  // The file opens via its path directly (read endpoint), so it works even
+  // when the tree hides the folder (e.g. dot-directories like `.deco`).
+  const [prevOpenPath, setPrevOpenPath] = useState<string | null>(null);
+  if (openPath && openPath !== prevOpenPath) {
+    setPrevOpenPath(openPath);
+    handleFileClick(openPath);
   }
 
   async function fetchFileTree() {
@@ -345,15 +402,19 @@ export function FileExplorer({
               const isExpanded = expandedDirs.has(node.path);
               const isSelected = selectedFile === node.path;
 
+              const { Icon: FileVisualIcon, color: fileColor } = getFileVisual(
+                node.name,
+              );
+
               return (
                 <button
                   key={node.path}
                   type="button"
                   className={cn(
-                    "flex w-full items-center gap-1 px-2 py-1 text-left text-xs hover:bg-accent transition-colors",
+                    "flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-[13px] hover:bg-accent transition-colors",
                     isSelected && "bg-accent",
                   )}
-                  style={{ paddingLeft: `${depth * 12 + 8}px` }}
+                  style={{ paddingLeft: `${depth * 14 + 8}px` }}
                   onClick={() => {
                     if (isDir) {
                       toggleDir(node.path);
@@ -366,26 +427,28 @@ export function FileExplorer({
                     <>
                       {isExpanded ? (
                         <ChevronDown
-                          size={12}
+                          size={14}
                           className="shrink-0 text-muted-foreground"
                         />
                       ) : (
                         <ChevronRight
-                          size={12}
+                          size={14}
                           className="shrink-0 text-muted-foreground"
                         />
                       )}
-                      <FolderClosed
-                        size={14}
-                        className="shrink-0 text-muted-foreground"
+                      <Folder
+                        size={16}
+                        className="shrink-0"
+                        style={{ color: FOLDER_COLOR }}
                       />
                     </>
                   ) : (
                     <>
-                      <span className="w-3 shrink-0" />
-                      <File06
-                        size={14}
-                        className="shrink-0 text-muted-foreground"
+                      <span className="w-3.5 shrink-0" />
+                      <FileVisualIcon
+                        size={16}
+                        className="shrink-0"
+                        style={{ color: fileColor }}
                       />
                     </>
                   )}

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -65,6 +65,18 @@ function toDaemonPath(treePath: string) {
   return treePath.startsWith("/") ? treePath.slice(1) : treePath;
 }
 
+/** Reject path traversal and absolute paths outside the workspace root. */
+function isSafeExplorerOpenPath(path: string): boolean {
+  const normalized = toDaemonPath(path);
+  if (!normalized || normalized.includes("..") || normalized.includes("\\")) {
+    return false;
+  }
+  return (
+    normalized.startsWith(".deco/blocks/") ||
+    (!normalized.startsWith("/") && !normalized.includes("://"))
+  );
+}
+
 type FileIcon = React.ComponentType<{
   size?: number;
   className?: string;
@@ -145,12 +157,15 @@ export function FileExplorer({
   }
 
   // Deep-link: open the requested file when `openPath` is set or changes.
-  // The file opens via its path directly (read endpoint), so it works even
-  // when the tree hides the folder (e.g. dot-directories like `.deco`).
   const [prevOpenPath, setPrevOpenPath] = useState<string | null>(null);
   if (openPath && openPath !== prevOpenPath) {
     setPrevOpenPath(openPath);
-    handleFileClick(openPath);
+    const pathToOpen = openPath;
+    queueMicrotask(() => {
+      if (isSafeExplorerOpenPath(pathToOpen)) {
+        handleFileClick(pathToOpen);
+      }
+    });
   }
 
   async function fetchFileTree() {

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -757,7 +757,7 @@ export function PreviewContent() {
                                 setCodeFilePath(
                                   decoBlockFileViewPath(currentPageKey),
                                 );
-                                setViewMode("code");
+                                handleViewModeChange("code");
                               } catch {
                                 toast.error("Invalid page block key");
                               }
@@ -842,7 +842,7 @@ export function PreviewContent() {
                   onViewJsonFile={(pageKey) => {
                     try {
                       setCodeFilePath(decoBlockFileViewPath(pageKey));
-                      setViewMode("code");
+                      handleViewModeChange("code");
                     } catch {
                       toast.error("Invalid page block key");
                     }

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -6,6 +6,7 @@ import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-life
 
 import {
   ChevronDown,
+  Code01,
   Code02,
   CursorClick01,
   DotsHorizontal,
@@ -14,6 +15,7 @@ import {
   LinkExternal01,
   Plus,
   SearchLg,
+  CreditCardSearch,
   TextInput,
   Loading01,
   Monitor04,
@@ -34,6 +36,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { useDecofile } from "@/web/components/sections-editor/use-decofile";
@@ -71,6 +74,18 @@ import { track } from "@/web/lib/posthog-client";
 const SectionsEditor = lazy(() =>
   import("@/web/components/sections-editor/sections-editor").then((m) => ({
     default: m.SectionsEditor,
+  })),
+);
+
+const PageSeoSheet = lazy(() =>
+  import("@/web/components/sections-editor/page-seo-sheet").then((m) => ({
+    default: m.PageSeoSheet,
+  })),
+);
+
+const SiteSeoSheet = lazy(() =>
+  import("@/web/components/sections-editor/page-seo-sheet").then((m) => ({
+    default: m.SiteSeoSheet,
   })),
 );
 
@@ -122,6 +137,12 @@ export function PreviewContent() {
   // Current iframe path (for sections editor)
   const [currentPath, setCurrentPath] = useState("/");
 
+  // SEO panel state
+  const [seoPageKey, setSeoPageKey] = useState<string | null>(null);
+  const [siteSeoOpen, setSiteSeoOpen] = useState(false);
+  // File deep-link for "View JSON" — opens the page's block file in code mode.
+  const [codeFilePath, setCodeFilePath] = useState<string | null>(null);
+
   const virtualMcpId = inset?.entity?.id ?? null;
   const { org } = useProjectContext();
 
@@ -168,9 +189,13 @@ export function PreviewContent() {
       section.resolveType.toLowerCase().includes(q)
     );
   });
+  const currentPage = activeGlobalSection
+    ? null
+    : (pages.find((p) => normPath(p.path) === normPath(currentPath)) ?? null);
   const currentPageName = activeGlobalSection
     ? activeGlobalSection.name
-    : pages.find((p) => normPath(p.path) === normPath(currentPath))?.name;
+    : currentPage?.name;
+  const currentPageKey = currentPage?.key ?? null;
 
   const iframeSrcRef = useRef<string | null>(null);
   /** Path we navigated to programmatically; ignore stale iframe onLoad events. */
@@ -705,13 +730,43 @@ export function PreviewContent() {
                       <DotsHorizontal size={14} />
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
+                  <DropdownMenuContent align="end" className="w-44">
                     <DropdownMenuItem onClick={handleHardReload}>
                       Hard Reload
                     </DropdownMenuItem>
                     <DropdownMenuItem onClick={handleCopyUrl}>
                       Copy Current URL
                     </DropdownMenuItem>
+                    {decofile && meta && (
+                      <>
+                        <DropdownMenuSeparator />
+                        {currentPageKey && (
+                          <DropdownMenuItem
+                            onClick={() => setSeoPageKey(currentPageKey)}
+                          >
+                            <CreditCardSearch size={14} />
+                            Edit SEO
+                          </DropdownMenuItem>
+                        )}
+                        {currentPageKey && (
+                          <DropdownMenuItem
+                            onClick={() => {
+                              setCodeFilePath(
+                                `/.deco/blocks/${currentPageKey}.json`,
+                              );
+                              setViewMode("code");
+                            }}
+                          >
+                            <Code01 size={14} />
+                            View JSON
+                          </DropdownMenuItem>
+                        )}
+                        <DropdownMenuItem onClick={() => setSiteSeoOpen(true)}>
+                          <CreditCardSearch size={14} />
+                          Site SEO
+                        </DropdownMenuItem>
+                      </>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
@@ -775,6 +830,10 @@ export function PreviewContent() {
                       iframe.addEventListener("load", restore);
                       setTimeout(restore, 3000);
                     }, DEV_SERVER_SETTLE_MS);
+                  }}
+                  onViewJsonFile={(pageKey) => {
+                    setCodeFilePath(`/.deco/blocks/${pageKey}.json`);
+                    setViewMode("code");
                   }}
                 />
               </Suspense>
@@ -853,6 +912,7 @@ export function PreviewContent() {
                   orgSlug={org.slug}
                   virtualMcpId={virtualMcpId}
                   branch={branch}
+                  openPath={codeFilePath}
                 />
               </Suspense>
             </div>
@@ -916,6 +976,37 @@ export function PreviewContent() {
         error={createPageError}
         onSubmit={handleCreatePage}
       />
+
+      {seoPageKey && decofile && meta && (
+        <Suspense fallback={null}>
+          <PageSeoSheet
+            open={!!seoPageKey}
+            onOpenChange={(open) => {
+              if (!open) setSeoPageKey(null);
+            }}
+            orgSlug={org.slug}
+            virtualMcpId={virtualMcpId ?? ""}
+            branch={branch ?? ""}
+            pageKey={seoPageKey}
+            decofile={decofile}
+            meta={meta}
+          />
+        </Suspense>
+      )}
+
+      {siteSeoOpen && decofile && meta && (
+        <Suspense fallback={null}>
+          <SiteSeoSheet
+            open={siteSeoOpen}
+            onOpenChange={setSiteSeoOpen}
+            orgSlug={org.slug}
+            virtualMcpId={virtualMcpId ?? ""}
+            branch={branch ?? ""}
+            decofile={decofile}
+            meta={meta}
+          />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -51,6 +51,7 @@ import {
   normalizePagePath,
   validatePagePath,
 } from "@/web/components/sections-editor/page-path-utils";
+import { decoBlockFileViewPath } from "@/web/components/sections-editor/deco-block-key";
 import { findLivePageResolveType } from "@/web/components/sections-editor/section-catalog";
 import { buildGlobalSectionPreviewUrl } from "@/web/components/sections-editor/section-preview-url";
 import { useCreatePage } from "@/web/components/sections-editor/use-create-page";
@@ -748,10 +749,14 @@ export function PreviewContent() {
                         {currentPageKey && (
                           <DropdownMenuItem
                             onClick={() => {
-                              setCodeFilePath(
-                                `/.deco/blocks/${currentPageKey}.json`,
-                              );
-                              setViewMode("code");
+                              try {
+                                setCodeFilePath(
+                                  decoBlockFileViewPath(currentPageKey),
+                                );
+                                setViewMode("code");
+                              } catch {
+                                toast.error("Invalid page block key");
+                              }
                             }}
                           >
                             <Code01 size={14} />
@@ -828,9 +833,14 @@ export function PreviewContent() {
                       setTimeout(restore, 3000);
                     }, DEV_SERVER_SETTLE_MS);
                   }}
+                  onEditPageSeo={(pageKey) => setSeoPageKey(pageKey)}
                   onViewJsonFile={(pageKey) => {
-                    setCodeFilePath(`/.deco/blocks/${pageKey}.json`);
-                    setViewMode("code");
+                    try {
+                      setCodeFilePath(decoBlockFileViewPath(pageKey));
+                      setViewMode("code");
+                    } catch {
+                      toast.error("Invalid page block key");
+                    }
                   }}
                 />
               </Suspense>
@@ -986,6 +996,18 @@ export function PreviewContent() {
             branch={branch ?? ""}
             decofile={decofile}
             meta={meta}
+            onSaved={() => {
+              setTimeout(() => {
+                const iframe = previewIframeRef.current;
+                if (!iframe) return;
+                try {
+                  iframe.contentWindow?.location.reload();
+                } catch {
+                  const src = iframeSrcRef.current;
+                  if (src) iframe.src = src;
+                }
+              }, DEV_SERVER_SETTLE_MS);
+            }}
             target={{
               kind: "page",
               pageKey: seoPageKey,
@@ -1006,6 +1028,18 @@ export function PreviewContent() {
             branch={branch ?? ""}
             decofile={decofile}
             meta={meta}
+            onSaved={() => {
+              setTimeout(() => {
+                const iframe = previewIframeRef.current;
+                if (!iframe) return;
+                try {
+                  iframe.contentWindow?.location.reload();
+                } catch {
+                  const src = iframeSrcRef.current;
+                  if (src) iframe.src = src;
+                }
+              }, DEV_SERVER_SETTLE_MS);
+            }}
             target={{ kind: "site" }}
           />
         </Suspense>

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -77,15 +77,9 @@ const SectionsEditor = lazy(() =>
   })),
 );
 
-const PageSeoSheet = lazy(() =>
+const SeoSheet = lazy(() =>
   import("@/web/components/sections-editor/page-seo-sheet").then((m) => ({
-    default: m.PageSeoSheet,
-  })),
-);
-
-const SiteSeoSheet = lazy(() =>
-  import("@/web/components/sections-editor/page-seo-sheet").then((m) => ({
-    default: m.SiteSeoSheet,
+    default: m.SeoSheet,
   })),
 );
 
@@ -382,6 +376,9 @@ export function PreviewContent() {
     const prev = viewMode;
     setViewMode(mode);
     setVisualElement(null);
+    // Leaving code mode clears the "View JSON" deep-link so re-entering code
+    // mode later opens the file tree, not the previously-viewed page JSON.
+    if (mode !== "code") setCodeFilePath(null);
     if (mode !== "cms") setCmsSelectedSectionIndex(null);
     if (prev === "visual") deactivateVisualEditor();
     if (prev === "cms") deactivateCmsEditor();
@@ -979,7 +976,7 @@ export function PreviewContent() {
 
       {seoPageKey && decofile && meta && (
         <Suspense fallback={null}>
-          <PageSeoSheet
+          <SeoSheet
             open={!!seoPageKey}
             onOpenChange={(open) => {
               if (!open) setSeoPageKey(null);
@@ -987,16 +984,21 @@ export function PreviewContent() {
             orgSlug={org.slug}
             virtualMcpId={virtualMcpId ?? ""}
             branch={branch ?? ""}
-            pageKey={seoPageKey}
             decofile={decofile}
             meta={meta}
+            target={{
+              kind: "page",
+              pageKey: seoPageKey,
+              pageName: pages.find((p) => p.key === seoPageKey)?.name ?? "Page",
+              path: pages.find((p) => p.key === seoPageKey)?.path ?? "/",
+            }}
           />
         </Suspense>
       )}
 
       {siteSeoOpen && decofile && meta && (
         <Suspense fallback={null}>
-          <SiteSeoSheet
+          <SeoSheet
             open={siteSeoOpen}
             onOpenChange={setSiteSeoOpen}
             orgSlug={org.slug}
@@ -1004,6 +1006,7 @@ export function PreviewContent() {
             branch={branch ?? ""}
             decofile={decofile}
             meta={meta}
+            target={{ kind: "site" }}
           />
         </Suspense>
       )}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -133,7 +133,7 @@ export function PreviewContent() {
   const [currentPath, setCurrentPath] = useState("/");
 
   // SEO panel state
-  const [seoPageKey, setSeoPageKey] = useState<string | null>(null);
+  const [cmsInitialEditSeo, setCmsInitialEditSeo] = useState(false);
   const [siteSeoOpen, setSiteSeoOpen] = useState(false);
   // File deep-link for "View JSON" — opens the page's block file in code mode.
   const [codeFilePath, setCodeFilePath] = useState<string | null>(null);
@@ -427,6 +427,7 @@ export function PreviewContent() {
     setDirectPreviewUrl(null);
     setCurrentPath(path);
     setCmsSelectedSectionIndex(null);
+    setCmsInitialEditSeo(false);
   };
 
   const navigatePreviewToGlobalSection = (section: GlobalSectionEntry) => {
@@ -740,7 +741,10 @@ export function PreviewContent() {
                         <DropdownMenuSeparator />
                         {currentPageKey && (
                           <DropdownMenuItem
-                            onClick={() => setSeoPageKey(currentPageKey)}
+                            onClick={() => {
+                              setCmsInitialEditSeo(true);
+                              handleViewModeChange("cms");
+                            }}
                           >
                             <CreditCardSearch size={14} />
                             Edit SEO
@@ -833,7 +837,8 @@ export function PreviewContent() {
                       setTimeout(restore, 3000);
                     }, DEV_SERVER_SETTLE_MS);
                   }}
-                  onEditPageSeo={(pageKey) => setSeoPageKey(pageKey)}
+                  initialEditSeo={cmsInitialEditSeo}
+                  onExitSeo={() => setCmsInitialEditSeo(false)}
                   onViewJsonFile={(pageKey) => {
                     try {
                       setCodeFilePath(decoBlockFileViewPath(pageKey));
@@ -983,40 +988,6 @@ export function PreviewContent() {
         error={createPageError}
         onSubmit={handleCreatePage}
       />
-
-      {seoPageKey && decofile && meta && (
-        <Suspense fallback={null}>
-          <SeoSheet
-            open={!!seoPageKey}
-            onOpenChange={(open) => {
-              if (!open) setSeoPageKey(null);
-            }}
-            orgSlug={org.slug}
-            virtualMcpId={virtualMcpId ?? ""}
-            branch={branch ?? ""}
-            decofile={decofile}
-            meta={meta}
-            onSaved={() => {
-              setTimeout(() => {
-                const iframe = previewIframeRef.current;
-                if (!iframe) return;
-                try {
-                  iframe.contentWindow?.location.reload();
-                } catch {
-                  const src = iframeSrcRef.current;
-                  if (src) iframe.src = src;
-                }
-              }, DEV_SERVER_SETTLE_MS);
-            }}
-            target={{
-              kind: "page",
-              pageKey: seoPageKey,
-              pageName: pages.find((p) => p.key === seoPageKey)?.name ?? "Page",
-              path: pages.find((p) => p.key === seoPageKey)?.path ?? "/",
-            }}
-          />
-        </Suspense>
-      )}
 
       {siteSeoOpen && decofile && meta && (
         <Suspense fallback={null}>

--- a/apps/mesh/src/web/components/sections-editor/deco-block-key.ts
+++ b/apps/mesh/src/web/components/sections-editor/deco-block-key.ts
@@ -30,3 +30,8 @@ export function blockKeyToFileStem(blockKey: string): string {
 export function decoBlockFilePath(blockKey: string): string {
   return `.deco/blocks/${blockKeyToFileStem(blockKey)}.json`;
 }
+
+/** Path shape used by the sandbox file explorer deep-link (`openPath`). */
+export function decoBlockFileViewPath(blockKey: string): string {
+  return `/${decoBlockFilePath(blockKey)}`;
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
+import { ChevronDown, ChevronRight } from "@untitledui/icons";
 import {
   Select,
   SelectContent,
@@ -7,6 +8,7 @@ import {
   SelectValue,
 } from "@deco/ui/components/select.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
 import {
   embeddedUnionBlockId,
   isEmbeddedUnionResolveType,
@@ -83,6 +85,56 @@ function detectCurrentType(
   return best;
 }
 
+function CollapsibleLoaderConfig({
+  path,
+  open,
+  onOpenChange,
+  title,
+  nested,
+  nestedBlockRef,
+}: {
+  path: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  nested: ReactNode;
+  nestedBlockRef?: boolean;
+}) {
+  const contentId = `${path}-loader-config`;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-border/80 bg-muted/30",
+        nestedBlockRef && "ml-1",
+      )}
+    >
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={contentId}
+        onClick={() => onOpenChange(!open)}
+        className="group flex w-full min-w-0 items-center gap-2 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-accent/50"
+      >
+        <span className="flex size-6 shrink-0 items-center justify-center text-muted-foreground transition-colors group-hover:text-foreground">
+          {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </span>
+        <span className="min-w-0 truncate text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          {title}
+        </span>
+      </button>
+      {open && (
+        <div
+          id={contentId}
+          className="border-t border-border/60 px-4 pb-4 pt-3"
+        >
+          <div className="border-l border-border/80 pl-4">{nested}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function AnyOfField({
   schema,
   value,
@@ -98,6 +150,7 @@ export function AnyOfField({
       ? detectCurrentType(value, refs)
       : (refs[0]?.resolveType ?? "");
   const [selectedRt, setSelectedRt] = useState(inferredRt);
+  const [loaderConfigOpen, setLoaderConfigOpen] = useState(false);
 
   // ── block-ref mode (anyOfRefs from schema resolution) ─────────────
   if (refs.length > 0) {
@@ -143,8 +196,24 @@ export function AnyOfField({
       onChange(rest);
     };
 
+    const nestedProps = selectedRef?.schema?.properties ? (
+      <SchemaForm
+        schema={selectedRef.schema}
+        value={value}
+        onChange={persistUnionValue}
+        basePath={path}
+        breadcrumbPath={breadcrumbPath}
+        onBreadcrumbChange={onBreadcrumbChange}
+      />
+    ) : null;
+
+    // Block-ref loaders (jsonLD, slug, …): nest props in a card so they read
+    // as configuration for the selected block, not siblings of parent fields.
+    const isBlockRef = schema.type === "block-ref";
+    const isNestedBlockRef = path.includes(".");
+
     return (
-      <div className="space-y-4">
+      <div className="space-y-3">
         <div className="space-y-1.5">
           <Label htmlFor={path}>{label}</Label>
           <Select value={activeRt} onValueChange={handleRefChange}>
@@ -167,16 +236,21 @@ export function AnyOfField({
             </p>
           )}
         </div>
-        {selectedRef?.schema?.properties && (
-          <SchemaForm
-            schema={selectedRef.schema}
-            value={value}
-            onChange={persistUnionValue}
-            basePath={path}
-            breadcrumbPath={breadcrumbPath}
-            onBreadcrumbChange={onBreadcrumbChange}
-          />
-        )}
+        {nestedProps &&
+          (isBlockRef ? (
+            <CollapsibleLoaderConfig
+              path={path}
+              open={loaderConfigOpen}
+              onOpenChange={setLoaderConfigOpen}
+              title={
+                isNestedBlockRef ? "Configuration" : "Loader configuration"
+              }
+              nested={nestedProps}
+              nestedBlockRef={isNestedBlockRef}
+            />
+          ) : (
+            nestedProps
+          ))}
       </div>
     );
   }

--- a/apps/mesh/src/web/components/sections-editor/fields/enum-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/enum-field.tsx
@@ -7,6 +7,12 @@ import {
 } from "@deco/ui/components/select.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import type { FieldProps } from "./field-props";
+import {
+  enumOptionLabel,
+  enumOptionToSelectValue,
+  formValueToSelectValue,
+  selectValueToEnumOption,
+} from "./enum-select-value";
 
 export function EnumField({
   schema,
@@ -16,7 +22,7 @@ export function EnumField({
   label,
 }: FieldProps) {
   const options = schema.enum ?? [];
-  const strValue = value != null ? String(value) : "";
+  const selectValue = formValueToSelectValue(value, options);
 
   return (
     <div className="space-y-2">
@@ -29,21 +35,21 @@ export function EnumField({
         )}
       </div>
       <Select
-        value={strValue}
-        onValueChange={(v) => {
-          const original = options.find((opt) => String(opt) === v);
-          onChange(original !== undefined ? original : v);
-        }}
+        value={selectValue}
+        onValueChange={(v) => onChange(selectValueToEnumOption(v, options))}
       >
         <SelectTrigger className="h-10">
           <SelectValue placeholder="Select..." />
         </SelectTrigger>
         <SelectContent>
-          {options.map((opt) => (
-            <SelectItem key={String(opt)} value={String(opt)}>
-              {String(opt)}
-            </SelectItem>
-          ))}
+          {options.map((opt) => {
+            const itemValue = enumOptionToSelectValue(opt);
+            return (
+              <SelectItem key={itemValue} value={itemValue}>
+                {enumOptionLabel(opt)}
+              </SelectItem>
+            );
+          })}
         </SelectContent>
       </Select>
     </div>

--- a/apps/mesh/src/web/components/sections-editor/fields/enum-select-value.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/enum-select-value.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ENUM_EMPTY_SELECT_VALUE,
+  enumOptionLabel,
+  enumOptionToSelectValue,
+  formValueToSelectValue,
+  selectValueToEnumOption,
+} from "./enum-select-value";
+
+describe("enumOptionToSelectValue", () => {
+  test("maps empty string enum to sentinel", () => {
+    expect(enumOptionToSelectValue("")).toBe(ENUM_EMPTY_SELECT_VALUE);
+  });
+
+  test("stringifies other values", () => {
+    expect(enumOptionToSelectValue("website")).toBe("website");
+    expect(enumOptionToSelectValue(0)).toBe("0");
+  });
+});
+
+describe("selectValueToEnumOption", () => {
+  test("maps sentinel back to empty string", () => {
+    expect(selectValueToEnumOption(ENUM_EMPTY_SELECT_VALUE, ["", "a"])).toBe(
+      "",
+    );
+  });
+
+  test("returns original enum value", () => {
+    expect(selectValueToEnumOption("article", ["website", "article"])).toBe(
+      "article",
+    );
+  });
+});
+
+describe("formValueToSelectValue", () => {
+  test("uses undefined when unset and no empty enum option", () => {
+    expect(formValueToSelectValue(undefined, ["website", "article"])).toBe(
+      undefined,
+    );
+  });
+
+  test("uses sentinel when unset and empty enum is allowed", () => {
+    expect(formValueToSelectValue(null, ["", "custom"])).toBe(
+      ENUM_EMPTY_SELECT_VALUE,
+    );
+  });
+});
+
+describe("enumOptionLabel", () => {
+  test("keeps empty option label blank like admin", () => {
+    expect(enumOptionLabel("")).toBe("");
+    expect(enumOptionLabel("website")).toBe("website");
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/fields/enum-select-value.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/enum-select-value.ts
@@ -1,0 +1,32 @@
+/** Radix Select reserves `""` for clearing; map real empty-string enums to this. */
+export const ENUM_EMPTY_SELECT_VALUE = "__enum_empty__";
+
+export function enumOptionToSelectValue(opt: unknown): string {
+  if (opt === "") return ENUM_EMPTY_SELECT_VALUE;
+  return String(opt);
+}
+
+export function selectValueToEnumOption(
+  value: string,
+  options: unknown[],
+): unknown {
+  if (value === ENUM_EMPTY_SELECT_VALUE) return "";
+  const match = options.find((opt) => enumOptionToSelectValue(opt) === value);
+  return match !== undefined ? match : value;
+}
+
+export function formValueToSelectValue(
+  value: unknown,
+  options: unknown[],
+): string | undefined {
+  if (value === undefined || value === null) {
+    return options.some((opt) => opt === "")
+      ? ENUM_EMPTY_SELECT_VALUE
+      : undefined;
+  }
+  return enumOptionToSelectValue(value);
+}
+
+export function enumOptionLabel(opt: unknown): string {
+  return opt === "" ? "" : String(opt);
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
@@ -115,8 +115,10 @@ export function FileField({
 
   return (
     // See ImageField for the grid-cols-[minmax(0,1fr)] rationale —
-    // bulletproofs against any broken min-w-0 chain above.
-    <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2 overflow-hidden">
+    // bulletproofs against any broken min-w-0 chain above. No
+    // `overflow-hidden`: it clips the input/button focus rings and right
+    // borders; the grid track already caps width.
+    <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2">
       <div className="min-w-0 space-y-0.5">
         <Label htmlFor={path} className="text-muted-foreground">
           {label}

--- a/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
@@ -141,8 +141,10 @@ export function ImageField({
     // grid-cols-[minmax(0,1fr)] forces every child to be at most 100% of
     // the grid, no matter what intrinsic-content sizing tries to do —
     // the only reliable way to bulletproof a deeply-nested form field
-    // against a misbehaving min-w-0 chain.
-    <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2 overflow-hidden">
+    // against a misbehaving min-w-0 chain. No `overflow-hidden` here: it
+    // clips the input/button focus rings and right borders (cutting off the
+    // URL input + Browse button); the grid track already caps width.
+    <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)] gap-2">
       <div className="min-w-0 space-y-0.5">
         <Label htmlFor={path} className="text-muted-foreground">
           {label}

--- a/apps/mesh/src/web/components/sections-editor/general-seo-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/general-seo-form.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import { Label } from "@deco/ui/components/label.tsx";
+import { Switch } from "@deco/ui/components/switch.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import type { SchemaProperty } from "./resolve-schema";
+import { renderField } from "./schema-form";
+import {
+  filterSeoSchema,
+  generalSeoFieldsWithDefaultToggle,
+  GENERAL_SEO_FIELD_KEYS,
+} from "./seo-form-mode";
+import { DEFAULT_SEO_RESOLVE_TYPE } from "./seo-block";
+
+interface GeneralSeoFormProps {
+  schema: SchemaProperty;
+  value: Record<string, unknown>;
+  onChange: (value: Record<string, unknown>) => void;
+  /** Site/default SEO — page overrides inherit when a field is unset. */
+  siteDefaultSeo?: Record<string, unknown>;
+  formResetKey: number;
+}
+
+function humanize(key: string): string {
+  return key
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (c) => c.toUpperCase())
+    .trim();
+}
+
+function fieldUsesDefault(
+  value: Record<string, unknown>,
+  key: string,
+): boolean {
+  return value[key] === undefined;
+}
+
+/**
+ * Admin's BaseSEOForm for General pages: curated fields plus per-field
+ * "Use default" on page SEO (inherits site SEO when unset).
+ */
+export function GeneralSeoForm({
+  schema,
+  value,
+  onChange,
+  siteDefaultSeo,
+  formResetKey,
+}: GeneralSeoFormProps) {
+  const filtered = filterSeoSchema(schema, DEFAULT_SEO_RESOLVE_TYPE);
+  const properties = filtered.properties ?? {};
+  const inheritKeys = generalSeoFieldsWithDefaultToggle();
+  const showInherit =
+    !!siteDefaultSeo && Object.keys(siteDefaultSeo).length > 0;
+
+  const [prevResetKey, setPrevResetKey] = useState(formResetKey);
+  const [inheritByField, setInheritByField] = useState<Record<string, boolean>>(
+    {},
+  );
+  if (prevResetKey !== formResetKey) {
+    setPrevResetKey(formResetKey);
+    setInheritByField({});
+  }
+
+  const usesDefault = (key: string): boolean => {
+    if (inheritByField[key] !== undefined) return inheritByField[key]!;
+    return fieldUsesDefault(value, key);
+  };
+
+  const handleUseDefaultChange = (key: string, next: boolean) => {
+    setInheritByField((prev) => ({ ...prev, [key]: next }));
+    const nextValue = { ...value };
+    if (next) {
+      delete nextValue[key];
+    } else {
+      const seed = siteDefaultSeo?.[key];
+      nextValue[key] =
+        seed !== undefined && seed !== null
+          ? seed
+          : key === "type"
+            ? "website"
+            : "";
+    }
+    onChange(nextValue);
+  };
+
+  return (
+    <div key={formResetKey} className="min-w-0 space-y-6">
+      {GENERAL_SEO_FIELD_KEYS.map((key) => {
+        const propSchema = properties[key];
+        if (!propSchema) return null;
+
+        const inherit = showInherit && inheritKeys.includes(key);
+        const useDefault = inherit && usesDefault(key);
+        const displayValue = useDefault
+          ? (siteDefaultSeo?.[key] ?? value[key])
+          : value[key];
+        const label = propSchema.title ?? humanize(key);
+
+        return (
+          <div key={key} className="space-y-2">
+            <div className={cn(useDefault && "pointer-events-none opacity-60")}>
+              {renderField({
+                schema: propSchema,
+                value: displayValue,
+                onChange: (fieldValue) => {
+                  if (useDefault) return;
+                  onChange({ ...value, [key]: fieldValue });
+                },
+                path: key,
+                label,
+                breadcrumbPath: [],
+                onBreadcrumbChange: () => {},
+              })}
+            </div>
+            {inherit && (
+              <div className="flex items-center gap-2">
+                <Switch
+                  id={`seo-use-default-${key}`}
+                  checked={useDefault}
+                  onCheckedChange={(checked) =>
+                    handleUseDefaultChange(key, checked)
+                  }
+                />
+                <Label
+                  htmlFor={`seo-use-default-${key}`}
+                  className="text-xs font-normal text-muted-foreground"
+                >
+                  Use default
+                </Label>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/page-json-dialog.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-json-dialog.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { Copy01, CheckCircle } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+
+interface PageJsonDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pageKey: string;
+  decofile: Record<string, unknown>;
+}
+
+export function PageJsonDialog({
+  open,
+  onOpenChange,
+  pageKey,
+  decofile,
+}: PageJsonDialogProps) {
+  const [copied, setCopied] = useState(false);
+  const pageData = decofile[pageKey];
+  const json = JSON.stringify(pageData, null, 2);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(json).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl p-0 gap-0">
+        <DialogHeader className="px-4 py-3 border-b flex-row items-center justify-between space-y-0">
+          <DialogTitle className="text-sm font-semibold">Page JSON</DialogTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleCopy}
+            className="h-7 gap-1.5 text-xs"
+          >
+            {copied ? <CheckCircle size={12} /> : <Copy01 size={12} />}
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        </DialogHeader>
+        <ScrollArea className="max-h-[70vh]">
+          <pre className="p-4 text-xs font-mono text-foreground/90 whitespace-pre overflow-auto">
+            {json}
+          </pre>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/page-json-dialog.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-json-dialog.tsx
@@ -24,7 +24,11 @@ export function PageJsonDialog({
 }: PageJsonDialogProps) {
   const [copied, setCopied] = useState(false);
   const pageData = decofile[pageKey];
-  const json = JSON.stringify(pageData, null, 2);
+  // A missing key would otherwise stringify to the literal "undefined".
+  const json =
+    pageData === undefined
+      ? "// Page not found."
+      : JSON.stringify(pageData, null, 2);
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(json).then(() => {

--- a/apps/mesh/src/web/components/sections-editor/page-seo-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-seo-form.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from "react";
+import { SeoFormChrome } from "./seo-form-chrome";
+import { SeoFormFields } from "./seo-form-fields";
+import { SeoTypeSelect } from "./seo-type-select";
+import type { SchemaProperty } from "./resolve-schema";
+import type { SeoTypeOption } from "./seo-schema";
+import {
+  defaultEnabledSeo,
+  isSeoEnabled,
+  toggleSeoAsyncRender,
+} from "./seo-lazy-render";
+
+interface PageSeoFormProps {
+  rawSeo: unknown;
+  innerSeo: Record<string, unknown>;
+  defaultResolveType: string;
+  seoSchema: SchemaProperty | null;
+  activeResolveType: string | null;
+  seoTypeOptions?: SeoTypeOption[];
+  formResetKey: number;
+  siteDefaultSeo?: Record<string, unknown>;
+  onBreadcrumbChange?: (path: string[]) => void;
+  onPersistRaw: (raw: Record<string, unknown> | null) => void;
+  onInnerChange: (inner: Record<string, unknown>) => void;
+  /** Clears inner form state (enable/disable). */
+  onClearForm: () => void;
+  /** Remounts schema widgets (type change). */
+  onBumpFormKey: () => void;
+  beforeFields?: ReactNode;
+}
+
+/** Page SEO: Enable + type + fields + Async render (admin EditSEO layout). */
+export function PageSeoForm({
+  rawSeo,
+  innerSeo,
+  defaultResolveType,
+  seoSchema,
+  activeResolveType,
+  seoTypeOptions,
+  formResetKey,
+  siteDefaultSeo,
+  onBreadcrumbChange,
+  onPersistRaw,
+  onInnerChange,
+  onClearForm,
+  onBumpFormKey,
+  beforeFields,
+}: PageSeoFormProps) {
+  const handleEnableChange = (enabled: boolean) => {
+    if (enabled) {
+      const nextRaw = defaultEnabledSeo(defaultResolveType);
+      onPersistRaw(nextRaw);
+      onClearForm();
+      onBumpFormKey();
+      return;
+    }
+    onPersistRaw(null);
+    onClearForm();
+    onBumpFormKey();
+  };
+
+  const handleAsyncRenderChange = (enabled: boolean) => {
+    const nextRaw = toggleSeoAsyncRender(enabled, rawSeo);
+    onPersistRaw(nextRaw);
+  };
+
+  const handleTypeChange = (nextType: string) => {
+    onInnerChange({ ...innerSeo, __resolveType: nextType });
+    onBumpFormKey();
+  };
+
+  return (
+    <SeoFormChrome
+      rawSeo={rawSeo}
+      onEnableChange={handleEnableChange}
+      onAsyncRenderChange={handleAsyncRenderChange}
+    >
+      {beforeFields}
+      {isSeoEnabled(rawSeo) &&
+        seoSchema &&
+        activeResolveType &&
+        seoTypeOptions &&
+        seoTypeOptions.length > 0 && (
+          <SeoTypeSelect
+            options={seoTypeOptions}
+            value={activeResolveType}
+            onChange={handleTypeChange}
+          />
+        )}
+      {isSeoEnabled(rawSeo) && seoSchema && activeResolveType && (
+        <SeoFormFields
+          schema={seoSchema}
+          resolveType={activeResolveType}
+          value={innerSeo}
+          formResetKey={formResetKey}
+          onChange={(next) => onInnerChange(next as Record<string, unknown>)}
+          onBreadcrumbChange={onBreadcrumbChange}
+          siteDefaultSeo={siteDefaultSeo}
+        />
+      )}
+    </SeoFormChrome>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/page-seo-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-seo-form.tsx
@@ -65,7 +65,8 @@ export function PageSeoForm({
   };
 
   const handleTypeChange = (nextType: string) => {
-    onInnerChange({ ...innerSeo, __resolveType: nextType });
+    // Drop fields from the previous type so PDP/PLP keys do not leak across.
+    onInnerChange({ __resolveType: nextType });
     onBumpFormKey();
   };
 

--- a/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
@@ -1,6 +1,5 @@
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { Loading01 } from "@untitledui/icons";
-import { toast } from "sonner";
 import {
   Sheet,
   SheetContent,
@@ -8,77 +7,78 @@ import {
   SheetTitle,
 } from "@deco/ui/components/sheet.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { useSaveBlock } from "./use-save-block";
+import { useDebouncedSaveBlock } from "./use-save-block";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema } from "./resolve-schema";
 import type { LiveMeta } from "./resolve-schema";
-import { buildSiteSeoBlockData, findSiteSeoEntry } from "./seo-block";
+import { resolveSeoTarget } from "./seo-block";
+import type { SeoTarget } from "./seo-block";
 
-const AUTOSAVE_DELAY = 700;
-
-interface PageSeoSheetProps {
+interface SeoSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
-  pageKey: string;
   decofile: Record<string, unknown>;
   meta: LiveMeta;
+  target: SeoTarget;
   onSaved?: () => void;
 }
 
-export function PageSeoSheet({
+/**
+ * Form-only SEO editor rendered as a right-hand drawer (used from the preview
+ * toolbar, where the two-pane SeoEditor would crowd the iframe). Shares the
+ * same block resolution and debounced-save loop as the editor — the only
+ * difference is the chrome and the lack of a live-preview pane.
+ */
+export function SeoSheet({
   open,
   onOpenChange,
   orgSlug,
   virtualMcpId,
   branch,
-  pageKey,
   decofile,
   meta,
+  target,
   onSaved,
-}: PageSeoSheetProps) {
-  const pageData = decofile[pageKey] as Record<string, unknown> | undefined;
-  const seoData = pageData?.seo as Record<string, unknown> | undefined;
-  const seoResolveType =
-    typeof seoData?.__resolveType === "string" ? seoData.__resolveType : null;
-  const seoSchema = seoResolveType ? resolveSchema(seoResolveType, meta) : null;
+}: SeoSheetProps) {
+  const resolved = resolveSeoTarget(decofile, target);
+  const seoSchema = resolved
+    ? resolveSchema(resolved.seoResolveType, meta)
+    : null;
 
+  const targetId = target.kind === "site" ? "site" : target.pageKey;
+  const [prevTargetId, setPrevTargetId] = useState(targetId);
   const [formValue, setFormValue] = useState<Record<string, unknown> | null>(
     null,
   );
-  const [prevPageKey, setPrevPageKey] = useState(pageKey);
-  if (prevPageKey !== pageKey) {
-    setPrevPageKey(pageKey);
+  if (prevTargetId !== targetId) {
+    setPrevTargetId(targetId);
     setFormValue(null);
   }
 
-  const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const latestFormRef = useRef<Record<string, unknown> | null>(null);
+  const { save, isPending } = useDebouncedSaveBlock(
+    { orgSlug, virtualMcpId, branch },
+    { onSaved },
+  );
 
-  const effectiveSeoValue = formValue ?? seoData ?? {};
+  const effectiveSeoValue = formValue ?? resolved?.seoData ?? {};
 
   const handleChange = (next: unknown) => {
+    if (!resolved) return;
     const nextRecord = next as Record<string, unknown>;
     setFormValue(nextRecord);
-    latestFormRef.current = nextRecord;
-
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      const value = latestFormRef.current;
-      if (!value || !pageData) return;
-      const updatedPageData = { ...pageData, seo: value };
-      saveBlock.mutate(
-        { blockKey: pageKey, data: updatedPageData },
-        {
-          onSuccess: () => onSaved?.(),
-          onError: (err) => toast.error(`Save failed: ${err.message}`),
-        },
-      );
-    }, AUTOSAVE_DELAY);
+    save(resolved.blockKey, resolved.build(nextRecord));
   };
+
+  const title = target.kind === "site" ? "Site SEO" : "Page SEO";
+  const emptyMessage =
+    target.kind === "site"
+      ? "No site-level SEO block found."
+      : resolved?.seoData
+        ? "SEO schema not found."
+        : "This page has no SEO block configured.";
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -87,8 +87,8 @@ export function PageSeoSheet({
         className="w-[400px] sm:max-w-[440px] p-0 gap-0"
       >
         <SheetHeader className="px-4 py-3 border-b flex-row items-center justify-between space-y-0">
-          <SheetTitle className="text-sm font-semibold">Page SEO</SheetTitle>
-          {saveBlock.isPending && (
+          <SheetTitle className="text-sm font-semibold">{title}</SheetTitle>
+          {isPending && (
             <Loading01
               size={14}
               className="animate-spin text-muted-foreground"
@@ -96,106 +96,9 @@ export function PageSeoSheet({
           )}
         </SheetHeader>
 
-        {!seoSchema ? (
+        {!resolved || !seoSchema ? (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            {!seoData
-              ? "This page has no SEO block configured."
-              : "SEO schema not found."}
-          </div>
-        ) : (
-          <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
-            <div className="px-6 py-4">
-              <div className="mx-auto max-w-sm">
-                <SchemaForm
-                  schema={seoSchema}
-                  value={effectiveSeoValue}
-                  onChange={handleChange}
-                  basePath=""
-                  breadcrumbPath={[]}
-                  onBreadcrumbChange={() => {}}
-                />
-              </div>
-            </div>
-          </ScrollArea>
-        )}
-      </SheetContent>
-    </Sheet>
-  );
-}
-
-interface SiteSeoSheetProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  orgSlug: string;
-  virtualMcpId: string;
-  branch: string;
-  decofile: Record<string, unknown>;
-  meta: LiveMeta;
-  onSaved?: () => void;
-}
-
-export function SiteSeoSheet({
-  open,
-  onOpenChange,
-  orgSlug,
-  virtualMcpId,
-  branch,
-  decofile,
-  meta,
-  onSaved,
-}: SiteSeoSheetProps) {
-  const entry = findSiteSeoEntry(decofile);
-  const seoSchema = entry ? resolveSchema(entry.seoResolveType, meta) : null;
-
-  const [formValue, setFormValue] = useState<Record<string, unknown> | null>(
-    null,
-  );
-
-  const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const latestFormRef = useRef<Record<string, unknown> | null>(null);
-
-  const effectiveSeoValue = formValue ?? entry?.seoData ?? {};
-
-  const handleChange = (next: unknown) => {
-    if (!entry) return;
-    const nextRecord = next as Record<string, unknown>;
-    setFormValue(nextRecord);
-    latestFormRef.current = nextRecord;
-
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      const value = latestFormRef.current;
-      if (!value) return;
-      saveBlock.mutate(
-        { blockKey: entry.blockKey, data: buildSiteSeoBlockData(entry, value) },
-        {
-          onSuccess: () => onSaved?.(),
-          onError: (err) => toast.error(`Save failed: ${err.message}`),
-        },
-      );
-    }, AUTOSAVE_DELAY);
-  };
-
-  return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        side="right"
-        className="w-[400px] sm:max-w-[440px] p-0 gap-0"
-      >
-        <SheetHeader className="px-4 py-3 border-b flex-row items-center justify-between space-y-0">
-          <SheetTitle className="text-sm font-semibold">Site SEO</SheetTitle>
-          {saveBlock.isPending && (
-            <Loading01
-              size={14}
-              className="animate-spin text-muted-foreground"
-            />
-          )}
-        </SheetHeader>
-
-        {!entry || !seoSchema ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            No site-level SEO block found.
+            {emptyMessage}
           </div>
         ) : (
           <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">

--- a/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
@@ -1,0 +1,219 @@
+import { useState, useRef } from "react";
+import { Loading01 } from "@untitledui/icons";
+import { toast } from "sonner";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@deco/ui/components/sheet.tsx";
+import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { useSaveBlock } from "./use-save-block";
+import { SchemaForm } from "./schema-form";
+import { resolveSchema } from "./resolve-schema";
+import type { LiveMeta } from "./resolve-schema";
+import { buildSiteSeoBlockData, findSiteSeoEntry } from "./seo-block";
+
+const AUTOSAVE_DELAY = 700;
+
+interface PageSeoSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  pageKey: string;
+  decofile: Record<string, unknown>;
+  meta: LiveMeta;
+  onSaved?: () => void;
+}
+
+export function PageSeoSheet({
+  open,
+  onOpenChange,
+  orgSlug,
+  virtualMcpId,
+  branch,
+  pageKey,
+  decofile,
+  meta,
+  onSaved,
+}: PageSeoSheetProps) {
+  const pageData = decofile[pageKey] as Record<string, unknown> | undefined;
+  const seoData = pageData?.seo as Record<string, unknown> | undefined;
+  const seoResolveType =
+    typeof seoData?.__resolveType === "string" ? seoData.__resolveType : null;
+  const seoSchema = seoResolveType ? resolveSchema(seoResolveType, meta) : null;
+
+  const [formValue, setFormValue] = useState<Record<string, unknown> | null>(
+    null,
+  );
+  const [prevPageKey, setPrevPageKey] = useState(pageKey);
+  if (prevPageKey !== pageKey) {
+    setPrevPageKey(pageKey);
+    setFormValue(null);
+  }
+
+  const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestFormRef = useRef<Record<string, unknown> | null>(null);
+
+  const effectiveSeoValue = formValue ?? seoData ?? {};
+
+  const handleChange = (next: unknown) => {
+    const nextRecord = next as Record<string, unknown>;
+    setFormValue(nextRecord);
+    latestFormRef.current = nextRecord;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const value = latestFormRef.current;
+      if (!value || !pageData) return;
+      const updatedPageData = { ...pageData, seo: value };
+      saveBlock.mutate(
+        { blockKey: pageKey, data: updatedPageData },
+        {
+          onSuccess: () => onSaved?.(),
+          onError: (err) => toast.error(`Save failed: ${err.message}`),
+        },
+      );
+    }, AUTOSAVE_DELAY);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-[400px] sm:max-w-[440px] p-0 gap-0"
+      >
+        <SheetHeader className="px-4 py-3 border-b flex-row items-center justify-between space-y-0">
+          <SheetTitle className="text-sm font-semibold">Page SEO</SheetTitle>
+          {saveBlock.isPending && (
+            <Loading01
+              size={14}
+              className="animate-spin text-muted-foreground"
+            />
+          )}
+        </SheetHeader>
+
+        {!seoSchema ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            {!seoData
+              ? "This page has no SEO block configured."
+              : "SEO schema not found."}
+          </div>
+        ) : (
+          <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
+            <div className="px-6 py-4">
+              <div className="mx-auto max-w-sm">
+                <SchemaForm
+                  schema={seoSchema}
+                  value={effectiveSeoValue}
+                  onChange={handleChange}
+                  basePath=""
+                  breadcrumbPath={[]}
+                  onBreadcrumbChange={() => {}}
+                />
+              </div>
+            </div>
+          </ScrollArea>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+interface SiteSeoSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  decofile: Record<string, unknown>;
+  meta: LiveMeta;
+  onSaved?: () => void;
+}
+
+export function SiteSeoSheet({
+  open,
+  onOpenChange,
+  orgSlug,
+  virtualMcpId,
+  branch,
+  decofile,
+  meta,
+  onSaved,
+}: SiteSeoSheetProps) {
+  const entry = findSiteSeoEntry(decofile);
+  const seoSchema = entry ? resolveSchema(entry.seoResolveType, meta) : null;
+
+  const [formValue, setFormValue] = useState<Record<string, unknown> | null>(
+    null,
+  );
+
+  const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestFormRef = useRef<Record<string, unknown> | null>(null);
+
+  const effectiveSeoValue = formValue ?? entry?.seoData ?? {};
+
+  const handleChange = (next: unknown) => {
+    if (!entry) return;
+    const nextRecord = next as Record<string, unknown>;
+    setFormValue(nextRecord);
+    latestFormRef.current = nextRecord;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const value = latestFormRef.current;
+      if (!value) return;
+      saveBlock.mutate(
+        { blockKey: entry.blockKey, data: buildSiteSeoBlockData(entry, value) },
+        {
+          onSuccess: () => onSaved?.(),
+          onError: (err) => toast.error(`Save failed: ${err.message}`),
+        },
+      );
+    }, AUTOSAVE_DELAY);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-[400px] sm:max-w-[440px] p-0 gap-0"
+      >
+        <SheetHeader className="px-4 py-3 border-b flex-row items-center justify-between space-y-0">
+          <SheetTitle className="text-sm font-semibold">Site SEO</SheetTitle>
+          {saveBlock.isPending && (
+            <Loading01
+              size={14}
+              className="animate-spin text-muted-foreground"
+            />
+          )}
+        </SheetHeader>
+
+        {!entry || !seoSchema ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            No site-level SEO block found.
+          </div>
+        ) : (
+          <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
+            <div className="px-6 py-4">
+              <div className="mx-auto max-w-sm">
+                <SchemaForm
+                  schema={seoSchema}
+                  value={effectiveSeoValue}
+                  onChange={handleChange}
+                  basePath=""
+                  breadcrumbPath={[]}
+                  onBreadcrumbChange={() => {}}
+                />
+              </div>
+            </div>
+          </ScrollArea>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
@@ -7,13 +7,18 @@ import {
   SheetTitle,
 } from "@deco/ui/components/sheet.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { SchemaForm } from "./schema-form";
+import {
+  findSiteSeoEntry,
+  resolveSeoTarget,
+  type SeoTarget,
+} from "./seo-block";
+import { SeoFormFields } from "./seo-form-fields";
 import { resolveSchema } from "./resolve-schema";
 import type { LiveMeta } from "./resolve-schema";
-import { resolveSeoTarget } from "./seo-block";
-import type { SeoTarget } from "./seo-block";
+import { isSeoEnabled, unwrapSeoConfig } from "./seo-lazy-render";
+import { PageSeoForm } from "./page-seo-form";
+import { defaultPageSeoResolveType } from "./seo-schema";
 import { activeSeoResolveType, useSeoFormSave } from "./seo-save";
-import { SeoTypeSelect } from "./seo-type-select";
 
 interface SeoSheetProps {
   open: boolean;
@@ -51,14 +56,18 @@ export function SeoSheet({
   const [formValue, setFormValue] = useState<Record<string, unknown> | null>(
     null,
   );
+  const [rawSeoOverride, setRawSeoOverride] = useState<
+    Record<string, unknown> | null | undefined
+  >(undefined);
   const [formResetKey, setFormResetKey] = useState(0);
   if (prevTargetId !== targetId) {
     setPrevTargetId(targetId);
     setFormValue(null);
+    setRawSeoOverride(undefined);
     setFormResetKey((k) => k + 1);
   }
 
-  const { persistSeo, flush, isPending } = useSeoFormSave({
+  const { persistSeo, persistRawSeo, flush, isPending } = useSeoFormSave({
     orgSlug,
     virtualMcpId,
     branch,
@@ -67,13 +76,29 @@ export function SeoSheet({
     onSaved,
   });
 
-  const effectiveSeo = formValue ?? resolved?.seoData ?? {};
+  const isPageTarget = target.kind === "page";
+  const savedRawSeo = isPageTarget ? resolved?.rawSeoData : undefined;
+  const displayRawSeo =
+    rawSeoOverride !== undefined ? rawSeoOverride : savedRawSeo;
+  const innerFromSaved = isPageTarget
+    ? (unwrapSeoConfig(displayRawSeo) ?? undefined)
+    : undefined;
+  const effectiveSeo = (formValue ??
+    innerFromSaved ??
+    resolved?.seoData ??
+    {}) as Record<string, unknown>;
   const activeResolveType = resolved
     ? activeSeoResolveType(effectiveSeo, resolved)
     : null;
-  const seoSchema = activeResolveType
-    ? resolveSchema(activeResolveType, meta)
-    : null;
+  const seoSchema =
+    activeResolveType && (isPageTarget ? isSeoEnabled(displayRawSeo) : true)
+      ? resolveSchema(activeResolveType, meta)
+      : null;
+  const siteDefaultSeo =
+    target.kind === "page"
+      ? (findSiteSeoEntry(decofile, meta)?.seoData ?? undefined)
+      : undefined;
+  const defaultResolveType = defaultPageSeoResolveType(meta);
 
   const handleChange = (next: unknown) => {
     if (!resolved) return;
@@ -88,12 +113,17 @@ export function SeoSheet({
   };
 
   const title = target.kind === "site" ? "Site SEO" : "Page SEO";
+  const showPageSeoChrome = isPageTarget && resolved;
+  const showSiteForm = target.kind === "site" && resolved && seoSchema;
   const emptyMessage =
     target.kind === "site"
       ? "No site-level SEO block found."
-      : seoSchema
-        ? "No editable SEO fields found."
-        : "SEO schema not found for this page.";
+      : resolved
+        ? "SEO schema not found for this page."
+        : "Could not load page SEO.";
+
+  const clearSeoForm = () => setFormValue(null);
+  const bumpSeoFormKey = () => setFormResetKey((k) => k + 1);
 
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>
@@ -111,7 +141,7 @@ export function SeoSheet({
           )}
         </SheetHeader>
 
-        {!resolved || !seoSchema ? (
+        {!resolved || (!showPageSeoChrome && !showSiteForm) ? (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
             {emptyMessage}
           </div>
@@ -119,30 +149,39 @@ export function SeoSheet({
           <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
             <div className="px-6 py-4">
               <div className="mx-auto max-w-sm">
-                {resolved.seoTypeOptions && activeResolveType && (
-                  <SeoTypeSelect
-                    options={resolved.seoTypeOptions}
-                    value={activeResolveType}
-                    onChange={(nextType) => {
-                      const nextRecord = {
-                        ...effectiveSeo,
-                        __resolveType: nextType,
-                      };
-                      setFormValue(nextRecord);
-                      setFormResetKey((k) => k + 1);
-                      persistSeo(nextRecord);
+                {showPageSeoChrome ? (
+                  <PageSeoForm
+                    rawSeo={displayRawSeo}
+                    innerSeo={effectiveSeo}
+                    defaultResolveType={defaultResolveType}
+                    seoSchema={seoSchema}
+                    activeResolveType={activeResolveType}
+                    seoTypeOptions={resolved.seoTypeOptions}
+                    formResetKey={formResetKey}
+                    siteDefaultSeo={siteDefaultSeo}
+                    onPersistRaw={(raw) => {
+                      setRawSeoOverride(raw);
+                      persistRawSeo(raw);
                     }}
+                    onInnerChange={(inner) => {
+                      setFormValue(inner);
+                      persistSeo(inner);
+                    }}
+                    onClearForm={clearSeoForm}
+                    onBumpFormKey={bumpSeoFormKey}
                   />
+                ) : (
+                  seoSchema &&
+                  activeResolveType && (
+                    <SeoFormFields
+                      schema={seoSchema}
+                      resolveType={activeResolveType}
+                      value={effectiveSeo}
+                      formResetKey={formResetKey}
+                      onChange={handleChange}
+                    />
+                  )
                 )}
-                <SchemaForm
-                  key={formResetKey}
-                  schema={seoSchema}
-                  value={effectiveSeo}
-                  onChange={handleChange}
-                  basePath=""
-                  breadcrumbPath={[]}
-                  onBreadcrumbChange={() => {}}
-                />
               </div>
             </div>
           </ScrollArea>

--- a/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
@@ -43,7 +43,7 @@ export function SeoSheet({
   target,
   onSaved,
 }: SeoSheetProps) {
-  const resolved = resolveSeoTarget(decofile, target);
+  const resolved = resolveSeoTarget(decofile, target, meta);
   const seoSchema = resolved
     ? resolveSchema(resolved.seoResolveType, meta)
     : null;

--- a/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-seo-sheet.tsx
@@ -7,12 +7,13 @@ import {
   SheetTitle,
 } from "@deco/ui/components/sheet.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { useDebouncedSaveBlock } from "./use-save-block";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema } from "./resolve-schema";
 import type { LiveMeta } from "./resolve-schema";
 import { resolveSeoTarget } from "./seo-block";
 import type { SeoTarget } from "./seo-block";
+import { activeSeoResolveType, useSeoFormSave } from "./seo-save";
+import { SeoTypeSelect } from "./seo-type-select";
 
 interface SeoSheetProps {
   open: boolean;
@@ -44,44 +45,58 @@ export function SeoSheet({
   onSaved,
 }: SeoSheetProps) {
   const resolved = resolveSeoTarget(decofile, target, meta);
-  const seoSchema = resolved
-    ? resolveSchema(resolved.seoResolveType, meta)
-    : null;
 
   const targetId = target.kind === "site" ? "site" : target.pageKey;
   const [prevTargetId, setPrevTargetId] = useState(targetId);
   const [formValue, setFormValue] = useState<Record<string, unknown> | null>(
     null,
   );
+  const [formResetKey, setFormResetKey] = useState(0);
   if (prevTargetId !== targetId) {
     setPrevTargetId(targetId);
     setFormValue(null);
+    setFormResetKey((k) => k + 1);
   }
 
-  const { save, isPending } = useDebouncedSaveBlock(
-    { orgSlug, virtualMcpId, branch },
-    { onSaved },
-  );
+  const { persistSeo, flush, isPending } = useSeoFormSave({
+    orgSlug,
+    virtualMcpId,
+    branch,
+    target,
+    resolved,
+    onSaved,
+  });
 
-  const effectiveSeoValue = formValue ?? resolved?.seoData ?? {};
+  const effectiveSeo = formValue ?? resolved?.seoData ?? {};
+  const activeResolveType = resolved
+    ? activeSeoResolveType(effectiveSeo, resolved)
+    : null;
+  const seoSchema = activeResolveType
+    ? resolveSchema(activeResolveType, meta)
+    : null;
 
   const handleChange = (next: unknown) => {
     if (!resolved) return;
     const nextRecord = next as Record<string, unknown>;
     setFormValue(nextRecord);
-    save(resolved.blockKey, resolved.build(nextRecord));
+    persistSeo(nextRecord);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) flush();
+    onOpenChange(nextOpen);
   };
 
   const title = target.kind === "site" ? "Site SEO" : "Page SEO";
   const emptyMessage =
     target.kind === "site"
       ? "No site-level SEO block found."
-      : resolved?.seoData
-        ? "SEO schema not found."
-        : "This page has no SEO block configured.";
+      : seoSchema
+        ? "No editable SEO fields found."
+        : "SEO schema not found for this page.";
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    <Sheet open={open} onOpenChange={handleOpenChange}>
       <SheetContent
         side="right"
         className="w-[400px] sm:max-w-[440px] p-0 gap-0"
@@ -104,9 +119,25 @@ export function SeoSheet({
           <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
             <div className="px-6 py-4">
               <div className="mx-auto max-w-sm">
+                {resolved.seoTypeOptions && activeResolveType && (
+                  <SeoTypeSelect
+                    options={resolved.seoTypeOptions}
+                    value={activeResolveType}
+                    onChange={(nextType) => {
+                      const nextRecord = {
+                        ...effectiveSeo,
+                        __resolveType: nextType,
+                      };
+                      setFormValue(nextRecord);
+                      setFormResetKey((k) => k + 1);
+                      persistSeo(nextRecord);
+                    }}
+                  />
+                )}
                 <SchemaForm
+                  key={formResetKey}
                   schema={seoSchema}
-                  value={effectiveSeoValue}
+                  value={effectiveSeo}
                   onChange={handleChange}
                   basePath=""
                   breadcrumbPath={[]}

--- a/apps/mesh/src/web/components/sections-editor/section-catalog.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-catalog.ts
@@ -51,7 +51,8 @@ export function findLivePageResolveType(meta: LiveMeta): string {
   return LIVE_PAGE_RESOLVE_TYPES[0];
 }
 
-function collectAnyOfRefsFromSchema(
+/** Collects block-ref variants from a resolved schema subtree (e.g. page `seo` or `sections`). */
+export function collectAnyOfRefsFromSchema(
   schema: SchemaProperty | null | undefined,
 ): Array<{ resolveType: string; title: string; description?: string }> {
   if (!schema) return [];

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, type ReactNode } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -35,7 +35,19 @@ import { arrayMove } from "@dnd-kit/sortable";
 import type { ParsedSection } from "./section-list";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema, type SchemaProperty } from "./resolve-schema";
-import { resolvePageSeoResolveType } from "./seo-schema";
+import { findSiteSeoEntry } from "./seo-block";
+import {
+  defaultPageSeoResolveType,
+  listPageSeoTypeOptions,
+  resolvePageSeoResolveType,
+} from "./seo-schema";
+import { activeSeoResolveType } from "./seo-save";
+import {
+  isSeoEnabled,
+  unwrapSeoConfig,
+  wrapSeoPersistValue,
+} from "./seo-lazy-render";
+import { PageSeoForm } from "./page-seo-form";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
 import { PageVariantTabs, VariantTabIcon } from "./page-variant-tabs";
 import { MakeReusableModal } from "./make-reusable-modal";
@@ -94,6 +106,9 @@ function SchemaFormPanel({
   onFormChange,
   onBreadcrumbChange,
   emptyMessage,
+  beforeForm,
+  seoResolveType,
+  siteDefaultSeo,
 }: {
   activeSchema: SchemaProperty | null | undefined;
   formValue: unknown;
@@ -101,21 +116,40 @@ function SchemaFormPanel({
   onFormChange: (v: unknown) => void;
   onBreadcrumbChange: (path: string[]) => void;
   emptyMessage: string;
+  beforeForm?: ReactNode;
+  seoResolveType?: string;
+  siteDefaultSeo?: Record<string, unknown>;
 }) {
+  const formBody =
+    activeSchema && formValue ? (
+      seoResolveType ? (
+        <SeoFormFields
+          schema={activeSchema}
+          resolveType={seoResolveType}
+          value={formValue as Record<string, unknown>}
+          formResetKey={formResetKey}
+          onChange={onFormChange}
+          onBreadcrumbChange={onBreadcrumbChange}
+          siteDefaultSeo={siteDefaultSeo}
+        />
+      ) : (
+        <SchemaForm
+          key={formResetKey}
+          schema={activeSchema}
+          value={formValue}
+          onChange={onFormChange}
+          basePath=""
+          breadcrumbPath={[]}
+          onBreadcrumbChange={onBreadcrumbChange}
+        />
+      )
+    ) : null;
+
   return (
     <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
       <div className="mx-auto max-w-2xl">
-        {activeSchema && formValue ? (
-          <SchemaForm
-            key={formResetKey}
-            schema={activeSchema}
-            value={formValue}
-            onChange={onFormChange}
-            basePath=""
-            breadcrumbPath={[]}
-            onBreadcrumbChange={onBreadcrumbChange}
-          />
-        ) : (
+        {beforeForm}
+        {formBody ?? (
           <div className="px-3 py-6 text-center text-xs text-muted-foreground">
             {emptyMessage}
           </div>
@@ -425,7 +459,8 @@ export function SectionsEditor({
   activeGlobalBlockKey = null,
   externalSelectedIndex,
   onSaved,
-  onEditPageSeo,
+  initialEditSeo = false,
+  onExitSeo,
   onViewJsonFile,
 }: {
   orgSlug: string;
@@ -446,12 +481,10 @@ export function SectionsEditor({
   externalSelectedIndex?: number | null;
   /** Called after a successful auto-save so the parent can reload the preview. */
   onSaved?: () => void;
-  /**
-   * When provided, the page-header "Edit SEO" button delegates to the host
-   * (passing the page block key) — e.g. the Content tab opens its two-pane SEO
-   * editor with live previews. Hosts that omit it get the inline SEO mode.
-   */
-  onEditPageSeo?: (pageKey: string) => void;
+  /** Open the inline page SEO form on mount (e.g. after "Edit SEO" from a host menu). */
+  initialEditSeo?: boolean;
+  /** Called when the user leaves inline SEO via the breadcrumb bar. */
+  onExitSeo?: () => void;
   /**
    * When provided, "View JSON" opens the page's block file in the host's file
    * view (passing the decofile block key) instead of the built-in JSON modal.
@@ -498,11 +531,26 @@ export function SectionsEditor({
   const [jsonOpen, setJsonOpen] = useState(false);
 
   // Inline SEO editing mode — same breadcrumb UX as editing a section
-  const [editingSeo, setEditingSeo] = useState(false);
+  const [editingSeo, setEditingSeo] = useState(initialEditSeo);
+  const [prevInitialEditSeo, setPrevInitialEditSeo] = useState(initialEditSeo);
+  if (initialEditSeo && !prevInitialEditSeo) {
+    setPrevInitialEditSeo(true);
+    setEditingSeo(true);
+    setSelectedSectionIndex(null);
+    setFormValue(null);
+    setActiveResolveType(null);
+    setFieldBreadcrumbs([]);
+  }
+  if (!initialEditSeo && prevInitialEditSeo) {
+    setPrevInitialEditSeo(false);
+  }
   const [seoFormValue, setSeoFormValue] = useState<Record<
     string,
     unknown
   > | null>(null);
+  const [seoRawOverride, setSeoRawOverride] = useState<
+    Record<string, unknown> | null | undefined
+  >(undefined);
   const [seoFieldBreadcrumbs, setSeoFieldBreadcrumbs] = useState<string[]>([]);
   const [seoFormResetKey, setSeoFormResetKey] = useState(0);
   const [activeSectionVariantIndex, setActiveSectionVariantIndex] = useState(0);
@@ -543,6 +591,7 @@ export function SectionsEditor({
     setFormResetKey((key) => key + 1);
     setEditingSeo(false);
     setSeoFormValue(null);
+    setSeoRawOverride(undefined);
     setSeoFieldBreadcrumbs([]);
     setSeoFormResetKey((key) => key + 1);
   }
@@ -629,17 +678,33 @@ export function SectionsEditor({
       : null;
 
   // SEO computed values
-  const seoData = pageData
-    ? (pageData.seo as Record<string, unknown> | undefined)
-    : undefined;
-  const seoResolveType = pageData
-    ? resolvePageSeoResolveType(
-        meta,
-        seoData as Record<string, unknown> | undefined,
-      )
+  const savedRawSeo = pageData?.seo;
+  const displayRawSeo =
+    seoRawOverride !== undefined ? seoRawOverride : savedRawSeo;
+  const innerFromSaved = unwrapSeoConfig(displayRawSeo);
+  const seoTypeOptions = pageData ? listPageSeoTypeOptions(meta) : [];
+  const defaultSeoResolveType = pageData
+    ? resolvePageSeoResolveType(meta, innerFromSaved ?? undefined)
     : null;
+  const defaultResolveType = pageData ? defaultPageSeoResolveType(meta) : "";
+  const effectiveInner = (seoFormValue ?? innerFromSaved ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const activeSeoType =
+    pageData && activePageKey && defaultSeoResolveType
+      ? activeSeoResolveType(effectiveInner, {
+          blockKey: activePageKey,
+          seoData: innerFromSaved ?? undefined,
+          seoResolveType: defaultSeoResolveType,
+          build: (value) => ({ ...pageData!, seo: value }),
+        })
+      : null;
   const seoSchema =
-    pageData && seoResolveType ? resolveSchema(seoResolveType, meta) : null;
+    pageData && activeSeoType && isSeoEnabled(displayRawSeo)
+      ? resolveSchema(activeSeoType, meta)
+      : null;
+  const siteDefaultSeo = findSiteSeoEntry(decofile, meta)?.seoData;
 
   const pageVariants = isGlobalBlockMode
     ? [
@@ -1849,31 +1914,48 @@ export function SectionsEditor({
     clearSectionEditing();
   };
 
-  const handleSeoFormChange = (next: unknown) => {
-    const nextRecord = next as Record<string, unknown>;
+  const handleSeoInnerChange = (nextRecord: Record<string, unknown>) => {
     setSeoFormValue(nextRecord);
     if (!activePageKey) return;
-    // Resolve the merge at fire time against the freshest page block, not a
-    // keystroke-time snapshot: page name/path edits write the same block from a
-    // separate debounce, so spreading a stale `pageData` here would clobber
-    // them. `latestRef.current.decofile` tracks the live (optimistically
-    // updated) decofile.
     seoSave.save(activePageKey, () => {
       const latestPage = latestRef.current.decofile[activePageKey] as
         | Record<string, unknown>
         | undefined;
       if (!latestPage) return null;
-      return { ...latestPage, seo: nextRecord };
+      return {
+        ...latestPage,
+        seo: wrapSeoPersistValue(nextRecord, latestPage.seo),
+      };
     });
   };
+
+  const handlePersistRawSeo = (raw: Record<string, unknown> | null) => {
+    setSeoRawOverride(raw);
+    if (!activePageKey) return;
+    seoSave.save(activePageKey, () => {
+      const latestPage = latestRef.current.decofile[activePageKey] as
+        | Record<string, unknown>
+        | undefined;
+      if (!latestPage) return null;
+      return { ...latestPage, seo: raw };
+    });
+  };
+
+  const clearSeoForm = () => {
+    setSeoFormValue(null);
+    setSeoFieldBreadcrumbs([]);
+  };
+  const bumpSeoFormKey = () => setSeoFormResetKey((key) => key + 1);
 
   const handleBreadcrumbClick = (index: number) => {
     if (editingSeo) {
       if (index === 0) {
         setEditingSeo(false);
         setSeoFormValue(null);
+        setSeoRawOverride(undefined);
         setSeoFieldBreadcrumbs([]);
         setSeoFormResetKey((key) => key + 1);
+        onExitSeo?.();
         return;
       }
       if (index === 1) {
@@ -2030,11 +2112,7 @@ export function SectionsEditor({
                   size="icon"
                   aria-label="Edit SEO"
                   className="size-7 shrink-0"
-                  onClick={() =>
-                    onEditPageSeo && activePageKey
-                      ? onEditPageSeo(activePageKey)
-                      : setEditingSeo(true)
-                  }
+                  onClick={() => setEditingSeo(true)}
                 >
                   <CreditCardSearch size={14} />
                 </Button>
@@ -2100,18 +2178,31 @@ export function SectionsEditor({
       {/* Drill-down: SEO form, section form, or section list */}
       {editingSeo ? (
         <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
-          <SchemaFormPanel
-            activeSchema={seoSchema}
-            formValue={seoFormValue ?? seoData ?? {}}
-            formResetKey={seoFormResetKey}
-            onFormChange={handleSeoFormChange}
-            onBreadcrumbChange={setSeoFieldBreadcrumbs}
-            emptyMessage={
-              !seoSchema
-                ? "SEO schema not found for this site."
-                : "No editable SEO fields found."
-            }
-          />
+          <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
+            <div className="mx-auto max-w-2xl">
+              {pageData && activePageKey ? (
+                <PageSeoForm
+                  rawSeo={displayRawSeo}
+                  innerSeo={effectiveInner}
+                  defaultResolveType={defaultResolveType}
+                  seoSchema={seoSchema}
+                  activeResolveType={activeSeoType}
+                  seoTypeOptions={seoTypeOptions}
+                  formResetKey={seoFormResetKey}
+                  siteDefaultSeo={siteDefaultSeo}
+                  onBreadcrumbChange={setSeoFieldBreadcrumbs}
+                  onPersistRaw={handlePersistRawSeo}
+                  onInnerChange={handleSeoInnerChange}
+                  onClearForm={clearSeoForm}
+                  onBumpFormKey={bumpSeoFormKey}
+                />
+              ) : (
+                <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+                  SEO schema not found for this site.
+                </div>
+              )}
+            </div>
+          </div>
         </ScrollArea>
       ) : isEditing ? (
         <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -35,6 +35,7 @@ import { arrayMove } from "@dnd-kit/sortable";
 import type { ParsedSection } from "./section-list";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema, type SchemaProperty } from "./resolve-schema";
+import { resolvePageSeoResolveType } from "./seo-schema";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
 import { PageVariantTabs, VariantTabIcon } from "./page-variant-tabs";
 import { MakeReusableModal } from "./make-reusable-modal";
@@ -631,9 +632,14 @@ export function SectionsEditor({
   const seoData = pageData
     ? (pageData.seo as Record<string, unknown> | undefined)
     : undefined;
-  const seoResolveType =
-    typeof seoData?.__resolveType === "string" ? seoData.__resolveType : null;
-  const seoSchema = seoResolveType ? resolveSchema(seoResolveType, meta) : null;
+  const seoResolveType = pageData
+    ? resolvePageSeoResolveType(
+        meta,
+        seoData as Record<string, unknown> | undefined,
+      )
+    : null;
+  const seoSchema =
+    pageData && seoResolveType ? resolveSchema(seoResolveType, meta) : null;
 
   const pageVariants = isGlobalBlockMode
     ? [
@@ -2101,8 +2107,8 @@ export function SectionsEditor({
             onFormChange={handleSeoFormChange}
             onBreadcrumbChange={setSeoFieldBreadcrumbs}
             emptyMessage={
-              !seoData
-                ? "This page has no SEO block configured."
+              !seoSchema
+                ? "SEO schema not found for this site."
                 : "No editable SEO fields found."
             }
           />

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -961,8 +961,14 @@ export function SectionsEditor({
     pageDebounceRef.current = setTimeout(() => {
       const pending = pendingPageFieldsRef.current;
       pendingPageFieldsRef.current = {};
+      // Read-modify-write against the freshest block (see handleSeoFormChange):
+      // SEO edits write the same block from a separate debounce, so a stale
+      // render-closure snapshot here would drop a concurrent SEO change.
       const fullPageData = {
-        ...(decofile[activePageKey] as Record<string, unknown>),
+        ...(latestRef.current.decofile[activePageKey] as Record<
+          string,
+          unknown
+        >),
         ...pending,
       };
       // No onSaved/iframe reload — name/path don't affect the visual preview
@@ -1840,8 +1846,19 @@ export function SectionsEditor({
   const handleSeoFormChange = (next: unknown) => {
     const nextRecord = next as Record<string, unknown>;
     setSeoFormValue(nextRecord);
-    if (!activePageKey || !pageData) return;
-    seoSave.save(activePageKey, { ...pageData, seo: nextRecord });
+    if (!activePageKey) return;
+    // Resolve the merge at fire time against the freshest page block, not a
+    // keystroke-time snapshot: page name/path edits write the same block from a
+    // separate debounce, so spreading a stale `pageData` here would clobber
+    // them. `latestRef.current.decofile` tracks the live (optimistically
+    // updated) decofile.
+    seoSave.save(activePageKey, () => {
+      const latestPage = latestRef.current.decofile[activePageKey] as
+        | Record<string, unknown>
+        | undefined;
+      if (!latestPage) return null;
+      return { ...latestPage, seo: nextRecord };
+    });
   };
 
   const handleBreadcrumbClick = (index: number) => {

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1,4 +1,6 @@
 import { useState, useRef, type ReactNode } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
 import {
   ChevronDown,
   ChevronRight,
@@ -35,18 +37,10 @@ import { arrayMove } from "@dnd-kit/sortable";
 import type { ParsedSection } from "./section-list";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema, type SchemaProperty } from "./resolve-schema";
-import { findSiteSeoEntry } from "./seo-block";
-import {
-  defaultPageSeoResolveType,
-  listPageSeoTypeOptions,
-  resolvePageSeoResolveType,
-} from "./seo-schema";
-import { activeSeoResolveType } from "./seo-save";
-import {
-  isSeoEnabled,
-  unwrapSeoConfig,
-  wrapSeoPersistValue,
-} from "./seo-lazy-render";
+import { findSiteSeoEntry, resolveSeoTarget } from "./seo-block";
+import { defaultPageSeoResolveType } from "./seo-schema";
+import { activeSeoResolveType, buildSeoSavePayload } from "./seo-save";
+import { isSeoEnabled, unwrapSeoConfig } from "./seo-lazy-render";
 import { PageSeoForm } from "./page-seo-form";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
 import { PageVariantTabs, VariantTabIcon } from "./page-variant-tabs";
@@ -564,6 +558,7 @@ export function SectionsEditor({
   const [prevAutoGlobalKey, setPrevAutoGlobalKey] = useState<string | null>(
     null,
   );
+  const seoFlushRef = useRef<() => void>(() => {});
 
   // Reset form state when the active page or global block changes
   const [prevPath, setPrevPath] = useState(currentPath);
@@ -575,6 +570,7 @@ export function SectionsEditor({
     prevPageBlockKey !== activePageBlockKey ||
     prevGlobalBlockKey !== activeGlobalBlockKey
   ) {
+    seoFlushRef.current();
     setPrevPath(currentPath);
     setPrevPageBlockKey(activePageBlockKey);
     setPrevGlobalBlockKey(activeGlobalBlockKey);
@@ -596,15 +592,20 @@ export function SectionsEditor({
     setSeoFormResetKey((key) => key + 1);
   }
 
+  const queryClient = useQueryClient();
+  const decofileCacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
   const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
   const deleteBlock = useDeleteBlock({ orgSlug, virtualMcpId, branch });
-  const seoSave = useDebouncedSaveBlock(
-    { orgSlug, virtualMcpId, branch },
-    { onSaved },
-  );
+  // Page block writes (name/path + SEO) share one debouncer so concurrent edits
+  // merge at fire time. No onSaved — SEO autosave must not reload the preview.
+  const pageBlockSave = useDebouncedSaveBlock({
+    orgSlug,
+    virtualMcpId,
+    branch,
+  });
+  seoFlushRef.current = pageBlockSave.flush;
   const [renameVariantPending, setRenameVariantPending] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pageDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ruleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sectionRuleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -677,34 +678,44 @@ export function SectionsEditor({
       ? (decofile[activePageKey] as Record<string, unknown>)
       : null;
 
-  // SEO computed values
-  const savedRawSeo = pageData?.seo;
+  // SEO computed values — only while inline SEO is open
+  const inlineSeoResolved =
+    editingSeo && decofile && meta && activePageKey && activePage
+      ? resolveSeoTarget(
+          decofile,
+          {
+            kind: "page",
+            pageKey: activePageKey,
+            pageName: String(activePage.name ?? ""),
+            path: String(activePage.path ?? ""),
+          },
+          meta,
+        )
+      : null;
+  const savedRawSeo = editingSeo ? pageData?.seo : undefined;
   const displayRawSeo =
     seoRawOverride !== undefined ? seoRawOverride : savedRawSeo;
-  const innerFromSaved = unwrapSeoConfig(displayRawSeo);
-  const seoTypeOptions = pageData ? listPageSeoTypeOptions(meta) : [];
-  const defaultSeoResolveType = pageData
-    ? resolvePageSeoResolveType(meta, innerFromSaved ?? undefined)
-    : null;
-  const defaultResolveType = pageData ? defaultPageSeoResolveType(meta) : "";
+  const innerFromSaved = editingSeo
+    ? unwrapSeoConfig(displayRawSeo)
+    : undefined;
+  const seoTypeOptions = inlineSeoResolved?.seoTypeOptions ?? [];
+  const defaultResolveType =
+    editingSeo && meta ? defaultPageSeoResolveType(meta) : "";
   const effectiveInner = (seoFormValue ?? innerFromSaved ?? {}) as Record<
     string,
     unknown
   >;
   const activeSeoType =
-    pageData && activePageKey && defaultSeoResolveType
-      ? activeSeoResolveType(effectiveInner, {
-          blockKey: activePageKey,
-          seoData: innerFromSaved ?? undefined,
-          seoResolveType: defaultSeoResolveType,
-          build: (value) => ({ ...pageData!, seo: value }),
-        })
+    editingSeo && inlineSeoResolved
+      ? activeSeoResolveType(effectiveInner, inlineSeoResolved)
       : null;
   const seoSchema =
-    pageData && activeSeoType && isSeoEnabled(displayRawSeo)
+    editingSeo && activeSeoType && isSeoEnabled(displayRawSeo)
       ? resolveSchema(activeSeoType, meta)
       : null;
-  const siteDefaultSeo = findSiteSeoEntry(decofile, meta)?.seoData;
+  const siteDefaultSeo = editingSeo
+    ? findSiteSeoEntry(decofile, meta)?.seoData
+    : undefined;
 
   const pageVariants = isGlobalBlockMode
     ? [
@@ -1023,33 +1034,52 @@ export function SectionsEditor({
     }
   };
 
+  const schedulePageBlockWrite = (seoPatch?: {
+    inner?: Record<string, unknown>;
+    raw?: Record<string, unknown> | null;
+  }) => {
+    if (!activePageKey || !decofile || !meta || !activePage) return;
+    const target = {
+      kind: "page" as const,
+      pageKey: activePageKey,
+      pageName: String(activePage.name ?? ""),
+      path: String(activePage.path ?? ""),
+    };
+    const resolved = resolveSeoTarget(decofile, target, meta);
+    if (!resolved) return;
+
+    pageBlockSave.save(activePageKey, () => {
+      const latest = queryClient.getQueryData<Record<string, unknown>>(
+        KEYS.decofile(decofileCacheKey),
+      )?.[activePageKey];
+      if (
+        !latest ||
+        typeof latest !== "object" ||
+        latest === null ||
+        Array.isArray(latest)
+      ) {
+        return null;
+      }
+      const block = {
+        ...(latest as Record<string, unknown>),
+        ...pendingPageFieldsRef.current,
+      };
+      pendingPageFieldsRef.current = {};
+
+      if (seoPatch?.raw !== undefined) {
+        return { ...block, seo: seoPatch.raw };
+      }
+      if (seoPatch?.inner !== undefined) {
+        return buildSeoSavePayload(target, resolved, block, seoPatch.inner);
+      }
+      return block;
+    });
+  };
+
   const savePageField = (field: "name" | "path", value: string) => {
     if (!activePageKey) return;
-    // Accumulate all pending field changes so rapid edits to name+path
-    // are merged into a single save instead of overwriting each other.
     pendingPageFieldsRef.current[field] = value;
-    if (pageDebounceRef.current) clearTimeout(pageDebounceRef.current);
-    pageDebounceRef.current = setTimeout(() => {
-      const pending = pendingPageFieldsRef.current;
-      pendingPageFieldsRef.current = {};
-      // Read-modify-write against the freshest block (see handleSeoFormChange):
-      // SEO edits write the same block from a separate debounce, so a stale
-      // render-closure snapshot here would drop a concurrent SEO change.
-      const fullPageData = {
-        ...(latestRef.current.decofile[activePageKey] as Record<
-          string,
-          unknown
-        >),
-        ...pending,
-      };
-      // No onSaved/iframe reload — name/path don't affect the visual preview
-      saveBlock.mutate(
-        { blockKey: activePageKey, data: fullPageData },
-        {
-          onError: (err) => toast.error(`Save failed: ${err.message}`),
-        },
-      );
-    }, AUTOSAVE_DELAY);
+    schedulePageBlockWrite();
   };
 
   const handleReorder = (fromIndex: number, toIndex: number) => {
@@ -1916,29 +1946,12 @@ export function SectionsEditor({
 
   const handleSeoInnerChange = (nextRecord: Record<string, unknown>) => {
     setSeoFormValue(nextRecord);
-    if (!activePageKey) return;
-    seoSave.save(activePageKey, () => {
-      const latestPage = latestRef.current.decofile[activePageKey] as
-        | Record<string, unknown>
-        | undefined;
-      if (!latestPage) return null;
-      return {
-        ...latestPage,
-        seo: wrapSeoPersistValue(nextRecord, latestPage.seo),
-      };
-    });
+    schedulePageBlockWrite({ inner: nextRecord });
   };
 
   const handlePersistRawSeo = (raw: Record<string, unknown> | null) => {
     setSeoRawOverride(raw);
-    if (!activePageKey) return;
-    seoSave.save(activePageKey, () => {
-      const latestPage = latestRef.current.decofile[activePageKey] as
-        | Record<string, unknown>
-        | undefined;
-      if (!latestPage) return null;
-      return { ...latestPage, seo: raw };
-    });
+    schedulePageBlockWrite({ raw });
   };
 
   const clearSeoForm = () => {
@@ -1950,6 +1963,7 @@ export function SectionsEditor({
   const handleBreadcrumbClick = (index: number) => {
     if (editingSeo) {
       if (index === 0) {
+        pageBlockSave.flush();
         setEditingSeo(false);
         setSeoFormValue(null);
         setSeoRawOverride(undefined);

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -22,7 +22,11 @@ import { toast } from "sonner";
 import { useDecofile } from "./use-decofile";
 import { useLiveMeta } from "./use-live-meta";
 import { useDeleteBlock } from "./use-delete-block";
-import { useSaveBlock } from "./use-save-block";
+import {
+  AUTOSAVE_DELAY,
+  useDebouncedSaveBlock,
+  useSaveBlock,
+} from "./use-save-block";
 import { extractPages, globalSectionLabel } from "./page-list";
 import { normalizePagePath } from "./page-path-utils";
 import { SectionList, parseSections } from "./section-list";
@@ -81,8 +85,6 @@ import {
   updateMultivariateSectionVariantValue,
 } from "./section-variants";
 import { PageJsonDialog } from "./page-json-dialog";
-
-const AUTOSAVE_DELAY = 700;
 
 function SchemaFormPanel({
   activeSchema,
@@ -546,6 +548,10 @@ export function SectionsEditor({
 
   const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
   const deleteBlock = useDeleteBlock({ orgSlug, virtualMcpId, branch });
+  const seoSave = useDebouncedSaveBlock(
+    { orgSlug, virtualMcpId, branch },
+    { onSaved },
+  );
   const [renameVariantPending, setRenameVariantPending] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pageDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -553,8 +559,6 @@ export function SectionsEditor({
   const sectionRuleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const seoDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const latestSeoFormRef = useRef<Record<string, unknown> | null>(null);
   // Accumulates pending page header field changes to avoid losing edits
   const pendingPageFieldsRef = useRef<Record<string, string>>({});
 
@@ -1836,21 +1840,8 @@ export function SectionsEditor({
   const handleSeoFormChange = (next: unknown) => {
     const nextRecord = next as Record<string, unknown>;
     setSeoFormValue(nextRecord);
-    latestSeoFormRef.current = nextRecord;
-
-    if (seoDebounceRef.current) clearTimeout(seoDebounceRef.current);
-    seoDebounceRef.current = setTimeout(() => {
-      const value = latestSeoFormRef.current;
-      if (!value || !activePageKey || !pageData) return;
-      const updatedPageData = { ...pageData, seo: value };
-      saveBlock.mutate(
-        { blockKey: activePageKey, data: updatedPageData },
-        {
-          onSuccess: () => onSaved?.(),
-          onError: (err) => toast.error(`Save failed: ${err.message}`),
-        },
-      );
-    }, AUTOSAVE_DELAY);
+    if (!activePageKey || !pageData) return;
+    seoSave.save(activePageKey, { ...pageData, seo: nextRecord });
   };
 
   const handleBreadcrumbClick = (index: number) => {

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -3,9 +3,11 @@ import {
   ChevronDown,
   ChevronRight,
   ChevronUp,
+  Code01,
   Flag01,
   Globe01,
   Loading01,
+  CreditCardSearch,
 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
@@ -78,6 +80,7 @@ import {
   updateMultivariateSectionVariantRule,
   updateMultivariateSectionVariantValue,
 } from "./section-variants";
+import { PageJsonDialog } from "./page-json-dialog";
 
 const AUTOSAVE_DELAY = 700;
 
@@ -419,6 +422,8 @@ export function SectionsEditor({
   activeGlobalBlockKey = null,
   externalSelectedIndex,
   onSaved,
+  onEditPageSeo,
+  onViewJsonFile,
 }: {
   orgSlug: string;
   virtualMcpId: string;
@@ -438,6 +443,18 @@ export function SectionsEditor({
   externalSelectedIndex?: number | null;
   /** Called after a successful auto-save so the parent can reload the preview. */
   onSaved?: () => void;
+  /**
+   * When provided, the page-header "Edit SEO" button delegates to the host
+   * (passing the page block key) — e.g. the Content tab opens its two-pane SEO
+   * editor with live previews. Hosts that omit it get the inline SEO mode.
+   */
+  onEditPageSeo?: (pageKey: string) => void;
+  /**
+   * When provided, "View JSON" opens the page's block file in the host's file
+   * view (passing the decofile block key) instead of the built-in JSON modal.
+   * Hosts without a file surface (Content tab) omit this and get the modal.
+   */
+  onViewJsonFile?: (pageKey: string) => void;
 }) {
   const previewFetchParams = previewReady
     ? { orgSlug, virtualMcpId, branch }
@@ -475,6 +492,16 @@ export function SectionsEditor({
   );
   const [isVariantRuleOpen, setIsVariantRuleOpen] = useState(true);
   const [addSectionOpen, setAddSectionOpen] = useState(false);
+  const [jsonOpen, setJsonOpen] = useState(false);
+
+  // Inline SEO editing mode — same breadcrumb UX as editing a section
+  const [editingSeo, setEditingSeo] = useState(false);
+  const [seoFormValue, setSeoFormValue] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+  const [seoFieldBreadcrumbs, setSeoFieldBreadcrumbs] = useState<string[]>([]);
+  const [seoFormResetKey, setSeoFormResetKey] = useState(0);
   const [activeSectionVariantIndex, setActiveSectionVariantIndex] = useState(0);
   const [sectionRuleFormValue, setSectionRuleFormValue] = useState<Record<
     string,
@@ -511,6 +538,10 @@ export function SectionsEditor({
     setSectionRuleResolveType(null);
     setFieldBreadcrumbs([]);
     setFormResetKey((key) => key + 1);
+    setEditingSeo(false);
+    setSeoFormValue(null);
+    setSeoFieldBreadcrumbs([]);
+    setSeoFormResetKey((key) => key + 1);
   }
 
   const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
@@ -522,6 +553,8 @@ export function SectionsEditor({
   const sectionRuleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const seoDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestSeoFormRef = useRef<Record<string, unknown> | null>(null);
   // Accumulates pending page header field changes to avoid losing edits
   const pendingPageFieldsRef = useRef<Record<string, string>>({});
 
@@ -589,6 +622,15 @@ export function SectionsEditor({
     !isGlobalBlockMode && activePageKey && decofile[activePageKey]
       ? (decofile[activePageKey] as Record<string, unknown>)
       : null;
+
+  // SEO computed values
+  const seoData = pageData
+    ? (pageData.seo as Record<string, unknown> | undefined)
+    : undefined;
+  const seoResolveType =
+    typeof seoData?.__resolveType === "string" ? seoData.__resolveType : null;
+  const seoSchema = seoResolveType ? resolveSchema(seoResolveType, meta) : null;
+
   const pageVariants = isGlobalBlockMode
     ? [
         {
@@ -1507,11 +1549,17 @@ export function SectionsEditor({
       : [];
   // The global header still needs a crumb at the top level of a directly-opened
   // global block, where editingBreadcrumbs is empty — fall back to its name.
-  const headerCrumbs = showGlobalBanner
-    ? editingBreadcrumbs.length > 0
-      ? editingBreadcrumbs
-      : [globalBannerName]
-    : editingBreadcrumbs;
+  const seoBreadcrumbs =
+    editingSeo && activePage
+      ? [activePage.name, "SEO", ...seoFieldBreadcrumbs]
+      : [];
+  const headerCrumbs = editingSeo
+    ? seoBreadcrumbs
+    : showGlobalBanner
+      ? editingBreadcrumbs.length > 0
+        ? editingBreadcrumbs
+        : [globalBannerName]
+      : editingBreadcrumbs;
   const handleAddPageVariant = () => {
     if (!activePageKey) return;
     const fullPageData = decofile[activePageKey] as Record<string, unknown>;
@@ -1784,7 +1832,46 @@ export function SectionsEditor({
   const exitSectionEditing = () => {
     clearSectionEditing();
   };
+
+  const handleSeoFormChange = (next: unknown) => {
+    const nextRecord = next as Record<string, unknown>;
+    setSeoFormValue(nextRecord);
+    latestSeoFormRef.current = nextRecord;
+
+    if (seoDebounceRef.current) clearTimeout(seoDebounceRef.current);
+    seoDebounceRef.current = setTimeout(() => {
+      const value = latestSeoFormRef.current;
+      if (!value || !activePageKey || !pageData) return;
+      const updatedPageData = { ...pageData, seo: value };
+      saveBlock.mutate(
+        { blockKey: activePageKey, data: updatedPageData },
+        {
+          onSuccess: () => onSaved?.(),
+          onError: (err) => toast.error(`Save failed: ${err.message}`),
+        },
+      );
+    }, AUTOSAVE_DELAY);
+  };
+
   const handleBreadcrumbClick = (index: number) => {
+    if (editingSeo) {
+      if (index === 0) {
+        setEditingSeo(false);
+        setSeoFormValue(null);
+        setSeoFieldBreadcrumbs([]);
+        setSeoFormResetKey((key) => key + 1);
+        return;
+      }
+      if (index === 1) {
+        setSeoFieldBreadcrumbs([]);
+        setSeoFormResetKey((key) => key + 1);
+        return;
+      }
+      setSeoFieldBreadcrumbs(seoFieldBreadcrumbs.slice(0, index - 1));
+      setSeoFormResetKey((key) => key + 1);
+      return;
+    }
+
     if (isGlobalBlockMode) {
       setFieldBreadcrumbs(fieldBreadcrumbs.slice(0, index));
       setFormResetKey((key) => key + 1);
@@ -1819,7 +1906,7 @@ export function SectionsEditor({
         {/* When editing a reusable/global block (opened directly or from inside
             a page), the breadcrumb bar goes purple with a globe and a note that
             changes apply everywhere — so it never reads as a local edit. */}
-        {showGlobalBanner || isEditing ? (
+        {showGlobalBanner || isEditing || editingSeo ? (
           <div
             className={cn(
               "border-b px-3 py-2.5",
@@ -1927,6 +2014,44 @@ export function SectionsEditor({
                   type="button"
                   variant="ghost"
                   size="icon"
+                  aria-label="Edit SEO"
+                  className="size-7 shrink-0"
+                  onClick={() =>
+                    onEditPageSeo && activePageKey
+                      ? onEditPageSeo(activePageKey)
+                      : setEditingSeo(true)
+                  }
+                >
+                  <CreditCardSearch size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Edit SEO</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="View JSON"
+                  className="size-7 shrink-0"
+                  onClick={() =>
+                    onViewJsonFile && activePageKey
+                      ? onViewJsonFile(activePageKey)
+                      : setJsonOpen(true)
+                  }
+                >
+                  <Code01 size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">View JSON</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
                   aria-label="Add variant"
                   className="size-7 shrink-0"
                   style={{ color: "oklch(0.65 0.15 160)" }}
@@ -1942,7 +2067,7 @@ export function SectionsEditor({
       </div>
 
       {/* Variant selector (when page sections are multivariate) */}
-      {hasMultipleVariants && !isEditing && activePageKey && (
+      {hasMultipleVariants && !isEditing && !editingSeo && activePageKey && (
         <PageVariantTabs
           listKey={activePageKey}
           variants={pageVariants}
@@ -1958,8 +2083,23 @@ export function SectionsEditor({
         />
       )}
 
-      {/* Drill-down: section list OR section form */}
-      {isEditing ? (
+      {/* Drill-down: SEO form, section form, or section list */}
+      {editingSeo ? (
+        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
+          <SchemaFormPanel
+            activeSchema={seoSchema}
+            formValue={seoFormValue ?? seoData ?? {}}
+            formResetKey={seoFormResetKey}
+            onFormChange={handleSeoFormChange}
+            onBreadcrumbChange={setSeoFieldBreadcrumbs}
+            emptyMessage={
+              !seoData
+                ? "This page has no SEO block configured."
+                : "No editable SEO fields found."
+            }
+          />
+        </ScrollArea>
+      ) : isEditing ? (
         <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
           {isEditingMultivariateSection && sectionFlagVariants.length > 0 && (
             <>
@@ -2116,6 +2256,15 @@ export function SectionsEditor({
           decofile={decofile}
           previewBaseUrl={previewUrl}
           onSelect={handleAddSection}
+        />
+      )}
+
+      {jsonOpen && activePageKey && decofile && (
+        <PageJsonDialog
+          open={jsonOpen}
+          onOpenChange={setJsonOpen}
+          pageKey={activePageKey}
+          decofile={decofile}
         />
       )}
 

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -42,6 +42,7 @@ import { defaultPageSeoResolveType } from "./seo-schema";
 import { activeSeoResolveType, buildSeoSavePayload } from "./seo-save";
 import { isSeoEnabled, unwrapSeoConfig } from "./seo-lazy-render";
 import { PageSeoForm } from "./page-seo-form";
+import { SeoFormFields } from "./seo-form-fields";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
 import { PageVariantTabs, VariantTabIcon } from "./page-variant-tabs";
 import { MakeReusableModal } from "./make-reusable-modal";
@@ -558,7 +559,14 @@ export function SectionsEditor({
   const [prevAutoGlobalKey, setPrevAutoGlobalKey] = useState<string | null>(
     null,
   );
-  const seoFlushRef = useRef<() => void>(() => {});
+
+  const queryClient = useQueryClient();
+  const decofileCacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
+  const pageBlockSave = useDebouncedSaveBlock({
+    orgSlug,
+    virtualMcpId,
+    branch,
+  });
 
   // Reset form state when the active page or global block changes
   const [prevPath, setPrevPath] = useState(currentPath);
@@ -570,7 +578,7 @@ export function SectionsEditor({
     prevPageBlockKey !== activePageBlockKey ||
     prevGlobalBlockKey !== activeGlobalBlockKey
   ) {
-    seoFlushRef.current();
+    queueMicrotask(() => pageBlockSave.flush());
     setPrevPath(currentPath);
     setPrevPageBlockKey(activePageBlockKey);
     setPrevGlobalBlockKey(activeGlobalBlockKey);
@@ -592,18 +600,8 @@ export function SectionsEditor({
     setSeoFormResetKey((key) => key + 1);
   }
 
-  const queryClient = useQueryClient();
-  const decofileCacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
   const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
   const deleteBlock = useDeleteBlock({ orgSlug, virtualMcpId, branch });
-  // Page block writes (name/path + SEO) share one debouncer so concurrent edits
-  // merge at fire time. No onSaved — SEO autosave must not reload the preview.
-  const pageBlockSave = useDebouncedSaveBlock({
-    orgSlug,
-    virtualMcpId,
-    branch,
-  });
-  seoFlushRef.current = pageBlockSave.flush;
   const [renameVariantPending, setRenameVariantPending] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ruleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/apps/mesh/src/web/components/sections-editor/seo-block.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.test.ts
@@ -178,6 +178,39 @@ describe("resolveSeoTarget", () => {
     expect(resolved?.seoResolveType).toBe(DEFAULT_SEO_RESOLVE_TYPE);
   });
 
+  test("page target whose entry is not an object resolves to null", () => {
+    const decofile = { home: "not-an-object" as unknown as object };
+    expect(
+      resolveSeoTarget(decofile, {
+        kind: "page",
+        pageKey: "home",
+        pageName: "Home",
+        path: "/",
+      }),
+    ).toBeNull();
+  });
+
+  test("page target with a non-object seo treats it as no seo", () => {
+    const decofile = {
+      home: {
+        __resolveType: "website/pages/Page.tsx",
+        seo: "oops" as unknown as object,
+      },
+    };
+    const resolved = resolveSeoTarget(decofile, {
+      kind: "page",
+      pageKey: "home",
+      pageName: "Home",
+      path: "/",
+    });
+    expect(resolved?.seoData).toBeUndefined();
+    // The malformed seo must not be spread into the saved payload.
+    expect(resolved?.build({ title: "T" })).toEqual({
+      __resolveType: "website/pages/Page.tsx",
+      seo: { title: "T" },
+    });
+  });
+
   test("page target for a missing key resolves to null", () => {
     expect(
       resolveSeoTarget(

--- a/apps/mesh/src/web/components/sections-editor/seo-block.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.test.ts
@@ -38,7 +38,7 @@ describe("findSiteSeoEntry", () => {
     expect(entry?.seoResolveType).toBe(DEFAULT_SEO_RESOLVE_TYPE);
   });
 
-  test("infers seoResolveType from another block when inlined props lack one", () => {
+  test("without meta, inlined site seo does not scan other blocks for resolveType", () => {
     const decofile = {
       config: {
         __resolveType: "website/loaders/config.ts",
@@ -50,7 +50,7 @@ describe("findSiteSeoEntry", () => {
       },
     };
     const entry = findSiteSeoEntry(decofile);
-    expect(entry?.seoResolveType).toBe("website/sections/Seo/SeoV3.tsx");
+    expect(entry?.seoResolveType).toBe(DEFAULT_SEO_RESOLVE_TYPE);
   });
 
   test("finds a standalone SEO block when no nested SEO exists", () => {
@@ -237,5 +237,62 @@ describe("resolveSeoTarget", () => {
 
   test("site target resolves to null when no site SEO exists", () => {
     expect(resolveSeoTarget({}, { kind: "site" })).toBeNull();
+  });
+
+  test("page target uses manifest seo union when meta is provided", () => {
+    const meta = {
+      manifest: {
+        blocks: {
+          pages: {
+            "website/pages/Page.tsx": { $ref: "#/definitions/Page" },
+          },
+          sections: {
+            "website/sections/Seo/SeoPDPV2.tsx": {
+              $ref: "#/definitions/SeoPDP",
+            },
+          },
+        },
+      },
+      schema: {
+        definitions: {
+          Page: {
+            type: "object",
+            properties: {
+              seo: {
+                anyOf: [{ $ref: "#/definitions/SeoPDPSection" }],
+              },
+            },
+          },
+          SeoPDPSection: {
+            allOf: [
+              {
+                properties: {
+                  __resolveType: {
+                    enum: ["website/sections/Seo/SeoPDPV2.tsx"],
+                  },
+                },
+              },
+            ],
+            title: "PDP",
+          },
+          SeoPDP: {},
+        },
+      },
+    };
+    const resolved = resolveSeoTarget(
+      {
+        pdp: {
+          __resolveType: "website/pages/Page.tsx",
+          name: "PDP",
+          path: "/p",
+        },
+      },
+      { kind: "page", pageKey: "pdp", pageName: "PDP", path: "/p" },
+      meta,
+    );
+    expect(resolved?.seoResolveType).toBe("website/sections/Seo/SeoPDPV2.tsx");
+    expect(resolved?.seoTypeOptions?.map((o) => o.resolveType)).toEqual([
+      "website/sections/Seo/SeoPDPV2.tsx",
+    ]);
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/seo-block.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.test.ts
@@ -75,6 +75,19 @@ describe("findSiteSeoEntry", () => {
     expect(findSiteSeoEntry(decofile)).toBeNull();
   });
 
+  test("tolerates a non-string __resolveType (not treated as a page skip)", () => {
+    const decofile = {
+      weird: {
+        // number, not a string — must not crash or be mistaken for a page type
+        __resolveType: 42 as unknown as string,
+        seo: { title: "Still SEO" },
+      },
+    };
+    const entry = findSiteSeoEntry(decofile);
+    expect(entry?.kind).toBe("nested");
+    expect(entry?.blockKey).toBe("weird");
+  });
+
   test("returns null when there is no SEO anywhere", () => {
     const decofile = {
       home: { __resolveType: "website/pages/Page.tsx", sections: [] },

--- a/apps/mesh/src/web/components/sections-editor/seo-block.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_SEO_RESOLVE_TYPE,
+  buildSiteSeoBlockData,
+  findSiteSeoEntry,
+  resolveSeoTarget,
+  type SiteSeoEntry,
+} from "./seo-block";
+
+describe("findSiteSeoEntry", () => {
+  test("finds SEO nested on a non-page config block", () => {
+    const decofile = {
+      site: {
+        __resolveType: "website/loaders/config.ts",
+        seo: {
+          __resolveType: "website/sections/Seo/SeoV2.tsx",
+          title: "Home",
+        },
+      },
+    };
+    const entry = findSiteSeoEntry(decofile);
+    expect(entry?.kind).toBe("nested");
+    expect(entry?.blockKey).toBe("site");
+    expect(entry?.seoResolveType).toBe("website/sections/Seo/SeoV2.tsx");
+    expect(entry?.seoData).toEqual(decofile.site.seo);
+  });
+
+  test("recognizes nested SEO by field hints when __resolveType is absent", () => {
+    const decofile = {
+      config: {
+        __resolveType: "website/loaders/config.ts",
+        seo: { title: "Inlined", description: "no resolveType here" },
+      },
+    };
+    const entry = findSiteSeoEntry(decofile);
+    expect(entry?.kind).toBe("nested");
+    // Falls back to the inferred/default resolveType for inlined props.
+    expect(entry?.seoResolveType).toBe(DEFAULT_SEO_RESOLVE_TYPE);
+  });
+
+  test("infers seoResolveType from another block when inlined props lack one", () => {
+    const decofile = {
+      config: {
+        __resolveType: "website/loaders/config.ts",
+        seo: { title: "Inlined" },
+      },
+      somePage: {
+        __resolveType: "website/pages/Page.tsx",
+        seo: { __resolveType: "website/sections/Seo/SeoV3.tsx", title: "P" },
+      },
+    };
+    const entry = findSiteSeoEntry(decofile);
+    expect(entry?.seoResolveType).toBe("website/sections/Seo/SeoV3.tsx");
+  });
+
+  test("finds a standalone SEO block when no nested SEO exists", () => {
+    const decofile = {
+      seoBlock: {
+        __resolveType: "website/sections/Seo/SeoV2.tsx",
+        title: "Standalone",
+      },
+    };
+    const entry = findSiteSeoEntry(decofile);
+    expect(entry?.kind).toBe("block");
+    expect(entry?.blockKey).toBe("seoBlock");
+  });
+
+  test("ignores SEO nested under a page block (not a site default)", () => {
+    const decofile = {
+      home: {
+        __resolveType: "website/pages/Page.tsx",
+        seo: { __resolveType: "website/sections/Seo/SeoV2.tsx", title: "Home" },
+      },
+    };
+    expect(findSiteSeoEntry(decofile)).toBeNull();
+  });
+
+  test("returns null when there is no SEO anywhere", () => {
+    const decofile = {
+      home: { __resolveType: "website/pages/Page.tsx", sections: [] },
+    };
+    expect(findSiteSeoEntry(decofile)).toBeNull();
+  });
+
+  test("prefers nested site SEO over a standalone block", () => {
+    const decofile = {
+      standalone: {
+        __resolveType: "website/sections/Seo/SeoV2.tsx",
+        title: "A",
+      },
+      config: {
+        __resolveType: "website/loaders/config.ts",
+        seo: { __resolveType: "website/sections/Seo/SeoV2.tsx", title: "B" },
+      },
+    };
+    expect(findSiteSeoEntry(decofile)?.kind).toBe("nested");
+  });
+});
+
+describe("buildSiteSeoBlockData", () => {
+  test("block entry: replaces the whole block with the new value", () => {
+    const entry: SiteSeoEntry = {
+      blockKey: "seoBlock",
+      kind: "block",
+      seoData: { title: "old" },
+      blockData: { title: "old" },
+      seoResolveType: DEFAULT_SEO_RESOLVE_TYPE,
+    };
+    expect(buildSiteSeoBlockData(entry, { title: "new" })).toEqual({
+      title: "new",
+    });
+  });
+
+  test("nested entry: preserves sibling block fields and replaces seo", () => {
+    const entry: SiteSeoEntry = {
+      blockKey: "config",
+      kind: "nested",
+      seoData: { title: "old" },
+      blockData: { __resolveType: "website/loaders/config.ts", other: 1 },
+      seoResolveType: DEFAULT_SEO_RESOLVE_TYPE,
+    };
+    expect(buildSiteSeoBlockData(entry, { title: "new" })).toEqual({
+      __resolveType: "website/loaders/config.ts",
+      other: 1,
+      seo: { title: "new" },
+    });
+  });
+});
+
+describe("resolveSeoTarget", () => {
+  test("page target: builds a payload that keeps page fields and nests seo", () => {
+    const decofile = {
+      home: {
+        __resolveType: "website/pages/Page.tsx",
+        sections: ["a"],
+        seo: { __resolveType: "website/sections/Seo/SeoV2.tsx", title: "Home" },
+      },
+    };
+    const resolved = resolveSeoTarget(decofile, {
+      kind: "page",
+      pageKey: "home",
+      pageName: "Home",
+      path: "/",
+    });
+    expect(resolved?.blockKey).toBe("home");
+    expect(resolved?.seoResolveType).toBe("website/sections/Seo/SeoV2.tsx");
+    expect(resolved?.build({ title: "Updated" })).toEqual({
+      __resolveType: "website/pages/Page.tsx",
+      sections: ["a"],
+      seo: { title: "Updated" },
+    });
+  });
+
+  test("page target without seo: falls back to the default resolveType", () => {
+    const decofile = {
+      home: { __resolveType: "website/pages/Page.tsx", sections: [] },
+    };
+    const resolved = resolveSeoTarget(decofile, {
+      kind: "page",
+      pageKey: "home",
+      pageName: "Home",
+      path: "/",
+    });
+    expect(resolved?.seoData).toBeUndefined();
+    expect(resolved?.seoResolveType).toBe(DEFAULT_SEO_RESOLVE_TYPE);
+  });
+
+  test("page target for a missing key resolves to null", () => {
+    expect(
+      resolveSeoTarget(
+        {},
+        { kind: "page", pageKey: "ghost", pageName: "Ghost", path: "/x" },
+      ),
+    ).toBeNull();
+  });
+
+  test("site target resolves to the site SEO entry", () => {
+    const decofile = {
+      config: {
+        __resolveType: "website/loaders/config.ts",
+        seo: { __resolveType: "website/sections/Seo/SeoV2.tsx", title: "Site" },
+      },
+    };
+    const resolved = resolveSeoTarget(decofile, { kind: "site" });
+    expect(resolved?.blockKey).toBe("config");
+    expect(resolved?.build({ title: "New" })).toEqual({
+      __resolveType: "website/loaders/config.ts",
+      seo: { title: "New" },
+    });
+  });
+
+  test("site target resolves to null when no site SEO exists", () => {
+    expect(resolveSeoTarget({}, { kind: "site" })).toBeNull();
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/seo-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.ts
@@ -1,6 +1,8 @@
 import type { LiveMeta } from "./resolve-schema";
 import {
+  isSeoSectionResolveType,
   listPageSeoTypeOptions,
+  listSiteSeoTypeOptions,
   resolvePageSeoResolveType,
   resolveSiteSeoResolveType,
   type SeoTypeOption,
@@ -46,16 +48,13 @@ function isPlainObject(val: unknown): val is Record<string, unknown> {
   return typeof val === "object" && val !== null && !Array.isArray(val);
 }
 
-/** Matches SEO section resolveTypes, e.g. "website/sections/Seo/SeoV2.tsx". */
-function isSeoResolveType(rt: unknown): rt is string {
-  return (
-    typeof rt === "string" &&
-    (/\/Seo(V\d+)?\.tsx$/i.test(rt) || rt.includes("/sections/Seo"))
-  );
-}
-
 function looksLikeSeo(obj: Record<string, unknown>): boolean {
-  if (isSeoResolveType(obj.__resolveType)) return true;
+  if (
+    typeof obj.__resolveType === "string" &&
+    isSeoSectionResolveType(obj.__resolveType)
+  ) {
+    return true;
+  }
   return SEO_FIELD_HINTS.some((k) => k in obj);
 }
 
@@ -90,7 +89,8 @@ export function findSiteSeoEntry(
           blockData: obj,
           seoResolveType: meta
             ? resolveSiteSeoResolveType(meta, obj, seoObj)
-            : isSeoResolveType(seoObj.__resolveType)
+            : typeof seoObj.__resolveType === "string" &&
+                isSeoSectionResolveType(seoObj.__resolveType)
               ? seoObj.__resolveType
               : DEFAULT_SEO_RESOLVE_TYPE,
         };
@@ -102,7 +102,10 @@ export function findSiteSeoEntry(
   for (const [key, val] of Object.entries(decofile)) {
     if (!isPlainObject(val)) continue;
     const obj = val;
-    if (isSeoResolveType(obj.__resolveType)) {
+    if (
+      typeof obj.__resolveType === "string" &&
+      isSeoSectionResolveType(obj.__resolveType)
+    ) {
       return {
         blockKey: key,
         kind: "block",
@@ -133,7 +136,9 @@ export interface ResolvedSeo {
   seoData: Record<string, unknown> | undefined;
   /** resolveType to resolve the form schema with. */
   seoResolveType: string;
-  /** Page targets: SEO variants from the live page schema (when `meta` is passed). */
+  /** Site target only: how SEO is stored on the owning block. */
+  siteKind?: "block" | "nested";
+  /** SEO variants from the live schema (when `meta` is passed). */
   seoTypeOptions?: SeoTypeOption[];
   /** Builds the full decofile block payload to persist an edited SEO value. */
   build: (value: Record<string, unknown>) => Record<string, unknown>;
@@ -156,6 +161,10 @@ export function resolveSeoTarget(
       blockKey: entry.blockKey,
       seoData: entry.seoData,
       seoResolveType: entry.seoResolveType,
+      siteKind: entry.kind,
+      seoTypeOptions: meta
+        ? listSiteSeoTypeOptions(meta, entry.blockData)
+        : undefined,
       build: (value) => buildSiteSeoBlockData(entry, value),
     };
   }

--- a/apps/mesh/src/web/components/sections-editor/seo-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.ts
@@ -81,7 +81,8 @@ export function findSiteSeoEntry(
   for (const [key, val] of Object.entries(decofile)) {
     if (!val || typeof val !== "object" || Array.isArray(val)) continue;
     const obj = val as Record<string, unknown>;
-    if (PAGE_RESOLVE_TYPES.has(obj.__resolveType as string)) continue;
+    const rt = obj.__resolveType;
+    if (typeof rt === "string" && PAGE_RESOLVE_TYPES.has(rt)) continue;
     const seo = obj.seo;
     if (seo && typeof seo === "object" && !Array.isArray(seo)) {
       const seoObj = seo as Record<string, unknown>;

--- a/apps/mesh/src/web/components/sections-editor/seo-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.ts
@@ -4,7 +4,7 @@ const PAGE_RESOLVE_TYPES = new Set([
 ]);
 
 /** Default deco SEO section type — schema fallback for inlined SEO props. */
-const DEFAULT_SEO_RESOLVE_TYPE = "website/sections/Seo/SeoV2.tsx";
+export const DEFAULT_SEO_RESOLVE_TYPE = "website/sections/Seo/SeoV2.tsx";
 
 /** Props that mark an object as SEO config even without a `__resolveType`. */
 const SEO_FIELD_HINTS = [
@@ -122,4 +122,53 @@ export function buildSiteSeoBlockData(
   value: Record<string, unknown>,
 ): Record<string, unknown> {
   return entry.kind === "block" ? value : { ...entry.blockData, seo: value };
+}
+
+/** What a SEO surface is editing: a specific page, or the site default. */
+export type SeoTarget =
+  | { kind: "page"; pageKey: string; pageName: string; path: string }
+  | { kind: "site" };
+
+export interface ResolvedSeo {
+  blockKey: string;
+  seoData: Record<string, unknown> | undefined;
+  /** resolveType to resolve the form schema with. */
+  seoResolveType: string;
+  /** Builds the full decofile block payload to persist an edited SEO value. */
+  build: (value: Record<string, unknown>) => Record<string, unknown>;
+}
+
+/**
+ * Resolves the SEO block + write target for a page or the site default. Shared
+ * by every SEO surface (the two-pane editor and the sheets) so they all read
+ * and persist SEO the same way. Returns null when no SEO block exists.
+ */
+export function resolveSeoTarget(
+  decofile: Record<string, unknown>,
+  target: SeoTarget,
+): ResolvedSeo | null {
+  if (target.kind === "site") {
+    const entry = findSiteSeoEntry(decofile);
+    if (!entry) return null;
+    return {
+      blockKey: entry.blockKey,
+      seoData: entry.seoData,
+      seoResolveType: entry.seoResolveType,
+      build: (value) => buildSiteSeoBlockData(entry, value),
+    };
+  }
+  const blockData = decofile[target.pageKey] as
+    | Record<string, unknown>
+    | undefined;
+  if (!blockData) return null;
+  const seo = blockData.seo as Record<string, unknown> | undefined;
+  return {
+    blockKey: target.pageKey,
+    seoData: seo,
+    seoResolveType:
+      typeof seo?.__resolveType === "string"
+        ? seo.__resolveType
+        : DEFAULT_SEO_RESOLVE_TYPE,
+    build: (value) => ({ ...blockData, seo: value }),
+  };
 }

--- a/apps/mesh/src/web/components/sections-editor/seo-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.ts
@@ -1,4 +1,5 @@
 import type { LiveMeta } from "./resolve-schema";
+import { unwrapSeoConfig, wrapSeoPersistValue } from "./seo-lazy-render";
 import {
   isSeoSectionResolveType,
   listPageSeoTypeOptions,
@@ -133,7 +134,10 @@ export type SeoTarget =
 
 export interface ResolvedSeo {
   blockKey: string;
+  /** Inner SEO config (lazy wrapper stripped). Undefined when SEO is disabled. */
   seoData: Record<string, unknown> | undefined;
+  /** Full `page.seo` as stored — may be lazy-wrapped. */
+  rawSeoData?: unknown;
   /** resolveType to resolve the form schema with. */
   seoResolveType: string;
   /** Site target only: how SEO is stored on the owning block. */
@@ -173,16 +177,23 @@ export function resolveSeoTarget(
   const rawBlock = decofile[target.pageKey];
   if (!isPlainObject(rawBlock)) return null;
   const blockData = rawBlock;
-  const seo = isPlainObject(blockData.seo) ? blockData.seo : undefined;
+  const rawSeo = blockData.seo;
+  const innerSeo = unwrapSeoConfig(rawSeo);
+  const innerRecord =
+    innerSeo && isPlainObject(innerSeo) ? innerSeo : undefined;
   return {
     blockKey: target.pageKey,
-    seoData: seo,
+    seoData: innerRecord,
+    rawSeoData: rawSeo,
     seoResolveType: meta
-      ? resolvePageSeoResolveType(meta, seo)
-      : typeof seo?.__resolveType === "string"
-        ? seo.__resolveType
+      ? resolvePageSeoResolveType(meta, innerRecord)
+      : typeof innerRecord?.__resolveType === "string"
+        ? innerRecord.__resolveType
         : DEFAULT_SEO_RESOLVE_TYPE,
     seoTypeOptions: meta ? listPageSeoTypeOptions(meta) : undefined,
-    build: (value) => ({ ...blockData, seo: value }),
+    build: (value) => ({
+      ...blockData,
+      seo: value === null ? null : wrapSeoPersistValue(value, rawSeo),
+    }),
   };
 }

--- a/apps/mesh/src/web/components/sections-editor/seo-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.ts
@@ -33,6 +33,11 @@ export interface SiteSeoEntry {
   seoResolveType: string;
 }
 
+/** Narrows a decofile value to a plain (non-array) object. */
+function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === "object" && val !== null && !Array.isArray(val);
+}
+
 /** Matches SEO section resolveTypes, e.g. "website/sections/Seo/SeoV2.tsx". */
 function isSeoResolveType(rt: unknown): rt is string {
   return (
@@ -53,11 +58,11 @@ function looksLikeSeo(obj: Record<string, unknown>): boolean {
  */
 function inferSeoResolveType(decofile: Record<string, unknown>): string {
   for (const val of Object.values(decofile)) {
-    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
-    const obj = val as Record<string, unknown>;
+    if (!isPlainObject(val)) continue;
+    const obj = val;
     if (isSeoResolveType(obj.__resolveType)) return obj.__resolveType;
-    const seo = obj.seo as Record<string, unknown> | undefined;
-    if (seo && typeof seo === "object" && isSeoResolveType(seo.__resolveType)) {
+    const seo = obj.seo;
+    if (isPlainObject(seo) && isSeoResolveType(seo.__resolveType)) {
       return seo.__resolveType;
     }
   }
@@ -79,13 +84,13 @@ export function findSiteSeoEntry(
 ): SiteSeoEntry | null {
   // 1) SEO nested on a non-page config block.
   for (const [key, val] of Object.entries(decofile)) {
-    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
-    const obj = val as Record<string, unknown>;
+    if (!isPlainObject(val)) continue;
+    const obj = val;
     const rt = obj.__resolveType;
     if (typeof rt === "string" && PAGE_RESOLVE_TYPES.has(rt)) continue;
     const seo = obj.seo;
-    if (seo && typeof seo === "object" && !Array.isArray(seo)) {
-      const seoObj = seo as Record<string, unknown>;
+    if (isPlainObject(seo)) {
+      const seoObj = seo;
       if (looksLikeSeo(seoObj)) {
         return {
           blockKey: key,
@@ -102,8 +107,8 @@ export function findSiteSeoEntry(
 
   // 2) Standalone SEO block.
   for (const [key, val] of Object.entries(decofile)) {
-    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
-    const obj = val as Record<string, unknown>;
+    if (!isPlainObject(val)) continue;
+    const obj = val;
     if (isSeoResolveType(obj.__resolveType)) {
       return {
         blockKey: key,
@@ -158,11 +163,12 @@ export function resolveSeoTarget(
       build: (value) => buildSiteSeoBlockData(entry, value),
     };
   }
-  const blockData = decofile[target.pageKey] as
-    | Record<string, unknown>
-    | undefined;
-  if (!blockData) return null;
-  const seo = blockData.seo as Record<string, unknown> | undefined;
+  // Guard against malformed entries: a non-object page block (or a non-object
+  // `seo`) would otherwise be spread into the saved payload and corrupt it.
+  const rawBlock = decofile[target.pageKey];
+  if (!isPlainObject(rawBlock)) return null;
+  const blockData = rawBlock;
+  const seo = isPlainObject(blockData.seo) ? blockData.seo : undefined;
   return {
     blockKey: target.pageKey,
     seoData: seo,

--- a/apps/mesh/src/web/components/sections-editor/seo-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.ts
@@ -1,9 +1,17 @@
+import type { LiveMeta } from "./resolve-schema";
+import {
+  listPageSeoTypeOptions,
+  resolvePageSeoResolveType,
+  resolveSiteSeoResolveType,
+  type SeoTypeOption,
+} from "./seo-schema";
+
 const PAGE_RESOLVE_TYPES = new Set([
   "website/pages/Page.tsx",
   "$live/pages/LivePage.tsx",
 ]);
 
-/** Default deco SEO section type — schema fallback for inlined SEO props. */
+/** Default deco SEO section type when manifest schemas are unavailable. */
 export const DEFAULT_SEO_RESOLVE_TYPE = "website/sections/Seo/SeoV2.tsx";
 
 /** Props that mark an object as SEO config even without a `__resolveType`. */
@@ -52,24 +60,6 @@ function looksLikeSeo(obj: Record<string, unknown>): boolean {
 }
 
 /**
- * The SEO section resolveType used somewhere in this decofile (pages reference
- * it via `seo.__resolveType`), so the site default's inlined props get the
- * right form schema. Falls back to the deco default.
- */
-function inferSeoResolveType(decofile: Record<string, unknown>): string {
-  for (const val of Object.values(decofile)) {
-    if (!isPlainObject(val)) continue;
-    const obj = val;
-    if (isSeoResolveType(obj.__resolveType)) return obj.__resolveType;
-    const seo = obj.seo;
-    if (isPlainObject(seo) && isSeoResolveType(seo.__resolveType)) {
-      return seo.__resolveType;
-    }
-  }
-  return DEFAULT_SEO_RESOLVE_TYPE;
-}
-
-/**
  * Finds the site-level (default) SEO that pages inherit from. Deco sites store
  * this in one of a few shapes, checked in order:
  *
@@ -81,6 +71,7 @@ function inferSeoResolveType(decofile: Record<string, unknown>): string {
  */
 export function findSiteSeoEntry(
   decofile: Record<string, unknown>,
+  meta?: LiveMeta,
 ): SiteSeoEntry | null {
   // 1) SEO nested on a non-page config block.
   for (const [key, val] of Object.entries(decofile)) {
@@ -97,9 +88,11 @@ export function findSiteSeoEntry(
           kind: "nested",
           seoData: seoObj,
           blockData: obj,
-          seoResolveType: isSeoResolveType(seoObj.__resolveType)
-            ? seoObj.__resolveType
-            : inferSeoResolveType(decofile),
+          seoResolveType: meta
+            ? resolveSiteSeoResolveType(meta, obj, seoObj)
+            : isSeoResolveType(seoObj.__resolveType)
+              ? seoObj.__resolveType
+              : DEFAULT_SEO_RESOLVE_TYPE,
         };
       }
     }
@@ -140,6 +133,8 @@ export interface ResolvedSeo {
   seoData: Record<string, unknown> | undefined;
   /** resolveType to resolve the form schema with. */
   seoResolveType: string;
+  /** Page targets: SEO variants from the live page schema (when `meta` is passed). */
+  seoTypeOptions?: SeoTypeOption[];
   /** Builds the full decofile block payload to persist an edited SEO value. */
   build: (value: Record<string, unknown>) => Record<string, unknown>;
 }
@@ -152,9 +147,10 @@ export interface ResolvedSeo {
 export function resolveSeoTarget(
   decofile: Record<string, unknown>,
   target: SeoTarget,
+  meta?: LiveMeta,
 ): ResolvedSeo | null {
   if (target.kind === "site") {
-    const entry = findSiteSeoEntry(decofile);
+    const entry = findSiteSeoEntry(decofile, meta);
     if (!entry) return null;
     return {
       blockKey: entry.blockKey,
@@ -172,10 +168,12 @@ export function resolveSeoTarget(
   return {
     blockKey: target.pageKey,
     seoData: seo,
-    seoResolveType:
-      typeof seo?.__resolveType === "string"
+    seoResolveType: meta
+      ? resolvePageSeoResolveType(meta, seo)
+      : typeof seo?.__resolveType === "string"
         ? seo.__resolveType
         : DEFAULT_SEO_RESOLVE_TYPE,
+    seoTypeOptions: meta ? listPageSeoTypeOptions(meta) : undefined,
     build: (value) => ({ ...blockData, seo: value }),
   };
 }

--- a/apps/mesh/src/web/components/sections-editor/seo-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-block.ts
@@ -1,0 +1,125 @@
+const PAGE_RESOLVE_TYPES = new Set([
+  "website/pages/Page.tsx",
+  "$live/pages/LivePage.tsx",
+]);
+
+/** Default deco SEO section type — schema fallback for inlined SEO props. */
+const DEFAULT_SEO_RESOLVE_TYPE = "website/sections/Seo/SeoV2.tsx";
+
+/** Props that mark an object as SEO config even without a `__resolveType`. */
+const SEO_FIELD_HINTS = [
+  "title",
+  "titleTemplate",
+  "description",
+  "descriptionTemplate",
+  "image",
+  "favicon",
+  "type",
+  "noIndexing",
+];
+
+export interface SiteSeoEntry {
+  /** Decofile key of the block that owns the SEO data. */
+  blockKey: string;
+  /**
+   * "block": the decofile entry *is* the SEO block — saving replaces the entry.
+   * "nested": the SEO lives under `entry.seo` on a config block (e.g. the
+   * website/site app) — saving writes `{ ...blockData, seo }`.
+   */
+  kind: "block" | "nested";
+  seoData: Record<string, unknown>;
+  blockData: Record<string, unknown>;
+  /** resolveType to resolve the form schema with (SEO props may be inlined). */
+  seoResolveType: string;
+}
+
+/** Matches SEO section resolveTypes, e.g. "website/sections/Seo/SeoV2.tsx". */
+function isSeoResolveType(rt: unknown): rt is string {
+  return (
+    typeof rt === "string" &&
+    (/\/Seo(V\d+)?\.tsx$/i.test(rt) || rt.includes("/sections/Seo"))
+  );
+}
+
+function looksLikeSeo(obj: Record<string, unknown>): boolean {
+  if (isSeoResolveType(obj.__resolveType)) return true;
+  return SEO_FIELD_HINTS.some((k) => k in obj);
+}
+
+/**
+ * The SEO section resolveType used somewhere in this decofile (pages reference
+ * it via `seo.__resolveType`), so the site default's inlined props get the
+ * right form schema. Falls back to the deco default.
+ */
+function inferSeoResolveType(decofile: Record<string, unknown>): string {
+  for (const val of Object.values(decofile)) {
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+    const obj = val as Record<string, unknown>;
+    if (isSeoResolveType(obj.__resolveType)) return obj.__resolveType;
+    const seo = obj.seo as Record<string, unknown> | undefined;
+    if (seo && typeof seo === "object" && isSeoResolveType(seo.__resolveType)) {
+      return seo.__resolveType;
+    }
+  }
+  return DEFAULT_SEO_RESOLVE_TYPE;
+}
+
+/**
+ * Finds the site-level (default) SEO that pages inherit from. Deco sites store
+ * this in one of a few shapes, checked in order:
+ *
+ *   1. SEO nested under a non-page config block (e.g. the `site` app config's
+ *      `seo` prop) — often inlined props with no `__resolveType`. This is the
+ *      true "applied to every page unless overridden" default.
+ *   2. A standalone SEO block — a decofile entry whose own `__resolveType` is
+ *      an SEO type (the block *is* the SEO).
+ */
+export function findSiteSeoEntry(
+  decofile: Record<string, unknown>,
+): SiteSeoEntry | null {
+  // 1) SEO nested on a non-page config block.
+  for (const [key, val] of Object.entries(decofile)) {
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+    const obj = val as Record<string, unknown>;
+    if (PAGE_RESOLVE_TYPES.has(obj.__resolveType as string)) continue;
+    const seo = obj.seo;
+    if (seo && typeof seo === "object" && !Array.isArray(seo)) {
+      const seoObj = seo as Record<string, unknown>;
+      if (looksLikeSeo(seoObj)) {
+        return {
+          blockKey: key,
+          kind: "nested",
+          seoData: seoObj,
+          blockData: obj,
+          seoResolveType: isSeoResolveType(seoObj.__resolveType)
+            ? seoObj.__resolveType
+            : inferSeoResolveType(decofile),
+        };
+      }
+    }
+  }
+
+  // 2) Standalone SEO block.
+  for (const [key, val] of Object.entries(decofile)) {
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+    const obj = val as Record<string, unknown>;
+    if (isSeoResolveType(obj.__resolveType)) {
+      return {
+        blockKey: key,
+        kind: "block",
+        seoData: obj,
+        blockData: obj,
+        seoResolveType: obj.__resolveType,
+      };
+    }
+  }
+  return null;
+}
+
+/** Builds the decofile block payload to persist an edited site-SEO value. */
+export function buildSiteSeoBlockData(
+  entry: SiteSeoEntry,
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return entry.kind === "block" ? value : { ...entry.blockData, seo: value };
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
@@ -1,6 +1,14 @@
 import { useState } from "react";
 import { ChevronRight, CreditCardSearch, Loading01 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import { useDebouncedSaveBlock } from "./use-save-block";
 import { SchemaForm } from "./schema-form";
@@ -40,7 +48,7 @@ export function SeoEditor({
   onEditDefaultSeo,
   onBack,
 }: SeoEditorProps) {
-  const resolved = resolveSeoTarget(decofile, target);
+  const resolved = resolveSeoTarget(decofile, target, meta);
   const seoData = resolved?.seoData;
   const seoSchema = resolved
     ? resolveSchema(resolved.seoResolveType, meta)
@@ -158,6 +166,37 @@ export function SeoEditor({
                   resolved result.
                 </p>
               )}
+              {resolved.seoTypeOptions &&
+                resolved.seoTypeOptions.length > 1 && (
+                  <div className="mb-4 flex flex-col gap-1.5">
+                    <Label className="text-xs text-muted-foreground">
+                      SEO type
+                    </Label>
+                    <Select
+                      value={resolved.seoResolveType}
+                      onValueChange={(nextType) => {
+                        handleChange({
+                          ...effectiveSeo,
+                          __resolveType: nextType,
+                        });
+                      }}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select SEO type" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {resolved.seoTypeOptions.map((option) => (
+                          <SelectItem
+                            key={option.resolveType}
+                            value={option.resolveType}
+                          >
+                            {option.title}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
               <SchemaForm
                 schema={seoSchema}
                 value={effectiveSeo}

--- a/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
@@ -1,22 +1,15 @@
 import { useState } from "react";
 import { ChevronRight, CreditCardSearch, Loading01 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@deco/ui/components/select.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { useDebouncedSaveBlock } from "./use-save-block";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema } from "./resolve-schema";
 import type { LiveMeta } from "./resolve-schema";
 import { findSiteSeoEntry, resolveSeoTarget } from "./seo-block";
 import type { SeoTarget } from "./seo-block";
+import { activeSeoResolveType, useSeoFormSave } from "./seo-save";
 import { SeoPreview } from "./seo-preview";
+import { SeoTypeSelect } from "./seo-type-select";
 
 export type { SeoTarget } from "./seo-block";
 
@@ -50,32 +43,40 @@ export function SeoEditor({
 }: SeoEditorProps) {
   const resolved = resolveSeoTarget(decofile, target, meta);
   const seoData = resolved?.seoData;
-  const seoSchema = resolved
-    ? resolveSchema(resolved.seoResolveType, meta)
-    : null;
 
   const targetId = target.kind === "site" ? "site" : target.pageKey;
   const [prevTargetId, setPrevTargetId] = useState(targetId);
   const [formValue, setFormValue] = useState<Record<string, unknown> | null>(
     null,
   );
+  const [formResetKey, setFormResetKey] = useState(0);
   if (prevTargetId !== targetId) {
     setPrevTargetId(targetId);
     setFormValue(null);
+    setFormResetKey((k) => k + 1);
   }
 
-  const { save, isPending } = useDebouncedSaveBlock(
-    { orgSlug, virtualMcpId, branch },
-    { onSaved },
-  );
+  const { persistSeo, flush, isPending } = useSeoFormSave({
+    orgSlug,
+    virtualMcpId,
+    branch,
+    target,
+    resolved,
+    onSaved,
+  });
 
   const effectiveSeo = formValue ?? seoData ?? {};
+  const activeResolveType = resolved
+    ? activeSeoResolveType(effectiveSeo, resolved)
+    : null;
+  const seoSchema = activeResolveType
+    ? resolveSchema(activeResolveType, meta)
+    : null;
 
-  // For a page, the live result is the site default with the page's own
-  // (non-empty) values layered on top — that's what actually renders. The form
-  // still edits only the page's own values, so inheritance isn't baked in.
   const siteDefaultSeo =
-    target.kind === "page" ? (findSiteSeoEntry(decofile)?.seoData ?? {}) : {};
+    target.kind === "page"
+      ? (findSiteSeoEntry(decofile, meta)?.seoData ?? {})
+      : {};
   const previewSeo =
     target.kind === "page"
       ? mergeSeo(siteDefaultSeo, effectiveSeo)
@@ -85,7 +86,20 @@ export function SeoEditor({
     if (!resolved) return;
     const nextRecord = next as Record<string, unknown>;
     setFormValue(nextRecord);
-    save(resolved.blockKey, resolved.build(nextRecord));
+    persistSeo(nextRecord);
+  };
+
+  const handleSeoTypeChange = (nextType: string) => {
+    if (!resolved) return;
+    const nextRecord = { ...effectiveSeo, __resolveType: nextType };
+    setFormValue(nextRecord);
+    setFormResetKey((k) => k + 1);
+    persistSeo(nextRecord);
+  };
+
+  const handleBack = () => {
+    flush();
+    onBack?.();
   };
 
   const path = target.kind === "page" ? target.path : "/";
@@ -94,15 +108,21 @@ export function SeoEditor({
       ? safeUrl(path, previewBaseUrl)
       : (previewBaseUrl ?? null);
 
+  const emptyMessage =
+    target.kind === "site"
+      ? "No site-level SEO block found."
+      : seoSchema
+        ? "No editable SEO fields found."
+        : "SEO schema not found for this page.";
+
   return (
     <div className="flex h-full w-full flex-col">
-      {/* Header */}
       <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
         {target.kind === "page" ? (
           <nav className="flex min-w-0 items-center gap-1 text-sm">
             <button
               type="button"
-              onClick={onBack}
+              onClick={handleBack}
               title={target.pageName}
               className="min-w-0 truncate rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
             >
@@ -145,16 +165,9 @@ export function SeoEditor({
         </div>
       </div>
 
-      {/* Two-pane: form + live previews */}
-      {!resolved ? (
+      {!resolved || !seoSchema ? (
         <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
-          No default SEO block found in this site.
-        </div>
-      ) : !seoSchema ? (
-        <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
-          {seoData
-            ? "SEO schema not found."
-            : "This page has no SEO block configured."}
+          {emptyMessage}
         </div>
       ) : (
         <div className="flex min-h-0 flex-1">
@@ -166,38 +179,15 @@ export function SeoEditor({
                   resolved result.
                 </p>
               )}
-              {resolved.seoTypeOptions &&
-                resolved.seoTypeOptions.length > 1 && (
-                  <div className="mb-4 flex flex-col gap-1.5">
-                    <Label className="text-xs text-muted-foreground">
-                      SEO type
-                    </Label>
-                    <Select
-                      value={resolved.seoResolveType}
-                      onValueChange={(nextType) => {
-                        handleChange({
-                          ...effectiveSeo,
-                          __resolveType: nextType,
-                        });
-                      }}
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Select SEO type" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {resolved.seoTypeOptions.map((option) => (
-                          <SelectItem
-                            key={option.resolveType}
-                            value={option.resolveType}
-                          >
-                            {option.title}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                )}
+              {resolved.seoTypeOptions && activeResolveType && (
+                <SeoTypeSelect
+                  options={resolved.seoTypeOptions}
+                  value={activeResolveType}
+                  onChange={handleSeoTypeChange}
+                />
+              )}
               <SchemaForm
+                key={formResetKey}
                 schema={seoSchema}
                 value={effectiveSeo}
                 onChange={handleChange}
@@ -226,15 +216,19 @@ function safeUrl(path: string, base: string): string | null {
   }
 }
 
-/**
- * Layers a page's own SEO over the site default — a field is overridden only
- * when the page sets a non-empty value, mirroring how deco resolves SEO at
- * render time. Used for the preview, never for the editable form value.
- */
 function mergeSeo(
   base: Record<string, unknown>,
   override: Record<string, unknown>,
 ): Record<string, unknown> {
+  const pageRt = override.__resolveType;
+  const siteRt = base.__resolveType;
+  if (
+    typeof pageRt === "string" &&
+    typeof siteRt === "string" &&
+    pageRt !== siteRt
+  ) {
+    return { ...override };
+  }
   const merged = { ...base };
   for (const [key, value] of Object.entries(override)) {
     if (key === "__resolveType") continue;

--- a/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
@@ -1,0 +1,265 @@
+import { useRef, useState } from "react";
+import { ChevronRight, CreditCardSearch, Loading01 } from "@untitledui/icons";
+import { toast } from "sonner";
+import { Button } from "@deco/ui/components/button.tsx";
+import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { useSaveBlock } from "./use-save-block";
+import { SchemaForm } from "./schema-form";
+import { resolveSchema } from "./resolve-schema";
+import type { LiveMeta } from "./resolve-schema";
+import { buildSiteSeoBlockData, findSiteSeoEntry } from "./seo-block";
+import { SeoPreview } from "./seo-preview";
+
+const AUTOSAVE_DELAY = 700;
+
+export type SeoTarget =
+  | { kind: "page"; pageKey: string; pageName: string; path: string }
+  | { kind: "site" };
+
+interface SeoEditorProps {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  decofile: Record<string, unknown>;
+  meta: LiveMeta;
+  target: SeoTarget;
+  /** Sandbox preview base URL — used to render the host/path in the previews. */
+  previewBaseUrl?: string | null;
+  onSaved?: () => void;
+  /** Page targets only: jump to the site/default SEO editor. */
+  onEditDefaultSeo?: () => void;
+  /** Page targets only: breadcrumb back to the page's section editor. */
+  onBack?: () => void;
+}
+
+interface ResolvedSeo {
+  blockKey: string;
+  seoData: Record<string, unknown> | undefined;
+  /** resolveType to resolve the form schema with. */
+  seoResolveType: string;
+  /** Builds the full decofile block payload to persist an edited SEO value. */
+  build: (value: Record<string, unknown>) => Record<string, unknown>;
+}
+
+/**
+ * Resolves the SEO block + write target for a page or the site default.
+ */
+function resolveTarget(
+  decofile: Record<string, unknown>,
+  target: SeoTarget,
+): ResolvedSeo | null {
+  if (target.kind === "site") {
+    const entry = findSiteSeoEntry(decofile);
+    if (!entry) return null;
+    return {
+      blockKey: entry.blockKey,
+      seoData: entry.seoData,
+      seoResolveType: entry.seoResolveType,
+      build: (value) => buildSiteSeoBlockData(entry, value),
+    };
+  }
+  const blockData = decofile[target.pageKey] as
+    | Record<string, unknown>
+    | undefined;
+  if (!blockData) return null;
+  const seo = blockData.seo as Record<string, unknown> | undefined;
+  return {
+    blockKey: target.pageKey,
+    seoData: seo,
+    seoResolveType:
+      typeof seo?.__resolveType === "string"
+        ? seo.__resolveType
+        : "website/sections/Seo/SeoV2.tsx",
+    build: (value) => ({ ...blockData, seo: value }),
+  };
+}
+
+export function SeoEditor({
+  orgSlug,
+  virtualMcpId,
+  branch,
+  decofile,
+  meta,
+  target,
+  previewBaseUrl,
+  onSaved,
+  onEditDefaultSeo,
+  onBack,
+}: SeoEditorProps) {
+  const resolved = resolveTarget(decofile, target);
+  const seoData = resolved?.seoData;
+  const seoSchema = resolved
+    ? resolveSchema(resolved.seoResolveType, meta)
+    : null;
+
+  const targetId = target.kind === "site" ? "site" : target.pageKey;
+  const [prevTargetId, setPrevTargetId] = useState(targetId);
+  const [formValue, setFormValue] = useState<Record<string, unknown> | null>(
+    null,
+  );
+  if (prevTargetId !== targetId) {
+    setPrevTargetId(targetId);
+    setFormValue(null);
+  }
+
+  const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestFormRef = useRef<Record<string, unknown> | null>(null);
+
+  const effectiveSeo = formValue ?? seoData ?? {};
+
+  // For a page, the live result is the site default with the page's own
+  // (non-empty) values layered on top — that's what actually renders. The form
+  // still edits only the page's own values, so inheritance isn't baked in.
+  const siteDefaultSeo =
+    target.kind === "page" ? (findSiteSeoEntry(decofile)?.seoData ?? {}) : {};
+  const previewSeo =
+    target.kind === "page"
+      ? mergeSeo(siteDefaultSeo, effectiveSeo)
+      : effectiveSeo;
+
+  const handleChange = (next: unknown) => {
+    if (!resolved) return;
+    const nextRecord = next as Record<string, unknown>;
+    setFormValue(nextRecord);
+    latestFormRef.current = nextRecord;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const value = latestFormRef.current;
+      if (!value) return;
+      saveBlock.mutate(
+        { blockKey: resolved.blockKey, data: resolved.build(value) },
+        {
+          onSuccess: () => onSaved?.(),
+          onError: (err) => toast.error(`Save failed: ${err.message}`),
+        },
+      );
+    }, AUTOSAVE_DELAY);
+  };
+
+  const path = target.kind === "page" ? target.path : "/";
+  const previewUrl =
+    target.kind === "page" && previewBaseUrl
+      ? safeUrl(path, previewBaseUrl)
+      : (previewBaseUrl ?? null);
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      {/* Header */}
+      <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+        {target.kind === "page" ? (
+          <nav className="flex min-w-0 items-center gap-1 text-sm">
+            <button
+              type="button"
+              onClick={onBack}
+              title={target.pageName}
+              className="min-w-0 truncate rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              {target.pageName}
+            </button>
+            <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" />
+            <span className="px-1 py-0.5 font-medium text-foreground">SEO</span>
+          </nav>
+        ) : (
+          <div className="flex min-w-0 items-center gap-2">
+            <CreditCardSearch
+              size={16}
+              className="shrink-0 text-muted-foreground"
+            />
+            <span className="text-sm font-medium">Default SEO</span>
+            <span className="hidden truncate text-xs text-muted-foreground sm:inline">
+              · applied to every page unless overridden
+            </span>
+          </div>
+        )}
+
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          {saveBlock.isPending && (
+            <Loading01
+              size={14}
+              className="animate-spin text-muted-foreground"
+            />
+          )}
+          {target.kind === "page" && onEditDefaultSeo && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onEditDefaultSeo}
+            >
+              <CreditCardSearch size={14} />
+              Edit default SEO
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Two-pane: form + live previews */}
+      {!resolved ? (
+        <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+          No default SEO block found in this site.
+        </div>
+      ) : !seoSchema ? (
+        <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+          {seoData
+            ? "SEO schema not found."
+            : "This page has no SEO block configured."}
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          <ScrollArea className="w-full max-w-md shrink-0 border-r [&_[data-slot=scroll-area-viewport]>div]:!block">
+            <div className="px-5 py-4">
+              {target.kind === "page" && (
+                <p className="mb-3 text-xs text-muted-foreground">
+                  Empty fields inherit the default SEO. The preview shows the
+                  resolved result.
+                </p>
+              )}
+              <SchemaForm
+                schema={seoSchema}
+                value={effectiveSeo}
+                onChange={handleChange}
+                basePath=""
+                breadcrumbPath={[]}
+                onBreadcrumbChange={() => {}}
+              />
+            </div>
+          </ScrollArea>
+          <ScrollArea className="min-w-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block">
+            <div className="@container px-5 py-4">
+              <SeoPreview seo={previewSeo} url={previewUrl} path={path} />
+            </div>
+          </ScrollArea>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function safeUrl(path: string, base: string): string | null {
+  try {
+    return new URL(path, base).href;
+  } catch {
+    return base;
+  }
+}
+
+/**
+ * Layers a page's own SEO over the site default — a field is overridden only
+ * when the page sets a non-empty value, mirroring how deco resolves SEO at
+ * render time. Used for the preview, never for the editable form value.
+ */
+function mergeSeo(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    if (key === "__resolveType") continue;
+    if (value === undefined || value === null) continue;
+    if (typeof value === "string" && value.trim() === "") continue;
+    merged[key] = value;
+  }
+  return merged;
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
@@ -2,14 +2,16 @@ import { useState } from "react";
 import { ChevronRight, CreditCardSearch, Loading01 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { SchemaForm } from "./schema-form";
+import { SeoFormFields } from "./seo-form-fields";
 import { resolveSchema } from "./resolve-schema";
 import type { LiveMeta } from "./resolve-schema";
 import { findSiteSeoEntry, resolveSeoTarget } from "./seo-block";
 import type { SeoTarget } from "./seo-block";
+import { isSeoEnabled, unwrapSeoConfig } from "./seo-lazy-render";
+import { PageSeoForm } from "./page-seo-form";
+import { defaultPageSeoResolveType } from "./seo-schema";
 import { activeSeoResolveType, useSeoFormSave } from "./seo-save";
 import { SeoPreview } from "./seo-preview";
-import { SeoTypeSelect } from "./seo-type-select";
 
 export type { SeoTarget } from "./seo-block";
 
@@ -50,13 +52,17 @@ export function SeoEditor({
     null,
   );
   const [formResetKey, setFormResetKey] = useState(0);
+  const [rawSeoOverride, setRawSeoOverride] = useState<
+    Record<string, unknown> | null | undefined
+  >(undefined);
   if (prevTargetId !== targetId) {
     setPrevTargetId(targetId);
     setFormValue(null);
+    setRawSeoOverride(undefined);
     setFormResetKey((k) => k + 1);
   }
 
-  const { persistSeo, flush, isPending } = useSeoFormSave({
+  const { persistSeo, persistRawSeo, flush, isPending } = useSeoFormSave({
     orgSlug,
     virtualMcpId,
     branch,
@@ -65,13 +71,25 @@ export function SeoEditor({
     onSaved,
   });
 
-  const effectiveSeo = formValue ?? seoData ?? {};
+  const isPageTarget = target.kind === "page";
+  const savedRawSeo = isPageTarget ? resolved?.rawSeoData : undefined;
+  const displayRawSeo =
+    rawSeoOverride !== undefined ? rawSeoOverride : savedRawSeo;
+  const innerFromSaved = isPageTarget
+    ? (unwrapSeoConfig(displayRawSeo) ?? undefined)
+    : undefined;
+  const effectiveSeo = (formValue ?? innerFromSaved ?? seoData ?? {}) as Record<
+    string,
+    unknown
+  >;
   const activeResolveType = resolved
     ? activeSeoResolveType(effectiveSeo, resolved)
     : null;
-  const seoSchema = activeResolveType
-    ? resolveSchema(activeResolveType, meta)
-    : null;
+  const seoSchema =
+    activeResolveType && (isPageTarget ? isSeoEnabled(displayRawSeo) : true)
+      ? resolveSchema(activeResolveType, meta)
+      : null;
+  const defaultResolveType = defaultPageSeoResolveType(meta);
 
   const siteDefaultSeo =
     target.kind === "page"
@@ -89,13 +107,8 @@ export function SeoEditor({
     persistSeo(nextRecord);
   };
 
-  const handleSeoTypeChange = (nextType: string) => {
-    if (!resolved) return;
-    const nextRecord = { ...effectiveSeo, __resolveType: nextType };
-    setFormValue(nextRecord);
-    setFormResetKey((k) => k + 1);
-    persistSeo(nextRecord);
-  };
+  const clearSeoForm = () => setFormValue(null);
+  const bumpSeoFormKey = () => setFormResetKey((k) => k + 1);
 
   const handleBack = () => {
     flush();
@@ -111,9 +124,11 @@ export function SeoEditor({
   const emptyMessage =
     target.kind === "site"
       ? "No site-level SEO block found."
-      : seoSchema
-        ? "No editable SEO fields found."
-        : "SEO schema not found for this page.";
+      : resolved
+        ? "SEO schema not found for this page."
+        : "Could not load page SEO.";
+  const showPageSeoChrome = isPageTarget && resolved;
+  const showSiteForm = target.kind === "site" && resolved && seoSchema;
 
   return (
     <div className="flex h-full w-full flex-col">
@@ -165,7 +180,7 @@ export function SeoEditor({
         </div>
       </div>
 
-      {!resolved || !seoSchema ? (
+      {!resolved || (!showPageSeoChrome && !showSiteForm) ? (
         <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
           {emptyMessage}
         </div>
@@ -173,28 +188,45 @@ export function SeoEditor({
         <div className="flex min-h-0 flex-1">
           <ScrollArea className="w-full max-w-md shrink-0 border-r [&_[data-slot=scroll-area-viewport]>div]:!block">
             <div className="px-5 py-4">
-              {target.kind === "page" && (
-                <p className="mb-3 text-xs text-muted-foreground">
-                  Empty fields inherit the default SEO. The preview shows the
-                  resolved result.
-                </p>
+              {showPageSeoChrome ? (
+                <>
+                  <p className="mb-3 text-xs text-muted-foreground">
+                    Empty fields inherit the default SEO. The preview shows the
+                    resolved result.
+                  </p>
+                  <PageSeoForm
+                    rawSeo={displayRawSeo}
+                    innerSeo={effectiveSeo}
+                    defaultResolveType={defaultResolveType}
+                    seoSchema={seoSchema}
+                    activeResolveType={activeResolveType}
+                    seoTypeOptions={resolved.seoTypeOptions}
+                    formResetKey={formResetKey}
+                    siteDefaultSeo={siteDefaultSeo}
+                    onPersistRaw={(raw) => {
+                      setRawSeoOverride(raw);
+                      persistRawSeo(raw);
+                    }}
+                    onInnerChange={(inner) => {
+                      setFormValue(inner);
+                      persistSeo(inner);
+                    }}
+                    onClearForm={clearSeoForm}
+                    onBumpFormKey={bumpSeoFormKey}
+                  />
+                </>
+              ) : (
+                seoSchema &&
+                activeResolveType && (
+                  <SeoFormFields
+                    schema={seoSchema}
+                    resolveType={activeResolveType}
+                    value={effectiveSeo}
+                    formResetKey={formResetKey}
+                    onChange={handleChange}
+                  />
+                )
               )}
-              {resolved.seoTypeOptions && activeResolveType && (
-                <SeoTypeSelect
-                  options={resolved.seoTypeOptions}
-                  value={activeResolveType}
-                  onChange={handleSeoTypeChange}
-                />
-              )}
-              <SchemaForm
-                key={formResetKey}
-                schema={seoSchema}
-                value={effectiveSeo}
-                onChange={handleChange}
-                basePath=""
-                breadcrumbPath={[]}
-                onBreadcrumbChange={() => {}}
-              />
             </div>
           </ScrollArea>
           <ScrollArea className="min-w-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block">

--- a/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-editor.tsx
@@ -1,20 +1,16 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { ChevronRight, CreditCardSearch, Loading01 } from "@untitledui/icons";
-import { toast } from "sonner";
 import { Button } from "@deco/ui/components/button.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { useSaveBlock } from "./use-save-block";
+import { useDebouncedSaveBlock } from "./use-save-block";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema } from "./resolve-schema";
 import type { LiveMeta } from "./resolve-schema";
-import { buildSiteSeoBlockData, findSiteSeoEntry } from "./seo-block";
+import { findSiteSeoEntry, resolveSeoTarget } from "./seo-block";
+import type { SeoTarget } from "./seo-block";
 import { SeoPreview } from "./seo-preview";
 
-const AUTOSAVE_DELAY = 700;
-
-export type SeoTarget =
-  | { kind: "page"; pageKey: string; pageName: string; path: string }
-  | { kind: "site" };
+export type { SeoTarget } from "./seo-block";
 
 interface SeoEditorProps {
   orgSlug: string;
@@ -32,48 +28,6 @@ interface SeoEditorProps {
   onBack?: () => void;
 }
 
-interface ResolvedSeo {
-  blockKey: string;
-  seoData: Record<string, unknown> | undefined;
-  /** resolveType to resolve the form schema with. */
-  seoResolveType: string;
-  /** Builds the full decofile block payload to persist an edited SEO value. */
-  build: (value: Record<string, unknown>) => Record<string, unknown>;
-}
-
-/**
- * Resolves the SEO block + write target for a page or the site default.
- */
-function resolveTarget(
-  decofile: Record<string, unknown>,
-  target: SeoTarget,
-): ResolvedSeo | null {
-  if (target.kind === "site") {
-    const entry = findSiteSeoEntry(decofile);
-    if (!entry) return null;
-    return {
-      blockKey: entry.blockKey,
-      seoData: entry.seoData,
-      seoResolveType: entry.seoResolveType,
-      build: (value) => buildSiteSeoBlockData(entry, value),
-    };
-  }
-  const blockData = decofile[target.pageKey] as
-    | Record<string, unknown>
-    | undefined;
-  if (!blockData) return null;
-  const seo = blockData.seo as Record<string, unknown> | undefined;
-  return {
-    blockKey: target.pageKey,
-    seoData: seo,
-    seoResolveType:
-      typeof seo?.__resolveType === "string"
-        ? seo.__resolveType
-        : "website/sections/Seo/SeoV2.tsx",
-    build: (value) => ({ ...blockData, seo: value }),
-  };
-}
-
 export function SeoEditor({
   orgSlug,
   virtualMcpId,
@@ -86,7 +40,7 @@ export function SeoEditor({
   onEditDefaultSeo,
   onBack,
 }: SeoEditorProps) {
-  const resolved = resolveTarget(decofile, target);
+  const resolved = resolveSeoTarget(decofile, target);
   const seoData = resolved?.seoData;
   const seoSchema = resolved
     ? resolveSchema(resolved.seoResolveType, meta)
@@ -102,9 +56,10 @@ export function SeoEditor({
     setFormValue(null);
   }
 
-  const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const latestFormRef = useRef<Record<string, unknown> | null>(null);
+  const { save, isPending } = useDebouncedSaveBlock(
+    { orgSlug, virtualMcpId, branch },
+    { onSaved },
+  );
 
   const effectiveSeo = formValue ?? seoData ?? {};
 
@@ -122,20 +77,7 @@ export function SeoEditor({
     if (!resolved) return;
     const nextRecord = next as Record<string, unknown>;
     setFormValue(nextRecord);
-    latestFormRef.current = nextRecord;
-
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      const value = latestFormRef.current;
-      if (!value) return;
-      saveBlock.mutate(
-        { blockKey: resolved.blockKey, data: resolved.build(value) },
-        {
-          onSuccess: () => onSaved?.(),
-          onError: (err) => toast.error(`Save failed: ${err.message}`),
-        },
-      );
-    }, AUTOSAVE_DELAY);
+    save(resolved.blockKey, resolved.build(nextRecord));
   };
 
   const path = target.kind === "page" ? target.path : "/";
@@ -175,7 +117,7 @@ export function SeoEditor({
         )}
 
         <div className="ml-auto flex shrink-0 items-center gap-2">
-          {saveBlock.isPending && (
+          {isPending && (
             <Loading01
               size={14}
               className="animate-spin text-muted-foreground"

--- a/apps/mesh/src/web/components/sections-editor/seo-form-chrome.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-form-chrome.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from "react";
+import { Label } from "@deco/ui/components/label.tsx";
+import { Switch } from "@deco/ui/components/switch.tsx";
+import { isSeoEnabled, isSeoLazyRender } from "./seo-lazy-render";
+
+const ASYNC_RENDER_DOCS_URL =
+  "https://deco.cx/docs/en/performance/edge-async-render";
+
+interface SeoFormChromeProps {
+  rawSeo: unknown;
+  onEnableChange: (enabled: boolean) => void;
+  onAsyncRenderChange: (enabled: boolean) => void;
+  children?: ReactNode;
+}
+
+/** Page SEO chrome — Enable SEO + optional form + Async render (admin parity). */
+export function SeoFormChrome({
+  rawSeo,
+  onEnableChange,
+  onAsyncRenderChange,
+  children,
+}: SeoFormChromeProps) {
+  const enabled = isSeoEnabled(rawSeo);
+  const asyncRender = isSeoLazyRender(rawSeo);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <Label htmlFor="seo-enable" className="text-sm font-medium">
+          Enable SEO
+        </Label>
+        <Switch
+          id="seo-enable"
+          checked={enabled}
+          onCheckedChange={onEnableChange}
+        />
+      </div>
+
+      {enabled && (
+        <>
+          {children}
+          <div className="flex items-start justify-between gap-3 border-t pt-4">
+            <div className="min-w-0 space-y-1">
+              <p className="text-sm font-medium">Async render</p>
+              <p className="text-xs leading-normal text-muted-foreground">
+                Render SEO asynchronously with edge caching. Learn more in our{" "}
+                <a
+                  href={ASYNC_RENDER_DOCS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline-offset-4 hover:underline"
+                >
+                  documentation
+                </a>
+                .
+              </p>
+            </div>
+            <Switch
+              id="seo-async-render"
+              checked={asyncRender}
+              onCheckedChange={onAsyncRenderChange}
+              className="shrink-0"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-form-fields.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-form-fields.tsx
@@ -1,0 +1,57 @@
+import type { SchemaProperty } from "./resolve-schema";
+import { SchemaForm } from "./schema-form";
+import { GeneralSeoForm } from "./general-seo-form";
+import { filterSeoSchema, getSeoFormMode } from "./seo-form-mode";
+
+interface SeoFormFieldsProps {
+  schema: SchemaProperty;
+  resolveType: string;
+  value: Record<string, unknown>;
+  formResetKey: number;
+  onChange: (value: unknown) => void;
+  onBreadcrumbChange?: (path: string[]) => void;
+  /** Page SEO only — enables General "Use default" toggles. */
+  siteDefaultSeo?: Record<string, unknown>;
+}
+
+/**
+ * Renders SEO fields like admin: General uses BaseSEOForm fields + inherit
+ * toggles; PDP/PLP use a filtered schema subset; other types use full schema.
+ */
+export function SeoFormFields({
+  schema,
+  resolveType,
+  value,
+  formResetKey,
+  onChange,
+  onBreadcrumbChange,
+  siteDefaultSeo,
+}: SeoFormFieldsProps) {
+  const mode = getSeoFormMode(resolveType);
+
+  if (mode === "general") {
+    return (
+      <GeneralSeoForm
+        schema={schema}
+        value={value}
+        onChange={(next) => onChange(next)}
+        siteDefaultSeo={siteDefaultSeo}
+        formResetKey={formResetKey}
+      />
+    );
+  }
+
+  const filtered = filterSeoSchema(schema, resolveType);
+
+  return (
+    <SchemaForm
+      key={formResetKey}
+      schema={filtered}
+      value={value}
+      onChange={onChange}
+      basePath=""
+      breadcrumbPath={[]}
+      onBreadcrumbChange={onBreadcrumbChange ?? (() => {})}
+    />
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-form-mode.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-form-mode.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_SEO_RESOLVE_TYPE } from "./seo-block";
+import {
+  filterSeoSchema,
+  GENERAL_SEO_FIELD_KEYS,
+  getSeoFormMode,
+  PDP_SEO_FIELD_KEYS,
+  PLP_SEO_FIELD_KEYS,
+} from "./seo-form-mode";
+import type { SchemaProperty } from "./resolve-schema";
+
+const sampleSchema: SchemaProperty = {
+  type: "object",
+  properties: {
+    __resolveType: { type: "string" },
+    type: { type: "string", enum: ["website", "article"] },
+    title: { type: "string", title: "Title Override" },
+    description: { type: "string" },
+    canonical: { type: "string" },
+    favicon: { type: "string", format: "image-uri" },
+    image: { type: "string", format: "image-uri" },
+    themeColor: { type: "string", format: "color-input" },
+    titleTemplate: { type: "string" },
+    jsonLD: { type: "block-ref", title: "Data Source" },
+    omitVariants: { type: "boolean", title: "Omit Variants" },
+    noIndexing: { type: "boolean" },
+    ignoreStructuredData: { type: "boolean" },
+    configJsonLD: { type: "object" },
+  },
+};
+
+describe("getSeoFormMode", () => {
+  test("classifies SeoV2 as general", () => {
+    expect(getSeoFormMode(DEFAULT_SEO_RESOLVE_TYPE)).toBe("general");
+  });
+
+  test("classifies PDP and PLP resolve types", () => {
+    expect(getSeoFormMode("commerce/sections/Seo/SeoPDPV2.tsx")).toBe("pdp");
+    expect(getSeoFormMode("commerce/sections/Seo/SeoPLPV2.tsx")).toBe("plp");
+  });
+});
+
+describe("filterSeoSchema", () => {
+  test("general keeps only admin base fields", () => {
+    const filtered = filterSeoSchema(sampleSchema, DEFAULT_SEO_RESOLVE_TYPE);
+    expect(Object.keys(filtered.properties ?? {}).sort()).toEqual(
+      [...GENERAL_SEO_FIELD_KEYS].sort(),
+    );
+  });
+
+  test("pdp keeps commerce PDP fields", () => {
+    const filtered = filterSeoSchema(
+      sampleSchema,
+      "commerce/sections/Seo/SeoPDPV2.tsx",
+    );
+    expect(Object.keys(filtered.properties ?? {}).sort()).toEqual(
+      [...PDP_SEO_FIELD_KEYS].sort(),
+    );
+  });
+
+  test("plp keeps commerce PLP fields", () => {
+    const filtered = filterSeoSchema(
+      sampleSchema,
+      "commerce/sections/Seo/SeoPLPV2.tsx",
+    );
+    expect(Object.keys(filtered.properties ?? {}).sort()).toEqual(
+      [...PLP_SEO_FIELD_KEYS].sort(),
+    );
+  });
+
+  test("unknown type returns full schema", () => {
+    const filtered = filterSeoSchema(
+      sampleSchema,
+      "site/sections/Seo/SeoCustom.tsx",
+    );
+    expect(filtered).toBe(sampleSchema);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/seo-form-mode.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-form-mode.ts
@@ -1,0 +1,79 @@
+import { DEFAULT_SEO_RESOLVE_TYPE } from "./seo-block";
+import type { SchemaProperty } from "./resolve-schema";
+
+/** Admin `SEO_BASE_SCHEMA` — General pages only. */
+export const GENERAL_SEO_FIELD_KEYS = [
+  "type",
+  "title",
+  "description",
+  "canonical",
+  "favicon",
+  "image",
+  "themeColor",
+] as const;
+
+/** Product details (PDP) — matches commerce SeoPDP* props. */
+export const PDP_SEO_FIELD_KEYS = [
+  "jsonLD",
+  "omitVariants",
+  "title",
+  "description",
+  "noIndexing",
+  "ignoreStructuredData",
+] as const;
+
+/** Product listing (PLP) — matches commerce SeoPLP* props. */
+export const PLP_SEO_FIELD_KEYS = [
+  "jsonLD",
+  "title",
+  "description",
+  "noIndexing",
+  "configJsonLD",
+] as const;
+
+export type SeoFormMode = "general" | "pdp" | "plp" | "full";
+
+export function getSeoFormMode(resolveType: string): SeoFormMode {
+  if (
+    resolveType === DEFAULT_SEO_RESOLVE_TYPE ||
+    /\/Seo\/SeoV2\.tsx$/i.test(resolveType)
+  ) {
+    return "general";
+  }
+  if (/\/Seo\/SeoPDP/i.test(resolveType)) return "pdp";
+  if (/\/Seo\/SeoPLP/i.test(resolveType)) return "plp";
+  return "full";
+}
+
+function fieldKeysForMode(mode: SeoFormMode): readonly string[] | null {
+  switch (mode) {
+    case "general":
+      return GENERAL_SEO_FIELD_KEYS;
+    case "pdp":
+      return PDP_SEO_FIELD_KEYS;
+    case "plp":
+      return PLP_SEO_FIELD_KEYS;
+    default:
+      return null;
+  }
+}
+
+/** Picks the property subset shown in admin per SEO type. */
+export function filterSeoSchema(
+  schema: SchemaProperty,
+  resolveType: string,
+): SchemaProperty {
+  const keys = fieldKeysForMode(getSeoFormMode(resolveType));
+  if (!keys || !schema.properties) return schema;
+
+  const properties: Record<string, SchemaProperty> = {};
+  for (const key of keys) {
+    const prop = schema.properties[key];
+    if (prop) properties[key] = prop;
+  }
+  return { ...schema, properties };
+}
+
+export function generalSeoFieldsWithDefaultToggle(): readonly string[] {
+  return GENERAL_SEO_FIELD_KEYS.filter((k) => k !== "type");
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-lazy-render.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-lazy-render.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_SEO_RESOLVE_TYPE } from "./seo-block";
+import {
+  defaultEnabledSeo,
+  isSeoEnabled,
+  isSeoLazyRender,
+  LAZY_RENDER_RESOLVE_TYPE,
+  toggleSeoAsyncRender,
+  unwrapSeoConfig,
+  wrapSeoPersistValue,
+} from "./seo-lazy-render";
+
+describe("unwrapSeoConfig", () => {
+  test("returns null/undefined for disabled seo", () => {
+    expect(unwrapSeoConfig(null)).toBeNull();
+    expect(unwrapSeoConfig(undefined)).toBeUndefined();
+  });
+
+  test("unwraps lazy wrapper", () => {
+    const inner = {
+      __resolveType: "website/sections/Seo/SeoV2.tsx",
+      title: "A",
+    };
+    const raw = {
+      __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+      section: inner,
+    };
+    expect(isSeoLazyRender(raw)).toBe(true);
+    expect(unwrapSeoConfig(raw)).toEqual(inner);
+  });
+
+  test("passes through direct seo config", () => {
+    const seo = { __resolveType: DEFAULT_SEO_RESOLVE_TYPE, title: "Home" };
+    expect(unwrapSeoConfig(seo)).toEqual(seo);
+  });
+});
+
+describe("wrapSeoPersistValue", () => {
+  test("preserves lazy wrapper on save", () => {
+    const raw = {
+      __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+      section: { __resolveType: DEFAULT_SEO_RESOLVE_TYPE },
+    };
+    const next = wrapSeoPersistValue(
+      { __resolveType: DEFAULT_SEO_RESOLVE_TYPE, title: "New" },
+      raw,
+    );
+    expect(next).toEqual({
+      __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+      section: { __resolveType: DEFAULT_SEO_RESOLVE_TYPE, title: "New" },
+    });
+  });
+});
+
+describe("toggleSeoAsyncRender", () => {
+  test("wraps direct seo in lazy render", () => {
+    const seo = { __resolveType: DEFAULT_SEO_RESOLVE_TYPE };
+    const wrapped = toggleSeoAsyncRender(true, seo);
+    expect(wrapped).toEqual({
+      __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+      section: seo,
+    });
+  });
+
+  test("unwraps lazy render", () => {
+    const inner = { __resolveType: DEFAULT_SEO_RESOLVE_TYPE, title: "X" };
+    const wrapped = toggleSeoAsyncRender(false, {
+      __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+      section: inner,
+    });
+    expect(wrapped).toEqual(inner);
+  });
+});
+
+describe("defaultEnabledSeo", () => {
+  test("creates minimal enabled seo", () => {
+    expect(defaultEnabledSeo(DEFAULT_SEO_RESOLVE_TYPE)).toEqual({
+      __resolveType: DEFAULT_SEO_RESOLVE_TYPE,
+    });
+    expect(isSeoEnabled(defaultEnabledSeo(DEFAULT_SEO_RESOLVE_TYPE))).toBe(
+      true,
+    );
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/seo-lazy-render.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-lazy-render.ts
@@ -1,0 +1,74 @@
+import { isLazyResolveType } from "./section-lazy";
+
+export const LAZY_RENDER_RESOLVE_TYPE = "website/sections/Rendering/Lazy.tsx";
+
+function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === "object" && val !== null && !Array.isArray(val);
+}
+
+export interface SeoLazyWrapper {
+  __resolveType: string;
+  section?: Record<string, unknown> | null;
+}
+
+/** True when `page.seo` is wrapped in Lazy / SingleDeferred (admin async render). */
+export function isSeoLazyRender(raw: unknown): raw is SeoLazyWrapper {
+  if (!isPlainObject(raw)) return false;
+  const rt = raw.__resolveType;
+  return typeof rt === "string" && isLazyResolveType(rt);
+}
+
+export function isSeoEnabled(raw: unknown): boolean {
+  return raw !== null && raw !== undefined;
+}
+
+/** Inner SEO config for the form — unwraps lazy wrapper when present. */
+export function unwrapSeoConfig(
+  raw: unknown,
+): Record<string, unknown> | null | undefined {
+  if (raw === null || raw === undefined) return raw;
+  if (isSeoLazyRender(raw)) {
+    const section = raw.section;
+    if (section === null || section === undefined) return null;
+    return isPlainObject(section) ? section : {};
+  }
+  return isPlainObject(raw) ? raw : undefined;
+}
+
+/** Writes inner SEO edits back onto `page.seo`, preserving lazy wrapper when set. */
+export function wrapSeoPersistValue(
+  inner: Record<string, unknown> | null,
+  rawSeo: unknown,
+): Record<string, unknown> | null {
+  if (inner === null) return null;
+  if (isSeoLazyRender(rawSeo)) {
+    return { ...rawSeo, section: inner };
+  }
+  return inner;
+}
+
+export function defaultEnabledSeo(
+  defaultResolveType: string,
+): Record<string, unknown> {
+  return { __resolveType: defaultResolveType };
+}
+
+/** Wrap or unwrap lazy render on the full `page.seo` value (admin parity). */
+export function toggleSeoAsyncRender(
+  enabled: boolean,
+  rawSeo: unknown,
+): Record<string, unknown> | null {
+  if (!isSeoEnabled(rawSeo)) return null;
+  if (enabled) {
+    const inner = unwrapSeoConfig(rawSeo) ?? {};
+    return {
+      __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+      section: inner,
+    };
+  }
+  if (isSeoLazyRender(rawSeo)) {
+    const inner = unwrapSeoConfig(rawSeo);
+    return inner;
+  }
+  return isPlainObject(rawSeo) ? rawSeo : null;
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-lazy-render.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-lazy-render.ts
@@ -67,8 +67,7 @@ export function toggleSeoAsyncRender(
     };
   }
   if (isSeoLazyRender(rawSeo)) {
-    const inner = unwrapSeoConfig(rawSeo);
-    return inner;
+    return unwrapSeoConfig(rawSeo) ?? null;
   }
   return isPlainObject(rawSeo) ? rawSeo : null;
 }

--- a/apps/mesh/src/web/components/sections-editor/seo-preview.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-preview.tsx
@@ -21,6 +21,21 @@ function str(v: unknown): string | undefined {
   return typeof v === "string" && v.trim() ? v : undefined;
 }
 
+/** Only allow remote https images in the editor preview (blocks javascript:, data:, etc.). */
+function safePreviewImageUrl(
+  raw: string | undefined,
+  baseUrl: string | null | undefined,
+): string | undefined {
+  if (!raw) return undefined;
+  try {
+    const url = baseUrl ? new URL(raw, baseUrl) : new URL(raw);
+    if (url.protocol !== "https:") return undefined;
+    return url.href;
+  } catch {
+    return undefined;
+  }
+}
+
 function readSeo(seo: Record<string, unknown> | null | undefined): SeoValues {
   if (!seo) return {};
   const rawTitle = str(seo.title);
@@ -83,6 +98,7 @@ function PreviewImage({
       <img
         src={src}
         alt=""
+        referrerPolicy="no-referrer"
         className={className}
         style={{ objectFit: "cover" }}
       />
@@ -323,7 +339,12 @@ export function SeoPreview({
   url: string | null | undefined;
   path?: string;
 }) {
-  const values = readSeo(seo);
+  const raw = readSeo(seo);
+  const values: SeoValues = {
+    ...raw,
+    image: safePreviewImageUrl(raw.image, url),
+    favicon: safePreviewImageUrl(raw.favicon, url),
+  };
   const host = hostFromUrl(url);
   const displayPath = path === "/" ? "" : path;
 

--- a/apps/mesh/src/web/components/sections-editor/seo-preview.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-preview.tsx
@@ -1,0 +1,343 @@
+import { Image01 } from "@untitledui/icons";
+
+/**
+ * Live, multi-platform preview of how a page's SEO/Open-Graph metadata renders
+ * across search and social/chat apps. Read-only — purely reflects the current
+ * SEO form values so editors can see the result while they type.
+ *
+ * The cards intentionally use fixed (non-theme) colors: they emulate the real
+ * apps (Google's blue link, Discord's dark embed, …), so they look the same in
+ * light and dark mode, like a screenshot would.
+ */
+
+interface SeoValues {
+  title?: string;
+  description?: string;
+  image?: string;
+  favicon?: string;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim() ? v : undefined;
+}
+
+function readSeo(seo: Record<string, unknown> | null | undefined): SeoValues {
+  if (!seo) return {};
+  const rawTitle = str(seo.title);
+  const template = str(seo.titleTemplate);
+  const title =
+    rawTitle && template?.includes("%s")
+      ? template.replace(/%s/g, rawTitle)
+      : rawTitle;
+  return {
+    title,
+    description: str(seo.description),
+    image: str(seo.image),
+    favicon: str(seo.favicon),
+  };
+}
+
+function hostFromUrl(url: string | null | undefined): string {
+  if (!url) return "example.com";
+  try {
+    return new URL(url).host;
+  } catch {
+    return "example.com";
+  }
+}
+
+const FALLBACK_TITLE = "Your page title";
+const FALLBACK_DESC = "Your meta description will appear here.";
+
+type Layout = "search" | "card" | "chat" | "attachment";
+
+interface Platform {
+  id: string;
+  label: string;
+  color: string;
+  layout: Layout;
+}
+
+const PLATFORMS: Platform[] = [
+  { id: "google", label: "Google", color: "#4285F4", layout: "search" },
+  { id: "facebook", label: "Facebook", color: "#1877F2", layout: "card" },
+  { id: "twitter", label: "X (Twitter)", color: "#0f1419", layout: "card" },
+  { id: "linkedin", label: "LinkedIn", color: "#0A66C2", layout: "card" },
+  { id: "whatsapp", label: "WhatsApp", color: "#25D366", layout: "chat" },
+  { id: "telegram", label: "Telegram", color: "#229ED9", layout: "chat" },
+  { id: "slack", label: "Slack", color: "#611f69", layout: "attachment" },
+  { id: "discord", label: "Discord", color: "#5865F2", layout: "attachment" },
+];
+
+function PreviewImage({
+  src,
+  className,
+  iconSize = 20,
+}: {
+  src?: string;
+  className?: string;
+  iconSize?: number;
+}) {
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt=""
+        className={className}
+        style={{ objectFit: "cover" }}
+      />
+    );
+  }
+  return (
+    <div
+      className={className}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#e5e7eb",
+        color: "#9ca3af",
+      }}
+    >
+      <Image01 size={iconSize} />
+    </div>
+  );
+}
+
+function GoogleCard({ seo, host, path }: PreviewBodyProps) {
+  return (
+    <div
+      className="rounded-lg p-3 text-left"
+      style={{ background: "#fff", border: "1px solid #dadce0" }}
+    >
+      <div className="flex items-center gap-2">
+        <div
+          className="flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-full"
+          style={{ background: "#f1f3f4" }}
+        >
+          {seo.favicon ? (
+            <img src={seo.favicon} alt="" className="size-full object-cover" />
+          ) : (
+            <Image01 size={12} color="#9aa0a6" />
+          )}
+        </div>
+        <div className="min-w-0">
+          <div
+            className="truncate text-[13px] leading-tight"
+            style={{ color: "#202124" }}
+          >
+            {host}
+          </div>
+          <div
+            className="truncate text-[12px] leading-tight"
+            style={{ color: "#4d5156" }}
+          >
+            {host}
+            {path}
+          </div>
+        </div>
+      </div>
+      <div
+        className="mt-1.5 truncate text-[18px] leading-snug"
+        style={{ color: "#1a0dab" }}
+      >
+        {seo.title ?? FALLBACK_TITLE}
+      </div>
+      <div
+        className="mt-0.5 line-clamp-2 text-[13px] leading-snug"
+        style={{ color: "#4d5156" }}
+      >
+        {seo.description ?? FALLBACK_DESC}
+      </div>
+    </div>
+  );
+}
+
+function OgCard({ seo, host }: PreviewBodyProps) {
+  return (
+    <div
+      className="overflow-hidden rounded-lg text-left"
+      style={{ background: "#fff", border: "1px solid #e2e8f0" }}
+    >
+      <PreviewImage src={seo.image} className="h-40 w-full" />
+      <div className="px-3 py-2" style={{ borderTop: "1px solid #e2e8f0" }}>
+        <div className="truncate text-[11px]" style={{ color: "#8a9099" }}>
+          {host}
+        </div>
+        <div
+          className="line-clamp-1 text-[14px] font-semibold"
+          style={{ color: "#1c2024" }}
+        >
+          {seo.title ?? FALLBACK_TITLE}
+        </div>
+        <div className="line-clamp-2 text-[12px]" style={{ color: "#60666c" }}>
+          {seo.description ?? FALLBACK_DESC}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChatCard({
+  seo,
+  host,
+  accent,
+}: PreviewBodyProps & { accent: string }) {
+  return (
+    <div className="rounded-lg p-2 text-left" style={{ background: "#f0f2f5" }}>
+      <p className="px-1 pb-1.5 text-[12px]" style={{ color: "#3b4045" }}>
+        Here's a post you might write with the link of your website:
+      </p>
+      <div
+        className="overflow-hidden rounded-md"
+        style={{
+          background: "#fff",
+          borderLeft: `3px solid ${accent}`,
+        }}
+      >
+        <PreviewImage src={seo.image} className="h-28 w-full" iconSize={18} />
+        <div className="px-2.5 py-1.5">
+          <div
+            className="line-clamp-1 text-[12px] font-semibold"
+            style={{ color: "#1c2024" }}
+          >
+            {seo.title ?? FALLBACK_TITLE}
+          </div>
+          <div
+            className="line-clamp-2 text-[11px]"
+            style={{ color: "#60666c" }}
+          >
+            {seo.description ?? FALLBACK_DESC}
+          </div>
+          <div className="mt-0.5 text-[10px]" style={{ color: "#8a9099" }}>
+            {host}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AttachmentCard({
+  seo,
+  host,
+  accent,
+  dark,
+}: PreviewBodyProps & { accent: string; dark?: boolean }) {
+  const bg = dark ? "#2b2d31" : "#fff";
+  const titleColor = dark ? "#00a8fc" : "#1264a3";
+  const descColor = dark ? "#dbdee1" : "#3b4045";
+  const metaColor = dark ? "#949ba4" : "#8a9099";
+  return (
+    <div
+      className="rounded-lg p-2.5 text-left"
+      style={{ background: bg, border: dark ? "none" : "1px solid #e2e8f0" }}
+    >
+      <div
+        className="flex gap-2.5 pl-2.5"
+        style={{ borderLeft: `3px solid ${accent}`, borderRadius: 2 }}
+      >
+        <div className="min-w-0 flex-1">
+          <div className="text-[10px]" style={{ color: metaColor }}>
+            {host}
+          </div>
+          <div
+            className="line-clamp-1 text-[13px] font-semibold"
+            style={{ color: titleColor }}
+          >
+            {seo.title ?? FALLBACK_TITLE}
+          </div>
+          <div
+            className="line-clamp-2 text-[12px]"
+            style={{ color: descColor }}
+          >
+            {seo.description ?? FALLBACK_DESC}
+          </div>
+        </div>
+        <PreviewImage
+          src={seo.image}
+          className="size-14 shrink-0 rounded"
+          iconSize={16}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface PreviewBodyProps {
+  seo: SeoValues;
+  host: string;
+  path: string;
+}
+
+function PlatformCard({
+  platform,
+  seo,
+  host,
+  path,
+}: {
+  platform: Platform;
+  seo: SeoValues;
+  host: string;
+  path: string;
+}) {
+  const body =
+    platform.layout === "search" ? (
+      <GoogleCard seo={seo} host={host} path={path} />
+    ) : platform.layout === "card" ? (
+      <OgCard seo={seo} host={host} path={path} />
+    ) : platform.layout === "chat" ? (
+      <ChatCard seo={seo} host={host} path={path} accent={platform.color} />
+    ) : (
+      <AttachmentCard
+        seo={seo}
+        host={host}
+        path={path}
+        accent={platform.color}
+        dark={platform.id === "discord"}
+      />
+    );
+
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center gap-1.5">
+        <span
+          className="size-2 shrink-0 rounded-full"
+          style={{ background: platform.color }}
+        />
+        <span className="text-xs font-medium text-muted-foreground">
+          {platform.label}
+        </span>
+      </div>
+      {body}
+    </div>
+  );
+}
+
+export function SeoPreview({
+  seo,
+  url,
+  path = "/",
+}: {
+  seo: Record<string, unknown> | null | undefined;
+  url: string | null | undefined;
+  path?: string;
+}) {
+  const values = readSeo(seo);
+  const host = hostFromUrl(url);
+  const displayPath = path === "/" ? "" : path;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 @2xl:grid-cols-2">
+      {PLATFORMS.map((platform) => (
+        <PlatformCard
+          key={platform.id}
+          platform={platform}
+          seo={values}
+          host={host}
+          path={displayPath}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-save.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-save.test.ts
@@ -146,6 +146,7 @@ describe("buildSeoSavePayload", () => {
   test("page: seo null payload disables seo", () => {
     const resolved: ResolvedSeo = {
       blockKey: "home",
+      seoData: undefined,
       seoResolveType: "website/sections/Seo/SeoV2.tsx",
       build: () => ({}),
     };
@@ -166,6 +167,7 @@ describe("buildSeoSavePayload", () => {
 describe("activeSeoResolveType", () => {
   const resolved: ResolvedSeo = {
     blockKey: "home",
+    seoData: undefined,
     seoResolveType: "website/sections/Seo/SeoV2.tsx",
     build: () => ({}),
   };

--- a/apps/mesh/src/web/components/sections-editor/seo-save.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-save.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { buildSeoSavePayload } from "./seo-save";
+import type { ResolvedSeo } from "./seo-block";
+
+describe("buildSeoSavePayload", () => {
+  test("page: merges seo into the latest page block", () => {
+    const resolved: ResolvedSeo = {
+      blockKey: "home",
+      seoData: { title: "Old" },
+      seoResolveType: "website/sections/Seo/SeoV2.tsx",
+      build: () => ({}),
+    };
+    const latest = {
+      __resolveType: "website/pages/Page.tsx",
+      name: "Renamed",
+      sections: ["a"],
+      seo: { title: "Old" },
+    };
+    expect(
+      buildSeoSavePayload(
+        { kind: "page", pageKey: "home", pageName: "Home", path: "/" },
+        resolved,
+        latest,
+        { title: "New" },
+      ),
+    ).toEqual({
+      __resolveType: "website/pages/Page.tsx",
+      name: "Renamed",
+      sections: ["a"],
+      seo: { title: "New" },
+    });
+  });
+
+  test("site nested: preserves sibling fields on the config block", () => {
+    const resolved: ResolvedSeo = {
+      blockKey: "site",
+      seoData: { title: "Old" },
+      seoResolveType: "website/sections/Seo/SeoV2.tsx",
+      siteKind: "nested",
+      build: () => ({}),
+    };
+    const latest = {
+      __resolveType: "site/apps/site.ts",
+      theme: { color: "blue" },
+      seo: { title: "Old" },
+    };
+    expect(
+      buildSeoSavePayload({ kind: "site" }, resolved, latest, { title: "New" }),
+    ).toEqual({
+      __resolveType: "site/apps/site.ts",
+      theme: { color: "blue" },
+      seo: { title: "New" },
+    });
+  });
+
+  test("site block: replaces the whole SEO block entry", () => {
+    const resolved: ResolvedSeo = {
+      blockKey: "seoBlock",
+      seoData: { title: "Old" },
+      seoResolveType: "website/sections/Seo/SeoV2.tsx",
+      siteKind: "block",
+      build: () => ({}),
+    };
+    expect(
+      buildSeoSavePayload(
+        { kind: "site" },
+        resolved,
+        { __resolveType: "website/sections/Seo/SeoV2.tsx", title: "Old" },
+        { title: "Standalone" },
+      ),
+    ).toEqual({ title: "Standalone" });
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/seo-save.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-save.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { buildSeoSavePayload } from "./seo-save";
+import { activeSeoResolveType, buildSeoSavePayload } from "./seo-save";
 import type { ResolvedSeo } from "./seo-block";
+import { LAZY_RENDER_RESOLVE_TYPE } from "./seo-lazy-render";
 
 describe("buildSeoSavePayload", () => {
   test("page: merges seo into the latest page block", () => {
@@ -69,5 +70,118 @@ describe("buildSeoSavePayload", () => {
         { title: "Standalone" },
       ),
     ).toEqual({ title: "Standalone" });
+  });
+
+  test("page: preserves lazy wrapper when editing inner seo", () => {
+    const resolved: ResolvedSeo = {
+      blockKey: "pdp",
+      seoData: { __resolveType: "commerce/sections/Seo/SeoPDPV2.tsx" },
+      rawSeoData: {
+        __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+        section: { __resolveType: "commerce/sections/Seo/SeoPDPV2.tsx" },
+      },
+      seoResolveType: "commerce/sections/Seo/SeoPDPV2.tsx",
+      build: () => ({}),
+    };
+    const latest = {
+      __resolveType: "website/pages/Page.tsx",
+      seo: {
+        __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+        section: {
+          __resolveType: "commerce/sections/Seo/SeoPDPV2.tsx",
+          title: "Old",
+        },
+      },
+    };
+    expect(
+      buildSeoSavePayload(
+        { kind: "page", pageKey: "pdp", pageName: "PDP", path: "/p" },
+        resolved,
+        latest,
+        {
+          __resolveType: "commerce/sections/Seo/SeoPDPV2.tsx",
+          title: "New",
+        },
+      ),
+    ).toEqual({
+      __resolveType: "website/pages/Page.tsx",
+      seo: {
+        __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+        section: {
+          __resolveType: "commerce/sections/Seo/SeoPDPV2.tsx",
+          title: "New",
+        },
+      },
+    });
+  });
+
+  test("page: latest seo null does not resurrect lazy rawSeoData on inner save", () => {
+    const resolved: ResolvedSeo = {
+      blockKey: "home",
+      seoData: { title: "Old" },
+      rawSeoData: {
+        __resolveType: LAZY_RENDER_RESOLVE_TYPE,
+        section: { title: "Old" },
+      },
+      seoResolveType: "website/sections/Seo/SeoV2.tsx",
+      build: () => ({}),
+    };
+    const latest = {
+      __resolveType: "website/pages/Page.tsx",
+      seo: null,
+    };
+    expect(
+      buildSeoSavePayload(
+        { kind: "page", pageKey: "home", pageName: "Home", path: "/" },
+        resolved,
+        latest,
+        { title: "Re-enabled" },
+      ),
+    ).toEqual({
+      __resolveType: "website/pages/Page.tsx",
+      seo: { title: "Re-enabled" },
+    });
+  });
+
+  test("page: seo null payload disables seo", () => {
+    const resolved: ResolvedSeo = {
+      blockKey: "home",
+      seoResolveType: "website/sections/Seo/SeoV2.tsx",
+      build: () => ({}),
+    };
+    expect(
+      buildSeoSavePayload(
+        { kind: "page", pageKey: "home", pageName: "Home", path: "/" },
+        resolved,
+        { __resolveType: "website/pages/Page.tsx", seo: { title: "X" } },
+        null,
+      ),
+    ).toEqual({
+      __resolveType: "website/pages/Page.tsx",
+      seo: null,
+    });
+  });
+});
+
+describe("activeSeoResolveType", () => {
+  const resolved: ResolvedSeo = {
+    blockKey: "home",
+    seoResolveType: "website/sections/Seo/SeoV2.tsx",
+    build: () => ({}),
+  };
+
+  test("uses effective __resolveType when set", () => {
+    expect(
+      activeSeoResolveType(
+        { __resolveType: "commerce/sections/Seo/SeoPDPV2.tsx" },
+        resolved,
+      ),
+    ).toBe("commerce/sections/Seo/SeoPDPV2.tsx");
+  });
+
+  test("falls back to resolved default when __resolveType missing", () => {
+    expect(activeSeoResolveType({ title: "X" }, resolved)).toBe(
+      "website/sections/Seo/SeoV2.tsx",
+    );
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/seo-save.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-save.ts
@@ -1,0 +1,74 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+import type { ResolvedSeo, SeoTarget } from "./seo-block";
+import { useDebouncedSaveBlock } from "./use-save-block";
+
+function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === "object" && val !== null && !Array.isArray(val);
+}
+
+/**
+ * Merges edited SEO into the latest decofile block at save time (read-modify-write),
+ * so concurrent section/name/path edits are not clobbered by a render-time snapshot.
+ */
+export function buildSeoSavePayload(
+  target: SeoTarget,
+  resolved: ResolvedSeo,
+  latestBlock: unknown,
+  seoValue: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (target.kind === "page") {
+    if (!isPlainObject(latestBlock)) return null;
+    return { ...latestBlock, seo: seoValue };
+  }
+  if (!isPlainObject(latestBlock)) return null;
+  if (resolved.siteKind === "block") return seoValue;
+  return { ...latestBlock, seo: seoValue };
+}
+
+export function activeSeoResolveType(
+  effectiveSeo: Record<string, unknown>,
+  resolved: ResolvedSeo,
+): string {
+  const rt = effectiveSeo.__resolveType;
+  return typeof rt === "string" && rt.length > 0 ? rt : resolved.seoResolveType;
+}
+
+interface UseSeoFormSaveParams {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  target: SeoTarget;
+  resolved: ResolvedSeo | null;
+  onSaved?: () => void;
+}
+
+/** Debounced SEO persist with fire-time decofile merge and explicit flush on close. */
+export function useSeoFormSave({
+  orgSlug,
+  virtualMcpId,
+  branch,
+  target,
+  resolved,
+  onSaved,
+}: UseSeoFormSaveParams) {
+  const queryClient = useQueryClient();
+  const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
+  const { save, flush, isPending } = useDebouncedSaveBlock(
+    { orgSlug, virtualMcpId, branch },
+    { onSaved },
+  );
+
+  const persistSeo = (seoValue: Record<string, unknown>) => {
+    if (!resolved) return;
+    save(resolved.blockKey, () => {
+      const decofile = queryClient.getQueryData<Record<string, unknown>>(
+        KEYS.decofile(cacheKey),
+      );
+      const latest = decofile?.[resolved.blockKey];
+      return buildSeoSavePayload(target, resolved, latest, seoValue);
+    });
+  };
+
+  return { persistSeo, flush, isPending };
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-save.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-save.ts
@@ -1,6 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
 import type { ResolvedSeo, SeoTarget } from "./seo-block";
+import { wrapSeoPersistValue } from "./seo-lazy-render";
 import { useDebouncedSaveBlock } from "./use-save-block";
 
 function isPlainObject(val: unknown): val is Record<string, unknown> {
@@ -15,11 +16,18 @@ export function buildSeoSavePayload(
   target: SeoTarget,
   resolved: ResolvedSeo,
   latestBlock: unknown,
-  seoValue: Record<string, unknown>,
+  seoValue: Record<string, unknown> | null,
 ): Record<string, unknown> | null {
   if (target.kind === "page") {
     if (!isPlainObject(latestBlock)) return null;
-    return { ...latestBlock, seo: seoValue };
+    const latestRawSeo = latestBlock.seo;
+    return {
+      ...latestBlock,
+      seo:
+        seoValue === null
+          ? null
+          : wrapSeoPersistValue(seoValue, latestRawSeo ?? resolved.rawSeoData),
+    };
   }
   if (!isPlainObject(latestBlock)) return null;
   if (resolved.siteKind === "block") return seoValue;
@@ -59,7 +67,7 @@ export function useSeoFormSave({
     { onSaved },
   );
 
-  const persistSeo = (seoValue: Record<string, unknown>) => {
+  const persistSeo = (seoValue: Record<string, unknown> | null) => {
     if (!resolved) return;
     save(resolved.blockKey, () => {
       const decofile = queryClient.getQueryData<Record<string, unknown>>(
@@ -70,5 +78,18 @@ export function useSeoFormSave({
     });
   };
 
-  return { persistSeo, flush, isPending };
+  /** Persists the full `page.seo` value (enable/disable, async render toggles). */
+  const persistRawSeo = (rawSeo: Record<string, unknown> | null) => {
+    if (!resolved || target.kind !== "page") return;
+    save(resolved.blockKey, () => {
+      const decofile = queryClient.getQueryData<Record<string, unknown>>(
+        KEYS.decofile(cacheKey),
+      );
+      const latest = decofile?.[resolved.blockKey];
+      if (!isPlainObject(latest)) return null;
+      return { ...latest, seo: rawSeo };
+    });
+  };
+
+  return { persistSeo, persistRawSeo, flush, isPending };
 }

--- a/apps/mesh/src/web/components/sections-editor/seo-save.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-save.ts
@@ -20,13 +20,11 @@ export function buildSeoSavePayload(
 ): Record<string, unknown> | null {
   if (target.kind === "page") {
     if (!isPlainObject(latestBlock)) return null;
-    const latestRawSeo = latestBlock.seo;
+    const rawForWrap =
+      latestBlock.seo !== undefined ? latestBlock.seo : resolved.rawSeoData;
     return {
       ...latestBlock,
-      seo:
-        seoValue === null
-          ? null
-          : wrapSeoPersistValue(seoValue, latestRawSeo ?? resolved.rawSeoData),
+      seo: seoValue === null ? null : wrapSeoPersistValue(seoValue, rawForWrap),
     };
   }
   if (!isPlainObject(latestBlock)) return null;

--- a/apps/mesh/src/web/components/sections-editor/seo-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-schema.test.ts
@@ -77,6 +77,9 @@ describe("listPageSeoTypeOptions", () => {
       "website/sections/Seo/SeoV2.tsx",
       "website/sections/Seo/SeoPDPV2.tsx",
     ]);
+    expect(
+      options.find((o) => o.resolveType === DEFAULT_SEO_RESOLVE_TYPE)?.title,
+    ).toBe("General");
     expect(options[1]?.title).toBe("Product page");
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/seo-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-schema.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import type { LiveMeta } from "./resolve-schema";
+import {
+  defaultPageSeoResolveType,
+  defaultSiteSeoResolveType,
+  listPageSeoTypeOptions,
+  resolvePageSeoResolveType,
+  resolveSiteSeoResolveType,
+} from "./seo-schema";
+import { DEFAULT_SEO_RESOLVE_TYPE } from "./seo-block";
+
+function metaWithPageSeoUnion(): LiveMeta {
+  return {
+    manifest: {
+      blocks: {
+        pages: {
+          "website/pages/Page.tsx": { $ref: "#/definitions/Page" },
+        },
+        sections: {
+          "website/sections/Seo/SeoV2.tsx": {
+            $ref: "#/definitions/SeoV2",
+          },
+          "website/sections/Seo/SeoPDPV2.tsx": {
+            $ref: "#/definitions/SeoPDPV2",
+          },
+        },
+      },
+    },
+    schema: {
+      definitions: {
+        Page: {
+          type: "object",
+          properties: {
+            seo: {
+              anyOf: [
+                { $ref: "#/definitions/SeoV2Section" },
+                { $ref: "#/definitions/SeoPDPV2Section" },
+              ],
+            },
+          },
+        },
+        SeoV2Section: {
+          allOf: [
+            {
+              properties: {
+                __resolveType: {
+                  enum: ["website/sections/Seo/SeoV2.tsx"],
+                },
+              },
+            },
+          ],
+          title: "General pages",
+        },
+        SeoPDPV2Section: {
+          allOf: [
+            {
+              properties: {
+                __resolveType: {
+                  enum: ["website/sections/Seo/SeoPDPV2.tsx"],
+                },
+              },
+            },
+          ],
+          title: "Product page",
+        },
+        SeoV2: { title: "Seo V2" },
+        SeoPDPV2: { title: "Seo PDP V2" },
+      },
+    },
+  };
+}
+
+describe("listPageSeoTypeOptions", () => {
+  test("reads SEO variants from the live page schema seo anyOf", () => {
+    const options = listPageSeoTypeOptions(metaWithPageSeoUnion());
+    expect(options.map((o) => o.resolveType)).toEqual([
+      "website/sections/Seo/SeoV2.tsx",
+      "website/sections/Seo/SeoPDPV2.tsx",
+    ]);
+    expect(options[1]?.title).toBe("Product page");
+  });
+});
+
+describe("resolvePageSeoResolveType", () => {
+  test("uses page data __resolveType when set", () => {
+    expect(
+      resolvePageSeoResolveType(metaWithPageSeoUnion(), {
+        __resolveType: "website/sections/Seo/SeoPDPV2.tsx",
+      }),
+    ).toBe("website/sections/Seo/SeoPDPV2.tsx");
+  });
+
+  test("defaults to SeoV2 when schema lists it and data has no type", () => {
+    expect(
+      resolvePageSeoResolveType(metaWithPageSeoUnion(), { title: "Home" }),
+    ).toBe(DEFAULT_SEO_RESOLVE_TYPE);
+    expect(defaultPageSeoResolveType(metaWithPageSeoUnion())).toBe(
+      DEFAULT_SEO_RESOLVE_TYPE,
+    );
+  });
+});
+
+describe("resolveSiteSeoResolveType", () => {
+  test("defaults inlined site seo using site block schema", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          apps: {
+            "site/apps/site.ts": { $ref: "#/definitions/SiteApp" },
+          },
+          pages: {
+            "website/pages/Page.tsx": { $ref: "#/definitions/Page" },
+          },
+          sections: {
+            "website/sections/Seo/SeoV3.tsx": {
+              $ref: "#/definitions/SeoV3",
+            },
+          },
+        },
+      },
+      schema: {
+        definitions: {
+          SiteApp: {
+            type: "object",
+            properties: {
+              seo: {
+                anyOf: [{ $ref: "#/definitions/SeoV3Section" }],
+              },
+            },
+          },
+          SeoV3Section: {
+            allOf: [
+              {
+                properties: {
+                  __resolveType: {
+                    enum: ["website/sections/Seo/SeoV3.tsx"],
+                  },
+                },
+              },
+            ],
+            title: "Site SEO",
+          },
+          Page: {
+            type: "object",
+            properties: {
+              seo: {
+                anyOf: [{ $ref: "#/definitions/SeoV2Section" }],
+              },
+            },
+          },
+          SeoV2Section: {
+            allOf: [
+              {
+                properties: {
+                  __resolveType: {
+                    enum: ["website/sections/Seo/SeoV2.tsx"],
+                  },
+                },
+              },
+            ],
+            title: "General",
+          },
+          SeoV3: {},
+        },
+      },
+    };
+
+    expect(
+      resolveSiteSeoResolveType(
+        meta,
+        { __resolveType: "site/apps/site.ts" },
+        { title: "Store" },
+      ),
+    ).toBe("website/sections/Seo/SeoV3.tsx");
+    expect(
+      defaultSiteSeoResolveType(meta, { __resolveType: "site/apps/site.ts" }),
+    ).toBe("website/sections/Seo/SeoV3.tsx");
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/seo-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-schema.ts
@@ -10,6 +10,9 @@ import {
 } from "./resolve-schema";
 import { DEFAULT_SEO_RESOLVE_TYPE } from "./seo-block";
 
+/** Admin's `SEO_OPTION` label for `website/sections/Seo/SeoV2.tsx`. */
+export const DEFAULT_SEO_TYPE_LABEL = "General";
+
 export interface SeoTypeOption {
   resolveType: string;
   title: string;
@@ -22,6 +25,11 @@ export function isSeoSectionResolveType(resolveType: string): boolean {
     /\/Seo(V\d+)?\.tsx$/i.test(resolveType) ||
     resolveType.includes("/sections/Seo")
   );
+}
+
+function seoTypeLabel(resolveType: string, title: string): string {
+  if (resolveType === DEFAULT_SEO_RESOLVE_TYPE) return DEFAULT_SEO_TYPE_LABEL;
+  return title;
 }
 
 function seoOptionsFromPropertySchema(
@@ -37,7 +45,7 @@ function seoOptionsFromPropertySchema(
     seen.add(ref.resolveType);
     options.push({
       resolveType: ref.resolveType,
-      title: ref.title,
+      title: seoTypeLabel(ref.resolveType, ref.title),
       description: ref.description,
     });
   }
@@ -65,13 +73,14 @@ function listManifestSeoSectionOptions(meta: LiveMeta): SeoTypeOption[] {
     if (!blockType.includes("sections")) continue;
     for (const resolveType of Object.keys(blockMap)) {
       if (!isSeoSectionResolveType(resolveType)) continue;
+      const shortTitle =
+        resolveType
+          .split("/")
+          .pop()
+          ?.replace(/\.tsx?$/, "") ?? resolveType;
       options.push({
         resolveType,
-        title:
-          resolveType
-            .split("/")
-            .pop()
-            ?.replace(/\.tsx?$/, "") ?? resolveType,
+        title: seoTypeLabel(resolveType, shortTitle),
       });
     }
   }

--- a/apps/mesh/src/web/components/sections-editor/seo-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-schema.ts
@@ -1,0 +1,142 @@
+import { isSavedBlockResolveType } from "./block-type-utils";
+import {
+  collectAnyOfRefsFromSchema,
+  findLivePageResolveType,
+} from "./section-catalog";
+import {
+  resolveSchema,
+  type LiveMeta,
+  type SchemaProperty,
+} from "./resolve-schema";
+import { DEFAULT_SEO_RESOLVE_TYPE } from "./seo-block";
+
+export interface SeoTypeOption {
+  resolveType: string;
+  title: string;
+  description?: string;
+}
+
+/** Matches SEO section resolveTypes, e.g. "website/sections/Seo/SeoV2.tsx". */
+export function isSeoSectionResolveType(resolveType: string): boolean {
+  return (
+    /\/Seo(V\d+)?\.tsx$/i.test(resolveType) ||
+    resolveType.includes("/sections/Seo")
+  );
+}
+
+function seoOptionsFromPropertySchema(
+  schema: SchemaProperty | null | undefined,
+): SeoTypeOption[] {
+  const refs = collectAnyOfRefsFromSchema(schema);
+  const seen = new Set<string>();
+  const options: SeoTypeOption[] = [];
+  for (const ref of refs) {
+    if (!isSeoSectionResolveType(ref.resolveType)) continue;
+    if (isSavedBlockResolveType(ref.resolveType)) continue;
+    if (seen.has(ref.resolveType)) continue;
+    seen.add(ref.resolveType);
+    options.push({
+      resolveType: ref.resolveType,
+      title: ref.title,
+      description: ref.description,
+    });
+  }
+  return options;
+}
+
+/**
+ * Lists valid page-level SEO section types from the live page schema's `seo`
+ * property (JSON Schema anyOf), mirroring admin's `getAllPageSeoSectionSchemas`.
+ */
+export function listPageSeoTypeOptions(meta: LiveMeta): SeoTypeOption[] {
+  const pageRt = findLivePageResolveType(meta);
+  const pageSchema = resolveSchema(pageRt, meta);
+  const fromPage = seoOptionsFromPropertySchema(pageSchema?.properties?.seo);
+  if (fromPage.length > 0) return fromPage;
+
+  return listManifestSeoSectionOptions(meta);
+}
+
+/** SEO section types declared in the manifest when the page schema has no `seo` union. */
+function listManifestSeoSectionOptions(meta: LiveMeta): SeoTypeOption[] {
+  const blocks = meta.manifest?.blocks ?? {};
+  const options: SeoTypeOption[] = [];
+  for (const [blockType, blockMap] of Object.entries(blocks)) {
+    if (!blockType.includes("sections")) continue;
+    for (const resolveType of Object.keys(blockMap)) {
+      if (!isSeoSectionResolveType(resolveType)) continue;
+      options.push({
+        resolveType,
+        title:
+          resolveType
+            .split("/")
+            .pop()
+            ?.replace(/\.tsx?$/, "") ?? resolveType,
+      });
+    }
+  }
+  return options;
+}
+
+/**
+ * Default page SEO type: prefer SeoV2 when the schema allows it (admin's
+ * `SEO_OPTION`), otherwise the first schema-listed SEO variant.
+ */
+export function defaultPageSeoResolveType(meta: LiveMeta): string {
+  const options = listPageSeoTypeOptions(meta);
+  const preferred = options.find(
+    (o) => o.resolveType === DEFAULT_SEO_RESOLVE_TYPE,
+  );
+  if (preferred) return preferred.resolveType;
+  return options[0]?.resolveType ?? DEFAULT_SEO_RESOLVE_TYPE;
+}
+
+/**
+ * Lists SEO types allowed on the site config's `seo` prop (site app schema),
+ * falling back to page SEO options when the site schema has no union.
+ */
+export function listSiteSeoTypeOptions(
+  meta: LiveMeta,
+  siteBlockData: Record<string, unknown>,
+): SeoTypeOption[] {
+  const siteRt = siteBlockData.__resolveType;
+  if (typeof siteRt === "string") {
+    const siteSchema = resolveSchema(siteRt, meta);
+    const fromSite = seoOptionsFromPropertySchema(siteSchema?.properties?.seo);
+    if (fromSite.length > 0) return fromSite;
+  }
+  return listPageSeoTypeOptions(meta);
+}
+
+export function defaultSiteSeoResolveType(
+  meta: LiveMeta,
+  siteBlockData: Record<string, unknown>,
+): string {
+  const options = listSiteSeoTypeOptions(meta, siteBlockData);
+  const preferred = options.find(
+    (o) => o.resolveType === DEFAULT_SEO_RESOLVE_TYPE,
+  );
+  if (preferred) return preferred.resolveType;
+  return options[0]?.resolveType ?? defaultPageSeoResolveType(meta);
+}
+
+/** Resolve type for `page.seo` form schema — data wins, then manifest default. */
+export function resolvePageSeoResolveType(
+  meta: LiveMeta,
+  seoData: Record<string, unknown> | undefined,
+): string {
+  const rt = seoData?.__resolveType;
+  if (typeof rt === "string" && rt.length > 0) return rt;
+  return defaultPageSeoResolveType(meta);
+}
+
+/** Resolve type for site/default SEO when props may be inlined without `__resolveType`. */
+export function resolveSiteSeoResolveType(
+  meta: LiveMeta,
+  siteBlockData: Record<string, unknown>,
+  seoData: Record<string, unknown>,
+): string {
+  const rt = seoData.__resolveType;
+  if (typeof rt === "string" && isSeoSectionResolveType(rt)) return rt;
+  return defaultSiteSeoResolveType(meta, siteBlockData);
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/seo-schema.ts
@@ -11,7 +11,7 @@ import {
 import { DEFAULT_SEO_RESOLVE_TYPE } from "./seo-block";
 
 /** Admin's `SEO_OPTION` label for `website/sections/Seo/SeoV2.tsx`. */
-export const DEFAULT_SEO_TYPE_LABEL = "General";
+const DEFAULT_SEO_TYPE_LABEL = "General";
 
 export interface SeoTypeOption {
   resolveType: string;

--- a/apps/mesh/src/web/components/sections-editor/seo-type-select.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-type-select.tsx
@@ -1,0 +1,41 @@
+import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import type { SeoTypeOption } from "./seo-schema";
+
+interface SeoTypeSelectProps {
+  options: SeoTypeOption[];
+  value: string;
+  onChange: (resolveType: string) => void;
+}
+
+export function SeoTypeSelect({
+  options,
+  value,
+  onChange,
+}: SeoTypeSelectProps) {
+  if (options.length <= 1) return null;
+
+  return (
+    <div className="mb-4 flex flex-col gap-1.5">
+      <Label className="text-xs text-muted-foreground">SEO type</Label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Select SEO type" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.resolveType} value={option.resolveType}>
+              {option.title}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/seo-type-select.tsx
+++ b/apps/mesh/src/web/components/sections-editor/seo-type-select.tsx
@@ -29,11 +29,13 @@ export function SeoTypeSelect({
           <SelectValue placeholder="Select SEO type" />
         </SelectTrigger>
         <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.resolveType} value={option.resolveType}>
-              {option.title}
-            </SelectItem>
-          ))}
+          {options
+            .filter((option) => option.resolveType.length > 0)
+            .map((option) => (
+              <SelectItem key={option.resolveType} value={option.resolveType}>
+                {option.title}
+              </SelectItem>
+            ))}
         </SelectContent>
       </Select>
     </div>

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { decoBlockFilePath } from "./deco-block-key";
 import { KEYS } from "@/web/lib/query-keys";
+import { decoBlockFilePath } from "./deco-block-key";
 
 /** Debounce window for form-driven block autosaves (ms). */
 export const AUTOSAVE_DELAY = 700;
@@ -80,7 +81,6 @@ export function useSaveBlock({
 }
 
 /**
-/**
  * The payload for a debounced save: either a ready object, or a builder
  * resolved at fire time. Pass a builder when the block is also written by
  * another debounced path (e.g. a page's name/path edits vs. its SEO edits) so
@@ -108,8 +108,33 @@ export function useDebouncedSaveBlock(
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestRef = useRef<{ blockKey: string; data: SaveData } | null>(null);
 
+  const runPendingSave = () => {
+    const pending = latestRef.current;
+    if (!pending) return;
+    const resolved =
+      typeof pending.data === "function" ? pending.data() : pending.data;
+    if (!resolved) return;
+    latestRef.current = null;
+    saveBlock.mutate(
+      { blockKey: pending.blockKey, data: resolved },
+      {
+        onSuccess: () => opts?.onSaved?.(),
+        onError: (err) => toast.error(`Save failed: ${err.message}`),
+      },
+    );
+  };
+
+  const flush = () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    runPendingSave();
+  };
+
   // Cancel a pending debounced save on unmount so it can't fire against a torn
-  // -down editor and persist a snapshot the user already navigated away from.
+  // -down editor after navigation. Call `flush()` explicitly when closing a sheet
+  // or leaving an editor so edits inside the debounce window still persist.
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — timer lifecycle cleanup on unmount
   useEffect(() => {
     return () => {
@@ -121,20 +146,10 @@ export function useDebouncedSaveBlock(
     latestRef.current = { blockKey, data };
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      const pending = latestRef.current;
-      if (!pending) return;
-      const resolved =
-        typeof pending.data === "function" ? pending.data() : pending.data;
-      if (!resolved) return;
-      saveBlock.mutate(
-        { blockKey: pending.blockKey, data: resolved },
-        {
-          onSuccess: () => opts?.onSaved?.(),
-          onError: (err) => toast.error(`Save failed: ${err.message}`),
-        },
-      );
+      debounceRef.current = null;
+      runPendingSave();
     }, AUTOSAVE_DELAY);
   };
 
-  return { save, isPending: saveBlock.isPending };
+  return { save, flush, isPending: saveBlock.isPending };
 }

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -80,11 +80,25 @@ export function useSaveBlock({
 }
 
 /**
+/**
+ * The payload for a debounced save: either a ready object, or a builder
+ * resolved at fire time. Pass a builder when the block is also written by
+ * another debounced path (e.g. a page's name/path edits vs. its SEO edits) so
+ * the persisted value is a read-modify-write against the freshest block data
+ * instead of a stale keystroke-time snapshot — otherwise the later-firing save
+ * clobbers the other path's concurrent edit.
+ */
+type SaveData =
+  | Record<string, unknown>
+  | (() => Record<string, unknown> | null);
+
+/**
  * Wraps {@link useSaveBlock} with the standard debounced-autosave loop shared by
  * every form-driven block editor (section forms, the SEO editor, the SEO
  * sheets). Call `save(blockKey, data)` on each change; the latest payload is
  * persisted once edits settle for {@link AUTOSAVE_DELAY}ms, with a toast on
- * failure.
+ * failure. `data` may be a builder (see {@link SaveData}) that returns null to
+ * abort the save.
  */
 export function useDebouncedSaveBlock(
   params: UseSaveBlockParams,
@@ -92,21 +106,24 @@ export function useDebouncedSaveBlock(
 ) {
   const saveBlock = useSaveBlock(params);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const latestRef = useRef<{
-    blockKey: string;
-    data: Record<string, unknown>;
-  } | null>(null);
+  const latestRef = useRef<{ blockKey: string; data: SaveData } | null>(null);
 
-  const save = (blockKey: string, data: Record<string, unknown>) => {
+  const save = (blockKey: string, data: SaveData) => {
     latestRef.current = { blockKey, data };
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       const pending = latestRef.current;
       if (!pending) return;
-      saveBlock.mutate(pending, {
-        onSuccess: () => opts?.onSaved?.(),
-        onError: (err) => toast.error(`Save failed: ${err.message}`),
-      });
+      const resolved =
+        typeof pending.data === "function" ? pending.data() : pending.data;
+      if (!resolved) return;
+      saveBlock.mutate(
+        { blockKey: pending.blockKey, data: resolved },
+        {
+          onSuccess: () => opts?.onSaved?.(),
+          onError: (err) => toast.error(`Save failed: ${err.message}`),
+        },
+      );
     }, AUTOSAVE_DELAY);
   };
 

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { decoBlockFilePath } from "./deco-block-key";
@@ -107,6 +107,15 @@ export function useDebouncedSaveBlock(
   const saveBlock = useSaveBlock(params);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestRef = useRef<{ blockKey: string; data: SaveData } | null>(null);
+
+  // Cancel a pending debounced save on unmount so it can't fire against a torn
+  // -down editor and persist a snapshot the user already navigated away from.
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect — timer lifecycle cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
 
   const save = (blockKey: string, data: SaveData) => {
     latestRef.current = { blockKey, data };

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -1,6 +1,11 @@
+import { useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { decoBlockFilePath } from "./deco-block-key";
 import { KEYS } from "@/web/lib/query-keys";
+
+/** Debounce window for form-driven block autosaves (ms). */
+export const AUTOSAVE_DELAY = 700;
 
 interface UseSaveBlockParams {
   orgSlug: string;
@@ -72,4 +77,38 @@ export function useSaveBlock({
       );
     },
   });
+}
+
+/**
+ * Wraps {@link useSaveBlock} with the standard debounced-autosave loop shared by
+ * every form-driven block editor (section forms, the SEO editor, the SEO
+ * sheets). Call `save(blockKey, data)` on each change; the latest payload is
+ * persisted once edits settle for {@link AUTOSAVE_DELAY}ms, with a toast on
+ * failure.
+ */
+export function useDebouncedSaveBlock(
+  params: UseSaveBlockParams,
+  opts?: { onSaved?: () => void },
+) {
+  const saveBlock = useSaveBlock(params);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestRef = useRef<{
+    blockKey: string;
+    data: Record<string, unknown>;
+  } | null>(null);
+
+  const save = (blockKey: string, data: Record<string, unknown>) => {
+    latestRef.current = { blockKey, data };
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const pending = latestRef.current;
+      if (!pending) return;
+      saveBlock.mutate(pending, {
+        onSuccess: () => opts?.onSaved?.(),
+        onError: (err) => toast.error(`Save failed: ${err.message}`),
+      });
+    }, AUTOSAVE_DELAY);
+  };
+
+  return { save, isPending: saveBlock.isPending };
 }

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -3,7 +3,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { decoBlockFilePath } from "./deco-block-key";
 import { KEYS } from "@/web/lib/query-keys";
-import { decoBlockFilePath } from "./deco-block-key";
 
 /** Debounce window for form-driven block autosaves (ms). */
 export const AUTOSAVE_DELAY = 700;


### PR DESCRIPTION
## What is this contribution about?
Brings the deco.cx **SEO** and **JSON viewer** experiences into Studio's CMS. The Content tab gains an **SEO** section for editing the site default SEO, plus a two-pane page-SEO editor (form on the left, live previews on the right across Google, Facebook, X, LinkedIn, WhatsApp, Telegram, Slack and Discord), where page previews layer the site default behind page overrides to show what actually renders. "View JSON" now opens the page's block file in the code view, and SEO is also reachable from the Preview tab's `…` menu and the sections editor header (with an "Edit default SEO" shortcut). Also includes polish: colorized/typed file-tree icons with a proper folder icon, a `credit-card-search` SEO icon, and a fix for image/file widget inputs being clipped by an `overflow-hidden`.

## How to Test
1. Open a project's **Content** tab → click **SEO** to edit the site default; edit a field and confirm the previews update and the value persists.
2. Open a page → **Edit SEO**: confirm the two-pane editor shows inherited defaults in the previews, the "Edit default SEO" button jumps to the site SEO, and empty fields stay empty in the form.
3. Use **View JSON** on a page (Content or Preview) and confirm the block file opens in the code/file view.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a schema-driven SEO editor with live, multi-format previews and a “View JSON” viewer. Also adds SEO type selection from the manifest schema, admin-parity controls, safer previews/file access, and CI/type fixes.

- **New Features**
  - Content tab: SEO section for editing the site default.
  - Page SEO: two-pane editor with live previews (Google, Facebook, X, LinkedIn, WhatsApp, Telegram, Slack, Discord) with defaults layered under page overrides.
  - Admin parity: Enable SEO and async render toggles, per-type field subsets (General/PDP/PLP), and a collapsible loader config for block-ref fields.
  - SEO type selection when multiple variants are exposed by the manifest; defaults resolved from the schema.
  - Entry points: “SEO” in Content; “Edit SEO”, “Site SEO”, and “View JSON” from Preview, pages, and headers; Preview routes to a shared SEO sheet.
  - File explorer: deep-link file opening (e.g., `/.deco/blocks/<key>.json`), JSON dialog with copy, and colorized file/folder/code/image icons.

- **Bug Fixes**
  - Autosave: unified page header + SEO saves via shared `useDebouncedSaveBlock` with read-modify-write at fire time; cancel on unmount; flush pending saves on close.
  - Schema correctness: drive forms from the active `__resolveType` with page/site SEO type options; avoid hardcoded types.
  - Safety: guard malformed SEO/page entries and `__resolveType` casts; restrict preview images to https; validate file-explorer deep-links; clear code-view deep-links when exiting code mode.
  - Selects: handle empty-string enum values correctly.
  - Accessibility: restored focus rings by removing overflow clipping in image/file inputs.
  - Reliability: gate SEO compute while editing and fix null SEO wrapper fallback.
  - CI/types: restore missing imports, widen a content counter type, correct lazy-render return types and test fixtures, and replace a ref flush with a microtask to stabilize saves.

<sup>Written for commit ee4aa4c4933e483540231be656c3ce8b2e99fd42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

