### PR TITLE
refactor(cli): simplify link command TUI by removing idle metrics

### DIFF
--- a/apps/mesh/src/cli/link-app.tsx
+++ b/apps/mesh/src/cli/link-app.tsx
@@ -3,39 +3,10 @@ import { useSyncExternalStore } from "react";
 import pkg from "../../package.json" with { type: "json" };
 import { Banner } from "./banner";
 import {
-  formatIdle,
   getLinkState,
   type SandboxRow,
   subscribeLinkState,
 } from "./link-store";
-
-// 1 Hz clock so relative IDLE times re-render. This is display-only; it never
-// polls the provider (structural changes arrive via link-store events).
-let clockNow = Date.now();
-const clockListeners = new Set<() => void>();
-let clockTimer: ReturnType<typeof setInterval> | null = null;
-
-function subscribeClock(cb: () => void): () => void {
-  clockListeners.add(cb);
-  if (!clockTimer) {
-    clockTimer = setInterval(() => {
-      clockNow = Date.now();
-      for (const fn of clockListeners) fn();
-    }, 1000);
-    clockTimer.unref?.();
-  }
-  return () => {
-    clockListeners.delete(cb);
-    if (clockListeners.size === 0 && clockTimer) {
-      clearInterval(clockTimer);
-      clockTimer = null;
-    }
-  };
-}
-
-function getClock(): number {
-  return clockNow;
-}
 
 function statusCell(row: SandboxRow): { color: string; text: string } {
   if (row.status === "ready") return { color: "green", text: "● Live" };
@@ -50,13 +21,10 @@ function statusCell(row: SandboxRow): { color: string; text: string } {
 const COLS = {
   project: 18,
   status: 14,
-  requests: 10,
-  lastUsed: 11,
 } as const;
 
 export function LinkApp() {
   const state = useSyncExternalStore(subscribeLinkState, getLinkState);
-  const now = useSyncExternalStore(subscribeClock, getClock);
   const rows = [...state.sandboxes.values()].sort((a, b) =>
     a.handle.localeCompare(b.handle),
   );
@@ -110,16 +78,6 @@ export function LinkApp() {
                 STATUS
               </Text>
             </Box>
-            <Box width={COLS.requests} flexShrink={0} marginRight={1}>
-              <Text dimColor wrap="truncate-end">
-                REQUESTS
-              </Text>
-            </Box>
-            <Box width={COLS.lastUsed} flexShrink={0} marginRight={1}>
-              <Text dimColor wrap="truncate-end">
-                LAST USED
-              </Text>
-            </Box>
             <Box flexGrow={1}>
               <Text dimColor wrap="truncate-end">
                 PREVIEW URL
@@ -128,10 +86,6 @@ export function LinkApp() {
           </Box>
           {rows.map((row) => {
             const s = statusCell(row);
-            const idle =
-              row.activeDispatchCount > 0
-                ? "—"
-                : formatIdle(now - row.lastChangeAt);
             return (
               <Box key={row.handle}>
                 <Box width={COLS.project} flexShrink={0} marginRight={1}>
@@ -141,14 +95,6 @@ export function LinkApp() {
                   <Text color={s.color} wrap="truncate-end">
                     {s.text}
                   </Text>
-                </Box>
-                <Box width={COLS.requests} flexShrink={0} marginRight={1}>
-                  <Text wrap="truncate-end">
-                    {String(row.activeDispatchCount)}
-                  </Text>
-                </Box>
-                <Box width={COLS.lastUsed} flexShrink={0} marginRight={1}>
-                  <Text wrap="truncate-end">{idle}</Text>
                 </Box>
                 <Box flexGrow={1}>
                   <Text dimColor wrap="truncate-end">

--- a/apps/mesh/src/cli/link-store.test.ts
+++ b/apps/mesh/src/cli/link-store.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
   applySandboxEvent,
-  formatIdle,
   getLinkState,
-  setLogPath,
   type SandboxRow,
+  setLogPath,
 } from "./link-store";
 
 function empty(): Map<string, SandboxRow> {
@@ -13,94 +12,68 @@ function empty(): Map<string, SandboxRow> {
 
 describe("applySandboxEvent", () => {
   it("adds a spawning row then promotes it to ready with port", () => {
-    let m = applySandboxEvent(
-      empty(),
-      { handle: "a", phase: "spawning" },
-      1000,
-    );
+    let m = applySandboxEvent(empty(), { handle: "a", phase: "spawning" });
     expect(m.get("a")?.status).toBe("spawning");
 
-    m = applySandboxEvent(
-      m,
-      {
-        handle: "a",
-        phase: "ready",
-        port: 51234,
-        previewUrl: "http://a.localhost:5174",
-      },
-      2000,
-    );
+    m = applySandboxEvent(m, {
+      handle: "a",
+      phase: "ready",
+      port: 51234,
+      previewUrl: "http://a.localhost:5174",
+    });
     expect(m.get("a")?.status).toBe("ready");
     expect(m.get("a")?.port).toBe(51234);
     expect(m.get("a")?.previewUrl).toBe("http://a.localhost:5174");
   });
 
   it("records the error on failure and retains the row", () => {
-    let m = applySandboxEvent(
-      empty(),
-      { handle: "a", phase: "spawning" },
-      1000,
-    );
-    m = applySandboxEvent(
-      m,
-      { handle: "a", phase: "failed", error: "clone failed" },
-      2000,
-    );
+    let m = applySandboxEvent(empty(), { handle: "a", phase: "spawning" });
+    m = applySandboxEvent(m, {
+      handle: "a",
+      phase: "failed",
+      error: "clone failed",
+    });
     expect(m.get("a")?.status).toBe("failed");
     expect(m.get("a")?.error).toBe("clone failed");
   });
 
   it("clears the error when a failed handle starts spawning again", () => {
-    let m = applySandboxEvent(
-      empty(),
-      { handle: "a", phase: "failed", error: "x" },
-      1000,
-    );
-    m = applySandboxEvent(m, { handle: "a", phase: "spawning" }, 2000);
+    let m = applySandboxEvent(empty(), {
+      handle: "a",
+      phase: "failed",
+      error: "x",
+    });
+    m = applySandboxEvent(m, { handle: "a", phase: "spawning" });
     expect(m.get("a")?.status).toBe("spawning");
     expect(m.get("a")?.error).toBeNull();
   });
 
-  it("preserves the port across a dispatch-count update", () => {
-    let m = applySandboxEvent(
-      empty(),
-      { handle: "a", phase: "ready", port: 7 },
-      1000,
-    );
-    m = applySandboxEvent(
-      m,
-      { handle: "a", phase: "ready", activeDispatchCount: 2 },
-      2000,
-    );
+  it("preserves the port across a follow-up ready event", () => {
+    let m = applySandboxEvent(empty(), {
+      handle: "a",
+      phase: "ready",
+      port: 7,
+    });
+    m = applySandboxEvent(m, { handle: "a", phase: "ready" });
     expect(m.get("a")?.port).toBe(7);
-    expect(m.get("a")?.activeDispatchCount).toBe(2);
   });
 
   it("removes the row on evicted and deleted", () => {
-    let m = applySandboxEvent(
-      empty(),
-      { handle: "a", phase: "ready", port: 7 },
-      1000,
-    );
-    m = applySandboxEvent(m, { handle: "a", phase: "evicted" }, 2000);
+    let m = applySandboxEvent(empty(), {
+      handle: "a",
+      phase: "ready",
+      port: 7,
+    });
+    m = applySandboxEvent(m, { handle: "a", phase: "evicted" });
     expect(m.has("a")).toBe(false);
 
-    let n = applySandboxEvent(
-      empty(),
-      { handle: "b", phase: "ready", port: 8 },
-      1000,
-    );
-    n = applySandboxEvent(n, { handle: "b", phase: "deleted" }, 2000);
+    let n = applySandboxEvent(empty(), {
+      handle: "b",
+      phase: "ready",
+      port: 8,
+    });
+    n = applySandboxEvent(n, { handle: "b", phase: "deleted" });
     expect(n.has("b")).toBe(false);
-  });
-});
-
-describe("formatIdle", () => {
-  it("formats sub-minute, minute, and hour ranges", () => {
-    expect(formatIdle(500)).toBe("0s");
-    expect(formatIdle(5_000)).toBe("5s");
-    expect(formatIdle(65_000)).toBe("1m");
-    expect(formatIdle(3_700_000)).toBe("1h");
   });
 });
 

--- a/apps/mesh/src/cli/link-store.ts
+++ b/apps/mesh/src/cli/link-store.ts
@@ -14,9 +14,6 @@ export interface SandboxRow {
   previewUrl: string | null;
   status: "spawning" | "ready" | "failed";
   error: string | null;
-  activeDispatchCount: number;
-  /** Wall-clock ms of the last event for this handle; drives the IDLE column. */
-  lastChangeAt: number;
 }
 
 // Not exported — mirrors cli-store's CliState.
@@ -43,7 +40,6 @@ const DEFAULT_CAP = 20;
 export function applySandboxEvent(
   sandboxes: Map<string, SandboxRow>,
   e: SandboxEvent,
-  now: number,
 ): Map<string, SandboxRow> {
   const next = new Map(sandboxes);
   if (e.phase === "evicted" || e.phase === "deleted") {
@@ -57,20 +53,8 @@ export function applySandboxEvent(
     previewUrl: e.previewUrl ?? prev?.previewUrl ?? null,
     status: e.phase, // "spawning" | "ready" | "failed"
     error: e.phase === "failed" ? (e.error ?? "failed") : null,
-    activeDispatchCount:
-      e.activeDispatchCount ?? prev?.activeDispatchCount ?? 0,
-    lastChangeAt: now,
   });
   return next;
-}
-
-/** Relative idle duration, coarse (`0s`/`5s`/`1m`/`1h`). */
-export function formatIdle(ms: number): string {
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  return `${Math.floor(m / 60)}h`;
 }
 
 let state: LinkState = {
@@ -133,7 +117,7 @@ export function setLogPath(path: string) {
 export function pushSandboxEvent(event: SandboxEvent) {
   state = {
     ...state,
-    sandboxes: applySandboxEvent(state.sandboxes, event, Date.now()),
+    sandboxes: applySandboxEvent(state.sandboxes, event),
   };
   emit();
 }

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -37,7 +37,6 @@ export interface SandboxEvent {
   previewUrl?: string;
   /** Set on `failed`. */
   error?: string;
-  activeDispatchCount?: number;
 }
 
 export interface SpawnResult {
@@ -413,7 +412,6 @@ export function createDesktopSandboxProvider(
       phase: "ready",
       port,
       previewUrl,
-      activeDispatchCount: 0,
     });
 
     // Watchdog: clear the map entry if the daemon process exits unexpectedly.
@@ -493,11 +491,6 @@ export function createDesktopSandboxProvider(
       const s = sandboxes.get(handle);
       if (!s) return () => {};
       s.activeDispatchCount += 1;
-      emit({
-        handle,
-        phase: "ready",
-        activeDispatchCount: s.activeDispatchCount,
-      });
       let released = false;
       return () => {
         if (released) return;
@@ -505,11 +498,6 @@ export function createDesktopSandboxProvider(
         const cur = sandboxes.get(handle);
         if (cur) {
           cur.activeDispatchCount = Math.max(0, cur.activeDispatchCount - 1);
-          emit({
-            handle,
-            phase: "ready",
-            activeDispatchCount: cur.activeDispatchCount,
-          });
         }
       };
     },


### PR DESCRIPTION
Remove the REQUESTS and LAST USED columns from the link command's TUI table, which were displaying misleading values.

## Changes
- Remove `activeDispatchCount` and `lastChangeAt` from SandboxRow
- Remove the 1 Hz clock subscription that only refreshed the IDLE column  
- Drop `formatIdle` helper function
- Remove dispatch-only emit events in acquireDispatch (internal counter for eviction is preserved)
- Update tests to match the new reducer signatures

## Stats
- 4 files changed: +40 / −149 lines
- All tests passing (121 pass / 0 fail)
- TypeScript clean
- No linting issues

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the `link` command TUI by removing misleading idle metrics and the REQUESTS/LAST USED columns. Reduces overhead and keeps the table focused on status and preview URL.

- **Refactors**
  - Removed `REQUESTS` and `LAST USED` columns from the TUI.
  - Dropped idle tracking: `lastChangeAt`, `formatIdle`, and the 1 Hz clock.
  - Removed `activeDispatchCount` from `SandboxRow` and daemon emit events; eviction counter remains.
  - Simplified `applySandboxEvent` by removing the `now` parameter and timestamp logic.
  - Updated tests to match the new reducer signatures and state shape.

<sup>Written for commit 5657d509cf10a9f34870d03856e6e10c27f65de1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

