### PR TITLE
fix(bundler): dereference symlinks and nest version-conflicting deps

### DIFF
--- a/apps/mesh/scripts/bundle-server-script.ts
+++ b/apps/mesh/scripts/bundle-server-script.ts
@@ -63,6 +63,34 @@ const ALWAYS_INCLUDE = [
   "@opentelemetry/sdk-metrics",
   "@opentelemetry/sdk-node",
   "@opentelemetry/sdk-trace-base",
+  // The better-auth family: every one of these uses a package.json `exports`
+  // map with a non-standard "dev-source" condition listed BEFORE "default",
+  // which makes @vercel/nft give up part-way and report 0 traced files from
+  // the source-level import path. Without nft seeing them, bun build inlines
+  // their code into cli.js/server.js, while their internal cross-package
+  // imports (e.g. `from "ms"`, `from "@better-auth/core/utils"`) stay
+  // externalized — so at runtime the bundle reaches into top-level
+  // dist/server/node_modules/<pkg>/ for whichever version of <pkg> happened
+  // to win the last-write-wins dedupe. That mismatched the inlined source
+  // and crashed with cryptic SyntaxErrors:
+  //   - "Export named 'ms' not found"  (better-auth needs ms@4 named exports
+  //     but ms@2.1.3 won the dedupe; fix: list @decocms/better-auth here +
+  //     nest ms@4 under it)
+  //   - "Export named 'createRateLimitKey' not found in @better-auth/core/
+  //     utils"  (better-auth@1.4.22 needs @better-auth/core@1.4.22, but
+  //     @decocms/better-auth's transitive @better-auth/core@1.4.6-beta.3
+  //     won; fix: list better-auth + @better-auth/sso here so nft sees the
+  //     1.4.22 chain and nests it under better-auth/)
+  //
+  // Listing each better-auth-family package mesh imports here turns them
+  // into nft root entries (nft starts from the resolved file, skipping the
+  // broken exports map walk), so each version they need ends up in the
+  // trace. The version-conflict handler in pruneNodeModules then hoists one
+  // version and nests the rest under their consuming package's
+  // node_modules/<dep>/, where Node's resolution walk finds them first.
+  "@decocms/better-auth",
+  "better-auth",
+  "@better-auth/sso",
 ];
 const ALWAYS_EXCLUDE = [
   "kysely-codegen",
@@ -97,17 +125,20 @@ const OUTPUT_DIR = distPath
   : join(process.cwd(), "dist/server");
 
 // Cache to store resolved package names for directories to avoid repeated FS calls
-// Map<directoryPath, { name: string, path: string } | null>
-const packageCache = new Map<string, { name: string; path: string } | null>();
+// Map<directoryPath, { name: string, version: string, path: string } | null>
+const packageCache = new Map<
+  string,
+  { name: string; version: string; path: string } | null
+>();
 
 /**
  * Walks up the directory tree from a file path to find the enclosing package.json
- * and returns the package name and its root directory.
+ * and returns the package name, version, and its root directory.
  */
 async function resolvePackage(
   filePath: string,
   rootDir: string,
-): Promise<{ name: string; path: string } | null> {
+): Promise<{ name: string; version: string; path: string } | null> {
   // Convert to absolute path if it isn't already
   let currentDir = resolve(rootDir, filePath);
 
@@ -136,7 +167,13 @@ async function resolvePackage(
           throw new Error(`Invalid package.json: ${pkgJsonPath}`);
         }
 
-        const result = { name, path: currentDir };
+        // Some packages (esp. workspace roots like @decocms/*) omit
+        // "version" — fall back to a sentinel so the dedup key still works.
+        // Real npm packages always declare a version, so collisions on this
+        // sentinel only happen between workspace packages, which we skip
+        // copying anyway.
+        const version = typeof pkg.version === "string" ? pkg.version : "0.0.0";
+        const result = { name, version, path: currentDir };
 
         // Cache this result for this directory
         packageCache.set(currentDir, result);
@@ -156,6 +193,47 @@ async function resolvePackage(
   // Cache failure to avoid re-walking
   // Note: this might be too aggressive if we traverse deeply, but for node_modules usually fine
   return null;
+}
+
+// Copies a package directory with dereference: true. See the long comment
+// inline below for why dereference is required (TL;DR: bun's isolated install
+// is symlink-heavy, and `cp` without dereference recreates dangling symlinks
+// in the output that survive build but fail at install time).
+async function copyPackage(
+  source: string,
+  dest: string,
+  label: string,
+): Promise<void> {
+  if (!existsSync(source)) {
+    console.warn(`⚠️  Package source not found: ${label} at ${source}`);
+    return;
+  }
+  try {
+    // dereference: true — bun's isolated install routes many packages
+    // through symlinks (apps/mesh/node_modules/@opentelemetry/api →
+    // ../../../../node_modules/.bun/<pkg>@<ver>/..., plus per-package
+    // peer-dep symlinks inside .bun/<pkg>@<ver>/node_modules/). nft's
+    // fileList can return paths *through* those symlinks, so the
+    // packagePath we resolved may itself be a symlinked directory.
+    //
+    // With dereference: false (the cp default), `cp` recreates the
+    // symlink at the destination — and the link's relative target
+    // (e.g. ../../../@opentelemetry+api@1.9.1/...) doesn't resolve
+    // from dist/server/node_modules/. The build verifier passed
+    // anyway because existsSync(symlinkPath) happened to resolve via
+    // the still-present `.bun/` in the build dir, but `npm pack`
+    // shipped the dangling symlink — and the published cli.js
+    // crashed at startup with "Cannot find module '@opentelemetry/...'"
+    // (decocms 2.393.5 incident, caught by the new smoke test).
+    //
+    // Forcing dereference: true copies the *real files* the link
+    // resolves to, so dist/server/node_modules/ contains standalone
+    // package directories that survive `npm pack` + reinstall.
+    await cp(source, dest, { recursive: true, dereference: true });
+    console.log(`✅ Copied package: ${label}`);
+  } catch (error) {
+    console.warn(`⚠️  Failed to copy package ${label}: ${error}`);
+  }
 }
 
 async function pruneNodeModules(): Promise<Set<string>> {
@@ -191,7 +269,7 @@ async function pruneNodeModules(): Promise<Set<string>> {
   console.log(`📦 CLI entry point: ${cliEntryPointPath}`);
 
   // Trace all file dependencies for all entry points
-  const { fileList } = await nodeFileTrace(
+  const { fileList, reasons } = await nodeFileTrace(
     [...migrateEntryPointPaths, serverEntryPointPath, cliEntryPointPath],
     {
       base: WORKSPACE_ROOT,
@@ -200,30 +278,86 @@ async function pruneNodeModules(): Promise<Set<string>> {
 
   console.log(`📋 Found ${fileList.size} files in dependency tree`);
 
-  // Extract unique packages from traced files
-  // Map<packageName, packageRootPath>
-  const packagesToCopy = new Map<string, string>();
+  // Collect every package the trace touched, deduped by (name, version).
+  //
+  // Why we can't just dedupe by name (the original behavior): when two
+  // versions of the same package coexist in the dependency graph, last-write
+  // wins, and the loser silently never ships. Concrete fallout caught by
+  // smoke-tarball: @decocms/better-auth needs ms@4 (named exports, ESM-only)
+  // while debug/express need ms@2.1.3 (default-callable CJS function). When
+  // ms@2 won, better-auth's inlined `import { ms } from "ms"` crashed at
+  // startup with "Export named 'ms' not found".
+  //
+  // Why not dedupe by ABSOLUTE PATH: bun's isolated install gives each
+  // peer-resolved variant of a package its own bucket directory
+  // (.bun/<pkg>@<ver>+<peer-hash>/...). Walking up from a traced file via
+  // a symlinked peer dep lands you in the CONSUMER's bucket — so the same
+  // (name, version) appears under many distinct paths. That blew up the
+  // first attempt at this fix: @opentelemetry/api@1.9.1 (only one published
+  // version) ended up nested under 20 different consumer packages because
+  // each consumer's bucket was a different "path".
+  //
+  // (name, version) is the right grain: it matches how npm/bun's resolution
+  // actually views identity, and avoids exploding duplicates of single-
+  // version packages.
+  type TracedPackage = { name: string; version: string; path: string };
+  const tracedPackagesByKey = new Map<string, TracedPackage>(); // key: name@version
+  const keyOf = (p: { name: string; version: string }) =>
+    `${p.name}@${p.version}`;
 
-  // Use parallel processing for faster resolution
   await Promise.all(
     Array.from(fileList).map(async (file) => {
-      // Only check files that look like they are in node_modules
       if (!file.includes("node_modules/")) return;
-
       const pkg = await resolvePackage(file, WORKSPACE_ROOT);
-      if (pkg) {
-        // We might encounter the same package multiple times from different files
-        // We just overwrite, assuming consistent locations for the same package name
-        // or that we want the last one found.
-        packagesToCopy.set(pkg.name, pkg.path);
+      if (pkg) tracedPackagesByKey.set(keyOf(pkg), pkg);
+    }),
+  );
+
+  // Build (name@version) → set of importer package keys, by replaying nft's
+  // reasons map. reasons.get(file).parents lists files that imported `file`;
+  // walking each parent up to its enclosing package.json gives us the
+  // consuming package. We collect by NAME (a.k.a. the importer's identity at
+  // resolution time, not which symlinked path it was reached through) so
+  // every nesting candidate gets credit from the full set of dependents.
+  const importerNamesByKey = new Map<string, Set<string>>();
+  await Promise.all(
+    Array.from(reasons.entries()).map(async ([file, reason]) => {
+      const owner = await resolvePackage(file, WORKSPACE_ROOT);
+      if (!owner) return;
+      const ownerKey = keyOf(owner);
+      for (const parent of reason.parents ?? []) {
+        const parentPkg = await resolvePackage(parent, WORKSPACE_ROOT);
+        if (!parentPkg) continue;
+        if (parentPkg.name === owner.name) continue; // self
+        if (!importerNamesByKey.has(ownerKey)) {
+          importerNamesByKey.set(ownerKey, new Set());
+        }
+        importerNamesByKey.get(ownerKey)!.add(parentPkg.name);
       }
     }),
   );
 
-  console.log(
-    `📦 Found ${packagesToCopy.size} packages to copy:`,
-    Array.from(packagesToCopy.keys()).join(", "),
-  );
+  // Group by name to find version conflicts.
+  const versionsByName = new Map<string, TracedPackage[]>();
+  for (const pkg of tracedPackagesByKey.values()) {
+    if (!versionsByName.has(pkg.name)) versionsByName.set(pkg.name, []);
+    versionsByName.get(pkg.name)!.push(pkg);
+  }
+
+  const conflictNames = [...versionsByName.entries()]
+    .filter(([, vs]) => vs.length > 1)
+    .map(
+      ([name, vs]) =>
+        `${name} (${vs
+          .map((v) => v.version)
+          .sort()
+          .join(", ")})`,
+    );
+  if (conflictNames.length > 0) {
+    console.log(
+      `⚠️  ${conflictNames.length} packages with multiple versions:\n   - ${conflictNames.join("\n   - ")}`,
+    );
+  }
 
   // Create output directory structure
   if (existsSync(OUTPUT_DIR)) {
@@ -233,13 +367,20 @@ async function pruneNodeModules(): Promise<Set<string>> {
   const outputNodeModules = join(OUTPUT_DIR, "node_modules");
   await mkdir(outputNodeModules, { recursive: true });
 
-  // Copy entire package directories to ensure package.json and all metadata are included
-  // Only externalize packages that are successfully copied (not workspace packages)
   const successfullyCopied = new Set<string>();
+  // Track which (consumerName, nestedName) pairs we've already nested so we
+  // don't double-copy when several files in one consumer pull the same dep.
+  const nestedCopiesCreated = new Set<string>();
 
-  for (const [packageName, packagePath] of packagesToCopy.entries()) {
-    // Skip workspace packages - they should be bundled inline, not externalized
-    // Workspace packages use the @decocms/ scope (except @decocms/better-auth which is published)
+  // For each package name, hoist the version with the most distinct consumer
+  // packages (canonical), and nest the rest under their consumers'
+  // node_modules/<name>/ — which is where Node's resolution algorithm checks
+  // first when the consumer asks for `<name>`. Ties broken by version string
+  // so builds are deterministic.
+  for (const [packageName, versions] of versionsByName.entries()) {
+    // Workspace packages stay inlined (bun build will pull source directly).
+    // @decocms/better-auth is the one published @decocms/* dep, so it ships
+    // like any other.
     if (
       packageName.startsWith("@decocms/") &&
       packageName !== "@decocms/better-auth"
@@ -248,21 +389,51 @@ async function pruneNodeModules(): Promise<Set<string>> {
       continue;
     }
 
-    const destPackagePath = join(outputNodeModules, packageName);
+    versions.sort((a, b) => {
+      const ca = importerNamesByKey.get(keyOf(a))?.size ?? 0;
+      const cb = importerNamesByKey.get(keyOf(b))?.size ?? 0;
+      if (ca !== cb) return cb - ca; // more consumers = more canonical
+      return a.version.localeCompare(b.version);
+    });
+    const [canonical, ...nested] = versions;
 
-    if (!existsSync(packagePath)) {
-      console.warn(
-        `⚠️  Package source not found: ${packageName} at ${packagePath}`,
-      );
-      continue;
-    }
+    await copyPackage(
+      canonical.path,
+      join(outputNodeModules, packageName),
+      packageName,
+    );
+    successfullyCopied.add(packageName);
 
-    try {
-      await cp(packagePath, destPackagePath, { recursive: true });
-      successfullyCopied.add(packageName);
-      console.log(`✅ Copied package: ${packageName}`);
-    } catch (error) {
-      console.warn(`⚠️  Failed to copy package ${packageName}: ${error}`);
+    // Nest non-canonical versions under each of their consumer packages.
+    // Skipping versions with no known consumer would silently drop them
+    // (the trace included them for some reason), so we WARN loudly instead —
+    // the maintainer needs to decide whether to add the consumer to
+    // ALWAYS_INCLUDE or accept that the version is unused.
+    for (const v of nested) {
+      const consumers = importerNamesByKey.get(keyOf(v));
+      if (!consumers || consumers.size === 0) {
+        console.warn(
+          `⚠️  Could not place non-canonical ${packageName}@${v.version} — no consumer found in trace. Skipping (this version may not be reachable at runtime).`,
+        );
+        continue;
+      }
+      for (const consumerName of consumers) {
+        if (consumerName === packageName) continue; // self
+        const dedupKey = `${consumerName}\0${packageName}`;
+        if (nestedCopiesCreated.has(dedupKey)) continue;
+        nestedCopiesCreated.add(dedupKey);
+        const dest = join(
+          outputNodeModules,
+          consumerName,
+          "node_modules",
+          packageName,
+        );
+        await copyPackage(
+          v.path,
+          dest,
+          `${packageName}@${v.version} (nested under ${consumerName})`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Two related crashes were taking down freshly-published `decocms` builds — both invisible until the new smoke-tarball test (added in #3683) actually ran the packed artifact. The Release Mesh CI has been failing on every push because of these.

### Bug 1: `Cannot find module '@opentelemetry/resources'` at startup

`cp`'s default mode preserves symlinks. Bun's isolated install stores most packages behind chained symlinks (`.bun/<pkg>@<ver>+<hash>/node_modules/<pkg>`). The recreated symlinks had relative targets that resolved from the source tree (so `existsSync` passed in the build verifier) but pointed nowhere once `npm pack` shipped them.

**Fix:** `cp(source, dest, { recursive: true, dereference: true })` materializes the real package files in the output.

### Bug 2: `Export named 'ms' not found` (and an analogous `createRateLimitKey` failure)

`@vercel/nft`'s walk silently aborts on packages whose `package.json` `exports` map uses non-standard conditions before `"default"` — the better-auth family is the offender. `bun build` then inlines those packages into `cli.js`/`server.js` while leaving their cross-package imports (`from "ms"`, `from "@better-auth/core/utils"`) externalized, so the bundle reaches into top-level `dist/server/node_modules/<dep>` for whichever version happened to win the previous last-write-wins dedupe.

Two collateral problems:
- `@decocms/better-auth` needs `ms@4` (named exports); `debug`/`express` need `ms@2.1.3` (default-callable CJS). Only one ships.
- `better-auth@1.4.22` needs `@better-auth/core@1.4.22`; `@decocms/better-auth@1.5.17` needs `@better-auth/core@1.4.6-beta.3`. Only one ships.

**Fix:** list each better-auth-family entry in `ALWAYS_INCLUDE` so nft roots from the resolved file (skipping the broken exports walk), then rewrite `pruneNodeModules` to dedupe by `(name, version)` instead of just name. The canonical version (most distinct consumers) is hoisted at top level; the rest get copied into each consumer package's nested `node_modules/<dep>/`, where Node's resolution walk finds them first.

## Test plan

- [x] `bun run --cwd=apps/mesh build:server` succeeds, surfaces the version-conflict packages in build output
- [x] `npm pack && bun run scripts/smoke-tarball.ts <packed>.tgz` prints `Deco CMS v...` (`deco --version`) cleanly — previously crashed at startup with `Cannot find module '@opentelemetry/resources'`, then with `Export named 'ms' not found`, then with `Export named 'createRateLimitKey' not found`
- [x] `bun run check` (TypeScript) passes
- [x] `bun run lint` passes
- [x] `bun run fmt:check` passes
- [ ] Watch Release Mesh CI on this PR (the smoke test from #3683 runs there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two bundler crashes by dereferencing symlinks during package copy and correctly handling multiple versions of dependencies so freshly packed `decocms` builds start cleanly. The Release Mesh smoke test should pass again.

- **Bug Fixes**
  - Dereference symlinks when copying traced packages to `dist` to avoid dangling links from Bun’s isolated install; fixes startup error `Cannot find module '@opentelemetry/resources'`.
  - Make `@vercel/nft` reliably include the better-auth family and resolve version conflicts:
    - Added `@decocms/better-auth`, `better-auth`, and `@better-auth/sso` to `ALWAYS_INCLUDE`.
    - Dedupe by `name@version`, hoist the most-used version, and nest other versions under each consumer’s `node_modules/<dep>/`. This fixes `Export named 'ms' not found` and `createRateLimitKey` errors from mixed `ms` and `@better-auth/core` versions.

<sup>Written for commit 215ec983d9651583cfcd7632bdd9786db8129aad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

