### PR TITLE
feat(shutdown): improve graceful shutdown handling and health check e…

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1135,6 +1135,17 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Health Check & Metrics
   // ============================================================================
 
+  // AWS NLB target-group health check (path "/health"). Cheap — no DB/NATS
+  // probe — but flips to 503 during shutdown so the load balancer stops routing
+  // to a draining pod. Without an explicit route this falls through to the SPA
+  // handler and returns 200 forever, hiding shutdown from the NLB.
+  app.get(SYSTEM_PATHS.HEALTH, (c) => {
+    if (isShuttingDown) {
+      return c.json({ status: "shutting_down" }, 503);
+    }
+    return c.json({ status: "ok" });
+  });
+
   // Liveness probe — the process is alive and the event loop is not stuck
   app.get(SYSTEM_PATHS.HEALTH_LIVE, (c) => {
     return c.json({ status: "ok" });

--- a/apps/mesh/src/api/utils/paths.ts
+++ b/apps/mesh/src/api/utils/paths.ts
@@ -7,6 +7,10 @@
 
 /** System paths that don't require authentication or special handling */
 export const SYSTEM_PATHS = {
+  // Bare /health is the AWS NLB target-group health-check path. Kept distinct
+  // from the K8s liveness/readiness probes so the load balancer can pull a
+  // draining pod on its own during rollout.
+  HEALTH: "/health",
   HEALTH_LIVE: "/health/live",
   HEALTH_READY: "/health/ready",
   METRICS: "/metrics",
@@ -29,6 +33,7 @@ const STATIC_FILE_PATTERN =
 /** Check if a path is a system endpoint (health, metrics, well-known) */
 function isSystemPath(path: string): boolean {
   return (
+    path === SYSTEM_PATHS.HEALTH ||
     path === SYSTEM_PATHS.HEALTH_LIVE ||
     path === SYSTEM_PATHS.HEALTH_READY ||
     path === SYSTEM_PATHS.METRICS ||

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -6,6 +6,7 @@
  * Or: bun run src/index.ts
  */
 
+import { sleep } from "@decocms/std";
 import { getSettings } from "./settings";
 import { initObservability } from "./observability";
 
@@ -275,8 +276,15 @@ async function gracefulShutdown(signal: string) {
     // 1. Mark as shutting down — readiness returns 503 immediately
     app.markShuttingDown();
 
-    // 2. Let K8s notice the 503 before we close connections.
-    await new Promise((r) => setTimeout(r, 2_000));
+    // 2. Keep serving while the load balancer stops routing to this pod.
+    //    With the AWS NLB in ip-target mode, deregistration is driven by the
+    //    LB controller observing the pod enter Terminating (this SIGTERM), not
+    //    by the K8s Endpoints path — and it takes far longer than the old 2s to
+    //    propagate. Closing the listener early leaves the NLB forwarding new
+    //    connections to a dead socket -> CF 520 during rollout. Stay well under
+    //    terminationGracePeriodSeconds (60s) so the force-exit timer never trips.
+    const drainMs = Number(process.env.SHUTDOWN_DRAIN_MS ?? 25_000);
+    await sleep(drainMs);
 
     // 3. Force-close connections (SSE streams are long-lived and would block
     //    graceful drain indefinitely).


### PR DESCRIPTION
…ndpoint

- Added a health check endpoint at "/health" to indicate when the application is shutting down, allowing the AWS NLB to stop routing traffic to draining pods.
- Updated graceful shutdown logic to extend the connection drain time, preventing premature closure of connections during pod termination.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a lightweight `/health` endpoint and extend graceful shutdown drain time so AWS NLB can stop routing to a terminating pod before connections are closed, reducing rollout 5xxs.

- **New Features**
  - Added `/health` that returns 200 when healthy and 503 during shutdown; kept separate from `/health/live` and `/health/ready` and avoids DB/NATS.
  - Graceful shutdown now waits `SHUTDOWN_DRAIN_MS` (default 25,000 ms) before closing connections to allow NLB deregistration.

- **Migration**
  - Point the AWS NLB target group health check to `/health`.
  - Optionally set `SHUTDOWN_DRAIN_MS` to fit your rollout; keep it below `terminationGracePeriodSeconds` (default 25,000 ms).

<sup>Written for commit 039994933a6f45df1307b7e8765f46666cf39591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

