### PR TITLE
fix(tests/resilience): persist daemon session before connect

### DIFF
--- a/tests/resilience/link-daemon-entrypoint.ts
+++ b/tests/resilience/link-daemon-entrypoint.ts
@@ -4,9 +4,17 @@
  * Runs inside the `link-daemon` container. Authenticates with a pre-minted
  * Better Auth API key (injected as DAEMON_API_KEY by the test that mints it),
  * dials studio through the Toxiproxy `studio_ws` proxy (MESH_CLUSTER_URL), and
- * spawns real sandboxes on demand. No OAuth, no session file.
+ * spawns real sandboxes on demand. No OAuth.
+ *
+ * The session is persisted to disk under `DATA_DIR` before the daemon starts.
+ * The daemon resolves the bearer for every (re)connect via `getValidSession`,
+ * which reads `dataDir/session.<host>.json`. Production's `deco link` command
+ * writes this file via `ensureSession` before invoking `startLinkDaemon`; the
+ * resilience harness must mirror that or the first connect fails fatally with
+ * `Session for ${clusterUrl} is no longer valid`.
  */
 import { startLinkDaemon } from "../../apps/mesh/src/link-daemon/index";
+import { writeSession } from "../../apps/mesh/src/cli/lib/session";
 import type { Session } from "../../apps/mesh/src/cli/lib/session";
 
 export function buildDaemonSession(input: {
@@ -37,6 +45,13 @@ async function main(): Promise<void> {
     clusterUrl,
     nowIso: new Date().toISOString(),
   });
+
+  // Persist the API-key session to disk so the daemon's `getAccessToken`
+  // callback (which calls `getValidSession({ dataDir, target })`) finds it on
+  // first connect. Without this, `getValidSession` returns null, the daemon
+  // throws `{ fatal: true }`, and the reconnect loop exits before opening
+  // the WebSocket — see resilience CI failure on commit a83e96e.
+  await writeSession(dataDir, session);
 
   console.log(
     `[resilience-link-daemon] starting; cluster=${clusterUrl} port=${port}`,


### PR DESCRIPTION
## Summary
- Two resilience scenarios fail deterministically on `main` — `sandbox log/event SSE replay` and `sandbox↔studio WS partition` — the only two that actually boot the `link-daemon` container. Latest red run: [#26955365071](https://github.com/decocms/studio/actions/runs/26955365071/job/79531032265).
- Root cause: the link-daemon resolves its bearer on every (re)connect via `getValidSession({ dataDir, target })`, which reads `<dataDir>/session.<host>.json`. The resilience entrypoint built a `Session` in memory only — so `readSession` returned `null`, the `getAccessToken` callback threw `{ fatal: true }`, and the reconnect loop exited on attempt 1 before the WebSocket ever opened. CI shows the smoking gun in the link-daemon logs: `token resolution failed (fatal — stopping reconnect): Session for http://toxiproxy:3010 is no longer valid`.
- Fix: one `writeSession(dataDir, session)` call in `tests/resilience/link-daemon-entrypoint.ts` before `startLinkDaemon`. This matches production's `deco link`, which writes the session via `ensureSession` before invoking `startLinkDaemon`. No production code changes.

## Test plan
- [x] `bun test tests/resilience/link-daemon-entrypoint.test.ts` — `buildDaemonSession` unit tests still pass
- [x] `bun run fmt` — clean
- [ ] `./tests/resilience/run.sh` locally — expected: 23 pass / 1 skip / 0 fail (the existing `daemon reconnects after pod crash` skip is unrelated `test.skip`). Currently running on my box; will update if it surfaces anything new
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the daemon session to disk before starting the `link-daemon` in resilience tests to prevent fatal reconnect failures. This fixes the two CI scenarios that boot the daemon.

- **Bug Fixes**
  - Write the session with `writeSession(dataDir, session)` so `getValidSession` resolves a bearer on first connect.
  - Mirrors `deco link` behavior; no production code changes. Fixes `sandbox log/event SSE replay` and `sandbox↔studio WS partition`.

<sup>Written for commit 11340a8aa7b1f400b6fe61471de4a4d70483d368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

