### PR TITLE
fix(github): repair submit-for-review push and PR flow in sandboxes

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -38,6 +38,11 @@ import {
   buildLoaderInvokeUrl,
   parseLoaderInvokeRequest,
 } from "../../lib/loader-invoke";
+import {
+  GitPushAuthError,
+  parseGithubRepoFromMetadata,
+  refreshSandboxGitCredentials,
+} from "../../tools/sandbox/sync-git-credentials";
 
 // ---- Middleware types -------------------------------------------------------
 
@@ -433,12 +438,37 @@ export const createSandboxRoutes = () => {
       map404to410: true,
     }),
   );
-  app.post("/:virtualMcpId/:branch/git/publish", (c) =>
-    proxyDaemon(c, "/_sandbox/git/publish", {
+  app.post("/:virtualMcpId/:branch/git/publish", async (c) => {
+    const runner = requireRunner(c);
+    if (runner instanceof Response) return runner;
+
+    const { claimName, virtualMcpId, virtualMcpMetadata } = c.get("vmClaim");
+    const ctx = c.var.meshContext;
+
+    try {
+      const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
+      const connectionIds =
+        virtualMcp?.connections?.map((conn) => conn.connection_id) ?? [];
+      const githubRepo = parseGithubRepoFromMetadata(
+        virtualMcpMetadata,
+        connectionIds,
+      );
+      if (githubRepo) {
+        await refreshSandboxGitCredentials(ctx, runner, claimName, githubRepo);
+      }
+    } catch (err) {
+      if (err instanceof GitPushAuthError) {
+        return c.json({ error: err.message }, 403, SANDBOX_PROXY_CACHE_HEADERS);
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
+    }
+
+    return proxyDaemon(c, "/_sandbox/git/publish", {
       forwardJsonBody: true,
       map404to410: true,
-    }),
-  );
+    });
+  });
   app.post("/:virtualMcpId/:branch/git/discard", (c) =>
     proxyDaemon(c, "/_sandbox/git/discard", {
       forwardJsonBody: true,
@@ -470,20 +500,35 @@ export const createSandboxRoutes = () => {
       const ctx = c.var.meshContext;
 
       try {
-        const [status, diff] = await Promise.all([
-          fetchDaemonJson<GitStatusLike>(
-            runner,
-            claimName,
-            "/_sandbox/git/status",
-            "GET",
-          ),
-          fetchDaemonJson<GitDiffLike>(
-            runner,
-            claimName,
-            "/_sandbox/git/diff",
-            "GET",
-          ),
-        ]);
+        const body = (await c.req.json().catch(() => ({}))) as {
+          status?: GitStatusLike;
+          diff?: GitDiffLike;
+        };
+
+        const clientStatus = body.status;
+        const clientDiff = body.diff;
+        const hasClientDiff =
+          clientDiff != null &&
+          typeof clientDiff.diffs === "object" &&
+          clientDiff.diffs !== null;
+
+        const [status, diff] =
+          clientStatus && hasClientDiff
+            ? [clientStatus, clientDiff]
+            : await Promise.all([
+                fetchDaemonJson<GitStatusLike>(
+                  runner,
+                  claimName,
+                  "/_sandbox/git/status",
+                  "GET",
+                ),
+                fetchDaemonJson<GitDiffLike>(
+                  runner,
+                  claimName,
+                  "/_sandbox/git/diff",
+                  "GET",
+                ),
+              ]);
         const suggestion = await suggestCommitMessageWithLlm(ctx, status, diff);
         return c.json(suggestion, 200, SANDBOX_PROXY_CACHE_HEADERS);
       } catch (err) {

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -32,6 +32,7 @@ import { readValidatedRuntimeEnv } from "../../tools/sandbox/helpers";
 import {
   type GitDiffLike,
   type GitStatusLike,
+  isGitStatusLike,
   suggestCommitMessageWithLlm,
 } from "../../lib/suggest-commit-message";
 import {
@@ -55,6 +56,7 @@ interface VmClaim {
   userId: string;
   projectRef: string;
   virtualMcpMetadata: Record<string, unknown> | null;
+  connectionIds: string[];
 }
 
 type VmEnv = Env & { Variables: Env["Variables"] & { vmClaim: VmClaim } };
@@ -165,6 +167,8 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
     userId,
     projectRef,
     virtualMcpMetadata,
+    connectionIds:
+      virtualMcp.connections?.map((conn) => conn.connection_id) ?? [],
   });
   return next();
 });
@@ -442,13 +446,10 @@ export const createSandboxRoutes = () => {
     const runner = requireRunner(c);
     if (runner instanceof Response) return runner;
 
-    const { claimName, virtualMcpId, virtualMcpMetadata } = c.get("vmClaim");
+    const { claimName, virtualMcpMetadata, connectionIds } = c.get("vmClaim");
     const ctx = c.var.meshContext;
 
     try {
-      const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
-      const connectionIds =
-        virtualMcp?.connections?.map((conn) => conn.connection_id) ?? [];
       const githubRepo = parseGithubRepoFromMetadata(
         virtualMcpMetadata,
         connectionIds,
@@ -513,7 +514,7 @@ export const createSandboxRoutes = () => {
           clientDiff.diffs !== null;
 
         const [status, diff] =
-          clientStatus && hasClientDiff
+          isGitStatusLike(clientStatus) && hasClientDiff
             ? [clientStatus, clientDiff]
             : await Promise.all([
                 fetchDaemonJson<GitStatusLike>(

--- a/apps/mesh/src/lib/suggest-commit-message.test.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildCommitContextSummary,
   fallbackCommitSuggestion,
+  isGitStatusLike,
   parseCommitSuggestionJson,
 } from "./suggest-commit-message";
 
@@ -25,6 +26,26 @@ describe("parseCommitSuggestionJson", () => {
     const result = parseCommitSuggestionJson("Plain title\n\nMore detail");
     expect(result?.title).toBe("Plain title");
     expect(result?.body).toBe("More detail");
+  });
+});
+
+describe("isGitStatusLike", () => {
+  test("accepts valid status shape", () => {
+    expect(
+      isGitStatusLike({
+        modified: [],
+        created: [],
+        deleted: [],
+        not_added: [],
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects non-objects and arrays", () => {
+    expect(isGitStatusLike(null)).toBe(false);
+    expect(isGitStatusLike("status")).toBe(false);
+    expect(isGitStatusLike([])).toBe(false);
+    expect(isGitStatusLike({ modified: [] })).toBe(false);
   });
 });
 

--- a/apps/mesh/src/lib/suggest-commit-message.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.ts
@@ -15,6 +15,19 @@ export interface GitStatusLike {
   not_added: string[];
 }
 
+export function isGitStatusLike(value: unknown): value is GitStatusLike {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    Array.isArray(record.modified) &&
+    Array.isArray(record.created) &&
+    Array.isArray(record.deleted) &&
+    Array.isArray(record.not_added)
+  );
+}
+
 export interface GitDiffLike {
   diffs: Record<string, { from: string | null; to: string | null }>;
 }

--- a/apps/mesh/src/tools/sandbox/sync-git-credentials.test.ts
+++ b/apps/mesh/src/tools/sandbox/sync-git-credentials.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+  GitPushAuthError,
+  parseGithubRepoFromMetadata,
+} from "./sync-git-credentials";
+
+describe("parseGithubRepoFromMetadata", () => {
+  test("returns public-clone repo without connectionId", () => {
+    const repo = parseGithubRepoFromMetadata(
+      {
+        githubRepo: {
+          owner: "deco-sites",
+          name: "baggagio-tanstack",
+        },
+      },
+      [],
+    );
+    expect(repo?.owner).toBe("deco-sites");
+    expect(repo?.connectionId).toBeUndefined();
+  });
+
+  test("returns null when connectionId is stale", () => {
+    const repo = parseGithubRepoFromMetadata(
+      {
+        githubRepo: {
+          owner: "deco-sites",
+          name: "baggagio-tanstack",
+          connectionId: "conn_github",
+        },
+      },
+      ["conn_other"],
+    );
+    expect(repo).toBeNull();
+  });
+
+  test("returns repo when connectionId is attached", () => {
+    const repo = parseGithubRepoFromMetadata(
+      {
+        githubRepo: {
+          owner: "deco-sites",
+          name: "baggagio-tanstack",
+          connectionId: "conn_github",
+        },
+      },
+      ["conn_github"],
+    );
+    expect(repo?.connectionId).toBe("conn_github");
+  });
+});
+
+describe("GitPushAuthError", () => {
+  test("is instanceof Error", () => {
+    const err = new GitPushAuthError("nope");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("GitPushAuthError");
+  });
+});

--- a/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
@@ -1,0 +1,65 @@
+import type { GithubRepo } from "@decocms/mesh-sdk/types";
+import type { SandboxProvider } from "@decocms/sandbox/provider";
+import type { StudioContext } from "../../core/studio-context";
+import { buildCloneInfo } from "../../shared/github-clone-info";
+
+export class GitPushAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GitPushAuthError";
+  }
+}
+
+export function parseGithubRepoFromMetadata(
+  metadata: Record<string, unknown> | null,
+  connectionIds: readonly string[],
+): GithubRepo | null {
+  const repo = metadata?.githubRepo as GithubRepo | undefined;
+  if (!repo?.owner || !repo?.name) return null;
+  if (!repo.connectionId) return repo;
+  if (!connectionIds.includes(repo.connectionId)) return null;
+  return repo;
+}
+
+/**
+ * Refreshes the OAuth token baked into the sandbox clone URL and patches the
+ * running daemon config so git push can sync `origin` before publishing.
+ */
+export async function refreshSandboxGitCredentials(
+  ctx: StudioContext,
+  runner: SandboxProvider,
+  handle: string,
+  githubRepo: GithubRepo,
+): Promise<void> {
+  if (!githubRepo.connectionId) {
+    throw new GitPushAuthError(
+      "Push requires a connected GitHub account. Connect mcp-github for this project and restart the sandbox.",
+    );
+  }
+
+  const { cloneUrl, gitUserName, gitUserEmail } = await buildCloneInfo(
+    githubRepo.connectionId,
+    githubRepo.owner,
+    githubRepo.name,
+    ctx.db,
+    ctx.vault,
+  );
+
+  const res = await runner.proxyDaemonRequest(handle, "/_sandbox/config", {
+    method: "PUT",
+    headers: new Headers({ "content-type": "application/json" }),
+    body: JSON.stringify({
+      git: {
+        repository: { cloneUrl },
+        identity: { userName: gitUserName, userEmail: gitUserEmail },
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => res.statusText);
+    throw new Error(
+      `Failed to refresh sandbox git credentials (${res.status}): ${body}`,
+    );
+  }
+}

--- a/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
@@ -1,7 +1,10 @@
 import type { GithubRepo } from "@decocms/mesh-sdk/types";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import type { StudioContext } from "../../core/studio-context";
+import { ensureRepoScopedToken } from "../../oauth/github-mint";
+import { RECONNECT_ERROR } from "../../oauth/token-refresh";
 import { buildCloneInfo } from "../../shared/github-clone-info";
+import { getRepoScope } from "../../shared/github-repo-scope";
 
 export class GitPushAuthError extends Error {
   constructor(message: string) {
@@ -22,8 +25,9 @@ export function parseGithubRepoFromMetadata(
 }
 
 /**
- * Refreshes the OAuth token baked into the sandbox clone URL and patches the
+ * Refreshes the GitHub token baked into the sandbox clone URL and patches the
  * running daemon config so git push can sync `origin` before publishing.
+ * Repo-scoped child connections are re-minted on demand (no OAuth refresh path).
  */
 export async function refreshSandboxGitCredentials(
   ctx: StudioContext,
@@ -35,6 +39,24 @@ export async function refreshSandboxGitCredentials(
     throw new GitPushAuthError(
       "Push requires a connected GitHub account. Connect mcp-github for this project and restart the sandbox.",
     );
+  }
+
+  const organizationId = ctx.organization?.id;
+  if (!organizationId) {
+    throw new GitPushAuthError(RECONNECT_ERROR);
+  }
+
+  const repoConn = await ctx.storage.connections.findById(
+    githubRepo.connectionId,
+    organizationId,
+  );
+  if (repoConn && getRepoScope(repoConn)) {
+    try {
+      await ensureRepoScopedToken(ctx, repoConn);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : RECONNECT_ERROR;
+      throw new GitPushAuthError(message);
+    }
   }
 
   const { cloneUrl, gitUserName, gitUserEmail } = await buildCloneInfo(

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -306,9 +306,20 @@ describe("selectHeaderButton", () => {
     expect(r.action).toBe("create-pr");
   });
 
-  test("unpushed commits without base divergence → Save changes", () => {
+  test("unpushed commits without base divergence and no PR → Submit for review", () => {
     const r = selectHeaderButton(
       happyInput({ branch: ready({ unpushed: 2, aheadOfBase: 0 }) }),
+    );
+    expect(r.label).toBe("Submit for review");
+    expect(r.action).toBe("create-pr");
+  });
+
+  test("unpushed commits with open PR → Save changes", () => {
+    const r = selectHeaderButton(
+      happyInput({
+        branch: ready({ unpushed: 2, aheadOfBase: 2 }),
+        pr: pr(),
+      }),
     );
     expect(r.label).toBe("Save changes");
     expect(r.action).toBe("commit-and-push");

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -298,11 +298,20 @@ describe("selectHeaderButton", () => {
     expect(r.disabled).toBeFalsy();
   });
 
-  test("unpushed commits → Save changes", () => {
+  test("unpushed commits ahead of base with no PR → Submit for review", () => {
     const r = selectHeaderButton(
-      happyInput({ branch: ready({ unpushed: 2 }) }),
+      happyInput({ branch: ready({ unpushed: 2, aheadOfBase: 2 }) }),
+    );
+    expect(r.label).toBe("Submit for review");
+    expect(r.action).toBe("create-pr");
+  });
+
+  test("unpushed commits without base divergence → Save changes", () => {
+    const r = selectHeaderButton(
+      happyInput({ branch: ready({ unpushed: 2, aheadOfBase: 0 }) }),
     );
     expect(r.label).toBe("Save changes");
+    expect(r.action).toBe("commit-and-push");
   });
 
   test("ahead of base + closed non-merged PR → Reopen PR", () => {

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -162,13 +162,29 @@ export function selectHeaderButton(
   }
   const ready = branch;
 
-  const hasLocalWork = ready.workingTreeDirty || ready.unpushed > 0;
-  if (hasLocalWork) {
+  if (ready.workingTreeDirty) {
     return {
       label: "Save changes",
       action: "commit-and-push",
       variant: "default",
       tooltip: "Commit and push local changes",
+    };
+  }
+
+  if (ready.unpushed > 0) {
+    if (!pr && ready.aheadOfBase > 0) {
+      return {
+        label: "Submit for review",
+        action: "create-pr",
+        variant: "default",
+        tooltip: `Push and open a PR for ${ready.branch} → ${ready.base}`,
+      };
+    }
+    return {
+      label: "Save changes",
+      action: "commit-and-push",
+      variant: "default",
+      tooltip: "Push local commits",
     };
   }
 

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -172,7 +172,7 @@ export function selectHeaderButton(
   }
 
   if (ready.unpushed > 0) {
-    if (!pr && ready.aheadOfBase > 0) {
+    if (!pr) {
       return {
         label: "Submit for review",
         action: "create-pr",

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -241,6 +241,13 @@ function PublishDialogBody({
       ? PUBLISH_REQUIRES_SUBMIT_TOOLTIP
       : null;
 
+  /** Push + open PR — open-pr dialog, or save dialog with commits vs base. */
+  const showSubmitForReviewButton =
+    openPrFromCommits || (!commitToOpenPr && (gitStatus?.aheadOfBase ?? 0) > 0);
+  const canSubmitForReview =
+    !isLoadingGitDiff &&
+    (showSubmitForReviewButton || hasLocalUnpublished || openPrFromCommits);
+
   const commitMessage = () =>
     [publishTitle.trim(), publishBody.trim()].filter(Boolean).join("\n\n");
 
@@ -283,15 +290,13 @@ function PublishDialogBody({
       const prBody = publishBody.trim() || undefined;
       const message = commitMessage() || prTitle;
 
-      if (hasLocalUnpublished) {
-        try {
-          await publishGitChanges(orgSlug, virtualMcpId, branch, message);
-        } catch (error) {
-          throw new PublishFlowError(
-            error instanceof Error ? error.message : "Failed to push changes",
-            "push",
-          );
-        }
+      try {
+        await publishGitChanges(orgSlug, virtualMcpId, branch, message);
+      } catch (error) {
+        throw new PublishFlowError(
+          error instanceof Error ? error.message : "Failed to push changes",
+          "push",
+        );
       }
 
       try {
@@ -420,9 +425,9 @@ function PublishDialogBody({
       const prBody = publishBody.trim() || undefined;
       const message = commitMessage() || prTitle;
 
-      if (hasLocalUnpublished) {
-        await publishGitChanges(orgSlug, virtualMcpId, branch, message);
-      }
+      // GitHub requires head on the remote; push even when commits are already
+      // local-only (unpushed can read 0 until origin/<branch> exists).
+      await publishGitChanges(orgSlug, virtualMcpId, branch, message);
 
       const pr = await openPullRequestForBranch(githubClient, {
         owner,
@@ -663,7 +668,7 @@ function PublishDialogBody({
         </div>
 
         <div className="shrink-0 border-t px-6 py-3">
-          {isSaveChangesFlow ? (
+          {isSaveChangesFlow && !showSubmitForReviewButton ? (
             <>
               <Button
                 type="button"
@@ -682,6 +687,52 @@ function PublishDialogBody({
                 </p>
               )}
             </>
+          ) : isSaveChangesFlow ? (
+            <>
+              <div className="flex items-center gap-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="flex-1"
+                  onClick={handleSaveChanges}
+                  disabled={
+                    !canSubmit || isSavingChanges || isSubmittingForReview
+                  }
+                >
+                  {isSavingChanges ? (
+                    <Loading01 className="h-4 w-4 animate-spin" />
+                  ) : null}
+                  Save changes
+                </Button>
+                <Button
+                  type="button"
+                  className="flex-1"
+                  onClick={handleSubmitForReview}
+                  disabled={
+                    !canSubmitForReview ||
+                    isSubmittingForReview ||
+                    isSavingChanges
+                  }
+                >
+                  {isSubmittingForReview ? (
+                    <Loading01 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <GitBranch01 className="h-4 w-4" />
+                  )}
+                  Submit for review
+                </Button>
+              </div>
+              {saveChangesError && (
+                <p className="mt-2 text-xs text-destructive">
+                  {saveChangesError}
+                </p>
+              )}
+              {submitForReviewError && (
+                <p className="mt-2 text-xs text-destructive">
+                  {submitForReviewError}
+                </p>
+              )}
+            </>
           ) : (
             <>
               <div className="flex items-center gap-3">
@@ -690,7 +741,9 @@ function PublishDialogBody({
                   variant="outline"
                   className="flex-1"
                   onClick={handleSubmitForReview}
-                  disabled={!canSubmit || isSubmittingForReview || isPublishing}
+                  disabled={
+                    !canSubmitForReview || isSubmittingForReview || isPublishing
+                  }
                 >
                   {isSubmittingForReview ? (
                     <Loading01 className="h-4 w-4 animate-spin" />

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -167,16 +167,22 @@ function PublishDialogBody({
       setSubmitForReviewError(undefined);
       setSaveChangesError(undefined);
       try {
-        const diffOpts = openPrFromCommits
+        const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
+        const needsBaseDiff =
+          openPrFromCommits ||
+          (!commitToOpenPr && (status.aheadOfBase ?? 0) > 0);
+        const diffOpts = needsBaseDiff
           ? {
               base: baseBranch,
               ...(headSha ? { headSha } : {}),
             }
           : undefined;
-        const [status, diff] = await Promise.all([
-          fetchGitStatus(orgSlug, virtualMcpId, branch),
-          fetchGitDiff(orgSlug, virtualMcpId, branch, diffOpts),
-        ]);
+        const diff = await fetchGitDiff(
+          orgSlug,
+          virtualMcpId,
+          branch,
+          diffOpts,
+        );
         setGitStatus(status);
         setGitDiff(diff);
         setPublishTitle(`Changes from ${status.current ?? branch}`);
@@ -246,7 +252,8 @@ function PublishDialogBody({
     openPrFromCommits || (!commitToOpenPr && (gitStatus?.aheadOfBase ?? 0) > 0);
   const canSubmitForReview =
     !isLoadingGitDiff &&
-    (showSubmitForReviewButton || hasLocalUnpublished || openPrFromCommits);
+    (showSubmitForReviewButton || hasLocalUnpublished) &&
+    (diffCount > 0 || hasLocalUnpublished);
 
   const commitMessage = () =>
     [publishTitle.trim(), publishBody.trim()].filter(Boolean).join("\n\n");

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -113,7 +113,18 @@ describe("hasLocalWorkToPush", () => {
     ).toBe(true);
   });
 
-  test("true when ahead of base on a branch with no upstream", () => {
+  test("true when ahead of base on a branch with no upstream (legacy daemon)", () => {
+    expect(
+      hasLocalWorkToPush({
+        ...cleanStatus,
+        tracking: null,
+        ahead: 0,
+        aheadOfBase: 1,
+      }),
+    ).toBe(true);
+  });
+
+  test("false when daemon reports unpushed 0 with no upstream", () => {
     expect(
       hasLocalWorkToPush({
         ...cleanStatus,
@@ -122,7 +133,7 @@ describe("hasLocalWorkToPush", () => {
         unpushed: 0,
         aheadOfBase: 1,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -100,6 +100,30 @@ describe("hasLocalWorkToPush", () => {
   test("true when ahead of tracking", () => {
     expect(hasLocalWorkToPush({ ...cleanStatus, ahead: 1 })).toBe(true);
   });
+
+  test("true when unpushed is set without upstream tracking", () => {
+    expect(
+      hasLocalWorkToPush({
+        ...cleanStatus,
+        tracking: null,
+        ahead: 0,
+        unpushed: 1,
+        aheadOfBase: 1,
+      }),
+    ).toBe(true);
+  });
+
+  test("true when ahead of base on a branch with no upstream", () => {
+    expect(
+      hasLocalWorkToPush({
+        ...cleanStatus,
+        tracking: null,
+        ahead: 0,
+        unpushed: 0,
+        aheadOfBase: 1,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("hasUnpublishedWork", () => {

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -257,9 +257,12 @@ export function hasLocalWorkToPush(
   ) {
     return true;
   }
-  // Committed work vs base on a branch with no upstream yet. Older sandboxes
-  // report unpushed=0 until origin/<branch> exists on the remote.
-  return (status.aheadOfBase ?? 0) > 0 && status.tracking == null;
+  // Legacy sandboxes omitted unpushed until origin/<branch> existed remotely.
+  return (
+    status.unpushed === undefined &&
+    (status.aheadOfBase ?? 0) > 0 &&
+    status.tracking == null
+  );
 }
 
 /** True when there is local work to commit, unpushed commits, or working-tree diff paths. */

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -250,9 +250,16 @@ export function hasLocalWorkToPush(
   status: GitStatus | null | undefined,
 ): boolean {
   if (!status) return false;
-  return (
-    hasGitLocalWork(status) || status.ahead > 0 || (status.unpushed ?? 0) > 0
-  );
+  if (
+    hasGitLocalWork(status) ||
+    status.ahead > 0 ||
+    (status.unpushed ?? 0) > 0
+  ) {
+    return true;
+  }
+  // Committed work vs base on a branch with no upstream yet. Older sandboxes
+  // report unpushed=0 until origin/<branch> exists on the remote.
+  return (status.aheadOfBase ?? 0) > 0 && status.tracking == null;
 }
 
 /** True when there is local work to commit, unpushed commits, or working-tree diff paths. */

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -326,7 +326,11 @@ const bashH = makeBashHandler({
   repoDir,
   taskManager,
 });
-const gitDeps = { appRoot, repoDir };
+const gitDeps = {
+  appRoot,
+  repoDir,
+  getCloneUrl: () => store.read()?.git?.repository?.cloneUrl ?? null,
+};
 const gitStatusH = makeGitStatusHandler(gitDeps);
 const gitDiffH = makeGitDiffHandler(gitDeps);
 const gitPublishH = makeGitPublishHandler(gitDeps);

--- a/packages/sandbox/daemon/git/branch-divergence.ts
+++ b/packages/sandbox/daemon/git/branch-divergence.ts
@@ -42,14 +42,9 @@ export function computeBranchDivergence(
   const refExists = (ref: string) =>
     tryGit(["rev-parse", "--verify", "--quiet", ref]) !== null;
 
-  const branchRef = refExists(`origin/${branch}`) ? `origin/${branch}` : "HEAD";
-
-  let unpushed = 0;
-  if (branch && branchRef === `origin/${branch}`) {
-    unpushed = Number(
-      tryGit(["rev-list", "--count", `${branchRef}..HEAD`]) ?? "0",
-    );
-  }
+  const remoteBranchRef = `origin/${branch}`;
+  const hasRemoteBranch = refExists(remoteBranchRef);
+  const branchRef = hasRemoteBranch ? remoteBranchRef : "HEAD";
 
   let aheadOfBase = 0;
   let behindBase = 0;
@@ -65,6 +60,16 @@ export function computeBranchDivergence(
       behindBase = Number(m[1]);
       aheadOfBase = Number(m[2]);
     }
+  }
+
+  let unpushed = 0;
+  if (branch && hasRemoteBranch) {
+    unpushed = Number(
+      tryGit(["rev-list", "--count", `${remoteBranchRef}..HEAD`]) ?? "0",
+    );
+  } else if (branch && !hasRemoteBranch) {
+    // Branch never pushed (or removed on origin): local commits vs base need push.
+    unpushed = aheadOfBase;
   }
 
   const headSha = tryGit(["rev-parse", branchRef]) ?? "";

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -39,6 +39,39 @@ describe("git routes", () => {
     expect(body.modified).toContain("README.md");
   });
 
+  it("status reports unpushed when feature branch has no remote ref", async () => {
+    const { appRoot, repoDir } = initRepo();
+    gitSync(["checkout", "-b", "deco/thin-crane"], {
+      cwd: repoDir,
+      asUser: false,
+    });
+    writeFileSync(join(repoDir, "feature.txt"), "x\n");
+    gitSync(["add", "feature.txt"], { cwd: repoDir, asUser: false });
+    gitSync(["commit", "-m", "feature"], { cwd: repoDir, asUser: false });
+    const mainSha = gitSync(["rev-parse", "main"], {
+      cwd: repoDir,
+      asUser: false,
+    }).trim();
+    gitSync(["update-ref", "refs/remotes/origin/main", mainSha], {
+      cwd: repoDir,
+      asUser: false,
+    });
+
+    const handler = makeGitStatusHandler({ appRoot, repoDir });
+    const res = await handler(new Request("http://x/git/status"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      aheadOfBase: number;
+      unpushed: number;
+      tracking: string | null;
+      current: string | null;
+    };
+    expect(body.current).toBe("deco/thin-crane");
+    expect(body.tracking).toBeNull();
+    expect(body.aheadOfBase).toBe(1);
+    expect(body.unpushed).toBe(1);
+  });
+
   it("status reports aheadOfBase on a feature branch", async () => {
     const { appRoot, repoDir } = initRepo();
     gitSync(["checkout", "-b", "feat/test"], { cwd: repoDir, asUser: false });

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -405,15 +405,16 @@ function publish(deps: GitDeps, message: string): { pushed: boolean } {
   const cloneUrl = deps.getCloneUrl?.();
   if (typeof cloneUrl === "string" && cloneUrl.length > 0) {
     syncOriginRemote(repoDir, cloneUrl);
-  } else if (
-    tryGit(repoDir, ["remote", "get-url", "origin"])?.includes("github.com") &&
-    !cloneUrlHasCredentials(
-      tryGit(repoDir, ["remote", "get-url", "origin"]) ?? "",
-    )
-  ) {
-    throw new Error(
-      "GitHub push requires an authenticated clone URL. Connect GitHub for this project and restart the sandbox.",
-    );
+  } else {
+    const originUrl = tryGit(repoDir, ["remote", "get-url", "origin"]) ?? "";
+    if (
+      originUrl.includes("github.com") &&
+      !cloneUrlHasCredentials(originUrl)
+    ) {
+      throw new Error(
+        "GitHub push requires an authenticated clone URL. Connect GitHub for this project and restart the sandbox.",
+      );
+    }
   }
 
   pushBranch(repoDir, branch);

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -15,6 +15,8 @@ import { jsonResponse, parseJsonBody } from "./body-parser";
 export interface GitDeps {
   appRoot: string;
   repoDir: string;
+  /** Authenticated clone URL from daemon config (may embed OAuth token). */
+  getCloneUrl?: () => string | null | undefined;
 }
 
 function gitEnv(repoDir: string): Record<string, string> {
@@ -325,6 +327,44 @@ function resolveRepoRelativePath(deps: GitDeps, userPath: string): string {
   return rel;
 }
 
+function cloneUrlHasCredentials(url: string): boolean {
+  try {
+    const u = new URL(url);
+    return u.username.length > 0 || u.password.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function syncOriginRemote(repoDir: string, cloneUrl: string): void {
+  if (!cloneUrlHasCredentials(cloneUrl)) return;
+  runGit(repoDir, ["remote", "set-url", "origin", cloneUrl]);
+}
+
+function pushBranch(repoDir: string, branch: string): void {
+  runGit(
+    repoDir,
+    [
+      "-c",
+      "credential.helper=",
+      "-c",
+      "safe.directory=*",
+      "push",
+      "-u",
+      "origin",
+      branch,
+    ],
+    {
+      env: {
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_ASKPASS: "true",
+        LEFTHOOK: "0",
+        HUSKY: "0",
+      },
+    },
+  );
+}
+
 function publish(deps: GitDeps, message: string): { pushed: boolean } {
   const repoDir = deps.repoDir;
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
@@ -362,7 +402,21 @@ function publish(deps: GitDeps, message: string): { pushed: boolean } {
     );
   }
 
-  runGit(repoDir, ["push", "origin", branch]);
+  const cloneUrl = deps.getCloneUrl?.();
+  if (typeof cloneUrl === "string" && cloneUrl.length > 0) {
+    syncOriginRemote(repoDir, cloneUrl);
+  } else if (
+    tryGit(repoDir, ["remote", "get-url", "origin"])?.includes("github.com") &&
+    !cloneUrlHasCredentials(
+      tryGit(repoDir, ["remote", "get-url", "origin"]) ?? "",
+    )
+  ) {
+    throw new Error(
+      "GitHub push requires an authenticated clone URL. Connect GitHub for this project and restart the sandbox.",
+    );
+  }
+
+  pushBranch(repoDir, branch);
   return { pushed: true };
 }
 


### PR DESCRIPTION
## Summary
- Fix Submit for review when commits exist on a local-only branch: always push before opening a PR, detect unpushed work correctly, and show the Submit button in the publish dialog when there are commits vs base.
- Refresh GitHub OAuth credentials on git publish and sync `origin` from the authenticated clone URL so sandbox pushes do not fail with anonymous HTTPS.
- Fix suggest-commit to use the client-provided base diff (committed changes) instead of only the working tree.

## Test plan
- [x] `bun test` on panel-state, sandbox-git-api, suggest-commit-message, sync-git-credentials, and daemon git routes
- [ ] Commit CMS changes on a new sandbox branch → header shows **Submit for review**
- [ ] Open dialog → title/description are generated from committed diff
- [ ] **Submit for review** pushes branch and opens GitHub PR
- [ ] Push works with connected mcp-github (reconnect + sandbox restart if token was stale)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Submit for review in sandboxes: we always push before opening a PR, detect local-only work reliably, and require an authenticated GitHub clone URL. Credentials are refreshed at publish time, including re-minting repo‑scoped tokens when needed; suggest-commit validates client input and uses the committed base diff.

- **Bug Fixes**
  - Push and PR run in one flow; always push first so GitHub sees the branch (even when upstream is missing or unpushed reads 0).
  - Detect unpushed work on branches without a remote (daemon sets `unpushed = aheadOfBase`; client falls back to `aheadOfBase`) and route: Submit for review when no PR; Save changes when a PR exists; show Submit in the Save dialog when commits vs base exist.
  - Refresh OAuth and re-mint repo-scoped tokens on publish; proxy patches the sandbox with the authenticated `origin` and identity; daemon syncs `origin` and fails fast on anonymous GitHub remotes; proxy returns 403 with a clear message when the GitHub connection is missing or stale.
  - Validate client-provided git status/diff for suggest-commit (`isGitStatusLike`) and fall back to daemon; in the Save flow, show the base diff and offer Submit for review when there are commits vs base.

- **Migration**
  - Connect `mcp-github` and restart the sandbox; otherwise pushes will fail with an auth error.

<sup>Written for commit 1a472281abe4cd7a176493065ab390d81f381865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

