### PR TITLE
fix(agent-sandbox): improve error message handling in port-forward lo…

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -88,6 +88,22 @@ const RUNNER_KIND = "agent-sandbox" as const;
 const LOG_LABEL = "AgentSandboxProvider";
 
 /**
+ * Readable message from an unknown throwable. The k8s client's port-forward
+ * rejects with a WebSocket `ErrorEvent` (not an `Error`), which `String(err)`
+ * renders as the useless `[object ErrorEvent]`; pull `.error.message`/`.message`
+ * off it instead.
+ */
+function errMsg(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object") {
+    const e = err as { error?: unknown; message?: unknown };
+    if (e.error instanceof Error) return e.error.message;
+    if (typeof e.message === "string" && e.message) return e.message;
+  }
+  return String(err);
+}
+
+/**
  * Response-header marker on the preview-proxy's "sandbox not ready" envelopes
  * (404 "sandbox not found" in dev, 502 "sandbox daemon unreachable" in prod).
  * The mesh edge (`apps/mesh/src/sandbox/preview-proxy.ts`) swaps these for an
@@ -1852,7 +1868,7 @@ export class AgentSandboxProvider implements SandboxProvider {
       })
       .catch((err: unknown) => {
         console.warn(
-          `[${LOG_LABEL}] port-forward to ${podName}:${containerPort} failed: ${err instanceof Error ? err.message : String(err)}`,
+          `[${LOG_LABEL}] port-forward to ${podName}:${containerPort} failed: ${errMsg(err)}`,
         );
         this.invalidateRecord(handle);
         cleanup();


### PR DESCRIPTION
…gging

- Added a new utility function `errMsg` to extract meaningful error messages from various throwable types, enhancing the clarity of error logs during port-forward failures.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve port-forward error logging in the agent sandbox by extracting readable messages from non-Error throwables. Adds `errMsg` and uses it in the catch path so WebSocket `ErrorEvent` cases log the real message instead of `[object ErrorEvent]`.

<sup>Written for commit 2902f96c9c4a01cb277e2542cc6104c73cb3f505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

