### PR TITLE
Batch desktop sandbox result ingest

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -2057,6 +2057,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     kvStorage,
     runRegistry,
     streamBuffer,
+    sseHub,
     cancelBroadcast,
     tokenStorage: triggerCallbackTokenStorage,
     automationEventDispatcher,

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { linkIngestBatchSchema } from "./link-ingest-batch-schema";
+
+const row = {
+  id: "run_1:0",
+  seq: 0,
+  org_id: "org_1",
+  thread_id: "run_1",
+  run_id: "run_1",
+  message_id: "assistant_1",
+  role: "assistant",
+  kind: "text",
+  payload: { type: "text", text: "hello" },
+  payload_ref: null,
+  metadata: null,
+  created_at: "2026-06-09T00:00:00.000Z",
+};
+
+describe("linkIngestBatchSchema", () => {
+  it("accepts rows with done false", () => {
+    const parsed = linkIngestBatchSchema.parse({
+      batchId: "batch_1",
+      rows: [row],
+      done: false,
+    });
+    expect(parsed.rows).toHaveLength(1);
+  });
+
+  it("accepts a terminal empty batch", () => {
+    const parsed = linkIngestBatchSchema.parse({
+      batchId: "batch_final",
+      rows: [],
+      done: true,
+    });
+    expect(parsed.done).toBe(true);
+  });
+
+  it("accepts row shape without path-level run matching", () => {
+    const parsed = linkIngestBatchSchema.safeParse({
+      batchId: "batch_bad",
+      rows: [{ ...row, run_id: "other" }],
+      done: false,
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.test.ts
@@ -35,6 +35,15 @@ describe("linkIngestBatchSchema", () => {
     expect(parsed.done).toBe(true);
   });
 
+  it("rejects terminal batches with rows", () => {
+    const parsed = linkIngestBatchSchema.safeParse({
+      batchId: "batch_final_with_rows",
+      rows: [row],
+      done: true,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
   it("accepts row shape without path-level run matching", () => {
     const parsed = linkIngestBatchSchema.safeParse({
       batchId: "batch_bad",

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.test.ts
@@ -43,4 +43,68 @@ describe("linkIngestBatchSchema", () => {
     });
     expect(parsed.success).toBe(true);
   });
+
+  it("rejects rows without payload", () => {
+    const { payload, ...rowWithoutPayload } = row;
+    void payload;
+
+    const parsed = linkIngestBatchSchema.safeParse({
+      batchId: "batch_missing_payload",
+      rows: [rowWithoutPayload],
+      done: false,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects rows without metadata", () => {
+    const { metadata, ...rowWithoutMetadata } = row;
+    void metadata;
+
+    const parsed = linkIngestBatchSchema.safeParse({
+      batchId: "batch_missing_metadata",
+      rows: [rowWithoutMetadata],
+      done: false,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects rows with invalid kind", () => {
+    const parsed = linkIngestBatchSchema.safeParse({
+      batchId: "batch_invalid_kind",
+      rows: [{ ...row, kind: "unknown" }],
+      done: false,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects rows with invalid role", () => {
+    const parsed = linkIngestBatchSchema.safeParse({
+      batchId: "batch_invalid_role",
+      rows: [{ ...row, role: "tool" }],
+      done: false,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects rows with invalid created_at", () => {
+    const parsed = linkIngestBatchSchema.safeParse({
+      batchId: "batch_invalid_created_at",
+      rows: [{ ...row, created_at: "not-a-date" }],
+      done: false,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects batches with more than 512 rows", () => {
+    const parsed = linkIngestBatchSchema.safeParse({
+      batchId: "batch_too_large",
+      rows: Array.from({ length: 513 }, (_, seq) => ({
+        ...row,
+        id: `run_1:${seq}`,
+        seq,
+      })),
+      done: false,
+    });
+    expect(parsed.success).toBe(false);
+  });
 });

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.test.ts
@@ -68,6 +68,15 @@ describe("linkIngestBatchSchema", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("rejects rows with null payload", () => {
+    const parsed = linkIngestBatchSchema.safeParse({
+      batchId: "batch_null_payload",
+      rows: [{ ...row, payload: null }],
+      done: false,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
   it("rejects rows with invalid kind", () => {
     const parsed = linkIngestBatchSchema.safeParse({
       batchId: "batch_invalid_kind",

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
@@ -18,6 +18,10 @@ const requiredUnknownSchema = z
     message: "Required",
   });
 
+const payloadSchema = requiredUnknownSchema.refine((value) => value !== null, {
+  message: "Required",
+});
+
 export const linkIngestPartRowSchema = z.object({
   id: z.string().min(1),
   seq: z.number().int().nonnegative(),
@@ -27,7 +31,7 @@ export const linkIngestPartRowSchema = z.object({
   message_id: z.string().min(1),
   role: roleSchema,
   kind: partKindSchema,
-  payload: requiredUnknownSchema,
+  payload: payloadSchema,
   payload_ref: z.string().nullable(),
   metadata: requiredUnknownSchema.nullable(),
   created_at: z.string().datetime(),

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
@@ -12,15 +12,19 @@ const partKindSchema = z.enum([
 
 const roleSchema = z.enum(["user", "assistant", "system"]);
 
-const requiredUnknownSchema = z
-  .unknown()
-  .refine((value) => value !== undefined, {
+const requiredUnknownSchema = z.custom<unknown>(
+  (value) => value !== undefined,
+  {
     message: "Required",
-  });
+  },
+);
 
-const payloadSchema = requiredUnknownSchema.refine((value) => value !== null, {
-  message: "Required",
-});
+const payloadSchema = z.custom<unknown>(
+  (value) => value !== undefined && value !== null,
+  {
+    message: "Required",
+  },
+);
 
 export const linkIngestPartRowSchema = z.object({
   id: z.string().min(1),

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
@@ -12,6 +12,12 @@ const partKindSchema = z.enum([
 
 const roleSchema = z.enum(["user", "assistant", "system"]);
 
+const requiredUnknownSchema = z
+  .unknown()
+  .refine((value) => value !== undefined, {
+    message: "Required",
+  });
+
 export const linkIngestPartRowSchema = z.object({
   id: z.string().min(1),
   seq: z.number().int().nonnegative(),
@@ -21,9 +27,9 @@ export const linkIngestPartRowSchema = z.object({
   message_id: z.string().min(1),
   role: roleSchema,
   kind: partKindSchema,
-  payload: z.unknown(),
+  payload: requiredUnknownSchema,
   payload_ref: z.string().nullable(),
-  metadata: z.unknown().nullable(),
+  metadata: requiredUnknownSchema.nullable(),
   created_at: z.string().datetime(),
 });
 

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
@@ -26,7 +26,7 @@ const payloadSchema = z.custom<unknown>(
   },
 );
 
-export const linkIngestPartRowSchema = z.object({
+const linkIngestPartRowSchema = z.object({
   id: z.string().min(1),
   seq: z.number().int().nonnegative(),
   org_id: z.string().min(1),

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+const partKindSchema = z.enum([
+  "text",
+  "reasoning",
+  "tool_call",
+  "tool_result",
+  "file",
+  "error",
+  "finish",
+]);
+
+const roleSchema = z.enum(["user", "assistant", "system"]);
+
+export const linkIngestPartRowSchema = z.object({
+  id: z.string().min(1),
+  seq: z.number().int().nonnegative(),
+  org_id: z.string().min(1),
+  thread_id: z.string().min(1),
+  run_id: z.string().min(1),
+  message_id: z.string().min(1),
+  role: roleSchema,
+  kind: partKindSchema,
+  payload: z.unknown(),
+  payload_ref: z.string().nullable(),
+  metadata: z.unknown().nullable(),
+  created_at: z.string().datetime(),
+});
+
+export const linkIngestBatchSchema = z.object({
+  batchId: z.string().min(1),
+  rows: z.array(linkIngestPartRowSchema).max(512),
+  done: z.boolean().default(false),
+});
+
+export type LinkIngestBatch = z.infer<typeof linkIngestBatchSchema>;

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.ts
@@ -41,10 +41,15 @@ export const linkIngestPartRowSchema = z.object({
   created_at: z.string().datetime(),
 });
 
-export const linkIngestBatchSchema = z.object({
-  batchId: z.string().min(1),
-  rows: z.array(linkIngestPartRowSchema).max(512),
-  done: z.boolean().default(false),
-});
+export const linkIngestBatchSchema = z
+  .object({
+    batchId: z.string().min(1),
+    rows: z.array(linkIngestPartRowSchema).max(512),
+    done: z.boolean().default(false),
+  })
+  .refine((batch) => !batch.done || batch.rows.length === 0, {
+    message: "done batches must not contain rows",
+    path: ["rows"],
+  });
 
 export type LinkIngestBatch = z.infer<typeof linkIngestBatchSchema>;

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
@@ -34,7 +34,10 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
   const pumpPromises: Promise<void>[] = [];
   const sseEvents: Array<{ orgId: string; event: SSEEvent }> = [];
   const insertedIds = new Set<string>();
-  let threadStatus = "in_progress";
+  let threadStatus =
+    typeof ctx.initialThreadStatus === "string"
+      ? ctx.initialThreadStatus
+      : "in_progress";
   const app = new Hono<Env>();
   app.use("*", async (c, next) => {
     c.set("meshContext", {
@@ -68,7 +71,7 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
             }
           },
           completeRunIfNotCompleted: async () => {
-            if (threadStatus === "completed") return null;
+            if (threadStatus !== "in_progress") return null;
             const update = {
               status: "completed",
               run_owner_pod: null,
@@ -233,6 +236,24 @@ describe("link ingest parts route", () => {
       "decopilot.thread.status",
       "decopilot.finish",
     ]);
+  });
+
+  test("does not complete or publish finish for a late done batch after failure", async () => {
+    const { app, pumped, pumpPromises, updates, purged, sseEvents } =
+      appWithContext({ initialThreadStatus: "failed" });
+
+    const res = await postParts(app, {
+      batchId: "batch_1",
+      rows: [],
+      done: true,
+    });
+    await Promise.all(pumpPromises);
+
+    expect(res.status).toBe(200);
+    expect(pumped).toEqual([]);
+    expect(updates).toEqual([]);
+    expect(purged).toEqual([]);
+    expect(sseEvents).toEqual([]);
   });
 
   test("publishes appended rows and finish to the live stream buffer", async () => {

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { ThreadMessagePart } from "@/storage/fold-parts";
+import type { Env } from "../../hono-env";
+import { createLinkIngestRoutes } from "./link-ingest-routes";
+
+function makeRow(
+  overrides: Partial<ThreadMessagePart> = {},
+): ThreadMessagePart {
+  return {
+    id: "run_1:0",
+    seq: 0,
+    org_id: "org_1",
+    thread_id: "run_1",
+    run_id: "run_1",
+    message_id: "assistant_1",
+    role: "assistant",
+    kind: "text",
+    payload: { type: "text", text: "hello" },
+    payload_ref: null,
+    metadata: null,
+    created_at: "2026-06-09T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function appWithContext(ctx: Record<string, unknown> = {}) {
+  const appended: ThreadMessagePart[][] = [];
+  const updates: unknown[] = [];
+  const purged: string[] = [];
+  const app = new Hono<Env>();
+  app.use("*", async (c, next) => {
+    c.set("meshContext", {
+      auth: { user: { id: "user_1" } },
+      organization: { id: "org_1", slug: "acme" },
+      storage: {
+        threads: {
+          getCancelRequestedAt: async () => null,
+          getRunFence: async () => "fence_1",
+          bumpProgress: async () => undefined,
+          update: async (_id: string, data: unknown) => {
+            updates.push(data);
+          },
+          messageParts: () => ({
+            appendParts: async (rows: ThreadMessagePart[]) => {
+              appended.push(rows);
+            },
+          }),
+        },
+      },
+      ...ctx,
+    } as unknown as Env["Variables"]["meshContext"]);
+    await next();
+  });
+  app.route(
+    "/api/:org",
+    createLinkIngestRoutes({
+      streamBuffer: {
+        init: async () => undefined,
+        pump: () => undefined,
+        createTailStream: async () => null,
+        purge: (taskId: string) => {
+          purged.push(taskId);
+        },
+        teardown: () => undefined,
+      },
+    }),
+  );
+  return { app, appended, updates, purged };
+}
+
+async function postParts(
+  app: Hono<Env>,
+  body: unknown,
+  headers: Record<string, string> = { "x-fence-token": "fence_1" },
+) {
+  return await app.request("/api/acme/links/runs/run_1/parts", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("link ingest parts route", () => {
+  test("appends rows and returns ok", async () => {
+    const { app, appended } = appWithContext();
+    const row = makeRow();
+
+    const res = await postParts(app, {
+      batchId: "batch_1",
+      rows: [row],
+      done: false,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      appended: 1,
+      done: false,
+    });
+    expect(appended).toEqual([[row]]);
+  });
+
+  test("rejects rows whose run_id does not match path", async () => {
+    const { app, appended } = appWithContext();
+
+    const res = await postParts(app, {
+      batchId: "batch_1",
+      rows: [makeRow({ run_id: "other_run" })],
+      done: false,
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "row run mismatch" });
+    expect(appended).toEqual([]);
+  });
+
+  test("rejects schema failures as a bad batch", async () => {
+    const { app, appended } = appWithContext();
+
+    const res = await postParts(app, {
+      rows: [makeRow()],
+      done: false,
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "bad batch" });
+    expect(appended).toEqual([]);
+  });
+
+  test("marks the run completed on done true", async () => {
+    const { app, updates, purged } = appWithContext();
+
+    const res = await postParts(app, {
+      batchId: "batch_1",
+      rows: [makeRow()],
+      done: true,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      appended: 1,
+      done: true,
+    });
+    expect(updates).toEqual([
+      {
+        status: "completed",
+        run_owner_pod: null,
+        run_config: null,
+        run_started_at: null,
+      },
+    ]);
+    expect(purged).toEqual(["run_1"]);
+  });
+
+  test("rejects cancelled runs before fence check", async () => {
+    let fenceChecks = 0;
+    const { app } = appWithContext({
+      storage: {
+        threads: {
+          getCancelRequestedAt: async () => "2026-06-09T00:00:00.000Z",
+          getRunFence: async () => {
+            fenceChecks++;
+            return "fence_1";
+          },
+          bumpProgress: async () => undefined,
+          update: async () => undefined,
+          messageParts: () => ({
+            appendParts: async () => undefined,
+          }),
+        },
+      },
+    });
+
+    const res = await postParts(app, {
+      batchId: "batch_1",
+      rows: [makeRow()],
+      done: false,
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "cancelled" });
+    expect(fenceChecks).toBe(0);
+  });
+
+  test("rejects bad fence", async () => {
+    const { app, appended } = appWithContext();
+
+    const res = await postParts(
+      app,
+      {
+        batchId: "batch_1",
+        rows: [makeRow()],
+        done: false,
+      },
+      { "x-fence-token": "wrong_fence" },
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "fenced" });
+    expect(appended).toEqual([]);
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
@@ -213,14 +213,14 @@ describe("link ingest parts route", () => {
 
     const res = await postParts(app, {
       batchId: "batch_1",
-      rows: [makeRow()],
+      rows: [],
       done: true,
     });
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       ok: true,
-      appended: 1,
+      appended: 0,
       done: true,
     });
     expect(updates).toEqual([
@@ -259,14 +259,20 @@ describe("link ingest parts route", () => {
   test("publishes appended rows and finish to the live stream buffer", async () => {
     const { app, pumped, pumpPromises } = appWithContext();
 
-    const res = await postParts(app, {
+    const rowRes = await postParts(app, {
       batchId: "batch_1",
       rows: [makeRow()],
+      done: false,
+    });
+    const doneRes = await postParts(app, {
+      batchId: "batch_done",
+      rows: [],
       done: true,
     });
     await Promise.all(pumpPromises);
 
-    expect(res.status).toBe(200);
+    expect(rowRes.status).toBe(200);
+    expect(doneRes.status).toBe(200);
     expect(pumped).toEqual([
       [
         { type: "start", messageId: "assistant_1" },
@@ -282,18 +288,27 @@ describe("link ingest parts route", () => {
 
   test("does not republish live chunks for a retried batch", async () => {
     const { app, pumped, pumpPromises, updates, sseEvents } = appWithContext();
-    const body = {
+    const rowBatch = {
       batchId: "batch_1",
       rows: [makeRow()],
+      done: false,
+    };
+    const doneBatch = {
+      batchId: "batch_done",
+      rows: [],
       done: true,
     };
 
-    const first = await postParts(app, body);
-    const second = await postParts(app, body);
+    const firstRow = await postParts(app, rowBatch);
+    const secondRow = await postParts(app, rowBatch);
+    const firstDone = await postParts(app, doneBatch);
+    const secondDone = await postParts(app, doneBatch);
     await Promise.all(pumpPromises);
 
-    expect(first.status).toBe(200);
-    expect(second.status).toBe(200);
+    expect(firstRow.status).toBe(200);
+    expect(secondRow.status).toBe(200);
+    expect(firstDone.status).toBe(200);
+    expect(secondDone.status).toBe(200);
     expect(pumped).toHaveLength(2);
     expect(updates).toHaveLength(1);
     expect(sseEvents.map(({ event }) => event.type)).toEqual([

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Hono } from "hono";
+import type { UIMessageChunk } from "ai";
+import type { SSEEvent } from "@/event-bus";
 import type { ThreadMessagePart } from "@/storage/fold-parts";
 import type { Env } from "../../hono-env";
 import { createLinkIngestRoutes } from "./link-ingest-routes";
@@ -28,6 +30,9 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
   const appended: ThreadMessagePart[][] = [];
   const updates: unknown[] = [];
   const purged: string[] = [];
+  const pumped: UIMessageChunk[][] = [];
+  const pumpPromises: Promise<void>[] = [];
+  const sseEvents: Array<{ orgId: string; event: SSEEvent }> = [];
   const app = new Hono<Env>();
   app.use("*", async (c, next) => {
     c.set("meshContext", {
@@ -38,6 +43,16 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
           getCancelRequestedAt: async () => null,
           getRunFence: async () => "fence_1",
           bumpProgress: async () => undefined,
+          get: async () => ({
+            id: "run_1",
+            virtual_mcp_id: "vmcp_1",
+            created_by: "user_1",
+            trigger_id: null,
+            title: "Test thread",
+            branch: null,
+            created_at: "2026-06-09T00:00:00.000Z",
+            updated_at: "2026-06-09T00:00:01.000Z",
+          }),
           update: async (_id: string, data: unknown) => {
             updates.push(data);
           },
@@ -57,16 +72,37 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
     createLinkIngestRoutes({
       streamBuffer: {
         init: async () => undefined,
-        pump: () => undefined,
+        pump: (stream: ReadableStream) => {
+          const promise = (async () => {
+            const reader = stream.getReader();
+            const chunks: UIMessageChunk[] = [];
+            try {
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                chunks.push(value as UIMessageChunk);
+              }
+            } finally {
+              reader.releaseLock();
+            }
+            pumped.push(chunks);
+          })();
+          pumpPromises.push(promise);
+        },
         createTailStream: async () => null,
         purge: (taskId: string) => {
           purged.push(taskId);
         },
         teardown: () => undefined,
       },
+      sseHub: {
+        emit: (orgId: string, event: SSEEvent) => {
+          sseEvents.push({ orgId, event });
+        },
+      },
     }),
   );
-  return { app, appended, updates, purged };
+  return { app, appended, updates, purged, pumped, pumpPromises, sseEvents };
 }
 
 async function postParts(
@@ -132,7 +168,7 @@ describe("link ingest parts route", () => {
   });
 
   test("marks the run completed on done true", async () => {
-    const { app, updates, purged } = appWithContext();
+    const { app, updates, purged, sseEvents } = appWithContext();
 
     const res = await postParts(app, {
       batchId: "batch_1",
@@ -155,6 +191,34 @@ describe("link ingest parts route", () => {
       },
     ]);
     expect(purged).toEqual(["run_1"]);
+    expect(sseEvents.map(({ event }) => event.type)).toEqual([
+      "decopilot.thread.status",
+      "decopilot.finish",
+    ]);
+  });
+
+  test("publishes appended rows and finish to the live stream buffer", async () => {
+    const { app, pumped, pumpPromises } = appWithContext();
+
+    const res = await postParts(app, {
+      batchId: "batch_1",
+      rows: [makeRow()],
+      done: true,
+    });
+    await Promise.all(pumpPromises);
+
+    expect(res.status).toBe(200);
+    expect(pumped).toEqual([
+      [
+        { type: "start", messageId: "assistant_1" },
+        { type: "start-step" },
+        { type: "text-start", id: "run_1:0" },
+        { type: "text-delta", id: "run_1:0", delta: "hello" },
+        { type: "text-end", id: "run_1:0" },
+        { type: "finish-step" },
+        { type: "finish" },
+      ],
+    ]);
   });
 
   test("rejects cancelled runs before fence check", async () => {

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
@@ -67,6 +67,28 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
               threadStatus = data.status;
             }
           },
+          completeRunIfNotCompleted: async () => {
+            if (threadStatus === "completed") return null;
+            const update = {
+              status: "completed",
+              run_owner_pod: null,
+              run_config: null,
+              run_started_at: null,
+            };
+            updates.push(update);
+            threadStatus = "completed";
+            return {
+              id: "run_1",
+              status: threadStatus,
+              virtual_mcp_id: "vmcp_1",
+              created_by: "user_1",
+              trigger_id: null,
+              title: "Test thread",
+              branch: null,
+              created_at: "2026-06-09T00:00:00.000Z",
+              updated_at: "2026-06-09T00:00:01.000Z",
+            };
+          },
           messageParts: () => ({
             appendParts: async (rows: ThreadMessagePart[]) => {
               const inserted = rows.filter((row) => !insertedIds.has(row.id));
@@ -87,6 +109,8 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
       streamBuffer: {
         init: async () => undefined,
         pump: (stream: ReadableStream) => {
+          const index = pumped.length;
+          pumped.push([]);
           const promise = (async () => {
             const reader = stream.getReader();
             const chunks: UIMessageChunk[] = [];
@@ -99,7 +123,7 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
             } finally {
               reader.releaseLock();
             }
-            pumped.push(chunks);
+            pumped[index] = chunks;
           })();
           pumpPromises.push(promise);
         },
@@ -230,8 +254,8 @@ describe("link ingest parts route", () => {
         { type: "text-delta", id: "run_1:0", delta: "hello" },
         { type: "text-end", id: "run_1:0" },
         { type: "finish-step" },
-        { type: "finish" },
       ],
+      [{ type: "finish" }],
     ]);
   });
 
@@ -249,7 +273,7 @@ describe("link ingest parts route", () => {
 
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
-    expect(pumped).toHaveLength(1);
+    expect(pumped).toHaveLength(2);
     expect(updates).toHaveLength(1);
     expect(sseEvents.map(({ event }) => event.type)).toEqual([
       "decopilot.thread.status",

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
@@ -33,6 +33,8 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
   const pumped: UIMessageChunk[][] = [];
   const pumpPromises: Promise<void>[] = [];
   const sseEvents: Array<{ orgId: string; event: SSEEvent }> = [];
+  const insertedIds = new Set<string>();
+  let threadStatus = "in_progress";
   const app = new Hono<Env>();
   app.use("*", async (c, next) => {
     c.set("meshContext", {
@@ -45,6 +47,7 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
           bumpProgress: async () => undefined,
           get: async () => ({
             id: "run_1",
+            status: threadStatus,
             virtual_mcp_id: "vmcp_1",
             created_by: "user_1",
             trigger_id: null,
@@ -55,10 +58,21 @@ function appWithContext(ctx: Record<string, unknown> = {}) {
           }),
           update: async (_id: string, data: unknown) => {
             updates.push(data);
+            if (
+              typeof data === "object" &&
+              data !== null &&
+              "status" in data &&
+              typeof data.status === "string"
+            ) {
+              threadStatus = data.status;
+            }
           },
           messageParts: () => ({
             appendParts: async (rows: ThreadMessagePart[]) => {
-              appended.push(rows);
+              const inserted = rows.filter((row) => !insertedIds.has(row.id));
+              for (const row of inserted) insertedIds.add(row.id);
+              appended.push(inserted);
+              return inserted;
             },
           }),
         },
@@ -218,6 +232,28 @@ describe("link ingest parts route", () => {
         { type: "finish-step" },
         { type: "finish" },
       ],
+    ]);
+  });
+
+  test("does not republish live chunks for a retried batch", async () => {
+    const { app, pumped, pumpPromises, updates, sseEvents } = appWithContext();
+    const body = {
+      batchId: "batch_1",
+      rows: [makeRow()],
+      done: true,
+    };
+
+    const first = await postParts(app, body);
+    const second = await postParts(app, body);
+    await Promise.all(pumpPromises);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(pumped).toHaveLength(1);
+    expect(updates).toHaveLength(1);
+    expect(sseEvents.map(({ event }) => event.type)).toEqual([
+      "decopilot.thread.status",
+      "decopilot.finish",
     ]);
   });
 

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
@@ -319,19 +319,26 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
       return c.json({ error: "row run mismatch" }, 400);
     }
 
-    await ctx.storage.threads.messageParts().appendParts(rows);
-    if (rows.length > 0) {
+    const threadBeforeDone = parsed.data.done
+      ? await ctx.storage.threads.get(runId)
+      : null;
+    const shouldComplete =
+      parsed.data.done && threadBeforeDone?.status !== "completed";
+    const insertedRows = await ctx.storage.threads
+      .messageParts()
+      .appendParts(rows);
+    if (insertedRows.length > 0) {
       ctx.storage.threads.bumpProgress(runId).catch(() => {});
     }
     await publishLiveChunks(
       deps,
       runId,
       orgId,
-      liveChunksForRows(rows, parsed.data.done),
+      liveChunksForRows(insertedRows, shouldComplete),
       c.req.raw.signal,
     );
 
-    if (parsed.data.done) {
+    if (shouldComplete) {
       await ctx.storage.threads.update(runId, {
         status: "completed",
         run_owner_pod: null,
@@ -340,7 +347,7 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
       });
       deps.streamBuffer.purge(runId);
       if (deps.sseHub) {
-        const thread = await ctx.storage.threads.get(runId);
+        const thread = threadBeforeDone;
         deps.sseHub.emit(
           orgId,
           createDecopilotThreadStatusEvent(runId, "completed", {

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
@@ -333,9 +333,7 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
       c.req.raw.signal,
     );
 
-    const mayComplete =
-      parsed.data.done && (rows.length === 0 || insertedRows.length > 0);
-    const completedThread = mayComplete
+    const completedThread = parsed.data.done
       ? await ctx.storage.threads.completeRunIfNotCompleted(runId)
       : null;
 

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
@@ -319,11 +319,6 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
       return c.json({ error: "row run mismatch" }, 400);
     }
 
-    const threadBeforeDone = parsed.data.done
-      ? await ctx.storage.threads.get(runId)
-      : null;
-    const shouldComplete =
-      parsed.data.done && threadBeforeDone?.status !== "completed";
     const insertedRows = await ctx.storage.threads
       .messageParts()
       .appendParts(rows);
@@ -334,30 +329,36 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
       deps,
       runId,
       orgId,
-      liveChunksForRows(insertedRows, shouldComplete),
+      liveChunksForRows(insertedRows, false),
       c.req.raw.signal,
     );
 
-    if (shouldComplete) {
-      await ctx.storage.threads.update(runId, {
-        status: "completed",
-        run_owner_pod: null,
-        run_config: null,
-        run_started_at: null,
-      });
+    const mayComplete =
+      parsed.data.done && (rows.length === 0 || insertedRows.length > 0);
+    const completedThread = mayComplete
+      ? await ctx.storage.threads.completeRunIfNotCompleted(runId)
+      : null;
+
+    if (completedThread) {
+      await publishLiveChunks(
+        deps,
+        runId,
+        orgId,
+        liveChunksForRows([], true),
+        c.req.raw.signal,
+      );
       deps.streamBuffer.purge(runId);
       if (deps.sseHub) {
-        const thread = threadBeforeDone;
         deps.sseHub.emit(
           orgId,
           createDecopilotThreadStatusEvent(runId, "completed", {
-            virtualMcpId: thread?.virtual_mcp_id ?? undefined,
-            createdBy: thread?.created_by,
-            triggerId: thread?.trigger_id,
-            title: thread?.title,
-            branch: thread?.branch ?? null,
-            createdAt: thread?.created_at,
-            updatedAt: thread?.updated_at,
+            virtualMcpId: completedThread.virtual_mcp_id ?? undefined,
+            createdBy: completedThread.created_by,
+            triggerId: completedThread.trigger_id,
+            title: completedThread.title,
+            branch: completedThread.branch ?? null,
+            createdAt: completedThread.created_at,
+            updatedAt: completedThread.updated_at,
           }),
         );
         deps.sseHub.emit(orgId, createDecopilotFinishEvent(runId, "completed"));

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
@@ -11,12 +11,13 @@
  * that phase: also org-scope the fence lookup (`getRunFence` currently resolves
  * any thread id) and enforce thread ownership.
  */
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { parseDispatchSSEStream } from "@/harnesses/parse-dispatch-sse";
 import { fenceMatches } from "@/storage/run-fence";
 import { isCancelRequested } from "@/storage/cancel-flag";
 import { PartEmitter } from "./part-emitter";
 import { consumePartStream } from "./consume-part-stream";
+import { linkIngestBatchSchema } from "./link-ingest-batch-schema";
 import type { StreamBuffer } from "./stream-buffer";
 import type { Env } from "../../hono-env";
 
@@ -39,7 +40,7 @@ async function drain(stream: ReadableStream): Promise<void> {
 export function createLinkIngestRoutes(deps: LinkIngestDeps) {
   const app = new Hono<Env>();
 
-  app.post("/links/runs/:runId/stream", async (c) => {
+  async function validateRunAccess(c: Context<Env>) {
     const ctx = c.get("meshContext");
 
     // resolveOrgFromPath does NOT require a principal — enforce auth here.
@@ -47,6 +48,9 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
     if (!userId) return c.json({ error: "unauthorized" }, 401);
 
     const runId = c.req.param("runId");
+    if (!runId) {
+      return c.json({ error: "invalid runId" }, 400);
+    }
     if (!/^[A-Za-z0-9_-]+$/.test(runId)) {
       return c.json({ error: "invalid runId" }, 400);
     }
@@ -68,6 +72,14 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
     if (!fenceMatches(current, presented)) {
       return c.json({ error: "fenced" }, 409);
     }
+
+    return { ctx, runId };
+  }
+
+  app.post("/links/runs/:runId/stream", async (c) => {
+    const access = await validateRunAccess(c);
+    if (access instanceof Response) return access;
+    const { ctx, runId } = access;
 
     const body = c.req.raw.body;
     if (!body) return c.json({ error: "missing body" }, 400);
@@ -121,6 +133,64 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
     deps.streamBuffer.purge(runId);
 
     return c.json({ ok: true });
+  });
+
+  app.post("/links/runs/:runId/parts", async (c) => {
+    const access = await validateRunAccess(c);
+    if (access instanceof Response) return access;
+    const { ctx, runId } = access;
+
+    let json: unknown;
+    try {
+      json = await c.req.json();
+    } catch (error) {
+      return c.json(
+        {
+          error: "bad batch",
+          detail: error instanceof Error ? error.message : "Invalid JSON",
+        },
+        400,
+      );
+    }
+
+    const parsed = linkIngestBatchSchema.safeParse(json);
+    if (!parsed.success) {
+      return c.json({ error: "bad batch", detail: parsed.error.message }, 400);
+    }
+
+    const rows = parsed.data.rows;
+    const orgId = ctx.organization!.id;
+    if (
+      rows.some(
+        (row) =>
+          row.run_id !== runId ||
+          row.thread_id !== runId ||
+          row.org_id !== orgId,
+      )
+    ) {
+      return c.json({ error: "row run mismatch" }, 400);
+    }
+
+    await ctx.storage.threads.messageParts().appendParts(rows);
+    if (rows.length > 0) {
+      ctx.storage.threads.bumpProgress(runId).catch(() => {});
+    }
+
+    if (parsed.data.done) {
+      await ctx.storage.threads.update(runId, {
+        status: "completed",
+        run_owner_pod: null,
+        run_config: null,
+        run_started_at: null,
+      });
+      deps.streamBuffer.purge(runId);
+    }
+
+    return c.json({
+      ok: true,
+      appended: rows.length,
+      done: parsed.data.done,
+    });
   });
 
   return app;

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
@@ -1,8 +1,11 @@
 /**
  * Link ingest — the RETURN path of the pull-inverted local link.
- * The desktop daemon runs the harness and POSTs its UIMessageChunk SSE stream
- * here; this endpoint commits completed parts to `thread_message_parts` (via
- * PartEmitter) and republishes chunks to the JetStream live edge.
+ *
+ * Preferred path: desktop posts deterministic `thread_message_parts` rows to
+ * `/links/runs/:runId/parts` in short JSON batches.
+ *
+ * Transitional path: `/links/runs/:runId/stream` still accepts the old
+ * long-lived SSE upload until all shipped daemons have moved to batched parts.
  *
  * SECURITY POSTURE (this phase): run fences are not minted yet, so the endpoint
  * is deliberately INERT — it requires an authenticated principal AND a non-null

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
@@ -15,9 +15,16 @@
  * any thread id) and enforce thread ownership.
  */
 import { Hono, type Context } from "hono";
+import type { UIMessageChunk } from "ai";
+import type { SSEEvent } from "@/event-bus";
 import { parseDispatchSSEStream } from "@/harnesses/parse-dispatch-sse";
 import { fenceMatches } from "@/storage/run-fence";
 import { isCancelRequested } from "@/storage/cancel-flag";
+import type { ThreadMessagePart } from "@/storage/fold-parts";
+import {
+  createDecopilotFinishEvent,
+  createDecopilotThreadStatusEvent,
+} from "@decocms/mesh-sdk";
 import { PartEmitter } from "./part-emitter";
 import { consumePartStream } from "./consume-part-stream";
 import { linkIngestBatchSchema } from "./link-ingest-batch-schema";
@@ -26,6 +33,144 @@ import type { Env } from "../../hono-env";
 
 export interface LinkIngestDeps {
   streamBuffer: StreamBuffer;
+  sseHub?: { emit(orgId: string, event: SSEEvent): void };
+}
+
+type PartPayload = Record<string, unknown> & { type?: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function chunksForPartRow(row: ThreadMessagePart): UIMessageChunk[] {
+  if (row.kind === "finish" || !isRecord(row.payload)) return [];
+
+  const part = row.payload as PartPayload;
+  const type = stringField(part.type);
+  if (!type) return [];
+
+  if (type === "text") {
+    return [
+      { type: "text-start", id: row.id } as UIMessageChunk,
+      {
+        type: "text-delta",
+        id: row.id,
+        delta: typeof part.text === "string" ? part.text : "",
+      } as UIMessageChunk,
+      { type: "text-end", id: row.id } as UIMessageChunk,
+    ];
+  }
+
+  if (type === "reasoning") {
+    return [
+      { type: "reasoning-start", id: row.id } as UIMessageChunk,
+      {
+        type: "reasoning-delta",
+        id: row.id,
+        delta: typeof part.text === "string" ? part.text : "",
+      } as UIMessageChunk,
+      { type: "reasoning-end", id: row.id } as UIMessageChunk,
+    ];
+  }
+
+  if (type.startsWith("tool-") || type === "dynamic-tool") {
+    const toolCallId = stringField(part.toolCallId) ?? row.id;
+    const toolName =
+      stringField(part.toolName) ??
+      (type.startsWith("tool-") ? type.slice("tool-".length) : "dynamic");
+    const chunks: UIMessageChunk[] = [];
+    if ("input" in part) {
+      chunks.push({
+        type: "tool-input-available",
+        toolCallId,
+        toolName,
+        input: part.input,
+      } as UIMessageChunk);
+    }
+    if (part.state === "output-available") {
+      chunks.push({
+        type: "tool-output-available",
+        toolCallId,
+        output: part.output,
+      } as UIMessageChunk);
+    } else if (
+      part.state === "output-error" ||
+      part.state === "output-denied"
+    ) {
+      chunks.push({
+        type: "tool-output-error",
+        toolCallId,
+        errorText:
+          typeof part.errorText === "string"
+            ? part.errorText
+            : part.state === "output-denied"
+              ? "Tool output denied"
+              : "Tool output error",
+      } as UIMessageChunk);
+    }
+    return chunks;
+  }
+
+  return [part as UIMessageChunk];
+}
+
+function liveChunksForRows(
+  rows: ThreadMessagePart[],
+  done: boolean,
+): UIMessageChunk[] {
+  const chunks: UIMessageChunk[] = [];
+  const byMessage = new Map<string, ThreadMessagePart[]>();
+  for (const row of rows) {
+    if (row.role !== "assistant" || row.kind === "finish") continue;
+    const group = byMessage.get(row.message_id) ?? [];
+    group.push(row);
+    byMessage.set(row.message_id, group);
+  }
+
+  for (const [messageId, messageRows] of byMessage) {
+    chunks.push({ type: "start", messageId } as UIMessageChunk);
+    chunks.push({ type: "start-step" } as UIMessageChunk);
+    for (const row of messageRows.sort((a, b) => a.seq - b.seq)) {
+      chunks.push(...chunksForPartRow(row));
+    }
+    chunks.push({ type: "finish-step" } as UIMessageChunk);
+  }
+
+  if (done) {
+    chunks.push({ type: "finish" } as UIMessageChunk);
+  }
+  return chunks;
+}
+
+function streamFromChunks(chunks: UIMessageChunk[]): ReadableStream {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+async function publishLiveChunks(
+  deps: LinkIngestDeps,
+  runId: string,
+  orgId: string,
+  chunks: UIMessageChunk[],
+  signal: AbortSignal,
+): Promise<void> {
+  if (chunks.length === 0) return;
+  const tail = await deps.streamBuffer.createTailStream(runId, signal, {
+    deliverPolicy: "new",
+    closeOnDone: true,
+  });
+  deps.streamBuffer.pump(streamFromChunks(chunks), runId, signal, orgId);
+  if (tail) {
+    await drain(tail).catch(() => {});
+  }
 }
 
 async function drain(stream: ReadableStream): Promise<void> {
@@ -178,6 +323,13 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
     if (rows.length > 0) {
       ctx.storage.threads.bumpProgress(runId).catch(() => {});
     }
+    await publishLiveChunks(
+      deps,
+      runId,
+      orgId,
+      liveChunksForRows(rows, parsed.data.done),
+      c.req.raw.signal,
+    );
 
     if (parsed.data.done) {
       await ctx.storage.threads.update(runId, {
@@ -187,6 +339,22 @@ export function createLinkIngestRoutes(deps: LinkIngestDeps) {
         run_started_at: null,
       });
       deps.streamBuffer.purge(runId);
+      if (deps.sseHub) {
+        const thread = await ctx.storage.threads.get(runId);
+        deps.sseHub.emit(
+          orgId,
+          createDecopilotThreadStatusEvent(runId, "completed", {
+            virtualMcpId: thread?.virtual_mcp_id ?? undefined,
+            createdBy: thread?.created_by,
+            triggerId: thread?.trigger_id,
+            title: thread?.title,
+            branch: thread?.branch ?? null,
+            createdAt: thread?.created_at,
+            updatedAt: thread?.updated_at,
+          }),
+        );
+        deps.sseHub.emit(orgId, createDecopilotFinishEvent(runId, "completed"));
+      }
     }
 
     return c.json({

--- a/apps/mesh/src/api/routes/decopilot/part-emitter.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-emitter.test.ts
@@ -156,6 +156,40 @@ describe("PartEmitter", () => {
     expect(rows.map((r) => r.id)).toEqual(["run1:0", "run1:1"]);
   });
 
+  it("rebuilds rows on retry when storage fails before persisting", async () => {
+    const rows: ThreadMessagePart[] = [];
+    let shouldFail = true;
+    const storage = {
+      appendParts: async (parts: ThreadMessagePart[]) => {
+        if (shouldFail) {
+          shouldFail = false;
+          throw new Error("write failed");
+        }
+        rows.push(...parts);
+      },
+    } as unknown as SqlThreadMessagePartStorage;
+    const emitter = new PartEmitter({
+      storage,
+      orgId: "org1",
+      threadId: "thrd1",
+      runId: "run1",
+      baseTimeMs: 1_000,
+    });
+    const message = {
+      id: "m",
+      role: "assistant" as const,
+      parts: [{ type: "text", text: "a", state: "done" }],
+    };
+
+    await expect(emitter.emitFinal(message)).rejects.toThrow("write failed");
+    await emitter.emitFinal(message);
+
+    expect(rows.map((r) => [r.id, r.kind])).toEqual([
+      ["run1:0", "text"],
+      ["run1:1", "finish"],
+    ]);
+  });
+
   it("finish anchor is emitted at most once per message", async () => {
     const { rows, emitter } = newEmitter();
     await emitter.emitFinal({

--- a/apps/mesh/src/api/routes/decopilot/part-emitter.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-emitter.ts
@@ -41,6 +41,7 @@
  */
 
 import type { SqlThreadMessagePartStorage } from "@/storage/thread-message-parts";
+import type { ThreadMessagePart } from "@/storage/fold-parts";
 import {
   type AnyMessage,
   isFinalPart,
@@ -69,12 +70,17 @@ export class PartEmitter {
     this.builder = new PartRowBuilder(ctx);
   }
 
+  private async appendBuiltRows(rows: ThreadMessagePart[]): Promise<void> {
+    await this.ctx.storage.appendParts(rows);
+    this.builder.acknowledge(rows);
+  }
+
   /**
    * Initial user-message save: persist the user's parts + a `finish` anchor so
    * the message is immediately complete in the v2 read path.
    */
   async emitUserMessage(message: AnyMessage): Promise<void> {
-    await this.ctx.storage.appendParts(this.builder.emitUserMessage(message));
+    await this.appendBuiltRows(this.builder.emitUserMessage(message));
   }
 
   /**
@@ -82,7 +88,7 @@ export class PartEmitter {
    * No `finish` marker yet — the message may continue in later steps.
    */
   async emitStepParts(message: AnyMessage): Promise<void> {
-    await this.ctx.storage.appendParts(this.builder.emitStepParts(message));
+    await this.appendBuiltRows(this.builder.emitStepParts(message));
   }
 
   /**
@@ -90,7 +96,7 @@ export class PartEmitter {
    * message with a single `finish` anchor.
    */
   async emitFinal(message: AnyMessage): Promise<void> {
-    await this.ctx.storage.appendParts(this.builder.emitFinal(message));
+    await this.appendBuiltRows(this.builder.emitFinal(message));
   }
 
   /**
@@ -99,8 +105,6 @@ export class PartEmitter {
    * dangling in-progress message.
    */
   async emitError(messageId: string, errorText: string): Promise<void> {
-    await this.ctx.storage.appendParts(
-      this.builder.emitError(messageId, errorText),
-    );
+    await this.appendBuiltRows(this.builder.emitError(messageId, errorText));
   }
 }

--- a/apps/mesh/src/api/routes/decopilot/part-emitter.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-emitter.ts
@@ -41,14 +41,13 @@
  */
 
 import type { SqlThreadMessagePartStorage } from "@/storage/thread-message-parts";
-import type { PartKind, ThreadMessagePart } from "@/storage/fold-parts";
+import {
+  type AnyMessage,
+  isFinalPart,
+  PartRowBuilder,
+} from "./part-row-builder";
 
-type AnyPart = { type?: string; state?: string } & Record<string, unknown>;
-type AnyMessage = {
-  id: string;
-  role: "user" | "assistant" | "system";
-  parts?: unknown[];
-};
+export { isFinalPart };
 
 export interface PartEmitterCtx {
   storage: SqlThreadMessagePartStorage;
@@ -63,130 +62,11 @@ export interface PartEmitterCtx {
   baseTimeMs?: number;
 }
 
-/**
- * True when a part has reached a terminal/renderable state and is safe to
- * freeze. Streaming text/reasoning and in-flight tool calls return false.
- */
-export function isFinalPart(part: AnyPart): boolean {
-  const type = part.type;
-  if (typeof type !== "string") return false;
-
-  if (type === "text" || type === "reasoning") {
-    // `state` is 'streaming' | 'done' (may be absent on a step-final snapshot).
-    return part.state !== "streaming";
-  }
-
-  if (type === "step-start") {
-    // Never persisted (folded away as a boundary marker), but treat as final.
-    return false;
-  }
-
-  if (type.startsWith("tool-") || type === "dynamic-tool") {
-    // Final only at a terminal output state. Anything earlier
-    // (input-streaming/input-available/approval-*) is still in flight.
-    return (
-      part.state === "output-available" ||
-      part.state === "output-error" ||
-      part.state === "output-denied"
-    );
-  }
-
-  // file / source-url / source-document / data-* — terminal by nature.
-  return true;
-}
-
-/** Map an AI-SDK part `type` to the storage `PartKind` taxonomy. */
-function kindForPart(part: AnyPart): PartKind {
-  const type = part.type ?? "";
-  if (type === "reasoning") return "reasoning";
-  if (type === "file") return "file";
-  if (type.startsWith("tool-") || type === "dynamic-tool") {
-    return part.state === "output-available" ||
-      part.state === "output-error" ||
-      part.state === "output-denied"
-      ? "tool_result"
-      : "tool_call";
-  }
-  // text, source-*, data-* and anything else render as text-equivalent payloads.
-  return "text";
-}
-
 export class PartEmitter {
-  private readonly base: number;
-  /** `${messageId}#${index}` → assigned seq (stable per logical part). */
-  private readonly seqByPart = new Map<string, number>();
-  /** Message ids for which the `finish` anchor has already been emitted. */
-  private readonly finished = new Set<string>();
-  private nextSeq = 0;
+  private readonly builder: PartRowBuilder;
 
   constructor(private readonly ctx: PartEmitterCtx) {
-    this.base = ctx.baseTimeMs ?? Date.now();
-  }
-
-  /** Allocate (or reuse) the stable seq for a logical part. */
-  private seqFor(messageId: string, index: number): number {
-    const key = `${messageId}#${index}`;
-    const existing = this.seqByPart.get(key);
-    if (existing !== undefined) return existing;
-    const seq = this.nextSeq++;
-    this.seqByPart.set(key, seq);
-    return seq;
-  }
-
-  private row(
-    messageId: string,
-    role: AnyMessage["role"],
-    seq: number,
-    kind: PartKind,
-    payload: unknown,
-  ): ThreadMessagePart {
-    return {
-      id: `${this.ctx.runId}:${seq}`,
-      seq,
-      org_id: this.ctx.orgId,
-      thread_id: this.ctx.threadId,
-      run_id: this.ctx.runId,
-      message_id: messageId,
-      role,
-      kind,
-      payload,
-      payload_ref: null,
-      metadata: null,
-      // Monotonic per run, derived from seq (NOT Date.now() per part).
-      created_at: new Date(this.base + seq).toISOString(),
-    };
-  }
-
-  /**
-   * Emit the FINAL parts of a message that are not yet persisted. Walks the
-   * (cumulative) `parts` array; idempotent via stable seq + ON CONFLICT.
-   * Does NOT emit a `finish` marker — call `markFinished` for that.
-   */
-  private async emitMessageParts(message: AnyMessage): Promise<void> {
-    const parts = (message.parts ?? []) as AnyPart[];
-    const rows: ThreadMessagePart[] = [];
-    for (let i = 0; i < parts.length; i++) {
-      const part = parts[i]!;
-      if (!isFinalPart(part)) continue;
-      const seq = this.seqFor(message.id, i);
-      rows.push(
-        this.row(message.id, message.role, seq, kindForPart(part), part),
-      );
-    }
-    if (rows.length > 0) await this.ctx.storage.appendParts(rows);
-  }
-
-  /** Append the single `finish` anchor for a message (idempotent). */
-  private async markFinished(
-    messageId: string,
-    role: AnyMessage["role"],
-  ): Promise<void> {
-    if (this.finished.has(messageId)) return;
-    this.finished.add(messageId);
-    const seq = this.seqFor(`${messageId}#finish`, 0);
-    await this.ctx.storage.appendParts([
-      this.row(messageId, role, seq, "finish", {}),
-    ]);
+    this.builder = new PartRowBuilder(ctx);
   }
 
   /**
@@ -194,8 +74,7 @@ export class PartEmitter {
    * the message is immediately complete in the v2 read path.
    */
   async emitUserMessage(message: AnyMessage): Promise<void> {
-    await this.emitMessageParts(message);
-    await this.markFinished(message.id, message.role);
+    await this.ctx.storage.appendParts(this.builder.emitUserMessage(message));
   }
 
   /**
@@ -203,7 +82,7 @@ export class PartEmitter {
    * No `finish` marker yet — the message may continue in later steps.
    */
   async emitStepParts(message: AnyMessage): Promise<void> {
-    await this.emitMessageParts(message);
+    await this.ctx.storage.appendParts(this.builder.emitStepParts(message));
   }
 
   /**
@@ -211,8 +90,7 @@ export class PartEmitter {
    * message with a single `finish` anchor.
    */
   async emitFinal(message: AnyMessage): Promise<void> {
-    await this.emitMessageParts(message);
-    await this.markFinished(message.id, message.role);
+    await this.ctx.storage.appendParts(this.builder.emitFinal(message));
   }
 
   /**
@@ -221,13 +99,8 @@ export class PartEmitter {
    * dangling in-progress message.
    */
   async emitError(messageId: string, errorText: string): Promise<void> {
-    const seq = this.seqFor(`${messageId}#error`, 0);
-    await this.ctx.storage.appendParts([
-      this.row(messageId, "assistant", seq, "error", {
-        type: "text",
-        text: `Error: ${errorText}`,
-      }),
-    ]);
-    await this.markFinished(messageId, "assistant");
+    await this.ctx.storage.appendParts(
+      this.builder.emitError(messageId, errorText),
+    );
   }
 }

--- a/apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts
@@ -62,8 +62,10 @@ describe("PartRowBuilder", () => {
     };
 
     const firstStep = builder.emitStepParts(message);
+    builder.acknowledge(firstStep);
     const secondStep = builder.emitStepParts(message);
     const finalRows = builder.emitFinal(message);
+    builder.acknowledge(finalRows);
     const repeatedFinalRows = builder.emitFinal(message);
 
     expect(firstStep.map((row) => row.id)).toEqual(["thread_1:0"]);
@@ -72,6 +74,55 @@ describe("PartRowBuilder", () => {
       ["thread_1:1", "finish"],
     ]);
     expect(repeatedFinalRows).toEqual([]);
+  });
+
+  it("emits a skipped in-flight tool part when the same index becomes terminal", () => {
+    const builder = new PartRowBuilder({
+      orgId: "org_1",
+      threadId: "thread_1",
+      runId: "thread_1",
+      baseTimeMs: 1_700_000_000_000,
+    });
+
+    const firstStep = builder.emitStepParts({
+      id: "assistant_1",
+      role: "assistant",
+      parts: [{ type: "tool-search", state: "input-available", input: {} }],
+    });
+    const secondStep = builder.emitStepParts({
+      id: "assistant_1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-search",
+          state: "output-available",
+          input: {},
+          output: "ok",
+        },
+      ],
+    });
+
+    expect(firstStep).toEqual([]);
+    expect(
+      secondStep.map((row) => ({
+        id: row.id,
+        seq: row.seq,
+        kind: row.kind,
+        payload: row.payload,
+      })),
+    ).toEqual([
+      {
+        id: "thread_1:0",
+        seq: 0,
+        kind: "tool_result",
+        payload: {
+          type: "tool-search",
+          state: "output-available",
+          input: {},
+          output: "ok",
+        },
+      },
+    ]);
   });
 
   it("builds an error part and closes the assistant message", () => {

--- a/apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { isFinalPart, PartRowBuilder } from "./part-row-builder";
+
+describe("PartRowBuilder", () => {
+  it("builds deterministic final rows and a finish anchor", () => {
+    const builder = new PartRowBuilder({
+      orgId: "org_1",
+      threadId: "thread_1",
+      runId: "thread_1",
+      baseTimeMs: 1_700_000_000_000,
+    });
+
+    const rows = builder.emitFinal({
+      id: "assistant_1",
+      role: "assistant",
+      parts: [{ type: "text", text: "hello" }],
+    });
+
+    expect(
+      rows.map((row) => ({
+        id: row.id,
+        seq: row.seq,
+        kind: row.kind,
+        message_id: row.message_id,
+        role: row.role,
+        payload: row.payload,
+        created_at: row.created_at,
+      })),
+    ).toEqual([
+      {
+        id: "thread_1:0",
+        seq: 0,
+        kind: "text",
+        message_id: "assistant_1",
+        role: "assistant",
+        payload: { type: "text", text: "hello" },
+        created_at: "2023-11-14T22:13:20.000Z",
+      },
+      {
+        id: "thread_1:1",
+        seq: 1,
+        kind: "finish",
+        message_id: "assistant_1",
+        role: "assistant",
+        payload: {},
+        created_at: "2023-11-14T22:13:20.001Z",
+      },
+    ]);
+  });
+
+  it("is idempotent for repeated step and final snapshots", () => {
+    const builder = new PartRowBuilder({
+      orgId: "org_1",
+      threadId: "thread_1",
+      runId: "thread_1",
+      baseTimeMs: 1_700_000_000_000,
+    });
+    const message = {
+      id: "assistant_1",
+      role: "assistant" as const,
+      parts: [{ type: "text", text: "hello" }],
+    };
+
+    const firstStep = builder.emitStepParts(message);
+    const secondStep = builder.emitStepParts(message);
+    const finalRows = builder.emitFinal(message);
+    const repeatedFinalRows = builder.emitFinal(message);
+
+    expect(firstStep.map((row) => row.id)).toEqual(["thread_1:0"]);
+    expect(secondStep).toEqual([]);
+    expect(finalRows.map((row) => [row.id, row.kind])).toEqual([
+      ["thread_1:1", "finish"],
+    ]);
+    expect(repeatedFinalRows).toEqual([]);
+  });
+
+  it("builds an error part and closes the assistant message", () => {
+    const builder = new PartRowBuilder({
+      orgId: "org_1",
+      threadId: "thread_1",
+      runId: "thread_1",
+      baseTimeMs: 1_700_000_000_000,
+    });
+
+    const rows = builder.emitError("error_msg", "desktop failed");
+
+    expect(rows.map((row) => [row.id, row.kind, row.payload])).toEqual([
+      ["thread_1:0", "error", { type: "text", text: "Error: desktop failed" }],
+      ["thread_1:1", "finish", {}],
+    ]);
+  });
+
+  it("does not freeze streaming text", () => {
+    expect(isFinalPart({ type: "text", state: "streaming", text: "he" })).toBe(
+      false,
+    );
+    expect(isFinalPart({ type: "text", state: "done", text: "hello" })).toBe(
+      true,
+    );
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/part-row-builder.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-row-builder.ts
@@ -75,10 +75,14 @@ export class PartRowBuilder {
   private readonly base: number;
   /** `${messageId}#${index}` → assigned seq (stable per logical part). */
   private readonly seqByPart = new Map<string, number>();
-  /** Logical part keys that have already been returned by this builder. */
+  /** Logical part keys that have been successfully handed off by this builder. */
   private readonly emitted = new Set<string>();
-  /** Message ids for which the `finish` anchor has already been emitted. */
+  /** Message ids for which the `finish` anchor has been successfully handed off. */
   private readonly finished = new Set<string>();
+  /** Row id → logical part key, used to commit pending rows after persistence. */
+  private readonly partKeyByRowId = new Map<string, string>();
+  /** Row id → message id, used to commit pending finish anchors after persistence. */
+  private readonly finishMessageIdByRowId = new Map<string, string>();
   private nextSeq = 0;
 
   constructor(private readonly ctx: PartRowBuilderCtx) {
@@ -119,8 +123,8 @@ export class PartRowBuilder {
   }
 
   /**
-   * Emit the FINAL parts of a message that are not yet returned. Walks the
-   * cumulative `parts` array; idempotent by logical part key within this builder.
+   * Emit the FINAL parts of a message that have not been acknowledged. Walks the
+   * cumulative `parts` array; pending rows repeat until `acknowledge` is called.
    */
   private emitMessageParts(message: AnyMessage): ThreadMessagePart[] {
     const parts = (message.parts ?? []) as AnyPart[];
@@ -133,23 +137,44 @@ export class PartRowBuilder {
       if (this.emitted.has(key)) continue;
 
       const seq = this.seqFor(key);
-      rows.push(
-        this.row(message.id, message.role, seq, kindForPart(part), part),
+      const row = this.row(
+        message.id,
+        message.role,
+        seq,
+        kindForPart(part),
+        part,
       );
-      this.emitted.add(key);
+      this.partKeyByRowId.set(row.id, key);
+      rows.push(row);
     }
     return rows;
   }
 
-  /** Append the single `finish` anchor for a message (idempotent). */
+  /** Return the single `finish` anchor for a message until it is acknowledged. */
   private markFinished(
     messageId: string,
     role: AnyMessage["role"],
   ): ThreadMessagePart[] {
     if (this.finished.has(messageId)) return [];
-    this.finished.add(messageId);
     const seq = this.seqFor(`${messageId}#finish`);
-    return [this.row(messageId, role, seq, "finish", {})];
+    const row = this.row(messageId, role, seq, "finish", {});
+    this.finishMessageIdByRowId.set(row.id, messageId);
+    return [row];
+  }
+
+  /**
+   * Commit rows that have been successfully handed off to durable storage or a
+   * desktop batcher. Rows are intentionally not committed during `emit*` so a
+   * failed handoff can retry and receive the same deterministic rows again.
+   */
+  acknowledge(rows: ThreadMessagePart[]): void {
+    for (const row of rows) {
+      const partKey = this.partKeyByRowId.get(row.id);
+      if (partKey !== undefined) this.emitted.add(partKey);
+
+      const finishMessageId = this.finishMessageIdByRowId.get(row.id);
+      if (finishMessageId !== undefined) this.finished.add(finishMessageId);
+    }
   }
 
   /**
@@ -192,13 +217,12 @@ export class PartRowBuilder {
     const rows: ThreadMessagePart[] = [];
     if (!this.emitted.has(key)) {
       const seq = this.seqFor(key);
-      rows.push(
-        this.row(messageId, "assistant", seq, "error", {
-          type: "text",
-          text: `Error: ${errorText}`,
-        }),
-      );
-      this.emitted.add(key);
+      const row = this.row(messageId, "assistant", seq, "error", {
+        type: "text",
+        text: `Error: ${errorText}`,
+      });
+      this.partKeyByRowId.set(row.id, key);
+      rows.push(row);
     }
     return [...rows, ...this.markFinished(messageId, "assistant")];
   }

--- a/apps/mesh/src/api/routes/decopilot/part-row-builder.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-row-builder.ts
@@ -1,0 +1,205 @@
+import type { PartKind, ThreadMessagePart } from "@/storage/fold-parts";
+
+export type AnyPart = { type?: string; state?: string } & Record<
+  string,
+  unknown
+>;
+
+export type AnyMessage = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  parts?: unknown[];
+};
+
+export interface PartRowBuilderCtx {
+  orgId: string;
+  threadId: string;
+  runId: string;
+  /**
+   * Base epoch-ms for this run's `created_at` derivation. Defaults to
+   * `Date.now()` at construction. Each emitted part's `created_at` is
+   * `base + seq`, so ordering is driven by the monotonic seq, not wall clock.
+   */
+  baseTimeMs?: number;
+}
+
+/**
+ * True when a part has reached a terminal/renderable state and is safe to
+ * freeze. Streaming text/reasoning and in-flight tool calls return false.
+ */
+export function isFinalPart(part: AnyPart): boolean {
+  const type = part.type;
+  if (typeof type !== "string") return false;
+
+  if (type === "text" || type === "reasoning") {
+    // `state` is 'streaming' | 'done' (may be absent on a step-final snapshot).
+    return part.state !== "streaming";
+  }
+
+  if (type === "step-start") {
+    // Never persisted (folded away as a boundary marker), but treat as final.
+    return false;
+  }
+
+  if (type.startsWith("tool-") || type === "dynamic-tool") {
+    // Final only at a terminal output state. Anything earlier
+    // (input-streaming/input-available/approval-*) is still in flight.
+    return (
+      part.state === "output-available" ||
+      part.state === "output-error" ||
+      part.state === "output-denied"
+    );
+  }
+
+  // file / source-url / source-document / data-* — terminal by nature.
+  return true;
+}
+
+/** Map an AI-SDK part `type` to the storage `PartKind` taxonomy. */
+function kindForPart(part: AnyPart): PartKind {
+  const type = part.type ?? "";
+  if (type === "reasoning") return "reasoning";
+  if (type === "file") return "file";
+  if (type.startsWith("tool-") || type === "dynamic-tool") {
+    return part.state === "output-available" ||
+      part.state === "output-error" ||
+      part.state === "output-denied"
+      ? "tool_result"
+      : "tool_call";
+  }
+  // text, source-*, data-* and anything else render as text-equivalent payloads.
+  return "text";
+}
+
+export class PartRowBuilder {
+  private readonly base: number;
+  /** `${messageId}#${index}` → assigned seq (stable per logical part). */
+  private readonly seqByPart = new Map<string, number>();
+  /** Logical part keys that have already been returned by this builder. */
+  private readonly emitted = new Set<string>();
+  /** Message ids for which the `finish` anchor has already been emitted. */
+  private readonly finished = new Set<string>();
+  private nextSeq = 0;
+
+  constructor(private readonly ctx: PartRowBuilderCtx) {
+    this.base = ctx.baseTimeMs ?? Date.now();
+  }
+
+  /** Allocate (or reuse) the stable seq for a logical part. */
+  private seqFor(key: string): number {
+    const existing = this.seqByPart.get(key);
+    if (existing !== undefined) return existing;
+    const seq = this.nextSeq++;
+    this.seqByPart.set(key, seq);
+    return seq;
+  }
+
+  private row(
+    messageId: string,
+    role: AnyMessage["role"],
+    seq: number,
+    kind: PartKind,
+    payload: unknown,
+  ): ThreadMessagePart {
+    return {
+      id: `${this.ctx.runId}:${seq}`,
+      seq,
+      org_id: this.ctx.orgId,
+      thread_id: this.ctx.threadId,
+      run_id: this.ctx.runId,
+      message_id: messageId,
+      role,
+      kind,
+      payload,
+      payload_ref: null,
+      metadata: null,
+      // Monotonic per run, derived from seq (NOT Date.now() per part).
+      created_at: new Date(this.base + seq).toISOString(),
+    };
+  }
+
+  /**
+   * Emit the FINAL parts of a message that are not yet returned. Walks the
+   * cumulative `parts` array; idempotent by logical part key within this builder.
+   */
+  private emitMessageParts(message: AnyMessage): ThreadMessagePart[] {
+    const parts = (message.parts ?? []) as AnyPart[];
+    const rows: ThreadMessagePart[] = [];
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]!;
+      if (!isFinalPart(part)) continue;
+
+      const key = `${message.id}#${i}`;
+      if (this.emitted.has(key)) continue;
+
+      const seq = this.seqFor(key);
+      rows.push(
+        this.row(message.id, message.role, seq, kindForPart(part), part),
+      );
+      this.emitted.add(key);
+    }
+    return rows;
+  }
+
+  /** Append the single `finish` anchor for a message (idempotent). */
+  private markFinished(
+    messageId: string,
+    role: AnyMessage["role"],
+  ): ThreadMessagePart[] {
+    if (this.finished.has(messageId)) return [];
+    this.finished.add(messageId);
+    const seq = this.seqFor(`${messageId}#finish`);
+    return [this.row(messageId, role, seq, "finish", {})];
+  }
+
+  /**
+   * Initial user-message save: persist the user's parts + a `finish` anchor so
+   * the message is immediately complete in the v2 read path.
+   */
+  emitUserMessage(message: AnyMessage): ThreadMessagePart[] {
+    return [
+      ...this.emitMessageParts(message),
+      ...this.markFinished(message.id, message.role),
+    ];
+  }
+
+  /**
+   * `onStepFinish`: persist any newly-final parts of the assistant message.
+   * No `finish` marker yet — the message may continue in later steps.
+   */
+  emitStepParts(message: AnyMessage): ThreadMessagePart[] {
+    return this.emitMessageParts(message);
+  }
+
+  /**
+   * `onFinish`: persist remaining final parts, then close the assistant
+   * message with a single `finish` anchor.
+   */
+  emitFinal(message: AnyMessage): ThreadMessagePart[] {
+    return [
+      ...this.emitMessageParts(message),
+      ...this.markFinished(message.id, message.role),
+    ];
+  }
+
+  /**
+   * `onError`: persist an `error` part for the assistant message and close it
+   * with a `finish` anchor so the thread renders the failure rather than a
+   * dangling in-progress message.
+   */
+  emitError(messageId: string, errorText: string): ThreadMessagePart[] {
+    const key = `${messageId}#error`;
+    const rows: ThreadMessagePart[] = [];
+    if (!this.emitted.has(key)) {
+      const seq = this.seqFor(key);
+      rows.push(
+        this.row(messageId, "assistant", seq, "error", {
+          type: "text",
+          text: `Error: ${errorText}`,
+        }),
+      );
+      this.emitted.add(key);
+    }
+    return [...rows, ...this.markFinished(messageId, "assistant")];
+  }
+}

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -4,6 +4,7 @@ import type { AutomationEventDispatcher } from "@/automations/automation-event-d
 import type { CancelBroadcast } from "@/api/routes/decopilot/cancel-broadcast";
 import type { RunRegistry } from "@/api/routes/decopilot/run-registry";
 import type { StreamBuffer } from "@/api/routes/decopilot/stream-buffer";
+import type { SSEEvent } from "@/event-bus";
 import type { KVStorage } from "@/storage/kv";
 import type { TriggerCallbackTokenStorage } from "@/storage/trigger-callback-tokens";
 import { resolveOrgFromPath } from "../middleware/resolve-org-from-path";
@@ -38,6 +39,7 @@ interface OrgScopedDeps {
    */
   runRegistry: RunRegistry;
   streamBuffer: StreamBuffer;
+  sseHub: { emit(orgId: string, event: SSEEvent): void };
   cancelBroadcast: CancelBroadcast;
   tokenStorage: TriggerCallbackTokenStorage;
   automationEventDispatcher: AutomationEventDispatcher;
@@ -93,7 +95,13 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
     }),
   ); // /api/:org/trigger-callback
   app.route("/webhooks", createAutomationWebhookRoutes()); // /api/:org/webhooks/:triggerId[/:token]
-  app.route("/", createLinkIngestRoutes({ streamBuffer: deps.streamBuffer })); // /api/:org/links/runs/:runId/stream
+  app.route(
+    "/",
+    createLinkIngestRoutes({
+      streamBuffer: deps.streamBuffer,
+      sseHub: deps.sseHub,
+    }),
+  ); // /api/:org/links/runs/:runId/stream
 
   if (deps.mountDevAssets) {
     app.route("/dev-assets", createDevAssetsRoutes({ orgFromPath: true }));

--- a/apps/mesh/src/link-daemon/cluster-connection-pull.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-pull.ts
@@ -217,10 +217,6 @@ export async function connectToClusterPull(
       // acquireDispatch pins the sandbox for the full duration of the relay so
       // the LRU eviction logic skips it (activeDispatchCount > 0). Released in
       // `finally` to guarantee the counter is always decremented.
-      //
-      // The work item's orgSlug is authoritative — it is resolved cluster-side
-      // at pullDispatch time and is always present (required field on WorkItem).
-      const effectiveOrgSlug = item.orgSlug;
       const releaseDispatch = input.provider.acquireDispatch(handle);
       // Phase C: register a per-run AbortController so the control-poll loop
       // can abort this specific dispatch when the cluster sends a cancel frame.
@@ -233,7 +229,6 @@ export async function connectToClusterPull(
           sandboxDispatchUrl: sandboxApiUrl,
           sandboxDaemonToken,
           clusterBaseUrl: input.clusterBaseUrl,
-          orgSlug: effectiveOrgSlug,
           getClusterToken: input.getAccessToken,
           fetchImpl: input.fetchImpl,
           signal: AbortSignal.any([ac.signal, runAc.signal]),

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
@@ -129,7 +129,6 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: "stale-deps-org",
       getClusterToken: async () => {
         clusterTokenCalls++;
         return CLUSTER_TOKEN;
@@ -210,7 +209,6 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: ORG_SLUG,
       getClusterToken: async () => CLUSTER_TOKEN,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     };
@@ -252,7 +250,6 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: ORG_SLUG,
       getClusterToken: async () => CLUSTER_TOKEN,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     };
@@ -293,7 +290,6 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: ORG_SLUG,
       getClusterToken: async () => CLUSTER_TOKEN,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     };
@@ -334,7 +330,6 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: ORG_SLUG,
       getClusterToken: async () => CLUSTER_TOKEN,
       harnessId: "codex",
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -383,7 +378,6 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: ORG_SLUG,
       getClusterToken: async () => CLUSTER_TOKEN,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     };
@@ -445,7 +439,6 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: ORG_SLUG,
       getClusterToken: async () => CLUSTER_TOKEN,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     };
@@ -495,7 +488,6 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: ORG_SLUG,
       getClusterToken: async () => CLUSTER_TOKEN,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     };
@@ -537,7 +529,6 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: ORG_SLUG,
       getClusterToken: async () => CLUSTER_TOKEN,
       fetchImpl: fetchImpl as unknown as typeof fetch,
       signal: ac.signal,

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
@@ -129,7 +129,7 @@ describe("handleLocalDispatch", () => {
       sandboxDispatchUrl: SANDBOX_BASE,
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
-      orgSlug: ORG_SLUG,
+      orgSlug: "stale-deps-org",
       getClusterToken: async () => {
         clusterTokenCalls++;
         return CLUSTER_TOKEN;

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
@@ -260,6 +260,47 @@ describe("handleLocalDispatch", () => {
     await expect(handleLocalDispatch(validWorkItem, deps)).rejects.toThrow(
       "[handleLocalDispatch] fenced",
     );
+    expect(appendCount).toBe(2);
+  });
+
+  it("retries a transient failed part append", async () => {
+    let appendAttempts = 0;
+
+    const fetchImpl = async (url: string): Promise<Response> => {
+      if (url.includes("/_sandbox/dispatch")) {
+        return new Response(makeBodyStream(dispatchSSE(TEXT_CHUNKS)), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      if (url.endsWith("/parts")) {
+        appendAttempts++;
+        if (appendAttempts === 1) {
+          return new Response(JSON.stringify({ error: "temporary" }), {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch to ${url}`);
+    };
+
+    const deps: LocalDispatchDeps = {
+      sandboxDispatchUrl: SANDBOX_BASE,
+      sandboxDaemonToken: DAEMON_TOKEN,
+      clusterBaseUrl: CLUSTER_BASE,
+      orgSlug: ORG_SLUG,
+      getClusterToken: async () => CLUSTER_TOKEN,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    };
+
+    await handleLocalDispatch(validWorkItem, deps);
+
+    expect(appendAttempts).toBeGreaterThan(1);
   });
 
   // ── Test: harnessId from explicit deps override ─────────────────────────

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
@@ -5,11 +5,13 @@
  * The ReadableStream body is simulated via a simple string-encoded SSE block.
  */
 import { describe, expect, it } from "bun:test";
+import type { UIMessageChunk } from "ai";
+import type { LinkIngestBatch } from "../api/routes/decopilot/link-ingest-batch-schema";
+import type { WorkItem } from "../api/routes/decopilot/link-work-queue";
 import {
   handleLocalDispatch,
   type LocalDispatchDeps,
 } from "./handle-local-dispatch";
-import type { WorkItem } from "../api/routes/decopilot/link-work-queue";
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -56,6 +58,16 @@ const validWorkItem: WorkItem = {
 /** Minimal SSE payload the local sandbox would return. */
 const FAKE_SSE_BODY = `data: {"type":"done"}\n\n`;
 
+const TEXT_CHUNKS = [
+  { type: "start" },
+  { type: "start-step" },
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: "hello" },
+  { type: "text-end", id: "t1" },
+  { type: "finish-step" },
+  { type: "finish" },
+] as UIMessageChunk[];
+
 /**
  * Build a fake ReadableStream from a string, for simulating the sandbox SSE
  * response body.
@@ -71,12 +83,22 @@ function makeBodyStream(content: string): ReadableStream<Uint8Array> {
   });
 }
 
+function dispatchSSE(chunks: UIMessageChunk[]): string {
+  return `${chunks
+    .map(
+      (chunk) =>
+        `data: ${JSON.stringify({ type: "ui-message-chunk", chunk })}\n\n`,
+    )
+    .join("")}data: {"type":"done"}\n\n`;
+}
+
 // ── Test: successful relay ──────────────────────────────────────────────────
 
 describe("handleLocalDispatch", () => {
-  it("POSTs to sandbox dispatch and relays SSE body to cluster ingest", async () => {
+  it("POSTs to sandbox dispatch and appends JSON part batches to cluster ingest", async () => {
     const capturedRequests: Array<{ url: string; init: RequestInit }> = [];
-    let capturedIngestBody: string | null = null;
+    const capturedBatches: LinkIngestBatch[] = [];
+    let clusterTokenCalls = 0;
 
     const fetchImpl = async (
       url: string,
@@ -86,25 +108,14 @@ describe("handleLocalDispatch", () => {
 
       if (url.includes("/_sandbox/dispatch")) {
         // Sandbox dispatch: return 200 with a fake SSE stream body.
-        return new Response(makeBodyStream(FAKE_SSE_BODY), {
+        return new Response(makeBodyStream(dispatchSSE(TEXT_CHUNKS)), {
           status: 200,
           headers: { "content-type": "text/event-stream" },
         });
       }
 
       if (url.includes("/links/runs/")) {
-        // Cluster ingest: capture the relayed body and return 200.
-        if (init?.body instanceof ReadableStream) {
-          const reader = init.body.getReader();
-          const dec = new TextDecoder();
-          let text = "";
-          while (true) {
-            const { value, done } = await reader.read();
-            if (done) break;
-            if (value) text += dec.decode(value, { stream: true });
-          }
-          capturedIngestBody = text;
-        }
+        capturedBatches.push(JSON.parse(init?.body as string));
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -119,7 +130,10 @@ describe("handleLocalDispatch", () => {
       sandboxDaemonToken: DAEMON_TOKEN,
       clusterBaseUrl: CLUSTER_BASE,
       orgSlug: ORG_SLUG,
-      getClusterToken: async () => CLUSTER_TOKEN,
+      getClusterToken: async () => {
+        clusterTokenCalls++;
+        return CLUSTER_TOKEN;
+      },
       fetchImpl: fetchImpl as unknown as typeof fetch,
     };
 
@@ -150,23 +164,33 @@ describe("handleLocalDispatch", () => {
     expect(dispatchBody.input).toEqual(validWorkItem.harnessInput);
 
     // ── Assert cluster ingest call ──────────────────────────────────────────
-    const ingestCall = capturedRequests.find((r) =>
+    const ingestCalls = capturedRequests.filter((r) =>
       r.url.includes("/links/runs/"),
     );
-    expect(ingestCall).toBeDefined();
-    expect(ingestCall!.url).toBe(
-      `${CLUSTER_BASE}/api/${ORG_SLUG}/links/runs/${RUN_ID}/stream`,
+    expect(ingestCalls).toHaveLength(2);
+    expect(ingestCalls.every((call) => call.url.endsWith("/parts"))).toBe(true);
+    expect(ingestCalls[0]!.url).toBe(
+      `${CLUSTER_BASE}/api/${ORG_SLUG}/links/runs/${RUN_ID}/parts`,
     );
-    const ingestHeaders = ingestCall!.init.headers as Record<string, string>;
-    expect(ingestHeaders.authorization).toBe(`Bearer ${CLUSTER_TOKEN}`);
-    expect(ingestHeaders["x-fence-token"]).toBe(FENCE_TOKEN);
-    expect(ingestHeaders["content-type"]).toBe("text/event-stream");
+    expect(clusterTokenCalls).toBe(1);
+    for (const call of ingestCalls) {
+      const ingestHeaders = call.init.headers as Record<string, string>;
+      expect(ingestHeaders.authorization).toBe(`Bearer ${CLUSTER_TOKEN}`);
+      expect(ingestHeaders["x-fence-token"]).toBe(FENCE_TOKEN);
+      expect(ingestHeaders["content-type"]).toBe("application/json");
+    }
 
-    // ── Assert SSE body was relayed (not buffered: it's a ReadableStream) ──
-    expect(ingestCall!.init.body).toBeInstanceOf(ReadableStream);
-    // capturedIngestBody is mutated inside the async fetchImpl closure —
-    // TypeScript does not narrow it; assert non-null explicitly.
-    expect(capturedIngestBody!).toBe(FAKE_SSE_BODY);
+    // ── Assert JSON batches were appended, not a streaming upload ──────────
+    expect(ingestCalls[0]!.init.body).toBeString();
+    expect(ingestCalls[0]!.init.body).not.toBeInstanceOf(ReadableStream);
+    expect(capturedBatches[0]?.batchId).toBe(`${RUN_ID}:0`);
+    expect(capturedBatches[0]?.done).toBe(false);
+    expect(capturedBatches[0]?.rows.length).toBeGreaterThan(0);
+    expect(capturedBatches.at(-1)).toEqual({
+      batchId: `${RUN_ID}:done`,
+      rows: [],
+      done: true,
+    });
   });
 
   // ── Test: non-ok sandbox dispatch → throw ──────────────────────────────
@@ -199,6 +223,8 @@ describe("handleLocalDispatch", () => {
   // ── Test: non-ok cluster ingest → throw ────────────────────────────────
 
   it("throws when the cluster ingest returns a non-2xx response", async () => {
+    let appendCount = 0;
+
     const fetchImpl = async (url: string): Promise<Response> => {
       if (url.includes("/_sandbox/dispatch")) {
         return new Response(makeBodyStream(FAKE_SSE_BODY), {
@@ -207,13 +233,17 @@ describe("handleLocalDispatch", () => {
         });
       }
       if (url.includes("/links/runs/")) {
-        // Drain the stream to avoid AbortError on the sandbox side.
-        if (typeof url === "string") {
-          return new Response(JSON.stringify({ error: "fenced" }), {
-            status: 409,
+        appendCount++;
+        if (appendCount === 1) {
+          return new Response(JSON.stringify({ ok: true }), {
+            status: 200,
             headers: { "content-type": "application/json" },
           });
         }
+        return new Response(JSON.stringify({ error: "fenced" }), {
+          status: 409,
+          headers: { "content-type": "application/json" },
+        });
       }
       throw new Error(`Unexpected fetch to ${url}`);
     };
@@ -251,14 +281,6 @@ describe("handleLocalDispatch", () => {
         });
       }
       if (url.includes("/links/runs/")) {
-        // Drain the body so the stream doesn't hang.
-        if (init?.body instanceof ReadableStream) {
-          const reader = init.body.getReader();
-          while (true) {
-            const { done } = await reader.read();
-            if (done) break;
-          }
-        }
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -299,13 +321,6 @@ describe("handleLocalDispatch", () => {
         });
       }
       if (url.includes("/links/runs/")) {
-        if (init?.body instanceof ReadableStream) {
-          const reader = init.body.getReader();
-          while (true) {
-            const { done } = await reader.read();
-            if (done) break;
-          }
-        }
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -363,13 +378,6 @@ describe("handleLocalDispatch", () => {
         });
       }
       if (url.includes("/links/runs/")) {
-        if (init?.body instanceof ReadableStream) {
-          const reader = init.body.getReader();
-          while (true) {
-            const { done } = await reader.read();
-            if (done) break;
-          }
-        }
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -434,13 +442,6 @@ describe("handleLocalDispatch", () => {
         });
       }
       if (url.includes("/links/runs/")) {
-        if (init?.body instanceof ReadableStream) {
-          const reader = init.body.getReader();
-          while (true) {
-            const { done } = await reader.read();
-            if (done) break;
-          }
-        }
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -477,19 +478,12 @@ describe("handleLocalDispatch", () => {
     ): Promise<Response> => {
       capturedSignals.push(init?.signal ?? null);
       if (url.includes("/_sandbox/dispatch")) {
-        return new Response(makeBodyStream(FAKE_SSE_BODY), {
+        return new Response(makeBodyStream(dispatchSSE(TEXT_CHUNKS)), {
           status: 200,
           headers: { "content-type": "text/event-stream" },
         });
       }
       if (url.includes("/links/runs/")) {
-        if (init?.body instanceof ReadableStream) {
-          const reader = init.body.getReader();
-          while (true) {
-            const { done } = await reader.read();
-            if (done) break;
-          }
-        }
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -510,9 +504,10 @@ describe("handleLocalDispatch", () => {
 
     await handleLocalDispatch(validWorkItem, deps);
 
-    // Both fetches should have received the abort signal.
-    expect(capturedSignals.length).toBe(2);
+    // Dispatch plus every cluster append fetch should receive the abort signal.
+    expect(capturedSignals.length).toBe(3);
     expect(capturedSignals[0]).toBe(ac.signal);
     expect(capturedSignals[1]).toBe(ac.signal);
+    expect(capturedSignals[2]).toBe(ac.signal);
   });
 });

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.ts
@@ -36,6 +36,7 @@
  *
  * ⚠️ SHIPPED DAEMON — needs human review before merge.
  */
+import { retry } from "@decocms/std";
 import type { WorkItem } from "../api/routes/decopilot/link-work-queue";
 import { relayDispatchSSEAsPartBatches } from "./link-part-batcher";
 
@@ -182,29 +183,45 @@ export async function handleLocalDispatch(
     runId: work.runId,
     orgId: work.orgId,
     postBatch: async (batch) => {
-      const ingestRes = await fetcher(ingestUrl, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${clusterToken}`,
-          "x-fence-token": work.runFenceToken,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(batch),
-        signal: deps.signal,
-      });
+      await retry(
+        async () => {
+          const ingestRes = await fetcher(ingestUrl, {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${clusterToken}`,
+              "x-fence-token": work.runFenceToken,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(batch),
+            signal: deps.signal,
+          });
 
-      if (!ingestRes.ok) {
-        let detail = `ingest failed (${ingestRes.status})`;
-        try {
-          const j = (await ingestRes.json()) as Record<string, unknown>;
-          if (j && typeof j.error === "string" && j.error) {
-            detail = j.error;
+          if (!ingestRes.ok) {
+            let detail = `ingest failed (${ingestRes.status})`;
+            try {
+              const j = (await ingestRes.json()) as Record<string, unknown>;
+              if (j && typeof j.error === "string" && j.error) {
+                detail = j.error;
+              }
+            } catch {
+              // JSON parse failed — keep the status-code detail.
+            }
+            const err = new Error(`[handleLocalDispatch] ${detail}`);
+            (err as { status?: number }).status = ingestRes.status;
+            throw err;
           }
-        } catch {
-          // JSON parse failed — keep the status-code detail.
-        }
-        throw new Error(`[handleLocalDispatch] ${detail}`);
-      }
+        },
+        {
+          maxAttempts: 5,
+          minTimeout: 250,
+          maxTimeout: 5_000,
+          signal: deps.signal,
+          isRetriable: (err) => {
+            const status = (err as { status?: number }).status;
+            return status === undefined || status >= 500;
+          },
+        },
+      );
     },
   });
 }

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.ts
@@ -1,6 +1,6 @@
 /**
  * handleLocalDispatch — relay a pulled work item to the local sandbox and
- * stream the SSE result back to the cluster ingest (Phase D, Task 7).
+ * append the SSE result back to the cluster ingest as short JSON batches.
  *
  * Flow:
  *   1. POST ${sandboxDispatchUrl}/_sandbox/dispatch with a JSON body whose
@@ -10,12 +10,11 @@
  *      `sandboxDaemonToken` and returns a `text/event-stream` SSE body of
  *      `ui-message-chunk` / `error` / `done` events.
  *
- *   2. Relay the SSE response body — WITHOUT buffering — as a chunked
- *      POST to the cluster ingest endpoint:
- *        POST ${clusterBaseUrl}/api/${orgSlug}/links/runs/${runId}/stream
+ *   2. Convert the SSE response body to durable part batches and POST each
+ *      batch to the cluster ingest endpoint:
+ *        POST ${clusterBaseUrl}/api/${orgSlug}/links/runs/${runId}/parts
  *      with `x-fence-token: ${runFenceToken}` and `Authorization: Bearer
- *      <cluster token>`. This is the Phase-A ingest endpoint
- *      (link-ingest-routes.ts) which commits parts to durable storage.
+ *      <cluster token>`.
  *
  * ⚠️ ORG SLUG vs ID NOTE:
  *   WorkItem carries `orgId` (the DB UUID) and `orgSlug` (the URL-safe slug).
@@ -38,6 +37,7 @@
  * ⚠️ SHIPPED DAEMON — needs human review before merge.
  */
 import type { WorkItem } from "../api/routes/decopilot/link-work-queue";
+import { relayDispatchSSEAsPartBatches } from "./link-part-batcher";
 
 export interface LocalDispatchDeps {
   /**
@@ -52,8 +52,8 @@ export interface LocalDispatchDeps {
    */
   sandboxDaemonToken: string;
   /**
-   * Cluster origin, e.g. "https://studio.deco.cx". The ingest POST is sent
-   * to `${clusterBaseUrl}/api/${orgSlug}/links/runs/${runId}/stream`.
+   * Cluster origin, e.g. "https://studio.deco.cx". The ingest POSTs are sent
+   * to `${clusterBaseUrl}/api/${orgSlug}/links/runs/${runId}/parts`.
    */
   clusterBaseUrl: string;
   /**
@@ -107,12 +107,11 @@ function deriveHarnessId(work: WorkItem, depsHarnessId?: string): string {
 }
 
 /**
- * Run a pulled work item against the local sandbox and stream the SSE result
- * to the cluster ingest. Resolves when the ingest POST completes (i.e. the
- * full SSE body has been relayed). Throws on:
+ * Run a pulled work item against the local sandbox and append the SSE result
+ * to the cluster ingest. Resolves when all batch POSTs complete. Throws on:
  *   - A non-2xx response from the sandbox dispatch (JSON error is extracted
  *     and included in the thrown Error, mirroring remote-dispatch.ts).
- *   - A non-2xx response from the cluster ingest.
+ *   - A non-2xx response from any cluster append.
  *   - Any network error from either fetch.
  */
 export async function handleLocalDispatch(
@@ -174,39 +173,38 @@ export async function handleLocalDispatch(
     throw new Error("[handleLocalDispatch] dispatch response body is null");
   }
 
-  // ── Step 2: relay the SSE body to the cluster ingest (no buffering) ────
-  // The SSE stream is piped directly as the ingest POST body using the
-  // Fetch streaming upload API (`body: ReadableStream, duplex: "half"`).
-  // This avoids buffering the entire run output in memory.
+  // ── Step 2: append parsed part batches to the cluster ingest ───────────
   const clusterToken = await deps.getClusterToken();
-  const ingestUrl = `${deps.clusterBaseUrl}/api/${deps.orgSlug}/links/runs/${work.runId}/stream`;
+  const ingestUrl = `${deps.clusterBaseUrl}/api/${deps.orgSlug}/links/runs/${work.runId}/parts`;
 
-  const ingestRes = await fetcher(ingestUrl, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${clusterToken}`,
-      "x-fence-token": work.runFenceToken,
-      "content-type": "text/event-stream",
-    },
-    body: dispatchRes.body,
-    // @ts-expect-error — `duplex: "half"` is required by the Fetch spec for
-    // streaming request bodies. Not yet in all TypeScript DOM typings but
-    // supported by Node/Bun/undici. See:
-    // https://fetch.spec.whatwg.org/#dom-requestinit-duplex
-    duplex: "half",
-    signal: deps.signal,
-  });
+  await relayDispatchSSEAsPartBatches({
+    dispatchBody: dispatchRes.body,
+    runId: work.runId,
+    orgId: work.orgId,
+    postBatch: async (batch) => {
+      const ingestRes = await fetcher(ingestUrl, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${clusterToken}`,
+          "x-fence-token": work.runFenceToken,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(batch),
+        signal: deps.signal,
+      });
 
-  if (!ingestRes.ok) {
-    let detail = `ingest failed (${ingestRes.status})`;
-    try {
-      const j = (await ingestRes.json()) as Record<string, unknown>;
-      if (j && typeof j.error === "string" && j.error) {
-        detail = j.error;
+      if (!ingestRes.ok) {
+        let detail = `ingest failed (${ingestRes.status})`;
+        try {
+          const j = (await ingestRes.json()) as Record<string, unknown>;
+          if (j && typeof j.error === "string" && j.error) {
+            detail = j.error;
+          }
+        } catch {
+          // JSON parse failed — keep the status-code detail.
+        }
+        throw new Error(`[handleLocalDispatch] ${detail}`);
       }
-    } catch {
-      // JSON parse failed — keep the status-code detail.
-    }
-    throw new Error(`[handleLocalDispatch] ${detail}`);
-  }
+    },
+  });
 }

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.ts
@@ -175,7 +175,7 @@ export async function handleLocalDispatch(
 
   // ── Step 2: append parsed part batches to the cluster ingest ───────────
   const clusterToken = await deps.getClusterToken();
-  const ingestUrl = `${deps.clusterBaseUrl}/api/${deps.orgSlug}/links/runs/${work.runId}/parts`;
+  const ingestUrl = `${deps.clusterBaseUrl}/api/${work.orgSlug}/links/runs/${work.runId}/parts`;
 
   await relayDispatchSSEAsPartBatches({
     dispatchBody: dispatchRes.body,

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.ts
@@ -1,6 +1,11 @@
 /**
  * handleLocalDispatch — relay a pulled work item to the local sandbox and
- * append the SSE result back to the cluster ingest as short JSON batches.
+ * return completed message parts to the cluster via short JSON append requests.
+ *
+ * The local sandbox still streams SSE over loopback. The desktop link daemon
+ * consumes that stream locally, assembles stable message part rows, and POSTs
+ * small idempotent batches to the cluster. This avoids holding a multi-hour
+ * streaming upload open through proxies/CDNs.
  *
  * Flow:
  *   1. POST ${sandboxDispatchUrl}/_sandbox/dispatch with a JSON body whose
@@ -19,9 +24,8 @@
  * ⚠️ ORG SLUG vs ID NOTE:
  *   WorkItem carries `orgId` (the DB UUID) and `orgSlug` (the URL-safe slug).
  *   The ingest route uses `resolveOrgFromPath` which looks up the org by slug
- *   (the `:org` path segment in `/api/:org/links/runs/...`). The `orgSlug`
- *   field on the work item is required and must be passed to
- *   `LocalDispatchDeps.orgSlug` so it is available for the ingest URL.
+ *   (the `:org` path segment in `/api/:org/links/runs/...`). The work item's
+ *   `orgSlug` is authoritative for the ingest URL.
  *
  * ⚠️ HARNESS ID NOTE:
  *   `WorkItem.harnessInput` is a `HarnessStreamInputWire` — a plain JSON
@@ -57,12 +61,6 @@ export interface LocalDispatchDeps {
    * to `${clusterBaseUrl}/api/${orgSlug}/links/runs/${runId}/parts`.
    */
   clusterBaseUrl: string;
-  /**
-   * Org SLUG for the ingest URL path segment. MUST be the slug, not the
-   * UUID orgId — resolveOrgFromPath looks up by slug. Sourced from the work
-   * item's required `orgSlug` field.
-   */
-  orgSlug: string;
   /**
    * Returns the bearer token for the cluster ingest endpoint. Called once
    * per dispatch so that a refreshed token is used (mirrors work-poller's
@@ -108,8 +106,9 @@ function deriveHarnessId(work: WorkItem, depsHarnessId?: string): string {
 }
 
 /**
- * Run a pulled work item against the local sandbox and append the SSE result
- * to the cluster ingest. Resolves when all batch POSTs complete. Throws on:
+ * Run a pulled work item against the local sandbox and append completed part
+ * batches to the cluster ingest. Resolves when all batch POSTs complete.
+ * Throws on:
  *   - A non-2xx response from the sandbox dispatch (JSON error is extracted
  *     and included in the thrown Error, mirroring remote-dispatch.ts).
  *   - A non-2xx response from any cluster append.

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.ts
@@ -36,7 +36,7 @@
  *
  * ⚠️ SHIPPED DAEMON — needs human review before merge.
  */
-import { retry } from "@decocms/std";
+import { retry, RetryError } from "@decocms/std";
 import type { WorkItem } from "../api/routes/decopilot/link-work-queue";
 import { relayDispatchSSEAsPartBatches } from "./link-part-batcher";
 
@@ -183,45 +183,50 @@ export async function handleLocalDispatch(
     runId: work.runId,
     orgId: work.orgId,
     postBatch: async (batch) => {
-      await retry(
-        async () => {
-          const ingestRes = await fetcher(ingestUrl, {
-            method: "POST",
-            headers: {
-              authorization: `Bearer ${clusterToken}`,
-              "x-fence-token": work.runFenceToken,
-              "content-type": "application/json",
-            },
-            body: JSON.stringify(batch),
-            signal: deps.signal,
-          });
+      try {
+        await retry(
+          async () => {
+            const ingestRes = await fetcher(ingestUrl, {
+              method: "POST",
+              headers: {
+                authorization: `Bearer ${clusterToken}`,
+                "x-fence-token": work.runFenceToken,
+                "content-type": "application/json",
+              },
+              body: JSON.stringify(batch),
+              signal: deps.signal,
+            });
 
-          if (!ingestRes.ok) {
-            let detail = `ingest failed (${ingestRes.status})`;
-            try {
-              const j = (await ingestRes.json()) as Record<string, unknown>;
-              if (j && typeof j.error === "string" && j.error) {
-                detail = j.error;
+            if (!ingestRes.ok) {
+              let detail = `ingest failed (${ingestRes.status})`;
+              try {
+                const j = (await ingestRes.json()) as Record<string, unknown>;
+                if (j && typeof j.error === "string" && j.error) {
+                  detail = j.error;
+                }
+              } catch {
+                // JSON parse failed — keep the status-code detail.
               }
-            } catch {
-              // JSON parse failed — keep the status-code detail.
+              const err = new Error(`[handleLocalDispatch] ${detail}`);
+              (err as { status?: number }).status = ingestRes.status;
+              throw err;
             }
-            const err = new Error(`[handleLocalDispatch] ${detail}`);
-            (err as { status?: number }).status = ingestRes.status;
-            throw err;
-          }
-        },
-        {
-          maxAttempts: 5,
-          minTimeout: 250,
-          maxTimeout: 5_000,
-          signal: deps.signal,
-          isRetriable: (err) => {
-            const status = (err as { status?: number }).status;
-            return status === undefined || status >= 500;
           },
-        },
-      );
+          {
+            maxAttempts: 5,
+            minTimeout: 250,
+            maxTimeout: 5_000,
+            signal: deps.signal,
+            isRetriable: (err) => {
+              const status = (err as { status?: number }).status;
+              return status === undefined || status >= 500;
+            },
+          },
+        );
+      } catch (error) {
+        if (error instanceof RetryError) throw error.cause;
+        throw error;
+      }
     },
   });
 }

--- a/apps/mesh/src/link-daemon/link-part-batcher.test.ts
+++ b/apps/mesh/src/link-daemon/link-part-batcher.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import type { UIMessageChunk } from "ai";
+import type { LinkIngestBatch } from "../api/routes/decopilot/link-ingest-batch-schema";
+import { relayDispatchSSEAsPartBatches } from "./link-part-batcher";
+
+function dispatchSSE(chunks: UIMessageChunk[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({ type: "ui-message-chunk", chunk })}\n\n`,
+          ),
+        );
+      }
+      controller.enqueue(encoder.encode(`data: {"type":"done"}\n\n`));
+      controller.close();
+    },
+  });
+}
+
+function errorDispatchSSE(): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          `data: ${JSON.stringify({
+            type: "error",
+            code: "harness_crashed",
+            message: "boom",
+          })}\n\n`,
+        ),
+      );
+      controller.close();
+    },
+  });
+}
+
+async function relayForTest(input: {
+  dispatchBody: ReadableStream<Uint8Array>;
+  postBatch: (batch: LinkIngestBatch) => Promise<void>;
+}) {
+  await relayDispatchSSEAsPartBatches({
+    dispatchBody: input.dispatchBody,
+    runId: "run_1",
+    orgId: "org_1",
+    postBatch: input.postBatch,
+  });
+}
+
+const successfulTextChunks = [
+  { type: "start" },
+  { type: "start-step" },
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: "hello" },
+  { type: "text-end", id: "t1" },
+  { type: "finish-step" },
+  { type: "finish" },
+] as UIMessageChunk[];
+
+describe("relayDispatchSSEAsPartBatches", () => {
+  it("posts one rows batch and final done for a successful text stream", async () => {
+    const batches: LinkIngestBatch[] = [];
+
+    await relayForTest({
+      dispatchBody: dispatchSSE(successfulTextChunks),
+      postBatch: async (batch) => {
+        batches.push(batch);
+      },
+    });
+
+    expect(batches).toHaveLength(2);
+    expect(batches[0]?.batchId).toBe("run_1:0");
+    expect(batches[0]?.done).toBe(false);
+    expect(
+      batches[0]?.rows.map((row) => ({
+        id: row.id,
+        kind: row.kind,
+        payload: row.payload,
+      })),
+    ).toEqual([
+      {
+        id: "run_1:0",
+        kind: "text",
+        payload: expect.objectContaining({ type: "text", text: "hello" }),
+      },
+      {
+        id: "run_1:1",
+        kind: "finish",
+        payload: {},
+      },
+    ]);
+    expect(batches[1]).toEqual({
+      batchId: "run_1:done",
+      rows: [],
+      done: true,
+    });
+  });
+
+  it("posts an error row batch and final done for dispatch SSE errors", async () => {
+    const batches: LinkIngestBatch[] = [];
+
+    await relayForTest({
+      dispatchBody: errorDispatchSSE(),
+      postBatch: async (batch) => {
+        batches.push(batch);
+      },
+    });
+
+    expect(batches).toHaveLength(2);
+    expect(batches[0]?.batchId).toBe("run_1:0");
+    expect(batches[0]?.done).toBe(false);
+    expect(batches[0]?.rows.map((row) => [row.id, row.kind])).toEqual([
+      ["run_1:0", "error"],
+      ["run_1:1", "finish"],
+    ]);
+    expect(batches[1]).toEqual({
+      batchId: "run_1:done",
+      rows: [],
+      done: true,
+    });
+  });
+
+  it("rejects and does not post final done when postBatch fails", async () => {
+    const batches: LinkIngestBatch[] = [];
+    const failure = new Error("handoff failed");
+
+    await expect(
+      relayForTest({
+        dispatchBody: dispatchSSE(successfulTextChunks),
+        postBatch: async (batch) => {
+          batches.push(batch);
+          if (!batch.done) throw failure;
+        },
+      }),
+    ).rejects.toThrow("handoff failed");
+
+    expect(batches.map((batch) => batch.batchId)).toEqual(["run_1:0"]);
+  });
+
+  it("acknowledges successful handoffs so cumulative snapshots do not duplicate rows", async () => {
+    const batches: LinkIngestBatch[] = [];
+    const chunks = [
+      { type: "start" },
+      { type: "start-step" },
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "hello" },
+      { type: "text-end", id: "t1" },
+      { type: "finish-step" },
+      { type: "start-step" },
+      { type: "text-start", id: "t2" },
+      { type: "text-delta", id: "t2", delta: " world" },
+      { type: "text-end", id: "t2" },
+      { type: "finish-step" },
+      { type: "finish" },
+    ] as UIMessageChunk[];
+
+    await relayForTest({
+      dispatchBody: dispatchSSE(chunks),
+      postBatch: async (batch) => {
+        batches.push(batch);
+      },
+    });
+
+    expect(batches.map((batch) => batch.batchId)).toEqual([
+      "run_1:0",
+      "run_1:1",
+      "run_1:done",
+    ]);
+    expect(batches[0]?.rows.map((row) => row.id)).toEqual(["run_1:0"]);
+    expect(batches[1]?.rows.map((row) => row.id)).toEqual([
+      "run_1:1",
+      "run_1:2",
+    ]);
+    expect(
+      batches
+        .filter((batch) => !batch.done)
+        .flatMap((batch) => batch.rows.map((row) => row.id)),
+    ).toEqual(["run_1:0", "run_1:1", "run_1:2"]);
+  });
+});

--- a/apps/mesh/src/link-daemon/link-part-batcher.test.ts
+++ b/apps/mesh/src/link-daemon/link-part-batcher.test.ts
@@ -3,6 +3,20 @@ import type { UIMessageChunk } from "ai";
 import type { LinkIngestBatch } from "../api/routes/decopilot/link-ingest-batch-schema";
 import { relayDispatchSSEAsPartBatches } from "./link-part-batcher";
 
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function dispatchSSE(chunks: UIMessageChunk[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   return new ReadableStream({
@@ -59,6 +73,40 @@ const successfulTextChunks = [
   { type: "finish-step" },
   { type: "finish" },
 ] as UIMessageChunk[];
+
+function multiStepChunks(count: number): UIMessageChunk[] {
+  const chunks: UIMessageChunk[] = [{ type: "start" } as UIMessageChunk];
+  for (let i = 0; i < count; i++) {
+    chunks.push(
+      { type: "start-step" } as UIMessageChunk,
+      { type: "text-start", id: `t${i}` } as UIMessageChunk,
+      { type: "text-delta", id: `t${i}`, delta: `part ${i}` } as UIMessageChunk,
+      { type: "text-end", id: `t${i}` } as UIMessageChunk,
+      { type: "finish-step" } as UIMessageChunk,
+    );
+  }
+  chunks.push({ type: "finish" } as UIMessageChunk);
+  return chunks;
+}
+
+function manyTextPartsInOneStep(count: number): UIMessageChunk[] {
+  const chunks: UIMessageChunk[] = [
+    { type: "start" } as UIMessageChunk,
+    { type: "start-step" } as UIMessageChunk,
+  ];
+  for (let i = 0; i < count; i++) {
+    chunks.push(
+      { type: "text-start", id: `t${i}` } as UIMessageChunk,
+      { type: "text-delta", id: `t${i}`, delta: `part ${i}` } as UIMessageChunk,
+      { type: "text-end", id: `t${i}` } as UIMessageChunk,
+    );
+  }
+  chunks.push(
+    { type: "finish-step" } as UIMessageChunk,
+    { type: "finish" } as UIMessageChunk,
+  );
+  return chunks;
+}
 
 describe("relayDispatchSSEAsPartBatches", () => {
   it("posts one rows batch and final done for a successful text stream", async () => {
@@ -179,5 +227,92 @@ describe("relayDispatchSSEAsPartBatches", () => {
         .filter((batch) => !batch.done)
         .flatMap((batch) => batch.rows.map((row) => row.id)),
     ).toEqual(["run_1:0", "run_1:1", "run_1:2"]);
+  });
+
+  it("serializes slow postBatch calls so overlapping step callbacks do not duplicate row ids", async () => {
+    const batches: LinkIngestBatch[] = [];
+    const firstPostStarted = deferred();
+    const releaseFirstPost = deferred();
+    let firstNonDone = true;
+
+    const relayPromise = relayForTest({
+      dispatchBody: dispatchSSE(multiStepChunks(3)),
+      postBatch: async (batch) => {
+        batches.push(batch);
+        if (!batch.done && firstNonDone) {
+          firstNonDone = false;
+          firstPostStarted.resolve();
+          await releaseFirstPost.promise;
+        }
+      },
+    });
+
+    await firstPostStarted.promise;
+    await Promise.resolve();
+    expect(batches.map((batch) => batch.batchId)).toEqual(["run_1:0"]);
+
+    releaseFirstPost.resolve();
+    await relayPromise;
+
+    expect(batches.map((batch) => batch.batchId)).toEqual([
+      "run_1:0",
+      "run_1:1",
+      "run_1:2",
+      "run_1:done",
+    ]);
+    const rowIds = batches
+      .filter((batch) => !batch.done)
+      .flatMap((batch) => batch.rows.map((row) => row.id));
+    expect(rowIds).toEqual(["run_1:0", "run_1:1", "run_1:2", "run_1:3"]);
+    expect(new Set(rowIds).size).toBe(rowIds.length);
+  });
+
+  it("splits more than 512 rows into multiple non-done batches before final done", async () => {
+    const batches: LinkIngestBatch[] = [];
+
+    await relayForTest({
+      dispatchBody: dispatchSSE(manyTextPartsInOneStep(513)),
+      postBatch: async (batch) => {
+        batches.push(batch);
+      },
+    });
+
+    expect(batches.map((batch) => batch.batchId)).toEqual([
+      "run_1:0",
+      "run_1:1",
+      "run_1:done",
+    ]);
+    expect(batches[0]?.done).toBe(false);
+    expect(batches[1]?.done).toBe(false);
+    expect(batches[0]?.rows).toHaveLength(512);
+    expect(batches[1]?.rows).toHaveLength(2);
+    expect(batches[0]?.rows.length).toBeLessThanOrEqual(512);
+    expect(batches[1]?.rows.length).toBeLessThanOrEqual(512);
+    expect(batches[2]).toEqual({
+      batchId: "run_1:done",
+      rows: [],
+      done: true,
+    });
+  });
+
+  it("rejects and does not post final done when a later split chunk fails", async () => {
+    const batches: LinkIngestBatch[] = [];
+
+    await expect(
+      relayForTest({
+        dispatchBody: dispatchSSE(manyTextPartsInOneStep(513)),
+        postBatch: async (batch) => {
+          batches.push(batch);
+          if (batch.batchId === "run_1:1") {
+            throw new Error("second chunk failed");
+          }
+        },
+      }),
+    ).rejects.toThrow("second chunk failed");
+
+    expect(batches.map((batch) => batch.batchId)).toEqual([
+      "run_1:0",
+      "run_1:1",
+    ]);
   });
 });

--- a/apps/mesh/src/link-daemon/link-part-batcher.ts
+++ b/apps/mesh/src/link-daemon/link-part-batcher.ts
@@ -1,0 +1,118 @@
+import type { ThreadMessagePart } from "@/storage/fold-parts";
+import {
+  consumePartStream,
+  type PartEmitterLike,
+} from "../api/routes/decopilot/consume-part-stream";
+import type { LinkIngestBatch } from "../api/routes/decopilot/link-ingest-batch-schema";
+import {
+  type AnyMessage,
+  PartRowBuilder,
+} from "../api/routes/decopilot/part-row-builder";
+import { parseDispatchSSEStream } from "../harnesses/parse-dispatch-sse";
+
+export interface RelayDispatchSSEAsPartBatchesInput {
+  dispatchBody: ReadableStream<Uint8Array>;
+  runId: string;
+  orgId: string;
+  postBatch: (batch: LinkIngestBatch) => Promise<void>;
+}
+
+class RowBatchEmitter implements PartEmitterLike {
+  private readonly builder: PartRowBuilder;
+  private pendingStepRows: ThreadMessagePart[] = [];
+  private batchIndex = 0;
+  private firstFailure: unknown = null;
+
+  constructor(private readonly input: RelayDispatchSSEAsPartBatchesInput) {
+    this.builder = new PartRowBuilder({
+      orgId: input.orgId,
+      threadId: input.runId,
+      runId: input.runId,
+    });
+  }
+
+  private uniqueRows(rows: ThreadMessagePart[]): ThreadMessagePart[] {
+    const seen = new Set<string>();
+    const unique: ThreadMessagePart[] = [];
+    for (const row of rows) {
+      if (seen.has(row.id)) continue;
+      seen.add(row.id);
+      unique.push(row);
+    }
+    return unique;
+  }
+
+  private async postRows(rows: ThreadMessagePart[]): Promise<void> {
+    if (rows.length === 0) return;
+    if (this.firstFailure) throw this.firstFailure;
+
+    try {
+      await this.input.postBatch({
+        batchId: `${this.input.runId}:${this.batchIndex++}`,
+        rows,
+        done: false,
+      });
+      this.builder.acknowledge(rows);
+    } catch (error) {
+      this.firstFailure ??= error;
+      throw error;
+    }
+  }
+
+  async emitStepParts(message: AnyMessage): Promise<void> {
+    await this.postRows(this.pendingStepRows);
+    this.pendingStepRows = this.builder.emitStepParts(message);
+  }
+
+  async emitFinal(message: AnyMessage): Promise<void> {
+    const rows = this.uniqueRows([
+      ...this.pendingStepRows,
+      ...this.builder.emitFinal(message),
+    ]);
+    this.pendingStepRows = [];
+    await this.postRows(rows);
+  }
+
+  async emitError(messageId: string, errorText: string): Promise<void> {
+    const rows = this.uniqueRows([
+      ...this.pendingStepRows,
+      ...this.builder.emitError(messageId, errorText),
+    ]);
+    this.pendingStepRows = [];
+    await this.postRows(rows);
+  }
+
+  throwIfFailed(): void {
+    if (this.firstFailure) throw this.firstFailure;
+  }
+}
+
+async function drain(stream: ReadableStream): Promise<void> {
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export async function relayDispatchSSEAsPartBatches(
+  input: RelayDispatchSSEAsPartBatchesInput,
+): Promise<void> {
+  const emitter = new RowBatchEmitter(input);
+  const chunks = parseDispatchSSEStream(input.dispatchBody);
+  const { uiStream, whenComplete } = consumePartStream(chunks, emitter);
+
+  await drain(uiStream).catch(() => {});
+  await whenComplete;
+  emitter.throwIfFailed();
+
+  await input.postBatch({
+    batchId: `${input.runId}:done`,
+    rows: [],
+    done: true,
+  });
+}

--- a/apps/mesh/src/link-daemon/link-part-batcher.ts
+++ b/apps/mesh/src/link-daemon/link-part-batcher.ts
@@ -10,6 +10,8 @@ import {
 } from "../api/routes/decopilot/part-row-builder";
 import { parseDispatchSSEStream } from "../harnesses/parse-dispatch-sse";
 
+const MAX_BATCH_ROWS = 512;
+
 export interface RelayDispatchSSEAsPartBatchesInput {
   dispatchBody: ReadableStream<Uint8Array>;
   runId: string;
@@ -22,6 +24,7 @@ class RowBatchEmitter implements PartEmitterLike {
   private pendingStepRows: ThreadMessagePart[] = [];
   private batchIndex = 0;
   private firstFailure: unknown = null;
+  private queue: Promise<void> = Promise.resolve();
 
   constructor(private readonly input: RelayDispatchSSEAsPartBatchesInput) {
     this.builder = new PartRowBuilder({
@@ -42,44 +45,66 @@ class RowBatchEmitter implements PartEmitterLike {
     return unique;
   }
 
+  private enqueue(operation: () => Promise<void>): Promise<void> {
+    const run = this.queue.then(async () => {
+      if (this.firstFailure) throw this.firstFailure;
+      await operation();
+    });
+    this.queue = run.catch(() => {});
+    return run;
+  }
+
   private async postRows(rows: ThreadMessagePart[]): Promise<void> {
     if (rows.length === 0) return;
     if (this.firstFailure) throw this.firstFailure;
 
-    try {
-      await this.input.postBatch({
-        batchId: `${this.input.runId}:${this.batchIndex++}`,
-        rows,
-        done: false,
-      });
-      this.builder.acknowledge(rows);
-    } catch (error) {
-      this.firstFailure ??= error;
-      throw error;
+    for (let offset = 0; offset < rows.length; offset += MAX_BATCH_ROWS) {
+      const chunk = rows.slice(offset, offset + MAX_BATCH_ROWS);
+      try {
+        await this.input.postBatch({
+          batchId: `${this.input.runId}:${this.batchIndex++}`,
+          rows: chunk,
+          done: false,
+        });
+        this.builder.acknowledge(chunk);
+      } catch (error) {
+        this.firstFailure ??= error;
+        throw error;
+      }
     }
   }
 
   async emitStepParts(message: AnyMessage): Promise<void> {
-    await this.postRows(this.pendingStepRows);
-    this.pendingStepRows = this.builder.emitStepParts(message);
+    return this.enqueue(async () => {
+      await this.postRows(this.pendingStepRows);
+      this.pendingStepRows = this.builder.emitStepParts(message);
+    });
   }
 
   async emitFinal(message: AnyMessage): Promise<void> {
-    const rows = this.uniqueRows([
-      ...this.pendingStepRows,
-      ...this.builder.emitFinal(message),
-    ]);
-    this.pendingStepRows = [];
-    await this.postRows(rows);
+    return this.enqueue(async () => {
+      const rows = this.uniqueRows([
+        ...this.pendingStepRows,
+        ...this.builder.emitFinal(message),
+      ]);
+      this.pendingStepRows = [];
+      await this.postRows(rows);
+    });
   }
 
   async emitError(messageId: string, errorText: string): Promise<void> {
-    const rows = this.uniqueRows([
-      ...this.pendingStepRows,
-      ...this.builder.emitError(messageId, errorText),
-    ]);
-    this.pendingStepRows = [];
-    await this.postRows(rows);
+    return this.enqueue(async () => {
+      const rows = this.uniqueRows([
+        ...this.pendingStepRows,
+        ...this.builder.emitError(messageId, errorText),
+      ]);
+      this.pendingStepRows = [];
+      await this.postRows(rows);
+    });
+  }
+
+  async flush(): Promise<void> {
+    await this.queue;
   }
 
   throwIfFailed(): void {
@@ -106,8 +131,12 @@ export async function relayDispatchSSEAsPartBatches(
   const chunks = parseDispatchSSEStream(input.dispatchBody);
   const { uiStream, whenComplete } = consumePartStream(chunks, emitter);
 
+  // Dispatch parse/provider errors are converted into error parts by
+  // consumePartStream; postBatch failures are captured by RowBatchEmitter and
+  // rethrown after the stream drains and the serialized emitter queue settles.
   await drain(uiStream).catch(() => {});
   await whenComplete;
+  await emitter.flush();
   emitter.throwIfFailed();
 
   await input.postBatch({

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -36,6 +36,15 @@ export interface ThreadStoragePort {
     data: Partial<Thread>,
   ): Promise<Thread>;
   /**
+   * Atomically transition a thread to completed unless it is already completed.
+   * Returns the updated row when this call won the transition, or null when the
+   * run was already completed by another caller.
+   */
+  completeRunIfNotCompleted(
+    id: string,
+    organizationId: string,
+  ): Promise<Thread | null>;
+  /**
    * Atomically transitions a thread to "failed" only when its current
    * persisted status is "in_progress". Safe to call concurrently — the
    * conditional WHERE clause prevents clobbering a terminal status.

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -36,9 +36,9 @@ export interface ThreadStoragePort {
     data: Partial<Thread>,
   ): Promise<Thread>;
   /**
-   * Atomically transition a thread to completed unless it is already completed.
+   * Atomically transition an in-progress thread to completed.
    * Returns the updated row when this call won the transition, or null when the
-   * run was already completed by another caller.
+   * run was already terminal or no longer active.
    */
   completeRunIfNotCompleted(
     id: string,

--- a/apps/mesh/src/storage/thread-message-parts.ts
+++ b/apps/mesh/src/storage/thread-message-parts.ts
@@ -10,13 +10,28 @@ export class SqlThreadMessagePartStorage {
   constructor(private db: Kysely<Database>) {}
 
   /** Idempotent append; rows are immutable (ON CONFLICT (id) DO NOTHING). */
-  async appendParts(parts: ThreadMessagePart[]): Promise<void> {
-    if (parts.length === 0) return;
+  async appendParts(parts: ThreadMessagePart[]): Promise<ThreadMessagePart[]> {
+    if (parts.length === 0) return [];
     const seen = new Set<string>();
-    const rows = [];
+    const rows: Array<{
+      id: string;
+      seq: number;
+      org_id: string;
+      thread_id: string;
+      run_id: string;
+      message_id: string;
+      role: ThreadMessagePart["role"];
+      kind: ThreadMessagePart["kind"];
+      payload: string;
+      payload_ref: string | null;
+      metadata: string | null;
+      created_at: string;
+    }> = [];
+    const partsById = new Map<string, ThreadMessagePart>();
     for (const p of parts) {
       if (seen.has(p.id)) continue; // can't affect same row twice in one INSERT
       seen.add(p.id);
+      partsById.set(p.id, p);
       rows.push({
         id: p.id,
         seq: p.seq,
@@ -32,11 +47,15 @@ export class SqlThreadMessagePartStorage {
         created_at: p.created_at,
       });
     }
-    await this.db
+    const inserted = await this.db
       .insertInto("thread_message_parts")
       .values(rows)
       .onConflict((oc) => oc.column("id").doNothing())
+      .returning("id")
       .execute();
+    return inserted
+      .map((row) => partsById.get(row.id))
+      .filter((part): part is ThreadMessagePart => part !== undefined);
   }
 
   /**

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -387,7 +387,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
       })
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
-      .where("status", "!=", "completed")
+      .where("status", "=", "in_progress")
       .returningAll()
       .execute();
 

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -83,6 +83,10 @@ export class OrgScopedThreadStorage {
     return this.inner.update(id, this.requireOrg(), data);
   }
 
+  completeRunIfNotCompleted(id: string): Promise<Thread | null> {
+    return this.inner.completeRunIfNotCompleted(id, this.requireOrg());
+  }
+
   forceFailIfInProgress(id: string): Promise<boolean> {
     return this.inner.forceFailIfInProgress(id, this.requireOrg());
   }
@@ -366,6 +370,29 @@ export class SqlThreadStorage implements ThreadStoragePort {
     }
 
     return thread;
+  }
+
+  async completeRunIfNotCompleted(
+    id: string,
+    organizationId: string,
+  ): Promise<Thread | null> {
+    const rows = await this.db
+      .updateTable("threads")
+      .set({
+        status: "completed",
+        run_owner_pod: null,
+        run_config: null,
+        run_started_at: null,
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .where("status", "!=", "completed")
+      .returningAll()
+      .execute();
+
+    const row = rows[0];
+    return row ? this.threadFromDbRow(row) : null;
   }
 
   async forceFailIfInProgress(


### PR DESCRIPTION
## What is this contribution about?
> Replaces the desktop sandbox return path's long-running cluster upload with short JSON message-part batches, while preserving the local loopback SSE dispatch.
> Adds the `/links/runs/:runId/parts` ingest route, deterministic part-row building, desktop-side batching, transient append retries, live client notifications, and atomic terminal completion for active runs.

## Screenshots/Demonstration
> Not applicable; this is transport and persistence behavior.

## How to Test
> 1. Run `bun test apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts apps/mesh/src/api/routes/decopilot/part-emitter.test.ts apps/mesh/src/api/routes/decopilot/link-ingest-batch-schema.test.ts apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts apps/mesh/src/link-daemon/link-part-batcher.test.ts apps/mesh/src/link-daemon/handle-local-dispatch.test.ts`.
> 2. Run `bun run fmt`.
> 3. Run `bun run check`.
> Expected outcome: all commands pass.

## Migration Notes
> No database migration or configuration change required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch desktop sandbox result ingest from long-lived SSE uploads to short JSON batches of deterministic `thread_message_parts`, improving reliability through proxies and enabling atomic run completion and live updates.

- **New Features**
  - Added `POST /links/runs/:runId/parts` to ingest short JSON batches (max 512 rows) with strict server-side validation.
  - Built a deterministic part-row builder and desktop batcher to convert local loopback SSE into idempotent rows.
  - Live updates: publish only fresh rows to the stream buffer and emit `decopilot.thread.status` and `decopilot.finish` via `sseHub`; purge buffers on completion.
  - Atomic completion with `completeRunIfNotCompleted` to claim terminal state exactly once.
  - Transitional support: `/links/runs/:runId/stream` remains available while daemons upgrade.

- **Bug Fixes**
  - Prevent duplicate live chunk publishes on retried batches and avoid re-appending already-inserted rows.
  - Reject mismatched org/thread/run in batches and enforce empty terminal batches (`done: true` requires `rows: []`).
  - Respect cancel-before-fence and fence validation; use the work item’s `orgSlug` for ingest URL.
  - Retry transient append failures with backoff using `@decocms/std`, preserving detailed errors.
  - Keep the ingest row schema private to the server; not exposed publicly.

<sup>Written for commit 37f42da100ff3117bc22743b5ff6a1b0e4db5866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

