### PR TITLE
feat(ai-providers): swap Claude Code Thinking tier to Fable 5

### DIFF
--- a/apps/mesh/src/ai-providers/agent-tiers.ts
+++ b/apps/mesh/src/ai-providers/agent-tiers.ts
@@ -20,7 +20,7 @@ export type AgentTierMap = Record<ChatTier, AgentTierEntry>;
 const CLAUDE_CODE_TIERS: AgentTierMap = {
   fast: { modelId: "claude-code:haiku", label: "Haiku 4.5" },
   smart: { modelId: "claude-code:sonnet", label: "Sonnet 4.6" },
-  thinking: { modelId: "claude-code:opus", label: "Opus 4.8" },
+  thinking: { modelId: "claude-code:fable", label: "Fable 5" },
 };
 
 const CODEX_TIERS: AgentTierMap = {

--- a/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
@@ -41,8 +41,8 @@ const CLAUDE_CODE_TIERS: AgentTierMap = {
     iconNode: <ClaudeCodeIcon size={16} />,
   },
   thinking: {
-    modelId: "claude-code:opus",
-    label: "Opus 4.8",
+    modelId: "claude-code:fable",
+    label: "Fable 5",
     description: "Deeper reasoning",
     iconNode: <ClaudeCodeIcon size={16} />,
   },

--- a/apps/mesh/src/web/components/chat/use-agent-mode.test.ts
+++ b/apps/mesh/src/web/components/chat/use-agent-mode.test.ts
@@ -48,9 +48,9 @@ describe("resolveTierSubtitle", () => {
         "Sonnet 4.6",
       );
     });
-    it("thinking → Opus 4.8", () => {
+    it("thinking → Fable 5", () => {
       expect(resolveTierSubtitle("local-claude-code", "thinking")).toBe(
-        "Opus 4.8",
+        "Fable 5",
       );
     });
   });

--- a/apps/mesh/src/web/lib/release-feed.ts
+++ b/apps/mesh/src/web/lib/release-feed.ts
@@ -30,6 +30,30 @@ export interface Release {
  */
 export const RELEASES: Release[] = [
   {
+    id: "claude-fable-5",
+    date: "2026-06-09",
+    eyebrow: "Now Available",
+    title: "Claude Fable 5 leads the Thinking tier",
+    bullets: [
+      {
+        icon: Stars02,
+        title: "State-of-the-art reasoning",
+        body: "Fable 5 takes the Thinking tier, posting top scores across software engineering, knowledge work, and vision — and outperforming Opus 4.8 on nearly every benchmark Anthropic tested.",
+      },
+      {
+        icon: CheckCircle,
+        title: "Safety without the slowdown",
+        body: "New classifiers route the small slice of high-risk requests (cybersecurity, bio/chem) back to Opus 4.8. Anthropic reports more than 95% of sessions never trigger a fallback.",
+      },
+      {
+        icon: Zap,
+        title: "Nothing to change",
+        body: "Chats and agents pick up Fable 5 automatically wherever the Thinking tier is selected. Opus 4.8 stays available as the safety fallback.",
+      },
+    ],
+    learnMoreHref: "https://www.anthropic.com/news/claude-fable-5-mythos-5",
+  },
+  {
     id: "claude-opus-4-8",
     date: "2026-05-28",
     eyebrow: "Now Available",

--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -89,20 +89,27 @@ export const SMART_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
  */
 export const THINKING_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
   {
-    anthropic: ["claude-opus-4-8", "claude-sonnet-4-6", "claude-sonnet"],
+    anthropic: [
+      "claude-fable-5",
+      "claude-opus-4-8",
+      "claude-sonnet-4-6",
+      "claude-sonnet",
+    ],
     openrouter: [
+      "anthropic/claude-fable-5",
       "anthropic/claude-opus-4.8",
       "anthropic/claude-sonnet-4.6:extended",
       "anthropic/claude-sonnet-4.6",
       "google/gemini-3-pro",
     ],
     deco: [
+      "anthropic/claude-fable",
       "anthropic/claude-opus",
       "anthropic/claude-sonnet-4.6",
       "anthropic/claude-sonnet",
     ],
     google: ["gemini-3-pro"],
-    "claude-code": ["claude-code:opus", "claude-code:sonnet"],
+    "claude-code": ["claude-code:fable", "claude-code:sonnet"],
     codex: ["codex:gpt-5.5"],
   };
 


### PR DESCRIPTION
## Summary

Claude Fable 5 launched today (2026-06-09) and supersedes Opus 4.8 as Anthropic's top public model. This wires Fable 5 into the Claude Code Thinking tier and adds a release-feed entry announcing it.

- **UI tier maps** (`agent-tiers.ts`, `agent-models.tsx`): the claude-code Thinking entry now reads `claude-code:fable` / "Fable 5".
- **Preference chains** (`packages/mesh-sdk/src/lib/default-model.ts`): Fable 5 is prepended to `THINKING_MODEL_PREFERENCES` for `anthropic`, `openrouter`, and `deco` — Opus 4.8 stays as the safety fallback (mirrors Anthropic's own architecture, where Opus 4.8 is what Fable 5's classifiers fall back to for high-risk requests). For `claude-code` specifically, the chain is the strict `["claude-code:fable", "claude-code:sonnet"]` — no Opus fallback.
- **Test** (`use-agent-mode.test.ts`): `thinking → Opus 4.8` assertion updated to `thinking → Fable 5`.
- **Release feed** (`release-feed.ts`): new entry at the top of `RELEASES`, modeled on the Opus 4.8 entry shape (3 bullets, existing `Stars02`/`CheckCircle`/`Zap` icons, `learnMoreHref` pointing at the Anthropic announcement).

Out of scope on purpose: `DEFAULT_MODEL_PREFERENCES`, `SMART_MODEL_PREFERENCES`, the `decopilot.tsx` Smarter shortlist, and `chat-input-draft.spec.ts` (historical comment) — none are thinking-tier.

## Test plan

- [x] `bun run fmt` — clean
- [x] `bun run --cwd=apps/mesh check` (`tsc --noEmit`) — clean
- [x] `bun test apps/mesh/src/web/components/chat/use-agent-mode.test.ts` — 17/17 pass, including the new `thinking → Fable 5` assertion
- [ ] Manual: open the chat input, confirm the Claude Code Thinking row shows "Fable 5" with the "Deeper reasoning" subtitle
- [ ] Manual: confirm the release card surfaces the Fable 5 announcement on first home-page render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swap the Claude Code Thinking tier to Fable 5 and announce it in the release feed. Opus 4.8 remains as the safety fallback where applicable.

- **New Features**
  - UI: the Claude Code "thinking" row now uses `claude-code:fable` and shows "Fable 5".
  - Model preferences: prepended `claude-fable-5` to `THINKING_MODEL_PREFERENCES` for `anthropic`, `openrouter`, and `deco` (Opus 4.8 stays as fallback). For `claude-code`, use a strict `["claude-code:fable", "claude-code:sonnet"]` chain.
  - Release feed: added a Fable 5 entry with learn-more link to the Anthropic announcement.

<sup>Written for commit 2c29ada12cb0ef4ea8e9f55a4100c7cf26051505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

