### PR TITLE
feat(github-import): per-agent repo-scoped GitHub connections

### DIFF
--- a/apps/mesh/e2e/fixtures/test-mcp-server.ts
+++ b/apps/mesh/e2e/fixtures/test-mcp-server.ts
@@ -36,8 +36,19 @@ export interface TestMcpTool {
    */
   inputSchema?: Record<string, z.ZodTypeAny>;
   /**
+   * Optional Zod *raw shape* for the tool's output. When present, the
+   * handler's (object) return value is ALSO surfaced as `structuredContent`
+   * on the MCP result — the SDK only emits/validates structuredContent for
+   * tools that declare an outputSchema. Consumers that read
+   * `result.structuredContent` (e.g. mesh's MINT_REPO_TOKEN caller) need
+   * this; plain text-only tools can omit it.
+   */
+  outputSchema?: Record<string, z.ZodTypeAny>;
+  /**
    * Whatever this returns is wrapped into a `content: [{type: "text", text}]`
-   * MCP response. If omitted, the tool returns `{ ok: true }`.
+   * MCP response. If omitted, the tool returns `{ ok: true }`. When the tool
+   * declares an `outputSchema`, an object return is additionally emitted as
+   * `structuredContent`.
    */
   handler?: ToolHandler;
 }
@@ -113,17 +124,24 @@ export async function startTestMcpServer(
         {
           description: tool.description,
           inputSchema: tool.inputSchema ?? {},
+          ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
         },
         async (args: Record<string, unknown>) => {
           const result = tool.handler ? await tool.handler(args) : { ok: true };
+          const text =
+            typeof result === "string" ? result : JSON.stringify(result);
+          // Only emit structuredContent when the tool declares an
+          // outputSchema. The MCP SDK enforces outputSchema⟺structuredContent
+          // parity (and clients re-validate structuredContent against the
+          // schema with Ajv), so emitting it without a declared schema would
+          // break consumers. Object results back both channels.
+          const structured =
+            tool.outputSchema && typeof result === "object" && result !== null
+              ? (result as Record<string, unknown>)
+              : undefined;
           return {
-            content: [
-              {
-                type: "text" as const,
-                text:
-                  typeof result === "string" ? result : JSON.stringify(result),
-              },
-            ],
+            content: [{ type: "text" as const, text }],
+            ...(structured ? { structuredContent: structured } : {}),
           };
         },
       );

--- a/apps/mesh/e2e/tests/github-import-repo-scope.spec.ts
+++ b/apps/mesh/e2e/tests/github-import-repo-scope.spec.ts
@@ -1,0 +1,381 @@
+/**
+ * End-to-end tests for per-agent repo-scoped GitHub connections.
+ *
+ * Feature under test (Tasks 1-6): an imported GitHub agent gets a dedicated
+ * child `mcp-github` connection whose `metadata.repoScope` recipe drives
+ * on-demand minting of a short-lived, repo-scoped GitHub token via the ORG
+ * connection's `MINT_REPO_TOKEN` tool. Deleting the agent tears the child
+ * connection (and its minted token) down.
+ *
+ * Scenarios covered here:
+ *   1. Cross-tenant guard — org B cannot read org A's connection through
+ *      GITHUB_LIST_USER_ORGS (the guard throws "Connection not found" before
+ *      any token read / GitHub call).
+ *   2. Teardown FK-ordering — deleting the agent removes the child connection,
+ *      its connection_aggregations rows, and (when seeded) its downstream
+ *      token, WITHOUT tripping the ON DELETE RESTRICT FK (the agent is deleted
+ *      first, clearing the aggregation rows, then the child).
+ *   3. Runtime mint-on-demand — calling a tool on a repo-scoped child through
+ *      the proxy mints a token via the org connection's MINT_REPO_TOKEN and
+ *      caches it in downstream_tokens.
+ *
+ * OUT OF SCOPE (not attempted here): driving the full GitHub repo-picker UI
+ * import. That needs real GitHub OAuth + a live `/user/installations` listing,
+ * neither of which is reproducible in a hermetic Playwright run. The runtime
+ * behavior the picker depends on (mint, teardown, cross-tenant guard) is
+ * exercised directly against the built-in tools instead.
+ */
+
+import { z } from "zod";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { connectDevDb } from "../fixtures/db";
+import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
+import {
+  startTestMcpServer,
+  type TestMcpServer,
+} from "../fixtures/test-mcp-server";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+test.describe("GitHub import repo-scoped connections", () => {
+  /**
+   * Scenario 1 — cross-tenant guard.
+   *
+   * The simplest, no-stub case: GITHUB_LIST_USER_ORGS confirms the named
+   * connection belongs to the caller's org before reading its token. Org B
+   * passing org A's connectionId must fail with "Connection not found" — the
+   * guard fires before any GitHub network call, so no token/stub is needed.
+   *
+   * `callSelfMcpTool` throws on tool error (it inspects `result.isError` and
+   * re-throws the first text-content block), so we assert via `rejects`.
+   */
+  test("GITHUB_LIST_USER_ORGS rejects a connectionId from another org", async ({
+    playwright,
+  }) => {
+    // User A: signs up and owns a connection.
+    const ctxA = await newApiContext(playwright);
+    // User B: a separate principal in a separate org.
+    const ctxB = await newApiContext(playwright);
+    try {
+      const userA = await signUpViaApi(ctxA);
+      const connA = await createHttpConnection(ctxA, userA.orgSlug, {
+        title: `Org A conn ${Date.now()}`,
+        url: "https://example.com/mcp",
+      });
+
+      const userB = await signUpViaApi(ctxB);
+
+      // Org B cannot read org A's connection — the ownership guard throws
+      // "Connection not found" before any token read or GitHub call.
+      await expect(
+        callSelfMcpTool(ctxB, userB.orgSlug, "GITHUB_LIST_USER_ORGS", {
+          connectionId: connA.id,
+        }),
+      ).rejects.toThrow(/Connection not found/);
+    } finally {
+      await ctxA.dispose();
+      await ctxB.dispose();
+    }
+  });
+
+  /**
+   * Scenario 2 — teardown removes the child connection + token.
+   *
+   * Validates the Critical FK-ordering fix in COLLECTION_VIRTUAL_MCP_DELETE:
+   * the agent is deleted FIRST (clearing the ON DELETE RESTRICT
+   * connection_aggregations rows that reference the child), THEN the child
+   * connection is deleted (its downstream_tokens cascade). Without the
+   * ordering fix, deleting the child first would throw a foreign-key
+   * violation and make the agent undeletable.
+   *
+   * We DO seed a downstream_tokens row so the cascade is asserted. Per the
+   * task note this makes teardown's best-effort revoke fire one
+   * fast-failing, swallowed request to api.github.com with a dummy token —
+   * acceptable; the delete must still succeed regardless.
+   */
+  test("deleting the agent tears down the repo-scoped child connection + token", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+    const org = user.orgSlug;
+
+    // An org connection to reference as the mint source. Its reachability
+    // doesn't matter for teardown (no mint happens during delete).
+    const orgConn = await createHttpConnection(ctx, org, {
+      title: `Org GitHub ${Date.now()}`,
+      url: "https://example.com/mcp",
+    });
+
+    // The per-agent repo-scoped child connection. app_name "mcp-github" +
+    // metadata.repoScope mark it as a disposable child (getRepoScope must
+    // return truthy for teardown to delete it).
+    const child = await callSelfMcpTool<{ item: { id: string } }>(
+      ctx,
+      org,
+      "COLLECTION_CONNECTIONS_CREATE",
+      {
+        data: {
+          title: `GitHub: acme/widget ${Date.now()}`,
+          app_name: "mcp-github",
+          connection_type: "HTTP",
+          connection_url: "https://example.com/mcp",
+          metadata: {
+            repoScope: {
+              sourceConnectionId: orgConn.id,
+              installationId: 1,
+              owner: "acme",
+              repo: "widget",
+              permissions: { contents: "write" },
+            },
+          },
+        },
+      },
+    );
+    const childId = child.item.id;
+    expect(childId).toBeTruthy();
+
+    // The agent, wired to the child connection. metadata.githubRepo.connectionId
+    // is what the delete handler reads to find the child to tear down.
+    const agent = await callSelfMcpTool<{ item: { id: string } }>(
+      ctx,
+      org,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      {
+        data: {
+          title: `widget ${Date.now()}`,
+          metadata: {
+            githubRepo: {
+              owner: "acme",
+              name: "widget",
+              url: "https://github.com/acme/widget",
+              installationId: 1,
+              connectionId: childId,
+            },
+          },
+          connections: [{ connection_id: childId }],
+        },
+      },
+    );
+    const agentId = agent.item.id;
+    expect(agentId).toBeTruthy();
+
+    // Seed a downstream token for the child so the cascade-on-delete is
+    // observable. The dummy token triggers a swallowed best-effort revoke
+    // against api.github.com during teardown — that must not fail the delete.
+    const tokenRes = await ctx.post(
+      `/api/${org}/connections/${childId}/oauth-token`,
+      {
+        data: { accessToken: "ghs_e2e_dummy", expiresIn: 3600 },
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    expect(tokenRes.ok()).toBe(true);
+
+    const db = await connectDevDb();
+    try {
+      // Sanity: the seeded rows exist before deletion.
+      const beforeAgg = await db.query(
+        "SELECT 1 FROM connection_aggregations WHERE child_connection_id = $1",
+        [childId],
+      );
+      expect(beforeAgg.rowCount).toBeGreaterThan(0);
+      const beforeTok = await db.query(
+        'SELECT 1 FROM downstream_tokens WHERE "connectionId" = $1',
+        [childId],
+      );
+      expect(beforeTok.rowCount).toBeGreaterThan(0);
+
+      // The delete MUST succeed. Without the FK-ordering fix this throws a
+      // foreign-key violation (child deleted before its aggregation rows).
+      await callSelfMcpTool(ctx, org, "COLLECTION_VIRTUAL_MCP_DELETE", {
+        id: agentId,
+      });
+
+      // The agent connection row is gone.
+      const agentRow = await db.query(
+        "SELECT 1 FROM connections WHERE id = $1",
+        [agentId],
+      );
+      expect(agentRow.rowCount).toBe(0);
+
+      // The child connection row is gone.
+      const childRow = await db.query(
+        "SELECT 1 FROM connections WHERE id = $1",
+        [childId],
+      );
+      expect(childRow.rowCount).toBe(0);
+
+      // Its aggregation rows are gone (cascade off the parent delete).
+      const aggRows = await db.query(
+        "SELECT 1 FROM connection_aggregations WHERE child_connection_id = $1 OR parent_connection_id = $1",
+        [childId],
+      );
+      expect(aggRows.rowCount).toBe(0);
+
+      // Its downstream token is gone (cascade off the child connection delete).
+      const tokRows = await db.query(
+        'SELECT 1 FROM downstream_tokens WHERE "connectionId" = $1',
+        [childId],
+      );
+      expect(tokRows.rowCount).toBe(0);
+    } finally {
+      await db.end();
+      await ctx.dispose();
+    }
+  });
+
+  /**
+   * Scenario 3 — runtime mint-on-demand.
+   *
+   * Calling any tool on a repo-scoped child through the proxy triggers the
+   * outbound header builder → ensureRepoScopedToken → mintRepoToken, which
+   * opens an MCP client to the ORG connection and calls MINT_REPO_TOKEN. The
+   * minted token is then cached (vault-encrypted) in downstream_tokens.
+   *
+   * Two stubs: `orgStub` exposes MINT_REPO_TOKEN (with an outputSchema so the
+   * SDK emits the structuredContent the mesh mint caller reads), `repoStub`
+   * exposes a trivial `whoami` tool the child surfaces.
+   *
+   * Assertions: orgStub recorded a tools/call naming MINT_REPO_TOKEN, AND a
+   * downstream_tokens row now exists for the child with expiresAt set. The
+   * stored access token is vault-encrypted, so we assert existence rather than
+   * matching plaintext.
+   */
+  test("calling a repo-scoped child tool mints + caches a token via the org connection", async ({
+    playwright,
+  }) => {
+    let orgStub: TestMcpServer | undefined;
+    let repoStub: TestMcpServer | undefined;
+    const ctx = await newApiContext(playwright);
+    const db = await connectDevDb();
+    try {
+      orgStub = await startTestMcpServer({
+        tools: [
+          {
+            name: "MINT_REPO_TOKEN",
+            description: "Mint a repo-scoped GitHub App installation token.",
+            inputSchema: {
+              installationId: z.number(),
+              owner: z.string(),
+              repo: z.string(),
+              permissions: z.record(z.string(), z.string()).optional(),
+            },
+            // outputSchema is required for the SDK to emit structuredContent,
+            // which mintRepoToken reads (res.structuredContent.token).
+            outputSchema: {
+              token: z.string(),
+              expiresAt: z.string(),
+              permissions: z.record(z.string(), z.string()),
+              repository: z.object({ owner: z.string(), name: z.string() }),
+              installationId: z.number(),
+            },
+            handler: () => ({
+              token: "ghs_minted_e2e",
+              expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+              permissions: {},
+              repository: { owner: "acme", name: "widget" },
+              installationId: 1,
+            }),
+          },
+        ],
+      });
+
+      repoStub = await startTestMcpServer({
+        tools: [
+          {
+            name: "whoami",
+            description: "Trivial tool exposed by the repo-scoped child.",
+            handler: () => ({ ok: true }),
+          },
+        ],
+      });
+
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+
+      // Org connection: the mint source. Points at orgStub so MINT_REPO_TOKEN
+      // resolves to a reachable tool.
+      const orgConn = await createHttpConnection(ctx, org, {
+        title: `Org GitHub ${Date.now()}`,
+        url: orgStub.url,
+      });
+
+      // Repo-scoped child: points at repoStub, carries the mint recipe, and has
+      // NO downstream token yet (so the first proxied call must mint).
+      const child = await callSelfMcpTool<{ item: { id: string } }>(
+        ctx,
+        org,
+        "COLLECTION_CONNECTIONS_CREATE",
+        {
+          data: {
+            title: `GitHub: acme/widget ${Date.now()}`,
+            app_name: "mcp-github",
+            connection_type: "HTTP",
+            connection_url: repoStub.url,
+            metadata: {
+              repoScope: {
+                sourceConnectionId: orgConn.id,
+                installationId: 1,
+                owner: "acme",
+                repo: "widget",
+                permissions: { contents: "write" },
+              },
+            },
+          },
+        },
+      );
+      const childId = child.item.id;
+      expect(childId).toBeTruthy();
+
+      // No token before the first proxied call.
+      const before = await db.query(
+        'SELECT 1 FROM downstream_tokens WHERE "connectionId" = $1',
+        [childId],
+      );
+      expect(before.rowCount).toBe(0);
+
+      // Hit the proxy for the child connection. The outbound header builder
+      // runs per request and mints the repo-scoped token on the way out.
+      const res = await ctx.post(`/api/${org}/mcp/${childId}`, {
+        data: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "whoami", arguments: {} },
+        },
+        headers: { Accept: "application/json, text/event-stream" },
+      });
+      expect(res.ok()).toBe(true);
+      const envelope = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+        error?: unknown;
+      };
+      expect(envelope.error).toBeUndefined();
+      expect(envelope.result?.isError).not.toBe(true);
+
+      // The org stub must have been asked to mint.
+      const mintCall = orgStub.requests.some(
+        (r) =>
+          r.method === "tools/call" &&
+          typeof r.body === "object" &&
+          r.body !== null &&
+          (r.body as { params?: { name?: string } }).params?.name ===
+            "MINT_REPO_TOKEN",
+      );
+      expect(mintCall).toBe(true);
+
+      // The minted token is now cached (vault-encrypted) with an expiry set.
+      const after = await db.query<{ expiresAt: string | null }>(
+        'SELECT "expiresAt" FROM downstream_tokens WHERE "connectionId" = $1',
+        [childId],
+      );
+      expect(after.rowCount).toBe(1);
+      expect(after.rows[0]?.expiresAt).toBeTruthy();
+    } finally {
+      await db.end();
+      await ctx.dispose();
+      await orgStub?.stop();
+      await repoStub?.stop();
+    }
+  });
+});

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -12,6 +12,8 @@ import { SpanStatusCode } from "@opentelemetry/api";
 import { refreshAccessToken } from "@/oauth/token-refresh";
 import { resolveOriginTokenEndpoint } from "@/oauth/resolve-token-endpoint";
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
+import { ensureRepoScopedToken } from "@/oauth/github-mint";
+import { getRepoScope } from "@/shared/github-repo-scope";
 import type { ConnectionEntity } from "@/tools/connection/schema";
 
 /**
@@ -147,8 +149,26 @@ async function _buildRequestHeaders(
   // This supports OAuth token refresh for connections that use OAuth
   let accessToken: string | null = null;
 
+  // Per-agent repo-scoped child connections carry a MINTED token (no refresh
+  // token), so mint-on-demand instead of refreshing. getRepoScope returns null
+  // for ordinary connections, which keep the cached-token + refresh path below.
+  const repoScope = getRepoScope(connection);
   const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
-  const cachedToken = await tokenStorage.get(connectionId);
+  const cachedToken = repoScope ? null : await tokenStorage.get(connectionId);
+
+  if (repoScope) {
+    // Mint failure leaves accessToken null → the request goes out without an
+    // Authorization header and fails downstream (same resilience as a failed
+    // refresh); the next call retries the mint.
+    try {
+      accessToken = await ensureRepoScopedToken(ctx, connection);
+    } catch (err) {
+      console.error("[Proxy] repo-scoped token mint failed", {
+        connectionId,
+        error: (err as Error).message,
+      });
+    }
+  }
 
   if (cachedToken) {
     const canRefresh =

--- a/apps/mesh/src/oauth/github-mint.ts
+++ b/apps/mesh/src/oauth/github-mint.ts
@@ -1,0 +1,143 @@
+/**
+ * Repo-scoped GitHub token minting — storage-aware helpers.
+ *
+ * Minted GitHub App installation tokens are short-lived (~1h) and have NO
+ * refresh token, so instead of refreshing we RE-MINT on demand by calling the
+ * deco/mcp-github `MINT_REPO_TOKEN` tool through the ORG connection (the broad
+ * user-to-server OAuth connection — a scoped ghs_ token cannot pass the mint
+ * gate). The mint "recipe" (which org connection, installation, repo,
+ * permissions) lives on the child connection's metadata; see github-repo-scope.
+ *
+ * Sibling to token-refresh.ts; reuses PROACTIVE_REFRESH_BUFFER_MS / RECONNECT_ERROR.
+ */
+
+import type { StudioContext } from "@/core/studio-context";
+import {
+  PROACTIVE_REFRESH_BUFFER_MS,
+  RECONNECT_ERROR,
+} from "@/oauth/token-refresh";
+import { getRepoScope, type RepoScopeRecipe } from "@/shared/github-repo-scope";
+import { DownstreamTokenStorage } from "@/storage/downstream-token";
+import type { ConnectionEntity } from "@/tools/connection/schema";
+
+interface MintedToken {
+  accessToken: string;
+  expiresAt: Date | null;
+}
+
+/**
+ * Mint a fresh repo-scoped token by calling MINT_REPO_TOKEN through the org
+ * connection named in the recipe. Validates org ownership of the source
+ * connection. Always closes the temporary client.
+ *
+ * NOTE: clientFromConnection is dynamically imported to avoid a static import
+ * cycle (headers.ts → github-mint.ts → client.ts → outbound → headers.ts).
+ */
+export async function mintRepoToken(
+  ctx: StudioContext,
+  recipe: RepoScopeRecipe,
+): Promise<MintedToken> {
+  const organizationId = ctx.organization?.id;
+  if (!organizationId) {
+    // No org scope → refuse to mint rather than fall back to an unscoped lookup.
+    throw new Error(RECONNECT_ERROR);
+  }
+  const orgConn = await ctx.storage.connections.findById(
+    recipe.sourceConnectionId,
+    organizationId,
+  );
+  if (!orgConn) {
+    // Source connection gone or not in this org → cannot mint.
+    throw new Error(RECONNECT_ERROR);
+  }
+
+  const { clientFromConnection } = await import("@/mcp-clients/client");
+  // superUser: runs in background contexts (token expiry mid-run, SANDBOX_START)
+  // where ctx.auth.user may be absent; the org connection's broad OAuth token is
+  // injected as the bearer either way (the gate needs the user-to-server token).
+  const client = await clientFromConnection(orgConn, ctx, true);
+  try {
+    const res = (await client.callTool({
+      name: "MINT_REPO_TOKEN",
+      arguments: {
+        installationId: recipe.installationId,
+        owner: recipe.owner,
+        repo: recipe.repo,
+        permissions: recipe.permissions,
+      },
+    })) as {
+      isError?: boolean;
+      structuredContent?: { token?: string; expiresAt?: string };
+    };
+
+    const token = res.structuredContent?.token;
+    if (res.isError || !token) {
+      throw new Error(RECONNECT_ERROR);
+    }
+    const expiresAtRaw = res.structuredContent?.expiresAt;
+    return {
+      accessToken: token,
+      expiresAt: expiresAtRaw ? new Date(expiresAtRaw) : null,
+    };
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+// Single-flight: collapse concurrent mints for the same connection so a burst of
+// tool calls near expiry triggers exactly one MINT_REPO_TOKEN call (which is
+// rate-limit-expensive on the caller's GitHub budget).
+const inflight = new Map<string, Promise<string>>();
+
+async function mintAndStore(
+  ctx: StudioContext,
+  connectionId: string,
+  recipe: RepoScopeRecipe,
+  tokenStorage: DownstreamTokenStorage,
+): Promise<string> {
+  const minted = await mintRepoToken(ctx, recipe);
+  await tokenStorage.upsert({
+    connectionId,
+    accessToken: minted.accessToken,
+    refreshToken: null,
+    scope: null,
+    expiresAt: minted.expiresAt,
+    clientId: null,
+    clientSecret: null,
+    tokenEndpoint: null,
+  });
+  return minted.accessToken;
+}
+
+/**
+ * Return a valid repo-scoped access token for a per-agent child connection,
+ * minting (and caching in downstream_tokens) only when the cached token is
+ * missing or within the proactive-refresh buffer. Throws if `connection` is not
+ * repo-scoped or minting fails.
+ */
+export async function ensureRepoScopedToken(
+  ctx: StudioContext,
+  connection: ConnectionEntity,
+): Promise<string> {
+  const recipe = getRepoScope(connection);
+  if (!recipe) {
+    throw new Error("Connection is not repo-scoped");
+  }
+
+  const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
+  const cached = await tokenStorage.get(connection.id);
+  if (cached && !tokenStorage.isExpired(cached, PROACTIVE_REFRESH_BUFFER_MS)) {
+    return cached.accessToken;
+  }
+
+  const existing = inflight.get(connection.id);
+  if (existing) return existing;
+
+  const p = mintAndStore(ctx, connection.id, recipe, tokenStorage).finally(
+    () => {
+      inflight.delete(connection.id);
+    },
+  );
+  inflight.set(connection.id, p);
+  return p;
+}

--- a/apps/mesh/src/oauth/github-mint.ts
+++ b/apps/mesh/src/oauth/github-mint.ts
@@ -32,8 +32,10 @@ interface MintedToken {
  *
  * NOTE: clientFromConnection is dynamically imported to avoid a static import
  * cycle (headers.ts → github-mint.ts → client.ts → outbound → headers.ts).
+ *
+ * Module-internal: the only public entry point is ensureRepoScopedToken.
  */
-export async function mintRepoToken(
+async function mintRepoToken(
   ctx: StudioContext,
   recipe: RepoScopeRecipe,
 ): Promise<MintedToken> {

--- a/apps/mesh/src/shared/github-repo-scope.test.ts
+++ b/apps/mesh/src/shared/github-repo-scope.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { getRepoScope, GITHUB_SCOPED_PERMISSIONS } from "./github-repo-scope";
+
+describe("getRepoScope", () => {
+  it("returns the recipe for a well-formed repoScope", () => {
+    const recipe = {
+      sourceConnectionId: "conn_org",
+      installationId: 123,
+      owner: "acme",
+      repo: "widget",
+      permissions: { contents: "write" },
+    };
+    expect(getRepoScope({ metadata: { repoScope: recipe } })).toEqual(recipe);
+  });
+
+  it("defaults permissions when omitted", () => {
+    const result = getRepoScope({
+      metadata: {
+        repoScope: {
+          sourceConnectionId: "conn_org",
+          installationId: 1,
+          owner: "a",
+          repo: "b",
+        },
+      },
+    });
+    expect(result?.permissions).toEqual(GITHUB_SCOPED_PERMISSIONS);
+  });
+
+  it("returns null when metadata is null", () => {
+    expect(getRepoScope({ metadata: null })).toBeNull();
+  });
+
+  it("returns null when repoScope is absent", () => {
+    expect(getRepoScope({ metadata: { source: "store" } })).toBeNull();
+  });
+
+  it("returns null when required fields are missing or mistyped", () => {
+    expect(
+      getRepoScope({
+        metadata: {
+          repoScope: {
+            sourceConnectionId: "x",
+            installationId: "nope",
+            owner: "a",
+            repo: "b",
+          },
+        },
+      }),
+    ).toBeNull();
+    expect(
+      getRepoScope({
+        metadata: { repoScope: { installationId: 1, owner: "a", repo: "b" } },
+      }),
+    ).toBeNull();
+    expect(
+      getRepoScope({
+        metadata: {
+          repoScope: {
+            sourceConnectionId: "x",
+            installationId: 1,
+            owner: "",
+            repo: "b",
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -1,0 +1,63 @@
+/**
+ * Repo-scoped GitHub connection — shared, pure helpers.
+ *
+ * A "repo-scoped" mcp-github connection is a per-agent child connection whose
+ * downstream token is minted (by deco/mcp-github's MINT_REPO_TOKEN) for exactly
+ * one repository. The mint "recipe" lives on the connection's metadata under
+ * `repoScope`; its presence also marks the connection as a disposable per-agent
+ * child for teardown.
+ *
+ * Pure module (no DB / network / node deps) so both the server
+ * (oauth/github-mint) and the web import flow (github-repo-picker) can import it.
+ */
+
+/** Least-privilege permission set minted for an imported agent's repo token. */
+export const GITHUB_SCOPED_PERMISSIONS: Record<string, string> = {
+  contents: "write",
+  metadata: "read",
+  pull_requests: "write",
+  issues: "write",
+};
+
+/** The mint recipe stored at `connection.metadata.repoScope`. */
+export interface RepoScopeRecipe {
+  /** Org mcp-github connection (broad user-to-server OAuth) used to mint. */
+  sourceConnectionId: string;
+  installationId: number;
+  owner: string;
+  repo: string;
+  permissions: Record<string, string>;
+}
+
+/**
+ * Read + validate the repoScope recipe from a connection's metadata.
+ * Returns null when the connection is not a repo-scoped child (or the recipe is
+ * malformed) so callers can branch on it safely.
+ */
+export function getRepoScope(connection: {
+  metadata: Record<string, unknown> | null;
+}): RepoScopeRecipe | null {
+  const raw = connection.metadata?.repoScope as
+    | Partial<RepoScopeRecipe>
+    | undefined;
+  if (
+    !raw ||
+    typeof raw.sourceConnectionId !== "string" ||
+    typeof raw.installationId !== "number" ||
+    typeof raw.owner !== "string" ||
+    typeof raw.repo !== "string" ||
+    raw.owner.length === 0 ||
+    raw.repo.length === 0
+  ) {
+    return null;
+  }
+  return {
+    sourceConnectionId: raw.sourceConnectionId,
+    installationId: raw.installationId,
+    owner: raw.owner,
+    repo: raw.repo,
+    permissions:
+      (raw.permissions as Record<string, string> | undefined) ??
+      GITHUB_SCOPED_PERMISSIONS,
+  };
+}

--- a/apps/mesh/src/tools/github/list-user-orgs.ts
+++ b/apps/mesh/src/tools/github/list-user-orgs.ts
@@ -39,6 +39,22 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
   handler: async (input, ctx) => {
     await ctx.access.check();
 
+    // Connection-ownership guard: confirm the named connection belongs to the
+    // caller's org before reading its token. Mirrors the guard in
+    // POST /connections/:id/oauth-token. Without this, any member could read
+    // another org's GitHub token by passing its connectionId.
+    const organizationId = ctx.organization?.id;
+    if (!organizationId) {
+      throw new Error("Organization context required");
+    }
+    const connection = await ctx.storage.connections.findById(
+      input.connectionId,
+      organizationId,
+    );
+    if (!connection) {
+      throw new Error("Connection not found");
+    }
+
     const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
     let token = await tokenStorage.get(input.connectionId);
     if (!token) {

--- a/apps/mesh/src/tools/sandbox/start.test.ts
+++ b/apps/mesh/src/tools/sandbox/start.test.ts
@@ -233,6 +233,13 @@ function makeCtx(overrides: {
     },
     storage: {
       virtualMcps: { findById, update: updateSpy },
+      // Non-repo-scoped org connection: getRepoScope() returns null, so the
+      // repo-scoped mint path in provisionSandbox is skipped and these tests
+      // exercise the clone/token path unchanged. (Minting is covered by the
+      // e2e suite, github-import-repo-scope.spec.ts.)
+      connections: {
+        findById: mock(async (_id: string) => ({ metadata: null })),
+      },
     } as never,
     timings: {
       measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -43,6 +43,8 @@ import {
   detectRepoRuntimeAnonymous,
 } from "../../shared/github-runtime-detect";
 import { generateBranchName } from "../../shared/branch-name";
+import { ensureRepoScopedToken } from "@/oauth/github-mint";
+import { getRepoScope } from "@/shared/github-repo-scope";
 import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
@@ -292,6 +294,29 @@ async function provisionSandbox(
     | undefined;
 
   if (githubRepo) {
+    // Repo-scoped child connections carry a minted token with no refresh path,
+    // so re-mint it now if expired before it gets baked into the clone URL or
+    // used for the lockfile probe. No-op for org connections and public repos.
+    if (githubRepo.connectionId) {
+      const repoConn = await ctx.storage.connections.findById(
+        githubRepo.connectionId,
+        orgId,
+      );
+      if (repoConn && getRepoScope(repoConn)) {
+        try {
+          await ensureRepoScopedToken(ctx, repoConn);
+        } catch (err) {
+          // Swallow + log: a failed mint intentionally falls through to
+          // buildCloneInfo's own "No GitHub token found" throw below (sandbox
+          // start fails loudly — never an unauthenticated clone).
+          console.error("[provisionSandbox] repo-scoped token mint failed", {
+            connectionId: githubRepo.connectionId,
+            error: (err as Error).message,
+          });
+        }
+      }
+    }
+
     // Connection-backed (authenticated) vs public-clone (anonymous). The
     // daemon's clone behavior is identical — only the URL and identity
     // change. Push-back fails in the anonymous case; that's the documented

--- a/apps/mesh/src/tools/virtual/delete.ts
+++ b/apps/mesh/src/tools/virtual/delete.ts
@@ -5,6 +5,8 @@
  */
 
 import { z } from "zod";
+import { getRepoScope } from "@/shared/github-repo-scope";
+import { DownstreamTokenStorage } from "@/storage/downstream-token";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { VirtualMCPEntitySchema } from "./schema";
@@ -53,8 +55,55 @@ export const COLLECTION_VIRTUAL_MCP_DELETE = defineTool({
       throw new Error(`Virtual MCP not found: ${input.id}`);
     }
 
-    // Delete the virtual MCP (connections are deleted via CASCADE)
+    // Delete the agent first. virtualMcps.delete() removes (in its transaction)
+    // the connection_aggregations rows that reference the per-agent child
+    // connection under an ON DELETE RESTRICT FK (migration 026) — deleting the
+    // child before this would throw and make the agent undeletable. The child
+    // connection row itself is NOT removed by this (it's a separate, non-VIRTUAL
+    // connection), so its token is still readable below.
     await ctx.storage.virtualMcps.delete(input.id);
+
+    // Tear down the per-agent repo-scoped mcp-github child connection (if any).
+    // Best-effort: the agent is already deleted, so a cleanup hiccup must not
+    // fail the user's delete (worst case it orphans a child whose minted token
+    // self-expires within ~1h). Self-revoke the token first, then delete the
+    // child (its downstream_tokens + now-unreferenced aggregation rows cascade).
+    const childConnectionId = (
+      existing.metadata as { githubRepo?: { connectionId?: string } } | null
+    )?.githubRepo?.connectionId;
+    if (childConnectionId) {
+      try {
+        const child = await ctx.storage.connections.findById(
+          childConnectionId,
+          organization.id,
+        );
+        if (child && getRepoScope(child)) {
+          const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
+          const tok = await tokenStorage.get(childConnectionId);
+          if (tok?.accessToken) {
+            try {
+              await fetch("https://api.github.com/installation/token", {
+                method: "DELETE",
+                headers: {
+                  Authorization: `Bearer ${tok.accessToken}`,
+                  Accept: "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                },
+                signal: AbortSignal.timeout(5000),
+              });
+            } catch {
+              // Best-effort revoke; the token self-expires within ~1h regardless.
+            }
+          }
+          await ctx.storage.connections.delete(childConnectionId);
+        }
+      } catch (err) {
+        console.error(
+          "[VIRTUAL_MCP_DELETE] failed to tear down repo-scoped connection",
+          { childConnectionId, error: (err as Error).message },
+        );
+      }
+    }
 
     // Return virtual MCP entity directly (already in correct format)
     return {

--- a/apps/mesh/src/tools/virtual/delete.ts
+++ b/apps/mesh/src/tools/virtual/delete.ts
@@ -77,6 +77,11 @@ export const COLLECTION_VIRTUAL_MCP_DELETE = defineTool({
           childConnectionId,
           organization.id,
         );
+        // No need to check whether the child is aggregated under another agent:
+        // the import flow creates a fresh child per agent (1:1), and the
+        // ON DELETE RESTRICT FK on connection_aggregations.child_connection_id
+        // makes connections.delete throw (caught + logged below) rather than
+        // orphan a still-referenced child.
         if (child && getRepoScope(child)) {
           const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
           const tok = await tokenStorage.get(childConnectionId);

--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -38,6 +38,7 @@ import {
   STOREFRONT_GITHUB_AUTOMATIONS,
   setupStorefrontGithubAutomations,
 } from "@/tools/virtual/storefront-github-automations";
+import { GITHUB_SCOPED_PERMISSIONS } from "@/shared/github-repo-scope";
 
 export interface GitHubInstallation {
   installationId: number;
@@ -287,69 +288,179 @@ function PickerContent({
         throw new Error("No GitHub connection or installation");
       }
 
-      const connectionId = effectiveConnection.id;
+      const sourceConnectionId = effectiveConnection.id;
+      const installationId = selectedInstallation.installationId;
 
-      const result = (await selfClient.callTool({
-        name: "COLLECTION_VIRTUAL_MCP_CREATE",
+      // 1. Mint a token scoped to ONLY this repo, via the org mcp-github connection.
+      const mintRes = (await githubClient.callTool({
+        name: "MINT_REPO_TOKEN",
+        arguments: {
+          installationId,
+          owner: repo.owner,
+          repo: repo.name,
+          permissions: GITHUB_SCOPED_PERMISSIONS,
+        },
+      })) as {
+        isError?: boolean;
+        structuredContent?: { token?: string; expiresAt?: string };
+        content?: Array<{ type?: string; text?: string }>;
+      };
+      const minted = mintRes.structuredContent;
+      if (mintRes.isError || !minted?.token) {
+        const detail = mintRes.content?.find((c) => c.type === "text")?.text;
+        throw new Error(
+          detail
+            ? `Failed to mint a repo-scoped GitHub token: ${detail}`
+            : "Failed to mint a repo-scoped GitHub token",
+        );
+      }
+      const parsedExpiry = minted.expiresAt
+        ? Date.parse(minted.expiresAt)
+        : NaN;
+      const expiresIn = Number.isFinite(parsedExpiry)
+        ? Math.max(0, Math.floor((parsedExpiry - Date.now()) / 1000))
+        : null;
+
+      // 2. Create a dedicated per-agent mcp-github child connection that carries
+      //    the mint recipe. Derive the new id from the create result (handles
+      //    both `{ item: { id } }` and `{ id }` response shapes). No
+      //    connection_token — the minted token is stored in downstream_tokens
+      //    (step 3); a connection_token would defeat the repo scoping.
+      const createRes = (await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_CREATE",
         arguments: {
           data: {
-            title: repo.name,
-            description: repo.description || "Imported from GitHub",
-            pinned: true,
-            icon: null,
+            title: `GitHub: ${repo.owner}/${repo.name}`,
+            description: `Repo-scoped GitHub access for ${repo.owner}/${repo.name}`,
+            icon: effectiveConnection.icon,
+            app_name: effectiveConnection.app_name,
+            app_id: effectiveConnection.app_id,
+            connection_type: effectiveConnection.connection_type,
+            connection_url: effectiveConnection.connection_url,
+            configuration_scopes: effectiveConnection.configuration_scopes,
             metadata: {
-              githubRepo: {
+              repoScope: {
+                sourceConnectionId,
+                installationId,
                 owner: repo.owner,
-                name: repo.name,
-                url: repo.url,
-                installationId: selectedInstallation.installationId,
-                connectionId,
-              },
-              instructions: null,
-              // runtime is resolved server-side inside SANDBOX_START's lockfile
-              // probe (github-runtime-detect.ts). Writing a client-side
-              // sentinel here only re-created the race the probe fixed.
-              ui: {
-                pinnedViews: null,
-                layout: {
-                  defaultMainView: {
-                    type: "preview",
-                  },
-                  chatDefaultOpen: true,
-                },
+                repo: repo.name,
+                permissions: GITHUB_SCOPED_PERMISSIONS,
               },
             },
-            connections: [{ connection_id: connectionId }],
           },
         },
       })) as { structuredContent?: unknown };
-
-      const payload = (result.structuredContent ?? result) as {
-        item: { id: string; title: string };
+      const createdConn = (createRes.structuredContent ?? createRes) as {
+        item?: { id?: string };
+        id?: string;
       };
-
-      const virtualMcpId = payload.item.id;
-
-      if (effectiveSelectedKeys.size > 0) {
-        await setupGithubAutomations({
-          virtualMcpId,
-          repo,
-          connectionId,
-          selectedKeys: effectiveSelectedKeys,
-        }).catch((err) => {
-          console.error("Failed to set up GitHub automations:", err);
-          toast.warning(
-            "Imported repo, but failed to set up GitHub automations. You can add triggers manually from the automations view.",
-          );
-        });
+      const childConnectionId = createdConn.item?.id ?? createdConn.id;
+      if (!childConnectionId) {
+        throw new Error("Failed to create the repo-scoped GitHub connection");
       }
 
-      return {
-        virtualMcpId,
-        repo,
-        connectionId,
-        item: payload.item,
-      };
+      let createdAgentId: string | null = null;
+
+      try {
+        // 3. Persist the minted token on the child connection.
+        const tokenRes = await fetch(
+          `/api/${org.slug}/connections/${childConnectionId}/oauth-token`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({ accessToken: minted.token, expiresIn }),
+          },
+        );
+        if (!tokenRes.ok) {
+          throw new Error("Failed to persist the repo-scoped token");
+        }
+
+        // 4. Create the agent wired to the CHILD connection (not the org one).
+        const result = (await selfClient.callTool({
+          name: "COLLECTION_VIRTUAL_MCP_CREATE",
+          arguments: {
+            data: {
+              title: repo.name,
+              description: repo.description || "Imported from GitHub",
+              pinned: true,
+              icon: null,
+              metadata: {
+                githubRepo: {
+                  owner: repo.owner,
+                  name: repo.name,
+                  url: repo.url,
+                  installationId,
+                  connectionId: childConnectionId,
+                },
+                instructions: null,
+                // runtime is resolved server-side inside SANDBOX_START's
+                // lockfile probe (github-runtime-detect.ts). Writing a
+                // client-side sentinel here only re-created the race the probe
+                // fixed.
+                ui: {
+                  pinnedViews: null,
+                  layout: {
+                    defaultMainView: { type: "preview" },
+                    chatDefaultOpen: true,
+                  },
+                },
+              },
+              connections: [{ connection_id: childConnectionId }],
+            },
+          },
+        })) as { structuredContent?: unknown };
+
+        const payload = (result.structuredContent ?? result) as {
+          item?: { id: string; title: string };
+        };
+        const virtualMcpId = payload.item?.id;
+        if (!payload.item || !virtualMcpId) {
+          throw new Error("Failed to create the imported agent");
+        }
+        createdAgentId = virtualMcpId;
+
+        // 5. Repoint automations at the per-agent child connection.
+        if (effectiveSelectedKeys.size > 0) {
+          await setupGithubAutomations({
+            virtualMcpId,
+            repo,
+            connectionId: childConnectionId,
+            selectedKeys: effectiveSelectedKeys,
+          }).catch((err) => {
+            console.error("Failed to set up GitHub automations:", err);
+            toast.warning(
+              "Imported repo, but failed to set up GitHub automations. You can add triggers manually from the automations view.",
+            );
+          });
+        }
+
+        return {
+          virtualMcpId,
+          repo,
+          connectionId: childConnectionId,
+          item: payload.item,
+        };
+      } catch (err) {
+        // Rollback: leave nothing behind. If the agent was created, delete it
+        // (which also tears down its repo-scoped child via server-side cleanup);
+        // always attempt the child delete as a harmless belt-and-suspenders.
+        if (createdAgentId) {
+          await selfClient
+            .callTool({
+              name: "COLLECTION_VIRTUAL_MCP_DELETE",
+              arguments: { id: createdAgentId },
+            })
+            .catch(() => {});
+        }
+        await selfClient
+          .callTool({
+            name: "COLLECTION_CONNECTIONS_DELETE",
+            arguments: { id: childConnectionId, force: true },
+          })
+          .catch(() => {});
+        throw err;
+      }
     },
     onSuccess: ({ virtualMcpId, repo, connectionId, item }) => {
       queryClient.setQueryData(

--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -337,7 +337,6 @@ function PickerContent({
             app_id: effectiveConnection.app_id,
             connection_type: effectiveConnection.connection_type,
             connection_url: effectiveConnection.connection_url,
-            configuration_scopes: effectiveConnection.configuration_scopes,
             metadata: {
               repoScope: {
                 sourceConnectionId,


### PR DESCRIPTION
## Summary

Closes the GitHub-token over-broad-credential leak in the **Import from GitHub** flow. Previously an imported agent was wired to the shared org-wide `mcp-github` connection, whose installation token can reach **every** repo the installation covers — so an agent (and its sandbox) could clone/query repos other than the one it was imported from.

Now each imported agent gets a **dedicated `mcp-github` child connection** carrying a **repo-scoped token, minted on demand** for that one repository, used for **both** the sandbox clone and the agent's runtime MCP tool calls. The broad org token is used only transiently, server-side, to mint.

## What changed

- **`shared/github-repo-scope.ts`** (new) — pure `RepoScopeRecipe` + `getRepoScope()` validator + `GITHUB_SCOPED_PERMISSIONS` (`contents:write, metadata:read, pull_requests:write, issues:write`). Importable by both server and web.
- **`oauth/github-mint.ts`** (new) — `mintRepoToken()` calls `MINT_REPO_TOKEN` on the org connection (org-ownership validated); `ensureRepoScopedToken()` mints-and-caches only near expiry, single-flight, honoring GitHub's returned `expiresAt`. (Re-mint always goes through the broad-OAuth org connection — a scoped token can't pass the mint gate.)
- **`mcp-clients/outbound/headers.ts`** — repo-scoped connections mint-on-demand instead of OAuth-refresh; ordinary connections unchanged.
- **`tools/sandbox/start.ts`** — re-mint a fresh token before it's baked into the clone URL / lockfile probe (covers both `SANDBOX_START` and lazy `ensureSandbox`).
- **`tools/github/list-user-orgs.ts`** — cross-tenant ownership guard (a foreign `connectionId` → "Connection not found" before any token read).
- **`tools/virtual/delete.ts`** — teardown: delete the agent first (clears the `ON DELETE RESTRICT` aggregation rows), then best-effort self-revoke (`DELETE /installation/token`) + delete the otherwise-orphaned child connection (its `downstream_tokens` cascade).
- **`web/components/github-repo-picker.tsx`** — frontend import orchestration: mint → create child connection (recipe in `metadata.repoScope`, **no `connection_token`**) → persist token → create agent wired to the child → repoint automations → rollback on failure.

**Cross-service dependency:** the `MINT_REPO_TOKEN` tool on `deco/mcp-github` (mints a repo-scoped, least-privilege installation token; already live).

## Test plan

- [x] Unit (pure): `getRepoScope` validation — `bun test apps/mesh/src/shared/github-repo-scope.test.ts` (5/5).
- [x] E2E (real Postgres + NATS, stubbed `MINT_REPO_TOKEN`) in `apps/mesh/e2e/tests/github-import-repo-scope.spec.ts` — 3 scenarios, all passing:
  - cross-tenant guard (org B cannot read org A's connection),
  - teardown removes the child connection + token + aggregation (FK-ordering),
  - runtime mint-on-demand populates the child's `downstream_tokens` via the org connection.
- [x] `bun run check`, `bun run lint`, `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements per-agent, repo-scoped GitHub connections for imports, minting short‑lived tokens on demand via the org `mcp-github` connection. This removes broad org token access and confines each agent to its repo for sandbox clones and MCP calls.

- New Features
  - Each imported agent gets a dedicated `mcp-github` child connection with a repo-scoped token, used by the sandbox and MCP tools.
  - Mint-on-demand via `MINT_REPO_TOKEN` on the org connection, with caching, single-flight, and expiry-aware re-minting.
  - Outbound proxy mints for repo-scoped connections; normal OAuth refresh stays unchanged.
  - Sandbox start re-mints before cloning to avoid baking an expired token.
  - Web import flow: mint → create child connection with `metadata.repoScope` (no `connection_token`) → persist token → create agent wired to the child → repoint automations → rollback on failure.
  - Shared `RepoScopeRecipe` + `getRepoScope()` validator and default `GITHUB_SCOPED_PERMISSIONS`.

- Bug Fixes
  - Added org-ownership guard to `GITHUB_LIST_USER_ORGS` to prevent cross-tenant token reads.
  - Agent delete now revokes the repo token and deletes the child connection after removing aggregation rows, fixing FK ordering and cascading token cleanup.
  - Dropped unused `mintRepoToken` export to satisfy build checks; fixed `SANDBOX_START` unit test by stubbing `storage.connections`.

<sup>Written for commit 53a1123ac2dbb0cc7967ae79c5ae6576851b1f6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

