### PR TITLE
fix(harnesses): inject AbortSignal on remote dispatch to stop genTitle crash

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/title-generator.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.test.ts
@@ -94,6 +94,21 @@ describe("genTitle fallback", () => {
     expect(result).toBe("New chat");
   });
 
+  test("missing abortSignal does not throw and still produces a fallback", async () => {
+    // Repro for the remote-dispatch crash: the wire input cannot carry a
+    // (non-serializable) AbortSignal, so genTitle may be called with
+    // `abortSignal: undefined`. It must degrade to "no parent abort wiring"
+    // instead of throwing `addEventListener of undefined`.
+    const handle = genTitle({
+      abortSignal: undefined,
+      model: makeFailingModel(new Error("boom")),
+      userMessage: "Fix the login button on mobile devices please",
+    });
+    handle.finish();
+    const result = await handle.promise;
+    expect(result).toBe("Fix the lo");
+  });
+
   test("parent abort resolves to null (no fallback emitted)", async () => {
     const abortController = new AbortController();
     abortController.abort();

--- a/apps/mesh/src/harnesses/decopilot/title-generator.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.ts
@@ -40,7 +40,10 @@ const hasUsableText = (s: string): boolean => /[\p{L}\p{N}]/u.test(s);
 const POST_STREAM_GRACE_MS = 10_000;
 
 export function genTitle(config: {
-  abortSignal: AbortSignal;
+  /** Optional: aborts title generation when the parent stream is cancelled.
+   *  Undefined on the remote-dispatch path, where the wire input cannot carry
+   *  a (non-serializable) AbortSignal. */
+  abortSignal?: AbortSignal;
   model: LanguageModelV3;
   userMessage: string;
 }): { promise: Promise<string | null>; finish: () => void } {
@@ -48,9 +51,13 @@ export function genTitle(config: {
 
   const titleAbortController = new AbortController();
 
-  // Abort title generation if parent stream is aborted
+  // Abort title generation if parent stream is aborted. `abortSignal` is
+  // optional-at-runtime: on the remote-dispatch path the wire input omits the
+  // (non-serializable) AbortSignal, and a caller may legitimately have nothing
+  // to tie lifetime to. Guard so a missing signal degrades to "no parent abort
+  // wiring" instead of throwing `addEventListener of undefined`.
   const onParentAbort = () => titleAbortController.abort();
-  abortSignal.addEventListener("abort", onParentAbort, { once: true });
+  abortSignal?.addEventListener("abort", onParentAbort, { once: true });
 
   let graceTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
@@ -108,7 +115,7 @@ export function genTitle(config: {
       return fallbackTitle;
     } finally {
       clearTimeout(graceTimeoutId);
-      abortSignal.removeEventListener("abort", onParentAbort);
+      abortSignal?.removeEventListener("abort", onParentAbort);
     }
   })();
 

--- a/packages/sandbox/daemon/routes/dispatch.test.ts
+++ b/packages/sandbox/daemon/routes/dispatch.test.ts
@@ -186,6 +186,53 @@ describe("POST /_sandbox/dispatch", () => {
     expect(crashed).toBe(false);
   });
 
+  it("injects a live AbortSignal into the harness input (cancel aborts it)", async () => {
+    // The wire input cannot carry a (non-serializable) AbortSignal, so the
+    // daemon must reconstruct `input.signal` from its per-run AbortController.
+    // Without this, harnesses see `input.signal === undefined` — which crashed
+    // `genTitle`'s `addEventListener` and silently dropped cancellation.
+    const runId = "run-signal-inject";
+    let captured: { signal?: AbortSignal } | undefined;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+
+    const deps = makeDeps({
+      lookupHarness: (_id, input) => {
+        captured = input as { signal?: AbortSignal };
+        return {
+          async *stream() {
+            yield { type: "start", id: "m1" } as const;
+            await gate; // hold the run open so cancel can land
+          },
+        };
+      },
+    });
+
+    const body = JSON.stringify({
+      harnessId: "fake",
+      input: { ...fixtures.FIXTURE_MINIMAL_INPUT, runId },
+    });
+    const res = await handleDispatchRequest(authedDispatch(body), deps);
+    expect(res.status).toBe(200);
+
+    const reader = res.body!.getReader();
+    await reader.read(); // ensure start() ran → lookupHarness called
+
+    expect(captured?.signal).toBeInstanceOf(AbortSignal);
+    expect(captured?.signal?.aborted).toBe(false);
+
+    // Cancelling the run must flip the injected signal.
+    await handleCancelRequest(authedCancel(runId), {
+      daemonToken: DAEMON_TOKEN,
+    });
+    expect(captured?.signal?.aborted).toBe(true);
+
+    release();
+    await reader.cancel();
+  });
+
   it("wraps harness errors as an error SSE event followed by done", async () => {
     const harnessId = "throws";
     const body = JSON.stringify({

--- a/packages/sandbox/daemon/routes/dispatch.ts
+++ b/packages/sandbox/daemon/routes/dispatch.ts
@@ -260,6 +260,16 @@ export async function handleDispatchRequest(
 
         activeRuns.set(input.runId, ctrl);
 
+        // Re-inject the per-run AbortSignal. `HarnessStreamInput.signal` is an
+        // AbortSignal and therefore NOT JSON-serializable, so it never survives
+        // the wire (see `harnessStreamInputSchema`, which omits it). The daemon
+        // reconstructs cancellation locally via `ctrl`; wire its signal back
+        // onto the input so the harness's `streamText({ abortSignal })` and
+        // `genTitle({ abortSignal })` receive a real signal instead of
+        // `undefined` (which crashes genTitle's `addEventListener`) — and so a
+        // DELETE /_sandbox/runs/:id actually aborts the in-flight model call.
+        (input as { signal?: AbortSignal }).signal = ctrl.signal;
+
         console.log(
           `[dispatch] received (offload) harness=${harnessId} runId=${input.runId} threadId=${input.threadId} bytes=${messagesRef.bytes}`,
         );
@@ -331,6 +341,11 @@ export async function handleDispatchRequest(
 
   const ctrl = new AbortController();
   activeRuns.set(input.runId, ctrl);
+
+  // Re-inject the per-run AbortSignal — see the offload path above for the full
+  // rationale. The wire input never carries `signal` (not serializable), so the
+  // harness would otherwise see `input.signal === undefined`.
+  (input as { signal?: AbortSignal }).signal = ctrl.signal;
 
   console.log(
     `[dispatch] received harness=${harnessId} runId=${input.runId} threadId=${input.threadId}`,


### PR DESCRIPTION
## Summary

Fixes the `[dispatch] harness crashed ... TypeError: undefined is not an object (evaluating 'abortSignal.addEventListener')` crash on the remote-dispatch path (desktop link daemon running the codex / claude-code harness).

**Root cause:** `HarnessStreamInput.signal` is an `AbortSignal`, which is not JSON-serializable — the wire schema (`links/protocol/schemas.ts`) deliberately omits it. The daemon reconstructs a per-run `AbortController` for cancellation but never wired its signal back onto `input.signal`, so harnesses saw `input.signal === undefined`. This was a harmless latent gap until #3659 added `genTitle`, which calls `abortSignal.addEventListener("abort", ...)` unconditionally — throwing synchronously inside `stream()` and crashing the whole run (`harness_crashed` → cluster re-dispatch). Both `codex` and `claude-code` harnesses were affected.

## Changes

- **`packages/sandbox/daemon/routes/dispatch.ts`** — the real fix. Inject the per-run `AbortController`'s signal onto `input.signal` before `lookupHarness` in both the offload and non-offload paths. This also fixes a second latent bug: cancellation previously only broke the chunk-relay loop and never propagated into the codex/claude CLI or `genTitle` — now a `DELETE /_sandbox/runs/:id` actually aborts the in-flight model call.
- **`apps/mesh/src/harnesses/decopilot/title-generator.ts`** — defense in depth. `abortSignal` is now optional in the type, and `add`/`removeEventListener` are guarded with `?.`.

## Testing

- Added a dispatch test asserting a live `AbortSignal` is injected into the harness input and that cancel flips it to `aborted`.
- Added a title-generator test asserting `genTitle({ abortSignal: undefined })` doesn't throw and still produces a fallback title.
- `bun test` (affected files): 18/18 pass. `bun run check` green. `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in remote dispatch by injecting a live AbortSignal into harness inputs and making `genTitle` handle missing signals. Cancellation now reaches the model call, so deleting a run actually aborts it.

- **Bug Fixes**
  - Inject `AbortController.signal` into `input.signal` before `lookupHarness` in both offload and non-offload paths (`packages/sandbox/daemon/routes/dispatch.ts`).
  - Make `abortSignal` optional and guard event listeners in `apps/mesh/src/harnesses/decopilot/title-generator.ts`.
  - Add tests to assert signal injection/cancellation and safe `genTitle` behavior without an `abortSignal`.

<sup>Written for commit 248696b5ae66426909a5ae0652a0397ce4d376c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

