### PR TITLE
feat(org-fs): near-realtime mount freshness (change-feed → rclone vfs/forget)

### DIFF
--- a/apps/mesh/src/file-storage/mount/client.ts
+++ b/apps/mesh/src/file-storage/mount/client.ts
@@ -31,6 +31,25 @@ function toNode(e: ApiEntry): OrgFsNode {
   return { path: e.path, kind: e.kind, size: e.size, updatedAt: e.updatedAt };
 }
 
+/** One entry from the change feed (a live row or a tombstone). */
+export interface OrgFsChange {
+  path: string;
+  /** Parent dir of `path` ("" = volume root) — the dir to invalidate. */
+  parent: string;
+  kind: "file" | "dir";
+  /** Set when this change is a deletion. */
+  deletedAt: string | null;
+}
+
+/** A page of the change feed. */
+export interface OrgFsChangePage {
+  entries: OrgFsChange[];
+  /** Cursor to pass as `since` on the next poll. */
+  cursor: string;
+  /** A full page came back — poll again immediately rather than waiting. */
+  hasMore: boolean;
+}
+
 /**
  * Daemon-side client for the mesh org-fs HTTP contract. One instance per
  * (org, volume). Used by the WebDAV serve layer; never touches the DB.
@@ -133,5 +152,20 @@ export class OrgFsClient implements OrgFsApi {
       body: JSON.stringify({ from, to }),
     });
     if (!res.ok) return this.fail(res);
+  }
+
+  /**
+   * Poll the change feed from `since` ("0" = beginning). Drives the mount's
+   * cache invalidation (see the daemon invalidator) — not part of OrgFsApi
+   * since the WebDAV serve layer never needs it.
+   */
+  async changes(since: string, limit?: number): Promise<OrgFsChangePage> {
+    const params: Record<string, string> = { since };
+    if (limit != null) params.limit = String(limit);
+    const res = await this.fetch(this.url("changes", params), {
+      headers: this.headers,
+    });
+    if (!res.ok) return this.fail(res);
+    return (await res.json()) as OrgFsChangePage;
   }
 }

--- a/packages/sandbox/daemon/org-fs/invalidator.test.ts
+++ b/packages/sandbox/daemon/org-fs/invalidator.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { runInvalidator } from "./invalidator";
+
+type Page = { entries: { parent: string }[]; cursor: string; hasMore: boolean };
+
+/**
+ * Drives runInvalidator over a scripted sequence of change-feed pages, then
+ * aborts once the script is exhausted. Returns the dirs passed to forget().
+ */
+async function drive(pages: Page[]) {
+  const ac = new AbortController();
+  const forgotten: string[] = [];
+  const seen: string[] = []; // cursors requested, in order
+  let i = 0;
+  await runInvalidator({
+    changes: async (since) => {
+      seen.push(since);
+      if (i < pages.length) return pages[i++]!;
+      ac.abort(); // script done — stop the loop after this empty tail
+      return { entries: [], cursor: since, hasMore: false };
+    },
+    forget: async (dir) => {
+      forgotten.push(dir);
+    },
+    signal: ac.signal,
+    pollMs: 0,
+  });
+  return { forgotten, seen };
+}
+
+describe("runInvalidator", () => {
+  it("primes to head without forgetting, then forgets parents of new changes", async () => {
+    const { forgotten } = await drive([
+      // priming drain (hasMore=false ends priming) — must NOT forget
+      {
+        entries: [{ parent: "" }, { parent: "a" }],
+        cursor: "2",
+        hasMore: false,
+      },
+      // a real post-prime change → forget its parent dir
+      { entries: [{ parent: "a/b" }], cursor: "3", hasMore: false },
+    ]);
+    expect(forgotten).toEqual(["a/b"]);
+  });
+
+  it("dedupes multiple changes in the same dir to one forget", async () => {
+    const { forgotten } = await drive([
+      { entries: [], cursor: "0", hasMore: false }, // prime (empty)
+      {
+        entries: [{ parent: "x" }, { parent: "x" }, { parent: "y" }],
+        cursor: "5",
+        hasMore: false,
+      },
+    ]);
+    expect(forgotten.sort()).toEqual(["x", "y"]);
+  });
+
+  it("advances the cursor across pages (no re-reading from 0)", async () => {
+    const { seen } = await drive([
+      { entries: [], cursor: "10", hasMore: false }, // prime → cursor 10
+      { entries: [{ parent: "z" }], cursor: "11", hasMore: false },
+    ]);
+    // first poll from "0", then from the advanced cursors
+    expect(seen.slice(0, 3)).toEqual(["0", "10", "11"]);
+  });
+
+  it("drains a multi-page backlog (hasMore) before forgetting new changes", async () => {
+    const { forgotten } = await drive([
+      // priming spans two pages (hasMore on the first)
+      { entries: [{ parent: "old1" }], cursor: "1", hasMore: true },
+      { entries: [{ parent: "old2" }], cursor: "2", hasMore: false },
+      // only this post-prime change is forgotten
+      { entries: [{ parent: "new" }], cursor: "3", hasMore: false },
+    ]);
+    expect(forgotten).toEqual(["new"]);
+  });
+});

--- a/packages/sandbox/daemon/org-fs/invalidator.test.ts
+++ b/packages/sandbox/daemon/org-fs/invalidator.test.ts
@@ -5,11 +5,11 @@ type Page = { entries: { parent: string }[]; cursor: string; hasMore: boolean };
 
 /**
  * Drives runInvalidator over a scripted sequence of change-feed pages, then
- * aborts once the script is exhausted. Returns the dirs passed to forget().
+ * aborts once the script is exhausted. Returns the dirs passed to refresh().
  */
 async function drive(pages: Page[]) {
   const ac = new AbortController();
-  const forgotten: string[] = [];
+  const refreshed: string[] = [];
   const seen: string[] = []; // cursors requested, in order
   let i = 0;
   await runInvalidator({
@@ -19,32 +19,32 @@ async function drive(pages: Page[]) {
       ac.abort(); // script done — stop the loop after this empty tail
       return { entries: [], cursor: since, hasMore: false };
     },
-    forget: async (dir) => {
-      forgotten.push(dir);
+    refresh: async (dir) => {
+      refreshed.push(dir);
     },
     signal: ac.signal,
     pollMs: 0,
   });
-  return { forgotten, seen };
+  return { refreshed, seen };
 }
 
 describe("runInvalidator", () => {
-  it("primes to head without forgetting, then forgets parents of new changes", async () => {
-    const { forgotten } = await drive([
-      // priming drain (hasMore=false ends priming) — must NOT forget
+  it("primes to head without refreshing, then refreshes parents of new changes", async () => {
+    const { refreshed } = await drive([
+      // priming drain (hasMore=false ends priming) — must NOT refresh
       {
         entries: [{ parent: "" }, { parent: "a" }],
         cursor: "2",
         hasMore: false,
       },
-      // a real post-prime change → forget its parent dir
+      // a real post-prime change → refresh its parent dir
       { entries: [{ parent: "a/b" }], cursor: "3", hasMore: false },
     ]);
-    expect(forgotten).toEqual(["a/b"]);
+    expect(refreshed).toEqual(["a/b"]);
   });
 
-  it("dedupes multiple changes in the same dir to one forget", async () => {
-    const { forgotten } = await drive([
+  it("dedupes multiple changes in the same dir to one refresh", async () => {
+    const { refreshed } = await drive([
       { entries: [], cursor: "0", hasMore: false }, // prime (empty)
       {
         entries: [{ parent: "x" }, { parent: "x" }, { parent: "y" }],
@@ -52,7 +52,7 @@ describe("runInvalidator", () => {
         hasMore: false,
       },
     ]);
-    expect(forgotten.sort()).toEqual(["x", "y"]);
+    expect(refreshed.sort()).toEqual(["x", "y"]);
   });
 
   it("advances the cursor across pages (no re-reading from 0)", async () => {
@@ -64,14 +64,14 @@ describe("runInvalidator", () => {
     expect(seen.slice(0, 3)).toEqual(["0", "10", "11"]);
   });
 
-  it("drains a multi-page backlog (hasMore) before forgetting new changes", async () => {
-    const { forgotten } = await drive([
+  it("drains a multi-page backlog (hasMore) before refreshing new changes", async () => {
+    const { refreshed } = await drive([
       // priming spans two pages (hasMore on the first)
       { entries: [{ parent: "old1" }], cursor: "1", hasMore: true },
       { entries: [{ parent: "old2" }], cursor: "2", hasMore: false },
-      // only this post-prime change is forgotten
+      // only this post-prime change is refreshed
       { entries: [{ parent: "new" }], cursor: "3", hasMore: false },
     ]);
-    expect(forgotten).toEqual(["new"]);
+    expect(refreshed).toEqual(["new"]);
   });
 });

--- a/packages/sandbox/daemon/org-fs/invalidator.ts
+++ b/packages/sandbox/daemon/org-fs/invalidator.ts
@@ -1,0 +1,101 @@
+/**
+ * Near-realtime mount freshness for an org-fs volume.
+ *
+ * WebDAV has no ChangeNotify, so rclone can't learn about *external* writes on
+ * its own — its only lever is the dir-cache TTL (a blunt time bound). This
+ * closes that gap: poll the mesh change feed (`/api/:org/fs/:volume/changes`,
+ * a single indexed query — NOT a directory re-listing) and, for every changed
+ * path, tell rclone via its rc API to `vfs/forget` that path's parent dir. The
+ * next access re-lists only that dir, picking up adds/deletes and (via the
+ * refreshed modtime) modified content.
+ *
+ * Result: external changes surface in ~1 poll interval instead of a dir-cache
+ * TTL. The poll is the interim trigger; a NATS nudge can later wake this loop
+ * instantly (the codebase's NatsNotify + polling-safety-net pattern), removing
+ * the steady-state poll without changing the forget logic.
+ *
+ * Deps are injected so the loop is unit-testable without a real mesh or rclone.
+ */
+
+import { sleep } from "@decocms/std";
+
+export interface InvalidatorDeps {
+  /** Poll the change feed from `since` ("0" = beginning). */
+  changes: (since: string) => Promise<{
+    entries: { parent: string }[];
+    cursor: string;
+    hasMore: boolean;
+  }>;
+  /** Invalidate one directory's cached listing (rclone `vfs/forget dir=`). */
+  forget: (dir: string) => Promise<void>;
+  /** Aborts the loop (mount teardown). */
+  signal: AbortSignal;
+  /** Idle poll interval; default 1s. */
+  pollMs?: number;
+  log?: (msg: string, err?: unknown) => void;
+}
+
+const DEFAULT_POLL_MS = 1000;
+
+/**
+ * Run until `signal` aborts. First drains the feed to its head WITHOUT
+ * forgetting (the mount's initial listing already reflects that state), then
+ * forgets the parent dir of every subsequent change. Never throws.
+ */
+export async function runInvalidator(deps: InvalidatorDeps): Promise<void> {
+  const pollMs = deps.pollMs ?? DEFAULT_POLL_MS;
+  const log = deps.log ?? (() => {});
+  let since = "0";
+  let primed = false;
+
+  while (!deps.signal.aborted) {
+    let page: Awaited<ReturnType<InvalidatorDeps["changes"]>>;
+    try {
+      page = await deps.changes(since);
+    } catch (err) {
+      // rclone rc not up yet, transient mesh error, etc. — back off and retry.
+      log("change-feed poll failed", err);
+      await sleep(pollMs, { signal: deps.signal }).catch(() => {});
+      continue;
+    }
+
+    if (primed && page.entries.length > 0) {
+      // Dedupe: many changes in one dir collapse to a single forget.
+      const dirs = new Set(page.entries.map((e) => e.parent));
+      for (const dir of dirs) {
+        if (deps.signal.aborted) break;
+        try {
+          await deps.forget(dir);
+        } catch (err) {
+          log(`vfs/forget failed for "${dir}"`, err);
+        }
+      }
+    }
+
+    since = page.cursor;
+    if (!page.hasMore) {
+      primed = true; // caught up to head; everything after this is a real change
+      await sleep(pollMs, { signal: deps.signal }).catch(() => {});
+    }
+    // hasMore → loop immediately to drain the backlog.
+  }
+}
+
+/**
+ * The real `forget`: POST rclone's rc `vfs/forget`. Loopback + `--rc-no-auth`
+ * (same trust boundary as the loopback WebDAV server). An empty `dir` (a
+ * root-level change) forgets the whole VFS, which re-lists the root on next
+ * access — rare and cheap enough.
+ */
+export function makeRcForget(rcUrl: string) {
+  return async (dir: string): Promise<void> => {
+    const res = await fetch(`${rcUrl}/vfs/forget`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(dir ? { dir } : {}),
+    });
+    if (!res.ok) {
+      throw new Error(`vfs/forget ${res.status}: ${await res.text()}`);
+    }
+  };
+}

--- a/packages/sandbox/daemon/org-fs/invalidator.ts
+++ b/packages/sandbox/daemon/org-fs/invalidator.ts
@@ -5,14 +5,20 @@
  * its own — its only lever is the dir-cache TTL (a blunt time bound). This
  * closes that gap: poll the mesh change feed (`/api/:org/fs/:volume/changes`,
  * a single indexed query — NOT a directory re-listing) and, for every changed
- * path, tell rclone via its rc API to `vfs/forget` that path's parent dir. The
- * next access re-lists only that dir, picking up adds/deletes and (via the
- * refreshed modtime) modified content.
+ * path, tell rclone via its rc API to `vfs/refresh` that path's parent dir.
+ * That re-lists only that dir, picking up adds/deletes and (via the refreshed
+ * modtime) modified content.
+ *
+ * `vfs/refresh`, NOT `vfs/forget`: forget drops VFS nodes (it's a memory
+ * reclaim), which kills handles open on them — and the mount's own writes echo
+ * through the change feed, so forget would sever a file mid-write (observed on
+ * macOS NFS: hung writer + an empty flushed file). Refresh re-lists in place;
+ * open handles and dirty cache entries survive.
  *
  * Result: external changes surface in ~1 poll interval instead of a dir-cache
  * TTL. The poll is the interim trigger; a NATS nudge can later wake this loop
  * instantly (the codebase's NatsNotify + polling-safety-net pattern), removing
- * the steady-state poll without changing the forget logic.
+ * the steady-state poll without changing the refresh logic.
  *
  * Deps are injected so the loop is unit-testable without a real mesh or rclone.
  */
@@ -26,8 +32,8 @@ export interface InvalidatorDeps {
     cursor: string;
     hasMore: boolean;
   }>;
-  /** Invalidate one directory's cached listing (rclone `vfs/forget dir=`). */
-  forget: (dir: string) => Promise<void>;
+  /** Re-list one directory's cached entries (rclone `vfs/refresh dir=`). */
+  refresh: (dir: string) => Promise<void>;
   /** Aborts the loop (mount teardown). */
   signal: AbortSignal;
   /** Idle poll interval; default 1s. */
@@ -39,8 +45,8 @@ const DEFAULT_POLL_MS = 1000;
 
 /**
  * Run until `signal` aborts. First drains the feed to its head WITHOUT
- * forgetting (the mount's initial listing already reflects that state), then
- * forgets the parent dir of every subsequent change. Never throws.
+ * refreshing (the mount's initial listing already reflects that state), then
+ * refreshes the parent dir of every subsequent change. Never throws.
  */
 export async function runInvalidator(deps: InvalidatorDeps): Promise<void> {
   const pollMs = deps.pollMs ?? DEFAULT_POLL_MS;
@@ -60,14 +66,14 @@ export async function runInvalidator(deps: InvalidatorDeps): Promise<void> {
     }
 
     if (primed && page.entries.length > 0) {
-      // Dedupe: many changes in one dir collapse to a single forget.
+      // Dedupe: many changes in one dir collapse to a single refresh.
       const dirs = new Set(page.entries.map((e) => e.parent));
       for (const dir of dirs) {
         if (deps.signal.aborted) break;
         try {
-          await deps.forget(dir);
+          await deps.refresh(dir);
         } catch (err) {
-          log(`vfs/forget failed for "${dir}"`, err);
+          log(`vfs/refresh failed for "${dir}"`, err);
         }
       }
     }
@@ -82,20 +88,19 @@ export async function runInvalidator(deps: InvalidatorDeps): Promise<void> {
 }
 
 /**
- * The real `forget`: POST rclone's rc `vfs/forget`. Loopback + `--rc-no-auth`
+ * The real `refresh`: POST rclone's rc `vfs/refresh`. Loopback + `--rc-no-auth`
  * (same trust boundary as the loopback WebDAV server). An empty `dir` (a
- * root-level change) forgets the whole VFS, which re-lists the root on next
- * access — rare and cheap enough.
+ * root-level change) refreshes the root listing.
  */
-export function makeRcForget(rcUrl: string) {
+export function makeRcRefresh(rcUrl: string) {
   return async (dir: string): Promise<void> => {
-    const res = await fetch(`${rcUrl}/vfs/forget`, {
+    const res = await fetch(`${rcUrl}/vfs/refresh`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(dir ? { dir } : {}),
     });
     if (!res.ok) {
-      throw new Error(`vfs/forget ${res.status}: ${await res.text()}`);
+      throw new Error(`vfs/refresh ${res.status}: ${await res.text()}`);
     }
   };
 }

--- a/packages/sandbox/daemon/org-fs/mount-manager.test.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.test.ts
@@ -3,12 +3,27 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
+  type InvalidatorFactory,
   type Mounter,
   MountManager,
   type OrgFsMountConfig,
   resolveMountPath,
 } from "./mount-manager";
 import { parseOrgFsConfig } from "./config";
+
+/**
+ * Records invalidator start/stop per volume; never polls or touches rclone rc
+ * (keeps these unit tests network-free).
+ */
+function fakeInvalidators() {
+  const started: { volume: string; rcUrl: string }[] = [];
+  const stopped: string[] = [];
+  const factory: InvalidatorFactory = ({ volume, rcUrl }) => {
+    started.push({ volume, rcUrl });
+    return { stop: () => stopped.push(volume) };
+  };
+  return { factory, started, stopped };
+}
 
 describe("parseOrgFsConfig", () => {
   const valid = JSON.stringify({
@@ -105,7 +120,8 @@ describe("MountManager", () => {
 
   it("serves + mounts each volume, then unmounts + stops on stop()", async () => {
     const { mounter, calls, unmounted } = fakeMounter();
-    const mm = new MountManager(mounter, () => {});
+    const inv = fakeInvalidators();
+    const mm = new MountManager(mounter, () => {}, inv.factory);
     await mm.start(
       config([
         { volume: "skills", path: "skills" },
@@ -128,9 +144,18 @@ describe("MountManager", () => {
         .map((m) => m.volume)
         .sort(),
     ).toEqual(["skills", "things"]);
+    // an invalidator was started per mounted volume, each pointed at a
+    // loopback rclone rc URL
+    expect(inv.started.map((s) => s.volume).sort()).toEqual([
+      "skills",
+      "things",
+    ]);
+    for (const s of inv.started)
+      expect(s.rcUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
 
     await mm.stop();
     expect(unmounted.length).toBe(2);
+    expect(inv.stopped.sort()).toEqual(["skills", "things"]);
     expect(mm.list()).toEqual([]);
   });
 
@@ -138,7 +163,8 @@ describe("MountManager", () => {
     const { mounter, unmounted } = fakeMounter({
       failVolumes: new Set(["bad"]),
     });
-    const mm = new MountManager(mounter, () => {});
+    const inv = fakeInvalidators();
+    const mm = new MountManager(mounter, () => {}, inv.factory);
     await mm.start(
       config([
         { volume: "good", path: "good" },
@@ -148,15 +174,19 @@ describe("MountManager", () => {
     );
     // only the good one is active; the failed one's server was torn down
     expect(mm.list().map((m) => m.volume)).toEqual(["good"]);
+    // no invalidator for the failed mount
+    expect(inv.started.map((s) => s.volume)).toEqual(["good"]);
     await mm.stop();
     expect(unmounted).toEqual([join(appRoot, "org/good")]);
   });
 
   it("skips a mount whose path escapes appRoot without mounting it", async () => {
     const { mounter, calls } = fakeMounter();
-    const mm = new MountManager(mounter, () => {});
+    const inv = fakeInvalidators();
+    const mm = new MountManager(mounter, () => {}, inv.factory);
     await mm.start(config([{ volume: "evil", path: "../../etc" }]), appRoot);
     expect(calls.length).toBe(0);
+    expect(inv.started).toEqual([]);
     expect(mm.list()).toEqual([]);
   });
 });

--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -17,6 +17,7 @@
  */
 
 import { mkdirSync } from "node:fs";
+import * as net from "node:net";
 import { join, isAbsolute } from "node:path";
 import { safePath } from "../paths";
 // Portable serve-layer leaves from the mesh workspace (same cross-package
@@ -24,6 +25,7 @@ import { safePath } from "../paths";
 import { OrgFsClient } from "../../../../apps/mesh/src/file-storage/mount/client";
 import { createWebdavHandler } from "../../../../apps/mesh/src/file-storage/mount/webdav";
 import type { OrgFsMountConfig } from "./config";
+import { makeRcForget, runInvalidator } from "./invalidator";
 
 export type { OrgFsMountConfig, OrgFsVolumeMount } from "./config";
 
@@ -32,16 +34,73 @@ export interface MountHandle {
   unmount(): Promise<void>;
 }
 
-/** Has the OS mount the loopback WebDAV URL at `mountPath` (impl in mounter.ts). */
+/**
+ * Has the OS mount the loopback WebDAV URL at `mountPath` (impl in mounter.ts).
+ * `rcAddr`, when set, is where rclone should expose its control API so the
+ * invalidator can drive `vfs/forget`.
+ */
 export interface Mounter {
-  mount(opts: { webdavUrl: string; mountPath: string }): Promise<MountHandle>;
+  mount(opts: {
+    webdavUrl: string;
+    mountPath: string;
+    rcAddr?: string;
+  }): Promise<MountHandle>;
 }
+
+/** Background cache-invalidation for one mounted volume. */
+export interface VolumeInvalidator {
+  stop(): void;
+}
+
+/**
+ * Starts near-realtime invalidation for a freshly-mounted volume. Injected so
+ * MountManager's orchestration is unit-testable without a real rclone rc or
+ * mesh (mirrors the `Mounter` seam).
+ */
+export type InvalidatorFactory = (opts: {
+  client: OrgFsClient;
+  rcUrl: string;
+  volume: string;
+  log: (msg: string, err?: unknown) => void;
+}) => VolumeInvalidator;
+
+/** Real factory: poll the change feed → rclone `vfs/forget` (see invalidator.ts). */
+const defaultInvalidatorFactory: InvalidatorFactory = ({
+  client,
+  rcUrl,
+  log,
+}) => {
+  const ac = new AbortController();
+  void runInvalidator({
+    changes: (since) => client.changes(since),
+    forget: makeRcForget(rcUrl),
+    signal: ac.signal,
+    log,
+  });
+  return { stop: () => ac.abort() };
+};
 
 interface ActiveMount {
   volume: string;
   mountPath: string;
   stopServer: () => void;
   handle: MountHandle;
+  invalidator: VolumeInvalidator;
+}
+
+/** Bind :0 to grab a free loopback port for rclone's rc, then release it. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const port = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) =>
+        err || !port ? reject(err ?? new Error("no free port")) : resolve(port),
+      );
+    });
+  });
 }
 
 /**
@@ -64,6 +123,7 @@ export class MountManager {
     private readonly mounter: Mounter,
     private readonly log: (msg: string, err?: unknown) => void = (m, e) =>
       e ? console.warn(`[org-fs] ${m}`, e) : console.log(`[org-fs] ${m}`),
+    private readonly startInvalidator: InvalidatorFactory = defaultInvalidatorFactory,
   ) {}
 
   /** Serve + mount every configured volume. Never throws. */
@@ -92,12 +152,25 @@ export class MountManager {
         const webdavUrl = `http://127.0.0.1:${server.port}`;
 
         try {
-          const handle = await this.mounter.mount({ webdavUrl, mountPath });
+          const rcAddr = `127.0.0.1:${await freePort()}`;
+          const handle = await this.mounter.mount({
+            webdavUrl,
+            mountPath,
+            rcAddr,
+          });
+          // Near-realtime freshness: feed-driven vfs/forget against rclone's rc.
+          const invalidator = this.startInvalidator({
+            client,
+            rcUrl: `http://${rcAddr}`,
+            volume: m.volume,
+            log: this.log,
+          });
           this.active.push({
             volume: m.volume,
             mountPath,
             stopServer: () => server.stop(true),
             handle,
+            invalidator,
           });
           this.log(`mounted ${m.volume} at ${mountPath}`);
         } catch (err) {
@@ -116,6 +189,11 @@ export class MountManager {
     this.active = [];
     await Promise.all(
       mounts.map(async (a) => {
+        try {
+          a.invalidator.stop();
+        } catch {
+          // already stopped
+        }
         try {
           await a.handle.unmount();
         } catch (err) {

--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -25,7 +25,7 @@ import { safePath } from "../paths";
 import { OrgFsClient } from "../../../../apps/mesh/src/file-storage/mount/client";
 import { createWebdavHandler } from "../../../../apps/mesh/src/file-storage/mount/webdav";
 import type { OrgFsMountConfig } from "./config";
-import { makeRcForget, runInvalidator } from "./invalidator";
+import { makeRcRefresh, runInvalidator } from "./invalidator";
 
 export type { OrgFsMountConfig, OrgFsVolumeMount } from "./config";
 
@@ -37,7 +37,7 @@ export interface MountHandle {
 /**
  * Has the OS mount the loopback WebDAV URL at `mountPath` (impl in mounter.ts).
  * `rcAddr`, when set, is where rclone should expose its control API so the
- * invalidator can drive `vfs/forget`.
+ * invalidator can drive `vfs/refresh`.
  */
 export interface Mounter {
   mount(opts: {
@@ -64,7 +64,7 @@ export type InvalidatorFactory = (opts: {
   log: (msg: string, err?: unknown) => void;
 }) => VolumeInvalidator;
 
-/** Real factory: poll the change feed → rclone `vfs/forget` (see invalidator.ts). */
+/** Real factory: poll the change feed → rclone `vfs/refresh` (see invalidator.ts). */
 const defaultInvalidatorFactory: InvalidatorFactory = ({
   client,
   rcUrl,
@@ -73,7 +73,7 @@ const defaultInvalidatorFactory: InvalidatorFactory = ({
   const ac = new AbortController();
   void runInvalidator({
     changes: (since) => client.changes(since),
-    forget: makeRcForget(rcUrl),
+    refresh: makeRcRefresh(rcUrl),
     signal: ac.signal,
     log,
   });
@@ -158,7 +158,7 @@ export class MountManager {
             mountPath,
             rcAddr,
           });
-          // Near-realtime freshness: feed-driven vfs/forget against rclone's rc.
+          // Near-realtime freshness: feed-driven vfs/refresh against rclone's rc.
           const invalidator = this.startInvalidator({
             client,
             rcUrl: `http://${rcAddr}`,

--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -7,38 +7,50 @@
  *
  * rclone reads the WebDAV server via an env-config remote ("wd:") — the
  * connection-string form breaks on the URL's colons — and `--vfs-cache-mode
- * full` gives the lazy per-file fetch + write-back. Mounting is daemonized so
- * the spawn returns immediately; the mount runs detached until `unmount()`.
+ * full` gives the lazy per-file fetch + write-back. When an `rcAddr` is given,
+ * rclone also exposes its control API there so the invalidator can drive
+ * `vfs/forget` for near-realtime freshness.
+ *
+ * rclone runs in the FOREGROUND (not `--daemon`): `mount --rc --daemon` is
+ * broken in rclone (the launcher hangs and never attaches the mount), so we
+ * keep rclone as a managed child and wait for the mount to come up via the rc
+ * API instead of awaiting the launcher's exit. `unmount()` detaches the OS
+ * mount and kills the child.
  *
  * `rclonePath` must point at a real rclone binary with mount support (the
  * Homebrew build notably lacks it). When rclone isn't available the daemon
  * should not construct this — see MountManager (mounting is then skipped).
  */
 
+import { sleep } from "@decocms/std";
 import type { MountHandle, Mounter } from "./mount-manager";
+
+/** How long to wait for the mount to attach before giving up. */
+const READY_TIMEOUT_MS = 15_000;
+const READY_POLL_MS = 200;
 
 export function createRcloneMounter(rclonePath: string): Mounter {
   const isMac = process.platform === "darwin";
   return {
-    async mount({ webdavUrl, mountPath }) {
+    async mount({ webdavUrl, mountPath, rcAddr }) {
       const args = isMac
         ? ["nfsmount", "wd:", mountPath]
         : ["mount", "wd:", mountPath];
+      const rcArgs = rcAddr
+        ? ["--rc", "--rc-addr", rcAddr, "--rc-no-auth"]
+        : [];
       const proc = Bun.spawn(
         [
           rclonePath,
           ...args,
           "--vfs-cache-mode",
           "full",
-          // WebDAV has no ChangeNotify, so freshness for *external* writes is
-          // bounded by this dir-cache TTL (rclone defaults to 5m — far too
-          // stale for a shared fs). 10s is the interim; a change-feed-driven
-          // `vfs/forget` over rclone's rc API will make it near-instant and let
-          // this relax back to a long safety net.
+          // Safety-net TTL if the invalidator isn't running or misses a change;
+          // the change-feed-driven vfs/forget (invalidator.ts) is what makes
+          // external writes show up in ~1s.
           "--dir-cache-time",
           "10s",
-          "--daemon",
-          "--daemon-timeout=30s",
+          ...rcArgs,
         ],
         {
           env: {
@@ -51,21 +63,69 @@ export function createRcloneMounter(rclonePath: string): Mounter {
           stderr: "ignore",
         },
       );
-      // `--daemon` forks rclone and the launcher exits; await that exit.
-      const code = await proc.exited;
-      if (code !== 0) {
-        throw new Error(`rclone ${args[0]} exited ${code} for ${mountPath}`);
+      try {
+        await waitForMount(proc, rcAddr, args[0]!, mountPath);
+      } catch (err) {
+        proc.kill();
+        throw err;
       }
-      return makeHandle(mountPath, isMac);
+      return makeHandle(proc, mountPath, isMac);
     },
   };
 }
 
-function makeHandle(mountPath: string, isMac: boolean): MountHandle {
+/**
+ * Resolve once the mount is live. With an rc address, poll `vfs/list` until a
+ * VFS is registered (mount attached); without one, fall back to a short grace
+ * wait. Throws if rclone exits early (mount failed) or the deadline passes.
+ */
+async function waitForMount(
+  proc: { exitCode: number | null; exited: Promise<number> },
+  rcAddr: string | undefined,
+  subcommand: string,
+  mountPath: string,
+): Promise<void> {
+  if (!rcAddr) {
+    await sleep(1000);
+    if (proc.exitCode !== null) {
+      throw new Error(`rclone ${subcommand} exited ${proc.exitCode}`);
+    }
+    return;
+  }
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      throw new Error(
+        `rclone ${subcommand} exited ${proc.exitCode} before mounting ${mountPath}`,
+      );
+    }
+    try {
+      const res = await fetch(`http://${rcAddr}/vfs/list`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      if (res.ok) {
+        const body = (await res.json()) as { vfses?: string[] };
+        if (Array.isArray(body.vfses) && body.vfses.length > 0) return;
+      }
+    } catch {
+      // rc server not up yet — keep polling.
+    }
+    await sleep(READY_POLL_MS);
+  }
+  throw new Error(`rclone ${subcommand} not ready for ${mountPath} in time`);
+}
+
+function makeHandle(
+  proc: { kill: () => void; exited: Promise<number> },
+  mountPath: string,
+  isMac: boolean,
+): MountHandle {
   return {
     async unmount() {
-      // NFS + FUSE both unmount via `umount`; on Linux `fusermount -u` is the
-      // unprivileged path for a FUSE mount, so try it first there.
+      // Detach the OS mount first; NFS + FUSE both unmount via `umount`, and on
+      // Linux `fusermount -u` is the unprivileged path, so try it first there.
       const cmds: string[][] = isMac
         ? [["umount", "-f", mountPath]]
         : [
@@ -74,8 +134,15 @@ function makeHandle(mountPath: string, isMac: boolean): MountHandle {
           ];
       for (const cmd of cmds) {
         const p = Bun.spawnSync(cmd, { stdout: "ignore", stderr: "ignore" });
-        if (p.exitCode === 0) return;
+        if (p.exitCode === 0) break;
       }
+      // Then stop the foreground rclone child.
+      try {
+        proc.kill();
+      } catch {
+        // already gone
+      }
+      await proc.exited.catch(() => {});
     },
   };
 }

--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -9,7 +9,7 @@
  * connection-string form breaks on the URL's colons — and `--vfs-cache-mode
  * full` gives the lazy per-file fetch + write-back. When an `rcAddr` is given,
  * rclone also exposes its control API there so the invalidator can drive
- * `vfs/forget` for near-realtime freshness.
+ * `vfs/refresh` for near-realtime freshness.
  *
  * rclone runs in the FOREGROUND (not `--daemon`): `mount --rc --daemon` is
  * broken in rclone (the launcher hangs and never attaches the mount), so we
@@ -34,7 +34,10 @@ export function createRcloneMounter(rclonePath: string): Mounter {
   return {
     async mount({ webdavUrl, mountPath, rcAddr }) {
       const args = isMac
-        ? ["nfsmount", "wd:", mountPath]
+        ? // actimeo=1: the macOS NFS client caches dir/file attributes ~5s by
+          // default, which would mask the invalidator's freshness; 1s is cheap
+          // against a loopback server.
+          ["nfsmount", "wd:", mountPath, "--option", "actimeo=1"]
         : ["mount", "wd:", mountPath];
       const rcArgs = rcAddr
         ? ["--rc", "--rc-addr", rcAddr, "--rc-no-auth"]
@@ -46,7 +49,7 @@ export function createRcloneMounter(rclonePath: string): Mounter {
           "--vfs-cache-mode",
           "full",
           // Safety-net TTL if the invalidator isn't running or misses a change;
-          // the change-feed-driven vfs/forget (invalidator.ts) is what makes
+          // the change-feed-driven vfs/refresh (invalidator.ts) is what makes
           // external writes show up in ~1s.
           "--dir-cache-time",
           "10s",

--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -37,7 +37,11 @@ export function createRcloneMounter(rclonePath: string): Mounter {
         ? // actimeo=1: the macOS NFS client caches dir/file attributes ~5s by
           // default, which would mask the invalidator's freshness; 1s is cheap
           // against a loopback server.
-          ["nfsmount", "wd:", mountPath, "--option", "actimeo=1"]
+          // locallocks: rclone's NFS server has no lock daemon (NLM), so apps
+          // that take file locks (sqlite, editors) would hang against it. The
+          // mount is strictly single-client (loopback), so client-local lock
+          // semantics are exact.
+          ["nfsmount", "wd:", mountPath, "--option", "actimeo=1,locallocks"]
         : ["mount", "wd:", mountPath];
       const rcArgs = rcAddr
         ? ["--rc", "--rc-addr", rcAddr, "--rc-no-auth"]


### PR DESCRIPTION
## Summary
Stacked on #3726. Makes the org-fs mount reflect **external** writes in ~1 poll interval instead of waiting out the dir-cache TTL. WebDAV has no ChangeNotify, so the only lever is active invalidation: poll the change feed (built in #3723) and drive rclone's `vfs/forget` over its rc API.

- `OrgFsClient.changes()` — poll `/api/:org/fs/:volume/changes` (cursor + tombstones).
- `invalidator.ts` — prime to head, then `vfs/forget` the parent dir of every new change (deduped). Deps injected → unit-tested without a real mesh/rclone.
- `MountManager` — allocate an rc port per mount, start/stop an invalidator per volume (factory injected, keeps orchestration unit-testable).
- `mounter.ts` — run rclone **foreground**, not `--daemon`: `mount --rc --daemon` hangs the launcher and never attaches the mount in rclone 1.60.1. Wait for readiness via rc `vfs/list`; kill the managed child on unmount.

The 10s `--dir-cache-time` stays as a safety net. A NATS nudge can later replace the poll without changing the forget logic.

## Testing
- Unit: `invalidator.test.ts` (prime/forget/dedupe/cursor) + `mount-manager.test.ts` (invalidator lifecycle), 12/12.
- Live (Linux container against a real dev mesh): external **add 71ms · modify 82ms · delete 450ms** to appear in the mount; clean SIGTERM unmount (exit 0). typecheck + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds near‑realtime freshness to org‑fs mounts by polling the change feed and calling `rclone` rc `vfs/refresh` on changed parent dirs, so external writes show up in ~1s. Runs `rclone` in the foreground with a per‑mount rc endpoint; on macOS NFS, sets `actimeo=1` and `locallocks` for fast attributes and client‑local locking.

- **New Features**
  - `OrgFsClient.changes()` to page `/api/:org/fs/:volume/changes` (cursor, tombstones, `hasMore`).
  - Invalidator loop: prime to head and drain `hasMore`, then dedupe parent dirs and call rc `vfs/refresh` (avoids killing open handles).
  - `MountManager`: allocates a free loopback rc port and starts/stops an invalidator per volume via an injected factory.

- **Refactors**
  - `mounter.ts`: run `rclone` in the foreground; wait for readiness via rc `vfs/list`; kill the child on unmount; enable rc only when `rcAddr` is provided; add macOS NFS `actimeo=1,locallocks`. Keep `--dir-cache-time 10s` as a safety net.

<sup>Written for commit 8e9df8330027e8d6f4e6df6f82c69676c1e15145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

