### PR TITLE
fix(sandbox): introduce ConfigRequestError for improved error handling

### DIFF
--- a/packages/sandbox/server/daemon-client.ts
+++ b/packages/sandbox/server/daemon-client.ts
@@ -9,6 +9,19 @@ import { sleep } from "../shared";
 
 export type { ConfigPatch };
 
+/** Error thrown by config requests when the daemon responds non-2xx; carries
+ *  the HTTP status so callers can branch (e.g. 401 → re-auth with another
+ *  token rather than tear the sandbox down). */
+export class ConfigRequestError extends Error {
+  constructor(
+    readonly status: number,
+    body: string,
+  ) {
+    super(`sandbox daemon /_sandbox/config returned ${status}: ${body}`);
+    this.name = "ConfigRequestError";
+  }
+}
+
 const HEALTH_PROBE_TIMEOUT_MS = 500;
 // Config application can run a cold clone + install on a heavy sandbox; 10s was
 // too tight and routinely tripped `AbortSignal.timeout()`, surfacing benign
@@ -136,9 +149,7 @@ async function configRequest(
   });
   const body = await res.text();
   if (!res.ok) {
-    throw new Error(
-      `sandbox daemon /_sandbox/config returned ${res.status}: ${body}`,
-    );
+    throw new ConfigRequestError(res.status, body);
   }
   return JSON.parse(body) as ConfigResponse;
 }

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -38,6 +38,7 @@ import type {
   UpDownCounter,
 } from "@opentelemetry/api";
 import {
+  ConfigRequestError,
   postConfig,
   postOrgFsConfig,
   probeDaemonHealth,
@@ -1292,15 +1293,31 @@ export class AgentSandboxProvider implements SandboxProvider {
     ensureOpts: EnsureOptions | null,
   ): Promise<boolean> {
     if (this.sentinelToken === null) return false;
+    const payload = this.workloadConfigPayload(ensureOpts) ?? {};
     try {
-      await postConfig(
-        daemonUrl,
-        this.sentinelToken,
-        this.workloadConfigPayload(ensureOpts) ?? {},
-        { rotateToken: token },
-      );
+      await postConfig(daemonUrl, this.sentinelToken, payload, {
+        rotateToken: token,
+      });
       return true;
     } catch (err) {
+      // A 401 means the daemon no longer accepts the sentinel: it was already
+      // rotated to our per-claim token (a stale stored bootId triggered this
+      // re-bootstrap against a pod we'd already healed — the resume/reactive-401
+      // paths don't persist bootId). The pod is still ours, so re-assert the
+      // workload authenticated with our own token (rotating token→token is a
+      // no-op) instead of tearing the sandbox down. Only if THAT also fails is
+      // the pod genuinely not ours and the caller should reprovision.
+      if (err instanceof ConfigRequestError && err.status === 401) {
+        try {
+          await postConfig(daemonUrl, token, payload, { rotateToken: token });
+          return true;
+        } catch (retryErr) {
+          console.warn(
+            `[${LOG_LABEL}] re-bootstrap retry with claim token failed: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`,
+          );
+          return false;
+        }
+      }
       console.warn(
         `[${LOG_LABEL}] re-bootstrap failed: ${err instanceof Error ? err.message : String(err)}`,
       );


### PR DESCRIPTION
Added a new ConfigRequestError class to encapsulate errors from config requests to the daemon, providing clearer error messages with HTTP status codes. Updated the AgentSandboxProvider to utilize this new error class, enhancing the handling of 401 responses during re-bootstrap attempts.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves error handling for sandbox config requests. Adds a ConfigRequestError and retries re-bootstrap on 401 using the claim token to avoid unnecessary sandbox teardown.

- **Bug Fixes**
  - Introduced ConfigRequestError in daemon client to surface HTTP status and body for non-2xx responses.
  - Updated AgentSandboxProvider to catch 401s on postConfig and retry with the claim token, keeping the existing pod when the sentinel token was rotated.
  - Improved warning logs for failed retries; behavior remains backward compatible.

<sup>Written for commit 18da04d908502d122fb7f1babacea1f2b64cf220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

