### PR TITLE
fix(chat): remove lock icon from harness and branch pills

### DIFF
--- a/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
+++ b/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
@@ -5,7 +5,7 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { GitBranch01, Lock01 } from "@untitledui/icons";
+import { GitBranch01 } from "@untitledui/icons";
 import { useOptionalChatTask } from "../chat-context";
 import { BranchPicker } from "../../thread/github/branch-picker";
 
@@ -58,7 +58,6 @@ export function BranchPill({ locked, placement, ...props }: Props) {
                 : "h-9 px-2",
             )}
           >
-            <Lock01 className="h-3 w-3 shrink-0" aria-hidden="true" />
             <GitBranch01 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
             <span
               className={cn(

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
@@ -11,7 +11,7 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { Check, ChevronDown, Cloud01, Lock01 } from "@untitledui/icons";
+import { Check, ChevronDown, Cloud01 } from "@untitledui/icons";
 import {
   SELF_MCP_ALIAS_ID,
   useMCPClient,
@@ -160,9 +160,6 @@ export function ModePickerPure({
                   locked ? "gap-0" : "gap-0 @[320px]/chat-bottom:gap-1.5",
                 )}
               >
-                {isThreadLocked && (
-                  <Lock01 className="h-3 w-3 shrink-0" aria-hidden="true" />
-                )}
                 {icon}
                 <span
                   className={cn(


### PR DESCRIPTION
## Summary
- Removed the `Lock01` icon that the chat harness/branch lock feature was rendering inside the mode picker button (`mode-picker.tsx`) and the locked branch chip (`branch-pill.tsx`).
- Dropped the now-unused `Lock01` import from both files.
- Locked-state behavior is unchanged: the picker is still disabled, the branch chip is still non-interactive (`aria-disabled`, `data-testid="branch-picker-locked"`), and the tooltip copy still explains why those controls can't be changed.

## Test plan
- [ ] Open a chat thread that has been locked (≥1 message sent or `isThreadLocked` true) and confirm the harness mode pill no longer shows a lock icon — only the harness icon + label remain.
- [ ] On the same thread, confirm the branch pill shows only the git-branch icon + branch label, without the lock icon.
- [ ] Hover the locked harness pill and locked branch pill — the existing tooltips ("This chat is using …. Start a new chat …") still render.
- [ ] On an unlocked thread, both pickers still open their popovers normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `Lock01` icon from the chat mode picker and branch pill to reduce visual noise. Locked behavior is unchanged (controls disabled, tooltips intact), and the unused `Lock01` import was removed.

<sup>Written for commit 2ef6c64b0d67089e6c2dd5f1af419f9a8e080b9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

