### PR TITLE
Enhance Better Auth logging and error handling

### DIFF
--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -449,6 +449,20 @@ const MAX_INLINE_AVATAR_LENGTH = 256 * 1024;
 export const auth = betterAuth({
   secret: settings.betterAuthSecret || "deco-default-secret-k7x9m2p4q8w3n5v6",
 
+  // customAPIKeyGetter probes every `Authorization: Bearer …` as an API key,
+  // so OAuth tokens, mesh JWTs and stale keys routinely miss and Better Auth
+  // logs an ERROR + full source-mapped stack on each one — flooding prod logs.
+  // Drop only that expected 401; forward everything else with the same format.
+  logger: {
+    log: (level, message, ...args) => {
+      if (level === "error" && message.includes("validate API key")) return;
+      const line = `${new Date().toISOString()} ${level.toUpperCase()} [Better Auth]: ${message}`;
+      if (level === "error") console.error(line, ...args);
+      else if (level === "warn") console.warn(line, ...args);
+      else console.log(line, ...args);
+    },
+  },
+
   // Base URL for OAuth - will be overridden by request context
   baseURL: baseUrl,
 

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -821,8 +821,28 @@ async function authenticateRequest(
         };
       }
     } catch (error) {
-      const err = error as Error;
-      console.error("[Auth] API key check failed:", err);
+      const err = error as Error & { body?: { code?: string } };
+      // INVALID_API_KEY is expected here (any Bearer token is probed as an API
+      // key). Better Auth's noisy ERROR+stack is suppressed in its logger; emit
+      // one concise line with caller context so a flood can be traced to its
+      // source. Token prefix only — never the full secret.
+      const isInvalidKey =
+        err.body?.code === "INVALID_API_KEY" ||
+        err.message?.includes("Invalid API key");
+      if (isInvalidKey) {
+        console.warn("[Auth] invalid API key (Bearer)", {
+          path: new URL(req.url).pathname,
+          method: req.method,
+          ua: req.headers.get("user-agent") ?? undefined,
+          ip:
+            req.headers.get("x-forwarded-for") ??
+            req.headers.get("x-real-ip") ??
+            undefined,
+          tokenPrefix: token.slice(0, 8),
+        });
+      } else {
+        console.error("[Auth] API key check failed:", err);
+      }
     }
   }
 


### PR DESCRIPTION
- Introduced a custom logger for Better Auth to suppress excessive error logs related to invalid API keys, improving log clarity.
- Updated error handling in the authentication request to provide concise warnings for invalid API keys while maintaining detailed error logging for other failures.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce log noise from `better-auth` by filtering expected invalid API key errors. Keep full error logs for real failures and add concise, contextual warnings.

- **Bug Fixes**
  - Added a custom `better-auth` logger to drop only "validate API key" error spam while preserving other logs.
  - Updated request auth handling to warn on `INVALID_API_KEY` with path, method, UA, IP, and token prefix; non-key errors still log as errors.

<sup>Written for commit 173c10d7df1930dd4c41dc647a7a5782829cf0e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

