### PR TITLE
feat(monitoring): read self-hosted monitoring data from GCS via DuckDB

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
@@ -81,11 +81,38 @@ Studio ──OTLP logs──▶ OTel Collector ──awss3exporter (otlp_json)�
                                   embedded DuckDB reads + flattens at query time
 ```
 
-**1. Create a bucket and an HMAC key.** In Google Cloud Storage, create a bucket and a [Cloud Storage HMAC key](https://cloud.google.com/storage/docs/authentication/hmackeys) (Settings → Interoperability). Add a bucket lifecycle rule for retention if desired.
+Starting from scratch (no bucket yet)? The steps below use the `gcloud` CLI — set `PROJECT_ID` and a globally-unique `BUCKET` first.
 
-**2. Send Studio's monitoring logs to your collector.** Set `MONITORING_OTLP_ENDPOINT` (or enable the in-cluster collector) so Studio exports OTLP logs to it.
+**1. Create the bucket.**
 
-**3. Configure the collector to write OTLP-JSON to GCS.** Add an `awss3exporter` to the collector's **logs** pipeline, pointed at the GCS S3-compatible endpoint with the HMAC key as AWS credentials:
+```bash
+gcloud storage buckets create "gs://${BUCKET}" \
+  --project="${PROJECT_ID}" --location=us --uniform-bucket-level-access
+```
+
+**2. Create a service account + HMAC key.** GCS's S3-compatible API authenticates with HMAC keys; the same key is used by the collector (write) and Studio (read).
+
+```bash
+gcloud iam service-accounts create studio-monitoring --project="${PROJECT_ID}"
+SA="studio-monitoring@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Grant bucket access (objectAdmin covers both write and read).
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
+  --member="serviceAccount:${SA}" --role="roles/storage.objectAdmin"
+
+# Create the HMAC key — capture BOTH values (the secret is shown only once).
+gcloud storage hmac keys create "${SA}" --project="${PROJECT_ID}"
+#  → accessId  = MONITORING_S3_ACCESS_KEY_ID  (GOOG1E...)
+#  → secret    = MONITORING_S3_SECRET_ACCESS_KEY
+```
+
+<Callout type="tip">
+  For tighter separation you can use two HMAC keys — one with `objectCreator` for the collector, one with `objectViewer` for Studio. The single-key path above is the simplest.
+</Callout>
+
+**3. Send Studio's monitoring logs to your collector.** Set `MONITORING_OTLP_ENDPOINT` (or enable the in-cluster collector) so Studio exports OTLP logs to it.
+
+**4. Configure the collector to write OTLP-JSON to GCS.** Add an `awss3exporter` to the collector's **logs** pipeline, pointed at the GCS S3-compatible endpoint with the HMAC key as AWS credentials:
 
 ```yaml
 exporters:
@@ -94,7 +121,7 @@ exporters:
     s3uploader:
       region: auto
       s3_bucket: your-bucket
-      s3_prefix: logs
+      s3_prefix: logs            # must match MONITORING_S3_PREFIX
       endpoint: https://storage.googleapis.com
       s3_force_path_style: true
 service:
@@ -105,7 +132,7 @@ service:
 #   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
 ```
 
-**4. Point Studio's reader at the same bucket:**
+**5. Point Studio's reader at the same bucket:**
 
 ```bash
 MONITORING_S3_BUCKET=your-bucket
@@ -117,9 +144,28 @@ MONITORING_S3_SECRET_ACCESS_KEY=<hmac-secret>
 
 When `MONITORING_S3_BUCKET` is set (and `CLICKHOUSE_URL` is not), the dashboard reads OTLP-JSON log files from the bucket. Metrics (calls, errors, latency percentiles) are derived from those same log rows, so there is no separate metrics store. The `httpfs` extension DuckDB needs is baked into the official image, so this works with strict outbound network policies.
 
+**6. Verify.** Make a few tool calls through Studio, then confirm files land (the collector flushes on its batch timeout) and the dashboard populates:
+
+```bash
+gcloud storage ls --recursive "gs://${BUCKET}/logs/" | head
+```
+
+**Retention (optional).** Studio applies no retention to the bucket — add a lifecycle rule if you want objects auto-deleted, e.g. after 30 days:
+
+```bash
+echo '{"rule":[{"action":{"type":"Delete"},"condition":{"age":30}}]}' > /tmp/lifecycle.json
+gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.json
+```
+
 <Callout type="info">
   The OTLP export caps each tool call's `output` payload at 8&nbsp;KB (matching the hosted ClickHouse path). Tool **inputs** and all analytics (counts, error rate, latency) are unaffected; only very large response bodies are clipped in the call inspector.
 </Callout>
+
+### Troubleshooting
+
+- **Dashboard empty / "Monitoring stats unavailable":** check the collector logs for `awss3exporter` errors (credentials, endpoint, `s3_force_path_style`); confirm objects exist with `gcloud storage ls "gs://${BUCKET}/logs/"`; and confirm `MONITORING_S3_PREFIX` **exactly matches** the collector's `s3_prefix`.
+- **Studio fails to start with a config error:** when `MONITORING_S3_BUCKET` is set, the access key and secret are required (the DuckDB extension directory is baked into the official image).
+- **`otlp_proto` produces unreadable files:** DuckDB cannot read binary protobuf — the collector `marshaler` must be `otlp_json`.
 
 ## Environment Variables
 

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
@@ -160,7 +160,7 @@ When `MONITORING_S3_BUCKET` is set (and `CLICKHOUSE_URL` is not), the dashboard 
 gcloud storage ls --recursive "gs://${BUCKET}/logs/" | head
 ```
 
-**Retention (optional).** Studio applies no retention to the bucket — add a lifecycle rule if you want objects auto-deleted, e.g. after 30 days:
+**Retention (recommended).** Each dashboard query scans the whole prefix (there is no time-based file pruning yet), so a bucket lifecycle rule is the practical way to bound query cost and latency as history accumulates. Studio applies no retention itself — add a rule to auto-delete objects, e.g. after 30 days:
 
 ```bash
 echo '{"rule":[{"action":{"type":"Delete"},"condition":{"age":30}}]}' > /tmp/lifecycle.json

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
@@ -125,7 +125,9 @@ processors:
   batch:
     # One object is written per flush. Keep batches bounded so each file stays
     # well under the reader's 32 MiB per-file limit, and to limit how many
-    # objects each dashboard query scans.
+    # objects each dashboard query scans. (send_batch_max_size must be >=
+    # send_batch_size.)
+    send_batch_size: 2048
     send_batch_max_size: 2048
     timeout: 60s
 exporters:

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
@@ -121,6 +121,13 @@ gcloud storage hmac keys create "${SA}" --project="${PROJECT_ID}"
 **5. Configure the collector to write OTLP-JSON to GCS.** Add the `google_cloud_storage` exporter to the collector's **logs** pipeline. It marshals to OTLP JSON by default — exactly what the dashboard reads.
 
 ```yaml
+processors:
+  batch:
+    # One object is written per flush. Keep batches bounded so each file stays
+    # well under the reader's 32 MiB per-file limit, and to limit how many
+    # objects each dashboard query scans.
+    send_batch_max_size: 2048
+    timeout: 60s
 exporters:
   google_cloud_storage:
     bucket:
@@ -135,11 +142,16 @@ exporters:
 service:
   pipelines:
     logs:
+      processors: [batch]
       exporters: [google_cloud_storage]
 ```
 
 <Callout type="warning">
   `reuse_if_exists: true` is required. With the default (`false`) the exporter tries to **create** the bucket on every startup and fails with a `409 Conflict` once it exists — so the collector won't restart.
+</Callout>
+
+<Callout type="info">
+  The reader caps a single file at 32 MiB; larger files are skipped. The `batch` settings above keep each flushed object well under that — bound `send_batch_max_size` if your tool inputs are large. (Smaller, fewer files also make each dashboard query cheaper.)
 </Callout>
 
 **6. Point Studio's reader at the same bucket:**

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
@@ -71,9 +71,66 @@ DATA_DIR=/mnt/monitoring
 
 No `CLICKHOUSE_URL` is needed — DuckDB queries the NDJSON files on disk.
 
+## Option C: Google Cloud Storage (OTLP via collector)
+
+For self-hosted deployments on GCP that want **no ClickHouse and no disk/sidecar**, Studio can read its monitoring data directly from a GCS bucket. Studio already emits monitoring data as standard OTLP logs over the network; you point those at an OpenTelemetry Collector that writes them to GCS, and the embedded DuckDB engine reads them back via GCS's S3-compatible endpoint.
+
+```
+Studio ──OTLP logs──▶ OTel Collector ──awss3exporter (otlp_json)──▶ gs://bucket/<prefix>/...
+                                                                          ▲
+                                  embedded DuckDB reads + flattens at query time
+```
+
+**1. Create a bucket and an HMAC key.** In Google Cloud Storage, create a bucket and a [Cloud Storage HMAC key](https://cloud.google.com/storage/docs/authentication/hmackeys) (Settings → Interoperability). Add a bucket lifecycle rule for retention if desired.
+
+**2. Send Studio's monitoring logs to your collector.** Set `MONITORING_OTLP_ENDPOINT` (or enable the in-cluster collector) so Studio exports OTLP logs to it.
+
+**3. Configure the collector to write OTLP-JSON to GCS.** Add an `awss3exporter` to the collector's **logs** pipeline, pointed at the GCS S3-compatible endpoint with the HMAC key as AWS credentials:
+
+```yaml
+exporters:
+  awss3:
+    marshaler: otlp_json        # DuckDB-readable (do NOT use otlp_proto)
+    s3uploader:
+      region: auto
+      s3_bucket: your-bucket
+      s3_prefix: logs
+      endpoint: https://storage.googleapis.com
+      s3_force_path_style: true
+service:
+  pipelines:
+    logs:
+      exporters: [awss3]
+# Provide the HMAC key to the collector as AWS credentials:
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+```
+
+**4. Point Studio's reader at the same bucket:**
+
+```bash
+MONITORING_S3_BUCKET=your-bucket
+MONITORING_S3_PREFIX=logs
+MONITORING_S3_ENDPOINT=https://storage.googleapis.com
+MONITORING_S3_ACCESS_KEY_ID=<hmac-key>
+MONITORING_S3_SECRET_ACCESS_KEY=<hmac-secret>
+```
+
+When `MONITORING_S3_BUCKET` is set (and `CLICKHOUSE_URL` is not), the dashboard reads OTLP-JSON log files from the bucket. Metrics (calls, errors, latency percentiles) are derived from those same log rows, so there is no separate metrics store. The `httpfs` extension DuckDB needs is baked into the official image, so this works with strict outbound network policies.
+
+<Callout type="info">
+  The OTLP export caps each tool call's `output` payload at 8&nbsp;KB (matching the hosted ClickHouse path). Tool **inputs** and all analytics (counts, error rate, latency) are unaffected; only very large response bodies are clipped in the call inspector.
+</Callout>
+
 ## Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATA_DIR` | `~/deco` | Base directory for monitoring NDJSON files |
 | `CLICKHOUSE_URL` | *(not set)* | ClickHouse HTTP endpoint. When set, the monitoring UI uses ClickHouse instead of DuckDB |
+| `MONITORING_OTLP_ENDPOINT` | *(falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`)* | OTLP endpoint Studio exports monitoring logs to (your collector) |
+| `MONITORING_S3_BUCKET` | *(not set)* | GCS bucket holding OTLP-JSON logs. When set (and `CLICKHOUSE_URL` is not), the dashboard reads from this bucket via DuckDB |
+| `MONITORING_S3_PREFIX` | *(none)* | Key prefix within the bucket (matches the collector's `s3_prefix`) |
+| `MONITORING_S3_ENDPOINT` | falls back to `S3_ENDPOINT` | S3-compatible endpoint, e.g. `https://storage.googleapis.com` |
+| `MONITORING_S3_REGION` | falls back to `S3_REGION` | Region for SigV4 signing (`auto` for GCS) |
+| `MONITORING_S3_ACCESS_KEY_ID` | falls back to `S3_ACCESS_KEY_ID` | GCS HMAC key |
+| `MONITORING_S3_SECRET_ACCESS_KEY` | falls back to `S3_SECRET_ACCESS_KEY` | GCS HMAC secret |

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
@@ -73,78 +73,88 @@ No `CLICKHOUSE_URL` is needed — DuckDB queries the NDJSON files on disk.
 
 ## Option C: Google Cloud Storage (OTLP via collector)
 
-For self-hosted deployments on GCP that want **no ClickHouse and no disk/sidecar**, Studio can read its monitoring data directly from a GCS bucket. Studio already emits monitoring data as standard OTLP logs over the network; you point those at an OpenTelemetry Collector that writes them to GCS, and the embedded DuckDB engine reads them back via GCS's S3-compatible endpoint.
+For self-hosted deployments on GCP that want **no ClickHouse and no disk/sidecar**, Studio can read its monitoring data directly from a GCS bucket. Studio already emits monitoring data as standard OTLP logs over the network; you point those at an OpenTelemetry Collector that writes them to GCS with the `google_cloud_storage` exporter, and the embedded DuckDB engine reads them back via GCS's S3-compatible endpoint.
 
 ```
-Studio ──OTLP logs──▶ OTel Collector ──awss3exporter (otlp_json)──▶ gs://bucket/<prefix>/...
-                                                                          ▲
-                                  embedded DuckDB reads + flattens at query time
+Studio ──OTLP logs──▶ OTel Collector ──google_cloud_storage exporter──▶ gs://bucket/<prefix>/...
+                              (OTLP JSON, native GCS client)                  ▲
+                                            embedded DuckDB reads + flattens at query time
 ```
+
+The collector **writes** with a Google service account (native GCS client — no S3 signing). Studio **reads** via DuckDB's `httpfs`, which speaks GCS's S3-compatible API, so it needs an HMAC key. Both can use the **same** service account.
+
+<Callout type="warning">
+  Do **not** use the `awss3` exporter for GCS. The AWS SDK v2's default request checksums are rejected by GCS (`SignatureDoesNotMatch`), and the env workaround does not take effect inside that exporter. Use `google_cloud_storage`.
+</Callout>
 
 Starting from scratch (no bucket yet)? The steps below use the `gcloud` CLI — set `PROJECT_ID` and a globally-unique `BUCKET` first.
 
-**1. Create the bucket.**
+**1. Create the bucket.** (Pre-create it — the exporter reuses it, see step 5.)
 
 ```bash
 gcloud storage buckets create "gs://${BUCKET}" \
   --project="${PROJECT_ID}" --location=us --uniform-bucket-level-access
 ```
 
-**2. Create a service account + HMAC key.** GCS's S3-compatible API authenticates with HMAC keys; the same key is used by the collector (write) and Studio (read).
+**2. Create a service account and grant bucket access.** Bucket-scoped `storage.admin` covers what the exporter needs (object writes **and** `storage.buckets.get`, which `reuse_if_exists` calls). No project-level `buckets.create` is required.
 
 ```bash
 gcloud iam service-accounts create studio-monitoring --project="${PROJECT_ID}"
 SA="studio-monitoring@${PROJECT_ID}.iam.gserviceaccount.com"
 
-# Grant bucket access (objectAdmin covers both write and read).
 gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
-  --member="serviceAccount:${SA}" --role="roles/storage.objectAdmin"
-
-# Create the HMAC key — capture BOTH values (the secret is shown only once).
-gcloud storage hmac keys create "${SA}" --project="${PROJECT_ID}"
-#  → accessId  = MONITORING_S3_ACCESS_KEY_ID  (GOOG1E...)
-#  → secret    = MONITORING_S3_SECRET_ACCESS_KEY
+  --member="serviceAccount:${SA}" --role="roles/storage.admin"
 ```
 
-<Callout type="tip">
-  For tighter separation you can use two HMAC keys — one with `objectCreator` for the collector, one with `objectViewer` for Studio. The single-key path above is the simplest.
-</Callout>
+On GKE, bind this SA to the collector's Kubernetes SA via **Workload Identity** (no key file needed). Off-GKE, create a key (`gcloud iam service-accounts keys create key.json --iam-account="${SA}"`) and mount it with `GOOGLE_APPLICATION_CREDENTIALS`.
 
-**3. Send Studio's monitoring logs to your collector.** Set `MONITORING_OTLP_ENDPOINT` (or enable the in-cluster collector) so Studio exports OTLP logs to it.
+**3. Create an HMAC key for Studio's read.** DuckDB reads via the S3-compatible API, which needs an HMAC key on the same SA:
 
-**4. Configure the collector to write OTLP-JSON to GCS.** Add an `awss3exporter` to the collector's **logs** pipeline, pointed at the GCS S3-compatible endpoint with the HMAC key as AWS credentials:
+```bash
+gcloud storage hmac keys create "${SA}" --project="${PROJECT_ID}"
+#  → accessId  = MONITORING_S3_ACCESS_KEY_ID  (GOOG1E...)
+#  → secret    = MONITORING_S3_SECRET_ACCESS_KEY   (shown only once)
+```
+
+**4. Send Studio's monitoring logs to your collector.** Set `MONITORING_OTLP_ENDPOINT` (or enable the in-cluster collector) so Studio exports OTLP logs to it.
+
+**5. Configure the collector to write OTLP-JSON to GCS.** Add the `google_cloud_storage` exporter to the collector's **logs** pipeline. It marshals to OTLP JSON by default — exactly what the dashboard reads.
 
 ```yaml
 exporters:
-  awss3:
-    marshaler: otlp_json        # DuckDB-readable (do NOT use otlp_proto)
-    s3uploader:
-      region: auto
-      s3_bucket: your-bucket
-      s3_prefix: logs            # must match MONITORING_S3_PREFIX
-      endpoint: https://storage.googleapis.com
-      s3_force_path_style: true
+  google_cloud_storage:
+    bucket:
+      name: your-bucket
+      project_id: your-project   # auto-detected on GKE; required off-GCP
+      region: us
+      reuse_if_exists: true      # use the pre-created bucket; required for restart-safety
+      file_prefix: logs
+      partition:
+        prefix: logs             # the read prefix (must match MONITORING_S3_PREFIX)
+        format: "year=%Y/month=%m/day=%d/hour=%H"
 service:
   pipelines:
     logs:
-      exporters: [awss3]
-# Provide the HMAC key to the collector as AWS credentials:
-#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+      exporters: [google_cloud_storage]
 ```
 
-**5. Point Studio's reader at the same bucket:**
+<Callout type="warning">
+  `reuse_if_exists: true` is required. With the default (`false`) the exporter tries to **create** the bucket on every startup and fails with a `409 Conflict` once it exists — so the collector won't restart.
+</Callout>
+
+**6. Point Studio's reader at the same bucket:**
 
 ```bash
 MONITORING_S3_BUCKET=your-bucket
-MONITORING_S3_PREFIX=logs
+MONITORING_S3_PREFIX=logs       # matches the collector's partition.prefix
 MONITORING_S3_ENDPOINT=https://storage.googleapis.com
 MONITORING_S3_ACCESS_KEY_ID=<hmac-key>
 MONITORING_S3_SECRET_ACCESS_KEY=<hmac-secret>
 ```
 
-When `MONITORING_S3_BUCKET` is set (and `CLICKHOUSE_URL` is not), the dashboard reads OTLP-JSON log files from the bucket. Metrics (calls, errors, latency percentiles) are derived from those same log rows, so there is no separate metrics store. The `httpfs` extension DuckDB needs is baked into the official image, so this works with strict outbound network policies.
+When `MONITORING_S3_BUCKET` is set (and `CLICKHOUSE_URL` is not), the dashboard reads the OTLP-JSON log files from the bucket. Metrics (calls, errors, latency percentiles) are derived from those same log rows, so there is no separate metrics store. The `httpfs` extension DuckDB needs is baked into the official image, so this works with strict outbound network policies.
 
-**6. Verify.** Make a few tool calls through Studio, then confirm files land (the collector flushes on its batch timeout) and the dashboard populates:
+**7. Verify.** Make a few tool calls through Studio, then confirm files land (the collector flushes on its batch timeout) and the dashboard populates:
 
 ```bash
 gcloud storage ls --recursive "gs://${BUCKET}/logs/" | head
@@ -163,9 +173,10 @@ gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.j
 
 ### Troubleshooting
 
-- **Dashboard empty / "Monitoring stats unavailable":** check the collector logs for `awss3exporter` errors (credentials, endpoint, `s3_force_path_style`); confirm objects exist with `gcloud storage ls "gs://${BUCKET}/logs/"`; and confirm `MONITORING_S3_PREFIX` **exactly matches** the collector's `s3_prefix`.
-- **Studio fails to start with a config error:** when `MONITORING_S3_BUCKET` is set, the access key and secret are required (the DuckDB extension directory is baked into the official image).
-- **`otlp_proto` produces unreadable files:** DuckDB cannot read binary protobuf — the collector `marshaler` must be `otlp_json`.
+- **Collector won't start / `409 Conflict` on the bucket:** set `bucket.reuse_if_exists: true` and pre-create the bucket (step 1).
+- **`403 storage.buckets.get denied` on startup:** the collector's service account needs bucket-level `storage.admin` (or at least `storage.buckets.get` plus object write) — see step 2.
+- **Dashboard empty / "Monitoring stats unavailable":** confirm objects exist with `gcloud storage ls "gs://${BUCKET}/logs/"`, and confirm `MONITORING_S3_PREFIX` **exactly matches** the collector's `partition.prefix`.
+- **Studio fails to start with a config error:** when `MONITORING_S3_BUCKET` is set, the HMAC access key and secret are required (the DuckDB extension directory is baked into the official image).
 
 ## Environment Variables
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
@@ -121,6 +121,13 @@ gcloud storage hmac keys create "${SA}" --project="${PROJECT_ID}"
 **5. Configure o collector para gravar OTLP-JSON no GCS.** Adicione o exporter `google_cloud_storage` ao pipeline de **logs** do collector. Ele serializa em OTLP JSON por padrão — exatamente o que o dashboard lê.
 
 ```yaml
+processors:
+  batch:
+    # Um objeto é gravado por flush. Mantenha os batches limitados para cada
+    # arquivo ficar bem abaixo do limite de 32 MiB por arquivo do leitor, e para
+    # limitar quantos objetos cada query do dashboard varre.
+    send_batch_max_size: 2048
+    timeout: 60s
 exporters:
   google_cloud_storage:
     bucket:
@@ -135,11 +142,16 @@ exporters:
 service:
   pipelines:
     logs:
+      processors: [batch]
       exporters: [google_cloud_storage]
 ```
 
 <Callout type="warning">
   `reuse_if_exists: true` é obrigatório. Com o default (`false`) o exporter tenta **criar** o bucket a cada startup e falha com `409 Conflict` quando ele já existe — então o collector não reinicia.
+</Callout>
+
+<Callout type="info">
+  O leitor limita um arquivo a 32 MiB; arquivos maiores são ignorados. Os ajustes de `batch` acima mantêm cada objeto bem abaixo disso — limite o `send_batch_max_size` se os inputs das suas ferramentas forem grandes. (Arquivos menores e em menor quantidade também deixam cada query do dashboard mais barata.)
 </Callout>
 
 **6. Aponte o leitor do Studio para o mesmo bucket:**

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
@@ -125,7 +125,9 @@ processors:
   batch:
     # Um objeto é gravado por flush. Mantenha os batches limitados para cada
     # arquivo ficar bem abaixo do limite de 32 MiB por arquivo do leitor, e para
-    # limitar quantos objetos cada query do dashboard varre.
+    # limitar quantos objetos cada query do dashboard varre. (send_batch_max_size
+    # precisa ser >= send_batch_size.)
+    send_batch_size: 2048
     send_batch_max_size: 2048
     timeout: 60s
 exporters:

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
@@ -73,70 +73,80 @@ Não é necessário definir `CLICKHOUSE_URL` — o DuckDB consulta os arquivos N
 
 ## Opção C: Google Cloud Storage (OTLP via collector)
 
-Para deployments self-hosted no GCP que querem **sem ClickHouse e sem disco/sidecar**, o Studio pode ler seus dados de monitoramento diretamente de um bucket no GCS. O Studio já emite os dados de monitoramento como logs OTLP padrão pela rede; você os aponta para um OpenTelemetry Collector que os grava no GCS, e o engine DuckDB embutido os lê de volta pelo endpoint compatível com S3 do GCS.
+Para deployments self-hosted no GCP que querem **sem ClickHouse e sem disco/sidecar**, o Studio pode ler seus dados de monitoramento diretamente de um bucket no GCS. O Studio já emite os dados de monitoramento como logs OTLP padrão pela rede; você os aponta para um OpenTelemetry Collector que os grava no GCS com o exporter `google_cloud_storage`, e o engine DuckDB embutido os lê de volta pelo endpoint compatível com S3 do GCS.
 
 ```
-Studio ──logs OTLP──▶ OTel Collector ──awss3exporter (otlp_json)──▶ gs://bucket/<prefix>/...
-                                                                          ▲
-                                  DuckDB embutido lê + achata na consulta
+Studio ──logs OTLP──▶ OTel Collector ──exporter google_cloud_storage──▶ gs://bucket/<prefix>/...
+                              (OTLP JSON, cliente nativo GCS)                  ▲
+                                            DuckDB embutido lê + achata na consulta
 ```
+
+O collector **escreve** com uma service account do Google (cliente nativo do GCS — sem assinatura S3). O Studio **lê** via `httpfs` do DuckDB, que fala a API compatível com S3 do GCS, então precisa de uma chave HMAC. Ambos podem usar a **mesma** service account.
+
+<Callout type="warning">
+  **Não** use o exporter `awss3` para GCS. Os checksums de request default do AWS SDK v2 são rejeitados pelo GCS (`SignatureDoesNotMatch`), e o workaround via env **não** tem efeito dentro desse exporter. Use o `google_cloud_storage`.
+</Callout>
 
 Começando do zero (ainda sem bucket)? Os passos abaixo usam a CLI `gcloud` — defina `PROJECT_ID` e um `BUCKET` globalmente único primeiro.
 
-**1. Crie o bucket.**
+**1. Crie o bucket.** (Pré-crie — o exporter reaproveita ele, veja o passo 5.)
 
 ```bash
 gcloud storage buckets create "gs://${BUCKET}" \
   --project="${PROJECT_ID}" --location=us --uniform-bucket-level-access
 ```
 
-**2. Crie uma service account + chave HMAC.** A API compatível com S3 do GCS autentica com chaves HMAC; a mesma chave é usada pelo collector (escrita) e pelo Studio (leitura).
+**2. Crie uma service account e conceda acesso ao bucket.** O `storage.admin` no escopo do bucket cobre o que o exporter precisa (escrita de objetos **e** `storage.buckets.get`, que o `reuse_if_exists` chama). Não precisa de `buckets.create` no projeto.
 
 ```bash
 gcloud iam service-accounts create studio-monitoring --project="${PROJECT_ID}"
 SA="studio-monitoring@${PROJECT_ID}.iam.gserviceaccount.com"
 
-# Conceda acesso ao bucket (objectAdmin cobre escrita e leitura).
 gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
-  --member="serviceAccount:${SA}" --role="roles/storage.objectAdmin"
-
-# Crie a chave HMAC — capture AMBOS os valores (o secret é exibido só uma vez).
-gcloud storage hmac keys create "${SA}" --project="${PROJECT_ID}"
-#  → accessId  = MONITORING_S3_ACCESS_KEY_ID  (GOOG1E...)
-#  → secret    = MONITORING_S3_SECRET_ACCESS_KEY
+  --member="serviceAccount:${SA}" --role="roles/storage.admin"
 ```
 
-<Callout type="tip">
-  Para uma separação mais estrita, você pode usar duas chaves HMAC — uma com `objectCreator` para o collector e outra com `objectViewer` para o Studio. O caminho de chave única acima é o mais simples.
-</Callout>
+No GKE, vincule essa SA à Kubernetes SA do collector via **Workload Identity** (sem arquivo de key). Fora do GKE, crie uma key (`gcloud iam service-accounts keys create key.json --iam-account="${SA}"`) e monte com `GOOGLE_APPLICATION_CREDENTIALS`.
 
-**3. Envie os logs de monitoramento do Studio para o seu collector.** Defina `MONITORING_OTLP_ENDPOINT` (ou habilite o collector no cluster) para que o Studio exporte os logs OTLP para ele.
+**3. Crie uma chave HMAC para a leitura do Studio.** O DuckDB lê via API compatível com S3, que precisa de uma chave HMAC na mesma SA:
 
-**4. Configure o collector para gravar OTLP-JSON no GCS.** Adicione um `awss3exporter` ao pipeline de **logs** do collector, apontado para o endpoint compatível com S3 do GCS, usando a chave HMAC como credenciais AWS:
+```bash
+gcloud storage hmac keys create "${SA}" --project="${PROJECT_ID}"
+#  → accessId  = MONITORING_S3_ACCESS_KEY_ID  (GOOG1E...)
+#  → secret    = MONITORING_S3_SECRET_ACCESS_KEY   (exibido só uma vez)
+```
+
+**4. Envie os logs de monitoramento do Studio para o seu collector.** Defina `MONITORING_OTLP_ENDPOINT` (ou habilite o collector no cluster) para que o Studio exporte os logs OTLP para ele.
+
+**5. Configure o collector para gravar OTLP-JSON no GCS.** Adicione o exporter `google_cloud_storage` ao pipeline de **logs** do collector. Ele serializa em OTLP JSON por padrão — exatamente o que o dashboard lê.
 
 ```yaml
 exporters:
-  awss3:
-    marshaler: otlp_json        # legível pelo DuckDB (NÃO use otlp_proto)
-    s3uploader:
-      region: auto
-      s3_bucket: your-bucket
-      s3_prefix: logs            # precisa bater com MONITORING_S3_PREFIX
-      endpoint: https://storage.googleapis.com
-      s3_force_path_style: true
+  google_cloud_storage:
+    bucket:
+      name: your-bucket
+      project_id: your-project   # auto-detectado no GKE; obrigatório fora do GCP
+      region: us
+      reuse_if_exists: true      # usa o bucket pré-criado; necessário p/ sobreviver a restart
+      file_prefix: logs
+      partition:
+        prefix: logs             # o prefixo de leitura (precisa bater com MONITORING_S3_PREFIX)
+        format: "year=%Y/month=%m/day=%d/hour=%H"
 service:
   pipelines:
     logs:
-      exporters: [awss3]
-# Forneça a chave HMAC ao collector como credenciais AWS:
-#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+      exporters: [google_cloud_storage]
 ```
 
-**5. Aponte o leitor do Studio para o mesmo bucket:**
+<Callout type="warning">
+  `reuse_if_exists: true` é obrigatório. Com o default (`false`) o exporter tenta **criar** o bucket a cada startup e falha com `409 Conflict` quando ele já existe — então o collector não reinicia.
+</Callout>
+
+**6. Aponte o leitor do Studio para o mesmo bucket:**
 
 ```bash
 MONITORING_S3_BUCKET=your-bucket
-MONITORING_S3_PREFIX=logs
+MONITORING_S3_PREFIX=logs       # bate com o partition.prefix do collector
 MONITORING_S3_ENDPOINT=https://storage.googleapis.com
 MONITORING_S3_ACCESS_KEY_ID=<hmac-key>
 MONITORING_S3_SECRET_ACCESS_KEY=<hmac-secret>
@@ -144,7 +154,7 @@ MONITORING_S3_SECRET_ACCESS_KEY=<hmac-secret>
 
 Quando `MONITORING_S3_BUCKET` está definida (e `CLICKHOUSE_URL` não), o dashboard lê os arquivos OTLP-JSON do bucket. As métricas (chamadas, erros, percentis de latência) são derivadas dessas mesmas linhas de log, então não há um armazenamento de métricas separado. A extensão `httpfs` que o DuckDB precisa já vem embutida na imagem oficial, então isso funciona mesmo com políticas restritas de rede de saída.
 
-**6. Verifique.** Faça algumas chamadas de ferramenta pelo Studio, depois confirme que os arquivos chegaram (o collector faz flush no timeout do batch) e que o dashboard popula:
+**7. Verifique.** Faça algumas chamadas de ferramenta pelo Studio, depois confirme que os arquivos chegaram (o collector faz flush no timeout do batch) e que o dashboard popula:
 
 ```bash
 gcloud storage ls --recursive "gs://${BUCKET}/logs/" | head
@@ -163,9 +173,10 @@ gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.j
 
 ### Solução de problemas
 
-- **Dashboard vazio / "Monitoring stats unavailable":** verifique os logs do collector por erros do `awss3exporter` (credenciais, endpoint, `s3_force_path_style`); confirme que os objetos existem com `gcloud storage ls "gs://${BUCKET}/logs/"`; e confirme que `MONITORING_S3_PREFIX` **bate exatamente** com o `s3_prefix` do collector.
-- **Studio falha ao iniciar com erro de config:** quando `MONITORING_S3_BUCKET` está definida, a access key e o secret são obrigatórios (o diretório de extensão do DuckDB já vem embutido na imagem oficial).
-- **`otlp_proto` gera arquivos ilegíveis:** o DuckDB não lê protobuf binário — o `marshaler` do collector precisa ser `otlp_json`.
+- **Collector não inicia / `409 Conflict` no bucket:** defina `bucket.reuse_if_exists: true` e pré-crie o bucket (passo 1).
+- **`403 storage.buckets.get denied` no startup:** a service account do collector precisa de `storage.admin` no escopo do bucket (ou ao menos `storage.buckets.get` + escrita de objetos) — veja o passo 2.
+- **Dashboard vazio / "Monitoring stats unavailable":** confirme que os objetos existem com `gcloud storage ls "gs://${BUCKET}/logs/"`; e confirme que `MONITORING_S3_PREFIX` **bate exatamente** com o `partition.prefix` do collector.
+- **Studio falha ao iniciar com erro de config:** quando `MONITORING_S3_BUCKET` está definida, a access key e o secret HMAC são obrigatórios (o diretório de extensão do DuckDB já vem embutido na imagem oficial).
 
 ## Variáveis de ambiente
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
@@ -81,11 +81,38 @@ Studio ──logs OTLP──▶ OTel Collector ──awss3exporter (otlp_json)�
                                   DuckDB embutido lê + achata na consulta
 ```
 
-**1. Crie um bucket e uma chave HMAC.** No Google Cloud Storage, crie um bucket e uma [chave HMAC do Cloud Storage](https://cloud.google.com/storage/docs/authentication/hmackeys) (Configurações → Interoperabilidade). Adicione uma regra de ciclo de vida no bucket para retenção, se desejar.
+Começando do zero (ainda sem bucket)? Os passos abaixo usam a CLI `gcloud` — defina `PROJECT_ID` e um `BUCKET` globalmente único primeiro.
 
-**2. Envie os logs de monitoramento do Studio para o seu collector.** Defina `MONITORING_OTLP_ENDPOINT` (ou habilite o collector no cluster) para que o Studio exporte os logs OTLP para ele.
+**1. Crie o bucket.**
 
-**3. Configure o collector para gravar OTLP-JSON no GCS.** Adicione um `awss3exporter` ao pipeline de **logs** do collector, apontado para o endpoint compatível com S3 do GCS, usando a chave HMAC como credenciais AWS:
+```bash
+gcloud storage buckets create "gs://${BUCKET}" \
+  --project="${PROJECT_ID}" --location=us --uniform-bucket-level-access
+```
+
+**2. Crie uma service account + chave HMAC.** A API compatível com S3 do GCS autentica com chaves HMAC; a mesma chave é usada pelo collector (escrita) e pelo Studio (leitura).
+
+```bash
+gcloud iam service-accounts create studio-monitoring --project="${PROJECT_ID}"
+SA="studio-monitoring@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Conceda acesso ao bucket (objectAdmin cobre escrita e leitura).
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
+  --member="serviceAccount:${SA}" --role="roles/storage.objectAdmin"
+
+# Crie a chave HMAC — capture AMBOS os valores (o secret é exibido só uma vez).
+gcloud storage hmac keys create "${SA}" --project="${PROJECT_ID}"
+#  → accessId  = MONITORING_S3_ACCESS_KEY_ID  (GOOG1E...)
+#  → secret    = MONITORING_S3_SECRET_ACCESS_KEY
+```
+
+<Callout type="tip">
+  Para uma separação mais estrita, você pode usar duas chaves HMAC — uma com `objectCreator` para o collector e outra com `objectViewer` para o Studio. O caminho de chave única acima é o mais simples.
+</Callout>
+
+**3. Envie os logs de monitoramento do Studio para o seu collector.** Defina `MONITORING_OTLP_ENDPOINT` (ou habilite o collector no cluster) para que o Studio exporte os logs OTLP para ele.
+
+**4. Configure o collector para gravar OTLP-JSON no GCS.** Adicione um `awss3exporter` ao pipeline de **logs** do collector, apontado para o endpoint compatível com S3 do GCS, usando a chave HMAC como credenciais AWS:
 
 ```yaml
 exporters:
@@ -94,7 +121,7 @@ exporters:
     s3uploader:
       region: auto
       s3_bucket: your-bucket
-      s3_prefix: logs
+      s3_prefix: logs            # precisa bater com MONITORING_S3_PREFIX
       endpoint: https://storage.googleapis.com
       s3_force_path_style: true
 service:
@@ -105,7 +132,7 @@ service:
 #   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
 ```
 
-**4. Aponte o leitor do Studio para o mesmo bucket:**
+**5. Aponte o leitor do Studio para o mesmo bucket:**
 
 ```bash
 MONITORING_S3_BUCKET=your-bucket
@@ -117,9 +144,28 @@ MONITORING_S3_SECRET_ACCESS_KEY=<hmac-secret>
 
 Quando `MONITORING_S3_BUCKET` está definida (e `CLICKHOUSE_URL` não), o dashboard lê os arquivos OTLP-JSON do bucket. As métricas (chamadas, erros, percentis de latência) são derivadas dessas mesmas linhas de log, então não há um armazenamento de métricas separado. A extensão `httpfs` que o DuckDB precisa já vem embutida na imagem oficial, então isso funciona mesmo com políticas restritas de rede de saída.
 
+**6. Verifique.** Faça algumas chamadas de ferramenta pelo Studio, depois confirme que os arquivos chegaram (o collector faz flush no timeout do batch) e que o dashboard popula:
+
+```bash
+gcloud storage ls --recursive "gs://${BUCKET}/logs/" | head
+```
+
+**Retenção (opcional).** O Studio não aplica retenção ao bucket — adicione uma regra de ciclo de vida se quiser deletar objetos automaticamente, ex. após 30 dias:
+
+```bash
+echo '{"rule":[{"action":{"type":"Delete"},"condition":{"age":30}}]}' > /tmp/lifecycle.json
+gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.json
+```
+
 <Callout type="info">
   A exportação OTLP limita o payload de `output` de cada chamada de ferramenta em 8&nbsp;KB (igual ao caminho do ClickHouse hospedado). Os **inputs** das ferramentas e todas as análises (contagens, taxa de erro, latência) não são afetados; apenas corpos de resposta muito grandes são cortados no inspetor de chamadas.
 </Callout>
+
+### Solução de problemas
+
+- **Dashboard vazio / "Monitoring stats unavailable":** verifique os logs do collector por erros do `awss3exporter` (credenciais, endpoint, `s3_force_path_style`); confirme que os objetos existem com `gcloud storage ls "gs://${BUCKET}/logs/"`; e confirme que `MONITORING_S3_PREFIX` **bate exatamente** com o `s3_prefix` do collector.
+- **Studio falha ao iniciar com erro de config:** quando `MONITORING_S3_BUCKET` está definida, a access key e o secret são obrigatórios (o diretório de extensão do DuckDB já vem embutido na imagem oficial).
+- **`otlp_proto` gera arquivos ilegíveis:** o DuckDB não lê protobuf binário — o `marshaler` do collector precisa ser `otlp_json`.
 
 ## Variáveis de ambiente
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
@@ -160,7 +160,7 @@ Quando `MONITORING_S3_BUCKET` está definida (e `CLICKHOUSE_URL` não), o dashbo
 gcloud storage ls --recursive "gs://${BUCKET}/logs/" | head
 ```
 
-**Retenção (opcional).** O Studio não aplica retenção ao bucket — adicione uma regra de ciclo de vida se quiser deletar objetos automaticamente, ex. após 30 dias:
+**Retenção (recomendado).** Cada query do dashboard varre o prefixo inteiro (ainda não há poda por data dos arquivos), então uma regra de ciclo de vida no bucket é a forma prática de limitar custo e latência conforme o histórico cresce. O Studio não aplica retenção sozinho — adicione uma regra pra deletar objetos automaticamente, ex. após 30 dias:
 
 ```bash
 echo '{"rule":[{"action":{"type":"Delete"},"condition":{"age":30}}]}' > /tmp/lifecycle.json

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
@@ -71,9 +71,66 @@ DATA_DIR=/mnt/monitoring
 
 Não é necessário definir `CLICKHOUSE_URL` — o DuckDB consulta os arquivos NDJSON em disco.
 
+## Opção C: Google Cloud Storage (OTLP via collector)
+
+Para deployments self-hosted no GCP que querem **sem ClickHouse e sem disco/sidecar**, o Studio pode ler seus dados de monitoramento diretamente de um bucket no GCS. O Studio já emite os dados de monitoramento como logs OTLP padrão pela rede; você os aponta para um OpenTelemetry Collector que os grava no GCS, e o engine DuckDB embutido os lê de volta pelo endpoint compatível com S3 do GCS.
+
+```
+Studio ──logs OTLP──▶ OTel Collector ──awss3exporter (otlp_json)──▶ gs://bucket/<prefix>/...
+                                                                          ▲
+                                  DuckDB embutido lê + achata na consulta
+```
+
+**1. Crie um bucket e uma chave HMAC.** No Google Cloud Storage, crie um bucket e uma [chave HMAC do Cloud Storage](https://cloud.google.com/storage/docs/authentication/hmackeys) (Configurações → Interoperabilidade). Adicione uma regra de ciclo de vida no bucket para retenção, se desejar.
+
+**2. Envie os logs de monitoramento do Studio para o seu collector.** Defina `MONITORING_OTLP_ENDPOINT` (ou habilite o collector no cluster) para que o Studio exporte os logs OTLP para ele.
+
+**3. Configure o collector para gravar OTLP-JSON no GCS.** Adicione um `awss3exporter` ao pipeline de **logs** do collector, apontado para o endpoint compatível com S3 do GCS, usando a chave HMAC como credenciais AWS:
+
+```yaml
+exporters:
+  awss3:
+    marshaler: otlp_json        # legível pelo DuckDB (NÃO use otlp_proto)
+    s3uploader:
+      region: auto
+      s3_bucket: your-bucket
+      s3_prefix: logs
+      endpoint: https://storage.googleapis.com
+      s3_force_path_style: true
+service:
+  pipelines:
+    logs:
+      exporters: [awss3]
+# Forneça a chave HMAC ao collector como credenciais AWS:
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+```
+
+**4. Aponte o leitor do Studio para o mesmo bucket:**
+
+```bash
+MONITORING_S3_BUCKET=your-bucket
+MONITORING_S3_PREFIX=logs
+MONITORING_S3_ENDPOINT=https://storage.googleapis.com
+MONITORING_S3_ACCESS_KEY_ID=<hmac-key>
+MONITORING_S3_SECRET_ACCESS_KEY=<hmac-secret>
+```
+
+Quando `MONITORING_S3_BUCKET` está definida (e `CLICKHOUSE_URL` não), o dashboard lê os arquivos OTLP-JSON do bucket. As métricas (chamadas, erros, percentis de latência) são derivadas dessas mesmas linhas de log, então não há um armazenamento de métricas separado. A extensão `httpfs` que o DuckDB precisa já vem embutida na imagem oficial, então isso funciona mesmo com políticas restritas de rede de saída.
+
+<Callout type="info">
+  A exportação OTLP limita o payload de `output` de cada chamada de ferramenta em 8&nbsp;KB (igual ao caminho do ClickHouse hospedado). Os **inputs** das ferramentas e todas as análises (contagens, taxa de erro, latência) não são afetados; apenas corpos de resposta muito grandes são cortados no inspetor de chamadas.
+</Callout>
+
 ## Variáveis de ambiente
 
 | Variável | Padrão | Descrição |
 |----------|---------|-------------|
 | `DATA_DIR` | `~/deco` | Diretório base para os arquivos NDJSON de monitoramento |
 | `CLICKHOUSE_URL` | *(não definida)* | Endpoint HTTP do ClickHouse. Quando definida, a UI de monitoramento usa ClickHouse em vez de DuckDB |
+| `MONITORING_OTLP_ENDPOINT` | *(usa `OTEL_EXPORTER_OTLP_ENDPOINT` como fallback)* | Endpoint OTLP para onde o Studio exporta os logs de monitoramento (seu collector) |
+| `MONITORING_S3_BUCKET` | *(não definida)* | Bucket no GCS com os logs OTLP-JSON. Quando definida (e `CLICKHOUSE_URL` não), o dashboard lê deste bucket via DuckDB |
+| `MONITORING_S3_PREFIX` | *(nenhum)* | Prefixo de chave dentro do bucket (igual ao `s3_prefix` do collector) |
+| `MONITORING_S3_ENDPOINT` | usa `S3_ENDPOINT` como fallback | Endpoint compatível com S3, ex. `https://storage.googleapis.com` |
+| `MONITORING_S3_REGION` | usa `S3_REGION` como fallback | Região para assinatura SigV4 (`auto` para GCS) |
+| `MONITORING_S3_ACCESS_KEY_ID` | usa `S3_ACCESS_KEY_ID` como fallback | Chave HMAC do GCS |
+| `MONITORING_S3_SECRET_ACCESS_KEY` | usa `S3_SECRET_ACCESS_KEY` como fallback | Segredo HMAC do GCS |

--- a/apps/mesh/Dockerfile
+++ b/apps/mesh/Dockerfile
@@ -31,10 +31,20 @@ COPY decocms.tgz /tmp/decocms.tgz
 RUN bun add /tmp/decocms.tgz
 
 # Drop the build toolchain now that native modules have been compiled.
+# Also create the DuckDB extension dir (owned by bunuser) where httpfs is baked.
 USER root
 RUN apt-get purge -y --auto-remove python3 build-essential && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /opt/duckdb/extensions && \
+    chown -R bunuser:bunapp /opt/duckdb
 USER bunuser
+
+# Bake the DuckDB httpfs extension into the image so the GCS monitoring read
+# path never reaches the DuckDB extension CDN at runtime (strict-outbound
+# self-hosters). At runtime DuckDBEngine sets autoinstall/autoload off and
+# LOADs from this directory. Network is available here at build time.
+ENV DUCKDB_EXTENSION_DIRECTORY=/opt/duckdb/extensions
+RUN bun -e "const {DuckDBInstance}=await import('@duckdb/node-api'); const c=await (await DuckDBInstance.create('',{threads:'1'})).connect(); await c.run(\"SET extension_directory='/opt/duckdb/extensions'; INSTALL httpfs;\");"
 
 # Expose the default port
 EXPOSE 3000

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -24,8 +24,10 @@ import {
 import {
   createMonitoringEngine,
   ClickHouseClientEngine,
+  DuckDBEngine,
+  buildOtlpFlatSource,
 } from "../monitoring/query-engine";
-import type { QueryEngine } from "../monitoring/query-engine";
+import type { QueryEngine, DuckDBGcsConfig } from "../monitoring/query-engine";
 import { getLogsDir, getMetricsDir } from "../monitoring/schema";
 import { OrganizationSettingsStorage } from "../storage/organization-settings";
 import { VirtualMcpPluginConfigsStorage } from "../storage/virtual-mcp-plugin-configs";
@@ -1041,17 +1043,32 @@ export async function createStudioContextFactory(
   // Create vault instance for credential encryption
   const vault = new CredentialVault(config.encryption.key);
 
-  // Create monitoring engines (shared across requests)
-  const clickhouseUrl = getSettings().clickhouseUrl;
+  // Create monitoring engines (shared across requests).
+  // Precedence: ClickHouse (otel_logs view) > GCS OTLP-JSON (embedded DuckDB +
+  // httpfs) > local NDJSON (embedded DuckDB). The test-stub path overrides all.
+  const settings = getSettings();
+  const clickhouseUrl = settings.clickhouseUrl;
   const isClickHouse = !!clickhouseUrl;
-  const dialect: SqlDialect = config.monitoringEngines
-    ? "duckdb"
-    : isClickHouse
-      ? "clickhouse"
-      : "duckdb";
+  const isGcsOtlp = !isClickHouse && !!settings.monitoringS3Bucket;
+  const dialect: SqlDialect = isClickHouse ? "clickhouse" : "duckdb";
+
+  const { resolve } = await import("node:path");
+  const logsBasePath = resolve(getLogsDir());
+  const metricsBasePath = resolve(getMetricsDir());
+
+  // DuckDB reads local NDJSON files; org-sharded directory layout.
+  const localLogSourceFactory = (orgId: string) =>
+    `read_ndjson('${logsBasePath}/${orgId}/**/*.ndjson', auto_detect=true)`;
+  const localMetricSourceFactory = (orgId: string) =>
+    `read_ndjson('${metricsBasePath}/${orgId}/**/*.ndjson', auto_detect=true)`;
 
   let monitoringEngine: QueryEngine;
   let metricEngine: QueryEngine;
+  let logSourceFactory: (orgId: string) => string;
+  let metricSourceFactory: (orgId: string) => string;
+  // When true, metrics are derived from flat log rows instead of histogram
+  // MetricRow files (the GCS OTLP path; see SqlMonitoringStorage).
+  let metricsFromLogs = false;
 
   if (config.monitoringEngines) {
     // Test-only path: caller supplied stubs to avoid loading
@@ -1059,9 +1076,57 @@ export async function createStudioContextFactory(
     // crash). See StudioContextConfig.monitoringEngines for the why.
     monitoringEngine = config.monitoringEngines.monitoringEngine;
     metricEngine = config.monitoringEngines.metricEngine;
+    logSourceFactory = localLogSourceFactory;
+    metricSourceFactory = localMetricSourceFactory;
   } else if (isClickHouse) {
+    // ClickHouse reads the studio_monitoring_logs VIEW (a flat projection of the
+    // OTel-native otel_logs table — provisioned manually, see
+    // monitoring/clickhouse-setup.md). Metrics are derived from those same log
+    // rows, so both factories point at the view.
     monitoringEngine = new ClickHouseClientEngine(clickhouseUrl!);
     metricEngine = new ClickHouseClientEngine(clickhouseUrl!);
+    logSourceFactory = (_orgId: string) => "studio_monitoring_logs";
+    metricSourceFactory = (_orgId: string) => "studio_monitoring_logs";
+  } else if (isGcsOtlp) {
+    // GCS OTLP-JSON path: embedded DuckDB reads OTLP-JSON log files from the
+    // bucket over the S3-compatible endpoint, flattens them to the dashboard's
+    // flat columns, and derives metrics from those log rows. The flat source is
+    // the same for logs and metrics; org scoping is the outer WHERE.
+    const accessKeyId =
+      settings.monitoringS3AccessKeyId ?? settings.s3AccessKeyId;
+    const secretAccessKey =
+      settings.monitoringS3SecretAccessKey ?? settings.s3SecretAccessKey;
+    const extensionDirectory = settings.duckdbExtensionDirectory;
+    if (!accessKeyId || !secretAccessKey || !extensionDirectory) {
+      throw new Error(
+        "MONITORING_S3_BUCKET is set but the GCS monitoring path is misconfigured: " +
+          "MONITORING_S3_ACCESS_KEY_ID/S3_ACCESS_KEY_ID, " +
+          "MONITORING_S3_SECRET_ACCESS_KEY/S3_SECRET_ACCESS_KEY, and " +
+          "DUCKDB_EXTENSION_DIRECTORY are all required.",
+      );
+    }
+    const gcs: DuckDBGcsConfig = {
+      endpoint:
+        settings.monitoringS3Endpoint ??
+        settings.s3Endpoint ??
+        "storage.googleapis.com",
+      region: settings.monitoringS3Region ?? settings.s3Region,
+      accessKeyId,
+      secretAccessKey,
+      extensionDirectory,
+    };
+    // One shared engine: same files for logs and log-derived metrics, so the
+    // httpfs + SECRET setup runs once.
+    const gcsEngine = new DuckDBEngine(gcs);
+    monitoringEngine = gcsEngine;
+    metricEngine = gcsEngine;
+    const otlpSource = buildOtlpFlatSource({
+      bucket: settings.monitoringS3Bucket!,
+      prefix: settings.monitoringS3Prefix ?? "",
+    });
+    logSourceFactory = (_orgId: string) => otlpSource;
+    metricSourceFactory = (_orgId: string) => otlpSource;
+    metricsFromLogs = true;
   } else {
     const { engine: me } = await createMonitoringEngine({
       basePath: getLogsDir(),
@@ -1071,27 +1136,9 @@ export async function createStudioContextFactory(
     });
     monitoringEngine = me;
     metricEngine = metricE;
+    logSourceFactory = localLogSourceFactory;
+    metricSourceFactory = localMetricSourceFactory;
   }
-
-  const { resolve } = await import("node:path");
-  const logsBasePath = resolve(getLogsDir());
-  const metricsBasePath = resolve(getMetricsDir());
-
-  // ClickHouse reads the studio_monitoring_logs VIEW (a flat projection of the
-  // OTel-native otel_logs table — provisioned manually, see
-  // monitoring/clickhouse-setup.md); DuckDB reads the local NDJSON files.
-  // Metrics (counts, durations, percentiles) are derived from the same
-  // monitoring log rows — each tool_call log carries duration_ms and is_error —
-  // so there is no separate metrics table to query.
-  const logSourceFactory = isClickHouse
-    ? (_orgId: string) => "studio_monitoring_logs"
-    : (orgId: string) =>
-        `read_ndjson('${logsBasePath}/${orgId}/**/*.ndjson', auto_detect=true)`;
-
-  const metricSourceFactory = isClickHouse
-    ? (_orgId: string) => "studio_monitoring_logs"
-    : (orgId: string) =>
-        `read_ndjson('${metricsBasePath}/${orgId}/**/*.ndjson', auto_detect=true)`;
 
   // Create storage adapters once (singleton pattern)
   const threadDb = new SqlThreadStorage(config.db);
@@ -1106,6 +1153,7 @@ export async function createStudioContextFactory(
       metricEngine,
       metricSourceFactory,
       dialect,
+      metricsFromLogs,
     ),
     virtualMcps: new VirtualMCPStorage(config.db),
     users: new UserStorage(config.db),

--- a/apps/mesh/src/monitoring/query-engine.test.ts
+++ b/apps/mesh/src/monitoring/query-engine.test.ts
@@ -3,11 +3,18 @@ import {
   DuckDBEngine,
   ClickHouseClientEngine,
   createMonitoringEngine,
+  buildOtlpFlatSource,
+  buildOtlpFlatSourceFromGlob,
 } from "./query-engine";
 import { mkdtemp, rm, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { makeTestMonitoringRow, writeTestNDJSON } from "./test-utils";
+import {
+  makeTestMonitoringRow,
+  writeTestNDJSON,
+  makeTestOtlpLogRecord,
+  writeTestOtlpJson,
+} from "./test-utils";
 
 let duckdbAvailable = false;
 try {
@@ -122,5 +129,90 @@ describe("createMonitoringEngine", () => {
     });
     expect(engine).toBeInstanceOf(ClickHouseClientEngine);
     expect(source).toBe("custom_table");
+  });
+});
+
+describe("buildOtlpFlatSource", () => {
+  it("builds an s3:// glob with prefix", () => {
+    const src = buildOtlpFlatSource({ bucket: "my-bucket", prefix: "logs" });
+    expect(src).toContain("s3://my-bucket/logs/**/*.json");
+  });
+
+  it("omits an empty prefix", () => {
+    const src = buildOtlpFlatSource({ bucket: "my-bucket", prefix: "" });
+    expect(src).toContain("s3://my-bucket/**/*.json");
+  });
+
+  it("trims slashes from the prefix", () => {
+    const src = buildOtlpFlatSource({ bucket: "b", prefix: "/logs/" });
+    expect(src).toContain("s3://b/logs/**/*.json");
+  });
+
+  it("rejects injection in bucket/prefix", () => {
+    expect(() =>
+      buildOtlpFlatSource({ bucket: "b';--", prefix: "" }),
+    ).toThrow();
+    expect(() => buildOtlpFlatSource({ bucket: "b", prefix: "p'" })).toThrow();
+  });
+});
+
+describe.skipIf(!duckdbAvailable)("OTLP flat source over local fixture", () => {
+  let tmpDir: string;
+  let engine: DuckDBEngine;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "otlp-flat-test-"));
+    await writeTestOtlpJson(tmpDir, [
+      makeTestOtlpLogRecord({
+        id: "span_a",
+        tool_name: "TOOL_A",
+        is_error: 0,
+        duration_ms: 100,
+        input: '{"q":"hi"}',
+        output: '{"tokens":42}',
+        timestamp: "2026-03-05T12:00:00.000Z",
+      }),
+      makeTestOtlpLogRecord({
+        id: "span_b",
+        tool_name: "TOOL_B",
+        is_error: 1,
+        error_message: "boom",
+        duration_ms: 250.5,
+        timestamp: "2026-03-05T12:01:00.000Z",
+      }),
+      // Non-monitoring record — must be filtered out.
+      makeTestOtlpLogRecord({ id: "span_c", type: "infra_noise" }),
+    ]);
+    engine = new DuckDBEngine();
+  });
+
+  afterAll(async () => {
+    await engine.destroy();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("flattens OTLP-JSON to the flat columns and filters non-monitoring rows", async () => {
+    const source = buildOtlpFlatSourceFromGlob(`${tmpDir}/**/*.json`);
+    const rows = await engine.query(
+      `SELECT * FROM ${source} WHERE organization_id = 'org_test' ORDER BY id`,
+    );
+    expect(rows.length).toBe(2); // infra_noise excluded
+
+    const a = rows[0]!;
+    expect(a.id).toBe("span_a"); // id === spanId
+    expect(a.tool_name).toBe("TOOL_A");
+    expect(a.is_error).toBe(0);
+    expect(Number(a.duration_ms)).toBe(100);
+    expect(a.input).toBe('{"q":"hi"}');
+    expect(a.output).toBe('{"tokens":42}');
+    // timestamp round-trips from timeUnixNano
+    expect(new Date(String(a.timestamp)).toISOString()).toBe(
+      "2026-03-05T12:00:00.000Z",
+    );
+
+    const b = rows[1]!;
+    expect(b.is_error).toBe(1);
+    expect(b.error_message).toBe("boom");
+    expect(Number(b.duration_ms)).toBe(250.5);
   });
 });

--- a/apps/mesh/src/monitoring/query-engine.test.ts
+++ b/apps/mesh/src/monitoring/query-engine.test.ts
@@ -5,6 +5,7 @@ import {
   createMonitoringEngine,
   buildOtlpFlatSource,
   buildOtlpFlatSourceFromGlob,
+  normalizeS3Endpoint,
 } from "./query-engine";
 import { mkdtemp, rm, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -129,6 +130,36 @@ describe("createMonitoringEngine", () => {
     });
     expect(engine).toBeInstanceOf(ClickHouseClientEngine);
     expect(source).toBe("custom_table");
+  });
+});
+
+describe("normalizeS3Endpoint", () => {
+  it("strips https scheme and keeps SSL on", () => {
+    expect(normalizeS3Endpoint("https://storage.googleapis.com")).toEqual({
+      host: "storage.googleapis.com",
+      useSsl: true,
+    });
+  });
+
+  it("strips http scheme and turns SSL off", () => {
+    expect(normalizeS3Endpoint("http://localhost:9000")).toEqual({
+      host: "localhost:9000",
+      useSsl: false,
+    });
+  });
+
+  it("defaults a scheme-less host to SSL", () => {
+    expect(normalizeS3Endpoint("storage.googleapis.com")).toEqual({
+      host: "storage.googleapis.com",
+      useSsl: true,
+    });
+  });
+
+  it("trims trailing slashes", () => {
+    expect(normalizeS3Endpoint("https://storage.googleapis.com/")).toEqual({
+      host: "storage.googleapis.com",
+      useSsl: true,
+    });
   });
 });
 

--- a/apps/mesh/src/monitoring/query-engine.test.ts
+++ b/apps/mesh/src/monitoring/query-engine.test.ts
@@ -164,19 +164,21 @@ describe("normalizeS3Endpoint", () => {
 });
 
 describe("buildOtlpFlatSource", () => {
+  // glob is **/* (not *.json) — the google_cloud_storage exporter writes
+  // extensionless objects (logs_<uuid>); read_json(format='auto') detects JSON.
   it("builds an s3:// glob with prefix", () => {
     const src = buildOtlpFlatSource({ bucket: "my-bucket", prefix: "logs" });
-    expect(src).toContain("s3://my-bucket/logs/**/*.json");
+    expect(src).toContain("s3://my-bucket/logs/**/*");
   });
 
   it("omits an empty prefix", () => {
     const src = buildOtlpFlatSource({ bucket: "my-bucket", prefix: "" });
-    expect(src).toContain("s3://my-bucket/**/*.json");
+    expect(src).toContain("s3://my-bucket/**/*");
   });
 
   it("trims slashes from the prefix", () => {
     const src = buildOtlpFlatSource({ bucket: "b", prefix: "/logs/" });
-    expect(src).toContain("s3://b/logs/**/*.json");
+    expect(src).toContain("s3://b/logs/**/*");
   });
 
   it("rejects injection in bucket/prefix", () => {

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -18,23 +18,90 @@ export interface QueryEngine {
 }
 
 /**
- * DuckDB engine for local dev monitoring queries.
- * Uses embedded DuckDB to query NDJSON files from disk.
+ * Credentials + extension dir for reading object storage (GCS via its
+ * S3-compatible endpoint) through DuckDB's httpfs extension. When supplied to
+ * DuckDBEngine, the connection is primed once with `LOAD httpfs` + a `CREATE
+ * SECRET` so `read_json('s3://…')` works against the bucket.
+ */
+export interface DuckDBGcsConfig {
+  /** Host only, no scheme — e.g. "storage.googleapis.com". */
+  endpoint: string;
+  /** "auto" or a concrete region. */
+  region: string;
+  /** GCS HMAC access key. */
+  accessKeyId: string;
+  /** GCS HMAC secret. */
+  secretAccessKey: string;
+  /** Absolute path to the extension dir holding the pre-installed httpfs. */
+  extensionDirectory: string;
+}
+
+/** Escape a value for a single-quoted DuckDB SQL literal. */
+function escSqlLiteral(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * DuckDB engine for embedded monitoring queries.
+ * Reads NDJSON files from local disk, or — when `gcs` is supplied — OTLP-JSON
+ * files from object storage via httpfs.
  */
 export class DuckDBEngine implements QueryEngine {
   private connectionPromise: Promise<
     import("@duckdb/node-api").DuckDBConnection
   >;
 
-  constructor() {
+  constructor(gcs?: DuckDBGcsConfig) {
     this.connectionPromise = import("@duckdb/node-api").then(
       async ({ DuckDBInstance }) => {
         const { cpus } = await import("node:os");
         const threads = String(Math.max(1, cpus().length));
         const instance = await DuckDBInstance.create("", { threads });
-        return instance.connect();
+        const connection = await instance.connect();
+        if (gcs) {
+          await DuckDBEngine.setupGcs(connection, gcs);
+        }
+        return connection;
       },
     );
+  }
+
+  /**
+   * Prime a connection to read from GCS: load the pre-baked httpfs extension
+   * (no runtime download) and register an s3-type secret pointed at the GCS
+   * S3-compatible endpoint.
+   */
+  private static async setupGcs(
+    connection: import("@duckdb/node-api").DuckDBConnection,
+    gcs: DuckDBGcsConfig,
+  ): Promise<void> {
+    // httpfs is baked into the image at build time; never reach out to the
+    // DuckDB extension CDN at runtime (strict-outbound self-hosters).
+    await connection.run(
+      [
+        `SET extension_directory='${escSqlLiteral(gcs.extensionDirectory)}';`,
+        `SET autoinstall_known_extensions=false;`,
+        `SET autoload_known_extensions=false;`,
+        `LOAD httpfs;`,
+      ].join("\n"),
+    );
+
+    const secretSql = `CREATE OR REPLACE SECRET studio_gcs (
+  TYPE s3,
+  PROVIDER config,
+  KEY_ID '${escSqlLiteral(gcs.accessKeyId)}',
+  SECRET '${escSqlLiteral(gcs.secretAccessKey)}',
+  REGION '${escSqlLiteral(gcs.region)}',
+  ENDPOINT '${escSqlLiteral(gcs.endpoint)}',
+  URL_STYLE 'path',
+  USE_SSL true
+);`;
+    try {
+      await connection.run(secretSql);
+    } catch {
+      // Never surface the SECRET DDL — it carries the HMAC secret.
+      throw new Error("Failed to initialize DuckDB GCS secret");
+    }
   }
 
   async query(sql: string): Promise<Record<string, unknown>[]> {
@@ -152,4 +219,87 @@ export async function createMonitoringEngine(
   const source = `read_ndjson('${resolvedPath}/**/*.ndjson', auto_detect=true)`;
 
   return { engine: new DuckDBEngine(), source };
+}
+
+/** Attribute-key prefix on Studio's monitoring OTel log records. */
+const MONITORING_ATTR_PREFIX = "studio.monitoring.";
+
+/**
+ * Build a DuckDB subquery that flattens OTLP-JSON log files
+ * (`ExportLogsServiceRequest`: resourceLogs[] -> scopeLogs[] -> logRecords[])
+ * into the flat row shape the dashboard SQL expects. The caller scopes by org
+ * via the outer `organization_id = '...'` WHERE — OTLP files are time-sharded,
+ * not org-sharded, so the glob reads all orgs and the subquery only exposes the
+ * column.
+ *
+ * Attribute values are read via `to_json(value)` + `json_extract_string` rather
+ * than struct-field access: DuckDB infers the `value` struct shape from sampled
+ * data, so a direct `value.intValue` reference bind-errors on files that only
+ * contain `stringValue`. The JSON path returns NULL for absent fields instead.
+ */
+export function buildOtlpFlatSourceFromGlob(glob: string): string {
+  const A = MONITORING_ATTR_PREFIX;
+  const attr = (key: string) => `attrs['${A}${key}']`;
+  return `(
+  WITH _raw AS (
+    SELECT unnest(resourceLogs) AS rl
+    FROM read_json('${glob}', format='auto', union_by_name=true, maximum_object_size=33554432, ignore_errors=true)
+  ),
+  _scopes AS (SELECT unnest(rl.scopeLogs) AS sl FROM _raw),
+  _recs AS (SELECT unnest(sl.logRecords) AS lr FROM _scopes),
+  _flat AS (
+    SELECT
+      lr.spanId AS span_id,
+      lr.timeUnixNano AS ts_nano,
+      map_from_entries(
+        list_transform(lr.attributes, a -> struct_pack(
+          k := a.key,
+          v := coalesce(
+            json_extract_string(to_json(a.value), '$.stringValue'),
+            json_extract_string(to_json(a.value), '$.intValue'),
+            json_extract_string(to_json(a.value), '$.boolValue'),
+            json_extract_string(to_json(a.value), '$.doubleValue')
+          )
+        ))
+      ) AS attrs
+    FROM _recs
+  )
+  SELECT
+    span_id AS id,
+    ${attr("organization_id")} AS organization_id,
+    ${attr("connection_id")} AS connection_id,
+    ${attr("connection_title")} AS connection_title,
+    ${attr("tool_name")} AS tool_name,
+    ${attr("input")} AS input,
+    ${attr("output")} AS output,
+    CASE WHEN ${attr("is_error")} = 'true' THEN 1 ELSE 0 END AS is_error,
+    ${attr("error_message")} AS error_message,
+    TRY_CAST(${attr("duration_ms")} AS DOUBLE) AS duration_ms,
+    make_timestamp(CAST(ts_nano AS BIGINT) // 1000) AS timestamp,
+    ${attr("user_id")} AS user_id,
+    ${attr("request_id")} AS request_id,
+    ${attr("user_agent")} AS user_agent,
+    ${attr("virtual_mcp_id")} AS virtual_mcp_id,
+    ${attr("properties")} AS properties
+  FROM _flat
+  WHERE ${attr("type")} IN ('tool_call', 'llm_call')
+)`;
+}
+
+/**
+ * Build the GCS-backed OTLP flat source for a bucket/prefix. Org scoping is the
+ * caller's outer WHERE (see buildOtlpFlatSourceFromGlob).
+ */
+export function buildOtlpFlatSource(opts: {
+  bucket: string;
+  prefix: string;
+}): string {
+  if (/[';]/.test(opts.bucket) || /[';]/.test(opts.prefix)) {
+    throw new Error("Invalid monitoring GCS bucket/prefix");
+  }
+  const prefix = opts.prefix.replace(/^\/+|\/+$/g, "");
+  const glob = prefix
+    ? `s3://${opts.bucket}/${prefix}/**/*.json`
+    : `s3://${opts.bucket}/**/*.json`;
+  return buildOtlpFlatSourceFromGlob(glob);
 }

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -24,7 +24,12 @@ export interface QueryEngine {
  * SECRET` so `read_json('s3://…')` works against the bucket.
  */
 export interface DuckDBGcsConfig {
-  /** Host only, no scheme — e.g. "storage.googleapis.com". */
+  /**
+   * Object-storage endpoint. May include a scheme (e.g.
+   * "https://storage.googleapis.com" or "http://localhost:9000") — it is
+   * normalized to a bare host for DuckDB's `ENDPOINT`, and the scheme (if any)
+   * determines `USE_SSL`. A scheme-less value defaults to SSL.
+   */
   endpoint: string;
   /** "auto" or a concrete region. */
   region: string;
@@ -39,6 +44,24 @@ export interface DuckDBGcsConfig {
 /** Escape a value for a single-quoted DuckDB SQL literal. */
 function escSqlLiteral(value: string): string {
   return value.replace(/'/g, "''");
+}
+
+/**
+ * Normalize an object-storage endpoint for a DuckDB s3 secret. DuckDB's
+ * `ENDPOINT` is the bare host (no scheme) and the scheme is carried by
+ * `USE_SSL`; passing a scheme-prefixed endpoint yields a broken read URL
+ * (e.g. `https://https://...`). Strips the scheme to derive the host and
+ * `useSsl` (https → true, http → false, scheme-less → true).
+ */
+export function normalizeS3Endpoint(raw: string): {
+  host: string;
+  useSsl: boolean;
+} {
+  const trimmed = raw.trim();
+  const match = /^(https?):\/\//i.exec(trimmed);
+  const useSsl = match ? match[1]!.toLowerCase() === "https" : true;
+  const host = trimmed.replace(/^https?:\/\//i, "").replace(/\/+$/, "");
+  return { host, useSsl };
 }
 
 /**
@@ -86,15 +109,17 @@ export class DuckDBEngine implements QueryEngine {
       ].join("\n"),
     );
 
+    // DuckDB's ENDPOINT is a bare host; the scheme is carried by USE_SSL.
+    const { host, useSsl } = normalizeS3Endpoint(gcs.endpoint);
     const secretSql = `CREATE OR REPLACE SECRET studio_gcs (
   TYPE s3,
   PROVIDER config,
   KEY_ID '${escSqlLiteral(gcs.accessKeyId)}',
   SECRET '${escSqlLiteral(gcs.secretAccessKey)}',
   REGION '${escSqlLiteral(gcs.region)}',
-  ENDPOINT '${escSqlLiteral(gcs.endpoint)}',
+  ENDPOINT '${escSqlLiteral(host)}',
   URL_STYLE 'path',
-  USE_SSL true
+  USE_SSL ${useSsl}
 );`;
     try {
       await connection.run(secretSql);

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -314,6 +314,12 @@ export function buildOtlpFlatSourceFromGlob(glob: string): string {
 /**
  * Build the GCS-backed OTLP flat source for a bucket/prefix. Org scoping is the
  * caller's outer WHERE (see buildOtlpFlatSourceFromGlob).
+ *
+ * The glob matches every object under the prefix (`**​/*`), not just `*.json`,
+ * because the OTel `google_cloud_storage` exporter writes objects with no file
+ * extension (e.g. `logs_<uuid>`). `read_json(format='auto')` detects the JSON
+ * content regardless. The prefix is therefore expected to be dedicated to the
+ * monitoring logs.
  */
 export function buildOtlpFlatSource(opts: {
   bucket: string;
@@ -324,7 +330,7 @@ export function buildOtlpFlatSource(opts: {
   }
   const prefix = opts.prefix.replace(/^\/+|\/+$/g, "");
   const glob = prefix
-    ? `s3://${opts.bucket}/${prefix}/**/*.json`
-    : `s3://${opts.bucket}/**/*.json`;
+    ? `s3://${opts.bucket}/${prefix}/**/*`
+    : `s3://${opts.bucket}/**/*`;
   return buildOtlpFlatSourceFromGlob(glob);
 }

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -261,6 +261,14 @@ const MONITORING_ATTR_PREFIX = "studio.monitoring.";
  * than struct-field access: DuckDB infers the `value` struct shape from sampled
  * data, so a direct `value.intValue` reference bind-errors on files that only
  * contain `stringValue`. The JSON path returns NULL for absent fields instead.
+ *
+ * COST: the glob has no time-based pruning — every query reads every object in
+ * the prefix over httpfs, regardless of the dashboard's date range (the
+ * collector writes Hive-style `year=/month=/day=/hour=` partitions, but the
+ * query filters on the row-content `timestamp`, not the path). Bound the cost
+ * with a bucket lifecycle/retention rule (see monitoring docs). A future
+ * improvement is to thread the query date range in and prune via Hive
+ * partition predicates.
  */
 export function buildOtlpFlatSourceFromGlob(glob: string): string {
   const A = MONITORING_ATTR_PREFIX;

--- a/apps/mesh/src/monitoring/test-utils.ts
+++ b/apps/mesh/src/monitoring/test-utils.ts
@@ -56,6 +56,75 @@ export async function writeTestNDJSON(
 }
 
 /**
+ * Build a single OTLP-JSON logRecord (the shape inside
+ * resourceLogs[].scopeLogs[].logRecords[]) from a partial MonitoringRow, with
+ * `studio.monitoring.*` attributes as `{key, value:{stringValue}}` entries.
+ * Mirrors makeTestMonitoringRow defaults so OTLP and NDJSON fixtures align.
+ */
+export function makeTestOtlpLogRecord(row: Partial<MonitoringRow> = {}): {
+  timeUnixNano: string;
+  spanId: string;
+  attributes: Array<{ key: string; value: { stringValue: string } }>;
+} {
+  const A = MONITORING_LOG_ATTR;
+  const id = row.id ?? `span_${Math.random().toString(36).slice(2)}`;
+  const tsMs = Date.parse(row.timestamp ?? "2026-03-05T12:00:00.000Z");
+  const attrs: Record<string, string | null | undefined> = {
+    [A.TYPE]: row.type ?? MONITORING_LOG_TYPE_VALUE,
+    [A.ORGANIZATION_ID]: row.organization_id ?? "org_test",
+    [A.CONNECTION_ID]: row.connection_id ?? "conn_1",
+    [A.CONNECTION_TITLE]: row.connection_title ?? "Test Server",
+    [A.TOOL_NAME]: row.tool_name ?? "EXAMPLE_TOOL",
+    [A.INPUT]: row.input ?? '{"query":"hello"}',
+    [A.OUTPUT]: row.output ?? '{"tokens":100}',
+    [A.IS_ERROR]: (row.is_error ?? 0) ? "true" : "false",
+    [A.ERROR_MESSAGE]: row.error_message ?? undefined,
+    [A.DURATION_MS]: String(row.duration_ms ?? 150),
+    [A.USER_ID]: row.user_id ?? "user_1",
+    [A.REQUEST_ID]: row.request_id ?? "req_1",
+    [A.USER_AGENT]: row.user_agent ?? "cursor/1.0",
+    [A.VIRTUAL_MCP_ID]: row.virtual_mcp_id ?? undefined,
+    [A.PROPERTIES]: row.properties ?? undefined,
+  };
+  const attributes = Object.entries(attrs)
+    .filter(([, v]) => v != null)
+    .map(([key, value]) => ({ key, value: { stringValue: String(value) } }));
+  return {
+    timeUnixNano: String(BigInt(tsMs) * 1_000_000n),
+    spanId: id,
+    attributes,
+  };
+}
+
+/**
+ * Write OTLP log records to a `.json` file as a single
+ * `ExportLogsServiceRequest` (resourceLogs -> scopeLogs -> logRecords), the
+ * shape an OTel collector's awss3exporter (marshaler: otlp_json) produces.
+ */
+export async function writeTestOtlpJson(
+  dir: string,
+  records: Array<ReturnType<typeof makeTestOtlpLogRecord>>,
+): Promise<void> {
+  const request = {
+    resourceLogs: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "studio" } },
+          ],
+        },
+        scopeLogs: [{ scope: {}, logRecords: records }],
+      },
+    ],
+  };
+  await writeFile(
+    join(dir, `otlp-${crypto.randomUUID()}.json`),
+    JSON.stringify(request),
+    { mode: 0o600 },
+  );
+}
+
+/**
  * Creates a minimal ReadableLogRecord-like object for testing.
  * Used by NDJSONLogExporter tests and pipeline integration tests.
  *

--- a/apps/mesh/src/monitoring/test-utils.ts
+++ b/apps/mesh/src/monitoring/test-utils.ts
@@ -55,40 +55,65 @@ export async function writeTestNDJSON(
   });
 }
 
+/** OTLP AnyValue JSON forms (protojson): int64 is string-encoded. */
+type OtlpValue =
+  | { stringValue: string }
+  | { boolValue: boolean }
+  | { intValue: string }
+  | { doubleValue: number };
+
 /**
  * Build a single OTLP-JSON logRecord (the shape inside
- * resourceLogs[].scopeLogs[].logRecords[]) from a partial MonitoringRow, with
- * `studio.monitoring.*` attributes as `{key, value:{stringValue}}` entries.
+ * resourceLogs[].scopeLogs[].logRecords[]) from a partial MonitoringRow.
  * Mirrors makeTestMonitoringRow defaults so OTLP and NDJSON fixtures align.
+ *
+ * Attribute value types match what Studio actually emits (see emit.ts): most
+ * are `stringValue`, but `is_error` is a `boolValue` and `duration_ms` is an
+ * `intValue`/`doubleValue` — so the flat-source `coalesce(...)` over the typed
+ * AnyValue fields is exercised, not just the string path.
  */
 export function makeTestOtlpLogRecord(row: Partial<MonitoringRow> = {}): {
   timeUnixNano: string;
   spanId: string;
-  attributes: Array<{ key: string; value: { stringValue: string } }>;
+  attributes: Array<{ key: string; value: OtlpValue }>;
 } {
   const A = MONITORING_LOG_ATTR;
   const id = row.id ?? `span_${Math.random().toString(36).slice(2)}`;
   const tsMs = Date.parse(row.timestamp ?? "2026-03-05T12:00:00.000Z");
-  const attrs: Record<string, string | null | undefined> = {
-    [A.TYPE]: row.type ?? MONITORING_LOG_TYPE_VALUE,
-    [A.ORGANIZATION_ID]: row.organization_id ?? "org_test",
-    [A.CONNECTION_ID]: row.connection_id ?? "conn_1",
-    [A.CONNECTION_TITLE]: row.connection_title ?? "Test Server",
-    [A.TOOL_NAME]: row.tool_name ?? "EXAMPLE_TOOL",
-    [A.INPUT]: row.input ?? '{"query":"hello"}',
-    [A.OUTPUT]: row.output ?? '{"tokens":100}',
-    [A.IS_ERROR]: (row.is_error ?? 0) ? "true" : "false",
-    [A.ERROR_MESSAGE]: row.error_message ?? undefined,
-    [A.DURATION_MS]: String(row.duration_ms ?? 150),
-    [A.USER_ID]: row.user_id ?? "user_1",
-    [A.REQUEST_ID]: row.request_id ?? "req_1",
-    [A.USER_AGENT]: row.user_agent ?? "cursor/1.0",
-    [A.VIRTUAL_MCP_ID]: row.virtual_mcp_id ?? undefined,
-    [A.PROPERTIES]: row.properties ?? undefined,
+  const durationMs = row.duration_ms ?? 150;
+  const attrs: Record<string, OtlpValue | undefined> = {
+    [A.TYPE]: { stringValue: row.type ?? MONITORING_LOG_TYPE_VALUE },
+    [A.ORGANIZATION_ID]: { stringValue: row.organization_id ?? "org_test" },
+    [A.CONNECTION_ID]: { stringValue: row.connection_id ?? "conn_1" },
+    [A.CONNECTION_TITLE]: {
+      stringValue: row.connection_title ?? "Test Server",
+    },
+    [A.TOOL_NAME]: { stringValue: row.tool_name ?? "EXAMPLE_TOOL" },
+    [A.INPUT]: { stringValue: row.input ?? '{"query":"hello"}' },
+    [A.OUTPUT]: { stringValue: row.output ?? '{"tokens":100}' },
+    // boolean, like production
+    [A.IS_ERROR]: { boolValue: !!(row.is_error ?? 0) },
+    [A.ERROR_MESSAGE]:
+      row.error_message != null
+        ? { stringValue: row.error_message }
+        : undefined,
+    // numeric, like production: int64 → intValue (string), fractional → doubleValue
+    [A.DURATION_MS]: Number.isInteger(durationMs)
+      ? { intValue: String(durationMs) }
+      : { doubleValue: durationMs },
+    [A.USER_ID]: { stringValue: row.user_id ?? "user_1" },
+    [A.REQUEST_ID]: { stringValue: row.request_id ?? "req_1" },
+    [A.USER_AGENT]: { stringValue: row.user_agent ?? "cursor/1.0" },
+    [A.VIRTUAL_MCP_ID]:
+      row.virtual_mcp_id != null
+        ? { stringValue: row.virtual_mcp_id }
+        : undefined,
+    [A.PROPERTIES]:
+      row.properties != null ? { stringValue: row.properties } : undefined,
   };
   const attributes = Object.entries(attrs)
     .filter(([, v]) => v != null)
-    .map(([key, value]) => ({ key, value: { stringValue: String(value) } }));
+    .map(([key, value]) => ({ key, value: value as OtlpValue }));
   return {
     timeUnixNano: String(BigInt(tsMs) * 1_000_000n),
     spanId: id,
@@ -99,7 +124,7 @@ export function makeTestOtlpLogRecord(row: Partial<MonitoringRow> = {}): {
 /**
  * Write OTLP log records to a `.json` file as a single
  * `ExportLogsServiceRequest` (resourceLogs -> scopeLogs -> logRecords), the
- * shape an OTel collector's awss3exporter (marshaler: otlp_json) produces.
+ * shape an OTel collector's google_cloud_storage exporter (OTLP JSON) produces.
  */
 export async function writeTestOtlpJson(
   dir: string,

--- a/apps/mesh/src/observability/index.ts
+++ b/apps/mesh/src/observability/index.ts
@@ -111,6 +111,19 @@ class TruncateMonitoringOutputProcessor implements LogRecordProcessor {
     const output = record.attributes?.[outputKey];
     if (typeof output === "string" && output.length > this.maxBytes) {
       const truncated = truncateString(output, this.maxBytes);
+      // Surface the data loss — truncation is otherwise silent. Identifiers +
+      // sizes only; never the payload (PII/volume). Captured by the infra
+      // logger provider (different provider → no emit loop) and subject to
+      // INFRA_LOG_SAMPLE_RATIO.
+      console.warn("[monitoring] output truncated to OTLP cap — data lost", {
+        tool_name: record.attributes?.[MONITORING_LOG_ATTR.TOOL_NAME],
+        organization_id:
+          record.attributes?.[MONITORING_LOG_ATTR.ORGANIZATION_ID],
+        connection_id: record.attributes?.[MONITORING_LOG_ATTR.CONNECTION_ID],
+        request_id: record.attributes?.[MONITORING_LOG_ATTR.REQUEST_ID],
+        originalBytes: Buffer.byteLength(output, "utf8"),
+        maxBytes: this.maxBytes,
+      });
       this.inner.onEmit(
         {
           ...record,

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -99,6 +99,17 @@ export function resolveConfig(
       envVars.S3_FORCE_PATH_STYLE === "true" ||
       envVars.S3_FORCE_PATH_STYLE === "1",
 
+    // Monitoring object storage (OTLP-JSON over GCS). Raw env passthrough;
+    // fallback to s3* is applied at the context-factory consumption point.
+    monitoringS3Bucket: envVars.MONITORING_S3_BUCKET,
+    monitoringS3Endpoint: envVars.MONITORING_S3_ENDPOINT,
+    monitoringS3Region: envVars.MONITORING_S3_REGION,
+    monitoringS3AccessKeyId: envVars.MONITORING_S3_ACCESS_KEY_ID,
+    monitoringS3SecretAccessKey: envVars.MONITORING_S3_SECRET_ACCESS_KEY,
+    monitoringS3Prefix: envVars.MONITORING_S3_PREFIX,
+    duckdbExtensionDirectory:
+      envVars.DUCKDB_EXTENSION_DIRECTORY || "/opt/duckdb/extensions",
+
     // Runtime flags
     isCli: true,
     noTui: flags.noTui === true,

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -58,6 +58,20 @@ export interface Settings {
   s3SecretAccessKey: string | undefined;
   s3ForcePathStyle: boolean;
 
+  // Monitoring object storage (OTLP-JSON over GCS S3-compatible endpoint).
+  // When monitoringS3Bucket is set and clickhouseUrl is not, the dashboard reads
+  // OTLP-JSON log files from this bucket via embedded DuckDB + httpfs. Endpoint /
+  // region / credentials fall back to the matching s3* value when unset.
+  monitoringS3Bucket: string | undefined;
+  monitoringS3Endpoint: string | undefined;
+  monitoringS3Region: string | undefined;
+  monitoringS3AccessKeyId: string | undefined;
+  monitoringS3SecretAccessKey: string | undefined;
+  monitoringS3Prefix: string | undefined;
+  // Absolute path to the DuckDB extension directory baked into the image
+  // (contains httpfs). Required for the GCS OTLP monitoring path.
+  duckdbExtensionDirectory: string | undefined;
+
   // Runtime flags (set by CLI)
   isCli: boolean;
   noTui: boolean;

--- a/apps/mesh/src/storage/monitoring-sql.test.ts
+++ b/apps/mesh/src/storage/monitoring-sql.test.ts
@@ -2,11 +2,16 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { DuckDBEngine } from "../monitoring/query-engine";
+import {
+  DuckDBEngine,
+  buildOtlpFlatSourceFromGlob,
+} from "../monitoring/query-engine";
 import type { MetricRow } from "../monitoring/schema";
 import {
   makeTestMonitoringRow,
   writeTestNDJSON,
+  makeTestOtlpLogRecord,
+  writeTestOtlpJson,
 } from "../monitoring/test-utils";
 import { SqlMonitoringStorage } from "./monitoring-sql";
 
@@ -669,3 +674,115 @@ describe.skipIf(!duckdbAvailable)("SqlMonitoringStorage", () => {
     });
   });
 });
+
+// The existing suite above (metricsFromLogs=false, histogram MetricRow files)
+// is the regression control for the local-NDJSON metric path.
+describe.skipIf(!duckdbAvailable)(
+  "SqlMonitoringStorage (OTLP flat-log source, metricsFromLogs=true)",
+  () => {
+    let tmpDir: string;
+    let engine: DuckDBEngine;
+    let storage: SqlMonitoringStorage;
+
+    beforeAll(async () => {
+      tmpDir = await mkdtemp(join(tmpdir(), "monitoring-otlp-test-"));
+      await writeTestOtlpJson(tmpDir, [
+        makeTestOtlpLogRecord({
+          id: "span_1",
+          tool_name: "TOOL_A",
+          duration_ms: 100,
+          is_error: 0,
+          connection_id: "conn_1",
+          output: '{"tokens":42}',
+          timestamp: "2026-03-05T12:00:00.000Z",
+        }),
+        makeTestOtlpLogRecord({
+          id: "span_2",
+          tool_name: "TOOL_A",
+          duration_ms: 300,
+          is_error: 1,
+          error_message: "timeout",
+          connection_id: "conn_1",
+          timestamp: "2026-03-05T12:01:00.000Z",
+        }),
+        makeTestOtlpLogRecord({
+          id: "span_3",
+          tool_name: "TOOL_B",
+          duration_ms: 50,
+          is_error: 0,
+          connection_id: "conn_2",
+          timestamp: "2026-03-05T12:02:00.000Z",
+        }),
+      ]);
+
+      engine = new DuckDBEngine();
+      const otlpSource = buildOtlpFlatSourceFromGlob(`${tmpDir}/**/*.json`);
+      storage = new SqlMonitoringStorage(
+        engine,
+        () => otlpSource,
+        engine,
+        () => otlpSource,
+        "duckdb",
+        true, // metricsFromLogs
+      );
+    });
+
+    afterAll(async () => {
+      await engine.destroy();
+      await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    test("query returns flattened log rows", async () => {
+      const result = await storage.query({ organizationId: "org_test" });
+      expect(result.total).toBe(3);
+      expect(result.logs.map((l) => l.id).sort()).toEqual([
+        "span_1",
+        "span_2",
+        "span_3",
+      ]);
+      const errored = result.logs.find((l) => l.id === "span_2")!;
+      expect(errored.isError).toBe(true);
+      expect(errored.errorMessage).toBe("timeout");
+    });
+
+    test("getById returns a single flattened row", async () => {
+      const log = await storage.getById("org_test", "span_1");
+      expect(log?.toolName).toBe("TOOL_A");
+      expect(log?.durationMs).toBe(100);
+    });
+
+    test("getStats aggregates over flat rows", async () => {
+      const stats = await storage.getStats({ organizationId: "org_test" });
+      expect(stats.totalCalls).toBe(3);
+      expect(stats.errorRate).toBeCloseTo(1 / 3, 5);
+      expect(stats.avgDurationMs).toBeCloseTo(150, 5);
+    });
+
+    test("queryMetricTimeseries derives metrics from log rows", async () => {
+      const result = await storage.queryMetricTimeseries({
+        organizationId: "org_test",
+        interval: "1d",
+        startDate: new Date("2026-03-01T00:00:00.000Z"),
+        endDate: new Date("2026-03-10T00:00:00.000Z"),
+      });
+      expect(result.totalCalls).toBe(3);
+      expect(result.totalErrors).toBe(1);
+      expect(result.avgDurationMs).toBeCloseTo(150, 5);
+      expect(result.p95DurationMs).toBeGreaterThan(0);
+      expect(result.connectionBreakdown.length).toBe(2);
+    });
+
+    test("queryMetricTopToolsTimeseries derives top tools from log rows", async () => {
+      const result = await storage.queryMetricTopToolsTimeseries({
+        organizationId: "org_test",
+        interval: "1d",
+        startDate: new Date("2026-03-01T00:00:00.000Z"),
+        endDate: new Date("2026-03-10T00:00:00.000Z"),
+      });
+      expect(result.topTools.length).toBe(2);
+      // TOOL_A has 2 calls, TOOL_B has 1 → TOOL_A ranks first
+      expect(result.topTools[0]!.toolName).toBe("TOOL_A");
+      expect(result.topTools[0]!.calls).toBe(2);
+    });
+  },
+);

--- a/apps/mesh/src/storage/monitoring-sql.ts
+++ b/apps/mesh/src/storage/monitoring-sql.ts
@@ -411,6 +411,11 @@ export class SqlMonitoringStorage implements MonitoringStorage {
     private metricEngine: QueryEngine,
     private metricSourceFactory: (organizationId: string) => string,
     private dialect: SqlDialect = "clickhouse",
+    // When true (DuckDB reading OTLP flat-log rows from GCS), metrics are
+    // derived from the log rows (count/avg/quantile over duration_ms + is_error)
+    // instead of the pre-aggregated histogram MetricRow columns the local-NDJSON
+    // path uses. Default false preserves the local histogram path.
+    private metricsFromLogs: boolean = false,
   ) {}
 
   async query(filters: {
@@ -733,6 +738,9 @@ export class SqlMonitoringStorage implements MonitoringStorage {
     // below still reads pre-aggregated histograms from local NDJSON files.
     if (this.dialect === "clickhouse") {
       return this.queryMetricTimeseriesClickHouse(params, emptyResult);
+    }
+    if (this.metricsFromLogs) {
+      return this.queryMetricTimeseriesDuckDBLogs(params, emptyResult);
     }
 
     // ── DuckDB path (local NDJSON, pre-aggregated histograms) ──────────────
@@ -1084,6 +1092,159 @@ WHERE ${whereClause}`;
     }
   }
 
+  /**
+   * DuckDB metric timeseries derived from OTLP flat-log rows (count/avg/quantile
+   * over duration_ms + is_error). Same shape as the ClickHouse variant; DuckDB
+   * syntax (count(*) / FILTER / quantile_cont / time_bucket).
+   */
+  private async queryMetricTimeseriesDuckDBLogs(
+    params: {
+      organizationId: string;
+      interval: string;
+      startDate?: Date;
+      endDate?: Date;
+      filters?: {
+        connectionIds?: string[];
+        excludeConnectionIds?: string[];
+        toolNames?: string[];
+        status?: "success" | "error";
+      };
+    },
+    emptyResult: {
+      totalCalls: number;
+      totalErrors: number;
+      avgDurationMs: number;
+      p50DurationMs: number;
+      p95DurationMs: number;
+      connectionBreakdown: Array<{
+        connectionId: string;
+        calls: number;
+        errors: number;
+        errorRate: number;
+        avgDurationMs: number;
+      }>;
+      timeseries: Array<{
+        timestamp: string;
+        calls: number;
+        errors: number;
+        errorRate: number;
+        avg: number;
+        p50: number;
+        p95: number;
+      }>;
+    },
+  ): Promise<typeof emptyResult> {
+    const source = this.metricSourceFactory(params.organizationId);
+    const bucketExpr = intervalToSQL(params.interval, "duckdb", "timestamp");
+
+    const where: string[] = [
+      `organization_id = '${esc(params.organizationId)}'`,
+    ];
+    applyStartDateBound(where, params.startDate, "duckdb");
+    if (params.endDate) {
+      where.push(tsLte(params.endDate, "duckdb"));
+    }
+    if (params.filters?.toolNames?.length) {
+      const names = params.filters.toolNames
+        .slice(0, 100)
+        .map((n) => `'${esc(n)}'`)
+        .join(",");
+      where.push(`tool_name IN (${names})`);
+    }
+    if (params.filters?.connectionIds?.length) {
+      const ids = params.filters.connectionIds
+        .slice(0, 100)
+        .map((id) => `'${esc(id)}'`)
+        .join(",");
+      where.push(`connection_id IN (${ids})`);
+    }
+    if (params.filters?.excludeConnectionIds?.length) {
+      const ids = params.filters.excludeConnectionIds
+        .slice(0, 100)
+        .map((id) => `'${esc(id)}'`)
+        .join(",");
+      where.push(`connection_id NOT IN (${ids})`);
+    }
+    const whereClause = where.join(" AND ");
+
+    const timeseriesSql = `SELECT
+  ${bucketExpr} AS bucket,
+  count(*) AS calls,
+  count(*) FILTER (WHERE is_error = 1) AS errors,
+  avg(duration_ms) AS avg,
+  quantile_cont(duration_ms, 0.5) AS p50,
+  quantile_cont(duration_ms, 0.95) AS p95
+FROM ${source}
+WHERE ${whereClause}
+GROUP BY bucket
+ORDER BY bucket ASC`;
+
+    const breakdownSql = `SELECT
+  connection_id,
+  count(*) AS calls,
+  count(*) FILTER (WHERE is_error = 1) AS errors,
+  avg(duration_ms) AS avg
+FROM ${source}
+WHERE ${whereClause} AND connection_id != ''
+GROUP BY connection_id
+ORDER BY calls DESC
+LIMIT 1000`;
+
+    const totalsSql = `SELECT
+  count(*) AS calls,
+  count(*) FILTER (WHERE is_error = 1) AS errors,
+  avg(duration_ms) AS avg,
+  quantile_cont(duration_ms, 0.5) AS p50,
+  quantile_cont(duration_ms, 0.95) AS p95
+FROM ${source}
+WHERE ${whereClause}`;
+
+    try {
+      const [tsRows, breakdownRows, totalsRows] = await Promise.all([
+        this.metricEngine.query(timeseriesSql),
+        this.metricEngine.query(breakdownSql),
+        this.metricEngine.query(totalsSql),
+      ]);
+
+      const totals = totalsRows[0] ?? {};
+
+      return {
+        totalCalls: Number(totals.calls ?? 0),
+        totalErrors: Number(totals.errors ?? 0),
+        avgDurationMs: finiteOrZero(totals.avg),
+        p50DurationMs: finiteOrZero(totals.p50),
+        p95DurationMs: finiteOrZero(totals.p95),
+        connectionBreakdown: breakdownRows.map((row) => {
+          const calls = Number(row.calls ?? 0);
+          const errors = Number(row.errors ?? 0);
+          return {
+            connectionId: String(row.connection_id ?? ""),
+            calls,
+            errors,
+            errorRate: calls > 0 ? (errors / calls) * 100 : 0,
+            avgDurationMs: finiteOrZero(row.avg),
+          };
+        }),
+        timeseries: tsRows.map((row) => {
+          const calls = Number(row.calls ?? 0);
+          const errors = Number(row.errors ?? 0);
+          return {
+            timestamp: toISOBucket(row.bucket),
+            calls,
+            errors,
+            errorRate: calls > 0 ? errors / calls : 0,
+            avg: finiteOrZero(row.avg),
+            p50: finiteOrZero(row.p50),
+            p95: finiteOrZero(row.p95),
+          };
+        }),
+      };
+    } catch (err) {
+      console.error("queryMetricTimeseries failed:", err);
+      throw new Error("Monitoring stats unavailable", { cause: err });
+    }
+  }
+
   async queryMetricTopToolsTimeseries(params: {
     organizationId: string;
     interval: string;
@@ -1124,6 +1285,9 @@ WHERE ${whereClause}`;
     // reads pre-aggregated histograms from local NDJSON files.
     if (this.dialect === "clickhouse") {
       return this.queryMetricTopToolsTimeseriesClickHouse(params, emptyResult);
+    }
+    if (this.metricsFromLogs) {
+      return this.queryMetricTopToolsTimeseriesDuckDBLogs(params, emptyResult);
     }
 
     // ── DuckDB path (local NDJSON, pre-aggregated histograms) ──────────────
@@ -1357,6 +1521,137 @@ LIMIT ${topN}`;
   countIf(is_error = 1) AS errors,
   avg(duration_ms) AS avg,
   quantile(0.95)(duration_ms) AS p95
+FROM ${source}
+WHERE ${whereClause} AND tool_name IN (${toolNamesSql})
+GROUP BY bucket, tool_name
+ORDER BY bucket ASC, tool_name ASC`;
+
+      const rows = await this.metricEngine.query(timeseriesSql);
+
+      return {
+        topTools: topToolRows.map((row) => ({
+          toolName: String(row.tool_name ?? ""),
+          connectionId:
+            row.connection_id != null ? String(row.connection_id) : null,
+          calls: Number(row.calls ?? 0),
+        })),
+        timeseries: rows.map((row) => ({
+          timestamp: toISOBucket(row.bucket),
+          toolName: String(row.tool_name ?? ""),
+          calls: Number(row.calls ?? 0),
+          errors: Number(row.errors ?? 0),
+          avg: finiteOrZero(row.avg),
+          p95: finiteOrZero(row.p95),
+        })),
+      };
+    } catch (err) {
+      console.error("queryMetricTopToolsTimeseries failed:", err);
+      throw new Error("Monitoring stats unavailable", { cause: err });
+    }
+  }
+
+  /**
+   * DuckDB top-tools metric timeseries derived from OTLP flat-log rows. Same
+   * shape as the ClickHouse variant; DuckDB syntax (count(*) / FILTER /
+   * quantile_cont / arg_max / time_bucket).
+   */
+  private async queryMetricTopToolsTimeseriesDuckDBLogs(
+    params: {
+      organizationId: string;
+      interval: string;
+      startDate?: Date;
+      endDate?: Date;
+      topN?: number;
+      filters?: {
+        connectionIds?: string[];
+        excludeConnectionIds?: string[];
+        toolNames?: string[];
+        status?: "success" | "error";
+      };
+    },
+    emptyResult: {
+      topTools: Array<{
+        toolName: string;
+        connectionId: string | null;
+        calls: number;
+      }>;
+      timeseries: Array<{
+        timestamp: string;
+        toolName: string;
+        calls: number;
+        errors: number;
+        avg: number;
+        p95: number;
+      }>;
+    },
+  ): Promise<typeof emptyResult> {
+    const source = this.metricSourceFactory(params.organizationId);
+    const bucketExpr = intervalToSQL(params.interval, "duckdb", "timestamp");
+    const where: string[] = [
+      `organization_id = '${esc(params.organizationId)}'`,
+    ];
+    applyStartDateBound(where, params.startDate, "duckdb");
+    if (params.endDate) {
+      where.push(tsLte(params.endDate, "duckdb"));
+    }
+    if (params.filters?.toolNames?.length) {
+      const names = params.filters.toolNames
+        .slice(0, 100)
+        .map((n) => `'${esc(n)}'`)
+        .join(",");
+      where.push(`tool_name IN (${names})`);
+    }
+    if (params.filters?.connectionIds?.length) {
+      const ids = params.filters.connectionIds
+        .slice(0, 100)
+        .map((id) => `'${esc(id)}'`)
+        .join(",");
+      where.push(`connection_id IN (${ids})`);
+    }
+    if (params.filters?.excludeConnectionIds?.length) {
+      const ids = params.filters.excludeConnectionIds
+        .slice(0, 100)
+        .map((id) => `'${esc(id)}'`)
+        .join(",");
+      where.push(`connection_id NOT IN (${ids})`);
+    }
+    const whereClause = where.join(" AND ");
+    const topN = Math.min(Math.max(1, Math.floor(params.topN ?? 10)), 20);
+
+    try {
+      const topToolsSql = `SELECT
+  tool_name,
+  arg_max(connection_id, conn_calls) AS connection_id,
+  sum(conn_calls) AS calls
+FROM (
+  SELECT tool_name, connection_id, count(*) AS conn_calls
+  FROM ${source}
+  WHERE ${whereClause} AND tool_name != ''
+  GROUP BY tool_name, connection_id
+)
+GROUP BY tool_name
+ORDER BY calls DESC
+LIMIT ${topN}`;
+
+      const topToolRows = await this.metricEngine.query(topToolsSql);
+      if (topToolRows.length === 0) {
+        return emptyResult;
+      }
+
+      const topToolNames = topToolRows
+        .map((row) => String(row.tool_name ?? ""))
+        .filter(Boolean);
+      const toolNamesSql = topToolNames
+        .map((name) => `'${esc(name)}'`)
+        .join(",");
+
+      const timeseriesSql = `SELECT
+  ${bucketExpr} AS bucket,
+  tool_name,
+  count(*) AS calls,
+  count(*) FILTER (WHERE is_error = 1) AS errors,
+  avg(duration_ms) AS avg,
+  quantile_cont(duration_ms, 0.95) AS p95
 FROM ${source}
 WHERE ${whereClause} AND tool_name IN (${toolNamesSql})
 GROUP BY bucket, tool_name


### PR DESCRIPTION
## What is this contribution about?
Self-hosted tenants without ClickHouse couldn't see their monitoring dashboard when telemetry lived in Google Cloud Storage instead of on the pod's local disk. This adds a third read path (precedence: ClickHouse > GCS-OTLP > local NDJSON): Studio's existing OTLP log emit feeds an OTel collector that writes `otlp_json` to GCS, and the embedded DuckDB engine reads those files over the GCS S3-compatible endpoint (httpfs + an `s3` secret, with httpfs baked into the image so strict-outbound deployments never hit the DuckDB CDN). DuckDB flattens the nested OTLP into the flat columns the dashboard SQL already expects and derives metrics (calls/errors/latency percentiles) from the log rows, mirroring the production ClickHouse view path. It also adds a `console.warn` when the existing 8 KB OTLP output-truncation actually drops bytes. No ClickHouse and no disk/sidecar required.

## Screenshots/Demonstration
N/A — backend + docs only.

## How to Test
1. Unit (CI-equivalent, per file): `bun test apps/mesh/src/monitoring/query-engine.test.ts` and `bun test apps/mesh/src/storage/monitoring-sql.test.ts` — covers the OTLP→flat projection, record filtering, and log-derived metrics.
2. `bun run check` and `bun run lint` — both pass.
3. Manual/e2e (needs a live bucket): create a GCS bucket + HMAC key, point an OTel collector's `awss3exporter` (`marshaler: otlp_json`, endpoint `https://storage.googleapis.com`, `s3_force_path_style: true`) at it, set `MONITORING_S3_*` on Studio, and confirm the dashboard renders logs + timeseries.

## Migration Notes
No DB migration. New env vars (read path): `MONITORING_S3_BUCKET` (enables the path when `CLICKHOUSE_URL` is unset), `MONITORING_S3_PREFIX/ENDPOINT/REGION/ACCESS_KEY_ID/SECRET_ACCESS_KEY` (each falls back to the matching `S3_*`), and `MONITORING_OTLP_ENDPOINT` (emit side). The official image now bakes the DuckDB `httpfs` extension into `DUCKDB_EXTENSION_DIRECTORY=/opt/duckdb/extensions`. See `monitoring.mdx` "Option C" for full setup.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GCS-backed monitoring read path using embedded DuckDB to read OTLP‑JSON logs, so self‑hosted deployments can run without ClickHouse or local disk. Docs now include end‑to‑end GCS setup, corrected collector batch config, per‑query scan notes, and a 32 MiB per‑file cap; we also normalize the GCS endpoint for DuckDB and exercise real OTLP value types in tests.

- **New Features**
  - Read monitoring data from GCS via DuckDB `httpfs`; flatten OTLP logs to the existing schema and derive metrics (precedence: ClickHouse > GCS OTLP > local NDJSON). Image bakes in the `httpfs` extension and initializes an `s3` secret at runtime; works with strict egress.
  - Normalize the GCS endpoint for DuckDB `CREATE SECRET` (strip scheme, set `USE_SSL`) to accept `https://storage.googleapis.com` or `http://...`; unit tests added.
  - Handle extensionless objects from the collector (`**/*` glob with `read_json(format='auto')`); warn when the 8 KB OTLP output cap truncates payloads. Docs call out full‑prefix scans and the 32 MiB per‑file skip, recommend bounded batches, and use the collector `google_cloud_storage` exporter with `bucket.reuse_if_exists: true` and `batch` (`send_batch_size: 2048`, `send_batch_max_size: 2048`).

- **Migration**
  - Enable by setting `MONITORING_S3_BUCKET` and HMAC creds (`MONITORING_S3_ACCESS_KEY_ID`/`MONITORING_S3_SECRET_ACCESS_KEY`), plus optional `MONITORING_S3_PREFIX`/`MONITORING_S3_ENDPOINT`/`MONITORING_S3_REGION` (each falls back to `S3_*`). `DUCKDB_EXTENSION_DIRECTORY` defaults to `/opt/duckdb/extensions`.
  - Set `MONITORING_OTLP_ENDPOINT` to send Studio’s OTLP logs to your collector, and configure the collector `google_cloud_storage` exporter with `bucket.reuse_if_exists: true` and a `batch` processor (`send_batch_size: 2048`, `send_batch_max_size: 2048`) to keep files under 32 MiB. Pre‑create the bucket. No DB migration.

<sup>Written for commit a2181858b7e883113b5fec6df3a376000440b73b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

