### PR TITLE
fix(chat): sort live SSE messages like refresh does

### DIFF
--- a/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
@@ -681,7 +681,76 @@ describe("mergeAndSort", () => {
     expect(out[0]?.role).toBe("assistant");
   });
 
-  test("metadata.created_at is ignored — only top-level created_at is used", () => {
+  test("in-flight turn-1 assistant (metadata only) stays before turn-2 user", () => {
+    const wrongOrder = [
+      {
+        id: "u1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+        created_at: "2026-06-09T12:00:00.000Z",
+        // biome-ignore lint/suspicious/noExplicitAny: test helper
+      } as any,
+      {
+        id: "u2",
+        role: "user",
+        parts: [{ type: "text", text: "second" }],
+        metadata: { created_at: "2026-06-09T12:00:05.000Z" },
+        // biome-ignore lint/suspicious/noExplicitAny: test helper
+      } as any,
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Hello!" }],
+        metadata: { created_at: "2026-06-09T12:00:01.000Z" },
+        // biome-ignore lint/suspicious/noExplicitAny: test helper
+      } as any,
+    ];
+    expect(mergeAndSort(wrongOrder, []).map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "u2",
+    ]);
+  });
+
+  test("user metadata.created_at sorts before in-flight assistant (+Infinity)", () => {
+    const wrongOrder = [
+      {
+        id: "u1",
+        role: "user",
+        parts: [],
+        created_at: "2026-06-09T12:00:00.000Z",
+        // biome-ignore lint/suspicious/noExplicitAny: test helper
+      } as any,
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [],
+        created_at: "2026-06-09T12:00:01.000Z",
+        // biome-ignore lint/suspicious/noExplicitAny: test helper
+      } as any,
+      {
+        id: "a2",
+        role: "assistant",
+        parts: [{ type: "reasoning", text: "thinking" }],
+        // biome-ignore lint/suspicious/noExplicitAny: test helper
+      } as any,
+      {
+        id: "u2",
+        role: "user",
+        parts: [{ type: "text", text: "second" }],
+        metadata: { created_at: "2026-06-09T12:00:02.000Z" },
+        // biome-ignore lint/suspicious/noExplicitAny: test helper
+      } as any,
+    ];
+    expect(mergeAndSort(wrongOrder, []).map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "u2",
+      "a2",
+    ]);
+  });
+
+  test("metadata.created_at is ignored for assistant — only top-level created_at is used", () => {
     // Regression: persisted assistant rows in the wild carry
     // `metadata.created_at` stamped at the run-start time, which is EARLIER
     // than the user message they answer. If readTimestamp pulled from

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -260,6 +260,8 @@ export class ThreadConnection {
    * user has queued in the meantime.
    */
   private waitingForNewRun = false;
+  /** `start` chunk opened a new assistant turn — don't seed the prior one. */
+  private freshRunSubstream = false;
   private client: MCPClient | null;
   private serverFetchedCount = 0;
   private readonly pageSize = 5;
@@ -311,7 +313,10 @@ export class ThreadConnection {
     if (!next) {
       throw new Error(`submit: target not found for ${describe(action)}`);
     }
-    this.messages.set(next);
+    // Same sort pass refresh uses (mergeAndSort + DB `created_at`). Without
+    // it, an in-flight SSE assistant row can sit above the user we just
+    // appended because foldSubStream only upserts by id.
+    this.messages.set(mergeAndSort(next, []));
 
     // A new user turn always POSTs. For approval / toolOutput actions, only
     // POST once the assistant turn has no remaining client-side resolutions
@@ -359,6 +364,19 @@ export class ThreadConnection {
     if (this.subController) {
       this.forceCloseSubStream(true);
     }
+    // Anchor the frozen assistant so mergeAndSort on the next submit doesn't
+    // pull a timestamp-less user row ahead of it (role tiebreak or +Infinity).
+    this.messages.update((msgs) => {
+      const last = msgs.at(-1);
+      if (last?.role !== "assistant") return msgs;
+      const row = last as UIMessage & { created_at?: string };
+      if (row.created_at != null) return msgs;
+      const anchored = {
+        ...last,
+        created_at: new Date().toISOString(),
+      } as UIMessage;
+      return [...msgs.slice(0, -1), anchored];
+    });
     this.waitingForNewRun = true;
   }
 
@@ -777,6 +795,9 @@ export class ThreadConnection {
         },
       });
     }
+    if (chunk.type === "start") {
+      this.freshRunSubstream = true;
+    }
     const sub = this.ensureSubStream();
     sub.enqueue(chunk);
     if (chunk.type === "finish") {
@@ -833,9 +854,12 @@ export class ThreadConnection {
   ): Promise<void> {
     const prev = this.messages.get();
     const seed =
-      prev.length > 0 && prev.at(-1)?.role === "assistant"
+      !this.freshRunSubstream &&
+      prev.length > 0 &&
+      prev.at(-1)?.role === "assistant"
         ? prev.at(-1)
         : undefined;
+    this.freshRunSubstream = false;
     const iter = readUIMessageStream({
       message: seed,
       stream: sub,
@@ -860,7 +884,9 @@ export class ThreadConnection {
       if (!pending) return;
       const msg = pending;
       pending = null;
-      this.messages.update((curr) => dropRedundantStubs(upsertById(curr, msg)));
+      this.messages.update((curr) =>
+        mergeAndSort(dropRedundantStubs(upsertById(curr, msg)), []),
+      );
     };
     for await (const msg of iter) {
       last = msg;
@@ -997,6 +1023,13 @@ export function mergeAndSort(
     const ta = readTimestamp(a);
     const tb = readTimestamp(b);
     if (ta !== tb) return ta - tb;
+    // Mirrors `listMessages` role tiebreak: user before assistant on equal
+    // timestamps (in-flight rows with no top-level `created_at` yet).
+    const roleRank = (m: UIMessage) =>
+      m.role === "user" ? 0 : m.role === "assistant" ? 1 : 2;
+    const ra = roleRank(a);
+    const rb = roleRank(b);
+    if (ra !== rb) return ra - rb;
     return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });
   return dropRedundantStubs(merged);
@@ -1006,16 +1039,24 @@ export function mergeAndSort(
  * Persisted messages from COLLECTION_THREAD_MESSAGES_LIST carry the DB row's
  * `created_at` at the top level. AI-SDK UIMessages don't declare that field,
  * so we read it via a defensive cast. Some assistant messages additionally
- * stamp a `metadata.created_at` at the run-start time — that field reflects
- * the user-turn timestamp, NOT when the assistant row was actually written,
- * so it sorts the assistant BEFORE the user it answered. We deliberately
- * ignore `metadata.created_at` for ordering and trust only the top-level
- * persisted timestamp.
+ * stamp a `metadata.created_at` at run-start. Once the row is persisted the
+ * top-level `created_at` is authoritative — using metadata then would sort
+ * the assistant too early. In-flight assistants (no top-level yet) may fall
+ * back to metadata so a still-streaming turn-1 reply doesn't leap behind a
+ * newly-submitted turn-2 user row during live mergeAndSort.
  */
 function readTimestamp(m: UIMessage): number {
   const withTs = m as unknown as { created_at?: string | number | Date };
-  if (withTs.created_at == null) return Number.POSITIVE_INFINITY;
-  return new Date(withTs.created_at).getTime();
+  if (withTs.created_at != null) {
+    return new Date(withTs.created_at).getTime();
+  }
+  const meta = m.metadata as
+    | { created_at?: string | number | Date }
+    | undefined;
+  if (meta?.created_at != null) {
+    return new Date(meta.created_at).getTime();
+  }
+  return Number.POSITIVE_INFINITY;
 }
 
 // ─── Module-scoped slot ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fix live chat message ordering during SSE streaming — assistant responses could appear before the user message (or a prior turn's reply could jump behind a newer user message) until page refresh
- Apply `mergeAndSort` on `submit()` and streaming commits so the in-memory list uses the same sort logic as refresh/DB load
- Use `metadata.created_at` for in-flight rows without a top-level `created_at`, anchor assistants on `stop()`, and avoid seeding a new run from the prior assistant sub-stream

## Test plan

- [x] `bun test apps/mesh/src/web/components/chat/store/thread-connection.test.ts` (41 pass)
- [ ] Send two messages in quick succession without refresh — user/assistant pairs stay in chronological order
- [ ] Stop mid-stream, send another message — prior assistant stays before the new user turn
- [ ] Refresh thread — order unchanged (regression)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live SSE chat ordering so user and assistant messages stay chronological without a refresh. In-memory sorting now matches refresh/DB behavior and handles in-flight timestamps correctly.

- **Bug Fixes**
  - Apply `mergeAndSort` on `submit()` and during SSE updates to keep order consistent with refresh.
  - Anchor stopped assistant turns by adding `created_at` to prevent them from jumping behind the next user message.
  - Use `metadata.created_at` only for in-flight rows; once persisted, rely on top-level `created_at`. Add role tiebreak (user before assistant) on equal timestamps.
  - Avoid seeding a new run from the prior assistant sub-stream when a `start` chunk opens a fresh turn.
  - Add tests covering in-flight ordering and metadata timestamp behavior.

<sup>Written for commit 58409ef4a23f4f7c3bd21adbb1638613a755f62a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

