### PR TITLE
fix(sandbox-proxy): improve error handling for preview URL and upstre…

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -606,7 +606,12 @@ export const createSandboxRoutes = () => {
       return c.json({ error: "Path not allowed" }, 403);
     }
 
-    const previewUrl = await runner.getPreviewUrl(claimName);
+    let previewUrl: string | null;
+    try {
+      previewUrl = await runner.getPreviewUrl(claimName);
+    } catch {
+      return c.json({ error: "Preview not available" }, 502);
+    }
     if (!previewUrl) {
       return c.json({ error: "Preview not available" }, 502);
     }
@@ -619,7 +624,12 @@ export const createSandboxRoutes = () => {
       return c.json({ error: "Preview unreachable" }, 502);
     }
 
-    const text = await upstream.text();
+    let text: string;
+    try {
+      text = await upstream.text();
+    } catch {
+      return c.json({ error: "Preview unreachable" }, 502);
+    }
     return new Response(text, {
       status: upstream.status,
       headers: {
@@ -641,7 +651,12 @@ export const createSandboxRoutes = () => {
       if (runner instanceof Response) return runner;
 
       const { claimName } = c.get("vmClaim");
-      const previewUrl = await runner.getPreviewUrl(claimName);
+      let previewUrl: string | null;
+      try {
+        previewUrl = await runner.getPreviewUrl(claimName);
+      } catch {
+        return c.json({ error: "Preview not available" }, 502);
+      }
       if (!previewUrl) {
         return c.json({ error: "Preview not available" }, 502);
       }
@@ -677,7 +692,12 @@ export const createSandboxRoutes = () => {
         return c.json({ error: "Preview unreachable" }, 502);
       }
 
-      const text = await upstream.text();
+      let text: string;
+      try {
+        text = await upstream.text();
+      } catch {
+        return c.json({ error: "Preview unreachable" }, 502);
+      }
       return new Response(text, {
         status: upstream.status,
         headers: {


### PR DESCRIPTION
…am text retrieval

Enhanced the error handling in the sandbox-proxy routes by wrapping the calls to getPreviewUrl and upstream.text in try-catch blocks. This change ensures that appropriate error responses are returned when the preview is not available or unreachable, improving the robustness of the API.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve error handling in sandbox-proxy to prevent crashes when preview URL fetch or upstream text retrieval fails. Return clear 502 JSON errors for unavailable or unreachable previews.

- **Bug Fixes**
  - Wrap `runner.getPreviewUrl` and `upstream.text` in try/catch.
  - Return consistent 502 responses with `{ error: "Preview not available" | "Preview unreachable" }`.

<sup>Written for commit 907304677c2c43db8d63fcc458c1e0c83ca05111. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

