### PR TITLE
feat(ui): make GitHub import available to all users

### DIFF
--- a/apps/mesh/src/web/components/create-agent-dropdown.tsx
+++ b/apps/mesh/src/web/components/create-agent-dropdown.tsx
@@ -5,7 +5,6 @@ import {
 import { Globe02, Users03 } from "@untitledui/icons";
 import { GitHubIcon } from "@/web/components/icons/github-icon";
 import { SHOPIFY_HYDROGEN_ICON } from "@/web/hooks/use-create-website-agent";
-import { usePreferences } from "@/web/hooks/use-preferences.ts";
 
 interface CreateAgentDropdownContentProps {
   onCreateFromScratch: () => void;
@@ -30,8 +29,6 @@ export function CreateAgentDropdownContent({
   side,
   showBetaBadge,
 }: CreateAgentDropdownContentProps) {
-  const [preferences] = usePreferences();
-
   return (
     <DropdownMenuContent side={side} align={align} className="w-48">
       <DropdownMenuItem disabled={isCreating} onClick={onCreateFromScratch}>
@@ -50,17 +47,15 @@ export function CreateAgentDropdownContent({
         />
         Create Shopify Headless Store
       </DropdownMenuItem>
-      {preferences.experimental_vibecode && (
-        <DropdownMenuItem onClick={onImportGitHub}>
-          <GitHubIcon className="size-3.5" />
-          Import from GitHub
-          {showBetaBadge && (
-            <span className="ml-auto text-[10px] font-medium text-muted-foreground bg-muted rounded px-1 py-0.5">
-              Beta
-            </span>
-          )}
-        </DropdownMenuItem>
-      )}
+      <DropdownMenuItem onClick={onImportGitHub}>
+        <GitHubIcon className="size-3.5" />
+        Import from GitHub
+        {showBetaBadge && (
+          <span className="ml-auto text-[10px] font-medium text-muted-foreground bg-muted rounded px-1 py-0.5">
+            Beta
+          </span>
+        )}
+      </DropdownMenuItem>
       <DropdownMenuItem onClick={onImportDeco}>
         <img src="/logos/deco%20logo.svg" alt="deco.cx" className="size-3.5" />
         Import from deco.cx

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -48,7 +48,6 @@ import {
 import { track } from "@/web/lib/posthog-client";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { GitHubIcon } from "@/web/components/icons/github-icon";
-import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { GitHubRepoPicker } from "@/web/components/github-repo-picker.tsx";
 import { useThreadActions } from "@/web/components/chat/store/hooks";
@@ -177,7 +176,6 @@ function PinAgentPopoverContent({
   });
   const { createFromTemplate, isCreating: isCreatingFromTemplate } =
     useCreateAgentFromTemplate();
-  const [preferences] = usePreferences();
   const isDecoUser = useIsDecoUser();
 
   const navigateToNewTask = useNavigateToNewTaskWithBranchCarry(org.slug);
@@ -282,24 +280,22 @@ function PinAgentPopoverContent({
             </span>
           </button>
 
-          {preferences.experimental_vibecode && (
-            <button
-              type="button"
-              onClick={() => {
-                track("agent_import_clicked", { source: "github" });
-                onOpenGithubImport();
-                onClose();
-              }}
-              className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group"
-            >
-              <div className="w-12 h-12 rounded-xl border-2 border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-                <GitHubIcon className="size-5 text-muted-foreground" />
-              </div>
-              <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
-                Import GitHub
-              </span>
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => {
+              track("agent_import_clicked", { source: "github" });
+              onOpenGithubImport();
+              onClose();
+            }}
+            className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group"
+          >
+            <div className="w-12 h-12 rounded-xl border-2 border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
+              <GitHubIcon className="size-5 text-muted-foreground" />
+            </div>
+            <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
+              Import GitHub
+            </span>
+          </button>
 
           {isDecoUser && (
             <button

--- a/apps/mesh/src/web/hooks/use-preferences.ts
+++ b/apps/mesh/src/web/hooks/use-preferences.ts
@@ -8,7 +8,6 @@ interface Preferences {
   enableNotifications: boolean;
   enableSounds: boolean;
   theme: ThemeMode;
-  experimental_vibecode: boolean;
 }
 
 const DEFAULT_PREFERENCES: Preferences = {
@@ -16,7 +15,6 @@ const DEFAULT_PREFERENCES: Preferences = {
   enableNotifications: typeof Notification !== "undefined" ? true : false,
   enableSounds: false,
   theme: "system",
-  experimental_vibecode: false,
 };
 
 const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = ["auto", "readonly"];

--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -354,44 +354,6 @@ function PreferencesSection() {
   );
 }
 
-function ExperimentalSection() {
-  const [preferences, setPreferences] = usePreferences();
-
-  return (
-    <SettingsSection title="Experimental">
-      <SettingsCard>
-        <SettingsCardItem
-          title="Import from GitHub"
-          description="Enable importing agents from GitHub repositories."
-          onClick={() => {
-            track("preferences_experimental_vibecode_toggled", {
-              enabled: !preferences.experimental_vibecode,
-            });
-            setPreferences((prev) => ({
-              ...prev,
-              experimental_vibecode: !prev.experimental_vibecode,
-            }));
-          }}
-          action={
-            <Switch
-              checked={preferences.experimental_vibecode}
-              onCheckedChange={(checked) => {
-                track("preferences_experimental_vibecode_toggled", {
-                  enabled: checked,
-                });
-                setPreferences((prev) => ({
-                  ...prev,
-                  experimental_vibecode: checked,
-                }));
-              }}
-            />
-          }
-        />
-      </SettingsCard>
-    </SettingsSection>
-  );
-}
-
 export function ProfilePreferencesPage() {
   return (
     <Page>
@@ -401,7 +363,6 @@ export function ProfilePreferencesPage() {
             <Page.Title>Profile & Preferences</Page.Title>
             <ProfileSection />
             <PreferencesSection />
-            <ExperimentalSection />
           </SettingsPage>
         </Page.Body>
       </Page.Content>


### PR DESCRIPTION
## Summary
- Remove the `experimental_vibecode` preference flag that gated GitHub import behind Profile & Preferences
- Always show "Import from GitHub" in the create-agent dropdown and sidebar browse-agents popover
- Remove the Experimental section from Profile & Preferences

## Test plan
- [ ] Open Profile & Preferences — confirm the Experimental section is gone
- [ ] Open Create Agent dropdown on agents list — confirm "Import from GitHub" is visible without enabling any preference
- [ ] Open sidebar browse-agents popover — confirm "Import GitHub" tile is visible
- [ ] Click Import from GitHub and verify the repo picker still opens and works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GitHub import available to all users by removing the experimental preference gate. The repo picker flow is unchanged; the option now always shows in agent creation.

- **New Features**
  - Always show "Import from GitHub" in the Create Agent dropdown and the sidebar browse-agents popover.
  - Removed the Experimental section and GitHub import toggle from Profile & Preferences, and deleted the `experimental_vibecode` preference and related gating checks.

<sup>Written for commit 8690552f6785aa05f77ee476f15e7dbd8511c401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

