### PR TITLE
Enhance deprecated route logging and trigger callback handling

### DIFF
--- a/apps/mesh/src/api/middleware/log-deprecated-route.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.ts
@@ -1,7 +1,22 @@
 import type { MiddlewareHandler } from "hono";
 import type { StudioContext } from "../../core/studio-context";
 
-type Variables = { meshContext: StudioContext };
+/**
+ * Attribution set by token-authenticated legacy handlers (e.g.
+ * `/api/trigger-callback`) that don't resolve a session-based `meshContext`,
+ * so their org/connection can still appear in the deprecation log. The handler
+ * sets this via `c.set("deprecatedRouteAttribution", ...)` after validating its
+ * own token; the middleware reads it after `next()`.
+ */
+export interface DeprecatedRouteAttribution {
+  organizationId?: string;
+  connectionId?: string;
+}
+
+type Variables = {
+  meshContext: StudioContext;
+  deprecatedRouteAttribution?: DeprecatedRouteAttribution;
+};
 
 /**
  * Permanent (non-deprecated) routes that any legacy deprecation middleware
@@ -70,11 +85,13 @@ const buildLogDeprecatedRoute =
     }
 
     const ctx = c.get("meshContext");
+    const attribution = c.get("deprecatedRouteAttribution");
     console.log("deprecated route", {
       route: c.req.routePath,
       method: c.req.method,
-      org: ctx?.organization?.slug,
+      org: ctx?.organization?.slug ?? attribution?.organizationId,
       user: ctx?.auth?.user?.id,
+      connection: attribution?.connectionId,
       ua: c.req.header("user-agent"),
     });
   };

--- a/apps/mesh/src/api/routes/trigger-callback.ts
+++ b/apps/mesh/src/api/routes/trigger-callback.ts
@@ -12,6 +12,7 @@ import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
 import type { AutomationEventDispatcher } from "@/automations/automation-event-dispatcher";
+import type { DeprecatedRouteAttribution } from "@/api/middleware/log-deprecated-route";
 import type { TriggerCallbackTokenStorage } from "@/storage/trigger-callback-tokens";
 
 const TriggerCallbackBodySchema = z.object({
@@ -27,7 +28,9 @@ interface TriggerCallbackDeps {
 const MAX_BODY_SIZE = 1_048_576; // 1MB
 
 export function createTriggerCallbackRoutes(deps: TriggerCallbackDeps) {
-  const app = new Hono();
+  const app = new Hono<{
+    Variables: { deprecatedRouteAttribution?: DeprecatedRouteAttribution };
+  }>();
 
   app.post(
     "/trigger-callback",
@@ -51,6 +54,13 @@ export function createTriggerCallbackRoutes(deps: TriggerCallbackDeps) {
       if (!context) {
         return c.json({ error: "Invalid callback token" }, 401);
       }
+
+      // Attribute the legacy-route deprecation log to the token's
+      // org/connection — this route has no session-based meshContext.
+      c.set("deprecatedRouteAttribution", {
+        organizationId: context.organizationId,
+        connectionId: context.connectionId,
+      });
 
       // Parse and validate body
       const parsed = TriggerCallbackBodySchema.safeParse(

--- a/apps/mesh/src/tools/automations/configure-trigger.ts
+++ b/apps/mesh/src/tools/automations/configure-trigger.ts
@@ -28,6 +28,7 @@ export async function configureTriggerOnMcp(
   if (!connection) return { success: true }; // Connection may have been deleted
 
   const organizationId = ctx.organization?.id;
+  const organizationSlug = ctx.organization?.slug;
 
   try {
     const mcpClient = await clientFromConnection(connection, ctx, true);
@@ -41,7 +42,11 @@ export async function configureTriggerOnMcp(
       const pair = await tokenStorage.generateTokenPair();
       callbackToken = pair.plaintext;
       tokenHash = pair.hash;
-      callbackUrl = `${ctx.baseUrl}/api/trigger-callback`;
+      // Prefer the org-scoped path; fall back to the legacy unscoped route
+      // only if the org slug is unavailable.
+      callbackUrl = organizationSlug
+        ? `${ctx.baseUrl}/api/${organizationSlug}/trigger-callback`
+        : `${ctx.baseUrl}/api/trigger-callback`;
     }
 
     const TIMEOUT_MS = 5000;


### PR DESCRIPTION
- Updated log-deprecated-route middleware to include optional `deprecatedRouteAttribution` for organization and connection IDs.
- Modified trigger-callback route to set `deprecatedRouteAttribution` based on token validation, allowing for accurate logging of legacy routes.
- Adjusted callback URL construction in configure-trigger to prefer organization-scoped paths when available.

These changes improve the tracking of deprecated routes and enhance the handling of callback tokens in the system.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves deprecated route tracking and trigger callback handling. Deprecated route logs now include org/connection attribution, and callback URLs prefer org-scoped paths.

- New Features
  - Added optional `deprecatedRouteAttribution` in logging middleware to record `organizationId` and `connectionId`.
  - `trigger-callback` sets `deprecatedRouteAttribution` after token validation to attribute legacy calls without a session.
  - `configure-trigger` now builds `/api/{orgSlug}/trigger-callback` when available, falling back to `/api/trigger-callback`.

<sup>Written for commit 1b47d6f06178605d1c990061dbb20f4c1142af54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

