### PR TITLE
fix(database): force UTF-8 for embedded Postgres on non-UTF-8 OS locales

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -89,6 +89,10 @@ function createPostgresDatabase(connectionString: string): StudioDatabase {
     connectionString,
     max: getPoolMax(),
     ssl: getSsl(),
+    // Force UTF-8 regardless of OS locale — on Windows the default client
+    // encoding resolves to WIN1252, which breaks non-Latin1 characters in
+    // seeded data and causes INSERT errors during migrations.
+    options: "-c client_encoding=UTF8",
     ...defaultPoolOptions,
   });
 
@@ -117,6 +121,7 @@ export function getDbDialect(databaseUrl?: string): Dialect {
       connectionString: url,
       max: getPoolMax(),
       ssl: getSsl(),
+      options: "-c client_encoding=UTF8",
       ...defaultPoolOptions,
     }),
   });

--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -354,6 +354,10 @@ async function ensurePostgres(home: string): Promise<ServiceInfo> {
     user: PG_USER,
     password: PG_PASSWORD,
     persistent: true,
+    // Force UTF-8 encoding regardless of OS locale. On Windows the system
+    // locale (e.g. Portuguese_Brazil.1252) causes initdb to pick WIN1252,
+    // which breaks non-Latin1 characters in seeded data (→ chars, etc.).
+    initdbFlags: ["--encoding=UTF8", "--locale=C", "--locale-provider=libc"],
     onLog: (msg: string) => {
       if (process.env.DEBUG_SERVICES) console.log(`[pg] ${msg}`);
     },


### PR DESCRIPTION
## What is this contribution about?
On a Windows host with a non-UTF-8 OS locale (e.g. Portuguese_Brazil.1252),
the embedded Postgres ends up on WIN1252 at two layers: `initdb` creates the
cluster using the OS locale, and the pg client connection defaults
`client_encoding` to WIN1252. Any non-Latin1 character in seeded data (e.g. the
`→` arrows in the default connection metadata) then fails to encode and the
INSERT throws 22P05 (untranslatable character).

The impact is not just a log error: it aborts the organization-creation hook
during local admin seeding, leaving the database half-seeded — the user can
then never log in ("Local admin user not found").

This forces UTF-8 at both layers:
- `initdb` runs with `--encoding=UTF8 --locale=C`, so the cluster is created in
  UTF-8 regardless of the OS locale.
- The pg pools pass `options: "-c client_encoding=UTF8"`, so the session
  encoding is UTF-8 on every connection.

No-op on systems already on a UTF-8 locale (macOS/Linux).

## How to Test
1. On a Windows host with a non-UTF-8 locale, start from a clean `.deco`
2. Run `bun run dev` and open http://localhost:3000
3. Expected: local admin is seeded, auto-login succeeds, no 22P05 in the logs

## Migration Notes
The `initdb` flags apply to newly created clusters; the `client_encoding`
option applies to every new connection. Existing UTF-8 setups are unchanged.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes (no-op on UTF-8 locales)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forces UTF-8 for embedded Postgres and client sessions to avoid encoding errors on Windows non‑UTF‑8 locales. Prevents seeding failures (22P05) and allows local admin auto‑login; no‑op on UTF‑8 systems.

- **Bug Fixes**
  - Run `initdb` with `--encoding=UTF8 --locale=C --locale-provider=libc` for embedded clusters.
  - Set pool `options: "-c client_encoding=UTF8"` for all Postgres connections.

- **Migration**
  - `initdb` flags affect new clusters only; existing UTF‑8 setups are unchanged.

<sup>Written for commit 039473675a7ba38cd2e8d2af5d4d6721e9fe79df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

