### PR TITLE
fix(sandbox): load full files in file explorer

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -204,7 +204,7 @@ export function FileExplorer({
         {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ path: toDaemonPath(path) }),
+          body: JSON.stringify({ path: toDaemonPath(path), full: true }),
         },
       );
       if (!res.ok) return;

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -52,6 +52,33 @@ describe("fs handlers", () => {
     expect(body.lineCount).toBeGreaterThanOrEqual(3);
   });
 
+  it("read: defaults to 2000 lines but full returns the entire file", async () => {
+    const lines = Array.from({ length: 2500 }, (_, i) => `line-${i + 1}`);
+    writeFileSync(join(appRoot, "big.txt"), lines.join("\n"));
+    const h = makeReadHandler({ appRoot, repoDir: appRoot });
+
+    const truncated = await h(post("/_sandbox/read", { path: "big.txt" }));
+    const truncatedBody = (await truncated.json()) as {
+      content: string;
+      lineCount: number;
+    };
+    expect(truncatedBody.lineCount).toBe(2500);
+    expect(truncatedBody.content).toContain("1\tline-1");
+    expect(truncatedBody.content).toContain("2000\tline-2000");
+    expect(truncatedBody.content).not.toContain("2500\tline-2500");
+
+    const full = await h(
+      post("/_sandbox/read", { path: "big.txt", full: true }),
+    );
+    const fullBody = (await full.json()) as {
+      content: string;
+      lineCount: number;
+    };
+    expect(fullBody.lineCount).toBe(2500);
+    expect(fullBody.content).toContain("1\tline-1");
+    expect(fullBody.content).toContain("2500\tline-2500");
+  });
+
   it("read: returns base64 + mediaType for jpeg", async () => {
     // Minimal JPEG: SOI + EOI markers, enough to pass the magic-byte sniff.
     const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0xff, 0xd9]);

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -109,7 +109,12 @@ function resolveReadPath(
 
 export function makeReadHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {
-    let body: { path?: string; offset?: number; limit?: number };
+    let body: {
+      path?: string;
+      offset?: number;
+      limit?: number;
+      full?: boolean;
+    };
     try {
       body = (await parseJsonBody(req)) as typeof body;
     } catch (e) {
@@ -167,8 +172,8 @@ export function makeReadHandler(deps: FsDeps) {
 
     const raw = fs.readFileSync(filePath, "utf-8");
     const lines = raw.split("\n");
-    const offset = Math.max(1, body.offset ?? 1);
-    const limit = body.limit ?? 2000;
+    const offset = body.full ? 1 : Math.max(1, body.offset ?? 1);
+    const limit = body.full ? lines.length : (body.limit ?? 2000);
     const slice = lines.slice(offset - 1, offset - 1 + limit);
     const numbered = slice.map((l, i) => `${offset + i}\t${l}`).join("\n");
     return jsonResponse({


### PR DESCRIPTION
## Summary
- Add `full: true` to the sandbox daemon `/read` endpoint so callers can request the entire text file instead of the default 2000-line window
- File explorer now passes `full: true` when loading files, so Monaco shows the complete content
- Agent `read` tool behavior is unchanged (still defaults to 2000 lines with `offset`/`limit` pagination)

## Test plan
- [x] `bun test packages/sandbox/daemon/routes/fs.test.ts` — verifies default truncation at 2000 lines and `full: true` returns all 2500 lines
- [ ] Open a sandbox file with >2000 lines in the file explorer and confirm all lines are visible in Monaco
- [ ] Confirm agent `read` still returns at most 2000 lines per call without `full`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load full files in the sandbox file explorer by using a `full: true` flag on the `/_sandbox/read` endpoint. Monaco now shows entire files; the agent `read` tool still defaults to a 2000-line window unless `full` is set.

- **Bug Fixes**
  - Added `full` option to `/_sandbox/read`; when true, returns all lines and ignores `offset`/`limit`.
  - File explorer sends `full: true` so files with >2000 lines render fully in Monaco.
  - Added tests to confirm default truncation and full read behavior.

<sup>Written for commit d68d73c513d94291968e11ce14d393761114dd41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

