### PR TITLE
fix(link-daemon): disable idle timeout on local-ingress Bun.serve

### DIFF
--- a/apps/mesh/src/link-daemon/local-ingress.test.ts
+++ b/apps/mesh/src/link-daemon/local-ingress.test.ts
@@ -304,6 +304,47 @@ describe("local-ingress WS proxying", () => {
   });
 });
 
+describe("local-ingress idle timeout (slow, local-only)", () => {
+  // A request the ingress proxies can legitimately stay open far longer than
+  // Bun.serve's DEFAULT 10s idleTimeout: SSE/streaming chat previews and
+  // cold-starting dev servers routinely produce no I/O for >10s. With the
+  // default timeout, Bun aborts the inbound (browser→ingress) connection at
+  // 10s and logs:
+  //   "[Bun.serve]: request timed out after 10 seconds. Pass `idleTimeout` to configure."
+  // dropping the user's preview mid-stream. The ingress therefore disables the
+  // idle timeout (idleTimeout: 0), matching apps/mesh/src/index.ts:147 and the
+  // sandbox daemon's Bun.serve (packages/sandbox/daemon/entry.ts:651). This
+  // reproduction waits >10s, so it's skipped in CI (same rationale as the Vite
+  // integration test below) and runs locally as the regression guard.
+  const SKIP_IN_CI = !!process.env.CI;
+  const itOrSkip = SKIP_IN_CI ? test.skip : test;
+
+  itOrSkip(
+    "keeps a slow (>10s) proxied response alive instead of timing out at 10s",
+    async () => {
+      upstream = Bun.serve({
+        port: 0,
+        idleTimeout: 0, // isolate the assertion to the ingress, not the upstream
+        async fetch() {
+          // Stay silent past the default 10s idle window before replying.
+          await new Promise((r) => setTimeout(r, 12_000));
+          return new Response("slow ok", { status: 200 });
+        },
+      });
+      ingress = await startLocalIngress({
+        port: 0,
+        lookupSandboxPort: () => upstream!.port ?? null,
+      });
+      const res = await fetch(`http://127.0.0.1:${ingress.port}/slow`, {
+        headers: { host: `abc.localhost:${ingress.port}` },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("slow ok");
+    },
+    20_000,
+  );
+});
+
 describe("local-ingress + real Vite HMR (integration)", () => {
   const VITE_BOOT_TIMEOUT_MS = 30_000;
   const HMR_HELLO_TIMEOUT_MS = 10_000;

--- a/apps/mesh/src/link-daemon/local-ingress.ts
+++ b/apps/mesh/src/link-daemon/local-ingress.ts
@@ -53,6 +53,15 @@ export async function startLocalIngress(
   const server = Bun.serve<WsData>({
     port: input.port,
     hostname: "127.0.0.1",
+    // Disable Bun's default 10s idle timeout: the ingress proxies long-lived
+    // requests to the sandbox dev server (SSE/streaming chat previews, Vite
+    // HMR, cold-starting servers) that legitimately produce no I/O for >10s.
+    // Without this, Bun aborts those connections at 10s and logs
+    //   "[Bun.serve]: request timed out after 10 seconds."
+    // dropping the preview mid-stream. Mirrors apps/mesh/src/index.ts and the
+    // sandbox daemon (packages/sandbox/daemon/entry.ts), which set this for the
+    // same SSE reason.
+    idleTimeout: 0,
     async fetch(req, srv) {
       const host = req.headers.get("host");
       const handle = parseHandleFromHost(host);


### PR DESCRIPTION
## What is this contribution about?

The link-daemon's local-ingress server proxies long-lived requests to the sandbox dev server (SSE/streaming chat previews, Vite HMR, cold-starting servers) that legitimately produce no I/O for >10s. Bun.serve defaults to a 10s `idleTimeout`, which aborts these requests mid-stream and logs `[Bun.serve]: request timed out after 10 seconds.` Fix by setting `idleTimeout: 0`, matching the pattern in `apps/mesh/src/index.ts` and `packages/sandbox/daemon/entry.ts`.

## How to Test

1. Run `bun test apps/mesh/src/link-daemon/local-ingress.test.ts -t "keeps a slow"` locally (CI-skipped)
2. The test proxies a deliberately slow (>10s) response and verifies it doesn't timeout
3. Existing local-ingress tests pass: `CI=1 bun test apps/mesh/src/link-daemon/local-ingress.test.ts` (10 pass, 2 skipped)

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested (new regression test + full suite passes)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the idle timeout on the link-daemon local-ingress `Bun.serve` to prevent 10s aborts of long-lived proxied requests (SSE, Vite HMR, cold starts). This keeps streaming previews and dev server proxies stable.

- **Bug Fixes**
  - Set `idleTimeout: 0` in `apps/mesh/src/link-daemon/local-ingress.ts`, matching `apps/mesh/src/index.ts` and `packages/sandbox/daemon/entry.ts`.
  - Added a regression test that proxies a >10s response and verifies it doesn’t timeout (skipped in CI).

<sup>Written for commit a6fde12cd07ef2b11a699a0fefa33253a709a3ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

