### PR TITLE
refactor(decopilot): enhance subtask functionality and usage guidance

### DIFF
--- a/apps/mesh/src/harnesses/decopilot-desktop/index.ts
+++ b/apps/mesh/src/harnesses/decopilot-desktop/index.ts
@@ -140,6 +140,12 @@ export const decopilotDesktopHarnessFactory: HarnessFactory = {
             toolApprovalLevel: input.toolApprovalLevel,
             isPlanMode: input.mode === "plan",
             ctx,
+            // subtask runs cluster-side via the SUBTASK_MCP relay. The wrapper
+            // injects these so the model never supplies credential/model ids,
+            // and defaults the target to this agent (omit agent_id → clone self).
+            mcpClient,
+            models: input.models,
+            selfAgentId: input.agent.id,
           });
 
           // 6. Process the conversation with the REAL tool set so prior-turn

--- a/apps/mesh/src/harnesses/decopilot-desktop/local-helpers.ts
+++ b/apps/mesh/src/harnesses/decopilot-desktop/local-helpers.ts
@@ -133,8 +133,17 @@ function buildShortNameMap(
   return map;
 }
 
+/** Cluster relay tools the desktop re-exposes through a LOCAL built-in wrapper
+ *  (e.g. `subtask` wraps `SUBTASK_MCP` to inject credential/model ids). The raw
+ *  relay tool is hidden from the model so it only sees the clean wrapper. */
+const LOCALLY_WRAPPED_RELAY_TOOLS = new Set<string>(["SUBTASK_MCP"]);
+
 /** MCP Apps visibility check — default (no visibility) = visible to model. */
-function isToolVisibleToModel(t: { _meta?: Record<string, unknown> }): boolean {
+function isToolVisibleToModel(t: {
+  name: string;
+  _meta?: Record<string, unknown>;
+}): boolean {
+  if (LOCALLY_WRAPPED_RELAY_TOOLS.has(t.name)) return false;
   const ui = t._meta?.ui as { visibility?: string | string[] } | undefined;
   const visibility = ui?.visibility;
   if (visibility == null) return true;

--- a/apps/mesh/src/harnesses/decopilot-desktop/local-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot-desktop/local-prompt.ts
@@ -93,6 +93,13 @@ For every request:
   <connections-usage>). Never call or invent a tool that isn't active.
 - Reach for sandbox when a task combines several tools, loops over data,
   or transforms results — it saves round-trips versus one call at a time.
+- Use subtask for discovery. Before an open-ended search, or before reading
+  more than ~3 files/resources/records to answer a question, call
+  subtask({ prompt }) FIRST — it clones you, does the digging in its own
+  context, and returns just the answer, so yours stays focused. Tell it exactly
+  what to return. Pass subtask({ agent_id, prompt }) to delegate to a different
+  agent instead. A single, targeted lookup stays inline. Launch multiple
+  subtask calls in one message to run independent searches in parallel.
 </tools>
 
 <safety>

--- a/apps/mesh/src/harnesses/decopilot-desktop/local-tools.ts
+++ b/apps/mesh/src/harnesses/decopilot-desktop/local-tools.ts
@@ -25,6 +25,11 @@
 
 import { tool, zodSchema, type ToolSet, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  CallToolResultSchema,
+  type CallToolResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import { userAskTool } from "../decopilot/built-in-tools/user-ask";
 import { todoWriteTool } from "../decopilot/built-in-tools/todo-write";
 import {
@@ -322,6 +327,133 @@ function createDesktopInspectPageTool(
 }
 
 // ─────────────────────────────────────────────────────────────────────
+// subtask (desktop wrapper) — recursive harness dispatch is unproven on the
+// daemon, so the subagent loop runs CLUSTER-side via the `SUBTASK_MCP` relay.
+// This wrapper is what the model sees: a clean `subtask({ prompt, agent_id? })`.
+// It injects the run's credential + model ids (which the model must never type)
+// and defaults `agent_id` to the caller's own agent so omitting it clones self.
+// ─────────────────────────────────────────────────────────────────────
+
+/** Tool name of the cluster relay on the management MCP server. */
+const SUBTASK_MCP_TOOL_NAME = "SUBTASK_MCP";
+/** A subtask blocks until the cluster-side subagent loop completes, which can
+ *  far exceed the per-tool default. Give it a generous ceiling. */
+const SUBTASK_TIMEOUT_MS = 600_000;
+
+/** Structural subset of ModelsConfig — avoids importing the cluster `@/` types
+ *  into the desktop graph. */
+export interface DesktopSubtaskModels {
+  credentialId: string;
+  thinking: { id: string };
+  coding?: { id: string };
+  fast?: { id: string };
+}
+
+const DESKTOP_SUBTASK_DESCRIPTION =
+  "Run a focused task in a fresh subagent that works independently and returns " +
+  "only its conclusion.\n\n" +
+  "USE THIS FOR DISCOVERY. Before an open-ended search, or before reading more " +
+  "than ~3 files / resources / records to answer a question, call subtask FIRST " +
+  "instead of doing it inline — the subagent spends ITS context on the digging " +
+  "and hands back just the answer, keeping yours focused. A single, targeted " +
+  "lookup you already know the shape of stays inline.\n\n" +
+  "OMIT agent_id to clone yourself (a fresh subagent with your exact tools and " +
+  "instructions, empty context). Pass agent_id to delegate to a different, " +
+  "specialized agent instead.\n\n" +
+  "Every subtask starts FRESH — no conversation history. Include full context in " +
+  "the prompt and state exactly what to return (the specific answer/list/paths " +
+  "you need, not a raw dump); never use 'continue'/'as before'. Launch multiple " +
+  "subtask calls in one message to run independent searches in parallel.";
+
+function extractSubtaskText(res: CallToolResult): string | undefined {
+  const structured = (
+    res as { structuredContent?: { result?: string; finishReason?: string } }
+  ).structuredContent;
+  if (typeof structured?.result === "string" && structured.result.length > 0) {
+    return structured.result;
+  }
+  const content = res.content ?? [];
+  const text = content
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("\n\n")
+    .trim();
+  return text.length > 0 ? text : undefined;
+}
+
+function createDesktopSubtaskTool(params: {
+  writer: UIMessageStreamWriter;
+  mcpClient: Client;
+  models: DesktopSubtaskModels;
+  selfAgentId: string;
+  needsApproval: boolean;
+}) {
+  const { writer, mcpClient, models, selfAgentId, needsApproval } = params;
+  return tool({
+    description: DESKTOP_SUBTASK_DESCRIPTION,
+    needsApproval,
+    inputSchema: zodSchema(
+      z.object({
+        prompt: z
+          .string()
+          .min(1)
+          .max(50_000)
+          .describe(
+            "The task to delegate. Be specific and self-contained — the " +
+              "subagent has no access to this conversation's history.",
+          ),
+        agent_id: z
+          .string()
+          .min(1)
+          .max(128)
+          .optional()
+          .describe(
+            "Agent (Virtual MCP) to delegate to. OMIT to clone yourself — a " +
+              "fresh subagent with your exact tools and instructions.",
+          ),
+      }),
+    ),
+    execute: async ({ prompt, agent_id }, options) => {
+      const startTime = performance.now();
+      try {
+        const res = (await mcpClient.callTool(
+          {
+            name: SUBTASK_MCP_TOOL_NAME,
+            arguments: {
+              prompt,
+              // Default to self so omitting agent_id clones the calling agent.
+              agent_id: agent_id ?? selfAgentId,
+              credentialId: models.credentialId,
+              thinkingModelId: models.thinking.id,
+              ...(models.coding ? { codingModelId: models.coding.id } : {}),
+              ...(models.fast ? { fastModelId: models.fast.id } : {}),
+            },
+          },
+          CallToolResultSchema,
+          { signal: options.abortSignal, timeout: SUBTASK_TIMEOUT_MS },
+        )) as CallToolResult;
+        return {
+          result: extractSubtaskText(res) ?? "Subtask completed (no output).",
+        };
+      } finally {
+        writer.write({
+          type: "data-tool-metadata",
+          id: options.toolCallId,
+          data: { latencyMs: performance.now() - startTime },
+        });
+      }
+    },
+    toModelOutput: ({ output }) => {
+      const o = output as { result?: string } | undefined;
+      return {
+        type: "text" as const,
+        value: o?.result?.trim() || "Subtask completed (no output).",
+      };
+    },
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────
 // Assembler
 // ─────────────────────────────────────────────────────────────────────
 
@@ -334,6 +466,15 @@ export interface BuildLocalToolsParams {
   /** Narrow ctx — present for parity, but the LOCAL-OK tools only read fields
    *  that degrade safely when absent. `objectStorage` is always null. */
   ctx: DesktopToolCtx;
+  /** Raw MCP client to the cluster endpoint — used by the `subtask` wrapper to
+   *  call the `SUBTASK_MCP` relay. When absent, `subtask` is not registered. */
+  mcpClient?: Client;
+  /** The run's model selection — injected into the `subtask` relay call so the
+   *  model never has to supply credential/model ids. */
+  models?: DesktopSubtaskModels;
+  /** The calling agent's own Virtual MCP id — the default `subtask` target so
+   *  omitting `agent_id` clones self. */
+  selfAgentId?: string;
 }
 
 /**
@@ -351,6 +492,9 @@ export function buildLocalTools(params: BuildLocalToolsParams): ToolSet {
     passthroughClient,
     toolApprovalLevel,
     isPlanMode,
+    mcpClient,
+    models,
+    selfAgentId,
   } = params;
 
   const sandboxNeedsApproval = isPlanMode || toolApprovalLevel !== "auto";
@@ -370,6 +514,18 @@ export function buildLocalTools(params: BuildLocalToolsParams): ToolSet {
       needsApproval: sandboxNeedsApproval,
     }),
   };
+
+  // subtask — registered only when the relay wiring is present (mcpClient +
+  // models + the caller's own agent id). Runs cluster-side via SUBTASK_MCP.
+  if (mcpClient && models && selfAgentId) {
+    tools.subtask = createDesktopSubtaskTool({
+      writer,
+      mcpClient,
+      models,
+      selfAgentId,
+      needsApproval: sandboxNeedsApproval,
+    });
+  }
 
   // scrape_url / inspect_page require Browserless — only register when the
   // token is present. Both call the external Browserless API only (no object

--- a/apps/mesh/src/harnesses/decopilot/agents-block.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/agents-block.test.ts
@@ -9,10 +9,17 @@ const entry = (
 ): AgentsBlockEntry => ({ id, name, description, status });
 
 describe("buildAgentsBlock", () => {
-  test("returns null when there are no other active agents", () => {
-    expect(
-      buildAgentsBlock([entry("vmcp_self", "Self", "Self")], "vmcp_self"),
-    ).toBeNull();
+  test("emits self-delegation usage (no agents table) when no other active agents", () => {
+    const result = buildAgentsBlock(
+      [entry("vmcp_self", "Self", "Self")],
+      "vmcp_self",
+    );
+    // Self-subtask is always available, so usage guidance is always present...
+    expect(result).toContain("<agents-usage>");
+    expect(result).toContain("subtask({ prompt })");
+    // ...but with no other agents to delegate to, the catalog table is omitted.
+    expect(result).not.toContain("id,name,description");
+    expect(result).not.toContain("vmcp_self");
   });
 
   test("emits CSV catalog with id,name,description header", () => {

--- a/apps/mesh/src/harnesses/decopilot/agents-block.ts
+++ b/apps/mesh/src/harnesses/decopilot/agents-block.ts
@@ -1,12 +1,11 @@
 /**
  * Builds the <available-agents> + <agents-usage> system-prompt block.
  *
- * Each decopilot run executes inside a single Virtual MCP. This
- * block advertises the *other* active Virtual MCPs in the organization
- * so the model can delegate cross-agent work via the subtask tool.
- *
- * Returns null when no other active agent exists so the block — and the
- * subtask delegation guidance — drops out of the prompt entirely.
+ * Each decopilot run executes inside a single Virtual MCP. The usage
+ * guidance is ALWAYS emitted because every agent can delegate to itself
+ * (`subtask({ prompt })` clones the current agent with a fresh context).
+ * When other active Virtual MCPs exist in the organization they are also
+ * listed so the model can delegate cross-agent work via `subtask({ agent_id })`.
  *
  * The block is stable per organization so the prompt prefix can be
  * cached across steps.
@@ -21,10 +20,24 @@ export interface AgentsBlockEntry {
   status: "active" | "inactive" | "error";
 }
 
-const USAGE = `<agents-usage>
-Other agents have their own tools and instructions. Delegate self-contained
-work with subtask({ agent_id, prompt }). Include full context in the prompt —
-subagents have no conversation history.
+const SELF_USAGE = `<agents-usage>
+Delegate self-contained work to a subagent with the subtask tool.
+
+- subtask({ prompt }) — clone YOURSELF: a fresh subagent with your exact tools
+  and instructions but an empty context window.
+- subtask({ agent_id, prompt }) — delegate to a DIFFERENT agent (see
+  <available-agents>), which has its own tools and instructions.
+
+REACH FOR IT ON DISCOVERY: before an open-ended search, or before reading more
+than ~3 files / resources / records to answer a question, run subtask FIRST so
+the digging burns the subagent's context, not yours. A single, targeted lookup
+you already know the shape of stays inline.
+
+Every subtask starts FRESH (no history). Include full context and tell the
+subagent exactly what to return (the specific answer/list/paths you need, not
+a raw dump); never use continuation phrases like "continue" or "as before".
+Launch multiple subtask calls in one message to run independent searches in
+parallel.
 </agents-usage>`;
 
 function csvField(s: string | null | undefined): string {
@@ -43,11 +56,17 @@ function truncate(s: string, max: number): string {
 export function buildAgentsBlock(
   agents: AgentsBlockEntry[],
   currentVirtualMcpId: string,
-): string | null {
+): string {
   const others = agents.filter(
     (a) => a.id !== currentVirtualMcpId && a.status === "active",
   );
-  if (others.length === 0) return null;
+
+  // Self-delegation is always available, so the usage guidance is always
+  // emitted. The <available-agents> table is added only when other active
+  // agents exist to delegate to.
+  if (others.length === 0) {
+    return `\n\n${SELF_USAGE}`;
+  }
 
   const rows = others.map((a) => {
     const desc = truncate(a.description ?? "", DESCRIPTION_MAX_LEN);
@@ -56,6 +75,6 @@ export function buildAgentsBlock(
 
   return (
     `\n\n<available-agents>\nid,name,description\n${rows.join("\n")}\n</available-agents>` +
-    `\n\n${USAGE}`
+    `\n\n${SELF_USAGE}`
   );
 }

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -23,7 +23,6 @@ import {
 import type { GithubRepo } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { buildSystemMessages, type SystemMessage } from "./system-prompt";
-import { DEBUG_USAGE_ENABLED, logUsageLine } from "./debug-usage-log";
 import {
   listPromptsBlock,
   listAgentsBlock,
@@ -267,16 +266,6 @@ export async function buildAgentSystemPrompt(
   add("agentInstructions", opts.agentInstructions);
 
   add("userContext", await buildUserContextBlock(opts));
-
-  if (DEBUG_USAGE_ENABLED) {
-    const sizes = labels
-      .map((label, i) => `${label}=~${Math.ceil(prompts[i]!.length / 4)}t`)
-      .join(" ");
-    const total = Math.ceil(prompts.reduce((n, s) => n + s.length, 0) / 4);
-    logUsageLine(
-      `[prompt] ${opts.kind}=${opts.virtualMcp.id} system blocks (~${total}t total): ${sizes}`,
-    );
-  }
 
   return buildSystemMessages(prompts, opts.date ?? new Date());
 }

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -23,6 +23,7 @@ import {
 import type { GithubRepo } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { buildSystemMessages, type SystemMessage } from "./system-prompt";
+import { DEBUG_USAGE_ENABLED, logUsageLine } from "./debug-usage-log";
 import {
   listPromptsBlock,
   listAgentsBlock,
@@ -207,8 +208,14 @@ export async function buildAgentSystemPrompt(
   opts: BuildAgentSystemPromptOptions,
 ): Promise<SystemMessage[]> {
   const prompts: string[] = [];
+  const labels: string[] = [];
+  const add = (label: string, text: string | null | undefined) => {
+    if (!text?.trim()) return;
+    prompts.push(text);
+    labels.push(label);
+  };
 
-  prompts.push(buildBasePlatformPrompt());
+  add("base", buildBasePlatformPrompt());
 
   if (opts.kind === "agent" && opts.planMode) {
     // Re-use the plan-mode prompt from mode-config (non-CLI variant).
@@ -216,57 +223,60 @@ export async function buildAgentSystemPrompt(
       "../../api/routes/decopilot/mode-config"
     );
     const modeConfig = resolveModeConfig("plan", { isCliAgent: false });
-    if (modeConfig.planPrompt) {
-      prompts.push(modeConfig.planPrompt);
-    }
+    add("planMode", modeConfig.planPrompt);
   }
 
   if (opts.virtualMcp.repo) {
-    prompts.push(buildRepoEnvironmentPrompt(opts.virtualMcp.repo));
+    add("repoEnv", buildRepoEnvironmentPrompt(opts.virtualMcp.repo));
   }
 
   if (opts.kind === "agent") {
     if (opts.isDecopilot) {
-      prompts.push(buildDecopilotAgentPrompt());
+      add("identity", buildDecopilotAgentPrompt());
     }
     // For custom agents (kind: "agent" && !isDecopilot), no identity
     // prompt — the agent's own instructions (via agentInstructions
     // param) serve as identity.
   } else {
-    prompts.push(SUBAGENT_IDENTITY_PROMPT);
+    add("identity", SUBAGENT_IDENTITY_PROMPT);
   }
 
-  const promptsBlock = await listPromptsBlock(
-    opts.ctx,
-    opts.organization,
-    opts.passthroughClient,
+  add(
+    "prompts",
+    await listPromptsBlock(opts.ctx, opts.organization, opts.passthroughClient),
   );
-  if (promptsBlock) prompts.push(promptsBlock);
 
   if (opts.kind === "agent") {
-    const agentsBlock = await listAgentsBlock(
+    add(
+      "agents",
+      await listAgentsBlock(opts.ctx, opts.organization, opts.virtualMcp.id),
+    );
+  }
+
+  add(
+    "connections",
+    await listConnectionsBlock(
       opts.ctx,
       opts.organization,
-      opts.virtualMcp.id,
-    );
-    if (agentsBlock) prompts.push(agentsBlock);
-  }
-
-  const connectionsBlock = await listConnectionsBlock(
-    opts.ctx,
-    opts.organization,
-    opts.connectionsData,
+      opts.connectionsData,
+    ),
   );
-  if (connectionsBlock) prompts.push(connectionsBlock);
 
-  prompts.push(buildTodoWritePrompt());
+  add("todoWrite", buildTodoWritePrompt());
 
-  if (opts.agentInstructions?.trim()) {
-    prompts.push(opts.agentInstructions);
+  add("agentInstructions", opts.agentInstructions);
+
+  add("userContext", await buildUserContextBlock(opts));
+
+  if (DEBUG_USAGE_ENABLED) {
+    const sizes = labels
+      .map((label, i) => `${label}=~${Math.ceil(prompts[i]!.length / 4)}t`)
+      .join(" ");
+    const total = Math.ceil(prompts.reduce((n, s) => n + s.length, 0) / 4);
+    logUsageLine(
+      `[prompt] ${opts.kind}=${opts.virtualMcp.id} system blocks (~${total}t total): ${sizes}`,
+    );
   }
-
-  const userContextBlock = await buildUserContextBlock(opts);
-  if (userContextBlock) prompts.push(userContextBlock);
 
   return buildSystemMessages(prompts, opts.date ?? new Date());
 }

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -288,6 +288,9 @@ async function buildAllTools(
         provider,
         organization,
         models,
+        // Pass the caller's own agent id so the model can clone itself by
+        // omitting agent_id (heavy discovery → fresh, isolated context).
+        self: { id: agentId },
         needsApproval:
           toolNeedsApproval(toolApprovalLevel, false, approvalOpts) !== false,
       },

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.test.ts
@@ -113,13 +113,13 @@ describe("SubtaskInputSchema", () => {
       expect(result.success).toBe(false);
     });
 
-    test("rejects missing agent_id", () => {
+    test("accepts missing agent_id (clone-self: omit agent_id)", () => {
       const input = {
         prompt: "Do something",
       };
 
       const result = SubtaskInputSchema.safeParse(input);
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
   });
 });
@@ -145,7 +145,7 @@ describe("createSubtaskTool", () => {
     const tool = createSubtaskTool(mockWriter, mockParams, mockCtx);
 
     expect(tool.description).toBeDefined();
-    expect(tool.description).toContain("Delegate");
+    expect(tool.description).toContain("subagent");
     expect(tool.inputSchema).toBeDefined();
   });
 });

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -11,6 +11,7 @@
 
 import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
+import type { PassthroughClient } from "@/mcp-clients/virtual-mcp/passthrough-client";
 import type { UIMessageStreamWriter } from "ai";
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
@@ -32,22 +33,28 @@ export const SubtaskInputSchema = z.object({
     .string()
     .min(1)
     .max(128)
+    .optional()
     .describe(
-      "The ID of the agent (Virtual MCP) to delegate to. " +
-        "This agent must exist and be active in the current organization.",
+      "The ID of the agent (Virtual MCP) to delegate to. Must exist and be " +
+        "active in the current organization. OMIT to clone yourself — a fresh " +
+        "subagent with your exact tools and instructions but an empty context.",
     ),
 });
 
 export type SubtaskInput = z.infer<typeof SubtaskInputSchema>;
 
 const SUBTASK_DESCRIPTION =
-  "Delegate a self-contained task to another agent. The subagent runs independently with its own tools " +
-  "and returns results when complete. Use this when a task is better handled by a specialized agent, " +
-  "or to parallelize work across agents.\n\n" +
+  "Run a focused task in a fresh subagent that works independently and returns only its conclusion.\n\n" +
+  "USE THIS FOR DISCOVERY. Before an open-ended search, or before reading more than ~3 files / resources / " +
+  "records to answer a question, call subtask FIRST instead of doing it inline — the subagent spends ITS " +
+  "context on the digging and hands back just the answer, keeping yours focused and cheap. A single, " +
+  "targeted lookup you already know the shape of stays inline.\n\n" +
+  "OMIT agent_id to clone yourself (a fresh subagent with your exact tools and instructions, empty context). " +
+  "Pass agent_id to delegate to a different, specialized agent instead.\n\n" +
   "Usage notes:\n" +
-  "- Every subtask call starts FRESH — no conversation history, no prior runs. Always include full context in the prompt; never use continuation phrases like 'continue' or 'as before'.\n" +
+  "- Every subtask call starts FRESH — no conversation history, no prior runs. Always include full context in the prompt and state exactly what to return (the specific answer/list/paths you need, not a raw dump); never use continuation phrases like 'continue' or 'as before'.\n" +
   "- Clearly tell the subagent whether you expect it to take action or just research.\n" +
-  "- To parallelize work, launch multiple subtask calls in the same message.\n" +
+  "- To parallelize independent searches, launch multiple subtask calls in the same message.\n" +
   "- The subagent's output should generally be trusted.";
 
 export interface SubtaskParams {
@@ -55,6 +62,18 @@ export interface SubtaskParams {
   organization: OrganizationScope;
   models: ModelsConfig;
   needsApproval?: boolean;
+  /**
+   * The calling agent's own Virtual MCP id. When present, omitting `agent_id`
+   * (or passing this id) clones the calling agent: a fresh subagent over the
+   * SAME Virtual MCP — identical tools + instructions, empty context. The clone
+   * opens its own superUser passthrough client (mirroring the parent's tool
+   * scope), so it is fully isolated from the parent loop.
+   * Absent on paths with no self context (e.g. subagents, which can't subtask
+   * at all): omitting `agent_id` there is an error.
+   */
+  self?: {
+    id: string;
+  };
 }
 
 const SUBTASK_ANNOTATIONS = {
@@ -69,7 +88,7 @@ export function createSubtaskTool(
   params: SubtaskParams,
   ctx: StudioContext,
 ) {
-  const { provider, organization, models, needsApproval } = params;
+  const { provider, organization, models, needsApproval, self } = params;
 
   return tool({
     description: SUBTASK_DESCRIPTION,
@@ -81,9 +100,20 @@ export function createSubtaskTool(
     ) {
       const startTime = performance.now();
 
+      // Self-subtask: omit agent_id (or pass the caller's own id) to clone the
+      // current agent — a fresh subagent over the SAME Virtual MCP, with
+      // identical tools + instructions but an empty context.
+      const isSelf = !!self && (!agent_id || agent_id === self.id);
+      const targetId = isSelf ? self!.id : agent_id;
+      if (!targetId) {
+        throw new Error(
+          "agent_id is required: this agent cannot delegate to itself here.",
+        );
+      }
+
       // 1. Validate the target agent.
       const virtualMcp = await ctx.storage.virtualMcps.findById(
-        agent_id,
+        targetId,
         organization.id,
       );
       if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
@@ -93,24 +123,28 @@ export function createSubtaskTool(
         throw new Error("Agent is not active");
       }
 
-      // 2. Create MCP client for the target.
-      const mcpClient = await createVirtualClientFrom(
+      // 2. Open an MCP client for the target. A self-clone uses superUser so
+      //    its tool scope mirrors the parent loop's passthrough client.
+      const mcpClient = (await createVirtualClientFrom(
         virtualMcp,
         ctx,
         "passthrough",
-      );
+        isSelf,
+      )) as PassthroughClient;
+      const targetLabel = virtualMcp.id;
 
       try {
+        const targetRef = {
+          id: virtualMcp.id,
+          instructions: mcpClient.getInstructions(),
+          repo: virtualMcp.metadata?.githubRepo ?? undefined,
+        };
         // 3. Call runAgentLoop with subagent kind.
         const handle = await runAgentLoop({
           kind: "subagent",
           ctx,
           organization,
-          virtualMcp: {
-            id: virtualMcp.id,
-            instructions: mcpClient.getInstructions(),
-            repo: virtualMcp.metadata?.githubRepo ?? undefined,
-          },
+          virtualMcp: targetRef,
           mcpClient,
           provider,
           models,
@@ -162,7 +196,7 @@ export function createSubtaskTool(
         const usage = await handle.result.usage;
 
         console.log(
-          `[subtask:${agent_id}] completed: finishReason=${finishReason}, steps=${steps.length}, textLength=${aggregatedText.length}, error=${error ? "yes" : "no"}, usage=${JSON.stringify({ inputTokens: usage.inputTokens, outputTokens: usage.outputTokens })}`,
+          `[subtask:${targetLabel}${isSelf ? ":self" : ""}] completed: finishReason=${finishReason}, steps=${steps.length}, textLength=${aggregatedText.length}, error=${error ? "yes" : "no"}, usage=${JSON.stringify({ inputTokens: usage.inputTokens, outputTokens: usage.outputTokens })}`,
         );
 
         // 6. Emit metadata chunks to the parent's writer.
@@ -175,7 +209,7 @@ export function createSubtaskTool(
         writer.write({
           type: "data-tool-subtask-metadata",
           id: toolCallId,
-          data: { usage, agent: agent_id, models },
+          data: { usage, agent: targetLabel, models },
         });
 
         // 7. Yield the structured result as the ONLY (and therefore

--- a/apps/mesh/src/tools/decopilot-mcp/subtask-tool.ts
+++ b/apps/mesh/src/tools/decopilot-mcp/subtask-tool.ts
@@ -47,8 +47,9 @@ const SubtaskMcpInputSchema = z.object({
     .min(1)
     .max(128)
     .describe(
-      "The ID of the agent (Virtual MCP) to delegate to. " +
-        "This agent must exist and be active in the current organization.",
+      "The ID of the agent (Virtual MCP) to run. To clone the calling agent " +
+        "(a fresh subagent with the same tools + instructions, empty context), " +
+        "pass the caller's own agent id. Must be active in the current organization.",
     ),
   credentialId: z
     .string()


### PR DESCRIPTION
- Updated `buildAgentsBlock` to always emit self-delegation usage guidance, ensuring clarity when no other active agents are present.
- Modified `SubtaskInputSchema` to accept missing `agent_id`, allowing for self-cloning of agents.
- Improved descriptions and documentation for subtask tools, emphasizing the benefits of using subtask for discovery and task delegation.

This commit enhances the overall usability and clarity of the subtask functionality, making it easier for agents to delegate tasks effectively.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances `subtask` with self-cloning by default and a desktop wrapper that hides the relay and injects safe IDs, plus clearer guidance in prompts and tools. Also streamlines system prompt building by labeling blocks and removing debug logging.

- **New Features**
  - `subtask` accepts missing `agent_id` to clone the caller (fresh context, same tools/instructions).
  - Desktop wrapper exposes `subtask({ prompt, agent_id? })`, routes to cluster relay `SUBTASK_MCP`, injects `credentialId` and model IDs, defaults target to self, and returns text.
  - Always emits `<agents-usage>` with self-delegation tips; omits the agents table when none are active. Local prompt expands when to use `subtask` (discovery, parallel searches).

- **Refactors**
  - Hide `SUBTASK_MCP` from the model; only expose the clean `subtask` tool. Register it only when `mcpClient`, models, and `selfAgentId` are available.
  - System prompt builder now labels blocks and removes debug usage logging. Tests and tool descriptions updated to reflect self-clone behavior and clearer guidance.

<sup>Written for commit dc32ef377e86866fe016e35b600b6dc5a91b7b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

