### PR TITLE
fix(proxy): enhance error logging for upstream responses

### DIFF
--- a/packages/sandbox/daemon/proxy.ts
+++ b/packages/sandbox/daemon/proxy.ts
@@ -72,7 +72,7 @@ export function makeProxyHandler({ broadcaster, getDevPort }: ProxyDeps) {
       clearTimeout(headersTimeout);
       req.signal.removeEventListener("abort", onClientAbort);
       const msg = (e as Error).message ?? String(e);
-      log("proxy error", req.method, url.pathname, msg);
+      log("proxy error", req.method, url.pathname, `port=${port}`, msg);
       const connErr =
         /ECONNREFUSED|ECONNRESET|ECONNABORTED|fetch failed|Unable to connect|TimeoutError|timed out/i.test(
           msg,
@@ -100,6 +100,21 @@ export function makeProxyHandler({ broadcaster, getDevPort }: ProxyDeps) {
           "Access-Control-Allow-Origin": "*",
         },
       });
+    }
+
+    // The fetch resolved, so routing to the dev server worked — but the dev
+    // server itself may have answered with a 5xx. That's invisible otherwise
+    // (the body just streams through), so log it explicitly: this is the
+    // "dev server responded but blew up" case, distinct from "couldn't reach
+    // it at all" handled in the catch above.
+    if (upstream.status >= 500) {
+      log(
+        "proxy upstream error",
+        req.method,
+        url.pathname,
+        `port=${port}`,
+        `status=${upstream.status}`,
+      );
     }
 
     const respHeaders = new Headers(upstream.headers);


### PR DESCRIPTION
- Improved logging for proxy errors by including the port number in the error message.
- Added explicit logging for 5xx responses from the upstream server to distinguish between connection issues and server errors.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhance proxy observability by adding the dev server port to error logs and explicitly logging upstream 5xx responses. This makes it easier to distinguish connection/routing failures from upstream server errors.

<sup>Written for commit ac562462d0fd322c9202d2f0c1d3c02dad70a92b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

