### PR TITLE
fix(link): honest 503 first-frame on sandbox connect-failure (no false proxy_no_first_frame)

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
@@ -846,7 +846,7 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
             if (done || firstFrameSeen) return;
             markFirstFrame();
             error = new Error(
-              "proxy_no_first_frame: no reply frame within first-frame timeout (request likely dropped — no daemon subscribed)",
+              "proxy_no_first_frame: no reply frame within first-frame timeout (sandbox unreachable or no daemon subscribed)",
             );
             logDiagnostic({
               event: "first_frame_timeout",

--- a/apps/mesh/src/link-daemon/control-handler.test.ts
+++ b/apps/mesh/src/link-daemon/control-handler.test.ts
@@ -96,4 +96,58 @@ describe("control-handler", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  test("handleStream yields 503 headers frame when sandbox connect fails", async () => {
+    const throwingFetch = (async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:51812");
+    }) as unknown as typeof fetch;
+    const handler = createControlHandler({
+      provider: fakeProvider(),
+      fetchImpl: throwingFetch,
+    });
+
+    const frames: Array<{ type: string; status?: number }> = [];
+    let bodyText = "";
+    for await (const ev of handler.handleStream({
+      type: "request",
+      reqId: "r",
+      method: "GET",
+      path: "/_sandbox/test-handle/dispatch",
+      headers: {},
+    })) {
+      frames.push(ev as { type: string; status?: number });
+      if (ev.type === "raw-chunk") {
+        bodyText += new TextDecoder().decode(ev.data);
+      }
+    }
+
+    expect(frames[0]).toEqual({
+      type: "headers",
+      status: 503,
+      headers: { "content-type": "text/plain" },
+    });
+    expect(bodyText).toContain("sandbox not reachable");
+  });
+
+  test("handleStream does NOT throw on sandbox connect failure", async () => {
+    const throwingFetch = (async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:51812");
+    }) as unknown as typeof fetch;
+    const handler = createControlHandler({
+      provider: fakeProvider(),
+      fetchImpl: throwingFetch,
+    });
+    const run = (async () => {
+      for await (const _ of handler.handleStream({
+        type: "request",
+        reqId: "r",
+        method: "GET",
+        path: "/_sandbox/test-handle/dispatch",
+        headers: {},
+      })) {
+        /* drain */
+      }
+    })();
+    await expect(run).resolves.toBeUndefined();
+  });
 });

--- a/apps/mesh/src/link-daemon/control-handler.test.ts
+++ b/apps/mesh/src/link-daemon/control-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createControlHandler } from "./control-handler";
+import { createControlHandler, type StreamEvent } from "./control-handler";
 import type { DesktopSandboxProvider } from "./user-desktop-provider";
 
 function fakeProvider(
@@ -106,7 +106,7 @@ describe("control-handler", () => {
       fetchImpl: throwingFetch,
     });
 
-    const frames: Array<{ type: string; status?: number }> = [];
+    const frames: StreamEvent[] = [];
     let bodyText = "";
     for await (const ev of handler.handleStream({
       type: "request",
@@ -115,7 +115,7 @@ describe("control-handler", () => {
       path: "/_sandbox/test-handle/dispatch",
       headers: {},
     })) {
-      frames.push(ev as { type: string; status?: number });
+      frames.push(ev);
       if (ev.type === "raw-chunk") {
         bodyText += new TextDecoder().decode(ev.data);
       }
@@ -126,6 +126,8 @@ describe("control-handler", () => {
       status: 503,
       headers: { "content-type": "text/plain" },
     });
+    expect(frames).toHaveLength(2);
+    expect(frames[1]?.type).toBe("raw-chunk");
     expect(bodyText).toContain("sandbox not reachable");
   });
 

--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -225,13 +225,25 @@ export function createControlHandler(deps: ControlHandlerDeps): ControlHandler {
             // freed). Return without an error frame.
             if (signal?.aborted) return;
             // Connection refused / reset: the spawned sandbox daemon died or
-            // never bound its port. Surface it — otherwise the cluster only
-            // sees a dropped dispatch and reports `decopilot.finish: failed`.
+            // respawned onto a different port (the cached proxy port is stale).
+            // Yield a real 503 first frame — mirroring the `port == null → 404`
+            // path above — so the cluster's first-frame timer disarms and the
+            // user sees a fast, honest "restarting" error instead of a 15s
+            // `proxy_no_first_frame (no daemon subscribed)` stall.
             console.error(
-              `[control] proxy ${req.method} ${rest} handle=${handle} port=${port} fetch failed:`,
+              `[control] proxy ${req.method} ${rest} handle=${handle} port=${port} fetch failed (yielding 503):`,
               err,
             );
-            throw err;
+            yield {
+              type: "headers" as const,
+              status: 503,
+              headers: { "content-type": "text/plain" },
+            };
+            yield {
+              type: "raw-chunk" as const,
+              data: textBytes("sandbox not reachable (restarting)"),
+            };
+            return;
           }
           if (verbose && (res.status < 200 || res.status >= 300)) {
             console.warn(

--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -230,10 +230,12 @@ export function createControlHandler(deps: ControlHandlerDeps): ControlHandler {
             // path above — so the cluster's first-frame timer disarms and the
             // user sees a fast, honest "restarting" error instead of a 15s
             // `proxy_no_first_frame (no daemon subscribed)` stall.
-            console.error(
-              `[control] proxy ${req.method} ${rest} handle=${handle} port=${port} fetch failed (yielding 503):`,
-              err,
-            );
+            if (verbose) {
+              console.error(
+                `[control] proxy ${req.method} ${rest} handle=${handle} port=${port} fetch failed (yielding 503):`,
+                err,
+              );
+            }
             yield {
               type: "headers" as const,
               status: 503,
@@ -241,7 +243,7 @@ export function createControlHandler(deps: ControlHandlerDeps): ControlHandler {
             };
             yield {
               type: "raw-chunk" as const,
-              data: textBytes("sandbox not reachable (restarting)"),
+              data: textBytes("sandbox not reachable"),
             };
             return;
           }


### PR DESCRIPTION
## Summary

When the daemon reverse-proxies a request to a local desktop sandbox whose port is **dead or stale** (the sandbox crashed / respawned onto a new port), `control-handler.ts`'s `handleStream` generator did `throw err` on the connect-failure **before yielding any frame**. The cluster therefore received no first frame and, after the 15s first-frame timer, reported the misleading `proxy_no_first_frame: ... (request likely dropped — no daemon subscribed)`.

This PR makes that failure **fast and honest**:

- **①** On a sandbox connect-failure, yield a real `503` `headers` frame + `"sandbox not reachable"` body (mirroring the existing `port == null → 404` path) instead of throwing frameless. The cluster's first-frame timer disarms; the user sees a quick, truthful error instead of a 15s stall.
- **②** Reword the cluster's `proxy_no_first_frame` message to `"(sandbox unreachable or no daemon subscribed)"` — it no longer asserts a cause it cannot know (live evidence shows a daemon is usually subscribed and *does* receive the request).
- The new `console.error` is gated behind the existing `verbose` flag so a flapping sandbox's `/events` reconnects don't spam the daemon log.

## Root cause (verified on studio-stg + a live daemon)

`poll_delivered` fires for the failing reqIds — a daemon **is** subscribed and receives the request (the per-second republish from #3704 delivers it repeatedly to `publishCount:15`). It never replies because its local sandbox port had walked across respawns (`49569 → 51812 → 53770 → 55983 …`) and the daemon held a dead port; `curl` to that port → connection refused. The frameless `throw` then surfaced as `proxy_no_first_frame`. (The `dispatch failed (404)` sibling error is the same root via the `port == null` branch when the handle is fully unspawned.)

## What this does / doesn't fix

This is the honest-failure slice. It does **not** yet make a flapping sandbox recover — follow-up PRs add: daemon `received` sentinel + dual-timer (distinguish "no daemon" from "sandbox produced no frame"), provider `invalidate` + re-ensure + retry-once (recovery), and `/events`/`/git/status` storm reduction. See `docs/superpowers/specs/2026-06-08-graceful-sandbox-failure-handling-design.md`.

## Testing

- `bun test apps/mesh/src/link-daemon/control-handler.test.ts apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts` → 24 pass / 0 fail (2 new tests: 503 frame shape + no-throw invariant).
- `bun run --cwd=apps/mesh check` (tsc) clean; `bun run fmt:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a real 503 first frame when the daemon can’t connect to the local sandbox, so requests fail fast instead of stalling for 15s. Also make the timeout message accurate by not claiming “no daemon subscribed.”

- **Bug Fixes**
  - `handleStream`: on connect failure, yield 503 headers + "sandbox not reachable" body; no throw; first-frame timer disarms.
  - Reword `proxy_no_first_frame` to “(sandbox unreachable or no daemon subscribed)”.
  - Gate connect-failure logging behind `verbose` to avoid log spam.

<sup>Written for commit ae8f15dfec03c70a137c89165d02125264236457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

