### PR TITLE
fix(oauth): handle bad_refresh_token as permanent error in refreshAcc…

### DIFF
--- a/apps/mesh/src/oauth/refresh-access-token.test.ts
+++ b/apps/mesh/src/oauth/refresh-access-token.test.ts
@@ -51,6 +51,25 @@ describe("refreshAccessToken", () => {
     expect(result.error).toContain("revoked");
   });
 
+  it("flags 400 bad_refresh_token as permanent (non-standard GitHub MCP code)", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            error: "bad_refresh_token",
+            error_description:
+              "The refresh token passed is incorrect or expired.",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(false);
+    expect(result.permanent).toBe(true);
+  });
+
   it("flags other 4xx errors as transient (could be config issue, retry-worthy)", async () => {
     installFetch(
       () =>

--- a/apps/mesh/src/oauth/refresh-access-token.ts
+++ b/apps/mesh/src/oauth/refresh-access-token.ts
@@ -10,11 +10,24 @@
 
 import type { DownstreamToken } from "../storage/types";
 
+/**
+ * 400 error codes that mean the refresh_token itself is permanently dead, so
+ * the cached token must be evicted instead of retried. `invalid_grant` is the
+ * RFC 6749 §5.2 standard; `bad_refresh_token` is the non-standard code some
+ * servers emit (e.g. the GitHub MCP token endpoint) — without it an expired
+ * GitHub token is retried on every request, hammering the token endpoint.
+ */
+const PERMANENT_REFRESH_ERROR_CODES = new Set([
+  "invalid_grant",
+  "bad_refresh_token",
+]);
+
 export interface TokenRefreshResult {
   success: boolean;
   /**
    * `true` only when the OAuth server told us the refresh_token itself is
-   * permanently invalid (RFC 6749 §5.2: `400 invalid_grant`). Callers use
+   * permanently invalid (a `400` with a code in `PERMANENT_REFRESH_ERROR_CODES`,
+   * e.g. RFC 6749 §5.2 `invalid_grant`). Callers use
    * this to decide whether to delete the cached token: deleting on transient
    * failures (5xx, network blips, non-spec status codes) silently logs users
    * out and forces a manual reconnect, so we only delete when we're certain.
@@ -94,11 +107,13 @@ export async function refreshAccessToken(
         // body wasn't JSON — fall through with undefined codes
       }
 
-      // Only `400 invalid_grant` means the refresh_token is permanently dead.
-      // Everything else (5xx, network blips, non-spec status codes) is treated
-      // as transient — the cached token should not be deleted.
+      // A 400 with a known dead-refresh-token code means it's permanently
+      // dead. Everything else (5xx, network blips, non-spec status codes) is
+      // treated as transient — the cached token should not be deleted.
       const permanent =
-        response.status === 400 && errorCode === "invalid_grant";
+        response.status === 400 &&
+        !!errorCode &&
+        PERMANENT_REFRESH_ERROR_CODES.has(errorCode);
 
       console.error("[TokenRefresh] refresh failed", {
         connectionId: token.connectionId,


### PR DESCRIPTION
…essToken

Added handling for the non-standard 400 error code "bad_refresh_token" in the refreshAccessToken function. This change ensures that tokens flagged with this error are treated as permanently invalid, preventing unnecessary retries. Updated tests to verify this behavior.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `400 bad_refresh_token` as a permanent error in `refreshAccessToken` to stop retry loops and evict invalid tokens. This prevents unnecessary calls to the token endpoint.

- **Bug Fixes**
  - Handle non-standard GitHub MCP `bad_refresh_token` as permanent (same as `invalid_grant`).
  - Set permanence only for status `400` with a code in `PERMANENT_REFRESH_ERROR_CODES`.
  - Added a unit test to confirm `permanent: true` for `bad_refresh_token`.

<sup>Written for commit 3fe53ef09d466787f1dbb18432675a8bcb28ce5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

