### PR TITLE
Add fast proxy request ack

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/link-proxy-frames.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-frames.test.ts
@@ -34,6 +34,10 @@ describe("link-proxy-frames codec", () => {
     ).toEqual({ type: "error", code: "x", message: "boom" });
   });
 
+  test("round-trips an ack frame", () => {
+    expect(decodeProxyReplyFrame('{"type":"ack"}')).toEqual({ type: "ack" });
+  });
+
   test("throws on malformed JSON", () => {
     expect(() => decodeProxyReplyFrame("{not json")).toThrow(/malformed JSON/);
   });

--- a/apps/mesh/src/api/routes/decopilot/link-proxy-frames.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-frames.ts
@@ -17,7 +17,16 @@
  * REPLY leg (daemon → cluster), POST body of
  *   `POST /api/links/proxy/:reqId/stream` as a `duplex:"half"` upload:
  *   A STREAM of NDJSON `ProxyReplyFrame` lines, consumed frame-by-frame WITHOUT
- *   buffering and each republished to `links.proxy.reply.<reqId>`. Ordering:
+ *   buffering and each republished to `links.proxy.reply.<reqId>`.
+ *
+ * ACK leg (daemon → cluster), POST
+ *   `POST /api/links/proxy/:reqId/ack` publishes `{ type:"ack" }` to
+ *   `links.proxy.reply.<reqId>`. This is a fast, bodyless acknowledgement that
+ *   the daemon dequeued the request. It stops request-leg re-publishing and the
+ *   first-frame timeout, but it is not yielded to the caller; the stream upload
+ *   still carries the actual response frames.
+ *
+ * Reply stream ordering:
  *     1. AT MOST ONE `headers` frame, FIRST (before any `chunk`). The awaiting
  *        `DispatchFn` surfaces it as `{ headers }`; `runner.ts` depends on it
  *        arriving before body bytes.
@@ -66,7 +75,12 @@ const errorReplyFrame = z.object({
   message: z.string(),
 });
 
+const ackReplyFrame = z.object({
+  type: z.literal("ack"),
+});
+
 export const proxyReplyFrameSchema = z.discriminatedUnion("type", [
+  ackReplyFrame,
   headersReplyFrame,
   chunkReplyFrame,
   endReplyFrame,

--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts
@@ -326,6 +326,51 @@ describe("createProxyDispatch — daemon-vanished fail-fast (S5, landmine #8)", 
 });
 
 describe("createProxyDispatch — first-frame timeout (no-subscriber fail-fast)", () => {
+  test("an ack frame stops first-frame timeout and republish without yielding to caller", async () => {
+    const f = makeFakeNats();
+    const diagnostics: Array<{ event: string; reqId?: string }> = [];
+    const dispatch = createProxyDispatch({
+      nats: f.nats,
+      republishIntervalMs: 10,
+      firstFrameTimeoutMs: 30,
+      diagnosticLog: (event) => diagnostics.push(event),
+    });
+    const reqSubject = buildRequestSubject("user-1");
+    const out: { data?: string; status?: number }[] = [];
+
+    const run = (async () => {
+      for await (const ev of dispatch("user-1", baseReq)) {
+        out.push({ data: ev.data, status: ev.headers?.status });
+      }
+    })();
+
+    await Promise.resolve();
+    const replySubject = f.ops.find((o) => o.kind === "subscribe")!.subject;
+    f.deliver(replySubject, { type: "ack" });
+    const publishCountAtAck = f.published.filter(
+      (p) => p.subject === reqSubject,
+    ).length;
+
+    await new Promise((r) => setTimeout(r, 80));
+    expect(f.published.filter((p) => p.subject === reqSubject).length).toBe(
+      publishCountAtAck,
+    );
+    expect(out).toEqual([]);
+
+    f.deliver(replySubject, { type: "headers", status: 200, headers: {} });
+    f.deliver(replySubject, { type: "chunk", data: "QQ==" });
+    f.deliver(replySubject, { type: "end" });
+    await run;
+
+    expect(out).toEqual([
+      { data: undefined, status: 200 },
+      { data: "QQ==", status: undefined },
+    ]);
+    expect(diagnostics.some((event) => event.event === "first_reply_ack")).toBe(
+      true,
+    );
+  });
+
   test("logs publish and first-frame timeout diagnostics with reqId correlation", async () => {
     const f = makeFakeNats();
     const diagnostics: Array<{ event: string; reqId?: string }> = [];

--- a/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-proxy-routes.ts
@@ -29,6 +29,7 @@
  *
  * Routes:
  *   GET /api/links/proxy            — Request leg long-poll
+ *   POST /api/links/proxy/:reqId/ack — Fast request receipt ack
  *   POST /api/links/proxy/:reqId/stream — Reply leg upload
  */
 import { Hono } from "hono";
@@ -290,6 +291,33 @@ export function createLinkProxyRoutes(deps: LinkProxyDeps) {
         // ignore double-unsubscribe
       }
     }
+  });
+
+  // ── ACK leg: bodyless request receipt ack ────────────────────────────────
+  app.post("/links/proxy/:reqId/ack", async (c) => {
+    const ctx = c.get("meshContext");
+    const userId = ctx.auth?.user?.id;
+    if (!userId) return c.json({ error: "unauthorized" }, 401);
+
+    const reqId = c.req.param("reqId");
+    if (!isSafeSubjectToken(reqId)) {
+      return c.json({ error: "invalid reqId" }, 400);
+    }
+
+    const nc = deps.getConnection();
+    if (!nc) {
+      logProxyRoute("reply_ack_nats_unavailable", { userId, reqId });
+      return c.json({ error: "proxy channel unavailable" }, 503);
+    }
+
+    const replySubject = buildReplySubject(reqId);
+    publishReplyFrame(nc, replySubject, { type: "ack" });
+    logProxyRoute("reply_ack_published", {
+      userId,
+      reqId,
+      replySubject,
+    });
+    return c.body(null, 204);
   });
 
   // ── REPLY leg: streaming NDJSON upload, republished frame-by-frame ────────
@@ -763,20 +791,31 @@ export function createProxyDispatch(deps: CreateProxyDispatchDeps): DispatchFn {
         // SUBSCRIBE BEFORE PUBLISH — guarantees we don't miss the first frame.
         const unsubscribe = deps.nats.subscribe(replySubject, (data) => {
           if (done) return;
-          // A real frame landed: disable the first-frame bound. SSE replies
-          // legitimately have long gaps between subsequent frames, so we do NOT
-          // re-arm or add a per-frame idle timeout.
-          const isFirstReplyFrame = !firstFrameSeen;
-          if (isFirstReplyFrame) {
-            logDiagnostic({
-              event: "first_reply_frame",
-              subject: replySubject,
-              queueDepth: queue.length,
-            });
-          }
-          markFirstFrame();
           try {
             const frame = decodeProxyReplyFrame(decoder.decode(data));
+            if (frame.type === "ack") {
+              const isFirstAck = !firstFrameSeen;
+              markFirstFrame();
+              logDiagnostic({
+                event: isFirstAck ? "first_reply_ack" : "reply_ack",
+                subject: replySubject,
+              });
+              wake();
+              return;
+            }
+
+            // A real response frame landed: disable the first-frame bound. SSE
+            // replies legitimately have long gaps between subsequent frames, so
+            // we do NOT re-arm or add a per-frame idle timeout.
+            const isFirstReplyFrame = !firstFrameSeen;
+            if (isFirstReplyFrame) {
+              logDiagnostic({
+                event: "first_reply_frame",
+                subject: replySubject,
+                queueDepth: queue.length,
+              });
+            }
+            markFirstFrame();
             queue.push(frame);
             if (isFirstReplyFrame) {
               logDiagnostic({

--- a/apps/mesh/src/link-daemon/proxy-poller.test.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "bun:test";
 import {
   buildReplyBody,
   formatProxyPollerLogLine,
+  runProxyPollLoop,
   runOverlapScheduler,
   type OverlapSchedulerDeps,
 } from "./proxy-poller";
@@ -47,6 +48,91 @@ describe("formatProxyPollerLogLine", () => {
       elapsedMs: 123,
       error: "TimeoutError: The operation timed out.",
     });
+  });
+});
+
+describe("runProxyPollLoop — request ack", () => {
+  it("POSTs an ack as soon as a request is dequeued, before the reply stream upload", async () => {
+    const ac = new AbortController();
+    const calls: string[] = [];
+    const frame = reqFrame("r-ack");
+    let pollCount = 0;
+
+    const fetchImpl = (async (input, init) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (method === "GET") {
+        pollCount++;
+        calls.push("poll");
+        if (pollCount === 1) return Response.json(frame);
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+
+      if (method === "POST" && url.endsWith("/ack")) {
+        calls.push("ack");
+        return new Response(null, { status: 204 });
+      }
+
+      if (method === "POST" && url.endsWith("/stream")) {
+        calls.push("stream");
+        return await new Promise<Response>((resolve) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => resolve(new Response(null, { status: 499 })),
+            { once: true },
+          );
+        });
+      }
+
+      throw new Error(`unexpected fetch ${method} ${url}`);
+    }) as typeof fetch;
+
+    const done = runProxyPollLoop({
+      baseUrl: "https://studio.test",
+      getAccessToken: () => "token",
+      controlHandler: {
+        handle: async () => ({ status: 404 }),
+        handleStream: async function* () {
+          yield { type: "headers", status: 200, headers: {} };
+          await new Promise<void>((resolve) => {
+            ac.signal.addEventListener("abort", () => resolve(), {
+              once: true,
+            });
+          });
+        },
+      },
+      signal: ac.signal,
+      fetchImpl,
+      concurrency: 1,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const deadline = setTimeout(
+        () => reject(new Error(`ack was not posted; calls=${calls.join(",")}`)),
+        100,
+      );
+      const tick = () => {
+        if (calls.includes("ack")) {
+          clearTimeout(deadline);
+          resolve();
+          return;
+        }
+        setTimeout(tick, 0);
+      };
+      tick();
+    }).finally(() => ac.abort());
+
+    await done;
+    expect(calls.indexOf("ack")).toBeGreaterThan(-1);
+    expect(calls.indexOf("stream")).toBeGreaterThan(-1);
+    expect(calls.indexOf("ack")).toBeLessThan(calls.indexOf("stream"));
   });
 });
 

--- a/apps/mesh/src/link-daemon/proxy-poller.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.ts
@@ -109,6 +109,64 @@ interface ReplyBodyDiagnosticEvent {
   error?: string;
 }
 
+async function postProxyAck(
+  fetcher: typeof fetch,
+  baseUrl: string,
+  token: string,
+  frame: RequestFrame,
+  signal: AbortSignal,
+  startedAt: number,
+): Promise<void> {
+  const url = `${baseUrl}/api/links/proxy/${frame.reqId}/ack`;
+  logProxyPoller("reply_ack_post_start", {
+    reqId: frame.reqId,
+    method: frame.method,
+    path: frame.path,
+    url,
+    elapsedMs: Date.now() - startedAt,
+  });
+  try {
+    const res = await fetcher(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+      signal,
+    });
+    if (!res.ok && res.status !== 204) {
+      console.warn(
+        `[proxy-poller] reply ack POST reqId=${frame.reqId} → ${res.status}`,
+      );
+    }
+    logProxyPoller("reply_ack_post_complete", {
+      reqId: frame.reqId,
+      method: frame.method,
+      path: frame.path,
+      status: res.status,
+      ok: res.ok,
+      elapsedMs: Date.now() - startedAt,
+    });
+  } catch (err) {
+    if (signal.aborted) {
+      logProxyPoller("reply_ack_post_aborted", {
+        reqId: frame.reqId,
+        method: frame.method,
+        path: frame.path,
+        elapsedMs: Date.now() - startedAt,
+      });
+      return;
+    }
+    console.warn(`[proxy-poller] reply ack POST failed reqId=${frame.reqId}`);
+    logProxyPoller("reply_ack_post_failed", {
+      reqId: frame.reqId,
+      method: frame.method,
+      path: frame.path,
+      elapsedMs: Date.now() - startedAt,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 /**
  * A `RequestFrame.path` routes to the one-shot `controlHandler.handle` (lifecycle
  * + liveness: `POST/DELETE/GET /api/sandboxes[...]`) rather than the streaming
@@ -361,6 +419,8 @@ async function handleProxyRequest(
       });
       return;
     }
+
+    void postProxyAck(fetcher, deps.baseUrl, token, frame, combined, startedAt);
 
     const body = buildReplyBody(deps.controlHandler, frame, combined, (ev) => {
       logProxyPoller(ev.event, {


### PR DESCRIPTION
## What is this contribution about?
Adds a bodyless proxy ack route so the daemon can acknowledge dequeued requests before opening the long reply stream. The ack frame clears request republishing and the first-frame timeout without yielding to callers, while the existing stream path still carries headers/chunks/end/errors.

## Screenshots/Demonstration
N/A, non-UI change.

## How to Test
1. Run `bun test apps/mesh/src/api/routes/decopilot/link-proxy-frames.test.ts apps/mesh/src/api/routes/decopilot/link-proxy-routes.test.ts apps/mesh/src/link-daemon/proxy-poller.test.ts`.
2. Run `bun run check`.
3. Run `bun run --cwd=apps/mesh build:server`.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fast, bodyless ack for link proxy requests. The daemon confirms dequeue immediately to stop republishing and the first-frame timeout, while the reply stream remains unchanged.

- **New Features**
  - New route: POST `/api/links/proxy/:reqId/ack` publishes `{ type: "ack" }` to `links.proxy.reply.<reqId>` and returns 204.
  - Dispatcher handles `ack` frames to stop republish and the first-frame timeout, without yielding to callers; logs `first_reply_ack`.
  - Daemon posts the ack as soon as a request is dequeued, before starting the reply stream upload.

<sup>Written for commit 53b08b615566c6746743a95f5b067027c23d6d06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

