### PR TITLE
refactor(organization-settings): rename and update hook for non-block…

### DIFF
--- a/apps/mesh/src/web/hooks/use-organization-settings.ts
+++ b/apps/mesh/src/web/hooks/use-organization-settings.ts
@@ -9,7 +9,6 @@ import {
   useMutation,
   useQuery,
   useQueryClient,
-  useSuspenseQuery,
   type MutateOptions,
   type UseMutationResult,
   type UseQueryResult,
@@ -118,25 +117,29 @@ function useOrganizationSettings<T = OrganizationSettings>(
 }
 
 /**
- * Suspense variant used by shell-layout, which mounts ProjectContextProvider
- * and therefore can't call useProjectContext() yet — so it passes `orgId`
- * explicitly. Same query key as the non-suspense variant — shares the cache.
+ * Non-blocking shell read. Used by shell-layout, which mounts
+ * ProjectContextProvider and therefore can't call useProjectContext() yet — so
+ * it passes `orgId`/`orgSlug` explicitly. Same query key as the other variants.
+ *
+ * Deliberately non-suspense: the shell must NOT block its whole subtree
+ * (sidebar, home, tiles) on the org-settings round-trip. `enabled_plugins` is
+ * the only field consumed downstream and every consumer is null-safe, so we
+ * render immediately with `null` and let the value fill in when the query
+ * resolves.
  */
-export function useOrganizationSettingsSuspense(
+export function useOrganizationSettingsNonBlocking(
   orgId: string,
   orgSlug: string,
-): OrganizationSettings {
+): OrganizationSettings | null {
   const client = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId,
     orgSlug,
   });
 
-  const { data } = useSuspenseQuery(
-    organizationSettingsQueryOptions(client, orgId),
-  );
+  const { data } = useQuery(organizationSettingsQueryOptions(client, orgId));
 
-  return data;
+  return data ?? null;
 }
 
 type OrgSettingsUpdateInput = Partial<

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -24,10 +24,7 @@ import {
 } from "@deco/ui/components/sidebar.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { Loading01 } from "@untitledui/icons";
-import { Outlet, useParams } from "@tanstack/react-router";
-import { useProjectContext } from "@decocms/mesh-sdk";
-import { useQuery } from "@tanstack/react-query";
-import { homeNextActionsQueryOptions } from "@/web/hooks/use-home-next-actions";
+import { Outlet } from "@tanstack/react-router";
 import { SidebarResizeHandle } from "@/web/components/sidebar/sidebar-resize-handle";
 import { useSidebarResize } from "@/web/hooks/use-sidebar-resize";
 import { StudioSidebar, StudioSidebarMobile } from "@/web/components/sidebar";
@@ -51,25 +48,6 @@ function RouteFallback() {
   );
 }
 
-/**
- * Warms the home feed during the shell render, before the home route's
- * component mounts. The home tiles are gated on this fetch, and HomePage only
- * mounts after the sidebar tree renders — so starting it here (scoped to the
- * index route, deduped with HomePage's own read) lets the tile-gating request
- * overlap the shell render instead of waiting behind it. Renders null.
- */
-function HomeFeedPrefetch() {
-  const { org } = useProjectContext();
-  const { taskId } = useParams({ strict: false }) as { taskId?: string };
-  useQuery({
-    ...homeNextActionsQueryOptions(org.slug),
-    // Only the org index route (no taskId) is the home page; chat shares this
-    // shell but doesn't render the home feed.
-    enabled: !taskId,
-  });
-  return null;
-}
-
 export default function OrgShellLayout() {
   const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useLocalStorage<boolean>(
@@ -83,7 +61,6 @@ export default function OrgShellLayout() {
       <Toolbar.Provider>
         <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
           <ChatPrefsProvider>
-            <HomeFeedPrefetch />
             <div className="app-shell-root flex flex-col h-dvh overflow-hidden">
               <Toolbar.Header>
                 <Toolbar.LeftColumn>

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -15,7 +15,7 @@ import {
   ProjectContextProvider,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import {
   Outlet,
   useMatch,
@@ -27,7 +27,8 @@ import { KEYS } from "../lib/query-keys";
 import { readCachedTaskBranch } from "../lib/read-cached-task-branch";
 import { useOptionalThreadManager } from "@/web/components/chat/store/hooks";
 import { isPerThreadTab } from "@/web/layouts/main-panel-tabs/tab-id";
-import { useOrganizationSettingsSuspense } from "../hooks/use-organization-settings";
+import { useOrganizationSettingsNonBlocking } from "../hooks/use-organization-settings";
+import { homeNextActionsQueryOptions } from "../hooks/use-home-next-actions";
 import { useOrgSsoStatus } from "../hooks/use-org-sso";
 import { SsoRequiredScreen } from "../components/sso-required-screen";
 import { ArchivedOrgScreen } from "../components/archived-org-screen";
@@ -49,7 +50,7 @@ function ShellProjectProvider({
   org: NonNullable<Parameters<typeof ProjectContextProvider>[0]["org"]>;
   children: React.ReactNode;
 }) {
-  const orgSettings = useOrganizationSettingsSuspense(org.id, org.slug);
+  const orgSettings = useOrganizationSettingsNonBlocking(org.id, org.slug);
 
   const project = {
     id: org.id,
@@ -207,7 +208,13 @@ export function usePanelActions() {
 function ShellLayoutContent() {
   const orgMatch = useMatch({ from: "/shell/$org", shouldThrow: false });
   const org = orgMatch?.params.org;
+  const { taskId } = useParams({ strict: false }) as { taskId?: string };
   const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false);
+
+  useQuery({
+    ...homeNextActionsQueryOptions(org ?? ""),
+    enabled: !!org && !taskId,
+  });
 
   // Session is guaranteed present here (this renders inside <SignedIn>), so the
   // user id is available synchronously to scope the org cache by principal.


### PR DESCRIPTION
…ing data fetching

- Renamed `useOrganizationSettingsSuspense` to `useOrganizationSettingsNonBlocking` to clarify its purpose.
- Changed the implementation to use `useQuery` instead of `useSuspenseQuery`, allowing for non-blocking data retrieval.
- Updated documentation to reflect the new behavior, ensuring immediate rendering with `null` until data is available.
- Adjusted references in `ShellLayoutContent` and `OrgShellLayout` to utilize the new hook, enhancing the loading experience.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor org settings fetching to be non-blocking so the shell renders immediately and fills in data when ready. Replaced the suspense hook with `useQuery` and renamed it to `useOrganizationSettingsNonBlocking`.

- **Refactors**
  - Renamed `useOrganizationSettingsSuspense` to `useOrganizationSettingsNonBlocking`.
  - Switched from `useSuspenseQuery` to `useQuery` from `@tanstack/react-query`; hook returns `null` until data loads.
  - Updated `ShellProjectProvider` and `ShellLayoutContent` to use the new hook; moved home feed prefetch to `ShellLayoutContent` via `useQuery`.
  - Removed `HomeFeedPrefetch` from `OrgShellLayout`.

- **Migration**
  - Replace `useOrganizationSettingsSuspense(orgId, orgSlug)` with `useOrganizationSettingsNonBlocking(orgId, orgSlug)`.
  - Handle a possible `null` return until the query resolves; do not rely on Suspense for loading.

<sup>Written for commit 48a7e53d79b4360315039eeb6f09faf93d4f77e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

