### PR TITLE
feat(github): self-refreshing repo-scoped tokens via downstream OAuth refresh

### DIFF
--- a/apps/mesh/e2e/tests/github-import-repo-scope.spec.ts
+++ b/apps/mesh/e2e/tests/github-import-repo-scope.spec.ts
@@ -2,10 +2,10 @@
  * End-to-end tests for per-agent repo-scoped GitHub connections.
  *
  * Feature under test (Tasks 1-6): an imported GitHub agent gets a dedicated
- * child `mcp-github` connection whose `metadata.repoScope` recipe drives
- * on-demand minting of a short-lived, repo-scoped GitHub token via the ORG
- * connection's `MINT_REPO_TOKEN` tool. Deleting the agent tears the child
- * connection (and its minted token) down.
+ * child `mcp-github` connection whose `metadata.repoScope` marks it as
+ * repo-scoped. Legacy children can mint a short-lived token through an ORG
+ * connection; refreshable children carry no sourceConnectionId and refresh
+ * their repo grant through the normal downstream_tokens OAuth path.
  *
  * Scenarios covered here:
  *   1. Cross-tenant guard — org B cannot read org A's connection through
@@ -15,9 +15,9 @@
  *      its connection_aggregations rows, and (when seeded) its downstream
  *      token, WITHOUT tripping the ON DELETE RESTRICT FK (the agent is deleted
  *      first, clearing the aggregation rows, then the child).
- *   3. Runtime mint-on-demand — calling a tool on a repo-scoped child through
- *      the proxy mints a token via the org connection's MINT_REPO_TOKEN and
- *      caches it in downstream_tokens.
+ *   3. Runtime refresh — calling a tool on a source-less repo-scoped child
+ *      refreshes its repo grant through downstream_tokens without using the
+ *      org connection.
  *
  * OUT OF SCOPE (not attempted here): driving the full GitHub repo-picker UI
  * import. That needs real GitHub OAuth + a live `/user/installations` listing,
@@ -26,7 +26,12 @@
  * exercised directly against the built-in tools instead.
  */
 
-import { z } from "zod";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import type { APIRequestContext } from "@playwright/test";
 import { signUpViaApi } from "../fixtures/auth-api";
 import { connectDevDb } from "../fixtures/db";
 import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
@@ -35,6 +40,162 @@ import {
   type TestMcpServer,
 } from "../fixtures/test-mcp-server";
 import { expect, newApiContext, test } from "../fixtures/test";
+
+interface TokenEndpointRequest {
+  method: string;
+  body: Record<string, string>;
+  timestamp: number;
+}
+
+interface TokenEndpointConfig {
+  status?: number;
+  body?: Record<string, unknown>;
+}
+
+interface TestTokenEndpoint {
+  url: string;
+  requests: ReadonlyArray<TokenEndpointRequest>;
+  stop: () => Promise<void>;
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+async function startTokenEndpoint(
+  config: TokenEndpointConfig = {},
+): Promise<TestTokenEndpoint> {
+  const status = config.status ?? 200;
+  const body = config.body ?? {
+    access_token: "ghs_refreshed_e2e",
+    refresh_token: "repo_grant_e2e_rotated",
+    expires_in: 3600,
+    scope: "repo:acme/widget",
+  };
+  const recorded: TokenEndpointRequest[] = [];
+
+  const server = createServer(
+    async (req: IncomingMessage, res: ServerResponse) => {
+      try {
+        const raw = req.method === "POST" ? await readBody(req) : "";
+        recorded.push({
+          method: req.method ?? "UNKNOWN",
+          body: Object.fromEntries(new URLSearchParams(raw)),
+          timestamp: Date.now(),
+        });
+
+        res.statusCode = status;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(body));
+      } catch (error) {
+        res.statusCode = 500;
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify({
+            error: error instanceof Error ? error.message : "request failed",
+          }),
+        );
+      }
+    },
+  );
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Token endpoint did not bind to a TCP port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/token`,
+    requests: recorded,
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function createRepoGrantChild(
+  ctx: APIRequestContext,
+  org: string,
+  connectionUrl: string,
+): Promise<string> {
+  const child = await callSelfMcpTool<{ item: { id: string } }>(
+    ctx,
+    org,
+    "COLLECTION_CONNECTIONS_CREATE",
+    {
+      data: {
+        title: `GitHub: acme/widget ${Date.now()}`,
+        app_name: "mcp-github",
+        connection_type: "HTTP",
+        connection_url: connectionUrl,
+        metadata: {
+          repoScope: {
+            installationId: 1,
+            repositoryId: 99,
+            owner: "acme",
+            repo: "widget",
+            permissions: { contents: "write" },
+            grantProvider: "github-mcp",
+          },
+        },
+      },
+    },
+  );
+  expect(child.item.id).toBeTruthy();
+  return child.item.id;
+}
+
+async function seedExpiredRepoGrantToken(
+  ctx: APIRequestContext,
+  org: string,
+  childId: string,
+  tokenEndpoint: string,
+): Promise<void> {
+  const tokenRes = await ctx.post(
+    `/api/${org}/connections/${childId}/oauth-token`,
+    {
+      data: {
+        accessToken: "ghs_expired_e2e",
+        refreshToken: "repo_grant_e2e",
+        expiresIn: -60,
+        clientId: "github-mcp",
+        tokenEndpoint,
+      },
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  expect(tokenRes.ok()).toBe(true);
+}
+
+async function callRepoChildWhoami(
+  ctx: APIRequestContext,
+  org: string,
+  childId: string,
+): Promise<void> {
+  const res = await ctx.post(`/api/${org}/mcp/${childId}`, {
+    data: {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "whoami", arguments: {} },
+    },
+    headers: { Accept: "application/json, text/event-stream" },
+  });
+  expect(res.ok()).toBe(true);
+  const envelope = (await res.json()) as {
+    result?: { isError?: boolean; content?: Array<{ text?: string }> };
+    error?: unknown;
+  };
+  expect(envelope.error).toBeUndefined();
+  expect(envelope.result?.isError).not.toBe(true);
+}
 
 test.describe("GitHub import repo-scoped connections", () => {
   /**
@@ -271,61 +432,21 @@ test.describe("GitHub import repo-scoped connections", () => {
   });
 
   /**
-   * Scenario 3 — runtime mint-on-demand.
+   * Scenario 3 — runtime refresh of a repo grant.
    *
-   * Calling any tool on a repo-scoped child through the proxy triggers the
-   * outbound header builder → ensureRepoScopedToken → mintRepoToken, which
-   * opens an MCP client to the ORG connection and calls MINT_REPO_TOKEN. The
-   * minted token is then cached (vault-encrypted) in downstream_tokens.
-   *
-   * Two stubs: `orgStub` exposes MINT_REPO_TOKEN (with an outputSchema so the
-   * SDK emits the structuredContent the mesh mint caller reads), `repoStub`
-   * exposes a trivial `whoami` tool the child surfaces.
-   *
-   * Assertions: orgStub recorded a tools/call naming MINT_REPO_TOKEN, AND a
-   * downstream_tokens row now exists for the child with expiresAt set. The
-   * stored access token is vault-encrypted, so we assert existence rather than
-   * matching plaintext.
+   * A source-less repo-scoped child has no org-parent soft link. Calling a tool
+   * through the proxy should refresh the expired repo grant via the stored
+   * OAuth-shaped downstream token fields, not call MINT_REPO_TOKEN.
    */
-  test("calling a repo-scoped child tool mints + caches a token via the org connection", async ({
+  test("calling a repo-scoped child tool refreshes a repo grant without using the org connection", async ({
     playwright,
   }) => {
-    let orgStub: TestMcpServer | undefined;
     let repoStub: TestMcpServer | undefined;
+    let tokenEndpoint: TestTokenEndpoint | undefined;
     const ctx = await newApiContext(playwright);
     const db = await connectDevDb();
     try {
-      orgStub = await startTestMcpServer({
-        tools: [
-          {
-            name: "MINT_REPO_TOKEN",
-            description: "Mint a repo-scoped GitHub App installation token.",
-            inputSchema: {
-              installationId: z.number(),
-              owner: z.string(),
-              repo: z.string(),
-              permissions: z.record(z.string(), z.string()).optional(),
-            },
-            // outputSchema is required for the SDK to emit structuredContent,
-            // which mintRepoToken reads (res.structuredContent.token).
-            outputSchema: {
-              token: z.string(),
-              expiresAt: z.string(),
-              permissions: z.record(z.string(), z.string()),
-              repository: z.object({ owner: z.string(), name: z.string() }),
-              installationId: z.number(),
-            },
-            handler: () => ({
-              token: "ghs_minted_e2e",
-              expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-              permissions: {},
-              repository: { owner: "acme", name: "widget" },
-              installationId: 1,
-            }),
-          },
-        ],
-      });
-
+      tokenEndpoint = await startTokenEndpoint();
       repoStub = await startTestMcpServer({
         tools: [
           {
@@ -339,78 +460,19 @@ test.describe("GitHub import repo-scoped connections", () => {
       const user = await signUpViaApi(ctx);
       const org = user.orgSlug;
 
-      // Org connection: the mint source. Points at orgStub so MINT_REPO_TOKEN
-      // resolves to a reachable tool.
-      const orgConn = await createHttpConnection(ctx, org, {
-        title: `Org GitHub ${Date.now()}`,
-        url: orgStub.url,
+      const childId = await createRepoGrantChild(ctx, org, repoStub.url);
+      await seedExpiredRepoGrantToken(ctx, org, childId, tokenEndpoint.url);
+
+      await callRepoChildWhoami(ctx, org, childId);
+
+      expect(tokenEndpoint.requests).toHaveLength(1);
+      expect(tokenEndpoint.requests[0]?.body).toMatchObject({
+        grant_type: "refresh_token",
+        refresh_token: "repo_grant_e2e",
+        client_id: "github-mcp",
       });
 
-      // Repo-scoped child: points at repoStub, carries the mint recipe, and has
-      // NO downstream token yet (so the first proxied call must mint).
-      const child = await callSelfMcpTool<{ item: { id: string } }>(
-        ctx,
-        org,
-        "COLLECTION_CONNECTIONS_CREATE",
-        {
-          data: {
-            title: `GitHub: acme/widget ${Date.now()}`,
-            app_name: "mcp-github",
-            connection_type: "HTTP",
-            connection_url: repoStub.url,
-            metadata: {
-              repoScope: {
-                sourceConnectionId: orgConn.id,
-                installationId: 1,
-                owner: "acme",
-                repo: "widget",
-                permissions: { contents: "write" },
-              },
-            },
-          },
-        },
-      );
-      const childId = child.item.id;
-      expect(childId).toBeTruthy();
-
-      // No token before the first proxied call.
-      const before = await db.query(
-        'SELECT 1 FROM downstream_tokens WHERE "connectionId" = $1',
-        [childId],
-      );
-      expect(before.rowCount).toBe(0);
-
-      // Hit the proxy for the child connection. The outbound header builder
-      // runs per request and mints the repo-scoped token on the way out.
-      const res = await ctx.post(`/api/${org}/mcp/${childId}`, {
-        data: {
-          jsonrpc: "2.0",
-          id: 1,
-          method: "tools/call",
-          params: { name: "whoami", arguments: {} },
-        },
-        headers: { Accept: "application/json, text/event-stream" },
-      });
-      expect(res.ok()).toBe(true);
-      const envelope = (await res.json()) as {
-        result?: { isError?: boolean; content?: Array<{ text?: string }> };
-        error?: unknown;
-      };
-      expect(envelope.error).toBeUndefined();
-      expect(envelope.result?.isError).not.toBe(true);
-
-      // The org stub must have been asked to mint.
-      const mintCall = orgStub.requests.some(
-        (r) =>
-          r.method === "tools/call" &&
-          typeof r.body === "object" &&
-          r.body !== null &&
-          (r.body as { params?: { name?: string } }).params?.name ===
-            "MINT_REPO_TOKEN",
-      );
-      expect(mintCall).toBe(true);
-
-      // The minted token is now cached (vault-encrypted) with an expiry set.
+      // The refreshed token is cached (vault-encrypted) with an expiry set.
       const after = await db.query<{ expiresAt: string | null }>(
         'SELECT "expiresAt" FROM downstream_tokens WHERE "connectionId" = $1',
         [childId],
@@ -418,10 +480,116 @@ test.describe("GitHub import repo-scoped connections", () => {
       expect(after.rowCount).toBe(1);
       expect(after.rows[0]?.expiresAt).toBeTruthy();
     } finally {
-      await db.end();
-      await ctx.dispose();
-      await orgStub?.stop();
-      await repoStub?.stop();
+      await Promise.allSettled([
+        db.end(),
+        ctx.dispose(),
+        tokenEndpoint?.stop(),
+        repoStub?.stop(),
+      ]);
+    }
+  });
+
+  test("permanently invalid repo grant refresh deletes the cached downstream token", async ({
+    playwright,
+  }) => {
+    let repoStub: TestMcpServer | undefined;
+    let tokenEndpoint: TestTokenEndpoint | undefined;
+    const ctx = await newApiContext(playwright);
+    const db = await connectDevDb();
+    try {
+      tokenEndpoint = await startTokenEndpoint({
+        status: 400,
+        body: { error: "invalid_grant", error_description: "grant revoked" },
+      });
+      repoStub = await startTestMcpServer({
+        tools: [
+          {
+            name: "whoami",
+            description: "Trivial tool exposed by the repo-scoped child.",
+            handler: () => ({ ok: true }),
+          },
+        ],
+      });
+
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+      const childId = await createRepoGrantChild(ctx, org, repoStub.url);
+      await seedExpiredRepoGrantToken(ctx, org, childId, tokenEndpoint.url);
+
+      await callRepoChildWhoami(ctx, org, childId);
+
+      expect(tokenEndpoint.requests.length).toBeGreaterThan(0);
+      for (const request of tokenEndpoint.requests) {
+        expect(request.body).toMatchObject({
+          grant_type: "refresh_token",
+          refresh_token: "repo_grant_e2e",
+          client_id: "github-mcp",
+        });
+      }
+      const after = await db.query(
+        'SELECT 1 FROM downstream_tokens WHERE "connectionId" = $1',
+        [childId],
+      );
+      expect(after.rowCount).toBe(0);
+    } finally {
+      await Promise.allSettled([
+        db.end(),
+        ctx.dispose(),
+        tokenEndpoint?.stop(),
+        repoStub?.stop(),
+      ]);
+    }
+  });
+
+  test("transient repo grant refresh failure keeps the cached downstream token", async ({
+    playwright,
+  }) => {
+    let repoStub: TestMcpServer | undefined;
+    let tokenEndpoint: TestTokenEndpoint | undefined;
+    const ctx = await newApiContext(playwright);
+    const db = await connectDevDb();
+    try {
+      tokenEndpoint = await startTokenEndpoint({
+        status: 503,
+        body: { error: "server_error" },
+      });
+      repoStub = await startTestMcpServer({
+        tools: [
+          {
+            name: "whoami",
+            description: "Trivial tool exposed by the repo-scoped child.",
+            handler: () => ({ ok: true }),
+          },
+        ],
+      });
+
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+      const childId = await createRepoGrantChild(ctx, org, repoStub.url);
+      await seedExpiredRepoGrantToken(ctx, org, childId, tokenEndpoint.url);
+
+      await callRepoChildWhoami(ctx, org, childId);
+
+      expect(tokenEndpoint.requests.length).toBeGreaterThan(0);
+      for (const request of tokenEndpoint.requests) {
+        expect(request.body).toMatchObject({
+          grant_type: "refresh_token",
+          refresh_token: "repo_grant_e2e",
+          client_id: "github-mcp",
+        });
+      }
+      const after = await db.query(
+        'SELECT 1 FROM downstream_tokens WHERE "connectionId" = $1',
+        [childId],
+      );
+      expect(after.rowCount).toBe(1);
+    } finally {
+      await Promise.allSettled([
+        db.end(),
+        ctx.dispose(),
+        tokenEndpoint?.stop(),
+        repoStub?.stop(),
+      ]);
     }
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -42,6 +42,7 @@ import { composeSandboxRef } from "@decocms/sandbox/provider";
 import {
   buildAnonymousCloneInfo,
   buildCloneInfo,
+  ensureGithubCloneToken,
 } from "@/shared/github-clone-info";
 import { resolveRuntimeConfig } from "@/tools/sandbox/helpers";
 import { deriveOffloadAllowlist } from "@/object-storage/offload-allowlist";
@@ -1517,14 +1518,32 @@ async function resolvePullSandboxConfig(
   let repo: WorkItemSandbox["repo"];
   if (githubRepo) {
     try {
-      const { cloneUrl, gitUserName, gitUserEmail } = githubRepo.connectionId
-        ? await buildCloneInfo(
-            githubRepo.connectionId,
-            githubRepo.owner,
-            githubRepo.name,
-            ctx.db,
-            ctx.vault,
-          )
+      const connectionId = githubRepo.connectionId;
+      const { cloneUrl, gitUserName, gitUserEmail } = connectionId
+        ? await (async () => {
+            await ensureGithubCloneToken({
+              ctx,
+              connectionId,
+              organizationId: input.organizationId,
+              onLegacyMintError: (error) => {
+                console.warn(
+                  "[pullDispatch] repo-scoped legacy token mint failed",
+                  {
+                    connectionId,
+                    error:
+                      error instanceof Error ? error.message : String(error),
+                  },
+                );
+              },
+            });
+            return buildCloneInfo(
+              connectionId,
+              githubRepo.owner,
+              githubRepo.name,
+              ctx.db,
+              ctx.vault,
+            );
+          })()
         : buildAnonymousCloneInfo(githubRepo.owner, githubRepo.name);
       repo = {
         cloneUrl,

--- a/apps/mesh/src/file-storage/mount/webdav.integration.test.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.integration.test.ts
@@ -39,6 +39,7 @@ const SLUG = "wdtest";
 const USER = "user_wd";
 const VOLUME = "skills";
 const ASSETS_DIR = `./data/assets/${ORG}`;
+const HOOK_TIMEOUT_MS = 30_000;
 
 type Variables = { meshContext: StudioContext };
 
@@ -108,7 +109,7 @@ describe("WebDAV serve layer (integration, full chain)", () => {
       fetch: (url, reqInit) => Promise.resolve(app.request(url, reqInit)),
     });
     dav = createWebdavHandler(api);
-  });
+  }, HOOK_TIMEOUT_MS);
 
   afterAll(async () => {
     rmSync(ASSETS_DIR, { recursive: true, force: true });

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -160,25 +160,29 @@ async function _buildRequestHeaders(
 
   if (tokenResult.accessToken) {
     accessToken = tokenResult.accessToken;
-  } else if (repoScope?.sourceConnectionId) {
-    try {
-      accessToken = await ensureRepoScopedToken(ctx, connection);
-    } catch (err) {
-      console.error("[Proxy] repo-scoped legacy token mint failed", {
+  } else {
+    if (tokenResult.state === "expired_without_refresh") {
+      console.warn(
+        `[Proxy] Token expired for ${connectionId} with no refresh capability`,
+      );
+    } else if (tokenResult.state === "refresh_failed") {
+      console.error("[Proxy] token refresh failed", {
         connectionId,
         tokenState: tokenResult.state,
-        error: (err as Error).message,
       });
     }
-  } else if (tokenResult.state === "expired_without_refresh") {
-    console.warn(
-      `[Proxy] Token expired for ${connectionId} with no refresh capability`,
-    );
-  } else if (tokenResult.state === "refresh_failed") {
-    console.error("[Proxy] token refresh failed", {
-      connectionId,
-      tokenState: tokenResult.state,
-    });
+
+    if (repoScope?.sourceConnectionId) {
+      try {
+        accessToken = await ensureRepoScopedToken(ctx, connection);
+      } catch (err) {
+        console.error("[Proxy] repo-scoped legacy token mint failed", {
+          connectionId,
+          tokenState: tokenResult.state,
+          error: (err as Error).message,
+        });
+      }
+    }
   }
 
   // Fall back to connection token if no cached token

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -9,8 +9,7 @@ import { extractConnectionPermissions } from "@/auth/configuration-scopes";
 import { issueMeshToken } from "@/auth/jwt";
 import type { StudioContext } from "@/core/studio-context";
 import { SpanStatusCode } from "@opentelemetry/api";
-import { refreshAccessToken } from "@/oauth/token-refresh";
-import { resolveOriginTokenEndpoint } from "@/oauth/resolve-token-endpoint";
+import { getValidDownstreamAccessToken } from "@/oauth/token-refresh";
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
 import { ensureRepoScopedToken } from "@/oauth/github-mint";
 import { getRepoScope } from "@/shared/github-repo-scope";
@@ -153,104 +152,33 @@ async function _buildRequestHeaders(
   // cached-token + refresh path below.
   const repoScope = getRepoScope(connection);
   const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
-  const useLegacyRepoMint = !!repoScope?.sourceConnectionId;
-  const cachedToken = useLegacyRepoMint
-    ? null
-    : await tokenStorage.get(connectionId);
+  const tokenResult = await getValidDownstreamAccessToken({
+    connectionId,
+    connectionUrl: connection.connection_url,
+    tokenStorage,
+  });
 
-  if (useLegacyRepoMint) {
-    // Mint failure leaves accessToken null → the request goes out without an
-    // Authorization header and fails downstream (same resilience as a failed
-    // refresh); the next call retries the mint.
+  if (tokenResult.accessToken) {
+    accessToken = tokenResult.accessToken;
+  } else if (repoScope?.sourceConnectionId) {
     try {
       accessToken = await ensureRepoScopedToken(ctx, connection);
     } catch (err) {
       console.error("[Proxy] repo-scoped legacy token mint failed", {
         connectionId,
+        tokenState: tokenResult.state,
         error: (err as Error).message,
       });
     }
-  }
-
-  if (cachedToken) {
-    const canRefresh =
-      !!cachedToken.refreshToken && !!cachedToken.tokenEndpoint;
-    // If we can refresh, treat "expiring soon" as expired to proactively refresh.
-    // If we cannot refresh, only treat as expired at actual expiry (no buffer),
-    // otherwise short-lived tokens would be deleted immediately.
-    const isExpired = tokenStorage.isExpired(
-      cachedToken,
-      canRefresh ? 5 * 60 * 1000 : 0,
+  } else if (tokenResult.state === "expired_without_refresh") {
+    console.warn(
+      `[Proxy] Token expired for ${connectionId} with no refresh capability`,
     );
-
-    if (isExpired) {
-      // Try to refresh if we have refresh capability
-      if (canRefresh) {
-        // If tokenEndpoint is a proxy URL, resolve the origin's actual endpoint
-        // to avoid a self-referential call through the proxy during refresh
-        let tokenEndpointForRefresh = cachedToken.tokenEndpoint;
-        if (
-          connection.connection_url &&
-          cachedToken.tokenEndpoint?.includes("/oauth-proxy/")
-        ) {
-          const originEndpoint = await resolveOriginTokenEndpoint(
-            connection.connection_url,
-          );
-          if (originEndpoint) {
-            tokenEndpointForRefresh = originEndpoint;
-          }
-        }
-
-        const refreshResult = await refreshAccessToken({
-          ...cachedToken,
-          tokenEndpoint: tokenEndpointForRefresh,
-        });
-
-        if (refreshResult.success && refreshResult.accessToken) {
-          // Save refreshed token (with resolved origin endpoint for future refreshes)
-          await tokenStorage.upsert({
-            connectionId,
-            accessToken: refreshResult.accessToken,
-            refreshToken:
-              refreshResult.refreshToken ?? cachedToken.refreshToken,
-            scope: refreshResult.scope ?? cachedToken.scope,
-            expiresAt: refreshResult.expiresIn
-              ? new Date(Date.now() + refreshResult.expiresIn * 1000)
-              : null,
-            clientId: cachedToken.clientId,
-            clientSecret: cachedToken.clientSecret,
-            tokenEndpoint: tokenEndpointForRefresh,
-          });
-
-          accessToken = refreshResult.accessToken;
-        } else {
-          // Only delete on a definitive `400 invalid_grant`. Transient
-          // failures (5xx, network, non-spec status codes) leave the cached
-          // row intact so the next request retries instead of forcing a
-          // manual reconnect.
-          if (refreshResult.permanent === true) {
-            await tokenStorage.delete(connectionId);
-          }
-          console.error("[Proxy] token refresh failed", {
-            connectionId,
-            status: refreshResult.status,
-            errorCode: refreshResult.errorCode,
-            permanent: refreshResult.permanent === true,
-            deleted: refreshResult.permanent === true,
-          });
-        }
-      } else {
-        // Token expired but no refresh capability - delete it
-        await tokenStorage.delete(connectionId);
-        console.warn(
-          `[Proxy] Token expired for ${connectionId} with no refresh capability ` +
-            `(refreshToken: ${!!cachedToken.refreshToken}, tokenEndpoint: ${!!cachedToken.tokenEndpoint})`,
-        );
-      }
-    } else {
-      // Token is still valid
-      accessToken = cachedToken.accessToken;
-    }
+  } else if (tokenResult.state === "refresh_failed") {
+    console.error("[Proxy] token refresh failed", {
+      connectionId,
+      tokenState: tokenResult.state,
+    });
   }
 
   // Fall back to connection token if no cached token

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -148,21 +148,24 @@ async function _buildRequestHeaders(
   // This supports OAuth token refresh for connections that use OAuth
   let accessToken: string | null = null;
 
-  // Per-agent repo-scoped child connections carry a MINTED token (no refresh
-  // token), so mint-on-demand instead of refreshing. getRepoScope returns null
-  // for ordinary connections, which keep the cached-token + refresh path below.
+  // Legacy per-agent repo-scoped child connections mint on demand through their
+  // source org connection. Refreshable repo-scoped children use the normal
+  // cached-token + refresh path below.
   const repoScope = getRepoScope(connection);
   const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
-  const cachedToken = repoScope ? null : await tokenStorage.get(connectionId);
+  const useLegacyRepoMint = !!repoScope?.sourceConnectionId;
+  const cachedToken = useLegacyRepoMint
+    ? null
+    : await tokenStorage.get(connectionId);
 
-  if (repoScope) {
+  if (useLegacyRepoMint) {
     // Mint failure leaves accessToken null → the request goes out without an
     // Authorization header and fails downstream (same resilience as a failed
     // refresh); the next call retries the mint.
     try {
       accessToken = await ensureRepoScopedToken(ctx, connection);
     } catch (err) {
-      console.error("[Proxy] repo-scoped token mint failed", {
+      console.error("[Proxy] repo-scoped legacy token mint failed", {
         connectionId,
         error: (err as Error).message,
       });

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -147,39 +147,37 @@ async function _buildRequestHeaders(
   // This supports OAuth token refresh for connections that use OAuth
   let accessToken: string | null = null;
 
-  // Legacy per-agent repo-scoped child connections mint on demand through their
-  // source org connection. Refreshable repo-scoped children use the normal
-  // cached-token + refresh path below.
   const repoScope = getRepoScope(connection);
-  const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
-  const tokenResult = await getValidDownstreamAccessToken({
-    connectionId,
-    connectionUrl: connection.connection_url,
-    tokenStorage,
-  });
+  const useLegacyRepoMint = !!repoScope?.sourceConnectionId;
 
-  if (tokenResult.accessToken) {
-    accessToken = tokenResult.accessToken;
-  } else {
-    if (tokenResult.state === "expired_without_refresh") {
-      console.warn(
-        `[Proxy] Token expired for ${connectionId} with no refresh capability`,
-      );
-    } else if (tokenResult.state === "refresh_failed") {
-      console.error("[Proxy] token refresh failed", {
+  if (useLegacyRepoMint) {
+    try {
+      accessToken = await ensureRepoScopedToken(ctx, connection);
+    } catch (err) {
+      console.error("[Proxy] repo-scoped legacy token mint failed", {
         connectionId,
-        tokenState: tokenResult.state,
+        error: (err as Error).message,
       });
     }
+  } else {
+    const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
+    const tokenResult = await getValidDownstreamAccessToken({
+      connectionId,
+      connectionUrl: connection.connection_url,
+      tokenStorage,
+    });
 
-    if (repoScope?.sourceConnectionId) {
-      try {
-        accessToken = await ensureRepoScopedToken(ctx, connection);
-      } catch (err) {
-        console.error("[Proxy] repo-scoped legacy token mint failed", {
+    if (tokenResult.accessToken) {
+      accessToken = tokenResult.accessToken;
+    } else {
+      if (tokenResult.state === "expired_without_refresh") {
+        console.warn(
+          `[Proxy] Token expired for ${connectionId} with no refresh capability`,
+        );
+      } else if (tokenResult.state === "refresh_failed") {
+        console.error("[Proxy] token refresh failed", {
           connectionId,
           tokenState: tokenResult.state,
-          error: (err as Error).message,
         });
       }
     }

--- a/apps/mesh/src/oauth/github-mint.ts
+++ b/apps/mesh/src/oauth/github-mint.ts
@@ -128,6 +128,9 @@ export async function ensureRepoScopedToken(
   if (!recipe) {
     throw new Error("Connection is not repo-scoped");
   }
+  if (!recipe.sourceConnectionId) {
+    throw new Error(RECONNECT_ERROR);
+  }
 
   const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
   const cached = await tokenStorage.get(connection.id);

--- a/apps/mesh/src/oauth/github-mint.ts
+++ b/apps/mesh/src/oauth/github-mint.ts
@@ -44,6 +44,9 @@ async function mintRepoToken(
     // No org scope → refuse to mint rather than fall back to an unscoped lookup.
     throw new Error(RECONNECT_ERROR);
   }
+  if (!recipe.sourceConnectionId) {
+    throw new Error(RECONNECT_ERROR);
+  }
   const orgConn = await ctx.storage.connections.findById(
     recipe.sourceConnectionId,
     organizationId,

--- a/apps/mesh/src/oauth/token-refresh.integration.test.ts
+++ b/apps/mesh/src/oauth/token-refresh.integration.test.ts
@@ -171,6 +171,7 @@ describe("refreshAndStore", () => {
     const first = refreshAndStore(token!, tokenStorage);
     await refreshStarted;
     const second = refreshAndStore(token!, tokenStorage);
+    expect(first).toBe(second);
     releaseRefresh();
 
     await expect(first).resolves.toBe("fresh-single-flight");

--- a/apps/mesh/src/oauth/token-refresh.integration.test.ts
+++ b/apps/mesh/src/oauth/token-refresh.integration.test.ts
@@ -31,51 +31,51 @@ mock.module("./refresh-access-token", () => ({
 
 const { refreshAndStore } = await import("./token-refresh");
 
+let database: StudioDatabase;
+let vault: CredentialVault;
+let tokenStorage: DownstreamTokenStorage;
+const connectionId = "conn_refresh_test";
+
+beforeAll(async () => {
+  database = await connectTestPgDatabase();
+  await resetTestPgDatabase(database);
+  await seedCommonTestPgFixtures(database);
+  vault = new CredentialVault(CredentialVault.generateKey());
+  tokenStorage = new DownstreamTokenStorage(database.db, vault);
+
+  const connectionStorage = new ConnectionStorage(database.db, vault);
+  await connectionStorage.create({
+    id: connectionId,
+    organization_id: "org_123",
+    created_by: "user_1",
+    title: "GitHub",
+    connection_type: "HTTP",
+    connection_url: "https://mcp.example.com/github",
+    connection_token: null,
+    tools: null,
+  });
+});
+
+afterAll(async () => {
+  await closeTestPgDatabase(database);
+});
+
+beforeEach(async () => {
+  mockRefreshAccessToken.mockReset();
+  await tokenStorage.delete(connectionId);
+  await tokenStorage.upsert({
+    connectionId,
+    accessToken: "stale",
+    refreshToken: "rt",
+    scope: "repo",
+    expiresAt: new Date(Date.now() - 1000),
+    clientId: "cid",
+    clientSecret: null,
+    tokenEndpoint: "https://example.com/token",
+  });
+});
+
 describe("refreshAndStore", () => {
-  let database: StudioDatabase;
-  let vault: CredentialVault;
-  let tokenStorage: DownstreamTokenStorage;
-  const connectionId = "conn_refresh_test";
-
-  beforeAll(async () => {
-    database = await connectTestPgDatabase();
-    await resetTestPgDatabase(database);
-    await seedCommonTestPgFixtures(database);
-    vault = new CredentialVault(CredentialVault.generateKey());
-    tokenStorage = new DownstreamTokenStorage(database.db, vault);
-
-    const connectionStorage = new ConnectionStorage(database.db, vault);
-    await connectionStorage.create({
-      id: connectionId,
-      organization_id: "org_123",
-      created_by: "user_1",
-      title: "GitHub",
-      connection_type: "HTTP",
-      connection_url: "https://mcp.example.com/github",
-      connection_token: null,
-      tools: null,
-    });
-  });
-
-  afterAll(async () => {
-    await closeTestPgDatabase(database);
-  });
-
-  beforeEach(async () => {
-    mockRefreshAccessToken.mockReset();
-    await tokenStorage.delete(connectionId);
-    await tokenStorage.upsert({
-      connectionId,
-      accessToken: "stale",
-      refreshToken: "rt",
-      scope: "repo",
-      expiresAt: new Date(Date.now() - 1000),
-      clientId: "cid",
-      clientSecret: null,
-      tokenEndpoint: "https://example.com/token",
-    });
-  });
-
   it("preserves the cached token on transient (5xx) failures", async () => {
     mockRefreshAccessToken.mockResolvedValueOnce({
       success: false,
@@ -144,5 +144,88 @@ describe("refreshAndStore", () => {
     const after = await tokenStorage.get(connectionId);
     expect(after?.accessToken).toBe("fresh");
     expect(after?.refreshToken).toBe("rt2");
+  });
+
+  it("collapses concurrent refreshes for the same connection", async () => {
+    let releaseRefresh!: () => void;
+    const refreshStarted = new Promise<void>((resolve) => {
+      mockRefreshAccessToken.mockImplementationOnce(
+        () =>
+          new Promise<TokenRefreshResult>((resolveRefresh) => {
+            resolve();
+            releaseRefresh = () =>
+              resolveRefresh({
+                success: true,
+                accessToken: "fresh-single-flight",
+                refreshToken: "rt-single-flight",
+                expiresIn: 3600,
+                scope: "repo",
+              });
+          }),
+      );
+    });
+
+    const token = await tokenStorage.get(connectionId);
+    expect(token).not.toBeNull();
+
+    const first = refreshAndStore(token!, tokenStorage);
+    await refreshStarted;
+    const second = refreshAndStore(token!, tokenStorage);
+    releaseRefresh();
+
+    await expect(first).resolves.toBe("fresh-single-flight");
+    await expect(second).resolves.toBe("fresh-single-flight");
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+});
+
+const { getValidDownstreamAccessToken } = await import("./token-refresh");
+
+describe("getValidDownstreamAccessToken", () => {
+  it("returns a cached valid token without refreshing", async () => {
+    await tokenStorage.delete(connectionId);
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "valid",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() + 3600_000),
+      clientId: "cid",
+      clientSecret: null,
+      tokenEndpoint: "https://example.com/token",
+    });
+
+    const result = await getValidDownstreamAccessToken({
+      connectionId,
+      tokenStorage,
+    });
+
+    expect(result).toEqual({ state: "valid", accessToken: "valid" });
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("deletes expired tokens that cannot refresh", async () => {
+    await tokenStorage.delete(connectionId);
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "expired",
+      refreshToken: null,
+      scope: null,
+      expiresAt: new Date(Date.now() - 1000),
+      clientId: null,
+      clientSecret: null,
+      tokenEndpoint: null,
+    });
+
+    const result = await getValidDownstreamAccessToken({
+      connectionId,
+      tokenStorage,
+    });
+
+    expect(result).toEqual({
+      state: "expired_without_refresh",
+      accessToken: null,
+    });
+    expect(await tokenStorage.get(connectionId)).toBeNull();
   });
 });

--- a/apps/mesh/src/oauth/token-refresh.ts
+++ b/apps/mesh/src/oauth/token-refresh.ts
@@ -61,7 +61,7 @@ async function refreshAndStoreOnce(
   return result.accessToken;
 }
 
-export async function refreshAndStore(
+export function refreshAndStore(
   token: DownstreamToken,
   tokenStorage: DownstreamTokenStorage,
 ): Promise<string | null> {

--- a/apps/mesh/src/oauth/token-refresh.ts
+++ b/apps/mesh/src/oauth/token-refresh.ts
@@ -16,7 +16,6 @@ import type { DownstreamTokenStorage } from "../storage/downstream-token";
 import { refreshAccessToken } from "./refresh-access-token";
 import { resolveOriginTokenEndpoint } from "./resolve-token-endpoint";
 
-export { refreshAccessToken } from "./refresh-access-token";
 export type { TokenRefreshResult } from "./refresh-access-token";
 
 export const PROACTIVE_REFRESH_BUFFER_MS = 5 * 60 * 1000;

--- a/apps/mesh/src/oauth/token-refresh.ts
+++ b/apps/mesh/src/oauth/token-refresh.ts
@@ -14,6 +14,7 @@
 import type { DownstreamToken } from "../storage/types";
 import type { DownstreamTokenStorage } from "../storage/downstream-token";
 import { refreshAccessToken } from "./refresh-access-token";
+import { resolveOriginTokenEndpoint } from "./resolve-token-endpoint";
 
 export { refreshAccessToken } from "./refresh-access-token";
 export type { TokenRefreshResult } from "./refresh-access-token";
@@ -27,7 +28,9 @@ export function canRefresh(token: DownstreamToken): boolean {
   return !!token.refreshToken && !!token.tokenEndpoint && !!token.clientId;
 }
 
-export async function refreshAndStore(
+const inflightRefreshes = new Map<string, Promise<string | null>>();
+
+async function refreshAndStoreOnce(
   token: DownstreamToken,
   tokenStorage: DownstreamTokenStorage,
 ): Promise<string | null> {
@@ -56,4 +59,63 @@ export async function refreshAndStore(
     tokenEndpoint: token.tokenEndpoint,
   });
   return result.accessToken;
+}
+
+export async function refreshAndStore(
+  token: DownstreamToken,
+  tokenStorage: DownstreamTokenStorage,
+): Promise<string | null> {
+  const existing = inflightRefreshes.get(token.connectionId);
+  if (existing) return existing;
+
+  const refresh = refreshAndStoreOnce(token, tokenStorage).finally(() => {
+    inflightRefreshes.delete(token.connectionId);
+  });
+  inflightRefreshes.set(token.connectionId, refresh);
+  return refresh;
+}
+
+export type ValidDownstreamAccessTokenResult =
+  | { state: "missing"; accessToken: null }
+  | { state: "valid"; accessToken: string }
+  | { state: "refreshed"; accessToken: string }
+  | { state: "refresh_failed"; accessToken: null }
+  | { state: "expired_without_refresh"; accessToken: null };
+
+export async function getValidDownstreamAccessToken(params: {
+  connectionId: string;
+  connectionUrl?: string | null;
+  tokenStorage: DownstreamTokenStorage;
+  bufferMs?: number;
+}): Promise<ValidDownstreamAccessTokenResult> {
+  const { connectionId, connectionUrl, tokenStorage } = params;
+  const token = await tokenStorage.get(connectionId);
+  if (!token) return { state: "missing", accessToken: null };
+
+  const refreshable = canRefresh(token);
+  const bufferMs = refreshable
+    ? (params.bufferMs ?? PROACTIVE_REFRESH_BUFFER_MS)
+    : 0;
+
+  if (!tokenStorage.isExpired(token, bufferMs)) {
+    return { state: "valid", accessToken: token.accessToken };
+  }
+
+  if (!refreshable) {
+    await tokenStorage.delete(connectionId);
+    return { state: "expired_without_refresh", accessToken: null };
+  }
+
+  let tokenEndpoint = token.tokenEndpoint;
+  if (connectionUrl && tokenEndpoint?.includes("/oauth-proxy/")) {
+    const originEndpoint = await resolveOriginTokenEndpoint(connectionUrl);
+    if (originEndpoint) tokenEndpoint = originEndpoint;
+  }
+
+  const accessToken = await refreshAndStore(
+    { ...token, tokenEndpoint },
+    tokenStorage,
+  );
+  if (!accessToken) return { state: "refresh_failed", accessToken: null };
+  return { state: "refreshed", accessToken };
 }

--- a/apps/mesh/src/shared/github-clone-info.test.ts
+++ b/apps/mesh/src/shared/github-clone-info.test.ts
@@ -1,42 +1,75 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
 import type { StudioContext } from "../core/studio-context";
-import type { ValidDownstreamAccessTokenResult } from "../oauth/token-refresh";
+import type { DownstreamToken } from "../storage/types";
 
 const mockEnsureRepoScopedToken = mock(async () => "ghs_repo_token");
 mock.module("../oauth/github-mint", () => ({
   ensureRepoScopedToken: mockEnsureRepoScopedToken,
 }));
 
-const mockGetValidDownstreamAccessToken = mock(
-  async (_params: unknown): Promise<ValidDownstreamAccessTokenResult> => ({
-    state: "valid",
-    accessToken: "ghu_valid_token",
-  }),
+const { buildCloneInfo, ensureGithubCloneToken } = await import(
+  "./github-clone-info"
 );
-mock.module("../oauth/token-refresh", () => ({
-  getValidDownstreamAccessToken: mockGetValidDownstreamAccessToken,
-  RECONNECT_ERROR:
-    "GitHub token refresh failed — reconnect the mcp-github integration.",
-}));
-
-const mockDownstreamTokenStorageConstructor = mock(
-  (_db: unknown, _vault: unknown) => ({}),
-);
-mock.module("../storage/downstream-token", () => ({
-  DownstreamTokenStorage: class MockDownstreamTokenStorage {
-    constructor(db: unknown, vault: unknown) {
-      return mockDownstreamTokenStorageConstructor(db, vault);
-    }
-  },
-}));
-
-const {
-  buildCloneInfo,
-  ensureGithubCloneToken,
-}: typeof import("./github-clone-info") = await import("./github-clone-info");
 const { RECONNECT_ERROR } = await import("../oauth/token-refresh");
 
 const originalFetch = globalThis.fetch;
+
+function makeRefreshableExpiredToken(): DownstreamToken {
+  return {
+    id: "dtok_1",
+    connectionId: "conn_repo",
+    accessToken: "ghu_expired_token",
+    refreshToken: "ghr_refresh_token",
+    scope: "repo",
+    expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    clientId: "Iv1.test_client",
+    clientSecret: "test_secret",
+    tokenEndpoint: "https://github.example.test/login/oauth/access_token",
+  };
+}
+
+function makeDb(token: DownstreamToken | null) {
+  return {
+    selectFrom: () => ({
+      selectAll: () => ({
+        where: () => ({
+          executeTakeFirst: async () => token,
+        }),
+      }),
+    }),
+    deleteFrom: () => ({
+      where: () => ({
+        execute: async () => {},
+      }),
+    }),
+  };
+}
+
+const vault = {
+  decrypt: async (value: string) => value,
+};
+
+afterAll(() => {
+  for (const cachePath of Object.keys(require.cache)) {
+    if (
+      cachePath.endsWith("/apps/mesh/src/oauth/token-refresh.ts") ||
+      cachePath.endsWith("/apps/mesh/src/oauth/refresh-access-token.ts") ||
+      cachePath.endsWith("/apps/mesh/src/shared/github-clone-info.ts")
+    ) {
+      delete require.cache[cachePath];
+    }
+  }
+});
 
 function makeCtx(connection: { metadata: Record<string, unknown> | null }) {
   return {
@@ -104,8 +137,6 @@ describe("ensureGithubCloneToken", () => {
 
 describe("buildCloneInfo", () => {
   beforeEach(() => {
-    mockGetValidDownstreamAccessToken.mockReset();
-    mockDownstreamTokenStorageConstructor.mockReset();
     globalThis.fetch = mock(
       async () => new Response("{}", { status: 404 }),
     ) as unknown as typeof fetch;
@@ -116,24 +147,37 @@ describe("buildCloneInfo", () => {
   });
 
   it("maps refresh failure to the reconnect message", async () => {
-    mockGetValidDownstreamAccessToken.mockResolvedValueOnce({
-      state: "refresh_failed",
-      accessToken: null,
-    });
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_grant",
+            error_description: "refresh token revoked",
+          }),
+          { status: 400 },
+        ),
+    ) as unknown as typeof fetch;
 
     await expect(
-      buildCloneInfo("conn_repo", "acme", "app", null as never, null as never),
+      buildCloneInfo(
+        "conn_repo",
+        "acme",
+        "app",
+        makeDb(makeRefreshableExpiredToken()) as never,
+        vault as never,
+      ),
     ).rejects.toThrow(RECONNECT_ERROR);
   });
 
   it("keeps the existing no-token message when the token is missing", async () => {
-    mockGetValidDownstreamAccessToken.mockResolvedValueOnce({
-      state: "missing",
-      accessToken: null,
-    });
-
     await expect(
-      buildCloneInfo("conn_repo", "acme", "app", null as never, null as never),
+      buildCloneInfo(
+        "conn_repo",
+        "acme",
+        "app",
+        makeDb(null) as never,
+        vault as never,
+      ),
     ).rejects.toThrow(
       "No GitHub token found. Ensure the mcp-github connection is authenticated.",
     );

--- a/apps/mesh/src/shared/github-clone-info.test.ts
+++ b/apps/mesh/src/shared/github-clone-info.test.ts
@@ -60,6 +60,7 @@ const vault = {
 };
 
 afterAll(() => {
+  mock.restore();
   for (const cachePath of Object.keys(require.cache)) {
     if (
       cachePath.endsWith("/apps/mesh/src/oauth/token-refresh.ts") ||

--- a/apps/mesh/src/shared/github-clone-info.test.ts
+++ b/apps/mesh/src/shared/github-clone-info.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { StudioContext } from "../core/studio-context";
+import type { ValidDownstreamAccessTokenResult } from "../oauth/token-refresh";
+
+const mockEnsureRepoScopedToken = mock(async () => "ghs_repo_token");
+mock.module("../oauth/github-mint", () => ({
+  ensureRepoScopedToken: mockEnsureRepoScopedToken,
+}));
+
+const mockGetValidDownstreamAccessToken = mock(
+  async (_params: unknown): Promise<ValidDownstreamAccessTokenResult> => ({
+    state: "valid",
+    accessToken: "ghu_valid_token",
+  }),
+);
+mock.module("../oauth/token-refresh", () => ({
+  getValidDownstreamAccessToken: mockGetValidDownstreamAccessToken,
+  RECONNECT_ERROR:
+    "GitHub token refresh failed — reconnect the mcp-github integration.",
+}));
+
+const mockDownstreamTokenStorageConstructor = mock(
+  (_db: unknown, _vault: unknown) => ({}),
+);
+mock.module("../storage/downstream-token", () => ({
+  DownstreamTokenStorage: class MockDownstreamTokenStorage {
+    constructor(db: unknown, vault: unknown) {
+      return mockDownstreamTokenStorageConstructor(db, vault);
+    }
+  },
+}));
+
+const {
+  buildCloneInfo,
+  ensureGithubCloneToken,
+}: typeof import("./github-clone-info") = await import("./github-clone-info");
+const { RECONNECT_ERROR } = await import("../oauth/token-refresh");
+
+const originalFetch = globalThis.fetch;
+
+function makeCtx(connection: { metadata: Record<string, unknown> | null }) {
+  return {
+    storage: {
+      connections: {
+        findById: mock(
+          async (_connectionId: string, _organizationId: string) => connection,
+        ),
+      },
+    },
+  } as unknown as StudioContext;
+}
+
+describe("ensureGithubCloneToken", () => {
+  beforeEach(() => {
+    mockEnsureRepoScopedToken.mockReset();
+  });
+
+  it("calls legacy minting for source-linked repo scopes", async () => {
+    const connection = {
+      metadata: {
+        repoScope: {
+          sourceConnectionId: "conn_source",
+          installationId: 123,
+          owner: "acme",
+          repo: "app",
+          permissions: { contents: "write" },
+        },
+      },
+    };
+    const ctx = makeCtx(connection);
+
+    await ensureGithubCloneToken({
+      ctx,
+      connectionId: "conn_repo",
+      organizationId: "org_1",
+    });
+
+    expect(mockEnsureRepoScopedToken).toHaveBeenCalledTimes(1);
+    expect(mockEnsureRepoScopedToken).toHaveBeenCalledWith(ctx, connection);
+  });
+
+  it("skips source-less repo grants", async () => {
+    const connection = {
+      metadata: {
+        repoScope: {
+          installationId: 123,
+          owner: "acme",
+          repo: "app",
+          permissions: { contents: "write" },
+          grantProvider: "github-mcp",
+        },
+      },
+    };
+
+    await ensureGithubCloneToken({
+      ctx: makeCtx(connection),
+      connectionId: "conn_repo",
+      organizationId: "org_1",
+    });
+
+    expect(mockEnsureRepoScopedToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildCloneInfo", () => {
+  beforeEach(() => {
+    mockGetValidDownstreamAccessToken.mockReset();
+    mockDownstreamTokenStorageConstructor.mockReset();
+    globalThis.fetch = mock(
+      async () => new Response("{}", { status: 404 }),
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("maps refresh failure to the reconnect message", async () => {
+    mockGetValidDownstreamAccessToken.mockResolvedValueOnce({
+      state: "refresh_failed",
+      accessToken: null,
+    });
+
+    await expect(
+      buildCloneInfo("conn_repo", "acme", "app", null as never, null as never),
+    ).rejects.toThrow(RECONNECT_ERROR);
+  });
+
+  it("keeps the existing no-token message when the token is missing", async () => {
+    mockGetValidDownstreamAccessToken.mockResolvedValueOnce({
+      state: "missing",
+      accessToken: null,
+    });
+
+    await expect(
+      buildCloneInfo("conn_repo", "acme", "app", null as never, null as never),
+    ).rejects.toThrow(
+      "No GitHub token found. Ensure the mcp-github connection is authenticated.",
+    );
+  });
+});

--- a/apps/mesh/src/shared/github-clone-info.ts
+++ b/apps/mesh/src/shared/github-clone-info.ts
@@ -15,10 +15,8 @@ import { DownstreamTokenStorage } from "../storage/downstream-token";
 import type { Database } from "../storage/types";
 import type { CredentialVault } from "../encryption/credential-vault";
 import {
-  canRefresh,
-  PROACTIVE_REFRESH_BUFFER_MS,
+  getValidDownstreamAccessToken,
   RECONNECT_ERROR,
-  refreshAndStore,
 } from "../oauth/token-refresh";
 
 export interface GitHubCloneInfo {
@@ -51,26 +49,19 @@ export async function buildCloneInfo(
   vault: CredentialVault,
 ): Promise<GitHubCloneInfo> {
   const tokenStorage = new DownstreamTokenStorage(db, vault);
-  const token = await tokenStorage.get(connectionId);
-  if (!token) {
+  const tokenResult = await getValidDownstreamAccessToken({
+    connectionId,
+    tokenStorage,
+  });
+  if (!tokenResult.accessToken) {
     throw new Error(
-      "No GitHub token found. Ensure the mcp-github connection is authenticated.",
+      tokenResult.state === "refresh_failed"
+        ? RECONNECT_ERROR
+        : "No GitHub token found. Ensure the mcp-github connection is authenticated.",
     );
   }
 
-  let accessToken = token.accessToken;
-
-  // Proactive refresh before baking into the clone URL. Mirrors GITHUB_LIST_USER_ORGS.
-  if (
-    canRefresh(token) &&
-    tokenStorage.isExpired(token, PROACTIVE_REFRESH_BUFFER_MS)
-  ) {
-    const refreshed = await refreshAndStore(token, tokenStorage);
-    if (!refreshed) {
-      throw new Error(RECONNECT_ERROR);
-    }
-    accessToken = refreshed;
-  }
+  const accessToken = tokenResult.accessToken;
 
   const cloneUrl = `https://x-access-token:${accessToken}@github.com/${owner}/${name}.git`;
 

--- a/apps/mesh/src/shared/github-clone-info.ts
+++ b/apps/mesh/src/shared/github-clone-info.ts
@@ -11,6 +11,8 @@
  */
 
 import type { Kysely } from "kysely";
+import type { StudioContext } from "../core/studio-context";
+import { ensureRepoScopedToken } from "../oauth/github-mint";
 import { DownstreamTokenStorage } from "../storage/downstream-token";
 import type { Database } from "../storage/types";
 import type { CredentialVault } from "../encryption/credential-vault";
@@ -18,6 +20,7 @@ import {
   getValidDownstreamAccessToken,
   RECONNECT_ERROR,
 } from "../oauth/token-refresh";
+import { getRepoScope } from "./github-repo-scope";
 
 export interface GitHubCloneInfo {
   cloneUrl: string;
@@ -39,6 +42,26 @@ export function buildAnonymousCloneInfo(
     gitUserName: "Deco Studio",
     gitUserEmail: "studio@deco.cx",
   };
+}
+
+export async function ensureGithubCloneToken(params: {
+  ctx: StudioContext;
+  connectionId: string;
+  organizationId: string;
+  onLegacyMintError?: (error: unknown) => void;
+}): Promise<void> {
+  const connection = await params.ctx.storage.connections.findById(
+    params.connectionId,
+    params.organizationId,
+  );
+  const repoScope = connection ? getRepoScope(connection) : null;
+  if (!connection || !repoScope?.sourceConnectionId) return;
+
+  try {
+    await ensureRepoScopedToken(params.ctx, connection);
+  } catch (error) {
+    params.onLegacyMintError?.(error);
+  }
 }
 
 export async function buildCloneInfo(

--- a/apps/mesh/src/shared/github-repo-scope.test.ts
+++ b/apps/mesh/src/shared/github-repo-scope.test.ts
@@ -48,6 +48,36 @@ describe("getRepoScope", () => {
     expect(result?.permissions).toEqual(GITHUB_SCOPED_PERMISSIONS);
   });
 
+  it("defaults permissions when permissions metadata is not an object", () => {
+    const result = getRepoScope({
+      metadata: {
+        repoScope: {
+          sourceConnectionId: "conn_org",
+          installationId: 1,
+          owner: "a",
+          repo: "b",
+          permissions: "bad",
+        },
+      },
+    });
+    expect(result?.permissions).toEqual(GITHUB_SCOPED_PERMISSIONS);
+  });
+
+  it("defaults permissions when permissions metadata has non-string values", () => {
+    const result = getRepoScope({
+      metadata: {
+        repoScope: {
+          sourceConnectionId: "conn_org",
+          installationId: 1,
+          owner: "a",
+          repo: "b",
+          permissions: { contents: 1 },
+        },
+      },
+    });
+    expect(result?.permissions).toEqual(GITHUB_SCOPED_PERMISSIONS);
+  });
+
   it("returns null when metadata is null", () => {
     expect(getRepoScope({ metadata: null })).toBeNull();
   });
@@ -129,12 +159,26 @@ describe("getOrgGithubConnections", () => {
       },
     },
   };
+  const refreshableScopedConn = {
+    id: "conn_refreshable_scoped",
+    metadata: {
+      repoScope: {
+        installationId: 1,
+        owner: "deco-sites",
+        repo: "demo-linkedin",
+      },
+    },
+  };
 
   it("drops repo-scoped child connections", () => {
-    expect(getOrgGithubConnections([scopedConn, orgConn])).toEqual([orgConn]);
+    expect(
+      getOrgGithubConnections([scopedConn, refreshableScopedConn, orgConn]),
+    ).toEqual([orgConn]);
   });
 
   it("returns an empty array when every connection is repo-scoped", () => {
-    expect(getOrgGithubConnections([scopedConn])).toEqual([]);
+    expect(
+      getOrgGithubConnections([scopedConn, refreshableScopedConn]),
+    ).toEqual([]);
   });
 });

--- a/apps/mesh/src/shared/github-repo-scope.test.ts
+++ b/apps/mesh/src/shared/github-repo-scope.test.ts
@@ -144,6 +144,23 @@ describe("getRepoScope", () => {
       ).toBeNull();
     }
   });
+
+  it("omits non-positive, non-integer, or non-finite repository ids", () => {
+    for (const repositoryId of [NaN, Infinity, -1, 0, 1.5]) {
+      expect(
+        getRepoScope({
+          metadata: {
+            repoScope: {
+              installationId: 1,
+              repositoryId,
+              owner: "a",
+              repo: "b",
+            },
+          },
+        })?.repositoryId,
+      ).toBeUndefined();
+    }
+  });
 });
 
 describe("getOrgGithubConnections", () => {

--- a/apps/mesh/src/shared/github-repo-scope.test.ts
+++ b/apps/mesh/src/shared/github-repo-scope.test.ts
@@ -3,6 +3,7 @@ import {
   getOrgGithubConnections,
   getRepoScope,
   GITHUB_SCOPED_PERMISSIONS,
+  type RepoScopeRecipe,
 } from "./github-repo-scope";
 
 describe("getRepoScope", () => {
@@ -14,7 +15,7 @@ describe("getRepoScope", () => {
       repo: "widget",
       permissions: { contents: "write" },
       grantProvider: "github-mcp",
-    };
+    } satisfies RepoScopeRecipe;
     expect(getRepoScope({ metadata: { repoScope: recipe } })).toEqual(recipe);
   });
 
@@ -55,6 +56,22 @@ describe("getRepoScope", () => {
     expect(getRepoScope({ metadata: { source: "store" } })).toBeNull();
   });
 
+  it("accepts repoScope metadata without legacy sourceConnectionId", () => {
+    expect(
+      getRepoScope({
+        metadata: { repoScope: { installationId: 1, owner: "a", repo: "b" } },
+      }),
+    ).toEqual({
+      installationId: 1,
+      repositoryId: undefined,
+      sourceConnectionId: undefined,
+      owner: "a",
+      repo: "b",
+      permissions: GITHUB_SCOPED_PERMISSIONS,
+      grantProvider: undefined,
+    });
+  });
+
   it("returns null when required fields are missing or mistyped", () => {
     expect(
       getRepoScope({
@@ -70,19 +87,6 @@ describe("getRepoScope", () => {
     ).toBeNull();
     expect(
       getRepoScope({
-        metadata: { repoScope: { installationId: 1, owner: "a", repo: "b" } },
-      }),
-    ).toEqual({
-      installationId: 1,
-      repositoryId: undefined,
-      sourceConnectionId: undefined,
-      owner: "a",
-      repo: "b",
-      permissions: GITHUB_SCOPED_PERMISSIONS,
-      grantProvider: undefined,
-    });
-    expect(
-      getRepoScope({
         metadata: {
           repoScope: {
             sourceConnectionId: "x",
@@ -93,6 +97,22 @@ describe("getRepoScope", () => {
         },
       }),
     ).toBeNull();
+  });
+
+  it("returns null for non-positive, non-integer, or non-finite installation ids", () => {
+    for (const installationId of [NaN, Infinity, -1, 1.5]) {
+      expect(
+        getRepoScope({
+          metadata: {
+            repoScope: {
+              installationId,
+              owner: "a",
+              repo: "b",
+            },
+          },
+        }),
+      ).toBeNull();
+    }
   });
 });
 

--- a/apps/mesh/src/shared/github-repo-scope.test.ts
+++ b/apps/mesh/src/shared/github-repo-scope.test.ts
@@ -6,7 +6,19 @@ import {
 } from "./github-repo-scope";
 
 describe("getRepoScope", () => {
-  it("returns the recipe for a well-formed repoScope", () => {
+  it("returns the grant metadata for a refreshable repoScope without sourceConnectionId", () => {
+    const recipe = {
+      installationId: 123,
+      repositoryId: 456,
+      owner: "acme",
+      repo: "widget",
+      permissions: { contents: "write" },
+      grantProvider: "github-mcp",
+    };
+    expect(getRepoScope({ metadata: { repoScope: recipe } })).toEqual(recipe);
+  });
+
+  it("accepts legacy repoScope metadata with sourceConnectionId", () => {
     const recipe = {
       sourceConnectionId: "conn_org",
       installationId: 123,
@@ -14,7 +26,11 @@ describe("getRepoScope", () => {
       repo: "widget",
       permissions: { contents: "write" },
     };
-    expect(getRepoScope({ metadata: { repoScope: recipe } })).toEqual(recipe);
+    expect(getRepoScope({ metadata: { repoScope: recipe } })).toEqual({
+      ...recipe,
+      grantProvider: undefined,
+      repositoryId: undefined,
+    });
   });
 
   it("defaults permissions when omitted", () => {
@@ -56,7 +72,15 @@ describe("getRepoScope", () => {
       getRepoScope({
         metadata: { repoScope: { installationId: 1, owner: "a", repo: "b" } },
       }),
-    ).toBeNull();
+    ).toEqual({
+      installationId: 1,
+      repositoryId: undefined,
+      sourceConnectionId: undefined,
+      owner: "a",
+      repo: "b",
+      permissions: GITHUB_SCOPED_PERMISSIONS,
+      grantProvider: undefined,
+    });
     expect(
       getRepoScope({
         metadata: {

--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -1,9 +1,12 @@
 /**
  * Repo-scoped GitHub connection — shared, pure helpers.
  *
- * A "repo-scoped" mcp-github connection is a per-agent child connection whose
- * downstream token is minted (by deco/mcp-github's MINT_REPO_TOKEN) for exactly
- * one repository. The mint "recipe" lives on the connection's metadata under
+ * A "repo-scoped" mcp-github connection is a per-agent child connection for
+ * exactly one repository. New refreshable repo children persist a GitHub MCP
+ * repo grant in downstream_tokens and refresh through the normal OAuth-shaped
+ * token path. Legacy repo children may still carry `sourceConnectionId` so
+ * callers can mint with deco/mcp-github's MINT_REPO_TOKEN during compatibility
+ * flows. The repo grant metadata lives on the connection's metadata under
  * `repoScope`; its presence also marks the connection as a disposable per-agent
  * child for teardown.
  *

--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -31,6 +31,17 @@ export interface RepoScopeRecipe {
   grantProvider?: "github-mcp";
 }
 
+function parsePermissions(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return GITHUB_SCOPED_PERMISSIONS;
+  }
+  const permissions = raw as Record<string, unknown>;
+  if (Object.values(permissions).some((value) => typeof value !== "string")) {
+    return GITHUB_SCOPED_PERMISSIONS;
+  }
+  return permissions as Record<string, string>;
+}
+
 /**
  * Read + validate the repoScope recipe from a connection's metadata.
  * Returns null when the connection is not a repo-scoped child (or the recipe is
@@ -65,9 +76,7 @@ export function getRepoScope(connection: {
       typeof raw.repositoryId === "number" ? raw.repositoryId : undefined,
     owner: raw.owner,
     repo: raw.repo,
-    permissions:
-      (raw.permissions as Record<string, string> | undefined) ??
-      GITHUB_SCOPED_PERMISSIONS,
+    permissions: parsePermissions(raw.permissions),
     grantProvider:
       raw.grantProvider === "github-mcp" ? "github-mcp" : undefined,
   };

--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -45,6 +45,9 @@ export function getRepoScope(connection: {
   if (
     !raw ||
     typeof raw.installationId !== "number" ||
+    !Number.isFinite(raw.installationId) ||
+    !Number.isInteger(raw.installationId) ||
+    raw.installationId <= 0 ||
     typeof raw.owner !== "string" ||
     typeof raw.repo !== "string" ||
     raw.owner.length === 0 ||

--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -19,14 +19,16 @@ export const GITHUB_SCOPED_PERMISSIONS: Record<string, string> = {
   issues: "write",
 };
 
-/** The mint recipe stored at `connection.metadata.repoScope`. */
+/** The repo grant metadata stored at `connection.metadata.repoScope`. */
 export interface RepoScopeRecipe {
-  /** Org mcp-github connection (broad user-to-server OAuth) used to mint. */
-  sourceConnectionId: string;
+  /** Legacy org mcp-github connection used to mint before refreshable grants. */
+  sourceConnectionId?: string;
   installationId: number;
+  repositoryId?: number;
   owner: string;
   repo: string;
   permissions: Record<string, string>;
+  grantProvider?: "github-mcp";
 }
 
 /**
@@ -42,7 +44,6 @@ export function getRepoScope(connection: {
     | undefined;
   if (
     !raw ||
-    typeof raw.sourceConnectionId !== "string" ||
     typeof raw.installationId !== "number" ||
     typeof raw.owner !== "string" ||
     typeof raw.repo !== "string" ||
@@ -52,13 +53,20 @@ export function getRepoScope(connection: {
     return null;
   }
   return {
-    sourceConnectionId: raw.sourceConnectionId,
+    sourceConnectionId:
+      typeof raw.sourceConnectionId === "string"
+        ? raw.sourceConnectionId
+        : undefined,
     installationId: raw.installationId,
+    repositoryId:
+      typeof raw.repositoryId === "number" ? raw.repositoryId : undefined,
     owner: raw.owner,
     repo: raw.repo,
     permissions:
       (raw.permissions as Record<string, string> | undefined) ??
       GITHUB_SCOPED_PERMISSIONS,
+    grantProvider:
+      raw.grantProvider === "github-mcp" ? "github-mcp" : undefined,
   };
 }
 

--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -45,6 +45,18 @@ function parsePermissions(raw: unknown): Record<string, string> {
   return permissions as Record<string, string>;
 }
 
+function parsePositiveInteger(raw: unknown): number | undefined {
+  if (
+    typeof raw !== "number" ||
+    !Number.isFinite(raw) ||
+    !Number.isInteger(raw) ||
+    raw <= 0
+  ) {
+    return undefined;
+  }
+  return raw;
+}
+
 /**
  * Read + validate the repoScope recipe from a connection's metadata.
  * Returns null when the connection is not a repo-scoped child (or the recipe is
@@ -69,14 +81,14 @@ export function getRepoScope(connection: {
   ) {
     return null;
   }
+  const repositoryId = parsePositiveInteger(raw.repositoryId);
   return {
     sourceConnectionId:
       typeof raw.sourceConnectionId === "string"
         ? raw.sourceConnectionId
         : undefined,
     installationId: raw.installationId,
-    repositoryId:
-      typeof raw.repositoryId === "number" ? raw.repositoryId : undefined,
+    repositoryId,
     owner: raw.owner,
     repo: raw.repo,
     permissions: parsePermissions(raw.permissions),

--- a/apps/mesh/src/shared/github-runtime-detect.ts
+++ b/apps/mesh/src/shared/github-runtime-detect.ts
@@ -10,6 +10,7 @@
 
 import type { Kysely } from "kysely";
 import type { CredentialVault } from "../encryption/credential-vault";
+import { getValidDownstreamAccessToken } from "../oauth/token-refresh";
 import { DownstreamTokenStorage } from "../storage/downstream-token";
 import type { Database } from "../storage/types";
 import type { PackageManager } from "./runtime-defaults";
@@ -48,9 +49,12 @@ export async function detectRepoRuntime(
   db: Kysely<Database>,
   vault: CredentialVault,
 ): Promise<DetectedRuntime | null> {
-  const token = await new DownstreamTokenStorage(db, vault).get(connectionId);
-  if (!token) return null;
-  return probeRuntime(owner, name, token.accessToken);
+  const tokenResult = await getValidDownstreamAccessToken({
+    connectionId,
+    tokenStorage: new DownstreamTokenStorage(db, vault),
+  });
+  if (!tokenResult.accessToken) return null;
+  return probeRuntime(owner, name, tokenResult.accessToken);
 }
 
 /**

--- a/apps/mesh/src/tools/sandbox/start.test.ts
+++ b/apps/mesh/src/tools/sandbox/start.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { SandboxMap, SandboxRecord } from "@decocms/mesh-sdk";
 import type { StudioContext } from "../../core/studio-context";
 import type {
@@ -159,6 +159,8 @@ mock.module("@/oauth/refresh-access-token", () => ({
 
 const { SANDBOX_START } = await import("./start");
 
+const originalFetch = globalThis.fetch;
+
 const BRANCH = "feat/example";
 const ORG_ID = "org_1";
 const VMCP_ID = "vmcp_1";
@@ -283,6 +285,9 @@ function makeCtx(overrides: {
 
 describe("SANDBOX_START", () => {
   beforeEach(() => {
+    globalThis.fetch = mock(
+      async () => new Response("{}", { status: 404 }),
+    ) as unknown as typeof fetch;
     mockEnsure.mockReset();
     mockClusterDelete.mockReset();
     mockAgentSandboxDelete.mockReset();
@@ -318,6 +323,10 @@ describe("SANDBOX_START", () => {
     mockTokenUpsert.mockImplementation(async () => {});
     mockTokenDelete.mockReset();
     mockTokenDelete.mockImplementation(async () => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   it("calls runner.ensure with composed projectRef + repo + workload", async () => {

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -40,8 +40,6 @@ import {
   detectRepoRuntimeAnonymous,
 } from "../../shared/github-runtime-detect";
 import { generateBranchName } from "../../shared/branch-name";
-import { ensureRepoScopedToken } from "@/oauth/github-mint";
-import { getRepoScope } from "@/shared/github-repo-scope";
 import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
@@ -302,32 +300,8 @@ async function provisionSandbox(
     | undefined;
 
   if (githubRepo) {
-    // Legacy repo-scoped child connections mint on demand before the token is
-    // baked into the clone URL or used for the lockfile probe. Refreshable repo
-    // grant children use buildCloneInfo's cached-token refresh path.
-    if (githubRepo.connectionId) {
-      const repoConn = await ctx.storage.connections.findById(
-        githubRepo.connectionId,
-        orgId,
-      );
-      const repoScope = repoConn ? getRepoScope(repoConn) : null;
-      if (repoConn && repoScope?.sourceConnectionId) {
-        try {
-          await ensureRepoScopedToken(ctx, repoConn);
-        } catch (err) {
-          // Swallow + log: a failed mint intentionally falls through to
-          // buildCloneInfo's own "No GitHub token found" throw below (sandbox
-          // start fails loudly — never an unauthenticated clone).
-          console.error(
-            "[provisionSandbox] repo-scoped legacy token mint failed",
-            {
-              connectionId: githubRepo.connectionId,
-              error: (err as Error).message,
-            },
-          );
-        }
-      }
-    }
+    // buildCloneInfo and detectRepoRuntime refresh connection-backed tokens before
+    // using them, including refreshable repo-scoped GitHub children.
 
     // Connection-backed (authenticated) vs public-clone (anonymous). The
     // daemon's clone behavior is identical — only the URL and identity

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -302,25 +302,29 @@ async function provisionSandbox(
     | undefined;
 
   if (githubRepo) {
-    // Repo-scoped child connections carry a minted token with no refresh path,
-    // so re-mint it now if expired before it gets baked into the clone URL or
-    // used for the lockfile probe. No-op for org connections and public repos.
+    // Legacy repo-scoped child connections mint on demand before the token is
+    // baked into the clone URL or used for the lockfile probe. Refreshable repo
+    // grant children use buildCloneInfo's cached-token refresh path.
     if (githubRepo.connectionId) {
       const repoConn = await ctx.storage.connections.findById(
         githubRepo.connectionId,
         orgId,
       );
-      if (repoConn && getRepoScope(repoConn)) {
+      const repoScope = repoConn ? getRepoScope(repoConn) : null;
+      if (repoConn && repoScope?.sourceConnectionId) {
         try {
           await ensureRepoScopedToken(ctx, repoConn);
         } catch (err) {
           // Swallow + log: a failed mint intentionally falls through to
           // buildCloneInfo's own "No GitHub token found" throw below (sandbox
           // start fails loudly — never an unauthenticated clone).
-          console.error("[provisionSandbox] repo-scoped token mint failed", {
-            connectionId: githubRepo.connectionId,
-            error: (err as Error).message,
-          });
+          console.error(
+            "[provisionSandbox] repo-scoped legacy token mint failed",
+            {
+              connectionId: githubRepo.connectionId,
+              error: (err as Error).message,
+            },
+          );
         }
       }
     }

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -34,6 +34,7 @@ import {
 import {
   buildAnonymousCloneInfo,
   buildCloneInfo,
+  ensureGithubCloneToken,
 } from "../../shared/github-clone-info";
 import {
   detectRepoRuntime,
@@ -300,8 +301,28 @@ async function provisionSandbox(
     | undefined;
 
   if (githubRepo) {
-    // buildCloneInfo and detectRepoRuntime refresh connection-backed tokens before
+    // Legacy repo-scoped children may mint through their source connection here.
+    // buildCloneInfo and detectRepoRuntime refresh OAuth-shaped tokens before
     // using them, including refreshable repo-scoped GitHub children.
+    if (githubRepo.connectionId) {
+      await ensureGithubCloneToken({
+        ctx,
+        connectionId: githubRepo.connectionId,
+        organizationId: orgId,
+        onLegacyMintError: (error) => {
+          // Swallow + log: a failed mint intentionally falls through to
+          // buildCloneInfo's own "No GitHub token found" throw below (sandbox
+          // start fails loudly — never an unauthenticated clone).
+          console.error(
+            "[provisionSandbox] repo-scoped legacy token mint failed",
+            {
+              connectionId: githubRepo.connectionId,
+              error: (error as Error).message,
+            },
+          );
+        },
+      });
+    }
 
     // Connection-backed (authenticated) vs public-clone (anonymous). The
     // daemon's clone behavior is identical — only the URL and identity

--- a/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
@@ -1,10 +1,8 @@
 import type { GithubRepo } from "@decocms/mesh-sdk/types";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import type { StudioContext } from "../../core/studio-context";
-import { ensureRepoScopedToken } from "../../oauth/github-mint";
 import { RECONNECT_ERROR } from "../../oauth/token-refresh";
 import { buildCloneInfo } from "../../shared/github-clone-info";
-import { getRepoScope } from "../../shared/github-repo-scope";
 
 export class GitPushAuthError extends Error {
   constructor(message: string) {
@@ -27,8 +25,7 @@ export function parseGithubRepoFromMetadata(
 /**
  * Refreshes the GitHub token baked into the sandbox clone URL and patches the
  * running daemon config so git push can sync `origin` before publishing.
- * Legacy repo-scoped child connections are re-minted on demand. Refreshable
- * repo grant children rely on buildCloneInfo's cached-token refresh path.
+ * buildCloneInfo owns token refresh before baking the clone URL.
  */
 export async function refreshSandboxGitCredentials(
   ctx: StudioContext,
@@ -45,20 +42,6 @@ export async function refreshSandboxGitCredentials(
   const organizationId = ctx.organization?.id;
   if (!organizationId) {
     throw new GitPushAuthError(RECONNECT_ERROR);
-  }
-
-  const repoConn = await ctx.storage.connections.findById(
-    githubRepo.connectionId,
-    organizationId,
-  );
-  const repoScope = repoConn ? getRepoScope(repoConn) : null;
-  if (repoConn && repoScope?.sourceConnectionId) {
-    try {
-      await ensureRepoScopedToken(ctx, repoConn);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : RECONNECT_ERROR;
-      throw new GitPushAuthError(message);
-    }
   }
 
   const { cloneUrl, gitUserName, gitUserEmail } = await buildCloneInfo(

--- a/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
@@ -27,7 +27,8 @@ export function parseGithubRepoFromMetadata(
 /**
  * Refreshes the GitHub token baked into the sandbox clone URL and patches the
  * running daemon config so git push can sync `origin` before publishing.
- * Repo-scoped child connections are re-minted on demand (no OAuth refresh path).
+ * Legacy repo-scoped child connections are re-minted on demand. Refreshable
+ * repo grant children rely on buildCloneInfo's cached-token refresh path.
  */
 export async function refreshSandboxGitCredentials(
   ctx: StudioContext,
@@ -50,7 +51,8 @@ export async function refreshSandboxGitCredentials(
     githubRepo.connectionId,
     organizationId,
   );
-  if (repoConn && getRepoScope(repoConn)) {
+  const repoScope = repoConn ? getRepoScope(repoConn) : null;
+  if (repoConn && repoScope?.sourceConnectionId) {
     try {
       await ensureRepoScopedToken(ctx, repoConn);
     } catch (err) {

--- a/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
@@ -2,7 +2,10 @@ import type { GithubRepo } from "@decocms/mesh-sdk/types";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import type { StudioContext } from "../../core/studio-context";
 import { RECONNECT_ERROR } from "../../oauth/token-refresh";
-import { buildCloneInfo } from "../../shared/github-clone-info";
+import {
+  buildCloneInfo,
+  ensureGithubCloneToken,
+} from "../../shared/github-clone-info";
 
 export class GitPushAuthError extends Error {
   constructor(message: string) {
@@ -43,6 +46,16 @@ export async function refreshSandboxGitCredentials(
   if (!organizationId) {
     throw new GitPushAuthError(RECONNECT_ERROR);
   }
+
+  await ensureGithubCloneToken({
+    ctx,
+    connectionId: githubRepo.connectionId,
+    organizationId,
+    onLegacyMintError: (error) => {
+      const message = error instanceof Error ? error.message : RECONNECT_ERROR;
+      throw new GitPushAuthError(message);
+    },
+  });
 
   const { cloneUrl, gitUserName, gitUserEmail } = await buildCloneInfo(
     githubRepo.connectionId,

--- a/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
+++ b/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
@@ -35,7 +35,16 @@ export async function provisionRepoScopedGithubConnection(params: {
     },
   })) as {
     isError?: boolean;
-    structuredContent?: { token?: string; expiresAt?: string };
+    structuredContent?: {
+      token?: string;
+      expiresAt?: string;
+      expiresIn?: number;
+      refreshToken?: string;
+      tokenEndpoint?: string;
+      clientId?: string;
+      scope?: string;
+      repository?: { id?: number; owner?: string; name?: string };
+    };
     content?: Array<{ type?: string; text?: string }>;
   };
   const minted = mintRes.structuredContent;
@@ -45,6 +54,11 @@ export async function provisionRepoScopedGithubConnection(params: {
       detail
         ? `Failed to mint a repo-scoped GitHub token: ${detail}`
         : "Failed to mint a repo-scoped GitHub token",
+    );
+  }
+  if (!minted.refreshToken || !minted.tokenEndpoint || !minted.clientId) {
+    throw new Error(
+      "GitHub MCP did not return refreshable repo grant metadata",
     );
   }
   const parsedExpiry = minted.expiresAt ? Date.parse(minted.expiresAt) : NaN;
@@ -65,11 +79,12 @@ export async function provisionRepoScopedGithubConnection(params: {
         connection_url: sourceConnection.connection_url,
         metadata: {
           repoScope: {
-            sourceConnectionId: sourceConnection.id,
             installationId,
+            repositoryId: minted.repository?.id,
             owner,
             repo,
             permissions: GITHUB_SCOPED_PERMISSIONS,
+            grantProvider: "github-mcp",
           },
         },
       },
@@ -90,7 +105,14 @@ export async function provisionRepoScopedGithubConnection(params: {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
-      body: JSON.stringify({ accessToken: minted.token, expiresIn }),
+      body: JSON.stringify({
+        accessToken: minted.token,
+        refreshToken: minted.refreshToken,
+        expiresIn: minted.expiresIn ?? expiresIn,
+        scope: minted.scope ?? null,
+        clientId: minted.clientId,
+        tokenEndpoint: minted.tokenEndpoint,
+      }),
     },
   );
   if (!tokenRes.ok) {

--- a/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
+++ b/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
@@ -6,6 +6,35 @@ type McpCallTool = (req: {
   arguments: Record<string, unknown>;
 }) => Promise<unknown>;
 
+const REFRESH_GRANT_METADATA_ERROR =
+  "GitHub MCP did not return refreshable repo grant metadata";
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isHttpTokenEndpoint(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeRepositoryId(value: unknown): number | undefined {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value > 0
+    ? value
+    : undefined;
+}
+
 export async function provisionRepoScopedGithubConnection(params: {
   orgSlug: string;
   sourceConnection: ConnectionEntity;
@@ -56,11 +85,32 @@ export async function provisionRepoScopedGithubConnection(params: {
         : "Failed to mint a repo-scoped GitHub token",
     );
   }
-  if (!minted.refreshToken || !minted.tokenEndpoint || !minted.clientId) {
+  const refreshToken = nonEmptyString(minted.refreshToken);
+  const tokenEndpoint = nonEmptyString(minted.tokenEndpoint);
+  const clientId = nonEmptyString(minted.clientId);
+  if (!refreshToken || !tokenEndpoint || !clientId) {
+    throw new Error(REFRESH_GRANT_METADATA_ERROR);
+  }
+  if (!isHttpTokenEndpoint(tokenEndpoint)) {
+    throw new Error(REFRESH_GRANT_METADATA_ERROR);
+  }
+  if (
+    minted.repository?.owner !== undefined &&
+    minted.repository.owner.toLowerCase() !== owner.toLowerCase()
+  ) {
     throw new Error(
-      "GitHub MCP did not return refreshable repo grant metadata",
+      "GitHub MCP returned refresh metadata for a different repository",
     );
   }
+  if (
+    minted.repository?.name !== undefined &&
+    minted.repository.name.toLowerCase() !== repo.toLowerCase()
+  ) {
+    throw new Error(
+      "GitHub MCP returned refresh metadata for a different repository",
+    );
+  }
+  const repositoryId = normalizeRepositoryId(minted.repository?.id);
   const parsedExpiry = minted.expiresAt ? Date.parse(minted.expiresAt) : NaN;
   const expiresIn = Number.isFinite(parsedExpiry)
     ? Math.max(0, Math.floor((parsedExpiry - Date.now()) / 1000))
@@ -80,7 +130,7 @@ export async function provisionRepoScopedGithubConnection(params: {
         metadata: {
           repoScope: {
             installationId,
-            repositoryId: minted.repository?.id,
+            repositoryId,
             owner,
             repo,
             permissions: GITHUB_SCOPED_PERMISSIONS,
@@ -107,11 +157,11 @@ export async function provisionRepoScopedGithubConnection(params: {
       credentials: "include",
       body: JSON.stringify({
         accessToken: minted.token,
-        refreshToken: minted.refreshToken,
+        refreshToken,
         expiresIn: minted.expiresIn ?? expiresIn,
         scope: minted.scope ?? null,
-        clientId: minted.clientId,
-        tokenEndpoint: minted.tokenEndpoint,
+        clientId,
+        tokenEndpoint,
       }),
     },
   );

--- a/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
+++ b/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
@@ -20,7 +20,11 @@ function nonEmptyString(value: unknown): string | null {
 function isHttpTokenEndpoint(value: string): boolean {
   try {
     const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      !url.username &&
+      !url.password
+    );
   } catch {
     return false;
   }
@@ -67,12 +71,12 @@ export async function provisionRepoScopedGithubConnection(params: {
     structuredContent?: {
       token?: string;
       expiresAt?: string;
-      expiresIn?: number;
+      expiresIn?: unknown;
       refreshToken?: string;
       tokenEndpoint?: string;
       clientId?: string;
       scope?: string;
-      repository?: { id?: number; owner?: string; name?: string };
+      repository?: { id?: unknown; owner?: unknown; name?: unknown };
     };
     content?: Array<{ type?: string; text?: string }>;
   };
@@ -94,27 +98,35 @@ export async function provisionRepoScopedGithubConnection(params: {
   if (!isHttpTokenEndpoint(tokenEndpoint)) {
     throw new Error(REFRESH_GRANT_METADATA_ERROR);
   }
+  const repositoryOwner = nonEmptyString(minted.repository?.owner);
+  const repositoryName = nonEmptyString(minted.repository?.name);
+  const repositoryMismatchError =
+    "GitHub MCP returned refresh metadata for a different repository";
   if (
     minted.repository?.owner !== undefined &&
-    minted.repository.owner.toLowerCase() !== owner.toLowerCase()
+    (!repositoryOwner || repositoryOwner.toLowerCase() !== owner.toLowerCase())
   ) {
-    throw new Error(
-      "GitHub MCP returned refresh metadata for a different repository",
-    );
+    throw new Error(repositoryMismatchError);
   }
   if (
     minted.repository?.name !== undefined &&
-    minted.repository.name.toLowerCase() !== repo.toLowerCase()
+    (!repositoryName || repositoryName.toLowerCase() !== repo.toLowerCase())
   ) {
-    throw new Error(
-      "GitHub MCP returned refresh metadata for a different repository",
-    );
+    throw new Error(repositoryMismatchError);
   }
   const repositoryId = normalizeRepositoryId(minted.repository?.id);
   const parsedExpiry = minted.expiresAt ? Date.parse(minted.expiresAt) : NaN;
   const expiresIn = Number.isFinite(parsedExpiry)
     ? Math.max(0, Math.floor((parsedExpiry - Date.now()) / 1000))
     : null;
+  const mintedExpiresIn =
+    typeof minted.expiresIn === "number" &&
+    Number.isFinite(minted.expiresIn) &&
+    Number.isInteger(minted.expiresIn) &&
+    minted.expiresIn > 0
+      ? minted.expiresIn
+      : null;
+  const tokenExpiresIn = mintedExpiresIn ?? expiresIn;
 
   const createRes = (await selfCallTool({
     name: "COLLECTION_CONNECTIONS_CREATE",
@@ -158,7 +170,7 @@ export async function provisionRepoScopedGithubConnection(params: {
       body: JSON.stringify({
         accessToken: minted.token,
         refreshToken,
-        expiresIn: minted.expiresIn ?? expiresIn,
+        expiresIn: tokenExpiresIn,
         scope: minted.scope ?? null,
         clientId,
         tokenEndpoint,


### PR DESCRIPTION
## What is this contribution about?
Repo-scoped GitHub child connections (created on agent import) previously carried a short-lived minted installation token with no refresh path, so every expiry required re-minting through the org-wide `mcp-github` connection (`MINT_REPO_TOKEN`), coupling the child's lifetime to that org connection. Provisioning now requires the GitHub MCP to return refresh-grant metadata (refreshToken/tokenEndpoint/clientId, validated against the requested repo) and stores a full OAuth-shaped row in `downstream_tokens`, making children self-refreshing through a new consolidated `getValidDownstreamAccessToken()` helper (proactive 5-min refresh buffer, single-flight refresh per connection, delete-on-`invalid_grant` but keep-on-transient-5xx). The proxy, sandbox clone/runtime-detect, decopilot dispatch, and git-credential-sync paths are unified behind `ensureGithubCloneToken()`, which only legacy-mints for children that still carry `sourceConnectionId` — legacy children keep working unchanged.

## How to Test
1. Import an agent with a GitHub repo so a repo-scoped child connection is provisioned — verify its metadata has no `sourceConnectionId` and a `downstream_tokens` row with refreshToken/tokenEndpoint/clientId exists.
2. Let the token expire (or shrink expiry) and call the child via the MCP proxy or start a sandbox — verify the token is refreshed via `grant_type=refresh_token` without any call to the org `mcp-github` connection.
3. Run `bun test apps/mesh/src/oauth/token-refresh.integration.test.ts apps/mesh/src/shared/github-clone-info.test.ts apps/mesh/src/shared/github-repo-scope.test.ts` and the e2e spec `apps/mesh/e2e/tests/github-import-repo-scope.spec.ts`.

## Migration Notes
No DB migrations or env vars — refresh data reuses existing `downstream_tokens` columns and `repoScope` lives in connection metadata. Cross-service contract: the deco/mcp-github server's `MINT_REPO_TOKEN` must return refresh-grant metadata for new provisioning to succeed.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repo-scoped GitHub connections now self-refresh via OAuth grants stored in `downstream_tokens`, and all call sites read from the cache. Legacy minting only runs when `repoScope.sourceConnectionId` is present.

- **New Features**
  - Provisioning persists refreshable repo grants with validation: `refreshToken`, `tokenEndpoint` (http/https), `clientId`, repository owner/name, optional `repositoryId`, `grantProvider`; expiry from `expiresIn` or `expiresAt`.
  - Centralized refresh in `getValidDownstreamAccessToken` (5‑min buffer, resolves origin endpoint for proxy URLs, single‑flight per connection, delete only on `400 invalid_grant`; returns token state).
  - Proxy headers now use `getValidDownstreamAccessToken`; legacy mint via `ensureRepoScopedToken` only when `sourceConnectionId` exists.
  - Added `ensureGithubCloneToken`; `buildCloneInfo` and runtime detection refresh before use and map refresh failures to the reconnect message; sandbox start/credentials and Decopilot dispatch call `ensureGithubCloneToken` for legacy then `buildCloneInfo`.
  - `github-repo-scope` accepts source‑less repo scopes and hardens parsing (validates permissions shape, positive integer `installationId`, optional positive `repositoryId`, preserves defaults).
  - Tests updated: e2e covers refresh (success, transient, `invalid_grant` delete); unit tests cover single‑flight, token state, and error mapping.

- **Migration**
  - No DB or env changes. New provisioning requires the GitHub MCP’s `MINT_REPO_TOKEN` to return refresh‑grant metadata (`refreshToken`, `tokenEndpoint`, `clientId`, optional `repository.id`, `scope`, and expiry). Legacy `sourceConnectionId` children mint; source‑less children refresh via `downstream_tokens`.

<sup>Written for commit 6934bcb90051fbb632ffeeaca5808a67a636230f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

