### PR TITLE
fix(ui): stop auto org-pinning agents on create and import

### DIFF
--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -311,7 +311,7 @@ function PickerContent({
             data: {
               title: repo.name,
               description: repo.description || "Imported from GitHub",
-              pinned: true,
+              pinned: false,
               icon: null,
               metadata: {
                 githubRepo: {

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -8,7 +8,6 @@ import {
   useProjectContext,
 } from "@decocms/mesh-sdk";
 import { useAutoInstallGitHub } from "@/web/hooks/use-auto-install-github";
-import { useCanPinAgentsForOrg } from "@/web/hooks/use-can-pin-agents-for-org";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { resolveDecoSiteGithubRepo } from "@/shared/deco-sites-github";
 import {
@@ -78,7 +77,6 @@ export function ImportFromDecoDialog({
   const navigateToAgent = useNavigateToAgent();
   const queryClient = useQueryClient();
   const { data: session } = authClient.useSession();
-  const canPinForOrg = useCanPinAgentsForOrg();
 
   const [selectedSite, setSelectedSite] = useState<string | null>(null);
   const [search, setSearch] = useState("");
@@ -251,7 +249,7 @@ export function ImportFromDecoDialog({
             data: {
               title: siteName,
               description: "Imported from deco.cx",
-              pinned: canPinForOrg,
+              pinned: false,
               icon: projectIcon ?? null,
               subtype: "project",
               metadata: {

--- a/apps/mesh/src/web/hooks/use-create-website-agent.ts
+++ b/apps/mesh/src/web/hooks/use-create-website-agent.ts
@@ -53,7 +53,7 @@ export function useCreateAgentFromTemplate() {
       description: template.description,
       icon: template.icon ?? null,
       status: "active",
-      pinned: true,
+      pinned: false,
       connections: [],
       metadata: {
         githubRepo: {


### PR DESCRIPTION
## Summary
- Stop GitHub import, deco.cx import, and template agent creation from setting `pinned: true` on the server
- New and imported agents now only appear in the creator personal sidebar (via `useNavigateToAgent`)
- Org-wide pin remains an explicit owner/admin action from the sidebar context menu

## Test plan
- [ ] Import a repo from GitHub as owner/admin — agent appears in your sidebar only, not org-pinned for other members
- [ ] Import from deco.cx — same behavior
- [ ] Create Website/Hydrogen template agent — same behavior
- [ ] Confirm "Pin for all members" context menu still works for admins


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-pinning newly created or imported agents to the org. New and imported agents now appear only in the creator’s sidebar; org-wide pin remains an explicit admin action.

- **Bug Fixes**
  - Set `pinned: false` in GitHub import, deco.cx import, and template create flows.
  - Removed `useCanPinAgentsForOrg` from the deco import dialog; navigation still uses `useNavigateToAgent`.
  - "Pin for all members" context menu behavior is unchanged.

<sup>Written for commit b70fbf77b0a6b0ef4168495906b5a7c6364bfc70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

