### PR TITLE
fix(link-proxy): add reply stream diagnostics

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
@@ -139,6 +139,32 @@ function logProxyRoute(
   });
 }
 
+function collectReplyUploadDiagnostics(
+  headers: Headers,
+): Record<string, string> {
+  const names = [
+    "cache-control",
+    "content-length",
+    "content-type",
+    "expect",
+    "pragma",
+    "transfer-encoding",
+    "user-agent",
+    "via",
+    "x-accel-buffering",
+    "x-amzn-trace-id",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-request-id",
+  ];
+  const out: Record<string, string> = {};
+  for (const name of names) {
+    const value = headers.get(name);
+    if (value != null && value.length > 0) out[name] = value;
+  }
+  return out;
+}
+
 export interface LinkProxyDeps {
   /** Native NATS connection getter (queue-group subscriptions need it). */
   getConnection: () => NatsConnection | null;
@@ -291,10 +317,14 @@ export function createLinkProxyRoutes(deps: LinkProxyDeps) {
     let frameCount = 0;
     let byteCount = 0;
     let firstFrameType: string | null = null;
+    let firstRawLineSeen = false;
     logProxyRoute("reply_stream_start", {
       userId,
       reqId,
       replySubject,
+      headers: collectReplyUploadDiagnostics(c.req.raw.headers),
+      bodyPresent: true,
+      signalAborted: c.req.raw.signal.aborted,
     });
 
     // Stream-consume the NDJSON body frame-by-frame WITHOUT buffering (landmine
@@ -302,79 +332,126 @@ export function createLinkProxyRoutes(deps: LinkProxyDeps) {
     // `await c.req.text()` — the `/events` SSE reply never ends and would hang.
     // The headers frame is published before any chunk because the daemon emits
     // it first and we publish in arrival order.
+    const reqSignal = c.req.raw.signal;
+    const abortListener = () => {
+      logProxyRoute("reply_stream_client_aborted", {
+        userId,
+        reqId,
+        replySubject,
+        frameCount,
+        byteCount,
+        firstFrameType,
+        firstRawLineSeen,
+        elapsedMs: Date.now() - startedAt,
+      });
+    };
+    reqSignal.addEventListener("abort", abortListener, { once: true });
     try {
-      for await (const line of splitNdjsonLines(body)) {
-        frameCount++;
-        byteCount += Buffer.byteLength(line, "utf8");
-        let frame: ProxyReplyFrame;
-        try {
-          frame = decodeProxyReplyFrame(line);
-        } catch (err) {
-          // A malformed frame is fatal for this reply: surface an error frame
-          // to the awaiter rather than silently dropping it.
-          logProxyRoute("reply_bad_frame", {
-            userId,
-            reqId,
-            replySubject,
-            frameCount,
-            byteCount,
-            elapsedMs: Date.now() - startedAt,
-            error: err instanceof Error ? err.message : String(err),
-          });
-          publishReplyFrame(nc, replySubject, {
-            type: "error",
-            code: "bad_frame",
-            message: err instanceof Error ? err.message : String(err),
-          });
-          return c.json({ error: "bad frame" }, 400);
+      try {
+        logProxyRoute("reply_stream_read_start", {
+          userId,
+          reqId,
+          replySubject,
+          elapsedMs: Date.now() - startedAt,
+        });
+        for await (const line of splitNdjsonLines(body)) {
+          if (!firstRawLineSeen) {
+            firstRawLineSeen = true;
+            logProxyRoute("reply_first_raw_line", {
+              userId,
+              reqId,
+              replySubject,
+              lineBytes: Buffer.byteLength(line, "utf8"),
+              elapsedMs: Date.now() - startedAt,
+            });
+          }
+          frameCount++;
+          byteCount += Buffer.byteLength(line, "utf8");
+          let frame: ProxyReplyFrame;
+          try {
+            frame = decodeProxyReplyFrame(line);
+          } catch (err) {
+            // A malformed frame is fatal for this reply: surface an error frame
+            // to the awaiter rather than silently dropping it.
+            logProxyRoute("reply_bad_frame", {
+              userId,
+              reqId,
+              replySubject,
+              frameCount,
+              byteCount,
+              elapsedMs: Date.now() - startedAt,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            publishReplyFrame(nc, replySubject, {
+              type: "error",
+              code: "bad_frame",
+              message: err instanceof Error ? err.message : String(err),
+            });
+            return c.json({ error: "bad frame" }, 400);
+          }
+          if (firstFrameType === null) {
+            firstFrameType = frame.type;
+            logProxyRoute("reply_first_frame", {
+              userId,
+              reqId,
+              replySubject,
+              frameType: frame.type,
+              ...(frame.type === "headers" ? { status: frame.status } : {}),
+              elapsedMs: Date.now() - startedAt,
+            });
+          }
+          publishReplyFrame(nc, replySubject, frame);
         }
-        if (firstFrameType === null) {
-          firstFrameType = frame.type;
-          logProxyRoute("reply_first_frame", {
-            userId,
-            reqId,
-            replySubject,
-            frameType: frame.type,
-            ...(frame.type === "headers" ? { status: frame.status } : {}),
-            elapsedMs: Date.now() - startedAt,
-          });
-        }
-        publishReplyFrame(nc, replySubject, frame);
+        // Clean body end. The daemon is expected to send its own terminal
+        // `end`/`error` frame; if it didn't (e.g. truncated stream that still
+        // closed cleanly without a terminal), we don't synthesize one here —
+        // S5's presence-expiry fanout is the backstop for a vanished daemon.
+        logProxyRoute("reply_stream_complete", {
+          userId,
+          reqId,
+          replySubject,
+          frameCount,
+          byteCount,
+          firstFrameType,
+          elapsedMs: Date.now() - startedAt,
+        });
+        return c.body(null, 204);
+      } catch (err) {
+        // Landmine #8 (POST-drop half): the upload connection broke mid-stream.
+        // Publish an error frame so the awaiting DispatchFn throws instead of
+        // hanging forever (full presence-expiry 502 fanout is S5).
+        logProxyRoute("reply_stream_dropped", {
+          userId,
+          reqId,
+          replySubject,
+          frameCount,
+          byteCount,
+          firstFrameType,
+          firstRawLineSeen,
+          elapsedMs: Date.now() - startedAt,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        publishReplyFrame(nc, replySubject, {
+          type: "error",
+          code: "reply_stream_dropped",
+          message: err instanceof Error ? err.message : String(err),
+        });
+        return c.json({ error: "reply stream dropped" }, 500);
       }
-      // Clean body end. The daemon is expected to send its own terminal
-      // `end`/`error` frame; if it didn't (e.g. truncated stream that still
-      // closed cleanly without a terminal), we don't synthesize one here —
-      // S5's presence-expiry fanout is the backstop for a vanished daemon.
-      logProxyRoute("reply_stream_complete", {
-        userId,
-        reqId,
-        replySubject,
-        frameCount,
-        byteCount,
-        firstFrameType,
-        elapsedMs: Date.now() - startedAt,
-      });
-      return c.body(null, 204);
-    } catch (err) {
-      // Landmine #8 (POST-drop half): the upload connection broke mid-stream.
-      // Publish an error frame so the awaiting DispatchFn throws instead of
-      // hanging forever (full presence-expiry 502 fanout is S5).
-      logProxyRoute("reply_stream_dropped", {
-        userId,
-        reqId,
-        replySubject,
-        frameCount,
-        byteCount,
-        firstFrameType,
-        elapsedMs: Date.now() - startedAt,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      publishReplyFrame(nc, replySubject, {
-        type: "error",
-        code: "reply_stream_dropped",
-        message: err instanceof Error ? err.message : String(err),
-      });
-      return c.json({ error: "reply stream dropped" }, 500);
+    } finally {
+      reqSignal.removeEventListener("abort", abortListener);
+      if (!firstRawLineSeen) {
+        logProxyRoute("reply_stream_closed_without_line", {
+          userId,
+          reqId,
+          replySubject,
+          frameCount,
+          byteCount,
+          firstFrameType,
+          signalAborted: reqSignal.aborted,
+          elapsedMs: Date.now() - startedAt,
+        });
+      }
     }
   });
 

--- a/apps/mesh/src/link-daemon/proxy-poller.test.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildReplyBody,
+  formatProxyPollerLogLine,
   runOverlapScheduler,
   type OverlapSchedulerDeps,
 } from "./proxy-poller";
@@ -25,6 +26,29 @@ import type { RequestFrame } from "../links/link-control-types";
 function reqFrame(reqId: string, path = "/_sandbox/h/events"): RequestFrame {
   return { type: "request", reqId, method: "GET", path, headers: {} };
 }
+
+describe("formatProxyPollerLogLine", () => {
+  it("formats diagnostic metadata as one JSON log line", () => {
+    const line = formatProxyPollerLogLine("reply_post_failed", {
+      reqId: "req-1",
+      method: "POST",
+      path: "/_sandbox/h/dispatch",
+      elapsedMs: 123,
+      error: "TimeoutError: The operation timed out.",
+    });
+
+    expect(line).toStartWith("[proxy-poller] reply_post_failed ");
+    const payload = JSON.parse(line.slice(line.indexOf("{")));
+    expect(payload).toEqual({
+      event: "reply_post_failed",
+      reqId: "req-1",
+      method: "POST",
+      path: "/_sandbox/h/dispatch",
+      elapsedMs: 123,
+      error: "TimeoutError: The operation timed out.",
+    });
+  });
+});
 
 /** Read an NDJSON ReadableStream fully into decoded reply frames. */
 async function readFrames(body: ReadableStream<Uint8Array>) {

--- a/apps/mesh/src/link-daemon/proxy-poller.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.ts
@@ -87,10 +87,17 @@ function logProxyPoller(
   event: string,
   fields: Record<string, unknown> = {},
 ): void {
-  console.log(`[proxy-poller] ${event}`, {
+  console.log(formatProxyPollerLogLine(event, fields));
+}
+
+export function formatProxyPollerLogLine(
+  event: string,
+  fields: Record<string, unknown> = {},
+): string {
+  return `[proxy-poller] ${event} ${JSON.stringify({
     event,
     ...fields,
-  });
+  })}`;
 }
 
 interface ReplyBodyDiagnosticEvent {


### PR DESCRIPTION
## Summary
- Add scoped reply-upload diagnostics around the link proxy stream ingest path.
- Log safe buffering/header metadata plus read milestones to distinguish missing POSTs, missing body lines, decode failures, and client aborts.
- Format local proxy poller diagnostics as single-line JSON for easier reqId correlation.

## Test Plan
- bun run fmt
- bun test apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts apps/mesh/src/link-daemon/proxy-poller.test.ts apps/mesh/src/api/routes/decopilot/link-proxy-frames.test.ts
- bun run --cwd=apps/mesh build:server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add detailed reply-stream diagnostics in the link proxy to debug missing frames, dropped uploads, and client aborts. Also switch proxy poller logs to single-line JSON for easier reqId correlation.

- **New Features**
  - Log safe request headers and read milestones; track `firstRawLineSeen`, `firstFrameType`, counts, and elapsed time.
  - Detect and log client-aborted uploads and streams that close without any line; publish `reply_stream_dropped` error frames on failures.
  - Add `formatProxyPollerLogLine` to emit single-line JSON diagnostics; tests cover the formatter.

<sup>Written for commit 6d0e7810de5d5adf2f12467a037fd84704d7600c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

