### PR TITLE
fix(title-generator): update title validation to require JSON respons…

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/title-generator.ts
+++ b/apps/mesh/src/harnesses/decopilot/title-generator.ts
@@ -22,7 +22,9 @@ Good examples:
 
 Bad (too vague): Help with task
 Bad (too long): Investigate and fix the issue where the login button does not respond on mobile devices
-Bad (wrong case): Fix Login Button On Mobile`;
+Bad (wrong case): Fix Login Button On Mobile
+
+Respond with a JSON object containing the title.`;
 
 // A title is usable only if it contains at least one letter or number in any
 // script. Unicode-aware (\p{L}\p{N}) so non-Latin titles (CJK, Arabic, etc.)


### PR DESCRIPTION
…e format

Modified the title validation logic to ensure that a valid title must now respond with a JSON object containing the title. This change enhances the clarity and usability of the title generation process.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require the Decopilot title generator to return a JSON object with the title (e.g., {"title":"..."}), ensuring consistent parsing and validation. Updated the harness prompt in the title generator to enforce this format.

<sup>Written for commit fc238a951a3301012235a1364da619868980ba06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

