### PR TITLE
feat(org-fs): Files browser UI; rename bucket configs page to Buckets

### DIFF
--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -1,0 +1,136 @@
+/**
+ * Data layer for the org filesystem browser (settings → Files). Talks the
+ * org-scoped HTTP contract at `/api/:org/fs/:volume/*` directly (same-origin
+ * session auth) — unlike most settings views this is NOT an MCP tool surface:
+ * uploads/downloads move raw bytes, which the HTTP routes are built for.
+ */
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { KEYS } from "@/web/lib/query-keys";
+
+export interface OrgFsEntry {
+  /** Normalized in-volume path, no leading/trailing slash. */
+  path: string;
+  kind: "file" | "dir";
+  size: number;
+  updatedAt: string;
+}
+
+export interface OrgFsUsage {
+  files: number;
+  bytes: number;
+}
+
+function fsUrl(
+  orgSlug: string,
+  volume: string,
+  op: string,
+  params?: Record<string, string>,
+): string {
+  const qs = new URLSearchParams(params).toString();
+  return `/api/${encodeURIComponent(orgSlug)}/fs/${encodeURIComponent(volume)}/${op}${qs ? `?${qs}` : ""}`;
+}
+
+async function fsFetch(url: string, init?: RequestInit): Promise<Response> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = ((await res.json()) as { error?: string }).error ?? "";
+    } catch {
+      // non-JSON body
+    }
+    throw new Error(detail || `HTTP ${res.status}`);
+  }
+  return res;
+}
+
+/** Children of `path` ("" = volume root), dirs first then by name. */
+export function useOrgFsList(volume: string, path: string) {
+  const { org } = useProjectContext();
+  return useQuery({
+    queryKey: KEYS.orgFsList(org.id, volume, path),
+    // Keep the previous listing on screen while navigating into a dir.
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const res = await fsFetch(fsUrl(org.slug, volume, "list", { path }));
+      const body = (await res.json()) as { entries: OrgFsEntry[] };
+      return body.entries.toSorted((a, b) =>
+        a.kind !== b.kind
+          ? a.kind === "dir"
+            ? -1
+            : 1
+          : a.path.localeCompare(b.path),
+      );
+    },
+  });
+}
+
+export function useOrgFsUsage(volume: string) {
+  const { org } = useProjectContext();
+  return useQuery({
+    queryKey: KEYS.orgFsUsage(org.id, volume),
+    queryFn: async () => {
+      const res = await fsFetch(fsUrl(org.slug, volume, "usage"));
+      return (await res.json()) as OrgFsUsage;
+    },
+  });
+}
+
+/** Same-origin byte URL for a file — usable as a download href. */
+export function useOrgFsDownloadUrl(volume: string) {
+  const { org } = useProjectContext();
+  return (path: string) => fsUrl(org.slug, volume, "read", { path });
+}
+
+/** Upload/mkdir/delete; each invalidates the whole volume's listings+usage. */
+export function useOrgFsMutations(volume: string) {
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: KEYS.orgFsVolume(org.id, volume),
+    });
+
+  const upload = useMutation({
+    mutationFn: async (input: { dir: string; files: File[] }) => {
+      for (const file of input.files) {
+        const path = input.dir ? `${input.dir}/${file.name}` : file.name;
+        await fsFetch(fsUrl(org.slug, volume, "file", { path }), {
+          method: "PUT",
+          headers: {
+            "content-type": file.type || "application/octet-stream",
+          },
+          body: file,
+        });
+      }
+    },
+    onSuccess: invalidate,
+  });
+
+  const mkdir = useMutation({
+    mutationFn: async (path: string) => {
+      await fsFetch(fsUrl(org.slug, volume, "dir", { path }), {
+        method: "POST",
+      });
+    },
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation({
+    mutationFn: async (path: string) => {
+      await fsFetch(fsUrl(org.slug, volume, "file", { path }), {
+        method: "DELETE",
+      });
+    },
+    onSuccess: invalidate,
+  });
+
+  return { upload, mkdir, remove };
+}

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -368,6 +368,14 @@ const settingsFilesRoute = createRoute({
   ),
 });
 
+const settingsBucketsRoute = createRoute({
+  getParentRoute: () => settingsLayout,
+  path: "/buckets",
+  component: lazyRouteComponent(
+    () => import("./routes/orgs/settings/buckets.tsx"),
+  ),
+});
+
 const settingsMembersRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/members",
@@ -552,6 +560,7 @@ const settingsWithChildren = settingsLayout.addChildren([
   settingsAiProvidersRoute,
   settingsSecretsRoute,
   settingsFilesRoute,
+  settingsBucketsRoute,
   settingsMembersRoute,
   settingsRolesRoute,
   settingsSsoRoute,

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -46,6 +46,7 @@ import {
   Users03,
   Zap,
   Key01,
+  Folder,
   HardDrive,
 } from "@untitledui/icons";
 import { useProjectContext } from "@decocms/mesh-sdk";
@@ -122,10 +123,18 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           requires: "secrets:manage",
         },
         {
+          // Org filesystem browser — member-accessible (org-fs ACL is
+          // basic-usage), so no `requires`.
           key: "files",
           label: "Files",
-          icon: <HardDrive size={14} />,
+          icon: <Folder size={14} />,
           to: "/$org/settings/files",
+        },
+        {
+          key: "buckets",
+          label: "Buckets",
+          icon: <HardDrive size={14} />,
+          to: "/$org/settings/buckets",
           requires: "file-configs:manage",
         },
       ],

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -313,6 +313,15 @@ export const KEYS = {
   // Org-scoped S3 bucket file configurations
   fileConfigs: (orgId: string) => ["file-configs", orgId] as const,
 
+  // Organization filesystem (volume browser). `orgFsVolume` is the prefix key
+  // a mutation invalidates to refresh every listing + usage for the volume.
+  orgFsVolume: (orgId: string, volume: string) =>
+    ["org-fs", orgId, volume] as const,
+  orgFsList: (orgId: string, volume: string, path: string) =>
+    ["org-fs", orgId, volume, "list", path] as const,
+  orgFsUsage: (orgId: string, volume: string) =>
+    ["org-fs", orgId, volume, "usage"] as const,
+
   // File picker — objects listed from a configured bucket
   filePickerObjects: (orgId: string, configId: string | null) =>
     ["file-picker-objects", orgId, configId] as const,

--- a/apps/mesh/src/web/routes/orgs/settings/buckets.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/buckets.tsx
@@ -1,0 +1,10 @@
+import { OrgBucketsPage } from "@/web/views/settings/buckets";
+import { RequireCapability } from "@/web/components/require-capability";
+
+export default function BucketsRoute() {
+  return (
+    <RequireCapability capability="file-configs:manage" area="files">
+      <OrgBucketsPage />
+    </RequireCapability>
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/settings/files.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/files.tsx
@@ -1,10 +1,7 @@
-import { OrgFilesPage } from "@/web/views/settings/files";
-import { RequireCapability } from "@/web/components/require-capability";
+import { OrgFsFilesPage } from "@/web/views/settings/org-files";
 
+// No capability gate: the org filesystem is member-accessible by design
+// (ORG_FS_READ/WRITE are basic-usage — see api/routes/org-fs.ts ACL note).
 export default function FilesRoute() {
-  return (
-    <RequireCapability capability="file-configs:manage" area="files">
-      <OrgFilesPage />
-    </RequireCapability>
-  );
+  return <OrgFsFilesPage />;
 }

--- a/apps/mesh/src/web/routes/orgs/settings/index-redirect.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/index-redirect.tsx
@@ -43,7 +43,7 @@ export default function SettingsIndexRedirect() {
     return <Navigate to="/$org/settings/secrets" params={{ org }} replace />;
   }
   if (can("file-configs:manage")) {
-    return <Navigate to="/$org/settings/files" params={{ org }} replace />;
+    return <Navigate to="/$org/settings/buckets" params={{ org }} replace />;
   }
   if (can("automations:manage")) {
     return (

--- a/apps/mesh/src/web/views/settings/buckets.tsx
+++ b/apps/mesh/src/web/views/settings/buckets.tsx
@@ -498,13 +498,13 @@ function FilesContent() {
   );
 }
 
-export function OrgFilesPage() {
+export function OrgBucketsPage() {
   return (
     <Page>
       <Page.Content>
         <Page.Body>
           <SettingsPage>
-            <Page.Title>Files</Page.Title>
+            <Page.Title>Buckets</Page.Title>
             <ErrorBoundary
               fallback={({ error }) => (
                 <ErrorFallback

--- a/apps/mesh/src/web/views/settings/org-files.tsx
+++ b/apps/mesh/src/web/views/settings/org-files.tsx
@@ -1,8 +1,10 @@
 /**
  * Settings → Files: browser over the organization filesystem — the same
  * volumes sandboxes mount at `org/` (skills = shared library, outputs =
- * agent run outputs). Browse, upload, download, create folders, delete.
- * Data layer in @/web/hooks/use-org-fs (org-scoped HTTP, session auth).
+ * agent run outputs). Volumes render as root-level folders so the whole
+ * thing reads as one filesystem; the first path segment is the volume.
+ * Browse, upload, download, create folders, delete. Data layer in
+ * @/web/hooks/use-org-fs (org-scoped HTTP, session auth).
  */
 
 import { useRef, useState } from "react";
@@ -40,13 +42,13 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { Tabs, TabsList, TabsTrigger } from "@deco/ui/components/tabs.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { Page } from "@/web/components/page";
 import { SettingsPage } from "@/web/components/settings/settings-section";
 import { KEYS } from "@/web/lib/query-keys";
 import {
   type OrgFsEntry,
+  type OrgFsUsage,
   useOrgFsDownloadUrl,
   useOrgFsList,
   useOrgFsMutations,
@@ -55,8 +57,8 @@ import {
 
 /** The volumes every sandbox mounts (see file-storage/mount/provisioning.ts). */
 const VOLUMES = [
-  { id: "skills", label: "Skills" },
-  { id: "outputs", label: "Outputs" },
+  { id: "skills", description: "Org-wide shared library" },
+  { id: "outputs", description: "Agent run outputs, one folder per thread" },
 ] as const;
 
 function basename(path: string): string {
@@ -83,24 +85,25 @@ function formatDate(iso: string): string {
 }
 
 function Breadcrumbs(props: {
-  path: string;
-  onNavigate: (path: string) => void;
+  segments: string[];
+  onNavigate: (segments: string[]) => void;
 }) {
-  const segments = props.path === "" ? [] : props.path.split("/");
   return (
     <div className="flex items-center gap-1 text-sm min-w-0 flex-wrap">
       <button
         type="button"
         className="text-muted-foreground hover:text-foreground hover:underline"
-        onClick={() => props.onNavigate("")}
+        onClick={() => props.onNavigate([])}
       >
-        root
+        org
       </button>
-      {segments.map((seg, i) => {
-        const target = segments.slice(0, i + 1).join("/");
-        const isLast = i === segments.length - 1;
+      {props.segments.map((seg, i) => {
+        const isLast = i === props.segments.length - 1;
         return (
-          <span key={target} className="flex items-center gap-1 min-w-0">
+          <span
+            key={props.segments.slice(0, i + 1).join("/")}
+            className="flex items-center gap-1 min-w-0"
+          >
             <ChevronRight
               size={12}
               className="text-muted-foreground shrink-0"
@@ -111,7 +114,7 @@ function Breadcrumbs(props: {
               <button
                 type="button"
                 className="text-muted-foreground hover:text-foreground hover:underline truncate"
-                onClick={() => props.onNavigate(target)}
+                onClick={() => props.onNavigate(props.segments.slice(0, i + 1))}
               >
                 {seg}
               </button>
@@ -123,23 +126,210 @@ function Breadcrumbs(props: {
   );
 }
 
-function VolumeBrowser(props: { volume: string }) {
-  const { volume } = props;
+function Row(props: {
+  icon: React.ReactNode;
+  name: React.ReactNode;
+  size: string;
+  modified: string;
+  actions?: React.ReactNode;
+  onOpen?: () => void;
+}) {
+  return (
+    <tr className="border-b border-border last:border-b-0 hover:bg-muted/50">
+      <td className="px-4 py-2">
+        {props.onOpen ? (
+          <button
+            type="button"
+            className="flex items-center gap-2 hover:underline"
+            onClick={props.onOpen}
+          >
+            {props.icon}
+            <span className="font-medium">{props.name}</span>
+          </button>
+        ) : (
+          <span className="flex items-center gap-2">
+            {props.icon}
+            {props.name}
+          </span>
+        )}
+      </td>
+      <td className="px-4 py-2 text-muted-foreground">{props.size}</td>
+      <td className="px-4 py-2 text-muted-foreground">{props.modified}</td>
+      <td className="px-4 py-2">
+        <div className="flex items-center justify-end gap-1">
+          {props.actions}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function ListFrame(props: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-border overflow-hidden">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border text-left text-muted-foreground">
+            <th className="px-4 py-2 font-medium">Name</th>
+            <th className="px-4 py-2 font-medium w-28">Size</th>
+            <th className="px-4 py-2 font-medium w-48">Modified</th>
+            <th className="px-4 py-2 w-20" />
+          </tr>
+        </thead>
+        <tbody>{props.children}</tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Root listing: each volume is a folder; usage doubles as its size. */
+function VolumeRootRows(props: { onOpen: (volume: string) => void }) {
+  const skills = useOrgFsUsage(VOLUMES[0].id);
+  const outputs = useOrgFsUsage(VOLUMES[1].id);
+  const usageFor: Record<string, OrgFsUsage | undefined> = {
+    skills: skills.data,
+    outputs: outputs.data,
+  };
+  return (
+    <>
+      {VOLUMES.map((v) => {
+        const usage = usageFor[v.id];
+        return (
+          <Row
+            key={v.id}
+            icon={<Folder size={15} className="text-muted-foreground" />}
+            name={
+              <span className="flex items-baseline gap-2">
+                {v.id}
+                <span className="text-xs font-normal text-muted-foreground">
+                  {v.description}
+                </span>
+              </span>
+            }
+            size={
+              usage ? `${usage.files} files · ${formatBytes(usage.bytes)}` : "—"
+            }
+            modified=""
+            onOpen={() => props.onOpen(v.id)}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+function VolumeListing(props: {
+  volume: string;
+  path: string;
+  onOpenDir: (path: string) => void;
+  onDelete: (entry: OrgFsEntry) => void;
+}) {
+  const { volume, path } = props;
+  const listing = useOrgFsList(volume, path);
+  const downloadUrl = useOrgFsDownloadUrl(volume);
+
+  if (listing.isLoading) {
+    return (
+      <tr>
+        <td colSpan={4} className="p-4">
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-2/3" />
+          </div>
+        </td>
+      </tr>
+    );
+  }
+  if (listing.isError) {
+    return (
+      <tr>
+        <td colSpan={4} className="p-6 text-sm text-destructive">
+          {listing.error instanceof Error
+            ? listing.error.message
+            : "Failed to load"}
+        </td>
+      </tr>
+    );
+  }
+  const entries = listing.data ?? [];
+  if (entries.length === 0) {
+    return (
+      <tr>
+        <td
+          colSpan={4}
+          className="p-10 text-center text-sm text-muted-foreground"
+        >
+          Empty folder — upload a file or create a folder to get started.
+        </td>
+      </tr>
+    );
+  }
+  return (
+    <>
+      {entries.map((entry) => {
+        const name = basename(entry.path);
+        const isDir = entry.kind === "dir";
+        return (
+          <Row
+            key={entry.path}
+            icon={
+              isDir ? (
+                <Folder size={15} className="text-muted-foreground" />
+              ) : (
+                <File02 size={15} className="text-muted-foreground" />
+              )
+            }
+            name={name}
+            size={isDir ? "—" : formatBytes(entry.size)}
+            modified={formatDate(entry.updatedAt)}
+            onOpen={isDir ? () => props.onOpenDir(entry.path) : undefined}
+            actions={
+              <>
+                {!isDir && (
+                  <Button variant="ghost" size="icon" asChild>
+                    <a
+                      href={downloadUrl(entry.path)}
+                      download={name}
+                      aria-label={`Download ${name}`}
+                    >
+                      <Download01 size={14} />
+                    </a>
+                  </Button>
+                )}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Delete ${name}`}
+                  onClick={() => props.onDelete(entry)}
+                >
+                  <Trash01 size={14} />
+                </Button>
+              </>
+            }
+          />
+        );
+      })}
+    </>
+  );
+}
+
+function FsBrowser() {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
-  const [path, setPath] = useState("");
+  // First segment is the volume; [] is the synthetic root listing volumes.
+  const [segments, setSegments] = useState<string[]>([]);
+  const volume = segments[0] ?? null;
+  const path = segments.slice(1).join("/");
+
   const [pendingDelete, setPendingDelete] = useState<OrgFsEntry | null>(null);
   const [newFolderOpen, setNewFolderOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const listing = useOrgFsList(volume, path);
-  const usage = useOrgFsUsage(volume);
-  const downloadUrl = useOrgFsDownloadUrl(volume);
-  const { upload, mkdir, remove } = useOrgFsMutations(volume);
+  const { upload, mkdir, remove } = useOrgFsMutations(volume ?? VOLUMES[0].id);
 
   async function handleUpload(files: FileList | null) {
-    if (!files || files.length === 0) return;
+    if (!volume || !files || files.length === 0) return;
     try {
       await upload.mutateAsync({ dir: path, files: [...files] });
       toast.success(
@@ -156,7 +346,7 @@ function VolumeBrowser(props: { volume: string }) {
 
   async function handleCreateFolder() {
     const name = newFolderName.trim();
-    if (!name) return;
+    if (!volume || !name) return;
     try {
       await mkdir.mutateAsync(path ? `${path}/${name}` : name);
       toast.success(`Folder "${name}" created`);
@@ -182,20 +372,22 @@ function VolumeBrowser(props: { volume: string }) {
     }
   }
 
-  const entries = listing.data ?? [];
-
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-3 flex-wrap">
-        <Breadcrumbs path={path} onNavigate={setPath} />
+        <Breadcrumbs segments={segments} onNavigate={setSegments} />
         <div className="flex items-center gap-2">
           <Button
             variant="outline"
             size="sm"
             onClick={() =>
-              queryClient.invalidateQueries({
-                queryKey: KEYS.orgFsVolume(org.id, volume),
-              })
+              Promise.all(
+                VOLUMES.map((v) =>
+                  queryClient.invalidateQueries({
+                    queryKey: KEYS.orgFsVolume(org.id, v.id),
+                  }),
+                ),
+              )
             }
           >
             <RefreshCw01 size={14} />
@@ -204,6 +396,7 @@ function VolumeBrowser(props: { volume: string }) {
           <Button
             variant="outline"
             size="sm"
+            disabled={!volume}
             onClick={() => setNewFolderOpen(true)}
           >
             <Plus size={14} />
@@ -211,7 +404,7 @@ function VolumeBrowser(props: { volume: string }) {
           </Button>
           <Button
             size="sm"
-            disabled={upload.isPending}
+            disabled={!volume || upload.isPending}
             onClick={() => fileInputRef.current?.click()}
           >
             <Upload01 size={14} />
@@ -227,108 +420,27 @@ function VolumeBrowser(props: { volume: string }) {
         </div>
       </div>
 
-      <div className="rounded-xl border border-border overflow-hidden">
-        {listing.isLoading ? (
-          <div className="p-4 flex flex-col gap-2">
-            <Skeleton className="h-8 w-full" />
-            <Skeleton className="h-8 w-full" />
-            <Skeleton className="h-8 w-2/3" />
-          </div>
-        ) : listing.isError ? (
-          <div className="p-6 text-sm text-destructive">
-            {listing.error instanceof Error
-              ? listing.error.message
-              : "Failed to load"}
-          </div>
-        ) : entries.length === 0 ? (
-          <div className="p-10 text-center text-sm text-muted-foreground">
-            Empty folder — upload a file or create a folder to get started.
-          </div>
+      <ListFrame>
+        {volume === null ? (
+          <VolumeRootRows onOpen={(v) => setSegments([v])} />
         ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-muted-foreground">
-                <th className="px-4 py-2 font-medium">Name</th>
-                <th className="px-4 py-2 font-medium w-28">Size</th>
-                <th className="px-4 py-2 font-medium w-48">Modified</th>
-                <th className="px-4 py-2 w-20" />
-              </tr>
-            </thead>
-            <tbody>
-              {entries.map((entry) => {
-                const name = basename(entry.path);
-                const isDir = entry.kind === "dir";
-                return (
-                  <tr
-                    key={entry.path}
-                    className="border-b border-border last:border-b-0 hover:bg-muted/50"
-                  >
-                    <td className="px-4 py-2">
-                      {isDir ? (
-                        <button
-                          type="button"
-                          className="flex items-center gap-2 hover:underline"
-                          onClick={() => setPath(entry.path)}
-                        >
-                          <Folder size={15} className="text-muted-foreground" />
-                          <span className="font-medium">{name}</span>
-                        </button>
-                      ) : (
-                        <span className="flex items-center gap-2">
-                          <File02 size={15} className="text-muted-foreground" />
-                          {name}
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-4 py-2 text-muted-foreground">
-                      {isDir ? "—" : formatBytes(entry.size)}
-                    </td>
-                    <td className="px-4 py-2 text-muted-foreground">
-                      {formatDate(entry.updatedAt)}
-                    </td>
-                    <td className="px-4 py-2">
-                      <div className="flex items-center justify-end gap-1">
-                        {!isDir && (
-                          <Button variant="ghost" size="icon" asChild>
-                            <a
-                              href={downloadUrl(entry.path)}
-                              download={name}
-                              aria-label={`Download ${name}`}
-                            >
-                              <Download01 size={14} />
-                            </a>
-                          </Button>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          aria-label={`Delete ${name}`}
-                          onClick={() => setPendingDelete(entry)}
-                        >
-                          <Trash01 size={14} />
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+          <VolumeListing
+            // remount on volume switch so list state never bleeds across
+            key={volume}
+            volume={volume}
+            path={path}
+            onOpenDir={(p) => setSegments([volume, ...p.split("/")])}
+            onDelete={setPendingDelete}
+          />
         )}
-      </div>
-
-      <div className="text-xs text-muted-foreground">
-        {usage.data
-          ? `${usage.data.files} files · ${formatBytes(usage.data.bytes)} used in this volume`
-          : " "}
-      </div>
+      </ListFrame>
 
       <Dialog open={newFolderOpen} onOpenChange={setNewFolderOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>New folder</DialogTitle>
             <DialogDescription>
-              Create a folder in {path ? `“${path}”` : "the volume root"}.
+              Create a folder in {segments.length ? segments.join("/") : "org"}.
             </DialogDescription>
           </DialogHeader>
           <Input
@@ -384,7 +496,6 @@ function VolumeBrowser(props: { volume: string }) {
 }
 
 export function OrgFsFilesPage() {
-  const [volume, setVolume] = useState<string>(VOLUMES[0].id);
   return (
     <Page>
       <Page.Content>
@@ -393,22 +504,12 @@ export function OrgFsFilesPage() {
             <div className="flex flex-col gap-1">
               <Page.Title>Files</Page.Title>
               <p className="text-sm text-muted-foreground">
-                The organization filesystem — these volumes are mounted at{" "}
+                The organization filesystem — mounted at{" "}
                 <code className="text-xs">org/</code> inside every sandbox.
               </p>
             </div>
             <ErrorBoundary>
-              <Tabs value={volume} onValueChange={setVolume}>
-                <TabsList>
-                  {VOLUMES.map((v) => (
-                    <TabsTrigger key={v.id} value={v.id}>
-                      {v.label}
-                    </TabsTrigger>
-                  ))}
-                </TabsList>
-              </Tabs>
-              {/* key resets the browse path when switching volumes */}
-              <VolumeBrowser key={volume} volume={volume} />
+              <FsBrowser />
             </ErrorBoundary>
           </SettingsPage>
         </Page.Body>

--- a/apps/mesh/src/web/views/settings/org-files.tsx
+++ b/apps/mesh/src/web/views/settings/org-files.tsx
@@ -1,0 +1,418 @@
+/**
+ * Settings → Files: browser over the organization filesystem — the same
+ * volumes sandboxes mount at `org/` (skills = shared library, outputs =
+ * agent run outputs). Browse, upload, download, create folders, delete.
+ * Data layer in @/web/hooks/use-org-fs (org-scoped HTTP, session auth).
+ */
+
+import { useRef, useState } from "react";
+import {
+  ChevronRight,
+  Download01,
+  File02,
+  Folder,
+  Plus,
+  RefreshCw01,
+  Trash01,
+  Upload01,
+} from "@untitledui/icons";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { Tabs, TabsList, TabsTrigger } from "@deco/ui/components/tabs.tsx";
+import { ErrorBoundary } from "@/web/components/error-boundary";
+import { Page } from "@/web/components/page";
+import { SettingsPage } from "@/web/components/settings/settings-section";
+import { KEYS } from "@/web/lib/query-keys";
+import {
+  type OrgFsEntry,
+  useOrgFsDownloadUrl,
+  useOrgFsList,
+  useOrgFsMutations,
+  useOrgFsUsage,
+} from "@/web/hooks/use-org-fs";
+
+/** The volumes every sandbox mounts (see file-storage/mount/provisioning.ts). */
+const VOLUMES = [
+  { id: "skills", label: "Skills" },
+  { id: "outputs", label: "Outputs" },
+] as const;
+
+function basename(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? path : path.slice(i + 1);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB"];
+  let value = bytes;
+  let unit = "B";
+  for (const u of units) {
+    if (value < 1024) break;
+    value /= 1024;
+    unit = u;
+  }
+  return `${value.toFixed(value >= 10 ? 0 : 1)} ${unit}`;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? "" : d.toLocaleString();
+}
+
+function Breadcrumbs(props: {
+  path: string;
+  onNavigate: (path: string) => void;
+}) {
+  const segments = props.path === "" ? [] : props.path.split("/");
+  return (
+    <div className="flex items-center gap-1 text-sm min-w-0 flex-wrap">
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground hover:underline"
+        onClick={() => props.onNavigate("")}
+      >
+        root
+      </button>
+      {segments.map((seg, i) => {
+        const target = segments.slice(0, i + 1).join("/");
+        const isLast = i === segments.length - 1;
+        return (
+          <span key={target} className="flex items-center gap-1 min-w-0">
+            <ChevronRight
+              size={12}
+              className="text-muted-foreground shrink-0"
+            />
+            {isLast ? (
+              <span className="font-medium truncate">{seg}</span>
+            ) : (
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground hover:underline truncate"
+                onClick={() => props.onNavigate(target)}
+              >
+                {seg}
+              </button>
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function VolumeBrowser(props: { volume: string }) {
+  const { volume } = props;
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const [path, setPath] = useState("");
+  const [pendingDelete, setPendingDelete] = useState<OrgFsEntry | null>(null);
+  const [newFolderOpen, setNewFolderOpen] = useState(false);
+  const [newFolderName, setNewFolderName] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const listing = useOrgFsList(volume, path);
+  const usage = useOrgFsUsage(volume);
+  const downloadUrl = useOrgFsDownloadUrl(volume);
+  const { upload, mkdir, remove } = useOrgFsMutations(volume);
+
+  async function handleUpload(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    try {
+      await upload.mutateAsync({ dir: path, files: [...files] });
+      toast.success(
+        files.length === 1
+          ? `Uploaded ${files[0]?.name}`
+          : `Uploaded ${files.length} files`,
+      );
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  async function handleCreateFolder() {
+    const name = newFolderName.trim();
+    if (!name) return;
+    try {
+      await mkdir.mutateAsync(path ? `${path}/${name}` : name);
+      toast.success(`Folder "${name}" created`);
+      setNewFolderOpen(false);
+      setNewFolderName("");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create folder",
+      );
+    }
+  }
+
+  async function handleDelete() {
+    if (!pendingDelete) return;
+    const entry = pendingDelete;
+    try {
+      await remove.mutateAsync(entry.path);
+      toast.success(`Deleted ${basename(entry.path)}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setPendingDelete(null);
+    }
+  }
+
+  const entries = listing.data ?? [];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <Breadcrumbs path={path} onNavigate={setPath} />
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              queryClient.invalidateQueries({
+                queryKey: KEYS.orgFsVolume(org.id, volume),
+              })
+            }
+          >
+            <RefreshCw01 size={14} />
+            Refresh
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setNewFolderOpen(true)}
+          >
+            <Plus size={14} />
+            New folder
+          </Button>
+          <Button
+            size="sm"
+            disabled={upload.isPending}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload01 size={14} />
+            {upload.isPending ? "Uploading…" : "Upload"}
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={(e) => void handleUpload(e.target.files)}
+          />
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-border overflow-hidden">
+        {listing.isLoading ? (
+          <div className="p-4 flex flex-col gap-2">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-2/3" />
+          </div>
+        ) : listing.isError ? (
+          <div className="p-6 text-sm text-destructive">
+            {listing.error instanceof Error
+              ? listing.error.message
+              : "Failed to load"}
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="p-10 text-center text-sm text-muted-foreground">
+            Empty folder — upload a file or create a folder to get started.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="px-4 py-2 font-medium">Name</th>
+                <th className="px-4 py-2 font-medium w-28">Size</th>
+                <th className="px-4 py-2 font-medium w-48">Modified</th>
+                <th className="px-4 py-2 w-20" />
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => {
+                const name = basename(entry.path);
+                const isDir = entry.kind === "dir";
+                return (
+                  <tr
+                    key={entry.path}
+                    className="border-b border-border last:border-b-0 hover:bg-muted/50"
+                  >
+                    <td className="px-4 py-2">
+                      {isDir ? (
+                        <button
+                          type="button"
+                          className="flex items-center gap-2 hover:underline"
+                          onClick={() => setPath(entry.path)}
+                        >
+                          <Folder size={15} className="text-muted-foreground" />
+                          <span className="font-medium">{name}</span>
+                        </button>
+                      ) : (
+                        <span className="flex items-center gap-2">
+                          <File02 size={15} className="text-muted-foreground" />
+                          {name}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {isDir ? "—" : formatBytes(entry.size)}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {formatDate(entry.updatedAt)}
+                    </td>
+                    <td className="px-4 py-2">
+                      <div className="flex items-center justify-end gap-1">
+                        {!isDir && (
+                          <Button variant="ghost" size="icon" asChild>
+                            <a
+                              href={downloadUrl(entry.path)}
+                              download={name}
+                              aria-label={`Download ${name}`}
+                            >
+                              <Download01 size={14} />
+                            </a>
+                          </Button>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Delete ${name}`}
+                          onClick={() => setPendingDelete(entry)}
+                        >
+                          <Trash01 size={14} />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="text-xs text-muted-foreground">
+        {usage.data
+          ? `${usage.data.files} files · ${formatBytes(usage.data.bytes)} used in this volume`
+          : " "}
+      </div>
+
+      <Dialog open={newFolderOpen} onOpenChange={setNewFolderOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New folder</DialogTitle>
+            <DialogDescription>
+              Create a folder in {path ? `“${path}”` : "the volume root"}.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            autoFocus
+            placeholder="folder-name"
+            value={newFolderName}
+            onChange={(e) => setNewFolderName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleCreateFolder();
+            }}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setNewFolderOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!newFolderName.trim() || mkdir.isPending}
+              onClick={() => void handleCreateFolder()}
+            >
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {pendingDelete ? basename(pendingDelete.path) : ""}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete?.kind === "dir"
+                ? "The folder and everything inside it will be deleted for the whole organization. Sandboxes see this change within seconds."
+                : "The file will be deleted for the whole organization. Sandboxes see this change within seconds."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void handleDelete()}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export function OrgFsFilesPage() {
+  const [volume, setVolume] = useState<string>(VOLUMES[0].id);
+  return (
+    <Page>
+      <Page.Content>
+        <Page.Body>
+          <SettingsPage>
+            <div className="flex flex-col gap-1">
+              <Page.Title>Files</Page.Title>
+              <p className="text-sm text-muted-foreground">
+                The organization filesystem — these volumes are mounted at{" "}
+                <code className="text-xs">org/</code> inside every sandbox.
+              </p>
+            </div>
+            <ErrorBoundary>
+              <Tabs value={volume} onValueChange={setVolume}>
+                <TabsList>
+                  {VOLUMES.map((v) => (
+                    <TabsTrigger key={v.id} value={v.id}>
+                      {v.label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </Tabs>
+              {/* key resets the browse path when switching volumes */}
+              <VolumeBrowser key={volume} volume={volume} />
+            </ErrorBoundary>
+          </SettingsPage>
+        </Page.Body>
+      </Page.Content>
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary

Gives the organization filesystem a face — built to smoke-test the org-fs rollout on staging.

**Settings → Files** (new): a browser over the org filesystem — the same `skills` / `outputs` volumes every sandbox mounts at `org/`:
- volume tabs (Skills / Outputs), breadcrumb navigation, dirs-first listing with size + modified time
- **upload** (multi-file, raw `PUT` per file), **download** (same-origin `read` link), **new folder**, **delete** (confirm dialog; folder delete is recursive, copy warns it's org-wide)
- per-volume usage footer (`files · bytes`)
- member-accessible — no capability gate, matching the org-fs ACL (ORG_FS_READ/WRITE are basic-usage; see the ACL note in `api/routes/org-fs.ts`)

**Settings → Buckets** (rename): the old "Files" page (S3 bucket configs) moves to `/settings/buckets`, keeping its `file-configs:manage` gate and content untouched; the settings index redirect follows.

Data layer (`hooks/use-org-fs.ts`) talks the org-scoped HTTP contract directly (session auth) rather than MCP tools — uploads/downloads move raw bytes, which those routes were built for (the route header names the "Drive-like UI" as an intended consumer). TanStack Query with hierarchical keys: one volume-prefix key invalidates every listing + usage after a mutation.

## Why now
With #3723–#3759 shipped, files written here appear inside linked/hosted sandboxes within ~1s (and vice-versa) — this UI is the easiest way to verify that loop on staging without a terminal.

## Testing
- typecheck, lint (incl. query-key constants, no-useEffect, kebab-case plugins), production client build — all green
- UI smoke on staging is the point of this PR; happy to pair on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a member-accessible Files browser for the org filesystem with upload, download, new folder, and delete — now shown as a single “org/” tree with volumes as root folders. Renames the old Files (S3 bucket configs) to Buckets and updates navigation and redirects.

- **New Features**
  - Settings → Files: org-rooted browser where each volume (Skills, Outputs) appears as a folder; breadcrumbs, dirs-first listing, size/modified; volume rows show usage as size.
  - Actions: multi-file upload (raw `PUT`), download, create folder, delete with confirm; upload/new-folder disabled at the org root.
  - Data: `hooks/use-org-fs.ts` talks `/api/:org/fs/:volume/*` with session auth; `@tanstack/react-query` keys with volume-level invalidation.

- **Refactors**
  - Settings → Buckets: moved the previous Files (S3 bucket configs); keeps `file-configs:manage`.
  - Sidebar: Files uses Folder icon; Buckets uses HardDrive. Added `/$org/settings/buckets`; settings index redirect now points there when `file-configs:manage` is present.

<sup>Written for commit 978583628340ba76e2640855e27e54b7701522bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

