### PR TITLE
Set executorID in DBOS configuration to use podName from settings

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -51,6 +51,7 @@ DBOS.setConfig({
   // N workers all call DBOS.launch(); the admin server would otherwise fight
   // over port 3001. Re-enable per-process once we need workflow admin HTTP.
   runAdminServer: false,
+  executorID: settings.podName,
 });
 
 const { createApp } = await import("./api/app");


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `executorID` in `DBOS.setConfig` to `settings.podName` so each pod has a stable, unique ID. This prevents cross-pod executor collisions and improves routing and log attribution in multi-pod deployments.

- **Migration**
  - Ensure `settings.podName` is populated for each environment (e.g., via Kubernetes Downward API or env var) so the executor ID isn’t empty.

<sup>Written for commit c5bc85795676e6fa2f09974fc3537d4c2227a13d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

