### PR TITLE
fix(chat): org-scope the persisted agent-mode pick

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -492,33 +492,22 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
   // `Codex desktop`). Persisted to localStorage so the choice survives
   // page reloads.
   //
+  // Scoped per `locator` (like the image-model and tier prefs) so a desktop
+  // pick made in one org doesn't leak into another — runtime availability is
+  // org/link-specific, and a "Claude Code desktop" pick carried across orgs
+  // used to mis-route to an offline link. A fresh org starts with no pick
+  // (`null`), letting the server choose its default.
+  //
   // Everything else (`pendingHarnessId`, `pendingSandboxProviderKind`,
   // the request body's harnessId/sandboxProviderKind) derives from this
   // through `AGENT_OPTION_PINS`, so the pill display and the submit can
   // never disagree.
-  const [pendingAgentOption, setPendingAgentOptionState] =
-    useState<AgentOption | null>(() => {
-      try {
-        const stored = localStorage.getItem(
-          "chat:lastAgentOption",
-        ) as AgentOption | null;
-        return stored && stored in AGENT_OPTION_PINS ? stored : null;
-      } catch {
-        return null;
-      }
-    });
-  const setPendingAgentOption = (option: AgentOption | null) => {
-    setPendingAgentOptionState(option);
-    try {
-      if (option === null) {
-        localStorage.removeItem("chat:lastAgentOption");
-      } else {
-        localStorage.setItem("chat:lastAgentOption", option);
-      }
-    } catch {
-      // ignore storage errors (private browsing, quota exceeded, etc.)
-    }
-  };
+  const [pendingAgentOption, setPendingAgentOption] =
+    useLocalStorage<AgentOption | null>(
+      LOCALSTORAGE_KEYS.chatLastAgentOption(locator),
+      (existing) =>
+        existing && existing in AGENT_OPTION_PINS ? existing : null,
+    );
 
   // Provider-tree wiring: `ChatPrefsProvider` is mounted INSIDE
   // `ChatTaskCtx.Provider` (see `ChatContextProvider` below), so the optional

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -18,6 +18,8 @@ export const LOCALSTORAGE_KEYS = {
     `mesh:chat:selectedDeepResearchModel:${locator}`,
   chatSimpleModeTier: (locator: ProjectLocator) =>
     `mesh:chat:simpleModeTier:${locator}`,
+  chatLastAgentOption: (locator: ProjectLocator) =>
+    `mesh:chat:lastAgentOption:${locator}`,
   chatAutosend: (locator: ProjectLocator | string, taskId: string) =>
     `mesh:chat:autosend:${locator}:${taskId}`,
   chatDraft: (locator: ProjectLocator | string, taskKey: string) =>


### PR DESCRIPTION
## Summary

Org-scopes the persisted agent-mode pick so a runtime selection made in one org doesn't leak into another.

**Stacked on #3731** — please merge that first. This PR's base is `fix/decopilot-mode-routing-divergence`; it will retarget to `main` once #3731 merges.

## Why

`chat:lastAgentOption` was a single **browser-global** `localStorage` key. A pick like **"Claude Code desktop"** — made in an org where the user runs the `bun link` — silently applied in every other org, including ones where they have no desktop link. Runtime availability is org/link-specific, so the carried-over pick mis-routed messages to an offline link. This is the upstream cause of the incident fixed by #3731.

#3731 makes a stale pick *harmless at dispatch* (it falls back to cloud when the runtime is unavailable). This PR stops the stale pick from leaking across orgs in the first place — defense in depth.

## Change

- Scope the pick per `locator` via `useLocalStorage` + `LOCALSTORAGE_KEYS.chatLastAgentOption(locator)`, matching the sibling chat prefs (`chatSelectedImageModel`, `chatSelectedDeepResearchModel`, `chatSimpleModeTier`), which are already locator-scoped.
- Replace the bespoke `useState` + manual `localStorage` read/write with the shared hook.

## Behavior change

Existing users' global pick is **not migrated** to the new per-org key, so each org starts fresh at the default (`null` → server default → cloud Decopilot when no desktop link). This is intentional and aligns with how the other chat prefs already behave. Desktop-centric users re-pick once per org.

## Testing

- `bun run check`, `bun run lint`, `bun run fmt`: clean.
- `bun test apps/mesh/src/web/components/chat/`: 290 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the saved agent-mode pick per org to prevent cross-org leaks and mis-routing. Replaces the global `chat:lastAgentOption` with `LOCALSTORAGE_KEYS.chatLastAgentOption(locator)`.

- **Bug Fixes**
  - Persist the pick with `useLocalStorage` and org-scoped keys, so a selection in one org doesn’t affect another.
  - Do not migrate the old global value; each org starts with `null`, letting the server choose its default (cloud when no desktop link).

- **Refactors**
  - Remove bespoke `useState` and manual `localStorage` read/write in `chat-context.tsx` in favor of the shared `useLocalStorage` hook.

<sup>Written for commit 6e3421a8f35dde93e70408ead0d99f6fcf38b75f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

