### PR TITLE
fix(dev): align auto-spawned link with OAuth user in --no-local-mode

### DIFF
--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -7,7 +7,6 @@
  */
 import { tmpdir } from "node:os";
 import { join } from "path";
-import { sleep } from "@decocms/std";
 import type { Subprocess } from "bun";
 import { buildSettings } from "../../settings/pipeline";
 import {
@@ -129,7 +128,13 @@ export async function startDevServer(
     process.env.WORKTREE_SLUG ??
     process.env.CONDUCTOR_WORKSPACE_NAME ??
     "default";
-  const linkDataDir = join(tmpdir(), `decocms-dev-link-${slug}`);
+  // Local mode mints an API-key session into an isolated tmpdir so sandbox
+  // clones never nest inside the mesh repo's .git. Non-local mode reuses
+  // DECOCMS_HOME so the auto-spawned link registers as the same OAuth user
+  // logged into the browser (e.g. tavano@deco.cx).
+  const linkDataDir = options.localMode
+    ? join(tmpdir(), `decocms-dev-link-${slug}`)
+    : settings.dataDir;
 
   // When TUI is active, pipe stdout/stderr so child output doesn't corrupt
   // Ink's cursor-based rendering. Lines are fed into the CLI store instead.
@@ -159,10 +164,10 @@ export async function startDevServer(
             S3_FORCE_PATH_STYLE: String(settings.s3ForcePathStyle),
           }
         : {}),
-      // Tell the cluster where to write the dev-link session file when
-      // local-sandbox-provider is on, so the auto-spawned link daemon
-      // finds session.json under its DATA_DIR.
-      ...(options.localSandboxProvider
+      // Local mode only: tell the cluster to mint an API-key session for the
+      // auto-spawned link. Non-local mode uses the developer's OAuth session
+      // from DECOCMS_HOME instead (see ensureDevLinkSession).
+      ...(options.localSandboxProvider && options.localMode
         ? { DEV_LINK_SESSION_PATH: join(linkDataDir, "session.json") }
         : {}),
       ...(settings.baseUrl ? { BASE_URL: settings.baseUrl } : {}),
@@ -229,21 +234,17 @@ export async function startDevServer(
             pipeToLogStore(proc.stderr as ReadableStream<Uint8Array>);
           },
           beforeSpawn: async () => {
-            // Wait for the cluster's HTTP port before spawning the link
-            // daemon so it can immediately reach the WS gateway.
             await waitForPort(Number(settings.port), { intervalMs: 500 });
-            // Then wait for the cluster's `bootstrapDevLinkSession` to drop
-            // session.json into linkDataDir, since the link CLI's
-            // `ensureSession` errors out (non-TTY auto-spawn) if it's missing.
-            const sessionPath = join(linkDataDir, "session.json");
-            const deadline = Date.now() + 30_000;
-            while (Date.now() < deadline) {
-              if (await Bun.file(sessionPath).exists()) return;
-              await sleep(250);
-            }
-            throw new Error(
-              `[dev-link] session.json not minted at ${sessionPath} after 30s — check cluster logs for [dev-link] errors`,
+            const { ensureDevLinkSession } = await import(
+              "../lib/ensure-dev-link-session"
             );
+            await ensureDevLinkSession({
+              localMode: options.localMode,
+              linkDataDir,
+              studioDataDir: settings.dataDir,
+              serverUrl,
+              isInteractive: Boolean(process.stdin.isTTY),
+            });
           },
           // Drive Sandbox status from real liveness: "ready" when the daemon's
           // HTTP port answers, "pending" (spinner) while it's down/respawning

--- a/apps/mesh/src/cli/lib/ensure-dev-link-session.test.ts
+++ b/apps/mesh/src/cli/lib/ensure-dev-link-session.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureDevLinkSession } from "./ensure-dev-link-session";
+
+describe("ensureDevLinkSession", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `ensure-dev-link-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("local mode: returns once session.json appears", async () => {
+    const linkDataDir = join(dir, "link");
+    await mkdir(linkDataDir, { recursive: true });
+    setTimeout(() => {
+      void writeFile(join(linkDataDir, "session.json"), "{}", "utf8");
+    }, 50);
+
+    await ensureDevLinkSession({
+      localMode: true,
+      linkDataDir,
+      studioDataDir: dir,
+      serverUrl: "http://localhost:3000",
+      isInteractive: false,
+    });
+  });
+
+  test("non-local mode: throws when no session and non-interactive", async () => {
+    await expect(
+      ensureDevLinkSession({
+        localMode: false,
+        linkDataDir: dir,
+        studioDataDir: dir,
+        serverUrl: "http://localhost:3999",
+        isInteractive: false,
+      }),
+    ).rejects.toThrow(/No session for http:\/\/localhost:3999/);
+  });
+
+  test("non-local mode: accepts an existing host-keyed session", async () => {
+    const session = {
+      target: "http://localhost:3000",
+      clientId: "test",
+      user: { sub: "user-1", email: "tavano@deco.cx" },
+      accessToken: "token",
+      createdAt: new Date().toISOString(),
+    };
+    await writeFile(
+      join(dir, "session.localhost_3000.json"),
+      JSON.stringify(session),
+      "utf8",
+    );
+
+    await ensureDevLinkSession({
+      localMode: false,
+      linkDataDir: dir,
+      studioDataDir: dir,
+      serverUrl: "http://localhost:3000",
+      isInteractive: false,
+    });
+  });
+});

--- a/apps/mesh/src/cli/lib/ensure-dev-link-session.ts
+++ b/apps/mesh/src/cli/lib/ensure-dev-link-session.ts
@@ -1,0 +1,60 @@
+import { join } from "node:path";
+import { sleep } from "@decocms/std";
+import { ensureSession } from "./ensure-session";
+import { getValidSession } from "./get-valid-session";
+
+const LOCAL_MODE_SESSION_WAIT_MS = 30_000;
+
+export interface EnsureDevLinkSessionOptions {
+  localMode: boolean;
+  /** Where the auto-spawned link daemon reads/writes session + sandboxes. */
+  linkDataDir: string;
+  /** Developer DECOCMS_HOME — source of OAuth sessions in non-local mode. */
+  studioDataDir: string;
+  serverUrl: string;
+  /** When true, may open the browser for a one-time `auth login` flow. */
+  isInteractive: boolean;
+}
+
+/**
+ * Prepares auth for the dev auto-spawned link daemon before `ensureLink` runs.
+ *
+ * - **local mode**: waits for the cluster's `bootstrapDevLinkSession` API-key
+ *   file at `<linkDataDir>/session.json`.
+ * - **non-local mode**: requires a valid OAuth session for `serverUrl` in
+ *   `studioDataDir` (same files as `decocms auth login --target <url>`).
+ *   Opens the browser once when interactive and no session exists yet.
+ */
+export async function ensureDevLinkSession(
+  opts: EnsureDevLinkSessionOptions,
+): Promise<void> {
+  if (opts.localMode) {
+    const sessionPath = join(opts.linkDataDir, "session.json");
+    const deadline = Date.now() + LOCAL_MODE_SESSION_WAIT_MS;
+    while (Date.now() < deadline) {
+      if (await Bun.file(sessionPath).exists()) return;
+      await sleep(250);
+    }
+    throw new Error(
+      `[dev-link] session.json not minted at ${sessionPath} after ${LOCAL_MODE_SESSION_WAIT_MS / 1000}s — check cluster logs for [dev-link] errors`,
+    );
+  }
+
+  let session = await getValidSession({
+    dataDir: opts.studioDataDir,
+    target: opts.serverUrl,
+  });
+  if (!session && opts.isInteractive) {
+    session = await ensureSession({
+      dataDir: opts.studioDataDir,
+      intent: "Link (dev sandbox)",
+      target: opts.serverUrl,
+      isInteractive: true,
+    });
+  }
+  if (!session) {
+    throw new Error(
+      `[dev-link] No session for ${opts.serverUrl}. Run \`decocms auth login --target ${opts.serverUrl}\` once, then re-run \`bun run dev\`.`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- With `--no-local-mode`, the auto-spawned `deco link` daemon now uses the developer's `DECOCMS_HOME` OAuth session instead of the local-admin tmpdir session minted for local mode
- Adds `ensureDevLinkSession` to wait for the local-mode API-key bootstrap or require/reuse the developer's localhost session (opening the browser once on first run when interactive)
- Fixes sandbox `No sandbox runner found` / "Waiting for desktop…" when the browser user (e.g. `tavano@deco.cx`) differed from the link daemon user (`@localhost.mesh`)

## Test plan
- [x] `bun test apps/mesh/src/cli/lib/ensure-dev-link-session.test.ts`
- [ ] `bun run dev --no-local-mode` — link registers as the OAuth user logged into the browser; sandbox starts without a separate `deco link` terminal
- [ ] `bun run dev` (local mode) — unchanged: tmpdir session + local admin bootstrap still work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the auto-spawned `deco link` with the developer’s OAuth session in `--no-local-mode`, fixing sandbox startup when identities differed. Local mode behavior is unchanged.

- **Bug Fixes**
  - Reuse OAuth session from `DECOCMS_HOME` for `--no-local-mode` instead of a tmpdir API-key session.
  - Added `ensureDevLinkSession` to wait for the local-mode API-key or ensure an OAuth session (opens the browser on first interactive run).
  - Fixed "No sandbox runner found" / "Waiting for desktop…" caused by mismatched users.
  - Added tests for session handling.

- **Migration**
  - For non-interactive `--no-local-mode`, ensure an OAuth session exists for your `serverUrl` by running: `decocms auth login --target <url>` once.

<sup>Written for commit 7565e7c5eb5a2258a09cff8c2bb69c791758934d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

