### PR TITLE
fix(chat): route decopilot to the runtime the picker actually shows

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -492,33 +492,22 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
   // `Codex desktop`). Persisted to localStorage so the choice survives
   // page reloads.
   //
+  // Scoped per `locator` (like the image-model and tier prefs) so a desktop
+  // pick made in one org doesn't leak into another — runtime availability is
+  // org/link-specific, and a "Claude Code desktop" pick carried across orgs
+  // used to mis-route to an offline link. A fresh org starts with no pick
+  // (`null`), letting the server choose its default.
+  //
   // Everything else (`pendingHarnessId`, `pendingSandboxProviderKind`,
   // the request body's harnessId/sandboxProviderKind) derives from this
   // through `AGENT_OPTION_PINS`, so the pill display and the submit can
   // never disagree.
-  const [pendingAgentOption, setPendingAgentOptionState] =
-    useState<AgentOption | null>(() => {
-      try {
-        const stored = localStorage.getItem(
-          "chat:lastAgentOption",
-        ) as AgentOption | null;
-        return stored && stored in AGENT_OPTION_PINS ? stored : null;
-      } catch {
-        return null;
-      }
-    });
-  const setPendingAgentOption = (option: AgentOption | null) => {
-    setPendingAgentOptionState(option);
-    try {
-      if (option === null) {
-        localStorage.removeItem("chat:lastAgentOption");
-      } else {
-        localStorage.setItem("chat:lastAgentOption", option);
-      }
-    } catch {
-      // ignore storage errors (private browsing, quota exceeded, etc.)
-    }
-  };
+  const [pendingAgentOption, setPendingAgentOption] =
+    useLocalStorage<AgentOption | null>(
+      LOCALSTORAGE_KEYS.chatLastAgentOption(locator),
+      (existing) =>
+        existing && existing in AGENT_OPTION_PINS ? existing : null,
+    );
 
   // Provider-tree wiring: `ChatPrefsProvider` is mounted INSIDE
   // `ChatTaskCtx.Provider` (see `ChatContextProvider` below), so the optional

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -45,8 +45,10 @@ import type { HarnessId } from "@/harnesses";
 import {
   AGENT_OPTION_PINS,
   agentOptionFor,
+  resolveAvailableAgentOption,
   type AgentOption,
 } from "./pills/agent-options";
+import { useAgentOptionAvailability } from "./use-agent-availability";
 import { resolveSubmitSettings } from "./resolve-submit-settings";
 import {
   pickSimpleModeDefaults,
@@ -535,9 +537,24 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
         )
       : null;
 
+  // Resolve the persisted pick against what's actually runnable right now,
+  // applying the same availability fallback the mode picker uses for display.
+  // A pick that points to an offline runtime — e.g. "Claude Code desktop"
+  // carried over from another org while this org's desktop link is offline —
+  // falls back to cloud Decopilot instead of dispatching to the dead desktop
+  // link (which 409s with `user_desktop_link_offline`). Because the picker's
+  // displayed mode is derived from `effectiveAgentOption` (exposed as
+  // `pendingAgentOption` below), this keeps the runtime the user sees selected
+  // and the runtime the message dispatches to in lockstep.
+  const availability = useAgentOptionAvailability();
+  const availableAgentOption = resolveAvailableAgentOption(
+    pendingAgentOption,
+    availability,
+  );
+
   // When the thread is locked, the agent option is dictated by the persisted
   // (harness, sandbox) pair — period. Otherwise, fall through to the user's
-  // global picker.
+  // availability-resolved global picker.
   //
   // When the thread is locked but the (harness, sandbox) tuple doesn't map
   // to a known AgentOption (legacy/trigger-created rows), we intentionally
@@ -546,7 +563,7 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
   // should consult isThreadLocked for the "locked" affordance and avoid
   // showing the global selection on a locked thread.
   const effectiveAgentOption: AgentOption | null =
-    taskCtxForLock?.isThreadLocked ? lockedAgentOption : pendingAgentOption;
+    taskCtxForLock?.isThreadLocked ? lockedAgentOption : availableAgentOption;
 
   const effectivePins = effectiveAgentOption
     ? AGENT_OPTION_PINS[effectiveAgentOption]

--- a/apps/mesh/src/web/components/chat/pills/agent-options.test.ts
+++ b/apps/mesh/src/web/components/chat/pills/agent-options.test.ts
@@ -3,9 +3,26 @@ import { describe, expect, test } from "bun:test";
 import {
   AGENT_OPTION_PINS,
   type AgentOption,
+  type AgentOptionAvailability,
   type AgentPins,
   agentOptionFor,
+  agentOptionIsAvailable,
+  resolveAvailableAgentOption,
 } from "./agent-options";
+
+const ALL_AVAILABLE: AgentOptionAvailability = {
+  agentSandbox: true,
+  userDesktop: true,
+  claudeCode: true,
+  codex: true,
+};
+
+const DESKTOP_OFFLINE: AgentOptionAvailability = {
+  agentSandbox: true,
+  userDesktop: false,
+  claudeCode: true, // capability advertised, but link offline → still unavailable
+  codex: true,
+};
 
 describe("agentOptionFor", () => {
   test("maps decopilot harness with agent-sandbox sandbox to decopilot option", () => {
@@ -52,5 +69,105 @@ describe("agentOptionFor", () => {
     ][]) {
       expect(agentOptionFor(pins.harness, pins.sandbox)).toBe(option);
     }
+  });
+});
+
+describe("agentOptionIsAvailable", () => {
+  test("cloud decopilot needs agent-sandbox only", () => {
+    expect(agentOptionIsAvailable("decopilot", ALL_AVAILABLE)).toBe(true);
+    expect(
+      agentOptionIsAvailable("decopilot", {
+        ...ALL_AVAILABLE,
+        agentSandbox: false,
+      }),
+    ).toBe(false);
+    // desktop being offline does not affect the cloud option
+    expect(agentOptionIsAvailable("decopilot", DESKTOP_OFFLINE)).toBe(true);
+  });
+
+  test("desktop options require the link to be online", () => {
+    expect(agentOptionIsAvailable("decopilot-desktop", ALL_AVAILABLE)).toBe(
+      true,
+    );
+    expect(agentOptionIsAvailable("decopilot-desktop", DESKTOP_OFFLINE)).toBe(
+      false,
+    );
+    expect(agentOptionIsAvailable("claude-code-desktop", DESKTOP_OFFLINE)).toBe(
+      false,
+    );
+    expect(agentOptionIsAvailable("codex-desktop", DESKTOP_OFFLINE)).toBe(
+      false,
+    );
+  });
+
+  test("CLI options require both the link and the advertised capability", () => {
+    expect(agentOptionIsAvailable("claude-code-desktop", ALL_AVAILABLE)).toBe(
+      true,
+    );
+    expect(
+      agentOptionIsAvailable("claude-code-desktop", {
+        ...ALL_AVAILABLE,
+        claudeCode: false,
+      }),
+    ).toBe(false);
+    expect(
+      agentOptionIsAvailable("codex-desktop", {
+        ...ALL_AVAILABLE,
+        codex: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveAvailableAgentOption", () => {
+  test("keeps an available pick unchanged", () => {
+    expect(
+      resolveAvailableAgentOption("claude-code-desktop", ALL_AVAILABLE),
+    ).toBe("claude-code-desktop");
+    expect(resolveAvailableAgentOption("decopilot", ALL_AVAILABLE)).toBe(
+      "decopilot",
+    );
+  });
+
+  test("null pick stays null (server picks the default)", () => {
+    expect(resolveAvailableAgentOption(null, ALL_AVAILABLE)).toBeNull();
+    expect(resolveAvailableAgentOption(null, DESKTOP_OFFLINE)).toBeNull();
+  });
+
+  // The reported bug: a "Claude Code desktop" pick carried over from another
+  // org while this org's desktop link is offline must fall back to cloud
+  // Decopilot rather than dispatch to the dead link (user_desktop_link_offline).
+  test("falls back to cloud Decopilot when the desktop pick is offline", () => {
+    expect(
+      resolveAvailableAgentOption("claude-code-desktop", DESKTOP_OFFLINE),
+    ).toBe("decopilot");
+    expect(
+      resolveAvailableAgentOption("decopilot-desktop", DESKTOP_OFFLINE),
+    ).toBe("decopilot");
+    expect(resolveAvailableAgentOption("codex-desktop", DESKTOP_OFFLINE)).toBe(
+      "decopilot",
+    );
+  });
+
+  test("returns null when nothing is available", () => {
+    expect(
+      resolveAvailableAgentOption("claude-code-desktop", {
+        agentSandbox: false,
+        userDesktop: false,
+        claudeCode: false,
+        codex: false,
+      }),
+    ).toBeNull();
+  });
+
+  test("prefers a desktop fallback when cloud is unavailable but a CLI is online", () => {
+    expect(
+      resolveAvailableAgentOption("codex-desktop", {
+        agentSandbox: false,
+        userDesktop: true,
+        claudeCode: true,
+        codex: false,
+      }),
+    ).toBe("decopilot-desktop");
   });
 });

--- a/apps/mesh/src/web/components/chat/pills/agent-options.ts
+++ b/apps/mesh/src/web/components/chat/pills/agent-options.ts
@@ -59,3 +59,70 @@ export function agentOptionFor(
   }
   return null;
 }
+
+/**
+ * Runtime availability of each agent option for the current org/session,
+ * derived from the public config (`agentSandbox`) and the user's desktop link
+ * (`userDesktop` + the CLI capabilities it advertises). Shared by the mode
+ * picker (which rows to show, which mode to display) and the chat submit path
+ * (which (harness, sandbox) pins to dispatch) so the two can never disagree.
+ */
+export interface AgentOptionAvailability {
+  agentSandbox: boolean;
+  userDesktop: boolean;
+  claudeCode: boolean;
+  codex: boolean;
+}
+
+/** Whether `option` can run given the current `availability`. */
+export function agentOptionIsAvailable(
+  option: AgentOption,
+  availability: AgentOptionAvailability,
+): boolean {
+  switch (option) {
+    case "decopilot":
+      return availability.agentSandbox;
+    case "decopilot-desktop":
+      return availability.userDesktop;
+    case "claude-code-desktop":
+      return availability.userDesktop && availability.claudeCode;
+    case "codex-desktop":
+      return availability.userDesktop && availability.codex;
+  }
+}
+
+/**
+ * Preference order used when the selected option is unavailable. Cloud
+ * Decopilot first — it's the only runtime that doesn't depend on a desktop
+ * link — mirroring the row order in the mode picker.
+ */
+const AGENT_OPTION_FALLBACK_ORDER: AgentOption[] = [
+  "decopilot",
+  "decopilot-desktop",
+  "claude-code-desktop",
+  "codex-desktop",
+];
+
+/**
+ * Resolve the option that will actually run, applying the same availability
+ * fallback the picker uses for display. When the persisted pick points to a
+ * runtime that isn't currently available — e.g. a "Claude Code desktop" pick
+ * carried over from another org while the desktop link is offline — fall back
+ * to the first available option instead of silently dispatching to the dead
+ * runtime (which 409s with `user_desktop_link_offline`).
+ *
+ * Returns `null` only when `option` is null (no explicit pick — let the server
+ * choose its default) or when nothing is available at all.
+ */
+export function resolveAvailableAgentOption(
+  option: AgentOption | null,
+  availability: AgentOptionAvailability,
+): AgentOption | null {
+  if (option == null) return null;
+  if (agentOptionIsAvailable(option, availability)) return option;
+  return (
+    AGENT_OPTION_FALLBACK_ORDER.find((o) =>
+      agentOptionIsAvailable(o, availability),
+    ) ?? null
+  );
+}

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
@@ -20,11 +20,11 @@ import {
 } from "@decocms/mesh-sdk";
 import type { HarnessId } from "@/harnesses";
 import { AgentAvatar } from "@/web/components/agent-icon";
-import { useCurrentLink } from "@/web/hooks/use-current-link";
-import { usePublicConfig } from "@/web/hooks/use-public-config";
 import { useSandboxStart } from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { track } from "@/web/lib/posthog-client";
 import { useOptionalChatTask } from "../chat-context";
+import { useAgentOptionAvailability } from "../use-agent-availability";
+import type { AgentOptionAvailability } from "./agent-options";
 import { ClaudeCodeIcon, CodexIcon } from "../agent-icons";
 import {
   type AgentMode,
@@ -57,12 +57,7 @@ function DecopilotIcon({ compact = false }: { compact?: boolean }) {
   );
 }
 
-export interface ModePickerAvailability {
-  agentSandbox: boolean;
-  userDesktop: boolean;
-  claudeCode: boolean;
-  codex: boolean;
-}
+export type ModePickerAvailability = AgentOptionAvailability;
 
 interface PureProps {
   mode: AgentMode;
@@ -343,8 +338,6 @@ export function ModePicker({
 }: SmartProps) {
   const selectedMode = useAgentMode();
   const setAgentMode = useSetAgentMode();
-  const link = useCurrentLink();
-  const publicConfig = usePublicConfig();
   const { org } = useProjectContext();
   const mcpClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
@@ -360,12 +353,9 @@ export function ModePicker({
   const taskCtx = useOptionalChatTask();
   const lockedHarness = taskCtx?.lockedHarness ?? null;
 
-  const availability: ModePickerAvailability = {
-    agentSandbox: publicConfig.runtime.agentSandbox,
-    userDesktop: link.online,
-    claudeCode: link.online && link.capabilities.includes("claude-code"),
-    codex: link.online && link.capabilities.includes("codex"),
-  };
+  // Same availability source `chat-context` resolves the submit pins from, so
+  // the displayed mode and the dispatched runtime stay in lockstep.
+  const availability = useAgentOptionAvailability();
   const mode = fallbackMode(selectedMode, availability);
 
   const handleSelect = (next: AgentMode) => {

--- a/apps/mesh/src/web/components/chat/use-agent-availability.ts
+++ b/apps/mesh/src/web/components/chat/use-agent-availability.ts
@@ -1,0 +1,21 @@
+import { useCurrentLink } from "@/web/hooks/use-current-link";
+import { usePublicConfig } from "@/web/hooks/use-public-config";
+import type { AgentOptionAvailability } from "./pills/agent-options";
+
+/**
+ * Runtime availability of each agent option for the current org/session.
+ *
+ * Single source consumed by both the mode picker (display) and the chat submit
+ * path (dispatch pins) via `chat-context`, so the runtime the user sees
+ * selected and the runtime the message dispatches to can never diverge.
+ */
+export function useAgentOptionAvailability(): AgentOptionAvailability {
+  const link = useCurrentLink();
+  const publicConfig = usePublicConfig();
+  return {
+    agentSandbox: publicConfig.runtime.agentSandbox,
+    userDesktop: link.online,
+    claudeCode: link.online && link.capabilities.includes("claude-code"),
+    codex: link.online && link.capabilities.includes("codex"),
+  };
+}

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -18,6 +18,8 @@ export const LOCALSTORAGE_KEYS = {
     `mesh:chat:selectedDeepResearchModel:${locator}`,
   chatSimpleModeTier: (locator: ProjectLocator) =>
     `mesh:chat:simpleModeTier:${locator}`,
+  chatLastAgentOption: (locator: ProjectLocator) =>
+    `mesh:chat:lastAgentOption:${locator}`,
   chatAutosend: (locator: ProjectLocator | string, taskId: string) =>
     `mesh:chat:autosend:${locator}:${taskId}`,
   chatDraft: (locator: ProjectLocator | string, taskKey: string) =>


### PR DESCRIPTION
## Summary

Fixes a production incident where users selecting **cloud Decopilot** got every message rejected with:

```json
{"error":"link_unavailable","code":"user_desktop_link_offline"}
```

even though the picker pill clearly showed **Cloud** selected.

## Root cause

The picker **display** and the chat **submit** derived the effective runtime two different ways:

- **Display** (`mode-picker.tsx`): `fallbackMode(selectedMode, availability)`. When the user's desktop link is offline, `availability.userDesktop = false`, the local rows drop out, and the pill falls back to showing **Cloud** Decopilot.
- **Submit** (`chat-context.tsx`): used the raw persisted `pendingAgentOption` pins via `AGENT_OPTION_PINS`, **with no availability fallback**.

`chat:lastAgentOption` is a browser-global `localStorage` key (not org-scoped). A user who picked **Claude Code desktop** in another org (where they ran the `bun link`) carried that value into an org where they have no desktop link. The pill fell back to "Cloud", but the submit shipped `sandboxProviderKind: "user-desktop"` + `harnessId: "claude-code"`. The server pinned the thread to `user-desktop`, found no online link claim, and 409'd — `resolveDispatchTarget` → `user_desktop_link_offline`.

Confirmed in prod: the affected user's threads were pinned `user-desktop`/`claude-code` with zero persisted messages (409'd before persistence), and clearing browser site data (wiping the stale `localStorage` pick) restored cloud routing.

## Fix

Resolve the persisted pick against current availability **before** deriving the submit pins, using the same fallback the picker uses for display. Because the picker's displayed mode is itself derived from `effectiveAgentOption` (exposed as `pendingAgentOption`), display and dispatch now flow from **one** availability-aware resolution and cannot diverge.

- `agent-options.ts` — add `AgentOptionAvailability`, `agentOptionIsAvailable`, `resolveAvailableAgentOption` (shared, pure, unit-tested).
- `use-agent-availability.ts` — single hook for the availability formula, consumed by both `chat-context` (submit) and `mode-picker` (display), so the formula lives in one place.
- `chat-context.tsx` — apply `resolveAvailableAgentOption` to the unlocked `effectiveAgentOption`.
- `mode-picker.tsx` — source availability from the shared hook.

A stale "Claude Code desktop" pick in an org with the desktop link offline now resolves to cloud Decopilot — matching what the user sees — instead of 409ing.

## Testing

- New unit tests in `agent-options.test.ts` for `agentOptionIsAvailable` and `resolveAvailableAgentOption` (including the exact bug: offline desktop pick → cloud fallback).
- `bun test` (agent-options + mode-picker): 27 pass.
- `bun run check`, `bun run lint`, `bun run fmt`: clean.

## Notes / affected areas

- Locked threads are unchanged — they still route by the immutable thread row. The two already-bricked stub threads (pinned `user-desktop`, no messages) are unaffected and can be ignored.
- Follow-up (separate PR): org-scope the `chat:lastAgentOption` key so a desktop pick doesn't leak across orgs in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a routing bug where chat submit could target a desktop runtime even when the picker showed Cloud, and scopes the persisted agent-mode pick per org to stop cross-org misrouting. Messages now route to the runtime the user sees, preventing 409 `user_desktop_link_offline` errors.

- **Bug Fixes**
  - Resolve the persisted pick against availability before deriving submit pins via `resolveAvailableAgentOption`.
  - Use shared availability `useAgentOptionAvailability` in both `chat-context` and `mode-picker` so display and dispatch stay in sync.
  - Org-scope the persisted pick via `LOCALSTORAGE_KEYS.chatLastAgentOption(locator)` with `useLocalStorage` to avoid cross-org desktop picks leaking.
  - Keep locked-thread routing unchanged.
  - Add unit tests for availability and fallback, including the offline-desktop → Cloud case.

<sup>Written for commit f8bf7c81cf746186806663e9c7de6090ab162591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

