### PR TITLE
fix(tests/resilience): wait out 60s presence TTL in link-offline assertion

### DIFF
--- a/apps/mesh/e2e/tests/chat-input-draft.spec.ts
+++ b/apps/mesh/e2e/tests/chat-input-draft.spec.ts
@@ -45,7 +45,9 @@ async function typeInComposer(page: Page, text: string): Promise<void> {
   const input = page.locator(CHAT_INPUT);
   await input.click();
   await page.keyboard.type(text);
-  await expect(input).toHaveText(text, { timeout: 5_000 });
+  // Tiptap may take time to render the typed text, especially under load.
+  // Use a more generous timeout to avoid flakiness in CI.
+  await expect(input).toHaveText(text, { timeout: 15_000 });
 }
 
 /** Read the visible text content of the chat input. */

--- a/apps/mesh/e2e/tests/clonable-agent-logo.spec.ts
+++ b/apps/mesh/e2e/tests/clonable-agent-logo.spec.ts
@@ -15,11 +15,12 @@ test.describe("clonable agent logo (settings tab)", () => {
     const { page, orgSlug } = authedPage;
     const api = page.context().request;
 
-    // Create a placeholder connection. The URL doesn't have to resolve;
-    // the UI only needs its id to make `agentHasConnectedGithub` true.
+    // Create a placeholder connection. Use the test studio server as a dummy URL
+    // since tool validation now requires a reachable endpoint. We only need the
+    // connection ID to populate `agentHasConnectedGithub`; the URL itself is unused.
     const conn = await createHttpConnection(api, orgSlug, {
       title: "github-placeholder",
-      url: "http://127.0.0.1:1/unused",
+      url: "http://127.0.0.1:3000/",
     });
 
     // Create the clonable agent: connections[] AND metadata.githubRepo

--- a/tests/resilience/scenarios/link-dispatch-log-replay.test.ts
+++ b/tests/resilience/scenarios/link-dispatch-log-replay.test.ts
@@ -158,9 +158,11 @@ describe("sandbox log/event SSE replay", () => {
     const baselineConnectedAt = baseline?.connectedAt ?? 0;
 
     await disableProxy(PROXY_NAMES.STUDIO_WS);
+    // Pull transport: the presence claim lingers until its 60s KV TTL lapses
+    // once the daemon can no longer re-arm it — wait the full TTL plus margin.
     await pollUntil(
       async () => (await getLinkClaim(testState.cookie)) === null,
-      { timeoutMs: 30_000, intervalMs: 1_000, label: "link-offline" },
+      { timeoutMs: 80_000, intervalMs: 1_000, label: "link-offline" },
     );
     await enableProxy(PROXY_NAMES.STUDIO_WS);
     await pollUntil(

--- a/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
+++ b/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
@@ -1,12 +1,16 @@
 /**
- * Resilience scenario: sandbox↔studio WS partition.
+ * Resilience scenario: sandbox↔studio transport partition.
  *
  * Drives a REAL link daemon + REAL spawned sandbox. Severs the daemon↔studio
- * WebSocket with Toxiproxy (clean TCP close) and asserts:
+ * link with Toxiproxy (clean TCP close on the `studio_ws` proxy — which now
+ * carries the pull-transport HTTP long-polls: control/work/proxy, NOT a
+ * WebSocket) and asserts:
  *   1. The sandbox responds to a write/read round-trip while connected.
- *   2. While the WS is severed, the link goes offline (/api/links/me → null)
- *      and a tunneled read fails FAST (no hang, no queue/replay).
- *   3. After the WS is restored, the daemon reconnects (connectedAt advances)
+ *   2. Once the link is severed the daemon can no longer re-arm its presence
+ *      claim, so the claim expires from the `studio_links` KV after its 60s TTL
+ *      and the link goes offline (/api/links/me → null); a tunneled read fails
+ *      FAST (no hang, no queue/replay).
+ *   3. After the link is restored, the daemon reconnects (connectedAt advances)
  *      and the same read returns the same content (state preserved).
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -112,10 +116,15 @@ describe("sandbox↔studio WS partition", () => {
 
     await disableProxy(PROXY_NAMES.STUDIO_WS);
 
-    // The link claim is released once the gateway observes the WS close.
+    // Under the pull transport the claim is presence-based: the daemon re-arms it
+    // on every work/control/proxy poll, and it lingers in the `studio_links` KV
+    // until its 60s TTL lapses once those polls can no longer reach the cluster.
+    // There is NO synchronous socket-close signal like the old reverse-WS
+    // transport had, so wait for the full TTL (plus margin) before asserting
+    // offline.
     await pollUntil(
       async () => (await getLinkClaim(testState.cookie)) === null,
-      { timeoutMs: 30_000, intervalMs: 1_000, label: "link-offline" },
+      { timeoutMs: 80_000, intervalMs: 1_000, label: "link-offline" },
     );
 
     // A tunneled read must fail FAST (not hang). Offline → 404; in-flight
@@ -132,7 +141,7 @@ describe("sandbox↔studio WS partition", () => {
     const durationMs = performance.now() - start;
     expect(read.status).toBeGreaterThanOrEqual(400);
     expect(durationMs).toBeLessThan(15_000);
-  }, 90_000);
+  }, 150_000);
 
   test("WS restored → daemon reconnects and the sandbox responds again", async () => {
     // Self-contained: start from a connected state (afterEach from the prior
@@ -143,10 +152,12 @@ describe("sandbox↔studio WS partition", () => {
     const connectedAt0 = before.connectedAt;
 
     await disableProxy(PROXY_NAMES.STUDIO_WS);
+    // 60s presence TTL + margin (see the "WS severed" test above for why the
+    // pull transport has no synchronous offline signal).
     await pollUntil(
       async () => (await getLinkClaim(testState.cookie)) === null,
       {
-        timeoutMs: 30_000,
+        timeoutMs: 80_000,
         intervalMs: 1_000,
         label: "link-offline-before-reconnect",
       },
@@ -181,5 +192,5 @@ describe("sandbox↔studio WS partition", () => {
       },
       { timeoutMs: 60_000, intervalMs: 2_000, label: "read-after-reconnect" },
     );
-  }, 240_000);
+  }, 300_000);
 });


### PR DESCRIPTION
## What is this contribution about?
The `Resilience Tests` suite has failed on `main` on every run since #3698 (2026-06-07), always on `sandbox↔studio WS partition > WS severed → link offline`. #3698 deleted the reverse-WebSocket daemon transport and made HTTP **pull** the only transport, so the link claim is now a `studio_links` NATS KV entry with a **60s TTL** re-armed on every work/control/proxy poll — not a socket whose close releases the claim in seconds — but the test still polled `/api/links/me === null` with a 30s budget, so it timed out deterministically (30s < 60s). This PR raises the offline-poll budget past the TTL (30s → 80s), bumps the affected sub-test timeouts, and rewrites the now-misleading "WS close" comments to describe the pull-transport presence model; the same TTL fix is applied to the (already-skipped) `link-dispatch-log-replay` scenario so it won't re-break when un-skipped.

## Screenshots/Demonstration
N/A — test-only change.

## How to Test
1. `docker compose -f tests/resilience/docker-compose.yml up -d --build --wait`
2. `bun test tests/resilience/scenarios/link-dispatch-ws-partition.test.ts --serial --timeout 900000`
3. Expected: all three sub-tests pass — `WS severed → link offline` now waits up to ~60s for the presence claim to expire instead of failing at 30s.
4. `docker compose -f tests/resilience/docker-compose.yml down -v`

## Migration Notes
None — no production code, schema, or config changes (test timeouts/comments only).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing resilience tests by waiting out the 60s presence TTL, and deflakes two e2e tests by relaxing timeouts and using a reachable test URL.

- **Bug Fixes**
  - Resilience: wait for the 60s KV presence TTL before asserting link-offline (poll budget 30s → 80s, 1s interval), bump sub-test timeouts (90s → 150s, 240s → 300s), and update comments to reflect the pull-transport presence model; apply the same TTL wait to the skipped log-replay scenario.
  - E2E: chat-input-draft uses a 15s `toHaveText` timeout to accommodate Tiptap rendering (5s → 15s); clonable-agent-logo creates the placeholder HTTP connection with a reachable test URL (`http://127.0.0.1:3000/` instead of `http://127.0.0.1:1`).

<sup>Written for commit 923e4c243d33de38fbf4e27baa0968d9faae65d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

