### PR TITLE
chore(link-daemon): drop verbose:true from proxy-poller fetch

### DIFF
--- a/apps/mesh/src/link-daemon/proxy-poller.test.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.test.ts
@@ -57,7 +57,6 @@ describe("runProxyPollLoop — request ack", () => {
     const calls: string[] = [];
     const frame = reqFrame("r-ack");
     let pollCount = 0;
-    let streamVerbose: unknown;
 
     const fetchImpl = (async (input, init) => {
       const url = String(input);
@@ -83,7 +82,6 @@ describe("runProxyPollLoop — request ack", () => {
 
       if (method === "POST" && url.endsWith("/stream")) {
         calls.push("stream");
-        streamVerbose = (init as RequestInit & { verbose?: boolean }).verbose;
         return await new Promise<Response>((resolve) => {
           init?.signal?.addEventListener(
             "abort",
@@ -135,7 +133,6 @@ describe("runProxyPollLoop — request ack", () => {
     expect(calls.indexOf("ack")).toBeGreaterThan(-1);
     expect(calls.indexOf("stream")).toBeGreaterThan(-1);
     expect(calls.indexOf("ack")).toBeLessThan(calls.indexOf("stream"));
-    expect(streamVerbose).toBe(true);
   });
 });
 

--- a/apps/mesh/src/link-daemon/proxy-poller.ts
+++ b/apps/mesh/src/link-daemon/proxy-poller.ts
@@ -445,7 +445,6 @@ async function handleProxyRequest(
       });
       const replyPostInit: RequestInit & {
         duplex: "half";
-        verbose: boolean;
       } = {
         method: "POST",
         headers: {
@@ -454,7 +453,6 @@ async function handleProxyRequest(
         },
         body,
         duplex: "half",
-        verbose: true,
         signal: combined,
       };
       const res = await fetcher(url, replyPostInit);


### PR DESCRIPTION
## Summary

The Bun fetch in `proxy-poller`'s reply POST was carrying `verbose: true`, which makes every proxy poll dump the full request/response roundtrip to stderr. That's noise — the existing `logProxyPoller("reply_post_complete", ...)` already captures the useful per-request metadata.

Removes both the property and the matching `verbose: boolean` field from the inline `RequestInit` intersection type so the type stays consistent.

## Test plan

- [x] `bun run --cwd=apps/mesh check` — `tsc --noEmit` clean
- [ ] Manual: run the local CLI link daemon, confirm stderr is no longer flooded by per-poll request dumps; structured `[proxy-poller] reply POST …` lines still appear on non-2xx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `verbose: true` from the `proxy-poller` reply POST `fetch` to stop Bun from dumping full request/response traffic to stderr on every poll. Also remove the `verbose` field from the local `RequestInit` type and drop the test assertion that expected `verbose: true`; existing `logProxyPoller` logs still capture per-request metadata.

<sup>Written for commit 68d7c748feb301d4bf698de101ec1d90544b8c4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

