### PR TITLE
fix(harnesses): codex CLI now runs in the same checkout as claude-code

### DIFF
--- a/apps/mesh/src/harnesses/claude-code/index.ts
+++ b/apps/mesh/src/harnesses/claude-code/index.ts
@@ -31,6 +31,7 @@
 
 import { streamText, type UIMessageChunk } from "ai";
 import { createClaudeCodeModel, resolveClaudeCodeModelId } from "./model";
+import { resolveCliCwd } from "../cli-cwd";
 import { extractUserText, prepCliMessages } from "../cli-message-prep";
 import { makeTitleResultChunk } from "../title-chunk";
 import { genTitle } from "../decopilot/title-generator";
@@ -41,46 +42,6 @@ import type {
   HarnessStreamInput,
 } from "../types";
 import { createUsageAccumulator } from "../usage-accumulator";
-
-/**
- * Compute the Claude Code working directory.
- *
- * Returns `undefined` when the agent has no `githubRepo` (ephemeral
- * agent → SDK default cwd) or no userId is available (defensive).
- *
- * Otherwise:
- *   - Desktop daemon (no `processLocal`): the sandbox daemon is spawned
- *     with `cwd = <appRoot>`, but the cloned repo lives at
- *     `<appRoot>/repo` (see `packages/sandbox/daemon/entry.ts` — it
- *     joins APP_ROOT with "repo" to form `repoDir`). Prefer the env
- *     vars the sandbox sets (`WORKDIR` / `APP_ROOT`) and fall through
- *     to `<cwd>/repo` so Claude Code actually runs inside the
- *     checkout. Final fallback is `process.cwd()` for non-sandbox
- *     environments (e.g. tests, ad-hoc invocations).
- *   - Cluster: no on-disk sandbox to point at after the host runner was
- *     retired, so fall through to `undefined` (SDK default). The
- *     `processLocal.resolveCwd` callback is kept as an extension point
- *     for future cluster-side runners that materialize files locally.
- */
-async function resolveClaudeCodeCwd(
-  input: HarnessStreamInput,
-): Promise<string | undefined> {
-  const vmMetadata = input.virtualMcp.metadata as {
-    githubRepo?: unknown;
-  } | null;
-  if (!vmMetadata?.githubRepo) return undefined;
-  if (!input.user?.id) return undefined;
-
-  if (!input.processLocal) {
-    const appRoot =
-      process.env.WORKDIR || process.env.APP_ROOT || process.cwd();
-    return `${appRoot.replace(/\/$/, "")}/repo`;
-  }
-
-  const resolveCwd = input.processLocal.resolveCwd;
-  if (!resolveCwd) return undefined;
-  return await resolveCwd();
-}
 
 async function* mergeTitleResult(
   uiStream: AsyncIterable<UIMessageChunk>,
@@ -147,8 +108,10 @@ export const claudeCodeHarnessFactory: HarnessFactory = {
 
         // 2. Compute the working directory for the CLI subprocess —
         //    github-linked agents get a per-branch sandbox path, ephemeral
-        //    agents fall through to undefined (SDK default).
-        const cwd = await resolveClaudeCodeCwd(input);
+        //    agents fall through to undefined (SDK default). Shared with
+        //    the Codex harness via `../cli-cwd` so both CLIs run inside
+        //    the same checkout.
+        const cwd = await resolveCliCwd(input);
 
         // Diagnostics: on the user-desktop path this runs inside the spawned
         // sandbox daemon (stdout inherited by `deco link`), so these lines

--- a/apps/mesh/src/harnesses/cli-cwd.ts
+++ b/apps/mesh/src/harnesses/cli-cwd.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared working-directory resolver for CLI harnesses (Claude Code, Codex).
+ *
+ * The two CLI harnesses spawn third-party subprocesses (`claude`, `codex`)
+ * that need to run inside the user's checkout — not wherever the host
+ * process happens to be. Both used to compute this independently and the
+ * codex harness simply never did, leaving its subprocess in the daemon's
+ * own cwd (typically the app root, not the cloned repo). This module is
+ * the single source of truth so the two CLIs stay in lockstep.
+ *
+ * Resolution rules (mirrors the cluster's pre-extraction
+ * `resolveClaudeCodeCwd`):
+ *
+ *   1. **Ephemeral agent** (no `virtualMcp.metadata.githubRepo`): return
+ *      `undefined`. There's no on-disk checkout to point at, so let the
+ *      SDK fall through to its own default (which in turn defaults to
+ *      `process.cwd()` for both providers).
+ *   2. **No authenticated user**: return `undefined`. Defensive — every
+ *      real request has a `user.id`, but the harness types allow the
+ *      absence and we'd rather skip than crash.
+ *   3. **Desktop daemon path** (`processLocal` is absent): the sandbox
+ *      daemon (`packages/sandbox/daemon/entry.ts`) spawns this process
+ *      with `cwd = <appRoot>` and clones the repo into `<appRoot>/repo`.
+ *      Prefer the env vars the sandbox sets (`WORKDIR` then `APP_ROOT`),
+ *      then fall back to `process.cwd()`. Append `/repo` in every case so
+ *      the CLI actually runs inside the checkout.
+ *   4. **Cluster path** (`processLocal` is set): defer to the optional
+ *      `processLocal.resolveCwd` callback. The cluster used to inject a
+ *      `host` runner that materialized files at a per-branch path; that
+ *      runner has been retired and the cluster no longer supplies a
+ *      resolver, so we fall through to `undefined`. The callback is kept
+ *      as an extension point for future cluster-side runners.
+ */
+
+import type { HarnessStreamInput } from "./types";
+
+/**
+ * Compute the CLI subprocess working directory for a harness call.
+ *
+ * Returns `undefined` to mean "let the SDK pick its own default" — both
+ * `ai-sdk-provider-claude-code` and `ai-sdk-provider-codex-cli` then use
+ * `process.cwd()` internally, which is fine for non-github-linked agents.
+ */
+export async function resolveCliCwd(
+  input: HarnessStreamInput,
+): Promise<string | undefined> {
+  const vmMetadata = input.virtualMcp.metadata as {
+    githubRepo?: unknown;
+  } | null;
+  if (!vmMetadata?.githubRepo) return undefined;
+  if (!input.user?.id) return undefined;
+
+  if (!input.processLocal) {
+    const appRoot =
+      process.env.WORKDIR || process.env.APP_ROOT || process.cwd();
+    return `${appRoot.replace(/\/$/, "")}/repo`;
+  }
+
+  const resolveCwd = input.processLocal.resolveCwd;
+  if (!resolveCwd) return undefined;
+  return await resolveCwd();
+}

--- a/apps/mesh/src/harnesses/codex/index.ts
+++ b/apps/mesh/src/harnesses/codex/index.ts
@@ -38,6 +38,7 @@
 
 import { streamText, type UIMessageChunk } from "ai";
 import { createCodexModel, resolveCodexModelId } from "./model";
+import { resolveCliCwd } from "../cli-cwd";
 import { extractUserText, prepCliMessages } from "../cli-message-prep";
 import { makeTitleResultChunk } from "../title-chunk";
 import { genTitle } from "../decopilot/title-generator";
@@ -100,7 +101,6 @@ async function* mergeTitleResult(
     if (!titleDone) titleHandle.finish();
   }
 }
-
 export const codexHarnessFactory: HarnessFactory = {
   id: "codex",
   create(_ctx: HarnessContext): Harness {
@@ -111,7 +111,26 @@ export const codexHarnessFactory: HarnessFactory = {
         //    name (e.g. `gpt-5.4`). Mirrors stream-core line 922.
         const sdkModelId = resolveCodexModelId(input.models.thinking.id);
 
-        // 2. Build the Codex language model. The MCP URL + headers are
+        // 2. Compute the working directory for the codex app-server
+        //    subprocess. Shared with the Claude Code harness via
+        //    `../cli-cwd` — github-linked agents resolve to the sandbox's
+        //    `<appRoot>/repo` checkout, ephemeral agents fall through to
+        //    undefined (SDK default = process.cwd()). Without this, the
+        //    codex CLI ran in the daemon's own cwd and file edits landed
+        //    outside the user's repo.
+        const cwd = await resolveCliCwd(input);
+
+        // Diagnostics: on the user-desktop path this runs inside the spawned
+        // sandbox daemon (stdout inherited by `deco link`), so these lines
+        // surface in the link terminal. They pin the three most common
+        // failure causes for a `decopilot.finish: failed` with no other
+        // signal — wrong cwd (CLI runs outside the checkout), an
+        // unreachable MCP endpoint, or a bad model id.
+        console.log(
+          `[codex] stream start model=${sdkModelId} cwd=${cwd ?? "(default)"} mcpUrl=${input.mcp.url} mode=${input.mode}`,
+        );
+
+        // 3. Build the Codex language model. The MCP URL + headers are
         //    already minted by the shared layer (it owns the
         //    temp-API-key lifecycle); the harness just forwards them.
         //    Mirrors stream-core lines 921–937 — all three options
@@ -136,6 +155,7 @@ export const codexHarnessFactory: HarnessFactory = {
           },
           toolApprovalLevel: input.toolApprovalLevel,
           isPlanMode: input.mode === "plan",
+          cwd,
         });
 
         try {
@@ -155,6 +175,7 @@ export const codexHarnessFactory: HarnessFactory = {
             createCodexModel(resolveCodexModelId("codex:gpt-5.4-mini"), {
               toolApprovalLevel: "readonly",
               isPlanMode: true,
+              cwd,
             });
           const titleHandle = genTitle({
             abortSignal: input.signal,

--- a/apps/mesh/src/harnesses/codex/model/index.ts
+++ b/apps/mesh/src/harnesses/codex/model/index.ts
@@ -27,6 +27,11 @@ export function createCodexModel(
     toolApprovalLevel?: ToolApprovalLevel;
     /** Chat mode plan — stricter approval policy */
     isPlanMode?: boolean;
+    /** Working directory for Codex's app-server subprocess. Defaults to
+     *  mesh's cwd — mirrors `createClaudeCodeModel`. Without this, the
+     *  codex CLI runs in the daemon's own cwd (typically the app root)
+     *  instead of the cloned repo, so file edits land in the wrong tree. */
+    cwd?: string;
   },
 ): { model: LanguageModelV3; provider: CodexAppServerProvider } {
   const mcpServers = options?.mcpServers
@@ -53,6 +58,7 @@ export function createCodexModel(
     defaultSettings: {
       mcpServers,
       approvalPolicy,
+      cwd: options?.cwd ?? process.cwd(),
       rmcpClient: true,
       sandboxPolicy: "workspace-write",
       connectionTimeoutMs: 30_000,


### PR DESCRIPTION
## Summary

- The codex harness never forwarded a `cwd` to `createCodexAppServer`, so the codex subprocess ran in the daemon's own working directory (typically the app root) instead of the cloned repo at `<appRoot>/repo`. File edits landed outside the user's checkout. Claude Code's harness already resolved the right path via an inline `resolveClaudeCodeCwd`.
- Extracted that resolver into a shared `apps/mesh/src/harnesses/cli-cwd.ts` module (`resolveCliCwd`) and delegated from both CLI harnesses so they stay in lockstep by construction.
- Threaded the resolved `cwd` through both `createCodexModel` calls (main + title app-server). Codex now also mirrors Claude Code's startup diagnostic log line (`[codex] stream start model=... cwd=...`) so wrong-cwd failures are visible in the `deco link` terminal.

## Test plan

- [x] `bun run check` (typecheck across all workspaces) — passes
- [x] `bun run lint` (oxlint) — 0 warnings, 0 errors
- [x] `bun run fmt:check` (biome) — no changes
- [x] `bun test apps/mesh/src/harnesses` — 205/206 pass (the 1 unrelated failure is `web_search async-research e2e`, which needs a live Postgres on :5432)
- [ ] Manual smoke: invoke a codex-backed agent on a github-linked workspace and confirm file edits land inside the `repo/` subtree of the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `codex` CLI to run inside the cloned repo checkout (same as `claude-code`) so file edits land in the user’s repo, not the daemon’s cwd.

- **Bug Fixes**
  - Added shared `resolveCliCwd` in `apps/mesh/src/harnesses/cli-cwd.ts` and used it in both CLI harnesses to point github-linked agents to `<appRoot>/repo` (ephemeral agents fall back to default).
  - Threaded `cwd` through `createCodexModel` (main and title) so `codex` writes to the correct tree.
  - Added a startup diagnostic: `[codex] stream start model=... cwd=...` to make wrong-cwd issues visible.

<sup>Written for commit b991311524e0e2ab1d5771d746f5304d8c14b2b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

