### PR TITLE
docs(studio): org filesystem mounts + macOS Network Volumes grant

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/decopilot/overview.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/decopilot/overview.mdx
@@ -68,6 +68,18 @@ Decopilot ships with tools for coordinating work across any scope:
 
 When an agent is backed by a sandbox (a linked GitHub repo), decopilot also gets six **VM tools** — `bash`, `read`, `write`, `edit`, `grep`, `glob` — so it can execute and modify code in that sandbox.
 
+Sandboxes also mount the **organization filesystem** under `org/`: `org/skills` is the org-wide shared library, and `org/output` is the current run's shared output folder. Files written there sync to your organization's cloud storage and are visible to every member and agent; external changes appear inside the sandbox within about a second.
+
+<Callout type="info">
+  **macOS desktop links:** when a sandbox runs on your machine (`deco link`),
+  the `org/` folders are network volumes, and macOS asks once per app for
+  permission to access them. Approve the "access files on a network volume"
+  prompt for your terminal or editor — or enable it manually under **System
+  Settings → Privacy & Security → Files & Folders → _your app_ → Network
+  Volumes**. Without the grant, reads and writes in `org/` fail with
+  "Operation not permitted".
+</Callout>
+
 For the full reference, see [Tools](/en/studio/decopilot/tools).
 
 ---


### PR DESCRIPTION
## Summary

Documents the organization filesystem that sandboxes now mount under `org/` (skills + per-run output, from #3726/#3730/#3750), and the one-time macOS **Network Volumes** TCC grant that desktop-link users need — discovered during the mac e2e: without it, every read/write in `org/` fails with a silent `EPERM`, with no prompt visible if the first one was dismissed.

EN only, per the pt-br sync convention (#3359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the organization filesystem mount under `org/` for sandboxes (`org/skills` shared library, `org/output` per-run output). Adds a macOS Network Volumes permission note for `deco link` users so reads/writes in `org/` work.

- **Migration**
  - macOS: When running a sandbox locally (`deco link`), approve the "access files on a network volume" prompt for your terminal/editor, or enable it in System Settings → Privacy & Security → Files & Folders → your app → Network Volumes.

<sup>Written for commit 726c7a18b3c7c641fcfaf49da5666b2194467850. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

