### PR TITLE
feat(org-shell-layout): add HomeFeedPrefetch component for preloading…

### DIFF
--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -24,7 +24,10 @@ import {
 } from "@deco/ui/components/sidebar.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { Loading01 } from "@untitledui/icons";
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useParams } from "@tanstack/react-router";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useQuery } from "@tanstack/react-query";
+import { homeNextActionsQueryOptions } from "@/web/hooks/use-home-next-actions";
 import { SidebarResizeHandle } from "@/web/components/sidebar/sidebar-resize-handle";
 import { useSidebarResize } from "@/web/hooks/use-sidebar-resize";
 import { StudioSidebar, StudioSidebarMobile } from "@/web/components/sidebar";
@@ -48,6 +51,25 @@ function RouteFallback() {
   );
 }
 
+/**
+ * Warms the home feed during the shell render, before the home route's
+ * component mounts. The home tiles are gated on this fetch, and HomePage only
+ * mounts after the sidebar tree renders — so starting it here (scoped to the
+ * index route, deduped with HomePage's own read) lets the tile-gating request
+ * overlap the shell render instead of waiting behind it. Renders null.
+ */
+function HomeFeedPrefetch() {
+  const { org } = useProjectContext();
+  const { taskId } = useParams({ strict: false }) as { taskId?: string };
+  useQuery({
+    ...homeNextActionsQueryOptions(org.slug),
+    // Only the org index route (no taskId) is the home page; chat shares this
+    // shell but doesn't render the home feed.
+    enabled: !taskId,
+  });
+  return null;
+}
+
 export default function OrgShellLayout() {
   const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useLocalStorage<boolean>(
@@ -61,6 +83,7 @@ export default function OrgShellLayout() {
       <Toolbar.Provider>
         <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
           <ChatPrefsProvider>
+            <HomeFeedPrefetch />
             <div className="app-shell-root flex flex-col h-dvh overflow-hidden">
               <Toolbar.Header>
                 <Toolbar.LeftColumn>


### PR DESCRIPTION
… home feed data

Introduces HomeFeedPrefetch to warm the home feed during the shell render, optimizing the loading experience by initiating data fetching before the HomePage component mounts. This enhancement allows for a smoother user experience by overlapping the tile-gating request with the shell render.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HomeFeedPrefetch to pre-load the home feed during the org shell render, reducing perceived load time by starting the tile-gating fetch before HomePage mounts.

- **New Features**
  - Uses `@tanstack/react-query` with `homeNextActionsQueryOptions(org.slug)` to warm the home feed cache (deduped with HomePage’s query).
  - Runs only on the org index route (no `taskId` from `@tanstack/react-router`) and renders null, so no UI changes.

<sup>Written for commit fa4614a1b2544a0462dfcddf8506d73629465d13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

