### PR TITLE
fix(observability): refine error span handling for specific HTTP stat…

### DIFF
--- a/apps/mesh/src/observability/instrumentations/fetch.ts
+++ b/apps/mesh/src/observability/instrumentations/fetch.ts
@@ -85,8 +85,17 @@ async function instrumentedFetch(
         // Record response attributes
         span.setAttribute("http.response.status_code", response.status);
 
-        // Set span status based on response
-        if (response.status >= 400) {
+        // The MCP Streamable HTTP transport opens its server->client stream
+        // with a GET (Accept: text/event-stream); the spec defines 405 as the
+        // expected "no SSE stream offered" reply, which the SDK swallows. Don't
+        // surface that handshake as an error span. All other 4xx/5xx are real
+        // client-span errors per OTel HTTP conventions.
+        const isMcpSseProbe405 =
+          response.status === 405 &&
+          method === "GET" &&
+          (headers.get("accept") ?? "").includes("text/event-stream");
+
+        if (response.status >= 400 && !isMcpSseProbe405) {
           span.setStatus({
             code: SpanStatusCode.ERROR,
             message: `HTTP ${response.status}`,


### PR DESCRIPTION
…us codes

Updated the instrumentedFetch function to prevent the 405 status code from being treated as an error span when it is part of the MCP Streamable HTTP transport handshake. This change aligns with OTel HTTP conventions by ensuring only genuine client errors (4xx/5xx) are reported as errors, improving observability accuracy.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines fetch tracing to avoid marking MCP SSE probe 405 responses as errors. This reduces false error spans and aligns with OTel HTTP conventions.

- **Bug Fixes**
  - In instrumentedFetch, skip setting error status for 405 on GET when Accept includes text/event-stream (MCP handshake). All other 4xx/5xx still mark spans as errors.

<sup>Written for commit 41f497cb7fb501376d669641b77ee2cc853d31f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

