### PR TITLE
feat(git): handle repository not initialized state in status and diff…

### DIFF
--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -94,11 +94,19 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const sandboxRouteBranch =
     branch ?? sandboxBranch ?? sandboxMapBranch ?? undefined;
 
+  // The repo doesn't exist on disk until the clone+checkout finishes, so don't
+  // poll /git/status during those phases (it would 409 until the repo lands).
+  const repoNotClonedYet =
+    lifecycle.phase === "cloning" ||
+    lifecycle.phase === "checking-out" ||
+    lifecycle.phase === "clone-failed";
+
   const gitStatusQuery = useSandboxGitStatus({
     orgSlug: org.slug,
     virtualMcpId,
     branch: sandboxRouteBranch ?? null,
-    enabled: !!githubRepo && !!sandboxRouteBranch && !sandboxGone,
+    enabled:
+      !!githubRepo && !!sandboxRouteBranch && !sandboxGone && !repoNotClonedYet,
   });
 
   const githubHeadBranch =

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -39,6 +39,32 @@ describe("git routes", () => {
     expect(body.modified).toContain("README.md");
   });
 
+  it("status returns 409 notReady before the repo is cloned", async () => {
+    const appRoot = mkdtempSync(join(tmpdir(), "git-route-root-"));
+    const repoDir = join(appRoot, "app");
+    mkdirSync(repoDir, { recursive: true });
+    const handler = makeGitStatusHandler({ appRoot, repoDir });
+    const res = await handler(new Request("http://x/git/status"));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "repository not initialized",
+      notReady: true,
+    });
+  });
+
+  it("diff returns 409 notReady before the repo is cloned", async () => {
+    const appRoot = mkdtempSync(join(tmpdir(), "git-route-root-"));
+    const repoDir = join(appRoot, "app");
+    mkdirSync(repoDir, { recursive: true });
+    const handler = makeGitDiffHandler({ appRoot, repoDir });
+    const res = await handler(new Request("http://x/git/diff"));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "repository not initialized",
+      notReady: true,
+    });
+  });
+
   it("status reports unpushed when feature branch has no remote ref", async () => {
     const { appRoot, repoDir } = initRepo();
     gitSync(["checkout", "-b", "deco/thin-crane"], {

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -42,6 +42,13 @@ function tryGit(repoDir: string, args: string[]): string | null {
   }
 }
 
+// repoDir is pre-created empty on boot; the clone only runs after config
+// arrives. Status/diff probes that race the clone would otherwise exit 128
+// ("not a git repository") and surface as a 500.
+function isGitRepo(repoDir: string): boolean {
+  return tryGit(repoDir, ["rev-parse", "--git-dir"]) !== null;
+}
+
 export interface GitStatusFile {
   path: string;
   index: string;
@@ -452,6 +459,12 @@ function discard(deps: GitDeps, filepaths: string[]): void {
 
 export function makeGitStatusHandler(deps: GitDeps) {
   return async (_req: Request): Promise<Response> => {
+    if (!isGitRepo(deps.repoDir)) {
+      return jsonResponse(
+        { error: "repository not initialized", notReady: true },
+        409,
+      );
+    }
     try {
       return jsonResponse(computeStatus(deps.repoDir));
     } catch (err) {
@@ -465,6 +478,12 @@ export function makeGitStatusHandler(deps: GitDeps) {
 
 export function makeGitDiffHandler(deps: GitDeps) {
   return async (req: Request): Promise<Response> => {
+    if (!isGitRepo(deps.repoDir)) {
+      return jsonResponse(
+        { error: "repository not initialized", notReady: true },
+        409,
+      );
+    }
     try {
       let base: string | undefined;
       let headSha: string | undefined;


### PR DESCRIPTION
… endpoints

- Added checks in the Git status and diff handlers to return a 409 error when the repository is not initialized, improving error handling during cloning operations.
- Updated the HeaderActions component to prevent polling for Git status while the repository is still being cloned or checked out.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 409 “repository not initialized” from Git status and diff until the repo is cloned, and pause UI polling during clone to avoid noisy errors and flicker.

- **Bug Fixes**
  - Added repo-ready check in `/git/status` and `/git/diff`; respond 409 with `{ error: "repository not initialized", notReady: true }`.
  - Updated `HeaderActions` to stop polling while cloning/checking-out/clone-failed.
  - Added tests for 409 behavior on both endpoints.

<sup>Written for commit 0c89732cd2ed2142acede30f8823098bb8001d6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

