### PR TITLE
fix(link-daemon): prevent reconnect loop crash on successful session close

### DIFF
--- a/apps/mesh/src/link-daemon/cluster-connection.test.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection.test.ts
@@ -133,4 +133,57 @@ describe("cluster-connection", () => {
     await new Promise((r) => setTimeout(r, 500));
     expect(opens).toBe(1);
   });
+
+  test("reconnects after a successful session closes unexpectedly (regression: #3666)", async () => {
+    let opens = 0;
+    const closeAfterMs = 50;
+    server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        if (req.headers.get("upgrade") === "websocket") {
+          srv.upgrade(req, { data: {} });
+          return undefined;
+        }
+        return new Response("nope", { status: 404 });
+      },
+      websocket: {
+        open(ws) {
+          opens++;
+          if (opens === 1) {
+            // First open: stay open briefly, then close (simulating a server restart/network blip)
+            setTimeout(() => ws.close(1000, "normal closure"), closeAfterMs);
+          }
+        },
+        message() {},
+        close() {},
+      },
+    });
+    handle = await connectToCluster({
+      url: `ws://127.0.0.1:${server.port}/api/links/connect`,
+      accessToken: "t",
+      hello: {
+        previewPort: 5174,
+        machineId: "m",
+        cliVersion: "1",
+        capabilities: [],
+      },
+      controlHandler: {
+        async handle() {
+          return { status: 404 };
+        },
+        handleStream() {
+          return (async function* () {})();
+        },
+      },
+      maxAttempts: 5,
+    });
+
+    // Wait for the first connection to open, close, and the backoff delay to elapse.
+    // The backoff is ~250-500ms for attempt=1, plus some buffer for socket setup.
+    // Before the fix, this would throw "attempt must be >= 1" and crash the reconnect loop.
+    await new Promise((r) => setTimeout(r, closeAfterMs + 750));
+
+    // Assert that the daemon attempted at least one reconnect after the close.
+    expect(opens).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/apps/mesh/src/link-daemon/cluster-connection.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection.ts
@@ -255,7 +255,7 @@ export async function connectToCluster(
     while (!stopped && attempt < maxAttempts) {
       const { shouldReconnect } = await runOnce();
       if (stopped || !shouldReconnect) break;
-      const backoffMs = computeBackoffMs(attempt);
+      const backoffMs = computeBackoffMs(Math.max(attempt, 1));
       console.log(
         `[cluster-connection] reconnecting in ${backoffMs}ms (attempt ${attempt})`,
       );


### PR DESCRIPTION
## Problem
The daemon's WebSocket reconnect loop crashed silently when a successful connection closed, leaving the link permanently dead until restart.

**Root cause:** After a successful WS open, the retry counter resets to 0. When the WS later closes, the backoff calculator is called with attempt=0, which throws because it counts from 1.

## Sequence
1. `runOnce()` increments attempt to 1
2. WS opens successfully → handler resets attempt to 0
3. WS closes → loop calls `computeBackoffMs(attempt=0)`
4. `computeBackoffMs(0)` throws "attempt must be >= 1"
5. Throw escapes the unawaited IIFE → reconnect loop dies silently
6. `resolveClosed()` never runs → connection hangs forever

## Reproduction
Any transient drop after a successful session: server restart, network blip, laptop sleep. Only triggers after at least one successful open (hence why it's rare in testing).

## Fix
Clamp attempt to 1 when computing backoff, preserving the author's intent to fast-retry after a stable session without paying max backoff:

\`\`\`ts
// cluster-connection.ts:258
const backoffMs = computeBackoffMs(Math.max(attempt, 1));
\`\`\`

## Testing
- Added regression test: open → close → verify reconnect happens without throw
- All 50 link-daemon tests pass
- All reconnect-backoff tests pass

Resolves the daemon connection loss from the WebSocket partition scenario in #3666.

Co-authored-by: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the `link-daemon` WebSocket reconnect loop from crashing after a successful session closes, so it auto-reconnects instead of hanging. Clamps the backoff attempt to 1 to avoid a throw and keep fast-retry behavior. Fixes #3666.

- **Bug Fixes**
  - Clamp attempt to at least 1 before `computeBackoffMs`.
  - Add regression test for open → close → reconnect without crash.

<sup>Written for commit 9b7a0f645c12a5cb077061dd6f06f899bd35c194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

