### PR TITLE
fix(link): add proxy dispatch diagnostics

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1779,11 +1779,25 @@ export async function createApp(options: CreateAppOptions = {}) {
   if (natsProvider != null) {
     const proxyNatsAdapter: ProxyNatsAdapter = {
       publish(subject, data) {
-        natsProvider?.getConnection()?.publish(subject, data);
+        const nc = natsProvider?.getConnection();
+        if (!nc) {
+          console.warn("[link-proxy.nats] publish skipped: nats unavailable", {
+            subject,
+            bytes: data.byteLength,
+          });
+          return;
+        }
+        nc.publish(subject, data);
       },
       subscribe(subject, onMessage) {
         const nc = natsProvider?.getConnection();
-        if (!nc) return () => {};
+        if (!nc) {
+          console.warn(
+            "[link-proxy.nats] subscribe skipped: nats unavailable",
+            { subject },
+          );
+          return () => {};
+        }
         const sub = nc.subscribe(subject);
         void (async () => {
           for await (const m of sub) {

--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts
@@ -326,6 +326,67 @@ describe("createProxyDispatch — daemon-vanished fail-fast (S5, landmine #8)", 
 });
 
 describe("createProxyDispatch — first-frame timeout (no-subscriber fail-fast)", () => {
+  test("logs publish and first-frame timeout diagnostics with reqId correlation", async () => {
+    const f = makeFakeNats();
+    const diagnostics: Array<{ event: string; reqId?: string }> = [];
+    const dispatch = createProxyDispatch({
+      nats: f.nats,
+      firstFrameTimeoutMs: 30,
+      diagnosticLog: (event) => diagnostics.push(event),
+    });
+
+    const run = (async () => {
+      for await (const _ev of dispatch("user-1", baseReq)) {
+        /* drain */
+      }
+    })();
+
+    await expect(run).rejects.toThrow(/proxy_no_first_frame/);
+
+    const published = diagnostics.find(
+      (event) => event.event === "request_published",
+    );
+    const timedOut = diagnostics.find(
+      (event) => event.event === "first_frame_timeout",
+    );
+
+    expect(published?.reqId).toBeDefined();
+    expect(timedOut?.reqId).toBe(published?.reqId);
+  });
+
+  test("logs the first reply frame once and includes the same reqId", async () => {
+    const f = makeFakeNats();
+    const diagnostics: Array<{ event: string; reqId?: string }> = [];
+    const dispatch = createProxyDispatch({
+      nats: f.nats,
+      firstFrameTimeoutMs: 1_000,
+      diagnosticLog: (event) => diagnostics.push(event),
+    });
+
+    const run = (async () => {
+      for await (const _ev of dispatch("user-1", baseReq)) {
+        /* drain */
+      }
+    })();
+    await Promise.resolve();
+
+    const replySubject = f.ops.find((o) => o.kind === "subscribe")!.subject;
+    f.deliver(replySubject, { type: "headers", status: 200, headers: {} });
+    f.deliver(replySubject, { type: "chunk", data: "QQ==" });
+    f.deliver(replySubject, { type: "end" });
+    await run;
+
+    const published = diagnostics.find(
+      (event) => event.event === "request_published",
+    );
+    const firstFrames = diagnostics.filter(
+      (event) => event.event === "first_reply_frame",
+    );
+
+    expect(firstFrames).toHaveLength(1);
+    expect(firstFrames[0]?.reqId).toBe(published?.reqId);
+  });
+
   test("rejects with proxy_no_first_frame when NO reply frame ever arrives", async () => {
     const f = makeFakeNats();
     // Tiny injected timeout so the test is fast — never sleep the real 15 s.

--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
@@ -108,6 +108,37 @@ export interface ProxyNatsAdapter {
   subscribe(subject: string, onMessage: (data: Uint8Array) => void): () => void;
 }
 
+export interface ProxyDispatchDiagnosticEvent {
+  event: string;
+  reqId: string;
+  userSub: string;
+  method: string;
+  path: string;
+  elapsedMs?: number;
+  subject?: string;
+  frameType?: string;
+  status?: number;
+  publishCount?: number;
+  queueDepth?: number;
+  error?: string;
+}
+
+function defaultProxyDispatchDiagnosticLog(
+  event: ProxyDispatchDiagnosticEvent,
+): void {
+  console.log(`[link-proxy.dispatch] ${event.event}`, event);
+}
+
+function logProxyRoute(
+  event: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.log(`[link-proxy.route] ${event}`, {
+    event,
+    ...fields,
+  });
+}
+
 export interface LinkProxyDeps {
   /** Native NATS connection getter (queue-group subscriptions need it). */
   getConnection: () => NatsConnection | null;
@@ -137,9 +168,14 @@ export function createLinkProxyRoutes(deps: LinkProxyDeps) {
     }
 
     const nc = deps.getConnection();
-    if (!nc) return c.json({ error: "proxy channel unavailable" }, 503);
+    if (!nc) {
+      logProxyRoute("poll_nats_unavailable", { userId });
+      return c.json({ error: "proxy channel unavailable" }, 503);
+    }
 
     const subject = buildRequestSubject(userId);
+    const startedAt = Date.now();
+    logProxyRoute("poll_subscribe", { userId, subject });
     // Queue group + max:1 — each published RequestFrame goes to exactly ONE of
     // the daemon's overlapping GETs (landmine #5).
     const sub = nc.subscribe(subject, {
@@ -148,6 +184,11 @@ export function createLinkProxyRoutes(deps: LinkProxyDeps) {
     });
 
     const abortListener = () => {
+      logProxyRoute("poll_client_aborted", {
+        userId,
+        subject,
+        elapsedMs: Date.now() - startedAt,
+      });
       try {
         sub.unsubscribe();
       } catch {
@@ -186,10 +227,32 @@ export function createLinkProxyRoutes(deps: LinkProxyDeps) {
       ]);
 
       if (result !== null) {
+        try {
+          const frame = JSON.parse(result) as RequestFrame;
+          logProxyRoute("poll_delivered", {
+            userId,
+            subject,
+            reqId: frame.reqId,
+            method: frame.method,
+            path: frame.path,
+            elapsedMs: Date.now() - startedAt,
+          });
+        } catch {
+          logProxyRoute("poll_delivered_malformed", {
+            userId,
+            subject,
+            elapsedMs: Date.now() - startedAt,
+          });
+        }
         // Re-emit as JSON. Parse-then-stringify would re-validate but also lose
         // forward-compatible fields; the daemon owns validation, so pass through.
         return c.body(result, 200, { "content-type": "application/json" });
       }
+      logProxyRoute("poll_timeout", {
+        userId,
+        subject,
+        elapsedMs: Date.now() - startedAt,
+      });
       return c.body(null, 204);
     } finally {
       if (reqSignal && !reqSignal.aborted) {
@@ -215,12 +278,24 @@ export function createLinkProxyRoutes(deps: LinkProxyDeps) {
     }
 
     const nc = deps.getConnection();
-    if (!nc) return c.json({ error: "proxy channel unavailable" }, 503);
+    if (!nc) {
+      logProxyRoute("reply_nats_unavailable", { userId, reqId });
+      return c.json({ error: "proxy channel unavailable" }, 503);
+    }
 
     const body = c.req.raw.body;
     if (!body) return c.json({ error: "missing body" }, 400);
 
     const replySubject = buildReplySubject(reqId);
+    const startedAt = Date.now();
+    let frameCount = 0;
+    let byteCount = 0;
+    let firstFrameType: string | null = null;
+    logProxyRoute("reply_stream_start", {
+      userId,
+      reqId,
+      replySubject,
+    });
 
     // Stream-consume the NDJSON body frame-by-frame WITHOUT buffering (landmine
     // #1) and core-NATS-publish each decoded frame to the reply subject. NEVER
@@ -229,12 +304,23 @@ export function createLinkProxyRoutes(deps: LinkProxyDeps) {
     // it first and we publish in arrival order.
     try {
       for await (const line of splitNdjsonLines(body)) {
+        frameCount++;
+        byteCount += Buffer.byteLength(line, "utf8");
         let frame: ProxyReplyFrame;
         try {
           frame = decodeProxyReplyFrame(line);
         } catch (err) {
           // A malformed frame is fatal for this reply: surface an error frame
           // to the awaiter rather than silently dropping it.
+          logProxyRoute("reply_bad_frame", {
+            userId,
+            reqId,
+            replySubject,
+            frameCount,
+            byteCount,
+            elapsedMs: Date.now() - startedAt,
+            error: err instanceof Error ? err.message : String(err),
+          });
           publishReplyFrame(nc, replySubject, {
             type: "error",
             code: "bad_frame",
@@ -242,17 +328,47 @@ export function createLinkProxyRoutes(deps: LinkProxyDeps) {
           });
           return c.json({ error: "bad frame" }, 400);
         }
+        if (firstFrameType === null) {
+          firstFrameType = frame.type;
+          logProxyRoute("reply_first_frame", {
+            userId,
+            reqId,
+            replySubject,
+            frameType: frame.type,
+            ...(frame.type === "headers" ? { status: frame.status } : {}),
+            elapsedMs: Date.now() - startedAt,
+          });
+        }
         publishReplyFrame(nc, replySubject, frame);
       }
       // Clean body end. The daemon is expected to send its own terminal
       // `end`/`error` frame; if it didn't (e.g. truncated stream that still
       // closed cleanly without a terminal), we don't synthesize one here —
       // S5's presence-expiry fanout is the backstop for a vanished daemon.
+      logProxyRoute("reply_stream_complete", {
+        userId,
+        reqId,
+        replySubject,
+        frameCount,
+        byteCount,
+        firstFrameType,
+        elapsedMs: Date.now() - startedAt,
+      });
       return c.body(null, 204);
     } catch (err) {
       // Landmine #8 (POST-drop half): the upload connection broke mid-stream.
       // Publish an error frame so the awaiting DispatchFn throws instead of
       // hanging forever (full presence-expiry 502 fanout is S5).
+      logProxyRoute("reply_stream_dropped", {
+        userId,
+        reqId,
+        replySubject,
+        frameCount,
+        byteCount,
+        firstFrameType,
+        elapsedMs: Date.now() - startedAt,
+        error: err instanceof Error ? err.message : String(err),
+      });
       publishReplyFrame(nc, replySubject, {
         type: "error",
         code: "reply_stream_dropped",
@@ -456,6 +572,11 @@ export interface CreateProxyDispatchDeps {
    * unit tests can use a tiny value.
    */
   republishIntervalMs?: number;
+  /**
+   * Diagnostic sink for request/reply correlation. Defaults to console logging
+   * in production; tests inject an array-backed sink.
+   */
+  diagnosticLog?: (event: ProxyDispatchDiagnosticEvent) => void;
 }
 
 /**
@@ -497,6 +618,28 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
 
         const reqId = crypto.randomUUID();
         const replySubject = buildReplySubject(reqId);
+        const startedAt = Date.now();
+        const diagnosticLog =
+          deps.diagnosticLog ?? defaultProxyDispatchDiagnosticLog;
+        const logDiagnostic = (
+          event: Omit<
+            ProxyDispatchDiagnosticEvent,
+            "reqId" | "userSub" | "method" | "path" | "elapsedMs"
+          >,
+        ): void => {
+          try {
+            diagnosticLog({
+              reqId,
+              userSub,
+              method: req.method,
+              path: req.path,
+              elapsedMs: Date.now() - startedAt,
+              ...event,
+            });
+          } catch {
+            // Diagnostics must never affect dispatch.
+          }
+        };
 
         const queue: ProxyReplyFrame[] = [];
         let resolve: (() => void) | null = null;
@@ -546,11 +689,33 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
           // A real frame landed: disable the first-frame bound. SSE replies
           // legitimately have long gaps between subsequent frames, so we do NOT
           // re-arm or add a per-frame idle timeout.
+          const isFirstReplyFrame = !firstFrameSeen;
+          if (isFirstReplyFrame) {
+            logDiagnostic({
+              event: "first_reply_frame",
+              subject: replySubject,
+              queueDepth: queue.length,
+            });
+          }
           markFirstFrame();
           try {
-            queue.push(decodeProxyReplyFrame(decoder.decode(data)));
+            const frame = decodeProxyReplyFrame(decoder.decode(data));
+            queue.push(frame);
+            if (isFirstReplyFrame) {
+              logDiagnostic({
+                event: "first_reply_frame_decoded",
+                subject: replySubject,
+                frameType: frame.type,
+                ...(frame.type === "headers" ? { status: frame.status } : {}),
+              });
+            }
           } catch (err) {
             error = err instanceof Error ? err : new Error(String(err));
+            logDiagnostic({
+              event: "reply_frame_decode_error",
+              subject: replySubject,
+              error: error.message,
+            });
             done = true;
           }
           wake();
@@ -579,6 +744,10 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
               error = new Error(
                 "link_unavailable: daemon presence lost (claim expired or disappeared)",
               );
+              logDiagnostic({
+                event: "presence_lost",
+                error: error.message,
+              });
               done = true;
               wake();
             }
@@ -618,6 +787,11 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
             encoder.encode(encodeControlFrame({ type: "cancel_req", reqId })),
           );
           error = new Error("dispatch aborted");
+          logDiagnostic({
+            event: "caller_aborted",
+            subject: buildControlSubject(userSub),
+            error: error.message,
+          });
           cleanup();
           wake();
         };
@@ -637,15 +811,29 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
         // absent, skip the publish (the subject has no subscriber — core NATS
         // would drop it) and let the loop below throw the fail-fast error.
         if (!done) {
+          let publishCount = 1;
           try {
             deps.nats.publish(
               buildRequestSubject(userSub),
               encoder.encode(JSON.stringify(requestFrame)),
             );
+            logDiagnostic({
+              event: "request_published",
+              subject: buildRequestSubject(userSub),
+              publishCount,
+            });
           } catch (err) {
+            const publishError =
+              err instanceof Error ? err : new Error(String(err));
+            logDiagnostic({
+              event: "request_publish_failed",
+              subject: buildRequestSubject(userSub),
+              publishCount,
+              error: publishError.message,
+            });
             opts?.signal?.removeEventListener("abort", onAbort);
             cleanup();
-            throw err instanceof Error ? err : new Error(String(err));
+            throw publishError;
           }
 
           // ARM the first-frame timeout AFTER the publish. Core NATS drops a
@@ -660,6 +848,12 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
             error = new Error(
               "proxy_no_first_frame: no reply frame within first-frame timeout (request likely dropped — no daemon subscribed)",
             );
+            logDiagnostic({
+              event: "first_frame_timeout",
+              subject: replySubject,
+              publishCount,
+              error: error.message,
+            });
             done = true;
             wake();
           }, firstFrameTimeoutMs);
@@ -684,11 +878,23 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
                 return;
               }
               try {
+                publishCount++;
                 deps.nats.publish(
                   buildRequestSubject(userSub),
                   encoder.encode(JSON.stringify(requestFrame)),
                 );
-              } catch {
+                logDiagnostic({
+                  event: "request_republished",
+                  subject: buildRequestSubject(userSub),
+                  publishCount,
+                });
+              } catch (err) {
+                logDiagnostic({
+                  event: "request_republish_failed",
+                  subject: buildRequestSubject(userSub),
+                  publishCount,
+                  error: err instanceof Error ? err.message : String(err),
+                });
                 // Best-effort — presence-loss and the first-frame timeout cover
                 // a genuinely dead channel.
               }
@@ -710,12 +916,23 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
             if (frame.type === "chunk") {
               yield { data: frame.data };
             } else if (frame.type === "headers") {
+              logDiagnostic({
+                event: "headers_frame_yielded",
+                frameType: frame.type,
+                status: frame.status,
+              });
               yield {
                 headers: { status: frame.status, headers: frame.headers },
               };
             } else if (frame.type === "end") {
+              logDiagnostic({ event: "terminal_end", frameType: frame.type });
               return;
             } else if (frame.type === "error") {
+              logDiagnostic({
+                event: "terminal_error",
+                frameType: frame.type,
+                error: `${frame.code}: ${frame.message}`,
+              });
               throw new Error(`${frame.code}: ${frame.message}`);
             }
           }

--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -238,6 +238,16 @@ export function createControlHandler(deps: ControlHandlerDeps): ControlHandler {
               `[control] proxy ${req.method} ${rest} → ${res.status} handle=${handle}`,
             );
           }
+          if (verbose) {
+            console.log("[control] proxy_result", {
+              method: req.method,
+              rest,
+              handle,
+              port,
+              status: res.status,
+              contentType: res.headers.get("content-type"),
+            });
+          }
           yield {
             type: "headers" as const,
             status: res.status,

--- a/apps/mesh/src/link-daemon/proxy-poller.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.ts
@@ -83,6 +83,25 @@ function chunkFrame(bytes: Uint8Array): ProxyReplyFrame {
 
 const encoder = new TextEncoder();
 
+function logProxyPoller(
+  event: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.log(`[proxy-poller] ${event}`, {
+    event,
+    ...fields,
+  });
+}
+
+interface ReplyBodyDiagnosticEvent {
+  event: string;
+  frame: RequestFrame;
+  frameType?: ProxyReplyFrame["type"];
+  status?: number;
+  elapsedMs?: number;
+  error?: string;
+}
+
 /**
  * A `RequestFrame.path` routes to the one-shot `controlHandler.handle` (lifecycle
  * + liveness: `POST/DELETE/GET /api/sandboxes[...]`) rather than the streaming
@@ -139,9 +158,34 @@ export function buildReplyBody(
   controlHandler: ControlHandler,
   frame: RequestFrame,
   signal: AbortSignal,
+  diagnosticLog?: (event: ReplyBodyDiagnosticEvent) => void,
 ): ReadableStream<Uint8Array> {
+  const startedAt = Date.now();
+  let firstFrameSeen = false;
+  const logFrame = (f: ProxyReplyFrame): void => {
+    if (!firstFrameSeen) {
+      firstFrameSeen = true;
+      diagnosticLog?.({
+        event: "reply_body_first_frame",
+        frame,
+        frameType: f.type,
+        ...(f.type === "headers" ? { status: f.status } : {}),
+        elapsedMs: Date.now() - startedAt,
+      });
+    }
+    if (f.type === "end" || f.type === "error") {
+      diagnosticLog?.({
+        event: "reply_body_terminal_frame",
+        frame,
+        frameType: f.type,
+        ...(f.type === "error" ? { error: `${f.code}: ${f.message}` } : {}),
+        elapsedMs: Date.now() - startedAt,
+      });
+    }
+  };
+
   if (isLifecyclePath(frame.path)) {
-    return buildLifecycleReplyBody(controlHandler, frame);
+    return buildLifecycleReplyBody(controlHandler, frame, logFrame);
   }
   // Thread `signal` into handleStream so a cancel aborts the upstream fetch +
   // read (frees the SSE slot via acquireDispatch's release — landmine #3),
@@ -154,6 +198,7 @@ export function buildReplyBody(
     controller: ReadableStreamDefaultController<Uint8Array>,
     f: ProxyReplyFrame,
   ): void => {
+    logFrame(f);
     controller.enqueue(encoder.encode(`${encodeProxyReplyFrame(f)}\n`));
   };
 
@@ -223,11 +268,13 @@ export function buildReplyBody(
 function buildLifecycleReplyBody(
   controlHandler: ControlHandler,
   frame: RequestFrame,
+  onFrame?: (frame: ProxyReplyFrame) => void,
 ): ReadableStream<Uint8Array> {
   const writeLine = (
     controller: ReadableStreamDefaultController<Uint8Array>,
     f: ProxyReplyFrame,
   ): void => {
+    onFrame?.(f);
     controller.enqueue(encoder.encode(`${encodeProxyReplyFrame(f)}\n`));
   };
   return new ReadableStream<Uint8Array>({
@@ -274,9 +321,20 @@ async function handleProxyRequest(
     // tolerance) and a copy raced a handler that's already running. Skip —
     // re-processing would double-execute the request (e.g. a second agent run).
     // Do NOT unregister here: the entry belongs to the in-flight handler.
+    logProxyPoller("duplicate_request_skipped", {
+      reqId,
+      method: frame.method,
+      path: frame.path,
+    });
     return;
   }
   const combined = AbortSignal.any([deps.signal, reqAc.signal]);
+  const startedAt = Date.now();
+  logProxyPoller("request_handling_start", {
+    reqId,
+    method: frame.method,
+    path: frame.path,
+  });
 
   try {
     let token: string;
@@ -287,13 +345,37 @@ async function handleProxyRequest(
         `[proxy-poller] getAccessToken failed for reqId=${reqId}`,
         err,
       );
+      logProxyPoller("reply_post_token_failed", {
+        reqId,
+        method: frame.method,
+        path: frame.path,
+        elapsedMs: Date.now() - startedAt,
+        error: err instanceof Error ? err.message : String(err),
+      });
       return;
     }
 
-    const body = buildReplyBody(deps.controlHandler, frame, combined);
+    const body = buildReplyBody(deps.controlHandler, frame, combined, (ev) => {
+      logProxyPoller(ev.event, {
+        reqId: ev.frame.reqId,
+        method: ev.frame.method,
+        path: ev.frame.path,
+        frameType: ev.frameType,
+        status: ev.status,
+        elapsedMs: ev.elapsedMs,
+        error: ev.error,
+      });
+    });
     const url = `${deps.baseUrl}/api/links/proxy/${reqId}/stream`;
 
     try {
+      logProxyPoller("reply_post_start", {
+        reqId,
+        method: frame.method,
+        path: frame.path,
+        url,
+        elapsedMs: Date.now() - startedAt,
+      });
       const res = await fetcher(url, {
         method: "POST",
         headers: {
@@ -312,11 +394,40 @@ async function handleProxyRequest(
           `[proxy-poller] reply POST reqId=${reqId} → ${res.status}`,
         );
       }
+      logProxyPoller("reply_post_complete", {
+        reqId,
+        method: frame.method,
+        path: frame.path,
+        status: res.status,
+        ok: res.ok,
+        elapsedMs: Date.now() - startedAt,
+      });
     } catch (err) {
-      if (combined.aborted) return; // expected on cancel/close
+      if (combined.aborted) {
+        logProxyPoller("reply_post_aborted", {
+          reqId,
+          method: frame.method,
+          path: frame.path,
+          elapsedMs: Date.now() - startedAt,
+        });
+        return; // expected on cancel/close
+      }
       console.error(`[proxy-poller] reply POST failed reqId=${reqId}`, err);
+      logProxyPoller("reply_post_failed", {
+        reqId,
+        method: frame.method,
+        path: frame.path,
+        elapsedMs: Date.now() - startedAt,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   } finally {
+    logProxyPoller("request_handling_done", {
+      reqId,
+      method: frame.method,
+      path: frame.path,
+      elapsedMs: Date.now() - startedAt,
+    });
     proxyAbortRegistry.unregister(reqId);
   }
 }
@@ -450,6 +561,11 @@ export async function runProxyPollLoop(deps: ProxyPollerDeps): Promise<void> {
     ) {
       throw new Error("proxy poll: malformed RequestFrame");
     }
+    logProxyPoller("poll_received_request", {
+      reqId: raw.reqId,
+      method: raw.method,
+      path: raw.path,
+    });
     return raw;
   };
 


### PR DESCRIPTION
## What is this contribution about?
Adds reqId-correlated diagnostics across the link proxy dispatch path so future `proxy_no_first_frame` and reply stream drops can be traced across cluster publish, proxy route ingest, daemon poll handling, reply upload, and local control proxy boundaries.

## Screenshots/Demonstration
Not applicable; this is logging/instrumentation only.

## How to Test
1. Run `bun test apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts apps/mesh/src/link-daemon/proxy-poller.test.ts apps/mesh/src/link-daemon/control-handler.test.ts`.
2. Run `bun run check`, `bun run lint`, and `bun run fmt`.
3. Expected outcome: tests/typecheck/lint pass and deploy logs include `[link-proxy.dispatch]`, `[link-proxy.route]`, `[proxy-poller]`, `[control] proxy_result`, and `[link-proxy.nats]` prefixes.

## Migration Notes
No migrations or configuration changes required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reqId-correlated diagnostics across the link proxy path to trace dispatches end-to-end and quickly spot no-first-frame timeouts and dropped reply streams. Improves debuggability with consistent, structured logs from publish → route → daemon poll → reply upload → control.

- New Features
  - `createProxyDispatch`: adds `diagnosticLog` hook and default console logger; logs publish/republish, first-frame timeout, first reply frame, headers yield, terminal end/error, decode errors, presence loss, and caller abort with `reqId` and `elapsedMs`.
  - API routes (`/proxy/poll` and `/proxy/:reqId/stream`): emit `[link-proxy.route]` logs for NATS availability, poll subscribe/deliver/timeout, reply stream start/first frame/complete/dropped, and bad frames.
  - Proxy poller: adds `[proxy-poller]` logs for received request, handling start/done, token failures, reply POST start/complete/aborted/failed, and reply-body first/terminal frames.
  - NATS adapter: warns under `[link-proxy.nats]` when publish/subscribe is skipped due to missing connection.
  - Control handler: logs `[control] proxy_result` with method, handle, port, status, and content type.
  - Tests: verify `reqId` correlation between `request_published` and `first_frame_timeout`, and that the first reply frame is logged once with the same `reqId`.

<sup>Written for commit 43b97d01169bdf849f45968d624187a44cc8cb3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

