### PR TITLE
feat(agent-sandbox): implement applyHttpRoute function for upserting …

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/client.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.test.ts
@@ -5,10 +5,12 @@ import {
   SandboxTimeoutError,
 } from "./constants";
 import {
+  applyHttpRoute,
   createSandboxClaim,
   deleteSandboxClaim,
   ensureServicePort,
   getSandboxClaim,
+  type HttpRoute,
   patchSandboxClaimShutdown,
   type SandboxClaim,
   type SandboxResource,
@@ -454,6 +456,75 @@ describe("ensureServicePort", () => {
         targetPort: 9000,
       }),
     ).rejects.toThrow(/Failed to apply Service ports: missing/);
+  });
+});
+
+describe("applyHttpRoute", () => {
+  const route: HttpRoute = {
+    apiVersion: "gateway.networking.k8s.io/v1",
+    kind: "HTTPRoute",
+    metadata: { name: "solar-vale", namespace: NS },
+    spec: {
+      parentRefs: [
+        {
+          kind: "Gateway",
+          group: "gateway.networking.k8s.io",
+          name: "agent-sandbox-preview-prod",
+          namespace: NS,
+        },
+      ],
+      hostnames: ["solar-vale.preview-studio.decocms.com"],
+      rules: [
+        {
+          backendRefs: [
+            {
+              group: "",
+              kind: "Service",
+              name: "studio-sandbox-prod-7nt7m",
+              port: 9000,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  it("upserts via server-side apply to the named route path with force", async () => {
+    fetchImpl = async () => jsonResponse(200, { kind: "HTTPRoute" });
+    await applyHttpRoute(makeKc(), NS, route);
+
+    expect(fetchCalls).toHaveLength(1);
+    const [call] = fetchCalls;
+    const url = new URL(call!.url);
+    // SSA targets the named resource (not the collection) so the same call
+    // creates-or-updates — this is what re-points a surviving route's
+    // backendRef at the freshly adopted Service instead of 409-swallowing.
+    expect(url.pathname).toBe(
+      `/apis/gateway.networking.k8s.io/v1/namespaces/${NS}/httproutes/solar-vale`,
+    );
+    expect(url.searchParams.get("fieldManager")).toBe("mesh-sandbox-runner");
+    expect(url.searchParams.get("force")).toBe("true");
+
+    expect(call!.init.method).toBe("PATCH");
+    const headers = call!.init.headers as Record<string, string>;
+    expect(headers["content-type"]).toBe("application/apply-patch+yaml");
+
+    const body = JSON.parse(String(call!.init.body));
+    expect(body.spec.rules[0].backendRefs[0].name).toBe(
+      "studio-sandbox-prod-7nt7m",
+    );
+  });
+
+  it("wraps non-2xx errors in SandboxError with the route name", async () => {
+    fetchImpl = async () =>
+      jsonResponse(403, {
+        kind: "Status",
+        reason: "Forbidden",
+        message: "forbidden",
+      });
+    await expect(applyHttpRoute(makeKc(), NS, route)).rejects.toThrow(
+      /Failed to apply HTTPRoute: solar-vale/,
+    );
   });
 });
 

--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -557,33 +557,45 @@ function httpRoutePath(namespace: string, routeName: string): string {
   return `${HTTPROUTE_PATH_PREFIX}/${encodeURIComponent(namespace)}/${HTTPROUTE_PLURAL}/${encodeURIComponent(routeName)}`;
 }
 
-function httpRouteCollectionPath(namespace: string): string {
-  return `${HTTPROUTE_PATH_PREFIX}/${encodeURIComponent(namespace)}/${HTTPROUTE_PLURAL}`;
-}
-
 /**
- * Create an HTTPRoute. 409 (AlreadyExists) is swallowed because the runner
- * calls this from both the fresh-provision path and the adopt-backfill
- * path — a pre-existing route from an earlier provision attempt is the
- * intended steady state, not an error.
+ * Upsert an HTTPRoute via Server-Side Apply. Creates the route when absent
+ * and — crucially — rewrites `spec.rules[].backendRefs` when it already
+ * exists, so a route minted for an earlier sandbox re-points at the freshly
+ * adopted Service instead of an orphaned one.
+ *
+ * The route name is stable per handle, so the runner calls this from both
+ * the fresh-provision and adopt-backfill paths. The old POST-create path
+ * swallowed the resulting 409, which left the backendRef pinned to a
+ * since-deleted Service: Envoy then serves an empty-body 500 for the preview
+ * hostname (see `ensureServicePort` for the same no-upstream signature) until
+ * the next teardown happened to delete the route. SSA with a stable field
+ * manager makes the write idempotent AND mutating — re-applying the same body
+ * is a no-op, re-applying a changed backendRef updates it in place.
+ *
+ * `force=true` so we take ownership even when the route was first created by
+ * the legacy POST path under the default field manager.
  */
-export async function createHttpRoute(
+export async function applyHttpRoute(
   kc: KubeConfig,
   namespace: string,
   route: HttpRoute,
 ): Promise<void> {
+  const query = new URLSearchParams({
+    fieldManager: SSA_FIELD_MANAGER,
+    force: "true",
+  });
+  const path = `${httpRoutePath(namespace, route.metadata.name)}?${query}`;
   try {
     const resp = await kubeFetch(kc, {
-      method: "POST",
-      path: httpRouteCollectionPath(namespace),
+      method: "PATCH",
+      path,
+      patchType: "apply",
       body: route,
     });
-    if (resp.status === 409) return;
-    await ensureOk(resp, "createHttpRoute");
+    await ensureOk(resp, "applyHttpRoute");
   } catch (error) {
-    if (error instanceof KubeHttpError && error.status === 409) return;
     throw new SandboxError(
-      `Failed to create HTTPRoute: ${route.metadata.name}`,
+      `Failed to apply HTTPRoute: ${route.metadata.name}`,
       error,
     );
   }

--- a/packages/sandbox/server/provider/agent-sandbox/index.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/index.ts
@@ -3,7 +3,7 @@
 export { KubeConfig } from "@kubernetes/client-node";
 export { K8S_CONSTANTS, SandboxError, SandboxTimeoutError } from "./constants";
 export {
-  createHttpRoute,
+  applyHttpRoute,
   createSandboxClaim,
   deleteHttpRoute,
   deleteSandboxClaim,

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -62,7 +62,7 @@ import type {
   Workload,
 } from "../types";
 import {
-  createHttpRoute,
+  applyHttpRoute,
   createSandboxClaim,
   deleteHttpRoute,
   deleteSandboxClaim,
@@ -1376,10 +1376,11 @@ export class AgentSandboxProvider implements SandboxProvider {
   }
 
   /**
-   * No-op when `previewGateway` isn't configured. Otherwise PUT-or-create
+   * No-op when `previewGateway` isn't configured. Otherwise upsert (SSA)
    * an HTTPRoute that maps `<handle>.<base>` → Service `<adoptedSandboxName>`
-   * port 9000. createHttpRoute swallows 409, so this is safe to call from
-   * both fresh-provision and adopt-backfill paths.
+   * port 9000. applyHttpRoute is idempotent and mutating, so calling it from
+   * the adopt path re-points the backendRef at the newly bound pool pod
+   * rather than leaving it on the previous (deleted) Service.
    *
    * Route name and hostname stay tied to `handle` so the public preview
    * URL is stable across pool re-adoptions and so cleanup
@@ -1438,7 +1439,7 @@ export class AgentSandboxProvider implements SandboxProvider {
         ],
       },
     };
-    await createHttpRoute(this.kubeConfig, this.namespace, route);
+    await applyHttpRoute(this.kubeConfig, this.namespace, route);
   }
 
   /** No-op when `previewGateway` isn't configured. 404-tolerant otherwise. */
@@ -1564,9 +1565,11 @@ export class AgentSandboxProvider implements SandboxProvider {
 
     const tenant = readClaimTenant(claim);
     // Backfill the Service port + HTTPRoute for legacy claims provisioned
-    // before per-claim routing existed. Both calls are idempotent — Service
-    // patch is a no-op once `port: 9000` is already declared, and
-    // createHttpRoute swallows 409. Failures here don't block adoption:
+    // before per-claim routing existed. Both calls are idempotent SSA upserts
+    // — the Service patch is a no-op once `port: 9000` is declared, and
+    // applyHttpRoute re-points the backendRef at this adoption's Service even
+    // when a route from a prior pool pod survives. Failures here don't block
+    // adoption:
     // preview traffic stays unrouted until the next ensure() picks it up;
     // the rest of the sandbox surface (exec, port-forward) is unaffected.
     // Service patch first so that, if the route is missing, recreating it


### PR DESCRIPTION
…HTTP routes

- Introduced the applyHttpRoute function to handle Server-Side Apply (SSA) for HTTP routes, allowing for idempotent updates and re-pointing of backend references to newly adopted services.
- Updated related tests to validate the new functionality and error handling for non-2xx responses.
- Refactored existing references from createHttpRoute to applyHttpRoute across the codebase for consistency.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upserts Kubernetes HTTPRoute via Server-Side Apply to keep preview routes pointing at the current Service and prevent empty 500s after sandbox adoption. Replaces `createHttpRoute` with `applyHttpRoute` and adds tests and stricter error handling.

- **Bug Fixes**
  - Re-points existing routes by applying to the named resource; idempotent and mutating.
  - Uses `fieldManager=mesh-sandbox-runner` with `force=true` to take ownership.
  - Wraps non-2xx responses in `SandboxError` including the route name; tests cover success and error paths.

<sup>Written for commit d50ae244b1126b120098f8957a861bf5afa9a5e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

