### PR TITLE
refactor(observability): remove silent truncation warning from LogRec…

### DIFF
--- a/apps/mesh/src/observability/index.ts
+++ b/apps/mesh/src/observability/index.ts
@@ -111,19 +111,6 @@ class TruncateMonitoringOutputProcessor implements LogRecordProcessor {
     const output = record.attributes?.[outputKey];
     if (typeof output === "string" && output.length > this.maxBytes) {
       const truncated = truncateString(output, this.maxBytes);
-      // Surface the data loss — truncation is otherwise silent. Identifiers +
-      // sizes only; never the payload (PII/volume). Captured by the infra
-      // logger provider (different provider → no emit loop) and subject to
-      // INFRA_LOG_SAMPLE_RATIO.
-      console.warn("[monitoring] output truncated to OTLP cap — data lost", {
-        tool_name: record.attributes?.[MONITORING_LOG_ATTR.TOOL_NAME],
-        organization_id:
-          record.attributes?.[MONITORING_LOG_ATTR.ORGANIZATION_ID],
-        connection_id: record.attributes?.[MONITORING_LOG_ATTR.CONNECTION_ID],
-        request_id: record.attributes?.[MONITORING_LOG_ATTR.REQUEST_ID],
-        originalBytes: Buffer.byteLength(output, "utf8"),
-        maxBytes: this.maxBytes,
-      });
       this.inner.onEmit(
         {
           ...record,


### PR DESCRIPTION
…ordProcessor

- Eliminated console warning for data loss during output truncation in the TruncateMonitoringOutputProcessor class. This change aims to streamline logging and reduce unnecessary noise in the output.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the console warning emitted when monitoring output was truncated, reducing log noise in observability. Truncation limits and processing are unchanged; records are emitted as before, just without the warning.

<sup>Written for commit 036d12ca5b86945cc272678c6d0d312e9eaf4236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

