### PR TITLE
fix(link): make decocms link user-scoped — no --org needed (fixes org-list 403)

### DIFF
--- a/apps/mesh/e2e/fixtures/links-presence.ts
+++ b/apps/mesh/e2e/fixtures/links-presence.ts
@@ -1,7 +1,7 @@
 /**
  * Establish pull-transport link presence for the authed user from a spec.
  *
- * A real desktop daemon holds an open long-poll on `GET /api/:org/links/work`;
+ * A real desktop daemon holds an open long-poll on `GET /api/links/work`;
  * the route synthetically mints a presence claim in the NATS KV bucket at the
  * start of the handler so `resolveDispatchTarget` sees the link as online (and
  * advertising the requested capabilities). Specs that previously brought a
@@ -11,7 +11,7 @@
  * `user-desktop` target, which this claim produces).
  *
  * Usage:
- *   const presence = claimPullPresence(api, orgSlug, ["claude-code"]);
+ *   const presence = claimPullPresence(api, ["claude-code"]);
  *   try { ...assertions... } finally { await presence; }
  *
  * The returned promise resolves when the long-poll request settles (a 204 on
@@ -23,13 +23,12 @@ import { expect, type APIRequestContext } from "@playwright/test";
 
 export function claimPullPresence(
   api: APIRequestContext,
-  orgSlug: string,
   capabilities: string[],
 ): Promise<unknown> {
   // Fire the long-poll with a short client timeout: just long enough for the
   // handler's synchronous claim refresh to land. 204/timeout is fine.
   const presencePromise = api
-    .get(`/api/${orgSlug}/links/work`, {
+    .get(`/api/links/work`, {
       timeout: 1_500,
       headers: {
         "x-link-capabilities": capabilities.join(","),

--- a/apps/mesh/e2e/tests/chat-locked-thread.spec.ts
+++ b/apps/mesh/e2e/tests/chat-locked-thread.spec.ts
@@ -160,7 +160,7 @@ test.describe("Thread runtime is locked after first message", () => {
     const { page, orgSlug } = authedPage;
     const api = page.context().request;
 
-    const presence = claimPullPresence(api, orgSlug, ["claude-code"]);
+    const presence = claimPullPresence(api, ["claude-code"]);
     const db = await connectDevDb();
     try {
       const { agentId, threadId } = await createAgentAndThread(api, orgSlug);
@@ -247,7 +247,7 @@ test.describe("Thread runtime is locked after first message", () => {
     const { page, orgSlug } = authedPage;
     const api = page.context().request;
 
-    const presence = claimPullPresence(api, orgSlug, ["claude-code"]);
+    const presence = claimPullPresence(api, ["claude-code"]);
     try {
       // Seed an AI provider key so the thread route renders the
       // composer instead of `NoAiProviderEmptyState`. Without this,

--- a/apps/mesh/e2e/tests/decopilot-messages.spec.ts
+++ b/apps/mesh/e2e/tests/decopilot-messages.spec.ts
@@ -115,7 +115,7 @@ test.describe("POST /messages — dispatch target gating", () => {
 
     // Link advertises only decopilot-sandbox; a claude-code harness needs the
     // "claude-code" capability.
-    const presence = claimPullPresence(api, orgSlug, ["decopilot-sandbox"]);
+    const presence = claimPullPresence(api, ["decopilot-sandbox"]);
     try {
       const res = await postMessage(
         api,
@@ -169,7 +169,7 @@ test.describe("POST /messages — first-message pinning", () => {
     const api = page.context().request;
 
     // user-desktop + claude-code resolves OK only when the link advertises it.
-    const presence = claimPullPresence(api, orgSlug, ["claude-code"]);
+    const presence = claimPullPresence(api, ["claude-code"]);
     const db = await connectDevDb();
     try {
       const { agentId, threadId } = await createAgentAndThread(api, orgSlug);
@@ -204,7 +204,7 @@ test.describe("POST /messages — first-message pinning", () => {
     const { page, orgSlug } = authedPage;
     const api = page.context().request;
 
-    const presence = claimPullPresence(api, orgSlug, ["claude-code"]);
+    const presence = claimPullPresence(api, ["claude-code"]);
     const db = await connectDevDb();
     try {
       const { agentId, threadId } = await createAgentAndThread(api, orgSlug);

--- a/apps/mesh/e2e/tests/link-control.spec.ts
+++ b/apps/mesh/e2e/tests/link-control.spec.ts
@@ -3,7 +3,7 @@
  *
  * Three assertions (Phase C correctness invariants):
  *
- *   (1) GET /api/:org/links/control with no auth → 401.
+ *   (1) GET /api/links/control with no auth → 401.
  *
  *   (2) Cancel → durable flag → ingest 409 (hard invariant):
  *       - Seed a pull thread with a fence token.
@@ -130,7 +130,7 @@ test.describe("link-control Phase C", () => {
   test("GET /links/control without auth returns 401", async ({
     authedPage,
   }) => {
-    const { page, orgSlug } = authedPage;
+    const { page } = authedPage;
     // Use a fresh context with no cookies to simulate an unauthenticated caller.
     const unauthCtx = await page
       .context()
@@ -141,7 +141,7 @@ test.describe("link-control Phase C", () => {
     const unauthApi = unauthCtx.request;
 
     try {
-      const res = await unauthApi.get(`/api/${orgSlug}/links/control`, {
+      const res = await unauthApi.get(`/api/links/control`, {
         timeout: 5_000,
       });
       expect(res.status()).toBe(401);
@@ -231,7 +231,7 @@ test.describe("link-control Phase C", () => {
       // Open the control poll FIRST with a short window; fire cancel concurrently.
       // The poll needs to beat the cancel frame by subscribing before it arrives.
       const pollPromise = api
-        .get(`/api/${orgSlug}/links/control`, {
+        .get(`/api/links/control`, {
           // Long enough to outlast the server's POLL_TIMEOUT_MS (28 s) if needed,
           // but we fire cancel almost immediately so it should resolve much sooner.
           timeout: 35_000,

--- a/apps/mesh/e2e/tests/link-dispatch-pull.spec.ts
+++ b/apps/mesh/e2e/tests/link-dispatch-pull.spec.ts
@@ -8,12 +8,12 @@
  *      created and wired to a real agent (virtual MCP). The S6 gate routes it
  *      to pull because the resolved dispatch target is `runsIn:'user-desktop'`.
  *   2. The "desktop daemon" establishes link presence by calling
- *      GET /api/:org/links/work — the route synthetically mints a claim in
+ *      GET /api/links/work — the route synthetically mints a claim in
  *      the NATS KV bucket so resolveDispatchTarget sees the link as online.
  *   3. POST /messages on the pull thread → 202 { taskId }. The thread-gate
  *      workflow fires pullDispatch (prepareRun → fence mint → work-item
  *      publish) and then polls threads.status until terminal.
- *   4. The "daemon" calls GET /api/:org/links/work and receives the work
+ *   4. The "daemon" calls GET /api/links/work and receives the work
  *      item; the test asserts its shape (runId, runFenceToken, harnessInput).
  *   5. The "daemon" POSTs a minimal dispatch SSE body to
  *      POST /api/:org/links/runs/:runId/stream with x-fence-token header.
@@ -39,7 +39,7 @@
  *       the real DB; the assertion sees the post-ingest row directly.
  *     - Body-offload and multi-chunk SSE streams (covered by link-ingest.spec.ts).
  *
- * Presence strategy: the spec uses GET /api/:org/links/work to establish the
+ * Presence strategy: the spec uses GET /api/links/work to establish the
  * claim (same as a real pull daemon holding the long-poll). The request carries
  * x-link-capabilities: claude-code so the minted claim advertises the required
  * capability and resolveDispatchTarget routes the thread correctly.
@@ -224,7 +224,7 @@ test.describe("pull-transport round-trip", () => {
 
       // ── Step 2: establish link presence ───────────────────────────────────
       //
-      // GET /api/:org/links/work hits the linkClaimRegistry and mints a
+      // GET /api/links/work hits the linkClaimRegistry and mints a
       // presence claim for this user.  We send x-link-capabilities so the
       // claim advertises "claude-code" — resolveDispatchTarget requires this
       // capability when harnessId='claude-code'; without it the route returns
@@ -234,7 +234,7 @@ test.describe("pull-transport round-trip", () => {
       // refresh is synchronous at the start of the handler; a 204/timeout on
       // the poll itself is fine) and resolves once the claim is visible in
       // /api/links/me — so presence is established BEFORE POST /messages runs.
-      await claimPullPresence(api, orgSlug, ["claude-code"]);
+      await claimPullPresence(api, ["claude-code"]);
 
       // ── Step 3: trigger the dispatch (POST /messages) ─────────────────────
       //
@@ -296,7 +296,7 @@ test.describe("pull-transport round-trip", () => {
 
       const MAX_WORK_POLL_RETRIES = 3;
       for (let attempt = 1; attempt <= MAX_WORK_POLL_RETRIES; attempt++) {
-        const res = await api.get(`/api/${orgSlug}/links/work`, {
+        const res = await api.get(`/api/links/work`, {
           // Must exceed the server long-poll hold (~30 s) so we don't time out
           // before the server either delivers a work item or returns 204.
           timeout: 35_000,

--- a/apps/mesh/e2e/tests/link-proxy.spec.ts
+++ b/apps/mesh/e2e/tests/link-proxy.spec.ts
@@ -2,8 +2,8 @@
  * E2E: the pull reverse-proxy channel, end-to-end (Phase C-bis S5).
  *
  * Validates the channel built dormant in S0-S4 — cluster `createProxyDispatch`
- * → `links.proxy.req.<userSub>` → `GET /api/:org/links/proxy` (the daemon's
- * long-poll) → a PROXY-DAEMON SIMULATOR → `POST /api/:org/links/proxy/:reqId/
+ * → `links.proxy.req.<userSub>` → `GET /api/links/proxy` (the daemon's
+ * long-poll) → a PROXY-DAEMON SIMULATOR → `POST /api/links/proxy/:reqId/
  * stream` (duplex NDJSON reply) → `links.proxy.reply.<reqId>` → back to the
  * awaiting caller — over REAL NATS + the REAL routes, BEFORE the S6 cutover.
  *
@@ -13,7 +13,7 @@
  * server does NOT set). Wiring full provider resolution (virtualMcp seed,
  * sandbox handle, presence) just to reach `proxyDaemonRequest` is disproporti-
  * onate, so this spec uses the sanctioned fallback: a non-production test-trigger
- * route (`POST /api/:org/links/proxy/_test/dispatch`, mounted only when
+ * route (`POST /api/links/proxy/_test/dispatch`, mounted only when
  * NODE_ENV!=="production") that drives a REAL `createProxyDispatch` over the SAME
  * live NATS connection and streams the decoded reply back. This is a true
  * cross-leg round-trip — only the caller is synthetic; both legs, both subjects,
@@ -125,7 +125,6 @@ class ProxyDaemonSimulator {
   readonly seenReqIds: string[] = [];
 
   constructor(
-    private readonly orgSlug: string,
     cookie: string,
     private readonly handler: RequestHandler,
     private readonly concurrency = 2,
@@ -157,7 +156,7 @@ class ProxyDaemonSimulator {
     while (!this.stop.signal.aborted) {
       let res: Response;
       try {
-        res = await fetch(`${BASE_URL}/api/${this.orgSlug}/links/proxy`, {
+        res = await fetch(`${BASE_URL}/api/links/proxy`, {
           headers: this.headers,
           signal: boundedSignal(LONGPOLL_FETCH_MS, this.stop.signal),
         });
@@ -192,7 +191,7 @@ class ProxyDaemonSimulator {
     while (!this.stop.signal.aborted) {
       let res: Response;
       try {
-        res = await fetch(`${BASE_URL}/api/${this.orgSlug}/links/control`, {
+        res = await fetch(`${BASE_URL}/api/links/control`, {
           headers: this.headers,
           signal: boundedSignal(LONGPOLL_FETCH_MS, this.stop.signal),
         });
@@ -276,23 +275,20 @@ class ProxyDaemonSimulator {
     })();
 
     try {
-      await fetch(
-        `${BASE_URL}/api/${this.orgSlug}/links/proxy/${frame.reqId}/stream`,
-        {
-          method: "POST",
-          headers: { ...this.headers, "content-type": "application/x-ndjson" },
-          body: stream,
-          // @ts-expect-error duplex is required for a streaming request body
-          // (undici/Node), not yet in all TS DOM typings.
-          duplex: "half",
-          // Hard ceiling on top of stop + per-request abort: even a stuck reply
-          // upload can't outlive REPLY_POST_FETCH_MS.
-          signal: AbortSignal.any([
-            combined,
-            AbortSignal.timeout(REPLY_POST_FETCH_MS),
-          ]),
-        },
-      );
+      await fetch(`${BASE_URL}/api/links/proxy/${frame.reqId}/stream`, {
+        method: "POST",
+        headers: { ...this.headers, "content-type": "application/x-ndjson" },
+        body: stream,
+        // @ts-expect-error duplex is required for a streaming request body
+        // (undici/Node), not yet in all TS DOM typings.
+        duplex: "half",
+        // Hard ceiling on top of stop + per-request abort: even a stuck reply
+        // upload can't outlive REPLY_POST_FETCH_MS.
+        signal: AbortSignal.any([
+          combined,
+          AbortSignal.timeout(REPLY_POST_FETCH_MS),
+        ]),
+      });
     } catch {
       /* reply POST aborted on cancel/close — expected */
     } finally {
@@ -314,7 +310,6 @@ class ProxyDaemonSimulator {
  */
 async function establishPresence(
   api: import("@playwright/test").APIRequestContext,
-  orgSlug: string,
 ): Promise<{ refresh: () => void; dispose: () => Promise<void> }> {
   const headers = {
     "x-link-capabilities": "claude-code",
@@ -323,7 +318,7 @@ async function establishPresence(
   };
   // First call mints the claim (claim refresh is synchronous at handler start).
   await api
-    .get(`/api/${orgSlug}/links/work`, { timeout: 1_500, headers })
+    .get(`/api/links/work`, { timeout: 1_500, headers })
     .catch(() => null);
 
   await expect
@@ -343,7 +338,7 @@ async function establishPresence(
   const loop = (): void => {
     if (!alive) return;
     current = api
-      .get(`/api/${orgSlug}/links/work`, { timeout: 35_000, headers })
+      .get(`/api/links/work`, { timeout: 35_000, headers })
       .catch(() => null)
       .then((r) => {
         if (alive) loop();
@@ -381,7 +376,6 @@ type WarmupOutcome = "ready" | "no-nats" | "not-ready";
  *   "not-ready" — never succeeded within the budget (caller should test.skip).
  */
 async function warmup(
-  orgSlug: string,
   cookie: string,
   sim: ProxyDaemonSimulator,
 ): Promise<WarmupOutcome> {
@@ -389,15 +383,12 @@ async function warmup(
   for (let i = 0; i < attempts; i++) {
     let res: Response;
     try {
-      res = await fetch(
-        `${BASE_URL}/api/${orgSlug}/links/proxy/_test/dispatch`,
-        {
-          method: "POST",
-          headers: { cookie, "content-type": "application/json" },
-          body: JSON.stringify({ method: "GET", path: "/_sandbox/warmup" }),
-          signal: boundedSignal(DISPATCH_FETCH_MS),
-        },
-      );
+      res = await fetch(`${BASE_URL}/api/links/proxy/_test/dispatch`, {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ method: "GET", path: "/_sandbox/warmup" }),
+        signal: boundedSignal(DISPATCH_FETCH_MS),
+      });
     } catch {
       // Hard-timeout abort or transport error — count as a failed attempt.
       await new Promise((r) => setTimeout(r, 250));
@@ -435,11 +426,11 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
     authedPage,
   }) => {
     test.setTimeout(60_000);
-    const { page, orgSlug } = authedPage;
+    const { page } = authedPage;
     const api = page.context().request;
     const cookie = await cookieHeader(page);
 
-    const presence = await establishPresence(api, orgSlug);
+    const presence = await establishPresence(api);
     presence.refresh();
 
     // Reply payload includes a non-UTF-8 byte (0xFF) to prove base64 fidelity.
@@ -447,7 +438,7 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
     const part2 = new Uint8Array([0x00, 0x41, 0x42]); // NUL + "AB"
     const chunkArrival: number[] = [];
 
-    const sim = new ProxyDaemonSimulator(orgSlug, cookie, async (_frame, w) => {
+    const sim = new ProxyDaemonSimulator(cookie, async (_frame, w) => {
       await w.write({ type: "headers", status: 200, headers: {} });
       await w.write({ type: "chunk", data: b64(part1) });
       // gap, then a second chunk — proves the cluster relays incrementally.
@@ -458,7 +449,7 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
     sim.start();
 
     try {
-      const ready = await warmup(orgSlug, cookie, sim);
+      const ready = await warmup(cookie, sim);
       if (ready === "no-nats") {
         test.skip(true, "NATS unavailable — proxy channel returned 503");
         return;
@@ -471,15 +462,12 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
         return;
       }
 
-      const res = await fetch(
-        `${BASE_URL}/api/${orgSlug}/links/proxy/_test/dispatch`,
-        {
-          method: "POST",
-          headers: { cookie, "content-type": "application/json" },
-          body: JSON.stringify({ method: "GET", path: "/_sandbox/events" }),
-          signal: boundedSignal(DISPATCH_FETCH_MS),
-        },
-      );
+      const res = await fetch(`${BASE_URL}/api/links/proxy/_test/dispatch`, {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ method: "GET", path: "/_sandbox/events" }),
+        signal: boundedSignal(DISPATCH_FETCH_MS),
+      });
       // 503 ⇒ NATS unavailable in this environment — tolerate (round-trip can't
       // be exercised without NATS; the unit tests cover the adapter logic).
       if (res.status === 503) {
@@ -521,11 +509,11 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
     authedPage,
   }) => {
     test.setTimeout(60_000);
-    const { page, orgSlug } = authedPage;
+    const { page } = authedPage;
     const api = page.context().request;
     const cookie = await cookieHeader(page);
 
-    const presence = await establishPresence(api, orgSlug);
+    const presence = await establishPresence(api);
     presence.refresh();
 
     // First request handler holds the reply open for a beat; second replies fast.
@@ -534,7 +522,7 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
       firstReleased = r;
     });
 
-    const sim = new ProxyDaemonSimulator(orgSlug, cookie, async (frame, w) => {
+    const sim = new ProxyDaemonSimulator(cookie, async (frame, w) => {
       const marker = frame.path.includes("first") ? "FIRST" : "SECOND";
       await w.write({ type: "headers", status: 200, headers: {} });
       if (marker === "FIRST") await firstHold; // stay mid-handling
@@ -547,7 +535,7 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
     sim.start();
 
     const dispatch = (path: string): Promise<string> =>
-      fetch(`${BASE_URL}/api/${orgSlug}/links/proxy/_test/dispatch`, {
+      fetch(`${BASE_URL}/api/links/proxy/_test/dispatch`, {
         method: "POST",
         headers: { cookie, "content-type": "application/json" },
         body: JSON.stringify({ method: "GET", path }),
@@ -559,7 +547,7 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
       });
 
     try {
-      const ready = await warmup(orgSlug, cookie, sim);
+      const ready = await warmup(cookie, sim);
       if (ready === "no-nats") {
         test.skip(true, "NATS unavailable — proxy channel returned 503");
         return;
@@ -605,47 +593,43 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
     authedPage,
   }) => {
     test.setTimeout(60_000);
-    const { page, orgSlug } = authedPage;
+    const { page } = authedPage;
     const api = page.context().request;
     const cookie = await cookieHeader(page);
 
-    const presence = await establishPresence(api, orgSlug);
+    const presence = await establishPresence(api);
     presence.refresh();
 
     // A long-lived /events-style reply: headers, one chunk, then it stalls
     // until the abort signal fires (mirrors an SSE that never ends on its own).
     let observedAbort = false;
-    const sim = new ProxyDaemonSimulator(
-      orgSlug,
-      cookie,
-      async (_frame, w, signal) => {
-        await w.write({ type: "headers", status: 200, headers: {} });
-        await w.write({
-          type: "chunk",
-          data: b64(new TextEncoder().encode("open")),
-        });
-        // Wait for cancel — the SSE has no natural end.
-        await new Promise<void>((resolve) => {
-          if (signal.aborted) {
+    const sim = new ProxyDaemonSimulator(cookie, async (_frame, w, signal) => {
+      await w.write({ type: "headers", status: 200, headers: {} });
+      await w.write({
+        type: "chunk",
+        data: b64(new TextEncoder().encode("open")),
+      });
+      // Wait for cancel — the SSE has no natural end.
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          observedAbort = true;
+          return resolve();
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
             observedAbort = true;
-            return resolve();
-          }
-          signal.addEventListener(
-            "abort",
-            () => {
-              observedAbort = true;
-              resolve();
-            },
-            { once: true },
-          );
-        });
-      },
-    );
+            resolve();
+          },
+          { once: true },
+        );
+      });
+    });
     sim.start();
 
     const ac = new AbortController();
     try {
-      const ready = await warmup(orgSlug, cookie, sim);
+      const ready = await warmup(cookie, sim);
       if (ready === "no-nats") {
         test.skip(true, "NATS unavailable — proxy channel returned 503");
         return;
@@ -658,19 +642,16 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
         return;
       }
 
-      const res = await fetch(
-        `${BASE_URL}/api/${orgSlug}/links/proxy/_test/dispatch`,
-        {
-          method: "POST",
-          headers: { cookie, "content-type": "application/json" },
-          body: JSON.stringify({ method: "GET", path: "/_sandbox/events" }),
-          // Caller cancel (ac) OR a hard ceiling — whichever first.
-          signal: AbortSignal.any([
-            ac.signal,
-            AbortSignal.timeout(DISPATCH_FETCH_MS),
-          ]),
-        },
-      );
+      const res = await fetch(`${BASE_URL}/api/links/proxy/_test/dispatch`, {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ method: "GET", path: "/_sandbox/events" }),
+        // Caller cancel (ac) OR a hard ceiling — whichever first.
+        signal: AbortSignal.any([
+          ac.signal,
+          AbortSignal.timeout(DISPATCH_FETCH_MS),
+        ]),
+      });
       if (res.status === 503) {
         test.skip(true, "NATS unavailable — proxy channel returned 503");
         return;
@@ -714,37 +695,33 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
     authedPage,
   }) => {
     test.setTimeout(60_000);
-    const { page, orgSlug } = authedPage;
+    const { page } = authedPage;
     const api = page.context().request;
     const cookie = await cookieHeader(page);
 
-    const presence = await establishPresence(api, orgSlug);
+    const presence = await establishPresence(api);
     presence.refresh();
 
     // Simulator emits headers + a chunk, then ABRUPTLY drops the reply POST
     // (returns without an end/error frame). The route's catch publishes an
     // error frame to links.proxy.reply.<reqId>, so the caller rejects.
-    const sim = new ProxyDaemonSimulator(
-      orgSlug,
-      cookie,
-      async (_frame, w, signal) => {
-        await w.write({ type: "headers", status: 200, headers: {} });
-        await w.write({
-          type: "chunk",
-          data: b64(new TextEncoder().encode("partial")),
-        });
-        // Abort the reply POST locally (daemon vanished) — no terminal frame.
-        // We throw so the simulator's handler wrapper closes the controller; the
-        // cluster sees the body end without a terminal → no synthesized end, and
-        // the presence/POST-drop backstops are what end the caller.
-        void signal;
-        throw new Error("simulated daemon vanish");
-      },
-    );
+    const sim = new ProxyDaemonSimulator(cookie, async (_frame, w, signal) => {
+      await w.write({ type: "headers", status: 200, headers: {} });
+      await w.write({
+        type: "chunk",
+        data: b64(new TextEncoder().encode("partial")),
+      });
+      // Abort the reply POST locally (daemon vanished) — no terminal frame.
+      // We throw so the simulator's handler wrapper closes the controller; the
+      // cluster sees the body end without a terminal → no synthesized end, and
+      // the presence/POST-drop backstops are what end the caller.
+      void signal;
+      throw new Error("simulated daemon vanish");
+    });
     sim.start();
 
     try {
-      const ready = await warmup(orgSlug, cookie, sim);
+      const ready = await warmup(cookie, sim);
       if (ready === "no-nats") {
         test.skip(true, "NATS unavailable — proxy channel returned 503");
         return;
@@ -757,15 +734,12 @@ test.describe("pull reverse-proxy channel (Phase C-bis S5)", () => {
         return;
       }
 
-      const res = await fetch(
-        `${BASE_URL}/api/${orgSlug}/links/proxy/_test/dispatch`,
-        {
-          method: "POST",
-          headers: { cookie, "content-type": "application/json" },
-          body: JSON.stringify({ method: "GET", path: "/_sandbox/events" }),
-          signal: boundedSignal(DISPATCH_FETCH_MS),
-        },
-      );
+      const res = await fetch(`${BASE_URL}/api/links/proxy/_test/dispatch`, {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ method: "GET", path: "/_sandbox/events" }),
+        signal: boundedSignal(DISPATCH_FETCH_MS),
+      });
       if (res.status === 503) {
         test.skip(true, "NATS unavailable — proxy channel returned 503");
         return;

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -48,6 +48,9 @@ import {
 } from "./middleware/log-deprecated-route";
 import { resolveOrgFromPath } from "./middleware/resolve-org-from-path";
 import { createOrgScopedApi } from "./routes/org-scoped";
+import { createLinkWorkRoutes } from "./routes/decopilot/link-work-routes";
+import { createLinkControlRoutes } from "./routes/decopilot/link-control-routes";
+import { createLinkProxyRoutes } from "./routes/decopilot/link-proxy-routes";
 import { createVmEventsRoutes } from "./routes/vm-events";
 import {
   createDecoSitesOrgRoutes,
@@ -1867,6 +1870,35 @@ export async function createApp(options: CreateAppOptions = {}) {
     });
   });
 
+  // User-scoped link daemon long-poll routes. The link is the USER, not an org:
+  // each handler reads ctx.auth.user.id (populated by the global
+  // ContextFactory.create middleware, which resolves the MCP OAuth bearer via
+  // getMcpSession) and ignores org entirely. Mounted at /api/links/* next to
+  // /api/links/me; the org for each run travels on the work item (orgSlug).
+  if (linkWorkQueue != null) {
+    app.route(
+      "/api",
+      createLinkWorkRoutes({ linkClaimRegistry, workQueue: linkWorkQueue }),
+    );
+  }
+  if (natsProvider != null) {
+    app.route(
+      "/api",
+      createLinkControlRoutes({
+        getConnection: () => natsProvider!.getConnection(),
+      }),
+    );
+    app.route(
+      "/api",
+      createLinkProxyRoutes({
+        getConnection: () => natsProvider!.getConnection(),
+        // Only consumed by the non-production test-trigger route to wire the S5
+        // fail-fast watcher; production createProxyDispatch is wired separately.
+        claimRegistry: linkClaimRegistry,
+      }),
+    );
+  }
+
   // Stable file redirect endpoint (resolves mesh-storage: URIs to presigned URLs).
   // Resolve the org from the URL before serving so the stable URL cannot drift
   // to the session-active org when the path targets a different org.
@@ -2019,28 +2051,6 @@ export async function createApp(options: CreateAppOptions = {}) {
     eventsHandler,
     watchHandler,
     betterAuthProtectedResourceHandler,
-    linkWorkDeps:
-      linkWorkQueue != null
-        ? {
-            linkClaimRegistry,
-            workQueue: linkWorkQueue,
-          }
-        : undefined,
-    linkControlDeps:
-      natsProvider != null
-        ? {
-            getConnection: () => natsProvider!.getConnection(),
-          }
-        : undefined,
-    linkProxyDeps:
-      natsProvider != null
-        ? {
-            getConnection: () => natsProvider!.getConnection(),
-            // Only consumed by the non-production test-trigger route to wire the
-            // S5 fail-fast watcher; production createProxyDispatch is wired above.
-            claimRegistry: linkClaimRegistry,
-          }
-        : undefined,
   });
   app.route("/api/:org", orgScopedApi);
 

--- a/apps/mesh/src/api/routes/decopilot/control-frames.ts
+++ b/apps/mesh/src/api/routes/decopilot/control-frames.ts
@@ -2,7 +2,7 @@
  * Control-frame codec for the pull-transport control channel (Phase C).
  *
  * Control frames are published cluster-side to `links.control.<userSub>` (core
- * NATS) and consumed by the daemon via the long-poll GET /api/:org/links/control
+ * NATS) and consumed by the daemon via the long-poll GET /api/links/control
  * endpoint.
  *
  * Frame types:

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1620,7 +1620,7 @@ export async function pullDispatch(
   harnessInput: WireHarnessInput;
   messagesRef: MessagesRef | null;
   sandboxConfig: WorkItemSandbox | null;
-  orgSlug: string | null;
+  orgSlug: string;
 }> {
   return traced(
     "decopilot.pullDispatch",
@@ -1723,7 +1723,27 @@ export async function pullDispatch(
         }
       }
 
-      const orgSlug = ctx.organization?.slug ?? null;
+      // The pull daemon is user-scoped and no longer carries a startup org, so
+      // the work item MUST carry the org slug for the ingest URL. Prefer the
+      // request-resolved org; fall back to a slug lookup by org id so it can
+      // never be missing (the daemon has no DB access to resolve it).
+      // ctx.organization is normally populated by the org-scoped route middleware
+      // (/api/:org/...); the DB lookup is only a safety net for internal callers
+      // that bypass that middleware (e.g. background automation).
+      let orgSlug = ctx.organization?.slug ?? null;
+      if (!orgSlug) {
+        const orgRow = await ctx.db
+          .selectFrom("organization")
+          .select("slug")
+          .where("id", "=", input.organizationId)
+          .executeTakeFirst();
+        orgSlug = orgRow?.slug ?? null;
+      }
+      if (!orgSlug) {
+        throw new Error(
+          `pullDispatch: could not resolve org slug for organization ${input.organizationId}`,
+        );
+      }
 
       return {
         taskId,

--- a/apps/mesh/src/api/routes/decopilot/link-control-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-control-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Control long-poll endpoint for pull-transport daemons (Phase C).
  *
- * GET /api/:org/links/control
+ * GET /api/links/control
  *
  * The daemon holds this connection continuously waiting for cluster-side
  * control frames (e.g. cancel). Each poll cycle:

--- a/apps/mesh/src/api/routes/decopilot/link-proxy-frames.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-frames.ts
@@ -15,7 +15,7 @@
  *   path, headers, body? }`. The `reqId` correlates the reply leg.
  *
  * REPLY leg (daemon → cluster), POST body of
- *   `POST /api/:org/links/proxy/:reqId/stream` as a `duplex:"half"` upload:
+ *   `POST /api/links/proxy/:reqId/stream` as a `duplex:"half"` upload:
  *   A STREAM of NDJSON `ProxyReplyFrame` lines, consumed frame-by-frame WITHOUT
  *   buffering and each republished to `links.proxy.reply.<reqId>`. Ordering:
  *     1. AT MOST ONE `headers` frame, FIRST (before any `chunk`). The awaiting

--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
@@ -26,6 +26,10 @@
  *
  * Wire framing: NDJSON — see `link-proxy-frames.ts` for the authoritative spec
  * that the daemon side (S2) must match.
+ *
+ * Routes:
+ *   GET /api/links/proxy            — Request leg long-poll
+ *   POST /api/links/proxy/:reqId/stream — Reply leg upload
  */
 import { Hono } from "hono";
 import type { NatsConnection } from "nats";

--- a/apps/mesh/src/api/routes/decopilot/link-work-queue.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-work-queue.test.ts
@@ -28,7 +28,7 @@ describe("buildConsumerName", () => {
 });
 
 describe("workItemSchema", () => {
-  it("accepts a valid work item (no sandbox / orgSlug)", () => {
+  it("accepts a valid work item (no sandbox)", () => {
     const item = {
       runId: "run_01",
       threadId: "thrd_01",
@@ -36,6 +36,7 @@ describe("workItemSchema", () => {
       userId: "usr_01",
       runFenceToken: "tok-abc",
       harnessInput: { threadId: "thrd_01" },
+      orgSlug: "test-org",
     };
     const parsed = workItemSchema.safeParse(item);
     expect(parsed.success).toBe(true);
@@ -84,6 +85,7 @@ describe("workItemSchema", () => {
       runFenceToken: "tok-ghi",
       harnessInput: { threadId: "thrd_03" },
       sandbox: { handle: "agent-vm-xyz" },
+      orgSlug: "test-org",
     };
     const parsed = workItemSchema.safeParse(item);
     expect(parsed.success).toBe(true);
@@ -123,6 +125,7 @@ describe("workItemSchema", () => {
       userId: "usr_05",
       runFenceToken: "tok-mno",
       harnessInput: { threadId: "thrd_05", messages: [] },
+      orgSlug: "test-org",
       messagesRef: {
         url: "https://s3.example.com/link-dispatch/abc123?X-Amz-Signature=sig",
         bytes: 123456,
@@ -146,10 +149,23 @@ describe("workItemSchema", () => {
       userId: "usr_06",
       runFenceToken: "tok-pqr",
       harnessInput: { threadId: "thrd_06" },
+      orgSlug: "test-org",
     };
     const parsed = workItemSchema.safeParse(item);
     expect(parsed.success).toBe(true);
     if (!parsed.success) return;
     expect(parsed.data.messagesRef).toBeUndefined();
+  });
+
+  it("rejects a work item missing orgSlug", () => {
+    const item = {
+      runId: "run_07",
+      threadId: "thrd_07",
+      orgId: "org_07",
+      userId: "usr_07",
+      runFenceToken: "tok-stu",
+      harnessInput: { threadId: "thrd_07" },
+    };
+    expect(workItemSchema.safeParse(item).success).toBe(false);
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/link-work-queue.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-work-queue.ts
@@ -113,11 +113,12 @@ export const workItemSchema = z.object({
    */
   sandbox: workItemSandboxSchema.optional(),
   /**
-   * Organization slug for the ingest URL path segment. Carried here so
-   * the daemon doesn't need to resolve it from `orgId` (UUID) without DB
-   * access. When absent, the daemon falls back to `DECO_ORG_SLUG` env var.
+   * Organization slug for the ingest URL path segment. Always present — the
+   * dispatcher resolves it (from the request org or a DB lookup by org id) so
+   * the user-scoped daemon can build the org-scoped ingest URL without a DB
+   * lookup of its own.
    */
-  orgSlug: z.string().optional(),
+  orgSlug: z.string(),
   /**
    * Object-storage ref for the offloaded `harnessInput.messages` array.
    * Present when the encoded harnessInput exceeded the NATS `MAX_PUBLISH_BYTES`

--- a/apps/mesh/src/api/routes/decopilot/link-work-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-work-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Work long-poll endpoint for pull-transport daemons (spec §3.2).
  *
- * GET /api/:org/links/work
+ * GET /api/links/work
  *
  * The daemon holds this connection continuously (even idle). Each poll cycle:
  *   1. Refreshes the studio_links presence claim (TTL re-arms on put).

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -25,15 +25,6 @@ import { createTriggerCallbackRoutes } from "./trigger-callback";
 import { createVirtualMcpRoutes } from "./virtual-mcp";
 import { createSandboxRoutes } from "./sandbox-proxy";
 import { createLinkIngestRoutes } from "./decopilot/link-ingest-routes";
-import { createLinkWorkRoutes } from "./decopilot/link-work-routes";
-import { createLinkControlRoutes } from "./decopilot/link-control-routes";
-import {
-  createLinkProxyRoutes,
-  type LinkProxyDeps,
-} from "./decopilot/link-proxy-routes";
-import type { LinkClaimRegistry } from "@/links/link-claim-registry";
-import type { LinkWorkQueue } from "./decopilot/link-work-queue";
-import type { NatsConnection } from "nats";
 
 interface OrgScopedDeps {
   kvStorage: KVStorage;
@@ -61,27 +52,6 @@ interface OrgScopedDeps {
    * connection's `organization_id` matches the resolved org).
    */
   oauthProxyHandler: MiddlewareHandler<Env>;
-  /**
-   * Link work-queue and claim registry for pull-transport work polling.
-   * Optional: when absent the GET /links/work route is not mounted.
-   */
-  linkWorkDeps?: {
-    linkClaimRegistry: LinkClaimRegistry;
-    workQueue: LinkWorkQueue;
-  };
-  /**
-   * NATS connection getter for the pull-transport control long-poll.
-   * Optional: when absent the GET /links/control route is not mounted.
-   */
-  linkControlDeps?: {
-    getConnection: () => NatsConnection | null;
-  };
-  /**
-   * NATS connection getter for the pull reverse-proxy channel (Phase C-bis).
-   * Optional: when absent the /links/proxy routes are not mounted. DORMANT —
-   * no production caller holds the GET open yet (S3 wires the provider).
-   */
-  linkProxyDeps?: LinkProxyDeps;
   /**
    * Public events handler (defined in app.ts). Mounted at
    * `POST /api/:org/events/:type`.
@@ -124,16 +94,6 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   ); // /api/:org/trigger-callback
   app.route("/webhooks", createAutomationWebhookRoutes()); // /api/:org/webhooks/:triggerId[/:token]
   app.route("/", createLinkIngestRoutes({ streamBuffer: deps.streamBuffer })); // /api/:org/links/runs/:runId/stream
-  if (deps.linkWorkDeps) {
-    app.route("/", createLinkWorkRoutes(deps.linkWorkDeps)); // /api/:org/links/work
-  }
-  if (deps.linkControlDeps) {
-    app.route("/", createLinkControlRoutes(deps.linkControlDeps)); // /api/:org/links/control
-  }
-  if (deps.linkProxyDeps) {
-    // /api/:org/links/proxy + /api/:org/links/proxy/:reqId/stream (dormant)
-    app.route("/", createLinkProxyRoutes(deps.linkProxyDeps));
-  }
 
   if (deps.mountDevAssets) {
     app.route("/dev-assets", createDevAssetsRoutes({ orgFromPath: true }));

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -309,9 +309,6 @@ if (command === "link") {
     // Managed daemons (dev / npx --local-sandbox-provider) suppress the
     // banner — the parent dev/serve process already renders one.
     banner: process.env.DECOCMS_LINK_MANAGED !== "1",
-    // Org slug for the org-scoped pull transport. Optional: falls back to
-    // DECO_ORG_SLUG, then auto-resolves the user's single org from the cluster.
-    orgSlug: values.org as string | undefined,
   });
   process.exit(code);
 }

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -107,63 +107,6 @@ async function assertStudioAcceptsToken(
   }
 }
 
-/**
- * Resolve the organization slug the daemon links against. The pull transport
- * routes are org-scoped (`/api/:org/links/*`), so a slug is required (the old
- * WS endpoint `/api/links/connect` was unscoped, so this used to be implicit).
- * Resolution: explicit `--org` → `DECO_ORG_SLUG` → the user's single org
- * (listed from the cluster with the session token). Throws a clear, actionable
- * error if it can't be determined.
- */
-async function resolveOrgSlug(
-  clusterBaseUrl: string,
-  token: string,
-  explicit: string | undefined,
-): Promise<string> {
-  const fromOpt = explicit?.trim();
-  if (fromOpt) return fromOpt;
-  const fromEnv = process.env.DECO_ORG_SLUG?.trim();
-  if (fromEnv) return fromEnv;
-  let res: Response;
-  try {
-    res = await fetch(`${clusterBaseUrl}/api/auth/organization/list`, {
-      headers: { authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(10_000),
-    });
-  } catch (err) {
-    throw new Error(
-      `Could not resolve your organization from ${clusterBaseUrl} ` +
-        `(${err instanceof Error ? err.message : String(err)}). ` +
-        `Pass --org <slug> or set DECO_ORG_SLUG.`,
-    );
-  }
-  if (!res.ok) {
-    throw new Error(
-      `Could not list organizations on ${clusterBaseUrl} (HTTP ${res.status}). ` +
-        `Pass --org <slug> or set DECO_ORG_SLUG.`,
-    );
-  }
-  const orgs = (await res.json().catch(() => null)) as Array<{
-    slug?: string;
-  }> | null;
-  const slugs = Array.isArray(orgs)
-    ? orgs.map((o) => o?.slug).filter((s): s is string => Boolean(s))
-    : [];
-  if (slugs.length === 0) {
-    throw new Error(
-      `No organization found for your account on ${clusterBaseUrl}. ` +
-        `Create one first, then re-run, or pass --org <slug>.`,
-    );
-  }
-  if (slugs.length > 1) {
-    throw new Error(
-      `You belong to multiple organizations (${slugs.join(", ")}). ` +
-        `Pass --org <slug> or set DECO_ORG_SLUG to choose which to link.`,
-    );
-  }
-  return slugs[0]!;
-}
-
 export async function runLinkCommand(
   opts: LinkCommandOptions = {},
 ): Promise<number> {
@@ -196,15 +139,6 @@ export async function runLinkCommand(
     if (process.env.DECOCMS_LINK_MANAGED !== "1") {
       await assertStudioAcceptsToken(clusterBaseUrl, session.accessToken);
     }
-
-    // The pull transport is org-scoped (`/api/:org/links/*`) — resolve the org
-    // slug before starting the daemon (else it exits with "requires an org
-    // slug"). Surfaces a clear error here, before any TUI render.
-    const orgSlug = await resolveOrgSlug(
-      clusterBaseUrl,
-      session.accessToken,
-      opts.orgSlug,
-    );
 
     let monitor: LinkDaemonMonitor | undefined;
 
@@ -252,7 +186,6 @@ export async function runLinkCommand(
       session,
       monitor,
       logFd,
-      orgSlug,
     });
     return await handle.stopped;
   } catch (err) {

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -2,8 +2,8 @@
  * `deco link` — start the desktop-side link daemon.
  *
  * Uses a pure-pull transport: long-polls `/api/links/work` for
- * dispatched sandbox requests, `/links/control` for cluster control frames,
- * and `/links/proxy` for reverse-proxy traffic. Presence is maintained via a
+ * dispatched sandbox requests, `/api/links/control` for cluster control frames,
+ * and `/api/links/proxy` for reverse-proxy traffic. Presence is maintained via a
  * 60 s NATS-KV TTL re-armed on every poll. Also runs a local ingress on
  * `--port` for `<handle>.localhost` sandbox previews.
  *

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -1,7 +1,7 @@
 /**
  * `deco link` — start the desktop-side link daemon.
  *
- * Uses a pure-pull transport: long-polls `/api/:org/links/work` for
+ * Uses a pure-pull transport: long-polls `/api/links/work` for
  * dispatched sandbox requests, `/links/control` for cluster control frames,
  * and `/links/proxy` for reverse-proxy traffic. Presence is maintained via a
  * 60 s NATS-KV TTL re-armed on every poll. Also runs a local ingress on
@@ -33,13 +33,6 @@ export interface LinkCommandOptions {
    * `dev`/`serve` TUI.
    */
   banner?: boolean;
-  /**
-   * Organization slug the daemon links against. The pull transport is
-   * org-scoped (`/api/:org/links/*`), so the daemon needs to know which org.
-   * Resolution order: this option → `DECO_ORG_SLUG` env → auto-resolve from
-   * the cluster (the user's single org; ambiguous if they belong to several).
-   */
-  orgSlug?: string;
 }
 
 /**

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -191,7 +191,7 @@ export interface ThreadGateRuntime {
     harnessInput: WireHarnessInput;
     messagesRef: MessagesRef | null;
     sandboxConfig: WorkItemSandbox | null;
-    orgSlug: string | null;
+    orgSlug: string;
   }>;
   workQueue?: LinkWorkQueue;
   /**
@@ -353,7 +353,7 @@ async function dispatchRunAndWaitStep(ctx: ThreadGateContext): Promise<void> {
       runFenceToken,
       harnessInput: harnessInput as Record<string, unknown>,
       ...(sandboxConfig ? { sandbox: sandboxConfig } : {}),
-      ...(orgSlug ? { orgSlug } : {}),
+      orgSlug,
       ...(messagesRef ? { messagesRef } : {}),
     };
     await rt.workQueue!.publish(request.userId, workItem);

--- a/apps/mesh/src/link-daemon/cluster-connection-pull.test.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-pull.test.ts
@@ -238,6 +238,7 @@ describe("sandbox config propagation", () => {
       orgId: "org-1",
       userId: "usr-1",
       runFenceToken: "tok-1",
+      orgSlug: "test-org",
       harnessInput: { agent: { id: "vm-abc" }, branch: "deco/my-branch" },
       sandbox: {
         handle: "agent-vm-abc-deco/my-branch",
@@ -277,6 +278,7 @@ describe("sandbox config propagation", () => {
       orgId: "org-2",
       userId: "usr-2",
       runFenceToken: "tok-2",
+      orgSlug: "test-org",
       harnessInput: { agent: { id: "vm-def" }, branch: "deco/other" },
     };
 

--- a/apps/mesh/src/link-daemon/cluster-connection-pull.test.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-pull.test.ts
@@ -239,7 +239,7 @@ describe("sandbox config propagation", () => {
     expect(call?.workload).toBeUndefined();
   });
 
-  it("prefers item.orgSlug over connection-level orgSlug for ingest", async () => {
+  it("uses item.orgSlug for the ingest URL", async () => {
     // We verify this indirectly: the dispatch will fail (sandbox token is
     // stub, ingest URL would 404) but the ensureSandbox call already ran.
     // The real check is that orgSlug on the item is accepted by the schema

--- a/apps/mesh/src/link-daemon/cluster-connection-pull.test.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-pull.test.ts
@@ -93,57 +93,6 @@ describe("LINK_TRANSPORT_MODE gate (env var logic)", () => {
   });
 });
 
-describe("org slug resolution logic", () => {
-  it("prefers caller-supplied orgSlug over DECO_ORG_SLUG env", () => {
-    const originalEnv = process.env.DECO_ORG_SLUG;
-    try {
-      process.env.DECO_ORG_SLUG = "from-env";
-      const callerSupplied = "from-caller";
-      // Mirrors the resolution in index.ts: opts.orgSlug ?? process.env.DECO_ORG_SLUG
-      const resolved = callerSupplied ?? process.env.DECO_ORG_SLUG;
-      expect(resolved).toBe("from-caller");
-    } finally {
-      if (originalEnv === undefined) {
-        delete process.env.DECO_ORG_SLUG;
-      } else {
-        process.env.DECO_ORG_SLUG = originalEnv;
-      }
-    }
-  });
-
-  it("falls back to DECO_ORG_SLUG when caller did not supply orgSlug", () => {
-    const originalEnv = process.env.DECO_ORG_SLUG;
-    try {
-      process.env.DECO_ORG_SLUG = "from-env";
-      const callerSupplied = undefined;
-      const resolved = callerSupplied ?? process.env.DECO_ORG_SLUG;
-      expect(resolved).toBe("from-env");
-    } finally {
-      if (originalEnv === undefined) {
-        delete process.env.DECO_ORG_SLUG;
-      } else {
-        process.env.DECO_ORG_SLUG = originalEnv;
-      }
-    }
-  });
-
-  it("is undefined when neither caller nor env provides the slug", () => {
-    const originalEnv = process.env.DECO_ORG_SLUG;
-    try {
-      delete process.env.DECO_ORG_SLUG;
-      const callerSupplied = undefined;
-      const resolved = callerSupplied ?? process.env.DECO_ORG_SLUG;
-      expect(resolved).toBeUndefined();
-    } finally {
-      if (originalEnv === undefined) {
-        delete process.env.DECO_ORG_SLUG;
-      } else {
-        process.env.DECO_ORG_SLUG = originalEnv;
-      }
-    }
-  });
-});
-
 describe("sandbox config propagation", () => {
   /**
    * Creates a stub provider that records ensureSandbox calls.
@@ -218,7 +167,6 @@ describe("sandbox config propagation", () => {
 
     const handle = await connectToClusterPull({
       clusterBaseUrl: "https://example.com",
-      orgSlug: "test-org",
       getAccessToken: async () => "access-tok",
       provider,
       fetchImpl,
@@ -364,7 +312,6 @@ describe("connectToClusterPull close()/abort", () => {
 
     const handle = await connectToClusterPull({
       clusterBaseUrl: "https://example.com",
-      orgSlug: "test-org",
       getAccessToken: async () => "test-token",
       provider,
       fetchImpl,
@@ -375,32 +322,5 @@ describe("connectToClusterPull close()/abort", () => {
     // If we reach here the loop exited cleanly. Verify the closed promise
     // is already resolved (should settle within close()).
     await expect(handle.closed).resolves.toBeUndefined();
-  });
-
-  it("throws when orgSlug is missing", async () => {
-    const provider: DesktopSandboxProvider = {
-      ensureSandbox: async () => ({
-        sandboxApiUrl: "http://127.0.0.1:9999",
-        previewUrl: "http://127.0.0.1:9999",
-        port: 9999,
-      }),
-      proxyPort: () => null,
-      getDaemonToken: () => null,
-      hasHandle: () => false,
-      recordHit: () => {},
-      acquireDispatch: () => () => {},
-      listSandboxes: () => [],
-      deleteSandbox: async () => {},
-      shutdown: async () => {},
-    };
-
-    await expect(
-      connectToClusterPull({
-        clusterBaseUrl: "https://example.com",
-        orgSlug: "",
-        getAccessToken: async () => "test-token",
-        provider,
-      }),
-    ).rejects.toThrow("connectToClusterPull: orgSlug is required");
   });
 });

--- a/apps/mesh/src/link-daemon/cluster-connection-pull.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-pull.ts
@@ -2,7 +2,7 @@
  * Pull-transport cluster connection entry point (Phase D, spec §3.1).
  *
  * Instead of a persistent WebSocket, runs a long-poll work loop that pulls
- * work items from `GET /api/:org/links/work` and dispatches each item to the
+ * work items from `GET /api/links/work` and dispatches each item to the
  * local sandbox via `handleLocalDispatch`, plus the proxy poll loop
  * (`runProxyPollLoop`) for sandbox control/events/vm-tools.
  *
@@ -11,15 +11,8 @@
  *
  * ⚠️ SHIPPED DAEMON — needs human review before merge.
  *
- * ORG DISCOVERY NOTE:
- * The daemon links a user who may span multiple orgs. The pull loop requires
- * a single org slug for the `/api/:org/links/work` endpoint. Currently `orgSlug`
- * must be supplied by the caller (sourced from `DECO_ORG_SLUG` env var or from
- * `StartLinkDaemonOptions.orgSlug`). Multi-org polling is a follow-up — for now
- * a single primary org is used.
- *
- * TODO(Phase D follow-up): multi-org polling — run one `runWorkPollLoop` per org
- * if the daemon is linked against multiple orgs.
+ * The daemon is user-scoped; there is no startup org. The org slug travels per
+ * work item (`item.orgSlug`) and is used only at ingest time.
  */
 
 import { runWorkPollLoop } from "./work-poller";
@@ -39,14 +32,6 @@ export interface ClusterConnectionPullInput {
    * Used as both the work-poll base URL and the ingest POST base URL.
    */
   clusterBaseUrl: string;
-  /**
-   * Org SLUG for the org-scoped `/api/:org/links/work` endpoint and the
-   * ingest POST path. MUST be the slug, not the UUID orgId.
-   *
-   * NOTE: the daemon currently supports a single primary org for the pull
-   * loop. Multi-org polling is a follow-up (see module header).
-   */
-  orgSlug: string;
   /**
    * Bearer token resolver. Called before each poll and before each ingest
    * POST so a refreshed token reaches every request (mirrors the WS path's
@@ -155,9 +140,6 @@ function deriveHandle(item: WorkItem): string {
 export async function connectToClusterPull(
   input: ClusterConnectionPullInput,
 ): Promise<ClusterConnectionHandle> {
-  if (!input.orgSlug)
-    throw new Error("connectToClusterPull: orgSlug is required");
-
   const ac = new AbortController();
   let resolveClosed!: () => void;
   const closed = new Promise<void>((r) => {
@@ -166,12 +148,11 @@ export async function connectToClusterPull(
 
   input.onConnected?.();
   console.log(
-    `[cluster-connection-pull] starting pull-transport loop org=${input.orgSlug} cluster=${input.clusterBaseUrl}`,
+    `[cluster-connection-pull] starting pull-transport loop cluster=${input.clusterBaseUrl}`,
   );
 
   const workPollDone = runWorkPollLoop({
     baseUrl: input.clusterBaseUrl,
-    orgSlug: input.orgSlug,
     getAccessToken: input.getAccessToken,
     signal: ac.signal,
     fetchImpl: input.fetchImpl,
@@ -237,10 +218,9 @@ export async function connectToClusterPull(
       // the LRU eviction logic skips it (activeDispatchCount > 0). Released in
       // `finally` to guarantee the counter is always decremented.
       //
-      // Prefer `item.orgSlug` (resolved cluster-side at pullDispatch time) over
-      // the daemon's configured `input.orgSlug` — the work item's slug is
-      // authoritative when present, avoiding reliance on DECO_ORG_SLUG env.
-      const effectiveOrgSlug = item.orgSlug ?? input.orgSlug;
+      // The work item's orgSlug is authoritative — it is resolved cluster-side
+      // at pullDispatch time and is always present (required field on WorkItem).
+      const effectiveOrgSlug = item.orgSlug;
       const releaseDispatch = input.provider.acquireDispatch(handle);
       // Phase C: register a per-run AbortController so the control-poll loop
       // can abort this specific dispatch when the cluster sends a cancel frame.
@@ -275,7 +255,6 @@ export async function connectToClusterPull(
   // which in turn fires AbortSignal.any([ac.signal, runAc.signal]) inside onWork.
   const controlPollDone = runControlPollLoop({
     baseUrl: input.clusterBaseUrl,
-    orgSlug: input.orgSlug,
     getAccessToken: input.getAccessToken,
     signal: ac.signal,
     fetchImpl: input.fetchImpl,
@@ -299,7 +278,6 @@ export async function connectToClusterPull(
   const proxyPollDone = input.controlHandler
     ? runProxyPollLoop({
         baseUrl: input.clusterBaseUrl,
-        orgSlug: input.orgSlug,
         getAccessToken: input.getAccessToken,
         controlHandler: input.controlHandler,
         signal: ac.signal,

--- a/apps/mesh/src/link-daemon/control-poller.test.ts
+++ b/apps/mesh/src/link-daemon/control-poller.test.ts
@@ -5,12 +5,11 @@
  * work-poller.test.ts). Focus: `cancel` routes to onCancel(runId) and
  * `cancel_req` routes to onCancelReq(reqId).
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import { runControlPollLoop } from "./control-poller";
 import { encodeControlFrame } from "../api/routes/decopilot/control-frames";
 
 const BASE_URL = "https://studio.example.com";
-const ORG_SLUG = "acme";
 
 function jsonResponse(status: number, text: string): Response {
   return {
@@ -38,7 +37,6 @@ describe("runControlPollLoop frame routing", () => {
 
     await runControlPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       getAccessToken: () => "tok",
       signal: ac.signal,
       fetchImpl,
@@ -67,7 +65,6 @@ describe("runControlPollLoop frame routing", () => {
 
     await runControlPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       getAccessToken: () => "tok",
       signal: ac.signal,
       fetchImpl,
@@ -97,7 +94,6 @@ describe("runControlPollLoop frame routing", () => {
     // No onCancelReq — must not throw / must keep looping until abort.
     await runControlPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       getAccessToken: () => "tok",
       signal: ac.signal,
       fetchImpl,
@@ -105,5 +101,29 @@ describe("runControlPollLoop frame routing", () => {
     });
 
     expect(call).toBeGreaterThanOrEqual(2);
+  });
+
+  it("uses the correct user-scoped URL with the timeout param", async () => {
+    const urls: string[] = [];
+    const ac = new AbortController();
+
+    const fetchImpl = mock(async (url: string) => {
+      urls.push(url);
+      ac.abort();
+      return new Response(null, { status: 204 });
+    });
+
+    await runControlPollLoop({
+      baseUrl: "https://cluster.example.com",
+      getAccessToken: async () => "tok",
+      signal: ac.signal,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      pollTimeoutSecs: 15,
+      onCancel: () => {},
+    });
+
+    expect(urls[0]).toBe(
+      "https://cluster.example.com/api/links/control?timeout=15",
+    );
   });
 });

--- a/apps/mesh/src/link-daemon/control-poller.ts
+++ b/apps/mesh/src/link-daemon/control-poller.ts
@@ -1,7 +1,7 @@
 /**
  * Control-poll loop for the pull-transport control channel (Phase C).
  *
- * Continuously long-polls GET /api/:org/links/control. On a 200 response,
+ * Continuously long-polls GET /api/links/control. On a 200 response,
  * decodes the body as a ControlFrame and dispatches:
  *   - `cancel`     → calls `onCancel(frame.runId)` to abort the in-flight RUN
  *                    (work-poll dispatch path → run-abort-registry).
@@ -26,8 +26,6 @@ import { decodeControlFrame } from "../api/routes/decopilot/control-frames";
 export interface ControlPollerDeps {
   /** Fully-qualified base URL, e.g. "https://studio.deco.cx". */
   baseUrl: string;
-  /** Org slug for the org-scoped route /api/:org/links/control. */
-  orgSlug: string;
   /**
    * Bearer token resolver. Called before each request so a refreshed token
    * reaches every poll without pinning a stale credential (mirrors
@@ -65,7 +63,7 @@ const MAX_DELAY_MS = 30_000;
  *
  * Structural twin of `runWorkPollLoop` (work-poller.ts):
  *   1. Resolves a fresh bearer token.
- *   2. GETs /api/:org/links/control?timeout=<N>.
+ *   2. GETs /api/links/control?timeout=<N>.
  *   3. On 200: decodes ControlFrame; dispatches cancel/keep_alive.
  *      On 204: server held the long-poll window; re-polls immediately.
  *      On error / bad-status: backs off with exponential-backoff-with-jitter.
@@ -74,11 +72,10 @@ const MAX_DELAY_MS = 30_000;
 export async function runControlPollLoop(
   deps: ControlPollerDeps,
 ): Promise<void> {
-  const { baseUrl, orgSlug, getAccessToken, signal, onCancel, onCancelReq } =
-    deps;
+  const { baseUrl, getAccessToken, signal, onCancel, onCancelReq } = deps;
   const fetcher = deps.fetchImpl ?? fetch;
   const pollTimeout = deps.pollTimeoutSecs ?? 29;
-  const url = `${baseUrl}/api/${orgSlug}/links/control?timeout=${pollTimeout}`;
+  const url = `${baseUrl}/api/links/control?timeout=${pollTimeout}`;
   let errorStreak = 0;
 
   while (!signal.aborted) {

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
@@ -28,6 +28,7 @@ const validWorkItem: WorkItem = {
   orgId: "org_01",
   userId: "usr_01",
   runFenceToken: FENCE_TOKEN,
+  orgSlug: ORG_SLUG,
   harnessInput: {
     threadId: "thrd_01",
     runId: RUN_ID,

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.ts
@@ -18,13 +18,11 @@
  *      (link-ingest-routes.ts) which commits parts to durable storage.
  *
  * ⚠️ ORG SLUG vs ID NOTE:
- *   WorkItem carries `orgId` (the DB UUID), but the ingest route uses
- *   `resolveOrgFromPath` which looks up the org by its URL-safe SLUG (the
- *   `:org` path segment in `/api/:org/links/runs/...`). The caller (Task 8
- *   / index.ts pull-loop-entry) MUST supply `orgSlug` in LocalDispatchDeps
- *   — it is NOT derivable from orgId here without a DB lookup. The
- *   `runWorkPollLoop` already receives `orgSlug`; the onWork handler should
- *   thread it through to `handleLocalDispatch`.
+ *   WorkItem carries `orgId` (the DB UUID) and `orgSlug` (the URL-safe slug).
+ *   The ingest route uses `resolveOrgFromPath` which looks up the org by slug
+ *   (the `:org` path segment in `/api/:org/links/runs/...`). The `orgSlug`
+ *   field on the work item is required and must be passed to
+ *   `LocalDispatchDeps.orgSlug` so it is available for the ingest URL.
  *
  * ⚠️ HARNESS ID NOTE:
  *   `WorkItem.harnessInput` is a `HarnessStreamInputWire` — a plain JSON
@@ -60,9 +58,8 @@ export interface LocalDispatchDeps {
   clusterBaseUrl: string;
   /**
    * Org SLUG for the ingest URL path segment. MUST be the slug, not the
-   * UUID orgId — resolveOrgFromPath looks up by slug. The caller (Task 8 /
-   * pull-loop-entry) sources this from the same `orgSlug` it passes to
-   * `runWorkPollLoop`.
+   * UUID orgId — resolveOrgFromPath looks up by slug. Sourced from the work
+   * item's required `orgSlug` field.
    */
   orgSlug: string;
   /**

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -52,15 +52,6 @@ export interface StartLinkDaemonOptions {
    * `ensureSession()` before invoking the daemon.
    */
   session: Session;
-  /**
-   * Org slug for the pull work-poll loop (`/api/:org/links/work`).
-   * Required for the pull transport (the only transport); falls back to
-   * `process.env.DECO_ORG_SLUG` if not supplied here.
-   *
-   * NOTE: the daemon currently supports a single primary org for the pull loop.
-   * Multi-org polling is a Phase D follow-up.
-   */
-  orgSlug?: string;
   /** Optional TUI hooks. Omitted in --no-tui mode. */
   monitor?: LinkDaemonMonitor;
   /**
@@ -201,22 +192,10 @@ export async function startLinkDaemon(
   };
 
   // Phase C-bis S8: the reverse-WS transport was deleted; the pull transport is
-  // the only path. The daemon long-polls `/api/:org/links/work` (chat) and
+  // the only path. The daemon long-polls `/api/links/work` (chat) and
   // `/links/proxy` (sandbox control/events/vm-tools), sharing the same
   // `controlHandler`, `provider`, and `getAccessToken` resolver.
-  //
-  // Resolve org slug: caller-supplied > env var > fatal.
-  const orgSlug = opts.orgSlug ?? process.env.DECO_ORG_SLUG;
-  if (!orgSlug) {
-    console.error(
-      "[link-daemon] pull transport requires an org slug. " +
-        "Pass `orgSlug` to startLinkDaemon or set DECO_ORG_SLUG.",
-    );
-    process.exit(1);
-  }
-  console.log(
-    `[link-daemon] transport=pull org=${orgSlug} cluster=${opts.clusterBaseUrl}`,
-  );
+  console.log(`[link-daemon] transport=pull cluster=${opts.clusterBaseUrl}`);
   // Advertise the daemon's identity + capabilities on every poll (the
   // x-link-* headers). The cluster mints the presence claim from these, and
   // `resolveDispatchTarget` checks the capabilities — without them the claim is
@@ -228,7 +207,6 @@ export async function startLinkDaemon(
   const capabilities = await detectCapabilities();
   const cluster = await connectToClusterPull({
     clusterBaseUrl: opts.clusterBaseUrl,
-    orgSlug,
     getAccessToken,
     provider,
     // The in-process control handler also serves the pull reverse-proxy loop's

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -4,7 +4,7 @@
  * - Receives an authenticated session from its caller (the CLI's `link`
  *   command obtains one via `ensureSession`).
  * - Runs the pull transport (`connectToClusterPull`): long-polls
- *   `<MESH_CLUSTER_URL>/api/:org/links/work` for chat work and `/links/proxy`
+ *   `<MESH_CLUSTER_URL>/api/links/work` for chat work and `/links/proxy`
  *   for sandbox control/events/vm-tools, re-resolving the bearer per poll.
  * - Spawns the local ingress on `--port` so browsers can reach
  *   `<handle>.localhost:<port>` for sandbox previews.

--- a/apps/mesh/src/link-daemon/proxy-poller.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.ts
@@ -3,10 +3,10 @@
  *
  * The desktop daemon is outbound-only, so the cluster cannot push the sandbox
  * control/events/vm-tools traffic to it. Instead the daemon long-polls
- * `GET /api/:org/links/proxy`; the cluster publishes one `RequestFrame` per
+ * `GET /api/links/proxy`; the cluster publishes one `RequestFrame` per
  * call (queue-group `link-proxy`). The daemon runs the request locally and
  * streams the framed reply back to the cluster as a `duplex:"half"` upload to
- * `POST /api/:org/links/proxy/:reqId/stream`.
+ * `POST /api/links/proxy/:reqId/stream`.
  *
  * Path routing (S3): the proxy channel serves ALL provider ops, not just the
  * `/_sandbox` streaming family. `buildReplyBody` dispatches `/api/sandboxes*`
@@ -55,8 +55,6 @@ const DEFAULT_PROXY_CONCURRENCY = 2;
 export interface ProxyPollerDeps {
   /** Fully-qualified base URL, e.g. "https://studio.deco.cx". */
   baseUrl: string;
-  /** Org slug for the org-scoped routes /api/:org/links/proxy[/...]. */
-  orgSlug: string;
   /**
    * Bearer token resolver. Called before each GET / reply-POST so a refreshed
    * token reaches every request (mirrors work-poller.ts's getAccessToken).
@@ -262,7 +260,7 @@ async function handleProxyRequest(
   frame: RequestFrame,
   deps: Pick<
     ProxyPollerDeps,
-    "baseUrl" | "orgSlug" | "getAccessToken" | "controlHandler" | "fetchImpl"
+    "baseUrl" | "getAccessToken" | "controlHandler" | "fetchImpl"
   > & { signal: AbortSignal },
 ): Promise<void> {
   const fetcher = deps.fetchImpl ?? fetch;
@@ -286,7 +284,7 @@ async function handleProxyRequest(
     }
 
     const body = buildReplyBody(deps.controlHandler, frame, combined);
-    const url = `${deps.baseUrl}/api/${deps.orgSlug}/links/proxy/${reqId}/stream`;
+    const url = `${deps.baseUrl}/api/links/proxy/${reqId}/stream`;
 
     try {
       const res = await fetcher(url, {
@@ -405,13 +403,13 @@ export async function runOverlapScheduler(
  * Run the proxy-poll loop with continuous overlap. Resolves when `signal` is
  * aborted and all in-flight polls have settled.
  *
- * Wires the real HTTP `pollOnce` (GET /api/:org/links/proxy) and the detached
+ * Wires the real HTTP `pollOnce` (GET /api/links/proxy) and the detached
  * `handle` (handleProxyRequest) into `runOverlapScheduler`.
  */
 export async function runProxyPollLoop(deps: ProxyPollerDeps): Promise<void> {
   const fetcher = deps.fetchImpl ?? fetch;
   const concurrency = deps.concurrency ?? DEFAULT_PROXY_CONCURRENCY;
-  const url = `${deps.baseUrl}/api/${deps.orgSlug}/links/proxy`;
+  const url = `${deps.baseUrl}/api/links/proxy`;
 
   const pollOnce = async (): Promise<RequestFrame | null> => {
     const token = await deps.getAccessToken();
@@ -446,7 +444,6 @@ export async function runProxyPollLoop(deps: ProxyPollerDeps): Promise<void> {
     // Detached — fire-and-forget. handleProxyRequest never throws.
     void handleProxyRequest(frame, {
       baseUrl: deps.baseUrl,
-      orgSlug: deps.orgSlug,
       getAccessToken: deps.getAccessToken,
       controlHandler: deps.controlHandler,
       fetchImpl: deps.fetchImpl,

--- a/apps/mesh/src/link-daemon/work-poller.test.ts
+++ b/apps/mesh/src/link-daemon/work-poller.test.ts
@@ -71,7 +71,6 @@ describe("runWorkPollLoop", () => {
 
     await runWorkPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       onWork: async (item) => {
         received.push(item);
       },
@@ -100,7 +99,6 @@ describe("runWorkPollLoop", () => {
 
     await runWorkPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       onWork: async (item) => {
         received.push(item);
       },
@@ -131,7 +129,6 @@ describe("runWorkPollLoop", () => {
 
     await runWorkPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       onWork: async (item) => {
         received.push(item);
       },
@@ -152,7 +149,6 @@ describe("runWorkPollLoop", () => {
 
     await runWorkPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       onWork: async () => {},
       getAccessToken: async () => "tok",
       signal: ac.signal,
@@ -163,7 +159,7 @@ describe("runWorkPollLoop", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("uses the correct URL including orgSlug and timeout param", async () => {
+  it("uses the correct user-scoped URL with the timeout param", async () => {
     const urls: string[] = [];
     const ac = new AbortController();
 
@@ -175,7 +171,6 @@ describe("runWorkPollLoop", () => {
 
     await runWorkPollLoop({
       baseUrl: "https://cluster.example.com",
-      orgSlug: "my-org",
       onWork: async () => {},
       getAccessToken: async () => "tok",
       signal: ac.signal,
@@ -184,7 +179,7 @@ describe("runWorkPollLoop", () => {
     });
 
     expect(urls[0]).toBe(
-      "https://cluster.example.com/api/my-org/links/work?timeout=15",
+      "https://cluster.example.com/api/links/work?timeout=15",
     );
   });
 
@@ -200,7 +195,6 @@ describe("runWorkPollLoop", () => {
 
     await runWorkPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       onWork: async () => {},
       getAccessToken: async () => "my-fresh-token",
       signal: ac.signal,
@@ -223,7 +217,6 @@ describe("runWorkPollLoop", () => {
 
     await runWorkPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       onWork: async () => {},
       getAccessToken: async () => {
         tokenCallCount++;
@@ -258,7 +251,6 @@ describe("runWorkPollLoop", () => {
 
     await runWorkPollLoop({
       baseUrl: BASE_URL,
-      orgSlug: ORG_SLUG,
       onWork: async (item) => {
         received.push(item.runId);
       },

--- a/apps/mesh/src/link-daemon/work-poller.test.ts
+++ b/apps/mesh/src/link-daemon/work-poller.test.ts
@@ -18,6 +18,7 @@ const validWorkItem: WorkItem = {
   orgId: "org_01",
   userId: "usr_01",
   runFenceToken: "tok-fence-1",
+  orgSlug: ORG_SLUG,
   harnessInput: {
     threadId: "thrd_01",
     runId: "run_01",

--- a/apps/mesh/src/link-daemon/work-poller.ts
+++ b/apps/mesh/src/link-daemon/work-poller.ts
@@ -1,7 +1,7 @@
 /**
  * Work-poll loop for the pull transport (Phase D, spec §3.2).
  *
- * Continuously long-polls GET /api/:org/links/work. On a 200 response, parses
+ * Continuously long-polls GET /api/links/work. On a 200 response, parses
  * and validates the JSON body as a WorkItem (envelope carrying harnessInput +
  * runFenceToken) and invokes `onWork`. On 204 (no work), immediately re-polls.
  * On errors, backs off using exponentialBackoffWithJitter from @decocms/std.
@@ -10,10 +10,9 @@
  * claim by piggy-backing on the request (the server updates `studio_links`
  * TTL on every work-poll hit, per spec §3.2).
  *
- * NOTE — org multiplicity: this module takes a single `orgSlug` parameter.
- * The daemon connects one pull loop per org. How the daemon discovers its
- * org(s) (e.g. from the session claim or a startup argument) is the concern
- * of the pull-loop-entry task (Task 8 / index.ts), not this module.
+ * NOTE — the route is user-scoped (no org segment). The org is carried inside
+ * the WorkItem payload (orgSlug field) so the daemon can route work to the
+ * correct org without needing to know it upfront.
  *
  * ⚠️ SHIPPED DAEMON — needs human review before merge.
  */
@@ -27,14 +26,6 @@ import type { Capability } from "../links/protocol";
 export interface WorkPollerDeps {
   /** Fully-qualified base URL, e.g. "https://studio.deco.cx". */
   baseUrl: string;
-  /**
-   * Org slug for the org-scoped route /api/:org/links/work.
-   *
-   * NOTE: the daemon links a user who may span multiple orgs. For this module,
-   * `orgSlug` is taken as a parameter; how the daemon discovers its org(s) is
-   * the pull-loop-entry task's concern (see Task 8).
-   */
-  orgSlug: string;
   /**
    * Called with each validated work item. Must not throw — errors are swallowed
    * by the loop; the item is not retried (best-effort, ACK-on-delivery per spec).
@@ -86,17 +77,17 @@ const MAX_DELAY_MS = 30_000;
  *
  * The loop:
  *   1. Resolves a fresh bearer token via `getAccessToken` before each poll (per-poll resolver avoids pinning a stale credential).
- *   2. GETs /api/:org/links/work?timeout=<N>.
+ *   2. GETs /api/links/work?timeout=<N>.
  *   3. On 200: parses + validates the WorkItem via workItemSchema; calls onWork.
  *      On 204: no work available (server held the long-poll window); re-polls immediately.
  *      On error / bad-status: backs off with exponential-backoff-with-jitter.
  *   4. Stops immediately when signal is aborted.
  */
 export async function runWorkPollLoop(deps: WorkPollerDeps): Promise<void> {
-  const { baseUrl, orgSlug, onWork, getAccessToken, signal } = deps;
+  const { baseUrl, onWork, getAccessToken, signal } = deps;
   const fetcher = deps.fetchImpl ?? fetch;
   const pollTimeout = deps.pollTimeoutSecs ?? 29;
-  const url = `${baseUrl}/api/${orgSlug}/links/work?timeout=${pollTimeout}`;
+  const url = `${baseUrl}/api/links/work?timeout=${pollTimeout}`;
   let errorStreak = 0;
 
   // Build the static presence headers once — these don't change between polls.


### PR DESCRIPTION
## Summary

`bunx decocms link` was failing with `Could not list organizations on <studio> (HTTP 403). Pass --org <slug> or set DECO_ORG_SLUG.` after the pull-inversion merge (#3698).

**Root cause:** the new daemon resolved a startup org slug by calling stock Better Auth `GET /api/auth/organization/list` with the CLI's MCP OAuth bearer token. That endpoint can't authenticate that token (no `bearer` plugin; the `apiKey` plugin's `customAPIKeyGetter` rejects it as `INVALID_API_KEY`) → 403. But the link substrate was already keyed by `userSub` — the org path segment was vestigial.

This makes the link daemon **user-scoped**, removing the need for an org entirely.

- Deleted `resolveOrgSlug` + the `/api/auth/organization/list` call. `decocms link` no longer needs `--org`/`DECO_ORG_SLUG`.
- Hard-cut the daemon long-poll routes from `/api/:org/links/{work,control,proxy}` to user-scoped `/api/links/*` (next to `/api/links/me`). Handlers already key off `ctx.auth.user.id`; auth comes from the existing global `ContextFactory.create` MCP-OAuth middleware.
- **Ingest stays org-scoped** (`POST /api/:org/links/runs/:runId/stream`), now fed by a **required** `orgSlug` on every work item (resolved in `pullDispatch`: request org → DB lookup → throw).
- Dropped `orgSlug` from all three pollers, `cluster-connection-pull`, and `index.ts` (incl. the startup fatal-exit). Multi-org now works for free — a user's daemon serves runs for any org they belong to.
- `--org` flag retained in `cli.ts` (still used by `backfill-assets`), just no longer plumbed into `link`.

**Authorization:** equal-or-tighter. Work is published to `link.work.<userId>` for runs the user owns, so a daemon only ever receives its own runs; the org-scoped ingest still re-validates writes.

Net: 10 commits, 26 files, −216 lines.

## Test Plan

- [x] `bun run check` (all workspaces) — green
- [x] `bun run lint` — 0 warnings / 0 errors
- [x] `bun run fmt:check` — clean
- [x] Unit tests for changed modules (pollers, work-queue schema incl. a new "rejects missing orgSlug" test) — 103 pass / 0 fail
- [x] Code-level smoke: no `resolveOrgSlug` / `organization/list` left; all daemon poll URLs user-scoped
- [ ] e2e (`link-dispatch-pull`, `link-control`, `link-proxy`, `link-ingest`) — specs repointed to `/api/links/*`; require Postgres+NATS so they run in CI
- [ ] Manual: `bunx decocms link` against staging with **no `--org`** → links + dispatches a real run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the link daemon user-scoped so `bunx decocms link` no longer needs `--org`, fixing the 403 from organization listing. Long-poll routes moved to `/api/links/*`, and one daemon now serves runs for any org the user belongs to.

- **Refactors**
  - Moved long-poll endpoints to `/api/links/{work,control,proxy}`; ingest stays at `/api/:org/links/runs/:runId/stream`.
  - Removed org discovery; deleted `resolveOrgSlug`. CLI stops passing org to link (flag retained for other commands).
  - Work items now require `orgSlug`; `pullDispatch` resolves it via request org or DB lookup.
  - Dropped `orgSlug` from pollers and daemon options; updated tests and e2e to user-scoped paths.

- **Migration**
  - Run `bunx decocms link` without `--org` or `DECO_ORG_SLUG`.
  - Update any direct calls/tests to use `/api/links/*` endpoints.
  - Ensure dispatchers include `orgSlug` on published work items.

<sup>Written for commit 6da8285a77d8560f5b271b060cb66b8683428dd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

