### PR TITLE
fix(chat/decopilot): reliability + correctness quick-wins (idempotency, backoff jitter, POST timeout, buffer-drain, metrics)

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -84,9 +84,18 @@ import type { CancelBroadcast } from "./cancel-broadcast";
 import type { ThreadMessage } from "@/storage/types";
 import type { PendingImage } from "@/harnesses/decopilot/built-in-tools";
 import { getInternalUrl, getPublicUrl } from "@/core/server-constants";
-import { traced } from "@/observability";
+import { meter, traced } from "@/observability";
 import { getPodId } from "@/core/pod-identity";
 import type { SSEEvent } from "@/event-bus";
+
+// B5/I1: counter for message-save failures — tagged by org.id (low cardinality).
+// Incremented at every save .catch site inside dispatch-run.ts so the frequency
+// of DB write failures is visible in OTEL without log scraping.
+const saveErrorsCounter = meter.createCounter("decopilot.save.errors", {
+  description:
+    "Number of message-save failures during decopilot run dispatch (v1 and v2 paths)",
+  unit: "{errors}",
+});
 
 /**
  * Process-wide progress-bump throttle (Task 9, A1/A2). One instance shared by
@@ -486,7 +495,7 @@ export async function dispatchRunAndWait(
         : null;
 
       if (buffer && tail) {
-        buffer.pump(uiStream, taskId, registrySignal);
+        buffer.pump(uiStream, taskId, registrySignal, input.organizationId);
         const reader = tail.getReader();
         try {
           while (true) {
@@ -763,6 +772,9 @@ async function prepareRun(
         }));
       if (messagesToSave.length === 0) return;
       await mem.save(messagesToSave as ThreadMessage[]).catch((error) => {
+        // B5/I1: count DB save failures so the metric fires even when logs
+        // aren't being watched. Tagged by org.id (low cardinality).
+        saveErrorsCounter.add(1, { "org.id": input.organizationId });
         console.error("[decopilot:stream] Error saving messages", error);
       });
     };
@@ -1350,6 +1362,7 @@ async function prepareRun(
           if (shouldSave) {
             pendingOps.push(
               saveMessagesToThread(responseMessage).catch((e) => {
+                saveErrorsCounter.add(1, { "org.id": input.organizationId });
                 console.error("[decopilot:stream] onStepFinish save failed", e);
               }),
             );
@@ -1416,6 +1429,7 @@ async function prepareRun(
             parts: [{ type: "text", text: `Error: ${sanitized}` }],
             metadata: { errorCategory: classifyStreamError(error) },
           } as ChatMessage).catch((e) => {
+            saveErrorsCounter.add(1, { "org.id": input.organizationId });
             console.error("[decopilot:stream] error-message save failed", e);
           });
         }

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -28,6 +28,19 @@ import {
 } from "nats";
 import { MAX_PUBLISH_BYTES } from "@/nats/payload-chunking";
 import type { StreamBuffer } from "./stream-buffer";
+import { meter } from "@/observability";
+
+// B5: counter for JetStream publish errors — tagged by org.id (low cardinality).
+// Increment happens inside createPublishTracker's catch where publish failures
+// are already sampled-logged; the counter lets alerting fire without log scraping.
+const publishErrorsCounter = meter.createCounter(
+  "decopilot.stream.publish_errors",
+  {
+    description:
+      "Number of JetStream publish failures for decopilot stream chunks",
+    unit: "{errors}",
+  },
+);
 
 const STREAM_NAME = "DECOPILOT_STREAMS";
 const SUBJECT_PREFIX = "decopilot.stream";
@@ -51,7 +64,7 @@ function streamSubject(taskId: string): string {
   return `${SUBJECT_PREFIX}.${taskId}`;
 }
 
-function createPublishTracker(taskId: string) {
+function createPublishTracker(taskId: string, orgId?: string) {
   let errors = 0;
   return {
     publish(
@@ -63,6 +76,11 @@ function createPublishTracker(taskId: string) {
       js.publish(subj, data, hdrs ? { headers: hdrs } : undefined).catch(
         (err) => {
           errors++;
+          // B5: increment OTEL counter on every publish failure so alerting can
+          // fire without log scraping. Tag by org.id (low cardinality); fall
+          // back to "unknown" when the org context isn't available at this
+          // call site (e.g. standalone test harness without a dispatch context).
+          publishErrorsCounter.add(1, { "org.id": orgId ?? "unknown" });
           if (errors === 1 || errors % 100 === 0) {
             console.warn(
               `[Decopilot] JetStream publish failed for thread ${taskId} (${errors} total):`,
@@ -128,12 +146,13 @@ export class NatsStreamBuffer implements StreamBuffer {
     stream: ReadableStream,
     taskId: string,
     registrySignal: AbortSignal,
+    orgId?: string,
   ): void {
     const js = this.js;
     if (!js) return;
 
     const subj = streamSubject(taskId);
-    const tracker = createPublishTracker(taskId);
+    const tracker = createPublishTracker(taskId, orgId);
     const encoder = this.encoder;
 
     let terminated = false;

--- a/apps/mesh/src/api/routes/decopilot/routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.test.ts
@@ -96,6 +96,43 @@ describe("computeIdempotencyKey", () => {
     const key = computeIdempotencyKey(msg);
     expect(key).toMatch(/^[0-9a-f]{40}$/);
   });
+
+  test("key-order-canonical: same message with different key insertion order produces the SAME hash", () => {
+    // Simulate two Objects built with different key-insertion order but
+    // semantically identical content — as can happen between a fresh
+    // round-trip serialization and the original runtime value.
+    const msgA = {
+      id: "msg_abc",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-bash",
+          state: "approval-responded",
+          approval: { id: "ap_1", approved: true },
+        },
+      ],
+    } as unknown as ChatMessage;
+
+    // msgB has the same data but keys inserted in reverse order inside `approval`.
+    const msgB = {
+      id: "msg_abc",
+      role: "assistant",
+      parts: [
+        {
+          // biome-ignore lint/suspicious/noExplicitAny: intentional key-order test
+          ...(Object.fromEntries(
+            Object.entries({
+              state: "approval-responded",
+              type: "tool-bash",
+              approval: { approved: true, id: "ap_1" },
+            }).reverse(),
+          ) as any),
+        },
+      ],
+    } as unknown as ChatMessage;
+
+    expect(computeIdempotencyKey(msgA)).toBe(computeIdempotencyKey(msgB));
+  });
 });
 
 // ============================================================================

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -57,6 +57,30 @@ import type { HarnessId } from "@/harnesses";
 import type { Thread } from "@/storage/types";
 
 // ============================================================================
+// Canonical serialization helper
+// ============================================================================
+
+/**
+ * Deterministic JSON serialization with sorted object keys. Arrays keep
+ * their original order; primitives are passed through as-is.
+ *
+ * Used by computeIdempotencyKey so that a re-serialized assistant
+ * continuation message (approval / tool-output round) always hashes to the
+ * same value regardless of the order in which JS inserted object keys at
+ * runtime.
+ */
+function canonicalStringify(v: unknown): string {
+  if (v === null || typeof v !== "object") return JSON.stringify(v);
+  if (Array.isArray(v)) return `[${v.map(canonicalStringify).join(",")}]`;
+  const keys = Object.keys(v as object).sort();
+  const pairs = keys.map(
+    (k) =>
+      `${JSON.stringify(k)}:${canonicalStringify((v as Record<string, unknown>)[k])}`,
+  );
+  return `{${pairs.join(",")}}`;
+}
+
+// ============================================================================
 // Idempotency
 // ============================================================================
 
@@ -75,7 +99,7 @@ export function computeIdempotencyKey(
 ): string | undefined {
   if (!lastMsg) return undefined;
   if (lastMsg.role === "user" && lastMsg.id) return lastMsg.id;
-  return createHash("sha1").update(JSON.stringify(lastMsg)).digest("hex");
+  return createHash("sha1").update(canonicalStringify(lastMsg)).digest("hex");
 }
 
 // ============================================================================

--- a/apps/mesh/src/api/routes/decopilot/run-registry.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.ts
@@ -50,6 +50,14 @@ const inflightRuns = meter.createUpDownCounter("decopilot.stream.inflight", {
   unit: "{requests}",
 });
 
+// I1: counter for reaper-forced run terminations — tagged by org.id and reason.
+// Incremented in reapStaleRuns whenever a stuck run is force-failed.
+const reapedRunsCounter = meter.createCounter("decopilot.run.reaped", {
+  description:
+    "Number of decopilot runs force-failed by the progress-based reaper",
+  unit: "{runs}",
+});
+
 export class RunRegistry {
   private readonly states = new Map<string, RunState>();
   private reaperTimer: ReturnType<typeof setInterval> | null = null;
@@ -318,6 +326,11 @@ export class RunRegistry {
           RUN_IDLE_TIMEOUT_MS / 60_000
         }m) ...`,
       );
+      // I1: emit metric before force-fail so it's visible even if execute() throws.
+      reapedRunsCounter.add(1, {
+        "org.id": state.orgId,
+        reason: "idle_timeout",
+      });
       await this.execute({
         type: "FORCE_FAIL",
         taskId,

--- a/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
@@ -27,11 +27,15 @@ export interface StreamBuffer {
    * The pump is the sole consumer of `stream`; do not also `pipeThrough` or
    * `tee` it for the HTTP response. Tail consumers read from JetStream via
    * `createTailStream`.
+   *
+   * `orgId` is optional but recommended — it tags the `decopilot.stream.publish_errors`
+   * OTEL counter so per-org alerting is possible.
    */
   pump(
     stream: ReadableStream,
     taskId: string,
     registrySignal: AbortSignal,
+    orgId?: string,
   ): void;
 
   /**

--- a/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
@@ -904,6 +904,45 @@ describe("boot buffering", () => {
     expect(conn.status.get().kind).toBe("error");
   });
 
+  // G3 regression test: live SSE chunks that arrive while loadInitialPage is
+  // in-flight must NOT get stuck in the buffer when loadInitialPage fails.
+  // Previously the catch branch called failTo() without draining chunkBuffer,
+  // so handleChunk kept buffering indefinitely and the chunks were never folded.
+  test("G3: initial-page error drains chunk buffer so live chunks are rendered", async () => {
+    const stream = controllableStream();
+    globalThis.fetch = makeFetchMock({
+      stream: () => stream.response,
+    }) as unknown as typeof globalThis.fetch;
+
+    const ctrl = makeControllableClient();
+    const conn = getOrOpenStream("acme", "thread-g3-drain", {
+      client: ctrl.client as never,
+    });
+
+    // Wait for loadInitialPage to reach the MCP callTool (and for SSE to open).
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Live chunks arrive while the initial page is still pending.
+    stream.enqueue({ type: "start", messageId: "m-live-g3" });
+    stream.enqueue({ type: "text-start", id: "p-g3" });
+    stream.enqueue({ type: "text-delta", id: "p-g3", delta: "live content" });
+    stream.enqueue({ type: "text-end", id: "p-g3" });
+    stream.enqueue({ type: "finish", finishReason: "stop" });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Status is still loading — the page hasn't resolved yet, chunks are buffered.
+    expect(conn.status.get().kind).toBe("loading");
+
+    // Initial page FAILS.
+    ctrl.reject(new Error("MCP load failed"));
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The buffer must have been drained: the live chunks folded into messages
+    // and the assistant message is visible despite the initial-page failure.
+    const ids = conn.messages.get().map((m) => m.id);
+    expect(ids).toContain("m-live-g3");
+  });
+
   test("a stray non-chunk SSE event is silently ignored", async () => {
     const stream = controllableStream();
     globalThis.fetch = makeFetchMock({

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -43,6 +43,7 @@ import {
   type UIMessage,
   type UIMessageChunk,
 } from "ai";
+import { exponentialBackoffWithJitter, sleep } from "@decocms/std";
 import type { Client as MCPClient } from "@modelcontextprotocol/sdk/client/index.js";
 import type { ToolApprovalLevel } from "@/web/hooks/use-preferences";
 import type { SimpleModeTier } from "@/tools/organization/schema";
@@ -125,6 +126,9 @@ export interface ThreadObserver {
 const BASE_DELAY_MS = 1_000;
 const MAX_DELAY_MS = 30_000;
 const CLEAN_RECONNECT_DELAY_MS = 50;
+/** G1: Maximum time (ms) to wait for the POST /messages response. The POST is
+ *  idempotency-keyed (workflowID), so a timeout-then-retry is safe. */
+const POST_TIMEOUT_MS = 60_000;
 
 // Browser uses rAF for chunk-coalescing; tests run under Bun where rAF is absent.
 const scheduleFrame: (cb: () => void) => number =
@@ -424,6 +428,13 @@ export class ThreadConnection {
       this.drainChunkBuffer();
     } catch (err) {
       this.failTo(err instanceof Error ? err : new Error(String(err)));
+      // G3: drain the chunk buffer even on failure so live SSE chunks that
+      // arrived while the initial page was in-flight aren't stuck forever.
+      // Without this, chunkBuffer stays non-null after the catch branch and
+      // handleChunk keeps buffering indefinitely — the thread is stuck.
+      // Subsequent successful SSE chunks fold live; dedupe-by-id handles
+      // any overlap with rows from a later successful loadInitialPage.
+      this.drainChunkBuffer();
     } finally {
       this.resolveReady();
     }
@@ -549,15 +560,31 @@ export class ThreadConnection {
     const messages = systemMessage ? [systemMessage, message] : [message];
     const body = { messages, ...rest };
     const url = `/api/${encodeURIComponent(this.orgSlug)}/decopilot/threads/${encodeURIComponent(this.threadId)}/messages`;
-    const resp = await fetch(url, {
-      method: "POST",
-      credentials: "include",
-      headers: {
-        "content-type": "application/json",
-      },
-      body: JSON.stringify(body),
-      signal,
-    });
+    // G1: combine the caller's stop() abort signal with a generous timeout so
+    // a stalled server never hangs the chat indefinitely. The POST is
+    // idempotency-keyed (workflowID), so a timeout-then-retry is safe.
+    const timeoutSignal = AbortSignal.timeout(POST_TIMEOUT_MS);
+    const combinedSignal = signal
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal;
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: combinedSignal,
+      });
+    } catch (err) {
+      // Surface timeout as a clear, user-actionable error message.
+      if (timeoutSignal.aborted && !signal?.aborted) {
+        throw new Error("request timed out — retry");
+      }
+      throw err;
+    }
     if (!resp.ok) {
       const text = await resp.text().catch(() => "");
       throw new Error(text || `POST /messages failed (${resp.status})`);
@@ -618,22 +645,25 @@ export class ThreadConnection {
       }
 
       if (this.abort.signal.aborted) return;
+      // G2: use @decocms/std exponential backoff with jitter (CLAUDE.md bans
+      // hand-rolled backoff). Clean exits use the fast-path const; error
+      // exits get jittered backoff so thundering-herd on server restarts is
+      // spread out.
       const delay = cleanExit
         ? CLEAN_RECONNECT_DELAY_MS
-        : Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS);
+        : exponentialBackoffWithJitter(
+            MAX_DELAY_MS,
+            BASE_DELAY_MS,
+            attempt,
+            2,
+            0.5,
+          );
       attempt++;
       if (delay > 0) {
-        await new Promise<void>((resolve) => {
-          const timer = setTimeout(resolve, delay);
-          this.abort.signal.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timer);
-              resolve();
-            },
-            { once: true },
-          );
-        });
+        // G2: use @decocms/std sleep (CLAUDE.md bans hand-rolled setTimeout
+        // promises). sleep() resolves (not rejects) on abort by default, which
+        // matches the previous "resolve on abort" semantics.
+        await sleep(delay, { signal: this.abort.signal }).catch(() => {});
       }
     }
   }


### PR DESCRIPTION
## Summary
Five small, independent reliability/correctness fixes flagged in the architecture report — all keep the current libs (DBOS / NATS / Postgres / Kysely / `@decocms/std`), no rewrites. Found via an incremental backlog pass over the planning docs; each verified still-open against `main`.

## Fixes
**C4 — canonical idempotency key** (`routes.ts`): `computeIdempotencyKey` hashed `JSON.stringify(lastMsg)`, which isn't key-order-canonical — a re-serialized assistant/tool-output retry could hash differently → two DBOS workflowIDs for one logical turn → duplicate agent loops / double tool calls. Now hashes a recursive key-sorted serialization. User-message `id` fast-path untouched. +unit test.

**G2 — jittered reconnect backoff** (`thread-connection.ts`): the SSE reconnect used a hand-rolled `Math.min(BASE * 2**attempt, MAX)` with no jitter (thundering herd on cluster-wide drop) — also a hand-rolled backoff/sleep the repo rules ban. Swapped to `exponentialBackoffWithJitter` + `sleep` from `@decocms/std`.

**G1 — POST /messages client timeout** (`thread-connection.ts`): the enqueue had no timeout → a wedged gate/NATS publish = indefinite "submitted". Added `AbortSignal.any([signal, AbortSignal.timeout(60s)])` + a clear surfaced error. The POST is workflowID-idempotent, so a bounded timeout is safe.

**G3 — drain chunk buffer on initial-load failure** (`thread-connection.ts`): a failed history fetch called `failTo` but never drained `chunkBuffer`, so live chunks buffered forever (stuck thread / ghost messages). Now drains in the catch branch. +unit test.

**B5/I1 — observability counters** (`nats-stream-buffer.ts`, `run-registry.ts`, `dispatch-run.ts`): the only decopilot metric was `stream.inflight`; the silent long-session failure modes emitted nothing. Added OTEL counters `decopilot.stream.publish_errors`, `decopilot.run.reaped`, `decopilot.save.errors` via the existing `meter`, tagged by `org.id` only (no per-run cardinality).

## Testing
`bun run check` / `lint` / `knip` green; 134 unit tests pass (incl. new C4 + G3 tests). DB-backed `(real Postgres)` tests need infra and aren't run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves decopilot chat reliability and observability. Fixes duplicate runs, thundering-herd reconnects, stuck buffers, and endless POST waits; adds OTEL counters for publish/save/reaper failures.

- Bug Fixes
  - Canonical idempotency key: use key-sorted JSON for assistant/tool messages to avoid duplicate workflow IDs; tests added.
  - POST /messages timeout: 60s via AbortSignal.any, with a clear "request timed out — retry" error; safe due to idempotency.
  - Drain SSE chunk buffer on initial-load failure so live chunks render; regression test added.
  - Jittered reconnect backoff: replace hand-rolled logic with `exponentialBackoffWithJitter` and `sleep` from `@decocms/std`.

- New Features
  - OTEL counters (tagged by org): `decopilot.stream.publish_errors`, `decopilot.save.errors`, `decopilot.run.reaped`. `StreamBuffer.pump` now accepts an optional orgId to tag publish errors.

<sup>Written for commit e2a0d78fa85d799f3f6acbea3e58e544226bd196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

