### PR TITLE
fix(dev): keep worktree data outside repo

### DIFF
--- a/scripts/dev-worktree-command.test.ts
+++ b/scripts/dev-worktree-command.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { buildDevCommand } from "./dev-worktree-command";
+
+describe("buildDevCommand", () => {
+  test("defaults dev home outside the repo for worktree runs", () => {
+    const command = buildDevCommand({
+      repoRoot: "/repo",
+      slug: "delhi-v4",
+      port: 3001,
+      vitePort: 4000,
+      extraArgs: ["--local-sandbox-provider"],
+      tmpRoot: "/tmp",
+    });
+
+    expect(command).toContain("--home");
+    expect(command).toContain("/tmp/decocms-dev-delhi-v4");
+  });
+
+  test("preserves an explicit home argument", () => {
+    const command = buildDevCommand({
+      repoRoot: "/repo",
+      slug: "delhi-v4",
+      port: 3001,
+      vitePort: 4000,
+      extraArgs: ["--home", "/custom/home", "--local-sandbox-provider"],
+      tmpRoot: "/tmp",
+    });
+
+    const homeIndexes = command
+      .map((arg, index) => (arg === "--home" ? index : -1))
+      .filter((index) => index !== -1);
+
+    expect(homeIndexes).toEqual([command.indexOf("--home")]);
+    expect(command).toContain("/custom/home");
+    expect(command).not.toContain("/tmp/decocms-dev-delhi-v4");
+  });
+});

--- a/scripts/dev-worktree-command.ts
+++ b/scripts/dev-worktree-command.ts
@@ -1,0 +1,39 @@
+import { join } from "path";
+
+interface BuildDevCommandOptions {
+  repoRoot: string;
+  slug: string;
+  port: number;
+  vitePort: number;
+  extraArgs: string[];
+  tmpRoot: string;
+}
+
+function hasExplicitHome(args: string[]): boolean {
+  return args.some((arg) => arg === "--home" || arg.startsWith("--home="));
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "-");
+}
+
+export function buildDevCommand(options: BuildDevCommandOptions): string[] {
+  const homeArgs = hasExplicitHome(options.extraArgs)
+    ? []
+    : [join(options.tmpRoot, `decocms-dev-${safePathSegment(options.slug)}`)];
+
+  return [
+    "bun",
+    "run",
+    join(options.repoRoot, "apps/mesh/src/cli.ts"),
+    "dev",
+    "--port",
+    String(options.port),
+    "--vite-port",
+    String(options.vitePort),
+    "--base-url",
+    `http://${options.slug}.localhost`,
+    ...(homeArgs.length > 0 ? ["--home", ...homeArgs] : []),
+    ...options.extraArgs,
+  ];
+}

--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -6,7 +6,9 @@
  * Called by `bun run dev:worktree` / `bun run dev:conductor`.
  */
 import { join } from "path";
+import { tmpdir } from "os";
 import { startWorktree } from "worktree-devservers";
+import { buildDevCommand } from "./dev-worktree-command";
 
 const slug = process.env.WORKTREE_SLUG;
 if (!slug) {
@@ -30,19 +32,14 @@ startWorktree(slug, async (ctx) => {
   const vitePort = await ctx.findFreePort(4000);
 
   const child = Bun.spawn(
-    [
-      "bun",
-      "run",
-      join(repoRoot, "apps/mesh/src/cli.ts"),
-      "dev",
-      "--port",
-      String(port),
-      "--vite-port",
-      String(vitePort),
-      "--base-url",
-      `http://${ctx.slug}.localhost`,
-      ...process.argv.slice(2),
-    ],
+    buildDevCommand({
+      repoRoot,
+      slug: ctx.slug,
+      port,
+      vitePort,
+      extraArgs: process.argv.slice(2),
+      tmpRoot: tmpdir(),
+    }),
     { stdio: ["inherit", "inherit", "inherit"] },
   );
 


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default worktree dev runs now store the app home outside the repo (system temp dir) to avoid repo noise and permission issues. If `--home` is provided, it is respected.

- **Bug Fixes**
  - Default `--home` to `<tmpdir>/decocms-dev-<slug>` for worktree runs.
  - Skip default when an explicit `--home` is passed.

- **Refactors**
  - Extracted command builder to `scripts/dev-worktree-command.ts` and added tests.
  - `scripts/dev-worktree.ts` now uses `tmpdir()` and the shared builder.

<sup>Written for commit 3bac20b5546a3c34834f8f033e3c0c1175366f2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

