### PR TITLE
feat(daemon): add runningCommandByLogName method and enhance orchestr…

### DIFF
--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -238,6 +238,17 @@ export class TaskManager {
     await Promise.all(initial.map((t) => t.finishedPromise));
   }
 
+  runningCommandByLogName(
+    logName: string,
+  ): { command: string; cwd: string } | null {
+    for (const t of this.tasks.values()) {
+      if (t.status === "running" && t.spec.logName === logName) {
+        return { command: t.spec.command, cwd: t.spec.cwd };
+      }
+    }
+    return null;
+  }
+
   list(filter?: { status?: ReadonlyArray<TaskStatus> }): TaskSummary[] {
     const out: TaskSummary[] = [];
     for (const t of this.tasks.values()) {

--- a/packages/sandbox/daemon/setup/orchestrator.test.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Broadcaster } from "../events/broadcast";
@@ -164,6 +164,147 @@ describe("SetupOrchestrator lifecycle integration", () => {
       cleanup();
     }
   }, 15_000);
+});
+
+describe("SetupOrchestrator idempotent start", () => {
+  // A port-change re-enqueues a `start` step. If a dev with the identical
+  // command is already running (or still mid-cold-boot), stepStart must skip
+  // the kill+respawn — otherwise it SIGTERMs the booting dev and forces a
+  // second cold compile (the prod crash-loop this fixes).
+  async function drain(o: {
+    isRunning: () => boolean;
+    pendingCount: () => number;
+  }) {
+    const deadline = Date.now() + 5_000;
+    while (o.isRunning() || o.pendingCount() > 0) {
+      if (Date.now() > deadline) throw new Error("orchestrator hung");
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  }
+
+  it("skips respawn when an identical dev is already running", async () => {
+    const { dir, cleanup } = tempRoot();
+    try {
+      const repoDir = join(dir, "repo");
+      mkdirSync(repoDir);
+      writeFileSync(
+        join(repoDir, "deno.json"),
+        JSON.stringify({ tasks: { dev: "echo hi" } }),
+      );
+      const broadcaster = new Broadcaster(1024);
+      const { lifecycle } = makeLifecycleSpy(broadcaster);
+
+      const spawns: Array<{ command: string; cwd: string }> = [];
+      // Mutable "what's currently running"; null until we plant the first spawn.
+      let running: { command: string; cwd: string } | null = null;
+
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir },
+        store: {
+          read: () => ({
+            application: { packageManager: { name: "deno" }, runtime: "deno" },
+          }),
+          hydrate: () => {},
+          applyInternal: async () => ({
+            kind: "applied",
+            before: null,
+            after: {},
+            transition: { kind: "no-op" },
+          }),
+        } as never,
+        taskManager: {
+          spawn: async (s: { command: string; cwd: string }) => {
+            spawns.push({ command: s.command, cwd: s.cwd });
+            return { id: `t${spawns.length}` };
+          },
+          killByLogName: () => 0,
+          waitForLogNamesIdle: async () => {},
+          runningCommandByLogName: () => running,
+          onTaskExit: () => () => {},
+        } as never,
+        setStatus: () => {},
+        getStatus: () => ({ state: "running" as const }),
+        broadcaster,
+        installState: { isInstalledFor: () => true } as never,
+        logsDir: dir,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
+      });
+
+      // 1st start: nothing running → spawns once.
+      orchestrator.handle({ kind: "port-change", from: undefined, to: 3000 });
+      await drain(orchestrator);
+      expect(spawns).toHaveLength(1);
+
+      // Plant the just-spawned dev as "running", then fire another start
+      // (a port-change to the sniffed port). Same command → no respawn.
+      running = spawns[0];
+      orchestrator.handle({ kind: "port-change", from: 3000, to: 8000 });
+      await drain(orchestrator);
+      expect(spawns).toHaveLength(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("respawns when the running command differs", async () => {
+    const { dir, cleanup } = tempRoot();
+    try {
+      const repoDir = join(dir, "repo");
+      mkdirSync(repoDir);
+      writeFileSync(
+        join(repoDir, "deno.json"),
+        JSON.stringify({ tasks: { dev: "echo hi" } }),
+      );
+      const broadcaster = new Broadcaster(1024);
+      const { lifecycle } = makeLifecycleSpy(broadcaster);
+
+      const spawns: Array<{ command: string; cwd: string }> = [];
+
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir },
+        store: {
+          read: () => ({
+            application: { packageManager: { name: "deno" }, runtime: "deno" },
+          }),
+          hydrate: () => {},
+          applyInternal: async () => ({
+            kind: "applied",
+            before: null,
+            after: {},
+            transition: { kind: "no-op" },
+          }),
+        } as never,
+        taskManager: {
+          spawn: async (s: { command: string; cwd: string }) => {
+            spawns.push({ command: s.command, cwd: s.cwd });
+            return { id: `t${spawns.length}` };
+          },
+          killByLogName: () => 0,
+          waitForLogNamesIdle: async () => {},
+          // A stale dev from a different command is running → must be replaced.
+          runningCommandByLogName: () => ({
+            command: "deno task old",
+            cwd: repoDir,
+          }),
+          onTaskExit: () => () => {},
+        } as never,
+        setStatus: () => {},
+        getStatus: () => ({ state: "running" as const }),
+        broadcaster,
+        installState: { isInstalledFor: () => true } as never,
+        logsDir: dir,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
+      });
+
+      orchestrator.handle({ kind: "port-change", from: undefined, to: 3000 });
+      await drain(orchestrator);
+      expect(spawns).toHaveLength(1);
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("SetupOrchestrator status transitions", () => {

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -79,6 +79,7 @@ export class SetupOrchestrator {
       if (summary.intentional) return;
       if (summary.exitCode === 0 || summary.exitCode === null) return;
       const reason = `dev script exited with code ${summary.exitCode}`;
+      this.chunk(`\r\n[orchestrator] ${reason}\r\n`);
       this.deps.setStatus({ state: "error", reason });
       // Lifecycle was at `starting` (post-spawn) or `running` (probe saw it
       // up briefly). Either way the dev script is gone now; surface a
@@ -173,7 +174,9 @@ export class SetupOrchestrator {
         await this.stepStart();
         return;
       case "start":
-        await this.stopDevTask();
+        // stepStart owns the stop: it skips the kill entirely when an
+        // identical dev is already running, so a port-change can't SIGTERM a
+        // mid-boot dev only to respawn the same command.
         await this.stepStart();
         return;
     }
@@ -362,6 +365,17 @@ export class SetupOrchestrator {
       });
       return;
     }
+
+    const running = this.deps.taskManager.runningCommandByLogName(
+      command.source,
+    );
+    if (running?.command === command.cmd && running?.cwd === command.cwd) {
+      this.chunk(
+        `[orchestrator] dev already running (${command.source}) — skipping restart\r\n`,
+      );
+      return;
+    }
+    await this.stopDevTask();
     this.deps.lifecycle.transition({ phase: "starting" });
     await this.deps.taskManager.spawn({
       command: command.cmd,


### PR DESCRIPTION
…ator behavior

- Implemented runningCommandByLogName in TaskManager to retrieve the command and cwd of currently running tasks by log name.
- Updated SetupOrchestrator to skip respawning when an identical command is already running, preventing unnecessary restarts during port changes.
- Enhanced logging to indicate when a dev command is already running, improving clarity in orchestrator operations.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the setup orchestrator idempotent by skipping respawns when the same dev command is already running. This prevents unnecessary restarts during port changes and reduces double cold-boot cycles.

- **New Features**
  - Added `runningCommandByLogName(logName)` in the task manager to report the running command and cwd.
  - Orchestrator compares the running command and skips restart when identical; otherwise stops then spawns.
  - Clearer logs: note when dev is already running and when a dev script exits with a non-zero code.
  - Tests for idempotent start and for respawn when the running command differs.

<sup>Written for commit edba4d56c7127c72a03c4a1cfcc9fb58ea702816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

