### PR TITLE
feat(web): rename PWA from "deco CMS" to "deco Studio"

### DIFF
--- a/apps/mesh/index.html
+++ b/apps/mesh/index.html
@@ -21,14 +21,14 @@
       })();
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>deco CMS</title>
+    <title>deco Studio</title>
     <meta name="description" content="Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in." />
-    <meta property="og:title" content="deco CMS" />
+    <meta property="og:title" content="deco Studio" />
     <meta property="og:description" content="Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in." />
     <meta property="og:image" content="/og-image.png" />
-    <meta property="og:site_name" content="deco CMS" />
+    <meta property="og:site_name" content="deco Studio" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="deco CMS" />
+    <meta name="twitter:title" content="deco Studio" />
     <meta name="twitter:description" content="Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in." />
     <meta name="twitter:image" content="/og-image.png" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/apps/mesh/public/manifest.webmanifest
+++ b/apps/mesh/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "deco CMS",
-  "short_name": "deco CMS",
+  "name": "deco Studio",
+  "short_name": "deco Studio",
   "description": "Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in.",
   "start_url": "/",
   "scope": "/",


### PR DESCRIPTION
## What is this contribution about?
Renames the PWA-facing app name from "deco CMS" to "deco Studio". Updates `name`/`short_name` in `apps/mesh/public/manifest.webmanifest` (installed app name / window-controls-overlay title bar) and the `<title>`, `og:title`, `og:site_name`, and `twitter:title` tags in `apps/mesh/index.html`. Scoped to PWA/browser-tab/social-preview metadata only — broader repo branding (README, docs, `decocms` package name, og image) is intentionally left unchanged.

## Screenshots/Demonstration
> N/A — text-only metadata change. Installed PWA and browser tab now read "deco Studio".

## How to Test
1. Run the mesh client (`bun run --cwd=apps/mesh dev:client`).
2. Check the browser tab title reads "deco Studio".
3. Install the PWA and confirm the app name / WCO title bar shows "deco Studio".

## Migration Notes
> Not applicable.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the PWA app from "deco CMS" to "deco Studio". Updated the manifest (`name`, `short_name`), page `<title>`, and social titles (`og:title`, `og:site_name`, `twitter:title`) so the installed app and browser tab show "deco Studio".

<sup>Written for commit 17e627c7f677b15c0179cc793a3fd995aece9d8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

