### PR TITLE
feat(org-fs): provision sandbox mounts — fs token + ORGFS_CONFIG + rclone

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -84,6 +84,7 @@ import type { CancelBroadcast } from "./cancel-broadcast";
 import type { ThreadMessage } from "@/storage/types";
 import type { PendingImage } from "@/harnesses/decopilot/built-in-tools";
 import { getInternalUrl, getPublicUrl } from "@/core/server-constants";
+import { mintOrgFsConfigJson } from "@/file-storage/mount/provisioning";
 import { meter, traced } from "@/observability";
 import { getPodId } from "@/core/pod-identity";
 import type { SSEEvent } from "@/event-bus";
@@ -1579,6 +1580,17 @@ async function resolvePullSandboxConfig(
     );
   }
 
+  // Org-fs mounts (desktop dispatch path; this fn already returned null for
+  // non-user-desktop). Mint an fs token + build ORGFS_CONFIG; guarded → no
+  // mounting on failure. Mirrors SANDBOX_START's provisionSandbox.
+  const orgFsConfigJson = ctx.organization?.slug
+    ? await mintOrgFsConfigJson(ctx, {
+        orgSlug: ctx.organization.slug,
+        orgId: input.organizationId,
+        baseUrl: getPublicUrl(),
+      })
+    : undefined;
+
   return {
     handle: sandboxHandle,
     ...(repo ? { repo } : {}),
@@ -1587,6 +1599,7 @@ async function resolvePullSandboxConfig(
     ...(offloadAllowSameHostDev !== undefined
       ? { offloadAllowSameHostDev }
       : {}),
+    ...(orgFsConfigJson ? { orgFsConfigJson } : {}),
   };
 }
 

--- a/apps/mesh/src/api/routes/decopilot/link-work-queue.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-work-queue.ts
@@ -87,6 +87,8 @@ const workItemSandboxSchema = z.object({
   offloadAllowedHosts: z.array(z.string()).optional(),
   /** Allow http:// loopback offload refs (dev MinIO). */
   offloadAllowSameHostDev: z.boolean().optional(),
+  /** org-fs mount config (JSON OrgFsMountConfig) → daemon ORGFS_CONFIG env. */
+  orgFsConfigJson: z.string().optional(),
 });
 
 export type WorkItemSandbox = z.infer<typeof workItemSandboxSchema>;

--- a/apps/mesh/src/file-storage/mount/provisioning.test.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { buildOrgFsConfig } from "./provisioning";
+
+describe("buildOrgFsConfig", () => {
+  it("returns the hardcoded skills + outputs mounts with the given identity", () => {
+    const c = buildOrgFsConfig({
+      baseUrl: "https://cluster.example",
+      orgSlug: "acme",
+      token: "tok_abc",
+    });
+    expect(c.orgSlug).toBe("acme");
+    expect(c.token).toBe("tok_abc");
+    expect(c.mounts).toEqual([
+      { volume: "skills", path: "skills" },
+      { volume: "outputs", path: ".outputs" },
+    ]);
+  });
+
+  it("strips trailing slashes from baseUrl", () => {
+    expect(
+      buildOrgFsConfig({ baseUrl: "http://x/", orgSlug: "o", token: "t" })
+        .baseUrl,
+    ).toBe("http://x");
+  });
+});

--- a/apps/mesh/src/file-storage/mount/provisioning.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.ts
@@ -1,0 +1,91 @@
+/**
+ * Builds the `ORGFS_CONFIG` payload the mesh pushes to a sandbox daemon (as a
+ * boot env var) to turn on org-fs mounting. The daemon's `parseOrgFsConfig`
+ * (packages/sandbox/daemon/org-fs/config.ts) validates this shape.
+ *
+ * The mounted set is hardcoded for now (per the team decision); later this
+ * becomes per-agent configurable. Two volumes:
+ *   - `skills`  → mounted at `<appRoot>/org/skills` (org-wide shared library)
+ *   - `outputs` → mounted at `<appRoot>/org/.outputs` (hidden); the daemon
+ *     repoints a per-run symlink `<appRoot>/org/output → .outputs/<threadId>`
+ *     so the agent sees a bare `output/` that is, externally, that thread's
+ *     subtree of the org-wide `outputs` volume (the share-files-back flow).
+ */
+
+/** Shape the daemon parses from ORGFS_CONFIG (mirrors OrgFsMountConfig). */
+export interface OrgFsProvisionConfig {
+  baseUrl: string;
+  orgSlug: string;
+  token: string;
+  mounts: { volume: string; path: string }[];
+}
+
+/** Hidden mount point for the outputs volume; the per-run `output` symlink
+ *  (daemon-side) points into here. Kept distinct from `skills` so a stray
+ *  `output` symlink never collides with a real volume mount. */
+const ORG_FS_OUTPUTS_MOUNT_PATH = ".outputs";
+
+const DEFAULT_MOUNTS: ReadonlyArray<{ volume: string; path: string }> = [
+  { volume: "skills", path: "skills" },
+  { volume: "outputs", path: ORG_FS_OUTPUTS_MOUNT_PATH },
+];
+
+export function buildOrgFsConfig(opts: {
+  baseUrl: string;
+  orgSlug: string;
+  token: string;
+}): OrgFsProvisionConfig {
+  return {
+    baseUrl: opts.baseUrl.replace(/\/+$/, ""),
+    orgSlug: opts.orgSlug,
+    token: opts.token,
+    mounts: DEFAULT_MOUNTS.map((m) => ({ ...m })),
+  };
+}
+
+/** API-key lifetime for the org-fs token baked into a sandbox's ORGFS_CONFIG.
+ *  Sandboxes are ephemeral and re-provisioned (re-minting) on restart, so a
+ *  generous fixed TTL is fine for now; tie to the sandbox lifecycle later. */
+const ORG_FS_KEY_TTL_SECONDS = 60 * 60 * 24 * 7;
+
+/**
+ * Mint an org-fs API key for the caller and return the JSON `ORGFS_CONFIG` the
+ * daemon mounts from — or `undefined` if minting fails (mounting is then simply
+ * skipped; never breaks sandbox provisioning). Used by both sandbox-ensure
+ * paths (SANDBOX_START + dispatch), desktop-only.
+ */
+export async function mintOrgFsConfigJson(
+  ctx: {
+    boundAuth: {
+      apiKey: {
+        create(data: {
+          name: string;
+          expiresIn?: number;
+          metadata?: Record<string, unknown>;
+        }): Promise<{ key: string }>;
+      };
+    };
+  },
+  opts: { orgSlug: string; orgId: string; baseUrl: string },
+): Promise<string | undefined> {
+  try {
+    const apiKey = await ctx.boundAuth.apiKey.create({
+      name: `orgfs-${opts.orgSlug}`,
+      expiresIn: ORG_FS_KEY_TTL_SECONDS,
+      metadata: { organization: { id: opts.orgId, slug: opts.orgSlug } },
+    });
+    return JSON.stringify(
+      buildOrgFsConfig({
+        baseUrl: opts.baseUrl,
+        orgSlug: opts.orgSlug,
+        token: apiKey.key,
+      }),
+    );
+  } catch (err) {
+    console.warn(
+      "[org-fs] token mint failed; mounts disabled for this sandbox",
+      err,
+    );
+    return undefined;
+  }
+}

--- a/apps/mesh/src/link-daemon/cluster-connection-pull.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-pull.ts
@@ -187,6 +187,9 @@ export async function connectToClusterPull(
                   offloadAllowSameHostDev: item.sandbox.offloadAllowSameHostDev,
                 }
               : {}),
+            ...(item.sandbox.orgFsConfigJson !== undefined
+              ? { orgFsConfigJson: item.sandbox.orgFsConfigJson }
+              : {}),
           }
         : { handle };
       let sandboxApiUrl: string;

--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -41,6 +41,8 @@ interface EnsureSandboxBody {
   offloadAllowedHosts?: string[];
   /** Permit http:// loopback offload refs (dev MinIO). */
   offloadAllowSameHostDev?: boolean;
+  /** org-fs mount config (JSON OrgFsMountConfig) → daemon ORGFS_CONFIG env. */
+  orgFsConfigJson?: string;
 }
 
 export type StreamEvent =

--- a/apps/mesh/src/link-daemon/ensure-rclone.ts
+++ b/apps/mesh/src/link-daemon/ensure-rclone.ts
@@ -1,0 +1,69 @@
+/**
+ * Ensures a pinned `rclone` binary (with mount support) is available on the
+ * user's machine for the org-fs mount, downloading + caching it under the link
+ * daemon's data dir on first use. The official rclone.org build is required —
+ * Homebrew's notably ships without `mount`. Returns the binary path, or null
+ * if unavailable (the daemon then simply skips mounting).
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const RCLONE_VERSION = "v1.74.3";
+
+/** rclone.org release slug for the current platform, or null if unsupported. */
+function platformSlug(): string | null {
+  const os =
+    process.platform === "darwin"
+      ? "osx"
+      : process.platform === "linux"
+        ? "linux"
+        : null;
+  const arch =
+    process.arch === "arm64"
+      ? "arm64"
+      : process.arch === "x64"
+        ? "amd64"
+        : null;
+  return os && arch ? `${os}-${arch}` : null;
+}
+
+export async function ensureRclone(dataDir: string): Promise<string | null> {
+  const slug = platformSlug();
+  if (!slug) return null;
+  const name = `rclone-${RCLONE_VERSION}-${slug}`;
+  const dir = join(dataDir, "cache", name);
+  const bin = join(dir, "rclone");
+  if (existsSync(bin)) return bin;
+
+  try {
+    mkdirSync(dir, { recursive: true });
+    const url = `https://downloads.rclone.org/${RCLONE_VERSION}/${name}.zip`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`download failed: HTTP ${res.status}`);
+    const zip = join(dir, "rclone.zip");
+    await Bun.write(zip, await res.arrayBuffer());
+    // The archive nests the binary under `<name>/rclone`; `-j` flattens it
+    // into `dir`, `-o` overwrites a partial prior attempt.
+    const unzip = Bun.spawnSync([
+      "unzip",
+      "-o",
+      "-j",
+      zip,
+      `${name}/rclone`,
+      "-d",
+      dir,
+    ]);
+    if (unzip.exitCode !== 0 || !existsSync(bin)) {
+      throw new Error("unzip failed (is `unzip` installed?)");
+    }
+    Bun.spawnSync(["chmod", "+x", bin]);
+    return bin;
+  } catch (err) {
+    console.warn(
+      "[org-fs] rclone unavailable; volume mounting disabled for this machine",
+      err,
+    );
+    return null;
+  }
+}

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -18,6 +18,7 @@ import {
   waitForDaemonReady,
 } from "@decocms/sandbox/daemon-client";
 import { createDefaultDaemonSpawn } from "@decocms/sandbox/daemon-spawn";
+import { ensureRclone } from "./ensure-rclone";
 import { createControlHandler } from "./control-handler";
 import { connectToClusterPull } from "./cluster-connection-pull";
 import { startLocalIngress } from "./local-ingress";
@@ -87,7 +88,7 @@ export async function startLinkDaemon(
       ingressPort > 0
         ? `http://${handle}.localhost:${ingressPort}`
         : `http://127.0.0.1:${port}`,
-    spawnDaemon: (args): Promise<SpawnResult> => {
+    spawnDaemon: async (args): Promise<SpawnResult> => {
       const env: Record<string, string> = {
         DAEMON_BOOT_ID: randomUUID(),
         APP_ROOT: args.workdir,
@@ -102,15 +103,26 @@ export async function startLinkDaemon(
           ? { OFFLOAD_ALLOW_SAME_HOST_DEV: "1" }
           : {}),
       };
-      return innerSpawn({
+      // org-fs mounting needs BOTH the config and a real rclone binary. Ensure
+      // rclone (downloaded + cached once) only when a mount is requested; if it
+      // can't be obtained, leave both unset so the daemon skips mounting.
+      if (args.orgFsConfigJson) {
+        const rclonePath = await ensureRclone(opts.dataDir);
+        if (rclonePath) {
+          env.ORGFS_CONFIG = args.orgFsConfigJson;
+          env.ORGFS_RCLONE_PATH = rclonePath;
+        }
+      }
+      const proc = await innerSpawn({
         workdir: args.workdir,
         env,
         daemonPort: args.port,
-      }).then((proc) => ({
+      });
+      return {
         port: args.port,
         kill: (sig) => proc.kill(sig),
         exited: proc.exited.then(() => undefined),
-      }));
+      };
     },
     postConfig: async (port, devPort, config, daemonToken) => {
       // Daemon's TenantConfig wire shape is `{ git, application }`. We

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -91,6 +91,9 @@ export interface EnsureSandboxInput {
   /** Permit http:// loopback offload refs (dev MinIO over localhost). Maps to
    *  the daemon's `OFFLOAD_ALLOW_SAME_HOST_DEV=1`. */
   offloadAllowSameHostDev?: boolean;
+  /** org-fs mount config (JSON OrgFsMountConfig) → daemon `ORGFS_CONFIG` boot
+   *  env so it mounts the configured volumes kext-free. Absent → no mounting. */
+  orgFsConfigJson?: string;
 }
 
 export interface SandboxState {
@@ -145,6 +148,8 @@ export interface DesktopSandboxProviderDeps {
     offloadAllowedHosts: string[];
     /** Maps to the daemon's `OFFLOAD_ALLOW_SAME_HOST_DEV=1`. */
     offloadAllowSameHostDev: boolean;
+    /** org-fs mount config (JSON) → daemon `ORGFS_CONFIG`. undefined = no mount. */
+    orgFsConfigJson?: string;
   }) => SpawnResult | Promise<SpawnResult>;
   postConfig: (
     port: number,
@@ -348,6 +353,8 @@ export function createDesktopSandboxProvider(
         // by an older cluster that doesn't push these stays safe.
         offloadAllowedHosts: input.offloadAllowedHosts ?? [],
         offloadAllowSameHostDev: input.offloadAllowSameHostDev ?? false,
+        // org-fs mount config (desktop-only); undefined → daemon skips mounting.
+        orgFsConfigJson: input.orgFsConfigJson,
       }),
     );
     try {

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -46,6 +46,8 @@ import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
 import { getSettings } from "../../settings";
+import { getPublicUrl } from "../../core/server-constants";
+import { mintOrgFsConfigJson } from "../../file-storage/mount/provisioning";
 import { setSandboxMapEntry } from "./sandbox-map";
 import type { VirtualMCPUpdateData } from "../virtual/schema";
 
@@ -411,6 +413,19 @@ async function provisionSandbox(
         })
       : null;
 
+  // Org-fs mounts: mint an fs-scoped token + build the daemon's ORGFS_CONFIG.
+  // Desktop-only — hosted pods can't mount (the privileged-sidecar path is
+  // separate). Guarded inside the helper: a mint failure → undefined → no
+  // mounting, never breaks provisioning.
+  const orgFsConfigJson =
+    runner.kind === "user-desktop" && ctx.organization?.slug
+      ? await mintOrgFsConfigJson(ctx, {
+          orgSlug: ctx.organization.slug,
+          orgId,
+          baseUrl: getPublicUrl(),
+        })
+      : undefined;
+
   const sandbox = await runner.ensure(
     { userId, projectRef },
     {
@@ -429,6 +444,7 @@ async function provisionSandbox(
             offloadAllowSameHostDev: offload.allowSameHostDev,
           }
         : {}),
+      ...(orgFsConfigJson ? { orgFsConfigJson } : {}),
     },
   );
 

--- a/packages/sandbox/server/provider/desktop/runner.ts
+++ b/packages/sandbox/server/provider/desktop/runner.ts
@@ -145,6 +145,11 @@ export class DesktopSandboxProvider implements SandboxProvider {
       ...(opts.offloadAllowSameHostDev !== undefined
         ? { offloadAllowSameHostDev: opts.offloadAllowSameHostDev }
         : {}),
+      // org-fs mount config (JSON OrgFsMountConfig) → daemon's ORGFS_CONFIG
+      // boot env. Desktop-only; absent → no mounting.
+      ...(opts.orgFsConfigJson
+        ? { orgFsConfigJson: opts.orgFsConfigJson }
+        : {}),
     });
     const responseText = await this.dispatchJson(
       "POST",

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -103,6 +103,13 @@ export interface EnsureOptions {
   offloadAllowedHosts?: string[];
   /** Permit http:// loopback offload refs (dev MinIO). false in production. */
   offloadAllowSameHostDev?: boolean;
+  /**
+   * org-fs mount config (a JSON `OrgFsMountConfig`) for the spawned daemon, set
+   * as its `ORGFS_CONFIG` boot env so it mounts the configured volumes
+   * kext-free. Only the `user-desktop` runner consumes it (hosted pods can't
+   * mount — that's the privileged-sidecar path). Absent → no mounting.
+   */
+  orgFsConfigJson?: string;
 }
 
 export interface ProxyRequestInit {


### PR DESCRIPTION
**Stacked on #3726** (base = `viktormarinho/org-fs-daemon-mount`, which is on #3723). Review the stack bottom-up; GitHub retargets this as each lands.

## Summary

The mesh-side provisioning that **turns org-fs mounting on** for desktop-link sandboxes. The daemon `MountManager` (#3726) consumes `ORGFS_CONFIG` + `ORGFS_RCLONE_PATH` — this PR produces and delivers them.

- **`buildOrgFsConfig` / `mintOrgFsConfigJson`** (`file-storage/mount/provisioning.ts`): mints an fs-scoped API key and builds the daemon's `ORGFS_CONFIG`. Hardcoded mounts for now (team decision): `skills` (org-wide) + `outputs` (the per-run `output/<threadId>` share-back, mounted hidden at `.outputs` with a daemon-side symlink — see #3726). Guarded: a mint failure → no mounting, never breaks provisioning.
- **Threaded `orgFsConfigJson` through both sandbox-ensure paths**, mirroring `offloadAllowedHosts` at every site:
  - SANDBOX_START → `provisionSandbox` (start.ts)
  - decopilot dispatch → `resolvePullSandboxConfig` (dispatch-run.ts)
  - → `EnsureOptions` → desktop runner / work-item schema (`link-work-queue`) → `cluster-connection-pull` / `control-handler` → `user-desktop-provider` → `link-daemon/index.ts` spawn env.
- **`ensureRclone`** (link-daemon): downloads + caches a pinned official rclone (the build with `mount`; Homebrew's lacks it) into the data dir, and sets `ORGFS_CONFIG` + `ORGFS_RCLONE_PATH` on the spawned daemon — both required to mount.
- **Desktop-only.** Hosted pods can't mount (locked-down securityContext); that's the privileged-sidecar follow-up. **Fully gated** — no rclone / no config → the daemon skips mounting, so this is inert for hosted execution and changes nothing until a desktop sandbox is provisioned.

## Testing

- `buildOrgFsConfig` unit-tested; daemon `MountManager` + `parseOrgFsConfig` tested (#3726). `bun run check` (all workspaces), lint, knip clean; daemon bundles (491 modules, no cluster-dep bleed).
- **The mount mechanism is proven end-to-end in a Linux container** (our WebDAV serve layer → `rclone mount` → read + write all work — the macOS `EPERM` was only the dev seatbelt). This PR's wiring mirrors the proven `offloadAllowedHosts` env path and typechecks across the full chain.
- ⚠️ Not yet run: the **full desktop chain e2e** (dev + `decocms link` + provision + mount) — best done in a Linux container (no seatbelt). That + the **cluster sidecar** (privileged-sidecar mount for hosted pods) are the remaining follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables org-fs mounts for desktop-link sandboxes by minting an fs-scoped token, building `ORGFS_CONFIG`, and provisioning a pinned `rclone`. Desktop-only and fully gated; hosted pods are unaffected.

- **New Features**
  - Add `buildOrgFsConfig` and `mintOrgFsConfigJson` to produce `ORGFS_CONFIG` with hardcoded mounts: `skills` and `.outputs` (symlinked to `output/<threadId>`). Failures disable mounts but never block provisioning.
  - Thread `orgFsConfigJson` through both sandbox-ensure paths (SANDBOX_START and decopilot dispatch) into `EnsureOptions` → desktop runner → work-item schema → cluster pull/control handler → link-daemon spawn env.
  - Add `ensureRclone` to download and cache the official `rclone`, setting `ORGFS_RCLONE_PATH` only when mounting is requested; if config or binary are missing, the daemon skips mounting.

<sup>Written for commit 46e98661daff569ce6cfdf2547c245d6bb7d6a9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

