### PR TITLE
fix(org-fs): drop macOS AppleDouble noise (._*, .DS_Store) at the WebDAV layer

### DIFF
--- a/apps/mesh/src/file-storage/mount/webdav.integration.test.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.integration.test.ts
@@ -85,6 +85,8 @@ async function seed(db: StudioDatabase) {
 describe("WebDAV serve layer (integration, full chain)", () => {
   let db: StudioDatabase;
   let dav: (req: Request) => Promise<Response>;
+  /** Same backing fs, NOT behind the WebDAV junk filter (external writer). */
+  let api: OrgFsClient;
 
   const req = (path: string, init?: RequestInit) =>
     dav(new Request(`http://dav${path}`, init));
@@ -98,14 +100,14 @@ describe("WebDAV serve layer (integration, full chain)", () => {
     await seed(db);
     rmSync(ASSETS_DIR, { recursive: true, force: true });
     const app = buildMeshApp(db);
-    const client = new OrgFsClient({
+    api = new OrgFsClient({
       baseUrl: "http://test",
       orgSlug: SLUG,
       volume: VOLUME,
       token: "test-token",
       fetch: (url, reqInit) => Promise.resolve(app.request(url, reqInit)),
     });
-    dav = createWebdavHandler(client);
+    dav = createWebdavHandler(api);
   });
 
   afterAll(async () => {
@@ -206,5 +208,64 @@ describe("WebDAV serve layer (integration, full chain)", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-length")).toBe("6");
     expect(await res.text()).toBe("");
+  });
+
+  describe("mac junk filter (._* / .DS_Store)", () => {
+    it("accepts-and-drops AppleDouble and .DS_Store PUTs", async () => {
+      // 201 keeps Finder copies working (rclone #7503) — but nothing stored.
+      expect(
+        (await req("/._sidecar.txt", { method: "PUT", body: "xattr blob" }))
+          .status,
+      ).toBe(201);
+      expect(
+        (await req("/.DS_Store", { method: "PUT", body: "finder" })).status,
+      ).toBe(201);
+      expect(await api.stat("._sidecar.txt")).toBeNull();
+      expect(await api.stat(".DS_Store")).toBeNull();
+    });
+
+    it("404s junk reads and no-ops junk DELETE/MOVE", async () => {
+      expect((await req("/._x")).status).toBe(404);
+      expect((await req("/._x", { method: "HEAD" })).status).toBe(404);
+      expect(
+        (await req("/._x", { method: "PROPFIND", headers: { depth: "0" } }))
+          .status,
+      ).toBe(404);
+      expect((await req("/._x", { method: "DELETE" })).status).toBe(204);
+      expect(
+        (
+          await req("/._x", {
+            method: "MOVE",
+            headers: { destination: "http://dav/real.txt" },
+          })
+        ).status,
+      ).toBe(201);
+      expect(await api.stat("real.txt")).toBeNull();
+    });
+
+    it("hides junk that leaked into the volume from listings", async () => {
+      // Written by an external (non-mount) client — pre-filter leftovers.
+      await api.write("._leaked.txt", new TextEncoder().encode("old"));
+      await api.write("real.txt", new TextEncoder().encode("keep"));
+      const res = await req("/", {
+        method: "PROPFIND",
+        headers: { depth: "1" },
+      });
+      const xml = await res.text();
+      expect(xml).toContain("/real.txt");
+      expect(xml).not.toContain("._leaked.txt");
+    });
+
+    it("does not treat dot-files or mid-name underscores as junk", async () => {
+      expect(
+        (await req("/.gitignore", { method: "PUT", body: "node_modules" }))
+          .status,
+      ).toBe(201);
+      expect(
+        (await req("/a._b.txt", { method: "PUT", body: "fine" })).status,
+      ).toBe(201);
+      expect(await (await req("/.gitignore")).text()).toBe("node_modules");
+      expect(await (await req("/a._b.txt")).text()).toBe("fine");
+    });
   });
 });

--- a/apps/mesh/src/file-storage/mount/webdav.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.ts
@@ -32,6 +32,18 @@ function basename(path: string): string {
   return i === -1 ? path : path.slice(i + 1);
 }
 
+/**
+ * macOS metadata noise: AppleDouble xattr sidecars (`._*`) and Finder's
+ * `.DS_Store`. Written through the NFS mount on every mac file operation —
+ * without this they'd sync into the org volume for every other consumer to
+ * see. PUTs are accepted-and-dropped rather than rejected: a failing
+ * AppleDouble write breaks the whole Finder copy (rclone #7503).
+ */
+function isMacJunk(path: string): boolean {
+  const name = basename(path);
+  return name.startsWith("._") || name === ".DS_Store";
+}
+
 /** WebDAV href for a node: leading slash, per-segment encoded, trailing slash for dirs. */
 function hrefFor(path: string, isDir: boolean): string {
   const segs = path === "" ? [] : path.split("/").map(encodeURIComponent);
@@ -124,6 +136,26 @@ export function createWebdavHandler(
     const path = pathFromUrl(req);
     const method = req.method.toUpperCase();
 
+    // mac junk never reaches the backing fs: pretend writes/deletes succeed
+    // (nothing stored), report reads as absent. A MOVE whose *source* is junk
+    // is equally a no-op; a real file moved TO a junk name falls through (a
+    // deliberate rename must not silently lose data).
+    if (isMacJunk(path)) {
+      switch (method) {
+        case "PUT":
+        case "MKCOL":
+        case "MOVE":
+          return new Response(null, { status: 201 });
+        case "DELETE":
+          return new Response(null, { status: 204 });
+        case "GET":
+        case "HEAD":
+        case "PROPFIND":
+          return new Response("Not Found", { status: 404 });
+        // OPTIONS/PROPPATCH/default fall through to the normal handling below.
+      }
+    }
+
     try {
       switch (method) {
         case "OPTIONS":
@@ -139,6 +171,8 @@ export function createWebdavHandler(
           const out = [propResponse(node)];
           if (depth !== "0" && node.kind === "dir") {
             for (const child of await api.listDir(path)) {
+              // Hide junk that leaked into the volume before this filter.
+              if (isMacJunk(child.path)) continue;
               out.push(propResponse(child));
             }
           }


### PR DESCRIPTION
## Summary

During the #3730 mac e2e, writing a file through the mount leaked a `._<name>` AppleDouble sidecar (macOS storing xattrs over xattr-less NFS) into the cloud volume — litter every Linux pod and external consumer then sees. Finder also drops `.DS_Store` everywhere it browses.

This filters them at the mount's WebDAV layer (the only place macOS writes through):

- **PUT/MKCOL → 201 accept-and-drop** — rejecting the AppleDouble write fails the whole Finder copy (rclone #7503), so we pretend success and store nothing
- **GET/HEAD/PROPFIND → 404** — never stored, never visible
- **DELETE → 204 no-op**, **MOVE with junk source → 201 no-op**
- **Listings hide junk that leaked in before this filter**
- A real file deliberately renamed TO a junk name still falls through (never silently lose data)
- Scope is exact: `.gitignore`, `a._b.txt` etc. are untouched

The volume HTTP API is unaffected — this is mount-layer policy only.

## Testing
4 new integration tests (full chain: WebDAV → OrgFsClient → real fs routes → real Postgres): accept-and-drop verified via the unfiltered API client, junk read/delete/move semantics, leaked-junk hiding, and the non-junk boundary cases. 14/14 in the suite; `bun run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters macOS AppleDouble sidecars (`._*`) and `.DS_Store` at the WebDAV mount to stop noisy files from syncing into org volumes. Writes are accepted-and-dropped to keep Finder copies working; junk reads 404; deletes no-op; listings hide pre-existing junk.

- **Bug Fixes**
  - Scope: WebDAV mount only; the volume HTTP API is unchanged.
  - Semantics: `PUT`/`MKCOL`/`MOVE` on junk return 201 without storing; `DELETE` returns 204; `GET`/`HEAD`/`PROPFIND` return 404. Renames to a junk name still write through to avoid data loss.
  - Tests: Added integration tests for accept-and-drop, read/delete/move behavior, leaked-junk hiding, and non-junk boundary cases.

<sup>Written for commit b150fcbe9ec5269b4803e560062ae54685e1f416. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

