### PR TITLE
feat(org-fs): per-run output link — org/output → .outputs/<threadId>

### DIFF
--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -15,6 +15,7 @@ import { readConfig } from "./persistence";
 import { MountManager } from "./org-fs/mount-manager";
 import { createRcloneMounter } from "./org-fs/mounter";
 import { parseOrgFsConfig } from "./org-fs/config";
+import { repointOutputLink } from "./org-fs/output-link";
 import { createPortSniffer } from "./process/port-sniffer";
 import { TaskManager } from "./process/task-manager";
 import { PhaseManager } from "./process/phase-manager";
@@ -436,7 +437,16 @@ const lookupDispatchHarness = (id: string, input: unknown) => {
     },
   };
   const harness = factory.create(ctx);
-  return { stream: () => harness.stream(harnessInput) };
+  return {
+    // Share-files-back: point `org/output` at this run's thread subtree of the
+    // outputs volume before the harness can touch it. Awaited so the link is
+    // correct from the run's first write; failures degrade to no link (never
+    // block the run).
+    stream: async function* () {
+      await repointOutputLinkForRun(harnessInput.threadId);
+      yield* harness.stream(harnessInput);
+    },
+  };
 };
 const wsProxy = makeWsUpgrader(getDevPort, { onClientMessage: bumpActivity });
 
@@ -714,6 +724,24 @@ let mountManager: MountManager | null = null;
       .start(orgFs, bootConfig.appRoot)
       .catch((err) => console.warn("[org-fs] mount start failed", err));
   }
+}
+
+/**
+ * Per-run share-files-back link (`org/output` → `.outputs/<threadId>`, see
+ * org-fs/output-link.ts). Gated on the outputs volume being ACTUALLY mounted —
+ * its mount-point dir exists locally even when the mount failed, and linking
+ * into that would silently strand files on local disk. Hoisted declaration:
+ * called from `lookupDispatchHarness` above, which only runs post-boot.
+ */
+async function repointOutputLinkForRun(threadId: string): Promise<void> {
+  const outputsMountPath = join(bootConfig.appRoot, "org", ".outputs");
+  const mounted = mountManager
+    ?.list()
+    .some((m) => m.mountPath === outputsMountPath);
+  if (!mounted) return;
+  await repointOutputLink(bootConfig.appRoot, threadId, (msg, err) =>
+    err ? console.warn(`[org-fs] ${msg}`, err) : console.log(`[org-fs] ${msg}`),
+  );
 }
 
 process.on("SIGTERM", async () => {

--- a/packages/sandbox/daemon/org-fs/output-link.test.ts
+++ b/packages/sandbox/daemon/org-fs/output-link.test.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { lstat, readlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { repointOutputLink } from "./output-link";
+
+describe("repointOutputLink", () => {
+  let appRoot: string;
+  const outputs = () => join(appRoot, "org", ".outputs");
+  const link = () => join(appRoot, "org", "output");
+
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "orgfs-out-"));
+    mkdirSync(outputs(), { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true });
+  });
+
+  it("creates the thread dir and a relative symlink", async () => {
+    await repointOutputLink(appRoot, "thread-1");
+    expect((await lstat(join(outputs(), "thread-1"))).isDirectory()).toBe(true);
+    expect(await readlink(link())).toBe(join(".outputs", "thread-1"));
+  });
+
+  it("repoints to a new thread and is idempotent for the same one", async () => {
+    await repointOutputLink(appRoot, "t1");
+    await repointOutputLink(appRoot, "t2");
+    expect(await readlink(link())).toBe(join(".outputs", "t2"));
+    await repointOutputLink(appRoot, "t2");
+    expect(await readlink(link())).toBe(join(".outputs", "t2"));
+  });
+
+  it("rejects traversal / multi-segment / hidden threadIds", async () => {
+    const logged: string[] = [];
+    for (const bad of ["../evil", "a/b", "..", ".hidden", ""]) {
+      await repointOutputLink(appRoot, bad, (m) => logged.push(m));
+    }
+    await expect(lstat(link())).rejects.toThrow(); // no link created
+    expect(logged.length).toBe(5);
+  });
+
+  it("is a no-op when the outputs mount dir is missing", async () => {
+    rmSync(outputs(), { recursive: true });
+    await repointOutputLink(appRoot, "t1");
+    await expect(lstat(link())).rejects.toThrow();
+    await expect(lstat(join(outputs(), "t1"))).rejects.toThrow();
+  });
+
+  it("refuses to clobber a non-symlink at org/output", async () => {
+    writeFileSync(link(), "real file");
+    const logged: string[] = [];
+    await repointOutputLink(appRoot, "t1", (m) => logged.push(m));
+    expect((await lstat(link())).isFile()).toBe(true);
+    expect(logged[0]).toContain("not a symlink");
+  });
+});

--- a/packages/sandbox/daemon/org-fs/output-link.ts
+++ b/packages/sandbox/daemon/org-fs/output-link.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-run "share files back" link: `<appRoot>/org/output` → `.outputs/<threadId>`.
+ *
+ * The outputs volume is mounted (hidden) at `<appRoot>/org/.outputs`; each run
+ * gets a thread-scoped subdir, so an agent writing to the bare `output/` path
+ * lands its files in that thread's subtree of the org-wide volume. Repointed
+ * per dispatch; concurrent runs in one sandbox share the link (last dispatch
+ * wins). The link target is relative so the tree survives being moved.
+ *
+ * All fs ops are async: the daemon serves the mount's WebDAV layer in-process,
+ * so a synchronous touch of its own mount would deadlock the event loop
+ * (kernel waits on rclone → rclone waits on WebDAV → WebDAV waits on the
+ * blocked event loop). Never throws.
+ */
+
+import { lstat, mkdir, readlink, symlink, unlink } from "node:fs/promises";
+import { join } from "node:path";
+
+/** One path segment, no traversal — threadIds are cluster-issued slugs/UUIDs. */
+const SAFE_THREAD_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export async function repointOutputLink(
+  appRoot: string,
+  threadId: string,
+  log: (msg: string, err?: unknown) => void = () => {},
+): Promise<void> {
+  try {
+    if (!SAFE_THREAD_ID.test(threadId)) {
+      log(`output link skipped: unsafe threadId ${JSON.stringify(threadId)}`);
+      return;
+    }
+    const orgRoot = join(appRoot, "org");
+    const outputsMount = join(orgRoot, ".outputs");
+    // Defense-in-depth (the caller already gates on the live mount): without
+    // the mount, mkdir would silently create local dirs that shadow it later.
+    const mountStat = await lstat(outputsMount).catch(() => null);
+    if (!mountStat?.isDirectory()) return;
+
+    // The thread's subtree in the outputs volume (created through the mount).
+    await mkdir(join(outputsMount, threadId), { recursive: true });
+
+    const link = join(orgRoot, "output");
+    const target = join(".outputs", threadId);
+    const cur = await lstat(link).catch(() => null);
+    if (cur) {
+      if (!cur.isSymbolicLink()) {
+        log(`output link skipped: ${link} exists and is not a symlink`);
+        return;
+      }
+      if ((await readlink(link).catch(() => null)) === target) return;
+      await unlink(link);
+    }
+    await symlink(target, link);
+  } catch (err) {
+    log("output link repoint failed", err);
+  }
+}


### PR DESCRIPTION
## Summary

Completes the share-files-back flow that #3730's `outputs` volume mount enabled: each harness dispatch repoints a relative symlink `<appRoot>/org/output → .outputs/<threadId>`, so an agent writing to the bare `output/` path lands its files in that thread's subtree of the org-wide `outputs` volume (exactly as documented in `provisioning.ts`).

## Design
- **Hook**: `lookupDispatchHarness` (entry.ts) — the repoint is awaited before `harness.stream()` so the link is correct from the run's first write; failures degrade to no link, never block the run.
- **Gate**: only when the outputs volume is **actually mounted** (`mountManager.list()`) — the mount-point dir exists locally even when mounting failed, and linking into it would silently strand files on local disk.
- **Async fs only**: the daemon serves the mount's WebDAV layer in-process; a synchronous touch of its own mount deadlocks the event loop (kernel → rclone → WebDAV → blocked loop). Empirically validated: async `mkdir` through the daemon's own live NFS mount completes in 13ms with no deadlock.
- **Safety**: thread IDs validated to a single path segment (no traversal); an existing non-symlink `output/` is never clobbered; concurrent runs share the link (last dispatch wins — single bare path by design).

## Testing
- 5 new unit tests (real tmpdir fs, no mocks): create+relative target, repoint/idempotency, traversal rejection, missing-mount no-op, non-symlink no-clobber
- `bun test packages/sandbox/` 379 pass / 0 fail; typecheck + lint green
- Async own-mount op validated against a live rclone NFS mount on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repoints `org/output` to `.outputs/<threadId>` per run so writes go to the thread’s folder in the org-wide outputs volume; the link is set before streaming begins and gracefully falls back to no link if needed.

- **New Features**
  - Adds `repointOutputLink(appRoot, threadId)` to create the thread dir and set a relative symlink.
  - Hooks into `lookupDispatchHarness` to await the repoint before the first write.
  - Runs only when the outputs volume is actually mounted; uses async fs to avoid event-loop deadlocks.
  - Safety: validates threadId, never clobbers a non-symlink at `org/output`, logs and no-ops on failure.

<sup>Written for commit 3f3f20a2d37c54b73c625492106009bae0dbad4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

