### PR TITLE
fix(cli): show vite and api ports in dev tui

### DIFF
--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -61,12 +61,35 @@ jobs:
             exit 0
           fi
           echo "Changed files:"; echo "$FILES"
+          # Storage integration is expensive and infrastructure-backed. Keep the
+          # required check scheduled, but only run the real DB/MinIO suite when
+          # files it actually exercises changed.
           relevant=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              .github/*|apps/docs/*|*.md) ;;
-              *) relevant=true; break ;;
+              apps/mesh/migrations/*|\
+              apps/mesh/src/api/*|\
+              apps/mesh/src/auth/*|\
+              apps/mesh/src/core/*|\
+              apps/mesh/src/database/*|\
+              apps/mesh/src/file-storage/*|\
+              apps/mesh/src/harnesses/*|\
+              apps/mesh/src/mcp-clients/*|\
+              apps/mesh/src/monitoring/*|\
+              apps/mesh/src/oauth/*|\
+              apps/mesh/src/object-storage/*|\
+              apps/mesh/src/storage/*|\
+              apps/mesh/src/tools/*|\
+              packages/bindings/*|\
+              packages/mesh-plugin-workflows/*|\
+              packages/runtime/*|\
+              .github/actions/start-minio/*|\
+              .github/workflows/storage-integration.yml|\
+              TESTING.md|\
+              package.json|\
+              bun.lock|\
+              apps/mesh/package.json) relevant=true; break ;;
             esac
           done <<< "$FILES"
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -61,35 +61,12 @@ jobs:
             exit 0
           fi
           echo "Changed files:"; echo "$FILES"
-          # Storage integration is expensive and infrastructure-backed. Keep the
-          # required check scheduled, but only run the real DB/MinIO suite when
-          # files it actually exercises changed.
           relevant=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              apps/mesh/migrations/*|\
-              apps/mesh/src/api/*|\
-              apps/mesh/src/auth/*|\
-              apps/mesh/src/core/*|\
-              apps/mesh/src/database/*|\
-              apps/mesh/src/file-storage/*|\
-              apps/mesh/src/harnesses/*|\
-              apps/mesh/src/mcp-clients/*|\
-              apps/mesh/src/monitoring/*|\
-              apps/mesh/src/oauth/*|\
-              apps/mesh/src/object-storage/*|\
-              apps/mesh/src/storage/*|\
-              apps/mesh/src/tools/*|\
-              packages/bindings/*|\
-              packages/mesh-plugin-workflows/*|\
-              packages/runtime/*|\
-              .github/actions/start-minio/*|\
-              .github/workflows/storage-integration.yml|\
-              TESTING.md|\
-              package.json|\
-              bun.lock|\
-              apps/mesh/package.json) relevant=true; break ;;
+              .github/*|apps/docs/*|*.md) ;;
+              *) relevant=true; break ;;
             esac
           done <<< "$FILES"
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"

--- a/apps/mesh/src/cli/cli-store.test.ts
+++ b/apps/mesh/src/cli/cli-store.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { getCliState, setDevMode, updateService } from "./cli-store";
+
+describe("cli-store dev mode services", () => {
+  it("tracks both Vite and API service ports for the TUI", () => {
+    setDevMode();
+
+    updateService({ name: "Vite", status: "ready", port: 4000 });
+    updateService({ name: "API", status: "ready", port: 3000 });
+
+    expect(getCliState().services).toEqual(
+      expect.arrayContaining([
+        { name: "Vite", status: "ready", port: 4000 },
+        { name: "API", status: "ready", port: 3000 },
+      ]),
+    );
+  });
+});

--- a/apps/mesh/src/cli/cli-store.ts
+++ b/apps/mesh/src/cli/cli-store.ts
@@ -72,6 +72,7 @@ export function setDevMode(opts: { localSandboxProvider?: boolean } = {}) {
     services: [
       ...state.services,
       { name: "Vite", status: "pending", port: 0 },
+      { name: "API", status: "pending", port: 0 },
       // Auto-spawned by `bun run dev --local-sandbox-provider` after the
       // cluster is up — see apps/mesh/src/cli/commands/dev.ts. The
       // desktop sandbox provider routes through this. Marked ready

--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -188,6 +188,7 @@ export async function startDevServer(
   const serverUrl = publicBaseUrl;
   setServerUrl(serverUrl);
   updateService({ name: "Vite", status: "ready", port: Number(vitePort) });
+  updateService({ name: "API", status: "ready", port: Number(settings.port) });
 
   // ── Auto-spawn `deco link` (opt-in) ──────────────────────────────
   // Gated on --local-sandbox-provider. When set, once the cluster is up

--- a/apps/mesh/src/cli/header.test.ts
+++ b/apps/mesh/src/cli/header.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { formatServiceLabel } from "./header";
+
+describe("formatServiceLabel", () => {
+  it("renders service ports with colon-separated labels", () => {
+    expect(
+      formatServiceLabel({ name: "Vite", status: "ready", port: 4000 }),
+    ).toBe("Vite: 4000");
+    expect(
+      formatServiceLabel({ name: "API", status: "ready", port: 3000 }),
+    ).toBe("API: 3000");
+  });
+
+  it("uses a placeholder before a service has a port", () => {
+    expect(
+      formatServiceLabel({ name: "API", status: "pending", port: 0 }),
+    ).toBe("API: ....");
+  });
+});

--- a/apps/mesh/src/cli/header.tsx
+++ b/apps/mesh/src/cli/header.tsx
@@ -23,6 +23,10 @@ function StatusIndicator({ status }: { status: "pending" | "ready" | "done" }) {
   return <Text color="green">{"✓"}</Text>;
 }
 
+export function formatServiceLabel(svc: ServiceStatus): string {
+  return `${svc.name}: ${svc.port || "...."}`;
+}
+
 export function Header({
   services,
   migrationsStatus,
@@ -44,9 +48,7 @@ export function Header({
       <Box gap={2}>
         {services.map((svc) => (
           <Box key={svc.name} gap={1}>
-            <Text>
-              {svc.name} :{svc.port || "...."}
-            </Text>
+            <Text>{formatServiceLabel(svc)}</Text>
             <StatusIndicator status={svc.status} />
           </Box>
         ))}


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Vite and API ports in the dev TUI header so you can see both endpoints at a glance. Uses a placeholder until each port is available.

- **Bug Fixes**
  - Track API alongside Vite in dev mode; show "Name: port" or "...." while pending.
  - Extract `formatServiceLabel` and add tests for service tracking and header rendering.
  - Revert CI change that skipped storage integration; suite runs again.

<sup>Written for commit 9d20b9b4b01fb5300668817b55c720b084ae7b77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

