### PR TITLE
feat(sandbox): blog content editor for posts, authors, and categories

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -34,6 +34,7 @@ import {
   type GitStatusLike,
   suggestCommitMessageWithLlm,
 } from "../../lib/suggest-commit-message";
+import { parseLoaderInvokeRequest } from "@/web/components/sandbox/content/blog/blocks/product-loader-utils";
 
 // ---- Middleware types -------------------------------------------------------
 
@@ -520,6 +521,55 @@ export const createSandboxRoutes = () => {
     let upstream: Response;
     try {
       upstream = await fetch(`${base}${path}`);
+    } catch {
+      return c.json({ error: "Preview unreachable" }, 502);
+    }
+
+    const text = await upstream.text();
+    return new Response(text, {
+      status: upstream.status,
+      headers: {
+        "content-type":
+          upstream.headers.get("content-type") ?? "application/json",
+      },
+    });
+  });
+
+  // -- Preview invoke (loader/action resolution) ------------------------------
+  app.post("/:virtualMcpId/:branch/preview-invoke", async (c) => {
+    const runner = requireRunner(c);
+    if (runner instanceof Response) return runner;
+
+    const { claimName } = c.get("vmClaim");
+    const previewUrl = await runner.getPreviewUrl(claimName);
+    if (!previewUrl) {
+      return c.json({ error: "Preview not available" }, 502);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const invoke = parseLoaderInvokeRequest(body as Record<string, unknown>);
+    if (!invoke) {
+      return c.json({ error: "Missing __resolveType" }, 400);
+    }
+
+    const base = previewUrl.replace(/\/+$/, "");
+    let upstream: Response;
+    try {
+      upstream = await fetch(`${base}/deco/invoke/${invoke.resolveType}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(invoke.payload),
+      });
     } catch {
       return c.json({ error: "Preview unreachable" }, 502);
     }

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -34,7 +34,10 @@ import {
   type GitStatusLike,
   suggestCommitMessageWithLlm,
 } from "../../lib/suggest-commit-message";
-import { parseLoaderInvokeRequest } from "@/web/components/sandbox/content/blog/blocks/product-loader-utils";
+import {
+  buildLoaderInvokeUrl,
+  parseLoaderInvokeRequest,
+} from "../../lib/loader-invoke";
 
 // ---- Middleware types -------------------------------------------------------
 
@@ -68,6 +71,7 @@ function assertSandboxBranchParam(branch: string): void {
 }
 
 const SUGGEST_COMMIT_MAX_BODY_BYTES = 512 * 1024;
+const PREVIEW_INVOKE_MAX_BODY_BYTES = 64 * 1024;
 
 // ---- Shared middleware ------------------------------------------------------
 
@@ -536,53 +540,63 @@ export const createSandboxRoutes = () => {
   });
 
   // -- Preview invoke (loader/action resolution) ------------------------------
-  app.post("/:virtualMcpId/:branch/preview-invoke", async (c) => {
-    const runner = requireRunner(c);
-    if (runner instanceof Response) return runner;
+  app.post(
+    "/:virtualMcpId/:branch/preview-invoke",
+    bodyLimit({
+      maxSize: PREVIEW_INVOKE_MAX_BODY_BYTES,
+      onError: (c) => c.json({ error: "Payload too large" }, 413),
+    }),
+    async (c) => {
+      const runner = requireRunner(c);
+      if (runner instanceof Response) return runner;
 
-    const { claimName } = c.get("vmClaim");
-    const previewUrl = await runner.getPreviewUrl(claimName);
-    if (!previewUrl) {
-      return c.json({ error: "Preview not available" }, 502);
-    }
+      const { claimName } = c.get("vmClaim");
+      const previewUrl = await runner.getPreviewUrl(claimName);
+      if (!previewUrl) {
+        return c.json({ error: "Preview not available" }, 502);
+      }
 
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
+      let body: unknown;
+      try {
+        body = await c.req.json();
+      } catch {
+        return c.json({ error: "Invalid JSON body" }, 400);
+      }
 
-    if (!body || typeof body !== "object" || Array.isArray(body)) {
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
+      if (!body || typeof body !== "object" || Array.isArray(body)) {
+        return c.json({ error: "Invalid JSON body" }, 400);
+      }
 
-    const invoke = parseLoaderInvokeRequest(body as Record<string, unknown>);
-    if (!invoke) {
-      return c.json({ error: "Missing __resolveType" }, 400);
-    }
+      const invoke = parseLoaderInvokeRequest(body as Record<string, unknown>);
+      if (!invoke) {
+        return c.json({ error: "Invalid or missing __resolveType" }, 400);
+      }
 
-    const base = previewUrl.replace(/\/+$/, "");
-    let upstream: Response;
-    try {
-      upstream = await fetch(`${base}/deco/invoke/${invoke.resolveType}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(invoke.payload),
+      let upstream: Response;
+      try {
+        upstream = await fetch(
+          buildLoaderInvokeUrl(previewUrl, invoke.resolveType),
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(invoke.payload),
+            signal: AbortSignal.timeout(30_000),
+          },
+        );
+      } catch {
+        return c.json({ error: "Preview unreachable" }, 502);
+      }
+
+      const text = await upstream.text();
+      return new Response(text, {
+        status: upstream.status,
+        headers: {
+          "content-type":
+            upstream.headers.get("content-type") ?? "application/json",
+        },
       });
-    } catch {
-      return c.json({ error: "Preview unreachable" }, 502);
-    }
-
-    const text = await upstream.text();
-    return new Response(text, {
-      status: upstream.status,
-      headers: {
-        "content-type":
-          upstream.headers.get("content-type") ?? "application/json",
-      },
-    });
-  });
+    },
+  );
 
   return app;
 };

--- a/apps/mesh/src/lib/loader-invoke.ts
+++ b/apps/mesh/src/lib/loader-invoke.ts
@@ -1,0 +1,45 @@
+/** Deco loader/action resolveType — alphanumeric path segments only. */
+const RESOLVE_TYPE_PATTERN = /^[\w./@-]+$/;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function isValidLoaderResolveType(resolveType: string): boolean {
+  if (!resolveType || resolveType.includes("..")) return false;
+  return RESOLVE_TYPE_PATTERN.test(resolveType);
+}
+
+/**
+ * Split a block-ref into the single-invoke target Deco expects:
+ * POST /deco/invoke/<resolveType> with loader props as the JSON body.
+ *
+ * Posting to /deco/invoke without a path key is batch mode and treats each
+ * top-level field as a separate handler name.
+ */
+export function parseLoaderInvokeRequest(body: Record<string, unknown>): {
+  resolveType: string;
+  payload: Record<string, unknown>;
+} | null {
+  const resolveType =
+    typeof body.__resolveType === "string" ? body.__resolveType : null;
+  if (!resolveType || !isValidLoaderResolveType(resolveType)) return null;
+
+  const props = asRecord(body.props);
+  if (props) {
+    return { resolveType, payload: { props } };
+  }
+
+  const { __resolveType: _, ...rest } = body;
+  return { resolveType, payload: rest };
+}
+
+export function buildLoaderInvokeUrl(
+  previewBaseUrl: string,
+  resolveType: string,
+): string {
+  const base = previewBaseUrl.replace(/\/+$/, "");
+  return `${base}/deco/invoke/${encodeURIComponent(resolveType)}`;
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/block-picker.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/block-picker.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { Plus } from "@untitledui/icons";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@deco/ui/components/command.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import type { BlogBlockType } from "./blog-data";
+
+/**
+ * The WordPress-style "insert here" affordance: a thin hover zone with a
+ * centered ⊕ that opens a searchable block-type picker and inserts at
+ * this position. Always visible (not just on hover) when `alwaysShow`.
+ */
+export function InsertBlockDivider({
+  blockTypes,
+  onInsert,
+  alwaysShow = false,
+}: {
+  blockTypes: BlogBlockType[];
+  onInsert: (resolveType: string) => void;
+  alwaysShow?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        "group/insert relative flex h-6 items-center justify-center",
+        alwaysShow ? "h-10" : "",
+      )}
+    >
+      <div
+        className={cn(
+          "absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border transition-opacity",
+          open || alwaysShow
+            ? "opacity-100"
+            : "opacity-0 group-hover/insert:opacity-100",
+        )}
+      />
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label="Insert block"
+            className={cn(
+              "relative z-10 flex h-6 w-6 items-center justify-center rounded-full border bg-background text-muted-foreground transition-all hover:border-primary hover:text-primary cursor-pointer",
+              open || alwaysShow
+                ? "opacity-100"
+                : "opacity-0 group-hover/insert:opacity-100",
+            )}
+          >
+            <Plus size={14} />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64 p-0" align="center">
+          <Command>
+            <CommandInput placeholder="Search blocks…" />
+            <CommandList>
+              <CommandEmpty>No blocks found.</CommandEmpty>
+              <CommandGroup>
+                {blockTypes.map((type) => (
+                  <CommandItem
+                    key={type.resolveType}
+                    value={`${type.title} ${type.resolveType}`}
+                    onSelect={() => {
+                      onInsert(type.resolveType);
+                      setOpen(false);
+                    }}
+                    className="flex flex-col items-start gap-0.5"
+                  >
+                    <span className="text-sm font-medium">{type.title}</span>
+                    {type.description && (
+                      <span className="line-clamp-1 text-xs text-muted-foreground">
+                        {type.description}
+                      </span>
+                    )}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-registry.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-registry.tsx
@@ -21,7 +21,7 @@ import {
   StepsBlock,
 } from "./list-blocks";
 import { ProductCardBlock, ProductShelfBlock } from "./product-blocks";
-import { blockComponentName } from "../blog-data";
+import { blockComponentName, isBlogPostBlockResolveType } from "../blog-data";
 import { str } from "./primitives";
 
 export type RawBlock = { __resolveType?: string } & Record<string, unknown>;
@@ -43,148 +43,154 @@ export function BlockEditor({
 }) {
   const resolveType = block.__resolveType ?? "";
   const componentName = blockComponentName(resolveType);
+  const bespoke = isBlogPostBlockResolveType(resolveType);
 
-  switch (componentName) {
-    case "Paragraph":
-      return (
-        <RichTextBlock
-          html={str(block.html)}
-          placeholder="Write something…"
-          onChange={(html) => onChange({ ...block, html })}
-        />
-      );
-    case "Heading":
-      return (
-        <HeadingBlock
-          text={str(block.text)}
-          level={str(block.level)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "Quote":
-      return (
-        <QuoteBlock
-          quote={str(block.quote)}
-          onChange={(quote) => onChange({ ...block, quote })}
-        />
-      );
-    case "Code":
-      return (
-        <CodeBlock
-          code={str(block.code)}
-          language={str(block.language)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "List":
-      return (
-        <ListBlock
-          items={str(block.items)}
-          style={str(block.style)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "BlockImage":
-      return <BlockImageBlock block={block} onChange={onChange} />;
-    case "Video":
-      return (
-        <VideoBlock
-          url={str(block.url)}
-          caption={str(block.caption)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "Divider":
-      return <DividerBlock />;
-    case "Cta":
-      return (
-        <CtaBlock
-          text={str(block.text)}
-          href={str(block.href)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "Callout":
-      return (
-        <CalloutBlock
-          title={str(block.title)}
-          body={str(block.body)}
-          variant={str(block.variant)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "Stat":
-      return (
-        <StatBlock
-          value={str(block.value)}
-          label={str(block.label)}
-          description={str(block.description)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "StatGroup":
-      return (
-        <StatGroupBlock
-          stats={str(block.stats)}
-          onChange={(stats) => onChange({ ...block, stats })}
-        />
-      );
-    case "CardGroup":
-      return (
-        <CardGroupBlock
-          cards={
-            typeof block.cards === "string"
-              ? block.cards
-              : JSON.stringify(block.cards ?? [])
-          }
-          onChange={(cards) => onChange({ ...block, cards })}
-        />
-      );
-    case "Checklist":
-      return (
-        <ChecklistBlock
-          title={str(block.title)}
-          items={str(block.items)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "Steps":
-      return (
-        <StepsBlock
-          title={str(block.title)}
-          steps={str(block.steps)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "Comparison":
-      return (
-        <ComparisonBlock
-          left={str(block.left)}
-          right={str(block.right)}
-          onChange={(next) => onChange({ ...block, ...next })}
-        />
-      );
-    case "ProductCard":
-      return <ProductCardBlock block={block} onChange={onChange} />;
-    case "ProductShelf":
-      return <ProductShelfBlock block={block} onChange={onChange} />;
-    default: {
-      const schema = resolveType ? resolveSchema(resolveType, meta) : null;
-      if (!schema) {
+  if (bespoke) {
+    switch (componentName) {
+      case "Paragraph":
         return (
-          <p className="text-xs text-muted-foreground">
-            Unknown block type{resolveType ? ` (${resolveType})` : ""}.
-          </p>
+          <RichTextBlock
+            html={str(block.html)}
+            placeholder="Write something…"
+            onChange={(html) => onChange({ ...block, html })}
+          />
         );
-      }
+      case "Heading":
+        return (
+          <HeadingBlock
+            text={str(block.text)}
+            level={str(block.level)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "Quote":
+        return (
+          <QuoteBlock
+            quote={str(block.quote)}
+            onChange={(quote) => onChange({ ...block, quote })}
+          />
+        );
+      case "Code":
+        return (
+          <CodeBlock
+            code={str(block.code)}
+            language={str(block.language)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "List":
+        return (
+          <ListBlock
+            items={str(block.items)}
+            style={str(block.style)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "BlockImage":
+        return <BlockImageBlock block={block} onChange={onChange} />;
+      case "Video":
+        return (
+          <VideoBlock
+            url={str(block.url)}
+            caption={str(block.caption)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "Divider":
+        return <DividerBlock />;
+      case "Cta":
+        return (
+          <CtaBlock
+            text={str(block.text)}
+            href={str(block.href)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "Callout":
+        return (
+          <CalloutBlock
+            title={str(block.title)}
+            body={str(block.body)}
+            variant={str(block.variant)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "Stat":
+        return (
+          <StatBlock
+            value={str(block.value)}
+            label={str(block.label)}
+            description={str(block.description)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "StatGroup":
+        return (
+          <StatGroupBlock
+            stats={str(block.stats)}
+            onChange={(stats) => onChange({ ...block, stats })}
+          />
+        );
+      case "CardGroup":
+        return (
+          <CardGroupBlock
+            cards={
+              typeof block.cards === "string"
+                ? block.cards
+                : JSON.stringify(block.cards ?? [])
+            }
+            onChange={(cards) => onChange({ ...block, cards })}
+          />
+        );
+      case "Checklist":
+        return (
+          <ChecklistBlock
+            title={str(block.title)}
+            items={str(block.items)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "Steps":
+        return (
+          <StepsBlock
+            title={str(block.title)}
+            steps={str(block.steps)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "Comparison":
+        return (
+          <ComparisonBlock
+            left={str(block.left)}
+            right={str(block.right)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "ProductCard":
+        return <ProductCardBlock block={block} onChange={onChange} />;
+      case "ProductShelf":
+        return <ProductShelfBlock block={block} onChange={onChange} />;
+      default:
+        break;
+    }
+  }
+
+  {
+    const schema = resolveType ? resolveSchema(resolveType, meta) : null;
+    if (!schema) {
       return (
-        <SchemaForm
-          schema={schema}
-          value={block}
-          onChange={(v) => onChange(v as RawBlock)}
-          basePath=""
-        />
+        <p className="text-xs text-muted-foreground">
+          Unknown block type{resolveType ? ` (${resolveType})` : ""}.
+        </p>
       );
     }
+    return (
+      <SchemaForm
+        schema={schema}
+        value={block}
+        onChange={(v) => onChange(v as RawBlock)}
+        basePath=""
+      />
+    );
   }
 }

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-registry.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-registry.tsx
@@ -1,0 +1,182 @@
+import { SchemaForm } from "@/web/components/sections-editor/schema-form";
+import {
+  resolveSchema,
+  type LiveMeta,
+} from "@/web/components/sections-editor/resolve-schema";
+import { RichTextBlock } from "./rich-text-block";
+import { CodeBlock, HeadingBlock, ListBlock, QuoteBlock } from "./plain-blocks";
+import {
+  BlockImageBlock,
+  CalloutBlock,
+  CtaBlock,
+  DividerBlock,
+  StatBlock,
+  VideoBlock,
+} from "./media-blocks";
+import {
+  CardGroupBlock,
+  ChecklistBlock,
+  ComparisonBlock,
+  StatGroupBlock,
+  StepsBlock,
+} from "./list-blocks";
+import { str } from "./primitives";
+
+export type RawBlock = { __resolveType?: string } & Record<string, unknown>;
+
+/**
+ * Render a single block as its native, inline-editable representation
+ * (Notion-style). Common blocks get bespoke editors; anything else falls
+ * back to the schema-driven form so it stays editable.
+ */
+export function BlockEditor({
+  block,
+  meta,
+  onChange,
+}: {
+  block: RawBlock;
+  meta: LiveMeta;
+  onChange: (next: RawBlock) => void;
+}) {
+  const resolveType = block.__resolveType ?? "";
+
+  switch (resolveType) {
+    case "blog/sections/blocks/Paragraph.tsx":
+      return (
+        <RichTextBlock
+          html={str(block.html)}
+          placeholder="Write something…"
+          onChange={(html) => onChange({ ...block, html })}
+        />
+      );
+    case "blog/sections/blocks/Heading.tsx":
+      return (
+        <HeadingBlock
+          text={str(block.text)}
+          level={str(block.level)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    case "blog/sections/blocks/Quote.tsx":
+      return (
+        <QuoteBlock
+          quote={str(block.quote)}
+          onChange={(quote) => onChange({ ...block, quote })}
+        />
+      );
+    case "blog/sections/blocks/Code.tsx":
+      return (
+        <CodeBlock
+          code={str(block.code)}
+          language={str(block.language)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    case "blog/sections/blocks/List.tsx":
+      return (
+        <ListBlock
+          items={str(block.items)}
+          style={str(block.style)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    case "blog/sections/blocks/BlockImage.tsx":
+      return <BlockImageBlock block={block} onChange={onChange} />;
+    case "blog/sections/blocks/Video.tsx":
+      return (
+        <VideoBlock
+          url={str(block.url)}
+          caption={str(block.caption)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    case "blog/sections/blocks/Divider.tsx":
+      return <DividerBlock />;
+    case "blog/sections/blocks/Cta.tsx":
+      return (
+        <CtaBlock
+          text={str(block.text)}
+          href={str(block.href)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    case "blog/sections/blocks/Callout.tsx":
+      return (
+        <CalloutBlock
+          title={str(block.title)}
+          body={str(block.body)}
+          variant={str(block.variant)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    case "blog/sections/blocks/Stat.tsx":
+      return (
+        <StatBlock
+          value={str(block.value)}
+          label={str(block.label)}
+          description={str(block.description)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    case "blog/sections/blocks/StatGroup.tsx":
+      return (
+        <StatGroupBlock
+          stats={str(block.stats)}
+          onChange={(stats) => onChange({ ...block, stats })}
+        />
+      );
+    case "blog/sections/blocks/CardGroup.tsx":
+      return (
+        <CardGroupBlock
+          cards={
+            typeof block.cards === "string"
+              ? block.cards
+              : JSON.stringify(block.cards ?? [])
+          }
+          onChange={(cards) => onChange({ ...block, cards })}
+        />
+      );
+    case "blog/sections/blocks/Checklist.tsx":
+      return (
+        <ChecklistBlock
+          title={str(block.title)}
+          items={str(block.items)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    case "blog/sections/blocks/Steps.tsx":
+      return (
+        <StepsBlock
+          title={str(block.title)}
+          steps={str(block.steps)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    case "blog/sections/blocks/Comparison.tsx":
+      return (
+        <ComparisonBlock
+          left={str(block.left)}
+          right={str(block.right)}
+          onChange={(next) => onChange({ ...block, ...next })}
+        />
+      );
+    default: {
+      const schema = resolveType ? resolveSchema(resolveType, meta) : null;
+      if (!schema) {
+        return (
+          <p className="text-xs text-muted-foreground">
+            Unknown block type{resolveType ? ` (${resolveType})` : ""}.
+          </p>
+        );
+      }
+      return (
+        <SchemaForm
+          schema={schema}
+          value={block}
+          onChange={(v) => onChange(v as RawBlock)}
+          basePath=""
+        />
+      );
+    }
+  }
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-registry.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-registry.tsx
@@ -20,14 +20,17 @@ import {
   StatGroupBlock,
   StepsBlock,
 } from "./list-blocks";
+import { ProductCardBlock, ProductShelfBlock } from "./product-blocks";
+import { blockComponentName } from "../blog-data";
 import { str } from "./primitives";
 
 export type RawBlock = { __resolveType?: string } & Record<string, unknown>;
 
 /**
  * Render a single block as its native, inline-editable representation
- * (Notion-style). Common blocks get bespoke editors; anything else falls
- * back to the schema-driven form so it stays editable.
+ * (Notion-style). Common blocks get bespoke editors matched by component
+ * filename (e.g. Paragraph.tsx), regardless of resolveType path prefix;
+ * anything else falls back to the schema-driven form so it stays editable.
  */
 export function BlockEditor({
   block,
@@ -39,9 +42,10 @@ export function BlockEditor({
   onChange: (next: RawBlock) => void;
 }) {
   const resolveType = block.__resolveType ?? "";
+  const componentName = blockComponentName(resolveType);
 
-  switch (resolveType) {
-    case "blog/sections/blocks/Paragraph.tsx":
+  switch (componentName) {
+    case "Paragraph":
       return (
         <RichTextBlock
           html={str(block.html)}
@@ -49,7 +53,7 @@ export function BlockEditor({
           onChange={(html) => onChange({ ...block, html })}
         />
       );
-    case "blog/sections/blocks/Heading.tsx":
+    case "Heading":
       return (
         <HeadingBlock
           text={str(block.text)}
@@ -57,14 +61,14 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
-    case "blog/sections/blocks/Quote.tsx":
+    case "Quote":
       return (
         <QuoteBlock
           quote={str(block.quote)}
           onChange={(quote) => onChange({ ...block, quote })}
         />
       );
-    case "blog/sections/blocks/Code.tsx":
+    case "Code":
       return (
         <CodeBlock
           code={str(block.code)}
@@ -72,7 +76,7 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
-    case "blog/sections/blocks/List.tsx":
+    case "List":
       return (
         <ListBlock
           items={str(block.items)}
@@ -80,9 +84,9 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
-    case "blog/sections/blocks/BlockImage.tsx":
+    case "BlockImage":
       return <BlockImageBlock block={block} onChange={onChange} />;
-    case "blog/sections/blocks/Video.tsx":
+    case "Video":
       return (
         <VideoBlock
           url={str(block.url)}
@@ -90,9 +94,9 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
-    case "blog/sections/blocks/Divider.tsx":
+    case "Divider":
       return <DividerBlock />;
-    case "blog/sections/blocks/Cta.tsx":
+    case "Cta":
       return (
         <CtaBlock
           text={str(block.text)}
@@ -100,7 +104,7 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
-    case "blog/sections/blocks/Callout.tsx":
+    case "Callout":
       return (
         <CalloutBlock
           title={str(block.title)}
@@ -109,7 +113,7 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
-    case "blog/sections/blocks/Stat.tsx":
+    case "Stat":
       return (
         <StatBlock
           value={str(block.value)}
@@ -118,14 +122,14 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
-    case "blog/sections/blocks/StatGroup.tsx":
+    case "StatGroup":
       return (
         <StatGroupBlock
           stats={str(block.stats)}
           onChange={(stats) => onChange({ ...block, stats })}
         />
       );
-    case "blog/sections/blocks/CardGroup.tsx":
+    case "CardGroup":
       return (
         <CardGroupBlock
           cards={
@@ -136,7 +140,7 @@ export function BlockEditor({
           onChange={(cards) => onChange({ ...block, cards })}
         />
       );
-    case "blog/sections/blocks/Checklist.tsx":
+    case "Checklist":
       return (
         <ChecklistBlock
           title={str(block.title)}
@@ -144,7 +148,7 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
-    case "blog/sections/blocks/Steps.tsx":
+    case "Steps":
       return (
         <StepsBlock
           title={str(block.title)}
@@ -152,7 +156,7 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
-    case "blog/sections/blocks/Comparison.tsx":
+    case "Comparison":
       return (
         <ComparisonBlock
           left={str(block.left)}
@@ -160,6 +164,10 @@ export function BlockEditor({
           onChange={(next) => onChange({ ...block, ...next })}
         />
       );
+    case "ProductCard":
+      return <ProductCardBlock block={block} onChange={onChange} />;
+    case "ProductShelf":
+      return <ProductShelfBlock block={block} onChange={onChange} />;
     default: {
       const schema = resolveType ? resolveSchema(resolveType, meta) : null;
       if (!schema) {

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-row.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-row.tsx
@@ -1,0 +1,70 @@
+import { DotsGrid, Trash01 } from "@untitledui/icons";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { cn } from "@deco/ui/lib/utils.js";
+import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import { BlockEditor, type RawBlock } from "./block-registry";
+
+/**
+ * One block in the post document. Borderless (Notion-style) — the gutter on
+ * the left reveals a drag handle and delete on hover; the body renders the
+ * block's native inline editor. Dragging is bound to the handle only so it
+ * never fights with selecting/editing the block text.
+ */
+export function BlockRow({
+  id,
+  block,
+  meta,
+  onChange,
+  onDelete,
+}: {
+  id: string;
+  block: RawBlock;
+  meta: LiveMeta;
+  onChange: (next: RawBlock) => void;
+  onDelete: () => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      className={cn(
+        "group/row relative rounded-md py-1.5 pl-12 pr-2 transition-colors hover:bg-muted/40",
+        isDragging && "opacity-50",
+      )}
+    >
+      <div className="absolute left-1 top-1.5 flex flex-col items-center gap-1 opacity-0 transition-opacity group-hover/row:opacity-100">
+        <button
+          type="button"
+          aria-label="Drag to reorder"
+          className="flex h-6 w-6 cursor-grab items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground active:cursor-grabbing"
+          {...attributes}
+          {...listeners}
+        >
+          <DotsGrid size={14} />
+        </button>
+        <button
+          type="button"
+          aria-label="Delete block"
+          onClick={onDelete}
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-destructive cursor-pointer"
+        >
+          <Trash01 size={14} />
+        </button>
+      </div>
+      <BlockEditor block={block} meta={meta} onChange={onChange} />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/list-blocks.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/list-blocks.tsx
@@ -1,0 +1,334 @@
+import { Check } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.js";
+import {
+  AddButton,
+  InlineText,
+  RemoveButton,
+  parseJsonArray,
+  str,
+} from "./primitives";
+
+// ---------------------------------------------------------------- CardGroup
+
+type Card = { icon?: string; title?: string; body?: string };
+
+export function CardGroupBlock({
+  cards,
+  onChange,
+}: {
+  cards: string;
+  onChange: (cards: string) => void;
+}) {
+  const items = parseJsonArray<Card>(cards);
+  const commit = (next: Card[]) => onChange(JSON.stringify(next));
+  const set = (i: number, patch: Partial<Card>) =>
+    commit(items.map((c, idx) => (idx === i ? { ...c, ...patch } : c)));
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {items.slice(0, 3).map((card, i) => (
+          <div
+            key={i}
+            className="group/item relative flex flex-col gap-2 rounded-lg border bg-card p-4"
+          >
+            <div className="absolute right-1 top-1">
+              <RemoveButton
+                label="Remove card"
+                onClick={() => commit(items.filter((_, idx) => idx !== i))}
+              />
+            </div>
+            <input
+              value={str(card.icon)}
+              onChange={(e) => set(i, { icon: e.target.value })}
+              placeholder="🎴"
+              className="flex h-9 w-9 items-center justify-center rounded-md border bg-background text-center text-lg outline-none focus:ring-0"
+            />
+            <input
+              value={str(card.title)}
+              onChange={(e) => set(i, { title: e.target.value })}
+              placeholder="Card title"
+              className="border-0 bg-transparent p-0 text-[15px] font-semibold outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+            />
+            <InlineText
+              value={str(card.body)}
+              onChange={(v) => set(i, { body: v })}
+              placeholder="Card body"
+              className="text-sm text-muted-foreground"
+            />
+          </div>
+        ))}
+      </div>
+      {items.length < 3 && (
+        <AddButton
+          label="Add card"
+          onClick={() => commit([...items, { title: "", body: "" }])}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- Checklist
+
+export function ChecklistBlock({
+  title,
+  items,
+  onChange,
+}: {
+  title: string;
+  items: string;
+  onChange: (next: { title: string; items: string }) => void;
+}) {
+  const list = parseJsonArray<string>(items);
+  const commit = (next: string[]) =>
+    onChange({ title, items: JSON.stringify(next) });
+
+  return (
+    <div className="space-y-2">
+      <input
+        value={title}
+        onChange={(e) => onChange({ title: e.target.value, items })}
+        placeholder="Checklist title (optional)"
+        className="w-full border-0 bg-transparent p-0 text-lg font-semibold outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+      />
+      <ul>
+        {list.map((item, i) => (
+          <li
+            key={i}
+            className="group/item flex items-start gap-3 border-b border-border/50 py-2.5"
+          >
+            <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center text-primary">
+              <Check size={15} />
+            </span>
+            <InlineText
+              value={item}
+              onChange={(v) =>
+                commit(list.map((x, idx) => (idx === i ? v : x)))
+              }
+              placeholder="Checklist item"
+              className="text-[15px] text-foreground"
+            />
+            <RemoveButton
+              label="Remove item"
+              onClick={() => commit(list.filter((_, idx) => idx !== i))}
+            />
+          </li>
+        ))}
+      </ul>
+      <AddButton label="Add item" onClick={() => commit([...list, ""])} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- StatGroup
+
+type StatItem = { value?: string; label?: string };
+
+export function StatGroupBlock({
+  stats,
+  onChange,
+}: {
+  stats: string;
+  onChange: (stats: string) => void;
+}) {
+  const items = parseJsonArray<StatItem>(stats);
+  const commit = (next: StatItem[]) => onChange(JSON.stringify(next));
+  const set = (i: number, patch: Partial<StatItem>) =>
+    commit(items.map((s, idx) => (idx === i ? { ...s, ...patch } : s)));
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {items.slice(0, 3).map((stat, i) => (
+          <div
+            key={i}
+            className="group/item relative rounded-lg border p-5 text-center"
+          >
+            <div className="absolute right-1 top-1">
+              <RemoveButton
+                label="Remove stat"
+                onClick={() => commit(items.filter((_, idx) => idx !== i))}
+              />
+            </div>
+            <input
+              value={str(stat.value)}
+              onChange={(e) => set(i, { value: e.target.value })}
+              placeholder="99%"
+              className="w-full border-0 bg-transparent p-0 text-center text-3xl font-bold tabular-nums text-foreground outline-none placeholder:text-muted-foreground/40 focus:ring-0"
+            />
+            <input
+              value={str(stat.label)}
+              onChange={(e) => set(i, { label: e.target.value })}
+              placeholder="Label"
+              className="mt-1 w-full border-0 bg-transparent p-0 text-center text-sm text-muted-foreground outline-none placeholder:text-muted-foreground/40 focus:ring-0"
+            />
+          </div>
+        ))}
+      </div>
+      {items.length < 3 && (
+        <AddButton
+          label="Add stat"
+          onClick={() => commit([...items, { value: "", label: "" }])}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- Steps
+
+type Step = { title?: string; description?: string };
+
+export function StepsBlock({
+  title,
+  steps,
+  onChange,
+}: {
+  title: string;
+  steps: string;
+  onChange: (next: { title: string; steps: string }) => void;
+}) {
+  const list = parseJsonArray<Step>(steps);
+  const commit = (next: Step[]) =>
+    onChange({ title, steps: JSON.stringify(next) });
+  const set = (i: number, patch: Partial<Step>) =>
+    commit(list.map((s, idx) => (idx === i ? { ...s, ...patch } : s)));
+
+  return (
+    <div className="space-y-2">
+      <input
+        value={title}
+        onChange={(e) => onChange({ title: e.target.value, steps })}
+        placeholder="Steps title (optional)"
+        className="w-full border-0 bg-transparent p-0 text-lg font-semibold uppercase tracking-wide outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+      />
+      <ol className="space-y-3">
+        {list.map((step, i) => (
+          <li key={i} className="group/item flex gap-4">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-sm font-semibold text-muted-foreground">
+              {i + 1}
+            </span>
+            <div className="min-w-0 flex-1 space-y-1 pt-0.5">
+              <input
+                value={str(step.title)}
+                onChange={(e) => set(i, { title: e.target.value })}
+                placeholder="Step title"
+                className="w-full border-0 bg-transparent p-0 text-[15px] font-semibold outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+              />
+              <InlineText
+                value={str(step.description)}
+                onChange={(v) => set(i, { description: v })}
+                placeholder="Step description"
+                className="text-sm text-muted-foreground"
+              />
+            </div>
+            <RemoveButton
+              label="Remove step"
+              onClick={() => commit(list.filter((_, idx) => idx !== i))}
+            />
+          </li>
+        ))}
+      </ol>
+      <AddButton
+        label="Add step"
+        onClick={() => commit([...list, { title: "", description: "" }])}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- Comparison
+
+type Col = { title?: string; items?: string[] };
+
+function parseCol(value: string, fallbackTitle: string): Col {
+  try {
+    const parsed = JSON.parse(value || "{}");
+    return {
+      title: typeof parsed?.title === "string" ? parsed.title : fallbackTitle,
+      items: Array.isArray(parsed?.items) ? parsed.items : [],
+    };
+  } catch {
+    return { title: fallbackTitle, items: [] };
+  }
+}
+
+export function ComparisonBlock({
+  left,
+  right,
+  onChange,
+}: {
+  left: string;
+  right: string;
+  onChange: (next: { left: string; right: string }) => void;
+}) {
+  const cols = {
+    left: parseCol(left, "Option A"),
+    right: parseCol(right, "Option B"),
+  };
+
+  const commit = (side: "left" | "right", col: Col) =>
+    onChange({
+      left: side === "left" ? JSON.stringify(col) : left,
+      right: side === "right" ? JSON.stringify(col) : right,
+    });
+
+  const renderCol = (side: "left" | "right", col: Col, accent: string) => {
+    const itemsList = col.items ?? [];
+    return (
+      <div className="space-y-2 rounded-lg border p-4">
+        <input
+          value={str(col.title)}
+          onChange={(e) => commit(side, { ...col, title: e.target.value })}
+          placeholder="Column title"
+          className="w-full border-0 bg-transparent p-0 text-xs font-semibold uppercase tracking-wide outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+        />
+        <ul className="space-y-1.5">
+          {itemsList.map((item, i) => (
+            <li key={i} className="group/item flex items-start gap-2">
+              <span
+                aria-hidden
+                className="mt-0.5 shrink-0 text-sm font-bold"
+                style={{ color: accent }}
+              >
+                ✓
+              </span>
+              <InlineText
+                value={item}
+                onChange={(v) =>
+                  commit(side, {
+                    ...col,
+                    items: itemsList.map((x, idx) => (idx === i ? v : x)),
+                  })
+                }
+                placeholder="Item"
+                className="text-sm text-foreground"
+              />
+              <RemoveButton
+                label="Remove item"
+                onClick={() =>
+                  commit(side, {
+                    ...col,
+                    items: itemsList.filter((_, idx) => idx !== i),
+                  })
+                }
+              />
+            </li>
+          ))}
+        </ul>
+        <AddButton
+          label="Add item"
+          onClick={() => commit(side, { ...col, items: [...itemsList, ""] })}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div className={cn("grid grid-cols-1 gap-3 sm:grid-cols-2")}>
+      {renderCol("left", cols.left, "oklch(0.65 0.17 150)")}
+      {renderCol("right", cols.right, "oklch(0.75 0.15 75)")}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/loader-invoke.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/loader-invoke.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildLoaderInvokeUrl,
+  isValidLoaderResolveType,
+  parseLoaderInvokeRequest,
+} from "@/lib/loader-invoke";
+
+describe("isValidLoaderResolveType", () => {
+  test("rejects path traversal", () => {
+    expect(isValidLoaderResolveType("vtex/../secret.ts")).toBe(false);
+  });
+
+  test("accepts standard loader paths", () => {
+    expect(
+      isValidLoaderResolveType("vtex/loaders/intelligentSearch/productList.ts"),
+    ).toBe(true);
+  });
+});
+
+describe("parseLoaderInvokeRequest", () => {
+  test("returns null without __resolveType", () => {
+    expect(parseLoaderInvokeRequest({ props: { ids: ["1"] } })).toBeNull();
+  });
+
+  test("rejects invalid resolveType", () => {
+    expect(
+      parseLoaderInvokeRequest({
+        __resolveType: "../../_health",
+        props: { ids: ["1"] },
+      }),
+    ).toBeNull();
+  });
+
+  test("maps block-ref to single invoke path payload", () => {
+    expect(
+      parseLoaderInvokeRequest({
+        __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+        props: { ids: ["149524"] },
+      }),
+    ).toEqual({
+      resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+      payload: { props: { ids: ["149524"] } },
+    });
+  });
+
+  test("uses spread payload when props key is absent", () => {
+    expect(
+      parseLoaderInvokeRequest({
+        __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+        ids: ["149524"],
+      }),
+    ).toEqual({
+      resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+      payload: { ids: ["149524"] },
+    });
+  });
+});
+
+describe("buildLoaderInvokeUrl", () => {
+  test("encodes resolveType in path", () => {
+    expect(
+      buildLoaderInvokeUrl(
+        "https://preview.example.com/",
+        "vtex/loaders/intelligentSearch/productList.ts",
+      ),
+    ).toBe(
+      "https://preview.example.com/deco/invoke/vtex%2Floaders%2FintelligentSearch%2FproductList.ts",
+    );
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/media-blocks.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/media-blocks.tsx
@@ -1,0 +1,278 @@
+import { useState } from "react";
+import { ImageField } from "@/web/components/sections-editor/fields/image-field";
+import { cn } from "@deco/ui/lib/utils.js";
+import { FloatingToolbar, InlineText, ToolbarButton, str } from "./primitives";
+
+// ---------------------------------------------------------------- Image
+
+export function BlockImageBlock({
+  block,
+  onChange,
+}: {
+  block: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+}) {
+  const size = str(block.size) || "normal";
+  return (
+    <div className="space-y-2">
+      <ImageField
+        schema={{ type: "string", format: "image-uri", title: "Image" }}
+        value={block.url}
+        onChange={(v) => onChange({ ...block, url: v })}
+        path="block-image-url"
+        label="Image"
+      />
+      <InlineText
+        value={str(block.caption)}
+        onChange={(v) => onChange({ ...block, caption: v })}
+        placeholder="Add a caption…"
+        className="text-center text-sm italic text-muted-foreground"
+      />
+      <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1">
+          {(["normal", "full"] as const).map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => onChange({ ...block, size: s })}
+              className={cn(
+                "rounded px-2 py-0.5 transition-colors cursor-pointer",
+                size === s
+                  ? "bg-accent text-accent-foreground"
+                  : "hover:bg-muted",
+              )}
+            >
+              {s === "full" ? "Full width" : "Normal"}
+            </button>
+          ))}
+        </div>
+        <input
+          value={str(block.alt)}
+          onChange={(e) => onChange({ ...block, alt: e.target.value })}
+          placeholder="Alt text (accessibility)"
+          className="flex-1 border-0 bg-transparent p-0 text-xs outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- Video
+
+function youtubeOrVimeoEmbed(raw: string): string | null {
+  const yt = raw.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([\w-]{11})/);
+  if (yt) return `https://www.youtube.com/embed/${yt[1]}`;
+  const vimeo = raw.match(/vimeo\.com\/(\d+)/);
+  if (vimeo) return `https://player.vimeo.com/video/${vimeo[1]}`;
+  return null;
+}
+
+export function VideoBlock({
+  url,
+  caption,
+  onChange,
+}: {
+  url: string;
+  caption: string;
+  onChange: (next: { url: string; caption: string }) => void;
+}) {
+  const embed = youtubeOrVimeoEmbed(url);
+  return (
+    <div className="space-y-2">
+      {embed ? (
+        <div className="relative aspect-video overflow-hidden rounded-md border bg-muted">
+          <iframe
+            src={embed}
+            title={caption || "Video"}
+            className="absolute inset-0 h-full w-full border-0"
+            allowFullScreen
+          />
+        </div>
+      ) : (
+        <div className="flex aspect-video items-center justify-center rounded-md border border-dashed bg-muted/40 text-xs text-muted-foreground">
+          Paste a YouTube or Vimeo URL to preview
+        </div>
+      )}
+      <input
+        value={url}
+        onChange={(e) => onChange({ url: e.target.value, caption })}
+        placeholder="https://youtube.com/watch?v=…"
+        className="h-9 w-full rounded-md border bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+      />
+      <InlineText
+        value={caption}
+        onChange={(v) => onChange({ url, caption: v })}
+        placeholder="Add a caption…"
+        className="text-center text-sm italic text-muted-foreground"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- Divider
+
+export function DividerBlock() {
+  return (
+    <div className="flex items-center py-3" aria-label="Divider">
+      <span className="h-px flex-1 bg-border" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- CTA
+
+export function CtaBlock({
+  text,
+  href,
+  onChange,
+}: {
+  text: string;
+  href: string;
+  onChange: (next: { text: string; href: string }) => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-2 py-2">
+      <div className="inline-flex items-center rounded-full bg-primary px-6 py-2 text-sm font-semibold text-primary-foreground">
+        <input
+          value={text}
+          onChange={(e) => onChange({ text: e.target.value, href })}
+          placeholder="Button label"
+          size={Math.max(text.length || 11, 8)}
+          className="border-0 bg-transparent p-0 text-center text-sm font-semibold text-primary-foreground outline-none placeholder:text-primary-foreground/60 focus:ring-0"
+        />
+      </div>
+      <input
+        value={href}
+        onChange={(e) => onChange({ text, href: e.target.value })}
+        placeholder="https://destination-url.com"
+        className="w-full max-w-sm border-0 bg-transparent p-0 text-center text-xs text-muted-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- Callout
+
+const CALLOUT_VARIANTS = [
+  { value: "info", icon: "ℹ", color: "oklch(0.62 0.19 250)" },
+  { value: "tip", icon: "✓", color: "oklch(0.65 0.17 150)" },
+  { value: "warning", icon: "⚠", color: "oklch(0.75 0.15 75)" },
+  { value: "product", icon: "★", color: "oklch(0.62 0.21 300)" },
+] as const;
+
+export function CalloutBlock({
+  title,
+  body,
+  variant,
+  onChange,
+}: {
+  title: string;
+  body: string;
+  variant: string;
+  onChange: (next: { title: string; body: string; variant: string }) => void;
+}) {
+  const [focused, setFocused] = useState(false);
+  const v =
+    CALLOUT_VARIANTS.find((x) => x.value === variant) ?? CALLOUT_VARIANTS[0];
+
+  return (
+    <div
+      className="relative"
+      onFocus={() => setFocused(true)}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+          setFocused(false);
+        }
+      }}
+    >
+      {focused && (
+        <FloatingToolbar>
+          {CALLOUT_VARIANTS.map((opt) => (
+            <ToolbarButton
+              key={opt.value}
+              active={v.value === opt.value}
+              label={opt.value}
+              onClick={() => onChange({ title, body, variant: opt.value })}
+            >
+              <span style={{ color: opt.color }}>{opt.icon}</span>
+            </ToolbarButton>
+          ))}
+        </FloatingToolbar>
+      )}
+      <div
+        className="rounded-md py-4 pl-5 pr-4"
+        style={{
+          borderLeft: `3px solid ${v.color}`,
+          backgroundColor: `color-mix(in oklch, ${v.color} 8%, transparent)`,
+        }}
+      >
+        <div
+          className="mb-1.5 flex items-center gap-2"
+          style={{ color: v.color }}
+        >
+          <span aria-hidden className="text-sm font-bold leading-none">
+            {v.icon}
+          </span>
+          <input
+            value={title}
+            onChange={(e) => onChange({ title: e.target.value, body, variant })}
+            placeholder="Callout title"
+            className="flex-1 border-0 bg-transparent p-0 text-xs font-semibold uppercase tracking-wide outline-none focus:ring-0"
+            style={{ color: v.color }}
+          />
+        </div>
+        <InlineText
+          value={body}
+          onChange={(b) => onChange({ title, body: b, variant })}
+          placeholder="Callout text…"
+          className="text-[15px] leading-relaxed text-foreground"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- Stat
+
+export function StatBlock({
+  value,
+  label,
+  description,
+  onChange,
+}: {
+  value: string;
+  label: string;
+  description: string;
+  onChange: (next: {
+    value: string;
+    label: string;
+    description: string;
+  }) => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1.5 border-y border-border/60 py-8 text-center">
+      <input
+        value={value}
+        onChange={(e) =>
+          onChange({ value: e.target.value, label, description })
+        }
+        placeholder="42%"
+        className="w-full border-0 bg-transparent p-0 text-center text-4xl font-bold tabular-nums text-foreground outline-none placeholder:text-muted-foreground/40 focus:ring-0"
+      />
+      <input
+        value={label}
+        onChange={(e) =>
+          onChange({ value, label: e.target.value, description })
+        }
+        placeholder="Label"
+        className="w-full border-0 bg-transparent p-0 text-center text-xs font-semibold uppercase tracking-wide text-muted-foreground outline-none placeholder:text-muted-foreground/40 focus:ring-0"
+      />
+      <InlineText
+        value={description}
+        onChange={(d) => onChange({ value, label, description: d })}
+        placeholder="Optional description"
+        className="max-w-md text-center text-sm text-muted-foreground"
+      />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/plain-blocks.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/plain-blocks.tsx
@@ -1,0 +1,222 @@
+import { useRef, useState } from "react";
+import { cn } from "@deco/ui/lib/utils.js";
+import { FloatingToolbar, InlineText, ToolbarButton } from "./primitives";
+
+const HEADING_LEVELS = ["1", "2", "3"] as const;
+
+const HEADING_CLASS: Record<string, string> = {
+  "1": "text-3xl font-bold",
+  "2": "text-2xl font-bold",
+  "3": "text-xl font-semibold",
+  "4": "text-lg font-semibold",
+  "5": "text-base font-semibold",
+  "6": "text-sm font-semibold",
+};
+
+export function HeadingBlock({
+  text,
+  level,
+  onChange,
+}: {
+  text: string;
+  level: string;
+  onChange: (next: { text: string; level: string }) => void;
+}) {
+  const [focused, setFocused] = useState(false);
+  const lvl = level || "2";
+
+  return (
+    <div className="relative">
+      {focused && (
+        <FloatingToolbar>
+          {HEADING_LEVELS.map((l) => (
+            <ToolbarButton
+              key={l}
+              active={lvl === l}
+              label={`Heading ${l}`}
+              onClick={() => onChange({ text, level: l })}
+            >
+              H{l}
+            </ToolbarButton>
+          ))}
+        </FloatingToolbar>
+      )}
+      <InlineText
+        value={text}
+        onChange={(v) => onChange({ text: v, level: lvl })}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder="Heading"
+        className={cn(
+          "text-foreground",
+          HEADING_CLASS[lvl] ?? HEADING_CLASS["2"],
+        )}
+      />
+    </div>
+  );
+}
+
+export function QuoteBlock({
+  quote,
+  onChange,
+}: {
+  quote: string;
+  onChange: (quote: string) => void;
+}) {
+  return (
+    <div className="border-l-2 border-foreground/30 pl-4">
+      <InlineText
+        value={quote}
+        onChange={onChange}
+        placeholder="Quote"
+        className="text-lg italic text-foreground/90"
+      />
+    </div>
+  );
+}
+
+export function CodeBlock({
+  code,
+  language,
+  onChange,
+}: {
+  code: string;
+  language: string;
+  onChange: (next: { code: string; language: string }) => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-md border bg-muted/50">
+      <input
+        value={language}
+        onChange={(e) => onChange({ code, language: e.target.value })}
+        placeholder="language"
+        className="w-full border-b bg-transparent px-3 py-1.5 font-mono text-xs text-muted-foreground outline-none placeholder:text-muted-foreground/50"
+      />
+      <InlineText
+        value={code}
+        onChange={(v) => onChange({ code: v, language })}
+        placeholder="Code"
+        spellCheck={false}
+        className="px-3 py-2.5 font-mono text-sm text-foreground"
+      />
+    </div>
+  );
+}
+
+/**
+ * List block. Deco stores items as a newline-separated string plus a
+ * `style` (ordered/unordered). Each item is a wrapping, inline-editable
+ * row: Enter adds the next item (and moves the caret there), Backspace on
+ * an empty row removes it, and Up/Down move between items at the edges.
+ */
+export function ListBlock({
+  items,
+  style,
+  onChange,
+}: {
+  items: string;
+  style: string;
+  onChange: (next: { items: string; style: string }) => void;
+}) {
+  const ordered = style === "ordered";
+  const rows = items.length ? items.split("\n") : [""];
+  const [focused, setFocused] = useState(false);
+  const refs = useRef<(HTMLTextAreaElement | null)[]>([]);
+
+  const commit = (nextRows: string[]) =>
+    onChange({ items: nextRows.join("\n"), style });
+
+  const focusRow = (i: number, caret: "start" | "end") =>
+    requestAnimationFrame(() => {
+      const el = refs.current[i];
+      if (!el) return;
+      el.focus();
+      const pos = caret === "end" ? el.value.length : 0;
+      el.setSelectionRange(pos, pos);
+    });
+
+  return (
+    <div
+      className="relative"
+      onFocus={() => setFocused(true)}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+          setFocused(false);
+        }
+      }}
+    >
+      {focused && (
+        <FloatingToolbar>
+          <ToolbarButton
+            active={!ordered}
+            label="Bulleted"
+            onClick={() => onChange({ items, style: "unordered" })}
+          >
+            •
+          </ToolbarButton>
+          <ToolbarButton
+            active={ordered}
+            label="Numbered"
+            onClick={() => onChange({ items, style: "ordered" })}
+          >
+            1.
+          </ToolbarButton>
+        </FloatingToolbar>
+      )}
+      <ul className="space-y-1">
+        {rows.map((row, i) => (
+          <li key={i} className="flex items-start gap-2.5">
+            <span className="min-w-5 shrink-0 select-none pt-px text-right text-[15px] leading-relaxed text-muted-foreground tabular-nums">
+              {ordered ? `${i + 1}.` : "•"}
+            </span>
+            <InlineText
+              inputRef={(el) => {
+                refs.current[i] = el;
+              }}
+              value={row}
+              onChange={(value) => {
+                const next = [...rows];
+                next[i] = value;
+                commit(next);
+              }}
+              onKeyDown={(e) => {
+                const el = e.currentTarget;
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  const next = [...rows];
+                  next.splice(i + 1, 0, "");
+                  commit(next);
+                  focusRow(i + 1, "start");
+                } else if (
+                  e.key === "Backspace" &&
+                  row === "" &&
+                  rows.length > 1
+                ) {
+                  e.preventDefault();
+                  commit(rows.filter((_, idx) => idx !== i));
+                  focusRow(Math.max(0, i - 1), "end");
+                } else if (
+                  e.key === "ArrowUp" &&
+                  el.selectionStart === 0 &&
+                  i > 0
+                ) {
+                  e.preventDefault();
+                  focusRow(i - 1, "end");
+                } else if (
+                  e.key === "ArrowDown" &&
+                  el.selectionEnd === row.length &&
+                  i < rows.length - 1
+                ) {
+                  e.preventDefault();
+                  focusRow(i + 1, "end");
+                }
+              }}
+              placeholder="List item"
+              className="text-[15px] leading-relaxed text-foreground"
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/primitives.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/primitives.tsx
@@ -1,0 +1,159 @@
+import { Plus, Trash01 } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.js";
+
+/**
+ * Borderless auto-growing text input shared by the block editors. Grows
+ * with content via `field-sizing:content`, with a JS fallback on input.
+ * Single logical line of text that wraps — Enter is left to callers.
+ */
+export function InlineText({
+  value,
+  onChange,
+  placeholder,
+  className,
+  onFocus,
+  onBlur,
+  onKeyDown,
+  spellCheck = true,
+  inputRef,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  onFocus?: () => void;
+  onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  spellCheck?: boolean;
+  inputRef?: (el: HTMLTextAreaElement | null) => void;
+}) {
+  return (
+    <textarea
+      ref={inputRef}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onInput={(e) => {
+        const el = e.currentTarget;
+        el.style.height = "auto";
+        el.style.height = `${el.scrollHeight}px`;
+      }}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      placeholder={placeholder}
+      spellCheck={spellCheck}
+      rows={1}
+      className={cn(
+        "w-full resize-none border-0 bg-transparent p-0 outline-none [field-sizing:content] placeholder:text-muted-foreground/50 focus:ring-0",
+        className,
+      )}
+    />
+  );
+}
+
+/** Faint field label used inside structured blocks. */
+export function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="mb-1 block text-[11px] font-medium text-muted-foreground/60">
+      {children}
+    </span>
+  );
+}
+
+export function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** "Add row" affordance for collection blocks. */
+export function AddButton({
+  label,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="flex items-center gap-1.5 rounded-md border border-dashed px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground disabled:opacity-40 disabled:hover:border-dashed disabled:hover:text-muted-foreground cursor-pointer"
+    >
+      <Plus size={13} />
+      {label}
+    </button>
+  );
+}
+
+/** Small "remove this row" icon button revealed on hover of a collection item. */
+export function RemoveButton({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition-opacity hover:text-destructive group-hover/item:opacity-100 cursor-pointer"
+    >
+      <Trash01 size={13} />
+    </button>
+  );
+}
+
+/** A floating segmented control shown above a focused block (variant/level). */
+export function FloatingToolbar({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="absolute -top-9 left-0 z-10 flex items-center gap-0.5 rounded-md border bg-popover p-0.5 shadow-md">
+      {children}
+    </div>
+  );
+}
+
+export function ToolbarButton({
+  active,
+  label,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className={cn(
+        "flex h-7 min-w-7 items-center justify-center rounded px-1.5 text-sm transition-colors cursor-pointer",
+        active
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** Parse a JSON-encoded array field, tolerating malformed/empty input. */
+export function parseJsonArray<T>(value: unknown): T[] {
+  if (Array.isArray(value)) return value as T[];
+  if (typeof value !== "string" || value.trim() === "") return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/primitives.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/primitives.tsx
@@ -51,15 +51,6 @@ export function InlineText({
   );
 }
 
-/** Faint field label used inside structured blocks. */
-export function FieldLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <span className="mb-1 block text-[11px] font-medium text-muted-foreground/60">
-      {children}
-    </span>
-  );
-}
-
 export function str(value: unknown): string {
   return typeof value === "string" ? value : "";
 }

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-blocks.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-blocks.tsx
@@ -1,0 +1,236 @@
+import { Label } from "@deco/ui/components/label.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import { useProductListPreview } from "../use-product-list-preview";
+import {
+  readProductListIds,
+  writeProductListIds,
+} from "./product-loader-utils";
+import type { ResolvedProductPreview } from "./product-preview-utils";
+import { AddButton, RemoveButton, str } from "./primitives";
+
+function ProductThumbnail({
+  preview,
+  loading,
+}: {
+  preview: ResolvedProductPreview | null;
+  loading?: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="h-12 w-12 shrink-0 animate-pulse rounded-md bg-muted" />
+    );
+  }
+
+  if (preview?.imageUrl) {
+    return (
+      <img
+        src={preview.imageUrl}
+        alt={preview.name}
+        className="h-12 w-12 shrink-0 rounded-md border object-cover"
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md border bg-muted text-[10px] text-muted-foreground">
+      No img
+    </div>
+  );
+}
+
+function ProductIdsEditor({
+  loader,
+  ids,
+  onChange,
+  label,
+}: {
+  loader: unknown;
+  ids: string[];
+  onChange: (ids: string[]) => void;
+  label: string;
+}) {
+  const { productsById, isLoading, isError } = useProductListPreview(loader);
+  const setAt = (index: number, value: string) =>
+    onChange(ids.map((id, i) => (i === index ? value : id)));
+
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      {isError && (
+        <p className="text-xs text-destructive">
+          Could not load product details from VTEX.
+        </p>
+      )}
+      {ids.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          No product IDs yet — add one below.
+        </p>
+      )}
+      <ul className="space-y-2">
+        {ids.map((id, index) => {
+          const preview = productsById[index] ?? null;
+          return (
+            <li key={index} className="group/item flex items-center gap-3">
+              <ProductThumbnail preview={preview} loading={isLoading && !!id} />
+              <div className="min-w-0 flex-1 space-y-1">
+                <p
+                  className={cn(
+                    "truncate text-sm font-medium",
+                    preview?.name ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  {preview?.name ||
+                    (isLoading && id ? "Loading product…" : "Product")}
+                </p>
+                <input
+                  value={id}
+                  onChange={(e) => setAt(index, e.target.value)}
+                  placeholder="151331"
+                  className="h-9 w-full rounded-md border bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+                />
+              </div>
+              <RemoveButton
+                label="Remove product ID"
+                onClick={() => onChange(ids.filter((_, i) => i !== index))}
+              />
+            </li>
+          );
+        })}
+      </ul>
+      <AddButton
+        label="Add product ID"
+        onClick={() => onChange([...ids, ""])}
+      />
+    </div>
+  );
+}
+
+export function ProductCardBlock({
+  block,
+  onChange,
+}: {
+  block: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+}) {
+  const ids = readProductListIds(block.product);
+  const productId = ids[0] ?? "";
+  const { productsById, isLoading, isError } = useProductListPreview(
+    block.product,
+  );
+  const preview = productsById[0] ?? null;
+
+  return (
+    <div className="space-y-4 rounded-lg border bg-card p-4">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Product card
+      </div>
+      <div className="flex items-center gap-3 rounded-md border bg-background p-3">
+        <ProductThumbnail
+          preview={preview}
+          loading={isLoading && !!productId}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">
+            {preview?.name ||
+              (isLoading && productId ? "Loading product…" : "Product preview")}
+          </p>
+          {productId && (
+            <p className="truncate text-xs text-muted-foreground">
+              ID {productId}
+            </p>
+          )}
+          {isError && (
+            <p className="text-xs text-destructive">
+              Could not load product details from VTEX.
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label
+          htmlFor="product-card-cta"
+          className="text-xs text-muted-foreground"
+        >
+          CTA label
+        </Label>
+        <input
+          id="product-card-cta"
+          value={str(block.textCta)}
+          onChange={(e) => onChange({ ...block, textCta: e.target.value })}
+          placeholder="Ver produto"
+          className="h-9 w-full rounded-md border bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label
+          htmlFor="product-card-slug"
+          className="text-xs text-muted-foreground"
+        >
+          Product slug
+        </Label>
+        <input
+          id="product-card-slug"
+          value={str(block.productSlug)}
+          onChange={(e) => onChange({ ...block, productSlug: e.target.value })}
+          placeholder="product-slug"
+          className="h-9 w-full rounded-md border bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label
+          htmlFor="product-card-id"
+          className="text-xs text-muted-foreground"
+        >
+          VTEX product ID
+        </Label>
+        <input
+          id="product-card-id"
+          value={productId}
+          onChange={(e) =>
+            onChange({
+              ...block,
+              product: writeProductListIds(
+                block.product,
+                e.target.value ? [e.target.value] : [],
+              ),
+            })
+          }
+          placeholder="151331"
+          className="h-9 w-full rounded-md border bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function ProductShelfBlock({
+  block,
+  onChange,
+}: {
+  block: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+}) {
+  const ids = readProductListIds(block.products);
+
+  return (
+    <div className="space-y-4 rounded-lg border bg-card p-4">
+      <input
+        value={str(block.title)}
+        onChange={(e) => onChange({ ...block, title: e.target.value })}
+        placeholder="Shelf title"
+        className="w-full border-0 bg-transparent p-0 text-lg font-semibold outline-none placeholder:text-muted-foreground/50 focus:ring-0"
+      />
+      <ProductIdsEditor
+        loader={block.products}
+        label="VTEX product IDs"
+        ids={ids}
+        onChange={(nextIds) =>
+          onChange({
+            ...block,
+            products: writeProductListIds(block.products, nextIds),
+          })
+        }
+      />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import {
-  buildLoaderInvokeUrl,
-  parseLoaderInvokeRequest,
   readProductListIds,
   toInvokeLoaderBody,
   writeProductListIds,
@@ -73,32 +71,5 @@ describe("toInvokeLoaderBody", () => {
       __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
       props: { ids: ["149524", "151294"] },
     });
-  });
-});
-
-describe("parseLoaderInvokeRequest", () => {
-  test("maps block-ref to single invoke path payload", () => {
-    expect(
-      parseLoaderInvokeRequest({
-        __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
-        props: { ids: ["149524"] },
-      }),
-    ).toEqual({
-      resolveType: "vtex/loaders/intelligentSearch/productList.ts",
-      payload: { props: { ids: ["149524"] } },
-    });
-  });
-});
-
-describe("buildLoaderInvokeUrl", () => {
-  test("targets path-based invoke endpoint", () => {
-    expect(
-      buildLoaderInvokeUrl(
-        "https://preview.example.com/",
-        "vtex/loaders/intelligentSearch/productList.ts",
-      ),
-    ).toBe(
-      "https://preview.example.com/deco/invoke/vtex/loaders/intelligentSearch/productList.ts",
-    );
   });
 });

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildLoaderInvokeUrl,
+  parseLoaderInvokeRequest,
+  readProductListIds,
+  toInvokeLoaderBody,
+  writeProductListIds,
+} from "./product-loader-utils";
+
+describe("readProductListIds", () => {
+  test("reads ids from vtex intelligentSearch loader", () => {
+    expect(
+      readProductListIds({
+        __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+        props: {
+          ids: ["149524", "151294"],
+          simulationBehavior: "default",
+        },
+      }),
+    ).toEqual(["149524", "151294"]);
+  });
+
+  test("returns empty array for missing loader", () => {
+    expect(readProductListIds(undefined)).toEqual([]);
+    expect(readProductListIds({})).toEqual([]);
+  });
+});
+
+describe("writeProductListIds", () => {
+  test("preserves resolveType and simulationBehavior", () => {
+    const loader = writeProductListIds(
+      {
+        __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+        props: {
+          ids: ["1"],
+          simulationBehavior: "default",
+        },
+      },
+      ["149524", "151294"],
+    );
+
+    expect(loader).toEqual({
+      __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+      props: {
+        ids: ["149524", "151294"],
+        simulationBehavior: "default",
+      },
+    });
+  });
+
+  test("creates default loader when missing", () => {
+    expect(writeProductListIds(undefined, ["151331"])).toEqual({
+      __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+      props: {
+        ids: ["151331"],
+        simulationBehavior: "default",
+      },
+    });
+  });
+});
+
+describe("toInvokeLoaderBody", () => {
+  test("strips non-loader props before invoke", () => {
+    expect(
+      toInvokeLoaderBody({
+        __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+        props: {
+          ids: ["149524", "151294"],
+          simulationBehavior: "default",
+        },
+      }),
+    ).toEqual({
+      __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+      props: { ids: ["149524", "151294"] },
+    });
+  });
+});
+
+describe("parseLoaderInvokeRequest", () => {
+  test("maps block-ref to single invoke path payload", () => {
+    expect(
+      parseLoaderInvokeRequest({
+        __resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+        props: { ids: ["149524"] },
+      }),
+    ).toEqual({
+      resolveType: "vtex/loaders/intelligentSearch/productList.ts",
+      payload: { props: { ids: ["149524"] } },
+    });
+  });
+});
+
+describe("buildLoaderInvokeUrl", () => {
+  test("targets path-based invoke endpoint", () => {
+    expect(
+      buildLoaderInvokeUrl(
+        "https://preview.example.com/",
+        "vtex/loaders/intelligentSearch/productList.ts",
+      ),
+    ).toBe(
+      "https://preview.example.com/deco/invoke/vtex/loaders/intelligentSearch/productList.ts",
+    );
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.ts
@@ -38,7 +38,7 @@ export function toInvokeLoaderBody(loader: unknown): Record<string, unknown> {
 }
 
 /** Resolve type for a productList block-ref. */
-export function readProductListResolveType(loader: unknown): string {
+function readProductListResolveType(loader: unknown): string {
   const existing = asRecord(loader) ?? {};
   return typeof existing.__resolveType === "string"
     ? existing.__resolveType

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.ts
@@ -45,39 +45,6 @@ export function readProductListResolveType(loader: unknown): string {
     : DEFAULT_VTEX_PRODUCT_LIST;
 }
 
-/**
- * Split a block-ref into the single-invoke target Deco expects:
- * POST /deco/invoke/<resolveType> with loader props as the JSON body.
- *
- * Posting to /deco/invoke without a path key is batch mode and treats each
- * top-level field as a separate handler name — hence the
- * "Unknown handler: __resolveType" error.
- */
-export function parseLoaderInvokeRequest(body: Record<string, unknown>): {
-  resolveType: string;
-  payload: Record<string, unknown>;
-} | null {
-  const resolveType =
-    typeof body.__resolveType === "string" ? body.__resolveType : null;
-  if (!resolveType) return null;
-
-  const props = asRecord(body.props);
-  if (props) {
-    return { resolveType, payload: { props } };
-  }
-
-  const { __resolveType: _, ...rest } = body;
-  return { resolveType, payload: rest };
-}
-
-export function buildLoaderInvokeUrl(
-  previewBaseUrl: string,
-  resolveType: string,
-): string {
-  const base = previewBaseUrl.replace(/\/+$/, "");
-  return `${base}/deco/invoke/${resolveType}`;
-}
-
 /** Update ids on a VTEX productList loader, preserving resolveType and props. */
 export function writeProductListIds(
   loader: unknown,
@@ -85,10 +52,7 @@ export function writeProductListIds(
 ): Record<string, unknown> {
   const existing = asRecord(loader) ?? {};
   const props = asRecord(existing.props) ?? {};
-  const resolveType =
-    typeof existing.__resolveType === "string"
-      ? existing.__resolveType
-      : DEFAULT_VTEX_PRODUCT_LIST;
+  const resolveType = readProductListResolveType(loader);
 
   return {
     ...existing,

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-loader-utils.ts
@@ -1,0 +1,102 @@
+const DEFAULT_VTEX_PRODUCT_LIST =
+  "vtex/loaders/intelligentSearch/productList.ts";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Read VTEX productList loader ids from a block-ref value. */
+export function readProductListIds(loader: unknown): string[] {
+  const props = asRecord(asRecord(loader)?.props);
+  if (!props || !Array.isArray(props.ids)) return [];
+  return props.ids
+    .map((id) =>
+      typeof id === "string" || typeof id === "number" ? String(id) : "",
+    )
+    .filter(Boolean);
+}
+
+/** Build the preview-invoke payload for a VTEX productList block-ref. */
+export function toInvokeLoaderBody(loader: unknown): Record<string, unknown> {
+  const existing = asRecord(loader) ?? {};
+  const resolveType = readProductListResolveType(loader);
+  const props = asRecord(existing.props) ?? {};
+  const ids = readProductListIds(loader);
+
+  const loaderProps: Record<string, unknown> = { ids };
+
+  if (typeof props.hideUnavailableItems === "boolean") {
+    loaderProps.hideUnavailableItems = props.hideUnavailableItems;
+  }
+
+  return {
+    __resolveType: resolveType,
+    props: loaderProps,
+  };
+}
+
+/** Resolve type for a productList block-ref. */
+export function readProductListResolveType(loader: unknown): string {
+  const existing = asRecord(loader) ?? {};
+  return typeof existing.__resolveType === "string"
+    ? existing.__resolveType
+    : DEFAULT_VTEX_PRODUCT_LIST;
+}
+
+/**
+ * Split a block-ref into the single-invoke target Deco expects:
+ * POST /deco/invoke/<resolveType> with loader props as the JSON body.
+ *
+ * Posting to /deco/invoke without a path key is batch mode and treats each
+ * top-level field as a separate handler name — hence the
+ * "Unknown handler: __resolveType" error.
+ */
+export function parseLoaderInvokeRequest(body: Record<string, unknown>): {
+  resolveType: string;
+  payload: Record<string, unknown>;
+} | null {
+  const resolveType =
+    typeof body.__resolveType === "string" ? body.__resolveType : null;
+  if (!resolveType) return null;
+
+  const props = asRecord(body.props);
+  if (props) {
+    return { resolveType, payload: { props } };
+  }
+
+  const { __resolveType: _, ...rest } = body;
+  return { resolveType, payload: rest };
+}
+
+export function buildLoaderInvokeUrl(
+  previewBaseUrl: string,
+  resolveType: string,
+): string {
+  const base = previewBaseUrl.replace(/\/+$/, "");
+  return `${base}/deco/invoke/${resolveType}`;
+}
+
+/** Update ids on a VTEX productList loader, preserving resolveType and props. */
+export function writeProductListIds(
+  loader: unknown,
+  ids: string[],
+): Record<string, unknown> {
+  const existing = asRecord(loader) ?? {};
+  const props = asRecord(existing.props) ?? {};
+  const resolveType =
+    typeof existing.__resolveType === "string"
+      ? existing.__resolveType
+      : DEFAULT_VTEX_PRODUCT_LIST;
+
+  return {
+    ...existing,
+    __resolveType: resolveType,
+    props: {
+      ...props,
+      ids,
+      simulationBehavior: props.simulationBehavior ?? "default",
+    },
+  };
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-preview-utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-preview-utils.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import {
+  alignProductsToIds,
+  parseProductListPreview,
+  parseSingleProduct,
+} from "./product-preview-utils";
+
+describe("parseSingleProduct", () => {
+  test("reads schema.org product fields", () => {
+    expect(
+      parseSingleProduct({
+        "@type": "Product",
+        productID: "151331",
+        sku: "151331",
+        inProductGroupWithID: "149524",
+        name: "Mala ABS",
+        image: [
+          { "@type": "ImageObject", url: "https://cdn.example/mala.jpg" },
+        ],
+      }),
+    ).toEqual({
+      id: "151331",
+      sku: "151331",
+      groupId: "149524",
+      name: "Mala ABS",
+      imageUrl: "https://cdn.example/mala.jpg",
+    });
+  });
+
+  test("falls back to product group name", () => {
+    expect(
+      parseSingleProduct({
+        sku: "999",
+        inProductGroupWithID: "149524",
+        isVariantOf: { name: "Group name" },
+      }),
+    ).toEqual({
+      id: "999",
+      sku: "999",
+      groupId: "149524",
+      name: "Group name",
+      imageUrl: null,
+    });
+  });
+
+  test("reads nested product.name from VTEX payloads", () => {
+    expect(
+      parseSingleProduct({
+        sku: "149524",
+        name: "0018592454003",
+        product: {
+          name: "Mala de Viagem ABS",
+          image: [{ url: "https://cdn.example/mala.jpg" }],
+        },
+      }),
+    ).toEqual({
+      id: "149524",
+      sku: "149524",
+      groupId: "",
+      name: "Mala de Viagem ABS",
+      imageUrl: "https://cdn.example/mala.jpg",
+    });
+  });
+
+  test("prefers isVariantOf.name over sku EAN in name", () => {
+    expect(
+      parseSingleProduct({
+        productID: "149524",
+        sku: "149524",
+        inProductGroupWithID: "149524",
+        name: "0018592454003",
+        gtin: "0018592454003",
+        isVariantOf: {
+          name: "Mala ABS Rígida 4 Rodas",
+          productGroupID: "149524",
+        },
+        image: [{ url: "https://cdn.example/mala.jpg" }],
+      }),
+    ).toEqual({
+      id: "149524",
+      sku: "149524",
+      groupId: "149524",
+      name: "Mala ABS Rígida 4 Rodas",
+      imageUrl: "https://cdn.example/mala.jpg",
+    });
+  });
+});
+
+describe("parseProductListPreview", () => {
+  test("parses a plain product array", () => {
+    expect(
+      parseProductListPreview([
+        { productID: "1", sku: "1", name: "One" },
+        { productID: "2", sku: "2", name: "Two" },
+      ]),
+    ).toEqual([
+      { id: "1", sku: "1", groupId: "", name: "One", imageUrl: null },
+      { id: "2", sku: "2", groupId: "", name: "Two", imageUrl: null },
+    ]);
+  });
+
+  test("preserves sparse slots from VTEX sortProducts", () => {
+    expect(
+      parseProductListPreview([
+        { sku: "149524", name: "A", image: ["https://cdn.example/a.jpg"] },
+        undefined,
+        null,
+        {
+          sku: "150522",
+          name: "D",
+          image: [{ url: "https://cdn.example/d.jpg" }],
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "149524",
+        sku: "149524",
+        groupId: "",
+        name: "A",
+        imageUrl: "https://cdn.example/a.jpg",
+      },
+      null,
+      null,
+      {
+        id: "150522",
+        sku: "150522",
+        groupId: "",
+        name: "D",
+        imageUrl: "https://cdn.example/d.jpg",
+      },
+    ]);
+  });
+});
+
+describe("alignProductsToIds", () => {
+  test("matches by sku or product group id", () => {
+    const products = [
+      { id: "111", sku: "111", groupId: "149524", name: "A", imageUrl: null },
+      { id: "222", sku: "222", groupId: "151294", name: "B", imageUrl: null },
+    ];
+    expect(alignProductsToIds(["149524", "151294"], products)).toEqual(
+      products,
+    );
+  });
+
+  test("uses positional slots when invoke preserves loader order", () => {
+    const products = parseProductListPreview([
+      { sku: "149524", name: "A", image: ["https://cdn.example/a.jpg"] },
+      undefined,
+      null,
+      {
+        sku: "150522",
+        name: "D",
+        image: [{ url: "https://cdn.example/d.jpg" }],
+      },
+    ]);
+    expect(
+      alignProductsToIds(["149524", "151294", "149526", "150522"], products),
+    ).toEqual(products);
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-preview-utils.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-preview-utils.ts
@@ -1,0 +1,170 @@
+import { readProductListIds } from "./product-loader-utils";
+
+export interface ResolvedProductPreview {
+  id: string;
+  sku: string;
+  groupId: string;
+  name: string;
+  imageUrl: string | null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function numStr(value: unknown): string {
+  return typeof value === "number" ? String(value) : str(value);
+}
+
+export function productListLoaderKey(loader: unknown): string {
+  const resolveType = str(asRecord(loader)?.__resolveType);
+  const ids = readProductListIds(loader).join(",");
+  return `${resolveType}|${ids}`;
+}
+
+function unwrapProductRecord(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  const nested = asRecord(value.product);
+  if (!nested) return value;
+  return { ...value, ...nested };
+}
+
+function extractImageUrl(product: Record<string, unknown>): string | null {
+  const nested = asRecord(product.product);
+  if (nested) {
+    const nestedImage = extractImageUrl(nested);
+    if (nestedImage) return nestedImage;
+  }
+
+  const direct = str(product.imageUrl) || str(product.thumbnailUrl);
+  if (direct) return direct;
+
+  for (const key of ["image", "images"] as const) {
+    const value = product[key];
+    if (typeof value === "string" && value) return value;
+    if (!Array.isArray(value)) continue;
+    for (const entry of value) {
+      if (typeof entry === "string" && entry) return entry;
+      const obj = asRecord(entry);
+      const url = str(obj?.url) || str(obj?.contentUrl);
+      if (url) return url;
+    }
+  }
+
+  return null;
+}
+
+function looksLikeEan(value: string): boolean {
+  return /^\d{8,14}$/.test(value.trim());
+}
+
+/** Prefer human titles; VTEX often puts the EAN/gtin in `name`. */
+function firstDisplayName(candidates: string[]): string {
+  for (const candidate of candidates) {
+    const value = candidate.trim();
+    if (!value) continue;
+    if (!looksLikeEan(value)) return value;
+  }
+  return candidates.find((candidate) => candidate.trim())?.trim() ?? "";
+}
+
+function extractProductName(product: Record<string, unknown>): string {
+  const variantOf = asRecord(product.isVariantOf);
+  const nested = asRecord(product.product);
+  const nestedVariantOf = nested ? asRecord(nested.isVariantOf) : null;
+
+  return firstDisplayName([
+    str(variantOf?.name),
+    str(nestedVariantOf?.name),
+    str(product.productName),
+    nested ? str(nested.productName) : "",
+    nested ? str(nested.name) : "",
+    str(product.name),
+    str(product.alternateName),
+    str(asRecord(product.brand)?.name),
+  ]);
+}
+
+export function parseSingleProduct(
+  value: unknown,
+): ResolvedProductPreview | null {
+  const raw = asRecord(value);
+  if (!raw) return null;
+  const product = unwrapProductRecord(raw);
+
+  const sku = numStr(product.sku) || numStr(product.productID);
+  const groupId = numStr(product.inProductGroupWithID);
+
+  return {
+    id: sku || groupId || numStr(product.productId) || str(product["@id"]),
+    sku,
+    groupId,
+    name: extractProductName(product),
+    imageUrl: extractImageUrl(product),
+  };
+}
+
+function parseProductArray(data: unknown[]): (ResolvedProductPreview | null)[] {
+  return data.map((entry) =>
+    entry == null ? null : parseSingleProduct(entry),
+  );
+}
+
+export function parseProductListPreview(
+  data: unknown,
+): (ResolvedProductPreview | null)[] {
+  if (Array.isArray(data)) {
+    return parseProductArray(data);
+  }
+
+  const obj = asRecord(data);
+  if (!obj) return [];
+
+  for (const key of [
+    "products",
+    "product",
+    "items",
+    "data",
+    "result",
+  ] as const) {
+    const nested = obj[key];
+    if (Array.isArray(nested)) {
+      return parseProductArray(nested);
+    }
+    const single = parseSingleProduct(nested);
+    if (single) return [single];
+  }
+
+  const single = parseSingleProduct(data);
+  return single ? [single] : [];
+}
+
+function lookupKeys(product: ResolvedProductPreview): string[] {
+  return [
+    ...new Set([product.id, product.sku, product.groupId].filter(Boolean)),
+  ];
+}
+
+/** Map loader ids to resolved products, preserving VTEX sort order and sparse slots. */
+export function alignProductsToIds(
+  ids: string[],
+  products: (ResolvedProductPreview | null)[],
+): (ResolvedProductPreview | null)[] {
+  const trimmed = ids.map((id) => id.trim()).filter(Boolean);
+  const byKey = new Map<string, ResolvedProductPreview>();
+  for (const product of products) {
+    if (!product) continue;
+    for (const key of lookupKeys(product)) {
+      byKey.set(key, product);
+    }
+  }
+
+  return trimmed.map((id, index) => byKey.get(id) ?? products[index] ?? null);
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/rich-text-block.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/rich-text-block.tsx
@@ -1,0 +1,143 @@
+import { useRef } from "react";
+import { Bold01, Italic01, Link01, Underline01 } from "@untitledui/icons";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import { cn } from "@deco/ui/lib/utils.js";
+
+/**
+ * Inline rich-text editor for Paragraph blocks. Renders the paragraph as
+ * formatted text (not a form field) and edits it in place — select text to
+ * bold/italic/underline/link via the toolbar that appears while focused.
+ * Stores the block's `html` field.
+ */
+export function RichTextBlock({
+  html,
+  placeholder,
+  onChange,
+}: {
+  html: string;
+  placeholder?: string;
+  onChange: (html: string) => void;
+}) {
+  // Keep the latest onChange reachable from TipTap's onUpdate without
+  // recreating the editor (which would reset selection/undo on every keystroke).
+  const onChangeRef = useRef(onChange);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read only inside the onUpdate callback, never during render
+  onChangeRef.current = onChange;
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        // Paragraph blocks are inline-only: structural blocks are their own
+        // deco blocks, so disable the block-level marks here.
+        heading: false,
+        blockquote: false,
+        codeBlock: false,
+        horizontalRule: false,
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+        dropcursor: false,
+        gapcursor: false,
+      }),
+      Placeholder.configure({ placeholder: placeholder ?? "Write something…" }),
+    ],
+    content: html || "",
+    editorProps: {
+      attributes: {
+        class: cn(
+          "prose prose-sm dark:prose-invert max-w-none focus:outline-none",
+          "leading-relaxed [&_p]:my-0",
+        ),
+      },
+    },
+    onUpdate: ({ editor }) => {
+      const next = editor.getHTML();
+      // TipTap emits "<p></p>" for empty content — normalize to "".
+      onChangeRef.current(next === "<p></p>" ? "" : next);
+    },
+  });
+
+  if (!editor) return null;
+
+  return (
+    <div className="relative">
+      {editor.isFocused && (
+        <div className="absolute -top-9 left-0 z-10 flex items-center gap-0.5 rounded-md border bg-popover p-0.5 shadow-md">
+          <MarkButton
+            active={editor.isActive("bold")}
+            label="Bold"
+            onClick={() => editor.chain().focus().toggleBold().run()}
+          >
+            <Bold01 size={14} />
+          </MarkButton>
+          <MarkButton
+            active={editor.isActive("italic")}
+            label="Italic"
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+          >
+            <Italic01 size={14} />
+          </MarkButton>
+          <MarkButton
+            active={editor.isActive("underline")}
+            label="Underline"
+            onClick={() => editor.chain().focus().toggleUnderline().run()}
+          >
+            <Underline01 size={14} />
+          </MarkButton>
+          <MarkButton
+            active={editor.isActive("link")}
+            label="Link"
+            onClick={() => {
+              const prev = editor.getAttributes("link").href as
+                | string
+                | undefined;
+              const url = window.prompt("Link URL", prev ?? "https://");
+              if (url === null) return;
+              if (url === "") {
+                editor.chain().focus().unsetLink().run();
+              } else {
+                editor.chain().focus().setLink({ href: url }).run();
+              }
+            }}
+          >
+            <Link01 size={14} />
+          </MarkButton>
+        </div>
+      )}
+      <EditorContent editor={editor} className="text-[15px] text-foreground" />
+    </div>
+  );
+}
+
+function MarkButton({
+  active,
+  label,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      // Keep the editor selection while clicking the toolbar.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className={cn(
+        "flex h-7 w-7 items-center justify-center rounded transition-colors cursor-pointer",
+        active
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { blockComponentName } from "./blog-data";
+
+describe("blockComponentName", () => {
+  test("extracts from standard blog block paths", () => {
+    expect(blockComponentName("blog/sections/blocks/Paragraph.tsx")).toBe(
+      "Paragraph",
+    );
+  });
+
+  test("extracts from site-specific blog block paths", () => {
+    expect(blockComponentName("site/sections/Blog/Post/Paragraph.tsx")).toBe(
+      "Paragraph",
+    );
+    expect(blockComponentName("site/sections/Blog/Post/ProductCard.tsx")).toBe(
+      "ProductCard",
+    );
+  });
+
+  test("strips .ts and .jsx extensions", () => {
+    expect(blockComponentName("blog/sections/blocks/Code.ts")).toBe("Code");
+    expect(blockComponentName("blog/sections/blocks/Video.jsx")).toBe("Video");
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -278,3 +278,15 @@ export function blockComponentName(resolveType: string): string {
   const base = resolveType.split("/").pop() ?? resolveType;
   return base.replace(/\.(tsx?|jsx?)$/, "");
 }
+
+const BLOG_POST_BLOCK_PREFIXES = [
+  "blog/sections/blocks/",
+  "site/sections/Blog/Post/",
+] as const;
+
+/** True when resolveType points at a blog post content block editor. */
+export function isBlogPostBlockResolveType(resolveType: string): boolean {
+  return BLOG_POST_BLOCK_PREFIXES.some((prefix) =>
+    resolveType.startsWith(prefix),
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -264,7 +264,7 @@ export function discoverBlogBlockTypes(meta: LiveMeta): BlogBlockType[] {
       const md = resolveBlockSchemaMetadata(resolveType, meta);
       out.push({
         resolveType,
-        title: md.title ?? blockTypeLabel(resolveType),
+        title: md.title ?? blockComponentName(resolveType),
         description: md.description,
         icon: md.icon,
       });
@@ -273,8 +273,8 @@ export function discoverBlogBlockTypes(meta: LiveMeta): BlogBlockType[] {
   return out.sort((a, b) => a.title.localeCompare(b.title));
 }
 
-/** "blog/sections/blocks/Paragraph.tsx" -> "Paragraph" */
-function blockTypeLabel(resolveType: string): string {
+/** "site/sections/Blog/Post/Paragraph.tsx" -> "Paragraph" */
+export function blockComponentName(resolveType: string): string {
   const base = resolveType.split("/").pop() ?? resolveType;
   return base.replace(/\.(tsx?|jsx?)$/, "");
 }

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -141,7 +141,7 @@ export function scanBlogEntries(
 }
 
 /** Extract all blog records of a given kind, sorted by label. */
-export function extractBlogEntries(
+function extractBlogEntries(
   decofile: Record<string, unknown>,
   kind: BlogKind,
 ): BlogEntry[] {
@@ -157,17 +157,6 @@ export function listBlogPayloads(
     key: entry.key,
     payload: getBlogPayload(asRecord(decofile[entry.key]) ?? undefined, kind),
   }));
-}
-
-export function blogCounts(
-  decofile: Record<string, unknown>,
-): Record<BlogKind, number> {
-  const all = scanBlogEntries(decofile);
-  return {
-    posts: all.posts.length,
-    authors: all.authors.length,
-    categories: all.categories.length,
-  };
 }
 
 /** Read the editable payload (the `post`/`author`/`category` object). */
@@ -285,7 +274,7 @@ export function discoverBlogBlockTypes(meta: LiveMeta): BlogBlockType[] {
 }
 
 /** "blog/sections/blocks/Paragraph.tsx" -> "Paragraph" */
-export function blockTypeLabel(resolveType: string): string {
+function blockTypeLabel(resolveType: string): string {
   const base = resolveType.split("/").pop() ?? resolveType;
   return base.replace(/\.(tsx?|jsx?)$/, "");
 }

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -1,0 +1,291 @@
+/**
+ * Pure helpers for the Blog content collections (Posts, Authors,
+ * Categories). Deco's blog app stores each record as a decofile block
+ * keyed `collections/blog/<kind>/<id>` whose `__resolveType` points at the
+ * matching loader. We detect by `__resolveType` (robust to however the
+ * decofile keys the entry) and edit the wrapper object in place.
+ *
+ * On-disk, block files are URL-encoded: the block id
+ * `collections/blog/posts/abc` lives at
+ * `.deco/blocks/collections%2Fblog%2Fposts%2Fabc.json`. So writes must
+ * encode the key into the filename — see `blogBlockFilePath`.
+ */
+import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import { resolveBlockSchemaMetadata } from "@/web/components/sections-editor/resolve-schema";
+
+const BLOG_LOADER_RESOLVE_TYPES = {
+  post: "blog/loaders/Blogpost.ts",
+  author: "blog/loaders/Author.ts",
+  category: "blog/loaders/Category.ts",
+} as const;
+
+/** Prefix every blog content block (Paragraph, Heading, …) shares. */
+const BLOG_BLOCK_PREFIX = "blog/sections/blocks/";
+
+export type BlogKind = "posts" | "authors" | "categories";
+
+export const BLOG_KINDS: readonly BlogKind[] = [
+  "posts",
+  "authors",
+  "categories",
+];
+
+export const BLOG_SINGULAR: Record<BlogKind, string> = {
+  posts: "post",
+  authors: "author",
+  categories: "category",
+};
+
+export function isBlogKind(id: string): id is BlogKind {
+  return (BLOG_KINDS as readonly string[]).includes(id);
+}
+
+/** Wrapper field that holds the editable payload for each loader block. */
+const WRAPPER_KEY: Record<BlogKind, "post" | "author" | "category"> = {
+  posts: "post",
+  authors: "author",
+  categories: "category",
+};
+
+const RESOLVE_TYPE_FOR_KIND: Record<BlogKind, string> = {
+  posts: BLOG_LOADER_RESOLVE_TYPES.post,
+  authors: BLOG_LOADER_RESOLVE_TYPES.author,
+  categories: BLOG_LOADER_RESOLVE_TYPES.category,
+};
+
+const KIND_FOR_RESOLVE_TYPE: Record<string, BlogKind> = Object.fromEntries(
+  Object.entries(RESOLVE_TYPE_FOR_KIND).map(([kind, rt]) => [
+    rt,
+    kind as BlogKind,
+  ]),
+);
+
+export interface BlogEntry {
+  /** Decofile key (block id), e.g. `collections/blog/posts/abc`. */
+  key: string;
+  kind: BlogKind;
+  /** Human label derived from the payload (title / name). */
+  label: string;
+  /** Secondary line (slug, email, …). */
+  subtitle: string;
+}
+
+function kindOfResolveType(resolveType: unknown): BlogKind | null {
+  return typeof resolveType === "string"
+    ? (KIND_FOR_RESOLVE_TYPE[resolveType] ?? null)
+    : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function entryLabelAndSubtitle(
+  kind: BlogKind,
+  payload: Record<string, unknown>,
+): { label: string; subtitle: string } {
+  switch (kind) {
+    case "posts":
+      return {
+        label: str(payload.title) || "Untitled post",
+        subtitle: str(payload.slug),
+      };
+    case "authors":
+      return {
+        label: str(payload.name) || "Unnamed author",
+        subtitle: str(payload.email),
+      };
+    case "categories":
+      return {
+        label: str(payload.name) || "Unnamed category",
+        subtitle: str(payload.slug),
+      };
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error(`Unhandled blog kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Single-pass scan that returns all blog entries grouped by kind.
+ * Use this in hot render paths instead of calling extractBlogEntries per kind.
+ */
+export function scanBlogEntries(
+  decofile: Record<string, unknown>,
+): Record<BlogKind, BlogEntry[]> {
+  const result: Record<BlogKind, BlogEntry[]> = {
+    posts: [],
+    authors: [],
+    categories: [],
+  };
+  for (const [key, value] of Object.entries(decofile)) {
+    const obj = asRecord(value);
+    if (!obj) continue;
+    const kind = kindOfResolveType(obj.__resolveType);
+    if (!kind) continue;
+    const payload = asRecord(obj[WRAPPER_KEY[kind]]) ?? {};
+    const { label, subtitle } = entryLabelAndSubtitle(kind, payload);
+    result[kind].push({ key, kind, label, subtitle });
+  }
+  for (const kind of BLOG_KINDS) {
+    result[kind].sort((a, b) => a.label.localeCompare(b.label));
+  }
+  return result;
+}
+
+/** Extract all blog records of a given kind, sorted by label. */
+export function extractBlogEntries(
+  decofile: Record<string, unknown>,
+  kind: BlogKind,
+): BlogEntry[] {
+  return scanBlogEntries(decofile)[kind];
+}
+
+/** All records of a kind paired with their editable payload. */
+export function listBlogPayloads(
+  decofile: Record<string, unknown>,
+  kind: BlogKind,
+): Array<{ key: string; payload: Record<string, unknown> }> {
+  return extractBlogEntries(decofile, kind).map((entry) => ({
+    key: entry.key,
+    payload: getBlogPayload(asRecord(decofile[entry.key]) ?? undefined, kind),
+  }));
+}
+
+export function blogCounts(
+  decofile: Record<string, unknown>,
+): Record<BlogKind, number> {
+  const all = scanBlogEntries(decofile);
+  return {
+    posts: all.posts.length,
+    authors: all.authors.length,
+    categories: all.categories.length,
+  };
+}
+
+/** Read the editable payload (the `post`/`author`/`category` object). */
+export function getBlogPayload(
+  block: Record<string, unknown> | undefined,
+  kind: BlogKind,
+): Record<string, unknown> {
+  if (!block) return {};
+  return asRecord(block[WRAPPER_KEY[kind]]) ?? {};
+}
+
+/** Rebuild the full block from an edited payload, preserving id + type. */
+export function buildBlogBlock(
+  key: string,
+  kind: BlogKind,
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    name: key,
+    __resolveType: RESOLVE_TYPE_FOR_KIND[kind],
+    [WRAPPER_KEY[kind]]: payload,
+  };
+}
+
+/**
+ * On-disk block filename. Deco encodes the block id, so slashes become
+ * `%2F`. `encodeURIComponent` reproduces deco's exact scheme (verified
+ * against existing `collections%2Fblog%2F…` files).
+ */
+export function blogBlockFilePath(key: string): string {
+  return `.deco/blocks/${encodeURIComponent(key)}.json`;
+}
+
+function randomHex(length: number): string {
+  const bytes = new Uint8Array(Math.ceil(length / 2));
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, length);
+}
+
+/** Fresh `collections/blog/<kind>/<id>` key not present in the decofile. */
+export function generateBlogKey(
+  decofile: Record<string, unknown>,
+  kind: BlogKind,
+): string {
+  const key = `collections/blog/${kind}/${randomHex(12)}`;
+  if (!Object.hasOwn(decofile, key)) return key;
+  throw new Error("Could not generate a unique blog block key");
+}
+
+/** Default payload for a freshly created record. */
+export function emptyBlogPayload(kind: BlogKind): Record<string, unknown> {
+  switch (kind) {
+    case "posts":
+      return {
+        title: "Untitled post",
+        excerpt: "",
+        slug: `untitled-${randomHex(8)}`,
+        date: new Date().toISOString().slice(0, 10),
+        image: "",
+        authors: [],
+        categories: [],
+        sections: [],
+      };
+    case "authors":
+      return {
+        name: "New author",
+        email: "",
+        jobTitle: "",
+        company: "",
+        avatar: "",
+      };
+    case "categories":
+      return { name: "New category", slug: `category-${randomHex(8)}` };
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error(`Unhandled blog kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+export interface BlogBlockType {
+  resolveType: string;
+  title: string;
+  description?: string;
+  icon?: string;
+}
+
+/**
+ * Discover the content block types a post can contain
+ * (`blog/sections/blocks/*`) from the live manifest, with title/icon
+ * metadata for the inserter UI.
+ */
+export function discoverBlogBlockTypes(meta: LiveMeta): BlogBlockType[] {
+  const seen = new Set<string>();
+  const out: BlogBlockType[] = [];
+  const groups = meta.manifest?.blocks ?? {};
+  for (const group of Object.values(groups)) {
+    for (const resolveType of Object.keys(group)) {
+      if (!resolveType.startsWith(BLOG_BLOCK_PREFIX) || seen.has(resolveType)) {
+        continue;
+      }
+      seen.add(resolveType);
+      const md = resolveBlockSchemaMetadata(resolveType, meta);
+      out.push({
+        resolveType,
+        title: md.title ?? blockTypeLabel(resolveType),
+        description: md.description,
+        icon: md.icon,
+      });
+    }
+  }
+  return out.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+/** "blog/sections/blocks/Paragraph.tsx" -> "Paragraph" */
+export function blockTypeLabel(resolveType: string): string {
+  const base = resolveType.split("/").pop() ?? resolveType;
+  return base.replace(/\.(tsx?|jsx?)$/, "");
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-sandbox-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-sandbox-context.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, type PropsWithChildren } from "react";
+
+export interface BlogSandboxContextValue {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+const BlogSandboxContext = createContext<BlogSandboxContextValue | null>(null);
+
+export function BlogSandboxProvider({
+  orgSlug,
+  virtualMcpId,
+  branch,
+  children,
+}: PropsWithChildren<BlogSandboxContextValue>) {
+  return (
+    <BlogSandboxContext.Provider value={{ orgSlug, virtualMcpId, branch }}>
+      {children}
+    </BlogSandboxContext.Provider>
+  );
+}
+
+export function useBlogSandbox(): BlogSandboxContextValue | null {
+  return useContext(BlogSandboxContext);
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
@@ -1,0 +1,363 @@
+import { useState } from "react";
+import { ChevronDown, Settings01 } from "@untitledui/icons";
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@deco/ui/components/collapsible.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import { MultiSelect } from "@deco/ui/components/multi-select.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import { ImageField } from "@/web/components/sections-editor/fields/image-field";
+import { StringField } from "@/web/components/sections-editor/fields/string-field";
+import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import {
+  buildBlogBlock,
+  discoverBlogBlockTypes,
+  getBlogPayload,
+  listBlogPayloads,
+} from "./blog-data";
+import { useSaveBlogBlock } from "./use-blog-mutations";
+import { useAutosave } from "./use-autosave";
+import { SaveStatus } from "./save-status";
+import { InsertBlockDivider } from "./block-picker";
+import { BlockRow } from "./blocks/block-row";
+import { type RawBlock } from "./blocks/block-registry";
+import { InlineText, str } from "./blocks/primitives";
+
+type BlockItem = { id: string; block: RawBlock };
+
+function asBlocks(value: unknown): RawBlock[] {
+  return Array.isArray(value) ? (value as RawBlock[]) : [];
+}
+
+/**
+ * Notion-style post editor: a title, a collapsible settings panel, and the
+ * post body rendered as a document of inline-editable blocks. Each block
+ * renders as its content type (paragraph, heading, list, …); a ⊕ between
+ * blocks inserts, and a drag handle reorders. Not a schema form.
+ */
+export function PostEditor({
+  orgSlug,
+  virtualMcpId,
+  branch,
+  blockKey,
+  block,
+  decofile,
+  meta,
+}: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  blockKey: string;
+  block: Record<string, unknown> | undefined;
+  decofile: Record<string, unknown>;
+  meta: LiveMeta;
+}) {
+  const save = useSaveBlogBlock({ orgSlug, virtualMcpId, branch });
+  const initial = getBlogPayload(block, "posts");
+
+  const [post, setPost] = useAutosave(initial, (next) => {
+    save.mutate({ blockKey, data: buildBlogBlock(blockKey, "posts", next) });
+  });
+
+  const blockTypes = discoverBlogBlockTypes(meta);
+
+  // Ids and blocks are co-located in one piece of state so dnd-kit's
+  // sortable identity never drifts from the block list. All mutations go
+  // through syncBlocks which updates both atomically.
+  const [blockItems, setBlockItems] = useState<BlockItem[]>(() =>
+    asBlocks(initial.sections).map((blk) => ({ id: uid(), block: blk })),
+  );
+
+  const ids = blockItems.map((x) => x.id);
+  const blocks = blockItems.map((x) => x.block);
+
+  const syncBlocks = (items: BlockItem[]) => {
+    setBlockItems(items);
+    setPost({ ...post, sections: items.map((x) => x.block) });
+  };
+
+  const setField = (key: string, value: unknown) =>
+    setPost({ ...post, [key]: value });
+
+  const insertAt = (index: number, resolveType: string) => {
+    const next = [...blockItems];
+    next.splice(index, 0, { id: uid(), block: { __resolveType: resolveType } });
+    syncBlocks(next);
+  };
+
+  const updateAt = (index: number, value: RawBlock) => {
+    syncBlocks(
+      blockItems.map((item, i) =>
+        i === index ? { ...item, block: value } : item,
+      ),
+    );
+  };
+
+  const removeAt = (index: number) => {
+    syncBlocks(blockItems.filter((_, i) => i !== index));
+  };
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = blockItems.findIndex((x) => x.id === String(active.id));
+    const newIndex = blockItems.findIndex((x) => x.id === String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+    syncBlocks(arrayMove(blockItems, oldIndex, newIndex));
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b px-6">
+        <span className="truncate text-sm font-medium">
+          {str(post.title) || "Untitled post"}
+        </span>
+        <SaveStatus isPending={save.isPending} isError={save.isError} />
+      </div>
+
+      <div className="min-w-0 flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-3xl px-8 py-8">
+          {/* Title — wraps onto multiple lines instead of truncating */}
+          <InlineText
+            value={str(post.title)}
+            onChange={(v) => setField("title", v)}
+            placeholder="Post title"
+            className="py-1 text-3xl font-bold text-foreground"
+          />
+
+          {/* Settings */}
+          <PostSettings post={post} decofile={decofile} onChange={setField} />
+
+          <div className="mt-6 border-t" />
+
+          {/* Block document */}
+          <div className="mt-2">
+            {blocks.length === 0 && (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                This post has no content yet. Use ⊕ to add your first block.
+              </p>
+            )}
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={ids}
+                strategy={verticalListSortingStrategy}
+              >
+                <InsertBlockDivider
+                  blockTypes={blockTypes}
+                  onInsert={(rt) => insertAt(0, rt)}
+                  alwaysShow={blocks.length === 0}
+                />
+                {blockItems.map(({ id, block: blk }, index) => (
+                  <div key={id}>
+                    <BlockRow
+                      id={id}
+                      block={blk}
+                      meta={meta}
+                      onChange={(v) => updateAt(index, v)}
+                      onDelete={() => removeAt(index)}
+                    />
+                    <InsertBlockDivider
+                      blockTypes={blockTypes}
+                      onInsert={(rt) => insertAt(index + 1, rt)}
+                    />
+                  </div>
+                ))}
+              </SortableContext>
+            </DndContext>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function uid(): string {
+  return crypto.randomUUID();
+}
+
+function PostSettings({
+  post,
+  decofile,
+  onChange,
+}: {
+  post: Record<string, unknown>;
+  decofile: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="mt-4">
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground cursor-pointer"
+        >
+          <Settings01 size={15} />
+          <span className="flex-1 text-left">Post settings</span>
+          <ChevronDown
+            size={15}
+            className={cn("transition-transform", open && "rotate-180")}
+          />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-5 px-2 pt-4">
+        <div className="space-y-2">
+          <Label htmlFor="post-excerpt">Excerpt</Label>
+          <Textarea
+            id="post-excerpt"
+            value={str(post.excerpt)}
+            onChange={(e) => onChange("excerpt", e.target.value)}
+            rows={2}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="post-slug">Slug</Label>
+            <Input
+              id="post-slug"
+              value={str(post.slug)}
+              onChange={(e) => onChange("slug", e.target.value)}
+              placeholder="my-post"
+              className="h-10"
+            />
+          </div>
+          <StringField
+            schema={{ type: "string", format: "date", title: "Date" }}
+            value={str(post.date)}
+            onChange={(v) => onChange("date", v)}
+            path="post-date"
+            label="Date"
+          />
+        </div>
+        <ImageField
+          schema={{ type: "string", format: "image-uri", title: "Cover image" }}
+          value={post.image}
+          onChange={(v) => onChange("image", v)}
+          path="post-image"
+          label="Cover image"
+        />
+        <RelationSelect
+          label="Authors"
+          decofile={decofile}
+          kind="authors"
+          valueField="email"
+          extraFields={["email"]}
+          selected={post.authors}
+          onChange={(v) => onChange("authors", v)}
+        />
+        <RelationSelect
+          label="Categories"
+          decofile={decofile}
+          kind="categories"
+          valueField="slug"
+          extraFields={["slug"]}
+          selected={post.categories}
+          onChange={(v) => onChange("categories", v)}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+/**
+ * Multi-select that links a post to existing Author/Category records.
+ * Stores the denormalized subset deco expects (e.g. `{ name, email }`).
+ */
+function RelationSelect({
+  label,
+  decofile,
+  kind,
+  valueField,
+  extraFields,
+  selected,
+  onChange,
+}: {
+  label: string;
+  decofile: Record<string, unknown>;
+  kind: "authors" | "categories";
+  valueField: string;
+  extraFields: string[];
+  selected: unknown;
+  onChange: (value: Array<Record<string, unknown>>) => void;
+}) {
+  const records = listBlogPayloads(decofile, kind);
+  const valueOf = (payload: Record<string, unknown>, key: string) =>
+    str(payload[valueField]) || key;
+
+  const options = records.map(({ key, payload }) => ({
+    value: valueOf(payload, key),
+    label: str(payload.name) || valueOf(payload, key),
+  }));
+
+  const selectedArr = Array.isArray(selected)
+    ? (selected as Array<Record<string, unknown>>)
+    : [];
+  const defaultValue = selectedArr
+    .map((s) => str(s[valueField]))
+    .filter(Boolean);
+
+  const handleChange = (values: string[]) => {
+    onChange(
+      values.map((value) => {
+        const match = records.find(
+          ({ key, payload }) => valueOf(payload, key) === value,
+        );
+        if (!match) return { name: value, [valueField]: value };
+        const out: Record<string, unknown> = { name: str(match.payload.name) };
+        for (const f of extraFields) out[f] = match.payload[f] ?? value;
+        return out;
+      }),
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      {options.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No {label.toLowerCase()} yet — create some in the{" "}
+          {label.toLowerCase()} collection.
+        </p>
+      ) : (
+        <MultiSelect
+          options={options}
+          defaultValue={defaultValue}
+          onValueChange={handleChange}
+          placeholder={`Select ${label.toLowerCase()}`}
+          maxCount={4}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
@@ -37,6 +37,7 @@ import {
 import { useSaveBlogBlock } from "./use-blog-mutations";
 import { useAutosave } from "./use-autosave";
 import { SaveStatus } from "./save-status";
+import { BlogSandboxProvider } from "./blog-sandbox-context";
 import { InsertBlockDivider } from "./block-picker";
 import { BlockRow } from "./blocks/block-row";
 import { type RawBlock } from "./blocks/block-registry";
@@ -133,71 +134,77 @@ export function PostEditor({
   };
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex h-12 shrink-0 items-center justify-between border-b px-6">
-        <span className="truncate text-sm font-medium">
-          {str(post.title) || "Untitled post"}
-        </span>
-        <SaveStatus isPending={save.isPending} isError={save.isError} />
-      </div>
+    <BlogSandboxProvider
+      orgSlug={orgSlug}
+      virtualMcpId={virtualMcpId}
+      branch={branch}
+    >
+      <div className="flex h-full flex-col">
+        <div className="flex h-12 shrink-0 items-center justify-between border-b px-6">
+          <span className="truncate text-sm font-medium">
+            {str(post.title) || "Untitled post"}
+          </span>
+          <SaveStatus isPending={save.isPending} isError={save.isError} />
+        </div>
 
-      <div className="min-w-0 flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-3xl px-8 py-8">
-          {/* Title — wraps onto multiple lines instead of truncating */}
-          <InlineText
-            value={str(post.title)}
-            onChange={(v) => setField("title", v)}
-            placeholder="Post title"
-            className="py-1 text-3xl font-bold text-foreground"
-          />
+        <div className="min-w-0 flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-3xl px-8 py-8">
+            {/* Title — wraps onto multiple lines instead of truncating */}
+            <InlineText
+              value={str(post.title)}
+              onChange={(v) => setField("title", v)}
+              placeholder="Post title"
+              className="py-1 text-3xl font-bold text-foreground"
+            />
 
-          {/* Settings */}
-          <PostSettings post={post} decofile={decofile} onChange={setField} />
+            {/* Settings */}
+            <PostSettings post={post} decofile={decofile} onChange={setField} />
 
-          <div className="mt-6 border-t" />
+            <div className="mt-6 border-t" />
 
-          {/* Block document */}
-          <div className="mt-2">
-            {blocks.length === 0 && (
-              <p className="py-6 text-center text-sm text-muted-foreground">
-                This post has no content yet. Use ⊕ to add your first block.
-              </p>
-            )}
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={ids}
-                strategy={verticalListSortingStrategy}
+            {/* Block document */}
+            <div className="mt-2">
+              {blocks.length === 0 && (
+                <p className="py-6 text-center text-sm text-muted-foreground">
+                  This post has no content yet. Use ⊕ to add your first block.
+                </p>
+              )}
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
               >
-                <InsertBlockDivider
-                  blockTypes={blockTypes}
-                  onInsert={(rt) => insertAt(0, rt)}
-                  alwaysShow={blocks.length === 0}
-                />
-                {blockItems.map(({ id, block: blk }, index) => (
-                  <div key={id}>
-                    <BlockRow
-                      id={id}
-                      block={blk}
-                      meta={meta}
-                      onChange={(v) => updateAt(index, v)}
-                      onDelete={() => removeAt(index)}
-                    />
-                    <InsertBlockDivider
-                      blockTypes={blockTypes}
-                      onInsert={(rt) => insertAt(index + 1, rt)}
-                    />
-                  </div>
-                ))}
-              </SortableContext>
-            </DndContext>
+                <SortableContext
+                  items={ids}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <InsertBlockDivider
+                    blockTypes={blockTypes}
+                    onInsert={(rt) => insertAt(0, rt)}
+                    alwaysShow={blocks.length === 0}
+                  />
+                  {blockItems.map(({ id, block: blk }, index) => (
+                    <div key={id}>
+                      <BlockRow
+                        id={id}
+                        block={blk}
+                        meta={meta}
+                        onChange={(v) => updateAt(index, v)}
+                        onDelete={() => removeAt(index)}
+                      />
+                      <InsertBlockDivider
+                        blockTypes={blockTypes}
+                        onInsert={(rt) => insertAt(index + 1, rt)}
+                      />
+                    </div>
+                  ))}
+                </SortableContext>
+              </DndContext>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </BlogSandboxProvider>
   );
 }
 

--- a/apps/mesh/src/web/components/sandbox/content/blog/record-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/record-editor.tsx
@@ -1,0 +1,118 @@
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { ImageField } from "@/web/components/sections-editor/fields/image-field";
+import { buildBlogBlock, getBlogPayload, type BlogKind } from "./blog-data";
+import { str } from "./blocks/primitives";
+import { useSaveBlogBlock } from "./use-blog-mutations";
+import { useAutosave } from "./use-autosave";
+import { SaveStatus } from "./save-status";
+
+type RecordKind = Extract<BlogKind, "authors" | "categories">;
+
+interface FieldDef {
+  key: string;
+  label: string;
+  widget: "text" | "textarea" | "image";
+  placeholder?: string;
+}
+
+const FIELDS: Record<RecordKind, FieldDef[]> = {
+  authors: [
+    { key: "name", label: "Name", widget: "text" },
+    {
+      key: "email",
+      label: "Email",
+      widget: "text",
+      placeholder: "author@example.com",
+    },
+    { key: "jobTitle", label: "Job title", widget: "text" },
+    { key: "company", label: "Company", widget: "text" },
+    { key: "avatar", label: "Avatar", widget: "image" },
+  ],
+  categories: [
+    { key: "name", label: "Name", widget: "text" },
+    { key: "slug", label: "Slug", widget: "text", placeholder: "my-category" },
+  ],
+};
+
+const TITLE: Record<RecordKind, string> = {
+  authors: "Author",
+  categories: "Category",
+};
+
+export function RecordEditor({
+  orgSlug,
+  virtualMcpId,
+  branch,
+  kind,
+  blockKey,
+  block,
+}: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  kind: RecordKind;
+  blockKey: string;
+  block: Record<string, unknown> | undefined;
+}) {
+  const save = useSaveBlogBlock({ orgSlug, virtualMcpId, branch });
+  const initial = getBlogPayload(block, kind);
+
+  const [payload, setPayload] = useAutosave(initial, (next) => {
+    save.mutate({ blockKey, data: buildBlogBlock(blockKey, kind, next) });
+  });
+
+  const setField = (key: string, value: unknown) =>
+    setPayload({ ...payload, [key]: value });
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b px-6">
+        <span className="text-sm font-medium">{TITLE[kind]}</span>
+        <SaveStatus isPending={save.isPending} isError={save.isError} />
+      </div>
+      <div className="min-w-0 flex-1 overflow-y-auto px-6 py-6">
+        <div className="mx-auto max-w-xl space-y-6">
+          {FIELDS[kind].map((field) => (
+            <div key={field.key} className="space-y-2">
+              {field.widget === "image" ? (
+                <ImageField
+                  schema={{
+                    type: "string",
+                    format: "image-uri",
+                    title: field.label,
+                  }}
+                  value={payload[field.key]}
+                  onChange={(v) => setField(field.key, v)}
+                  path={field.key}
+                  label={field.label}
+                />
+              ) : (
+                <>
+                  <Label htmlFor={field.key}>{field.label}</Label>
+                  {field.widget === "textarea" ? (
+                    <Textarea
+                      id={field.key}
+                      value={str(payload[field.key])}
+                      onChange={(e) => setField(field.key, e.target.value)}
+                      rows={3}
+                    />
+                  ) : (
+                    <Input
+                      id={field.key}
+                      value={str(payload[field.key])}
+                      placeholder={field.placeholder}
+                      onChange={(e) => setField(field.key, e.target.value)}
+                      className="h-10"
+                    />
+                  )}
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/save-status.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/save-status.tsx
@@ -1,0 +1,33 @@
+import { AlertCircle, Check, Loading01 } from "@untitledui/icons";
+
+/** Subtle autosave indicator shown in editor headers. */
+export function SaveStatus({
+  isPending,
+  isError,
+}: {
+  isPending: boolean;
+  isError: boolean;
+}) {
+  if (isError) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-destructive">
+        <AlertCircle size={13} />
+        Couldn't save
+      </span>
+    );
+  }
+  if (isPending) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Loading01 size={13} className="animate-spin" />
+        Saving…
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1.5 text-xs text-muted-foreground/70">
+      <Check size={13} />
+      Saved
+    </span>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/use-autosave.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-autosave.ts
@@ -1,0 +1,30 @@
+import { useRef, useState } from "react";
+
+const AUTOSAVE_DELAY = 700;
+
+/**
+ * Local draft state that persists via `save` after a debounce. Each edit
+ * resets the timer, so the final value wins (stale timers are cleared before
+ * they fire). Remount (via a `key` on the editor) re-seeds the draft.
+ *
+ * On unmount, a pending timer may fire and call `save` one last time. This
+ * is intentional: it ensures the user's final edit is persisted even on fast
+ * navigation. TanStack's `mutate` is fire-and-forget so the call is safe
+ * after the component unmounts.
+ */
+export function useAutosave<T>(
+  initial: T,
+  save: (value: T) => void,
+  delay = AUTOSAVE_DELAY,
+): readonly [T, (next: T) => void] {
+  const [draft, setDraft] = useState<T>(initial);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const update = (next: T) => {
+    setDraft(next);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => save(next), delay);
+  };
+
+  return [draft, update] as const;
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
@@ -1,0 +1,121 @@
+/**
+ * Save/delete hooks for blog collection blocks. These mirror the generic
+ * `use-save-block`/`use-delete-block` hooks but encode the block id into
+ * the on-disk filename (blog ids contain `/`, which the generic hooks
+ * reject). The React Query cache stays keyed by the decoded block id, so
+ * the rest of the Content tab reads blog blocks like any other entry.
+ */
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+import { blogBlockFilePath } from "./blog-data";
+
+interface BlogMutationParams {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+function decofileQueryKey({
+  orgSlug,
+  virtualMcpId,
+  branch,
+}: BlogMutationParams) {
+  return KEYS.decofile(`${orgSlug}/${virtualMcpId}/${branch}`);
+}
+
+function writeUrl(
+  { orgSlug, virtualMcpId, branch }: BlogMutationParams,
+  op: "write" | "unlink",
+) {
+  return `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/${op}`;
+}
+
+export function useSaveBlogBlock(params: BlogMutationParams) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      blockKey,
+      data,
+    }: {
+      blockKey: string;
+      data: unknown;
+    }) => {
+      const res = await fetch(writeUrl(params, "write"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          path: blogBlockFilePath(blockKey),
+          content: JSON.stringify(data, null, 2),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error ?? `Write failed (${res.status})`,
+        );
+      }
+      return res.json();
+    },
+    onMutate: async ({ blockKey, data }) => {
+      const queryKey = decofileQueryKey(params);
+      await queryClient.cancelQueries({ queryKey });
+      const previous =
+        queryClient.getQueryData<Record<string, unknown>>(queryKey);
+      queryClient.setQueryData(
+        queryKey,
+        (current: Record<string, unknown> | undefined) => ({
+          ...(current ?? {}),
+          [blockKey]: data,
+        }),
+      );
+      return { previous, queryKey };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.queryKey) {
+        queryClient.setQueryData(context.queryKey, context.previous);
+      }
+    },
+  });
+}
+
+export function useDeleteBlogBlock(params: BlogMutationParams) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ blockKey }: { blockKey: string }) => {
+      const res = await fetch(writeUrl(params, "unlink"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path: blogBlockFilePath(blockKey) }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error ?? `Delete failed (${res.status})`,
+        );
+      }
+      return res.json() as Promise<{ ok: true; existed: boolean }>;
+    },
+    onMutate: async ({ blockKey }) => {
+      const queryKey = decofileQueryKey(params);
+      await queryClient.cancelQueries({ queryKey });
+      const previous =
+        queryClient.getQueryData<Record<string, unknown>>(queryKey);
+      queryClient.setQueryData(
+        queryKey,
+        (current: Record<string, unknown> | undefined) => {
+          if (!current) return current;
+          const { [blockKey]: _removed, ...rest } = current;
+          return rest;
+        },
+      );
+      return { previous, queryKey };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.queryKey) {
+        queryClient.setQueryData(context.queryKey, context.previous);
+      }
+    },
+  });
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/use-product-list-preview.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-product-list-preview.ts
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+import { useBlogSandbox } from "./blog-sandbox-context";
+import {
+  readProductListIds,
+  toInvokeLoaderBody,
+} from "./blocks/product-loader-utils";
+import {
+  alignProductsToIds,
+  parseProductListPreview,
+  productListLoaderKey,
+  type ResolvedProductPreview,
+} from "./blocks/product-preview-utils";
+
+async function invokeProductListLoader(
+  sandbox: { orgSlug: string; virtualMcpId: string; branch: string },
+  loader: unknown,
+): Promise<unknown> {
+  const res = await fetch(
+    `/api/${sandbox.orgSlug}/sandbox/${encodeURIComponent(sandbox.virtualMcpId)}/${encodeURIComponent(sandbox.branch)}/preview-invoke`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(toInvokeLoaderBody(loader)),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to resolve product loader: ${res.status}`);
+  }
+  const data = await res.json();
+  if (
+    data &&
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    "error" in data &&
+    typeof (data as { error?: unknown }).error === "string"
+  ) {
+    throw new Error((data as { error: string }).error);
+  }
+  return data;
+}
+
+export function useProductListPreview(loader: unknown): {
+  products: ResolvedProductPreview[];
+  productsById: (ResolvedProductPreview | null)[];
+  isLoading: boolean;
+  isError: boolean;
+} {
+  const sandbox = useBlogSandbox();
+  const ids = readProductListIds(loader);
+  const loaderKey = productListLoaderKey(loader);
+  const sandboxKey = sandbox
+    ? `${sandbox.orgSlug}/${sandbox.virtualMcpId}/${sandbox.branch}`
+    : "";
+
+  const query = useQuery({
+    queryKey: KEYS.sandboxInvoke(sandboxKey, loaderKey),
+    queryFn: async () => {
+      const data = await invokeProductListLoader(sandbox!, loader);
+      return parseProductListPreview(data);
+    },
+    enabled: !!sandbox && ids.some((id) => id.trim()),
+    staleTime: 60_000,
+    retry: 1,
+  });
+
+  const parsed = query.data ?? [];
+  return {
+    products: parsed.filter(
+      (product): product is ResolvedProductPreview => product !== null,
+    ),
+    productsById: alignProductsToIds(ids, parsed),
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -1,16 +1,20 @@
 import { Suspense, lazy, useState } from "react";
 import {
   AlertCircle,
+  BookOpen01,
   Copy01,
   DotsHorizontal,
   Edit01,
+  File02,
   Flag01,
   Globe02,
   LayoutAlt01,
   Loading01,
   Plus,
   SearchLg,
+  Tag01,
   Trash01,
+  Users01,
 } from "@untitledui/icons";
 import { toast } from "sonner";
 import {
@@ -83,6 +87,30 @@ import {
 } from "./content-mutations";
 import { PageFormDialog, type PageFormMode } from "./page-form-dialog";
 import { SectionRenameDialog } from "./section-rename-dialog";
+import {
+  type BlogEntry,
+  type BlogKind,
+  BLOG_KINDS,
+  BLOG_SINGULAR,
+  buildBlogBlock,
+  emptyBlogPayload,
+  generateBlogKey,
+  getBlogPayload,
+  isBlogKind,
+  scanBlogEntries,
+} from "./blog/blog-data";
+import {
+  useDeleteBlogBlock,
+  useSaveBlogBlock,
+} from "./blog/use-blog-mutations";
+
+const PostEditor = lazy(() =>
+  import("./blog/post-editor").then((m) => ({ default: m.PostEditor })),
+);
+
+const RecordEditor = lazy(() =>
+  import("./blog/record-editor").then((m) => ({ default: m.RecordEditor })),
+);
 
 const SectionsEditor = lazy(() =>
   import("@/web/components/sections-editor/sections-editor").then((m) => ({
@@ -98,11 +126,12 @@ const AddSectionModal = lazy(() =>
 
 const VARIANT_GREEN = "oklch(0.65 0.15 160)";
 
-type CollectionId = "pages" | "sections";
+type CollectionId = "pages" | "sections" | BlogKind;
 
 type Selection =
   | { collection: "pages"; key: string; path: string }
   | { collection: "sections"; key: string }
+  | { collection: BlogKind; key: string }
   | null;
 
 type PageDialogState = {
@@ -115,6 +144,7 @@ type PageDialogState = {
 type DeleteTarget =
   | { kind: "page"; key: string; label: string }
   | { kind: "section"; key: string; label: string }
+  | { kind: "blog"; blogKind: BlogKind; key: string; label: string }
   | null;
 
 export function ContentBrowser() {
@@ -208,6 +238,8 @@ function ContentBrowserReady({
 
   const saveBlock = useSaveBlock(fetchParams);
   const deleteBlock = useDeleteBlock(fetchParams);
+  const saveBlogBlock = useSaveBlogBlock(fetchParams);
+  const deleteBlogBlock = useDeleteBlogBlock(fetchParams);
 
   const [activeCollection, setActiveCollection] =
     useState<CollectionId>("pages");
@@ -243,8 +275,13 @@ function ContentBrowserReady({
     a.name.localeCompare(b.name),
   );
   const globalSections = extractGlobalSections(decofile, meta);
+  const allBlogEntries = scanBlogEntries(decofile);
+  const showBlog = BLOG_KINDS.some((k) => allBlogEntries[k].length > 0);
+  const blogEntries = isBlogKind(activeCollection)
+    ? allBlogEntries[activeCollection]
+    : [];
 
-  if (pages.length === 0 && globalSections.length === 0) {
+  if (pages.length === 0 && globalSections.length === 0 && !showBlog) {
     return (
       <EmptyMessage
         icon={AlertCircle}
@@ -257,6 +294,9 @@ function ContentBrowserReady({
   const counts: Record<CollectionId, number> = {
     pages: pages.length,
     sections: globalSections.length,
+    posts: allBlogEntries.posts.length,
+    authors: allBlogEntries.authors.length,
+    categories: allBlogEntries.categories.length,
   };
   const takenPaths = new Set(pages.map((p) => normalizePagePath(p.path)));
   const takenPageNames = new Set(pages.map((p) => p.name));
@@ -453,21 +493,55 @@ function ContentBrowserReady({
     }
   };
 
+  // ------------------ Blog CRUD ------------------
+  const handleCreateBlog = async (kind: BlogKind) => {
+    const key = generateBlogKey(decofile, kind);
+    const data = buildBlogBlock(key, kind, emptyBlogPayload(kind));
+    try {
+      await saveBlogBlock.mutateAsync({ blockKey: key, data });
+      toast.success(`Created ${BLOG_SINGULAR[kind]}`);
+      setSelection({ collection: kind, key });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not create");
+    }
+  };
+
+  const handleDuplicateBlog = async (entry: BlogEntry) => {
+    const source = decofile[entry.key] as Record<string, unknown> | undefined;
+    if (!source) {
+      toast.error("Record not found.");
+      return;
+    }
+    const key = generateBlogKey(decofile, entry.kind);
+    const labelKey = entry.kind === "posts" ? "title" : "name";
+    const payload = {
+      ...structuredClone(getBlogPayload(source, entry.kind)),
+      [labelKey]: `${entry.label} (copy)`,
+    };
+    try {
+      await saveBlogBlock.mutateAsync({
+        blockKey: key,
+        data: buildBlogBlock(key, entry.kind, payload),
+      });
+      toast.success(`Duplicated "${entry.label}"`);
+      setSelection({ collection: entry.kind, key });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Duplicate failed");
+    }
+  };
+
   // ------------------ Delete ------------------
   const confirmDelete = async () => {
     if (!deleteTarget) return;
     const { kind, key, label } = deleteTarget;
     try {
-      await deleteBlock.mutateAsync({ blockKey: key });
+      if (kind === "blog") {
+        await deleteBlogBlock.mutateAsync({ blockKey: key });
+      } else {
+        await deleteBlock.mutateAsync({ blockKey: key });
+      }
       toast.success(`Deleted "${label}"`);
-      if (kind === "page") {
-        if (selection?.collection === "pages" && selection.key === key) {
-          setSelection(null);
-        }
-      } else if (
-        selection?.collection === "sections" &&
-        selection.key === key
-      ) {
+      if (selection && selection.key === key) {
         setSelection(null);
       }
       setDeleteTarget(null);
@@ -477,11 +551,17 @@ function ContentBrowserReady({
   };
 
   // ------------------ Render ------------------
+  const isDeleting = deleteBlock.isPending || deleteBlogBlock.isPending;
+  const deleteNoun =
+    deleteTarget?.kind === "blog"
+      ? BLOG_SINGULAR[deleteTarget.blogKind]
+      : (deleteTarget?.kind ?? "item");
   return (
     <div className="flex h-full w-full">
       <CollectionsSidebar
         active={activeCollection}
         counts={counts}
+        showBlog={showBlog}
         onSelect={(id) => {
           setActiveCollection(id);
           setSelection(null);
@@ -491,6 +571,7 @@ function ContentBrowserReady({
         activeCollection={activeCollection}
         pages={pages}
         sections={globalSections}
+        blogEntries={blogEntries}
         decofile={decofile}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
@@ -500,6 +581,8 @@ function ContentBrowserReady({
         onCreate={() => {
           if (activeCollection === "pages") {
             openCreatePage();
+          } else if (isBlogKind(activeCollection)) {
+            void handleCreateBlog(activeCollection);
           } else if (!previewUrl) {
             toast.error("Start the preview dev server to add sections.");
           } else {
@@ -517,6 +600,15 @@ function ContentBrowserReady({
         onDeleteSection={(s) =>
           setDeleteTarget({ kind: "section", key: s.key, label: s.name })
         }
+        onDuplicateBlog={handleDuplicateBlog}
+        onDeleteBlog={(e) =>
+          setDeleteTarget({
+            kind: "blog",
+            blogKind: e.kind,
+            key: e.key,
+            label: e.label,
+          })
+        }
       />
       <div className="flex-1 min-w-0">
         {selection ? (
@@ -530,40 +622,62 @@ function ContentBrowserReady({
               </div>
             }
           >
-            <SectionsEditor
-              key={
-                selection.collection === "pages"
-                  ? `page:${selection.key}`
-                  : `section:${selection.key}`
-              }
-              orgSlug={orgSlug}
-              virtualMcpId={virtualMcpId}
-              branch={branch}
-              previewReady
-              previewUrl={previewUrl ?? undefined}
-              currentPath={
-                selection.collection === "pages" ? selection.path : "/"
-              }
-              activePageBlockKey={
-                selection.collection === "pages" ? selection.key : null
-              }
-              activeGlobalBlockKey={
-                selection.collection === "sections" ? selection.key : null
-              }
-            />
+            {selection.collection === "posts" ? (
+              <PostEditor
+                key={`post:${selection.key}`}
+                orgSlug={orgSlug}
+                virtualMcpId={virtualMcpId}
+                branch={branch}
+                blockKey={selection.key}
+                block={decofile[selection.key] as Record<string, unknown>}
+                decofile={decofile}
+                meta={meta}
+              />
+            ) : selection.collection === "authors" ||
+              selection.collection === "categories" ? (
+              <RecordEditor
+                key={`${selection.collection}:${selection.key}`}
+                orgSlug={orgSlug}
+                virtualMcpId={virtualMcpId}
+                branch={branch}
+                kind={selection.collection}
+                blockKey={selection.key}
+                block={decofile[selection.key] as Record<string, unknown>}
+              />
+            ) : (
+              <SectionsEditor
+                key={
+                  selection.collection === "pages"
+                    ? `page:${selection.key}`
+                    : `section:${selection.key}`
+                }
+                orgSlug={orgSlug}
+                virtualMcpId={virtualMcpId}
+                branch={branch}
+                previewReady
+                previewUrl={previewUrl ?? undefined}
+                currentPath={
+                  selection.collection === "pages" ? selection.path : "/"
+                }
+                activePageBlockKey={
+                  selection.collection === "pages" ? selection.key : null
+                }
+                activeGlobalBlockKey={
+                  selection.collection === "sections" ? selection.key : null
+                }
+              />
+            )}
           </Suspense>
         ) : (
           <EmptyMessage
-            title={
-              activeCollection === "pages"
-                ? "Select a page to edit"
-                : "Select a section to edit"
-            }
-            description={
-              activeCollection === "pages"
-                ? 'Pick a page from the list, or click "+ New" to create one.'
-                : 'Pick a section from the list, or click "+ New" to create one.'
-            }
+            title={`Select ${
+              isBlogKind(activeCollection)
+                ? `a ${BLOG_SINGULAR[activeCollection]}`
+                : activeCollection === "pages"
+                  ? "a page"
+                  : "a section"
+            } to edit`}
+            description='Pick an item from the list, or click "+" to create one.'
           />
         )}
       </div>
@@ -623,35 +737,31 @@ function ContentBrowserReady({
       <AlertDialog
         open={!!deleteTarget}
         onOpenChange={(next) => {
-          if (!next && !deleteBlock.isPending) setDeleteTarget(null);
+          if (!next && !isDeleting) setDeleteTarget(null);
         }}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>
-              Delete {deleteTarget?.kind === "page" ? "page" : "section"}?
-            </AlertDialogTitle>
+            <AlertDialogTitle>Delete {deleteNoun}?</AlertDialogTitle>
             <AlertDialogDescription>
-              {deleteTarget?.kind === "page"
-                ? `"${deleteTarget.label}" will be removed permanently. This can't be undone.`
-                : deleteTarget?.kind === "section"
-                  ? `"${deleteTarget.label}" will be removed. Pages that still reference it will lose this section.`
+              {deleteTarget?.kind === "section"
+                ? `"${deleteTarget.label}" will be removed. Pages that still reference it will lose this section.`
+                : deleteTarget
+                  ? `"${deleteTarget.label}" will be removed permanently. This can't be undone.`
                   : null}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteBlock.isPending}>
-              Cancel
-            </AlertDialogCancel>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={(e) => {
                 e.preventDefault();
                 void confirmDelete();
               }}
-              disabled={deleteBlock.isPending}
+              disabled={isDeleting}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              {deleteBlock.isPending ? (
+              {isDeleting ? (
                 <>
                   <Loading01 size={14} className="animate-spin" />
                   Deleting…
@@ -670,10 +780,12 @@ function ContentBrowserReady({
 function CollectionsSidebar({
   active,
   counts,
+  showBlog,
   onSelect,
 }: {
   active: CollectionId;
   counts: Record<CollectionId, number>;
+  showBlog: boolean;
   onSelect: (id: CollectionId) => void;
 }) {
   return (
@@ -698,6 +810,38 @@ function CollectionsSidebar({
           active={active === "sections"}
           onSelect={onSelect}
         />
+        {showBlog && (
+          <>
+            <div className="mt-3 flex items-center gap-1.5 px-2.5 pb-1 pt-1 text-xs font-medium text-muted-foreground/70">
+              <BookOpen01 size={13} className="shrink-0" />
+              Blog
+            </div>
+            <CollectionRow
+              id="posts"
+              icon={File02}
+              label="Posts"
+              count={counts.posts}
+              active={active === "posts"}
+              onSelect={onSelect}
+            />
+            <CollectionRow
+              id="authors"
+              icon={Users01}
+              label="Authors"
+              count={counts.authors}
+              active={active === "authors"}
+              onSelect={onSelect}
+            />
+            <CollectionRow
+              id="categories"
+              icon={Tag01}
+              label="Categories"
+              count={counts.categories}
+              active={active === "categories"}
+              onSelect={onSelect}
+            />
+          </>
+        )}
       </nav>
     </div>
   );
@@ -747,6 +891,7 @@ function ItemList({
   activeCollection,
   pages,
   sections,
+  blogEntries,
   decofile,
   previewUrl,
   searchQuery,
@@ -761,10 +906,13 @@ function ItemList({
   onDuplicateSection,
   onRenameSection,
   onDeleteSection,
+  onDuplicateBlog,
+  onDeleteBlog,
 }: {
   activeCollection: CollectionId;
   pages: PageEntry[];
   sections: GlobalSectionEntry[];
+  blogEntries: BlogEntry[];
   decofile: Record<string, unknown>;
   previewUrl: string | null;
   searchQuery: string;
@@ -779,6 +927,8 @@ function ItemList({
   onDuplicateSection: (section: GlobalSectionEntry) => void;
   onRenameSection: (section: GlobalSectionEntry) => void;
   onDeleteSection: (section: GlobalSectionEntry) => void;
+  onDuplicateBlog: (entry: BlogEntry) => void;
+  onDeleteBlog: (entry: BlogEntry) => void;
 }) {
   const q = searchQuery.toLowerCase();
   const filteredPages = pages.filter(
@@ -794,11 +944,19 @@ function ItemList({
       s.key.toLowerCase().includes(q) ||
       s.resolveType.toLowerCase().includes(q),
   );
+  const filteredBlog = blogEntries.filter(
+    (e) =>
+      !q ||
+      e.label.toLowerCase().includes(q) ||
+      e.subtitle.toLowerCase().includes(q),
+  );
 
-  const placeholder =
-    activeCollection === "pages" ? "Search pages…" : "Search sections…";
-  const createTooltip =
-    activeCollection === "pages" ? "Create new page" : "Create new section";
+  const placeholder = `Search ${activeCollection}…`;
+  const createTooltip = isBlogKind(activeCollection)
+    ? `Create new ${BLOG_SINGULAR[activeCollection]}`
+    : activeCollection === "pages"
+      ? "Create new page"
+      : "Create new section";
   const sectionCreateBlocked = activeCollection === "sections" && !previewUrl;
   const createDisabledReason = sectionCreateBlocked
     ? "Start the preview dev server to add sections"
@@ -840,7 +998,9 @@ function ItemList({
           </TooltipContent>
         </Tooltip>
       </div>
-      <ScrollArea className="flex-1 min-h-0">
+      {/* Force Radix's inner `display:table` content wrapper back to block so
+          long titles truncate instead of widening the viewport. */}
+      <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
         <div className="flex flex-col gap-1 p-1.5">
           {activeCollection === "pages" ? (
             filteredPages.length === 0 ? (
@@ -882,36 +1042,78 @@ function ItemList({
                 );
               })
             )
-          ) : filteredSections.length === 0 ? (
+          ) : activeCollection === "sections" ? (
+            filteredSections.length === 0 ? (
+              <ListEmpty
+                hasItems={sections.length > 0}
+                emptyLabel="No saved sections yet."
+                emptyHint='Click "+" to create one, or save a section from a page.'
+              />
+            ) : (
+              filteredSections.map((section) => {
+                const isActive =
+                  selection?.collection === "sections" &&
+                  selection.key === section.key;
+                const typeLabel = section.resolveType
+                  .split("/")
+                  .pop()
+                  ?.replace(/\.tsx?$/, "");
+                return (
+                  <ItemRow
+                    key={section.key}
+                    icon={Globe02}
+                    title={section.name}
+                    subtitle={typeLabel ?? section.resolveType}
+                    active={isActive}
+                    onClick={() =>
+                      onSelect({ collection: "sections", key: section.key })
+                    }
+                    menu={
+                      <ItemActions
+                        onDuplicate={() => onDuplicateSection(section)}
+                        onRename={() => onRenameSection(section)}
+                        onDelete={() => onDeleteSection(section)}
+                      />
+                    }
+                  />
+                );
+              })
+            )
+          ) : filteredBlog.length === 0 ? (
             <ListEmpty
-              hasItems={sections.length > 0}
-              emptyLabel="No saved sections yet."
-              emptyHint='Click "+" to create one, or save a section from a page.'
+              hasItems={blogEntries.length > 0}
+              emptyLabel={`No ${activeCollection} yet.`}
+              emptyHint={`Click "+" to create your first ${
+                isBlogKind(activeCollection)
+                  ? BLOG_SINGULAR[activeCollection]
+                  : "item"
+              }.`}
             />
           ) : (
-            filteredSections.map((section) => {
+            filteredBlog.map((entry) => {
               const isActive =
-                selection?.collection === "sections" &&
-                selection.key === section.key;
-              const typeLabel = section.resolveType
-                .split("/")
-                .pop()
-                ?.replace(/\.tsx?$/, "");
+                selection?.collection === entry.kind &&
+                selection.key === entry.key;
               return (
                 <ItemRow
-                  key={section.key}
-                  icon={Globe02}
-                  title={section.name}
-                  subtitle={typeLabel ?? section.resolveType}
+                  key={entry.key}
+                  icon={
+                    entry.kind === "posts"
+                      ? File02
+                      : entry.kind === "authors"
+                        ? Users01
+                        : Tag01
+                  }
+                  title={entry.label}
+                  subtitle={entry.subtitle}
                   active={isActive}
                   onClick={() =>
-                    onSelect({ collection: "sections", key: section.key })
+                    onSelect({ collection: entry.kind, key: entry.key })
                   }
                   menu={
                     <ItemActions
-                      onDuplicate={() => onDuplicateSection(section)}
-                      onRename={() => onRenameSection(section)}
-                      onDelete={() => onDeleteSection(section)}
+                      onDuplicate={() => onDuplicateBlog(entry)}
+                      onDelete={() => onDeleteBlog(entry)}
                     />
                   }
                 />
@@ -948,7 +1150,7 @@ function ItemRow({
   return (
     <div
       className={cn(
-        "group relative flex items-center rounded-md transition-colors",
+        "group relative flex min-w-0 items-center rounded-md transition-colors",
         active ? "bg-accent text-accent-foreground" : "hover:bg-muted",
       )}
     >
@@ -1012,7 +1214,7 @@ function ItemActions({
   onDelete,
 }: {
   onDuplicate: () => void;
-  onRename: () => void;
+  onRename?: () => void;
   onAddVariant?: () => void;
   onDelete: () => void;
 }) {
@@ -1029,10 +1231,12 @@ function ItemActions({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-44">
-        <DropdownMenuItem onClick={onRename}>
-          <Edit01 size={14} />
-          Rename
-        </DropdownMenuItem>
+        {onRename && (
+          <DropdownMenuItem onClick={onRename}>
+            <Edit01 size={14} />
+            Rename
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onClick={onDuplicate}>
           <Copy01 size={14} />
           Duplicate

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -354,6 +354,8 @@ export const KEYS = {
   // Deco sections editor (sandbox preview)
   decofile: (previewUrl: string) => ["decofile", previewUrl] as const,
   liveMeta: (previewUrl: string) => ["live-meta", previewUrl] as const,
+  sandboxInvoke: (sandboxKey: string, loaderKey: string) =>
+    ["sandbox-invoke", sandboxKey, loaderKey] as const,
 
   // Link daemon status (user-scoped; the cluster derives the userSub
   // from the bearer session, so we don't include it in the key).


### PR DESCRIPTION
## What is this contribution about?

Adds a blog content editor to the sandbox content browser. When a site's decofile contains blog entries (posts, authors, or categories), a new "Blog" section appears in the collections sidebar. Users can create, duplicate, delete, and edit each kind directly inside the sandbox without leaving the Studio UI.

## Screenshots/Demonstration

> UI changes affect the content browser sidebar and main editing panel — a screenshot/Loom would be helpful here.

## How to Test

1. Open the sandbox for a project that has blog blocks (`posts`, `authors`, or `categories`) in its decofile.
2. Confirm "Blog" section appears in the sidebar with Posts, Authors, and Categories rows.
3. Click a post to open the `PostEditor` and an author/category to open `RecordEditor`.
4. Use the "+" button to create a new entry; use the context menu to duplicate or delete.
5. Confirm changes persist (autosave indicator shows saved state).

## Migration Notes

No database migrations or configuration changes required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-sandbox Blog editor for Posts, Authors, and Categories with inline block editing and VTEX product previews. Also hardens the preview-invoke flow and scopes bespoke block editors to known post block paths.

- **New Features**
  - "Blog" section in the Content tab (Posts, Authors, Categories) with search, counts, create, duplicate, delete.
  - Post editor with inline blocks (paragraph, headings, lists, images, video, callouts, CTA, stats), block picker (⊕), drag-to-reorder, and autosave.
  - Product blocks: ProductCard/ProductShelf editors with VTEX previews via `/preview-invoke`; aligns results to selected IDs and caches by `sandboxInvoke` key.
  - Post settings: excerpt, slug, date, cover image, and `authors`/`categories` via `MultiSelect`.
  - Author/Category editors with simple fields and autosave.
  - Block registry uses bespoke editors for known post blocks and falls back to schema-driven `SchemaForm`; matches site-specific paths by component filename.
  - Sandbox proxy: `/preview-invoke` routes to single `/deco/invoke/<loader>` calls.

- **Bug Fixes**
  - Hardened `/preview-invoke`: input validation (`resolveType`), URL encoding, body size limits, and upstream timeout; shared parsing in `loader-invoke`.
  - Scoped bespoke blog block UI to the allowed post block paths to avoid mis-rendering.
  - Correct VTEX product title parsing in previews.
  - Unexported `readProductListResolveType` to satisfy `knip` CI.

<sup>Written for commit 9ec1b2b0732014b8836af87f91eff11f9df3a294. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

