### PR TITLE
refactor(daemon): replace gitSync with publish function for shutdown …

### DIFF
--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -9,7 +9,6 @@ import { REPLAY_BYTES } from "./constants";
 import { Broadcaster } from "./events/broadcast";
 import type { DaemonStatus } from "./events/types";
 import { BranchStatusMonitor } from "./git/branch-status";
-import { gitSync } from "./git/git-sync";
 import { InstallState } from "./install/install-state";
 import { LifecycleManager } from "./lifecycle/manager";
 import { readConfig } from "./persistence";
@@ -32,6 +31,7 @@ import {
   makeGitPublishHandler,
   makeGitRebaseHandler,
   makeGitStatusHandler,
+  publish,
 } from "./routes/git";
 import {
   makeConfigReadHandler,
@@ -769,27 +769,20 @@ process.on("SIGTERM", async () => {
   if (mountManager) {
     await mountManager.stop().catch(() => {});
   }
+  // Reuse the same publish() path as POST /_sandbox/git/publish so the
+  // shutdown sync inherits credentialed-remote setup, hook-skipping, and
+  // non-interactive push — the blind add/commit/push it replaced silently
+  // failed on GitHub repos whose origin URL lacked embedded credentials and
+  // could hang on a credential prompt until SIGKILL.
   const branch = store.read()?.git?.repository?.branch;
   if (branch) {
     try {
-      gitSync(["-c", "safe.directory=*", "add", "-A"], {
-        cwd: bootConfig.repoDir,
-      });
-      gitSync(
-        [
-          "-c",
-          "safe.directory=*",
-          "commit",
-          "-m",
-          `chore(daemon): sync all local changes to remote on shutdown`,
-        ],
-        { cwd: bootConfig.repoDir },
+      publish(
+        gitDeps,
+        "chore(daemon): sync all local changes to remote on shutdown",
       );
-      gitSync(["-c", "safe.directory=*", "push", "origin", branch], {
-        cwd: bootConfig.repoDir,
-      });
-    } catch {
-      // best-effort
+    } catch (err) {
+      console.warn("[daemon] shutdown publish failed", err);
     }
   }
   process.exit(0);

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -365,7 +365,7 @@ function pushBranch(repoDir: string, branch: string): void {
   );
 }
 
-function publish(deps: GitDeps, message: string): { pushed: boolean } {
+export function publish(deps: GitDeps, message: string): { pushed: boolean } {
   const repoDir = deps.repoDir;
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {


### PR DESCRIPTION
…sync

- Updated the shutdown process to use the new publish function for syncing local changes to the remote repository, improving handling of credentialed-remote setups and preventing issues with GitHub repositories lacking embedded credentials.
- Exported the publish function from the git routes module for broader accessibility.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the shutdown Git sync in the sandbox daemon to use the shared `publish` path, improving reliability with credentialed remotes and avoiding hangs on GitHub repos without embedded credentials.

- **Refactors**
  - On SIGTERM, call `publish(gitDeps, "chore(daemon): sync all local changes to remote on shutdown")` instead of manual `gitSync` add/commit/push.
  - Exported `publish` from `packages/sandbox/daemon/routes/git.ts` for reuse by the daemon.

<sup>Written for commit ac67f1e14e5d5e8ee186c0eedaf79c32ae9bbf04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

