### PR TITLE
fix(auth): drop image from set-auth-jwt payload, disable avatar upload

### DIFF
--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -24,6 +24,7 @@ import {
   OrganizationOptions,
 } from "better-auth/plugins";
 import { emailOTP } from "better-auth/plugins/email-otp";
+import { APIError } from "better-auth/api";
 import {
   adminAc as systemAdminAc,
   defaultRoles as systemDefaultRoles,
@@ -337,6 +338,18 @@ const plugins = [
     jwt: {
       // Short expiration for proxy tokens (5 minutes)
       expirationTime: "5m",
+      // Only emit identity fields. The default payload is the entire user
+      // row, and this plugin attaches the signed JWT to every /get-session
+      // response via the `set-auth-jwt` header. A base64 `image` data URL
+      // (avatars can be megabytes) blows the header past the edge's limit, so
+      // the response is rejected and login breaks. Same class of bug as the
+      // mesh-token fix (#3716) — never put `image` in a header-bound JWT.
+      definePayload: ({ user }) => ({
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: (user as { role?: string }).role,
+      }),
     },
   }),
 
@@ -425,6 +438,13 @@ function getTrustedOrigins(): string[] {
 }
 
 const settings = getSettings();
+
+// Hard cap on inline base64 avatars stored in `user.image`. Avatar upload is
+// disabled in the UI, so `image` should only ever be a short OAuth provider
+// URL; this cap is a backstop against direct API callers. Oversized data: URLs
+// bloat every /get-session response and previously broke login via the
+// set-auth-jwt header.
+const MAX_INLINE_AVATAR_LENGTH = 256 * 1024;
 
 export const auth = betterAuth({
   secret: settings.betterAuthSecret || "deco-default-secret-k7x9m2p4q8w3n5v6",
@@ -571,6 +591,24 @@ export const auth = betterAuth({
                 return;
               }
             }
+          }
+        },
+      },
+      update: {
+        // Defense in depth: never persist an oversized base64 avatar. Upload
+        // is disabled in the UI, but a direct API caller could still send a
+        // multi-megabyte data: URL. See MAX_INLINE_AVATAR_LENGTH.
+        before: async (data) => {
+          const image = (data as { image?: unknown }).image;
+          if (
+            typeof image === "string" &&
+            image.startsWith("data:") &&
+            image.length > MAX_INLINE_AVATAR_LENGTH
+          ) {
+            throw new APIError("PAYLOAD_TOO_LARGE", {
+              message:
+                "Avatar image is too large. Upload an image smaller than 5MB.",
+            });
           }
         },
       },

--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -14,7 +14,6 @@ import {
 import { Input } from "@deco/ui/components/input.tsx";
 import { Moon01, Monitor01, Play, Sun } from "@untitledui/icons";
 import { Controller, useForm } from "react-hook-form";
-import { useRef, useState } from "react";
 import { authClient } from "@/web/lib/auth-client";
 import {
   usePreferences,
@@ -37,61 +36,10 @@ interface ProfileFormValues {
   name: string;
 }
 
-function ProfileAvatarUpload({
-  value,
-  name,
-  isUpdating,
-  onUpload,
-}: {
-  value?: string;
-  name?: string;
-  isUpdating: boolean;
-  onUpload: (dataUrl: string) => void;
-}) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    if (file.size > 2 * 1024 * 1024) {
-      toast.error("Image must be smaller than 2MB");
-      return;
-    }
-    const reader = new FileReader();
-    reader.onerror = () => toast.error("Failed to read image");
-    reader.onloadend = () => {
-      if (reader.result) onUpload(reader.result as string);
-      if (inputRef.current) inputRef.current.value = "";
-    };
-    reader.readAsDataURL(file);
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={() => inputRef.current?.click()}
-      disabled={isUpdating}
-      className="rounded-full overflow-hidden hover:ring-2 hover:ring-border transition-all disabled:opacity-50"
-      aria-label="Upload profile picture"
-    >
-      <input
-        ref={inputRef}
-        type="file"
-        accept="image/*"
-        onChange={handleFile}
-        className="hidden"
-        disabled={isUpdating}
-      />
-      <Avatar url={value} fallback={name ?? "U"} shape="circle" size="base" />
-    </button>
-  );
-}
-
 function ProfileSection() {
   const { data: session, isPending } = authClient.useSession();
   const user = session?.user;
   const userImage = (user as { image?: string } | undefined)?.image;
-  const [isUpdatingImage, setIsUpdatingImage] = useState(false);
 
   const form = useForm<ProfileFormValues>({
     values: { name: user?.name ?? "" },
@@ -127,19 +75,6 @@ function ProfileSection() {
     },
   });
 
-  const handleImageUpload = async (dataUrl: string) => {
-    setIsUpdatingImage(true);
-    try {
-      await authClient.updateUser({ image: dataUrl });
-      track("profile_updated", { fields: ["image"] });
-      toast.success("Profile picture updated");
-    } catch {
-      toast.error("Failed to update profile picture");
-    } finally {
-      setIsUpdatingImage(false);
-    }
-  };
-
   if (isPending) return null;
 
   return (
@@ -147,13 +82,12 @@ function ProfileSection() {
       <SettingsCard>
         <SettingsCardItem
           title="Avatar"
-          description="Click to upload a new picture"
           action={
-            <ProfileAvatarUpload
-              value={userImage}
-              name={user?.name}
-              isUpdating={isUpdatingImage}
-              onUpload={handleImageUpload}
+            <Avatar
+              url={userImage}
+              fallback={user?.name ?? "U"}
+              shape="circle"
+              size="base"
             />
           }
         />


### PR DESCRIPTION
## What is this contribution about?
Updating a profile picture logged the user out and blocked re-login. The better-auth `jwt()` plugin attaches the full user row to every `/get-session` response via the `set-auth-jwt` header, and its default payload included the base64 `image` data URL — a megabyte-sized avatar blew the header past the edge's limit, so the response was rejected and the session could never be read. This adds a `definePayload` that emits only `id/email/name/role`, a server-side backstop in `databaseHooks.user.update` that rejects inline `data:` URLs over 256 KB, and removes the avatar upload UI (which stored unbounded base64 straight into `user.image`), leaving the avatar display-only.

## How to Test
1. Pull this branch and run an account whose `user.image` is a large base64 `data:` URL (or set one via the API).
2. Load the app / hit `/api/auth/get-session` — the `set-auth-jwt` header stays small and the session loads instead of 4xx/5xx at the edge.
3. Go to Settings → Profile & Preferences — the avatar renders read-only with no upload control; display name editing still works.

## Migration Notes
No schema migration. Clear existing oversized inline avatars in prod so affected users can log in: `UPDATE "user" SET image = NULL WHERE image LIKE 'data:%';` (currently 2 affected users).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes logout/relogin failures caused by oversized `set-auth-jwt` headers when a base64 avatar was included. JWT now sends only identity fields, and avatar upload is disabled to prevent large inline images from being stored.

- **Bug Fixes**
  - `better-auth` `jwt()` uses `definePayload` to emit only `id`, `email`, `name`, `role`.
  - Server-side guard rejects `data:` avatars over 256 KB in `databaseHooks.user.update` with an `APIError`.
  - Removed avatar upload from Profile; avatar is display-only.

- **Migration**
  - No schema changes.
  - Clean existing inline avatars in prod to unblock logins: `UPDATE "user" SET image = NULL WHERE image LIKE 'data:%';`

<sup>Written for commit 7c966008df5da7ed06b2c7f00e0711c3f98ad3fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

