### PR TITLE
fix(monitor): render tool-call threads without ChatContextProvider

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -6,7 +6,7 @@ import { getUIResourceUri } from "@/mcp-apps/types.ts";
 import {
   useOptionalChatStream,
   useOptionalChatPrefs,
-  useChatTask,
+  useOptionalChatTask,
 } from "@/web/components/chat/context.tsx";
 import { useTaskExpandedTools } from "@/web/hooks/use-task-expanded-tools";
 import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
@@ -230,7 +230,9 @@ export function GenericToolCallPart({
   const { org } = useProjectContext();
 
   const { setChatOpen } = usePanelActions();
-  const { taskId } = useChatTask();
+  // Optional: the tool-call part is also rendered read-only in the Monitor
+  // threads view, which has no ChatContextProvider / ThreadManagerProvider.
+  const taskId = useOptionalChatTask()?.taskId ?? null;
   const { addOrReplaceEager } = useTaskExpandedTools(taskId);
   const navigate = useNavigate();
 
@@ -263,7 +265,8 @@ export function GenericToolCallPart({
   const hasMCPApp = !!uiResourceUri && part.state === "output-available";
   const sourceId = connectionId ? `${connectionId}:${rawToolName}` : null;
   const isDestructive = !!annotations?.destructiveHint;
-  const canOpenInPanel = hasMCPApp && !!connectionId && !isDestructive;
+  const canOpenInPanel =
+    hasMCPApp && !!connectionId && !isDestructive && !!taskId;
 
   const handleOpenInPanel = () => {
     if (!connectionId) return;

--- a/apps/mesh/src/web/hooks/use-task-expanded-tools.ts
+++ b/apps/mesh/src/web/hooks/use-task-expanded-tools.ts
@@ -14,7 +14,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { ThreadExpandedTool, ThreadMetadata } from "../../storage/types";
 import type { Task } from "../components/chat/task/types";
-import { useThreadManager } from "../components/chat/store/hooks";
+import { useOptionalThreadManager } from "../components/chat/store/hooks";
 import { KEYS } from "../lib/query-keys";
 
 export type { ThreadExpandedTool };
@@ -25,10 +25,10 @@ type ThreadGetItem = {
 
 type ThreadGetOutput = { item: ThreadGetItem };
 
-export function useTaskExpandedTools(taskId: string) {
+export function useTaskExpandedTools(taskId: string | null) {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
-  const manager = useThreadManager();
+  const manager = useOptionalThreadManager();
   const client = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
@@ -37,6 +37,7 @@ export function useTaskExpandedTools(taskId: string) {
 
   const mutation = useMutation({
     mutationFn: async (tool: Omit<ThreadExpandedTool, "expandedAt">) => {
+      if (!taskId) throw new Error("useTaskExpandedTools: no task in context");
       const getResult = (await client.callTool({
         name: "COLLECTION_THREADS_GET",
         arguments: { id: taskId },
@@ -71,7 +72,7 @@ export function useTaskExpandedTools(taskId: string) {
       // the full Task row (shared with useEnsureTask + useTaskMetadata);
       // patch task.metadata.expanded_tools in place so reads via `select`
       // see the new entry.
-      const key = KEYS.ensureTask(org.id, taskId);
+      const key = KEYS.ensureTask(org.id, taskId ?? "");
       await queryClient.cancelQueries({ queryKey: key });
       const previous = queryClient.getQueryData<Task | null>(key);
       const currentTools: ThreadExpandedTool[] =
@@ -96,11 +97,11 @@ export function useTaskExpandedTools(taskId: string) {
     onSuccess: () => {
       // Thread update materializes from the next SSE event via ThreadManagerStore
       queryClient.invalidateQueries({
-        queryKey: KEYS.ensureTask(org.id, taskId),
+        queryKey: KEYS.ensureTask(org.id, taskId ?? ""),
       });
     },
     onError: (error, _tool, context) => {
-      const key = KEYS.ensureTask(org.id, taskId);
+      const key = KEYS.ensureTask(org.id, taskId ?? "");
       if (context?.previous === undefined) {
         queryClient.removeQueries({ queryKey: key, exact: true });
       } else {
@@ -120,6 +121,9 @@ export function useTaskExpandedTools(taskId: string) {
    * metadata (missing args) when the navigate() triggers a re-render.
    */
   const addOrReplaceEager = (tool: Omit<ThreadExpandedTool, "expandedAt">) => {
+    // No task/manager in context (e.g. read-only Monitor thread view) — the
+    // "open in panel" affordance is hidden there, so there is nothing to do.
+    if (!taskId || !manager) return;
     const key = KEYS.ensureTask(org.id, taskId);
     const previous = queryClient.getQueryData<Task | null>(key);
     const currentTools: ThreadExpandedTool[] =


### PR DESCRIPTION
## What is this contribution about?
The Monitor → Threads sheet reuses the live chat renderer to display conversations read-only, but mounts it without a `ChatContextProvider`/`ThreadManagerProvider`. `GenericToolCallPart` called the throwing hooks `useChatTask()` and `useTaskExpandedTools()` → `useThreadManager()`, so any thread containing a tool call crashed its `ErrorBoundary` and showed "Failed to load messages" (text-only threads were unaffected, which is why it was intermittent). This switches those to the optional variants (`useOptionalChatTask()` / `useOptionalThreadManager()`), makes `useTaskExpandedTools` accept a null `taskId` and degrade to a no-op, and gates the "Open in panel" affordance on a present `taskId` so the read-only Monitor view renders tool calls without crashing. Live chat behavior is unchanged since a real `taskId` is always present there.

## Screenshots/Demonstration
N/A — fixes a crash; no visual change in the live chat. In Monitor, tool-call threads now render their conversation instead of "Failed to load messages".

## How to Test
1. Open Monitor → Threads (`/<org>/settings/monitor?tab=threads`).
2. Open a thread where the agent actually called a tool.
3. Expected: the full conversation (including tool-call output) renders, no "Failed to load messages" error and no `useChatTask must be used within ChatContextProvider` console error. The "Open in panel" button is hidden in this read-only view, while normal chat retains it.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in Monitor → Threads when rendering tool-call messages without a chat/thread context. Tool-call threads now render correctly; live chat behavior is unchanged.

- **Bug Fixes**
  - Switched to optional hooks (`useOptionalChatTask`, `useOptionalThreadManager`) to avoid throwing when providers are absent.
  - Updated `useTaskExpandedTools` to accept a null `taskId` and no-op when context is missing.
  - Hid "Open in panel" when no `taskId` is present in read-only Monitor views.

<sup>Written for commit 6c3c9aec9f6fe6d8aa9a53a15119a3131fd1e8f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

