### PR TITLE
Refactor automation workflows to simplify queue management

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -2163,6 +2163,16 @@ export async function createApp(options: CreateAppOptions = {}) {
     });
     await reconcileAutomationSchedules(automationsStorage);
 
+    // One-time cleanup of the retired per-automation/global gate queues.
+    // Fires now run directly on the per-org queue, so these rows are orphaned;
+    // deleteQueue is a no-op once they're gone. Stale gate workflows still
+    // ENQUEUED from a previous version are cancelled by the reconciler.
+    await Promise.allSettled(
+      ["automations-gate", "automations-global"].map((q) =>
+        DBOS.deleteQueue(q),
+      ),
+    );
+
     // Fire-and-forget backfill of studio pack agents for every org. Safe
     // to skip awaiting — the workflow IDs are deterministic per-org, so
     // replicas/workers all enqueueing in parallel collapse via OAOO.

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -122,10 +122,6 @@ import "../auth/install-studio-pack-workflow";
 import { cleanupOldMonitoringFiles } from "../monitoring/ndjson-retention";
 import { getLogsDir, getTracesDir, getMetricsDir } from "../monitoring/schema";
 import {
-  AUTOMATIONS_GATE_QUEUE,
-  AUTOMATIONS_GATE_PARTITION_CONCURRENCY,
-  AUTOMATIONS_GLOBAL_CONCURRENCY,
-  AUTOMATIONS_GLOBAL_QUEUE,
   AutomationEventDispatcher,
   enqueueAutomationFire,
   fireAutomationNow,
@@ -2151,22 +2147,12 @@ export async function createApp(options: CreateAppOptions = {}) {
    * — they don't need any setup here.
    */
   const initDbos = async () => {
-    // Three-level queue: per-org cap (lazily created per-org via
-    // `ensureOrgQueue` at fire time, mutable at runtime via UI/tools) →
-    // per-automation cap (shared partitioned queue) → global cap
-    // (pg-pool protection). All three caps apply to both cron and
-    // event-triggered fires since both paths enter via orgGateWorkflow.
+    // Automation fires run directly on the per-org queue
+    // `automations-org-<orgId>` — the queue's concurrency IS the per-org
+    // tenant-fairness cap. Those queues are NOT registered here: they are
+    // created on demand by `ensureOrgQueue` and auto-discovered by every
+    // replica's dispatcher via `wfQueueRunner.discoverAndLaunchDbQueues`.
     //
-    // The per-org queues are NOT registered here — they are created on
-    // demand by `ensureOrgQueue` and auto-discovered by every replica's
-    // dispatcher via `wfQueueRunner.discoverAndLaunchDbQueues`.
-    await DBOS.registerQueue(AUTOMATIONS_GATE_QUEUE, {
-      partitionQueue: true,
-      concurrency: AUTOMATIONS_GATE_PARTITION_CONCURRENCY,
-    });
-    await DBOS.registerQueue(AUTOMATIONS_GLOBAL_QUEUE, {
-      concurrency: AUTOMATIONS_GLOBAL_CONCURRENCY,
-    });
     // Per-thread agent-run gate. Partition key = threadId, concurrency=1,
     // so messages on the same thread serialize behind the active run while
     // different threads progress in parallel. Used by user-message POSTs

--- a/apps/mesh/src/automations/dbos-sync.ts
+++ b/apps/mesh/src/automations/dbos-sync.ts
@@ -14,7 +14,7 @@ import type { Automation, AutomationTrigger } from "@/storage/types";
 import {
   cronEntryWorkflow,
   ensureOrgQueue,
-  orgGateWorkflow,
+  fireAutomationWorkflow,
   orgQueueName,
   type FireAutomationContext,
   type FireAutomationOutcome,
@@ -124,7 +124,7 @@ export async function fireAutomationNow(
 ): Promise<FireAutomationOutcome> {
   await ensureOrgQueue(ctx.organizationId);
   const workflowID = workflowIdFromIdempotencyKey(ctx, opts?.idempotencyKey);
-  const handle = await DBOS.startWorkflow(orgGateWorkflow, {
+  const handle = await DBOS.startWorkflow(fireAutomationWorkflow, {
     workflowID,
     queueName: orgQueueName(ctx.organizationId),
   })(ctx);
@@ -138,7 +138,7 @@ export async function enqueueAutomationFire(
 ): Promise<void> {
   await ensureOrgQueue(ctx.organizationId);
   const workflowID = workflowIdFromIdempotencyKey(ctx, opts?.idempotencyKey);
-  await DBOS.startWorkflow(orgGateWorkflow, {
+  await DBOS.startWorkflow(fireAutomationWorkflow, {
     workflowID,
     queueName: orgQueueName(ctx.organizationId),
   })(ctx);

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -1,37 +1,26 @@
 /**
  * DBOS workflow definitions for automation fires.
  *
- * Three-level queueing (tenant isolation → per-automation isolation → global
- * resource cap):
+ * Single cap — per-org tenant fairness:
  * - `automations-org-<orgId>` — one queue per organization, lazily created
  *   on first fire via `ensureOrgQueue`. Per-org `concurrency` is mutable at
  *   runtime through `WorkflowQueue.setConcurrency`, so users/admins can
  *   self-tune the cap from a settings UI without redeploying. The
  *   `dbos.queues` row is the source of truth for the limit — mesh keeps
  *   no copy.
- * - `AUTOMATIONS_GATE_QUEUE` — partitioned by automationId,
- *   concurrency=`AUTOMATIONS_GATE_PARTITION_CONCURRENCY`. Caps per-automation
- *   concurrent fires.
- * - `AUTOMATIONS_GLOBAL_QUEUE` — flat queue,
- *   concurrency=`AUTOMATIONS_GLOBAL_CONCURRENCY`. Caps total in-flight fires
- *   across the whole cluster (protects the pg pool from exhaustion under
- *   burst load).
  *
- * Four workflows:
- * - `fireAutomationWorkflow` — runs on the global queue, split into recorded
+ * `fireAutomationWorkflow` runs *directly* on the per-org queue, so the
+ * queue's concurrency IS the cap — no dedicated gate workflow holds a slot
+ * just to enforce it. A queue caps whatever runs on it; one org saturating
+ * its slots only blocks its own fires, never another org's.
+ *
+ * Two workflows:
+ * - `fireAutomationWorkflow` — runs on the per-org queue, split into recorded
  *   steps (prepare → createRunThread → updateTriggerTiming → dispatchRunAndWait).
- * - `gateWorkflow` — enqueued on the per-automation gate queue with
- *   partitionKey=automationId, awaits a fire on the global queue. Holding
- *   the partition slot until the child returns is what enforces the
- *   per-automation cap.
- * - `orgGateWorkflow` — top-level entry for both cron and event paths.
- *   Enqueued on the org gate queue with partitionKey=organizationId, awaits
- *   the per-automation gate. Holding the org slot until the chain returns is
- *   what enforces the per-org cap.
  * - `cronEntryWorkflow` — bound to `DBOS.createSchedule`. The Schedule API
- *   can't carry a partition key, so this wrapper re-enqueues `orgGateWorkflow`
- *   on the org gate with the partition key. Returns without awaiting so the
- *   scheduler tick is never blocked.
+ *   can't target a dynamic per-org queue name, so this fire-and-forget shim
+ *   re-enqueues `fireAutomationWorkflow` on the org queue and returns without
+ *   awaiting so the scheduler tick is never blocked.
  *
  * Exactly-once semantics:
  * Cron is intrinsically exactly-once: `DBOS.createSchedule` assigns each tick
@@ -62,9 +51,6 @@ import {
 } from "./build-stream-request";
 import { computeNextRunAt, type StudioContextFactory } from "./fire";
 
-export const AUTOMATIONS_GATE_QUEUE = "automations-gate";
-export const AUTOMATIONS_GLOBAL_QUEUE = "automations-global";
-
 /**
  * Per-org queueing uses one DB-backed queue per organization, named
  * `automations-org-<orgId>`. The `dbos.queues` row IS the per-org config:
@@ -79,14 +65,6 @@ export const AUTOMATIONS_GLOBAL_QUEUE = "automations-global";
 const AUTOMATIONS_ORG_QUEUE_PREFIX = "automations-org-";
 /** Concurrency a new org's queue starts at. Updatable per-org afterwards. */
 const DEFAULT_ORG_CONCURRENCY = 10;
-/** Per-automation concurrent fire cap (partition cap on the gate queue). */
-export const AUTOMATIONS_GATE_PARTITION_CONCURRENCY = 5;
-/**
- * Global concurrent fire cap across the entire cluster. Set conservatively to
- * keep the pg pool from being exhausted by tool fan-out inside each fire's
- * dispatchRunAndWait call. Bump when `databasePoolMax` is bumped.
- */
-export const AUTOMATIONS_GLOBAL_CONCURRENCY = 50;
 const AUTOMATIONS_RUN_TIMEOUT_MS = 5 * 60 * 1000;
 export function orgQueueName(orgId: string): string {
   return `${AUTOMATIONS_ORG_QUEUE_PREFIX}${orgId}`;
@@ -394,69 +372,22 @@ async function fireAutomationWorkflowFn(
   return { taskId };
 }
 
-const fireAutomationWorkflow = DBOS.registerWorkflow(fireAutomationWorkflowFn, {
-  name: "fireAutomationWorkflow",
-});
-
-/**
- * Per-automation gate. Runs on the partitioned gate queue; holds its
- * partition slot until the inner fire on the global queue returns. That hold
- * is what enforces per-automation concurrency.
- *
- * Replays are safe: DBOS records the child workflow's ID via OAOO, so on
- * recovery `startWorkflow` returns the same handle and `getResult` waits on
- * the in-flight child rather than spawning a duplicate.
- */
-async function gateWorkflowFn(
-  ctx: FireAutomationContext,
-): Promise<FireAutomationOutcome> {
-  const handle = await DBOS.startWorkflow(fireAutomationWorkflow, {
-    queueName: AUTOMATIONS_GLOBAL_QUEUE,
-  })(ctx);
-  return await handle.getResult();
-}
-
-const gateWorkflow = DBOS.registerWorkflow(gateWorkflowFn, {
-  name: "automationGateWorkflow",
-});
-
-/**
- * Per-org gate. Top-level entry for both cron and event-triggered fires.
- * The workflow itself runs on the per-org queue `automations-org-<orgId>`
- * (set at enqueue time, not here); it holds that slot until the nested
- * per-automation gate returns. That hold is what enforces per-org
- * concurrency and prevents a single tenant from monopolising the global
- * queue's slot pool.
- *
- * Replays are safe: DBOS records the child workflow's ID via OAOO, so on
- * recovery `startWorkflow` returns the same handle and `getResult` waits on
- * the in-flight child rather than spawning a duplicate.
- */
-async function orgGateWorkflowFn(
-  ctx: FireAutomationContext,
-): Promise<FireAutomationOutcome> {
-  const handle = await DBOS.startWorkflow(gateWorkflow, {
-    queueName: AUTOMATIONS_GATE_QUEUE,
-    enqueueOptions: { queuePartitionKey: ctx.automationId },
-  })(ctx);
-  return await handle.getResult();
-}
-
-export const orgGateWorkflow = DBOS.registerWorkflow(orgGateWorkflowFn, {
-  name: "automationOrgGateWorkflow",
-});
+export const fireAutomationWorkflow = DBOS.registerWorkflow(
+  fireAutomationWorkflowFn,
+  { name: "fireAutomationWorkflow" },
+);
 
 /**
  * Scheduled-fire entry. Bound to DBOS schedules created per cron trigger.
- * Ensures the org queue exists, then re-enqueues `orgGateWorkflow` on it.
- * Returns without awaiting so the scheduler tick stays fast.
+ * Ensures the org queue exists, then re-enqueues `fireAutomationWorkflow` on
+ * it. Returns without awaiting so the scheduler tick stays fast.
  */
 async function cronEntryWorkflowFn(
   _scheduledTime: Date,
   ctx: FireAutomationContext,
 ): Promise<void> {
   await ensureOrgQueue(ctx.organizationId);
-  await DBOS.startWorkflow(orgGateWorkflow, {
+  await DBOS.startWorkflow(fireAutomationWorkflow, {
     queueName: orgQueueName(ctx.organizationId),
   })(ctx);
 }

--- a/apps/mesh/src/automations/index.ts
+++ b/apps/mesh/src/automations/index.ts
@@ -1,10 +1,4 @@
 export { AutomationEventDispatcher } from "./automation-event-dispatcher";
-export {
-  AUTOMATIONS_GATE_QUEUE,
-  AUTOMATIONS_GLOBAL_QUEUE,
-  AUTOMATIONS_GATE_PARTITION_CONCURRENCY,
-  AUTOMATIONS_GLOBAL_CONCURRENCY,
-  setAutomationRuntime,
-} from "./dbos-workflow";
+export { setAutomationRuntime } from "./dbos-workflow";
 export { enqueueAutomationFire, fireAutomationNow } from "./dbos-sync";
 export { reconcileAutomationSchedules } from "./dbos-reconciler";


### PR DESCRIPTION
- Removed the three-level queue structure in favor of a single per-org queue for automation fires, enhancing tenant fairness.
- Updated workflow registrations to use the new `fireAutomationWorkflow`, eliminating the previous `orgGateWorkflow` and `gateWorkflow`.
- Cleaned up unused constants related to the old queue structure, streamlining the codebase and improving maintainability.

These changes improve the efficiency and clarity of the automation firing process.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified automation firing by replacing the three-tier queue setup with a single per-org queue. Added a one-time cleanup to delete retired gate queues so only org queues remain.

- **Refactors**
  - Route cron and event fires to `fireAutomationWorkflow` on the per-org queue after `ensureOrgQueue`.
  - Removed `orgGateWorkflow` and `gateWorkflow`; deleted `AUTOMATIONS_*` queue constants and stopped registering global/gate queues.
  - Updated `cronEntryWorkflow` to fire-and-forget `fireAutomationWorkflow` on the org queue.
  - On startup, delete retired `automations-gate` and `automations-global` queues; reconciler cancels any stale ENQUEUED gate workflows.

<sup>Written for commit bf8dc8f3d4b428eee95b9581319d0c5b3f215759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

