### PR TITLE
fix(link): emit dispatch prelude before harness chunks

### DIFF
--- a/packages/sandbox/daemon/routes/dispatch.test.ts
+++ b/packages/sandbox/daemon/routes/dispatch.test.ts
@@ -71,6 +71,46 @@ describe("POST /_sandbox/dispatch", () => {
     expect(events.at(-1)).toBe('{"type":"done"}');
   });
 
+  it("emits an immediate SSE prelude before the first harness chunk", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const deps = makeDeps({
+      lookupHarness: () => ({
+        async *stream() {
+          await gate;
+          yield { type: "start", id: "m1" } as const;
+        },
+      }),
+    });
+    const body = JSON.stringify({
+      harnessId: "fake",
+      input: { ...fixtures.FIXTURE_MINIMAL_INPUT, runId: "run-prelude" },
+    });
+
+    const res = await handleDispatchRequest(authedDispatch(body), deps);
+    expect(res.status).toBe(200);
+
+    const reader = res.body!.getReader();
+    const first = await Promise.race([
+      reader.read(),
+      new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 25),
+      ),
+    ]);
+
+    expect(first).not.toBe("timeout");
+    if (first !== "timeout") {
+      expect(new TextDecoder().decode(first.value)).toBe(
+        ": dispatch accepted\n\n",
+      );
+    }
+
+    release();
+    await reader.cancel();
+  });
+
   it("rejects a request with no bearer token", async () => {
     const req = new Request("http://x/_sandbox/dispatch", {
       method: "POST",

--- a/packages/sandbox/daemon/routes/dispatch.ts
+++ b/packages/sandbox/daemon/routes/dispatch.ts
@@ -92,6 +92,21 @@ const SSE_HEADERS = {
   connection: "keep-alive",
 } as const;
 
+const DISPATCH_ACCEPTED_SSE_COMMENT = ": dispatch accepted\n\n";
+
+function writeDispatchAcceptedPrelude(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+  state: { closed: boolean },
+): void {
+  if (state.closed) return;
+  try {
+    controller.enqueue(encoder.encode(DISPATCH_ACCEPTED_SSE_COMMENT));
+  } catch {
+    state.closed = true;
+  }
+}
+
 /** Drive a harness's stream into an SSE controller. Reused verbatim by both
  *  paths so chunk relaying / abort handling / error wrapping / `done` framing
  *  stay identical. Always emits `done` and closes the controller; never hangs.
@@ -189,6 +204,7 @@ export async function handleDispatchRequest(
     const ctrl = new AbortController();
     const sseStream = new ReadableStream<Uint8Array>({
       async start(controller) {
+        writeDispatchAcceptedPrelude(controller, encoder, streamState);
         // write captures controller — cannot hoist above the stream
         const write = (event: DispatchSSEEvent): void => {
           if (streamState.closed || ctrl.signal.aborted) return;
@@ -379,6 +395,7 @@ export async function handleDispatchRequest(
   const streamState = { closed: false };
   const sseStream = new ReadableStream<Uint8Array>({
     async start(controller) {
+      writeDispatchAcceptedPrelude(controller, encoder, streamState);
       // write captures controller — cannot hoist above the stream
       const write = (event: DispatchSSEEvent): void => {
         if (streamState.closed || ctrl.signal.aborted) return;


### PR DESCRIPTION
## What is this contribution about?
Emit an immediate SSE comment from the sandbox dispatch route before waiting on harness output so the link proxy can deliver a first reply frame promptly and avoid `proxy_no_first_frame` timeouts.

## Screenshots/Demonstration
Not applicable; this is a transport/runtime fix.

## How to Test
1. Run `bun test packages/sandbox/daemon/routes/dispatch.test.ts`.
2. Run `bun test apps/mesh/src/harnesses/remote-dispatch.test.ts apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts apps/mesh/src/link-daemon/proxy-poller.test.ts`.
3. Expected outcome: all tests pass, including the regression that dispatch emits an immediate SSE prelude before the first harness chunk.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit an immediate SSE prelude from the dispatch route so the link proxy receives a first reply frame promptly, preventing `proxy_no_first_frame` timeouts.

- **Bug Fixes**
  - Send an SSE comment prelude `: dispatch accepted\n\n` before any harness chunks in both dispatch paths.
  - Added a test to ensure the prelude arrives quickly (within 25ms) before the first harness event.

<sup>Written for commit 3eac8e0d4d3fd673e1d0be9df00c11bfd4f133ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

