### PR TITLE
feat(sandbox): drawer below every tab + tab error boundary recovery

### DIFF
--- a/apps/mesh/e2e/tests/sandbox-drawer-everywhere.spec.ts
+++ b/apps/mesh/e2e/tests/sandbox-drawer-everywhere.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * E2E: the sandbox PreviewDrawer renders below every main-panel tab on
+ * cloneable agents — not just the preview tab. See spec at
+ * docs/superpowers/specs/2026-06-03-sandbox-drawer-everywhere-design.md.
+ */
+import { expect, test } from "../fixtures/test";
+import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
+
+test.describe("sandbox drawer is available on every main-panel tab", () => {
+  test("drawer toolbar renders on Settings and Preview tabs", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+
+    // Placeholder GitHub connection — the URL doesn't need to resolve; only
+    // its id is needed so `agentHasClonableSource` flips on.
+    const conn = await createHttpConnection(api, orgSlug, {
+      title: "github-placeholder",
+      url: "http://127.0.0.1:1/unused",
+    });
+
+    // Clonable agent: connections[] AND metadata.githubRepo both reference
+    // the same connection id (both halves are required for
+    // `getActiveGithubRepo` → non-null, which is what
+    // `agentHasClonableSource` checks).
+    const agent = await callSelfMcpTool<{ item: { id: string } }>(
+      api,
+      orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      {
+        data: {
+          title: "drawer-everywhere e2e",
+          description: "cloneable",
+          status: "active",
+          pinned: false,
+          connections: [{ connection_id: conn.id }],
+          metadata: {
+            githubRepo: {
+              url: "https://github.com/example/repo",
+              owner: "example",
+              name: "repo",
+              connectionId: conn.id,
+            },
+          },
+        },
+      },
+    );
+
+    const thread = await callSelfMcpTool<{ item: { id: string } }>(
+      api,
+      orgSlug,
+      "COLLECTION_THREADS_CREATE",
+      { data: { virtual_mcp_id: agent.item.id } },
+    );
+
+    // The drawer's setup tab is a <button> with visible text "sandbox" and
+    // a Terminal icon (see drawer/toolbar.tsx :: SetupTab). Asserting on it
+    // is the cheap proof that the drawer chrome is mounted under the tab;
+    // we deliberately don't try to start the sandbox.
+    const sandboxToolbarTab = page.getByRole("button", { name: /^sandbox$/i });
+
+    // Active tab is driven by ?main=… (see tab-id.ts grammar). Start on the
+    // settings tab — the most common non-preview tab and a strong signal
+    // that the drawer has been hoisted out of PreviewContent.
+    await page.goto(
+      `/${orgSlug}/${thread.item.id}?virtualmcpid=${agent.item.id}&main=settings`,
+    );
+    await expect(sandboxToolbarTab).toBeVisible({ timeout: 15_000 });
+
+    // Switch to the preview tab via URL — the drawer was already visible
+    // here before the refactor, so this is the regression-prevention half.
+    await page.goto(
+      `/${orgSlug}/${thread.item.id}?virtualmcpid=${agent.item.id}&main=preview`,
+    );
+    await expect(sandboxToolbarTab).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/apps/mesh/e2e/tests/tab-error-boundary-recovery.spec.ts
+++ b/apps/mesh/e2e/tests/tab-error-boundary-recovery.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * E2E: a render error in one main-panel tab no longer bricks the panel.
+ * Switching tabs remounts the ErrorBoundary (keyed on activeTab inside
+ * MainPanelContent) so the new tab renders normally. The sandbox drawer
+ * stays interactive throughout — it's a sibling of the boundary.
+ *
+ * See spec at docs/superpowers/specs/2026-06-03-sandbox-drawer-everywhere-design.md.
+ *
+ * Trigger: dev-only `window.__forceTabError = <activeTab>` hook in
+ * apps/mesh/src/web/layouts/main-panel-tabs/index.tsx's TabBody.
+ */
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
+
+test.describe("tab error boundary recovers on tab switch", () => {
+  // Helper: create a clonable agent + thread + return their ids. Mirrors the
+  // setup used in sandbox-drawer-everywhere.spec.ts so the drawer assertion
+  // in scenario B is meaningful (agentHasClonableSource must be true).
+  async function setup({ page, orgSlug }: { page: Page; orgSlug: string }) {
+    const api = page.context().request;
+    const conn = await createHttpConnection(api, orgSlug, {
+      title: "github-placeholder",
+      url: "http://127.0.0.1:1/unused",
+    });
+    const agent = await callSelfMcpTool<{ item: { id: string } }>(
+      api,
+      orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      {
+        data: {
+          title: "error-boundary e2e",
+          description: "cloneable",
+          status: "active",
+          pinned: false,
+          connections: [{ connection_id: conn.id }],
+          metadata: {
+            githubRepo: {
+              url: "https://github.com/example/repo",
+              owner: "example",
+              name: "repo",
+              connectionId: conn.id,
+            },
+          },
+        },
+      },
+    );
+    const thread = await callSelfMcpTool<{ item: { id: string } }>(
+      api,
+      orgSlug,
+      "COLLECTION_THREADS_CREATE",
+      { data: { virtual_mcp_id: agent.item.id } },
+    );
+    return { agentId: agent.item.id, threadId: thread.item.id };
+  }
+
+  test("error in one tab unblocks after switching to another tab", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const { agentId, threadId } = await setup({ page, orgSlug });
+
+    // Force the settings tab to throw on render. addInitScript runs before
+    // any script on every navigation in the page's context, so the hook
+    // survives the page.goto()s below.
+    await page.addInitScript(() => {
+      (window as unknown as { __forceTabError?: string }).__forceTabError =
+        "settings";
+    });
+
+    await page.goto(
+      `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&main=settings`,
+    );
+
+    // Error boundary fallback is visible — matches the default fallback text
+    // in apps/mesh/src/web/components/error-boundary.tsx.
+    await expect(page.getByText(/something went wrong/i)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Switch to the preview tab — renders cleanly, no leftover error.
+    await page.goto(
+      `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&main=preview`,
+    );
+    await expect(page.getByText(/something went wrong/i)).toBeHidden();
+
+    // Switch back to settings — error UI reappears (state was reset on
+    // remount via key={activeTab}, not memoized as healthy).
+    await page.goto(
+      `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&main=settings`,
+    );
+    await expect(page.getByText(/something went wrong/i)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("sandbox drawer stays interactive while a tab body shows the error", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const { agentId, threadId } = await setup({ page, orgSlug });
+
+    await page.addInitScript(() => {
+      (window as unknown as { __forceTabError?: string }).__forceTabError =
+        "settings";
+    });
+
+    await page.goto(
+      `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&main=settings`,
+    );
+
+    // Error UI is visible inside the boundary.
+    await expect(page.getByText(/something went wrong/i)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Sandbox drawer's setup button is a sibling of the boundary, so it
+    // stays mounted and interactive — the drawer chrome should still render
+    // even though the tab body crashed.
+    const sandboxToolbarTab = page.getByRole("button", { name: /^sandbox$/i });
+    await expect(sandboxToolbarTab).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import {
+  selectVmEntry,
+  shouldAutoStart,
+  shouldSelfHeal,
+  computeDrawerStatus,
+  type BranchMapEntryLike,
+} from "./sandbox-lifecycle-context";
+
+const entry = (
+  kind: string,
+  handle = "h1",
+  url: string | null = "https://example/preview",
+): BranchMapEntryLike => ({
+  sandboxHandle: handle,
+  previewUrl: url,
+  sandboxProviderKind: kind,
+});
+
+describe("selectVmEntry", () => {
+  test("returns null on empty map", () => {
+    expect(selectVmEntry({})).toBeNull();
+  });
+
+  test("prefers a non-user-desktop entry over a user-desktop entry", () => {
+    const result = selectVmEntry({
+      a: entry("user-desktop", "desk"),
+      b: entry("cluster", "vm"),
+    });
+    expect(result?.sandboxHandle).toBe("vm");
+  });
+
+  test("falls back to first entry when all are user-desktop", () => {
+    const result = selectVmEntry({
+      a: entry("user-desktop", "first"),
+      b: entry("user-desktop", "second"),
+    });
+    expect(result?.sandboxHandle).toBe("first");
+  });
+
+  test("returns the only entry when one is present", () => {
+    expect(selectVmEntry({ a: entry("cluster", "solo") })?.sandboxHandle).toBe(
+      "solo",
+    );
+  });
+});
+
+describe("shouldAutoStart", () => {
+  const base = {
+    hasActiveGithubRepo: true,
+    userId: "u1",
+    branch: "main",
+    vmEntry: null,
+    userStopped: false,
+    isPending: false,
+    attempted: false,
+  };
+
+  test("all conditions met → true", () => {
+    expect(shouldAutoStart(base)).toBe(true);
+  });
+
+  test("no github repo → false", () => {
+    expect(shouldAutoStart({ ...base, hasActiveGithubRepo: false })).toBe(
+      false,
+    );
+  });
+
+  test("no userId → false", () => {
+    expect(shouldAutoStart({ ...base, userId: null })).toBe(false);
+  });
+
+  test("no branch → false", () => {
+    expect(shouldAutoStart({ ...base, branch: null })).toBe(false);
+  });
+
+  test("vmEntry already present → false", () => {
+    expect(
+      shouldAutoStart({
+        ...base,
+        vmEntry: entry("cluster"),
+      }),
+    ).toBe(false);
+  });
+
+  test("user stopped → false", () => {
+    expect(shouldAutoStart({ ...base, userStopped: true })).toBe(false);
+  });
+
+  test("start already pending → false", () => {
+    expect(shouldAutoStart({ ...base, isPending: true })).toBe(false);
+  });
+
+  test("already attempted for this branch → false", () => {
+    expect(shouldAutoStart({ ...base, attempted: true })).toBe(false);
+  });
+});
+
+describe("shouldSelfHeal", () => {
+  const base = {
+    notFound: true,
+    deadVmId: "vm-dead",
+    lastDeadVmId: null as string | null,
+    isPending: false,
+    userStopped: false,
+  };
+
+  test("fresh dead vm → true", () => {
+    expect(shouldSelfHeal(base)).toBe(true);
+  });
+
+  test("not notFound → false", () => {
+    expect(shouldSelfHeal({ ...base, notFound: false })).toBe(false);
+  });
+
+  test("no deadVmId → false", () => {
+    expect(shouldSelfHeal({ ...base, deadVmId: null })).toBe(false);
+  });
+
+  test("already reprovisioned for this vm → false", () => {
+    expect(shouldSelfHeal({ ...base, lastDeadVmId: "vm-dead" })).toBe(false);
+  });
+
+  test("start already pending → false", () => {
+    expect(shouldSelfHeal({ ...base, isPending: true })).toBe(false);
+  });
+
+  test("user stopped → false", () => {
+    expect(shouldSelfHeal({ ...base, userStopped: true })).toBe(false);
+  });
+});
+
+describe("computeDrawerStatus", () => {
+  test("suspended → suspended", () => {
+    expect(computeDrawerStatus({ kind: "suspended" })).toBe("suspended");
+  });
+
+  test("starting → starting", () => {
+    expect(computeDrawerStatus({ kind: "starting" })).toBe("starting");
+  });
+
+  test("iframe → running", () => {
+    expect(
+      computeDrawerStatus({ kind: "iframe", previewUrl: "https://x" }),
+    ).toBe("running");
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -98,6 +98,7 @@ import {
 import type { SandboxMap } from "@decocms/mesh-sdk/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
+import { useChatTask } from "@/web/components/chat/context";
 import {
   sandboxUserStop,
   useSandboxStart,
@@ -159,6 +160,7 @@ export function SandboxLifecycleProvider({
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
+  const { setCurrentTaskBranch } = useChatTask();
   const events = useSandboxEvents();
   const queryClient = useQueryClient();
 
@@ -225,11 +227,25 @@ export function SandboxLifecycleProvider({
     autoStartAttemptedForBranchRef.current.add(branch);
     const args: SandboxStartArgs = { virtualMcpId, branch };
     startVmMutate(args, {
+      // When SANDBOX_START is invoked without a branch (new task → server
+      // picks/generates one), persist the server's choice onto the chat task.
+      // Mirrors the original onSuccess that lived on PreviewContent.triggerStart;
+      // without it, subsequent renders and the SSE provider lose track of which
+      // branch the VM is on.
+      onSuccess: (data) => {
+        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
+      },
       onError: (err) => {
         console.error("[sandbox-lifecycle] auto-start failed:", err);
       },
     });
-  }, [autoStartEligible, branch, virtualMcpId, startVmMutate]);
+  }, [
+    autoStartEligible,
+    branch,
+    virtualMcpId,
+    startVmMutate,
+    setCurrentTaskBranch,
+  ]);
 
   // Self-heal: SSE emits `gone` → reprovision via SANDBOX_START. Dedup by
   // dead handle so we don't loop on repeat 404s; a new dead handle is fine.
@@ -250,11 +266,21 @@ export function SandboxLifecycleProvider({
     const args: SandboxStartArgs = { virtualMcpId };
     if (branch) args.branch = branch;
     startVmMutate(args, {
+      onSuccess: (data) => {
+        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
+      },
       onError: (err) => {
         console.error("[sandbox-lifecycle] self-heal failed:", err);
       },
     });
-  }, [selfHealEligible, deadVmId, virtualMcpId, branch, startVmMutate]);
+  }, [
+    selfHealEligible,
+    deadVmId,
+    virtualMcpId,
+    branch,
+    startVmMutate,
+    setCurrentTaskBranch,
+  ]);
 
   // User-driven actions.
   const start = () => {
@@ -262,6 +288,9 @@ export function SandboxLifecycleProvider({
     const args: SandboxStartArgs = { virtualMcpId };
     if (branch) args.branch = branch;
     startVmMutate(args, {
+      onSuccess: (data) => {
+        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
+      },
       onError: (err) => {
         console.error("[sandbox-lifecycle] user start failed:", err);
       },

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -1,0 +1,86 @@
+/**
+ * Sandbox lifecycle: actions + effects.
+ *
+ * Owns the SANDBOX_START mutation, the consolidated auto-start effect,
+ * the self-heal effect, and user-driven start/stop/restart/retry/resume.
+ * Sibling of SandboxEventsProvider; reads `events.notFound` + `events.status`
+ * for self-heal and previewState.
+ *
+ * Pure helpers (selectVmEntry, shouldAutoStart, shouldSelfHeal,
+ * computeDrawerStatus) are exported so unit tests can exercise the
+ * consolidation logic without crossing the no-mocks line.
+ */
+
+import type { PreviewState } from "@/web/components/sandbox/preview/preview-state";
+import type { DrawerStatus } from "@/web/components/sandbox/preview/drawer/status-pill";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-testable)
+// ---------------------------------------------------------------------------
+
+export interface BranchMapEntryLike {
+  sandboxHandle: string;
+  previewUrl: string | null;
+  sandboxProviderKind: string;
+}
+
+export function selectVmEntry<T extends BranchMapEntryLike>(
+  branchMap: Record<string, T>,
+): T | null {
+  const entries = Object.values(branchMap);
+  if (entries.length === 0) return null;
+  return (
+    entries.find((e) => e.sandboxProviderKind !== "user-desktop") ?? entries[0]
+  );
+}
+
+export interface ShouldAutoStartArgs {
+  hasActiveGithubRepo: boolean;
+  userId: string | null;
+  branch: string | null;
+  vmEntry: BranchMapEntryLike | null;
+  userStopped: boolean;
+  isPending: boolean;
+  attempted: boolean;
+}
+
+export function shouldAutoStart(args: ShouldAutoStartArgs): boolean {
+  return (
+    args.hasActiveGithubRepo &&
+    !!args.userId &&
+    !!args.branch &&
+    !args.vmEntry &&
+    !args.userStopped &&
+    !args.isPending &&
+    !args.attempted
+  );
+}
+
+export interface ShouldSelfHealArgs {
+  notFound: boolean;
+  deadVmId: string | null;
+  lastDeadVmId: string | null;
+  isPending: boolean;
+  userStopped: boolean;
+}
+
+export function shouldSelfHeal(args: ShouldSelfHealArgs): boolean {
+  return (
+    args.notFound &&
+    !!args.deadVmId &&
+    !args.isPending &&
+    !args.userStopped &&
+    args.deadVmId !== args.lastDeadVmId
+  );
+}
+
+export function computeDrawerStatus(state: PreviewState): DrawerStatus {
+  switch (state.kind) {
+    case "suspended":
+      return "suspended";
+    case "iframe":
+      return "running";
+    case "starting":
+      return "starting";
+  }
+}

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -148,7 +148,6 @@ export function SandboxLifecycleProvider({
   userId,
   hasActiveGithubRepo,
   sandboxMap,
-  orgId,
   children,
 }: {
   virtualMcpId: string | null;
@@ -156,7 +155,6 @@ export function SandboxLifecycleProvider({
   userId: string | null;
   hasActiveGithubRepo: boolean;
   sandboxMap: SandboxMap | undefined;
-  orgId: string;
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
@@ -166,7 +164,7 @@ export function SandboxLifecycleProvider({
 
   const mcpClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
-    orgId,
+    orgId: org.id,
     orgSlug: org.slug,
   });
   const startVm = useSandboxStart(mcpClient);

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -223,27 +223,16 @@ export function SandboxLifecycleProvider({
   useEffect(() => {
     if (!autoStartEligible || !branch || !virtualMcpId) return;
     autoStartAttemptedForBranchRef.current.add(branch);
+    // Auto-start is gated on `!!branch` via shouldAutoStart, so the
+    // server-picks-a-branch flow (the onSuccess in self-heal + user start)
+    // is structurally unreachable here. No onSuccess needed.
     const args: SandboxStartArgs = { virtualMcpId, branch };
     startVmMutate(args, {
-      // When SANDBOX_START is invoked without a branch (new task → server
-      // picks/generates one), persist the server's choice onto the chat task.
-      // Mirrors the original onSuccess that lived on PreviewContent.triggerStart;
-      // without it, subsequent renders and the SSE provider lose track of which
-      // branch the VM is on.
-      onSuccess: (data) => {
-        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
-      },
       onError: (err) => {
         console.error("[sandbox-lifecycle] auto-start failed:", err);
       },
     });
-  }, [
-    autoStartEligible,
-    branch,
-    virtualMcpId,
-    startVmMutate,
-    setCurrentTaskBranch,
-  ]);
+  }, [autoStartEligible, branch, virtualMcpId, startVmMutate]);
 
   // Self-heal: SSE emits `gone` → reprovision via SANDBOX_START. Dedup by
   // dead handle so we don't loop on repeat 404s; a new dead handle is fine.

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -135,7 +135,7 @@ const DEFAULT_VALUE: SandboxLifecycleValue = {
   resume: () => {},
 };
 
-export const SandboxLifecycleContext =
+const SandboxLifecycleContext =
   createContext<SandboxLifecycleValue>(DEFAULT_VALUE);
 
 export function useSandboxLifecycle(): SandboxLifecycleValue {

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -28,10 +28,9 @@ export function selectVmEntry<T extends BranchMapEntryLike>(
   branchMap: Record<string, T>,
 ): T | null {
   const entries = Object.values(branchMap);
-  if (entries.length === 0) return null;
-  return (
-    entries.find((e) => e.sandboxProviderKind !== "user-desktop") ?? entries[0]
-  );
+  const [first] = entries;
+  if (!first) return null;
+  return entries.find((e) => e.sandboxProviderKind !== "user-desktop") ?? first;
 }
 
 export interface ShouldAutoStartArgs {
@@ -83,4 +82,246 @@ export function computeDrawerStatus(state: PreviewState): DrawerStatus {
     case "starting":
       return "starting";
   }
+}
+
+// ---------------------------------------------------------------------------
+// Provider + hook
+// ---------------------------------------------------------------------------
+
+import { createContext, use, useEffect, useRef, type ReactNode } from "react";
+import {
+  parseBranchMap,
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import type { SandboxMap } from "@decocms/mesh-sdk/types";
+import { useQueryClient } from "@tanstack/react-query";
+import { invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
+import {
+  sandboxUserStop,
+  useSandboxStart,
+  type SandboxStartArgs,
+} from "./use-sandbox-start";
+import { useSandboxEvents } from "./use-sandbox-events";
+import { computePreviewState } from "@/web/components/sandbox/preview/preview-state";
+
+export interface SandboxLifecycleValue {
+  branch: string | null;
+  previewState: PreviewState;
+  status: DrawerStatus;
+  vmEntry: BranchMapEntryLike | null;
+  previewUrl: string | null;
+  userStopped: boolean;
+  start: () => void;
+  stop: () => Promise<void>;
+  restart: () => Promise<void>;
+  retry: () => void;
+  resume: () => void;
+}
+
+const DEFAULT_VALUE: SandboxLifecycleValue = {
+  branch: null,
+  previewState: { kind: "starting" },
+  status: "idle",
+  vmEntry: null,
+  previewUrl: null,
+  userStopped: false,
+  start: () => {},
+  stop: async () => {},
+  restart: async () => {},
+  retry: () => {},
+  resume: () => {},
+};
+
+export const SandboxLifecycleContext =
+  createContext<SandboxLifecycleValue>(DEFAULT_VALUE);
+
+export function useSandboxLifecycle(): SandboxLifecycleValue {
+  return use(SandboxLifecycleContext);
+}
+
+export function SandboxLifecycleProvider({
+  virtualMcpId,
+  branch,
+  userId,
+  hasActiveGithubRepo,
+  sandboxMap,
+  orgId,
+  children,
+}: {
+  virtualMcpId: string | null;
+  branch: string | null;
+  userId: string | null;
+  hasActiveGithubRepo: boolean;
+  sandboxMap: SandboxMap | undefined;
+  orgId: string;
+  children: ReactNode;
+}) {
+  const { org } = useProjectContext();
+  const events = useSandboxEvents();
+  const queryClient = useQueryClient();
+
+  const mcpClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId,
+    orgSlug: org.slug,
+  });
+  const startVm = useSandboxStart(mcpClient);
+  // Destructure mutate/reset so they're stable references for effect deps.
+  const { mutate: startVmMutate, reset: startVmReset } = startVm;
+
+  // Branch-keyed dedup (replaces both legacy taskId-keyed (preview.tsx) and
+  // branch-keyed (VmEventsBridge) dedup refs).
+  const autoStartAttemptedForBranchRef = useRef<Set<string>>(new Set());
+  const reprovisionedForVmIdRef = useRef<string | null>(null);
+
+  // Derived values, recomputed each render.
+  // Cast: parseBranchMap returns SandboxRecord where sandboxProviderKind is
+  // optional, but BranchMapEntryLike requires it as string. selectVmEntry
+  // only filters on the value (undefined !== "user-desktop" still works) so
+  // the cast is safe in practice.
+  const branchMap =
+    userId && branch
+      ? (parseBranchMap(sandboxMap?.[userId]?.[branch]) as Record<
+          string,
+          BranchMapEntryLike
+        >)
+      : {};
+  const vmEntry = selectVmEntry(branchMap);
+  const previewUrl = vmEntry?.previewUrl ?? null;
+  const userStopped =
+    !!virtualMcpId &&
+    !!branch &&
+    sandboxUserStop.isStopped(virtualMcpId, branch);
+  const appPaused = events.status.state === "paused";
+  const previewState = computePreviewState({
+    previewUrl,
+    appPaused,
+    userStopped,
+  });
+  const status = computeDrawerStatus(previewState);
+
+  // Auto-start (consolidated): "arrive at a branch with no VM, no user-stop,
+  // not already started → fire SANDBOX_START once for this branch."
+  // Branch-keyed, not taskId-keyed: that matches useSandboxStart's own
+  // dedup and avoids resurrecting a user-killed VM across task switches.
+  const attempted =
+    branch !== null &&
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; mutation happens inside effect after add()
+    autoStartAttemptedForBranchRef.current.has(branch);
+  const autoStartEligible = shouldAutoStart({
+    hasActiveGithubRepo,
+    userId,
+    branch,
+    vmEntry,
+    userStopped,
+    isPending: startVm.isPending,
+    attempted,
+  });
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- bridges external state into a one-shot mutation; no render-time equivalent
+  useEffect(() => {
+    if (!autoStartEligible || !branch || !virtualMcpId) return;
+    autoStartAttemptedForBranchRef.current.add(branch);
+    const args: SandboxStartArgs = { virtualMcpId, branch };
+    startVmMutate(args, {
+      onError: (err) => {
+        console.error("[sandbox-lifecycle] auto-start failed:", err);
+      },
+    });
+  }, [autoStartEligible, branch, virtualMcpId, startVmMutate]);
+
+  // Self-heal: SSE emits `gone` → reprovision via SANDBOX_START. Dedup by
+  // dead handle so we don't loop on repeat 404s; a new dead handle is fine.
+  const deadVmId = events.notFound ? (vmEntry?.sandboxHandle ?? null) : null;
+  const selfHealEligible = shouldSelfHeal({
+    notFound: events.notFound,
+    deadVmId,
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; recorded inside effect after firing
+    lastDeadVmId: reprovisionedForVmIdRef.current,
+    isPending: startVm.isPending,
+    userStopped,
+  });
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- one-shot reprovision trigger gated on notFound→deadVmId
+  useEffect(() => {
+    if (!selfHealEligible || !deadVmId || !virtualMcpId) return;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- record dead handle to dedup repeat 404s
+    reprovisionedForVmIdRef.current = deadVmId;
+    const args: SandboxStartArgs = { virtualMcpId };
+    if (branch) args.branch = branch;
+    startVmMutate(args, {
+      onError: (err) => {
+        console.error("[sandbox-lifecycle] self-heal failed:", err);
+      },
+    });
+  }, [selfHealEligible, deadVmId, virtualMcpId, branch, startVmMutate]);
+
+  // User-driven actions.
+  const start = () => {
+    if (!virtualMcpId) return;
+    const args: SandboxStartArgs = { virtualMcpId };
+    if (branch) args.branch = branch;
+    startVmMutate(args, {
+      onError: (err) => {
+        console.error("[sandbox-lifecycle] user start failed:", err);
+      },
+    });
+  };
+
+  const stop = async () => {
+    if (!virtualMcpId || !branch) return;
+    const kindToStop = vmEntry?.sandboxProviderKind;
+    if (!kindToStop) return;
+    sandboxUserStop.mark(virtualMcpId, branch);
+    try {
+      await mcpClient.callTool({
+        name: "SANDBOX_DELETE",
+        arguments: {
+          virtualMcpId,
+          branch,
+          sandboxProviderKind: kindToStop,
+        },
+      });
+    } catch {
+      // Best effort
+    }
+    invalidateVirtualMcpQueries(queryClient);
+  };
+
+  const restart = async () => {
+    await stop();
+    start();
+  };
+
+  // Retry / Resume: clear dedup refs and re-fire start. The drawer toolbar
+  // calls onRetry for `errored` and onResume for `suspended`; both reduce
+  // to the same operation in the provider.
+  const retry = () => {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- reset dedup so a fresh start can fire
+    autoStartAttemptedForBranchRef.current = new Set();
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- reset dedup so self-heal can fire on next gone
+    reprovisionedForVmIdRef.current = null;
+    startVmReset();
+    start();
+  };
+  const resume = retry;
+
+  // Value is recomputed each render; React 19 Compiler handles memoization.
+  const value: SandboxLifecycleValue = {
+    branch,
+    previewState,
+    status,
+    vmEntry,
+    previewUrl,
+    userStopped,
+    start,
+    stop,
+    restart,
+    retry,
+    resume,
+  };
+
+  return (
+    <SandboxLifecycleContext value={value}>{children}</SandboxLifecycleContext>
+  );
 }

--- a/apps/mesh/src/web/components/sandbox/preview/drawer/drawer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/drawer/drawer.tsx
@@ -255,27 +255,3 @@ function DrawerBody({
     </div>
   );
 }
-
-const STORAGE_KEY = (id: string) => `preview-drawer:${id}`;
-
-export function readPersistedDrawerOpen(virtualMcpId: string): boolean {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY(virtualMcpId));
-    if (!raw) return false;
-    const p = JSON.parse(raw);
-    return !!p.open;
-  } catch {
-    return false;
-  }
-}
-
-export function writePersistedDrawerOpen(
-  virtualMcpId: string,
-  open: boolean,
-): void {
-  try {
-    localStorage.setItem(STORAGE_KEY(virtualMcpId), JSON.stringify({ open }));
-  } catch {
-    /* ignore */
-  }
-}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -1,12 +1,7 @@
 import { useState, useRef, useEffect, Suspense, lazy } from "react";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
-import { authClient } from "@/web/lib/auth-client";
 import { useChatTask } from "@/web/components/chat/context";
-import {
-  useMCPClient,
-  useProjectContext,
-  SELF_MCP_ALIAS_ID,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 
 import {
@@ -69,12 +64,6 @@ import {
   useSandboxEvents,
   useSandboxReloadHandler,
 } from "../hooks/use-sandbox-events";
-import {
-  useSandboxStart,
-  sandboxUserStop,
-  type SandboxStartArgs,
-} from "../hooks/use-sandbox-start";
-import type { PreviewState } from "./preview-state";
 import { SandboxStateCard } from "./state-card";
 import { derivePhaseProgress } from "./derive-phase-progress";
 import {
@@ -82,9 +71,6 @@ import {
   readPersistedDrawerOpen,
   writePersistedDrawerOpen,
 } from "./drawer/drawer";
-import type { DrawerStatus } from "./drawer/status-pill";
-import { invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
-import { useQueryClient } from "@tanstack/react-query";
 import { track } from "@/web/lib/posthog-client";
 
 const SectionsEditor = lazy(() =>
@@ -102,23 +88,11 @@ const FileExplorer = lazy(() =>
 /** Delay before reloading the preview iframe after a save, giving the dev server time to pick up file changes. */
 const DEV_SERVER_SETTLE_MS = 500;
 
-function drawerStatusFromPreview(state: PreviewState): DrawerStatus {
-  switch (state.kind) {
-    case "suspended":
-      return "suspended";
-    case "iframe":
-      return "running";
-    case "starting":
-      return "starting";
-  }
-}
-
 type PreviewViewMode = "preview" | "visual" | "cms" | "code";
 
 export function PreviewContent() {
   const inset = useInsetContext();
-  const { data: session } = authClient.useSession();
-  const { taskId, currentBranch: branch, setCurrentTaskBranch } = useChatTask();
+  const { currentBranch: branch } = useChatTask();
 
   // Visual editor state
   const [viewMode, setViewMode] = useState<PreviewViewMode>("preview");
@@ -152,8 +126,6 @@ export function PreviewContent() {
 
   // Current iframe path (for sections editor)
   const [currentPath, setCurrentPath] = useState("/");
-
-  const userId = session?.user?.id;
 
   const virtualMcpId = inset?.entity?.id ?? null;
   const { org } = useProjectContext();
@@ -223,19 +195,6 @@ export function PreviewContent() {
   // HTML page for it, so the iframe surfaces it; no dedicated overlay.
   const appPaused = vmEvents.status.state === "paused";
 
-  // One mutation, two triggers. Dedup differs by meaning:
-  //   auto-start: once per taskId
-  //   self-heal:  once per dead vmId (don't loop on repeat 404s; new vmId OK)
-  // A shared ref would conflate them.
-  const mcpClient = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: inset?.entity?.organization_id ?? "",
-    orgSlug: org.slug,
-  });
-  const startVm = useSandboxStart(mcpClient);
-  const autoStartedForTaskRef = useRef<string | null>(null);
-  const reprovisionedForVmIdRef = useRef<string | null>(null);
-
   const claimPhase = vmEvents.phase;
 
   const progress = derivePhaseProgress({
@@ -292,82 +251,8 @@ export function PreviewContent() {
       ? "preview"
       : viewMode;
 
-  // ref-latest pattern: effects below depend only on upstream signals, not
-  // on this closure's churning captures (branch, mutation, setter).
-  const triggerStart = (reason: "auto-start" | "self-heal") => {
-    if (!virtualMcpId) return;
-    const args: SandboxStartArgs = { virtualMcpId };
-    if (branch) args.branch = branch;
-    startVm.mutate(args, {
-      onSuccess: (data) => {
-        // Server-generated branch: persist so later renders resolve via sandboxMap.
-        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
-      },
-      onError: (err) => {
-        console.error(`[preview] ${reason} SANDBOX_START failed`, err);
-      },
-    });
-  };
-  const triggerStartRef = useRef(triggerStart);
-  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-  triggerStartRef.current = triggerStart;
-
-  // Auto-start = "arrive → provision one", NOT "always ensure exists". Once
-  // a vmEntry is seen for this taskId, explicit stop must NOT re-trigger (or
-  // it races the user's manual Start). Mark ref on first-sight, BEFORE
-  // evaluating shouldAutoStart, so a transient null can't sneak through.
-  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-  if (taskId && vmEntry && autoStartedForTaskRef.current !== taskId) {
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-    autoStartedForTaskRef.current = taskId;
-  }
-  // Branch must be resolved before firing: VmEventsBridge keys auto-start on
-  // `currentBranch`, and `useSandboxStart` dedupes by (virtualMcpId, branch).
-  // Firing here with branch=null uses a different dedup key AND asks the
-  // server to generate a fresh branch — that's a different sandbox than the
-  // one the page is actually on.
-  // Respect explicit user-stop across component remounts — the module-level `userStoppedVms` flag survives remounts but `autoStartedForTaskRef` resets, so without this gate a navigate-away-and-back would resurrect the killed VM.
-  const shouldAutoStart =
-    !!taskId &&
-    !!virtualMcpId &&
-    !!userId &&
-    !!branch &&
-    !vmEntry &&
-    !userStopped &&
-    !startVm.isPending &&
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-    autoStartedForTaskRef.current !== taskId;
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect — bridges external state (vmEntry derived from query cache, taskId from router) into a one-shot mutation; no render-time equivalent
-  useEffect(() => {
-    if (!shouldAutoStart || !taskId) return;
-    autoStartedForTaskRef.current = taskId;
-    triggerStartRef.current("auto-start");
-  }, [shouldAutoStart, taskId, userStopped]);
-
-  // Self-heal stale sandboxMap entries (SSE 404 → notFound). Dedup by dead handle.
-  const deadVmId = vmEvents.notFound ? (vmEntry?.sandboxHandle ?? null) : null;
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect — one-shot reprovision trigger gated on the notFound→deadVmId derivation
-  useEffect(() => {
-    if (!deadVmId || !virtualMcpId) return;
-    if (startVm.isPending) return;
-    if (reprovisionedForVmIdRef.current === deadVmId) return;
-    // Don't self-heal a VM the user explicitly stopped: the SSE "gone" event
-    // can arrive before the sandboxMap query refetch clears the stale entry.
-    if (branch && sandboxUserStop.isStopped(virtualMcpId, branch)) return;
-    reprovisionedForVmIdRef.current = deadVmId;
-    triggerStartRef.current("self-heal");
-  }, [deadVmId, virtualMcpId, startVm.isPending, branch]);
-
-  const retryAutoStart = () => {
-    autoStartedForTaskRef.current = null;
-    reprovisionedForVmIdRef.current = null;
-    startVm.reset();
-    triggerStartRef.current("auto-start");
-  };
-
   // Drawer state — open + height live here so state cards (Task 9) and the
   // "View logs" buttons can request the drawer to open.
-  const queryClient = useQueryClient();
   const drawerStorageKey = virtualMcpId ?? "__no-vmcp__";
   // `null` = not yet hydrated for this VM. We hydrate (and re-hydrate on
   // VM switch) via a render-time setState gated by `lastHydratedKeyRef`,
@@ -397,44 +282,6 @@ export function PreviewContent() {
     setDrawerOpen(next);
     writePersistedDrawerOpen(drawerStorageKey, next);
   };
-
-  // Stop / restart. SANDBOX_DELETE is best-effort; the sandboxMap query refetch is
-  // what actually flips the UI to idle. SANDBOX_DELETE requires the kind because
-  // sandboxMap is keyed by (user, branch, kind); we delete whichever sibling the
-  // preview surface is currently displaying.
-  const handleStop = async () => {
-    if (!virtualMcpId) return;
-    const branchToStop = branch;
-    if (!branchToStop) return;
-    const kindToStop = vmEntry?.sandboxProviderKind;
-    if (!kindToStop) return;
-    sandboxUserStop.mark(virtualMcpId, branchToStop);
-    try {
-      await mcpClient.callTool({
-        name: "SANDBOX_DELETE",
-        arguments: {
-          virtualMcpId,
-          branch: branchToStop,
-          sandboxProviderKind: kindToStop,
-        },
-      });
-    } catch {
-      // Best effort
-    }
-    invalidateVirtualMcpQueries(queryClient);
-  };
-
-  const handleRestart = async () => {
-    await handleStop();
-    triggerStartRef.current("auto-start");
-  };
-
-  // Slated for removal in Task 5 alongside the local auto-start/self-heal
-  // effects. JSX prop wires now route through `lifecycle.*`; suppress
-  // TS6133 (unused-locals) until the next commit deletes them.
-  void handleRestart;
-  void retryAutoStart;
-  void drawerStatusFromPreview;
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — DOM event subscription
   useEffect(() => {

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -6,8 +6,8 @@ import {
   useMCPClient,
   useProjectContext,
   SELF_MCP_ALIAS_ID,
-  parseBranchMap,
 } from "@decocms/mesh-sdk";
+import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 
 import {
   ChevronDown,
@@ -74,7 +74,7 @@ import {
   sandboxUserStop,
   type SandboxStartArgs,
 } from "../hooks/use-sandbox-start";
-import { computePreviewState, type PreviewState } from "./preview-state";
+import type { PreviewState } from "./preview-state";
 import { SandboxStateCard } from "./state-card";
 import { derivePhaseProgress } from "./derive-phase-progress";
 import {
@@ -153,27 +153,15 @@ export function PreviewContent() {
   // Current iframe path (for sections editor)
   const [currentPath, setCurrentPath] = useState("/");
 
-  // sandboxMap[userId][branch][sandboxProviderKind] -> { sandboxHandle, previewUrl, ... }
-  // Use parseBranchMap to handle both legacy 2-level and current 3-level shapes.
-  // For the preview surface we pick the first non-desktop entry (cloud VMs
-  // have an accessible previewUrl), falling back to the first entry of any kind.
-  // There is typically only one entry per branch in normal usage.
   const userId = session?.user?.id;
-  const metadata = inset?.entity?.metadata;
-  const branchMap =
-    userId && branch
-      ? parseBranchMap(metadata?.sandboxMap?.[userId]?.[branch])
-      : {};
-  const branchMapEntries = Object.values(branchMap);
-  const vmEntry =
-    branchMapEntries.find((e) => e.sandboxProviderKind !== "user-desktop") ??
-    branchMapEntries[0];
-  const previewUrl = vmEntry?.previewUrl ?? null;
 
   const virtualMcpId = inset?.entity?.id ?? null;
   const { org } = useProjectContext();
 
   const vmEvents = useSandboxEvents();
+  const lifecycle = useSandboxLifecycle();
+  const vmEntry = lifecycle.vmEntry;
+  const previewUrl = lifecycle.previewUrl;
   const lifecyclePhase = vmEvents.lifecycle.phase;
   const devServerReady = lifecyclePhase === "running";
 
@@ -255,16 +243,8 @@ export function PreviewContent() {
     lifecycle: vmEvents.lifecycle,
   });
 
-  const userStopped =
-    !!virtualMcpId &&
-    !!branch &&
-    sandboxUserStop.isStopped(virtualMcpId, branch);
-
-  const previewState = computePreviewState({
-    previewUrl,
-    appPaused,
-    userStopped,
-  });
+  const previewState = lifecycle.previewState;
+  const userStopped = lifecycle.userStopped;
 
   const iframeSrc =
     previewState.kind === "iframe"
@@ -448,6 +428,13 @@ export function PreviewContent() {
     await handleStop();
     triggerStartRef.current("auto-start");
   };
+
+  // Slated for removal in Task 5 alongside the local auto-start/self-heal
+  // effects. JSX prop wires now route through `lifecycle.*`; suppress
+  // TS6133 (unused-locals) until the next commit deletes them.
+  void handleRestart;
+  void retryAutoStart;
+  void drawerStatusFromPreview;
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — DOM event subscription
   useEffect(() => {
@@ -1020,7 +1007,7 @@ export function PreviewContent() {
 
           {previewState.kind === "suspended" && (
             <div className="absolute inset-0 z-30">
-              <SandboxStateCard kind="suspended" onResume={retryAutoStart} />
+              <SandboxStateCard kind="suspended" onResume={lifecycle.resume} />
             </div>
           )}
 
@@ -1121,15 +1108,15 @@ export function PreviewContent() {
         orgSlug={org.slug}
         virtualMcpId={virtualMcpId}
         branch={branch}
-        status={drawerStatusFromPreview(previewState)}
+        status={lifecycle.status}
         scripts={vmEvents.scripts}
         open={drawerOpenEffective}
         onOpenChange={handleDrawerOpenChange}
-        onStart={() => triggerStart("auto-start")}
-        onStop={handleStop}
-        onRestart={handleRestart}
-        onResume={retryAutoStart}
-        onRetry={retryAutoStart}
+        onStart={lifecycle.start}
+        onStop={lifecycle.stop}
+        onRestart={lifecycle.restart}
+        onResume={lifecycle.resume}
+        onRetry={lifecycle.retry}
       />
       <CreatePageModal
         open={createPageDialogOpen}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -66,11 +66,6 @@ import {
 } from "../hooks/use-sandbox-events";
 import { SandboxStateCard } from "./state-card";
 import { derivePhaseProgress } from "./derive-phase-progress";
-import {
-  PreviewDrawer,
-  readPersistedDrawerOpen,
-  writePersistedDrawerOpen,
-} from "./drawer/drawer";
 import { track } from "@/web/lib/posthog-client";
 
 const SectionsEditor = lazy(() =>
@@ -250,38 +245,6 @@ export function PreviewContent() {
     (viewMode === "visual" || viewMode === "cms")
       ? "preview"
       : viewMode;
-
-  // Drawer state — open + height live here so state cards (Task 9) and the
-  // "View logs" buttons can request the drawer to open.
-  const drawerStorageKey = virtualMcpId ?? "__no-vmcp__";
-  // `null` = not yet hydrated for this VM. We hydrate (and re-hydrate on
-  // VM switch) via a render-time setState gated by `lastHydratedKeyRef`,
-  // so the stored value always tracks the *current* `drawerStorageKey`.
-  // Without this, `useState`'s init callback would freeze the initial
-  // key — if `virtualMcpId` was undefined at mount, the state would
-  // forever reflect the `__no-vmcp__` slot. React bails on equal state,
-  // and this is the idiomatic "derive state from a prop change" pattern
-  // in this codebase (useEffect is banned for this).
-  const [drawerOpen, setDrawerOpen] = useState<boolean | null>(null);
-  const lastHydratedKeyRef = useRef<string | null>(null);
-  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-  if (lastHydratedKeyRef.current !== drawerStorageKey) {
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-    lastHydratedKeyRef.current = drawerStorageKey;
-    setDrawerOpen(readPersistedDrawerOpen(drawerStorageKey));
-  }
-  // Collapse to toolbar-only while the sandbox is still booting. Persisted
-  // preference is untouched so the drawer restores to the user's last
-  // open/closed state once the sandbox boots. `null` (pre-hydration) is
-  // treated as closed so the drawer doesn't flash open before the right
-  // key's value is read.
-  const drawerOpenEffective =
-    previewState.kind === "starting" ? false : (drawerOpen ?? false);
-
-  const handleDrawerOpenChange = (next: boolean) => {
-    setDrawerOpen(next);
-    writePersistedDrawerOpen(drawerStorageKey, next);
-  };
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — DOM event subscription
   useEffect(() => {
@@ -946,25 +909,6 @@ export function PreviewContent() {
           )}
         </div>
       </div>
-      <PreviewDrawer
-        // key forces a fresh drawer on each new VM so per-tab state
-        // (active tab, scriptTabs, killingScripts, the auto-open ref)
-        // resets cleanly without per-state reset plumbing.
-        key={vmEntry?.sandboxHandle ?? "no-vm"}
-        vmId={vmEntry?.sandboxHandle ?? null}
-        orgSlug={org.slug}
-        virtualMcpId={virtualMcpId}
-        branch={branch}
-        status={lifecycle.status}
-        scripts={vmEvents.scripts}
-        open={drawerOpenEffective}
-        onOpenChange={handleDrawerOpenChange}
-        onStart={lifecycle.start}
-        onStop={lifecycle.stop}
-        onRestart={lifecycle.restart}
-        onResume={lifecycle.resume}
-        onRetry={lifecycle.retry}
-      />
       <CreatePageModal
         open={createPageDialogOpen}
         onOpenChange={setCreatePageDialogOpen}

--- a/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
@@ -22,7 +22,6 @@ import { useChatPanelWidth } from "@/web/hooks/use-chat-panel-width";
 import { computeChatMainSizes } from "@/web/hooks/use-layout-state";
 import { ChatCenterPanel } from "@/web/layouts/chat-center-panel";
 import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
-import { ErrorBoundary } from "@/web/components/error-boundary";
 
 function PersistentChatPanel({
   children,
@@ -138,9 +137,7 @@ export function ChatMainPanelGroup({
             )}
           >
             <div className="flex-1 min-h-0 overflow-hidden">
-              <ErrorBoundary>
-                <MainPanelContent taskId={taskId} virtualMcpId={virtualMcpId} />
-              </ErrorBoundary>
+              <MainPanelContent taskId={taskId} virtualMcpId={virtualMcpId} />
             </div>
           </div>
         </div>

--- a/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
@@ -21,7 +21,7 @@ import {
 import { useChatPanelWidth } from "@/web/hooks/use-chat-panel-width";
 import { computeChatMainSizes } from "@/web/hooks/use-layout-state";
 import { ChatCenterPanel } from "@/web/layouts/chat-center-panel";
-import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
+import { MainPanelWithDrawer } from "@/web/layouts/main-panel-tabs/main-panel-with-drawer";
 
 function PersistentChatPanel({
   children,
@@ -137,7 +137,10 @@ export function ChatMainPanelGroup({
             )}
           >
             <div className="flex-1 min-h-0 overflow-hidden">
-              <MainPanelContent taskId={taskId} virtualMcpId={virtualMcpId} />
+              <MainPanelWithDrawer
+                taskId={taskId}
+                virtualMcpId={virtualMcpId}
+              />
             </div>
           </div>
         </div>

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -22,8 +22,9 @@
  *
  * Mobile layout:
  *   Chat.Provider
- *   └── Chat.ActiveTaskProvider
- *       └── MainPanelContent OR ActiveTaskBoundary (sheet-based)
+ *   └── VmEventsBridge
+ *       └── Chat.ActiveTaskProvider
+ *           └── MainPanelWithDrawer OR ActiveTaskBoundary (sheet-based)
  */
 
 import {
@@ -209,7 +210,6 @@ function VmEventsBridge({
   sandboxMap: SandboxMap | undefined;
   children: ReactNode;
 }) {
-  const { org } = useProjectContext();
   const { currentBranch } = useChatTask();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
@@ -242,7 +242,6 @@ function VmEventsBridge({
         userId={userId ?? null}
         hasActiveGithubRepo={hasActiveGithubRepo}
         sandboxMap={sandboxMap}
-        orgId={org.id}
       >
         {children}
       </SandboxLifecycleProvider>

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -191,11 +191,11 @@ function MobileToolbar({
 }
 
 // ---------------------------------------------------------------------------
-// VmEventsBridge — passes (virtualMcpId, branch) to the unified VM events
-// SSE provider and runs auto-start. Lives inside Chat.Provider so it can
-// read useChatTask, which keeps the SSE connection in sync with the active
-// task as the user navigates between tasks (different tasks may pin
-// different branches).
+// VmEventsBridge — thin branch resolver. Derives (branch, shouldConnect) and
+// mounts SandboxEventsProvider + SandboxLifecycleProvider. Lives inside
+// Chat.Provider so it can read useChatTask, which keeps the SSE connection
+// and the lifecycle provider in sync with the active task as the user
+// navigates between tasks (different tasks may pin different branches).
 // ---------------------------------------------------------------------------
 
 function VmEventsBridge({

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -69,8 +69,8 @@ import { getActiveGithubRepo } from "@/web/lib/github-repo";
 import { Toolbar } from "./toolbar";
 import { ChatMainPanelGroup } from "./chat-main-panel-group";
 import { ToggleButtons } from "./toggle-buttons";
-import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
 import { MainPanelTabsBar } from "@/web/layouts/main-panel-tabs/main-panel-tabs-bar";
+import { MainPanelWithDrawer } from "@/web/layouts/main-panel-tabs/main-panel-with-drawer";
 import { VirtualMcpHeaderInfo } from "../../views/virtual-mcp/header-info.tsx";
 import { SandboxEventsProvider } from "@/web/components/sandbox/hooks/sandbox-events-context.tsx";
 import { SandboxLifecycleProvider } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
@@ -455,7 +455,7 @@ function AgentInsetProvider() {
                             </div>
                           }
                         >
-                          <MainPanelContent
+                          <MainPanelWithDrawer
                             taskId={layout.taskId}
                             virtualMcpId={chatVirtualMcpId}
                           />

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -78,6 +78,7 @@ import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
 import { MainPanelTabsBar } from "@/web/layouts/main-panel-tabs/main-panel-tabs-bar";
 import { VirtualMcpHeaderInfo } from "../../views/virtual-mcp/header-info.tsx";
 import { SandboxEventsProvider } from "@/web/components/sandbox/hooks/sandbox-events-context.tsx";
+import { SandboxLifecycleProvider } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 import { useEnsureTask } from "@/web/hooks/use-ensure-task";
 
 // ---------------------------------------------------------------------------
@@ -289,7 +290,16 @@ function VmEventsBridge({
       branch={currentBranch ?? null}
       enabled={shouldConnect}
     >
-      {children}
+      <SandboxLifecycleProvider
+        virtualMcpId={virtualMcpId}
+        branch={currentBranch ?? null}
+        userId={userId ?? null}
+        hasActiveGithubRepo={hasActiveGithubRepo}
+        sandboxMap={sandboxMap}
+        orgId={org.id}
+      >
+        {children}
+      </SandboxLifecycleProvider>
     </SandboxEventsProvider>
   );
 }

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -53,18 +53,13 @@ import {
 import { cn } from "@deco/ui/lib/utils.js";
 import {
   getWellKnownDecopilotVirtualMCP,
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
   useProjectContext,
   useVirtualMCP,
   parseBranchMap,
 } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity, SandboxMap } from "@decocms/mesh-sdk/types";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import {
-  useSandboxStart,
-  useIsSandboxStartPending,
-} from "@/web/components/sandbox/hooks/use-sandbox-start";
+import { useIsSandboxStartPending } from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { useStatusSounds } from "../../hooks/use-status-sounds";
 import { authClient } from "@/web/lib/auth-client";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -219,61 +214,12 @@ function VmEventsBridge({
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
-  // Auto-start the VM when the active task points at a branch without any
-  // registered sandboxMap entry (regardless of kind). Routed through useSandboxStart so
-  // concurrent mounts (preview, env, this bridge) for the same
-  // (virtualMcpId, branch) collapse onto one in-flight upstream call.
-  // The server's resolveDefaultSandboxProviderKind decides the kind when
-  // sandboxProviderKind is omitted — this is intentional for implicit auto-start.
-  const autoStartClient = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
-  const { mutate: triggerAutoStart } = useSandboxStart(autoStartClient);
-  // Attempt at most one auto-start per (branch, mount). A user SANDBOX_DELETE
-  // removes the sandboxMap entry — without a permanent guard the effect would
-  // re-fire and resurrect the sandbox the user just stopped.
-  const autoStartAttemptedRef = useRef<Set<string>>(new Set());
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect — fires SANDBOX_START when sandboxMap is missing an entry for (user, branch); ref guard dedupes within this mount, module-level map dedupes across components
-  useEffect(() => {
-    if (!hasActiveGithubRepo) return;
-    if (!userId) return;
-    if (!currentBranch) return;
-    // Use parseBranchMap to handle both legacy 2-level and current 3-level shapes.
-    // If any entry exists for this (user, branch) — regardless of kind — a VM is
-    // already running; don't auto-start.
-    const branchMap = parseBranchMap(sandboxMap?.[userId]?.[currentBranch]);
-    if (Object.keys(branchMap).length > 0) {
-      // VM is already running — record the branch so a user stop won't
-      // re-trigger auto-start within this mount.
-      autoStartAttemptedRef.current.add(currentBranch);
-      return;
-    }
-    if (autoStartAttemptedRef.current.has(currentBranch)) return;
-    autoStartAttemptedRef.current.add(currentBranch);
-    triggerAutoStart(
-      { virtualMcpId, branch: currentBranch },
-      {
-        onError: (err) => {
-          console.error("[auto-start-vm] failed:", err);
-        },
-      },
-    );
-  }, [
-    hasActiveGithubRepo,
-    userId,
-    currentBranch,
-    sandboxMap,
-    virtualMcpId,
-    triggerAutoStart,
-  ]);
-
   // Open the events stream only when a sandbox actually exists or a start is
   // in flight — NOT merely because the agent has a GitHub repo configured.
   // Gate instead on a registered sandboxMap entry, or an in-flight
-  // SANDBOX_START (covers the booting window; the auto-start above shares this
-  // mutation key, so `useIsSandboxStartPending` observes it).
+  // SANDBOX_START (covers the booting window; SandboxLifecycleProvider's
+  // auto-start shares this mutation key, so `useIsSandboxStartPending`
+  // observes it).
   const isStartPending = useIsSandboxStartPending(
     virtualMcpId,
     currentBranch ?? undefined,

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -23,6 +23,7 @@ import {
   parsePinnedViewTabId,
   parseWebPageTabId,
 } from "./tab-id";
+import { ErrorBoundary } from "@/web/components/error-boundary";
 
 const AppViewContent = lazy(() =>
   import("@/web/routes/project-app-view").then((m) => ({
@@ -30,19 +31,21 @@ const AppViewContent = lazy(() =>
   })),
 );
 
-export function MainPanelContent({
-  taskId,
+function TabBody({
+  activeTab,
   virtualMcpId,
+  layoutTabs,
+  expandedTools,
+  automationTabParsed,
 }: {
-  taskId: string;
+  activeTab: string;
   virtualMcpId: string;
+  layoutTabs: ReturnType<typeof useMainPanelTabs>["layoutTabs"];
+  expandedTools: ReturnType<typeof useMainPanelTabs>["expandedTools"];
+  automationTabParsed: ReturnType<
+    typeof useMainPanelTabs
+  >["automationTabParsed"];
 }) {
-  const { activeTab, layoutTabs, expandedTools, automationTabParsed } =
-    useMainPanelTabs({
-      virtualMcpId,
-      taskId,
-    });
-
   if (isLegacySettingsTab(activeTab)) {
     return <SettingsTab virtualMcpId={virtualMcpId} />;
   }
@@ -119,4 +122,30 @@ export function MainPanelContent({
   }
 
   return <SettingsTab virtualMcpId={virtualMcpId} />;
+}
+
+export function MainPanelContent({
+  taskId,
+  virtualMcpId,
+}: {
+  taskId: string;
+  virtualMcpId: string;
+}) {
+  const { activeTab, layoutTabs, expandedTools, automationTabParsed } =
+    useMainPanelTabs({
+      virtualMcpId,
+      taskId,
+    });
+
+  return (
+    <ErrorBoundary key={activeTab}>
+      <TabBody
+        activeTab={activeTab}
+        virtualMcpId={virtualMcpId}
+        layoutTabs={layoutTabs}
+        expandedTools={expandedTools}
+        automationTabParsed={automationTabParsed}
+      />
+    </ErrorBoundary>
+  );
 }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -46,6 +46,19 @@ function TabBody({
     typeof useMainPanelTabs
   >["automationTabParsed"];
 }) {
+  // Test hook: e2e tests set window.__forceTabError = <activeTab> to deliberately
+  // crash the active tab and exercise the ErrorBoundary recovery flow.
+  // Dev-only — the guard ensures this code path is dead-stripped in production
+  // builds (Vite tree-shakes blocks guarded by `import.meta.env.DEV`).
+  if (
+    import.meta.env.DEV &&
+    typeof window !== "undefined" &&
+    (window as unknown as { __forceTabError?: string }).__forceTabError ===
+      activeTab
+  ) {
+    throw new Error(`forced tab error: ${activeTab}`);
+  }
+
   if (isLegacySettingsTab(activeTab)) {
     return <SettingsTab virtualMcpId={virtualMcpId} />;
   }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -152,13 +152,24 @@ export function MainPanelContent({
 
   return (
     <ErrorBoundary key={activeTab}>
-      <TabBody
-        activeTab={activeTab}
-        virtualMcpId={virtualMcpId}
-        layoutTabs={layoutTabs}
-        expandedTools={expandedTools}
-        automationTabParsed={automationTabParsed}
-      />
+      <Suspense
+        fallback={
+          <div className="h-full w-full flex items-center justify-center">
+            <Loading01
+              size={20}
+              className="animate-spin text-muted-foreground"
+            />
+          </div>
+        }
+      >
+        <TabBody
+          activeTab={activeTab}
+          virtualMcpId={virtualMcpId}
+          layoutTabs={layoutTabs}
+          expandedTools={expandedTools}
+          automationTabParsed={automationTabParsed}
+        />
+      </Suspense>
     </ErrorBoundary>
   );
 }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx
@@ -1,0 +1,30 @@
+/**
+ * MainPanelWithDrawer — composes the tab body (with its internal per-tab
+ * ErrorBoundary) above the sandbox PreviewDrawer. The drawer is gated on
+ * `hasClonableSource` so non-cloneable agents (e.g. decopilot) don't see it.
+ */
+
+import { useInsetContext } from "@/web/layouts/agent-shell-layout";
+import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
+import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
+import { PreviewDrawerHost } from "./preview-drawer-host";
+
+export function MainPanelWithDrawer({
+  virtualMcpId,
+  taskId,
+}: {
+  virtualMcpId: string;
+  taskId: string;
+}) {
+  const inset = useInsetContext();
+  const hasClonableSource = agentHasClonableSource(inset?.entity?.metadata);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <MainPanelContent taskId={taskId} virtualMcpId={virtualMcpId} />
+      </div>
+      {hasClonableSource && <PreviewDrawerHost />}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
@@ -55,10 +55,12 @@ export function PreviewDrawerHost() {
     setDrawerOpen(readPersisted(storageKey));
   }
 
-  // Force-collapsed while the sandbox is still booting; the persisted
-  // preference restores once preview state leaves "starting".
-  const open =
-    lifecycle.previewState.kind === "starting" ? false : (drawerOpen ?? false);
+  // The drawer's open state is driven entirely by the user's persisted
+  // preference. The setup tab inside renders the daemon's clone+install
+  // log stream as soon as it's available, so expanding the drawer is
+  // valuable even while the sandbox is still booting — don't override
+  // the user's intent.
+  const open = drawerOpen ?? false;
 
   const handleOpenChange = (next: boolean) => {
     setDrawerOpen(next);

--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
@@ -1,0 +1,86 @@
+/**
+ * PreviewDrawerHost — mounts the sandbox PreviewDrawer below the tab body.
+ *
+ * Reads sandbox state + actions from useSandboxLifecycle() and SSE state
+ * from useSandboxEvents(). Owns the persisted drawer-open boolean (per
+ * virtualMcpId, localStorage). Keys the drawer on the current vmId so per-VM
+ * internal state (active tab, scriptTabs, killingScripts) resets cleanly on
+ * VM switch.
+ */
+
+import { useRef, useState } from "react";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useInsetContext } from "@/web/layouts/agent-shell-layout";
+import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
+import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events";
+import { PreviewDrawer } from "@/web/components/sandbox/preview/drawer/drawer";
+
+const STORAGE_KEY = (id: string) => `preview-drawer:${id}`;
+
+function readPersisted(virtualMcpId: string): boolean {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY(virtualMcpId));
+    if (!raw) return false;
+    return !!JSON.parse(raw).open;
+  } catch {
+    return false;
+  }
+}
+
+function writePersisted(virtualMcpId: string, open: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY(virtualMcpId), JSON.stringify({ open }));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function PreviewDrawerHost() {
+  const inset = useInsetContext();
+  const { org } = useProjectContext();
+  const virtualMcpId = inset?.virtualMcpId ?? null;
+  const lifecycle = useSandboxLifecycle();
+  const events = useSandboxEvents();
+
+  // `null` = not yet hydrated for this VM. Render-time setState gated by a ref
+  // re-hydrates when virtualMcpId changes (idiomatic in this codebase;
+  // useEffect is banned for derived state).
+  const storageKey = virtualMcpId ?? "__no-vmcp__";
+  const [drawerOpen, setDrawerOpen] = useState<boolean | null>(null);
+  const lastHydratedKeyRef = useRef<string | null>(null);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- hydrate on VM switch
+  if (lastHydratedKeyRef.current !== storageKey) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- hydrate on VM switch
+    lastHydratedKeyRef.current = storageKey;
+    setDrawerOpen(readPersisted(storageKey));
+  }
+
+  // Force-collapsed while the sandbox is still booting; the persisted
+  // preference restores once preview state leaves "starting".
+  const open =
+    lifecycle.previewState.kind === "starting" ? false : (drawerOpen ?? false);
+
+  const handleOpenChange = (next: boolean) => {
+    setDrawerOpen(next);
+    writePersisted(storageKey, next);
+  };
+
+  return (
+    <PreviewDrawer
+      key={lifecycle.vmEntry?.sandboxHandle ?? "no-vm"}
+      vmId={lifecycle.vmEntry?.sandboxHandle ?? null}
+      orgSlug={org.slug}
+      virtualMcpId={virtualMcpId}
+      branch={lifecycle.branch}
+      status={lifecycle.status}
+      scripts={events.scripts}
+      open={open}
+      onOpenChange={handleOpenChange}
+      onStart={lifecycle.start}
+      onStop={lifecycle.stop}
+      onRestart={lifecycle.restart}
+      onResume={lifecycle.resume}
+      onRetry={lifecycle.retry}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- **Sandbox drawer on every main-panel tab.** Hoists `PreviewDrawer` out of `PreviewContent` into a new `MainPanelWithDrawer` composition layer. Start/Stop/Restart/Resume/Retry and the script terminal are now available from Settings, Git, Content, Automations, and ext-app pinned tabs — desktop and mobile.
- **Tab error boundary recovery.** Moves the `ErrorBoundary` inside `MainPanelContent` and keys it on `activeTab` so switching tabs remounts the boundary in a healthy state. A render error in `ext-apps` (or any tab) no longer bricks the panel; the drawer remains interactive while the errored tab shows its fallback UI.
- **Lifecycle consolidation.** New `SandboxLifecycleProvider` (sibling of `SandboxEventsProvider`) owns the single auto-start, self-heal, and user-driven `start/stop/restart/retry/resume`. `VmEventsBridge` reduces to a thin branch resolver. Auto-start dedup is now branch-keyed (matches `useSandboxStart`'s own dedup); previously it was split across `taskId` (preview) and `branch` (bridge).

See spec at `docs/superpowers/specs/2026-06-03-sandbox-drawer-everywhere-design.md` and plan at `docs/superpowers/plans/2026-06-03-sandbox-drawer-everywhere.md` (both gitignored).

## Test Plan

- [x] `bun run check` (all workspaces) PASS
- [x] `bun run lint` PASS (0 warnings, 0 errors)
- [x] `bun run fmt:check` PASS
- [x] 76 sandbox unit tests pass across 9 files (incl. 21 new pure-helper tests in `sandbox-lifecycle-context.test.ts`)
- [ ] E2E specs run on a stack with Postgres + NATS + Better Auth:
  - `apps/mesh/e2e/tests/sandbox-drawer-everywhere.spec.ts` — drawer visible on both Settings and Preview tabs
  - `apps/mesh/e2e/tests/tab-error-boundary-recovery.spec.ts` — error recovers on tab switch + drawer stays interactive (uses dev-only `window.__forceTabError` hook in `TabBody`)
- [ ] Manual smoke:
  - Drawer open/closed state persists per `virtualMcpId` across tab switches and page reloads
  - `ContentTab`/`GitTab`/`AutomationTab` content doesn't clip when drawer opens at 50% height
  - Switching tasks within the same agent on a different branch fires a fresh auto-start (branch-keyed dedup doesn't block)
  - Non-cloneable agents (e.g. decopilot) see no drawer — gate behaves the same as the old preview-tab gate

## Behavioral changes worth knowing

- Auto-start dedup is now exclusively branch-keyed; switching tasks within the same branch no longer bypasses an explicit user-stop.
- Server-generated branch persistence (`setCurrentTaskBranch(data.branch)` on `SANDBOX_START` success when local branch is null) is preserved in the new provider — see commit `ab999fd`.
- Drawer localStorage key shape unchanged (`preview-drawer:<virtualMcpId>`), so user preferences carry across the rollout.
- Public API of `PreviewDrawer` unchanged.

## Files of interest

- New: `apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx` (+ colocated tests)
- New: `apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx`
- New: `apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx`
- New: `apps/mesh/e2e/tests/sandbox-drawer-everywhere.spec.ts`, `tab-error-boundary-recovery.spec.ts`
- Modified: `apps/mesh/src/web/layouts/agent-shell-layout/index.tsx` (`VmEventsBridge` slim + mobile drawer mount)
- Modified: `apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx` (drops outer ErrorBoundary)
- Modified: `apps/mesh/src/web/layouts/main-panel-tabs/index.tsx` (TabBody extraction + keyed ErrorBoundary + dev-only `__forceTabError` test hook)
- Modified: `apps/mesh/src/web/components/sandbox/preview/preview.tsx` (loses ~150 lines of lifecycle/drawer machinery)
- Modified: `apps/mesh/src/web/components/sandbox/preview/drawer/drawer.tsx` (persistence helpers removed; consumed only by the new host)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the sandbox drawer below every main‑panel tab and makes tab errors recover on switch. Also fixes drawer open behavior while starting and adds a per‑tab loading spinner.

- **New Features**
  - Drawer mounted via `MainPanelWithDrawer`; shown only for clonable agents; open state persists per `virtualMcpId`.
  - ErrorBoundary is keyed by the active tab, so switching tabs recovers from a render error; the drawer stays interactive.
  - E2E coverage for drawer visibility across tabs and error‑recovery behavior.

- **Refactors & Fixes**
  - Introduced `SandboxLifecycleProvider` to own auto‑start, self‑heal, and Start/Stop/Restart/Retry/Resume; auto‑start dedup is branch‑keyed. Server‑picked branch is persisted on self‑heal and user start.
  - `VmEventsBridge` reduced to a branch resolver; `PreviewContent` drops lifecycle and drawer management; `PreviewDrawer` API unchanged.
  - Removed redundant `orgId` prop and updated the mobile layout; drawer renders on mobile too. Dropped unused `SandboxLifecycleContext` export.
  - Drawer no longer auto‑collapses while the sandbox is starting; the user’s open/closed preference is respected so setup/logs are visible pre‑boot.
  - Wrapped the tab body in `Suspense` inside `MainPanelContent` to show a per‑tab spinner and avoid replacing the whole panel with the chat skeleton on tab suspend.

<sup>Written for commit ee508a2d692775321b46d928274301157a82b48f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

