### PR TITLE
fix(web): render tool detail under settings without ThreadManagerProvider

### DIFF
--- a/apps/mesh/src/web/components/chat/store/hooks.tsx
+++ b/apps/mesh/src/web/components/chat/store/hooks.tsx
@@ -54,6 +54,16 @@ export function useThreadManager(): ThreadManagerStore {
   return m;
 }
 
+/**
+ * Non-throwing variant. Returns null outside a `ThreadManagerProvider` (e.g.
+ * the settings route tree, which mounts under `orgLayout` rather than
+ * `orgShellLayout`). Use this for navigation-only consumers that should work
+ * everywhere but only need the manager for thread mutations.
+ */
+export function useOptionalThreadManager(): ThreadManagerStore | null {
+  return useContext(ManagerContext);
+}
+
 export function useThreads(): {
   threads: Task[];
   status: ThreadsStatus;

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -25,7 +25,7 @@ import {
 } from "@tanstack/react-router";
 import { KEYS } from "../lib/query-keys";
 import { readCachedTaskBranch } from "../lib/read-cached-task-branch";
-import { useThreadActions } from "@/web/components/chat/store/hooks";
+import { useOptionalThreadManager } from "@/web/components/chat/store/hooks";
 import { isPerThreadTab } from "@/web/layouts/main-panel-tabs/tab-id";
 import { useOrganizationSettingsSuspense } from "../hooks/use-organization-settings";
 import { useOrgSsoStatus } from "../hooks/use-org-sso";
@@ -75,7 +75,9 @@ function ShellProjectProvider({
 
 export function usePanelActions() {
   const navigate = useNavigate();
-  const { create } = useThreadActions();
+  // Optional: the settings route tree has no ThreadManagerProvider, so this is
+  // null there. Navigation actions work regardless; only createNewTask needs it.
+  const manager = useOptionalThreadManager();
   const { org, locator } = useProjectContext();
 
   const params = useParams({ strict: false }) as {
@@ -157,7 +159,9 @@ export function usePanelActions() {
       ? readCachedTaskBranch(org.slug, locator, currentTaskId)
       : null;
     try {
-      await create({
+      // No manager (settings tree): skip the eager create and let the
+      // /$org/$taskId route loader's ensure-fallback create the thread.
+      await manager?.create({
         id: newId,
         virtual_mcp_id: targetVmcp,
         ...(branch ? { branch } : {}),


### PR DESCRIPTION
## What is this contribution about?
The settings route tree mounts under `orgLayout`, not `orgShellLayout`, so it has no `ThreadManagerProvider`. Opening a tool detail at `/$org/settings/connections/$app/tools/$tool` (matched by `collectionDetailRoute`) renders `ToolDetailsView`, which calls `usePanelActions()` — and that hook eagerly called `useThreadActions()` → `useThreadManager()`, throwing `useThreadManager: missing ThreadManagerProvider` and showing "Something went wrong". This makes the manager dependency optional via a new non-throwing `useOptionalThreadManager()`: only `createNewTask` needs it, while the navigation-only panel actions (including the `setChatOpen` used by the tool view) work everywhere. When no manager is present, `createNewTask` skips the eager create and lets the `/$org/$taskId` route loader's ensure-fallback create the thread.

## Screenshots/Demonstration
N/A — fixes a crash; no visual change to working paths.

## How to Test
1. Open `/<org>/settings/connections/<app>/tools/<TOOL_NAME>` (e.g. a VTEX connection's `VTEX_CREATE_BRAND`).
2. The tool detail page renders normally instead of showing "Something went wrong / useThreadManager: missing ThreadManagerProvider".
3. Confirm the same tool detail inside the chat shell still works and "open in chat" actions are unaffected.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crash when opening tool details under settings by making the thread manager optional. Tool detail pages now render without a `ThreadManagerProvider`, and chat navigation still works.

- **Bug Fixes**
  - Added `useOptionalThreadManager()` and updated `usePanelActions()` to use it; only `createNewTask` needs the manager.
  - When no manager is present, skip eager thread creation and rely on the `/$org/$taskId` route loader; settings tool detail renders normally and “open in chat” actions still work.

<sup>Written for commit 8352122c159998f93948d8a293d2e16989d88b28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

