### PR TITLE
docs(api-reference): remove streaming support details from connection…

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/api-reference/connection-proxy.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/api-reference/connection-proxy.mdx
@@ -169,31 +169,15 @@ Public tools allow unauthenticated access and bypass authorization checks.
 | `500` | Internal Server Error | Unexpected error during request processing |
 | `503` | Service Unavailable | Connection is inactive or upstream server is unreachable |
 
-## Streaming Support
-
-The Connection Proxy supports **streaming tool responses** for HTTP-based connections:
-
-### Streamable Tool Endpoint
-
-```
-POST https://your-mesh-instance.com/api/:org/mcp/:connectionId/call-tool/:toolName
-```
-
-This endpoint allows tools to stream responses back to the client, useful for long-running operations or large data transfers.
-
-<Callout type="warning">
-  Streaming is only supported for HTTP connections. STDIO and VIRTUAL connections fall back to regular tool calls.
-</Callout>
-
 ## Monitoring & Observability
 
 Every request through the Connection Proxy generates:
 
 ### Metrics
 
-- **Duration Histograms**: `connection.proxy.duration` and `connection.proxy.streamable.duration`
-- **Request Counters**: `connection.proxy.requests` and `connection.proxy.streamable.requests`
-- **Error Counters**: `connection.proxy.errors` and `connection.proxy.streamable.errors`
+- **Duration Histograms**: `connection.proxy.duration`
+- **Request Counters**: `connection.proxy.requests`
+- **Error Counters**: `connection.proxy.errors`
 
 All metrics include labels:
 - `connection.id`: The connection UUID
@@ -203,8 +187,7 @@ All metrics include labels:
 ### Traces
 
 OpenTelemetry spans are created for:
-- `mcp.proxy.callTool`: Regular tool invocations
-- `mcp.proxy.callStreamableTool`: Streaming tool invocations
+- `mcp.proxy.callTool`: Tool invocations
 
 Traces include attributes:
 - `connection.id`: Connection identifier

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/api-reference/connection-proxy.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/api-reference/connection-proxy.mdx
@@ -169,31 +169,15 @@ Tools públicas permitem acesso não autenticado e ignoram as verificações de 
 | `500` | Internal Server Error | Erro inesperado durante o processamento da requisição |
 | `503` | Service Unavailable | A connection está inativa ou o servidor upstream está inacessível |
 
-## Suporte a streaming
-
-O Connection Proxy suporta **respostas de tool em streaming** para connections baseadas em HTTP:
-
-### Endpoint de tool streamable
-
-```
-POST https://your-mesh-instance.com/api/:org/mcp/:connectionId/call-tool/:toolName
-```
-
-Esse endpoint permite que tools enviem respostas em streaming ao cliente, útil para operações de longa duração ou transferências grandes de dados.
-
-<Callout type="warning">
-  Streaming só é suportado em connections HTTP. Connections STDIO e VIRTUAL fazem fallback para chamadas de tool regulares.
-</Callout>
-
 ## Monitoramento e observabilidade
 
 Cada requisição pelo Connection Proxy gera:
 
 ### Métricas
 
-- **Histogramas de duração**: `connection.proxy.duration` e `connection.proxy.streamable.duration`
-- **Contadores de requisição**: `connection.proxy.requests` e `connection.proxy.streamable.requests`
-- **Contadores de erro**: `connection.proxy.errors` e `connection.proxy.streamable.errors`
+- **Histogramas de duração**: `connection.proxy.duration`
+- **Contadores de requisição**: `connection.proxy.requests`
+- **Contadores de erro**: `connection.proxy.errors`
 
 Todas as métricas incluem labels:
 - `connection.id`: o UUID da connection
@@ -203,8 +187,7 @@ Todas as métricas incluem labels:
 ### Traces
 
 Spans OpenTelemetry são criados para:
-- `mcp.proxy.callTool`: invocações regulares de tool
-- `mcp.proxy.callStreamableTool`: invocações de tool em streaming
+- `mcp.proxy.callTool`: invocações de tool
 
 Os traces incluem atributos:
 - `connection.id`: identificador da connection

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -262,10 +262,6 @@ export const createProxyRoutes = () => {
         arguments: await c.req.json(),
       });
 
-      if (result instanceof Response) {
-        return result;
-      }
-
       if (result.isError) {
         return new Response(JSON.stringify(result.content), {
           headers: {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -370,10 +370,6 @@ export const withRuntime = <
         toolCallInput,
       });
 
-      if (result instanceof Response) {
-        return result;
-      }
-
       return new Response(JSON.stringify(result), {
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
… proxy documentation

- Removed sections related to streaming tool responses and the streamable tool endpoint from both English and Portuguese documentation.
- Updated metrics and traces sections to reflect the removal of streaming-related metrics and traces.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed streaming support for tool responses in the Connection Proxy. Tool calls now return JSON only; streaming behavior, related metrics, and trace names were removed, and docs updated in EN/PT-BR.

- **Migration**
  - Remove any streaming handlers; use regular tool calls and read the full JSON response.
  - Update dashboards/alerts to drop `connection.proxy.streamable.*` metrics and `mcp.proxy.callStreamableTool` spans.
  - If you relied on HTTP Response passthrough from tool calls, this is no longer returned; responses are always JSON.

<sup>Written for commit 74f467b3f91aace2bb845616481351234d6dad4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

