### PR TITLE
Increase concurrency limits for automation queues in dbos-workflow.ts

### DIFF
--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -78,15 +78,15 @@ export const AUTOMATIONS_GLOBAL_QUEUE = "automations-global";
  */
 const AUTOMATIONS_ORG_QUEUE_PREFIX = "automations-org-";
 /** Concurrency a new org's queue starts at. Updatable per-org afterwards. */
-const DEFAULT_ORG_CONCURRENCY = 3;
+const DEFAULT_ORG_CONCURRENCY = 10;
 /** Per-automation concurrent fire cap (partition cap on the gate queue). */
-export const AUTOMATIONS_GATE_PARTITION_CONCURRENCY = 3;
+export const AUTOMATIONS_GATE_PARTITION_CONCURRENCY = 5;
 /**
  * Global concurrent fire cap across the entire cluster. Set conservatively to
  * keep the pg pool from being exhausted by tool fan-out inside each fire's
  * dispatchRunAndWait call. Bump when `databasePoolMax` is bumped.
  */
-export const AUTOMATIONS_GLOBAL_CONCURRENCY = 5;
+export const AUTOMATIONS_GLOBAL_CONCURRENCY = 50;
 const AUTOMATIONS_RUN_TIMEOUT_MS = 5 * 60 * 1000;
 export function orgQueueName(orgId: string): string {
   return `${AUTOMATIONS_ORG_QUEUE_PREFIX}${orgId}`;


### PR DESCRIPTION
- Updated DEFAULT_ORG_CONCURRENCY from 3 to 10
- Increased AUTOMATIONS_GATE_PARTITION_CONCURRENCY from 3 to 5
- Raised AUTOMATIONS_GLOBAL_CONCURRENCY from 5 to 50

These changes enhance the performance and scalability of automation processes.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised automation queue concurrency caps to improve throughput and reduce wait times. Defaults move from 3→10 per org, 3→5 per automation partition, and 5→50 globally, aligned with current database pool capacity.

<sup>Written for commit a7b96ca4b35bb80e4aba1db25a531a98d0e2eb02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

