### PR TITLE
test(resilience): sandbox↔studio WebSocket drop/restore suite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,3 +46,6 @@ docs
 .turbo
 .next
 .cache
+
+# Re-include the resilience link-daemon entrypoint (run inside the link-daemon container)
+!tests/resilience/link-daemon-entrypoint.ts

--- a/.github/workflows/resilience.yml
+++ b/.github/workflows/resilience.yml
@@ -43,6 +43,10 @@ jobs:
         if: failure()
         run: docker compose -f tests/resilience/docker-compose.yml logs studio
 
+      - name: Dump link-daemon logs
+        if: failure()
+        run: docker compose -f tests/resilience/docker-compose.yml --profile link logs link-daemon
+
       - name: Tear down infrastructure
         if: always()
         run: docker compose -f tests/resilience/docker-compose.yml down -v

--- a/tests/resilience/docker-compose.yml
+++ b/tests/resilience/docker-compose.yml
@@ -71,6 +71,7 @@ services:
     build:
       context: ../../
       dockerfile: tests/resilience/Dockerfile.studio
+    image: deco-resilience-studio:latest
     restart: unless-stopped
     environment:
       NODE_ENV: production
@@ -82,6 +83,7 @@ services:
       BETTER_AUTH_URL: http://localhost:3000
       BASE_URL: http://localhost:3000
       DECOCMS_LOCAL_MODE: "true"
+      STUDIO_SANDBOX_PROVIDER: user-desktop
       ENCRYPTION_KEY: test-encryption-key-32chars-long!
       DATA_DIR: /app/data
     ports:
@@ -96,3 +98,24 @@ services:
       start_period: 60s
       retries: 20
     volumes: []
+
+  link-daemon:
+    # Reuse the studio image (built once by the `studio` service); only override
+    # the command to run the headless link-daemon entrypoint. Behind the `link`
+    # profile so the default `up --wait` does NOT start it — the resilience
+    # scenarios start it explicitly with the test user's freshly-minted API key.
+    image: deco-resilience-studio:latest
+    profiles: ["link"]
+    working_dir: /app
+    command: ["bun", "run", "/app/tests/resilience/link-daemon-entrypoint.ts"]
+    environment:
+      NODE_ENV: production
+      MESH_CLUSTER_URL: http://toxiproxy:3010
+      DAEMON_API_KEY: "${DAEMON_API_KEY:-}"
+      DATA_DIR: /app/data/link-daemon
+      LINK_DAEMON_PORT: "4500"
+    depends_on:
+      studio:
+        condition: service_healthy
+      toxiproxy:
+        condition: service_healthy

--- a/tests/resilience/lib/link-daemon-control.test.ts
+++ b/tests/resilience/lib/link-daemon-control.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { parseSseLogFrames } from "./link-daemon-control";
+
+describe("parseSseLogFrames", () => {
+  test("extracts log frames keyed by source", () => {
+    const raw =
+      'event: lifecycle\ndata: {"state":"running"}\n\n' +
+      'event: log\ndata: {"source":"marker","data":"hello MARKER-123\\n"}\n\n' +
+      'event: log\ndata: {"source":"daemon","data":"GET /\\r\\n"}\n\n';
+    const frames = parseSseLogFrames(raw);
+    expect(frames.find((f) => f.source === "marker")?.data).toContain(
+      "MARKER-123",
+    );
+    expect(frames.some((f) => f.source === "daemon")).toBe(true);
+  });
+
+  test("ignores non-log events and malformed data", () => {
+    const raw =
+      'event: status\ndata: {"running":true}\n\n' +
+      "event: log\ndata: not-json\n\n";
+    expect(parseSseLogFrames(raw)).toEqual([]);
+  });
+
+  test("handles CRLF line endings and no-space event field", () => {
+    const raw =
+      'event:log\r\ndata: {"source":"marker","data":"CRLF-OK"}\r\n\r\n';
+    const frames = parseSseLogFrames(raw);
+    expect(frames.find((f) => f.source === "marker")?.data).toBe("CRLF-OK");
+  });
+});

--- a/tests/resilience/lib/link-daemon-control.ts
+++ b/tests/resilience/lib/link-daemon-control.ts
@@ -1,0 +1,290 @@
+/**
+ * Host-side controls for the resilience link-daemon scenarios:
+ *   - start/stop the `link-daemon` container with the test user's API key,
+ *   - poll `GET /api/links/me` for the link claim,
+ *   - create an agent (virtual MCP) + ensure a sandbox (SANDBOX_START),
+ *   - drive the org-scoped sandbox proxy routes (write/read/exec/config),
+ *   - read the `/events` SSE and parse its log-replay frames.
+ */
+import { mcpCall } from "./studio-client";
+import { pollUntil } from "./poll-until";
+
+const STUDIO_URL = "http://127.0.0.1:13000";
+
+/** Parse a string as JSON, returning undefined on failure (never throws). */
+function tryParseJson(text: unknown): unknown {
+  if (typeof text !== "string") return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+const COMPOSE_FILE = new URL("../docker-compose.yml", import.meta.url).pathname;
+
+export interface LinkClaim {
+  machineId: string;
+  hostname?: string;
+  cliVersion: string;
+  previewPort: number;
+  connectedAt: number;
+}
+
+/** Run `docker compose -f <file> <args>`, optionally with extra env. */
+export async function composeExec(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<string> {
+  const proc = Bun.spawn(["docker", "compose", "-f", COMPOSE_FILE, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: env ? { ...process.env, ...env } : process.env,
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(
+      `docker compose ${args.join(" ")} exited ${code}: ${stderr || stdout}`,
+    );
+  }
+  return stdout;
+}
+
+/** Start the profiled link-daemon container, injecting the API key. */
+export async function startLinkDaemonContainer(apiKey: string): Promise<void> {
+  await composeExec(
+    ["--profile", "link", "up", "-d", "--no-build", "link-daemon"],
+    { DAEMON_API_KEY: apiKey },
+  );
+}
+
+/** Stop + remove the link-daemon container (best effort). */
+export async function stopLinkDaemonContainer(): Promise<void> {
+  try {
+    await composeExec(["--profile", "link", "rm", "-sf", "link-daemon"]);
+  } catch {
+    /* best effort */
+  }
+}
+
+/** GET /api/links/me with the session cookie; returns the claim or null. */
+export async function getLinkClaim(cookie: string): Promise<LinkClaim | null> {
+  const res = await fetch(`${STUDIO_URL}/api/links/me`, {
+    headers: { cookie },
+  });
+  if (res.status !== 200) return null;
+  const body = (await res.json()) as LinkClaim | null;
+  return body;
+}
+
+/** Poll until a claim exists; returns it. */
+export async function waitForLinkClaim(
+  cookie: string,
+  timeoutMs = 60_000,
+): Promise<LinkClaim> {
+  let claim: LinkClaim | null = null;
+  await pollUntil(
+    async () => {
+      claim = await getLinkClaim(cookie);
+      return claim != null;
+    },
+    { timeoutMs, intervalMs: 1_000, label: "wait-for-link-claim" },
+  );
+  // pollUntil throws if not met, so claim is non-null here.
+  return claim as unknown as LinkClaim;
+}
+
+/** Create an agent (virtual MCP); returns its id. */
+export async function createAgent(
+  orgId: string,
+  cookie: string,
+  title: string,
+): Promise<string> {
+  const { result } = await mcpCall(
+    `${orgId}_self`,
+    "tools/call",
+    {
+      name: "COLLECTION_VIRTUAL_MCP_CREATE",
+      arguments: { data: { title, connections: [] } },
+    },
+    { cookie },
+  );
+  const data = tryParseJson(result?.content?.[0]?.text) ?? result;
+  const id = data?.item?.id ?? data?.id;
+  if (!id) {
+    throw new Error(`createAgent: no id in result: ${JSON.stringify(result)}`);
+  }
+  return id as string;
+}
+
+export interface SandboxStartResult {
+  sandboxHandle: string;
+  previewUrl?: string;
+  branch: string;
+  sandboxProviderKind: string;
+}
+
+/** Ensure a user-desktop sandbox for the agent; returns the handle. */
+export async function sandboxStart(
+  orgId: string,
+  cookie: string,
+  virtualMcpId: string,
+  branch: string,
+): Promise<SandboxStartResult> {
+  const { result } = await mcpCall(
+    `${orgId}_self`,
+    "tools/call",
+    {
+      name: "SANDBOX_START",
+      arguments: {
+        virtualMcpId,
+        branch,
+        sandboxProviderKind: "user-desktop",
+      },
+    },
+    { cookie },
+    { timeoutMs: 60_000 },
+  );
+  const data =
+    result?.structuredContent ??
+    tryParseJson(result?.content?.[0]?.text) ??
+    result;
+  if (!data?.sandboxHandle) {
+    throw new Error(
+      `sandboxStart: no sandboxHandle in result: ${JSON.stringify(result)}`,
+    );
+  }
+  return data as SandboxStartResult;
+}
+
+/** Look up the org slug for the org-scoped sandbox routes. */
+export async function getOrgSlug(
+  orgId: string,
+  cookie: string,
+): Promise<string> {
+  const { result } = await mcpCall(
+    `${orgId}_self`,
+    "tools/call",
+    { name: "ORGANIZATION_GET", arguments: {} },
+    { cookie },
+  );
+  const data =
+    result?.structuredContent ??
+    tryParseJson(result?.content?.[0]?.text) ??
+    result;
+  const slug = data?.slug ?? data?.organization?.slug ?? data?.item?.slug;
+  if (!slug) {
+    throw new Error(`getOrgSlug: no slug in result: ${JSON.stringify(result)}`);
+  }
+  return slug as string;
+}
+
+function sandboxBase(orgSlug: string, vmId: string, branch: string): string {
+  return `${STUDIO_URL}/api/${orgSlug}/sandbox/${vmId}/${encodeURIComponent(
+    branch,
+  )}`;
+}
+
+/** POST a sandbox proxy sub-route as JSON; returns the Response. */
+export async function sandboxPost(
+  orgSlug: string,
+  vmId: string,
+  branch: string,
+  subPath: string,
+  cookie: string,
+  body: unknown,
+): Promise<Response> {
+  return fetch(`${sandboxBase(orgSlug, vmId, branch)}${subPath}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify(body),
+  });
+}
+
+/** PUT the sandbox config. */
+export async function sandboxPutConfig(
+  orgSlug: string,
+  vmId: string,
+  branch: string,
+  cookie: string,
+  config: unknown,
+): Promise<Response> {
+  return fetch(`${sandboxBase(orgSlug, vmId, branch)}/config`, {
+    method: "PUT",
+    headers: { "content-type": "application/json", cookie },
+    body: JSON.stringify(config),
+  });
+}
+
+/** Open the `/events` SSE and read up to `maxMs`, returning the raw text. */
+export async function readEventsSnapshot(
+  orgSlug: string,
+  vmId: string,
+  branch: string,
+  cookie: string,
+  maxMs = 4_000,
+): Promise<string> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), maxMs);
+  try {
+    const res = await fetch(`${sandboxBase(orgSlug, vmId, branch)}/events`, {
+      headers: { accept: "text/event-stream", cookie },
+      signal: ctrl.signal,
+    });
+    if (!res.body) return "";
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let text = "";
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value, { stream: true });
+      }
+    } catch {
+      /* aborted by timer — return what we collected */
+    }
+    return text;
+  } catch {
+    return "";
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface SseLogFrame {
+  source: string;
+  data: string;
+}
+
+/** Parse `event: log\ndata: {source,data}\n\n` frames out of an SSE byte stream. */
+export function parseSseLogFrames(raw: string): SseLogFrame[] {
+  const frames: SseLogFrame[] = [];
+  for (const block of raw.split("\n\n")) {
+    const lines = block.split("\n");
+    const isLog = lines.some(
+      (l) => l.trim().replace(/^event:\s*/, "") === "log",
+    );
+    if (!isLog) continue;
+    const dataLine = lines.find((l) => l.startsWith("data: "));
+    if (!dataLine) continue;
+    try {
+      const parsed = JSON.parse(dataLine.slice("data: ".length)) as {
+        source?: unknown;
+        data?: unknown;
+      };
+      if (
+        typeof parsed.source === "string" &&
+        typeof parsed.data === "string"
+      ) {
+        frames.push({ source: parsed.source, data: parsed.data });
+      }
+    } catch {
+      /* malformed data line — skip */
+    }
+  }
+  return frames;
+}

--- a/tests/resilience/lib/link-daemon-control.ts
+++ b/tests/resilience/lib/link-daemon-control.ts
@@ -31,7 +31,7 @@ export interface LinkClaim {
 }
 
 /** Run `docker compose -f <file> <args>`, optionally with extra env. */
-export async function composeExec(
+async function composeExec(
   args: string[],
   env?: Record<string, string>,
 ): Promise<string> {

--- a/tests/resilience/lib/setup.ts
+++ b/tests/resilience/lib/setup.ts
@@ -46,6 +46,7 @@ export function registerTestHooks() {
       PROXY_NAMES.POSTGRES,
       PROXY_NAMES.NATS,
       PROXY_NAMES.EVERYTHING,
+      PROXY_NAMES.STUDIO_WS,
     ]) {
       if (!(name in (proxies as Record<string, unknown>))) {
         throw new Error(`Toxiproxy proxy "${name}" not found`);

--- a/tests/resilience/lib/toxic-presets.ts
+++ b/tests/resilience/lib/toxic-presets.ts
@@ -2,6 +2,7 @@ export const PROXY_NAMES = {
   POSTGRES: "postgres",
   NATS: "nats",
   EVERYTHING: "everything",
+  STUDIO_WS: "studio_ws",
 } as const;
 
 export const MODERATE_LATENCY = {

--- a/tests/resilience/link-daemon-entrypoint.test.ts
+++ b/tests/resilience/link-daemon-entrypoint.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { buildDaemonSession } from "./link-daemon-entrypoint";
+
+describe("buildDaemonSession", () => {
+  test("puts the API key in accessToken and the cluster URL in target", () => {
+    const session = buildDaemonSession({
+      apiKey: "key-abc",
+      clusterUrl: "http://toxiproxy:3010",
+      nowIso: "2026-06-03T00:00:00.000Z",
+    });
+    expect(session.accessToken).toBe("key-abc");
+    expect(session.target).toBe("http://toxiproxy:3010");
+    expect(session.clientId).toBe("resilience-link-daemon");
+    expect(session.user.sub).toBe("resilience-link-daemon");
+    expect(session.createdAt).toBe("2026-06-03T00:00:00.000Z");
+  });
+
+  test("throws when the API key is empty", () => {
+    expect(() =>
+      buildDaemonSession({
+        apiKey: "",
+        clusterUrl: "http://toxiproxy:3010",
+        nowIso: "2026-06-03T00:00:00.000Z",
+      }),
+    ).toThrow(/DAEMON_API_KEY/);
+  });
+});

--- a/tests/resilience/link-daemon-entrypoint.ts
+++ b/tests/resilience/link-daemon-entrypoint.ts
@@ -1,0 +1,62 @@
+/**
+ * Headless `deco link` daemon entrypoint for the resilience harness.
+ *
+ * Runs inside the `link-daemon` container. Authenticates with a pre-minted
+ * Better Auth API key (injected as DAEMON_API_KEY by the test that mints it),
+ * dials studio through the Toxiproxy `studio_ws` proxy (MESH_CLUSTER_URL), and
+ * spawns real sandboxes on demand. No OAuth, no session file.
+ */
+import { startLinkDaemon } from "../../apps/mesh/src/link-daemon/index";
+import type { Session } from "../../apps/mesh/src/cli/lib/session";
+
+export function buildDaemonSession(input: {
+  apiKey: string;
+  clusterUrl: string;
+  nowIso: string;
+}): Session {
+  if (!input.apiKey) {
+    throw new Error("DAEMON_API_KEY is required to start the link daemon");
+  }
+  return {
+    target: input.clusterUrl,
+    clientId: "resilience-link-daemon",
+    user: { sub: "resilience-link-daemon" },
+    accessToken: input.apiKey,
+    createdAt: input.nowIso,
+  };
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.DAEMON_API_KEY ?? "";
+  const clusterUrl = process.env.MESH_CLUSTER_URL ?? "http://toxiproxy:3010";
+  const dataDir = process.env.DATA_DIR ?? "/app/data/link-daemon";
+  const port = Number(process.env.LINK_DAEMON_PORT ?? "4500");
+
+  const session = buildDaemonSession({
+    apiKey,
+    clusterUrl,
+    nowIso: new Date().toISOString(),
+  });
+
+  console.log(
+    `[resilience-link-daemon] starting; cluster=${clusterUrl} port=${port}`,
+  );
+  const handle = await startLinkDaemon({
+    port,
+    clusterBaseUrl: clusterUrl,
+    dataDir,
+    session,
+  });
+
+  const code = await handle.stopped;
+  console.log(`[resilience-link-daemon] stopped (code ${code})`);
+  process.exit(code);
+}
+
+// Only run the daemon when executed directly (not when imported by the test).
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("[resilience-link-daemon] fatal:", err);
+    process.exit(1);
+  });
+}

--- a/tests/resilience/scenarios/link-dispatch-log-replay.test.ts
+++ b/tests/resilience/scenarios/link-dispatch-log-replay.test.ts
@@ -55,7 +55,7 @@ describe("sandbox log/event SSE replay", () => {
       }),
     });
     await sandboxPutConfig(orgSlug, vmId, BRANCH, testState.cookie, {
-      application: { packageManager: "npm" },
+      application: { packageManager: { name: "npm" } },
     });
   }, 180_000);
 

--- a/tests/resilience/scenarios/link-dispatch-log-replay.test.ts
+++ b/tests/resilience/scenarios/link-dispatch-log-replay.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Resilience scenario: sandbox log/event SSE replay across a WS reconnect.
+ *
+ * The daemon keeps a per-source ReplayBuffer (256 KB/source). Output of a
+ * named `exec` script lands in it under source=<script>. Because the daemon
+ * PROCESS survives a studio_ws Toxiproxy cut (only the WS is severed), the
+ * buffer is retained, so a reconnecting `/events` SSE replays the marker.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { registerTestHooks, testState } from "../lib/setup";
+import { disableProxy, enableProxy } from "../lib/toxiproxy";
+import { PROXY_NAMES } from "../lib/toxic-presets";
+import { pollUntil } from "../lib/poll-until";
+import {
+  createAgent,
+  getLinkClaim,
+  getOrgSlug,
+  parseSseLogFrames,
+  readEventsSnapshot,
+  sandboxPost,
+  sandboxPutConfig,
+  sandboxStart,
+  startLinkDaemonContainer,
+  stopLinkDaemonContainer,
+  waitForLinkClaim,
+} from "../lib/link-daemon-control";
+
+registerTestHooks();
+
+const BRANCH = "main";
+const MARKER = `MARKER-${testState.orgId || "x"}-${process.pid}`;
+
+let orgSlug = "";
+let vmId = "";
+
+describe("sandbox log/event SSE replay", () => {
+  beforeAll(async () => {
+    orgSlug = await getOrgSlug(testState.orgId, testState.cookie);
+    vmId = await createAgent(
+      testState.orgId,
+      testState.cookie,
+      "Log Replay Agent",
+    );
+    await startLinkDaemonContainer(testState.apiKey);
+    await waitForLinkClaim(testState.cookie, 90_000);
+    await sandboxStart(testState.orgId, testState.cookie, vmId, BRANCH);
+
+    // Configure exec: a packageManager + a package.json with a `marker` script.
+    await sandboxPost(orgSlug, vmId, BRANCH, "/write", testState.cookie, {
+      path: "package.json",
+      content: JSON.stringify({
+        name: "resilience-fixture",
+        packageManager: "npm@10.0.0",
+        scripts: { marker: `echo ${MARKER}` },
+      }),
+    });
+    await sandboxPutConfig(orgSlug, vmId, BRANCH, testState.cookie, {
+      application: { packageManager: "npm" },
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    await stopLinkDaemonContainer();
+  });
+
+  test("marker appears in the events replay snapshot", async () => {
+    // Emit the marker into the ReplayBuffer via a named exec script.
+    const exec = await sandboxPost(
+      orgSlug,
+      vmId,
+      BRANCH,
+      "/exec/marker",
+      testState.cookie,
+      {},
+    );
+    expect(exec.status).toBeLessThan(400);
+
+    await pollUntil(
+      async () => {
+        const raw = await readEventsSnapshot(
+          orgSlug,
+          vmId,
+          BRANCH,
+          testState.cookie,
+        );
+        return parseSseLogFrames(raw).some((f) => f.data.includes(MARKER));
+      },
+      { timeoutMs: 30_000, intervalMs: 2_000, label: "marker-in-snapshot" },
+    );
+  }, 90_000);
+
+  test("marker still replays after a WS drop + reconnect", async () => {
+    const baseline = await getLinkClaim(testState.cookie);
+    const baselineConnectedAt = baseline?.connectedAt ?? 0;
+
+    await disableProxy(PROXY_NAMES.STUDIO_WS);
+    await pollUntil(
+      async () => (await getLinkClaim(testState.cookie)) === null,
+      { timeoutMs: 30_000, intervalMs: 1_000, label: "link-offline" },
+    );
+    await enableProxy(PROXY_NAMES.STUDIO_WS);
+    await pollUntil(
+      async () => {
+        const claim = await getLinkClaim(testState.cookie);
+        return claim != null && claim.connectedAt > baselineConnectedAt;
+      },
+      { timeoutMs: 60_000, intervalMs: 1_000, label: "link-reconnect" },
+    );
+
+    // The daemon process survived → its ReplayBuffer still has the marker.
+    await pollUntil(
+      async () => {
+        const raw = await readEventsSnapshot(
+          orgSlug,
+          vmId,
+          BRANCH,
+          testState.cookie,
+        );
+        return parseSseLogFrames(raw).some((f) => f.data.includes(MARKER));
+      },
+      {
+        timeoutMs: 60_000,
+        intervalMs: 2_000,
+        label: "marker-replayed-after-reconnect",
+      },
+    );
+  }, 180_000);
+});

--- a/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
+++ b/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Resilience scenario: sandbox↔studio WS partition.
+ *
+ * Drives a REAL link daemon + REAL spawned sandbox. Severs the daemon↔studio
+ * WebSocket with Toxiproxy (clean TCP close) and asserts:
+ *   1. The sandbox responds to a write/read round-trip while connected.
+ *   2. While the WS is severed, the link goes offline (/api/links/me → null)
+ *      and a tunneled read fails FAST (no hang, no queue/replay).
+ *   3. After the WS is restored, the daemon reconnects (connectedAt advances)
+ *      and the same read returns the same content (state preserved).
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { registerTestHooks, testState } from "../lib/setup";
+import { disableProxy, enableProxy } from "../lib/toxiproxy";
+import { PROXY_NAMES } from "../lib/toxic-presets";
+import { pollUntil } from "../lib/poll-until";
+import {
+  createAgent,
+  getLinkClaim,
+  getOrgSlug,
+  sandboxPost,
+  sandboxStart,
+  startLinkDaemonContainer,
+  stopLinkDaemonContainer,
+  waitForLinkClaim,
+} from "../lib/link-daemon-control";
+
+registerTestHooks();
+
+const BRANCH = "main";
+const FILE_PATH = "resilience-marker.txt";
+const FILE_CONTENT = "ws-partition-content";
+
+let orgSlug = "";
+let vmId = "";
+
+describe("sandbox↔studio WS partition", () => {
+  beforeAll(async () => {
+    // setup's beforeAll already minted testState.apiKey/cookie/orgId.
+    orgSlug = await getOrgSlug(testState.orgId, testState.cookie);
+    vmId = await createAgent(
+      testState.orgId,
+      testState.cookie,
+      "WS Partition Agent",
+    );
+    await startLinkDaemonContainer(testState.apiKey);
+    await waitForLinkClaim(testState.cookie, 90_000);
+    await sandboxStart(testState.orgId, testState.cookie, vmId, BRANCH);
+  }, 180_000);
+
+  afterAll(async () => {
+    await stopLinkDaemonContainer();
+  });
+
+  test("write/read round-trip works while connected", async () => {
+    const write = await sandboxPost(
+      orgSlug,
+      vmId,
+      BRANCH,
+      "/write",
+      testState.cookie,
+      { path: FILE_PATH, content: FILE_CONTENT },
+    );
+    expect(write.status).toBeLessThan(300);
+
+    const read = await sandboxPost(
+      orgSlug,
+      vmId,
+      BRANCH,
+      "/read",
+      testState.cookie,
+      { path: FILE_PATH },
+    );
+    expect(read.status).toBe(200);
+    const text = await read.text();
+    expect(text).toContain(FILE_CONTENT);
+  }, 60_000);
+
+  test("WS severed → link offline + read fails fast (no queue/replay)", async () => {
+    const before = await getLinkClaim(testState.cookie);
+    expect(before).not.toBeNull();
+
+    await disableProxy(PROXY_NAMES.STUDIO_WS);
+
+    // The link claim is released once the gateway observes the WS close.
+    await pollUntil(
+      async () => (await getLinkClaim(testState.cookie)) === null,
+      { timeoutMs: 30_000, intervalMs: 1_000, label: "link-offline" },
+    );
+
+    // A tunneled read must fail FAST (not hang). Offline → 404; in-flight
+    // cut → 502 ws_closed. Either way: a non-2xx error, quickly.
+    const start = performance.now();
+    const read = await sandboxPost(
+      orgSlug,
+      vmId,
+      BRANCH,
+      "/read",
+      testState.cookie,
+      { path: FILE_PATH },
+    );
+    const durationMs = performance.now() - start;
+    expect(read.status).toBeGreaterThanOrEqual(400);
+    expect(durationMs).toBeLessThan(15_000);
+  }, 90_000);
+
+  test("WS restored → daemon reconnects and the sandbox responds again", async () => {
+    // Capture whatever claim exists now as the baseline (afterEach from a prior
+    // test may have re-enabled the proxy via resetAll; capture or fall back to 0).
+    const baseline = await getLinkClaim(testState.cookie);
+    const baselineConnectedAt = baseline?.connectedAt ?? 0;
+
+    await enableProxy(PROXY_NAMES.STUDIO_WS);
+
+    // Reconnect = a claim whose connectedAt advanced past the baseline.
+    await pollUntil(
+      async () => {
+        const claim = await getLinkClaim(testState.cookie);
+        return claim != null && claim.connectedAt > baselineConnectedAt;
+      },
+      { timeoutMs: 60_000, intervalMs: 1_000, label: "link-reconnect" },
+    );
+
+    // The same read now succeeds with preserved content (daemon process and
+    // its file state survived the WS cut).
+    await pollUntil(
+      async () => {
+        const read = await sandboxPost(
+          orgSlug,
+          vmId,
+          BRANCH,
+          "/read",
+          testState.cookie,
+          { path: FILE_PATH },
+        );
+        if (read.status !== 200) return false;
+        const text = await read.text();
+        return text.includes(FILE_CONTENT);
+      },
+      { timeoutMs: 60_000, intervalMs: 2_000, label: "read-after-reconnect" },
+    );
+  }, 150_000);
+});

--- a/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
+++ b/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
@@ -105,10 +105,22 @@ describe("sandbox↔studio WS partition", () => {
   }, 90_000);
 
   test("WS restored → daemon reconnects and the sandbox responds again", async () => {
-    // Capture whatever claim exists now as the baseline (afterEach from a prior
-    // test may have re-enabled the proxy via resetAll; capture or fall back to 0).
-    const baseline = await getLinkClaim(testState.cookie);
-    const baselineConnectedAt = baseline?.connectedAt ?? 0;
+    // Self-contained: start from a connected state (afterEach from the prior
+    // test re-enabled the proxy), capture the baseline connectedAt, then sever
+    // and restore WITHIN this test so the reconnect is observable regardless of
+    // whatever proxy state the previous test left behind.
+    const before = await waitForLinkClaim(testState.cookie, 60_000);
+    const connectedAt0 = before.connectedAt;
+
+    await disableProxy(PROXY_NAMES.STUDIO_WS);
+    await pollUntil(
+      async () => (await getLinkClaim(testState.cookie)) === null,
+      {
+        timeoutMs: 30_000,
+        intervalMs: 1_000,
+        label: "link-offline-before-reconnect",
+      },
+    );
 
     await enableProxy(PROXY_NAMES.STUDIO_WS);
 
@@ -116,7 +128,7 @@ describe("sandbox↔studio WS partition", () => {
     await pollUntil(
       async () => {
         const claim = await getLinkClaim(testState.cookie);
-        return claim != null && claim.connectedAt > baselineConnectedAt;
+        return claim != null && claim.connectedAt > connectedAt0;
       },
       { timeoutMs: 60_000, intervalMs: 1_000, label: "link-reconnect" },
     );
@@ -139,5 +151,5 @@ describe("sandbox↔studio WS partition", () => {
       },
       { timeoutMs: 60_000, intervalMs: 2_000, label: "read-after-reconnect" },
     );
-  }, 150_000);
+  }, 240_000);
 });

--- a/tests/resilience/toxiproxy.json
+++ b/tests/resilience/toxiproxy.json
@@ -5,5 +5,10 @@
     "name": "everything",
     "listen": "0.0.0.0:3001",
     "upstream": "everything-server:3002"
+  },
+  {
+    "name": "studio_ws",
+    "listen": "0.0.0.0:3010",
+    "upstream": "studio:3000"
   }
 ]


### PR DESCRIPTION
## Summary

Adds a Toxiproxy-backed resilience suite that proves the `deco link` daemon survives a **sandbox ↔ studio WebSocket drop and restore** — using a **real `deco link` daemon + a real spawned sandbox**, no LLM and no product-code changes.

A new `link-daemon` container runs the real daemon (authenticated with a pre-minted API key) dialing studio through a new `studio_ws` Toxiproxy proxy. Tests run on the host, drive a real sandbox through the existing org-scoped sandbox proxy routes, sever the WS with `disableProxy("studio_ws")` (clean TCP close), restore it, and assert recovery via `GET /api/links/me`.

### Harness
- `tests/resilience/toxiproxy.json` — new `studio_ws` proxy (`:3010` → `studio:3000`); `lib/toxic-presets.ts` `STUDIO_WS`; `lib/setup.ts` verifies it.
- `tests/resilience/docker-compose.yml` — pinned studio `image:`, `STUDIO_SANDBOX_PROVIDER=user-desktop`, and a **profiled** `link-daemon` service reusing the studio image (so default `up --wait`/CI doesn't start it; scenarios start it on demand with the test user's key).
- `link-daemon-entrypoint.ts` — headless daemon (pure, unit-tested `buildDaemonSession`).
- `lib/link-daemon-control.ts` — host helpers (start/stop daemon container, poll claim, create agent, `SANDBOX_START`, sandbox-proxy ops, SSE reader) + unit-tested `parseSseLogFrames`.
- `.dockerignore` — re-includes the entrypoint into the build context (it's under `tests/`, otherwise excluded).
- `.github/workflows/resilience.yml` — dumps `link-daemon` logs on failure.

### Scenarios
- **`link-dispatch-ws-partition.test.ts`** — write/read round-trip works while connected → WS severed → link goes offline + read **fails fast** (no queue/replay) → WS restored → daemon reconnects (`connectedAt` advances) → read returns preserved content. (The reconnect test is self-contained: it severs/restores within itself, independent of `afterEach` proxy resets.)
- **`link-dispatch-log-replay.test.ts`** — emit a marker via `exec/marker` → it appears in the `/events` SSE replay snapshot → WS drop + reconnect → marker **still replays** (the daemon process survives the WS cut, so its `ReplayBuffer` is retained).

### Why this shape (vs. the agentic `remote-dispatch` path)
There is no host route for `/bash` or `/dispatch` (the sandbox proxy is an allowlist), and the cluster only routes `claude-code`/`codex` harnesses from a real credential — so a deterministic, LLM-free agentic run isn't reachable end-to-end. These scenarios exercise the **same dispatcher fail-fast / no-replay contract** via the reachable file/exec/events routes. The literal `remote-dispatch` path is left as a documented follow-up.

## Testing
- ✅ `bun run check` (typecheck, all workspaces), `bun run fmt:check`, `bun run lint` (0 warnings / 0 errors), unit tests **5/5** (`buildDaemonSession`, `parseSseLogFrames`).
- The two scenarios run end-to-end under the Docker resilience suite in CI (`.github/workflows/resilience.yml`, on push to `main`); they're auto-discovered by the `tests/resilience/scenarios/` glob. Known integration-time assumptions (org-slug / `SANDBOX_START` result shapes, exec config) fail with clear labeled `pollUntil` timeouts, never silent passes.

## Follow-ups
- Literal `remote-dispatch` agentic path (needs an LLM or a fake `controlHandler` + a `claude-code` credential).
- Half-open / 60s-KV-TTL window (blackhole toxic); cross-pod re-claim handoff (`tests/multi-pod/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Toxiproxy-backed resilience suite that proves the `deco link` daemon survives a sandbox↔studio WebSocket drop and restore using the real daemon and real sandboxes. Covers WS partition behavior and SSE log replay across reconnects with no product code changes.

- **New Features**
  - Introduced Toxiproxy `studio_ws` proxy (`:3010` → `studio:3000`) and setup verification to route daemon WS traffic.
  - Added a profiled `link-daemon` service with a headless entrypoint; runs the real daemon with a pre-minted API key via the proxy and uses `STUDIO_SANDBOX_PROVIDER=user-desktop`.
  - Added host helpers to start/stop the daemon container, poll `GET /api/links/me`, create agents, drive sandbox proxy routes, and parse `/events` SSE logs.
  - Added two E2E scenarios:
    - WS partition: write/read works while connected; during cut the link goes offline and reads fail fast; after restore, `connectedAt` advances and reads return preserved content.
    - Log replay: a marker emitted via `exec/marker` appears in `/events` and still replays after a WS drop + reconnect.
  - CI: workflow now dumps `link-daemon` logs on failure.

<sup>Written for commit 2f3cb1f764a0e8972d05f9dc8f45aca7b5de0e20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

