### PR TITLE
fix(sandbox): normalize node-pty path so daemon resolves on Windows

### DIFF
--- a/packages/sandbox/server/daemon-spawn.ts
+++ b/packages/sandbox/server/daemon-spawn.ts
@@ -49,14 +49,17 @@ export function resolveSourceDaemonPath(): string {
 
 export function resolveNodePtyNodeModulesDir(): string {
   const ptyEntry = Bun.resolveSync("node-pty", import.meta.dir);
+  // Bun.resolveSync returns backslash-separated paths on Windows; normalize
+  // so the node_modules marker matches regardless of OS path separator.
+  const normalized = ptyEntry.replace(/\\/g, "/");
   const marker = "/node_modules/";
-  const idx = ptyEntry.lastIndexOf(marker);
+  const idx = normalized.lastIndexOf(marker);
   if (idx < 0) {
     throw new Error(
       `could not derive node_modules path from node-pty resolution: ${ptyEntry}`,
     );
   }
-  return ptyEntry.slice(0, idx + marker.length - 1);
+  return normalized.slice(0, idx + marker.length - 1);
 }
 
 export async function materializeDaemonBundle(


### PR DESCRIPTION
## What is this contribution about?
On Windows, running an agent fails immediately with
"could not derive node_modules path from node-pty resolution: C:\...\node-pty\lib\index.js".

`resolveNodePtyNodeModulesDir()` resolves node-pty via `Bun.resolveSync()`, which
returns a backslash path on Windows, then searches for the `/node_modules/`
marker with `lastIndexOf`. The forward-slash marker never matches a backslash
path, so `idx` is -1 and it throws. The unix separator works only by accident.

Impact: the sandbox daemon never spawns, so **agent execution is fully broken on
Windows** — any prompt that triggers a tool fails.

Fix: normalize the resolved path to forward slashes before matching the marker.
The returned value feeds `NODE_PATH`, and forward-slash paths work on both Windows
and Unix. No-op on macOS/Linux (no backslashes to replace). The throw still shows
the original path for accurate diagnostics.

## How to Test
1. On Windows, `bun run dev`, connect a model provider
2. Send a prompt that runs a tool (e.g. "write a song")
3. Expected: the agent executes and responds — no node-pty path error

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes (no-op on macOS/Linux)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the resolved `node-pty` path to forward slashes so the sandbox daemon finds the `node_modules` directory on Windows. This fixes broken agent execution on Windows and is a no-op on macOS/Linux.

<sup>Written for commit 7a3f59bccf000ad734da747425197d2a2ee0501d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

