### PR TITLE
fix(link): ensure the desktop sandbox on the remoteDispatch push path

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1145,21 +1145,19 @@ async function prepareRun(
         //     to the user's link daemon; the harness still runs here.
         let rawHarnessChunks;
         if (target.runsIn === "user-desktop") {
-          // Pure handle derivation — no ensure round-trip. The daemon self-ensures
-          // the sandbox from `WorkItem.sandbox` when it dequeues the item
-          // (cluster-connection-pull.ts:214: `input.provider.ensureSandbox(ensureInput)`),
-          // so the warm-ensure that `resolveRemoteCliSandboxHandle` performed here
-          // is redundant on the pull path (C-bis S4). The handle formula is
-          // identical to what `ensureSandbox`/`provisionSandbox` would compute:
-          // composeSandboxRef → computeClaimHandle. See `computeDesktopSandboxHandle`.
-          const effectiveBranch =
-            mem.thread.branch ?? input.branch ?? "ephemeral";
-          const sandboxHandle = computeDesktopSandboxHandle({
-            agentId: input.agent.id,
-            userId: input.userId,
-            organizationId: input.organizationId,
-            branch: effectiveBranch,
-          });
+          // PUSH path (remoteDispatch): the control handler has NO daemon
+          // self-ensure backstop — it just `proxyPort(handle)`s and 404s
+          // "unknown handle" for a sandbox that was never spawned
+          // (control-handler.ts:172-193). So ENSURE the sandbox here before
+          // dispatching, and dispatch the handle ensureSandbox actually
+          // provisioned so the two can never drift. (The pull site keeps the
+          // pure computeDesktopSandboxHandle — its daemon self-ensures.)
+          const sandboxHandle = await ensurePushDispatchSandboxHandle(
+            input.agent,
+            mem.thread.branch,
+            input.branch,
+            ctx,
+          );
           // Route through the unified `proxyDaemonRequest` seam: the desktop
           // provider tunnels `/dispatch` over the same WS+NATS link transport
           // the old raw `dispatch` dep used, but now consumes the returned
@@ -1845,4 +1843,41 @@ async function resolveRemoteCliSandboxHandle(
     );
   }
   return { sandboxHandle: entry.sandboxHandle, previewUrl: entry.previewUrl };
+}
+
+/**
+ * Resolve the desktop sandbox handle for the PUSH (`remoteDispatch`) dispatch
+ * path, ENSURING the sandbox is spawned first.
+ *
+ * Unlike the pull/work-queue path, the push path has NO daemon self-ensure
+ * backstop: `proxyDaemonRequest(handle, "/dispatch")` is rewritten to
+ * `/_sandbox/<handle>/dispatch` and reaches the link daemon's
+ * `control-handler.handleStream`, which just `proxyPort(handle)`s and returns
+ * `404 "unknown handle"` for a sandbox that was never spawned
+ * (`control-handler.ts:172-193`). So we run the full `ensureSandbox` here and
+ * return the handle it PROVISIONED — guaranteeing the dispatched handle equals
+ * the spawned one.
+ *
+ * `effectiveBranch` mirrors the dispatch-site formula (thread pin → request
+ * branch → synthetic "ephemeral"). Threading the SAME value into the ensure
+ * closes the handle-drift bug: `resolveRemoteCliSandboxHandle`'s internal
+ * `input.branch ?? "ephemeral"` would otherwise drop a thread-pinned branch.
+ *
+ * The pull site keeps the pure `computeDesktopSandboxHandle` — its daemon
+ * self-ensures from `WorkItem.sandbox` (`cluster-connection-pull.ts:214`).
+ *
+ * Exported for unit tests.
+ */
+export async function ensurePushDispatchSandboxHandle(
+  agent: { id: string },
+  threadBranch: string | null | undefined,
+  inputBranch: string | null | undefined,
+  ctx: StudioContext,
+): Promise<string> {
+  const effectiveBranch = threadBranch ?? inputBranch ?? "ephemeral";
+  const { sandboxHandle } = await resolveRemoteCliSandboxHandle(
+    { agent, branch: effectiveBranch },
+    ctx,
+  );
+  return sandboxHandle;
 }

--- a/apps/mesh/src/api/routes/decopilot/dispatch-sandbox.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-sandbox.test.ts
@@ -47,8 +47,11 @@ const nextEnsureSandboxReturn: { previewUrl: string | null } = {
   previewUrl: "http://sleek-flint-0000000000000000.localhost:5174",
 };
 
-const { resolveRemoteCliSandboxUrl, computeDesktopSandboxHandle } =
-  await import("./dispatch-run");
+const {
+  resolveRemoteCliSandboxUrl,
+  computeDesktopSandboxHandle,
+  ensurePushDispatchSandboxHandle,
+} = await import("./dispatch-run");
 
 describe("resolveRemoteCliSandboxUrl", () => {
   it("calls ensureSandbox with the agent id, branch, and user-desktop kind", async () => {
@@ -152,5 +155,61 @@ describe("computeDesktopSandboxHandle", () => {
     // "deco/sleek-flint" → last segment "sleek-flint" → slug prefix in handle.
     const handle = computeDesktopSandboxHandle(BASE);
     expect(handle).toMatch(/sleek-flint/);
+  });
+});
+
+describe("ensurePushDispatchSandboxHandle", () => {
+  it("ENSURES (spawns) the sandbox — the push path has no daemon self-ensure backstop", async () => {
+    ensureSandboxCalls.length = 0;
+    const handle = await ensurePushDispatchSandboxHandle(
+      { id: "vm-1" },
+      "deco/sleek-flint", // thread branch
+      null, // input branch
+      {} as never,
+    );
+    // It MUST run the full ensure (not a pure handle derivation).
+    expect(ensureSandboxCalls).toEqual([
+      {
+        virtualMcpId: "vm-1",
+        branch: "deco/sleek-flint",
+        sandboxProviderKind: "user-desktop",
+      },
+    ]);
+    // It returns the handle ensureSandbox actually provisioned, so the
+    // dispatched handle can never drift from the spawned one.
+    expect(handle).toBe("sleek-flint-0000000000000000");
+  });
+
+  it("prefers the thread branch over the request branch (handle-drift fix)", async () => {
+    ensureSandboxCalls.length = 0;
+    await ensurePushDispatchSandboxHandle(
+      { id: "vm-2" },
+      "deco/pinned",
+      "deco/from-request",
+      {} as never,
+    );
+    expect(ensureSandboxCalls[0]?.branch).toBe("deco/pinned");
+  });
+
+  it("falls back to the request branch when the thread has none", async () => {
+    ensureSandboxCalls.length = 0;
+    await ensurePushDispatchSandboxHandle(
+      { id: "vm-3" },
+      null,
+      "deco/from-request",
+      {} as never,
+    );
+    expect(ensureSandboxCalls[0]?.branch).toBe("deco/from-request");
+  });
+
+  it("falls back to 'ephemeral' when neither branch is set", async () => {
+    ensureSandboxCalls.length = 0;
+    await ensurePushDispatchSandboxHandle(
+      { id: "vm-4" },
+      null,
+      null,
+      {} as never,
+    );
+    expect(ensureSandboxCalls[0]?.branch).toBe("ephemeral");
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/dispatch-sandbox.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-sandbox.test.ts
@@ -2,9 +2,13 @@
  * Unit tests for:
  *   - `resolveRemoteCliSandboxUrl` — the ensure-backed preview-URL helper.
  *   - `computeDesktopSandboxHandle` — the pure, I/O-free handle derivation
- *     introduced in C-bis S4 to replace the warm-ensure round-trip at the
- *     two dispatch sites (prepareRun + pullDispatch). The preview-URL site
- *     (`resolveRemoteCliSandboxUrl`) keeps the full ensure path.
+ *     introduced in C-bis S4. It is still used at the pull/work-queue dispatch
+ *     site (`pullDispatch`), where the daemon self-ensures the sandbox from the
+ *     work item.
+ *   - `ensurePushDispatchSandboxHandle` — the push (`remoteDispatch`) dispatch
+ *     site's ensure-backed handle resolver. The push path has no daemon
+ *     self-ensure backstop, so it runs the full ensure (like the preview-URL
+ *     site) and dispatches the provisioned handle.
  */
 import { describe, expect, it, mock } from "bun:test";
 


### PR DESCRIPTION
## Summary

Fixes `[remoteDispatch] dispatch failed (404)` when running a user-desktop CLI agent (e.g. claude-code) via `decocms link`.

The push (`remoteDispatch`) dispatch path stopped ensuring (spawning) the desktop sandbox in C-bis S4 (#3698), on the rationale that "the daemon self-ensures from `WorkItem.sandbox` on dequeue." That backstop only exists on the **pull/work-queue** path (`cluster-connection-pull.ts`). On the **push** path the link daemon's `control-handler.handleStream` just calls `proxyPort(handle)` and returns `404 "unknown handle"` for a never-spawned handle (`control-handler.ts:172-193`). The plain-text body isn't JSON, so `remote-dispatch.ts` keeps its default detail → `[remoteDispatch] dispatch failed (404)`.

This restores the warm-ensure at the push site via a small `ensurePushDispatchSandboxHandle` helper and dispatches the handle `ensureSandbox` actually provisioned — which also closes a secondary handle-drift bug (dispatch used `mem.thread.branch ?? input.branch ?? "ephemeral"` while the ensure would have used `input.branch ?? "ephemeral"`, diverging on a repo-connected first message). The pull site is unchanged (its daemon self-ensure is genuine).

## Why it only bites now

`decidePullDispatch` routes to the pull path only when `message_storage_version === 2`, which is canary-gated off by default (`STREAM_OF_RECORD_V2_PERCENT=0`). So every normal (v1) user-desktop thread takes the push path that #3698 left without an ensure.

## Test plan

- [x] New unit tests (`dispatch-sandbox.test.ts`): the push helper runs the full ensure (not a pure derivation) and honors branch precedence (thread → request → `"ephemeral"`).
- [x] `bun test` green on the touched area + siblings (dispatch-sandbox / remote-dispatch / thread-gate-workflow / control-handler).
- [x] `bun run check`, `bun run lint`, `bun run fmt:check` all green.
- [ ] Manual e2e (not coverable in CI — no real link daemon): `bun run dev --local-sandbox-provider`, send a message in a user-desktop claude-code chat, confirm it streams with no `[remoteDispatch] dispatch failed (404)` and no `[control] handleStream unknown handle=...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404 errors in `remoteDispatch` for user-desktop CLI agents (e.g. `decocms link`) by ensuring the desktop sandbox is spawned on the push path and using the provisioned handle.

- **Bug Fixes**
  - Added `ensurePushDispatchSandboxHandle` to run `ensureSandbox` on the push path and dispatch the handle it provisions, preventing "unknown handle" 404s and handle drift (thread branch now correctly wins over request branch, else `"ephemeral"`).
  - Added unit tests for push-path ensure and branch precedence; pull/work-queue path remains unchanged.

<sup>Written for commit 30f70fdec8c7e7b0c63cc51e6c59934bbbac63a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

