### PR TITLE
fix(mesh): refresh repo-scoped GitHub tokens before clone URLs

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1524,6 +1524,7 @@ async function resolvePullSandboxConfig(
             githubRepo.name,
             ctx.db,
             ctx.vault,
+            ctx,
           )
         : buildAnonymousCloneInfo(githubRepo.owner, githubRepo.name);
       repo = {

--- a/apps/mesh/src/shared/github-clone-info.test.ts
+++ b/apps/mesh/src/shared/github-clone-info.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { StudioContext } from "../core/studio-context";
+import type { DownstreamToken } from "../storage/types";
+import { GITHUB_SCOPED_PERMISSIONS } from "./github-repo-scope";
+
+const mockEnsureRepoScopedToken = mock(async () => "ghs_fresh_minted");
+const mockTokenGet = mock(async (): Promise<DownstreamToken | null> => null);
+const mockRefreshAndStore = mock(async () => "ghu_refreshed");
+
+mock.module("../oauth/github-mint", () => ({
+  ensureRepoScopedToken: mockEnsureRepoScopedToken,
+}));
+
+mock.module("../oauth/token-refresh", () => ({
+  PROACTIVE_REFRESH_BUFFER_MS: 5 * 60 * 1000,
+  RECONNECT_ERROR:
+    "GitHub token refresh failed — reconnect the mcp-github integration.",
+  canRefresh: (token: DownstreamToken) =>
+    !!token.refreshToken && !!token.tokenEndpoint && !!token.clientId,
+  refreshAndStore: mockRefreshAndStore,
+}));
+
+const { DownstreamTokenStorage: RealDownstreamTokenStorage } = await import(
+  "../storage/downstream-token"
+);
+
+mock.module("../storage/downstream-token", () => ({
+  DownstreamTokenStorage: class MockDownstreamTokenStorage extends RealDownstreamTokenStorage {
+    override async get(connectionId: string) {
+      return mockTokenGet(connectionId);
+    }
+  },
+}));
+
+const { resolveGitHubAccessToken } = await import("./github-clone-info");
+
+function makeRepoScopedCtx(): StudioContext {
+  return {
+    organization: { id: "org_1", slug: "test", name: "Test" },
+    storage: {
+      connections: {
+        findById: mock(async () => ({
+          id: "conn_child",
+          metadata: {
+            repoScope: {
+              sourceConnectionId: "conn_org",
+              installationId: 42,
+              owner: "acme",
+              repo: "widget",
+              permissions: GITHUB_SCOPED_PERMISSIONS,
+            },
+          },
+        })),
+      },
+    },
+  } as never;
+}
+
+describe("resolveGitHubAccessToken", () => {
+  beforeEach(() => {
+    mockEnsureRepoScopedToken.mockClear();
+    mockTokenGet.mockClear();
+    mockRefreshAndStore.mockClear();
+  });
+
+  it("re-mints repo-scoped tokens via ensureRepoScopedToken", async () => {
+    const token = await resolveGitHubAccessToken(
+      "conn_child",
+      null as never,
+      null as never,
+      makeRepoScopedCtx(),
+    );
+
+    expect(token).toBe("ghs_fresh_minted");
+    expect(mockEnsureRepoScopedToken).toHaveBeenCalledTimes(1);
+    expect(mockTokenGet).not.toHaveBeenCalled();
+  });
+
+  it("refreshes expired OAuth tokens for org connections", async () => {
+    const pastExpiry = new Date(Date.now() - 60_000).toISOString();
+    mockTokenGet.mockImplementation(async () => ({
+      id: "dtok_1",
+      connectionId: "conn_org",
+      accessToken: "ghu_stale",
+      refreshToken: "ghr_refresh",
+      scope: "repo",
+      expiresAt: pastExpiry,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      clientId: "Iv1.test",
+      clientSecret: "secret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    }));
+
+    const token = await resolveGitHubAccessToken(
+      "conn_org",
+      null as never,
+      null as never,
+      {
+        organization: { id: "org_1", slug: "test", name: "Test" },
+        storage: {
+          connections: {
+            findById: mock(async () => ({ metadata: null })),
+          },
+        },
+      } as never,
+    );
+
+    expect(token).toBe("ghu_refreshed");
+    expect(mockRefreshAndStore).toHaveBeenCalledTimes(1);
+    expect(mockEnsureRepoScopedToken).not.toHaveBeenCalled();
+  });
+
+  it("throws when a minted token is expired and ctx is unavailable", async () => {
+    const pastExpiry = new Date(Date.now() - 60_000).toISOString();
+    mockTokenGet.mockImplementation(async () => ({
+      id: "dtok_1",
+      connectionId: "conn_child",
+      accessToken: "ghs_stale",
+      refreshToken: null,
+      scope: null,
+      expiresAt: pastExpiry,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      clientId: null,
+      clientSecret: null,
+      tokenEndpoint: null,
+    }));
+
+    await expect(
+      resolveGitHubAccessToken("conn_child", null as never, null as never),
+    ).rejects.toThrow(
+      "GitHub token refresh failed — reconnect the mcp-github integration.",
+    );
+  });
+});

--- a/apps/mesh/src/shared/github-clone-info.ts
+++ b/apps/mesh/src/shared/github-clone-info.ts
@@ -4,22 +4,25 @@
  * remote so subsequent fetch/pull/push from inside the sandbox keep
  * working with no further plumbing.
  *
- * The token is set once per sandbox. If it expires or is revoked, the
- * sandbox must be destroyed and recreated — studio does not push token
- * updates to running daemons. Falls back to generic identity defaults on
- * /user failure so callers never block on a flaky upstream.
+ * Repo-scoped child connections carry minted installation tokens (~1h, no
+ * refresh token) and are re-minted on demand via MINT_REPO_TOKEN. OAuth
+ * org connections use the standard refresh-token path. Running sandboxes can
+ * receive updated credentials via sync-git-credentials.
  */
 
 import type { Kysely } from "kysely";
-import { DownstreamTokenStorage } from "../storage/downstream-token";
-import type { Database } from "../storage/types";
-import type { CredentialVault } from "../encryption/credential-vault";
+import type { StudioContext } from "../core/studio-context";
+import { ensureRepoScopedToken } from "../oauth/github-mint";
 import {
   canRefresh,
   PROACTIVE_REFRESH_BUFFER_MS,
   RECONNECT_ERROR,
   refreshAndStore,
 } from "../oauth/token-refresh";
+import { getRepoScope } from "./github-repo-scope";
+import { DownstreamTokenStorage } from "../storage/downstream-token";
+import type { Database } from "../storage/types";
+import type { CredentialVault } from "../encryption/credential-vault";
 
 export interface GitHubCloneInfo {
   cloneUrl: string;
@@ -43,14 +46,29 @@ export function buildAnonymousCloneInfo(
   };
 }
 
-export async function buildCloneInfo(
+/**
+ * Resolve a fresh GitHub access token for clone/runtime operations.
+ * Repo-scoped connections are re-minted on demand; OAuth connections are
+ * proactively refreshed when a refresh token is available.
+ */
+export async function resolveGitHubAccessToken(
   connectionId: string,
-  owner: string,
-  name: string,
   db: Kysely<Database>,
   vault: CredentialVault,
-): Promise<GitHubCloneInfo> {
+  ctx?: StudioContext,
+): Promise<string> {
   const tokenStorage = new DownstreamTokenStorage(db, vault);
+
+  if (ctx?.organization?.id) {
+    const connection = await ctx.storage.connections.findById(
+      connectionId,
+      ctx.organization.id,
+    );
+    if (connection && getRepoScope(connection)) {
+      return ensureRepoScopedToken(ctx, connection);
+    }
+  }
+
   const token = await tokenStorage.get(connectionId);
   if (!token) {
     throw new Error(
@@ -58,9 +76,6 @@ export async function buildCloneInfo(
     );
   }
 
-  let accessToken = token.accessToken;
-
-  // Proactive refresh before baking into the clone URL. Mirrors GITHUB_LIST_USER_ORGS.
   if (
     canRefresh(token) &&
     tokenStorage.isExpired(token, PROACTIVE_REFRESH_BUFFER_MS)
@@ -69,8 +84,33 @@ export async function buildCloneInfo(
     if (!refreshed) {
       throw new Error(RECONNECT_ERROR);
     }
-    accessToken = refreshed;
+    return refreshed;
   }
+
+  if (
+    !canRefresh(token) &&
+    tokenStorage.isExpired(token, PROACTIVE_REFRESH_BUFFER_MS)
+  ) {
+    throw new Error(RECONNECT_ERROR);
+  }
+
+  return token.accessToken;
+}
+
+export async function buildCloneInfo(
+  connectionId: string,
+  owner: string,
+  name: string,
+  db: Kysely<Database>,
+  vault: CredentialVault,
+  ctx?: StudioContext,
+): Promise<GitHubCloneInfo> {
+  const accessToken = await resolveGitHubAccessToken(
+    connectionId,
+    db,
+    vault,
+    ctx,
+  );
 
   const cloneUrl = `https://x-access-token:${accessToken}@github.com/${owner}/${name}.git`;
 

--- a/apps/mesh/src/shared/github-runtime-detect.ts
+++ b/apps/mesh/src/shared/github-runtime-detect.ts
@@ -9,8 +9,9 @@
  */
 
 import type { Kysely } from "kysely";
+import type { StudioContext } from "../core/studio-context";
 import type { CredentialVault } from "../encryption/credential-vault";
-import { DownstreamTokenStorage } from "../storage/downstream-token";
+import { resolveGitHubAccessToken } from "./github-clone-info";
 import type { Database } from "../storage/types";
 import type { PackageManager } from "./runtime-defaults";
 
@@ -47,10 +48,19 @@ export async function detectRepoRuntime(
   name: string,
   db: Kysely<Database>,
   vault: CredentialVault,
+  ctx?: StudioContext,
 ): Promise<DetectedRuntime | null> {
-  const token = await new DownstreamTokenStorage(db, vault).get(connectionId);
-  if (!token) return null;
-  return probeRuntime(owner, name, token.accessToken);
+  try {
+    const accessToken = await resolveGitHubAccessToken(
+      connectionId,
+      db,
+      vault,
+      ctx,
+    );
+    return probeRuntime(owner, name, accessToken);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/mesh/src/tools/sandbox/start.test.ts
+++ b/apps/mesh/src/tools/sandbox/start.test.ts
@@ -153,6 +153,18 @@ const mockRefreshAccessToken = mock(
     error?: string;
   }> => ({ success: true, accessToken: "ghu_refreshed_token" }),
 );
+const mockRefreshAndStore = mock(async () => "ghu_refreshed_token");
+
+mock.module("../../oauth/token-refresh", () => ({
+  PROACTIVE_REFRESH_BUFFER_MS: 5 * 60 * 1000,
+  RECONNECT_ERROR:
+    "GitHub token refresh failed — reconnect the mcp-github integration.",
+  canRefresh: (token: DownstreamToken) =>
+    !!token.refreshToken && !!token.tokenEndpoint && !!token.clientId,
+  refreshAndStore: mockRefreshAndStore,
+  refreshAccessToken: mockRefreshAccessToken,
+}));
+
 mock.module("@/oauth/refresh-access-token", () => ({
   refreshAccessToken: mockRefreshAccessToken,
 }));
@@ -237,10 +249,9 @@ function makeCtx(overrides: {
     },
     storage: {
       virtualMcps: { findById, update: updateSpy },
-      // Non-repo-scoped org connection: getRepoScope() returns null, so the
-      // repo-scoped mint path in provisionSandbox is skipped and these tests
-      // exercise the clone/token path unchanged. (Minting is covered by the
-      // e2e suite, github-import-repo-scope.spec.ts.)
+      // Non-repo-scoped org connection: getRepoScope() returns null, so
+      // buildCloneInfo exercises the OAuth refresh path. Repo-scoped minting
+      // is covered by github-clone-info.test.ts and the e2e suite.
       connections: {
         findById: mock(async (_id: string) => ({ metadata: null })),
       },
@@ -574,12 +585,7 @@ describe("SANDBOX_START", () => {
       ctx,
     );
 
-    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
-    expect(mockTokenUpsert).toHaveBeenCalledTimes(1);
-    const upsertArg = (mockTokenUpsert.mock.calls as unknown[][])[0]![0] as {
-      accessToken: string;
-    };
-    expect(upsertArg.accessToken).toBe("ghu_refreshed_token");
+    expect(mockRefreshAndStore).toHaveBeenCalledTimes(1);
 
     const [, opts] = mockEnsure.mock.calls[0]! as [SandboxId, EnsureOptions];
     expect(opts.repo?.cloneUrl).toContain("ghu_refreshed_token");
@@ -870,13 +876,7 @@ describe("SANDBOX_START", () => {
       clientSecret: "test_secret",
       tokenEndpoint: "https://github.com/login/oauth/access_token",
     }));
-    mockRefreshAccessToken.mockImplementation(async () => ({
-      success: false,
-      permanent: true,
-      status: 400,
-      errorCode: "invalid_grant",
-      error: "refresh token revoked",
-    }));
+    mockRefreshAndStore.mockImplementation(async () => null);
 
     const virtualMcp = makeVirtualMcp("org_1", BASE_METADATA);
     const ctx = makeCtx({ virtualMcp });
@@ -886,7 +886,6 @@ describe("SANDBOX_START", () => {
     ).rejects.toThrow(
       "GitHub token refresh failed — reconnect the mcp-github integration.",
     );
-    expect(mockTokenDelete).toHaveBeenCalledWith("conn_github_1");
     expect(mockEnsure).not.toHaveBeenCalled();
   });
 });

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -40,8 +40,6 @@ import {
   detectRepoRuntimeAnonymous,
 } from "../../shared/github-runtime-detect";
 import { generateBranchName } from "../../shared/branch-name";
-import { ensureRepoScopedToken } from "@/oauth/github-mint";
-import { getRepoScope } from "@/shared/github-repo-scope";
 import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
@@ -302,29 +300,6 @@ async function provisionSandbox(
     | undefined;
 
   if (githubRepo) {
-    // Repo-scoped child connections carry a minted token with no refresh path,
-    // so re-mint it now if expired before it gets baked into the clone URL or
-    // used for the lockfile probe. No-op for org connections and public repos.
-    if (githubRepo.connectionId) {
-      const repoConn = await ctx.storage.connections.findById(
-        githubRepo.connectionId,
-        orgId,
-      );
-      if (repoConn && getRepoScope(repoConn)) {
-        try {
-          await ensureRepoScopedToken(ctx, repoConn);
-        } catch (err) {
-          // Swallow + log: a failed mint intentionally falls through to
-          // buildCloneInfo's own "No GitHub token found" throw below (sandbox
-          // start fails loudly — never an unauthenticated clone).
-          console.error("[provisionSandbox] repo-scoped token mint failed", {
-            connectionId: githubRepo.connectionId,
-            error: (err as Error).message,
-          });
-        }
-      }
-    }
-
     // Connection-backed (authenticated) vs public-clone (anonymous). The
     // daemon's clone behavior is identical — only the URL and identity
     // change. Push-back fails in the anonymous case; that's the documented
@@ -336,6 +311,7 @@ async function provisionSandbox(
           githubRepo.name,
           ctx.db,
           ctx.vault,
+          ctx,
         )
       : buildAnonymousCloneInfo(githubRepo.owner, githubRepo.name);
 
@@ -354,6 +330,7 @@ async function provisionSandbox(
             githubRepo.name,
             ctx.db,
             ctx.vault,
+            ctx,
           )
         : await detectRepoRuntimeAnonymous(githubRepo.owner, githubRepo.name);
       if (detected) {

--- a/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
@@ -1,10 +1,7 @@
 import type { GithubRepo } from "@decocms/mesh-sdk/types";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import type { StudioContext } from "../../core/studio-context";
-import { ensureRepoScopedToken } from "../../oauth/github-mint";
-import { RECONNECT_ERROR } from "../../oauth/token-refresh";
 import { buildCloneInfo } from "../../shared/github-clone-info";
-import { getRepoScope } from "../../shared/github-repo-scope";
 
 export class GitPushAuthError extends Error {
   constructor(message: string) {
@@ -41,31 +38,23 @@ export async function refreshSandboxGitCredentials(
     );
   }
 
-  const organizationId = ctx.organization?.id;
-  if (!organizationId) {
-    throw new GitPushAuthError(RECONNECT_ERROR);
+  let cloneUrl: string;
+  let gitUserName: string;
+  let gitUserEmail: string;
+  try {
+    ({ cloneUrl, gitUserName, gitUserEmail } = await buildCloneInfo(
+      githubRepo.connectionId,
+      githubRepo.owner,
+      githubRepo.name,
+      ctx.db,
+      ctx.vault,
+      ctx,
+    ));
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to refresh GitHub token.";
+    throw new GitPushAuthError(message);
   }
-
-  const repoConn = await ctx.storage.connections.findById(
-    githubRepo.connectionId,
-    organizationId,
-  );
-  if (repoConn && getRepoScope(repoConn)) {
-    try {
-      await ensureRepoScopedToken(ctx, repoConn);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : RECONNECT_ERROR;
-      throw new GitPushAuthError(message);
-    }
-  }
-
-  const { cloneUrl, gitUserName, gitUserEmail } = await buildCloneInfo(
-    githubRepo.connectionId,
-    githubRepo.owner,
-    githubRepo.name,
-    ctx.db,
-    ctx.vault,
-  );
 
   const res = await runner.proxyDaemonRequest(handle, "/_sandbox/config", {
     method: "PUT",


### PR DESCRIPTION
## Summary
- Centraliza a renovação de tokens GitHub em `resolveGitHubAccessToken()`, cobrindo re-mint de tokens repo-scoped (`MINT_REPO_TOKEN`) e refresh OAuth de conexões org.
- Garante que `buildCloneInfo` e `detectRepoRuntime` recebam `ctx` em todos os fluxos (sandbox start, sync de credenciais git e pull dispatch).
- Corrige o buraco no pull dispatch, que embutia tokens expirados na `cloneUrl` para harnesses CLI/desktop.

## Test plan
- [x] `bun test apps/mesh/src/shared/github-clone-info.test.ts`
- [x] `bun test apps/mesh/src/tools/sandbox/start.test.ts`
- [ ] Importar agente com repo-scoped GitHub e iniciar sandbox após ~1h (ou forçar expiração) — clone/push devem continuar funcionando
- [ ] Disparar run via harness CLI/desktop (pull dispatch) com token expirado — `cloneUrl` deve usar token reemitido


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized GitHub token resolution so repo-scoped installation tokens are re-minted and OAuth tokens are refreshed before building clone URLs. Fixes stale tokens leaking into clone URLs across sandbox start, git credential sync, and pull dispatch.

- **Bug Fixes**
  - Always resolve a fresh token via `resolveGitHubAccessToken` used by `buildCloneInfo` and `detectRepoRuntime`.
  - Pass `ctx` through sandbox start, credential sync, and pull dispatch so repo-scoped tokens are re-minted in time.
  - Added targeted tests for token mint/refresh behavior.

- **Refactors**
  - Introduced `resolveGitHubAccessToken` to unify repo-scoped minting (`ensureRepoScopedToken`) and OAuth refresh (`refreshAndStore`).
  - Removed ad-hoc mint/refresh code from `provisionSandbox` and `sync-git-credentials`.
  - Updated `detectRepoRuntime` and `buildCloneInfo` to accept `ctx` for repo-scoped flows.

<sup>Written for commit c4cb4c4f447372a05a3f29148d93802f2290de74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

