### PR TITLE
feat(preview): add mobile, tablet, and desktop iframe size toggle

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -993,7 +993,7 @@ export function PreviewContent() {
           {previewState.kind === "iframe" && iframeSrc && (
             <div
               className={cn(
-                "h-full",
+                "h-full transition-[width] duration-250 [transition-timing-function:var(--ease-in-out-cubic)]",
                 previewDeviceSize !== "desktop" &&
                   viewMode !== "code" &&
                   "w-full max-w-full border-x border-border bg-background shadow-sm",

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -104,6 +104,14 @@ const PREVIEW_DEVICE_WIDTHS: Record<PreviewDeviceSize, number | null> = {
   desktop: null,
 };
 
+const DEVICE_CYCLE: PreviewDeviceSize[] = ["desktop", "mobile", "tablet"];
+
+const DEVICE_LABELS: Record<PreviewDeviceSize, string> = {
+  mobile: "Mobile (375px)",
+  tablet: "Tablet (768px)",
+  desktop: "Desktop",
+};
+
 export function PreviewContent() {
   const inset = useInsetContext();
   const { currentBranch: branch } = useChatTask();
@@ -545,7 +553,7 @@ export function PreviewContent() {
               {/* Group 2: nav + url (hidden in code mode) */}
               <div
                 className={cn(
-                  "flex min-w-0 flex-1 items-center gap-0.5",
+                  "flex min-w-0 flex-1 items-center gap-0.5 ml-2",
                   viewMode === "code" && "hidden",
                 )}
               >
@@ -558,29 +566,38 @@ export function PreviewContent() {
                   <TooltipContent side="bottom">Refresh</TooltipContent>
                 </Tooltip>
 
-                <ViewModeToggle
-                  value={previewDeviceSize}
-                  onValueChange={setPreviewDeviceSize}
-                  options={[
-                    {
-                      value: "mobile",
-                      icon: <Phone02 size={14} />,
-                      tooltip: "Mobile",
-                    },
-                    {
-                      value: "tablet",
-                      icon: <Tablet01 size={14} />,
-                      tooltip: "Tablet",
-                    },
-                    {
-                      value: "desktop",
-                      icon: <Monitor04 size={14} />,
-                      tooltip: "Desktop",
-                    },
-                  ]}
-                  size="sm"
-                  className="shrink-0 bg-foreground/4.5"
-                />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        const idx = DEVICE_CYCLE.indexOf(previewDeviceSize);
+                        setPreviewDeviceSize(
+                          DEVICE_CYCLE[(idx + 1) % DEVICE_CYCLE.length]!,
+                        );
+                      }}
+                    >
+                      <span
+                        key={previewDeviceSize}
+                        className="flex items-center justify-center animate-device-icon-pop"
+                      >
+                        {previewDeviceSize === "mobile" && (
+                          <Phone02 size={14} />
+                        )}
+                        {previewDeviceSize === "tablet" && (
+                          <Tablet01 size={14} />
+                        )}
+                        {previewDeviceSize === "desktop" && (
+                          <Monitor04 size={14} />
+                        )}
+                      </span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {DEVICE_LABELS[previewDeviceSize]}
+                  </TooltipContent>
+                </Tooltip>
 
                 <div
                   ref={pagesContainerRef}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -19,7 +19,9 @@ import {
   TextInput,
   Loading01,
   Monitor04,
+  Phone02,
   RefreshCw01,
+  Tablet01,
 } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.js";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -94,6 +96,13 @@ const FileExplorer = lazy(() =>
 const DEV_SERVER_SETTLE_MS = 500;
 
 type PreviewViewMode = "preview" | "visual" | "cms" | "code";
+type PreviewDeviceSize = "mobile" | "tablet" | "desktop";
+
+const PREVIEW_DEVICE_WIDTHS: Record<PreviewDeviceSize, number | null> = {
+  mobile: 375,
+  tablet: 768,
+  desktop: null,
+};
 
 export function PreviewContent() {
   const inset = useInsetContext();
@@ -101,6 +110,8 @@ export function PreviewContent() {
 
   // Visual editor state
   const [viewMode, setViewMode] = useState<PreviewViewMode>("preview");
+  const [previewDeviceSize, setPreviewDeviceSize] =
+    useState<PreviewDeviceSize>("desktop");
   const [visualElement, setVisualElement] =
     useState<VisualEditorPayload | null>(null);
   const previewIframeRef = useRef<HTMLIFrameElement>(null);
@@ -547,6 +558,30 @@ export function PreviewContent() {
                   <TooltipContent side="bottom">Refresh</TooltipContent>
                 </Tooltip>
 
+                <ViewModeToggle
+                  value={previewDeviceSize}
+                  onValueChange={setPreviewDeviceSize}
+                  options={[
+                    {
+                      value: "mobile",
+                      icon: <Phone02 size={14} />,
+                      tooltip: "Mobile",
+                    },
+                    {
+                      value: "tablet",
+                      icon: <Tablet01 size={14} />,
+                      tooltip: "Tablet",
+                    },
+                    {
+                      value: "desktop",
+                      icon: <Monitor04 size={14} />,
+                      tooltip: "Desktop",
+                    },
+                  ]}
+                  size="sm"
+                  className="shrink-0 bg-foreground/4.5"
+                />
+
                 <div
                   ref={pagesContainerRef}
                   className="relative min-w-0 flex-1"
@@ -875,7 +910,15 @@ export function PreviewContent() {
           </>
         )}
 
-        <div className="flex-1 relative overflow-hidden">
+        <div
+          className={cn(
+            "flex-1 relative overflow-hidden",
+            previewDeviceSize !== "desktop" &&
+              previewState.kind === "iframe" &&
+              viewMode !== "code" &&
+              "flex justify-center bg-muted/30",
+          )}
+        >
           {previewState.kind === "starting" && (
             <div className="absolute inset-0 z-30">
               <SandboxStateCard
@@ -931,53 +974,68 @@ export function PreviewContent() {
           )}
 
           {previewState.kind === "iframe" && iframeSrc && (
-            <iframe
-              // Key on previewUrl: remount when the VM base URL changes (branch
-              // switch). Path navigation is driven by `iframeSrc` state.
-              key={previewState.previewUrl}
-              ref={previewIframeRef}
-              src={iframeSrc}
+            <div
               className={cn(
-                "w-full h-full border-0",
-                viewMode === "code" && "invisible",
+                "h-full",
+                previewDeviceSize !== "desktop" &&
+                  viewMode !== "code" &&
+                  "w-full max-w-full border-x border-border bg-background shadow-sm",
               )}
-              title="Dev Server Preview"
-              tabIndex={sectionsOpen ? -1 : undefined}
-              onLoad={() => {
-                // This is the VM dev-server preview (sandboxed running app),
-                // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
-                track("vm_preview_loaded", {
-                  view_mode: viewMode,
-                  vm_id: vmEntry?.sandboxHandle ?? null,
-                  // Intentionally excluding the full previewUrl — it can contain
-                  // ephemeral tokens / user data in the query string.
-                });
-                // Sync currentPath when the user navigates inside the iframe.
-                // Skip while a programmatic navigation is pending — stale
-                // onLoad events from the previous URL would reset us to "/".
-                if (!activeGlobalSection) {
-                  try {
-                    const iframePath =
-                      previewIframeRef.current?.contentWindow?.location
-                        ?.pathname;
-                    if (!iframePath) return;
-                    const intended = intendedPathRef.current;
-                    if (intended !== null) {
-                      intendedPathRef.current = null;
-                      if (normPath(iframePath) === normPath(intended)) {
-                        setCurrentPath(iframePath);
-                      }
-                      return;
-                    }
-                    setCurrentPath(iframePath);
-                  } catch {
-                    // Cross-origin — can't read, keep current value
-                  }
-                }
-                if (viewMode === "visual") injectVisualEditor();
-                if (viewMode === "cms") injectCmsEditor();
+              style={{
+                width:
+                  previewDeviceSize === "desktop" || viewMode === "code"
+                    ? "100%"
+                    : `${PREVIEW_DEVICE_WIDTHS[previewDeviceSize]}px`,
               }}
-            />
+            >
+              <iframe
+                // Key on previewUrl: remount when the VM base URL changes (branch
+                // switch). Path navigation is driven by `iframeSrc` state.
+                key={previewState.previewUrl}
+                ref={previewIframeRef}
+                src={iframeSrc}
+                className={cn(
+                  "w-full h-full border-0",
+                  viewMode === "code" && "invisible",
+                )}
+                title="Dev Server Preview"
+                tabIndex={sectionsOpen ? -1 : undefined}
+                onLoad={() => {
+                  // This is the VM dev-server preview (sandboxed running app),
+                  // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
+                  track("vm_preview_loaded", {
+                    view_mode: viewMode,
+                    vm_id: vmEntry?.sandboxHandle ?? null,
+                    // Intentionally excluding the full previewUrl — it can contain
+                    // ephemeral tokens / user data in the query string.
+                  });
+                  // Sync currentPath when the user navigates inside the iframe.
+                  // Skip while a programmatic navigation is pending — stale
+                  // onLoad events from the previous URL would reset us to "/".
+                  if (!activeGlobalSection) {
+                    try {
+                      const iframePath =
+                        previewIframeRef.current?.contentWindow?.location
+                          ?.pathname;
+                      if (!iframePath) return;
+                      const intended = intendedPathRef.current;
+                      if (intended !== null) {
+                        intendedPathRef.current = null;
+                        if (normPath(iframePath) === normPath(intended)) {
+                          setCurrentPath(iframePath);
+                        }
+                        return;
+                      }
+                      setCurrentPath(iframePath);
+                    } catch {
+                      // Cross-origin — can't read, keep current value
+                    }
+                  }
+                  if (viewMode === "visual") injectVisualEditor();
+                  if (viewMode === "cms") injectCmsEditor();
+                }}
+              />
+            </div>
           )}
         </div>
       </div>

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -112,6 +112,13 @@ const DEVICE_LABELS: Record<PreviewDeviceSize, string> = {
   desktop: "Desktop",
 };
 
+/** Deco reads `deviceHint` to force SSR device matchers (see deco `deviceOf`). */
+function withDeviceHint(url: string, device: PreviewDeviceSize): string {
+  const parsed = new URL(url, window.location.href);
+  parsed.searchParams.set("deviceHint", device);
+  return parsed.href;
+}
+
 export function PreviewContent() {
   const inset = useInsetContext();
   const { currentBranch: branch } = useChatTask();
@@ -241,7 +248,11 @@ export function PreviewContent() {
 
   const iframeSrc =
     previewState.kind === "iframe"
-      ? (directPreviewUrl ?? new URL(currentPath, previewState.previewUrl).href)
+      ? withDeviceHint(
+          directPreviewUrl ??
+            new URL(currentPath, previewState.previewUrl).href,
+          previewDeviceSize,
+        )
       : null;
 
   // Reset navigation when the VM preview base URL changes (branch switch, etc.)
@@ -420,6 +431,11 @@ export function PreviewContent() {
     previewIframeRef.current.src = `${iframeSrc}${sep}_r=${Date.now()}`;
   };
 
+  const handleDeviceToggle = () => {
+    const idx = DEVICE_CYCLE.indexOf(previewDeviceSize);
+    setPreviewDeviceSize(DEVICE_CYCLE[(idx + 1) % DEVICE_CYCLE.length]!);
+  };
+
   const handleCopyUrl = () => {
     const url =
       previewIframeRef.current?.contentWindow?.location?.href ??
@@ -571,12 +587,7 @@ export function PreviewContent() {
                     <Button
                       variant="ghost"
                       size="icon"
-                      onClick={() => {
-                        const idx = DEVICE_CYCLE.indexOf(previewDeviceSize);
-                        setPreviewDeviceSize(
-                          DEVICE_CYCLE[(idx + 1) % DEVICE_CYCLE.length]!,
-                        );
-                      }}
+                      onClick={handleDeviceToggle}
                     >
                       <span
                         key={previewDeviceSize}

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -273,6 +273,8 @@
   --spacing-96: calc(var(--spacing) * 96);
 
   --text-sm: 0.8125rem;
+
+  --animate-device-icon-pop: device-icon-pop 150ms var(--ease-out-cubic) both;
 }
 
 /* Animations */
@@ -298,6 +300,28 @@
   --ease-in-out-quint: cubic-bezier(0.86, 0, 0.07, 1);
   --ease-in-out-expo: cubic-bezier(1, 0, 0, 1);
   --ease-in-out-circ: cubic-bezier(0.785, 0.135, 0.15, 0.86);
+}
+
+@keyframes device-icon-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes device-icon-pop {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
 }
 
 /* Shadows */


### PR DESCRIPTION
## Summary
- Add a Mobile / Tablet / Desktop toggle in the sandbox preview address bar, next to the refresh button
- Constrain the preview iframe to 375px (mobile) or 768px (tablet), centered with a device frame; desktop remains full width
- Reuse the existing `ViewModeToggle` pattern and icons for consistency with the preview toolbar

## Test plan
- [ ] Open sandbox preview with a running dev server
- [ ] Toggle Mobile — iframe renders at 375px, centered with side borders
- [ ] Toggle Tablet — iframe renders at 768px, centered
- [ ] Toggle Desktop — iframe expands to full width
- [ ] Switch to code mode — device toggle hides with other preview controls; iframe stays full width
- [ ] Refresh and navigate pages — device size selection persists


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Mobile/Tablet/Desktop viewport toggle to the sandbox preview so you can test common widths without leaving the page. Toggling also reloads the iframe with a `deviceHint` param so server-rendered variants match the selected device.

- **New Features**
  - Cycling button in the preview address bar next to Refresh; cycles Desktop → Mobile (375px) → Tablet (768px) with a tooltip label, and passes `deviceHint` to reload the matching SSR variant.
  - Mobile/Tablet views are centered in a framed container with side borders, a subtle background, and an animated width transition; Desktop remains full width.
  - Toggle hides in Code mode; preview stays full width there.

<sup>Written for commit ddd5dced3373de40c97956d82b26105f00965cf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

