### PR TITLE
fix(sections-editor): encode block filenames on save/delete

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/deco-block-key.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/deco-block-key.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "bun:test";
-import { assertSafeDecoBlockKey, decoBlockFilePath } from "./deco-block-key";
+import {
+  assertSafeDecoBlockKey,
+  blockKeyToFileStem,
+  decoBlockFilePath,
+} from "./deco-block-key";
 
 describe("deco-block-key", () => {
-  it("decoBlockFilePath builds the blocks json path", () => {
+  it("decoBlockFilePath encodes spaces for the blocks json path", () => {
+    expect(decoBlockFilePath("Banner Category")).toBe(
+      ".deco/blocks/Banner%20Category.json",
+    );
     expect(decoBlockFilePath("pages-home-abc123456789")).toBe(
       ".deco/blocks/pages-home-abc123456789.json",
     );
+  });
+
+  it("blockKeyToFileStem does not double-encode an already-encoded key", () => {
+    expect(blockKeyToFileStem("Banner%20Category")).toBe("Banner%20Category");
   });
 
   it("allows spaces and encoded names", () => {

--- a/apps/mesh/src/web/components/sections-editor/deco-block-key.ts
+++ b/apps/mesh/src/web/components/sections-editor/deco-block-key.ts
@@ -13,7 +13,20 @@ export function assertSafeDecoBlockKey(blockKey: string): void {
   }
 }
 
-export function decoBlockFilePath(blockKey: string): string {
+function decodeDecoBlockKey(blockKey: string): string {
+  try {
+    return decodeURIComponent(blockKey);
+  } catch {
+    return blockKey;
+  }
+}
+
+/** Filename stem for `.deco/blocks/<stem>.json` (decode then encode to avoid `%2520`). */
+export function blockKeyToFileStem(blockKey: string): string {
   assertSafeDecoBlockKey(blockKey);
-  return `.deco/blocks/${blockKey}.json`;
+  return encodeURIComponent(decodeDecoBlockKey(blockKey));
+}
+
+export function decoBlockFilePath(blockKey: string): string {
+  return `.deco/blocks/${blockKeyToFileStem(blockKey)}.json`;
 }

--- a/apps/mesh/src/web/components/sections-editor/use-delete-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-delete-block.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
-import { assertSafeDecoBlockKey, decoBlockFilePath } from "./deco-block-key";
+import { decoBlockFilePath } from "./deco-block-key";
 
 interface UseDeleteBlockParams {
   orgSlug: string;
@@ -23,7 +23,6 @@ export function useDeleteBlock({
 
   return useMutation({
     mutationFn: async ({ blockKey }: { blockKey: string }) => {
-      assertSafeDecoBlockKey(blockKey);
       const path = decoBlockFilePath(blockKey);
       const res = await fetch(
         `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/unlink`,

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { decoBlockFilePath } from "./deco-block-key";
 import { KEYS } from "@/web/lib/query-keys";
 
 interface UseSaveBlockParams {
@@ -22,7 +23,7 @@ export function useSaveBlock({
       blockKey: string;
       data: unknown;
     }) => {
-      const path = `.deco/blocks/${blockKey}.json`;
+      const path = decoBlockFilePath(blockKey);
       const content = JSON.stringify(data, null, 2);
       const res = await fetch(
         `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/write`,


### PR DESCRIPTION
## Summary

- Encode `.deco/blocks/<key>.json` paths on save/delete via `decodeURIComponent` then `encodeURIComponent`, so block ids with spaces (e.g. `Banner Category`) write to `Banner%20Category.json` instead of creating a duplicate file with a literal space.
- Avoid double-encoding when the block key is already encoded (`Banner%20Category` stays `Banner%20Category`).

## Test plan

- [ ] Open a global section whose on-disk file is `Banner%20Category.json`, edit a field, confirm the `write` request path is `.deco/blocks/Banner%20Category.json` (not `Banner Category.json`).
- [ ] Run `bun test apps/mesh/src/web/components/sections-editor/deco-block-key.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encode `.deco/blocks` filenames on save/delete to match URL-encoded filenames, preventing duplicate files for keys with spaces and avoiding double-encoding.

- **Bug Fixes**
  - Introduced `blockKeyToFileStem` and `decoBlockFilePath` to decode then encode block keys before building `.deco/blocks/<stem>.json`.
  - Updated save/delete to use `decoBlockFilePath`, preventing `%2520` and handling already-encoded keys safely.
  - Added tests for space encoding and no double-encoding.

<sup>Written for commit 95ed408e51c447e6f6ece6472a04064e02532183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

