### PR TITLE
feat(org-fs): cluster sandbox mounts — privileged sidecar + post-bind config relay

### DIFF
--- a/.github/workflows/release-orgfs-sidecar.yaml
+++ b/.github/workflows/release-orgfs-sidecar.yaml
@@ -1,0 +1,113 @@
+name: Release orgfs-sidecar image
+
+# Tag is read back from deploy/helm/sandbox-env/values.yaml (`orgFs.image.tag`)
+# so the chart and the published image can't drift (netinit pattern).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/sandbox/daemon/org-fs/**"
+      - "apps/mesh/src/file-storage/mount/**"
+      - "packages/std/**"
+      - "deploy/helm/sandbox-env/orgfs-sidecar/**"
+      - "deploy/helm/sandbox-env/values.yaml"
+      - ".github/workflows/release-orgfs-sidecar.yaml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/orgfs-sidecar
+
+jobs:
+  build-push:
+    name: Build & Push orgfs-sidecar image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Read image tag from chart values
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(yq -r '.orgFs.image.tag' deploy/helm/sandbox-env/values.yaml)
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+            echo "::error::orgFs.image.tag missing from deploy/helm/sandbox-env/values.yaml"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=sha,format=short
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          # Repo-root context: the image bundles TS from packages/ + apps/mesh.
+          context: .
+          file: ./deploy/helm/sandbox-env/orgfs-sidecar/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      # Catch a Dockerfile regression that would otherwise only surface as a
+      # CrashLoopBackOff sidecar in prod.
+      - name: Smoke-test built image
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker pull --platform linux/amd64 "${IMAGE}"
+          docker run --rm --platform linux/amd64 "${IMAGE}" sh -c '
+            rclone version &&
+            grep -q user_allow_other /etc/fuse.conf &&
+            test -s /srv/sidecar.js
+          '
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with cosign
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $(echo "${TAGS}" | tr ',' '\n'); do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+
+      - name: Generate SLSA build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/apps/mesh/src/file-storage/mount/client.test.ts
+++ b/apps/mesh/src/file-storage/mount/client.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { OrgFsClient } from "./client";
+
+describe("OrgFsClient.readResponse", () => {
+  it("falls back (null) when the presigned host is unreachable", async () => {
+    // The mesh fetch is injected and presigns to a port nothing listens on —
+    // a real refused connection, like a cluster pod given a localhost MinIO
+    // URL. Found by the Stage-2 kind e2e: a propagated error here makes
+    // rclone retry-loop forever instead of using the buffered path.
+    const client = new OrgFsClient({
+      baseUrl: "http://mesh",
+      orgSlug: "acme",
+      volume: "skills",
+      token: "t",
+      fetch: async () =>
+        Response.json({ url: "http://127.0.0.1:1/bucket/key?sig=x" }),
+    });
+    expect(await client.readResponse("f.txt")).toBeNull();
+  });
+
+  it("falls back (null) on non-http presigned URLs (dev data: storage)", async () => {
+    const client = new OrgFsClient({
+      baseUrl: "http://mesh",
+      orgSlug: "acme",
+      volume: "skills",
+      token: "t",
+      fetch: async () => Response.json({ url: "data:text/plain;base64,aGk=" }),
+    });
+    expect(await client.readResponse("f.txt")).toBeNull();
+  });
+});

--- a/apps/mesh/src/file-storage/mount/client.ts
+++ b/apps/mesh/src/file-storage/mount/client.ts
@@ -123,7 +123,15 @@ export class OrgFsClient implements OrgFsApi {
     if (!/^https?:/i.test(url)) return null;
     // Global fetch on purpose: the presigned URL is external to the mesh (the
     // injected fetch only routes the mesh contract).
-    const res = await fetch(url, range ? { headers: { range } } : undefined);
+    let res: Response;
+    try {
+      res = await fetch(url, range ? { headers: { range } } : undefined);
+    } catch {
+      // Presigned host unreachable from THIS network (e.g. a cluster pod or
+      // remote desktop vs a localhost MinIO endpoint) — the mesh can still
+      // reach it, so fall back to the buffered read instead of erroring.
+      return null;
+    }
     if (res.status === 200 || res.status === 206 || res.status === 416) {
       return res;
     }

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -108,6 +108,7 @@ export function resolveConfig(
 
     // Feature Flags
     enableDecoImport: toBool(envVars.ENABLE_DECO_IMPORT),
+    orgFsClusterMounts: toBool(envVars.ORGFS_CLUSTER_MOUNTS),
 
     // Object Storage (S3-compatible)
     s3Endpoint: envVars.S3_ENDPOINT,

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -49,6 +49,9 @@ export interface Settings {
 
   // Feature Flags
   enableDecoImport: boolean;
+  /** Mint org-fs tokens for hosted (agent-sandbox) pods too — only useful
+   *  when the sandbox-env chart runs the org-fs sidecar (orgFs.enabled). */
+  orgFsClusterMounts: boolean;
 
   // Object Storage (S3-compatible)
   s3Endpoint: string | undefined;

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -414,11 +414,16 @@ async function provisionSandbox(
       : null;
 
   // Org-fs mounts: mint an fs-scoped token + build the daemon's ORGFS_CONFIG.
-  // Desktop-only — hosted pods can't mount (the privileged-sidecar path is
-  // separate). Guarded inside the helper: a mint failure → undefined → no
+  // Desktop links always mount; hosted pods only when the cluster runs the
+  // privileged org-fs sidecar (settings.orgFsClusterMounts ↔ the sandbox-env
+  // chart's orgFs.enabled — without the sidecar the minted key would just go
+  // unused). Guarded inside the helper: a mint failure → undefined → no
   // mounting, never breaks provisioning.
+  const wantsOrgFs =
+    runner.kind === "user-desktop" ||
+    (runner.kind === "agent-sandbox" && getSettings().orgFsClusterMounts);
   const orgFsConfigJson =
-    runner.kind === "user-desktop" && ctx.organization?.slug
+    wantsOrgFs && ctx.organization?.slug
       ? await mintOrgFsConfigJson(ctx, {
           orgSlug: ctx.organization.slug,
           orgId,

--- a/deploy/helm/sandbox-env/orgfs-sidecar/Dockerfile
+++ b/deploy/helm/sandbox-env/orgfs-sidecar/Dockerfile
@@ -1,0 +1,30 @@
+# org-fs sidecar: FUSE-mounts organization filesystem volumes inside sandbox
+# pods (see packages/sandbox/daemon/org-fs/sidecar.ts). Runs privileged with
+# Bidirectional mount propagation — see the orgFs block in ../values.yaml.
+#
+# Build context is the REPO ROOT (the bundle pulls TS from packages/ and
+# apps/mesh): docker build -f deploy/helm/sandbox-env/orgfs-sidecar/Dockerfile .
+
+FROM oven/bun:1.3.14-debian AS build
+WORKDIR /repo
+# Only the sidecar's import graph — no full workspace install. @decocms/std is
+# a zero-dependency workspace package; a hand-made node_modules link resolves
+# the specifier without bun install.
+COPY packages/std packages/std
+COPY packages/sandbox/daemon packages/sandbox/daemon
+COPY apps/mesh/src/file-storage/mount apps/mesh/src/file-storage/mount
+RUN mkdir -p node_modules/@decocms \
+  && ln -s ../../packages/std node_modules/@decocms/std \
+  && bun build packages/sandbox/daemon/org-fs/sidecar-main.ts \
+    --target bun --outfile /out/sidecar.js
+
+FROM oven/bun:1.3.14-debian
+LABEL org.opencontainers.image.source="https://github.com/decocms/studio"
+# rclone does the FUSE mounting; user_allow_other lets the unprivileged main
+# container (different uid) read the mounts after propagation.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends rclone fuse3 ca-certificates \
+  && rm -rf /var/lib/apt/lists/* \
+  && echo user_allow_other >> /etc/fuse.conf
+COPY --from=build /out/sidecar.js /srv/sidecar.js
+CMD ["bun", "run", "/srv/sidecar.js"]

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -6,6 +6,9 @@
 # default. The template *name* is suffixed with envName so multiple
 # environments' SandboxTemplates coexist; mesh in this env must reference
 # the suffixed name via STUDIO_SANDBOX_TEMPLATE_NAME.
+{{- if and .Values.orgFs.enabled (not .Values.hostUsers) }}
+{{- fail "orgFs.enabled requires hostUsers=true: privileged sidecar + Bidirectional mount propagation are incompatible with user-namespaced pods" }}
+{{- end }}
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
 metadata:
@@ -198,6 +201,14 @@ spec:
             - name: GIT_CONFIG_VALUE_0
               value: "*"
             {{- end }}
+            {{- if .Values.orgFs.enabled }}
+            # org-fs relay: the daemon writes the mount config here for the
+            # sidecar, and gates the per-run output link on its status file.
+            - name: ORGFS_SIDECAR_CONFIG_PATH
+              value: "/run/orgfs/config.json"
+            - name: ORGFS_SIDECAR_STATUS_PATH
+              value: "/run/orgfs/status.json"
+            {{- end }}
           ports:
             - name: daemon
               containerPort: 9000
@@ -221,6 +232,41 @@ spec:
             {{- end }}
             - name: home
               mountPath: /home/sandbox
+            {{- if .Values.orgFs.enabled }}
+            # The sidecar's FUSE mounts under /app/org surface here.
+            - name: orgfs-org
+              mountPath: /app/org
+              mountPropagation: HostToContainer
+            - name: orgfs-ctl
+              mountPath: /run/orgfs
+            {{- end }}
+        {{- if .Values.orgFs.enabled }}
+        # Privileged org-fs mounter: waits for the daemon to relay the mount
+        # config onto /run/orgfs (post-bind push), FUSE-mounts the org volumes
+        # under the shared /app/org, and Bidirectional propagation surfaces
+        # them in the (unprivileged) sandbox container. See
+        # packages/sandbox/daemon/org-fs/sidecar.ts.
+        - name: orgfs-sidecar
+          image: "{{ .Values.orgFs.image.repository }}:{{ .Values.orgFs.image.tag }}"
+          imagePullPolicy: {{ .Values.orgFs.image.pullPolicy }}
+          env:
+            - name: APP_ROOT
+              value: "/app"
+          securityContext:
+            # FUSE mount + Bidirectional propagation require privileged; root
+            # uid adds nothing on top of that, so keep it simple for fuse.
+            privileged: true
+            runAsUser: 0
+            runAsNonRoot: false
+          resources:
+            {{- toYaml .Values.orgFs.resources | nindent 12 }}
+          volumeMounts:
+            - name: orgfs-org
+              mountPath: /app/org
+              mountPropagation: Bidirectional
+            - name: orgfs-ctl
+              mountPath: /run/orgfs
+        {{- end }}
       volumes:
         {{- if .Values.readOnlyRootFilesystem }}
         # Sized to match the per-container ephemeral-storage limit shape;
@@ -235,3 +281,12 @@ spec:
         - name: home
           emptyDir:
             sizeLimit: 5Gi
+        {{- if .Values.orgFs.enabled }}
+        # Mount surface (volumes attach under it) + relay control files.
+        - name: orgfs-org
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: orgfs-ctl
+          emptyDir:
+            sizeLimit: 1Mi
+        {{- end }}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -180,6 +180,37 @@ dnsConfig:
     - name: ndots
       value: "1"
 
+# ── org-fs sidecar (organization filesystem mounts) ───────────────────
+# Opt-in: a privileged sidecar that FUSE-mounts the org filesystem volumes
+# (skills + outputs) at /app/org/* via WebDAV→rclone, propagated into the
+# unprivileged sandbox container (Bidirectional → HostToContainer). The
+# mount config arrives post-bind: mesh POSTs it to the daemon's
+# /_sandbox/orgfs-config, which relays it onto the shared /run/orgfs
+# control volume the sidecar watches (warm-pool claims reject spec.env,
+# so boot env can't carry it).
+#
+# REQUIRES hostUsers: true — Kubernetes forbids privileged containers in
+# user-namespaced pods, and Bidirectional propagation requires privileged.
+# Enabling this trades the userns-remap hardening for org-fs mounts; the
+# template fails to render otherwise so the trade-off stays explicit.
+# Mesh side: set ORGFS_CLUSTER_MOUNTS=1 on the studio install so it mints
+# org-fs tokens for hosted sandboxes.
+orgFs:
+  enabled: false
+  image:
+    repository: ghcr.io/decocms/studio/orgfs-sidecar
+    # Bump to ship a new sidecar image — release-orgfs-sidecar.yaml reads
+    # this field as the single source of truth (netinit pattern).
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 # ── sandbox-pod hardening ──────────────────────────────────────────────
 # User namespace remap (`spec.hostUsers: false`): UID 1000 inside the pod
 # maps to a high, unprivileged subordinate UID on the node, so a

--- a/deploy/helm/sandbox-operator/vendor.sh
+++ b/deploy/helm/sandbox-operator/vendor.sh
@@ -168,6 +168,48 @@ if ! grep -q '^[[:space:]]*-[[:space:]]*--extensions[[:space:]]*$' "${WORK}/mani
   exit 1
 fi
 
+# Inject the controller pod-template label/annotation hooks (chart values
+# `controller.podLabels` / `controller.podAnnotations` — added in #3519 for
+# annotation-based metrics scraping). Anchor: the 8-space-indented
+# `app: agent-sandbox-controller` line inside the Deployment's
+# `template.metadata.labels` (the top-level metadata and selector copies sit
+# at 4/6 spaces, so the indent disambiguates). Fail-loud check below.
+log "injecting controller podLabels/podAnnotations hooks into manifest.yaml Deployment"
+awk '
+  function flush(   i, is_dep) {
+    if (n == 0) return
+    is_dep = 0
+    for (i = 1; i <= n; i++) {
+      if (buf[i] ~ /^kind:[[:space:]]*Deployment[[:space:]]*$/) { is_dep = 1; break }
+    }
+    for (i = 1; i <= n; i++) {
+      print buf[i]
+      if (is_dep && buf[i] ~ /^        app: agent-sandbox-controller[[:space:]]*$/) {
+        print "        {{- with .Values.controller.podLabels }}"
+        print "        {{- toYaml . | nindent 8 }}"
+        print "        {{- end }}"
+        print "      {{- with .Values.controller.podAnnotations }}"
+        print "      annotations:"
+        print "        {{- toYaml . | nindent 8 }}"
+        print "      {{- end }}"
+      }
+    }
+    print "---"
+    n = 0
+  }
+  /^---[[:space:]]*$/ { flush(); next }
+  { buf[++n] = $0 }
+  END { flush() }
+' "${WORK}/manifest.yaml" > "${WORK}/manifest.patched.yaml"
+sed -i.bak -e '$d' "${WORK}/manifest.patched.yaml" && rm "${WORK}/manifest.patched.yaml.bak"
+mv "${WORK}/manifest.patched.yaml" "${WORK}/manifest.yaml"
+if ! grep -q 'Values.controller.podLabels' "${WORK}/manifest.yaml"; then
+  err "post-patch: controller podLabels/podAnnotations hooks were not injected"
+  err "  upstream may have changed the Deployment pod-template labels;"
+  err "  inspect ${WORK}/manifest.yaml and update the awk patch in this script"
+  exit 1
+fi
+
 # Inject PodSecurity admission labels into the agent-sandbox-system Namespace.
 #
 # Upstream ships a bare Namespace; we enforce `privileged` because the

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -35,9 +35,10 @@
     },
     "packages/sandbox": {
       // daemon/entry.ts is bundled via `bun build` into a standalone binary
-      // that runs inside sandbox VMs. Without marking it as an entry, knip
-      // treats the whole daemon graph as unused.
-      "entry": ["daemon/entry.ts"]
+      // that runs inside sandbox VMs; org-fs/sidecar-main.ts likewise into
+      // the orgfs-sidecar image (deploy/helm/sandbox-env/orgfs-sidecar).
+      // Without marking them as entries, knip treats their graphs as unused.
+      "entry": ["daemon/entry.ts", "daemon/org-fs/sidecar-main.ts"]
     },
     "packages/typegen": {}
   },

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { bumpActivity } from "./activity";
 import { requireToken } from "./auth";
@@ -16,6 +17,8 @@ import { MountManager } from "./org-fs/mount-manager";
 import { createRcloneMounter } from "./org-fs/mounter";
 import { parseOrgFsConfig } from "./org-fs/config";
 import { repointOutputLink } from "./org-fs/output-link";
+import type { SidecarStatus } from "./org-fs/sidecar";
+import { makeOrgFsConfigHandler } from "./routes/orgfs-config";
 import { createPortSniffer } from "./process/port-sniffer";
 import { TaskManager } from "./process/task-manager";
 import { PhaseManager } from "./process/phase-manager";
@@ -646,6 +649,8 @@ async function vmRouteH(
     : req;
 
   if (vmPath === "/config") return configH(rebuilt, prefix);
+  if (method === "POST" && vmPath === "/orgfs-config")
+    return orgFsConfigH(rebuilt);
   if (vmPath.startsWith("/tasks"))
     return tasksRouteH(rebuilt, method, vmPath, prefix);
   if (method === "POST" && vmPath in setupH) return setupH[vmPath]();
@@ -704,16 +709,16 @@ Bun.serve<WsProxyData, never>({
   },
 });
 
-// --- Org-filesystem mounts (desktop links only) ----------------------------
-// The mesh sets ORGFS_CONFIG (a JSON OrgFsMountConfig) + ORGFS_RCLONE_PATH at
-// spawn — as boot env, like OFFLOAD_ALLOWED_HOSTS, so it's available here at
-// boot (config pushed via /_sandbox/config arrives only AFTER boot, so it
-// can't drive the mount). Both are absent for cluster pods (locked-down
-// securityContext can't mount) and until the provisioning side ships — so this
-// is inert by default. The start is fire-and-forget and fully guarded (see
-// MountManager): a mount failure logs and never affects the daemon, dev
-// server, fs routes, or harnesses. A volume's bytes still reach harnesses via
-// the mesh API regardless.
+// --- Org-filesystem mounts ---------------------------------------------------
+// Desktop links: the mesh sets ORGFS_CONFIG (a JSON OrgFsMountConfig) +
+// ORGFS_RCLONE_PATH at spawn — as boot env, like OFFLOAD_ALLOWED_HOSTS, so the
+// daemon itself mounts here at boot.
+// Cluster pods: this container can't mount (locked-down securityContext); a
+// privileged sidecar does (org-fs/sidecar.ts). The mesh runner POSTs the
+// config to /_sandbox/orgfs-config post-bind (warm-pool claims reject
+// spec.env) and the handler relays it onto the shared control volume the
+// sidecar watches. Both paths are inert unless their env is set; every step
+// is guarded — a mount failure never affects the daemon or harnesses.
 let mountManager: MountManager | null = null;
 {
   const orgFs = parseOrgFsConfig(process.env.ORGFS_CONFIG);
@@ -725,19 +730,31 @@ let mountManager: MountManager | null = null;
       .catch((err) => console.warn("[org-fs] mount start failed", err));
   }
 }
+const orgFsConfigH = makeOrgFsConfigHandler({
+  configPath: process.env.ORGFS_SIDECAR_CONFIG_PATH,
+});
 
 /**
  * Per-run share-files-back link (`org/output` → `.outputs/<threadId>`, see
  * org-fs/output-link.ts). Gated on the outputs volume being ACTUALLY mounted —
  * its mount-point dir exists locally even when the mount failed, and linking
- * into that would silently strand files on local disk. Hoisted declaration:
- * called from `lookupDispatchHarness` above, which only runs post-boot.
+ * into that would silently strand files on local disk. The mount is either
+ * ours (desktop) or the sidecar's (cluster — its status file reports what it
+ * mounted). Hoisted declaration: called from `lookupDispatchHarness` above,
+ * which only runs post-boot.
  */
 async function repointOutputLinkForRun(threadId: string): Promise<void> {
   const outputsMountPath = join(bootConfig.appRoot, "org", ".outputs");
-  const mounted = mountManager
+  let mounted = mountManager
     ?.list()
     .some((m) => m.mountPath === outputsMountPath);
+  const statusPath = process.env.ORGFS_SIDECAR_STATUS_PATH;
+  if (!mounted && statusPath) {
+    const status = await readFile(statusPath, "utf8")
+      .then((raw) => JSON.parse(raw) as SidecarStatus)
+      .catch(() => null);
+    mounted = status?.mounts.some((m) => m.mountPath === outputsMountPath);
+  }
   if (!mounted) return;
   await repointOutputLink(bootConfig.appRoot, threadId, (msg, err) =>
     err ? console.warn(`[org-fs] ${msg}`, err) : console.log(`[org-fs] ${msg}`),

--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -29,7 +29,15 @@ import type { MountHandle, Mounter } from "./mount-manager";
 const READY_TIMEOUT_MS = 15_000;
 const READY_POLL_MS = 200;
 
-export function createRcloneMounter(rclonePath: string): Mounter {
+export function createRcloneMounter(
+  rclonePath: string,
+  opts: {
+    /** FUSE `--allow-other` (Linux): lets OTHER uids/containers read the
+     *  mount — required when a privileged sidecar mounts for an unprivileged
+     *  main container (cluster pods). Needs `user_allow_other` in fuse.conf. */
+    allowOther?: boolean;
+  } = {},
+): Mounter {
   const isMac = process.platform === "darwin";
   return {
     async mount({ webdavUrl, mountPath, rcAddr }) {
@@ -42,7 +50,12 @@ export function createRcloneMounter(rclonePath: string): Mounter {
           // mount is strictly single-client (loopback), so client-local lock
           // semantics are exact.
           ["nfsmount", "wd:", mountPath, "--option", "actimeo=1,locallocks"]
-        : ["mount", "wd:", mountPath];
+        : [
+            "mount",
+            "wd:",
+            mountPath,
+            ...(opts.allowOther ? ["--allow-other"] : []),
+          ];
       const rcArgs = rcAddr
         ? ["--rc", "--rc-addr", rcAddr, "--rc-no-auth"]
         : [];

--- a/packages/sandbox/daemon/org-fs/sidecar-main.ts
+++ b/packages/sandbox/daemon/org-fs/sidecar-main.ts
@@ -1,0 +1,36 @@
+/**
+ * Entry point for the org-fs sidecar image (see
+ * deploy/helm/sandbox-env/orgfs-sidecar/). Env contract (set by the chart):
+ *   APP_ROOT                   shared workdir root (default /app)
+ *   ORGFS_SIDECAR_CONFIG_PATH  relayed config file (default /run/orgfs/config.json)
+ *   ORGFS_SIDECAR_STATUS_PATH  mounted-status file (default /run/orgfs/status.json)
+ *   ORGFS_RCLONE_PATH          rclone binary (default: PATH lookup; baked in image)
+ */
+
+import { MountManager } from "./mount-manager";
+import { createRcloneMounter } from "./mounter";
+import { runSidecar } from "./sidecar";
+
+const rclonePath =
+  process.env.ORGFS_RCLONE_PATH ?? Bun.which("rclone") ?? "rclone";
+
+const ac = new AbortController();
+process.on("SIGTERM", () => ac.abort());
+process.on("SIGINT", () => ac.abort());
+
+console.log("[org-fs sidecar] waiting for relayed config…");
+await runSidecar({
+  configPath: process.env.ORGFS_SIDECAR_CONFIG_PATH ?? "/run/orgfs/config.json",
+  statusPath: process.env.ORGFS_SIDECAR_STATUS_PATH ?? "/run/orgfs/status.json",
+  appRoot: process.env.APP_ROOT ?? "/app",
+  manager: new MountManager(
+    createRcloneMounter(rclonePath, { allowOther: true }),
+  ),
+  signal: ac.signal,
+  log: (m, e) =>
+    e
+      ? console.warn(`[org-fs sidecar] ${m}`, e)
+      : console.log(`[org-fs sidecar] ${m}`),
+});
+console.log("[org-fs sidecar] stopped");
+process.exit(0);

--- a/packages/sandbox/daemon/org-fs/sidecar.test.ts
+++ b/packages/sandbox/daemon/org-fs/sidecar.test.ts
@@ -1,0 +1,134 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { runSidecar, type SidecarMountManager } from "./sidecar";
+
+/** Records start/stop; reports the started volumes as mounted. */
+function fakeManager() {
+  const calls: { config: unknown; appRoot: string }[] = [];
+  let stopped = 0;
+  let mounts: { volume: string; mountPath: string }[] = [];
+  const manager: SidecarMountManager = {
+    async start(config, appRoot) {
+      calls.push({ config, appRoot });
+      mounts = config.mounts.map((m) => ({
+        volume: m.volume,
+        mountPath: join(appRoot, "org", m.path),
+      }));
+    },
+    async stop() {
+      stopped++;
+      mounts = [];
+    },
+    list: () => mounts,
+  };
+  return { manager, calls, stopped: () => stopped };
+}
+
+const CONFIG = JSON.stringify({
+  baseUrl: "http://mesh",
+  orgSlug: "acme",
+  token: "t",
+  mounts: [{ volume: "skills", path: "skills" }],
+});
+
+describe("runSidecar", () => {
+  let dir: string;
+  const configPath = () => join(dir, "config.json");
+  const statusPath = () => join(dir, "status.json");
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "orgfs-sc-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("waits for the config file, mounts, writes status, unmounts on abort", async () => {
+    const { manager, calls, stopped } = fakeManager();
+    const ac = new AbortController();
+    const run = runSidecar({
+      configPath: configPath(),
+      statusPath: statusPath(),
+      appRoot: "/app",
+      manager,
+      signal: ac.signal,
+      pollMs: 5,
+    });
+    // no config yet → nothing mounted
+    await Bun.sleep(20);
+    expect(calls.length).toBe(0);
+
+    writeFileSync(configPath(), CONFIG);
+    await Bun.sleep(40);
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.appRoot).toBe("/app");
+    const status = JSON.parse(readFileSync(statusPath(), "utf8"));
+    expect(status.mounts).toEqual([
+      { volume: "skills", mountPath: "/app/org/skills" },
+    ]);
+
+    ac.abort();
+    await run;
+    expect(stopped()).toBe(1);
+  });
+
+  it("ignores an invalid config file and keeps waiting", async () => {
+    const { manager, calls } = fakeManager();
+    const ac = new AbortController();
+    writeFileSync(configPath(), "{not json");
+    const run = runSidecar({
+      configPath: configPath(),
+      statusPath: statusPath(),
+      appRoot: "/app",
+      manager,
+      signal: ac.signal,
+      pollMs: 5,
+    });
+    await Bun.sleep(25);
+    expect(calls.length).toBe(0);
+    writeFileSync(configPath(), CONFIG);
+    await Bun.sleep(40);
+    expect(calls.length).toBe(1);
+    ac.abort();
+    await run;
+  });
+
+  it("exits without mounting when aborted while waiting", async () => {
+    const { manager, calls, stopped } = fakeManager();
+    const ac = new AbortController();
+    const run = runSidecar({
+      configPath: configPath(),
+      statusPath: statusPath(),
+      appRoot: "/app",
+      manager,
+      signal: ac.signal,
+      pollMs: 5,
+    });
+    await Bun.sleep(15);
+    ac.abort();
+    await run;
+    expect(calls.length).toBe(0);
+    expect(stopped()).toBe(1); // stop() is safe on an idle manager
+  });
+
+  it("creates the status file's parent dir", async () => {
+    const { manager } = fakeManager();
+    const ac = new AbortController();
+    const nested = join(dir, "deep", "status.json");
+    writeFileSync(configPath(), CONFIG);
+    const run = runSidecar({
+      configPath: configPath(),
+      statusPath: nested,
+      appRoot: "/app",
+      manager,
+      signal: ac.signal,
+      pollMs: 5,
+    });
+    await Bun.sleep(40);
+    expect(JSON.parse(readFileSync(nested, "utf8")).mounts.length).toBe(1);
+    ac.abort();
+    await run;
+  });
+});

--- a/packages/sandbox/daemon/org-fs/sidecar.ts
+++ b/packages/sandbox/daemon/org-fs/sidecar.ts
@@ -1,0 +1,94 @@
+/**
+ * Org-fs sidecar runtime (cluster pods).
+ *
+ * Hosted sandboxes can't mount in the main container (locked-down
+ * securityContext), so a privileged sidecar does it: this loop waits for the
+ * daemon to relay the mount config onto the shared control volume (see
+ * routes/orgfs-config.ts — the config arrives post-bind, after this container
+ * is already running), mounts the volumes with the SAME MountManager the
+ * desktop daemon uses (FUSE + --allow-other), and lets Bidirectional mount
+ * propagation surface them in the unprivileged main container.
+ *
+ * After mounting it writes a status file so the daemon (a different
+ * container) can tell the mounts are live — e.g. the per-run output link
+ * gates on it. Pods are single-claim (warm Sandboxes are adopted once and
+ * die with the claim), so the config is consumed once; later writes are
+ * ignored.
+ */
+
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { sleep } from "@decocms/std";
+import { type OrgFsMountConfig, parseOrgFsConfig } from "./config";
+
+/** The MountManager surface the sidecar drives (structural, for tests). */
+export interface SidecarMountManager {
+  start(config: OrgFsMountConfig, appRoot: string): Promise<void>;
+  stop(): Promise<void>;
+  list(): { volume: string; mountPath: string }[];
+}
+
+export interface SidecarOpts {
+  /** Config file the daemon relays ORGFS_CONFIG into (shared volume). */
+  configPath: string;
+  /** Status file this writes once mounted (read by the daemon container). */
+  statusPath: string;
+  appRoot: string;
+  /** Real: MountManager over createRcloneMounter(..., { allowOther: true }). */
+  manager: SidecarMountManager;
+  signal: AbortSignal;
+  /** Config poll interval; default 1s. */
+  pollMs?: number;
+  log?: (msg: string, err?: unknown) => void;
+}
+
+/** Mirrors `MountManager.list()`; the daemon reads this from the status file. */
+export interface SidecarStatus {
+  mounts: { volume: string; mountPath: string }[];
+}
+
+function writeJsonAtomic(path: string, value: unknown): void {
+  // Local control volume, NOT a mount — sync fs is safe here. Atomic so the
+  // daemon never reads a torn status file.
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = join(dirname(path), `.status-${process.pid}.tmp`);
+  writeFileSync(tmp, JSON.stringify(value));
+  renameSync(tmp, path);
+}
+
+/** Run until `signal` aborts: wait for config, mount, report, then unmount. */
+export async function runSidecar(opts: SidecarOpts): Promise<void> {
+  const pollMs = opts.pollMs ?? 1000;
+  const log = opts.log ?? (() => {});
+
+  let mounted = false;
+  while (!opts.signal.aborted && !mounted) {
+    const raw = await readFile(opts.configPath, "utf8").catch(() => null);
+    const config = raw === null ? null : parseOrgFsConfig(raw);
+    if (!config) {
+      if (raw !== null) log("invalid org-fs config file; waiting for rewrite");
+      await sleep(pollMs, { signal: opts.signal }).catch(() => {});
+      continue;
+    }
+    await opts.manager.start(config, opts.appRoot); // never throws
+    try {
+      writeJsonAtomic(opts.statusPath, {
+        mounts: opts.manager.list(),
+      } satisfies SidecarStatus);
+    } catch (err) {
+      log("status write failed", err);
+    }
+    log(
+      `mounted ${opts.manager.list().length}/${config.mounts.length} volumes`,
+    );
+    mounted = true;
+  }
+
+  if (!opts.signal.aborted) {
+    await new Promise<void>((resolve) => {
+      opts.signal.addEventListener("abort", () => resolve(), { once: true });
+    });
+  }
+  await opts.manager.stop();
+}

--- a/packages/sandbox/daemon/routes/orgfs-config.test.ts
+++ b/packages/sandbox/daemon/routes/orgfs-config.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { makeOrgFsConfigHandler } from "./orgfs-config";
+
+const CONFIG = JSON.stringify({
+  baseUrl: "http://mesh",
+  orgSlug: "acme",
+  token: "t",
+  mounts: [{ volume: "skills", path: "skills" }],
+});
+
+const post = (body: string) =>
+  new Request("http://daemon/_sandbox/orgfs-config", {
+    method: "POST",
+    body,
+  });
+
+describe("makeOrgFsConfigHandler", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "orgfs-route-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes a valid config to the relay path (creating parents)", async () => {
+    const path = join(dir, "ctl", "config.json");
+    const h = makeOrgFsConfigHandler({ configPath: path });
+    const res = await h(post(CONFIG));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ written: true });
+    expect(readFileSync(path, "utf8")).toBe(CONFIG);
+  });
+
+  it("rejects malformed and invalid-shape bodies with 400", async () => {
+    const path = join(dir, "config.json");
+    const h = makeOrgFsConfigHandler({ configPath: path });
+    expect((await h(post("{nope"))).status).toBe(400);
+    expect((await h(post(JSON.stringify({ baseUrl: "x" })))).status).toBe(400);
+  });
+
+  it("answers written:false when no relay path is configured (desktop)", async () => {
+    const h = makeOrgFsConfigHandler({ configPath: undefined });
+    const res = await h(post(CONFIG));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ written: false });
+  });
+});

--- a/packages/sandbox/daemon/routes/orgfs-config.ts
+++ b/packages/sandbox/daemon/routes/orgfs-config.ts
@@ -1,0 +1,45 @@
+/**
+ * POST /_sandbox/orgfs-config — receive the org-fs mount config post-bind.
+ *
+ * Cluster pods can't get ORGFS_CONFIG as boot env (warm-pool claims reject
+ * `spec.env`), and TenantConfig is the wrong vehicle (an orgFs-only patch
+ * classifies as no-op and is dropped). So the mesh runner POSTs it here right
+ * after `/config`, and the daemon relays it to the privileged org-fs sidecar
+ * by writing a file on the shared control volume — the sidecar (which does
+ * the actual mounting; this container can't) is watching for it.
+ *
+ * Inert outside cluster pods: when `ORGFS_SIDECAR_CONFIG_PATH` is unset the
+ * handler answers `{ written: false }` and touches nothing. Desktop links
+ * keep their boot-env path.
+ */
+
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { parseOrgFsConfig } from "../org-fs/config";
+import { jsonResponse } from "./body-parser";
+
+export function makeOrgFsConfigHandler(opts: {
+  /** Shared-volume file the sidecar watches; unset = relay disabled. */
+  configPath: string | undefined;
+  log?: (msg: string, err?: unknown) => void;
+}): (req: Request) => Promise<Response> {
+  const log = opts.log ?? ((m, e) => console.warn(`[org-fs] ${m}`, e ?? ""));
+  return async (req) => {
+    const raw = await req.text();
+    if (!parseOrgFsConfig(raw)) {
+      return jsonResponse({ error: "invalid org-fs config" }, 400);
+    }
+    if (!opts.configPath) return jsonResponse({ written: false });
+    try {
+      // Atomic write: the sidecar must never read a torn file.
+      mkdirSync(dirname(opts.configPath), { recursive: true });
+      const tmp = join(dirname(opts.configPath), `.config-${process.pid}.tmp`);
+      writeFileSync(tmp, raw);
+      renameSync(tmp, opts.configPath);
+      return jsonResponse({ written: true });
+    } catch (err) {
+      log("sidecar config relay failed", err);
+      return jsonResponse({ error: "relay failed" }, 500);
+    }
+  };
+}

--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -132,6 +132,36 @@ async function configRequest(
   return JSON.parse(body) as ConfigResponse;
 }
 
+/**
+ * POST /_sandbox/orgfs-config — relay the org-fs mount config (a JSON
+ * `OrgFsMountConfig`) for the pod's privileged sidecar. Separate from
+ * `/config` on purpose: an orgFs-only TenantConfig patch classifies as no-op
+ * and would be dropped by the daemon's config store. Returns whether the
+ * daemon actually relayed it (false = no sidecar configured; desktop pods).
+ */
+export async function postOrgFsConfig(
+  daemonUrl: string,
+  token: string,
+  configJson: string,
+): Promise<{ written: boolean }> {
+  const res = await fetch(`${daemonUrl}/_sandbox/orgfs-config`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: configJson,
+    signal: AbortSignal.timeout(CONFIG_TIMEOUT_MS),
+  });
+  const body = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `sandbox daemon /_sandbox/orgfs-config returned ${res.status}: ${body}`,
+    );
+  }
+  return JSON.parse(body) as { written: boolean };
+}
+
 const STRIP_REQUEST_HEADERS = [
   "cookie",
   "host",

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -39,6 +39,7 @@ import type {
 } from "@opentelemetry/api";
 import {
   postConfig,
+  postOrgFsConfig,
   probeDaemonHealth,
   proxyDaemonRequest,
   waitForDaemonReady,
@@ -1214,6 +1215,15 @@ export class AgentSandboxProvider implements SandboxProvider {
         });
       } else if (configPayload) {
         await postConfig(daemonUrl, token, configPayload);
+      }
+      // Org-fs mounts: relay the config for the pod's privileged sidecar
+      // (separate endpoint — see postOrgFsConfig). Post-bind on purpose:
+      // warm-pool claims reject spec.env. Best-effort: mounts are additive,
+      // a relay failure must not fail provisioning.
+      if (opts.orgFsConfigJson) {
+        await postOrgFsConfig(daemonUrl, token, opts.orgFsConfigJson).catch(
+          (err) => console.warn("[org-fs] sidecar config relay failed", err),
+        );
       }
     } catch (err) {
       this.closeForwarder(daemonForward);


### PR DESCRIPTION
## Summary

Stage 2 of the org-fs rollout: hosted (agent-sandbox) pods get the same `org/` mounts desktop links have — **one PR, fully dormant** until the sandbox-env chart's `orgFs.enabled` is flipped (default `false`; default render has zero orgfs artifacts).

### How it works
```
claim binds → runner POSTs /_sandbox/orgfs-config (daemon token)
           → daemon relays JSON onto shared /run/orgfs (control emptyDir)
           → privileged sidecar (idle since pod boot) mounts skills+outputs
             via the SAME MountManager/mounter/invalidator the desktop uses
           → Bidirectional→HostToContainer propagation surfaces them in the
             unprivileged agent container at /app/org
```

### Key decisions
- **Delivery**: dedicated post-bind endpoint, not `claim.spec.env` (warm-pool claims reject it — resolving the Stage-1 spike's "DECISION NEEDED") and not TenantConfig (an orgFs-only patch classifies as no-op and is silently dropped by the config store). Mirrors the established DAEMON_TOKEN warm-pool pattern.
- **No cross-org leak**: warm Sandboxes are adopted once and deleted with the claim; pods are never reused across orgs.
- **`hostUsers` trade-off is explicit**: privileged + Bidirectional are incompatible with userns pods, so the template `fail`s loudly when `orgFs.enabled` is set without `hostUsers=true`.
- **Image**: `ghcr.io/decocms/studio/orgfs-sidecar` (bun + rclone + fuse3 + `user_allow_other`), published by `release-orgfs-sidecar.yaml` — exact netinit pattern, tag pinned in chart values.
- **Mesh gate**: `ORGFS_CLUSTER_MOUNTS` setting controls token minting for hosted pods (no wasted 7-day keys in clusters without the sidecar).
- Sidecar status file feeds the daemon's per-run `org/output` link gate, so the share-files-back flow (#3750) works in clusters too.

### Bug found & fixed by the e2e
#3753's read push-down **propagated** network errors when the presigned URL host is unreachable from the reader's network (dev MinIO presigns `localhost:9000` — inside a pod that's the pod itself), making rclone retry-loop instead of reading. `OrgFsClient.readResponse` now falls back to the buffered-through-mesh path (+ unit test with a real refused connection). Prod S3/R2 presigns public https, so push-down stays active there.

## Verification
**Kind e2e** (real image from the production Dockerfile, live dev mesh + MinIO, pod mirroring the chart render):
| flow | result |
|---|---|
| sidecar waits → relayed config → mounts both volumes | ✓ status file written |
| propagation into unprivileged container (uid 1000, caps dropped) | ✓ `allow_other` mounts visible |
| read volume content through mount | 298ms ✓ |
| external API add → visible in agent container | ~300ms ✓ |
| agent write → skills / outputs cloud state | ~5.3s ✓ each |

Also: 394 sandbox tests pass (8 new), all-workspace typecheck green, `helm template` verified (enabled render + guard failure + dormant default), Docker image builds + smoke-tests locally. Full notes in `.context/orgfs-stage2-e2e/RESULT.md` (untracked).

## Rollout (after merge)
1. CI publishes the sidecar image (workflow triggers on this merge)
2. sandbox-env: `orgFs.enabled=true` + `hostUsers=true` on a staging env
3. studio: `ORGFS_CLUSTER_MOUNTS=1`
4. EKS PodSecurity must permit the privileged sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds org filesystem mounts to hosted `agent-sandbox` pods using a privileged sidecar with a post-bind config relay. Ships off by default behind the `sandbox-env` `orgFs.enabled` flag and mesh `ORGFS_CLUSTER_MOUNTS`, and also adds a safe read fallback when presigned URLs are unreachable.

- **New Features**
  - Privileged `orgfs-sidecar` FUSE-mounts org volumes at `/app/org` via `rclone --allow-other`; Bidirectional propagation exposes mounts to the main container.
  - New daemon route `POST /_sandbox/orgfs-config` relays the JSON config to `/run/orgfs`; sidecar waits for it, mounts, and writes a status file used to gate the per-run `org/output` link.
  - Helm: opt-in sidecar in `sandbox-template.yaml`; render fails if `hostUsers=false` (privileged + Bidirectional require it).
  - Mesh: new setting `orgFsClusterMounts` (`ORGFS_CLUSTER_MOUNTS`) mints tokens for hosted pods; runner posts the config post-bind.
  - CI: `release-orgfs-sidecar.yaml` builds/signs/pushes the `orgfs-sidecar` image from chart-pinned tag.
  - Tooling: mark `packages/sandbox/daemon/org-fs/sidecar-main.ts` as a knip entry; `deploy/helm/sandbox-operator/vendor.sh` injects controller `podLabels`/`podAnnotations` hooks to prevent drift.

- **Migration**
  - In `sandbox-env` values: set `orgFs.enabled=true` and `hostUsers=true`.
  - Set `ORGFS_CLUSTER_MOUNTS=1` in the studio/mesh deployment.
  - Ensure cluster policy allows privileged containers and Bidirectional mount propagation, then deploy.

<sup>Written for commit c03219a903aa3b56c35c60547bcbd9a1a7248181. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

