### PR TITLE
refactor(core): rename MeshContext to StudioContext

### DIFF
--- a/.cursor/skills/add-mcp-tools/SKILL.md
+++ b/.cursor/skills/add-mcp-tools/SKILL.md
@@ -100,7 +100,7 @@ Each tool file follows this pattern:
 ```typescript
 // apps/mesh/src/tools/<domain>/create.ts
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth, requireOrganization } from "../../core/mesh-context";
+import { getUserId, requireAuth, requireOrganization } from "../../core/studio-context";
 import { MyCreateInputSchema, MyCreateOutputSchema } from "./schema";
 
 export const MY_DOMAIN_CREATE = defineTool({
@@ -255,10 +255,10 @@ apiKey({
 
 If your tools wrap Better Auth APIs, you need to:
 
-**a. Add types to `mesh-context.ts`:**
+**a. Add types to `studio-context.ts`:**
 
 ```typescript
-// apps/mesh/src/core/mesh-context.ts
+// apps/mesh/src/core/studio-context.ts
 
 // Add return types
 export type MyDomainCreateResult = Awaited<
@@ -391,3 +391,4 @@ Use the existing test patterns from `apps/mesh/src/tools/connection/` as referen
 4. **Missing default permissions** - Add to `auth/index.ts` if users should have access by default
 5. **Exposing sensitive data** - Only return secrets at creation time
 6. **Missing organization check** - Use `requireOrganization(ctx)` for org-scoped resources
+

--- a/.cursor/skills/review-plan/references/critic-prompts.md
+++ b/.cursor/skills/review-plan/references/critic-prompts.md
@@ -138,7 +138,7 @@ Critique this implementation plan from the ARCHITECTURE perspective.
 **Your role:** Assess fit with existing patterns, dependencies, and layering.
 
 **Check:**
-- Does it follow project conventions (e.g., defineTool, MeshContext)?
+- Does it follow project conventions (e.g., defineTool, StudioContext)?
 - Are dependencies on the right layers (no direct DB in tools)?
 - Does it integrate with existing systems correctly?
 - New dependencies justified?
@@ -175,3 +175,4 @@ Critique this implementation plan from the SCOPE perspective.
 - Recommendations
 - Verdict: Ready / Needs changes / High risk
 ```
+

--- a/.cursor/skills/review-pr/references/critic-prompts.md
+++ b/.cursor/skills/review-pr/references/critic-prompts.md
@@ -171,7 +171,7 @@ Critique these code changes from the ARCHITECTURE perspective.
 **Your role:** Assess whether the changes fit existing patterns and maintain clean layering.
 
 **Check:**
-- Do new tools use defineTool() and MeshContext correctly?
+- Do new tools use defineTool() and StudioContext correctly?
 - Are database operations going through ctx.storage (not raw Kysely)?
 - Are HTTP objects leaking into tool handlers?
 - Do new components follow existing UI patterns?
@@ -215,3 +215,4 @@ Critique these code changes from the SCOPE perspective.
 - **Recommendations:** what to remove, defer, or separate
 - **Verdict:** Ready / Needs changes / High risk
 ```
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ bun run --cwd=apps/mesh start
 
 ### Core Abstractions
 
-**MeshContext** (`apps/mesh/src/core/mesh-context.ts`)
+**StudioContext** (`apps/mesh/src/core/studio-context.ts`)
 The central runtime interface injected into all tools. Provides:
 - `auth`: Authentication state (user, session, organization)
 - `access`: Access control layer (RBAC checks)
@@ -123,7 +123,7 @@ The central runtime interface injected into all tools. Provides:
 - `tracer`: OpenTelemetry distributed tracing
 - `meter`: OpenTelemetry metrics collection
 
-Tools NEVER access HTTP objects, database drivers, or environment variables directly—all dependencies flow through MeshContext.
+Tools NEVER access HTTP objects, database drivers, or environment variables directly—all dependencies flow through StudioContext.
 
 **defineTool()** (`apps/mesh/src/core/define-tool.ts`)
 Declarative API for creating type-safe, auditable MCP tools. Automatically provides:
@@ -155,7 +155,7 @@ The workspace is managed via Bun workspaces. The main application lives in `apps
 **apps/mesh/** - Main full-stack application
 - `src/api/` - Hono HTTP routes + MCP proxy routes
 - `src/auth/` - Better Auth (OAuth 2.1 + SSO + API keys)
-- `src/core/` - MeshContext, AccessControl, defineTool
+- `src/core/` - StudioContext, AccessControl, defineTool
 - `src/tools/` - Built-in MCP management tools (organized by domain)
 - `src/storage/` - Kysely database adapters and operations
 - `src/event-bus/` - Pub/sub event delivery system (CloudEvents v1.0)
@@ -348,14 +348,14 @@ See [`TESTING.md`](./TESTING.md) for the testing philosophy and rules.
 - **Unit (`bun test`)** — pure logic only. No mocks, no DB, no network. Co-located `*.test.ts` next to source.
 - **E2E (Playwright)** — everything else. Real Postgres + NATS + Better Auth. Lives in `apps/mesh/e2e/tests/`.
 
-If a test needs `vi.mock`, `mock.module`, a stubbed `MeshContext`, or a fake `fetch` — it's not a unit test. Move it to e2e.
+If a test needs `vi.mock`, `mock.module`, a stubbed `StudioContext`, or a fake `fetch` — it's not a unit test. Move it to e2e.
 
 ## Working with Tools
 
 When creating new MCP tools:
 1. Use `defineTool()` from `apps/mesh/src/core/define-tool.ts`
 2. Place tools in appropriate domain folder under `apps/mesh/src/tools/`
-3. Always inject `MeshContext` as second parameter
+3. Always inject `StudioContext` as second parameter
 4. Call `await ctx.access.check()` for authorization
 5. Use `ctx.storage` for database operations (never access Kysely directly)
 6. Define Zod schemas for input/output validation
@@ -397,8 +397,8 @@ PRs should include:
 
 ## Common Gotchas
 
-1. **Never access environment variables directly in tools**—use MeshContext
-2. **Never access HTTP context in tools**—use MeshContext for all state
+1. **Never access environment variables directly in tools**—use StudioContext
+2. **Never access HTTP context in tools**—use StudioContext for all state
 3. **Database migrations**: Remember to run both Kysely migrations (`bun run migrate`) and Better Auth migrations (`bun run better-auth:migrate`)
 4. **Event bus**: The worker doesn't poll internally—it relies on NotifyStrategy to trigger processing
 5. **Formatting**: The pre-commit hook will reject commits if code isn't formatted with Biome
@@ -433,3 +433,4 @@ Sustainable Use License (SUL):
 - ⚠️ Commercial license required for SaaS or revenue-generating production systems
 
 See LICENSE.md for details. Questions: contact@decocms.com
+

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Every tool call gets input/output validation, access control, audit logging, and
 │   │   ├── src/
 │   │   │   ├── api/         # Hono HTTP + MCP proxy routes
 │   │   │   ├── auth/        # Better Auth (OAuth + API keys)
-│   │   │   ├── core/        # MeshContext, AccessControl, defineTool
+│   │   │   ├── core/        # StudioContext, AccessControl, defineTool
 │   │   │   ├── tools/       # Built-in MCP management tools
 │   │   │   ├── storage/     # Kysely DB adapters
 │   │   │   ├── event-bus/   # Pub/sub event delivery system
@@ -293,3 +293,4 @@ See `AGENTS.md` for coding guidelines.
 <div align="center">
   <sub>Made with care by the <a href="https://decocms.com">deco</a> community</sub>
 </div>
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This document is the source of truth for how we test in this repo. Read it befor
 
 Every other rule here is a consequence of this one. A test earns its place when it is likely to catch a real bug at a price worth paying. Mocking a dependency you own destroys the first half of that trade: you stop testing the contract and start testing a fiction you typed yourself. The test then stays green precisely when the real code breaks — the worst possible outcome, because it costs maintenance while catching nothing.
 
-So the enemy is **not** infrastructure. Postgres, NATS, and Better Auth are real dependencies; testing against them is good. The enemy is the *mock of your own contract* — a stubbed `MeshContext`, a fake `storage` adapter, a hand-written `fetch` that returns a response shape you invented. If your test asserts against something you made up, delete it and test the real thing.
+So the enemy is **not** infrastructure. Postgres, NATS, and Better Auth are real dependencies; testing against them is good. The enemy is the *mock of your own contract* — a stubbed `StudioContext`, a fake `storage` adapter, a hand-written `fetch` that returns a response shape you invented. If your test asserts against something you made up, delete it and test the real thing.
 
 Concretely: a test that mocks all of `storage` and then asserts "the handler called `storage.claimRunStart`" is asserting that the code calls the function the code calls. It is tautological. It will not catch the broken SQL inside `claimRunStart`, which is the only bug that handler can actually have.
 
@@ -93,7 +93,7 @@ Everything else uses `authedPage`.
 
 Don't do any of these:
 
-- **Mocking your own code to make a test green.** The headline rule. Stubbing `storage`, `MeshContext`, `auth.api.getSession`, `SandboxProvider`, `clientFromConnection`, or `global.fetch` means the test belongs in storage-integration (drop the mocks, use real Postgres) or e2e (go through the front door). (An *inert* collaborator a code path never invokes — e.g. the unused `storage` a pure in-memory state-machine test must hand to a constructor — is not this: nothing the assertion depends on is faked. Keep it plain and unexercised, not a `mock()` with canned return values.)
+- **Mocking your own code to make a test green.** The headline rule. Stubbing `storage`, `StudioContext`, `auth.api.getSession`, `SandboxProvider`, `clientFromConnection`, or `global.fetch` means the test belongs in storage-integration (drop the mocks, use real Postgres) or e2e (go through the front door). (An *inert* collaborator a code path never invokes — e.g. the unused `storage` a pure in-memory state-machine test must hand to a constructor — is not this: nothing the assertion depends on is faked. Keep it plain and unexercised, not a `mock()` with canned return values.)
 - **Asserting "the handler called the function."** If the assertion is `expect(storage.foo).toHaveBeenCalled()` against a mocked `storage.foo`, the test is tautological. Test the *effect* against the real dependency instead.
 - **A route/handler test with a mocked DB.** The bad-zone middle. Move to e2e.
 - **A CLI/client test with a hand-written `fetch` mock** that returns an invented server-response shape. You're asserting against your own fiction; it won't break when the real server changes. Stand the real server up as a fixture and round-trip against it.
@@ -160,3 +160,4 @@ Adding a test is just choosing the right filename — it auto-routes.
 - Good e2e spec: [`apps/mesh/e2e/tests/connection-create.spec.ts`](apps/mesh/e2e/tests/connection-create.spec.ts)
 </content>
 </invoke>
+

--- a/apps/mesh/README.md
+++ b/apps/mesh/README.md
@@ -138,9 +138,9 @@ apps/mesh/
 │   │
 │   ├── core/                   # Core abstractions
 │   │   ├── access-control.ts   # Permission checking
-│   │   ├── context-factory.ts  # MeshContext factory
+│   │   ├── context-factory.ts  # StudioContext factory
 │   │   ├── define-tool.ts      # Tool definition helper
-│   │   └── mesh-context.ts     # Request context type
+│   │   └── studio-context.ts     # Request context type
 │   │
 │   ├── database/               # Kysely database setup
 │   ├── encryption/             # Credential vault (AES-256-GCM)
@@ -444,4 +444,5 @@ MIT License - see [LICENSE](../../LICENSE.md) for details.
 <p align="center">
   Built with 💚 by <a href="https://decocms.com">decocms.com</a>
 </p>
+
 

--- a/apps/mesh/e2e/tests/decopilot-messages.spec.ts
+++ b/apps/mesh/e2e/tests/decopilot-messages.spec.ts
@@ -3,7 +3,7 @@
  *
  * These assertions used to live in a unit test that mocked resolveTier,
  * model-permissions, dispatch-queue, the sandbox-kind resolver, AND fabricated
- * a MeshContext — then drove the Hono route and checked the HTTP status. That
+ * a StudioContext — then drove the Hono route and checked the HTTP status. That
  * is the bad zone (a route handler with every dependency faked); per TESTING.md
  * a route belongs in e2e, exercised through the real front door.
  *

--- a/apps/mesh/spec/001.md
+++ b/apps/mesh/spec/001.md
@@ -102,7 +102,7 @@ apps/mesh/
 │   ├── api/
 │   │   ├── index.ts                 # Hono app initialization
 │   │   ├── middlewares/
-│   │   │   ├── inject-context.ts    # Middleware that injects MeshContext into requests
+│   │   │   ├── inject-context.ts    # Middleware that injects StudioContext into requests
 │   │   │   ├── auth.ts              # Authentication middleware
 │   │   │   ├── mcp-auth.ts          # MCP OAuth 2.1 authentication middleware (Bearer tokens)
 │   │   │   └── authorization.ts     # Authorization verification middleware
@@ -119,8 +119,8 @@ apps/mesh/
 │   │   │   └── test.ts              # CONNECTION_TEST
 │   │
 │   ├── core/
-│   │   ├── mesh-context.ts          # MeshContext interface definition
-│   │   ├── context-factory.ts       # Factory function to create MeshContext
+│   │   ├── studio-context.ts          # StudioContext interface definition
+│   │   ├── context-factory.ts       # Factory function to create StudioContext
 │   │   ├── access-control.ts        # Access control helper for authorization
 │   │   ├── define-tool.ts           # defineTool function for declarative tool definitions
 │   │   ├── bindings.ts              # MCP binding definitions (CHAT, EMAIL, STORAGE, etc.)
@@ -177,13 +177,13 @@ apps/mesh/
 - Import database drivers directly
 - Handle HTTP status codes
 
-#### 2. MeshContext: The Core Abstraction
+#### 2. StudioContext: The Core Abstraction
 
-Every tool receives a `MeshContext` that provides access to all necessary services through well-defined interfaces:
+Every tool receives a `StudioContext` that provides access to all necessary services through well-defined interfaces:
 
 ```typescript
-// core/mesh-context.ts
-interface MeshContext {
+// core/studio-context.ts
+interface StudioContext {
   // Authentication (via Better Auth)
   auth: {
     user?: User;
@@ -251,14 +251,14 @@ Tools are defined using the `defineTool` function with Zod schemas for type-safe
 ```typescript
 // core/define-tool.ts
 import { z } from 'zod';
-import type { MeshContext } from './mesh-context';
+import type { StudioContext } from './studio-context';
 
 export interface ToolDefinition<TInput extends z.ZodType, TOutput extends z.ZodType> {
   name: string;
   description: string;
   inputSchema: TInput;
   outputSchema?: TOutput;
-  handler: (input: z.infer<TInput>, ctx: MeshContext) => Promise<z.infer<TOutput>>;
+  handler: (input: z.infer<TInput>, ctx: StudioContext) => Promise<z.infer<TOutput>>;
 }
 
 export function defineTool<TInput extends z.ZodType, TOutput extends z.ZodType>(
@@ -268,7 +268,7 @@ export function defineTool<TInput extends z.ZodType, TOutput extends z.ZodType>(
     ...definition,
     
     // Wrapped handler that adds context, authorization, validation, and logging
-    execute: async (input: z.infer<TInput>, ctx: MeshContext): Promise<z.infer<TOutput>> => {
+    execute: async (input: z.infer<TInput>, ctx: StudioContext): Promise<z.infer<TOutput>> => {
       // Set tool name in context
       ctx.toolName = definition.name;
       
@@ -374,7 +374,7 @@ Tools must explicitly authorize operations using the improved access control API
 ```typescript
 // api/middlewares/inject-context.ts
 app.use('*', async (c, next) => {
-  const ctx: MeshContext = await createMeshContext(c);
+  const ctx: StudioContext = await createStudioContext(c);
   c.set('meshContext', ctx);
   await next();
 });
@@ -1471,7 +1471,7 @@ export function defineTool<TInput extends z.ZodType, TOutput extends z.ZodType>(
 ) {
   return {
     ...definition,
-    execute: async (input: z.infer<TInput>, ctx: MeshContext): Promise<z.infer<TOutput>> => {
+    execute: async (input: z.infer<TInput>, ctx: StudioContext): Promise<z.infer<TOutput>> => {
       const startTime = Date.now();
       
       return await ctx.tracer.startActiveSpan(
@@ -2111,7 +2111,7 @@ oauthCallbackRouter.get('/oauth/callback', async (c) => {
   }
   
   // Get connection details using Kysely
-  const ctx = c.get('meshContext') as MeshContext;
+  const ctx = c.get('meshContext') as StudioContext;
   const connection = await ctx.db
     .selectFrom('connections')
     .selectAll()
@@ -2854,14 +2854,14 @@ await eventBus.publish("org_123", "conn_shop", {
 
 #### 10. Context Factory
 
-The context factory creates MeshContext with [Kysely](https://kysely.dev) for database-agnostic access:
+The context factory creates StudioContext with [Kysely](https://kysely.dev) for database-agnostic access:
 
 ```typescript
 // core/context-factory.ts
 import { Kysely } from 'kysely';
 import type { Database } from '../storage/types';
 
-export interface MeshContextConfig {
+export interface StudioContextConfig {
   db: Kysely<Database>;           // Kysely instance (dialect-agnostic)
   auth: BetterAuthInstance;       // Better Auth instance
   encryption: {
@@ -2873,9 +2873,9 @@ export interface MeshContextConfig {
   };
 }
 
-export function createMeshContextFactory(
-  config: MeshContextConfig
-): (c: Context) => Promise<MeshContext> {
+export function createStudioContextFactory(
+  config: StudioContextConfig
+): (c: Context) => Promise<StudioContext> {
   // Create storage adapters using Kysely (works with any dialect)
   const storage = {
     connections: new ConnectionStorage(config.db),
@@ -2887,12 +2887,12 @@ export function createMeshContextFactory(
   const vault = new CredentialVault(config.encryption.key);
   
   // Return factory function
-  return async (c: Context): Promise<MeshContext> => {
+  return async (c: Context): Promise<StudioContext> => {
     // Extract API key from request
     const authHeader = c.req.header('Authorization');
     const key = authHeader?.replace('Bearer ', '');
     
-    let auth: MeshContext['auth'] = {};
+    let auth: StudioContext['auth'] = {};
     if (key) {
       // Verify API key with Better Auth
       // https://www.better-auth.com/docs/plugins/api-key#verify-an-api-key
@@ -2923,7 +2923,7 @@ export function createMeshContextFactory(
     
     // Extract project from path (Kubernetes namespace concept)
     const projectSlug = extractProjectSlug(c.req.path);
-    let project: MeshContext['project'] | undefined;
+    let project: StudioContext['project'] | undefined;
     if (projectSlug) {
       // Namespace-scoped (project-level) request
       project = await storage.projects.findBySlug(projectSlug);
@@ -3308,7 +3308,7 @@ app.post('/:connectionId', async (c) => {
 
 #### 10. Testing Strategy
 
-The MeshContext abstraction and `defineTool` pattern enable comprehensive testing without HTTP servers:
+The StudioContext abstraction and `defineTool` pattern enable comprehensive testing without HTTP servers:
 
 ```typescript
 // tools/connection/create.test.ts
@@ -3437,7 +3437,7 @@ To avoid confusion and maintain clean separation of concerns:
   - Takes: `name`, `description`, `inputSchema` (JSON Schema), `handler` function
   - Returns: Tool definition with `execute` method
   - Automatically handles: authorization checking, audit logging
-  - Handler signature: `async (input: TInput, ctx: MeshContext) => Promise<TOutput>`
+  - Handler signature: `async (input: TInput, ctx: StudioContext) => Promise<TOutput>`
   - Validation: Handled by MCP protocol layer (no duplicate validation needed)
 
 Benefits:
@@ -3480,10 +3480,10 @@ Benefits:
 
 **Context-Related Files:**
 
-- `core/mesh-context.ts` - The core MeshContext interface definition
-- `core/context-factory.ts` - Factory function that creates MeshContext instances
+- `core/studio-context.ts` - The core StudioContext interface definition
+- `core/context-factory.ts` - Factory function that creates StudioContext instances
 - `core/access-control.ts` - Access control helper for authorization tracking
-- `api/middlewares/inject-context.ts` - Hono middleware that injects MeshContext into requests
+- `api/middlewares/inject-context.ts` - Hono middleware that injects StudioContext into requests
 
 The `core/` folder contains the heart of the application: the context abstraction and its factory. The middleware simply uses the factory to inject context into HTTP requests.
 
@@ -4832,3 +4832,4 @@ We welcome contributions! Please see our [CONTRIBUTING.md](./CONTRIBUTING.md) fo
 ## License
 
 Studio is open-source software licensed under the [MIT License](./LICENSE).
+

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -21,9 +21,9 @@ import { auth } from "../auth";
 import { createMemberRoleCache } from "../auth/member-role-cache";
 import {
   ContextFactory,
-  createMeshContextFactory,
+  createStudioContextFactory,
 } from "../core/context-factory";
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 import { closeDatabase, getDb, type MeshDatabase } from "../database";
 import { createEventBus, type EventBus } from "../event-bus";
 import {
@@ -69,7 +69,7 @@ import publicConfigRoutes from "./routes/public-config";
 import filesRoutes from "./routes/files";
 import { createThreadOutputsRoutes } from "./routes/thread-outputs";
 import { createSelfRoutes } from "./routes/self";
-import { shouldSkipMeshContext, SYSTEM_PATHS } from "./utils/paths";
+import { shouldSkipStudioContext, SYSTEM_PATHS } from "./utils/paths";
 import {
   mountPluginRoutes,
   initializePluginStorage,
@@ -231,7 +231,7 @@ let currentDecopilotCleanup: (() => void | Promise<void>) | null = null;
  * @param organizationId - The organization ID to search for the registry connection
  */
 async function getDecoStoreProjectLocator(
-  ctx: MeshContext,
+  ctx: StudioContext,
   organizationId: string,
 ): Promise<string | null> {
   // Find registry connection by URL within the organization
@@ -1280,13 +1280,13 @@ export async function createApp(options: CreateAppOptions = {}) {
   );
 
   // ============================================================================
-  // MeshContext Injection Middleware
+  // StudioContext Injection Middleware
   // ============================================================================
 
   // Create context factory with the provided database and event bus
   // Context factory only needs the Kysely instance, not the full MeshDatabase
   const memberRoleCache = createMemberRoleCache({ ttlMs: 2 * 60 * 1000 });
-  const factory = await createMeshContextFactory({
+  const factory = await createStudioContextFactory({
     db: database.db,
     auth,
     encryption: {
@@ -1367,7 +1367,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Must run before DBOS.launch() (which fires in index.ts after createApp).
   registerMonitoringRetentionWorkflow();
 
-  const automationRunner: MeshContext["automationRunner"] = async (
+  const automationRunner: StudioContext["automationRunner"] = async (
     automationId,
     orgId,
     _userId,
@@ -1542,10 +1542,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   cleanupExpiredApiKeys();
   setInterval(cleanupExpiredApiKeys, 24 * 60 * 60 * 1000).unref();
 
-  // Inject MeshContext into requests
-  // Skip auth routes, static files, health check, and metrics - they don't need MeshContext
+  // Inject StudioContext into requests
+  // Skip auth routes, static files, health check, and metrics - they don't need StudioContext
   app.use("*", async (c, next) => {
-    if (shouldSkipMeshContext(c.req.path)) {
+    if (shouldSkipStudioContext(c.req.path)) {
       return next();
     }
 
@@ -1614,7 +1614,7 @@ export async function createApp(options: CreateAppOptions = {}) {
       return next();
     }
 
-    const ctx = c.get("meshContext") as MeshContext | undefined;
+    const ctx = c.get("meshContext") as StudioContext | undefined;
     if (!ctx?.organization?.id || !ctx?.auth?.user?.id) {
       return next();
     }
@@ -1644,7 +1644,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/org-sso with deprecation log; the new
   // /api/:org/org-sso mount is wired in a later task.
   const legacyOrgSso = new Hono<{
-    Variables: { meshContext: MeshContext };
+    Variables: { meshContext: StudioContext };
   }>();
   legacyOrgSso.use(
     "*",
@@ -1874,7 +1874,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/* with deprecation log; the new /api/:org/* mount
   // is wired in a later task.
   const legacyThreadOutputsRoutes = new Hono<{
-    Variables: { meshContext: MeshContext };
+    Variables: { meshContext: StudioContext };
   }>();
   legacyThreadOutputsRoutes.use(
     "*",
@@ -1890,7 +1890,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/trigger-callback with deprecation log; the new
   // /api/:org/trigger-callback mount is wired in a later task.
   const legacyTriggerCallback = new Hono<{
-    Variables: { meshContext: MeshContext };
+    Variables: { meshContext: StudioContext };
   }>();
   legacyTriggerCallback.use(
     "*",
@@ -1910,7 +1910,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // is wired in a later task.
   const kvStorage = new KyselyKVStorage(database.db);
   const legacyKVRoutes = new Hono<{
-    Variables: { meshContext: MeshContext };
+    Variables: { meshContext: StudioContext };
   }>();
   legacyKVRoutes.use("*", createLogDeprecatedRoute({ mountPath: "/api" }));
   legacyKVRoutes.route("/", createKVRoutes({ kvStorage }));
@@ -1925,7 +1925,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/* with deprecation log; the new /api/:org/* mount
   // is wired in a later task.
   const legacyDownstreamTokenRoutes = new Hono<{
-    Variables: { meshContext: MeshContext };
+    Variables: { meshContext: StudioContext };
   }>();
   legacyDownstreamTokenRoutes.use(
     "*",
@@ -1943,7 +1943,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // at /api/deco-sites with a deprecation log; the new /api/:org/deco-sites
   // mount is wired in a later task.
   const legacyDecoSitesOrg = new Hono<{
-    Variables: { meshContext: MeshContext };
+    Variables: { meshContext: StudioContext };
   }>();
   legacyDecoSitesOrg.use(
     "*",
@@ -1959,7 +1959,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/vm-events with deprecation log; the new
   // /api/:org/vm-events mount is wired in a later task.
   const legacyVmEvents = new Hono<{
-    Variables: { meshContext: MeshContext };
+    Variables: { meshContext: StudioContext };
   }>();
   legacyVmEvents.use(
     "*",

--- a/apps/mesh/src/api/hono-env.ts
+++ b/apps/mesh/src/api/hono-env.ts
@@ -1,10 +1,10 @@
 import { Span } from "@opentelemetry/api";
 import type { TimingVariables } from "hono/timing";
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 
 // Define Hono variables type
 type Variables = TimingVariables & {
-  meshContext: MeshContext;
+  meshContext: StudioContext;
   rootSpan: Span;
 };
 

--- a/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
@@ -1,21 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { Hono } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import {
   createLogDeprecatedRoute,
   logDeprecatedRoute,
 } from "./log-deprecated-route";
 
-type Variables = { meshContext: MeshContext };
+type Variables = { meshContext: StudioContext };
 
-const setMeshContext = async (
+const setStudioContext = async (
   c: import("hono").Context<{ Variables: Variables }>,
   next: () => Promise<void>,
 ) => {
   c.set("meshContext", {
     organization: { slug: "acme" },
     auth: { user: { id: "user-1" } },
-  } as unknown as MeshContext);
+  } as unknown as StudioContext);
   await next();
 };
 
@@ -26,7 +26,7 @@ describe("logDeprecatedRoute", () => {
   beforeEach(() => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     app = new Hono<{ Variables: Variables }>();
-    app.use("*", setMeshContext);
+    app.use("*", setStudioContext);
     app.use("/api/legacy/:id", logDeprecatedRoute);
     app.get("/api/legacy/:id", (c) => c.json({ ok: true }));
   });

--- a/apps/mesh/src/api/middleware/log-deprecated-route.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.ts
@@ -1,7 +1,7 @@
 import type { MiddlewareHandler } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 
-type Variables = { meshContext: MeshContext };
+type Variables = { meshContext: StudioContext };
 
 /**
  * Permanent (non-deprecated) routes that any legacy deprecation middleware

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.integration.test.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Hono } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import {
   closeTestPgDatabase,
   connectTestPgDatabase,
@@ -9,7 +9,7 @@ import {
 import type { MeshDatabase } from "../../database";
 import { resolveOrgFromPath } from "./resolve-org-from-path";
 
-type Variables = { meshContext: MeshContext };
+type Variables = { meshContext: StudioContext };
 
 interface FakeAuth {
   user?: { id: string };
@@ -60,7 +60,7 @@ const buildApp = (
         asyncResearchJobs: { setOrganizationId: () => {} },
       },
       objectStorage: opts.preboundObjectStorage ?? null,
-    } as unknown as MeshContext);
+    } as unknown as StudioContext);
     await next();
   });
   app.use("/api/:org/*", resolveOrgFromPath);
@@ -212,7 +212,7 @@ describe("resolveOrgFromPath", () => {
           asyncResearchJobs: { setOrganizationId: () => {} },
         },
         objectStorage: null,
-      } as unknown as MeshContext);
+      } as unknown as StudioContext);
       await next();
     });
     app.use("/api/:org/*", resolveOrgFromPath);

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareHandler } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { isOrgArchived } from "../../core/org-archived";
 import { createBoundObjectStorage } from "../../object-storage/bound-object-storage";
 import { DevObjectStorage } from "../../object-storage/dev-object-storage";
@@ -9,7 +9,7 @@ import { getObjectStorageS3Service } from "../../object-storage/factory";
 import { isBrowserNavigation } from "../utils/browser-navigation";
 
 export const resolveOrgFromPath: MiddlewareHandler<{
-  Variables: { meshContext: MeshContext };
+  Variables: { meshContext: StudioContext };
 }> = async (c, next) => {
   const slug = c.req.param("org");
   if (!slug) {

--- a/apps/mesh/src/api/routes/automation-webhooks.ts
+++ b/apps/mesh/src/api/routes/automation-webhooks.ts
@@ -21,7 +21,7 @@ import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { auth } from "@/auth";
 import { enqueueAutomationFire } from "@/automations";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { webhookPermissionResource } from "@/tools/automations/webhook-trigger";
 import type { Env } from "../hono-env";
 
@@ -51,7 +51,7 @@ interface VerifyApiKeyResponse {
 }
 
 async function verifyWebhookToken(
-  ctx: MeshContext,
+  ctx: StudioContext,
   triggerId: string,
   token: string,
 ): Promise<VerifyResult> {

--- a/apps/mesh/src/api/routes/deco-sites.test.ts
+++ b/apps/mesh/src/api/routes/deco-sites.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import type { FileConfigInfo } from "../../storage/types";
 import {
   provisionDecoAssetsCredentials,
@@ -26,7 +26,7 @@ function fetchFail(status: number, body = ""): typeof globalThis.fetch {
 }
 
 function makeCtx(existing: FileConfigInfo[] = []): {
-  ctx: MeshContext;
+  ctx: StudioContext;
   createCalls: Array<Record<string, unknown>>;
 } {
   const createCalls: Array<Record<string, unknown>> = [];
@@ -39,7 +39,7 @@ function makeCtx(existing: FileConfigInfo[] = []): {
   };
   const ctx = {
     storage: { orgFileConfigs },
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
   return { ctx, createCalls };
 }
 

--- a/apps/mesh/src/api/routes/deco-sites.ts
+++ b/apps/mesh/src/api/routes/deco-sites.ts
@@ -11,12 +11,12 @@
  */
 
 import { Hono } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
-import { getUserId } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
+import { getUserId } from "../../core/studio-context";
 import { generatePrefixedId } from "../../shared/utils/generate-id";
 import { fetchToolsFromMCP } from "../../tools/connection/fetch-tools";
 
-type Variables = { meshContext: MeshContext };
+type Variables = { meshContext: StudioContext };
 
 interface SupabaseSite {
   name: string;
@@ -362,7 +362,7 @@ export async function provisionDecoAssetsCredentials(
  * the user. Caller treats this as best-effort.
  */
 export async function provisionDecoAssetsFileConfig(params: {
-  ctx: MeshContext;
+  ctx: StudioContext;
   orgId: string;
   userId: string;
   siteName: string;

--- a/apps/mesh/src/api/routes/decopilot/automation-context.ts
+++ b/apps/mesh/src/api/routes/decopilot/automation-context.ts
@@ -1,7 +1,7 @@
 /**
  * Automation Context Factory
  *
- * Builds a MeshContext for background operations (automation recovery, cron,
+ * Builds a StudioContext for background operations (automation recovery, cron,
  * event triggers) without an HTTP request. Verifies the user still has an
  * active membership in the organization before constructing the context.
  */
@@ -12,7 +12,7 @@ import {
   createBoundAuthClient,
   fetchRolePermissions,
 } from "@/core/context-factory";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import type { Database } from "@/storage/types";
 import { OrgScopedThreadStorage } from "@/storage/threads";
 import type { Kysely } from "kysely";
@@ -21,7 +21,7 @@ import {
   OrgScopedAsyncResearchJobStorage,
   SqlAsyncResearchJobStorage,
 } from "@/storage/async-research-jobs";
-import type { MeshContextFactory } from "@/automations/fire";
+import type { StudioContextFactory } from "@/automations/fire";
 import { getObjectStorageS3Service } from "@/object-storage/factory";
 import { createBoundObjectStorage } from "@/object-storage/bound-object-storage";
 import { DevObjectStorage } from "@/object-storage/dev-object-storage";
@@ -34,14 +34,17 @@ export interface BuildAutomationContextDeps {
 }
 
 /**
- * Creates a MeshContextFactory that verifies org membership and builds a full
- * MeshContext scoped to the given user/org pair. Returns null when the user is
+ * Creates a StudioContextFactory that verifies org membership and builds a full
+ * StudioContext scoped to the given user/org pair. Returns null when the user is
  * no longer a member of the organization.
  */
 export function createAutomationContextFactory(
   deps: BuildAutomationContextDeps,
-): MeshContextFactory {
-  return async (orgId: string, userId: string): Promise<MeshContext | null> => {
+): StudioContextFactory {
+  return async (
+    orgId: string,
+    userId: string,
+  ): Promise<StudioContext | null> => {
     // Verify org membership
     const membership = await deps.db
       .selectFrom("member")

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -22,7 +22,7 @@
  * the drain reader consumes the result.
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { posthog } from "@/posthog";
 import { type UIMessageChunk, createUIMessageStream } from "ai";
 import type { MeshProvider } from "@/ai-providers/types";
@@ -218,7 +218,7 @@ function modelInfoFromResolvedTier(
 }
 
 async function resolveDecopilotTitleConfig(
-  ctx: MeshContext,
+  ctx: StudioContext,
   organizationId: string,
 ): Promise<{ provider: MeshProvider; model: ModelsConfig["thinking"] } | null> {
   const resolved = await tryResolveTier(ctx, "fast");
@@ -267,7 +267,7 @@ async function resolveDecopilotTitleConfig(
 const MCP_KEY_TTL_SECONDS = 3600;
 
 async function mintMcpEndpoint(
-  ctx: MeshContext,
+  ctx: StudioContext,
   agentId: string,
   organization: { id: string; slug?: string; name?: string },
   apiKeyName: string,
@@ -400,7 +400,7 @@ function dispatchRunSpanAttrs(input: DispatchRunInput): Record<string, string> {
  */
 export async function dispatchRunAndWait(
   input: DispatchRunInput,
-  ctx: MeshContext,
+  ctx: StudioContext,
   deps: DispatchRunDeps,
 ): Promise<DispatchRunResult> {
   return traced(
@@ -481,7 +481,7 @@ interface PreparedRun {
  */
 async function prepareRun(
   input: DispatchRunInput,
-  ctx: MeshContext,
+  ctx: StudioContext,
   deps: DispatchRunDeps,
   rootSpan: import("@opentelemetry/api").Span,
 ): Promise<PreparedRun> {
@@ -1241,7 +1241,7 @@ async function prepareRun(
  */
 export async function resolveRemoteCliSandboxUrl(
   input: { agent: { id: string }; branch?: string | null },
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<string> {
   const { previewUrl } = await resolveRemoteCliSandboxHandle(input, ctx);
   return previewUrl;
@@ -1255,7 +1255,7 @@ export async function resolveRemoteCliSandboxUrl(
  */
 async function resolveRemoteCliSandboxHandle(
   input: { agent: { id: string }; branch?: string | null },
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<{ sandboxHandle: string; previewUrl: string }> {
   const entry = await ensureSandbox(
     {

--- a/apps/mesh/src/api/routes/decopilot/file-materializer.ts
+++ b/apps/mesh/src/api/routes/decopilot/file-materializer.ts
@@ -18,7 +18,7 @@
  * - Base64 inline         : data: URL kept as-is in parts — when ctx.objectStorage is null
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { toFilesUrl } from "@/object-storage/key-utils";
 import type { ChatMessage } from "./types";
 import {
@@ -107,7 +107,7 @@ async function uploadBytes(
   bytes: Uint8Array,
   key: string,
   mimeType: string,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<string | null> {
   if (!ctx.objectStorage) return null;
   try {
@@ -129,7 +129,7 @@ const S3_PRESIGNED_EXPIRES_IN = 7 * 24 * 3600; // 7 days (SigV4 max)
  */
 export async function generatePresignedGetUrl(
   key: string,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<string | null> {
   if (!ctx.objectStorage) return null;
   try {
@@ -158,7 +158,7 @@ export async function generatePresignedGetUrl(
  */
 export async function uploadFileParts(
   messages: ChatMessage[],
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<ChatMessage[]> {
   if (!ctx.organization) return messages;
   const orgSlug = ctx.organization.slug;
@@ -284,7 +284,7 @@ export async function uploadFileParts(
  */
 export async function resolveStorageRefs(
   messages: ChatMessage[],
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<ChatMessage[]> {
   if (!ctx.organization) return messages;
 
@@ -367,7 +367,7 @@ export async function resolveStorageRefs(
  */
 export async function resolveArgsStorageRefs(
   args: Record<string, unknown>,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<Record<string, unknown>> {
   // Collect all mesh-storage: keys present anywhere in the args tree
   const keysFound = new Set<string>();
@@ -436,7 +436,7 @@ function substituteValues(
  */
 async function legacyMaterialize(
   messages: ChatMessage[],
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<ChatMessage[]> {
   const lastUserIdx = messages.findLastIndex((m) => m.role === "user");
   if (lastUserIdx === -1) return messages;

--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -17,7 +17,7 @@ import {
 } from "ai";
 import type { Context } from "hono";
 
-import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
+import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import { posthog } from "@/posthog";
 import { HTTPException } from "hono/http-exception";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/core/constants";
@@ -59,7 +59,7 @@ export function toolNeedsApproval(
  * Ensure organization context exists and matches route param
  */
 export function ensureOrganization(
-  c: Context<{ Variables: { meshContext: MeshContext } }>,
+  c: Context<{ Variables: { meshContext: StudioContext } }>,
 ): OrganizationScope {
   const organization = c.get("meshContext").organization;
   if (!organization) {
@@ -220,7 +220,7 @@ export async function toolsFromMCP(
   toolApprovalLevel: ToolApprovalLevel = "auto",
   options?: {
     disableOutputTruncation?: boolean;
-    ctx?: MeshContext;
+    ctx?: StudioContext;
     isPlanMode?: boolean;
   },
 ): Promise<{ tools: ToolSet; nameMap: Map<string, string> }> {
@@ -383,7 +383,7 @@ export async function toolsFromMCP(
  * Use this for read-only / observability endpoints (e.g. stream).
  */
 export async function validateThreadAccess(
-  c: Context<{ Variables: { meshContext: MeshContext } }>,
+  c: Context<{ Variables: { meshContext: StudioContext } }>,
 ) {
   const ctx = c.get("meshContext");
   const userId = ctx.auth?.user?.id;
@@ -411,7 +411,7 @@ export async function validateThreadAccess(
  * should be allowed to act.
  */
 export async function validateThreadOwnership(
-  c: Context<{ Variables: { meshContext: MeshContext } }>,
+  c: Context<{ Variables: { meshContext: StudioContext } }>,
 ) {
   const result = await validateThreadAccess(c);
   if (result.thread.created_by !== result.userId) {

--- a/apps/mesh/src/api/routes/decopilot/on-title-updated.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/on-title-updated.test.ts
@@ -54,7 +54,7 @@ describe("onTitleUpdated callback", () => {
           get: getThread,
         },
       },
-    } as unknown as import("@/core/mesh-context").MeshContext;
+    } as unknown as import("@/core/studio-context").StudioContext;
 
     const onTitleUpdated = buildOnTitleUpdated({
       ctx,
@@ -96,7 +96,7 @@ describe("onTitleUpdated callback", () => {
           get: getThread,
         },
       },
-    } as unknown as import("@/core/mesh-context").MeshContext;
+    } as unknown as import("@/core/studio-context").StudioContext;
 
     const onTitleUpdated = buildOnTitleUpdated({
       ctx,
@@ -132,7 +132,7 @@ describe("onTitleUpdated callback", () => {
           get: getThread,
         },
       },
-    } as unknown as import("@/core/mesh-context").MeshContext;
+    } as unknown as import("@/core/studio-context").StudioContext;
 
     const onTitleUpdated = buildOnTitleUpdated({
       ctx,
@@ -164,7 +164,7 @@ describe("onTitleUpdated callback", () => {
           get: getThread,
         },
       },
-    } as unknown as import("@/core/mesh-context").MeshContext;
+    } as unknown as import("@/core/studio-context").StudioContext;
 
     const onTitleUpdated = buildOnTitleUpdated({
       ctx,

--- a/apps/mesh/src/api/routes/decopilot/on-title-updated.ts
+++ b/apps/mesh/src/api/routes/decopilot/on-title-updated.ts
@@ -1,9 +1,9 @@
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import type { SSEEvent } from "@/event-bus";
 import { createDecopilotThreadStatusEvent } from "@decocms/mesh-sdk";
 
 export interface BuildOnTitleUpdatedDeps {
-  ctx: MeshContext;
+  ctx: StudioContext;
   sseHub: { emit(orgId: string, event: SSEEvent): void };
   threadId: string;
   organizationId: string;

--- a/apps/mesh/src/api/routes/decopilot/routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.test.ts
@@ -3,7 +3,7 @@
  *
  * The POST /messages dispatch/link-gating behavior that used to live here was
  * a route handler with every dependency mocked (resolveTier, model-permissions,
- * dispatch-queue, the sandbox-kind resolver, and a fabricated MeshContext) —
+ * dispatch-queue, the sandbox-kind resolver, and a fabricated StudioContext) —
  * the bad zone. It now runs through the real front door in
  * apps/mesh/e2e/tests/decopilot-messages.spec.ts. What remains is genuinely
  * pure: computeIdempotencyKey takes a message and returns a string, no I/O.

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHash } from "node:crypto";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import {
   TierUnavailableError,
   resolveTier,
@@ -81,7 +81,7 @@ export function computeIdempotencyKey(
 // ============================================================================
 
 async function validateRequest(
-  c: Context<{ Variables: { meshContext: MeshContext } }>,
+  c: Context<{ Variables: { meshContext: StudioContext } }>,
 ) {
   const organization = ensureOrganization(c);
   const rawPayload = await c.req.json();
@@ -111,7 +111,7 @@ async function validateRequest(
  * to "decopilot" (matches the existing prepareRun behavior).
  */
 async function resolveProviderId(
-  ctx: MeshContext,
+  ctx: StudioContext,
   credentialId: string,
   organizationId: string,
 ): Promise<string | undefined> {
@@ -167,7 +167,7 @@ function toModelInfo(resolved: Awaited<ReturnType<typeof resolveTier>>) {
  * duplicating the tier-resolution + tryResolve fallback logic.
  */
 async function resolvePerRequestModels(
-  ctx: MeshContext,
+  ctx: StudioContext,
   tier: SimpleModeTier | undefined,
   harnessId: HarnessId | null | undefined,
 ): Promise<ModelsConfig> {
@@ -234,7 +234,7 @@ async function resolvePerRequestModels(
  * Legacy callers that supply the id in the body alone are unaffected.
  */
 async function validate(
-  c: Context<{ Variables: { meshContext: MeshContext } }>,
+  c: Context<{ Variables: { meshContext: StudioContext } }>,
   threadIdParam: string | undefined,
 ): Promise<
   DispatchRunInput & {
@@ -335,7 +335,7 @@ export interface DecopilotDeps {
 export function createDecopilotRoutes(deps: DecopilotDeps) {
   const { cancelBroadcast, streamBuffer, runRegistry, linkClaimRegistry } =
     deps;
-  const app = new Hono<{ Variables: { meshContext: MeshContext } }>();
+  const app = new Hono<{ Variables: { meshContext: StudioContext } }>();
 
   // ============================================================================
   // Allowed Models Endpoint

--- a/apps/mesh/src/api/routes/decopilot/title-interceptor.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/title-interceptor.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the title interceptor — pure logic, no MeshContext, no
+ * Unit tests for the title interceptor — pure logic, no StudioContext, no
  * provider, no storage. Injected `persistTitle` deps keep this at the unit
  * tier per TESTING.md.
  *

--- a/apps/mesh/src/api/routes/decopilot/title-interceptor.ts
+++ b/apps/mesh/src/api/routes/decopilot/title-interceptor.ts
@@ -9,13 +9,13 @@
  * `data-thread-title` chunk while the stream is still open.
  */
 import type { UIMessageChunk, UIMessageStreamWriter } from "ai";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import type { HarnessProcessLocal } from "@/harnesses/types";
 import { isTitleInputChunk, isTitleResultChunk } from "@/harnesses/title-chunk";
 import { DEFAULT_THREAD_TITLE } from "./constants";
 
 export interface TitleInterceptorDeps {
-  ctx: MeshContext;
+  ctx: StudioContext;
   processLocal: HarnessProcessLocal;
   currentThreadTitle: string | null | undefined;
   threadId: string;

--- a/apps/mesh/src/api/routes/dev-assets-mcp.ts
+++ b/apps/mesh/src/api/routes/dev-assets-mcp.ts
@@ -32,8 +32,8 @@ import { join, relative } from "node:path";
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import type { MeshContext } from "../../core/mesh-context";
-import { requireOrganization } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
+import { requireOrganization } from "../../core/studio-context";
 import { getContentType } from "./dev-assets";
 
 // Local tool definition type
@@ -65,7 +65,7 @@ interface FileObject {
 
 // Define Hono variables type
 type Variables = {
-  meshContext: MeshContext;
+  meshContext: StudioContext;
 };
 
 const app = new Hono<{ Variables: Variables }>();
@@ -227,7 +227,7 @@ async function listFilesRecursive(
 // ============================================================================
 
 function createDevAssetsTools(
-  ctx: MeshContext,
+  ctx: StudioContext,
   baseUrl: string,
 ): ToolDefinition[] {
   const org = requireOrganization(ctx);
@@ -482,7 +482,7 @@ function createDevAssetsTools(
  */
 export async function handleDevAssetsMcpRequest(
   req: Request,
-  ctx: MeshContext,
+  ctx: StudioContext,
   baseUrl: string,
 ): Promise<Response> {
   const tools = createDevAssetsTools(ctx, baseUrl);
@@ -547,7 +547,7 @@ export async function handleDevAssetsMcpRequest(
 export async function callDevAssetsTool(
   toolName: string,
   args: Record<string, unknown>,
-  ctx: MeshContext,
+  ctx: StudioContext,
   baseUrl: string,
 ): Promise<{ content: unknown; isError?: boolean }> {
   const tools = createDevAssetsTools(ctx, baseUrl);

--- a/apps/mesh/src/api/routes/dev-assets.ts
+++ b/apps/mesh/src/api/routes/dev-assets.ts
@@ -15,7 +15,7 @@ import { Hono } from "hono";
 import { createHmac } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { getSettings } from "../../settings";
 
 // Base directory for dev assets (relative to cwd)
@@ -128,7 +128,7 @@ export function getContentType(key: string): string {
 // Routes
 // ============================================================================
 
-type DevAssetsVariables = { meshContext: MeshContext };
+type DevAssetsVariables = { meshContext: StudioContext };
 
 interface CreateDevAssetsRoutesOptions {
   /**

--- a/apps/mesh/src/api/routes/dev-only.ts
+++ b/apps/mesh/src/api/routes/dev-only.ts
@@ -18,7 +18,7 @@
 
 import { Hono } from "hono";
 import type { Context, MiddlewareHandler } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { createLogDeprecatedRoute } from "../middleware/log-deprecated-route";
 import { createDevAssetsRoutes } from "./dev-assets";
 import devAssetsMcpRoutes, {
@@ -45,7 +45,7 @@ export function mountDevRoutes(
     mcpAuth,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async (c: Context<any>) => {
-      const ctx = c.get("meshContext") as MeshContext;
+      const ctx = c.get("meshContext") as StudioContext;
       const url = new URL(c.req.url);
       const baseUrl = `${url.protocol}//${url.host}`;
       return handleDevAssetsMcpRequest(c.req.raw, ctx, baseUrl);
@@ -58,7 +58,7 @@ export function mountDevRoutes(
     mcpAuth,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async (c: Context<any>) => {
-      const ctx = c.get("meshContext") as MeshContext;
+      const ctx = c.get("meshContext") as StudioContext;
       const url = new URL(c.req.url);
       const baseUrl = `${url.protocol}//${url.host}`;
       const toolName = c.req.param("toolName");

--- a/apps/mesh/src/api/routes/downstream-token.integration.test.ts
+++ b/apps/mesh/src/api/routes/downstream-token.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { Hono } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { CredentialVault } from "../../encryption/credential-vault";
 import {
   closeTestPgDatabase,
@@ -13,7 +13,7 @@ import { createDownstreamTokenRoutes } from "./downstream-token";
 
 describe("Downstream Token Routes", () => {
   let database: MeshDatabase;
-  let app: Hono<{ Variables: { meshContext: MeshContext } }>;
+  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -41,7 +41,7 @@ describe("Downstream Token Routes", () => {
           findById: mock(async () => ({ id: "conn_1" })),
         },
       },
-    } as unknown as MeshContext;
+    } as unknown as StudioContext;
 
     app = new Hono();
     app.use("*", async (c, next) => {

--- a/apps/mesh/src/api/routes/downstream-token.ts
+++ b/apps/mesh/src/api/routes/downstream-token.ts
@@ -6,7 +6,7 @@
  */
 
 import { Hono } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { resolveOriginTokenEndpoint } from "../../oauth/resolve-token-endpoint";
 import {
   DownstreamTokenStorage,
@@ -15,7 +15,7 @@ import {
 
 // Define Hono variables type
 type Variables = {
-  meshContext: MeshContext;
+  meshContext: StudioContext;
 };
 
 export const createDownstreamTokenRoutes = () => {

--- a/apps/mesh/src/api/routes/file-uploads.ts
+++ b/apps/mesh/src/api/routes/file-uploads.ts
@@ -21,7 +21,7 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { buildPublicUrl } from "@/file-storage/file-config-s3";
 import {
   MAX_UPLOAD_BYTES,
@@ -30,7 +30,7 @@ import {
   buildObjectKey,
 } from "@/file-storage/upload-policy";
 
-type Variables = { meshContext: MeshContext };
+type Variables = { meshContext: StudioContext };
 
 export const createFileUploadRoutes = () => {
   const app = new Hono<{ Variables: Variables }>();

--- a/apps/mesh/src/api/routes/files.ts
+++ b/apps/mesh/src/api/routes/files.ts
@@ -11,18 +11,18 @@
  * annotation for uploaded files. Authenticated clients (UI <img> tags) can use
  * it instead of presigned URLs and it always works.
  *
- * Requires an authenticated session (MeshContext) — the org ID in the
+ * Requires an authenticated session (StudioContext) — the org ID in the
  * URL is only used to extract the file key, not to bypass auth.
  */
 
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { generatePresignedGetUrl } from "./decopilot/file-materializer";
 import { usesLocalObjectStorage } from "@/tools/connection/dev-assets";
 import { isBrowserNavigation } from "../utils/browser-navigation";
 
-type Variables = { meshContext: MeshContext };
+type Variables = { meshContext: StudioContext };
 
 const app = new Hono<{ Variables: Variables }>();
 

--- a/apps/mesh/src/api/routes/home-next-actions.ts
+++ b/apps/mesh/src/api/routes/home-next-actions.ts
@@ -17,7 +17,7 @@ import { Hono } from "hono";
 import { slugify } from "@decocms/mcp-utils/aggregate";
 import { getHomeTiles, WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
 import { getPrompts } from "@/tools/guides";
 import {
@@ -31,7 +31,7 @@ const MAX_PROMPTS_PER_AGENT = 10;
 const LIST_PROMPTS_TIMEOUT_MS = 5000;
 
 type Variables = {
-  meshContext: MeshContext;
+  meshContext: StudioContext;
 };
 interface PromptEntry {
   agentId: string;
@@ -87,7 +87,7 @@ function indexPromptsByName() {
  */
 async function defaultHomeAgentNextActions(
   orgId: string,
-  ctx: MeshContext,
+  ctx: StudioContext,
   skipAgentIds: Set<string>,
 ): Promise<{ prompts: PromptEntry[]; tiles: TileEntry[] }> {
   const settings = await ctx.storage.organizationSettings.get(orgId);

--- a/apps/mesh/src/api/routes/kv.ts
+++ b/apps/mesh/src/api/routes/kv.ts
@@ -7,12 +7,12 @@
 
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import type { KVStorage } from "@/storage/kv";
 import { INTERESTS_KEY_PREFIX } from "@/storage/interests";
 
 type Variables = {
-  meshContext: MeshContext;
+  meshContext: StudioContext;
 };
 
 interface KVRouteDeps {

--- a/apps/mesh/src/api/routes/mcp-proxy-factory.ts
+++ b/apps/mesh/src/api/routes/mcp-proxy-factory.ts
@@ -18,7 +18,7 @@ import {
 } from "@decocms/mesh-sdk";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/core/constants";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 
 // ============================================================================
 // Types
@@ -53,7 +53,7 @@ export function toServerClient(client: Client): ServerClient {
 
 async function createMCPProxyDoNotUseDirectly(
   connectionIdOrConnection: string | ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
   { superUser }: { superUser: boolean }, // this is basically used for background workers that needs cross-organization access
 ): Promise<MCPProxyClient> {
   // Non-superUser callers (user-facing tools) must have org context;
@@ -149,7 +149,7 @@ async function createMCPProxyDoNotUseDirectly(
  */
 export async function createMCPProxy(
   connectionIdOrConnection: string | ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ) {
   return createMCPProxyDoNotUseDirectly(connectionIdOrConnection, ctx, {
     superUser: false,
@@ -164,7 +164,7 @@ export async function createMCPProxy(
  */
 export async function dangerouslyCreateSuperUserMCPProxy(
   connectionIdOrConnection: string | ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ) {
   return createMCPProxyDoNotUseDirectly(connectionIdOrConnection, ctx, {
     superUser: true,

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -14,7 +14,7 @@
 
 import { Hono } from "hono";
 import { ContextFactory } from "../../core/context-factory";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { retry, RetryError } from "@decocms/std";
 import {
   authorizationServerMetadataUrls,
@@ -33,7 +33,7 @@ import {
 
 // Define Hono variables type
 type Variables = {
-  meshContext: MeshContext;
+  meshContext: StudioContext;
 };
 
 type HonoEnv = { Variables: Variables };
@@ -50,7 +50,7 @@ type HonoEnv = { Variables: Variables };
  */
 async function getConnectionUrl(
   connectionId: string,
-  ctx: MeshContext,
+  ctx: StudioContext,
   organizationId?: string,
 ): Promise<string | null> {
   const connection = await ctx.storage.connections.findById(
@@ -217,13 +217,13 @@ async function getOriginAuthServer(
 }
 
 /**
- * Ensure MeshContext is available, creating it if necessary
+ * Ensure StudioContext is available, creating it if necessary
  */
 async function ensureContext(c: {
   req: { raw: Request };
-  get: (key: "meshContext") => MeshContext | undefined;
-  set: (key: "meshContext", value: MeshContext) => void;
-}): Promise<MeshContext> {
+  get: (key: "meshContext") => StudioContext | undefined;
+  set: (key: "meshContext", value: StudioContext) => void;
+}): Promise<StudioContext> {
   let ctx = c.get("meshContext");
   if (!ctx) {
     ctx = await ContextFactory.create(c.req.raw);
@@ -335,8 +335,8 @@ export const protectedResourceMetadataHandler = async (c: {
     raw: Request;
     url: string;
   };
-  get: (key: "meshContext") => MeshContext | undefined;
-  set: (key: "meshContext", value: MeshContext) => void;
+  get: (key: "meshContext") => StudioContext | undefined;
+  set: (key: "meshContext", value: StudioContext) => void;
   json: (data: unknown, status?: number) => Response;
 }) => {
   const connectionId = c.req.param("connectionId");
@@ -661,8 +661,8 @@ export async function fetchAuthorizationServerMetadata(
  */
 const authServerMetadataHandler = async (c: {
   req: { param: (key: string) => string; raw: Request; url: string };
-  get: (key: "meshContext") => MeshContext | undefined;
-  set: (key: "meshContext", value: MeshContext) => void;
+  get: (key: "meshContext") => StudioContext | undefined;
+  set: (key: "meshContext", value: StudioContext) => void;
   json: (data: unknown, status?: number) => Response;
 }) => {
   const connectionId = c.req.param("connectionId");

--- a/apps/mesh/src/api/routes/openai-compat.integration.test.ts
+++ b/apps/mesh/src/api/routes/openai-compat.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { Hono } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import {
   closeTestPgDatabase,
   connectTestPgDatabase,
@@ -28,7 +28,7 @@ const ENDPOINT = `/${MOCK_ORG_SLUG}/v1/chat/completions`;
 
 describe("OpenAI-compat: Schema Validation", () => {
   let database: MeshDatabase;
-  let app: Hono<{ Variables: { meshContext: MeshContext } }>;
+  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -46,7 +46,7 @@ describe("OpenAI-compat: Schema Validation", () => {
           throw new Error("not mocked for schema tests");
         }),
       },
-    } as unknown as MeshContext;
+    } as unknown as StudioContext;
 
     app = new Hono();
     app.use("*", async (c, next) => {
@@ -182,7 +182,7 @@ describe("OpenAI-compat: Schema Validation", () => {
 
 describe("OpenAI-compat: Authentication", () => {
   let database: MeshDatabase;
-  let app: Hono<{ Variables: { meshContext: MeshContext } }>;
+  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -204,7 +204,7 @@ describe("OpenAI-compat: Authentication", () => {
           throw new Error("not mocked");
         }),
       },
-    } as unknown as MeshContext;
+    } as unknown as StudioContext;
 
     app = new Hono();
     app.use("*", async (c, next) => {
@@ -240,7 +240,7 @@ describe("OpenAI-compat: Authentication", () => {
           throw new Error("not mocked");
         }),
       },
-    } as unknown as MeshContext;
+    } as unknown as StudioContext;
 
     app = new Hono();
     app.use("*", async (c, next) => {
@@ -275,7 +275,7 @@ describe("OpenAI-compat: Authentication", () => {
           throw new Error("not mocked");
         }),
       },
-    } as unknown as MeshContext;
+    } as unknown as StudioContext;
 
     app = new Hono();
     app.use("*", async (c, next) => {
@@ -308,7 +308,7 @@ describe("OpenAI-compat: Authentication", () => {
 
 describe("OpenAI-compat: Authorization", () => {
   let database: MeshDatabase;
-  let app: Hono<{ Variables: { meshContext: MeshContext } }>;
+  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -330,7 +330,7 @@ describe("OpenAI-compat: Authorization", () => {
           throw new Error("not mocked");
         }),
       },
-    } as unknown as MeshContext;
+    } as unknown as StudioContext;
 
     app = new Hono();
     app.use("*", async (c, next) => {
@@ -364,7 +364,7 @@ describe("OpenAI-compat: Authorization", () => {
 
 describe("OpenAI-compat: Tools Schema", () => {
   let database: MeshDatabase;
-  let app: Hono<{ Variables: { meshContext: MeshContext } }>;
+  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -379,7 +379,7 @@ describe("OpenAI-compat: Tools Schema", () => {
           throw new Error("not mocked");
         }),
       },
-    } as unknown as MeshContext;
+    } as unknown as StudioContext;
 
     app = new Hono();
     app.use("*", async (c, next) => {
@@ -478,7 +478,7 @@ describe("OpenAI-compat: Tools Schema", () => {
 
 describe("OpenAI-compat: Response Format", () => {
   let database: MeshDatabase;
-  let app: Hono<{ Variables: { meshContext: MeshContext } }>;
+  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -493,7 +493,7 @@ describe("OpenAI-compat: Response Format", () => {
           throw new Error("not mocked");
         }),
       },
-    } as unknown as MeshContext;
+    } as unknown as StudioContext;
 
     app = new Hono();
     app.use("*", async (c, next) => {
@@ -581,7 +581,7 @@ describe("OpenAI-compat: Response Format", () => {
 
 describe("OpenAI-compat: Message Formats", () => {
   let database: MeshDatabase;
-  let app: Hono<{ Variables: { meshContext: MeshContext } }>;
+  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -596,7 +596,7 @@ describe("OpenAI-compat: Message Formats", () => {
           throw new Error("not mocked");
         }),
       },
-    } as unknown as MeshContext;
+    } as unknown as StudioContext;
 
     app = new Hono();
     app.use("*", async (c, next) => {

--- a/apps/mesh/src/api/routes/openai-compat.ts
+++ b/apps/mesh/src/api/routes/openai-compat.ts
@@ -20,7 +20,7 @@ import {
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 
 // ============================================================================
 // Types & Schemas
@@ -408,7 +408,7 @@ function convertFinishReason(
 // Route Handler
 // ============================================================================
 
-const app = new Hono<{ Variables: { meshContext: MeshContext } }>();
+const app = new Hono<{ Variables: { meshContext: StudioContext } }>();
 
 app.post("/:org/v1/chat/completions", async (c) => {
   const ctx = c.get("meshContext");

--- a/apps/mesh/src/api/routes/org-sso.ts
+++ b/apps/mesh/src/api/routes/org-sso.ts
@@ -11,11 +11,11 @@ import { Hono } from "hono";
 import { setCookie, getCookie } from "hono/cookie";
 import * as jose from "jose";
 import { getSettings } from "../../settings";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { ADMIN_ROLES } from "../../auth/roles";
 
 type Variables = {
-  meshContext: MeshContext;
+  meshContext: StudioContext;
 };
 
 export const createSsoRoutes = () => {
@@ -37,7 +37,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: GET /api/org-sso/status?orgId=<id>
    */
   app.get("/status", async (c) => {
-    const ctx = c.get("meshContext") as MeshContext;
+    const ctx = c.get("meshContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -81,7 +81,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: GET /api/org-sso/authorize?orgId=<id>
    */
   app.get("/authorize", async (c) => {
-    const ctx = c.get("meshContext") as MeshContext;
+    const ctx = c.get("meshContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -152,7 +152,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: GET /api/org-sso/callback
    */
   app.get("/callback", async (c) => {
-    const ctx = c.get("meshContext") as MeshContext;
+    const ctx = c.get("meshContext") as StudioContext;
 
     const code = c.req.query("code");
     const state = c.req.query("state");
@@ -293,7 +293,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: GET /api/org-sso/config
    */
   app.get("/config", async (c) => {
-    const ctx = c.get("meshContext") as MeshContext;
+    const ctx = c.get("meshContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -325,7 +325,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: POST /api/org-sso/config
    */
   app.post("/config", async (c) => {
-    const ctx = c.get("meshContext") as MeshContext;
+    const ctx = c.get("meshContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -404,7 +404,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: POST /api/org-sso/config/enforce
    */
   app.post("/config/enforce", async (c) => {
-    const ctx = c.get("meshContext") as MeshContext;
+    const ctx = c.get("meshContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -437,7 +437,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: DELETE /api/org-sso/config
    */
   app.delete("/config", async (c) => {
-    const ctx = c.get("meshContext") as MeshContext;
+    const ctx = c.get("meshContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -588,7 +588,7 @@ async function generateCodeChallenge(verifier: string): Promise<string> {
 }
 
 async function getOrgMembership(
-  ctx: MeshContext,
+  ctx: StudioContext,
   userId: string,
   orgId: string,
 ): Promise<{ orgSlug: string; role: string } | null> {
@@ -602,12 +602,12 @@ async function getOrgMembership(
   return row ?? null;
 }
 
-function isOrgAdmin(ctx: MeshContext): boolean {
+function isOrgAdmin(ctx: StudioContext): boolean {
   const role = ctx.auth.user?.role;
   if (!role) return false;
   return (ADMIN_ROLES as readonly string[]).includes(role);
 }
 
-function isOrgOwner(ctx: MeshContext): boolean {
+function isOrgOwner(ctx: StudioContext): boolean {
   return ctx.auth.user?.role === "owner";
 }

--- a/apps/mesh/src/api/routes/proxy-monitoring.test.ts
+++ b/apps/mesh/src/api/routes/proxy-monitoring.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "bun:test";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { createProxyMonitoringMiddleware } from "./proxy-monitoring";
 
 function createMockSpan() {
@@ -57,7 +57,7 @@ function createMockCtx(overrides?: {
       createHistogram,
       createCounter,
     },
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 
   return { ctx, spans, createHistogram, createCounter };
 }

--- a/apps/mesh/src/api/routes/proxy-monitoring.ts
+++ b/apps/mesh/src/api/routes/proxy-monitoring.ts
@@ -4,7 +4,7 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import { isDecopilot } from "@decocms/mesh-sdk";
 import { trace, context } from "@opentelemetry/api";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { emitMonitoringLog } from "../../monitoring/emit";
 import { recordToolExecutionMetrics } from "../../monitoring/record-tool-execution-metrics";
 import { MONITORING_SPAN_NAME } from "@/monitoring/schema";
@@ -107,7 +107,7 @@ function formatMonitoringOutput(value: unknown): Record<string, unknown> {
 }
 
 async function emitMonitoringSpan(args: {
-  ctx: MeshContext;
+  ctx: StudioContext;
   enabled: boolean;
   organizationId?: string;
   connectionId: string;
@@ -180,7 +180,7 @@ async function emitMonitoringSpan(args: {
 }
 
 export interface ProxyMonitoringMiddlewareParams {
-  ctx: MeshContext;
+  ctx: StudioContext;
   enabled: boolean;
   connectionId: string;
   virtualMcpId?: string; // Virtual MCP (Agent) ID if routed through an agent

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -16,7 +16,7 @@ import { SpanStatusCode } from "@opentelemetry/api";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Context, Hono } from "hono";
 import { endTime, startTime } from "hono/timing";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { managementMCP } from "../../tools";
 import { guardResponseStream } from "../utils/stream-guard";
 import { handleAuthError } from "./oauth-proxy";
@@ -27,7 +27,7 @@ export { toServerClient, type MCPProxyClient } from "./mcp-proxy-factory";
 
 // Define Hono variables type
 type Variables = {
-  meshContext: MeshContext;
+  meshContext: StudioContext;
 };
 
 type ProxyEnv = { Variables: Variables };

--- a/apps/mesh/src/api/routes/sandbox-events-handler.ts
+++ b/apps/mesh/src/api/routes/sandbox-events-handler.ts
@@ -16,7 +16,7 @@ import {
 } from "@decocms/sandbox/provider";
 import { delay } from "@decocms/std";
 import { subscribeLifecycle } from "../../sandbox/lifecycle";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { KyselySandboxProviderStateStore } from "../../storage/sandbox-runner-state";
 import { readSandboxMap, resolveVm } from "../../tools/sandbox/sandbox-map";
 import type { Env } from "../hono-env";
@@ -41,7 +41,7 @@ const PROXY_OPEN_RETRY_BUDGET_MS = 60_000;
 const PROXY_OPEN_RETRY_DELAY_MS = 500;
 
 export interface VmEventsHandlerArgs {
-  ctx: MeshContext;
+  ctx: StudioContext;
   claimName: string;
   runner: SandboxProvider;
   branch: string;
@@ -146,7 +146,7 @@ async function isStaleHandle(
 }
 
 async function cleanupStaleEntry(args: {
-  ctx: MeshContext;
+  ctx: StudioContext;
   runner: SandboxProvider;
   claimName: string;
   userId: string;

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -24,7 +24,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import type { Env } from "../hono-env";
 import { handleVmEvents } from "./sandbox-events-handler";
 import { resolveAndPushEnv } from "../../tools/sandbox/resolve-env";

--- a/apps/mesh/src/api/routes/self.ts
+++ b/apps/mesh/src/api/routes/self.ts
@@ -6,12 +6,12 @@
  */
 import { Hono } from "hono";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { managementMCP } from "../../tools";
 
 // Define Hono variables type
 type Variables = {
-  meshContext: MeshContext;
+  meshContext: StudioContext;
 };
 
 type SelfEnv = { Variables: Variables };

--- a/apps/mesh/src/api/routes/thread-outputs.ts
+++ b/apps/mesh/src/api/routes/thread-outputs.ts
@@ -15,9 +15,9 @@
 
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 
-type Variables = { meshContext: MeshContext };
+type Variables = { meshContext: StudioContext };
 
 export const createThreadOutputsRoutes = () => {
   const app = new Hono<{ Variables: Variables }>();

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -18,7 +18,7 @@ import { createServerFromClient, getDecopilotId } from "@decocms/mesh-sdk";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Hono } from "hono";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/core/constants";
 import { createVirtualClientFrom } from "../../mcp-clients/virtual-mcp";
 import type { Env } from "../hono-env";
@@ -30,7 +30,7 @@ import { guardResponseStream } from "../utils/stream-guard";
 
 export async function handleVirtualMcpRequest(
   c: {
-    get: (key: "meshContext") => MeshContext;
+    get: (key: "meshContext") => StudioContext;
     req: {
       header: (name: string) => string | undefined;
       param: (name: string) => string | undefined;

--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -50,8 +50,8 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-  type MeshContext,
-} from "../../core/mesh-context";
+  type StudioContext,
+} from "../../core/studio-context";
 import { KyselySandboxProviderStateStore } from "../../storage/sandbox-runner-state";
 import { readSandboxMap, resolveVm } from "../../tools/sandbox/sandbox-map";
 import type { Env } from "../hono-env";
@@ -282,7 +282,7 @@ async function isStaleHandle(
  * browser self-heal) is what matters; this is a fast-path optimisation.
  */
 async function cleanupStaleEntry(args: {
-  ctx: MeshContext;
+  ctx: StudioContext;
   runner: SandboxProvider;
   claimName: string;
   userId: string;

--- a/apps/mesh/src/api/utils/paths.ts
+++ b/apps/mesh/src/api/utils/paths.ts
@@ -77,18 +77,18 @@ export function isServerPath(path: string): boolean {
 }
 
 /**
- * Check if a path should skip MeshContext injection
+ * Check if a path should skip StudioContext injection
  * Used in the context middleware to avoid creating contexts for
  * paths that don't need database access
  */
-export function shouldSkipMeshContext(path: string): boolean {
+export function shouldSkipStudioContext(path: string): boolean {
   return (
     path === "/" ||
     path.startsWith(PATH_PREFIXES.API_AUTH) ||
     path === "/api/trigger-callback" ||
     isSystemPath(path) ||
     // Static file extension check only applies to non-API paths (e.g. Vite assets).
-    // API paths like /api/:org/files/image.jpeg still need MeshContext for auth.
+    // API paths like /api/:org/files/image.jpeg still need StudioContext for auth.
     (!isApiPath(path) && isStaticFilePath(path))
   );
 }

--- a/apps/mesh/src/api/watch.test.ts
+++ b/apps/mesh/src/api/watch.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { Hono } from "hono";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { watchHandler } from "./app";
 import type { Env } from "./hono-env";
 import type { Thread } from "@/storage/types";
@@ -41,7 +41,7 @@ function makeWatchApp(opts?: {
         },
       },
     },
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 
   const app = new Hono<Env>();
   app.use("*", async (c, next) => {

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -60,7 +60,7 @@ import {
   buildStreamRequest,
   type ResolvedAutomationModel,
 } from "./build-stream-request";
-import { computeNextRunAt, type MeshContextFactory } from "./fire";
+import { computeNextRunAt, type StudioContextFactory } from "./fire";
 
 export const AUTOMATIONS_GATE_QUEUE = "automations-gate";
 export const AUTOMATIONS_GLOBAL_QUEUE = "automations-global";
@@ -106,7 +106,7 @@ export async function ensureOrgQueue(orgId: string): Promise<void> {
 
 export interface AutomationRuntime {
   storage: AutomationsStorage;
-  meshContextFactory: MeshContextFactory;
+  meshContextFactory: StudioContextFactory;
   runTimeoutMs?: number;
 }
 

--- a/apps/mesh/src/automations/fire.ts
+++ b/apps/mesh/src/automations/fire.ts
@@ -1,10 +1,10 @@
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { Cron } from "croner";
 
-export type MeshContextFactory = (
+export type StudioContextFactory = (
   orgId: string,
   userId: string,
-) => Promise<MeshContext | null>;
+) => Promise<StudioContext | null>;
 
 export function computeNextRunAt(
   cronExpression: string,

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -4,7 +4,7 @@ import {
   ForbiddenError,
   UnauthorizedError,
 } from "./access-control";
-import type { BetterAuthInstance, BoundAuthClient } from "./mesh-context";
+import type { BetterAuthInstance, BoundAuthClient } from "./studio-context";
 import type { Permission } from "../storage/types";
 import { BASIC_USAGE_TOOLS } from "../tools/registry-metadata";
 

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -11,7 +11,7 @@
 
 import { MCP_MESH_KEY } from "@/core/constants";
 import { BASIC_USAGE_TOOLS } from "@/tools/registry-metadata";
-import type { BetterAuthInstance, BoundAuthClient } from "./mesh-context";
+import type { BetterAuthInstance, BoundAuthClient } from "./studio-context";
 
 // ============================================================================
 // Types

--- a/apps/mesh/src/core/context-factory.integration.test.ts
+++ b/apps/mesh/src/core/context-factory.integration.test.ts
@@ -7,8 +7,8 @@ import {
   resetTestPgDatabase,
 } from "../database/test-db-pg";
 import type { MeshDatabase } from "../database";
-import { createMeshContextFactory } from "./context-factory";
-import type { BetterAuthInstance } from "./mesh-context";
+import { createStudioContextFactory } from "./context-factory";
+import type { BetterAuthInstance } from "./studio-context";
 import type { EventBus } from "../event-bus/interface";
 import type { QueryEngine } from "../monitoring/query-engine";
 
@@ -46,7 +46,7 @@ const createMockEventBus = (): EventBus => ({
   isRunning: vi.fn().mockReturnValue(false),
 });
 
-describe("createMeshContextFactory", () => {
+describe("createStudioContextFactory", () => {
   let database: MeshDatabase;
 
   beforeAll(async () => {
@@ -97,7 +97,7 @@ describe("createMeshContextFactory", () => {
 
   describe("factory creation", () => {
     it("should create context factory function", async () => {
-      const factory = await createMeshContextFactory({
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: createMockAuth() as unknown as BetterAuthInstance,
@@ -123,9 +123,9 @@ describe("createMeshContextFactory", () => {
     },
   });
 
-  describe("MeshContext creation", () => {
-    it("should create MeshContext from Request", async () => {
-      const factory = await createMeshContextFactory({
+  describe("StudioContext creation", () => {
+    it("should create StudioContext from Request", async () => {
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
@@ -154,7 +154,7 @@ describe("createMeshContextFactory", () => {
     });
 
     it("should derive base URL from request", async () => {
-      const factory = await createMeshContextFactory({
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
@@ -178,7 +178,7 @@ describe("createMeshContextFactory", () => {
     });
 
     it("should populate request metadata", async () => {
-      const factory = await createMeshContextFactory({
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
@@ -209,7 +209,7 @@ describe("createMeshContextFactory", () => {
 
   describe("organization scope", () => {
     it("should extract organization from Better Auth", async () => {
-      const factory = await createMeshContextFactory({
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: createMockAuth() as unknown as BetterAuthInstance,
@@ -248,7 +248,7 @@ describe("createMeshContextFactory", () => {
         },
       };
 
-      const factory = await createMeshContextFactory({
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: authWithoutOrg as unknown as BetterAuthInstance,
@@ -270,7 +270,7 @@ describe("createMeshContextFactory", () => {
 
   describe("storage initialization", () => {
     it("should create storage adapters", async () => {
-      const factory = await createMeshContextFactory({
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
@@ -297,7 +297,7 @@ describe("createMeshContextFactory", () => {
 
   describe("access control initialization", () => {
     it("should create AccessControl instance", async () => {
-      const factory = await createMeshContextFactory({
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
@@ -349,7 +349,7 @@ describe("createMeshContextFactory", () => {
         },
       };
 
-      const factory = await createMeshContextFactory({
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: mockAuthWithOrgInApiKey as unknown as BetterAuthInstance,
@@ -392,7 +392,7 @@ describe("createMeshContextFactory", () => {
         },
       };
 
-      const factory = await createMeshContextFactory({
+      const factory = await createStudioContextFactory({
         db: database.db,
 
         auth: mockAuthWithoutOrg as unknown as BetterAuthInstance,
@@ -435,7 +435,7 @@ describe("createMeshContextFactory", () => {
         },
       };
 
-      const factoryA = await createMeshContextFactory({
+      const factoryA = await createStudioContextFactory({
         db: database.db,
 
         auth: mockAuthOrgA as unknown as BetterAuthInstance,
@@ -474,7 +474,7 @@ describe("createMeshContextFactory", () => {
         },
       };
 
-      const factoryB = await createMeshContextFactory({
+      const factoryB = await createStudioContextFactory({
         db: database.db,
 
         auth: mockAuthOrgB as unknown as BetterAuthInstance,

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -1,7 +1,7 @@
 /**
  * Context Factory
  *
- * Creates MeshContext instances from HTTP requests (via Hono Context).
+ * Creates StudioContext instances from HTTP requests (via Hono Context).
  * Handles:
  * - API key verification
  * - Organization scope extraction (from Better Auth)
@@ -53,9 +53,9 @@ import { isOrgArchived } from "./org-archived";
 import type {
   BetterAuthInstance,
   BoundAuthClient,
-  MeshContext,
+  StudioContext,
   Timings,
-} from "./mesh-context";
+} from "./studio-context";
 
 // ============================================================================
 // Configuration
@@ -103,7 +103,7 @@ function parsePropertiesHeader(
   }
 }
 
-export interface MeshContextConfig {
+export interface StudioContextConfig {
   db: Kysely<Database>;
   auth: BetterAuthInstance;
   encryption: {
@@ -249,7 +249,7 @@ export interface AuthContext {
 
 /**
  * Create a bound auth client that encapsulates HTTP headers and auth context
- * MeshContext stays HTTP-agnostic while delegating all Better Auth calls
+ * StudioContext stays HTTP-agnostic while delegating all Better Auth calls
  *
  * Two permission flows:
  * 1. API Key / MCP OAuth → check directly against stored `permissions`
@@ -1009,7 +1009,7 @@ interface FactoryOptions {
 type FactoryFunction = (
   req?: Request,
   options?: FactoryOptions,
-) => Promise<MeshContext>;
+) => Promise<StudioContext>;
 
 let createContextFn: FactoryFunction;
 
@@ -1033,10 +1033,10 @@ const wellKnownForwardableHeaders = ["x-hub-signature-256"];
  * Create a context factory function
  *
  * The factory creates storage adapters once (singleton pattern) and
- * returns a function that creates MeshContext from Hono Context
+ * returns a function that creates StudioContext from Hono Context
  */
-export async function createMeshContextFactory(
-  config: MeshContextConfig,
+export async function createStudioContextFactory(
+  config: StudioContextConfig,
 ): Promise<FactoryFunction> {
   // Create vault instance for credential encryption
   const vault = new CredentialVault(config.encryption.key);
@@ -1056,7 +1056,7 @@ export async function createMeshContextFactory(
   if (config.monitoringEngines) {
     // Test-only path: caller supplied stubs to avoid loading
     // `@duckdb/node-api` (whose native finalizer trips a Bun teardown
-    // crash). See MeshContextConfig.monitoringEngines for the why.
+    // crash). See StudioContextConfig.monitoringEngines for the why.
     monitoringEngine = config.monitoringEngines.monitoringEngine;
     metricEngine = config.monitoringEngines.metricEngine;
   } else if (isClickHouse) {
@@ -1145,7 +1145,7 @@ export async function createMeshContextFactory(
   return async (
     req?: Request,
     options?: FactoryOptions,
-  ): Promise<MeshContext> => {
+  ): Promise<StudioContext> => {
     const timings = options?.timings ?? DEFAULT_TIMINGS;
 
     // Client pool scoped to this request — reuses connections within the same
@@ -1200,8 +1200,8 @@ export async function createMeshContextFactory(
       userId: authResult.user?.id, // For server-side API key operations
     });
 
-    // Build auth object for MeshContext
-    const meshAuth: MeshContext["auth"] = {
+    // Build auth object for StudioContext
+    const meshAuth: StudioContext["auth"] = {
       user: authResult.user,
     };
 
@@ -1268,7 +1268,7 @@ export async function createMeshContextFactory(
       orgSlug: organization?.slug,
     });
 
-    const ctx: MeshContext = {
+    const ctx: StudioContext = {
       timings,
       auth: meshAuth,
       connectionId,

--- a/apps/mesh/src/core/define-tool.test.ts
+++ b/apps/mesh/src/core/define-tool.test.ts
@@ -9,11 +9,11 @@ import { describe, expect, it, vi } from "bun:test";
 import { z } from "zod";
 import { AccessControl } from "./access-control";
 import { defineTool } from "./define-tool";
-import type { MeshContext } from "./mesh-context";
+import type { StudioContext } from "./studio-context";
 import type { EventBus } from "../event-bus/interface";
 
-// Mock MeshContext
-const createMockContext = (): MeshContext => ({
+// Mock StudioContext
+const createMockContext = (): StudioContext => ({
   timings: {
     measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
   },

--- a/apps/mesh/src/core/define-tool.ts
+++ b/apps/mesh/src/core/define-tool.ts
@@ -11,7 +11,7 @@
 
 import { SpanStatusCode } from "@opentelemetry/api";
 import { z } from "zod";
-import type { MeshContext } from "./mesh-context";
+import type { StudioContext } from "./studio-context";
 
 // ============================================================================
 // Tool Definition Types
@@ -75,7 +75,7 @@ export interface ToolDefinition<
 > extends ToolBinder<TInput, TOutput, TName> {
   handler: (
     input: z.infer<TInput>,
-    ctx: MeshContext,
+    ctx: StudioContext,
   ) => Promise<z.infer<TOutput>>;
 }
 
@@ -92,7 +92,7 @@ export interface Tool<
 > extends ToolDefinition<TInput, TOutput, TName> {
   execute: (
     input: z.infer<TInput>,
-    ctx: MeshContext,
+    ctx: StudioContext,
   ) => Promise<z.infer<TOutput>>;
 }
 
@@ -141,7 +141,7 @@ export function defineTool<
      */
     execute: async (
       input: z.infer<TInput>,
-      ctx: MeshContext,
+      ctx: StudioContext,
     ): Promise<z.infer<TOutput>> => {
       return await ctx.timings.measure(
         `tool.${definition.name}`,

--- a/apps/mesh/src/core/harness-context.test.ts
+++ b/apps/mesh/src/core/harness-context.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { HarnessContext } from "./harness-context";
-import type { MeshContext } from "./mesh-context";
+import type { StudioContext } from "./studio-context";
 
 describe("HarnessContext", () => {
-  it("MeshContext is assignable to HarnessContext (narrowing)", () => {
-    const mesh: MeshContext = null as never;
+  it("StudioContext is assignable to HarnessContext (narrowing)", () => {
+    const mesh: StudioContext = null as never;
     const harness: HarnessContext = mesh;
     expect(harness).toBe(mesh);
   });

--- a/apps/mesh/src/core/plugin-loader.ts
+++ b/apps/mesh/src/core/plugin-loader.ts
@@ -20,7 +20,7 @@ import type {
 import type { z } from "zod";
 import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import { serverPlugins } from "../server-plugins";
-import type { MeshContext } from "./mesh-context";
+import type { StudioContext } from "./studio-context";
 import type { Tool, ToolDefinition } from "./define-tool";
 import type { CredentialVault } from "../encryption/credential-vault";
 import type { CloudEvent } from "@decocms/bindings";
@@ -39,7 +39,7 @@ const pluginToolMap = new Map<string, string>();
  * Checks both org settings (legacy) and all virtual MCPs.
  */
 async function isPluginEnabledForOrg(
-  ctx: MeshContext,
+  ctx: StudioContext,
   orgId: string,
   pluginId: string,
 ): Promise<boolean> {
@@ -68,7 +68,7 @@ async function isPluginEnabledForOrg(
  * Subsequent calls for the same org are no-ops (cached).
  */
 async function ensureSubscriptionsForOrg(
-  ctx: MeshContext,
+  ctx: StudioContext,
   orgId: string,
 ): Promise<void> {
   if (!hasPluginEventHandlers()) return;
@@ -184,12 +184,12 @@ export function collectPluginTools(): ToolDefinition<
 
     for (const toolDef of plugin.tools) {
       // Convert ServerPluginToolDefinition to Tool and wrap with gating.
-      // MeshContext is a superset of ServerPluginToolContext so the cast is safe.
-      // MeshContext is a superset of ServerPluginToolContext; the Kysely
+      // StudioContext is a superset of ServerPluginToolContext so the cast is safe.
+      // StudioContext is a superset of ServerPluginToolContext; the Kysely
       // generic parameter differs (Database vs unknown) so we go through unknown.
       const handler = toolDef.handler as unknown as (
         input: unknown,
-        ctx: MeshContext,
+        ctx: StudioContext,
       ) => Promise<unknown>;
       const tool = {
         name: toolDef.name,

--- a/apps/mesh/src/core/resolve-tier.test.ts
+++ b/apps/mesh/src/core/resolve-tier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { resolveTier, TierUnavailableError } from "./resolve-tier";
 
 interface ProviderKeyFixture {
@@ -27,7 +27,7 @@ function makeCtx(opts: {
   providerKeys?: ProviderKeyFixture[];
   models?: Record<string, ModelFixture[]>;
   listModelsThrows?: boolean;
-}): MeshContext {
+}): StudioContext {
   return {
     organization: { id: "org_1" },
     storage: {
@@ -59,7 +59,7 @@ function makeCtx(opts: {
         return Promise.resolve(opts.models?.[keyId] ?? []);
       }),
     },
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 }
 
 describe("resolveTier", () => {

--- a/apps/mesh/src/core/resolve-tier.ts
+++ b/apps/mesh/src/core/resolve-tier.ts
@@ -1,4 +1,4 @@
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import type { SimpleModeTier } from "@/tools/organization/schema";
 import {
   pickSimpleModeDefaults,
@@ -33,7 +33,7 @@ export interface ResolvedTier {
 const METADATA_FETCH_TIMEOUT_MS = 5_000;
 
 async function fetchModelList(
-  ctx: MeshContext,
+  ctx: StudioContext,
   keyId: string,
   orgId: string,
 ): Promise<AiProviderModel[]> {
@@ -89,7 +89,7 @@ function metaFromCatalogEntry(
 }
 
 export async function resolveTier(
-  ctx: MeshContext,
+  ctx: StudioContext,
   tier: SimpleModeTier,
 ): Promise<ResolvedTier> {
   const orgId = ctx.organization?.id;
@@ -153,7 +153,7 @@ export async function resolveTier(
 }
 
 export async function tryResolveTier(
-  ctx: MeshContext,
+  ctx: StudioContext,
   tier: SimpleModeTier,
 ): Promise<ResolvedTier | null> {
   try {

--- a/apps/mesh/src/core/studio-context.test.ts
+++ b/apps/mesh/src/core/studio-context.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, it } from "bun:test";
 import {
-  type MeshContext,
+  type StudioContext,
   getOrganizationId,
   getUserId,
   hasOrganization,
   isAuthenticated,
   requireAuth,
   requireOrganization,
-} from "./mesh-context";
+} from "./studio-context";
 import type { EventBus } from "../event-bus/interface";
 
 // Helper to create mock context
-const createMockContext = (overrides?: Partial<MeshContext>): MeshContext => ({
+const createMockContext = (
+  overrides?: Partial<StudioContext>,
+): StudioContext => ({
   timings: {
     measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
   },
@@ -74,7 +76,7 @@ const createMockContext = (overrides?: Partial<MeshContext>): MeshContext => ({
   ...overrides,
 });
 
-describe("MeshContext Utilities", () => {
+describe("StudioContext Utilities", () => {
   describe("hasOrganization", () => {
     it("should return true when organization is defined", () => {
       const ctx = createMockContext({

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -1,5 +1,5 @@
 /**
- * MeshContext - Core abstraction for all tools
+ * StudioContext - Core abstraction for all tools
  *
  * Provides tools with access to all necessary services without coupling them
  * to HTTP frameworks or database drivers.
@@ -68,7 +68,7 @@ export type UpdateApiKeyResult = Awaited<
 
 /**
  * Bound auth client for Better Auth operations
- * Encapsulates HTTP context internally, keeping MeshContext HTTP-agnostic
+ * Encapsulates HTTP context internally, keeping StudioContext HTTP-agnostic
  * Return types are derived from BetterAuthInstance.api using Awaited<ReturnType<>>
  */
 export interface BoundAuthClient {
@@ -314,7 +314,7 @@ export interface MeshStorage {
 }
 
 // ============================================================================
-// MeshContext Interface
+// StudioContext Interface
 // ============================================================================
 
 export interface Timings {
@@ -322,12 +322,12 @@ export interface Timings {
 }
 
 /**
- * MeshContext - The core abstraction passed to every tool handler
+ * StudioContext - The core abstraction passed to every tool handler
  *
  * This provides access to all necessary services without coupling
  * to implementation details.
  */
-export interface MeshContext extends HarnessContext {
+export interface StudioContext extends HarnessContext {
   // Connection ID (from url)
   connectionId?: string;
 
@@ -445,21 +445,21 @@ export interface MeshContext extends HarnessContext {
 /**
  * Check if context has organization scope
  */
-export function hasOrganization(ctx: MeshContext): boolean {
+export function hasOrganization(ctx: StudioContext): boolean {
   return ctx.organization !== undefined;
 }
 
 /**
  * Get organization ID or null
  */
-export function getOrganizationId(ctx: MeshContext): string | null {
+export function getOrganizationId(ctx: StudioContext): string | null {
   return ctx.organization?.id ?? null;
 }
 
 /**
  * Require organization scope (throws if not organization-scoped)
  */
-export function requireOrganization(ctx: MeshContext): OrganizationScope {
+export function requireOrganization(ctx: StudioContext): OrganizationScope {
   if (!ctx.organization) {
     throw new Error("This operation requires organization scope");
   }
@@ -469,21 +469,21 @@ export function requireOrganization(ctx: MeshContext): OrganizationScope {
 /**
  * Get user ID (from user or API key)
  */
-export function getUserId(ctx: MeshContext): string | undefined {
+export function getUserId(ctx: StudioContext): string | undefined {
   return ctx.auth.user?.id ?? ctx.auth.apiKey?.userId;
 }
 
 /**
  * Check if user is authenticated
  */
-export function isAuthenticated(ctx: MeshContext): boolean {
+export function isAuthenticated(ctx: StudioContext): boolean {
   return !!(ctx.auth.user || ctx.auth.apiKey);
 }
 
 /**
  * Require authentication (throws if not authenticated)
  */
-export function requireAuth(ctx: MeshContext): void {
+export function requireAuth(ctx: StudioContext): void {
   if (!isAuthenticated(ctx)) {
     throw new Error("Authentication required");
   }

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -14,7 +14,7 @@
  * layer their existing per-automation and global gates above this
  * per-thread one; user messages enter here directly.
  *
- * Runtime dependencies (dispatch fn, mesh-context factory, dispatch deps)
+ * Runtime dependencies (dispatch fn, studio-context factory, dispatch deps)
  * are looked up via a module-level registry. App boot wires them via
  * `setThreadGateRuntime` BEFORE `DBOS.launch()`. The workflow is registered
  * at import time so the recovery executor can replay it after a crash.
@@ -25,7 +25,7 @@ import type {
   DispatchRunDeps,
   DispatchRunInput,
 } from "@/api/routes/decopilot/dispatch-run";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { posthog } from "@/posthog";
 
 export const THREAD_GATE_QUEUE = "thread-gate";
@@ -72,18 +72,18 @@ export type ThreadGateOutcome = { taskId: string };
 
 export type DispatchRunAndWaitFn = (
   input: DispatchRunInput,
-  ctx: MeshContext,
+  ctx: StudioContext,
   deps: DispatchRunDeps,
 ) => Promise<{ taskId: string }>;
 
-export type MeshContextFactory = (
+export type StudioContextFactory = (
   orgId: string,
   userId: string,
-) => Promise<MeshContext | null>;
+) => Promise<StudioContext | null>;
 
 export interface ThreadGateRuntime {
   dispatchRunFn: DispatchRunAndWaitFn;
-  meshContextFactory: MeshContextFactory;
+  meshContextFactory: StudioContextFactory;
   deps: Pick<
     DispatchRunDeps,
     "runRegistry" | "cancelBroadcast" | "streamBuffer" | "sseHub"

--- a/apps/mesh/src/harnesses/decopilot/assemble-agent-tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/assemble-agent-tools.ts
@@ -14,7 +14,7 @@
 
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { ToolSet, UIMessageStreamWriter } from "ai";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import {
   toolsFromMCP,
   type ToolApprovalLevel,
@@ -35,7 +35,7 @@ export const EXCLUDED_FOR_SUBAGENT = [
 
 export interface AssembleAgentToolsOptions {
   kind: "agent" | "subagent";
-  ctx: MeshContext;
+  ctx: StudioContext;
   mcpClient: Client;
   writer: UIMessageStreamWriter;
   planMode: boolean;

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -13,7 +13,7 @@
  * are stubs returning null (wired up fully in Stage 2.3).
  */
 
-import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
+import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import {
   buildBasePlatformPrompt,
   buildDecopilotAgentPrompt,
@@ -167,7 +167,7 @@ End with a structured summary:
 This report is all the parent agent sees.`;
 
 export interface BuildAgentSystemPromptOptions {
-  ctx: MeshContext;
+  ctx: StudioContext;
   organization: OrganizationScope;
   virtualMcp: {
     id: string;

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
@@ -17,7 +17,7 @@
 import { tool, zodSchema, generateImage, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
 import type { MeshProvider } from "@/ai-providers/types";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { getSettings } from "@/settings";
 import type { ModelInfo } from "../../../api/routes/decopilot/types";
 import {
@@ -87,7 +87,7 @@ function assertReferenceImageSize(bytes: number): void {
  */
 async function fetchImageBytes(
   url: string,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<Uint8Array> {
   // mesh-storage://{key} — read directly from object storage
   const meshKey = parseMeshStorageKey(url);
@@ -164,7 +164,7 @@ function validateExternalUrl(url: string): void {
 
 async function readFromObjectStorage(
   key: string,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<Uint8Array> {
   if (!ctx.objectStorage) {
     throw new Error("Object storage not available");
@@ -180,7 +180,7 @@ export function createGenerateImageTool(
   params: {
     provider: MeshProvider;
     imageModelInfo: ModelInfo;
-    ctx: MeshContext;
+    ctx: StudioContext;
   },
 ) {
   const { provider, imageModelInfo, ctx } = params;

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -5,7 +5,7 @@
  * These use AI SDK tool() function and are registered directly in the decopilot API.
  */
 
-import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
+import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import { posthog } from "@/posthog";
 import type { UIMessageStreamWriter } from "ai";
 import {
@@ -134,7 +134,7 @@ export type BuiltInToolSet = Awaited<ReturnType<typeof buildAllTools>>;
 async function buildAllTools(
   writer: UIMessageStreamWriter,
   params: BuiltinToolParams,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ) {
   const {
     provider,
@@ -361,7 +361,7 @@ async function buildAllTools(
 export function instrumentBuiltIns<T extends Record<string, unknown>>(
   tools: T,
   params: BuiltinToolParams,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): T {
   const orgId = params.organization.id;
   const userId = ctx.auth?.user?.id;
@@ -440,7 +440,7 @@ export function instrumentBuiltIns<T extends Record<string, unknown>>(
 export async function getBuiltInTools(
   writer: UIMessageStreamWriter,
   params: BuiltinToolParams,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ) {
   const raw = await buildAllTools(writer, params, ctx);
   const tools = instrumentBuiltIns(raw, params, ctx) as typeof raw;
@@ -465,7 +465,7 @@ export async function getBuiltInTools(
  * these tools that don't apply for the current agent kind.
  */
 export interface BuildBuiltInToolsOptions {
-  ctx: MeshContext;
+  ctx: StudioContext;
   writer: UIMessageStreamWriter;
   toolOutputMap: Map<string, string>;
   subtaskParams: import("./subtask").SubtaskParams;

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/inspect-page.ts
@@ -15,7 +15,7 @@
 
 import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toMeshStorageUri } from "../../../api/routes/decopilot/mesh-storage-uri";
 import {
@@ -93,7 +93,7 @@ function buildFunctionCode(
 export function createInspectPageTool(
   writer: UIMessageStreamWriter,
   params: {
-    ctx: MeshContext;
+    ctx: StudioContext;
     toolOutputMap: Map<string, string>;
   },
 ) {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/resources.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/resources.ts
@@ -1,7 +1,7 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { VirtualClient } from "./sandbox";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import {
   MAX_RESULT_TOKENS,
   createOutputPreview,
@@ -16,7 +16,7 @@ const INLINE_RESOURCE_BYTE_LIMIT = 1_048_576; // 1 MiB
 export interface ResourceToolParams {
   readonly passthroughClient: VirtualClient;
   readonly toolOutputMap: Map<string, string>;
-  readonly ctx: MeshContext;
+  readonly ctx: StudioContext;
 }
 
 export function createReadResourceTool(params: ResourceToolParams) {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/scrape-url.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/scrape-url.ts
@@ -12,7 +12,7 @@
 
 import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toMeshStorageUri } from "../../../api/routes/decopilot/mesh-storage-uri";
 import {
@@ -29,7 +29,7 @@ export type ScrapeUrlInput = z.infer<typeof ScrapeUrlInputSchema>;
 export function createScrapeUrlTool(
   writer: UIMessageStreamWriter,
   params: {
-    ctx: MeshContext;
+    ctx: StudioContext;
     toolOutputMap: Map<string, string>;
   },
 ) {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -9,7 +9,7 @@
  * and yielding a single structured result for toModelOutput.
  */
 
-import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
+import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
 import type { UIMessageStreamWriter } from "ai";
 import { tool, zodSchema } from "ai";
@@ -67,7 +67,7 @@ const SUBTASK_ANNOTATIONS = {
 export function createSubtaskTool(
   writer: UIMessageStreamWriter,
   params: SubtaskParams,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ) {
   const { provider, organization, models, needsApproval } = params;
 

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/take-screenshot.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/take-screenshot.ts
@@ -11,7 +11,7 @@
 
 import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { toMeshStorageUri } from "../../../api/routes/decopilot/mesh-storage-uri";
 import { generatePresignedGetUrl } from "../../../api/routes/decopilot/file-materializer";
 import { BROWSERLESS_BASE_URL } from "./constants";
@@ -57,7 +57,7 @@ export interface PendingImage {
 export function createTakeScreenshotTool(
   writer: UIMessageStreamWriter,
   params: {
-    ctx: MeshContext;
+    ctx: StudioContext;
     toolOutputMap: Map<string, string>;
     pendingImages: PendingImage[];
   },

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/update-interests.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/update-interests.ts
@@ -9,7 +9,7 @@
 
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 
 const UpdateInterestsInputSchema = z.object({
   interests: z
@@ -38,7 +38,7 @@ const description =
   "that are clearly finished or abandoned. Order by importance, most first.";
 
 export function createUpdateInterestsTool(deps: {
-  ctx: MeshContext;
+  ctx: StudioContext;
   orgId: string;
   agentId: string;
   userId: string;

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/html-page-buffer.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/html-page-buffer.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UIMessageStreamWriter } from "ai";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import {
   createBoundObjectStorage,
   type BoundObjectStorage,
@@ -37,7 +37,7 @@ function matchHtmlPagePath(
   return { slug: m[1]!, key: normalized };
 }
 
-function resolveObjectStorage(ctx: MeshContext): BoundObjectStorage | null {
+function resolveObjectStorage(ctx: StudioContext): BoundObjectStorage | null {
   if (ctx.objectStorage) return ctx.objectStorage;
   const orgId = ctx.organization?.id;
   if (!orgId) return null;
@@ -81,7 +81,7 @@ export interface HtmlPageBuffer {
 }
 
 export function createHtmlPageBuffer(
-  ctx: MeshContext,
+  ctx: StudioContext,
   writer: UIMessageStreamWriter,
 ): HtmlPageBuffer {
   const pending = new Map<

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/types.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/types.ts
@@ -1,5 +1,5 @@
 import type { SandboxProvider } from "@decocms/sandbox/provider";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import type { PendingImage } from "../take-screenshot";
 import type { HtmlPageBuffer } from "./html-page-buffer";
 
@@ -45,7 +45,7 @@ export interface VmToolsParams {
    * org's object storage (`copy_to_sandbox`, `share_with_user`) or
    * resolve the org id for stable file URLs.
    */
-  readonly ctx: MeshContext;
+  readonly ctx: StudioContext;
   /**
    * Current chat thread id. `share_with_user` writes artifacts under
    * `model-outputs/<threadId>/<filename>` so the chat UI can list them.

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.integration.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.integration.test.ts
@@ -36,7 +36,7 @@ import {
   OrgScopedAsyncResearchJobStorage,
   SqlAsyncResearchJobStorage,
 } from "@/storage/async-research-jobs";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { googleAdapter } from "@/ai-providers/adapters/google";
 import { AsyncResearchTerminalError } from "@/ai-providers/types";
 import type { ModelInfo } from "@/api/routes/decopilot/types";
@@ -153,7 +153,7 @@ function startMockServer(defaults: SubmitOptions): MockServer {
 }
 
 // ============================================================================
-// Test harness — minimal MeshContext, real storage, real google adapter
+// Test harness — minimal StudioContext, real storage, real google adapter
 // ============================================================================
 
 const ORG_ID = "org_e2e_async_research";
@@ -179,14 +179,14 @@ function makeWriter(): {
   return { writer, events };
 }
 
-function makeCtx(storage: OrgScopedAsyncResearchJobStorage): MeshContext {
+function makeCtx(storage: OrgScopedAsyncResearchJobStorage): StudioContext {
   // The async path only reads `ctx.storage.asyncResearchJobs` and
   // `ctx.objectStorage`. Everything else can stay undefined behind the
   // unknown cast — this is a focused test, not an integration spec.
   return {
     storage: { asyncResearchJobs: storage },
     objectStorage: null,
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 }
 
 // ============================================================================

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.ts
@@ -33,7 +33,7 @@ import {
   AsyncResearchTerminalError,
   type MeshProvider,
 } from "@/ai-providers/types";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { sanitizeProviderMetadata } from "@decocms/mesh-sdk";
 import type { ModelInfo } from "../../../api/routes/decopilot/types";
 import { createOutputPreview } from "./read-tool-output";
@@ -78,7 +78,7 @@ export function createWebSearchTool(
   params: {
     provider: MeshProvider;
     deepResearchModelInfo: ModelInfo;
-    ctx: MeshContext;
+    ctx: StudioContext;
     toolOutputMap: Map<string, string>;
     /** Current thread/task id — used to scope persisted research jobs. */
     taskId: string;
@@ -165,7 +165,7 @@ interface AsyncResearchInvocation {
   asyncResearch: NonNullable<MeshProvider["asyncResearch"]>;
   providerId: string;
   modelId: string;
-  ctx: MeshContext;
+  ctx: StudioContext;
   taskId: string;
   toolOutputMap: Map<string, string>;
   writeProgress: (text: string) => void;
@@ -477,7 +477,7 @@ interface StreamingInvocation {
   provider: MeshProvider;
   modelId: string;
   toolOutputMap: Map<string, string>;
-  ctx: MeshContext;
+  ctx: StudioContext;
   writeProgress: (text: string) => void;
 }
 

--- a/apps/mesh/src/harnesses/decopilot/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/index.ts
@@ -30,7 +30,7 @@
 
 import type { UIMessageChunk, UIMessageStreamWriter } from "ai";
 import type { HarnessContext } from "../../core/harness-context";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import type { Harness, HarnessFactory, HarnessStreamInput } from "../types";
 import type { MeshProvider } from "../../ai-providers/types";
 import type { RunRegistry } from "../../api/routes/decopilot/run-registry";
@@ -101,21 +101,21 @@ export const decopilotHarnessFactory: HarnessFactory = {
   id: "decopilot",
   create(harnessCtx: HarnessContext): Harness {
     // `stream()` refuses to run without processLocal, so any cluster-only
-    // ctx field reads only happen on a real MeshContext value. The widening
+    // ctx field reads only happen on a real StudioContext value. The widening
     // cast here is a TS-level erasure; the defensive check below catches a
     // narrow HarnessContext smuggled in via misuse (e.g. a non-decopilot
     // caller mistakenly invoking this factory on the desktop).
     //
-    // `storage` and `db` are required fields on MeshContext but absent
+    // `storage` and `db` are required fields on StudioContext but absent
     // from HarnessContext, so their presence reliably distinguishes the
     // two at runtime.
     if (!("storage" in harnessCtx) || !("db" in harnessCtx)) {
       throw new Error(
-        "decopilot harness requires MeshContext (cluster-side only); " +
+        "decopilot harness requires StudioContext (cluster-side only); " +
           "got narrow HarnessContext",
       );
     }
-    const ctx = harnessCtx as MeshContext;
+    const ctx = harnessCtx as StudioContext;
     return {
       id: "decopilot",
       async *stream(input: HarnessStreamInput): AsyncIterable<UIMessageChunk> {

--- a/apps/mesh/src/harnesses/decopilot/prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/prompt.ts
@@ -24,7 +24,7 @@
  * providers — they have their own harnesses.
  */
 
-import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
+import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import { isDecopilot } from "@decocms/mesh-sdk";
 import type { GithubRepo } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -51,7 +51,7 @@ import type { AssembledTools } from "./tools";
  * provided. Returns null when no other active agents exist.
  */
 export async function listAgentsBlock(
-  ctx: MeshContext,
+  ctx: StudioContext,
   org: OrganizationScope,
   currentVirtualMcpId?: string,
 ): Promise<string | null> {
@@ -73,7 +73,7 @@ export async function listAgentsBlock(
  * client is provided (e.g., unit tests) or when the catalog is empty.
  */
 export async function listPromptsBlock(
-  _ctx: MeshContext,
+  _ctx: StudioContext,
   _org: OrganizationScope,
   passthroughClient?: Client,
 ): Promise<string | null> {
@@ -103,7 +103,7 @@ export async function listPromptsBlock(
  * there are no tools to expose.
  */
 export async function listConnectionsBlock(
-  _ctx: MeshContext,
+  _ctx: StudioContext,
   _org: OrganizationScope,
   data?: {
     tools: ConnectionsBlockTool[];
@@ -133,7 +133,7 @@ export interface AssembledPrompt {
  */
 export async function assembleDecopilotPrompt(
   input: HarnessStreamInput,
-  ctx: MeshContext,
+  ctx: StudioContext,
   tools: AssembledTools,
 ): Promise<AssembledPrompt> {
   const organization = ctx.organization!;

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -9,7 +9,7 @@
  * validation / MCP-client creation (subagent-wrapper concerns).
  */
 
-import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
+import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import type { MeshProvider } from "@/ai-providers/types";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
@@ -43,7 +43,7 @@ import type { SubtaskParams } from "./built-in-tools/subtask";
 import type { ConnectionsBlockTool } from "./connections-block";
 
 export interface RunAgentLoopOptions {
-  ctx: MeshContext;
+  ctx: StudioContext;
   organization: OrganizationScope;
   virtualMcp: {
     id: string;

--- a/apps/mesh/src/harnesses/decopilot/run-stream.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-stream.ts
@@ -38,7 +38,7 @@
  * `toUIMessageStream` output.
  */
 
-import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
+import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import { monitorLlmCall } from "@/monitoring/emit-llm-call";
 import { recordLlmCallMetrics } from "@/monitoring/record-llm-call-metrics";
 import {
@@ -370,7 +370,7 @@ function makeChunkQueue(): {
  */
 export async function* runDecopilotStream(
   input: HarnessStreamInput,
-  ctx: MeshContext,
+  ctx: StudioContext,
   tools: AssembledTools,
   prompt: AssembledPrompt,
   extras: RunDecopilotStreamExtras,

--- a/apps/mesh/src/harnesses/decopilot/tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/tools.ts
@@ -21,7 +21,7 @@
 
 import type { ToolSet, UIMessageStreamWriter } from "ai";
 import type { GithubRepo } from "@decocms/mesh-sdk";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
 import type { PassthroughClient } from "@/mcp-clients/virtual-mcp/passthrough-client";
 import type { MeshProvider } from "@/ai-providers/types";
@@ -122,7 +122,7 @@ export interface AssembleDecopilotToolsExtras {
  */
 export async function assembleDecopilotTools(
   input: HarnessStreamInput,
-  ctx: MeshContext,
+  ctx: StudioContext,
   extras: AssembleDecopilotToolsExtras,
 ): Promise<AssembledTools> {
   const organization = ctx.organization!;

--- a/apps/mesh/src/harnesses/local-dispatch.test.ts
+++ b/apps/mesh/src/harnesses/local-dispatch.test.ts
@@ -6,7 +6,7 @@ import type {
   HarnessFactory,
   HarnessStreamInput,
 } from "./types";
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 import { localDispatch } from "./local-dispatch";
 
 const makeInput = (): HarnessStreamInput => ({
@@ -28,7 +28,7 @@ const makeInput = (): HarnessStreamInput => ({
   signal: new AbortController().signal,
 });
 
-const stubCtx = {} as MeshContext;
+const stubCtx = {} as StudioContext;
 
 describe("localDispatch", () => {
   test("throws when harness id is not registered", async () => {

--- a/apps/mesh/src/harnesses/local-dispatch.ts
+++ b/apps/mesh/src/harnesses/local-dispatch.ts
@@ -1,7 +1,7 @@
 import type { UIMessageChunk } from "ai";
 import { getHarnessFactory } from "./registry";
 import type { HarnessId, HarnessStreamInput } from "./types";
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 
 /** Invoke a harness in-process. Looks up the factory, creates a harness with
  *  the provided `ctx`, and returns its stream. Throws synchronously if the id
@@ -13,7 +13,7 @@ import type { MeshContext } from "../core/mesh-context";
 export function localDispatch(
   id: HarnessId,
   input: HarnessStreamInput,
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): AsyncIterable<UIMessageChunk> {
   const factory = getHarnessFactory(id);
   if (!factory) {

--- a/apps/mesh/src/harnesses/types.ts
+++ b/apps/mesh/src/harnesses/types.ts
@@ -6,7 +6,7 @@ import type { UIMessage, UIMessageChunk, UIMessageStreamWriter } from "ai";
  * These types intentionally avoid importing from cluster-only paths
  * (`@/core/*`, `@/storage/*`, `@/api/*`, etc.) so this file stays portable
  * into the desktop daemon's bundle. The cluster-side shapes (`ChatMessage`
- * with metadata + tools, full `MeshContext`, decopilot-only
+ * with metadata + tools, full `StudioContext`, decopilot-only
  * `HarnessProcessLocal` internals) flow in via structural compatibility:
  * the cluster passes its richer types where the harness expects a
  * UIMessage / HarnessContext / unknown-extras-bag, and TS accepts the
@@ -263,7 +263,7 @@ export interface Harness {
 
 /** Narrow context interface every Harness factory takes. Cluster-specific
  *  surface (DB, vault, auth, MCP gateway internals) lives on the wider
- *  MeshContext and is only safe to read inside a harness that gates its
+ *  StudioContext and is only safe to read inside a harness that gates its
  *  cluster-side code path on `HarnessStreamInput.processLocal` (today,
  *  only decopilot does this).
  *
@@ -272,7 +272,7 @@ export interface Harness {
  *  without depending on cluster-only modules.
  *
  *  Re-declared here (mirroring `apps/mesh/src/core/harness-context.ts`) so
- *  the package stays portable. The cluster's richer `MeshContext` is
+ *  the package stays portable. The cluster's richer `StudioContext` is
  *  structurally assignable to this shape. */
 export interface HarnessContext {
   tracer: import("@opentelemetry/api").Tracer;

--- a/apps/mesh/src/lib/suggest-commit-message.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.ts
@@ -1,5 +1,5 @@
 import { generateText } from "ai";
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 import { resolveTier } from "../core/resolve-tier";
 
 export interface CommitSuggestion {
@@ -262,7 +262,7 @@ export function parseCommitSuggestionJson(
 }
 
 export async function suggestCommitMessageWithLlm(
-  ctx: MeshContext,
+  ctx: StudioContext,
   status: GitStatusLike,
   diff: GitDiffLike,
 ): Promise<CommitSuggestion> {

--- a/apps/mesh/src/mcp-clients/client.ts
+++ b/apps/mesh/src/mcp-clients/client.ts
@@ -5,7 +5,7 @@
  * Routes to appropriate factory based on connection type.
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import type { ConnectionEntity } from "@/tools/connection/schema";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { createOutboundClient } from "./outbound";
@@ -25,7 +25,7 @@ import { createVirtualClient } from "./virtual-mcp";
  */
 export async function clientFromConnection(
   connection: ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
   superUser = false,
 ): Promise<Client> {
   if (connection.connection_type === "VIRTUAL") {

--- a/apps/mesh/src/mcp-clients/lazy-client.test.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.test.ts
@@ -16,7 +16,7 @@ import { createBridgeTransportPair } from "@decocms/mesh-sdk";
 import { CircuitOpenError, resetAll } from "./circuit-breaker";
 import { createLazyClient } from "./lazy-client";
 import type { ConnectionEntity } from "../tools/connection/schema";
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 
 // Mock clientFromConnection — we control when it succeeds/fails
 const clientFromConnectionMock = mock(() =>
@@ -34,7 +34,7 @@ const fakeConnection = {
 
 const fakeCtx = {
   pendingRevalidations: [],
-} as unknown as MeshContext;
+} as unknown as StudioContext;
 
 /**
  * Helper: create a real MCP server with a tool, connect a client to it via bridge,

--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -20,7 +20,7 @@ import type {
   ListToolsResult,
   ReadResourceResult,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 import type { ConnectionEntity } from "../tools/connection/schema";
 import {
   assertCircuitClosed,
@@ -47,7 +47,7 @@ import { getMcpReadCache } from "./mcp-read-cache";
  */
 export function createLazyClient(
   connection: ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
   superUser: boolean,
   cache?: McpListCache,
 ): Client {

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -7,7 +7,7 @@
 
 import { extractConnectionPermissions } from "@/auth/configuration-scopes";
 import { issueMeshToken } from "@/auth/jwt";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { refreshAccessToken } from "@/oauth/token-refresh";
 import { resolveOriginTokenEndpoint } from "@/oauth/resolve-token-endpoint";
@@ -51,7 +51,7 @@ function stripBindingMetadata(
  */
 export async function buildRequestHeaders(
   connection: ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
   superUser: boolean,
 ): Promise<Record<string, string>> {
   return ctx.tracer.startActiveSpan(
@@ -78,7 +78,7 @@ export async function buildRequestHeaders(
 
 async function _buildRequestHeaders(
   connection: ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
   superUser: boolean,
 ): Promise<Record<string, string>> {
   const connectionId = connection.id;

--- a/apps/mesh/src/mcp-clients/outbound/index.ts
+++ b/apps/mesh/src/mcp-clients/outbound/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { getSettings } from "../../settings";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import {
   type ConnectionEntity,
   isStdioParameters,
@@ -25,7 +25,7 @@ import {
 } from "./transports";
 
 // Singleton pool for STDIO connections — child processes must persist across requests.
-// Separate from the per-request pool on MeshContext (used by HTTP/SSE).
+// Separate from the per-request pool on StudioContext (used by HTTP/SSE).
 const stdioPool = createClientPool();
 
 /**
@@ -38,7 +38,7 @@ const stdioPool = createClientPool();
  */
 export async function createOutboundClient(
   connection: ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
   superUser = false,
 ): Promise<Client> {
   const connectionId = connection.id;

--- a/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
@@ -6,7 +6,7 @@
  * falling back to a live tools/list request on cache miss.
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import {
   type McpListCache,
   getMcpListCache,
@@ -26,7 +26,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 const MCP_MESH_KEY = "mcp.mesh";
 
 interface AuthTransportOptions {
-  ctx: MeshContext;
+  ctx: StudioContext;
   connection: ConnectionEntity;
   superUser?: boolean;
   cache?: McpListCache;

--- a/apps/mesh/src/mcp-clients/outbound/transports/monitoring.test.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/monitoring.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, mock, beforeEach } from "bun:test";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
@@ -76,7 +76,7 @@ function createMockTransportAndCtx() {
       createHistogram,
       createCounter,
     },
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 
   const transport = new MonitoringTransport(innerTransport, {
     ctx,

--- a/apps/mesh/src/mcp-clients/outbound/transports/monitoring.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/monitoring.ts
@@ -5,7 +5,7 @@
  * Tracks in-flight requests to correlate requests with responses.
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { trace, context, type Context } from "@opentelemetry/api";
 import type { Span } from "@opentelemetry/api";
 import type {
@@ -26,7 +26,7 @@ import {
 } from "@/api/routes/proxy-monitoring";
 
 interface MonitoringTransportOptions {
-  ctx: MeshContext;
+  ctx: StudioContext;
   connectionId: string;
   virtualMcpId?: string;
 }

--- a/apps/mesh/src/mcp-clients/server.ts
+++ b/apps/mesh/src/mcp-clients/server.ts
@@ -24,7 +24,7 @@ import {
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 import { createLazyClient } from "./lazy-client";
 import { getMcpListCache } from "./mcp-list-cache";
 import { fallbackOnMethodNotFoundError } from "./utils";
@@ -64,7 +64,7 @@ const DEFAULT_SERVER_CAPABILITIES = {
  */
 export function serverFromConnection(
   connection: ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
   superUser: boolean,
 ): McpServer {
   // Create lazy client — no MCP connection is established until needed

--- a/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
@@ -9,7 +9,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { isDecopilot } from "@decocms/mesh-sdk";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { getMcpListCache } from "../mcp-list-cache";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import type { ConnectionEntity } from "../../tools/connection/schema";
 import type { VirtualMCPEntity } from "../../tools/virtual/schema";
 import { PassthroughClient } from "./passthrough-client";
@@ -38,7 +38,7 @@ function isSelfReferencingVirtual(
  */
 export async function createVirtualClient(
   connection: ConnectionEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
   superUser = false,
 ): Promise<Client> {
   // Virtual MCP ID is the connection ID
@@ -66,7 +66,7 @@ export async function createVirtualClient(
  */
 export async function createVirtualClientFrom(
   virtualMcp: VirtualMCPEntity,
-  ctx: MeshContext,
+  ctx: StudioContext,
   _strategy: "passthrough",
   superUser = false,
   options?: { listTimeoutMs?: number },

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -16,7 +16,7 @@ import type {
   ListPromptsRequest,
   ListPromptsResult,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import {
   findStudioPackAgentByMcpId,
   resolveStudioPackChecklist,
@@ -31,7 +31,7 @@ import type { VirtualClientOptions } from "./types";
 export class PassthroughClient extends GatewayClient {
   constructor(
     protected options: VirtualClientOptions,
-    protected ctx: MeshContext,
+    protected ctx: StudioContext,
   ) {
     // Build VirtualMCP connection lookup for per-client selection
     const vmcpConnMap = new Map(

--- a/apps/mesh/src/monitoring/emit-llm-call.ts
+++ b/apps/mesh/src/monitoring/emit-llm-call.ts
@@ -11,7 +11,7 @@
 
 import { context, trace } from "@opentelemetry/api";
 import type { Tracer } from "@opentelemetry/api";
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { emitMonitoringLog } from "./emit";
 import {
   DECOPILOT_CONNECTION_ID,
@@ -63,7 +63,7 @@ export interface EmitLlmCallLogParams {
  * recordLlmCallMetrics so that metrics reflect the actual LLM outcome.
  */
 export function monitorLlmCall(
-  params: Omit<EmitLlmCallLogParams, "tracer"> & { ctx: MeshContext },
+  params: Omit<EmitLlmCallLogParams, "tracer"> & { ctx: StudioContext },
 ): void {
   emitLlmCallLog({ ...params, tracer: params.ctx.tracer });
 }

--- a/apps/mesh/src/monitoring/record-llm-call-metrics.test.ts
+++ b/apps/mesh/src/monitoring/record-llm-call-metrics.test.ts
@@ -23,7 +23,7 @@ function makeFakeMeter(calls: CounterCall[]) {
 }
 
 function makeCtx(meter: ReturnType<typeof makeFakeMeter>) {
-  // biome-ignore lint/suspicious/noExplicitAny: test fixture mocks MeshContext shape
+  // biome-ignore lint/suspicious/noExplicitAny: test fixture mocks StudioContext shape
   return { meter } as any;
 }
 

--- a/apps/mesh/src/monitoring/record-llm-call-metrics.ts
+++ b/apps/mesh/src/monitoring/record-llm-call-metrics.ts
@@ -11,11 +11,11 @@
  * cost savings and hit ratios. A counter is only emitted for non-zero kinds.
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { DECOPILOT_CONNECTION_ID } from "./schema";
 
 export function recordLlmCallMetrics(params: {
-  ctx: MeshContext;
+  ctx: StudioContext;
   organizationId: string;
   modelId: string;
   durationMs: number;

--- a/apps/mesh/src/monitoring/record-tool-execution-metrics.ts
+++ b/apps/mesh/src/monitoring/record-tool-execution-metrics.ts
@@ -1,7 +1,7 @@
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 
 export function recordToolExecutionMetrics(params: {
-  ctx: MeshContext;
+  ctx: StudioContext;
   organizationId: string;
   connectionId: string;
   toolName: string;

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -4,7 +4,7 @@
  * between start and stop still tears down the right kind of sandbox.
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import {
   resolveSandboxProviderKindFromEnv,
   type SandboxProviderKind,
@@ -188,7 +188,7 @@ async function instantiate(
  * a different user).
  */
 export async function buildDesktopProvider(
-  _ctx: MeshContext,
+  _ctx: StudioContext,
   userSub: string,
 ): Promise<SandboxProvider> {
   const { DesktopSandboxProvider } = await import(
@@ -208,7 +208,7 @@ export async function buildDesktopProvider(
 
 /** SANDBOX_DELETE uses this so teardown follows the entry's recorded sandboxProviderKind. */
 export function getSandboxProviderByKind(
-  ctx: MeshContext,
+  ctx: StudioContext,
   kind: SandboxProviderKind,
 ): Promise<SandboxProvider> {
   return resolveOnce(kind, () => instantiate(kind, ctx.db));
@@ -218,7 +218,7 @@ export function getSandboxProviderByKind(
  * Eager provider accessor for paths that need the provider before any user
  * request — preview-host proxying at the Bun.serve layer is the only caller
  * today. Reads the provider kind from env and constructs without a
- * MeshContext (the state store only needs a Kysely instance). Returns null
+ * StudioContext (the state store only needs a Kysely instance). Returns null
  * when no provider kind is configured.
  *
  * `instantiate()` only ever yields the cluster `AgentSandboxProvider` (the

--- a/apps/mesh/src/sandbox/resolve-provider.test.ts
+++ b/apps/mesh/src/sandbox/resolve-provider.test.ts
@@ -6,7 +6,7 @@ import type {
   SandboxProvider,
 } from "@decocms/sandbox/provider";
 
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 import type {
   LinkClaim,
   LinkClaimRegistry,
@@ -70,7 +70,7 @@ function stubCtx(
     sandboxPreference?: "cluster-default" | "user-desktop";
     linkForCurrentRun?: LinkClaim;
   },
-): MeshContext {
+): StudioContext {
   const registry: LinkClaimRegistry = {
     get: async () => link,
   } as unknown as LinkClaimRegistry;
@@ -79,7 +79,7 @@ function stubCtx(
     db: {} as never,
     sandboxPreference: hints?.sandboxPreference,
     linkForCurrentRun: hints?.linkForCurrentRun,
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 }
 
 describe("resolveSandboxProvider", () => {

--- a/apps/mesh/src/sandbox/resolve-provider.ts
+++ b/apps/mesh/src/sandbox/resolve-provider.ts
@@ -34,7 +34,7 @@ import {
   type SandboxProviderKind,
 } from "@decocms/sandbox/provider";
 
-import type { MeshContext } from "../core/mesh-context";
+import type { StudioContext } from "../core/studio-context";
 import { readSandboxMap } from "../tools/sandbox/sandbox-map";
 import { buildDesktopProvider, getSandboxProviderByKind } from "./lifecycle";
 import { resolveDefaultSandboxProviderKind } from "./resolve-default-provider-kind";
@@ -61,7 +61,7 @@ export interface ResolvedSandboxProvider {
 }
 
 export async function resolveSandboxProvider(
-  ctx: MeshContext,
+  ctx: StudioContext,
   args: ResolveSandboxProviderArgs,
 ): Promise<ResolvedSandboxProvider> {
   const { userId, branch, virtualMcpMetadata, explicitKind } = args;
@@ -142,7 +142,7 @@ function readRecordedKinds(
  * SANDBOX_START with no explicit kind would have used.
  */
 async function pickRecordedKind(
-  ctx: MeshContext,
+  ctx: StudioContext,
   userId: string,
   first: SandboxProviderKind,
   rest: SandboxProviderKind[],
@@ -153,7 +153,7 @@ async function pickRecordedKind(
 }
 
 async function resolveDefaultKind(
-  ctx: MeshContext,
+  ctx: StudioContext,
   userId: string,
 ): Promise<SandboxProviderKind> {
   if (!ctx.linkClaimRegistry) return resolveSandboxProviderKindFromEnv();
@@ -164,7 +164,7 @@ async function resolveDefaultKind(
 }
 
 async function bindProviderForKind(
-  ctx: MeshContext,
+  ctx: StudioContext,
   userId: string,
   kind: SandboxProviderKind,
 ): Promise<SandboxProvider> {
@@ -172,7 +172,7 @@ async function bindProviderForKind(
 
   if (!ctx.linkClaimRegistry) {
     throw new Error(
-      "user-desktop sandbox provider requires ctx.linkClaimRegistry to be wired (set on MeshContextConfig).",
+      "user-desktop sandbox provider requires ctx.linkClaimRegistry to be wired (set on StudioContextConfig).",
     );
   }
   const link = await ctx.linkClaimRegistry.get(userId);

--- a/apps/mesh/src/tools/ai-providers/credits.ts
+++ b/apps/mesh/src/tools/ai-providers/credits.ts
@@ -4,7 +4,7 @@ import {
   requireAuth,
   requireOrganization,
   getUserId,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { PROVIDER_IDS } from "../../ai-providers/provider-ids";
 import { getProviders } from "../../ai-providers/registry";
 import { mintGatewayJwt } from "../../auth/jwt";

--- a/apps/mesh/src/tools/ai-providers/key-create.ts
+++ b/apps/mesh/src/tools/ai-providers/key-create.ts
@@ -1,7 +1,7 @@
 import z from "zod";
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { PROVIDER_IDS } from "../../ai-providers/provider-ids";
 
 export const providerKeyOutputSchema = z.object({

--- a/apps/mesh/src/tools/ai-providers/key-delete.ts
+++ b/apps/mesh/src/tools/ai-providers/key-delete.ts
@@ -1,7 +1,7 @@
 import z from "zod";
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import type {
   SimpleModeConfig,
   SimpleModeModelSlot,

--- a/apps/mesh/src/tools/ai-providers/key-list.ts
+++ b/apps/mesh/src/tools/ai-providers/key-list.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { PROVIDER_IDS } from "../../ai-providers/provider-ids";
 import {
   checkKeyPermission,

--- a/apps/mesh/src/tools/ai-providers/key-preview.ts
+++ b/apps/mesh/src/tools/ai-providers/key-preview.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const AI_PROVIDER_KEY_PREVIEW = defineTool({
   name: "AI_PROVIDER_KEY_PREVIEW",

--- a/apps/mesh/src/tools/ai-providers/key-update.ts
+++ b/apps/mesh/src/tools/ai-providers/key-update.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { providerKeyOutputSchema } from "./key-create";
 
 export const AI_PROVIDER_KEY_UPDATE = defineTool({

--- a/apps/mesh/src/tools/ai-providers/list-active.ts
+++ b/apps/mesh/src/tools/ai-providers/list-active.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { getProviders } from "../../ai-providers/registry";
 
 export const AI_PROVIDERS_ACTIVE = defineTool({

--- a/apps/mesh/src/tools/ai-providers/list-models.ts
+++ b/apps/mesh/src/tools/ai-providers/list-models.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   checkModelPermission,
   fetchModelPermissions,

--- a/apps/mesh/src/tools/ai-providers/list.ts
+++ b/apps/mesh/src/tools/ai-providers/list.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { getProviders } from "@/ai-providers/registry";
 
 export const AI_PROVIDERS_LIST = defineTool({

--- a/apps/mesh/src/tools/ai-providers/oauth-exchange.ts
+++ b/apps/mesh/src/tools/ai-providers/oauth-exchange.ts
@@ -4,7 +4,7 @@ import {
   requireAuth,
   requireOrganization,
   getUserId,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { PROVIDER_IDS } from "../../ai-providers/provider-ids";
 import { getProviders } from "../../ai-providers/registry";
 import { providerKeyOutputSchema } from "./key-create";

--- a/apps/mesh/src/tools/ai-providers/oauth-url.ts
+++ b/apps/mesh/src/tools/ai-providers/oauth-url.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { PROVIDER_IDS } from "../../ai-providers/provider-ids";
 import { getProviders } from "../../ai-providers/registry";
 import {

--- a/apps/mesh/src/tools/ai-providers/provision-key.ts
+++ b/apps/mesh/src/tools/ai-providers/provision-key.ts
@@ -4,7 +4,7 @@ import {
   requireAuth,
   requireOrganization,
   getUserId,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { PROVIDER_IDS } from "../../ai-providers/provider-ids";
 import { getProviders } from "../../ai-providers/registry";
 import { mintGatewayJwt } from "../../auth/jwt";

--- a/apps/mesh/src/tools/ai-providers/topup-url.ts
+++ b/apps/mesh/src/tools/ai-providers/topup-url.ts
@@ -4,7 +4,7 @@ import {
   requireAuth,
   requireOrganization,
   getUserId,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { PROVIDER_IDS } from "../../ai-providers/provider-ids";
 import { getProviders } from "../../ai-providers/registry";
 import { mintGatewayJwt } from "../../auth/jwt";

--- a/apps/mesh/src/tools/apiKeys/create.ts
+++ b/apps/mesh/src/tools/apiKeys/create.ts
@@ -7,7 +7,7 @@
 
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 import { ApiKeyCreateInputSchema, ApiKeyCreateOutputSchema } from "./schema";
 
 export const API_KEY_CREATE = defineTool({

--- a/apps/mesh/src/tools/apiKeys/delete.ts
+++ b/apps/mesh/src/tools/apiKeys/delete.ts
@@ -7,7 +7,7 @@
 
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 import { ApiKeyDeleteInputSchema, ApiKeyDeleteOutputSchema } from "./schema";
 
 // Type for API key metadata with organization

--- a/apps/mesh/src/tools/apiKeys/list.ts
+++ b/apps/mesh/src/tools/apiKeys/list.ts
@@ -6,7 +6,7 @@
  */
 
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 import {
   ApiKeyListInputSchema,
   ApiKeyListOutputSchema,

--- a/apps/mesh/src/tools/apiKeys/update.ts
+++ b/apps/mesh/src/tools/apiKeys/update.ts
@@ -6,7 +6,7 @@
  */
 
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 import { ApiKeyUpdateInputSchema, ApiKeyUpdateOutputSchema } from "./schema";
 
 // Type for API key metadata with organization

--- a/apps/mesh/src/tools/automations/configure-trigger.ts
+++ b/apps/mesh/src/tools/automations/configure-trigger.ts
@@ -6,7 +6,7 @@
  * so the external MCP can call back to Mesh when the trigger fires.
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { clientFromConnection } from "@/mcp-clients";
 import { toServerClient } from "@/api/routes/proxy";
 import type { AutomationTrigger } from "@/storage/types";
@@ -14,7 +14,7 @@ import type { TriggerCallbackTokenStorage } from "@/storage/trigger-callback-tok
 import { TriggerBinding } from "@decocms/bindings/trigger";
 
 export async function configureTriggerOnMcp(
-  ctx: MeshContext,
+  ctx: StudioContext,
   trigger: AutomationTrigger,
   enabled: boolean,
   tokenStorage?: TriggerCallbackTokenStorage,

--- a/apps/mesh/src/tools/automations/create.ts
+++ b/apps/mesh/src/tools/automations/create.ts
@@ -11,7 +11,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { ChatTierSchema } from "../organization/schema";
 import { normalizeMessages } from "./normalize-messages";
 

--- a/apps/mesh/src/tools/automations/delete.ts
+++ b/apps/mesh/src/tools/automations/delete.ts
@@ -13,7 +13,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { configureTriggerOnMcp } from "./configure-trigger";
 
 export const AUTOMATION_DELETE = defineTool({

--- a/apps/mesh/src/tools/automations/get.ts
+++ b/apps/mesh/src/tools/automations/get.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const AUTOMATION_GET = defineTool({
   name: "AUTOMATION_GET",

--- a/apps/mesh/src/tools/automations/list.ts
+++ b/apps/mesh/src/tools/automations/list.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const AUTOMATION_LIST = defineTool({
   name: "AUTOMATION_LIST",

--- a/apps/mesh/src/tools/automations/run.ts
+++ b/apps/mesh/src/tools/automations/run.ts
@@ -11,7 +11,7 @@ import {
   requireAuth,
   requireOrganization,
   getUserId,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 
 export const AUTOMATION_RUN = defineTool({
   name: "AUTOMATION_RUN",

--- a/apps/mesh/src/tools/automations/trigger-add.ts
+++ b/apps/mesh/src/tools/automations/trigger-add.ts
@@ -15,7 +15,7 @@ import { syncTriggerCreated } from "../../automations/dbos-sync";
 import { Cron } from "croner";
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { configureTriggerOnMcp } from "./configure-trigger";
 import { webhookPermissionResource, webhookUrl } from "./webhook-trigger";
 

--- a/apps/mesh/src/tools/automations/trigger-remove.ts
+++ b/apps/mesh/src/tools/automations/trigger-remove.ts
@@ -8,7 +8,7 @@
 import { z } from "zod";
 import { syncTriggerDeleted } from "../../automations/dbos-sync";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { configureTriggerOnMcp } from "./configure-trigger";
 
 export const AUTOMATION_TRIGGER_REMOVE = defineTool({

--- a/apps/mesh/src/tools/automations/trigger-rotate-token.ts
+++ b/apps/mesh/src/tools/automations/trigger-rotate-token.ts
@@ -14,7 +14,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { webhookPermissionResource, webhookUrl } from "./webhook-trigger";
 
 export const AUTOMATION_TRIGGER_ROTATE_TOKEN = defineTool({

--- a/apps/mesh/src/tools/automations/update.ts
+++ b/apps/mesh/src/tools/automations/update.ts
@@ -8,7 +8,7 @@
 import { z } from "zod";
 import { syncAutomationActiveChanged } from "../../automations/dbos-sync";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { ChatTierSchema } from "../organization/schema";
 import { configureTriggerOnMcp } from "./configure-trigger";
 import { normalizeMessages } from "./normalize-messages";

--- a/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
@@ -14,7 +14,7 @@ import {
   COLLECTION_CONNECTIONS_UPDATE,
   CONNECTION_TEST,
 } from "./index";
-import type { BoundAuthClient, MeshContext } from "../../core/mesh-context";
+import type { BoundAuthClient, StudioContext } from "../../core/studio-context";
 import { ConnectionStorage } from "../../storage/connection";
 import { DownstreamTokenStorage } from "../../storage/downstream-token";
 import type { EventBus } from "../../event-bus/interface";
@@ -39,7 +39,7 @@ const createMockBoundAuth = (): BoundAuthClient =>
 
 describe("Connection Tools", () => {
   let database: MeshDatabase;
-  let ctx: MeshContext;
+  let ctx: StudioContext;
   let vault: CredentialVault;
 
   beforeAll(async () => {

--- a/apps/mesh/src/tools/connection/create.ts
+++ b/apps/mesh/src/tools/connection/create.ts
@@ -13,7 +13,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
 import { fetchToolsFromMCP } from "./fetch-tools";
 import {

--- a/apps/mesh/src/tools/connection/delete.ts
+++ b/apps/mesh/src/tools/connection/delete.ts
@@ -15,7 +15,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
 import { getMcpReadCache } from "../../mcp-clients/mcp-read-cache";
 import { ConnectionEntitySchema } from "./schema";

--- a/apps/mesh/src/tools/connection/get.ts
+++ b/apps/mesh/src/tools/connection/get.ts
@@ -11,7 +11,7 @@ import {
 import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { defineTool } from "../../core/define-tool";
-import { requireOrganization } from "../../core/mesh-context";
+import { requireOrganization } from "../../core/studio-context";
 import { getBaseUrl } from "../../core/server-constants";
 import {
   getMcpListCache,

--- a/apps/mesh/src/tools/connection/list.ts
+++ b/apps/mesh/src/tools/connection/list.ts
@@ -29,7 +29,7 @@ import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
 import { getBaseUrl } from "../../core/server-constants";
-import { requireOrganization } from "../../core/mesh-context";
+import { requireOrganization } from "../../core/studio-context";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import {
   getMcpListCache,

--- a/apps/mesh/src/tools/connection/test.ts
+++ b/apps/mesh/src/tools/connection/test.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireOrganization } from "../../core/mesh-context";
+import { requireOrganization } from "../../core/studio-context";
 
 export const CONNECTION_TEST = defineTool({
   name: "CONNECTION_TEST",

--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -18,7 +18,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
 import { getMcpReadCache } from "../../mcp-clients/mcp-read-cache";
 import { fetchToolsFromMCP } from "./fetch-tools";

--- a/apps/mesh/src/tools/database/index.ts
+++ b/apps/mesh/src/tools/database/index.ts
@@ -2,7 +2,7 @@ import { sql } from "kysely";
 import type { Kysely } from "kysely";
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 
 const QueryResult = z.object({
   results: z.array(z.unknown()).optional(),

--- a/apps/mesh/src/tools/eventbus/ack.ts
+++ b/apps/mesh/src/tools/eventbus/ack.ts
@@ -7,7 +7,7 @@
  */
 
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { AckEventInputSchema, AckEventOutputSchema } from "./schema";
 
 export const EVENT_ACK = defineTool({

--- a/apps/mesh/src/tools/eventbus/cancel.ts
+++ b/apps/mesh/src/tools/eventbus/cancel.ts
@@ -6,7 +6,7 @@
  */
 
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { CancelEventInputSchema, CancelEventOutputSchema } from "./schema";
 
 export const EVENT_CANCEL = defineTool({

--- a/apps/mesh/src/tools/eventbus/list.ts
+++ b/apps/mesh/src/tools/eventbus/list.ts
@@ -5,7 +5,7 @@
  */
 
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   ListSubscriptionsInputSchema,
   ListSubscriptionsOutputSchema,

--- a/apps/mesh/src/tools/eventbus/publish.ts
+++ b/apps/mesh/src/tools/eventbus/publish.ts
@@ -11,7 +11,7 @@
  */
 
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { PublishEventInputSchema, PublishEventOutputSchema } from "./schema";
 
 export const EVENT_PUBLISH = defineTool({

--- a/apps/mesh/src/tools/eventbus/subscribe.ts
+++ b/apps/mesh/src/tools/eventbus/subscribe.ts
@@ -6,7 +6,7 @@
  */
 
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { SubscribeInputSchema, SubscribeOutputSchema } from "./schema";
 
 export const EVENT_SUBSCRIBE = defineTool({

--- a/apps/mesh/src/tools/eventbus/sync-subscriptions.ts
+++ b/apps/mesh/src/tools/eventbus/sync-subscriptions.ts
@@ -7,7 +7,7 @@
  */
 
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   SyncSubscriptionsInputSchema,
   SyncSubscriptionsOutputSchema,

--- a/apps/mesh/src/tools/eventbus/unsubscribe.ts
+++ b/apps/mesh/src/tools/eventbus/unsubscribe.ts
@@ -5,7 +5,7 @@
  */
 
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { UnsubscribeInputSchema, UnsubscribeOutputSchema } from "./schema";
 
 export const EVENT_UNSUBSCRIBE = defineTool({

--- a/apps/mesh/src/tools/file-configs/create.ts
+++ b/apps/mesh/src/tools/file-configs/create.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   fileConfigInfoSchema,
   fileConfigNameSchema,

--- a/apps/mesh/src/tools/file-configs/delete.ts
+++ b/apps/mesh/src/tools/file-configs/delete.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const FILE_CONFIG_DELETE = defineTool({
   name: "FILE_CONFIG_DELETE",

--- a/apps/mesh/src/tools/file-configs/list-objects.ts
+++ b/apps/mesh/src/tools/file-configs/list-objects.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   listObjects,
   resolveFileConfig,

--- a/apps/mesh/src/tools/file-configs/list.ts
+++ b/apps/mesh/src/tools/file-configs/list.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { fileConfigInfoSchema } from "./schema";
 
 export const FILE_CONFIG_LIST = defineTool({

--- a/apps/mesh/src/tools/file-configs/update.ts
+++ b/apps/mesh/src/tools/file-configs/update.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   fileConfigInfoSchema,
   fileConfigNameSchema,

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ToolAnnotations } from "@/core/define-tool";
-import { MeshContext } from "@/core/mesh-context";
+import { StudioContext } from "@/core/studio-context";
 import {
   collectPluginTools,
   filterToolsByEnabledPlugins,
@@ -201,8 +201,8 @@ interface CombinedTool {
   annotations?: ToolAnnotations;
   _meta?: Record<string, unknown>;
   modelSummary?: (result: unknown) => string;
-  handler: (input: unknown, ctx: MeshContext) => Promise<unknown>;
-  execute: (input: unknown, ctx: MeshContext) => Promise<unknown>;
+  handler: (input: unknown, ctx: StudioContext) => Promise<unknown>;
+  execute: (input: unknown, ctx: StudioContext) => Promise<unknown>;
 }
 
 // All available tools — core + plugin tools
@@ -217,7 +217,7 @@ export type MCPMeshTools = typeof ALL_TOOLS;
 // Derive tool name type from ALL_TOOLS
 export type ToolNameFromTools = (typeof ALL_TOOLS)[number]["name"];
 
-export const managementMCP = async (ctx: MeshContext) => {
+export const managementMCP = async (ctx: StudioContext) => {
   // Get enabled plugins for this organization to filter plugin tools
   // Check both org settings (legacy) and all virtual MCPs
   let enabledPlugins: string[] | null = null;
@@ -451,7 +451,7 @@ export const managementMCP = async (ctx: MeshContext) => {
  * connecting a client to the management server over InMemoryTransport.
  */
 export async function listManagementTools(
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<McpTool[]> {
   const server = await managementMCP(ctx);
   const [clientTransport, serverTransport] =

--- a/apps/mesh/src/tools/links/get-current.test.ts
+++ b/apps/mesh/src/tools/links/get-current.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { createInMemoryLinkClaimRegistry } from "../../links/link-claim-registry";
 import type { LinkClaim } from "../../links/link-claim-registry";
 import { LINK_CURRENT_GET } from "./get-current";
@@ -17,9 +17,9 @@ const USER_ID = "user_1";
 
 function makeCtx(
   overrides: Partial<
-    Pick<MeshContext, "linkClaimRegistry" | "auth" | "access">
+    Pick<StudioContext, "linkClaimRegistry" | "auth" | "access">
   > = {},
-): MeshContext {
+): StudioContext {
   return {
     auth: {
       user: {
@@ -70,7 +70,7 @@ function makeCtx(
     pendingRevalidations: [],
     monitoring: null as never,
     ...overrides,
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 }
 
 describe("LINK_CURRENT_GET", () => {

--- a/apps/mesh/src/tools/links/get-current.ts
+++ b/apps/mesh/src/tools/links/get-current.ts
@@ -1,7 +1,7 @@
 import z from "zod";
 import { capabilitySchema } from "@/links/protocol";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 
 export const LINK_CURRENT_GET = defineTool({
   name: "LINK_CURRENT_GET",

--- a/apps/mesh/src/tools/monitoring/get.ts
+++ b/apps/mesh/src/tools/monitoring/get.ts
@@ -4,7 +4,7 @@
  * Fetches a single monitoring log by ID with full input/output data.
  */
 
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { flushMonitoringData } from "@/observability";
 import { defineTool } from "../../core/define-tool";
 import { z } from "zod";

--- a/apps/mesh/src/tools/monitoring/list.ts
+++ b/apps/mesh/src/tools/monitoring/list.ts
@@ -4,7 +4,7 @@
  * Lists monitoring logs for the organization with filtering options.
  */
 
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { flushMonitoringData } from "@/observability";
 import { defineTool } from "../../core/define-tool";
 import { z } from "zod";

--- a/apps/mesh/src/tools/monitoring/stats.ts
+++ b/apps/mesh/src/tools/monitoring/stats.ts
@@ -5,7 +5,7 @@
  * Supports both summary stats (backward-compatible) and timeseries queries.
  */
 
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { flushMonitoringData } from "@/observability";
 import { defineTool } from "../../core/define-tool";
 import { z } from "zod";

--- a/apps/mesh/src/tools/object-storage/delete-object.ts
+++ b/apps/mesh/src/tools/object-storage/delete-object.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   DeleteObjectInputSchema,
   DeleteObjectOutputSchema,

--- a/apps/mesh/src/tools/object-storage/delete-objects.ts
+++ b/apps/mesh/src/tools/object-storage/delete-objects.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   DeleteObjectsInputSchema,
   DeleteObjectsOutputSchema,

--- a/apps/mesh/src/tools/object-storage/get-object-metadata.ts
+++ b/apps/mesh/src/tools/object-storage/get-object-metadata.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   GetObjectMetadataInputSchema,
   GetObjectMetadataOutputSchema,

--- a/apps/mesh/src/tools/object-storage/get-presigned-url.ts
+++ b/apps/mesh/src/tools/object-storage/get-presigned-url.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   GetPresignedUrlInputSchema,
   GetPresignedUrlOutputSchema,

--- a/apps/mesh/src/tools/object-storage/list-objects.ts
+++ b/apps/mesh/src/tools/object-storage/list-objects.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   ListObjectsInputSchema,
   ListObjectsOutputSchema,

--- a/apps/mesh/src/tools/object-storage/put-presigned-url.ts
+++ b/apps/mesh/src/tools/object-storage/put-presigned-url.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   PutPresignedUrlInputSchema,
   PutPresignedUrlOutputSchema,

--- a/apps/mesh/src/tools/object-storage/schema.ts
+++ b/apps/mesh/src/tools/object-storage/schema.ts
@@ -1,8 +1,8 @@
 import { OBJECT_STORAGE_BINDING } from "@decocms/bindings/object-storage";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import type { BoundObjectStorage } from "../../object-storage/bound-object-storage";
 
-export function requireObjectStorage(ctx: MeshContext): BoundObjectStorage {
+export function requireObjectStorage(ctx: StudioContext): BoundObjectStorage {
   if (!ctx.objectStorage) {
     throw new Error(
       "Object storage is not configured. Ensure S3 credentials are set.",

--- a/apps/mesh/src/tools/organization/brand-context-extract.ts
+++ b/apps/mesh/src/tools/organization/brand-context-extract.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 import { extractBrandFromDomain } from "../../auth/extract-brand";
 import { BrandContextSchema } from "./schema.ts";
 

--- a/apps/mesh/src/tools/organization/brand-context-get.ts
+++ b/apps/mesh/src/tools/organization/brand-context-get.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 import { BrandContextSchema } from "./schema.ts";
 
 const BrandContextOutput = BrandContextSchema.extend({

--- a/apps/mesh/src/tools/organization/brand-context-update.ts
+++ b/apps/mesh/src/tools/organization/brand-context-update.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 import { BrandContextSchema } from "./schema.ts";
 
 const BrandContextOutput = BrandContextSchema.extend({

--- a/apps/mesh/src/tools/organization/brand-get.ts
+++ b/apps/mesh/src/tools/organization/brand-get.ts
@@ -5,7 +5,7 @@ import {
   BrandListOutputSchema,
 } from "@decocms/bindings/brand";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 import type { BrandContext } from "../../storage/types";
 
 function toBrandOutput(brand: BrandContext) {

--- a/apps/mesh/src/tools/organization/create.ts
+++ b/apps/mesh/src/tools/organization/create.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 
 export const ORGANIZATION_CREATE = defineTool({
   name: "ORGANIZATION_CREATE" as const,

--- a/apps/mesh/src/tools/organization/delete.ts
+++ b/apps/mesh/src/tools/organization/delete.ts
@@ -7,7 +7,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 
 export const ORGANIZATION_DELETE = defineTool({
   name: "ORGANIZATION_DELETE",

--- a/apps/mesh/src/tools/organization/domain-get.ts
+++ b/apps/mesh/src/tools/organization/domain-get.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const ORGANIZATION_DOMAIN_GET = defineTool({
   name: "ORGANIZATION_DOMAIN_GET",

--- a/apps/mesh/src/tools/organization/domain-set.ts
+++ b/apps/mesh/src/tools/organization/domain-set.ts
@@ -7,7 +7,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { GENERIC_EMAIL_DOMAINS } from "../../auth";
 
 const DOMAIN_REGEX =

--- a/apps/mesh/src/tools/organization/get.ts
+++ b/apps/mesh/src/tools/organization/get.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 
 export const ORGANIZATION_GET = defineTool({
   name: "ORGANIZATION_GET",

--- a/apps/mesh/src/tools/organization/list.ts
+++ b/apps/mesh/src/tools/organization/list.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 
 export const ORGANIZATION_LIST = defineTool({
   name: "ORGANIZATION_LIST",

--- a/apps/mesh/src/tools/organization/member-add.ts
+++ b/apps/mesh/src/tools/organization/member-add.ts
@@ -7,7 +7,7 @@
 import { z } from "zod";
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 
 export const ORGANIZATION_MEMBER_ADD = defineTool({
   name: "ORGANIZATION_MEMBER_ADD",

--- a/apps/mesh/src/tools/organization/member-list.ts
+++ b/apps/mesh/src/tools/organization/member-list.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 
 export const ORGANIZATION_MEMBER_LIST = defineTool({
   name: "ORGANIZATION_MEMBER_LIST",

--- a/apps/mesh/src/tools/organization/member-remove.ts
+++ b/apps/mesh/src/tools/organization/member-remove.ts
@@ -7,7 +7,7 @@
 import { z } from "zod";
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 
 export const ORGANIZATION_MEMBER_REMOVE = defineTool({
   name: "ORGANIZATION_MEMBER_REMOVE",

--- a/apps/mesh/src/tools/organization/member-update-role.ts
+++ b/apps/mesh/src/tools/organization/member-update-role.ts
@@ -7,7 +7,7 @@
 import { z } from "zod";
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 
 export const ORGANIZATION_MEMBER_UPDATE_ROLE = defineTool({
   name: "ORGANIZATION_MEMBER_UPDATE_ROLE",

--- a/apps/mesh/src/tools/organization/organization-tools.test.ts
+++ b/apps/mesh/src/tools/organization/organization-tools.test.ts
@@ -13,8 +13,8 @@ import {
 import type {
   BetterAuthInstance,
   BoundAuthClient,
-  MeshContext,
-} from "../../core/mesh-context";
+  StudioContext,
+} from "../../core/studio-context";
 
 // Mock Better Auth instance (for legacy authInstance property)
 const createMockAuth = () => ({
@@ -163,7 +163,7 @@ const createMockBoundAuth = (
 
 const createMockContext = (
   authInstance: ReturnType<typeof createMockAuth> = createMockAuth(),
-): MeshContext => {
+): StudioContext => {
   const boundAuth = createMockBoundAuth(authInstance);
   return {
     timings: {

--- a/apps/mesh/src/tools/organization/settings-get.ts
+++ b/apps/mesh/src/tools/organization/settings-get.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 import {
   SidebarItemSchema,
   RegistryConfigSchema,

--- a/apps/mesh/src/tools/organization/settings-tools.test.ts
+++ b/apps/mesh/src/tools/organization/settings-tools.test.ts
@@ -6,8 +6,8 @@ import {
 import type {
   BetterAuthInstance,
   BoundAuthClient,
-  MeshContext,
-} from "../../core/mesh-context";
+  StudioContext,
+} from "../../core/studio-context";
 import type { OrganizationSettings } from "../../storage/types";
 
 const SAMPLE_SIMPLE_MODE = {
@@ -41,7 +41,7 @@ const buildStoredSettings = (
 
 const createMockContext = (
   storedSettings: OrganizationSettings | null,
-): MeshContext => {
+): StudioContext => {
   const get = vi.fn().mockResolvedValue(storedSettings);
   const upsert = vi.fn(async (_orgId: string, data) => ({
     ...buildStoredSettings(storedSettings ?? undefined),

--- a/apps/mesh/src/tools/organization/settings-update.ts
+++ b/apps/mesh/src/tools/organization/settings-update.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 import {
   SidebarItemSchema,
   RegistryConfigSchema,

--- a/apps/mesh/src/tools/organization/update.ts
+++ b/apps/mesh/src/tools/organization/update.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 
 export const ORGANIZATION_UPDATE = defineTool({
   name: "ORGANIZATION_UPDATE",

--- a/apps/mesh/src/tools/registry/ai-generate.ts
+++ b/apps/mesh/src/tools/registry/ai-generate.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { z } from "zod";
 import {
   RegistryAIGenerateInputSchema,

--- a/apps/mesh/src/tools/registry/bulk-create.ts
+++ b/apps/mesh/src/tools/registry/bulk-create.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   RegistryBulkCreateInputSchema,
   RegistryBulkCreateOutputSchema,

--- a/apps/mesh/src/tools/registry/collection-registry-app.ts
+++ b/apps/mesh/src/tools/registry/collection-registry-app.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { z } from "zod";
 import {
   RegistryFiltersOutputSchema,

--- a/apps/mesh/src/tools/registry/create.ts
+++ b/apps/mesh/src/tools/registry/create.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   RegistryCreateInputSchema,
   RegistryCreateOutputSchema,

--- a/apps/mesh/src/tools/registry/delete.ts
+++ b/apps/mesh/src/tools/registry/delete.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   RegistryDeleteInputSchema,
   RegistryDeleteOutputSchema,

--- a/apps/mesh/src/tools/registry/discover-tools.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";

--- a/apps/mesh/src/tools/registry/filters.ts
+++ b/apps/mesh/src/tools/registry/filters.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { z } from "zod";
 import { RegistryFiltersOutputSchema } from "./schema";
 

--- a/apps/mesh/src/tools/registry/get.ts
+++ b/apps/mesh/src/tools/registry/get.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { RegistryGetInputSchema, RegistryGetOutputSchema } from "./schema";
 
 export const REGISTRY_ITEM_GET = defineTool({

--- a/apps/mesh/src/tools/registry/list.ts
+++ b/apps/mesh/src/tools/registry/list.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { RegistryListInputSchema, RegistryListOutputSchema } from "./schema";
 
 export const REGISTRY_ITEM_LIST = defineTool({

--- a/apps/mesh/src/tools/registry/monitor-connection-list.ts
+++ b/apps/mesh/src/tools/registry/monitor-connection-list.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import type { z } from "zod";
 import {
   RegistryMonitorConnectionListInputSchema,

--- a/apps/mesh/src/tools/registry/monitor-connection-sync.ts
+++ b/apps/mesh/src/tools/registry/monitor-connection-sync.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   RegistryMonitorConnectionSyncInputSchema,
   RegistryMonitorConnectionSyncOutputSchema,

--- a/apps/mesh/src/tools/registry/monitor-connection-update-auth.ts
+++ b/apps/mesh/src/tools/registry/monitor-connection-update-auth.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   RegistryMonitorConnectionUpdateAuthInputSchema,
   RegistryMonitorConnectionUpdateAuthOutputSchema,

--- a/apps/mesh/src/tools/registry/monitor-result-list.ts
+++ b/apps/mesh/src/tools/registry/monitor-result-list.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   RegistryMonitorResultListInputSchema,
   RegistryMonitorResultListOutputSchema,

--- a/apps/mesh/src/tools/registry/monitor-run-cancel.ts
+++ b/apps/mesh/src/tools/registry/monitor-run-cancel.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import type { z } from "zod";
 import {
   RegistryMonitorRunCancelInputSchema,

--- a/apps/mesh/src/tools/registry/monitor-run-get.ts
+++ b/apps/mesh/src/tools/registry/monitor-run-get.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import type { z } from "zod";
 import {
   RegistryMonitorRunGetInputSchema,

--- a/apps/mesh/src/tools/registry/monitor-run-list.ts
+++ b/apps/mesh/src/tools/registry/monitor-run-list.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import type { z } from "zod";
 import {
   RegistryMonitorRunListInputSchema,

--- a/apps/mesh/src/tools/registry/monitor-run-start.ts
+++ b/apps/mesh/src/tools/registry/monitor-run-start.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization, type MeshContext } from "@/core/mesh-context";
+import { requireOrganization, type StudioContext } from "@/core/studio-context";
 import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import {
   generateText,
@@ -58,7 +58,7 @@ type MCPClientLike = {
   close?: () => Promise<void>;
 };
 
-type MonitorToolContext = MeshContext & {
+type MonitorToolContext = StudioContext & {
   organization: { id: string };
   storage: {
     connections: {
@@ -94,7 +94,7 @@ function logError(...msgParts: unknown[]): void {
   console.error(LOG_PREFIX, ...msgParts);
 }
 
-function resolveContext(ctx: MeshContext): MonitorToolContext {
+function resolveContext(ctx: StudioContext): MonitorToolContext {
   requireOrganization(ctx);
   return ctx as unknown as MonitorToolContext;
 }
@@ -1271,7 +1271,7 @@ function publishRequestToMonitorTarget(
 }
 
 async function startMonitorRun(
-  ctx: MeshContext,
+  ctx: StudioContext,
   config: RegistryMonitorConfig,
 ): Promise<{ run: { id: string } }> {
   const monitorCtx = resolveContext(ctx);

--- a/apps/mesh/src/tools/registry/monitor-schedule-cancel.ts
+++ b/apps/mesh/src/tools/registry/monitor-schedule-cancel.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import {
   RegistryMonitorScheduleCancelInputSchema,

--- a/apps/mesh/src/tools/registry/monitor-schedule-set.ts
+++ b/apps/mesh/src/tools/registry/monitor-schedule-set.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import {
   RegistryMonitorScheduleSetInputSchema,

--- a/apps/mesh/src/tools/registry/publish-api-key-generate.ts
+++ b/apps/mesh/src/tools/registry/publish-api-key-generate.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   PublishApiKeyGenerateInputSchema,
   PublishApiKeyGenerateOutputSchema,

--- a/apps/mesh/src/tools/registry/publish-api-key-list.ts
+++ b/apps/mesh/src/tools/registry/publish-api-key-list.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { z } from "zod";
 import { PublishApiKeyListOutputSchema } from "./schema";
 

--- a/apps/mesh/src/tools/registry/publish-api-key-revoke.ts
+++ b/apps/mesh/src/tools/registry/publish-api-key-revoke.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   PublishApiKeyRevokeInputSchema,
   PublishApiKeyRevokeOutputSchema,

--- a/apps/mesh/src/tools/registry/publish-request-count.ts
+++ b/apps/mesh/src/tools/registry/publish-request-count.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { z } from "zod";
 import { PublishRequestCountOutputSchema } from "./schema";
 

--- a/apps/mesh/src/tools/registry/publish-request-delete.ts
+++ b/apps/mesh/src/tools/registry/publish-request-delete.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   PublishRequestDeleteInputSchema,
   PublishRequestDeleteOutputSchema,

--- a/apps/mesh/src/tools/registry/publish-request-list.ts
+++ b/apps/mesh/src/tools/registry/publish-request-list.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   PublishRequestListInputSchema,
   PublishRequestListOutputSchema,

--- a/apps/mesh/src/tools/registry/publish-request-review.ts
+++ b/apps/mesh/src/tools/registry/publish-request-review.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   PublishRequestReviewInputSchema,
   PublishRequestReviewOutputSchema,

--- a/apps/mesh/src/tools/registry/search.ts
+++ b/apps/mesh/src/tools/registry/search.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   RegistrySearchInputSchema,
   RegistrySearchOutputSchema,

--- a/apps/mesh/src/tools/registry/update.ts
+++ b/apps/mesh/src/tools/registry/update.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import {
   RegistryUpdateInputSchema,
   RegistryUpdateOutputSchema,

--- a/apps/mesh/src/tools/registry/utils.ts
+++ b/apps/mesh/src/tools/registry/utils.ts
@@ -1,4 +1,4 @@
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 import { PLUGIN_ID } from "./shared";
 
 export interface PrivateRegistryPluginSettings {
@@ -24,7 +24,7 @@ function parsePluginSettings(raw: unknown): PrivateRegistryPluginSettings {
 }
 
 export async function getRegistryPluginSettings(
-  ctx: MeshContext,
+  ctx: StudioContext,
   organizationId: string,
 ): Promise<PrivateRegistryPluginSettings> {
   const rows = await (ctx.db as any)

--- a/apps/mesh/src/tools/registry/versions.ts
+++ b/apps/mesh/src/tools/registry/versions.ts
@@ -1,5 +1,5 @@
 import { defineTool } from "@/core/define-tool";
-import { requireOrganization } from "@/core/mesh-context";
+import { requireOrganization } from "@/core/studio-context";
 import { z } from "zod";
 import { RegistryGetInputSchema, RegistryItemSchema } from "./schema";
 

--- a/apps/mesh/src/tools/sandbox/delete.test.ts
+++ b/apps/mesh/src/tools/sandbox/delete.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import type { SandboxMap, SandboxRecord } from "@decocms/mesh-sdk";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import type {
   SandboxProvider,
   SandboxProviderKind,
@@ -85,7 +85,7 @@ function makeCtx(overrides: {
   userId?: string;
   virtualMcp?: ReturnType<typeof makeVirtualMcp> | null;
   updateSpy?: ReturnType<typeof mock>;
-}): MeshContext {
+}): StudioContext {
   const {
     orgId = "org_1",
     userId = "user-1",
@@ -146,7 +146,7 @@ function makeCtx(overrides: {
     getOrCreateClient: null as never,
     pendingRevalidations: [],
     monitoring: null as never,
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 }
 
 describe("SANDBOX_DELETE", () => {

--- a/apps/mesh/src/tools/sandbox/helpers.ts
+++ b/apps/mesh/src/tools/sandbox/helpers.ts
@@ -17,8 +17,8 @@ import {
   requireAuth,
   requireOrganization,
   getUserId,
-  type MeshContext,
-} from "../../core/mesh-context";
+  type StudioContext,
+} from "../../core/studio-context";
 import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
 import type { PackageManager } from "../../shared/runtime-defaults";
 import { readSandboxMap, resolveVm } from "./sandbox-map";
@@ -80,7 +80,7 @@ export async function requireVmEntry(
     branch: string;
     sandboxProviderKind: SandboxProviderKind;
   },
-  ctx: MeshContext,
+  ctx: StudioContext,
 ) {
   requireAuth(ctx);
   const organization = requireOrganization(ctx);

--- a/apps/mesh/src/tools/sandbox/resolve-env.ts
+++ b/apps/mesh/src/tools/sandbox/resolve-env.ts
@@ -4,10 +4,10 @@ import {
   SecretAccessDeniedError,
   SecretNotFoundError,
 } from "../../storage/secrets";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 
 interface ResolveAndPushParams {
-  ctx: MeshContext;
+  ctx: StudioContext;
   runner: SandboxProvider;
   handle: string;
   orgId: string;

--- a/apps/mesh/src/tools/sandbox/start.test.ts
+++ b/apps/mesh/src/tools/sandbox/start.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import type { SandboxMap, SandboxRecord } from "@decocms/mesh-sdk";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import type {
   LinkClaimRegistry,
   LinkClaim,
@@ -204,7 +204,7 @@ function makeCtx(overrides: {
   virtualMcp?: ReturnType<typeof makeVirtualMcp> | null;
   updateSpy?: ReturnType<typeof mock>;
   linkClaimRegistry?: LinkClaimRegistry;
-}): MeshContext {
+}): StudioContext {
   const {
     orgId = ORG_ID,
     userId = USER_ID,
@@ -267,7 +267,7 @@ function makeCtx(overrides: {
     pendingRevalidations: [],
     monitoring: null as never,
     linkClaimRegistry,
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 }
 
 describe("SANDBOX_START", () => {

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -21,8 +21,8 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-  type MeshContext,
-} from "../../core/mesh-context";
+  type StudioContext,
+} from "../../core/studio-context";
 import {
   requireVmEntry,
   resolveRuntimeConfig,
@@ -173,7 +173,7 @@ export async function ensureSandbox(
     branch: string;
     sandboxProviderKind: SandboxProviderKind;
   },
-  ctx: MeshContext,
+  ctx: StudioContext,
 ): Promise<SandboxRecord> {
   // Inline auth + lookup; the standard `requireVmEntry` runs
   // `ctx.access.check()`, which expects resource scoping that the
@@ -249,7 +249,7 @@ export async function ensureSandbox(
 }
 
 type StartParams = {
-  ctx: MeshContext;
+  ctx: StudioContext;
   userId: string;
   orgId: string;
   virtualMcpId: string;
@@ -460,7 +460,7 @@ async function provisionSandbox(
  * readers (resolveRuntimeConfig, any client inspectors) keep working.
  */
 async function persistDetectedRuntime(
-  ctx: MeshContext,
+  ctx: StudioContext,
   virtualMcpId: string,
   actingUserId: string,
   packageManager: string,

--- a/apps/mesh/src/tools/search/global-search.ts
+++ b/apps/mesh/src/tools/search/global-search.ts
@@ -16,7 +16,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireOrganization } from "../../core/mesh-context";
+import { requireOrganization } from "../../core/studio-context";
 
 const SEARCHABLE_TYPES = ["thread"] as const;
 

--- a/apps/mesh/src/tools/secrets/create.ts
+++ b/apps/mesh/src/tools/secrets/create.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { secretInfoSchema } from "./schema";
 
 export const SECRET_CREATE = defineTool({

--- a/apps/mesh/src/tools/secrets/list.ts
+++ b/apps/mesh/src/tools/secrets/list.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { secretInfoSchema } from "./schema";
 
 export const SECRET_LIST = defineTool({

--- a/apps/mesh/src/tools/tags/create.ts
+++ b/apps/mesh/src/tools/tags/create.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const TAGS_CREATE = defineTool({
   name: "TAGS_CREATE",

--- a/apps/mesh/src/tools/tags/delete.ts
+++ b/apps/mesh/src/tools/tags/delete.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const TAGS_DELETE = defineTool({
   name: "TAGS_DELETE",

--- a/apps/mesh/src/tools/tags/list.ts
+++ b/apps/mesh/src/tools/tags/list.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const TAGS_LIST = defineTool({
   name: "TAGS_LIST",

--- a/apps/mesh/src/tools/tags/member-get.ts
+++ b/apps/mesh/src/tools/tags/member-get.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const MEMBER_TAGS_GET = defineTool({
   name: "MEMBER_TAGS_GET",

--- a/apps/mesh/src/tools/tags/member-set.ts
+++ b/apps/mesh/src/tools/tags/member-set.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 export const MEMBER_TAGS_SET = defineTool({
   name: "MEMBER_TAGS_SET",

--- a/apps/mesh/src/tools/thread/create.ts
+++ b/apps/mesh/src/tools/thread/create.ts
@@ -22,7 +22,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { ThreadCreateDataSchema, ThreadEntitySchema } from "./schema";
 import { generatePrefixedId } from "@/shared/utils/generate-id";
 import { generateBranchName } from "@/shared/branch-name";

--- a/apps/mesh/src/tools/thread/delete.ts
+++ b/apps/mesh/src/tools/thread/delete.ts
@@ -14,7 +14,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { normalizeThreadForResponse } from "./helpers";
 import { ThreadEntitySchema } from "./schema";
 

--- a/apps/mesh/src/tools/thread/get.ts
+++ b/apps/mesh/src/tools/thread/get.ts
@@ -9,7 +9,7 @@ import {
   createCollectionGetOutputSchema,
 } from "@decocms/bindings/collections";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { normalizeThreadForResponse } from "./helpers";
 import { ThreadEntitySchema } from "./schema";
 

--- a/apps/mesh/src/tools/thread/list-messages.ts
+++ b/apps/mesh/src/tools/thread/list-messages.ts
@@ -11,7 +11,7 @@ import {
 } from "@decocms/bindings/collections";
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireOrganization } from "../../core/mesh-context";
+import { requireOrganization } from "../../core/studio-context";
 import { ThreadMessageEntitySchema } from "./schema";
 
 /**

--- a/apps/mesh/src/tools/thread/list.ts
+++ b/apps/mesh/src/tools/thread/list.ts
@@ -10,7 +10,7 @@ import {
   createCollectionListOutputSchema,
 } from "@decocms/bindings/collections";
 import { defineTool } from "../../core/define-tool";
-import { requireOrganization } from "../../core/mesh-context";
+import { requireOrganization } from "../../core/studio-context";
 import { normalizeThreadForResponse } from "./helpers";
 import { ThreadEntitySchema } from "./schema";
 import { z } from "zod";

--- a/apps/mesh/src/tools/thread/test-helpers.ts
+++ b/apps/mesh/src/tools/thread/test-helpers.ts
@@ -18,14 +18,14 @@ import {
   OrgScopedThreadStorage,
 } from "../../storage/threads";
 import { VirtualMCPStorage } from "../../storage/virtual";
-import type { BoundAuthClient, MeshContext } from "../../core/mesh-context";
+import type { BoundAuthClient, StudioContext } from "../../core/studio-context";
 
 const ORG_ID = "org_test";
 const USER_ID = "user_test";
 
 export interface ThreadTestEnv {
   database: MeshDatabase;
-  ctx: MeshContext;
+  ctx: StudioContext;
   orgId: string;
   userId: string;
   close: () => Promise<void>;
@@ -134,7 +134,7 @@ export async function buildThreadTestContext(): Promise<ThreadTestEnv> {
     createMCPProxy: vi.fn().mockResolvedValue({}),
     getOrCreateClient: vi.fn().mockResolvedValue({}),
     pendingRevalidations: [],
-  } as unknown as MeshContext;
+  } as unknown as StudioContext;
 
   return {
     database,

--- a/apps/mesh/src/tools/thread/update.ts
+++ b/apps/mesh/src/tools/thread/update.ts
@@ -11,7 +11,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { normalizeThreadForResponse } from "./helpers";
 import { ThreadEntitySchema, ThreadUpdateDataSchema } from "./schema";
 

--- a/apps/mesh/src/tools/user/get.ts
+++ b/apps/mesh/src/tools/user/get.ts
@@ -7,7 +7,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 
 const InputSchema = z.object({
   id: z.string().min(1),

--- a/apps/mesh/src/tools/virtual/create.ts
+++ b/apps/mesh/src/tools/virtual/create.ts
@@ -12,7 +12,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { VirtualMCPCreateDataSchema, VirtualMCPEntitySchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
 /**

--- a/apps/mesh/src/tools/virtual/delete.ts
+++ b/apps/mesh/src/tools/virtual/delete.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { VirtualMCPEntitySchema } from "./schema";
 
 /**

--- a/apps/mesh/src/tools/virtual/get.ts
+++ b/apps/mesh/src/tools/virtual/get.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { VirtualMCPEntitySchema } from "./schema";
 
 /**

--- a/apps/mesh/src/tools/virtual/last-used-list.ts
+++ b/apps/mesh/src/tools/virtual/last-used-list.ts
@@ -8,7 +8,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 const InputSchema = z.object({
   ids: z.array(z.string()).describe("Virtual MCP ids to look up"),

--- a/apps/mesh/src/tools/virtual/list.ts
+++ b/apps/mesh/src/tools/virtual/list.ts
@@ -12,7 +12,7 @@ import {
 } from "@decocms/bindings/collections";
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireOrganization } from "../../core/mesh-context";
+import { requireOrganization } from "../../core/studio-context";
 import { type VirtualMCPEntity, VirtualMCPEntitySchema } from "./schema";
 
 /**

--- a/apps/mesh/src/tools/virtual/pinned-views-update.ts
+++ b/apps/mesh/src/tools/virtual/pinned-views-update.ts
@@ -10,7 +10,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { VirtualMCPEntitySchema } from "./schema";
 
 const pinnedViewSchema = z.object({

--- a/apps/mesh/src/tools/virtual/plugin-config-get.ts
+++ b/apps/mesh/src/tools/virtual/plugin-config-get.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/mesh-context";
+import { requireAuth } from "../../core/studio-context";
 
 const serializedPluginConfigSchema = z.object({
   id: z.string(),

--- a/apps/mesh/src/tools/virtual/plugin-config-update.ts
+++ b/apps/mesh/src/tools/virtual/plugin-config-update.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/mesh-context";
+import { getUserId, requireAuth } from "../../core/studio-context";
 import {
   createDevAssetsConnectionEntity,
   isDevAssetsConnection,

--- a/apps/mesh/src/tools/virtual/require-org-admin-for-pin.test.ts
+++ b/apps/mesh/src/tools/virtual/require-org-admin-for-pin.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { ForbiddenError } from "../../core/access-control";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
 
-function ctxWithRole(role: string | undefined): MeshContext {
+function ctxWithRole(role: string | undefined): StudioContext {
   return {
     access: {
       getRole: () => role,
     },
-  } as MeshContext;
+  } as StudioContext;
 }
 
 describe("requireOrgAdminForPinnedField", () => {

--- a/apps/mesh/src/tools/virtual/require-org-admin-for-pin.ts
+++ b/apps/mesh/src/tools/virtual/require-org-admin-for-pin.ts
@@ -4,9 +4,9 @@
 
 import { ADMIN_ROLES, type BuiltinRole } from "../../auth/roles";
 import { ForbiddenError } from "../../core/access-control";
-import type { MeshContext } from "../../core/mesh-context";
+import type { StudioContext } from "../../core/studio-context";
 
-export function requireOrgAdminForPinnedField(ctx: MeshContext): void {
+export function requireOrgAdminForPinnedField(ctx: StudioContext): void {
   const role = ctx.access.getRole();
   if (!role || !ADMIN_ROLES.includes(role as BuiltinRole)) {
     throw new ForbiddenError(

--- a/apps/mesh/src/tools/virtual/studio-pack/helpers.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/helpers.ts
@@ -1,7 +1,7 @@
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 
 export async function hasAnyObject(
-  ctx: MeshContext,
+  ctx: StudioContext,
   prefix: string,
 ): Promise<boolean> {
   const storage = ctx.objectStorage;

--- a/apps/mesh/src/tools/virtual/studio-pack/types.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/types.ts
@@ -1,8 +1,8 @@
-import type { MeshContext } from "@/core/mesh-context";
+import type { StudioContext } from "@/core/studio-context";
 
 export type RuntimeResolveContext = {
   orgId: string;
-  ctx: MeshContext;
+  ctx: StudioContext;
 };
 
 export type ResolvedRuntime = {
@@ -16,7 +16,7 @@ export type ResolveRuntime = (
 
 export type ChecklistContext = {
   orgId: string;
-  ctx: MeshContext;
+  ctx: StudioContext;
 };
 
 /**

--- a/apps/mesh/src/tools/virtual/update.ts
+++ b/apps/mesh/src/tools/virtual/update.ts
@@ -10,7 +10,7 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
-} from "../../core/mesh-context";
+} from "../../core/studio-context";
 import { VirtualMCPEntitySchema, VirtualMCPUpdateDataSchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
 

--- a/packages/bindings/src/core/server-plugin.ts
+++ b/packages/bindings/src/core/server-plugin.ts
@@ -16,9 +16,9 @@ import type { Hono } from "hono";
 import type { Kysely } from "kysely";
 
 /**
- * Subset of MeshContext exposed to server plugin tool handlers.
+ * Subset of StudioContext exposed to server plugin tool handlers.
  *
- * Plugins receive the full MeshContext at runtime but should only depend on
+ * Plugins receive the full StudioContext at runtime but should only depend on
  * these properties. This keeps the plugin contract stable and avoids coupling
  * plugins to Mesh internals (db, vault, tracer, etc.).
  */

--- a/packages/mesh-plugin-workflows/CLAUDE.md
+++ b/packages/mesh-plugin-workflows/CLAUDE.md
@@ -121,7 +121,7 @@ Note: The bindings schema (`packages/bindings/src/well-known/workflow.ts`) defin
 | File | Purpose |
 |------|---------|
 | `server/index.ts` | Plugin registration + startup recovery |
-| `server/types.ts` | Type definitions, MeshContext interface |
+| `server/types.ts` | Type definitions, StudioContext interface |
 | `server/engine/orchestrator.ts` | Core orchestration: claim, dispatch, complete, forEach |
 | `server/engine/code-step.ts` | QuickJS sandbox execution (TS transpilation via sucrase) |
 | `server/engine/tool-step.ts` | MCP proxy tool calls + transformCode |
@@ -213,3 +213,4 @@ LLM-driven workflow building: start an empty execution → LLM calls tools natur
 #### No migration needed
 - `output: null` already supported in step results
 - `skipped` flag is optional metadata on the step result (no new column required)
+

--- a/packages/mesh-plugin-workflows/README.md
+++ b/packages/mesh-plugin-workflows/README.md
@@ -347,7 +347,7 @@ mesh-plugin-workflows/
 ├── shared.ts                    # Plugin constants (ID, description)
 ├── server/
 │   ├── index.ts                 # Plugin registration + startup recovery
-│   ├── types.ts                 # Type definitions, MeshContext interface
+│   ├── types.ts                 # Type definitions, StudioContext interface
 │   ├── engine/
 │   │   ├── orchestrator.ts      # Core: claim, dispatch, complete, forEach
 │   │   ├── code-step.ts         # QuickJS sandbox execution
@@ -395,3 +395,4 @@ bun test --cwd packages/mesh-plugin-workflows
 ## License
 
 See [LICENSE.md](../../LICENSE.md) in the repository root.
+

--- a/packages/mesh-plugin-workflows/server/types.ts
+++ b/packages/mesh-plugin-workflows/server/types.ts
@@ -1,8 +1,8 @@
 /**
  * Workflows Plugin - Server Types
  *
- * Type definitions for the MeshContext shape used by workflow tools.
- * Tools receive MeshContext as `unknown` -- these types provide safe casting.
+ * Type definitions for the StudioContext shape used by workflow tools.
+ * Tools receive StudioContext as `unknown` -- these types provide safe casting.
  */
 
 import type { WorkflowPluginStorage } from "./storage";
@@ -40,11 +40,11 @@ export interface MCPProxy {
 }
 
 /**
- * MeshContext shape available to workflow tools.
+ * StudioContext shape available to workflow tools.
  *
- * This is a subset of the full MeshContext -- only the parts workflows need.
+ * This is a subset of the full StudioContext -- only the parts workflows need.
  */
-export interface WorkflowMeshContext {
+export interface WorkflowStudioContext {
   organization: { id: string; slug?: string; name?: string };
   auth: {
     user: { id: string; email?: string } | null;
@@ -58,11 +58,11 @@ export interface WorkflowMeshContext {
 }
 
 /**
- * Cast unknown ctx to WorkflowMeshContext.
+ * Cast unknown ctx to WorkflowStudioContext.
  * Throws if organization context is missing.
  */
-export function requireWorkflowContext(ctx: unknown): WorkflowMeshContext {
-  const meshCtx = ctx as WorkflowMeshContext;
+export function requireWorkflowContext(ctx: unknown): WorkflowStudioContext {
+  const meshCtx = ctx as WorkflowStudioContext;
   if (!meshCtx.organization) {
     throw new Error("Organization context required for workflow tools");
   }

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -405,7 +405,7 @@ const lookupDispatchHarness = (id: string, input: unknown) => {
   if (!factory) throw new Error(`unknown harness: ${id}`);
   // Build a minimal HarnessContext. CLI harnesses don't read storage,
   // db, vault, or aiProviders — they only need tracer/meter for OTel
-  // and metadata for span attributes. The cluster's richer MeshContext
+  // and metadata for span attributes. The cluster's richer StudioContext
   // is structurally compatible with this shape (see
   // `apps/mesh/src/core/harness-context.ts`).
   const harnessInput = input as HarnessStreamInput;


### PR DESCRIPTION
## What is this contribution about?
Renames the core `MeshContext` interface to `StudioContext` to match the product/branding name used throughout the docs (Studio). All compound identifiers are renamed for consistency (`MeshContextFactory` → `StudioContextFactory`, `createMeshContextFactory` → `createStudioContextFactory`, `MeshContextConfig`, `WorkflowMeshContext`, `shouldSkipMeshContext`, etc.), and `apps/mesh/src/core/mesh-context.ts` is renamed to `studio-context.ts` with all 241 import paths and doc references updated. This is a pure, mechanical rename — no behavior changes; sibling types `MeshAuth`/`MeshStorage` are intentionally left untouched as they were out of scope.

## Screenshots/Demonstration
N/A — no UI changes.

## How to Test
1. `bun run check` — TypeScript typecheck passes across all workspaces.
2. `bun run lint` — passes (including the kebab-case file-name plugin for the renamed file).
3. `bun run fmt:check` — formatting is clean.
4. Confirm no remaining references: `git grep -iE 'MeshContext|mesh-context'` returns nothing.

## Migration Notes
None — no database, config, or runtime changes.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the core `MeshContext` interface and related identifiers to `StudioContext` across the codebase to match product naming. This is a pure rename with no runtime behavior changes.

- **Refactors**
  - `apps/mesh/src/core/mesh-context.ts` → `studio-context.ts`; all exports and imports updated.
  - Factories/config: `createMeshContextFactory` → `createStudioContextFactory`, `MeshContextFactory` → `StudioContextFactory`, `MeshContextConfig` → `StudioContextConfig`.
  - Hono env and middleware/routes now use `StudioContext` in `Variables.meshContext`.
  - Path util: `shouldSkipMeshContext` → `shouldSkipStudioContext`.
  - Docs and tests updated; `MeshAuth`/`MeshStorage` names left as-is.

<sup>Written for commit d62679bed74eff15bfa568e8f3310ae7fd67e408. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

