### PR TITLE
fix(deco-sites): use service.deco.cx domain for team service accounts

### DIFF
--- a/apps/mesh/src/api/routes/deco-sites.ts
+++ b/apps/mesh/src/api/routes/deco-sites.ts
@@ -124,7 +124,7 @@ async function getOrCreateDecoApiKey(
 }
 
 const SERVICE_ACCOUNT_EMAIL_PREFIX = "deco-team-";
-const SERVICE_ACCOUNT_EMAIL_DOMAIN = "deco.cx";
+const SERVICE_ACCOUNT_EMAIL_DOMAIN = "service.deco.cx";
 
 function serviceAccountEmail(teamId: number): string {
   return `${SERVICE_ACCOUNT_EMAIL_PREFIX}${teamId}@${SERVICE_ACCOUNT_EMAIL_DOMAIN}`;


### PR DESCRIPTION
## Summary
- Updates the deco.cx team service account email domain from `@deco.cx` to `@service.deco.cx`
- Service accounts are now provisioned as `deco-team-{teamId}@service.deco.cx`

## Test plan
- [x] `bun test apps/mesh/src/api/routes/deco-sites.test.ts`
- [ ] Verify new site imports provision service accounts with the updated domain


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Team service account emails now use the `@service.deco.cx` domain. New site imports will provision accounts like `deco-team-{teamId}@service.deco.cx`.

<sup>Written for commit d1dd50b210b48a9176507e46b8f8f393911c991f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

