### PR TITLE
Revert "feat(agent-sandbox): implement applyHttpRoute function for upserting …"

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/client.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.test.ts
@@ -5,12 +5,10 @@ import {
   SandboxTimeoutError,
 } from "./constants";
 import {
-  applyHttpRoute,
   createSandboxClaim,
   deleteSandboxClaim,
   ensureServicePort,
   getSandboxClaim,
-  type HttpRoute,
   patchSandboxClaimShutdown,
   type SandboxClaim,
   type SandboxResource,
@@ -456,75 +454,6 @@ describe("ensureServicePort", () => {
         targetPort: 9000,
       }),
     ).rejects.toThrow(/Failed to apply Service ports: missing/);
-  });
-});
-
-describe("applyHttpRoute", () => {
-  const route: HttpRoute = {
-    apiVersion: "gateway.networking.k8s.io/v1",
-    kind: "HTTPRoute",
-    metadata: { name: "solar-vale", namespace: NS },
-    spec: {
-      parentRefs: [
-        {
-          kind: "Gateway",
-          group: "gateway.networking.k8s.io",
-          name: "agent-sandbox-preview-prod",
-          namespace: NS,
-        },
-      ],
-      hostnames: ["solar-vale.preview-studio.decocms.com"],
-      rules: [
-        {
-          backendRefs: [
-            {
-              group: "",
-              kind: "Service",
-              name: "studio-sandbox-prod-7nt7m",
-              port: 9000,
-            },
-          ],
-        },
-      ],
-    },
-  };
-
-  it("upserts via server-side apply to the named route path with force", async () => {
-    fetchImpl = async () => jsonResponse(200, { kind: "HTTPRoute" });
-    await applyHttpRoute(makeKc(), NS, route);
-
-    expect(fetchCalls).toHaveLength(1);
-    const [call] = fetchCalls;
-    const url = new URL(call!.url);
-    // SSA targets the named resource (not the collection) so the same call
-    // creates-or-updates — this is what re-points a surviving route's
-    // backendRef at the freshly adopted Service instead of 409-swallowing.
-    expect(url.pathname).toBe(
-      `/apis/gateway.networking.k8s.io/v1/namespaces/${NS}/httproutes/solar-vale`,
-    );
-    expect(url.searchParams.get("fieldManager")).toBe("mesh-sandbox-runner");
-    expect(url.searchParams.get("force")).toBe("true");
-
-    expect(call!.init.method).toBe("PATCH");
-    const headers = call!.init.headers as Record<string, string>;
-    expect(headers["content-type"]).toBe("application/apply-patch+yaml");
-
-    const body = JSON.parse(String(call!.init.body));
-    expect(body.spec.rules[0].backendRefs[0].name).toBe(
-      "studio-sandbox-prod-7nt7m",
-    );
-  });
-
-  it("wraps non-2xx errors in SandboxError with the route name", async () => {
-    fetchImpl = async () =>
-      jsonResponse(403, {
-        kind: "Status",
-        reason: "Forbidden",
-        message: "forbidden",
-      });
-    await expect(applyHttpRoute(makeKc(), NS, route)).rejects.toThrow(
-      /Failed to apply HTTPRoute: solar-vale/,
-    );
   });
 });
 

--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -557,45 +557,33 @@ function httpRoutePath(namespace: string, routeName: string): string {
   return `${HTTPROUTE_PATH_PREFIX}/${encodeURIComponent(namespace)}/${HTTPROUTE_PLURAL}/${encodeURIComponent(routeName)}`;
 }
 
+function httpRouteCollectionPath(namespace: string): string {
+  return `${HTTPROUTE_PATH_PREFIX}/${encodeURIComponent(namespace)}/${HTTPROUTE_PLURAL}`;
+}
+
 /**
- * Upsert an HTTPRoute via Server-Side Apply. Creates the route when absent
- * and — crucially — rewrites `spec.rules[].backendRefs` when it already
- * exists, so a route minted for an earlier sandbox re-points at the freshly
- * adopted Service instead of an orphaned one.
- *
- * The route name is stable per handle, so the runner calls this from both
- * the fresh-provision and adopt-backfill paths. The old POST-create path
- * swallowed the resulting 409, which left the backendRef pinned to a
- * since-deleted Service: Envoy then serves an empty-body 500 for the preview
- * hostname (see `ensureServicePort` for the same no-upstream signature) until
- * the next teardown happened to delete the route. SSA with a stable field
- * manager makes the write idempotent AND mutating — re-applying the same body
- * is a no-op, re-applying a changed backendRef updates it in place.
- *
- * `force=true` so we take ownership even when the route was first created by
- * the legacy POST path under the default field manager.
+ * Create an HTTPRoute. 409 (AlreadyExists) is swallowed because the runner
+ * calls this from both the fresh-provision path and the adopt-backfill
+ * path — a pre-existing route from an earlier provision attempt is the
+ * intended steady state, not an error.
  */
-export async function applyHttpRoute(
+export async function createHttpRoute(
   kc: KubeConfig,
   namespace: string,
   route: HttpRoute,
 ): Promise<void> {
-  const query = new URLSearchParams({
-    fieldManager: SSA_FIELD_MANAGER,
-    force: "true",
-  });
-  const path = `${httpRoutePath(namespace, route.metadata.name)}?${query}`;
   try {
     const resp = await kubeFetch(kc, {
-      method: "PATCH",
-      path,
-      patchType: "apply",
+      method: "POST",
+      path: httpRouteCollectionPath(namespace),
       body: route,
     });
-    await ensureOk(resp, "applyHttpRoute");
+    if (resp.status === 409) return;
+    await ensureOk(resp, "createHttpRoute");
   } catch (error) {
+    if (error instanceof KubeHttpError && error.status === 409) return;
     throw new SandboxError(
-      `Failed to apply HTTPRoute: ${route.metadata.name}`,
+      `Failed to create HTTPRoute: ${route.metadata.name}`,
       error,
     );
   }

--- a/packages/sandbox/server/provider/agent-sandbox/index.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/index.ts
@@ -3,7 +3,7 @@
 export { KubeConfig } from "@kubernetes/client-node";
 export { K8S_CONSTANTS, SandboxError, SandboxTimeoutError } from "./constants";
 export {
-  applyHttpRoute,
+  createHttpRoute,
   createSandboxClaim,
   deleteHttpRoute,
   deleteSandboxClaim,

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -62,7 +62,7 @@ import type {
   Workload,
 } from "../types";
 import {
-  applyHttpRoute,
+  createHttpRoute,
   createSandboxClaim,
   deleteHttpRoute,
   deleteSandboxClaim,
@@ -1376,11 +1376,10 @@ export class AgentSandboxProvider implements SandboxProvider {
   }
 
   /**
-   * No-op when `previewGateway` isn't configured. Otherwise upsert (SSA)
+   * No-op when `previewGateway` isn't configured. Otherwise PUT-or-create
    * an HTTPRoute that maps `<handle>.<base>` → Service `<adoptedSandboxName>`
-   * port 9000. applyHttpRoute is idempotent and mutating, so calling it from
-   * the adopt path re-points the backendRef at the newly bound pool pod
-   * rather than leaving it on the previous (deleted) Service.
+   * port 9000. createHttpRoute swallows 409, so this is safe to call from
+   * both fresh-provision and adopt-backfill paths.
    *
    * Route name and hostname stay tied to `handle` so the public preview
    * URL is stable across pool re-adoptions and so cleanup
@@ -1439,7 +1438,7 @@ export class AgentSandboxProvider implements SandboxProvider {
         ],
       },
     };
-    await applyHttpRoute(this.kubeConfig, this.namespace, route);
+    await createHttpRoute(this.kubeConfig, this.namespace, route);
   }
 
   /** No-op when `previewGateway` isn't configured. 404-tolerant otherwise. */
@@ -1565,11 +1564,9 @@ export class AgentSandboxProvider implements SandboxProvider {
 
     const tenant = readClaimTenant(claim);
     // Backfill the Service port + HTTPRoute for legacy claims provisioned
-    // before per-claim routing existed. Both calls are idempotent SSA upserts
-    // — the Service patch is a no-op once `port: 9000` is declared, and
-    // applyHttpRoute re-points the backendRef at this adoption's Service even
-    // when a route from a prior pool pod survives. Failures here don't block
-    // adoption:
+    // before per-claim routing existed. Both calls are idempotent — Service
+    // patch is a no-op once `port: 9000` is already declared, and
+    // createHttpRoute swallows 409. Failures here don't block adoption:
     // preview traffic stays unrouted until the next ensure() picks it up;
     // the rest of the sandbox surface (exec, port-forward) is unaffected.
     // Service patch first so that, if the route is missing, recreating it


### PR DESCRIPTION
Reverts decocms/studio#3785

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the `applyHttpRoute` SSA upsert and restores create-once behavior for HTTPRoutes in `agent-sandbox`. Introduces `createHttpRoute` (POST, 409-tolerant) and updates call sites; removes the SSA-specific test.

- **Refactors**
  - Replace `applyHttpRoute` with `createHttpRoute` that POSTs to the collection and swallows 409.
  - Update exports and `AgentSandboxProvider` to use `createHttpRoute`; add `httpRouteCollectionPath`.
  - Remove `applyHttpRoute` tests and related SSA logic/comments.

<sup>Written for commit cac5a4beb015d6a64ff042fef4e45a20105c743e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

