### PR TITLE
fix(observability): enhance fetch error classification and timeout ha…

### DIFF
--- a/apps/mesh/src/observability/instrumentations/fetch.ts
+++ b/apps/mesh/src/observability/instrumentations/fetch.ts
@@ -21,6 +21,31 @@ import { tracer } from "../index";
 const originalFetch = globalThis.fetch;
 
 /**
+ * Classify a thrown fetch error as a benign abort so it isn't surfaced as an
+ * error span. Two shapes leak into error tracking as if they were failures:
+ *
+ * - `TimeoutError` — `AbortSignal.timeout()` elapsed ("The operation timed
+ *   out."). Used by the sandbox daemon-client config/health probes.
+ * - `AbortError` — a caller cancelled the request via `AbortController.abort()`
+ *   ("The operation was aborted."). Idle teardown, in-flight replacement, client
+ *   disconnect, and SWR revalidation cleanup all do this as normal control flow.
+ *
+ * Returns the abort reason for span tagging, or null for genuine failures.
+ */
+function classifyAbort(
+  error: unknown,
+  signal: AbortSignal | undefined,
+): "timeout" | "cancelled" | null {
+  const name = error instanceof Error ? error.name : undefined;
+  if (name === "TimeoutError") return "timeout";
+  if (name === "AbortError") return "cancelled";
+  // Fallback: the caller's own signal fired but the runtime threw a
+  // non-standard error shape.
+  if (signal?.aborted) return "cancelled";
+  return null;
+}
+
+/**
  * Instrumented fetch that creates spans for outbound requests
  * and propagates trace context.
  */
@@ -106,12 +131,24 @@ async function instrumentedFetch(
 
         return response;
       } catch (error) {
-        // Record exception and set error status
-        span.recordException(error as Exception);
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: error instanceof Error ? error.message : "Fetch failed",
-        });
+        const signal =
+          init?.signal ?? (input instanceof Request ? input.signal : undefined);
+        const abortReason = classifyAbort(error, signal ?? undefined);
+        if (abortReason) {
+          // Benign control-flow abort (timeout / caller cancellation), not a
+          // server failure. Tag the span with the reason and leave its status
+          // UNSET so it stays out of the error bucket while remaining visible
+          // and distinguishable in traces. We still re-throw — control flow is
+          // the caller's concern, untouched.
+          span.setAttribute("abort.reason", abortReason);
+        } else {
+          // Record exception and set error status
+          span.recordException(error as Exception);
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : "Fetch failed",
+          });
+        }
         throw error;
       } finally {
         span.end();

--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -10,7 +10,11 @@ import { sleep } from "../shared";
 export type { ConfigPatch };
 
 const HEALTH_PROBE_TIMEOUT_MS = 500;
-const CONFIG_TIMEOUT_MS = 10_000;
+// Config application can run a cold clone + install on a heavy sandbox; 10s was
+// too tight and routinely tripped `AbortSignal.timeout()`, surfacing benign
+// "operation timed out" aborts as a chronic error spike. 30s gives cold starts
+// headroom. Callers may override per-call via `postConfig`'s `timeoutMs`.
+const CONFIG_TIMEOUT_MS = 30_000;
 const READY_ATTEMPTS = 25;
 const READY_INTERVAL_MS = 200;
 const READY_JITTER_MS = 50;
@@ -85,6 +89,11 @@ export interface ConfigAuthPatch {
   rotateToken?: string;
 }
 
+export interface ConfigRequestOptions {
+  /** Override the abort timeout (ms). Defaults to `CONFIG_TIMEOUT_MS`. */
+  timeoutMs?: number;
+}
+
 /**
  * POST /_sandbox/config — set initial tenant config (or patch via
  * the same payload semantics; deep-merge happens daemon-side).
@@ -101,8 +110,9 @@ export async function postConfig(
   token: string,
   payload: ConfigPatch,
   auth?: ConfigAuthPatch,
+  opts?: ConfigRequestOptions,
 ): Promise<ConfigResponse> {
-  return configRequest(daemonUrl, token, "POST", payload, auth);
+  return configRequest(daemonUrl, token, "POST", payload, auth, opts);
 }
 
 async function configRequest(
@@ -111,6 +121,7 @@ async function configRequest(
   method: "POST" | "PUT",
   payload: ConfigPatch,
   auth?: ConfigAuthPatch,
+  opts?: ConfigRequestOptions,
 ): Promise<ConfigResponse> {
   const wire: Record<string, unknown> = { ...payload };
   if (auth && auth.rotateToken !== undefined) wire.auth = auth;
@@ -121,7 +132,7 @@ async function configRequest(
       Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(wire),
-    signal: AbortSignal.timeout(CONFIG_TIMEOUT_MS),
+    signal: AbortSignal.timeout(opts?.timeoutMs ?? CONFIG_TIMEOUT_MS),
   });
   const body = await res.text();
   if (!res.ok) {


### PR DESCRIPTION
…ndling

Updated the fetch instrumentation to classify benign abort errors (TimeoutError and AbortError) to prevent them from being recorded as error spans. This change improves observability by ensuring only genuine failures are reported. Additionally, increased the default configuration timeout from 10s to 30s to accommodate cold starts, with an option for callers to override the timeout per request.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies fetch timeouts and cancellations as non-errors in tracing, reducing false error spikes. Increases sandbox config request timeout to 30s and adds a per-call override for flexibility during cold starts.

- **Bug Fixes**
  - Treat `TimeoutError` and `AbortError` as benign aborts in fetch instrumentation; tag span with `abort.reason` and avoid error status.

- **New Features**
  - Default config request timeout raised from 10s to 30s.
  - `postConfig` now accepts `opts.timeoutMs` to override the abort timeout per call.

<sup>Written for commit 56267ef1b6d73f87fdc2f0b364e7f87a60bf7907. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

