### PR TITLE
refactor(database): rename MeshDatabase to StudioDatabase

### DIFF
--- a/apps/mesh/migrations/087-fix-vm-map-rekey.integration.test.ts
+++ b/apps/mesh/migrations/087-fix-vm-map-rekey.integration.test.ts
@@ -16,7 +16,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../src/database/test-db-pg";
-import type { MeshDatabase } from "../src/database";
+import type { StudioDatabase } from "../src/database";
 import { up as up087 } from "./087-fix-vm-map-rekey";
 
 const USER = "user_test";
@@ -27,7 +27,7 @@ interface ConnectionRow {
 }
 
 async function getMetadata(
-  database: MeshDatabase,
+  database: StudioDatabase,
   id: string,
 ): Promise<Record<string, unknown>> {
   const row = (await sql<ConnectionRow>`
@@ -39,7 +39,7 @@ async function getMetadata(
 }
 
 async function insertVirtualConnection(
-  database: MeshDatabase,
+  database: StudioDatabase,
   id: string,
   metadata: Record<string, unknown>,
 ): Promise<void> {
@@ -59,7 +59,7 @@ async function insertVirtualConnection(
 }
 
 describe("migration 082 — fix vmMap rekey", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();

--- a/apps/mesh/migrations/088-purge-cli-activate-keys.integration.test.ts
+++ b/apps/mesh/migrations/088-purge-cli-activate-keys.integration.test.ts
@@ -14,14 +14,14 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../src/database/test-db-pg";
-import type { MeshDatabase } from "../src/database";
+import type { StudioDatabase } from "../src/database";
 import { up as up088 } from "./088-purge-cli-activate-keys";
 
 const ORG = "org_test";
 const USER = "user_test";
 
 async function insertProviderKey(
-  database: MeshDatabase,
+  database: StudioDatabase,
   id: string,
   providerId: string,
 ): Promise<void> {
@@ -36,7 +36,7 @@ async function insertProviderKey(
 }
 
 async function countByProvider(
-  database: MeshDatabase,
+  database: StudioDatabase,
   providerId: string,
 ): Promise<number> {
   const result = await sql<{ n: number }>`
@@ -46,7 +46,7 @@ async function countByProvider(
 }
 
 describe("migration 083 — purge cli-activate sentinel keys", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();

--- a/apps/mesh/migrations/089-rename-remote-user-to-desktop.integration.test.ts
+++ b/apps/mesh/migrations/089-rename-remote-user-to-desktop.integration.test.ts
@@ -18,7 +18,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../src/database/test-db-pg";
-import type { MeshDatabase } from "../src/database";
+import type { StudioDatabase } from "../src/database";
 import { up as up089 } from "./089-rename-remote-user-to-desktop";
 
 const USER = "user_test";
@@ -29,7 +29,7 @@ interface ConnectionRow {
 }
 
 async function getMetadata(
-  database: MeshDatabase,
+  database: StudioDatabase,
   id: string,
 ): Promise<Record<string, unknown>> {
   const row = (await sql<ConnectionRow>`
@@ -41,7 +41,7 @@ async function getMetadata(
 }
 
 async function insertVirtualConnection(
-  database: MeshDatabase,
+  database: StudioDatabase,
   id: string,
   metadata: Record<string, unknown>,
 ): Promise<void> {
@@ -59,7 +59,7 @@ async function insertVirtualConnection(
 }
 
 describe("migration 089 — rename remote-user → desktop", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();

--- a/apps/mesh/migrations/092-sandbox-naming-uniformization.integration.test.ts
+++ b/apps/mesh/migrations/092-sandbox-naming-uniformization.integration.test.ts
@@ -25,7 +25,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../src/database/test-db-pg";
-import type { MeshDatabase } from "../src/database";
+import type { StudioDatabase } from "../src/database";
 import { up as up092 } from "./092-sandbox-naming-uniformization";
 
 const USER = "user_test";
@@ -43,7 +43,7 @@ interface RunnerStateRow {
 }
 
 async function getMetadata(
-  database: MeshDatabase,
+  database: StudioDatabase,
   id: string,
 ): Promise<Record<string, unknown>> {
   const row = (await sql<ConnectionRow>`
@@ -55,7 +55,7 @@ async function getMetadata(
 }
 
 async function insertVirtualConnection(
-  database: MeshDatabase,
+  database: StudioDatabase,
   id: string,
   metadata: Record<string, unknown>,
 ): Promise<void> {
@@ -73,7 +73,7 @@ async function insertVirtualConnection(
 }
 
 async function listRunnerState(
-  database: MeshDatabase,
+  database: StudioDatabase,
 ): Promise<RunnerStateRow[]> {
   const res = (await sql<RunnerStateRow>`
     SELECT user_id, project_ref, sandbox_provider_kind, handle
@@ -84,7 +84,7 @@ async function listRunnerState(
 }
 
 async function insertRunnerState(
-  database: MeshDatabase,
+  database: StudioDatabase,
   handle: string,
   sandboxProviderKind: string,
 ): Promise<void> {
@@ -100,7 +100,7 @@ async function insertRunnerState(
 }
 
 describe("migration 092 — sandbox naming uniformization", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();

--- a/apps/mesh/migrations/097-drop-local-docker-sandbox-state.integration.test.ts
+++ b/apps/mesh/migrations/097-drop-local-docker-sandbox-state.integration.test.ts
@@ -20,7 +20,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../src/database/test-db-pg";
-import type { MeshDatabase } from "../src/database";
+import type { StudioDatabase } from "../src/database";
 import { up as up097 } from "./097-drop-local-docker-sandbox-state";
 
 const USER = "user_test";
@@ -36,7 +36,7 @@ interface RunnerStateRow {
 }
 
 async function getMetadata(
-  database: MeshDatabase,
+  database: StudioDatabase,
   id: string,
 ): Promise<Record<string, unknown>> {
   const row = (await sql<ConnectionRow>`
@@ -48,7 +48,7 @@ async function getMetadata(
 }
 
 async function insertVirtualConnection(
-  database: MeshDatabase,
+  database: StudioDatabase,
   id: string,
   metadata: Record<string, unknown>,
 ): Promise<void> {
@@ -66,7 +66,7 @@ async function insertVirtualConnection(
 }
 
 async function listRunnerState(
-  database: MeshDatabase,
+  database: StudioDatabase,
 ): Promise<RunnerStateRow[]> {
   const res = (await sql<RunnerStateRow>`
     SELECT sandbox_provider_kind, handle
@@ -77,7 +77,7 @@ async function listRunnerState(
 }
 
 async function insertRunnerState(
-  database: MeshDatabase,
+  database: StudioDatabase,
   handle: string,
   sandboxProviderKind: string,
 ): Promise<void> {
@@ -91,7 +91,7 @@ async function insertRunnerState(
 }
 
 describe("migration 097 — drop local-docker sandbox state", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();

--- a/apps/mesh/src/api/access-control.integration.test.ts
+++ b/apps/mesh/src/api/access-control.integration.test.ts
@@ -14,7 +14,7 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import type { EventBus } from "../event-bus";
 import type { Permission } from "../storage/types";
 import { createApp } from "./app";
@@ -104,7 +104,7 @@ interface MCPRequest {
 // ============================================================================
 
 describe("Access Control Integration Tests", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;
   let testUsers: Map<string, TestUser>;
   let testOrganizations: Map<string, TestOrganization>;

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -24,7 +24,7 @@ import {
   createStudioContextFactory,
 } from "../core/context-factory";
 import type { StudioContext } from "../core/studio-context";
-import { closeDatabase, getDb, type MeshDatabase } from "../database";
+import { closeDatabase, getDb, type StudioDatabase } from "../database";
 import { createEventBus, type EventBus } from "../event-bus";
 import {
   flushMonitoringData,
@@ -811,7 +811,7 @@ interface ResourceServerMetadata {
  */
 export interface CreateAppOptions {
   /** Custom database instance (for testing) */
-  database?: MeshDatabase;
+  database?: StudioDatabase;
   /** Custom event bus instance (for testing) */
   eventBus?: EventBus;
 }
@@ -1284,7 +1284,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // ============================================================================
 
   // Create context factory with the provided database and event bus
-  // Context factory only needs the Kysely instance, not the full MeshDatabase
+  // Context factory only needs the Kysely instance, not the full StudioDatabase
   const memberRoleCache = createMemberRoleCache({ ttlMs: 2 * 60 * 1000 });
   const factory = await createStudioContextFactory({
     db: database.db,

--- a/apps/mesh/src/api/index.integration.test.ts
+++ b/apps/mesh/src/api/index.integration.test.ts
@@ -9,7 +9,7 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import type { EventBus } from "../event-bus";
 import { setGlobalSettings, getSettings } from "../settings";
 import { createApp } from "./app";
@@ -72,7 +72,7 @@ function createMockEventBus(): EventBus {
 }
 
 describe("Hono App", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;
 
   beforeEach(async () => {

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.integration.test.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.integration.test.ts
@@ -6,7 +6,7 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../../database/test-db-pg";
-import type { MeshDatabase } from "../../database";
+import type { StudioDatabase } from "../../database";
 import { resolveOrgFromPath } from "./resolve-org-from-path";
 
 type Variables = { meshContext: StudioContext };
@@ -22,7 +22,7 @@ interface BuildAppOptions {
 }
 
 const buildApp = (
-  db: MeshDatabase,
+  db: StudioDatabase,
   auth: FakeAuth,
   opts: BuildAppOptions = {},
 ) => {
@@ -83,7 +83,7 @@ const buildApp = (
 };
 
 describe("resolveOrgFromPath", () => {
-  let db: MeshDatabase;
+  let db: StudioDatabase;
 
   beforeEach(async () => {
     db = await connectTestPgDatabase();

--- a/apps/mesh/src/api/org-scoped.integration.test.ts
+++ b/apps/mesh/src/api/org-scoped.integration.test.ts
@@ -26,7 +26,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import type { EventBus } from "../event-bus";
 import { createApp } from "./app";
 
@@ -81,7 +81,7 @@ function mockApiKey(userId: string, orgId: string, orgSlug: string) {
 }
 
 describe("org-scoped API coexistence", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;
   let logSpy: ReturnType<typeof spyOn> | undefined;
 

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -26,7 +26,7 @@ import {
   afterAll,
   beforeEach,
 } from "bun:test";
-import type { MeshDatabase } from "@/database";
+import type { StudioDatabase } from "@/database";
 import {
   closeTestPgDatabase,
   connectTestPgDatabase,
@@ -43,7 +43,7 @@ import type { StreamBuffer } from "./stream-buffer";
 const ORG = "org_1";
 const USER = "user_1";
 
-let database: MeshDatabase;
+let database: StudioDatabase;
 let storage: SqlThreadStorage;
 
 beforeAll(async () => {

--- a/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
@@ -27,7 +27,7 @@ import {
   expect,
   it,
 } from "bun:test";
-import type { MeshDatabase } from "@/database";
+import type { StudioDatabase } from "@/database";
 import {
   closeTestPgDatabase,
   connectTestPgDatabase,
@@ -46,7 +46,7 @@ const USER = "user_1";
 const POD = "test-pod";
 const MAX_RUN_AGE_MS = 30 * 60 * 1000;
 
-let database: MeshDatabase;
+let database: StudioDatabase;
 let storage: SqlThreadStorage;
 const createdRegistries: RunRegistry[] = [];
 

--- a/apps/mesh/src/api/routes/downstream-token.integration.test.ts
+++ b/apps/mesh/src/api/routes/downstream-token.integration.test.ts
@@ -8,11 +8,11 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../../database/test-db-pg";
-import type { MeshDatabase } from "../../database";
+import type { StudioDatabase } from "../../database";
 import { createDownstreamTokenRoutes } from "./downstream-token";
 
 describe("Downstream Token Routes", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {

--- a/apps/mesh/src/api/routes/oauth-proxy.integration.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.integration.test.ts
@@ -27,7 +27,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../../database/test-db-pg";
-import type { MeshDatabase } from "../../database";
+import type { StudioDatabase } from "../../database";
 import { createApp } from "../app";
 import type { EventBus } from "../../event-bus";
 import { auth } from "../../auth";
@@ -108,7 +108,7 @@ function createMockEventBus(): EventBus {
   };
 }
 
-let database: MeshDatabase;
+let database: StudioDatabase;
 let app: Awaited<ReturnType<typeof createApp>>;
 const connectionMap = new Map<string, string>();
 

--- a/apps/mesh/src/api/routes/openai-compat.integration.test.ts
+++ b/apps/mesh/src/api/routes/openai-compat.integration.test.ts
@@ -6,7 +6,7 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../../database/test-db-pg";
-import type { MeshDatabase } from "../../database";
+import type { StudioDatabase } from "../../database";
 import openaiCompatRoutes from "./openai-compat";
 
 // ============================================================================
@@ -27,7 +27,7 @@ const ENDPOINT = `/${MOCK_ORG_SLUG}/v1/chat/completions`;
 // ============================================================================
 
 describe("OpenAI-compat: Schema Validation", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
@@ -181,7 +181,7 @@ describe("OpenAI-compat: Schema Validation", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Authentication", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
@@ -307,7 +307,7 @@ describe("OpenAI-compat: Authentication", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Authorization", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
@@ -363,7 +363,7 @@ describe("OpenAI-compat: Authorization", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Tools Schema", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
@@ -477,7 +477,7 @@ describe("OpenAI-compat: Tools Schema", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Response Format", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {
@@ -580,7 +580,7 @@ describe("OpenAI-compat: Response Format", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Message Formats", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Hono<{ Variables: { meshContext: StudioContext } }>;
 
   beforeEach(async () => {

--- a/apps/mesh/src/api/routes/proxy.integration.test.ts
+++ b/apps/mesh/src/api/routes/proxy.integration.test.ts
@@ -16,7 +16,7 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../../database/test-db-pg";
-import type { MeshDatabase } from "../../database";
+import type { StudioDatabase } from "../../database";
 import type { EventBus } from "../../event-bus";
 import { setGlobalSettings, getSettings } from "../../settings";
 import { createApp } from "../app";
@@ -55,7 +55,7 @@ function createMockEventBus(): EventBus {
 }
 
 describe("MCP Proxy null-org bypass", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;
 
   const attackerUserId = "user_attacker";

--- a/apps/mesh/src/core/context-factory.integration.test.ts
+++ b/apps/mesh/src/core/context-factory.integration.test.ts
@@ -6,7 +6,7 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import { createStudioContextFactory } from "./context-factory";
 import type { BetterAuthInstance } from "./studio-context";
 import type { EventBus } from "../event-bus/interface";
@@ -47,7 +47,7 @@ const createMockEventBus = (): EventBus => ({
 });
 
 describe("createStudioContextFactory", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
 
   beforeAll(async () => {
     database = await connectTestPgDatabase();

--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -2,7 +2,7 @@
  * Database Factory for MCP Mesh
  *
  * Creates a configured Kysely instance backed by PostgreSQL.
- * Returns a MeshDatabase that includes the Kysely instance and the
+ * Returns a StudioDatabase that includes the Kysely instance and the
  * shared Pool (reusable for LISTEN/NOTIFY).
  */
 
@@ -13,7 +13,7 @@ import { getSettings } from "../settings";
 import { meter } from "../observability";
 
 // ============================================================================
-// MeshDatabase Types
+// StudioDatabase Types
 // ============================================================================
 
 const queryDurationHistogram = meter.createHistogram("db.query.duration", {
@@ -50,7 +50,7 @@ const log = (event: LogEvent) => {
  * PostgreSQL database connection.
  * Includes the Pool for reuse (e.g., LISTEN/NOTIFY in EventBus).
  */
-export interface MeshDatabase {
+export interface StudioDatabase {
   type: "postgres";
   db: Kysely<DatabaseSchema>;
   pool: Pool;
@@ -84,7 +84,7 @@ function getPoolMax(): number {
   }
 }
 
-function createPostgresDatabase(connectionString: string): MeshDatabase {
+function createPostgresDatabase(connectionString: string): StudioDatabase {
   const pool = new Pool({
     connectionString,
     max: getPoolMax(),
@@ -122,12 +122,12 @@ export function getDbDialect(databaseUrl?: string): Dialect {
   });
 }
 
-export function createDatabase(databaseUrl?: string): MeshDatabase {
+export function createDatabase(databaseUrl?: string): StudioDatabase {
   const url = databaseUrl || getDatabaseUrl();
   return createPostgresDatabase(url);
 }
 
-export async function closeDatabase(database: MeshDatabase): Promise<void> {
+export async function closeDatabase(database: StudioDatabase): Promise<void> {
   await database.db.destroy();
 
   if (!database.pool.ended) {
@@ -139,9 +139,9 @@ export async function closeDatabase(database: MeshDatabase): Promise<void> {
   }
 }
 
-let dbInstance: MeshDatabase | null = null;
+let dbInstance: StudioDatabase | null = null;
 
-export function getDb(): MeshDatabase {
+export function getDb(): StudioDatabase {
   if (!dbInstance) {
     dbInstance = createDatabase(getDatabaseUrl());
   }

--- a/apps/mesh/src/database/migrate.ts
+++ b/apps/mesh/src/database/migrate.ts
@@ -15,7 +15,7 @@ import migrations from "../../migrations";
 import { runSeed, type SeedName } from "../../migrations/seeds";
 import { migrateBetterAuth } from "../auth/migrate";
 import { collectPluginMigrations } from "../core/plugin-loader";
-import { closeDatabase, getDb, type MeshDatabase } from "./index";
+import { closeDatabase, getDb, type StudioDatabase } from "./index";
 import type { Database } from "../storage/types";
 
 export { runSeed, type SeedName };
@@ -232,7 +232,7 @@ export interface MigrateOptions {
    * If not provided, uses the global database from getDb().
    * When provided, Better Auth migrations are skipped (they use their own connection).
    */
-  database?: MeshDatabase;
+  database?: StudioDatabase;
 
   /**
    * Skip Better Auth migrations.

--- a/apps/mesh/src/database/test-db-pg.ts
+++ b/apps/mesh/src/database/test-db-pg.ts
@@ -22,7 +22,7 @@
 import { Kysely, PostgresDialect, sql } from "kysely";
 import { Pool } from "pg";
 import type { Database as DatabaseSchema } from "../storage/types";
-import type { MeshDatabase } from "./index";
+import type { StudioDatabase } from "./index";
 
 const DEFAULT_DATABASE_URL =
   "postgresql://postgres:postgres@localhost:5432/postgres";
@@ -31,7 +31,7 @@ const DEFAULT_DATABASE_URL =
  * Connect to the real Postgres test database. Honors `DATABASE_URL` first,
  * falls back to the standard local-dev shape.
  */
-export async function connectTestPgDatabase(): Promise<MeshDatabase> {
+export async function connectTestPgDatabase(): Promise<StudioDatabase> {
   const connectionString = process.env.DATABASE_URL ?? DEFAULT_DATABASE_URL;
   const pool = new Pool({ connectionString });
   const dialect = new PostgresDialect({ pool });
@@ -43,7 +43,7 @@ export async function connectTestPgDatabase(): Promise<MeshDatabase> {
  * Close the test database, releasing the connection pool.
  */
 export async function closeTestPgDatabase(
-  database: MeshDatabase,
+  database: StudioDatabase,
 ): Promise<void> {
   await database.db.destroy();
   if (!database.pool.ended) {
@@ -61,7 +61,7 @@ export async function closeTestPgDatabase(
  * test only needs its own bespoke seed, skip this helper entirely.
  */
 export async function seedCommonTestPgFixtures(
-  database: MeshDatabase,
+  database: StudioDatabase,
 ): Promise<void> {
   const now = new Date().toISOString();
   for (const userId of ["user_1", "user_123", "user_test", "test_user"]) {
@@ -90,7 +90,7 @@ export async function seedCommonTestPgFixtures(
  * remember to update a cleanup list.
  */
 export async function resetTestPgDatabase(
-  database: MeshDatabase,
+  database: StudioDatabase,
 ): Promise<void> {
   const result = await sql<{
     tablename: string;

--- a/apps/mesh/src/event-bus/index.ts
+++ b/apps/mesh/src/event-bus/index.ts
@@ -19,7 +19,7 @@
 
 import { retry, RetryError } from "@decocms/std";
 import type { NatsConnectionProvider } from "../nats/connection";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import { createEventBusStorage } from "../storage/event-bus";
 import { EventBus as EventBusImpl } from "./event-bus";
 import {
@@ -83,13 +83,13 @@ async function startWithRetry(
  * fan-out). A PollingStrategy is always composed alongside NATS as a safety
  * net for scheduled/cron event delivery.
  *
- * @param database - MeshDatabase instance
+ * @param database - StudioDatabase instance
  * @param natsProvider - Shared NATS connection provider (required)
  * @param config - Optional event bus configuration
  * @returns EventBus instance
  */
 export function createEventBus(
-  database: MeshDatabase,
+  database: StudioDatabase,
   natsProvider: NatsConnectionProvider,
   config?: EventBusConfig,
 ): EventBus {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.integration.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.integration.test.ts
@@ -31,7 +31,7 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "@/database/test-db-pg";
-import type { MeshDatabase } from "@/database";
+import type { StudioDatabase } from "@/database";
 import {
   OrgScopedAsyncResearchJobStorage,
   SqlAsyncResearchJobStorage,
@@ -194,7 +194,7 @@ function makeCtx(storage: OrgScopedAsyncResearchJobStorage): StudioContext {
 // ============================================================================
 
 describe("web_search async-research e2e", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let storage: OrgScopedAsyncResearchJobStorage;
   let mock: MockServer;
 

--- a/apps/mesh/src/oauth/token-refresh.integration.test.ts
+++ b/apps/mesh/src/oauth/token-refresh.integration.test.ts
@@ -14,7 +14,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import { CredentialVault } from "../encryption/credential-vault";
 import { DownstreamTokenStorage } from "../storage/downstream-token";
 import { ConnectionStorage } from "../storage/connection";
@@ -32,7 +32,7 @@ mock.module("./refresh-access-token", () => ({
 const { refreshAndStore } = await import("./token-refresh");
 
 describe("refreshAndStore", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let vault: CredentialVault;
   let tokenStorage: DownstreamTokenStorage;
   const connectionId = "conn_refresh_test";

--- a/apps/mesh/src/storage/connection.integration.test.ts
+++ b/apps/mesh/src/storage/connection.integration.test.ts
@@ -5,12 +5,12 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import { ConnectionStorage } from "./connection";
 import { CredentialVault } from "../encryption/credential-vault";
 
 describe("ConnectionStorage", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let storage: ConnectionStorage;
   let vault: CredentialVault;
 

--- a/apps/mesh/src/storage/downstream-token.integration.test.ts
+++ b/apps/mesh/src/storage/downstream-token.integration.test.ts
@@ -6,7 +6,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import { CredentialVault } from "../encryption/credential-vault";
 import {
   DownstreamTokenStorage,
@@ -14,7 +14,7 @@ import {
 } from "./downstream-token";
 
 describe("DownstreamTokenStorage", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let storage: DownstreamTokenStorage;
 
   beforeAll(async () => {

--- a/apps/mesh/src/storage/sandbox-runner-state.integration.test.ts
+++ b/apps/mesh/src/storage/sandbox-runner-state.integration.test.ts
@@ -5,11 +5,11 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import { KyselySandboxProviderStateStore } from "./sandbox-runner-state";
 
 describe("KyselySandboxProviderStateStore", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let store: KyselySandboxProviderStateStore;
 
   beforeAll(async () => {

--- a/apps/mesh/src/storage/threads.integration.test.ts
+++ b/apps/mesh/src/storage/threads.integration.test.ts
@@ -5,12 +5,12 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import { SqlThreadStorage } from "./threads";
 import type { ThreadMessage } from "./types";
 
 describe("SqlThreadStorage", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let storage: SqlThreadStorage;
 
   beforeAll(async () => {

--- a/apps/mesh/src/storage/virtual.integration.test.ts
+++ b/apps/mesh/src/storage/virtual.integration.test.ts
@@ -5,12 +5,12 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../database/test-db-pg";
-import type { MeshDatabase } from "../database";
+import type { StudioDatabase } from "../database";
 import { VirtualMCPStorage } from "./virtual";
 import { getDecopilotId } from "@decocms/mesh-sdk";
 
 describe("VirtualMCPStorage.findById (Decopilot)", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let storage: VirtualMCPStorage;
   const orgId = "org_decopilot_test";
 

--- a/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
@@ -5,7 +5,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../../database/test-db-pg";
-import type { MeshDatabase } from "../../database";
+import type { StudioDatabase } from "../../database";
 import { CredentialVault } from "../../encryption/credential-vault";
 import {
   COLLECTION_CONNECTIONS_CREATE,
@@ -38,7 +38,7 @@ const createMockBoundAuth = (): BoundAuthClient =>
   }) as unknown as BoundAuthClient;
 
 describe("Connection Tools", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let ctx: StudioContext;
   let vault: CredentialVault;
 

--- a/apps/mesh/src/tools/thread/test-helpers.ts
+++ b/apps/mesh/src/tools/thread/test-helpers.ts
@@ -11,7 +11,7 @@ import {
   resetTestPgDatabase,
   seedCommonTestPgFixtures,
 } from "../../database/test-db-pg";
-import type { MeshDatabase } from "../../database";
+import type { StudioDatabase } from "../../database";
 import { CredentialVault } from "../../encryption/credential-vault";
 import {
   SqlThreadStorage,
@@ -24,7 +24,7 @@ const ORG_ID = "org_test";
 const USER_ID = "user_test";
 
 export interface ThreadTestEnv {
-  database: MeshDatabase;
+  database: StudioDatabase;
   ctx: StudioContext;
   orgId: string;
   userId: string;

--- a/apps/mesh/src/tools/virtual/studio-pack.integration.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack.integration.test.ts
@@ -6,14 +6,14 @@ import {
   connectTestPgDatabase,
   resetTestPgDatabase,
 } from "../../database/test-db-pg";
-import type { MeshDatabase } from "../../database";
+import type { StudioDatabase } from "../../database";
 import { CredentialVault } from "../../encryption/credential-vault";
 import { ConnectionStorage } from "../../storage/connection";
 import { VirtualMCPStorage } from "../../storage/virtual";
 import { installStudioPack } from "./studio-pack";
 
 describe("installStudioPack", () => {
-  let database: MeshDatabase;
+  let database: StudioDatabase;
   let virtualMcpStorage: VirtualMCPStorage;
   let connectionStorage: ConnectionStorage;
   const orgId = "org_studio_pack_test";


### PR DESCRIPTION
## What is this contribution about?
Follow-up to the `MeshContext` → `StudioContext` rename (#3680). Renames the internal database-wrapper type `MeshDatabase` → `StudioDatabase` (defined in `apps/mesh/src/database/index.ts`) and updates all 31 referencing files. This is a pure, internal type rename with no behavior changes — the type has no external/persisted surface (not a wire format, header, URI scheme, or published API).

## Screenshots/Demonstration
N/A — no UI changes.

## How to Test
1. `bun run check` — typecheck passes across all workspaces.
2. `bun run lint` and `bun run fmt:check` — pass.
3. `git grep MeshDatabase` returns nothing.

## Migration Notes
None — no database, config, or runtime changes.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the internal database wrapper type `MeshDatabase` to `StudioDatabase` for consistent Studio naming. No runtime, schema, or API changes.

- **Refactors**
  - Updated the type in `apps/mesh/src/database/index.ts` and replaced references across tests, API, storage, event bus, and migrations.
  - This type is internal; public surfaces remain unchanged.

- **Migration**
  - No action required.

<sup>Written for commit 977dea3385a5c3dfa8c9a7a27a4962e4d9973a13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

