### PR TITLE
fix(link): proxy_no_first_frame resilience — per-slot backoff + request-leg republish

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts
@@ -440,6 +440,55 @@ describe("createProxyDispatch — first-frame timeout (no-subscriber fail-fast)"
   });
 });
 
+describe("createProxyDispatch — request-leg republish (dropped-publish tolerance)", () => {
+  test("re-publishes the request frame until the first reply frame, then stops", async () => {
+    const f = makeFakeNats();
+    const dispatch = createProxyDispatch({
+      nats: f.nats,
+      republishIntervalMs: 10,
+      firstFrameTimeoutMs: 10_000, // large — must NOT fire during this test
+    });
+    const reqSubject = buildRequestSubject("user-1");
+
+    const out: string[] = [];
+    const run = (async () => {
+      for await (const ev of dispatch("user-1", baseReq)) {
+        if (ev.data) out.push(ev.data);
+      }
+    })();
+
+    await Promise.resolve(); // initial subscribe + publish
+
+    // No reply frame yet — models a publish dropped into a poll/backoff gap.
+    // Core NATS discards a publish with no live subscriber, so the frame MUST be
+    // re-published on the interval so the daemon's next poll can pick it up.
+    await new Promise((r) => setTimeout(r, 55));
+    const beforeFrame = f.published.filter(
+      (p) => p.subject === reqSubject,
+    ).length;
+    expect(beforeFrame).toBeGreaterThan(1); // initial publish + ≥1 republish
+
+    // A reply frame finally arrives (a republish reached a live subscriber).
+    const replySubject = f.ops.find((o) => o.kind === "subscribe")!.subject;
+    f.deliver(replySubject, { type: "headers", status: 200, headers: {} });
+    await Promise.resolve();
+    const atFrame = f.published.filter((p) => p.subject === reqSubject).length;
+
+    // Republishing STOPS once the channel responds (no point, and the daemon is
+    // now processing — further copies would only add dedup load).
+    await new Promise((r) => setTimeout(r, 40));
+    const afterFrame = f.published.filter(
+      (p) => p.subject === reqSubject,
+    ).length;
+    expect(afterFrame).toBe(atFrame);
+
+    f.deliver(replySubject, { type: "chunk", data: "QQ==" });
+    f.deliver(replySubject, { type: "end" });
+    await run;
+    expect(out).toEqual(["QQ=="]);
+  });
+});
+
 describe("subject builders", () => {
   test("derive subjects purely from ids", () => {
     expect(buildRequestSubject("u1")).toBe("links.proxy.req.u1");

--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
@@ -60,6 +60,16 @@ const POLL_TIMEOUT_MS = 28_000;
 // reply legitimately has long inter-frame gaps — no per-frame idle timeout).
 const FIRST_FRAME_TIMEOUT_MS = 15_000;
 
+// Cadence for re-publishing the RequestFrame on the request leg (request-leg
+// tolerance). A single core-NATS publish is DROPPED if it lands in a daemon
+// poll/backoff gap (no live subscriber — see FIRST_FRAME_TIMEOUT_MS). Rather
+// than wait out the full first-frame window, re-publish the SAME reqId on this
+// cadence so the daemon's NEXT poll picks it up; the daemon dedupes by reqId
+// (proxy-abort-registry) so a copy that races a live handler is a no-op.
+// Re-publishing stops at the first reply frame (or presence-loss / abort /
+// first-frame timeout) and is bounded by FIRST_FRAME_TIMEOUT_MS.
+const REPUBLISH_INTERVAL_MS = 1_000;
+
 // Shared queue group for the request leg. The daemon holds MULTIPLE overlapping
 // GETs open (continuous-overlap, S2) to avoid an unsubscribed gap; a plain
 // core-NATS subscription would fan each request out to ALL of them
@@ -437,6 +447,15 @@ export interface CreateProxyDispatchDeps {
    * Injectable so unit tests can use a tiny value instead of sleeping 15 s.
    */
   firstFrameTimeoutMs?: number;
+  /**
+   * Interval in ms for re-publishing the RequestFrame until the first reply
+   * frame arrives (default {@link REPUBLISH_INTERVAL_MS}; set `0` to disable).
+   * Bridges a dropped publish — core NATS discards a publish with no live
+   * subscriber — without waiting the full first-frame timeout: the daemon's
+   * next poll picks up a republished copy and dedupes by reqId. Injectable so
+   * unit tests can use a tiny value.
+   */
+  republishIntervalMs?: number;
 }
 
 /**
@@ -502,12 +521,23 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
             firstFrameTimer = null;
           }
         };
+        // Request-leg republish timer (bridges a dropped publish). Stopped the
+        // instant the channel responds — see markFirstFrame / cleanup.
+        let republishTimer: ReturnType<typeof setInterval> | null = null;
+        const clearRepublishTimer = (): void => {
+          if (republishTimer !== null) {
+            clearInterval(republishTimer);
+            republishTimer = null;
+          }
+        };
         // Any reply frame (or a presence-loss / abort fire) counts as "the
-        // channel responded" — disable the no-first-frame bound exactly once.
+        // channel responded" — disable the no-first-frame bound and stop
+        // re-publishing exactly once.
         const markFirstFrame = (): void => {
           if (firstFrameSeen) return;
           firstFrameSeen = true;
           clearFirstFrameTimer();
+          clearRepublishTimer();
         };
 
         // SUBSCRIBE BEFORE PUBLISH — guarantees we don't miss the first frame.
@@ -561,6 +591,7 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
           cleanedUp = true;
           done = true;
           clearFirstFrameTimer();
+          clearRepublishTimer();
           try {
             unsubscribe();
           } catch {
@@ -636,6 +667,32 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
           // in tests, or an already-present queue), disable it immediately.
           if (firstFrameSeen || queue.length > 0 || done) {
             clearFirstFrameTimer();
+          }
+
+          // Re-publish the RequestFrame on a bounded cadence until the first
+          // reply frame arrives (request-leg tolerance). A single core-NATS
+          // publish is lost if it lands in a daemon poll/backoff gap; the daemon
+          // dedupes by reqId so a copy that races a live handler is a no-op.
+          // markFirstFrame / cleanup / the first-frame timeout all stop it, so
+          // it never outlives the dispatch.
+          const republishIntervalMs =
+            deps.republishIntervalMs ?? REPUBLISH_INTERVAL_MS;
+          if (republishIntervalMs > 0 && !firstFrameSeen && !done) {
+            republishTimer = setInterval(() => {
+              if (done || firstFrameSeen) {
+                clearRepublishTimer();
+                return;
+              }
+              try {
+                deps.nats.publish(
+                  buildRequestSubject(userSub),
+                  encoder.encode(JSON.stringify(requestFrame)),
+                );
+              } catch {
+                // Best-effort — presence-loss and the first-frame timeout cover
+                // a genuinely dead channel.
+              }
+            }, republishIntervalMs);
           }
         }
 

--- a/apps/mesh/src/link-daemon/proxy-abort-registry.test.ts
+++ b/apps/mesh/src/link-daemon/proxy-abort-registry.test.ts
@@ -9,13 +9,13 @@ import { register, abort, unregister, size } from "./proxy-abort-registry";
 
 describe("proxy-abort-registry", () => {
   it("register returns an AbortController whose signal is not yet aborted", () => {
-    const ac = register("req-test-1");
+    const ac = register("req-test-1")!;
     expect(ac.signal.aborted).toBe(false);
     unregister("req-test-1");
   });
 
   it("abort(reqId) aborts the signal and returns true", () => {
-    const ac = register("req-test-2");
+    const ac = register("req-test-2")!;
     expect(ac.signal.aborted).toBe(false);
 
     const result = abort("req-test-2");
@@ -31,23 +31,32 @@ describe("proxy-abort-registry", () => {
   });
 
   it("unregister then abort returns false (no-op)", () => {
-    const ac = register("req-test-3");
+    const ac = register("req-test-3")!;
     unregister("req-test-3");
 
     expect(abort("req-test-3")).toBe(false);
     expect(ac.signal.aborted).toBe(false);
   });
 
-  it("register overwrites a prior controller for the same reqId", () => {
+  it("register returns null for a reqId already in-flight (idempotent-delivery dedup)", () => {
+    // The cluster re-publishes the SAME reqId (request-leg tolerance) so a
+    // dropped publish gets retried. A duplicate copy that races the in-flight
+    // handler must NOT register a second controller — processing it again would
+    // double-execute the request. The second register is a no-op returning null.
     const ac1 = register("req-test-4");
+    expect(ac1).not.toBeNull();
+
     const ac2 = register("req-test-4");
+    expect(ac2).toBeNull();
 
-    expect(ac1).not.toBe(ac2);
+    // The original controller is untouched (still the live one to abort).
+    expect(abort("req-test-4")).toBe(true);
+    expect(ac1!.signal.aborted).toBe(true);
 
-    abort("req-test-4");
-    expect(ac2.signal.aborted).toBe(true);
-    expect(ac1.signal.aborted).toBe(false);
-
+    // Once the in-flight request finishes and unregisters, the id is free again.
+    unregister("req-test-4");
+    const ac3 = register("req-test-4");
+    expect(ac3).not.toBeNull();
     unregister("req-test-4");
   });
 
@@ -65,7 +74,7 @@ describe("proxy-abort-registry", () => {
     // Models the cancel reconciliation: abort fires the signal (which releases
     // handleStream's reader + runs acquireDispatch's release), then the handler
     // finally-block unregisters. The Map must not retain the entry afterwards.
-    const ac = register("req-cancel-flow");
+    const ac = register("req-cancel-flow")!;
     abort("req-cancel-flow");
     expect(ac.signal.aborted).toBe(true);
     unregister("req-cancel-flow");

--- a/apps/mesh/src/link-daemon/proxy-abort-registry.ts
+++ b/apps/mesh/src/link-daemon/proxy-abort-registry.ts
@@ -27,11 +27,15 @@
 const registry = new Map<string, AbortController>();
 
 /**
- * Create a fresh AbortController for `reqId`, store it, and return it.
- * Overwrites any prior controller for the same reqId (a duplicate delivery of
- * the same reqId — should not happen with UUID reqIds, but kept idempotent).
+ * Create a fresh AbortController for `reqId`, store it, and return it — UNLESS
+ * `reqId` is already in-flight, in which case return `null` WITHOUT touching the
+ * existing entry (idempotent-delivery dedup). The cluster re-publishes the same
+ * RequestFrame to bridge a dropped publish (request-leg tolerance); a duplicate
+ * copy that races the live handler must be dropped, not processed twice. The
+ * caller skips the request when this returns `null`.
  */
-export function register(reqId: string): AbortController {
+export function register(reqId: string): AbortController | null {
+  if (registry.has(reqId)) return null;
   const ac = new AbortController();
   registry.set(reqId, ac);
   return ac;

--- a/apps/mesh/src/link-daemon/proxy-poller.test.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.test.ts
@@ -205,6 +205,43 @@ describe("runOverlapScheduler — continuous overlap (landmine #5)", () => {
     expect(seenStreaks).toEqual([0, 1]); // streak increments across rejections
   });
 
+  it("backs off per-slot — one slot's errors do not inflate another slot's streak (no shared-streak blackout)", async () => {
+    // Regression: a single systemic poll error (e.g. a Cloudflare 520 storm on
+    // the long-held GET /api/links/proxy) must NOT push every slot into an
+    // ever-deepening backoff at once. With a shared errorStreak, slot B's FIRST
+    // failure already reads slot A's increment (streak 1), so one error blacks
+    // out BOTH proxy subscribers for longer and longer — opening the
+    // zero-subscriber gap that drops dispatch publishes (proxy_no_first_frame).
+    // Each slot must track its OWN consecutive-failure streak.
+    const ac = new AbortController();
+    const concurrency = 2;
+    const seenStreaks: number[] = [];
+
+    // Every poll fails — models the 520 storm hitting both slots.
+    const pollOnce = (): Promise<RequestFrame | null> =>
+      Promise.reject(new Error("proxy poll unexpected status 520"));
+
+    const deps: OverlapSchedulerDeps = {
+      pollOnce,
+      handle: () => {},
+      concurrency,
+      signal: ac.signal,
+      backoff: (streak) => {
+        seenStreaks.push(streak);
+        // Stop once both slots have recorded their first backoff.
+        if (seenStreaks.length >= concurrency) ac.abort();
+        return 1;
+      },
+      wait: async () => {},
+    };
+
+    await runOverlapScheduler(deps);
+
+    // Each slot's FIRST failure backs off with streak 0. A shared counter would
+    // make this [0, 1].
+    expect(seenStreaks.slice(0, concurrency)).toEqual([0, 0]);
+  });
+
   it("exits when the signal is already aborted (no polls)", async () => {
     const ac = new AbortController();
     ac.abort();

--- a/apps/mesh/src/link-daemon/proxy-poller.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.ts
@@ -269,6 +269,13 @@ async function handleProxyRequest(
   // (not the loop-wide signal). Combine with the loop signal so close() also
   // tears the request down.
   const reqAc = proxyAbortRegistry.register(reqId);
+  if (!reqAc) {
+    // Duplicate delivery: the cluster re-published this reqId (request-leg
+    // tolerance) and a copy raced a handler that's already running. Skip —
+    // re-processing would double-execute the request (e.g. a second agent run).
+    // Do NOT unregister here: the entry belongs to the in-flight handler.
+    return;
+  }
   const combined = AbortSignal.any([deps.signal, reqAc.signal]);
 
   try {
@@ -361,12 +368,18 @@ export async function runOverlapScheduler(
   const wait =
     deps.wait ?? ((ms, s) => sleep(ms, { signal: s }).catch(() => {}));
 
-  let errorStreak = 0;
-
   // One slot = one perpetually-recurring poll. Each slot re-arms itself the
   // instant its poll settles, so the count of outstanding polls never drops
   // below `concurrency` while the loop is alive (the no-gap guarantee).
   const slot = async (): Promise<void> => {
+    // PER-SLOT backoff streak. A single systemic poll error (e.g. a Cloudflare
+    // 520 storm on the long-held GET /api/links/proxy) must not push every slot
+    // into an ever-deepening shared backoff at once — that would black out ALL
+    // proxy subscribers and drop dispatch publishes (proxy_no_first_frame).
+    // Each slot tracks only its OWN consecutive failures, so a slot that just
+    // succeeded re-polls immediately while another retries, keeping ≥1
+    // subscriber live through transient/intermittent errors.
+    let errorStreak = 0;
     while (!signal.aborted) {
       let frame: RequestFrame | null;
       try {


### PR DESCRIPTION
## Summary

Fixes dropped dispatches on the pull proxy channel when the daemon has transient subscriber gaps.

**Root cause:** 
- Shared `errorStreak` across proxy-poller concurrency slots: one systemic error (Cloudflare 520 on the 28s long-poll) backs off BOTH slots → 1–30s zero-subscriber window.
- Fire-and-forget core-NATS request leg with no buffer: publish into a gap is silently lost.
- Claim re-armed only by `/work` (not `/proxy`), so presence-loss fail-fast can't catch a dead proxy-poll while the link looks "connected."

**Result:** chat messages fail with `[remoteDispatch] proxy_no_first_frame: no reply frame within first-frame timeout` because the cluster's RequestFrame publish lands in a gap and is dropped. Cluster waits 15s with no reply, fails fast instead of hanging.

## Changes

### PART #1 — Per-slot backoff
`apps/mesh/src/link-daemon/proxy-poller.ts`
- Moved `errorStreak` from shared scheduler scope into each `slot()` closure.
- Each slot now backs off only its OWN consecutive failures; one slot recovering and re-polling immediately while another retries keeps ≥1 live subscriber through intermittent errors.
- TDD: new test "backs off per-slot" asserts seenStreaks=[0,0] not [0,1] under concurrency:2 with both slots failing.

### PART #2 — Request-leg tolerance
`apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts`
- Added bounded republish of the RequestFrame every 1s (injectable `republishIntervalMs`, default=1000, 0=off) until first reply frame arrives.
- Republish stops at first reply/presence-loss/abort/first-frame-timeout (never outlives dispatch, bounded by 15s window).

`apps/mesh/src/link-daemon/proxy-abort-registry.ts` + `apps/mesh/src/link-daemon/proxy-poller.ts`
- `register(reqId)` now returns `AbortController | null` — null if reqId already in-flight (dedup for republish duplicates).
- `handleProxyRequest` bails on null *before* try/finally, so duplicate copy is skipped without unregistering the original's controller.
- TDD: new registry test "idempotent-delivery dedup" asserts second register returns null, id freed after unregister.
- TDD: new cluster test "re-publishes...then stops" asserts frame is published >1× before reply, then republishing ceases.

## Test Plan

- [x] `bun test apps/mesh/src/link-daemon/proxy-abort-registry.test.ts` — 7 pass (including new dedup test)
- [x] `bun test apps/mesh/src/link-daemon/proxy-poller.test.ts` — 14 pass (including new per-slot test)  
- [x] `bun test apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts` — 16 pass (including new republish test)
- [x] Broader suite: 110 pass across link-daemon + link routes
- [x] `bun run fmt` — clean (no fixes)
- [x] `bun run check` — all workspaces exit 0
- [x] `bun run lint` — 0 warnings / 0 errors

## Notes

⚠️ **Daemon shipping caveat:** `proxy-abort-registry.ts` marked "SHIPPED DAEMON — needs human review before merge." The change is small and well-tested (7 existing + 1 new test), but shipped in the `decocms` CLI binary, so users must update their `deco link` for Part A's dedup to take effect. This is safe (the change is purely defensive — returns null instead of a controller) but worth careful review.

**Remaining work:**
- #3: Tie proxy-readiness to the claim. The doc at `link-proxy-routes.ts:407` claims work/control/proxy all re-arm the 60s claim TTL, but only `/work` does — a real doc-vs-code defect. Once #3 is done, a dead proxy-poll surfaces a clean `link_unavailable` instead of a 15s hang.
- Infra: Fix the Cloudflare 520 itself (long-poll idle timeout, eks-serverless pod churn, or HTTP/2 GOAWAY on drain). Cluster-side retry (this PR) buys time, but the 520 is the trigger.
- Dedup pattern: The `reqId` dedup pattern in this PR may apply to `run-abort-registry` in `thread-gate-workflow.ts` if similar republish lands there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the link proxy resilient to transient subscriber gaps by adding per-slot backoff in the daemon and bounded request-leg republishing with reqId dedup. Prevents dropped request publishes that triggered proxy_no_first_frame timeouts.

- **Bug Fixes**
  - Per-slot backoff: each poller slot tracks its own error streak, so one slot can re-poll while another retries.
  - Request-leg tolerance: republishes the RequestFrame every 1s until the first reply, then stops; configurable via `republishIntervalMs` (0 disables).
  - Dedup on the daemon: `register(reqId)` returns `AbortController | null`; duplicates are skipped to avoid double execution.

- **Migration**
  - Update the shipped daemon in the `decocms` CLI (update `deco link`) so the dedup change takes effect.

<sup>Written for commit a4bac51aff32f21c641cae4a68b41a8e2a99f3b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

