### PR TITLE
fix(chat): anchor live chronometer on user message created_at

### DIFF
--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -317,6 +317,15 @@ function CollapsedSection({
 
 interface MessageAssistantProps {
   message: ChatMessage | null;
+  /**
+   * Top-level `created_at` of the user message that opened this turn. Used as
+   * the anchor for the live elapsed-time chronometer so the value is stable
+   * across page reload, thread switch, and SSE resume (the user row is
+   * inserted once and never re-stamped). Null when there's no preceding user
+   * message in the pair (assistant-initiated welcomes, async-research stubs),
+   * in which case the chronometer falls back to `Date.now()` at mount.
+   */
+  turnStartedAt?: string | Date | null;
   status?: "streaming" | "submitted" | "ready" | "error";
   className?: string;
   isLast: boolean;
@@ -624,6 +633,7 @@ function Container({
 
 export function MessageAssistant({
   message,
+  turnStartedAt,
   status,
   className,
   isLast = false,
@@ -634,17 +644,22 @@ export function MessageAssistant({
   const isSubmitted = status === "submitted";
   const isLoading = isStreaming || isSubmitted;
 
-  // Track when this message's generation started for the live elapsed timer.
+  // Track when this turn started for the live elapsed-time chronometer.
   //
-  // Prefer the server-stamped stream start (`metadata.created_at`, set on the
-  // first stream chunk in run-stream.ts and persisted in thread_messages).
-  // This makes the chronometer survive a page refresh — it resumes counting
-  // from the real start time instead of restarting at 0 on remount.
+  // Anchor on the user message's top-level `created_at` (passed in via
+  // `turnStartedAt` from MessagePair). This timestamp is set once when the
+  // user row is inserted on the server and never re-stamped, so it survives
+  // page reload, thread switch, and SSE resume cleanly — the chronometer
+  // resumes counting from the real turn-start instead of restarting on
+  // remount. It's also the most semantically meaningful anchor: the chron
+  // shows how long the user has been waiting since *they* submitted.
   //
-  // Client fallback (`Date.now()`) covers the brief "submitted but no chunks
-  // yet" window where the server hasn't sent a `start` chunk; once that
-  // chunk arrives the server time takes over via the `??` below.
-  const serverStartedAt = toEpochMs(message?.metadata?.created_at);
+  // Client fallback (`Date.now()`) covers two cases:
+  //   1. The brief optimistic-submit window where the user row exists locally
+  //      but the server hasn't yet inserted it (no top-level `created_at`).
+  //   2. Assistant-only pairs (welcomes, async-research stubs) where there's
+  //      no preceding user message at all.
+  const turnEpochMs = toEpochMs(turnStartedAt);
   const [clientFallbackStartedAt, setClientFallbackStartedAt] = useState<
     number | null
   >(() => (isLoading ? Date.now() : null));
@@ -653,7 +668,7 @@ export function MessageAssistant({
     setPrevIsLoading(isLoading);
     setClientFallbackStartedAt(isLoading ? Date.now() : null);
   }
-  const startedAt = serverStartedAt ?? clientFallbackStartedAt;
+  const startedAt = turnEpochMs ?? clientFallbackStartedAt;
 
   // Handle null message or empty parts
   const hasContent = message !== null && message.parts.length > 0;

--- a/apps/mesh/src/web/components/chat/message/pair.tsx
+++ b/apps/mesh/src/web/components/chat/message/pair.tsx
@@ -111,6 +111,16 @@ export function MessagePair({ pair, isLastPair, status }: MessagePairProps) {
       )}
       <MessageAssistant
         message={pair.assistant}
+        // Top-level `created_at` on the user row is a custom field added by
+        // our DB pipeline (see `readTimestamp` in thread-connection.ts) and
+        // isn't declared on the AI-SDK UIMessage type, so cast to read it.
+        // Falls through to `undefined` for assistant-only pairs (no preceding
+        // user) or for optimistic user rows before the server-confirmed row
+        // replaces them — MessageAssistant handles that with `Date.now()`.
+        turnStartedAt={
+          (pair.user as unknown as { created_at?: string | Date | null })
+            ?.created_at ?? null
+        }
         status={status}
         isLast={isLastPair}
       />

--- a/apps/mesh/src/web/lib/format-time.ts
+++ b/apps/mesh/src/web/lib/format-time.ts
@@ -31,11 +31,12 @@ export function toEpochMs(
 /**
  * Compute elapsed milliseconds since `start`, clamped at 0.
  *
- * The clamp matters when `start` is a server-stamped timestamp (e.g.
- * `message.metadata.created_at` from the streaming pipeline) and the server
- * clock is ahead of the client clock — without it, `Date.now() - start`
- * would be negative and the live elapsed timer would briefly render a
- * negative duration like "-0.3s" until the client clock catches up.
+ * The clamp matters when `start` is a server-stamped timestamp (e.g. the
+ * user message's `created_at` row column, used to anchor the chat live
+ * elapsed-time chronometer) and the server clock is ahead of the client
+ * clock — without it, `Date.now() - start` would be negative and the
+ * timer would briefly render a negative duration like "-0.3s" until the
+ * client clock catches up.
  */
 export function computeElapsedMs(start: number, now: number): number {
   const diff = now - start;


### PR DESCRIPTION
## Summary

- Switches the streaming-state live elapsed-time chronometer (`MessageAssistant` → `LiveTimer`) from anchoring on `assistant.metadata.created_at` to the user message's top-level `created_at`.
- `assistant.metadata.created_at` lives inside a JSON blob and is set via `new Date()` inside the AI-SDK `messageMetadata({ part: "start" })` callback — fragile across SSE resume / message recreation, since the `start` part can re-emit and re-stamp the field.
- The user row's top-level `created_at` is a column set once on insert and never rewritten — stable across page reload, thread switch, and SSE resume.
- Semantically more meaningful: the chron now reads "how long has the user been waiting since *they* submitted", which matches the user mental model and handles multi-step turns (assistant → tool → assistant follow-up) by anchoring everything in the same turn to the same start.
- `Date.now()` fallback retained for two cases the new anchor can't cover: the brief optimistic-submit window before the server-confirmed user row arrives, and assistant-only pairs (welcomes, async-research stubs).

## Files changed

- `apps/mesh/src/web/components/chat/message/assistant.tsx` — new `turnStartedAt` prop; replaces the `serverStartedAt`/`clientFallbackStartedAt` precedence with `turnEpochMs ?? clientFallbackStartedAt`.
- `apps/mesh/src/web/components/chat/message/pair.tsx` — plumbs `pair.user`'s top-level `created_at` to `MessageAssistant`. Uses the same defensive cast pattern as `readTimestamp` in `thread-connection.ts` (AI-SDK `UIMessage` doesn't declare the field).
- `apps/mesh/src/web/lib/format-time.ts` — refreshes the now-stale `metadata.created_at` example in the `computeElapsedMs` doc comment. The server-skew clamp justification is unchanged and still valid.

## Test plan

- [x] `bun run check` — TypeScript, all workspaces (passes)
- [x] `bun test src/web/lib/format-time.test.ts src/web/components/chat/store/thread-connection.test.ts` — 59 tests passing
- [x] `bun run lint` — oxlint, 0 warnings / 0 errors
- [x] `bun run fmt` — Biome applied
- [ ] **Manual**: open a streaming thread, refresh mid-stream, confirm the chron reads ~real-elapsed (not 0). This is unchanged behavior vs main — the PR doesn't reset the timer on reload, it just changes which timestamp it reads from. Listed for completeness because the chron is in a hot path.
- [ ] **Manual**: open a thread that has never had a user message (welcome / async-research stub) and confirm the timer still renders via \`Date.now()\` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the chat live elapsed-time chronometer to the preceding user message’s `created_at` instead of `assistant.metadata.created_at`, making timing stable across reloads, thread switches, and SSE resumes. This reflects how long the user has waited since they submitted.

- **Bug Fixes**
  - `MessageAssistant` now uses a `turnStartedAt` prop sourced from the user row’s top-level `created_at` (plumbed in `MessagePair`).
  - Falls back to `Date.now()` for optimistic submit and assistant-only pairs (welcome/async-research).
  - Updated `format-time` docs to reflect the new anchor; no API changes.

<sup>Written for commit 2c9a2d2b16e66dbf6aad52be6ac3b460df84dad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

