### PR TITLE
fix(context-factory): improve error handling in permission checks

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -321,7 +321,18 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
 
         return wildcardResult?.success === true;
       } catch (err) {
-        console.error("[Auth] Permission check failed:", err);
+        // A 401/403 from the permission API is an expected denial (no session
+        // or insufficient scope) — we already deny by returning `false`, so
+        // don't log it as an error. Only surface genuinely unexpected failures
+        // (5xx, network), and log the message rather than dumping the whole
+        // APIError object.
+        const statusCode = (err as { statusCode?: number } | null)?.statusCode;
+        if (statusCode !== 401 && statusCode !== 403) {
+          console.error(
+            "[Auth] Permission check failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
         return false;
       }
     },


### PR DESCRIPTION
Updated the error handling in the createBoundAuthClient function to avoid logging expected 401/403 responses from the permission API as errors. Instead, only genuinely unexpected failures (e.g., 5xx errors) are logged, enhancing clarity and reducing noise in the logs.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `createBoundAuthClient` permission checks to stop logging expected 401/403 denials and only log unexpected failures (5xx/network) with a concise message. This reduces log noise and keeps auth behavior unchanged.

<sup>Written for commit 87917a7b7f1aa4bc85ea24ecec2da8e1febe1227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

