### PR TITLE
fix(services): flatten NATS archive on Windows so the binary resolves

### DIFF
--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -13,6 +13,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  rmSync,
   symlinkSync,
   writeFileSync,
 } from "fs";
@@ -565,6 +566,18 @@ async function downloadNats(home: string): Promise<string> {
       `Expand-Archive -Path '${zipPath}' -DestinationPath '${binDir}' -Force`,
     ]);
     await proc.exited;
+    // Expand-Archive preserves the zip's top-level directory (e.g.
+    // nats-server-v2.10.24-windows-amd64/nats-server.exe) instead of
+    // flattening like `unzip -j`. Move the binary up to binDir and remove
+    // the versioned subdirectory so binPath resolves correctly.
+    if (!existsSync(binPath)) {
+      const extractedDir = join(binDir, artifact.replace(/\.zip$/, ""));
+      const extractedBin = join(extractedDir, `nats-server${EXE_EXT}`);
+      if (existsSync(extractedBin)) {
+        renameSync(extractedBin, binPath);
+        rmSync(extractedDir, { recursive: true, force: true });
+      }
+    }
   } else {
     const proc = Bun.spawn([
       "unzip",


### PR DESCRIPTION
## What is this contribution about?
On Windows, `bun run dev` / `bunx decocms` crashes at startup with
"NATS binary not found ... after extraction". The binary downloads and extracts
fine — the issue is the extraction layout. The unix branch uses `unzip -j`,
which flattens the archive and drops the binary directly into `binDir`. The
Windows branch uses PowerShell `Expand-Archive`, which preserves the zip's
top-level folder, so the binary lands one level deeper
(`<binDir>/nats-server-<version>-windows-amd64/nats-server.exe`) and the
`existsSync(binPath)` check fails.

This flattens the Windows extraction to match the unix behavior: it moves the
binary up to `binPath` and removes the now-empty versioned subfolder. No-op on
macOS/Linux. (No existing issue found for this Windows-only failure.)

## How to Test
1. On Windows, remove `.deco/services/nats` (or start from a clean `.deco`)
2. Run `bun run dev`
3. Expected: NATS downloads, extracts, and starts — no "binary not found" error

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes (no-op on macOS/Linux)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows startup by flattening the NATS zip extraction so `nats-server.exe` lands in the expected `binPath`. This prevents the "NATS binary not found ... after extraction" error during `bun run dev` or `bunx decocms`.

- **Bug Fixes**
  - On Windows, move `nats-server.exe` up from the versioned subfolder after `Expand-Archive` and delete the empty folder, matching `unzip -j` behavior.
  - No changes on macOS/Linux.

<sup>Written for commit a12519439a99680605c9b16dc481021b6e149ce9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

