### PR TITLE
fix(decopilot): enhance error logging by using stringifyError

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1385,7 +1385,7 @@ async function prepareRun(
           });
           return sanitizeStreamError(error);
         }
-        console.error("[decopilot] stream error:", error);
+        console.error("[decopilot] stream error:", stringifyError(error));
         const sanitized = sanitizeStreamError(error);
         posthog.capture({
           distinctId: input.userId,

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -43,6 +43,7 @@ import { StreamRequestSchema } from "./schemas";
 import type { ChatMessage, ModelsConfig } from "./types";
 import type { DispatchRunInput } from "./dispatch-run";
 import { resolveHarnessId } from "./dispatch-run";
+import { stringifyError } from "@/harnesses/decopilot/stream-error";
 import { enqueueThreadRun } from "@/dispatch-queue";
 import { wrapWithSseKeepalive } from "./sse-keepalive";
 import type { LinkClaimRegistry } from "../../../links/link-claim-registry";
@@ -822,7 +823,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       return wrapWithSseKeepalive(baseResponse);
     } catch (err) {
       if (err instanceof HTTPException) throw err;
-      console.error("[decopilot:stream] Error", err);
+      console.error("[decopilot:stream] Error", stringifyError(err));
       return c.body(null, 500);
     }
   });

--- a/apps/mesh/src/harnesses/decopilot/run-stream.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-stream.ts
@@ -736,7 +736,7 @@ export async function* runDecopilotStream(
       // sets handle.error; we pick up the message from there.
       const rawError =
         error instanceof Error ? error : new Error(stringifyError(error));
-      console.error("[decopilot:stream] Error", rawError);
+      console.error("[decopilot:stream] Error", rawError.message);
       if (registrySignal.aborted) {
         return;
       }


### PR DESCRIPTION
Updated error logging in dispatch-run.ts, routes.ts, and run-stream.ts to utilize stringifyError for improved clarity in error messages. This change ensures that error details are more informative and consistent across the Decopilot API routes.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized Decopilot error logging by using stringifyError in API routes and dispatch, and logging rawError.message in the stream handler. This makes stream errors clearer and consistent in logs without changing runtime behavior.

<sup>Written for commit ef2b19d6438fb33d630cd6f875046acd59cbdf04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

