### PR TITLE
fix(link-daemon): refresh access token on WS reconnect

### DIFF
--- a/apps/mesh/src/link-daemon/cluster-connection.test.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection.test.ts
@@ -186,4 +186,216 @@ describe("cluster-connection", () => {
     // Assert that the daemon attempted at least one reconnect after the close.
     expect(opens).toBeGreaterThanOrEqual(2);
   });
+
+  test("presents a freshly-resolved token on reconnect (stale-token wedge after access-token expiry)", async () => {
+    // Reproduces the standalone `deco link` bug: the daemon works, then after
+    // some time the WS drops (staging deploy / network blip) and every
+    // reconnect re-presents the access token captured at startup. Once that
+    // token has expired the cluster rejects the handshake (401 → "Expected 101
+    // status code" → 1006 → infinite retry). The daemon must re-resolve the
+    // token before each handshake so a refreshed token reaches the reconnect.
+    const authHeaders: (string | null)[] = [];
+    let resolveSecond: (() => void) | null = null;
+    const secondConnected = new Promise<void>((r) => {
+      resolveSecond = r;
+    });
+
+    // Simulates the access token being refreshed between the first connect and
+    // the reconnect. The fix re-reads the token per (re)connect, so the second
+    // handshake should carry "refreshed-token".
+    const tokens = ["fresh-token", "refreshed-token"];
+    const getAccessToken = async () => tokens.shift() ?? "exhausted";
+
+    let opens = 0;
+    server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        if (req.headers.get("upgrade") === "websocket") {
+          authHeaders.push(req.headers.get("authorization"));
+          if (authHeaders.length >= 2) resolveSecond?.();
+          srv.upgrade(req, { data: {} });
+          return undefined;
+        }
+        return new Response("nope", { status: 404 });
+      },
+      websocket: {
+        open(ws) {
+          opens++;
+          // Drop the first connection to force a reconnect; the second
+          // handshake must carry the refreshed token.
+          if (opens === 1)
+            setTimeout(() => ws.close(1000, "normal closure"), 30);
+        },
+        message() {},
+        close() {},
+      },
+    });
+
+    handle = await connectToCluster({
+      url: `ws://127.0.0.1:${server.port}/api/links/connect`,
+      accessToken: "fresh-token", // legacy static token the buggy path reuses
+      getAccessToken,
+      hello: {
+        previewPort: 5174,
+        machineId: "m",
+        cliVersion: "1",
+        capabilities: [],
+      },
+      controlHandler: {
+        async handle() {
+          return { status: 404 };
+        },
+        handleStream() {
+          return (async function* () {})();
+        },
+      },
+      maxAttempts: 5,
+    });
+
+    await Promise.race([
+      secondConnected,
+      new Promise<void>((_, reject) =>
+        setTimeout(() => reject(new Error("no reconnect within 2s")), 2000),
+      ),
+    ]);
+
+    // Guard: the harness actually captures handshake headers (first connect
+    // carries the initial token). If this fails the test is broken, not the bug.
+    expect(authHeaders[0]).toBe("Bearer fresh-token");
+    // The bug: the reconnect handshake must present the REFRESHED token, not
+    // the stale startup token. Fails today (daemon pins `accessToken`), passes
+    // once `runOnce` consumes `getAccessToken`.
+    expect(authHeaders.length).toBeGreaterThanOrEqual(2);
+    expect(authHeaders[1]).toBe("Bearer refreshed-token");
+  });
+
+  test("stops reconnecting when the token resolver fails fatally (session unrecoverable)", async () => {
+    // When the refresh token itself is dead (re-login required), retrying is
+    // pointless — the daemon must stop instead of spinning on a dead credential.
+    let calls = 0;
+    const getAccessToken = async () => {
+      calls++;
+      throw Object.assign(
+        new Error("session expired — run `deco auth login`"),
+        { fatal: true },
+      );
+    };
+
+    let opens = 0;
+    server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        if (req.headers.get("upgrade") === "websocket") {
+          srv.upgrade(req, { data: {} });
+          return undefined;
+        }
+        return new Response("nope", { status: 404 });
+      },
+      websocket: {
+        open() {
+          opens++;
+        },
+        message() {},
+        close() {},
+      },
+    });
+
+    handle = await connectToCluster({
+      url: `ws://127.0.0.1:${server.port}/api/links/connect`,
+      accessToken: "unused",
+      getAccessToken,
+      hello: {
+        previewPort: 5174,
+        machineId: "m",
+        cliVersion: "1",
+        capabilities: [],
+      },
+      controlHandler: {
+        async handle() {
+          return { status: 404 };
+        },
+        handleStream() {
+          return (async function* () {})();
+        },
+      },
+      maxAttempts: 5,
+    });
+
+    // The loop must end (closed resolves) rather than hang/retry forever.
+    await Promise.race([
+      handle.closed,
+      new Promise<void>((_, reject) =>
+        setTimeout(() => reject(new Error("did not stop within 2s")), 2000),
+      ),
+    ]);
+
+    expect(calls).toBe(1); // no retry after a fatal resolver error
+    expect(opens).toBe(0); // never reached the handshake
+  });
+
+  test("keeps retrying when the token resolver fails transiently", async () => {
+    // A transient refresh failure (network blip while the token is expired)
+    // must NOT kill the daemon — it should retry with backoff and recover.
+    let calls = 0;
+    const getAccessToken = async () => {
+      calls++;
+      if (calls === 1) throw new Error("refresh network blip"); // transient (no `fatal`)
+      return "recovered-token";
+    };
+
+    let opens = 0;
+    let resolveOpened: (() => void) | null = null;
+    const opened = new Promise<void>((r) => {
+      resolveOpened = r;
+    });
+    server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        if (req.headers.get("upgrade") === "websocket") {
+          srv.upgrade(req, { data: {} });
+          return undefined;
+        }
+        return new Response("nope", { status: 404 });
+      },
+      websocket: {
+        open() {
+          opens++;
+          resolveOpened?.();
+        },
+        message() {},
+        close() {},
+      },
+    });
+
+    handle = await connectToCluster({
+      url: `ws://127.0.0.1:${server.port}/api/links/connect`,
+      accessToken: "unused",
+      getAccessToken,
+      hello: {
+        previewPort: 5174,
+        machineId: "m",
+        cliVersion: "1",
+        capabilities: [],
+      },
+      controlHandler: {
+        async handle() {
+          return { status: 404 };
+        },
+        handleStream() {
+          return (async function* () {})();
+        },
+      },
+      maxAttempts: 5,
+    });
+
+    await Promise.race([
+      opened,
+      new Promise<void>((_, reject) =>
+        setTimeout(() => reject(new Error("did not recover within 3s")), 3000),
+      ),
+    ]);
+
+    expect(calls).toBeGreaterThanOrEqual(2); // retried past the transient failure
+    expect(opens).toBeGreaterThanOrEqual(1); // eventually connected
+  });
 });

--- a/apps/mesh/src/link-daemon/cluster-connection.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection.ts
@@ -21,6 +21,18 @@ import type { Capability } from "../links/protocol/schemas";
 export interface ClusterConnectionInput {
   url: string;
   accessToken: string;
+  /**
+   * Resolves the bearer token to present on the NEXT handshake. Called once per
+   * (re)connect so a refreshed token reaches a reconnect after the startup
+   * `accessToken` has expired. Without this, the reconnect loop re-presents the
+   * stale token forever (401 → "Expected 101 status code" → abnormal 1006 close
+   * → retry). Falls back to the static `accessToken` when omitted.
+   *
+   * A rejection carrying a truthy `fatal` property stops the reconnect loop
+   * (the session is unrecoverable — re-auth required); any other rejection is
+   * treated as transient and retried with backoff.
+   */
+  getAccessToken?: () => Promise<string>;
   hello: {
     previewPort: number;
     machineId: string;
@@ -40,6 +52,18 @@ export interface ClusterConnectionHandle {
   close(): Promise<void>;
   /** Resolves when the connection is permanently closed (e.g., 4001 or `close()`). */
   closed: Promise<void>;
+}
+
+/**
+ * A `getAccessToken` rejection carrying a truthy `fatal` property means the
+ * session is unrecoverable (e.g. the refresh token was rejected) — the
+ * reconnect loop stops so the daemon doesn't spin forever on a dead
+ * credential. Any other rejection is treated as transient and retried.
+ */
+function isFatalAuthError(err: unknown): boolean {
+  return Boolean(
+    err && typeof err === "object" && (err as { fatal?: unknown }).fatal,
+  );
 }
 
 export async function connectToCluster(
@@ -165,9 +189,31 @@ export async function connectToCluster(
 
   const runOnce = async (): Promise<{ shouldReconnect: boolean }> => {
     attempt += 1;
+    // Resolve the bearer token immediately before each (re)connect so a token
+    // refreshed since the last attempt reaches the handshake. Without this, a
+    // reconnect after the startup token expired re-presents the dead token
+    // forever (401 → "Expected 101 status code" → 1006 close → retry).
+    let accessToken: string;
+    try {
+      accessToken = input.getAccessToken
+        ? await input.getAccessToken()
+        : input.accessToken;
+    } catch (err) {
+      // The token resolver rejected. A fatal rejection (the session is
+      // unrecoverable — refresh token dead, re-login required) stops the loop
+      // so the daemon doesn't spin forever on a dead credential; anything else
+      // is treated as transient and retried with backoff.
+      const fatal = isFatalAuthError(err);
+      console.error(
+        `[cluster-connection] token resolution failed (${
+          fatal ? "fatal — stopping reconnect" : "transient — will retry"
+        }): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { shouldReconnect: !fatal };
+    }
     return new Promise<{ shouldReconnect: boolean }>((resolve) => {
       const ws = new WebSocket(input.url, {
-        headers: { authorization: `Bearer ${input.accessToken}` },
+        headers: { authorization: `Bearer ${accessToken}` },
       } as unknown as string);
       activeWs = ws;
 

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -22,6 +22,7 @@ import { createControlHandler } from "./control-handler";
 import { connectToCluster } from "./cluster-connection";
 import { startLocalIngress } from "./local-ingress";
 import { loadOrCreateMachineId } from "./machine-id";
+import { getValidSession } from "../cli/lib/get-valid-session";
 import type { Session } from "../cli/lib/session";
 import {
   createDesktopSandboxProvider,
@@ -182,6 +183,28 @@ export async function startLinkDaemon(
   const cluster = await connectToCluster({
     url: wsUrl,
     accessToken: session.accessToken,
+    // Re-resolve (and refresh) the bearer before each (re)connect so a
+    // reconnect after the startup token expired presents a fresh token rather
+    // than the dead one — the cause of the WS "Expected 101 status code" loop.
+    // getValidSession refreshes via the refresh token and rewrites disk; a
+    // transient failure propagates (cluster-connection retries with backoff),
+    // and a null result (no session / refresh token rejected) is fatal so the
+    // daemon stops and asks the user to re-auth instead of spinning forever.
+    getAccessToken: async () => {
+      const fresh = await getValidSession({
+        dataDir: opts.dataDir,
+        target: opts.clusterBaseUrl,
+      });
+      if (!fresh) {
+        throw Object.assign(
+          new Error(
+            `Session for ${opts.clusterBaseUrl} is no longer valid — run \`deco auth login --target ${opts.clusterBaseUrl}\` and restart \`deco link\`.`,
+          ),
+          { fatal: true },
+        );
+      }
+      return fresh.accessToken;
+    },
     hello: {
       previewPort: ingress.port,
       machineId,


### PR DESCRIPTION
## Summary

The `deco link` daemon pinned the OAuth access token captured at startup (`index.ts` → `connectToCluster({ accessToken })`) and reused that same static string on **every** WebSocket reconnect (`cluster-connection.ts` `runOnce`). The gateway only validates the bearer at the handshake, so:

- Initial connect succeeds → chats work. While the WS stays open, token expiry is harmless.
- The access token (short-lived, has `expiresAt` + `refreshToken`) quietly expires.
- The WS eventually drops (staging deploy / pod recycle / idle-proxy timeout / network blip).
- The reconnect re-presents the **expired** token → `validateBearer` returns null → **401** → `[cluster-connection] ws error: … Expected 101 status code` → abnormal **1006** close → `shouldReconnectOnClose` retries everything except 4001 → **infinite loop on a dead token**.

This is why it "connects, runs chats, then breaks after some time," and it's the upstream cause of the downstream `handler_error: The operation timed out.` chat errors (no live daemon → dispatches time out).

## Fix

- **`cluster-connection.ts`**: new optional `getAccessToken?: () => Promise<string>` on `ClusterConnectionInput`, resolved **once before each (re)connect** so a refreshed token reaches the reconnect. A resolver rejection with `fatal: true` **stops** the reconnect loop (session unrecoverable, re-auth required); any other rejection is treated as **transient** and retried with backoff. Falls back to the static `accessToken` when omitted (existing callers unchanged).
- **`index.ts`**: wires `getAccessToken` to `getValidSession({ dataDir, target: clusterBaseUrl })`, which refreshes via the refresh token and rewrites disk. A `null` result (no session / `invalid_grant`) throws a `fatal` error telling the user to run `deco auth login`, instead of spinning forever.

## Testing

New unit tests in `cluster-connection.test.ts` (real `Bun.serve` capturing handshake `authorization` headers — no mocks):

- `presents a freshly-resolved token on reconnect` — the original bug repro.
- `stops reconnecting when the token resolver fails fatally (session unrecoverable)`.
- `keeps retrying when the token resolver fails transiently`.

Verification:
- cluster-connection: **6/6 pass**; full link-daemon suite: **53/53 pass**.
- `tsc --noEmit` (mesh): clean. `oxlint` on changed files: 0/0. Biome-formatted.

## Affected areas

`deco link` daemon ↔ cluster WebSocket auth only. No changes to dispatch, sandbox lifecycle, or the cluster gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes OAuth access tokens on every WebSocket (re)connect in the `deco link` daemon to prevent 401 handshakes and infinite reconnect loops after token expiry. Also stops retries on unrecoverable sessions and prompts re-auth to avoid downstream timeouts.

- **Bug Fixes**
  - Added optional `getAccessToken` to `connectToCluster`, resolved before each (re)connect (fallback to `accessToken`).
  - Wired to `getValidSession` in the daemon to refresh tokens; a missing/invalid session throws a fatal error to stop the loop.
  - Fatal resolver errors stop reconnects; transient errors retry with backoff; refreshed token is used in the handshake.
  - Added tests for refreshed token on reconnect, fatal stop, and transient retry/recovery.

- **Migration**
  - No action needed for valid sessions.
  - If the daemon stops with a re-auth message, run `deco auth login --target <cluster>` and restart `deco link`.

<sup>Written for commit b0ebb4dbd2a8aaad20d7541ccc1ae6224b534fb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

