### PR TITLE
fix(sandbox): stop DELETE 404 flood from stale ephemeral claims

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-events-handler.ts
+++ b/apps/mesh/src/api/routes/sandbox-events-handler.ts
@@ -18,7 +18,11 @@ import { delay } from "@decocms/std";
 import { subscribeLifecycle } from "../../sandbox/lifecycle";
 import type { StudioContext } from "../../core/studio-context";
 import { KyselySandboxProviderStateStore } from "../../storage/sandbox-runner-state";
-import { readSandboxMap, resolveVm } from "../../tools/sandbox/sandbox-map";
+import {
+  readSandboxMap,
+  removeSandboxMapEntry,
+  resolveVm,
+} from "../../tools/sandbox/sandbox-map";
 import type { Env } from "../hono-env";
 
 /**
@@ -44,6 +48,7 @@ export interface VmEventsHandlerArgs {
   ctx: StudioContext;
   claimName: string;
   runner: SandboxProvider;
+  virtualMcpId: string;
   branch: string;
   userId: string;
   projectRef: string;
@@ -55,6 +60,7 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
     ctx,
     claimName,
     runner,
+    virtualMcpId,
     branch,
     userId,
     projectRef,
@@ -97,6 +103,8 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
             ctx,
             runner,
             claimName,
+            virtualMcpId,
+            branch,
             userId,
             projectRef,
             sandboxProviderKind: existingProviderKind ?? providerKind,
@@ -149,12 +157,42 @@ async function cleanupStaleEntry(args: {
   ctx: StudioContext;
   runner: SandboxProvider;
   claimName: string;
+  virtualMcpId: string;
+  branch: string;
   userId: string;
   projectRef: string;
   sandboxProviderKind: SandboxProviderKind;
 }): Promise<void> {
-  const { ctx, runner, claimName, userId, projectRef, sandboxProviderKind } =
-    args;
+  const {
+    ctx,
+    runner,
+    claimName,
+    virtualMcpId,
+    branch,
+    userId,
+    projectRef,
+    sandboxProviderKind,
+  } = args;
+  // Drop the sandboxMap entry first. Without this the dangling `sandboxHandle`
+  // stays in the virtualmcp metadata, so every client SSE reconnect re-enters
+  // this stale path and re-issues a DELETE against the already-gone claim — a
+  // 404 flood that only stops when the tab closes. Mirrors SANDBOX_DELETE.
+  try {
+    await removeSandboxMapEntry(
+      ctx.storage.virtualMcps,
+      virtualMcpId,
+      userId,
+      userId,
+      branch,
+      sandboxProviderKind,
+    );
+  } catch (err) {
+    console.warn(
+      `[vm-events] sandboxMap cleanup failed for ${virtualMcpId}/${branch}/${sandboxProviderKind}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
   try {
     await runner.delete(claimName);
   } catch (err) {

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -404,6 +404,7 @@ export const createSandboxRoutes = () => {
       ctx: c.var.meshContext,
       claimName: claim.claimName,
       runner: claim.runner,
+      virtualMcpId: claim.virtualMcpId,
       branch: claim.branch,
       userId: claim.userId,
       projectRef: claim.projectRef,

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -199,9 +199,11 @@ export function SandboxEventsProvider({
         setPhase(next);
         // A fresh non-terminal phase means the lifecycle is making progress
         // again — clear notFound from a prior `gone` so the self-heal UI
-        // settles back into the booting overlay.
+        // settles back into the booting overlay, and treat it as a healthy
+        // connection so the reconnect backoff resets.
         if (next.kind !== "failed") {
           setNotFound(false);
+          reconnectAttempt = 0;
         }
       } catch (err) {
         console.warn("[vm-events] bad phase payload", err);
@@ -226,6 +228,8 @@ export function SandboxEventsProvider({
       try {
         const data = JSON.parse(e.data) as { source: string; data: string };
         if (typeof data.data !== "string") return;
+        // Real daemon output → the sandbox is alive; reset reconnect backoff.
+        reconnectAttempt = 0;
         // xterm.js reads bare `\n` as "cursor down, keep column" — normalize.
         const normalized = data.data.replace(/\r?\n/g, "\r\n");
         getOrCreateBuffer(data.source).append(normalized);
@@ -246,6 +250,8 @@ export function SandboxEventsProvider({
       const name = e.type as DaemonEventName;
       try {
         const payload = JSON.parse(e.data);
+        // Any daemon event proves the sandbox is reachable; reset backoff.
+        reconnectAttempt = 0;
         switch (name) {
           case "lifecycle": {
             const lp = payload as DaemonEventPayload<"lifecycle">;
@@ -316,9 +322,14 @@ export function SandboxEventsProvider({
 
       es = new EventSource(sseUrl);
 
-      es.onopen = () => {
-        reconnectAttempt = 0;
-      };
+      // NOTE: deliberately do NOT reset `reconnectAttempt` here. A connection
+      // that opens, immediately receives `gone` (handle evicted), and closes
+      // still fires `onopen` — resetting on open made that case tight-loop at
+      // the 1s floor forever. The backoff is reset only once real daemon
+      // data/phase progress arrives (see handleLog/handleDaemonEvent/
+      // handleClaimPhase), so repeated `gone`-only reconnects ramp toward the
+      // 30s cap instead of hammering.
+      es.onopen = () => {};
 
       es.onerror = () => {
         if (es?.readyState !== EventSource.CLOSED) return;


### PR DESCRIPTION
## Summary

Fixes a continuous `DELETE … /apis/extensions.agents.x-k8s.io/v1alpha1/namespaces/agent-sandbox-system/sandboxclaims/ephemeral-<id> → HTTP 404` flood seen in production observability (HyperDX), originating from the mesh pod itself. This PR carries the full root-cause analysis plus two fixes (server + client).

## How it was discovered

A flood of identical `DELETE` spans against the Kubernetes API, `deployment.environment=production`, `serviceName=studio`, from pod `deco-studio-5b8fb7f745-*` (i.e. the mesh server, not the housekeeper cron). Confirmed against prod DB (read-only).

## Root cause

The flood is a **browser EventSource reconnect loop firing a DELETE against an already-reaped SandboxClaim**.

1. The sandbox preview/agent UI opens an SSE to `/api/:org/sandbox/:virtualMcpId/:branch/events` (`handleVmEvents`).
2. On each connection it reads the `sandboxMap` from the virtualmcp `metadata` and sets `expectingHandle = sandboxHandle === claimName`.
3. When the cluster sandbox is reaped (idle/TTL by the housekeeper/operator), `isStaleHandle` → `runner.alive()` returns false → `cleanupStaleEntry` runs.
4. `cleanupStaleEntry` did `runner.delete()` (→ `deleteSandboxClaim` → **`DELETE … → 404`**) and deleted the `sandbox_runner_state` row, **but never removed the dangling `sandboxHandle` from `sandboxMap`.**
5. It then emits `event: gone` and closes the stream → the browser `EventSource` auto-reconnects → step 2 again → `expectingHandle` is still true (map unchanged) → DELETE again → 404 → forever.

Two compounding bugs:

- **Server — missing map cleanup.** `removeSandboxMapEntry` is called by every other delete path (`SANDBOX_DELETE`, `SANDBOX_START`, decopilot built-ins) but **not** by `cleanupStaleEntry`. So the stale path could never self-heal.
- **Client — premature backoff reset.** `SandboxEventsProvider` reset the reconnect backoff in `EventSource.onopen`. But a connection that opens, receives `gone`, and closes *still* fires `onopen` — so the backoff stayed pinned at the 1s floor and tight-looped. Worse, the self-heal in `sandbox-lifecycle-context` dedups by dead handle (`reprovisionedForVmIdRef`), so after a single failed reprovision it stops re-provisioning while the EventSource keeps reconnecting indefinitely → hours-long flood.

## Why it hit one user and not others

Dangling `sandboxMap` handles are the **normal steady state** — 26 users have them (one had 18). They're inert until a client actively reconnects against a claim that's actually gone. The trigger is specific:

- A **heavy, long-running cluster agent** (decopilot, `branch=ephemeral`, `sandbox=cluster`) whose run outlives the sandbox idle/TTL window.
- A thread left **stuck `in_progress`** with the tab open → a live EventSource at the moment the shared ephemeral sandbox (`computeHandle(id, "ephemeral")` → one handle per user+agent) gets reaped.
- Other users' dangling handles don't flood because their threads are `completed`/`requires_action` with no client reconnecting.

## Changes

**Server** (`apps/mesh/src/api/routes/sandbox-events-handler.ts`, `sandbox-proxy.ts`)
- `cleanupStaleEntry` now calls `removeSandboxMapEntry` first (mirrors `SANDBOX_DELETE`), so the map self-heals after the first stale detection and subsequent reconnects no longer enter the DELETE path. `virtualMcpId` is threaded through `handleVmEvents`.

**Client** (`apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx`)
- Reconnect backoff is reset only when **real daemon data / non-failed phase** arrives (`handleLog`, `handleDaemonEvent`, `handleClaimPhase`), not on bare `onopen`. Repeated `gone`-only reconnects now ramp toward the 30s cap instead of hammering at 1s.

## Impact

- Eliminates the k8s `DELETE … 404` flood: the stale path fires at most once per reap, then the map is clean.
- Bounds residual client reconnect churn; healthy reconnects still reset instantly on first real data.
- Self-heal (`gone` → `SANDBOX_START` reprovision) is preserved — the client cache still surfaces the dead handle long enough for `shouldSelfHeal` to fire.

## Testing

- `bun run --cwd=apps/mesh check` (tsc) ✓
- `bun run lint` (oxlint) ✓
- `bun run fmt` ✓
- No unit tests added: both paths require a live `StudioContext`/DB + SSE, which per `TESTING.md` belong in e2e (no-mocks rule). Manual e2e: start a cluster sandbox, let the claim be reaped with the preview open, confirm a single DELETE then no further k8s DELETEs and the map entry cleared.

## Ops note

The live flood for the reporting user (`phdro@deco.cx`, org `deco`) stops once their stuck `in_progress` thread / preview tab is closed, or by clearing the stale `sandboxMap` entry on the affected connection. After this PR, the server self-heals the map on the first stale reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the 404 DELETE flood against the Kubernetes API caused by stale ephemeral `SandboxClaim`s during SSE reconnects. Cleans the server’s `sandboxMap` and fixes the client reconnect backoff so loops stop while self-heal still works.

- **Bug Fixes**
  - Server: call `removeSandboxMapEntry` in `cleanupStaleEntry` (mirrors `SANDBOX_DELETE`) so the map self-heals; pass `virtualMcpId`/`branch` to enable cleanup before `runner.delete`.
  - Client: don’t reset backoff in `EventSource.onopen`; reset only on real daemon output or a non-failed phase. Repeated `gone` reconnects now back off up to 30s instead of hammering at 1s.

<sup>Written for commit ed393e2bc0ad66e8739b689b15dd24f203d000ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

