### PR TITLE
Fix desktop link part batching

### DIFF
--- a/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
@@ -166,7 +166,7 @@ describe("handleLocalDispatch", () => {
     const ingestCalls = capturedRequests.filter((r) =>
       r.url.includes("/links/runs/"),
     );
-    expect(ingestCalls).toHaveLength(2);
+    expect(ingestCalls).toHaveLength(3);
     expect(ingestCalls.every((call) => call.url.endsWith("/parts"))).toBe(true);
     expect(ingestCalls[0]!.url).toBe(
       `${CLUSTER_BASE}/api/${ORG_SLUG}/links/runs/${RUN_ID}/parts`,
@@ -537,9 +537,7 @@ describe("handleLocalDispatch", () => {
     await handleLocalDispatch(validWorkItem, deps);
 
     // Dispatch plus every cluster append fetch should receive the abort signal.
-    expect(capturedSignals.length).toBe(3);
-    expect(capturedSignals[0]).toBe(ac.signal);
-    expect(capturedSignals[1]).toBe(ac.signal);
-    expect(capturedSignals[2]).toBe(ac.signal);
+    expect(capturedSignals.length).toBe(4);
+    expect(capturedSignals.every((signal) => signal === ac.signal)).toBe(true);
   });
 });

--- a/apps/mesh/src/link-daemon/link-part-batcher.test.ts
+++ b/apps/mesh/src/link-daemon/link-part-batcher.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { sleep } from "@decocms/std";
 import type { UIMessageChunk } from "ai";
 import type { LinkIngestBatch } from "../api/routes/decopilot/link-ingest-batch-schema";
 import { relayDispatchSSEAsPartBatches } from "./link-part-batcher";
@@ -34,6 +35,35 @@ function dispatchSSE(chunks: UIMessageChunk[]): ReadableStream<Uint8Array> {
   });
 }
 
+function openDispatchSSE(): {
+  stream: ReadableStream<Uint8Array>;
+  enqueue: (chunks: UIMessageChunk[]) => void;
+  close: () => void;
+} {
+  const encoder = new TextEncoder();
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  return {
+    stream: new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+    }),
+    enqueue(chunks) {
+      for (const chunk of chunks) {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({ type: "ui-message-chunk", chunk })}\n\n`,
+          ),
+        );
+      }
+    },
+    close() {
+      controller.enqueue(encoder.encode(`data: {"type":"done"}\n\n`));
+      controller.close();
+    },
+  };
+}
+
 function errorDispatchSSE(): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   return new ReadableStream<Uint8Array>({
@@ -62,6 +92,13 @@ async function relayForTest(input: {
     orgId: "org_1",
     postBatch: input.postBatch,
   });
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (predicate()) return;
+    await sleep(5);
+  }
 }
 
 const successfulTextChunks = [
@@ -109,6 +146,48 @@ function manyTextPartsInOneStep(count: number): UIMessageChunk[] {
 }
 
 describe("relayDispatchSSEAsPartBatches", () => {
+  it("posts a closed step before waiting for the next step or final answer", async () => {
+    const batches: LinkIngestBatch[] = [];
+    const dispatch = openDispatchSSE();
+
+    const relayPromise = relayForTest({
+      dispatchBody: dispatch.stream,
+      postBatch: async (batch) => {
+        batches.push(batch);
+      },
+    });
+
+    dispatch.enqueue([
+      { type: "start" },
+      { type: "start-step" },
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "first step" },
+      { type: "text-end", id: "t1" },
+      { type: "finish-step" },
+    ] as UIMessageChunk[]);
+
+    await waitFor(() => batches.length > 0);
+    const batchesAfterFirstStep = batches.map((batch) => ({
+      done: batch.done,
+      rowIds: batch.rows.map((row) => row.id),
+    }));
+
+    dispatch.enqueue([
+      { type: "start-step" },
+      { type: "text-start", id: "t2" },
+      { type: "text-delta", id: "t2", delta: "final answer" },
+      { type: "text-end", id: "t2" },
+      { type: "finish-step" },
+      { type: "finish" },
+    ] as UIMessageChunk[]);
+    dispatch.close();
+    await relayPromise;
+
+    expect(batchesAfterFirstStep).toEqual([
+      { done: false, rowIds: ["run_1:0"] },
+    ]);
+  });
+
   it("posts one rows batch and final done for a successful text stream", async () => {
     const batches: LinkIngestBatch[] = [];
 
@@ -119,7 +198,7 @@ describe("relayDispatchSSEAsPartBatches", () => {
       },
     });
 
-    expect(batches).toHaveLength(2);
+    expect(batches).toHaveLength(3);
     expect(batches[0]?.batchId).toBe("run_1:0");
     expect(batches[0]?.done).toBe(false);
     expect(
@@ -134,13 +213,11 @@ describe("relayDispatchSSEAsPartBatches", () => {
         kind: "text",
         payload: expect.objectContaining({ type: "text", text: "hello" }),
       },
-      {
-        id: "run_1:1",
-        kind: "finish",
-        payload: {},
-      },
     ]);
-    expect(batches[1]).toEqual({
+    expect(batches[1]?.rows.map((row) => [row.id, row.kind])).toEqual([
+      ["run_1:1", "finish"],
+    ]);
+    expect(batches[2]).toEqual({
       batchId: "run_1:done",
       rows: [],
       done: true,
@@ -215,13 +292,12 @@ describe("relayDispatchSSEAsPartBatches", () => {
     expect(batches.map((batch) => batch.batchId)).toEqual([
       "run_1:0",
       "run_1:1",
+      "run_1:2",
       "run_1:done",
     ]);
     expect(batches[0]?.rows.map((row) => row.id)).toEqual(["run_1:0"]);
-    expect(batches[1]?.rows.map((row) => row.id)).toEqual([
-      "run_1:1",
-      "run_1:2",
-    ]);
+    expect(batches[1]?.rows.map((row) => row.id)).toEqual(["run_1:1"]);
+    expect(batches[2]?.rows.map((row) => row.id)).toEqual(["run_1:2"]);
     expect(
       batches
         .filter((batch) => !batch.done)
@@ -258,6 +334,7 @@ describe("relayDispatchSSEAsPartBatches", () => {
       "run_1:0",
       "run_1:1",
       "run_1:2",
+      "run_1:3",
       "run_1:done",
     ]);
     const rowIds = batches
@@ -280,15 +357,19 @@ describe("relayDispatchSSEAsPartBatches", () => {
     expect(batches.map((batch) => batch.batchId)).toEqual([
       "run_1:0",
       "run_1:1",
+      "run_1:2",
       "run_1:done",
     ]);
     expect(batches[0]?.done).toBe(false);
     expect(batches[1]?.done).toBe(false);
+    expect(batches[2]?.done).toBe(false);
     expect(batches[0]?.rows).toHaveLength(512);
-    expect(batches[1]?.rows).toHaveLength(2);
+    expect(batches[1]?.rows).toHaveLength(1);
+    expect(batches[2]?.rows).toHaveLength(1);
     expect(batches[0]?.rows.length).toBeLessThanOrEqual(512);
     expect(batches[1]?.rows.length).toBeLessThanOrEqual(512);
-    expect(batches[2]).toEqual({
+    expect(batches[2]?.rows.length).toBeLessThanOrEqual(512);
+    expect(batches[3]).toEqual({
       batchId: "run_1:done",
       rows: [],
       done: true,

--- a/apps/mesh/src/link-daemon/link-part-batcher.ts
+++ b/apps/mesh/src/link-daemon/link-part-batcher.ts
@@ -21,7 +21,6 @@ export interface RelayDispatchSSEAsPartBatchesInput {
 
 class RowBatchEmitter implements PartEmitterLike {
   private readonly builder: PartRowBuilder;
-  private pendingStepRows: ThreadMessagePart[] = [];
   private batchIndex = 0;
   private firstFailure: unknown = null;
   private queue: Promise<void> = Promise.resolve();
@@ -76,29 +75,22 @@ class RowBatchEmitter implements PartEmitterLike {
 
   async emitStepParts(message: AnyMessage): Promise<void> {
     return this.enqueue(async () => {
-      await this.postRows(this.pendingStepRows);
-      this.pendingStepRows = this.builder.emitStepParts(message);
+      await this.postRows(this.builder.emitStepParts(message));
     });
   }
 
   async emitFinal(message: AnyMessage): Promise<void> {
     return this.enqueue(async () => {
-      const rows = this.uniqueRows([
-        ...this.pendingStepRows,
-        ...this.builder.emitFinal(message),
-      ]);
-      this.pendingStepRows = [];
+      const rows = this.uniqueRows(this.builder.emitFinal(message));
       await this.postRows(rows);
     });
   }
 
   async emitError(messageId: string, errorText: string): Promise<void> {
     return this.enqueue(async () => {
-      const rows = this.uniqueRows([
-        ...this.pendingStepRows,
-        ...this.builder.emitError(messageId, errorText),
-      ]);
-      this.pendingStepRows = [];
+      const rows = this.uniqueRows(
+        this.builder.emitError(messageId, errorText),
+      );
       await this.postRows(rows);
     });
   }

--- a/apps/mesh/src/link-daemon/proxy-poller.test.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.test.ts
@@ -57,6 +57,7 @@ describe("runProxyPollLoop — request ack", () => {
     const calls: string[] = [];
     const frame = reqFrame("r-ack");
     let pollCount = 0;
+    let streamVerbose: unknown;
 
     const fetchImpl = (async (input, init) => {
       const url = String(input);
@@ -82,6 +83,7 @@ describe("runProxyPollLoop — request ack", () => {
 
       if (method === "POST" && url.endsWith("/stream")) {
         calls.push("stream");
+        streamVerbose = (init as RequestInit & { verbose?: boolean }).verbose;
         return await new Promise<Response>((resolve) => {
           init?.signal?.addEventListener(
             "abort",
@@ -133,6 +135,7 @@ describe("runProxyPollLoop — request ack", () => {
     expect(calls.indexOf("ack")).toBeGreaterThan(-1);
     expect(calls.indexOf("stream")).toBeGreaterThan(-1);
     expect(calls.indexOf("ack")).toBeLessThan(calls.indexOf("stream"));
+    expect(streamVerbose).toBe(true);
   });
 });
 

--- a/apps/mesh/src/link-daemon/proxy-poller.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.ts
@@ -443,19 +443,21 @@ async function handleProxyRequest(
         url,
         elapsedMs: Date.now() - startedAt,
       });
-      const res = await fetcher(url, {
+      const replyPostInit: RequestInit & {
+        duplex: "half";
+        verbose: boolean;
+      } = {
         method: "POST",
         headers: {
           authorization: `Bearer ${token}`,
           "content-type": "application/x-ndjson",
         },
         body,
-        // @ts-expect-error — `duplex: "half"` is required by the Fetch spec for
-        // streaming request bodies; supported by Node/Bun/undici but not yet in
-        // all TS DOM typings (see handle-local-dispatch.ts).
         duplex: "half",
+        verbose: true,
         signal: combined,
-      });
+      };
+      const res = await fetcher(url, replyPostInit);
       if (!res.ok && res.status !== 204) {
         console.warn(
           `[proxy-poller] reply POST reqId=${reqId} → ${res.status}`,


### PR DESCRIPTION
## What is this contribution about?
Flushes desktop local-link message part batches as soon as each step closes, so long final responses no longer hide completed work in the UI.
Also enables Bun verbose diagnostics on proxy reply uploads to improve local socket-failure logs.

## Screenshots/Demonstration
Not applicable; no UI changes.

## How to Test
1. Run `bun test apps/mesh/src/link-daemon/link-part-batcher.test.ts apps/mesh/src/link-daemon/handle-local-dispatch.test.ts apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts apps/mesh/src/api/routes/decopilot/consume-part-stream.test.ts apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts apps/mesh/src/api/routes/decopilot/part-emitter.test.ts`.
2. Run `bun test apps/mesh/src/link-daemon/proxy-poller.test.ts`.
3. Run `bun run fmt` and `bun run check`.
Expected outcome: all commands pass.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flushes desktop local-link message part batches at the end of each step so progress appears immediately during long replies. Also enables verbose logging on proxy reply uploads to improve local socket error diagnostics.

- **Bug Fixes**
  - Post step rows immediately in `RowBatchEmitter` (removed deferred accumulation), and send the finish row and final `done` batch separately.
  - Updated tests to expect per-step batches and the extra finish batch.
  - Proxy reply POST now sets `duplex: "half"` and `verbose: true`; added test to assert verbose mode.

<sup>Written for commit 5ad1502f7f200919786caf16f4f5121c7963cc00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

