### PR TITLE
fix(auth): improve error logging for OAuth redirects

### DIFF
--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -456,6 +456,18 @@ export const auth = betterAuth({
   logger: {
     log: (level, message, ...args) => {
       if (level === "error" && message.includes("validate API key")) return;
+      // Better Auth performs OAuth redirects by *throwing* an APIError with a
+      // 3xx status (e.g. "FOUND"/302 + Set-Cookie). A successful login is not
+      // a failure — drop these so they don't masquerade as errors in prod logs.
+      if (
+        level === "error" &&
+        args.some((a) => {
+          const code = (a as { statusCode?: unknown } | null)?.statusCode;
+          return typeof code === "number" && code >= 300 && code < 400;
+        })
+      ) {
+        return;
+      }
       const line = `${new Date().toISOString()} ${level.toUpperCase()} [Better Auth]: ${message}`;
       if (level === "error") console.error(line, ...args);
       else if (level === "warn") console.warn(line, ...args);


### PR DESCRIPTION
Enhanced the logging mechanism in the Better Auth module to prevent successful OAuth redirects (3xx status codes) from being logged as errors. This change ensures that production logs remain clean and focused on actual error conditions.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop logging successful OAuth redirects (3xx) as errors in the auth logger to keep production logs focused on real failures. The logger now detects 3xx status codes in thrown redirect errors and ignores them, while still logging actual errors and warnings.

<sup>Written for commit 0a1befac46712d5408638bf95b9daa76ebe327e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

