### PR TITLE
feat(org-fs): daemon mount manager — lazy kext-free volume mounts

### DIFF
--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -14,6 +14,7 @@ import { LifecycleManager } from "./lifecycle/manager";
 import { readConfig } from "./persistence";
 import { MountManager } from "./org-fs/mount-manager";
 import { createRcloneMounter } from "./org-fs/mounter";
+import { parseOrgFsConfig } from "./org-fs/config";
 import { createPortSniffer } from "./process/port-sniffer";
 import { TaskManager } from "./process/task-manager";
 import { PhaseManager } from "./process/phase-manager";
@@ -694,17 +695,20 @@ Bun.serve<WsProxyData, never>({
 });
 
 // --- Org-filesystem mounts (desktop links only) ----------------------------
-// Mesh pushes `orgFs` config + sets ORGFS_RCLONE_PATH for sandboxes whose host
-// can mount kext-free; it's absent in cluster pods (locked-down securityContext)
-// and until the provisioning side ships — so this is inert by default. The
-// start is fire-and-forget and fully guarded (see MountManager): a mount
-// failure logs and never affects the daemon, dev server, fs routes, or
-// harnesses. A volume's bytes still reach harnesses via the mesh API regardless.
+// The mesh sets ORGFS_CONFIG (a JSON OrgFsMountConfig) + ORGFS_RCLONE_PATH at
+// spawn — as boot env, like OFFLOAD_ALLOWED_HOSTS, so it's available here at
+// boot (config pushed via /_sandbox/config arrives only AFTER boot, so it
+// can't drive the mount). Both are absent for cluster pods (locked-down
+// securityContext can't mount) and until the provisioning side ships — so this
+// is inert by default. The start is fire-and-forget and fully guarded (see
+// MountManager): a mount failure logs and never affects the daemon, dev
+// server, fs routes, or harnesses. A volume's bytes still reach harnesses via
+// the mesh API regardless.
 let mountManager: MountManager | null = null;
 {
-  const orgFs = store.read()?.orgFs;
+  const orgFs = parseOrgFsConfig(process.env.ORGFS_CONFIG);
   const rclonePath = process.env.ORGFS_RCLONE_PATH;
-  if (orgFs?.mounts?.length && rclonePath) {
+  if (orgFs && rclonePath) {
     mountManager = new MountManager(createRcloneMounter(rclonePath));
     void mountManager
       .start(orgFs, bootConfig.appRoot)

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -12,6 +12,8 @@ import { gitSync } from "./git/git-sync";
 import { InstallState } from "./install/install-state";
 import { LifecycleManager } from "./lifecycle/manager";
 import { readConfig } from "./persistence";
+import { MountManager } from "./org-fs/mount-manager";
+import { createRcloneMounter } from "./org-fs/mounter";
 import { createPortSniffer } from "./process/port-sniffer";
 import { TaskManager } from "./process/task-manager";
 import { PhaseManager } from "./process/phase-manager";
@@ -691,9 +693,33 @@ Bun.serve<WsProxyData, never>({
   },
 });
 
-process.on("SIGTERM", () => {
+// --- Org-filesystem mounts (desktop links only) ----------------------------
+// Mesh pushes `orgFs` config + sets ORGFS_RCLONE_PATH for sandboxes whose host
+// can mount kext-free; it's absent in cluster pods (locked-down securityContext)
+// and until the provisioning side ships — so this is inert by default. The
+// start is fire-and-forget and fully guarded (see MountManager): a mount
+// failure logs and never affects the daemon, dev server, fs routes, or
+// harnesses. A volume's bytes still reach harnesses via the mesh API regardless.
+let mountManager: MountManager | null = null;
+{
+  const orgFs = store.read()?.orgFs;
+  const rclonePath = process.env.ORGFS_RCLONE_PATH;
+  if (orgFs?.mounts?.length && rclonePath) {
+    mountManager = new MountManager(createRcloneMounter(rclonePath));
+    void mountManager
+      .start(orgFs, bootConfig.appRoot)
+      .catch((err) => console.warn("[org-fs] mount start failed", err));
+  }
+}
+
+process.on("SIGTERM", async () => {
   taskManager.shutdown();
   branchStatus.stop();
+  // Best-effort unmount before exit (rclone --daemon detaches, so it would
+  // otherwise outlive us). Abrupt SIGKILL/pod-delete skips this — tolerated.
+  if (mountManager) {
+    await mountManager.stop().catch(() => {});
+  }
   const branch = store.read()?.git?.repository?.branch;
   if (branch) {
     try {

--- a/packages/sandbox/daemon/org-fs/config.ts
+++ b/packages/sandbox/daemon/org-fs/config.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure config types for org-fs mounting, shared by the daemon's `TenantConfig`
+ * (types.ts) and the `MountManager`. Kept import-free so `types.ts` doesn't
+ * pull in the mount-manager's runtime dependencies.
+ */
+
+/** One mountable volume → where it lands in the workspace. */
+export interface OrgFsVolumeMount {
+  readonly volume: string;
+  /** Mount point; relative paths resolve under `<appRoot>/org/`. */
+  readonly path: string;
+}
+
+/** Mesh-pushed config that turns on org-fs mounting for a sandbox. */
+export interface OrgFsMountConfig {
+  /** Mesh base URL the daemon calls (e.g. https://cluster.example). */
+  readonly baseUrl: string;
+  /** Immutable org slug (the `:org` path segment). */
+  readonly orgSlug: string;
+  /** Bearer token authorizing ORG_FS_READ/WRITE (an fs-scoped API key). */
+  readonly token: string;
+  readonly mounts: readonly OrgFsVolumeMount[];
+}

--- a/packages/sandbox/daemon/org-fs/config.ts
+++ b/packages/sandbox/daemon/org-fs/config.ts
@@ -21,3 +21,40 @@ export interface OrgFsMountConfig {
   readonly token: string;
   readonly mounts: readonly OrgFsVolumeMount[];
 }
+
+/**
+ * Parse the daemon's `ORGFS_CONFIG` boot env (a JSON `OrgFsMountConfig`). The
+ * mesh sets it at spawn (like `OFFLOAD_ALLOWED_HOSTS`) rather than via a
+ * post-boot config push, so it's available when the daemon reads it at boot.
+ * Returns null for absent/malformed/empty config (mounting is then skipped).
+ */
+export function parseOrgFsConfig(
+  raw: string | undefined,
+): OrgFsMountConfig | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const c = parsed as Record<string, unknown>;
+  if (
+    typeof c.baseUrl !== "string" ||
+    typeof c.orgSlug !== "string" ||
+    typeof c.token !== "string" ||
+    !Array.isArray(c.mounts)
+  ) {
+    return null;
+  }
+  const mounts = c.mounts.filter(
+    (m): m is OrgFsVolumeMount =>
+      typeof m === "object" &&
+      m !== null &&
+      typeof (m as OrgFsVolumeMount).volume === "string" &&
+      typeof (m as OrgFsVolumeMount).path === "string",
+  );
+  if (mounts.length === 0) return null;
+  return { baseUrl: c.baseUrl, orgSlug: c.orgSlug, token: c.token, mounts };
+}

--- a/packages/sandbox/daemon/org-fs/mount-manager.test.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.test.ts
@@ -8,6 +8,46 @@ import {
   type OrgFsMountConfig,
   resolveMountPath,
 } from "./mount-manager";
+import { parseOrgFsConfig } from "./config";
+
+describe("parseOrgFsConfig", () => {
+  const valid = JSON.stringify({
+    baseUrl: "http://m",
+    orgSlug: "acme",
+    token: "t",
+    mounts: [{ volume: "skills", path: "skills" }],
+  });
+  it("parses a valid config", () => {
+    expect(parseOrgFsConfig(valid)).toEqual({
+      baseUrl: "http://m",
+      orgSlug: "acme",
+      token: "t",
+      mounts: [{ volume: "skills", path: "skills" }],
+    });
+  });
+  it("returns null for absent / malformed / incomplete / empty-mounts", () => {
+    expect(parseOrgFsConfig(undefined)).toBeNull();
+    expect(parseOrgFsConfig("")).toBeNull();
+    expect(parseOrgFsConfig("{not json")).toBeNull();
+    expect(parseOrgFsConfig(JSON.stringify({ baseUrl: "x" }))).toBeNull();
+    expect(
+      parseOrgFsConfig(
+        JSON.stringify({ baseUrl: "m", orgSlug: "a", token: "t", mounts: [] }),
+      ),
+    ).toBeNull();
+  });
+  it("drops malformed mount entries", () => {
+    const c = parseOrgFsConfig(
+      JSON.stringify({
+        baseUrl: "m",
+        orgSlug: "a",
+        token: "t",
+        mounts: [{ volume: "ok", path: "ok" }, { volume: 1 }, "nope"],
+      }),
+    );
+    expect(c?.mounts).toEqual([{ volume: "ok", path: "ok" }]);
+  });
+});
 
 /** Records mount/unmount calls; never touches the OS. */
 function fakeMounter(opts: { failVolumes?: Set<string> } = {}) {

--- a/packages/sandbox/daemon/org-fs/mount-manager.test.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  type Mounter,
+  MountManager,
+  type OrgFsMountConfig,
+  resolveMountPath,
+} from "./mount-manager";
+
+/** Records mount/unmount calls; never touches the OS. */
+function fakeMounter(opts: { failVolumes?: Set<string> } = {}) {
+  const calls: { webdavUrl: string; mountPath: string }[] = [];
+  const unmounted: string[] = [];
+  const mounter: Mounter = {
+    async mount({ webdavUrl, mountPath }) {
+      calls.push({ webdavUrl, mountPath });
+      // Fail volumes whose mount path ends with a flagged segment.
+      for (const v of opts.failVolumes ?? [])
+        if (mountPath.endsWith(`/${v}`)) throw new Error(`forced fail ${v}`);
+      return {
+        async unmount() {
+          unmounted.push(mountPath);
+        },
+      };
+    },
+  };
+  return { mounter, calls, unmounted };
+}
+
+const config = (
+  mounts: { volume: string; path: string }[],
+): OrgFsMountConfig => ({
+  baseUrl: "http://mesh.invalid",
+  orgSlug: "acme",
+  token: "tok",
+  mounts,
+});
+
+describe("resolveMountPath", () => {
+  it("places relative paths under <appRoot>/org and clamps escapes", () => {
+    expect(resolveMountPath("/ws", "skills")).toBe("/ws/org/skills");
+    expect(resolveMountPath("/ws", "a/b")).toBe("/ws/org/a/b");
+    // traversal out of org/ but still inside appRoot is allowed by the clamp...
+    expect(resolveMountPath("/ws", "../tmp")).toBe("/ws/tmp");
+    // ...escaping appRoot entirely is rejected
+    expect(resolveMountPath("/ws", "../../etc")).toBeNull();
+  });
+  it("accepts an absolute path only if inside appRoot", () => {
+    expect(resolveMountPath("/ws", "/ws/org/x")).toBe("/ws/org/x");
+    expect(resolveMountPath("/ws", "/etc/passwd")).toBeNull();
+  });
+});
+
+describe("MountManager", () => {
+  let appRoot: string;
+
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "orgfs-mm-"));
+  });
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true });
+  });
+
+  it("serves + mounts each volume, then unmounts + stops on stop()", async () => {
+    const { mounter, calls, unmounted } = fakeMounter();
+    const mm = new MountManager(mounter, () => {});
+    await mm.start(
+      config([
+        { volume: "skills", path: "skills" },
+        { volume: "things", path: "things" },
+      ]),
+      appRoot,
+    );
+
+    expect(calls.length).toBe(2);
+    // each got a fresh loopback webdav url + the resolved mount path
+    for (const c of calls)
+      expect(c.webdavUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(calls.map((c) => c.mountPath).sort()).toEqual([
+      join(appRoot, "org/skills"),
+      join(appRoot, "org/things"),
+    ]);
+    expect(
+      mm
+        .list()
+        .map((m) => m.volume)
+        .sort(),
+    ).toEqual(["skills", "things"]);
+
+    await mm.stop();
+    expect(unmounted.length).toBe(2);
+    expect(mm.list()).toEqual([]);
+  });
+
+  it("is boot-safe: a failing mount is skipped, others still mount", async () => {
+    const { mounter, unmounted } = fakeMounter({
+      failVolumes: new Set(["bad"]),
+    });
+    const mm = new MountManager(mounter, () => {});
+    await mm.start(
+      config([
+        { volume: "good", path: "good" },
+        { volume: "bad", path: "bad" },
+      ]),
+      appRoot,
+    );
+    // only the good one is active; the failed one's server was torn down
+    expect(mm.list().map((m) => m.volume)).toEqual(["good"]);
+    await mm.stop();
+    expect(unmounted).toEqual([join(appRoot, "org/good")]);
+  });
+
+  it("skips a mount whose path escapes appRoot without mounting it", async () => {
+    const { mounter, calls } = fakeMounter();
+    const mm = new MountManager(mounter, () => {});
+    await mm.start(config([{ volume: "evil", path: "../../etc" }]), appRoot);
+    expect(calls.length).toBe(0);
+    expect(mm.list()).toEqual([]);
+  });
+});

--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -1,0 +1,140 @@
+/**
+ * Mounts org-fs volumes inside the sandbox so EVERY harness — including CLI
+ * ones (Claude Code, Codex) that only read real files — sees them at
+ * `<appRoot>/org/<volume>`, kext-free.
+ *
+ * Per volume: serve the WebDAV layer (over the mesh `/api/:org/fs` client) on a
+ * loopback port, then hand that URL to a `Mounter` which has the OS mount it
+ * (rclone nfsmount on macOS / rclone mount on Linux — see mounter.ts). The
+ * `Mounter` is injected so this orchestration is unit-testable without a real
+ * kernel mount.
+ *
+ * Boot-safety: a mount is purely additive. Every step is wrapped so a failure
+ * logs and is skipped — it never breaks the daemon, the dev server, the fs
+ * routes, or the harnesses. Mounting only happens when the mesh pushes
+ * `TenantConfig.orgFs` (it won't for cluster pods, whose security posture
+ * blocks mounts — desktop links are the target).
+ */
+
+import { mkdirSync } from "node:fs";
+import { join, isAbsolute } from "node:path";
+import { safePath } from "../paths";
+// Portable serve-layer leaves from the mesh workspace (same cross-package
+// import style entry.ts uses for harness factories).
+import { OrgFsClient } from "../../../../apps/mesh/src/file-storage/mount/client";
+import { createWebdavHandler } from "../../../../apps/mesh/src/file-storage/mount/webdav";
+import type { OrgFsMountConfig } from "./config";
+
+export type { OrgFsMountConfig, OrgFsVolumeMount } from "./config";
+
+/** A handle to an established OS mount. */
+export interface MountHandle {
+  unmount(): Promise<void>;
+}
+
+/** Has the OS mount the loopback WebDAV URL at `mountPath` (impl in mounter.ts). */
+export interface Mounter {
+  mount(opts: { webdavUrl: string; mountPath: string }): Promise<MountHandle>;
+}
+
+interface ActiveMount {
+  volume: string;
+  mountPath: string;
+  stopServer: () => void;
+  handle: MountHandle;
+}
+
+/**
+ * Resolve a mount path under `<appRoot>/org/`. Relative paths are placed there;
+ * absolute paths are still clamped inside `appRoot` (defense — the config comes
+ * from the cluster, but the clamp keeps a mount from escaping the workspace).
+ */
+export function resolveMountPath(appRoot: string, p: string): string | null {
+  const orgRoot = join(appRoot, "org");
+  if (isAbsolute(p)) {
+    return p.startsWith(`${appRoot}/`) || p === appRoot ? p : null;
+  }
+  return safePath(appRoot, orgRoot, p);
+}
+
+export class MountManager {
+  private active: ActiveMount[] = [];
+
+  constructor(
+    private readonly mounter: Mounter,
+    private readonly log: (msg: string, err?: unknown) => void = (m, e) =>
+      e ? console.warn(`[org-fs] ${m}`, e) : console.log(`[org-fs] ${m}`),
+  ) {}
+
+  /** Serve + mount every configured volume. Never throws. */
+  async start(config: OrgFsMountConfig, appRoot: string): Promise<void> {
+    for (const m of config.mounts) {
+      try {
+        const mountPath = resolveMountPath(appRoot, m.path);
+        if (!mountPath) {
+          this.log(`skip ${m.volume}: mount path "${m.path}" escapes appRoot`);
+          continue;
+        }
+        mkdirSync(mountPath, { recursive: true });
+
+        const client = new OrgFsClient({
+          baseUrl: config.baseUrl,
+          orgSlug: config.orgSlug,
+          volume: m.volume,
+          token: config.token,
+        });
+        // Loopback only; rclone is the sole client and it sits behind it.
+        const server = Bun.serve({
+          port: 0,
+          hostname: "127.0.0.1",
+          fetch: createWebdavHandler(client),
+        });
+        const webdavUrl = `http://127.0.0.1:${server.port}`;
+
+        try {
+          const handle = await this.mounter.mount({ webdavUrl, mountPath });
+          this.active.push({
+            volume: m.volume,
+            mountPath,
+            stopServer: () => server.stop(true),
+            handle,
+          });
+          this.log(`mounted ${m.volume} at ${mountPath}`);
+        } catch (err) {
+          server.stop(true);
+          this.log(`mount failed for ${m.volume} (skipped)`, err);
+        }
+      } catch (err) {
+        this.log(`mount failed for ${m.volume} (skipped)`, err);
+      }
+    }
+  }
+
+  /** Unmount everything and stop the WebDAV servers. Never throws. */
+  async stop(): Promise<void> {
+    const mounts = this.active;
+    this.active = [];
+    await Promise.all(
+      mounts.map(async (a) => {
+        try {
+          await a.handle.unmount();
+        } catch (err) {
+          this.log(`unmount failed for ${a.volume}`, err);
+        }
+        try {
+          a.stopServer();
+        } catch {
+          // server already stopped
+        }
+      }),
+    );
+  }
+
+  /** Mounted volumes (for status/health). */
+  list(): { volume: string; mountPath: string }[] {
+    return this.active.map((a) => ({
+      volume: a.volume,
+      mountPath: a.mountPath,
+    }));
+  }
+}

--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -30,6 +30,13 @@ export function createRcloneMounter(rclonePath: string): Mounter {
           ...args,
           "--vfs-cache-mode",
           "full",
+          // WebDAV has no ChangeNotify, so freshness for *external* writes is
+          // bounded by this dir-cache TTL (rclone defaults to 5m — far too
+          // stale for a shared fs). 10s is the interim; a change-feed-driven
+          // `vfs/forget` over rclone's rc API will make it near-instant and let
+          // this relax back to a long safety net.
+          "--dir-cache-time",
+          "10s",
           "--daemon",
           "--daemon-timeout=30s",
         ],

--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -1,0 +1,74 @@
+/**
+ * The real `Mounter`: has the OS mount a loopback WebDAV URL via rclone, with
+ * no kernel extension required.
+ *
+ *   macOS  → `rclone nfsmount` (built-in NFS client; no macFUSE/System Extension)
+ *   Linux  → `rclone mount`    (native FUSE via /dev/fuse; no install)
+ *
+ * rclone reads the WebDAV server via an env-config remote ("wd:") — the
+ * connection-string form breaks on the URL's colons — and `--vfs-cache-mode
+ * full` gives the lazy per-file fetch + write-back. Mounting is daemonized so
+ * the spawn returns immediately; the mount runs detached until `unmount()`.
+ *
+ * `rclonePath` must point at a real rclone binary with mount support (the
+ * Homebrew build notably lacks it). When rclone isn't available the daemon
+ * should not construct this — see MountManager (mounting is then skipped).
+ */
+
+import type { MountHandle, Mounter } from "./mount-manager";
+
+export function createRcloneMounter(rclonePath: string): Mounter {
+  const isMac = process.platform === "darwin";
+  return {
+    async mount({ webdavUrl, mountPath }) {
+      const args = isMac
+        ? ["nfsmount", "wd:", mountPath]
+        : ["mount", "wd:", mountPath];
+      const proc = Bun.spawn(
+        [
+          rclonePath,
+          ...args,
+          "--vfs-cache-mode",
+          "full",
+          "--daemon",
+          "--daemon-timeout=30s",
+        ],
+        {
+          env: {
+            ...process.env,
+            RCLONE_CONFIG_WD_TYPE: "webdav",
+            RCLONE_CONFIG_WD_URL: webdavUrl,
+            RCLONE_CONFIG_WD_VENDOR: "other",
+          },
+          stdout: "ignore",
+          stderr: "ignore",
+        },
+      );
+      // `--daemon` forks rclone and the launcher exits; await that exit.
+      const code = await proc.exited;
+      if (code !== 0) {
+        throw new Error(`rclone ${args[0]} exited ${code} for ${mountPath}`);
+      }
+      return makeHandle(mountPath, isMac);
+    },
+  };
+}
+
+function makeHandle(mountPath: string, isMac: boolean): MountHandle {
+  return {
+    async unmount() {
+      // NFS + FUSE both unmount via `umount`; on Linux `fusermount -u` is the
+      // unprivileged path for a FUSE mount, so try it first there.
+      const cmds: string[][] = isMac
+        ? [["umount", "-f", mountPath]]
+        : [
+            ["fusermount", "-u", mountPath],
+            ["umount", mountPath],
+          ];
+      for (const cmd of cmds) {
+        const p = Bun.spawnSync(cmd, { stdout: "ignore", stderr: "ignore" });
+        if (p.exitCode === 0) return;
+      }
+    },
+  };
+}

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -1,5 +1,3 @@
-import type { OrgFsMountConfig } from "./org-fs/config";
-
 export type PackageManager = "npm" | "pnpm" | "yarn" | "bun" | "deno";
 export type RuntimeName = "node" | "bun" | "deno";
 
@@ -63,12 +61,6 @@ export interface TenantConfig {
   readonly git?: GitConfig;
   readonly application?: Application;
   readonly env?: Readonly<Record<string, string>>;
-  /**
-   * Org-filesystem volumes to mount into the workspace (mesh-pushed; present
-   * only for desktop links, whose machine can mount kext-free). Absent → no
-   * mounting. See `./org-fs/mount-manager`.
-   */
-  readonly orgFs?: OrgFsMountConfig;
 }
 
 /** In-memory enriched view: TenantConfig + derivations. */

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -1,3 +1,5 @@
+import type { OrgFsMountConfig } from "./org-fs/config";
+
 export type PackageManager = "npm" | "pnpm" | "yarn" | "bun" | "deno";
 export type RuntimeName = "node" | "bun" | "deno";
 
@@ -61,6 +63,12 @@ export interface TenantConfig {
   readonly git?: GitConfig;
   readonly application?: Application;
   readonly env?: Readonly<Record<string, string>>;
+  /**
+   * Org-filesystem volumes to mount into the workspace (mesh-pushed; present
+   * only for desktop links, whose machine can mount kext-free). Absent → no
+   * mounting. See `./org-fs/mount-manager`.
+   */
+  readonly orgFs?: OrgFsMountConfig;
 }
 
 /** In-memory enriched view: TenantConfig + derivations. */


### PR DESCRIPTION
**Stacked on #3723** (base = `viktormarinho/org-filesystem-mount`). Review/merge that first; GitHub will retarget this to `main` once it lands.

## Summary

The sandbox-daemon side of the org filesystem: mounts volumes at `<appRoot>/org/<volume>` so **every harness — including CLI ones (Claude Code, Codex) that only read real files on disk — sees them, with no kernel extension.**

```
OrgFsClient (mesh /api/:org/fs)  →  createWebdavHandler (loopback Bun.serve)  →  rclone (nfsmount/mount)  →  OS mount at <appRoot>/org/<volume>
```

## What's here

- **`MountManager`** — per volume: serves the WebDAV layer (from #3723) on a loopback port and hands the URL to an injected **`Mounter`**. **Boot-safe**: every step is guarded, so a mount failure logs and is skipped — it never affects the daemon, dev server, fs routes, or harnesses (a volume's bytes still reach harnesses via the mesh API regardless). Mount paths are clamped to `<appRoot>/org`.
- **`createRcloneMounter`** — the real `Mounter`: `rclone nfsmount` on macOS (built-in NFS client) / `rclone mount` on Linux (native FUSE via `/dev/fuse`). **No macFUSE / System Extension** on either.
- **`TenantConfig.orgFs`** — the mesh-pushed config that turns mounting on. Present only for **desktop links** (their host can mount kext-free); absent for cluster pods, whose locked-down `securityContext` (drop-ALL caps, no `/dev/fuse`) blocks in-pod mounts — that's a later privileged-sidecar concern.
- **`entry.ts` wiring** — env-gated (`ORGFS_RCLONE_PATH`) **fire-and-forget** start after the daemon is serving + best-effort unmount on `SIGTERM`. **Inert by default** (no env / no config → no-op), so this commit changes nothing in current prod until the provisioning side ships.

## Testing

- Unit tests for the orchestration (injected fake `Mounter`, real loopback servers): serve→mount per volume, unmount+stop on `stop()`, boot-safety (a failing mount is skipped, others proceed), and mount-path clamping (escapes rejected).
- **Daemon bundles clean** (`bun build … --external node-pty` → 491 modules) — the org-fs serve layer are portable leaves, no cluster-dep bleed / TS-stack-overflow.
- Full org-fs suite green across both packages (75 tests). `bun run check`, lint, knip clean.
- ⚠️ The *actual* kernel mount (rclone + OS) is validated manually on macOS (kext-free, in #3723's notes) — it can't run in CI (no rclone/mount perms) or the dev sandbox (seatbelt blocks network-mount traversal). The `Mounter` is injected precisely so the orchestration is tested without it.

## Follow-up (not in this PR)

Mesh-side provisioning: mint an fs-scoped token (like `mintMcpEndpoint`), push `TenantConfig.orgFs` + set `ORGFS_RCLONE_PATH` in `provisionSandbox`, ship the rclone binary with the desktop daemon, and decide the **per-sandbox default-mount policy** (which volumes auto-mount) — a product call. That piece needs a real sandbox env to e2e-validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts org filesystem volumes inside the sandbox at <appRoot>/org/<volume> via loopback WebDAV + `rclone`, so all harnesses (including CLI ones) see real files with no kernel extensions. Controlled by `ORGFS_CONFIG` (boot JSON) and `ORGFS_RCLONE_PATH`; inert by default.

- **New Features**
  - `MountManager` orchestrates per-volume loopback WebDAV + OS mount; fire-and-forget start at boot; best-effort unmount on `SIGTERM`; failures are logged and skipped; mount paths clamped under `<appRoot>/org`.
  - Read mount config from `ORGFS_CONFIG` (boot JSON) via `parseOrgFsConfig`; validates input and ignores malformed/empty configs.
  - `createRcloneMounter` uses `rclone nfsmount` (macOS) and `rclone mount` (Linux); daemonized; sets `--dir-cache-time` to 10s for faster external write visibility; no macFUSE/system extension.

- **Migration**
  - Desktop links: set `ORGFS_CONFIG` (an `OrgFsMountConfig` JSON) and point `ORGFS_RCLONE_PATH` to an `rclone` binary with mount support. Cluster pods unchanged.

<sup>Written for commit 9611a2469ac7a0920dcd1edbeed7ac6999349342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

