### PR TITLE
fix(harnesses): map claude-code:fable to SDK "fable" alias

### DIFF
--- a/apps/mesh/src/harnesses/claude-code/model/index.test.ts
+++ b/apps/mesh/src/harnesses/claude-code/model/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { resolveAgentTier } from "../../../ai-providers/agent-tiers";
+import type { ChatTier } from "@/tools/organization/schema";
+import { resolveClaudeCodeModelId } from "./index";
+
+describe("resolveClaudeCodeModelId", () => {
+  it("resolves current Claude Code CLI model IDs to SDK aliases", () => {
+    expect(resolveClaudeCodeModelId("claude-code:opus")).toBe("opus");
+    expect(resolveClaudeCodeModelId("claude-code:sonnet")).toBe("sonnet");
+    expect(resolveClaudeCodeModelId("claude-code:haiku")).toBe("haiku");
+    expect(resolveClaudeCodeModelId("claude-code:fable")).toBe("fable");
+  });
+
+  it("passes through already-resolved aliases / full model IDs unchanged", () => {
+    expect(resolveClaudeCodeModelId("sonnet")).toBe("sonnet");
+    expect(resolveClaudeCodeModelId("claude-fable-5")).toBe("claude-fable-5");
+  });
+
+  // Regression guard for the drift that broke the Thinking tier (PR #3760):
+  // the tier map was switched to `claude-code:fable` without adding the
+  // corresponding SDK mapping, so the composite ID leaked straight to the
+  // CLI's `--model` flag. Every tier the harness can dispatch MUST resolve
+  // to a non-composite SDK alias.
+  it("maps every claude-code tier to a non-composite SDK alias", () => {
+    const tiers: ChatTier[] = ["fast", "smart", "thinking"];
+    for (const tier of tiers) {
+      const entry = resolveAgentTier("claude-code", tier);
+      expect(entry).not.toBeNull();
+      const resolved = resolveClaudeCodeModelId(entry!.modelId);
+      expect(resolved.startsWith("claude-code:")).toBe(false);
+    }
+  });
+});

--- a/apps/mesh/src/harnesses/claude-code/model/index.ts
+++ b/apps/mesh/src/harnesses/claude-code/model/index.ts
@@ -74,6 +74,7 @@ const CLAUDE_CODE_SDK_MODELS: Record<string, string> = {
   "claude-code:opus": "opus",
   "claude-code:sonnet": "sonnet",
   "claude-code:haiku": "haiku",
+  "claude-code:fable": "fable",
 };
 
 /** Resolve a composite claude-code model ID to the SDK model name. */


### PR DESCRIPTION
## What is this contribution about?
PR #3760 switched the Claude Code **Thinking** tier to `claude-code:fable` but never added the composite→SDK mapping in `CLAUDE_CODE_SDK_MODELS`, so the resolver's `?? modelId` fallback forwarded the literal `claude-code:fable` to the `claude` CLI's `--model` flag (which it doesn't recognize) and every Thinking-tier turn failed. This adds the `claude-code:fable` → `fable` mapping and a regression test that couples the tier map to the resolver, so a future tier swap that forgets the mapping fails CI instead of silently breaking the harness.

## Screenshots/Demonstration
N/A — no UI changes.

## How to Test
1. Run `bun test apps/mesh/src/harnesses/claude-code/model/index.test.ts` — 3 tests pass.
2. In chat, pick a Claude Code agent and select the **Thinking** tier (Fable 5).
3. Expected: the turn runs (CLI receives `--model fable`) instead of failing on an unknown model id.

## Migration Notes
Not applicable.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Claude Code Thinking tier by mapping `claude-code:fable` to the SDK `fable` alias so the CLI receives a valid model. Adds a regression test to prevent this mapping from drifting again.

- **Bug Fixes**
  - Map `claude-code:fable` → `fable` in `CLAUDE_CODE_SDK_MODELS`.
  - Add a test that ensures all `claude-code` tiers resolve to non-composite SDK aliases.

<sup>Written for commit 881a5250b956ba6b262c6c939c66616cd869f151. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

