### PR TITLE
fix(github): use org-level connection for import flows

### DIFF
--- a/apps/mesh/e2e/tests/github-import-repo-scope.spec.ts
+++ b/apps/mesh/e2e/tests/github-import-repo-scope.spec.ts
@@ -77,6 +77,52 @@ test.describe("GitHub import repo-scoped connections", () => {
     }
   });
 
+  test("GITHUB_LIST_USER_ORGS rejects repo-scoped child connections", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+
+      const orgConn = await createHttpConnection(ctx, org, {
+        title: `Org GitHub ${Date.now()}`,
+        url: "https://example.com/mcp",
+      });
+
+      const child = await callSelfMcpTool<{ item: { id: string } }>(
+        ctx,
+        org,
+        "COLLECTION_CONNECTIONS_CREATE",
+        {
+          data: {
+            title: `GitHub: deco-sites/demo ${Date.now()}`,
+            app_name: "mcp-github",
+            connection_type: "HTTP",
+            connection_url: "https://example.com/mcp",
+            metadata: {
+              repoScope: {
+                sourceConnectionId: orgConn.id,
+                installationId: 1,
+                owner: "deco-sites",
+                repo: "demo",
+                permissions: { contents: "write" },
+              },
+            },
+          },
+        },
+      );
+
+      await expect(
+        callSelfMcpTool(ctx, org, "GITHUB_LIST_USER_ORGS", {
+          connectionId: child.item.id,
+        }),
+      ).rejects.toThrow(/Repo-scoped connections cannot list installations/);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
   /**
    * Scenario 2 — teardown removes the child connection + token.
    *

--- a/apps/mesh/src/shared/github-repo-scope.test.ts
+++ b/apps/mesh/src/shared/github-repo-scope.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { getRepoScope, GITHUB_SCOPED_PERMISSIONS } from "./github-repo-scope";
+import {
+  getOrgGithubConnections,
+  getRepoScope,
+  GITHUB_SCOPED_PERMISSIONS,
+} from "./github-repo-scope";
 
 describe("getRepoScope", () => {
   it("returns the recipe for a well-formed repoScope", () => {
@@ -65,5 +69,28 @@ describe("getRepoScope", () => {
         },
       }),
     ).toBeNull();
+  });
+});
+
+describe("getOrgGithubConnections", () => {
+  const orgConn = { id: "conn_org", metadata: { source: "store" } };
+  const scopedConn = {
+    id: "conn_scoped",
+    metadata: {
+      repoScope: {
+        sourceConnectionId: "conn_org",
+        installationId: 1,
+        owner: "deco-sites",
+        repo: "demo-linkedin",
+      },
+    },
+  };
+
+  it("drops repo-scoped child connections", () => {
+    expect(getOrgGithubConnections([scopedConn, orgConn])).toEqual([orgConn]);
+  });
+
+  it("returns an empty array when every connection is repo-scoped", () => {
+    expect(getOrgGithubConnections([scopedConn])).toEqual([]);
   });
 });

--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -61,3 +61,14 @@ export function getRepoScope(connection: {
       GITHUB_SCOPED_PERMISSIONS,
   };
 }
+
+/**
+ * Org-level mcp-github connections (broad user OAuth). Per-agent repo-scoped
+ * children carry `metadata.repoScope` and must not be used for listing
+ * installations or minting new repo tokens.
+ */
+export function getOrgGithubConnections<
+  T extends { metadata: Record<string, unknown> | null },
+>(connections: T[]): T[] {
+  return connections.filter((c) => getRepoScope(c) === null);
+}

--- a/apps/mesh/src/tools/github/list-user-orgs.ts
+++ b/apps/mesh/src/tools/github/list-user-orgs.ts
@@ -6,6 +6,7 @@ import {
   RECONNECT_ERROR,
   refreshAndStore,
 } from "@/oauth/token-refresh";
+import { getRepoScope } from "@/shared/github-repo-scope";
 import { DownstreamTokenStorage } from "../../storage/downstream-token";
 
 const GITHUB_API = "https://api.github.com";
@@ -53,6 +54,11 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
     );
     if (!connection) {
       throw new Error("Connection not found");
+    }
+    if (getRepoScope(connection)) {
+      throw new Error(
+        "Repo-scoped connections cannot list installations — use an org-level mcp-github connection",
+      );
     }
 
     const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);

--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -128,6 +128,7 @@ export function GitHubRepoPicker({
             }
           >
             <PickerContent
+              open={open}
               onComplete={() => onOpenChange(false)}
               selectedInstallation={selectedInstallation}
               onSelectInstallation={setSelectedInstallation}
@@ -142,12 +143,14 @@ export function GitHubRepoPicker({
 }
 
 function PickerContent({
+  open,
   onComplete,
   selectedInstallation,
   onSelectInstallation,
   hideAutoRespondCheckbox,
   onImportComplete,
 }: {
+  open: boolean;
   onComplete: () => void;
   selectedInstallation: GitHubInstallation | null;
   onSelectInstallation: (inst: GitHubInstallation | null) => void;
@@ -183,7 +186,7 @@ function PickerContent({
   const orgGithubConnections = getOrgGithubConnections(allGithubConnections);
 
   const autoInstall = useAutoInstallGitHub({
-    enabled: orgGithubConnections.length === 0,
+    enabled: open && orgGithubConnections.length === 0,
   });
 
   const effectiveConnection =

--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -39,6 +39,7 @@ import {
   setupStorefrontGithubAutomations,
 } from "@/tools/virtual/storefront-github-automations";
 import { fetchGithubInstallations } from "@/web/lib/github-installations";
+import { getOrgGithubConnections } from "@/shared/github-repo-scope";
 import { provisionRepoScopedGithubConnection } from "@/web/lib/provision-repo-scoped-github-connection";
 
 export interface GitHubInstallation {
@@ -178,15 +179,16 @@ function PickerContent({
       ? selectedAutomationKeys
       : new Set<string>();
 
-  const githubConnections = useConnections({ slug: "mcp-github" });
+  const allGithubConnections = useConnections({ slug: "mcp-github" });
+  const orgGithubConnections = getOrgGithubConnections(allGithubConnections);
 
   const autoInstall = useAutoInstallGitHub({
-    enabled: githubConnections.length === 0,
+    enabled: orgGithubConnections.length === 0,
   });
 
   const effectiveConnection =
-    githubConnections.length === 1
-      ? (githubConnections[0] ?? null)
+    orgGithubConnections.length === 1
+      ? (orgGithubConnections[0] ?? null)
       : selectedConnection;
 
   const githubClient = useMCPClient({
@@ -446,7 +448,7 @@ function PickerContent({
     );
   }
 
-  if (githubConnections.length === 0 && autoInstall.status === "idle") {
+  if (orgGithubConnections.length === 0 && autoInstall.status === "idle") {
     return (
       <AutoInstallGitHubUI
         status="installing"
@@ -456,7 +458,7 @@ function PickerContent({
     );
   }
 
-  if (githubConnections.length > 1 && !effectiveConnection) {
+  if (orgGithubConnections.length > 1 && !effectiveConnection) {
     return (
       <div className="flex flex-col py-2">
         <div className="px-4 py-2">
@@ -464,7 +466,7 @@ function PickerContent({
             Select a connection
           </p>
         </div>
-        {githubConnections.map((conn) => (
+        {orgGithubConnections.map((conn) => (
           <button
             key={conn.id}
             type="button"
@@ -498,7 +500,7 @@ function PickerContent({
         orgId={org.id}
         orgSlug={org.slug}
         onSelect={onSelectInstallation}
-        showBackButton={githubConnections.length > 1}
+        showBackButton={orgGithubConnections.length > 1}
         onBack={() => setSelectedConnection(null)}
       />
     );

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -10,6 +10,7 @@ import {
 import { useAutoInstallGitHub } from "@/web/hooks/use-auto-install-github";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { resolveDecoSiteGithubRepo } from "@/shared/deco-sites-github";
+import { getOrgGithubConnections } from "@/shared/github-repo-scope";
 import {
   fetchGithubInstallations,
   findGithubInstallation,
@@ -87,11 +88,12 @@ export function ImportFromDecoDialog({
     orgSlug: org.slug,
   });
 
-  const githubConnections = useConnections({ slug: "mcp-github" });
+  const allGithubConnections = useConnections({ slug: "mcp-github" });
+  const orgGithubConnections = getOrgGithubConnections(allGithubConnections);
   const autoInstall = useAutoInstallGitHub({
-    enabled: open && githubConnections.length === 0,
+    enabled: open && orgGithubConnections.length === 0,
   });
-  const githubConnection = githubConnections[0] ?? null;
+  const githubConnection = orgGithubConnections[0] ?? null;
   const githubClient = useMCPClient({
     connectionId: githubConnection?.id ?? "",
     orgId: org.id,
@@ -100,7 +102,7 @@ export function ImportFromDecoDialog({
 
   const githubSetupPending =
     open &&
-    githubConnections.length === 0 &&
+    orgGithubConnections.length === 0 &&
     (autoInstall.status === "installing" ||
       autoInstall.status === "authenticating" ||
       autoInstall.status === "idle");

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -6,6 +6,7 @@ import {
   useConnections,
   useMCPClient,
   useProjectContext,
+  type ConnectionEntity,
 } from "@decocms/mesh-sdk";
 import { useAutoInstallGitHub } from "@/web/hooks/use-auto-install-github";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
@@ -30,6 +31,7 @@ import { authClient } from "@/web/lib/auth-client";
 import { KEYS } from "@/web/lib/query-keys";
 import { generateSlug } from "@/web/lib/slug";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
+import { GitHubIcon } from "@/web/components/icons/github-icon";
 import { track } from "@/web/lib/posthog-client";
 
 interface DecoSite {
@@ -80,6 +82,8 @@ export function ImportFromDecoDialog({
   const { data: session } = authClient.useSession();
 
   const [selectedSite, setSelectedSite] = useState<string | null>(null);
+  const [selectedGithubConnection, setSelectedGithubConnection] =
+    useState<ConnectionEntity | null>(null);
   const [search, setSearch] = useState("");
 
   const client = useMCPClient({
@@ -93,9 +97,14 @@ export function ImportFromDecoDialog({
   const autoInstall = useAutoInstallGitHub({
     enabled: open && orgGithubConnections.length === 0,
   });
-  const githubConnection = orgGithubConnections[0] ?? null;
+  const effectiveGithubConnection =
+    orgGithubConnections.length === 1
+      ? (orgGithubConnections[0] ?? null)
+      : selectedGithubConnection;
+  const needsGithubConnectionSelection =
+    orgGithubConnections.length > 1 && !effectiveGithubConnection;
   const githubClient = useMCPClient({
-    connectionId: githubConnection?.id ?? "",
+    connectionId: effectiveGithubConnection?.id ?? "",
     orgId: org.id,
     orgSlug: org.slug,
   });
@@ -124,6 +133,7 @@ export function ImportFromDecoDialog({
   const handleClose = (nextOpen: boolean) => {
     if (!nextOpen) {
       setSelectedSite(null);
+      setSelectedGithubConnection(null);
       setSearch("");
     }
     onOpenChange(nextOpen);
@@ -141,7 +151,7 @@ export function ImportFromDecoDialog({
 
   const importMutation = useMutation({
     mutationFn: async (siteName: string) => {
-      if (!githubConnection) {
+      if (!effectiveGithubConnection) {
         throw new Error(
           "GitHub is not connected. Complete GitHub setup and try again.",
         );
@@ -151,7 +161,7 @@ export function ImportFromDecoDialog({
 
       const { installations, appSlug } = await fetchGithubInstallations(
         (req) => client.callTool(req),
-        githubConnection.id,
+        effectiveGithubConnection.id,
       );
       const site = sites.find((s) => s.name === siteName);
       if (!site) {
@@ -231,7 +241,7 @@ export function ImportFromDecoDialog({
         const { childConnectionId } = await provisionRepoScopedGithubConnection(
           {
             orgSlug: org.slug,
-            sourceConnection: githubConnection,
+            sourceConnection: effectiveGithubConnection,
             installationId: githubInstallation.installationId,
             owner: githubRepo.owner,
             repo: githubRepo.name,
@@ -413,6 +423,39 @@ export function ImportFromDecoDialog({
             </div>
           )}
 
+          {needsGithubConnectionSelection &&
+            !githubSetupPending &&
+            autoInstall.status !== "error" && (
+              <div className="flex flex-col py-2">
+                <div className="px-8 py-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Select a GitHub connection
+                  </p>
+                </div>
+                {orgGithubConnections.map((conn) => (
+                  <button
+                    key={conn.id}
+                    type="button"
+                    onClick={() => setSelectedGithubConnection(conn)}
+                    className="flex items-center gap-3 px-8 py-3 hover:bg-accent transition-colors text-left"
+                  >
+                    {conn.icon ? (
+                      <img
+                        src={conn.icon}
+                        alt={conn.title}
+                        className="size-7 rounded-full shrink-0"
+                      />
+                    ) : (
+                      <div className="size-7 rounded-full bg-muted flex items-center justify-center shrink-0">
+                        <GitHubIcon className="size-3.5 text-muted-foreground" />
+                      </div>
+                    )}
+                    <span className="text-sm font-medium">{conn.title}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+
           {isLoading &&
             !githubSetupPending &&
             autoInstall.status !== "error" && (
@@ -423,6 +466,7 @@ export function ImportFromDecoDialog({
 
           {!isLoading &&
             !githubSetupPending &&
+            !needsGithubConnectionSelection &&
             autoInstall.status !== "error" &&
             !sitesError &&
             sites.length === 0 && (
@@ -433,6 +477,7 @@ export function ImportFromDecoDialog({
 
           {!isLoading &&
             !githubSetupPending &&
+            !needsGithubConnectionSelection &&
             autoInstall.status !== "error" &&
             sites.length > 0 && (
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 max-h-[420px] overflow-y-auto py-4 px-8 [scrollbar-gutter:stable]">
@@ -504,7 +549,8 @@ export function ImportFromDecoDialog({
               importMutation.isPending ||
               isLoading ||
               githubSetupPending ||
-              !githubConnection ||
+              needsGithubConnectionSelection ||
+              !effectiveGithubConnection ||
               autoInstall.status === "error"
             }
             onClick={() => selectedSite && importMutation.mutate(selectedSite)}


### PR DESCRIPTION
## Summary
- Import flows (deco.cx and GitHub repo picker) were picking the first `mcp-github` connection, which could be a per-agent repo-scoped child (e.g. `deco-sites/demo-linkedin`).
- Scoped connections use installation tokens that cannot call `GITHUB_LIST_USER_ORGS`, causing `Invalid response from GITHUB_LIST_USER_ORGS` on import.
- Added `getOrgGithubConnections()` to filter out repo-scoped children and use only org-level OAuth connections for listing installations and minting new repo tokens.

## Test plan
- [x] `bun test apps/mesh/src/shared/github-repo-scope.test.ts`
- [ ] With both a repo-scoped GitHub instance and a general org GitHub connection, import a deco.cx site — should succeed without `GITHUB_LIST_USER_ORGS` error
- [ ] GitHub repo import should auto-select the org connection when only one org-level connection exists (even if scoped connections are present)
- [ ] GitHub repo import connection picker should only list org-level connections


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Imports now always use org‑level `mcp-github` OAuth connections and ignore repo‑scoped children. This prevents installation listing errors and makes the deco.cx and repo picker imports reliable.

- **Bug Fixes**
  - Added `getOrgGithubConnections()` to filter out repo-scoped child connections.
  - Updated repo picker and deco import dialog to use only org-level connections; auto-select when only one exists; gate auto-install on dialog open; show a connection picker when multiple exist.
  - Server-side: `GITHUB_LIST_USER_ORGS` now rejects repo-scoped connection IDs; added unit and e2e tests.

<sup>Written for commit 184ebaf7a33a1bfbbd79aa80ee36e93b35afbc18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

