### PR TITLE
perf(org-fs): push mount reads down to object storage (presign + Range)

### DIFF
--- a/apps/mesh/src/file-storage/mount/api.ts
+++ b/apps/mesh/src/file-storage/mount/api.ts
@@ -26,6 +26,15 @@ export interface OrgFsApi {
   stat(path: string): Promise<OrgFsNode | null>;
   /** Full bytes of a file. Throws OrgFsApiError(404) if not a live file. */
   read(path: string): Promise<Uint8Array>;
+  /**
+   * Stream a file read straight from the byte store (presigned URL), pushing
+   * an optional `Range` header down so only the requested bytes move — where
+   * `read()` buffers every byte through the mesh and this process. Returns
+   * null when no streamable URL is available (presign failed, or dev storage's
+   * inline `data:` URLs); callers then fall back to `read()`. Throws
+   * OrgFsApiError(404) for a missing file.
+   */
+  readResponse?(path: string, range?: string): Promise<Response | null>;
   /** Create/overwrite a file. */
   write(path: string, body: Uint8Array, contentType?: string): Promise<void>;
   /** Create a directory (and ancestors). */

--- a/apps/mesh/src/file-storage/mount/client.ts
+++ b/apps/mesh/src/file-storage/mount/client.ts
@@ -111,6 +111,25 @@ export class OrgFsClient implements OrgFsApi {
     return new Uint8Array(await res.arrayBuffer());
   }
 
+  async readResponse(path: string, range?: string): Promise<Response | null> {
+    const presign = await this.fetch(this.url("read", { path, presign: "1" }), {
+      headers: this.headers,
+    });
+    if (presign.status === 404) return this.fail(presign);
+    if (!presign.ok) return null; // presign unavailable — buffered fallback
+    const { url } = (await presign.json()) as { url: string };
+    // Dev storage presigns to inline `data:` URLs (the full base64 payload) —
+    // no push-down win there; the buffered path is strictly cheaper.
+    if (!/^https?:/i.test(url)) return null;
+    // Global fetch on purpose: the presigned URL is external to the mesh (the
+    // injected fetch only routes the mesh contract).
+    const res = await fetch(url, range ? { headers: { range } } : undefined);
+    if (res.status === 200 || res.status === 206 || res.status === 416) {
+      return res;
+    }
+    return null; // expired/stale URL etc. — the buffered path is authoritative
+  }
+
   async write(
     path: string,
     body: Uint8Array,

--- a/apps/mesh/src/file-storage/mount/webdav.test.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tier: the WebDAV handler's read push-down logic over an in-memory
+ * OrgFsApi (no IO). The full-chain behavior (real routes + Postgres) lives in
+ * webdav.integration.test.ts; this covers the branch that can't be exercised
+ * there (Dev storage presigns to data: URLs, so integration always falls back).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { type OrgFsApi, OrgFsApiError, type OrgFsNode } from "./api";
+import { createWebdavHandler } from "./webdav";
+
+/** Real in-memory fs; `stream` adds a readResponse that honors Range like a
+ *  byte store. `streamed()` reports how many reads the push-down path served. */
+function memFs(opts: { stream?: "ranges" | "null" } = {}) {
+  const files = new Map<string, Uint8Array>();
+  const node = (p: string): OrgFsNode => ({
+    path: p,
+    kind: "file",
+    size: files.get(p)?.length ?? 0,
+    updatedAt: new Date().toISOString(),
+  });
+  let streamed = 0;
+  const api: OrgFsApi = {
+    listDir: async () => [...files.keys()].map(node),
+    stat: async (p) => (files.has(p) ? node(p) : null),
+    read: async (p) => {
+      const b = files.get(p);
+      if (!b) throw new OrgFsApiError(404, "not found");
+      return b;
+    },
+    write: async (p, b) => void files.set(p, b),
+    mkdir: async () => {},
+    remove: async (p) => void files.delete(p),
+    move: async (f, t) => {
+      const b = files.get(f);
+      if (b) files.set(t, b);
+      files.delete(f);
+    },
+  };
+  if (opts.stream === "null") {
+    api.readResponse = async () => null;
+  } else if (opts.stream === "ranges") {
+    api.readResponse = async (p, range) => {
+      const b = files.get(p);
+      if (!b) throw new OrgFsApiError(404, "not found");
+      streamed++;
+      const m = range ? /^bytes=(\d+)-(\d+)$/.exec(range) : null;
+      if (m) {
+        const start = Number(m[1]);
+        if (start >= b.length) return new Response(null, { status: 416 });
+        const end = Math.min(Number(m[2]), b.length - 1);
+        const slice = b.subarray(start, end + 1);
+        return new Response(slice as BodyInit, {
+          status: 206,
+          headers: {
+            "content-length": String(slice.length),
+            "content-range": `bytes ${start}-${end}/${b.length}`,
+          },
+        });
+      }
+      return new Response(b as BodyInit, {
+        status: 200,
+        headers: { "content-length": String(b.length) },
+      });
+    };
+  }
+  return { api, files, streamed: () => streamed };
+}
+
+const enc = (s: string) => new TextEncoder().encode(s);
+
+describe("WebDAV read push-down", () => {
+  it("streams a full GET through readResponse", async () => {
+    const fs = memFs({ stream: "ranges" });
+    fs.files.set("f.txt", enc("0123456789"));
+    const dav = createWebdavHandler(fs.api);
+    const res = await dav(new Request("http://dav/f.txt"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("0123456789");
+    expect(res.headers.get("content-length")).toBe("10");
+    expect(fs.streamed()).toBe(1);
+  });
+
+  it("forwards Range and passes 206 + content-range through", async () => {
+    const fs = memFs({ stream: "ranges" });
+    fs.files.set("f.txt", enc("0123456789"));
+    const dav = createWebdavHandler(fs.api);
+    const res = await dav(
+      new Request("http://dav/f.txt", { headers: { range: "bytes=2-5" } }),
+    );
+    expect(res.status).toBe(206);
+    expect(await res.text()).toBe("2345");
+    expect(res.headers.get("content-range")).toBe("bytes 2-5/10");
+    expect(fs.streamed()).toBe(1);
+  });
+
+  it("maps an unsatisfiable upstream range to 416", async () => {
+    const fs = memFs({ stream: "ranges" });
+    fs.files.set("f.txt", enc("abc"));
+    const dav = createWebdavHandler(fs.api);
+    const res = await dav(
+      new Request("http://dav/f.txt", { headers: { range: "bytes=99-100" } }),
+    );
+    expect(res.status).toBe(416);
+  });
+
+  it("falls back to buffered read when readResponse yields null", async () => {
+    const fs = memFs({ stream: "null" });
+    fs.files.set("f.txt", enc("0123456789"));
+    const dav = createWebdavHandler(fs.api);
+    const full = await dav(new Request("http://dav/f.txt"));
+    expect(full.status).toBe(200);
+    expect(await full.text()).toBe("0123456789");
+    // Range is applied locally on the buffered bytes.
+    const ranged = await dav(
+      new Request("http://dav/f.txt", { headers: { range: "bytes=2-5" } }),
+    );
+    expect(ranged.status).toBe(206);
+    expect(await ranged.text()).toBe("2345");
+  });
+
+  it("buffers via read() when the backend has no readResponse", async () => {
+    const fs = memFs();
+    fs.files.set("f.txt", enc("xyz"));
+    const dav = createWebdavHandler(fs.api);
+    const res = await dav(new Request("http://dav/f.txt"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("xyz");
+  });
+
+  it("404s a push-down read of a missing file", async () => {
+    const fs = memFs({ stream: "ranges" });
+    const dav = createWebdavHandler(fs.api);
+    expect((await dav(new Request("http://dav/nope.txt"))).status).toBe(404);
+  });
+});

--- a/apps/mesh/src/file-storage/mount/webdav.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.ts
@@ -197,6 +197,29 @@ export function createWebdavHandler(
               headers: { ...baseHeaders, "content-length": String(node.size) },
             });
           }
+          // Push the read down to the byte store when the backend can stream
+          // it: presigned URL + Range forwarded, so rclone's chunked reads of
+          // big files don't buffer whole objects through the mesh (or here).
+          if (api.readResponse) {
+            const upstream = await api.readResponse(
+              path,
+              req.headers.get("range") ?? undefined,
+            );
+            if (upstream) {
+              if (upstream.status === 416) {
+                return new Response("Range Not Satisfiable", { status: 416 });
+              }
+              const headers = { ...baseHeaders };
+              for (const h of ["content-length", "content-range"] as const) {
+                const v = upstream.headers.get(h);
+                if (v) headers[h] = v;
+              }
+              return new Response(upstream.body, {
+                status: upstream.status,
+                headers,
+              });
+            }
+          }
           const bytes = await api.read(path);
           const range = parseRange(req.headers.get("range"), bytes.length);
           if (range) {


### PR DESCRIPTION
## Summary

Closes the verified-Important finding from the #3723 review: the mount's WebDAV GET buffered **every byte through the mesh** (and the daemon process) — even when rclone asked for a 1KB chunk of a multi-GB file.

Now:
- `OrgFsClient.readResponse(path, range?)` presigns the read (`/read?presign=1`, the endpoint that's existed since #3723) and fetches the presigned URL directly, forwarding rclone's `Range` header so **only the requested bytes move, mesh-free**
- the WebDAV handler streams the upstream response through (200/206/416 + `content-range` passthrough)
- **fallback is total**: presign failure, expired URLs, or dev storage's inline `data:` URLs → `null` → the existing buffered `read()` path, which stays authoritative. `readResponse` is an optional method on `OrgFsApi`, so in-process adapters are untouched.

## Live verification (real dev mesh + MinIO, 64MiB file)

| | result |
|---|---|
| client ranged read via presign | 206, exact bytes, correct `content-range`, **6ms** |
| WebDAV ranged GET (last 4 bytes of 64MiB) | 206, **6ms** |
| old buffered path (full file through mesh) | 141ms — 24x slower on loopback; far worse over WAN |

## Testing
- 6 new unit tests (in-memory `OrgFsApi`, no mocks): full-GET passthrough, Range→206+content-range, 416 mapping, null-fallback with local Range slicing, absent-method fallback, 404
- 22/22 in the mount suites (incl. full-chain integration vs real Postgres); typecheck green
- Live probe above exercised client + handler against real MinIO

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pushes WebDAV GET reads down to object storage using presigned URLs and `Range`, so only requested bytes move and the mesh no longer buffers entire files. Falls back to the existing buffered path when presigning isn’t available.

- **Performance**
  - Added optional `readResponse(path, range?)` to `OrgFsApi`; `OrgFsClient` presigns via `/read?presign=1` and fetches the external URL with forwarded `Range`.
  - WebDAV handler streams upstream 200/206/416 responses and passes through `content-length`/`content-range`.
  - Full fallback to `read()` on presign failure, non-HTTP URLs (e.g. `data:`), expired URLs, or when `readResponse` is absent.
  - Added unit tests for passthrough, ranged reads, 416 mapping, fallbacks, and 404.

<sup>Written for commit 2e9200b1a3209369ca88813a7d08d4aa8d3547ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

