### PR TITLE
fix(link): honest 503 first-frame on sandbox connect-failure

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
@@ -846,7 +846,7 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
             if (done || firstFrameSeen) return;
             markFirstFrame();
             error = new Error(
-              "proxy_no_first_frame: no reply frame within first-frame timeout (request likely dropped — no daemon subscribed)",
+              "proxy_no_first_frame: no reply frame within first-frame timeout (sandbox unreachable or no daemon subscribed)",
             );
             logDiagnostic({
               event: "first_frame_timeout",

--- a/apps/mesh/src/link-daemon/control-handler.test.ts
+++ b/apps/mesh/src/link-daemon/control-handler.test.ts
@@ -96,4 +96,58 @@ describe("control-handler", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  test("handleStream yields 503 headers frame when sandbox connect fails", async () => {
+    const throwingFetch = (async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:51812");
+    }) as unknown as typeof fetch;
+    const handler = createControlHandler({
+      provider: fakeProvider(),
+      fetchImpl: throwingFetch,
+    });
+
+    const frames: Array<{ type: string; status?: number }> = [];
+    let bodyText = "";
+    for await (const ev of handler.handleStream({
+      type: "request",
+      reqId: "r",
+      method: "GET",
+      path: "/_sandbox/test-handle/dispatch",
+      headers: {},
+    })) {
+      frames.push(ev as { type: string; status?: number });
+      if (ev.type === "raw-chunk") {
+        bodyText += new TextDecoder().decode(ev.data);
+      }
+    }
+
+    expect(frames[0]).toEqual({
+      type: "headers",
+      status: 503,
+      headers: { "content-type": "text/plain" },
+    });
+    expect(bodyText).toContain("sandbox not reachable");
+  });
+
+  test("handleStream does NOT throw on sandbox connect failure", async () => {
+    const throwingFetch = (async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:51812");
+    }) as unknown as typeof fetch;
+    const handler = createControlHandler({
+      provider: fakeProvider(),
+      fetchImpl: throwingFetch,
+    });
+    const run = (async () => {
+      for await (const _ of handler.handleStream({
+        type: "request",
+        reqId: "r",
+        method: "GET",
+        path: "/_sandbox/test-handle/dispatch",
+        headers: {},
+      })) {
+        /* drain */
+      }
+    })();
+    await expect(run).resolves.toBeUndefined();
+  });
 });

--- a/apps/mesh/src/link-daemon/control-handler.test.ts
+++ b/apps/mesh/src/link-daemon/control-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createControlHandler } from "./control-handler";
+import { createControlHandler, type StreamEvent } from "./control-handler";
 import type { DesktopSandboxProvider } from "./user-desktop-provider";
 
 function fakeProvider(
@@ -106,7 +106,7 @@ describe("control-handler", () => {
       fetchImpl: throwingFetch,
     });
 
-    const frames: Array<{ type: string; status?: number }> = [];
+    const frames: StreamEvent[] = [];
     let bodyText = "";
     for await (const ev of handler.handleStream({
       type: "request",
@@ -115,7 +115,7 @@ describe("control-handler", () => {
       path: "/_sandbox/test-handle/dispatch",
       headers: {},
     })) {
-      frames.push(ev as { type: string; status?: number });
+      frames.push(ev);
       if (ev.type === "raw-chunk") {
         bodyText += new TextDecoder().decode(ev.data);
       }
@@ -126,6 +126,8 @@ describe("control-handler", () => {
       status: 503,
       headers: { "content-type": "text/plain" },
     });
+    expect(frames).toHaveLength(2);
+    expect(frames[1]?.type).toBe("raw-chunk");
     expect(bodyText).toContain("sandbox not reachable");
   });
 

--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -225,13 +225,25 @@ export function createControlHandler(deps: ControlHandlerDeps): ControlHandler {
             // freed). Return without an error frame.
             if (signal?.aborted) return;
             // Connection refused / reset: the spawned sandbox daemon died or
-            // never bound its port. Surface it — otherwise the cluster only
-            // sees a dropped dispatch and reports `decopilot.finish: failed`.
+            // respawned onto a different port (the cached proxy port is stale).
+            // Yield a real 503 first frame — mirroring the `port == null → 404`
+            // path above — so the cluster's first-frame timer disarms and the
+            // user sees a fast, honest "restarting" error instead of a 15s
+            // `proxy_no_first_frame (no daemon subscribed)` stall.
             console.error(
-              `[control] proxy ${req.method} ${rest} handle=${handle} port=${port} fetch failed:`,
+              `[control] proxy ${req.method} ${rest} handle=${handle} port=${port} fetch failed (yielding 503):`,
               err,
             );
-            throw err;
+            yield {
+              type: "headers" as const,
+              status: 503,
+              headers: { "content-type": "text/plain" },
+            };
+            yield {
+              type: "raw-chunk" as const,
+              data: textBytes("sandbox not reachable (restarting)"),
+            };
+            return;
           }
           if (verbose && (res.status < 200 || res.status >= 300)) {
             console.warn(

--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -230,10 +230,12 @@ export function createControlHandler(deps: ControlHandlerDeps): ControlHandler {
             // path above — so the cluster's first-frame timer disarms and the
             // user sees a fast, honest "restarting" error instead of a 15s
             // `proxy_no_first_frame (no daemon subscribed)` stall.
-            console.error(
-              `[control] proxy ${req.method} ${rest} handle=${handle} port=${port} fetch failed (yielding 503):`,
-              err,
-            );
+            if (verbose) {
+              console.error(
+                `[control] proxy ${req.method} ${rest} handle=${handle} port=${port} fetch failed (yielding 503):`,
+                err,
+              );
+            }
             yield {
               type: "headers" as const,
               status: 503,
@@ -241,7 +243,7 @@ export function createControlHandler(deps: ControlHandlerDeps): ControlHandler {
             };
             yield {
               type: "raw-chunk" as const,
-              data: textBytes("sandbox not reachable (restarting)"),
+              data: textBytes("sandbox not reachable"),
             };
             return;
           }


### PR DESCRIPTION
## What is this contribution about?
When the daemon reverse-proxies a request to a desktop sandbox whose local port is dead or stale (the sandbox crashed or respawned onto a new port), `control-handler.ts`'s `handleStream` did `throw err` on the connect-failure **before yielding any frame**, so the cluster received no first frame and — after a 15s timer — reported the misleading `proxy_no_first_frame: ... (request likely dropped — no daemon subscribed)`. This PR yields a real `503 "sandbox not reachable"` headers frame instead (mirroring the existing `port == null → 404` path) so the failure is fast and honest, gates that new log behind the existing `verbose` flag so `/events` reconnects don't spam, and rewords the cluster's `proxy_no_first_frame` message to `"(sandbox unreachable or no daemon subscribed)"` since a daemon is in fact usually subscribed and receives the request. This is the first slice of a larger plan (honest-failure now; sentinel/dual-timer, recovery, and storm-reduction to follow).

## Screenshots/Demonstration
N/A — daemon/cluster behavior only, no UI changes.

## How to Test
1. `bun test apps/mesh/src/link-daemon/control-handler.test.ts apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts` → 24 pass / 0 fail (2 new tests inject a throwing `fetchImpl` to simulate a dead sandbox port).
2. `bun run --cwd=apps/mesh check` (tsc) and `bun run fmt:check` → clean.
3. Expected: on a sandbox connect-failure the proxy now yields a `503` headers frame (the generator no longer rejects), so the cluster gets a first frame instead of stalling 15s on `proxy_no_first_frame`.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a 503 "sandbox not reachable" first frame when the link daemon can't connect to a desktop sandbox, so requests fail fast instead of timing out for 15s. Also clarifies the timeout message and reduces noisy logs.

- **Bug Fixes**
  - On sandbox connect failure, `handleStream` now yields a 503 headers frame with a plain-text body instead of throwing before any frame.
  - Reworded the first-frame timeout to "(sandbox unreachable or no daemon subscribed)" and gated the connect-failure log behind `verbose`.
  - Added tests for the 503 first frame and to ensure the stream does not throw.

<sup>Written for commit ae8f15dfec03c70a137c89165d02125264236457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

