### PR TITLE
feat(recovery): implement orphan workflow management for dead pods

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -133,6 +133,10 @@ import {
   THREAD_GATE_PARTITION_CONCURRENCY,
   THREAD_GATE_QUEUE,
 } from "../dispatch-queue";
+import {
+  cancelDeadPodWorkflows,
+  sweepOrphanedWorkflows,
+} from "../dispatch-queue/dbos-orphan-recovery";
 import { backfillStudioPackForAllOrgs } from "../auth/install-studio-pack-workflow";
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import {
@@ -1532,7 +1536,10 @@ export async function createApp(options: CreateAppOptions = {}) {
     );
   };
 
-  // Wire pod death watcher → orphan recovery
+  // Wire pod death watcher → orphan recovery. Two independent layers off the
+  // same dead-pod signal: the run-registry resumes/force-fails the user-facing
+  // run; `cancelDeadPodWorkflows` cancels the dead pod's orphaned DBOS rows so
+  // they stop pinning queue slots (fatal for the per-thread gate, concurrency=1).
   if (podHeartbeat) {
     podHeartbeat.onPodDeath((deadPodId) => {
       runRegistry
@@ -1543,12 +1550,29 @@ export async function createApp(options: CreateAppOptions = {}) {
             err,
           );
         });
+      cancelDeadPodWorkflows(deadPodId).catch((err) => {
+        console.error(
+          `[dbos-recovery] dead-pod workflow cleanup failed for ${deadPodId}:`,
+          err,
+        );
+      });
     });
   }
 
   setTimeout(() => {
     runRegistry.recoverOrphanedRuns(resumeOrphanedThread).catch((err) => {
       console.error("[recovery] Orphan recovery failed:", err);
+    });
+    // Boot-time DBOS sweep — safety net for orphans the onPodDeath event
+    // missed (hard crash, simultaneous full restart). Runs post-launch (this
+    // fires well after DBOS.launch in index.ts) behind the same grace window.
+    (async () => {
+      const alive = podHeartbeat
+        ? await podHeartbeat.listAlivePods()
+        : new Set<string>();
+      await sweepOrphanedWorkflows(alive, POD_ID);
+    })().catch((err) => {
+      console.error("[dbos-recovery] boot sweep failed:", err);
     });
   }, 10_000); // 10s grace for rolling deploys
 

--- a/apps/mesh/src/automations/dbos-reconciler.ts
+++ b/apps/mesh/src/automations/dbos-reconciler.ts
@@ -12,30 +12,6 @@ export interface ReconcileResult {
   kept: number;
   paused: number;
   resumed: number;
-  orphansCancelled: number;
-}
-
-const AUTOMATION_WORKFLOW_NAMES = [
-  "cronEntryWorkflow",
-  "automationOrgGateWorkflow",
-  "automationGateWorkflow",
-  "fireAutomationWorkflow",
-] as const;
-
-// DBOS only dequeues rows matching the current `application_version`; older
-// ENQUEUED rows would otherwise accumulate forever.
-async function cancelOrphanedEnqueued(): Promise<number> {
-  const orphans = await DBOS.listWorkflows({
-    status: ["ENQUEUED"],
-    workflowName: [...AUTOMATION_WORKFLOW_NAMES],
-    loadInput: false,
-    loadOutput: false,
-  });
-  const stale = orphans
-    .filter((w) => w.applicationVersion !== DBOS.applicationVersion)
-    .map((w) => w.workflowID);
-  if (stale.length) await DBOS.cancelWorkflows(stale);
-  return stale.length;
 }
 
 export async function reconcileAutomationSchedules(
@@ -120,11 +96,10 @@ export async function reconcileAutomationSchedules(
     zero,
   );
   const deleted = deleteOutcomes.reduce<number>((a, b) => a + b, 0);
-  const orphansCancelled = await cancelOrphanedEnqueued();
 
   console.log(
-    `[automation-reconciler] reconciled — created=${created} deleted=${deleted} kept=${kept} resumed=${resumed} paused=${paused} orphansCancelled=${orphansCancelled}`,
+    `[automation-reconciler] reconciled — created=${created} deleted=${deleted} kept=${kept} resumed=${resumed} paused=${paused}`,
   );
 
-  return { created, deleted, kept, paused, resumed, orphansCancelled };
+  return { created, deleted, kept, paused, resumed };
 }

--- a/apps/mesh/src/dispatch-queue/dbos-orphan-recovery.ts
+++ b/apps/mesh/src/dispatch-queue/dbos-orphan-recovery.ts
@@ -1,0 +1,130 @@
+/**
+ * Cancels DBOS workflows orphaned by pod death. DBOS's launch recovery only
+ * reclaims its OWN executorID (= pod name), so a dead pod's workflows are never
+ * picked up by the replacement (new name + new version) and sit non-terminal
+ * forever — pinning queue slots. Fatal for the thread-gate queue (partition
+ * concurrency=1): one stuck row freezes that thread.
+ *
+ * Cancel, don't resume: the thread-gate dispatch step is `retriesAllowed:false`
+ * (thread-gate-workflow.ts) — an interrupted run is meant to fail cleanly, and
+ * the user-facing run is separately resumed/failed by run-registry recovery.
+ *
+ * Two safe signals, by status:
+ *   - PENDING (has `executorId`) → orphaned iff executor ∉ live-pod set. Version
+ *     is unsafe here — a draining old-version pod is still running its PENDING.
+ *   - ENQUEUED (no `executorId` yet) → orphaned iff `applicationVersion` drifted.
+ *     A current-version ENQUEUED row is legitimately awaiting a live dequeuer.
+ */
+
+import { DBOS } from "@dbos-inc/dbos-sdk";
+
+const LIST_LIMIT = 1000;
+
+async function cancelAll(ids: string[]): Promise<number> {
+  if (ids.length === 0) return 0;
+  await DBOS.cancelWorkflows(ids);
+  return ids.length;
+}
+
+/**
+ * Cancel ENQUEUED workflows whose `applicationVersion` no live executor runs.
+ * Safe regardless of pod liveness (ENQUEUED = not yet started, nothing is
+ * mid-flight). Covers every workflow name — a drifted ENQUEUED thread-gate row
+ * would otherwise pin its thread's partition slot forever.
+ */
+async function cancelVersionDriftedEnqueued(): Promise<number> {
+  const rows = await DBOS.listWorkflows({
+    status: ["ENQUEUED"],
+    loadInput: false,
+    loadOutput: false,
+    limit: LIST_LIMIT,
+  });
+  const stale = rows
+    .filter((w) => w.applicationVersion !== DBOS.applicationVersion)
+    .map((w) => w.workflowID);
+  return cancelAll(stale);
+}
+
+/**
+ * Cancel PENDING workflows owned by an executor that is no longer heartbeating.
+ * `alivePods` MUST be trustworthy and include this pod — callers verify that
+ * before invoking (an empty/self-missing set means the heartbeat isn't ready,
+ * in which case classifying any executor as dead would be unsafe).
+ */
+async function cancelDeadExecutorPending(
+  alivePods: ReadonlySet<string>,
+): Promise<number> {
+  const rows = await DBOS.listWorkflows({
+    status: ["PENDING"],
+    loadInput: false,
+    loadOutput: false,
+    limit: LIST_LIMIT,
+  });
+  const dead = rows
+    .filter((w) => w.executorId != null && !alivePods.has(w.executorId))
+    .map((w) => w.workflowID);
+  return cancelAll(dead);
+}
+
+/**
+ * Cancel a single dead pod's still-running (PENDING) workflows. Driven by the
+ * heartbeat's `onPodDeath`, which fires the moment a pod's key expires/deletes
+ * — by then the executor is confirmed gone, so cancellation can't interrupt a
+ * live run.
+ */
+export async function cancelDeadPodWorkflows(
+  deadPodId: string,
+): Promise<number> {
+  const rows = await DBOS.listWorkflows({
+    status: ["PENDING"],
+    executorId: deadPodId,
+    loadInput: false,
+    loadOutput: false,
+    limit: LIST_LIMIT,
+  });
+  const n = await cancelAll(rows.map((w) => w.workflowID));
+  if (n > 0) {
+    console.log(
+      `[dbos-recovery] cancelled ${n} PENDING workflow(s) from dead pod ${deadPodId}`,
+    );
+  }
+  return n;
+}
+
+interface SweepResult {
+  deadExecutor: number;
+  versionDrift: number;
+}
+
+/**
+ * Boot-time safety net for orphans the `onPodDeath` event missed — a hard
+ * crash with no graceful KV delete, or a full simultaneous restart where no
+ * pod was watching at TTL expiry. Mirrors `runRegistry.recoverOrphanedRuns`;
+ * run it behind the same post-deploy grace window.
+ *
+ * The version-drift pass always runs (no liveness needed). The dead-executor
+ * pass runs only when `alivePods` is trustworthy (non-empty and contains
+ * `selfPodId`); otherwise it is skipped to avoid mis-classifying live runs.
+ */
+export async function sweepOrphanedWorkflows(
+  alivePods: ReadonlySet<string>,
+  selfPodId: string,
+): Promise<SweepResult> {
+  const versionDrift = await cancelVersionDriftedEnqueued();
+
+  let deadExecutor = 0;
+  if (alivePods.has(selfPodId)) {
+    deadExecutor = await cancelDeadExecutorPending(alivePods);
+  } else {
+    console.warn(
+      "[dbos-recovery] live-pod set unavailable or missing self; skipping dead-executor PENDING sweep",
+    );
+  }
+
+  if (deadExecutor > 0 || versionDrift > 0) {
+    console.log(
+      `[dbos-recovery] boot sweep cancelled ${deadExecutor} dead-executor PENDING + ${versionDrift} version-drifted ENQUEUED workflow(s)`,
+    );
+  }
+  return { deadExecutor, versionDrift };
+}

--- a/apps/mesh/src/nats/pod-heartbeat.ts
+++ b/apps/mesh/src/nats/pod-heartbeat.ts
@@ -20,6 +20,8 @@ export interface PodHeartbeat {
   start(podId: string): void;
   /** Watch for pod deaths. Callback receives the dead podId. */
   onPodDeath(callback: (deadPodId: string) => void): void;
+  /** Snapshot of currently-heartbeating pod ids. Empty set when unavailable. */
+  listAlivePods(): Promise<Set<string>>;
   stop(): Promise<void>;
 }
 
@@ -99,6 +101,22 @@ export class NatsPodHeartbeat implements PodHeartbeat {
       return;
     }
     this.startDeathWatcher(callback);
+  }
+
+  async listAlivePods(): Promise<Set<string>> {
+    const alive = new Set<string>();
+    // Make sure init (if in flight) settled, so a just-booted pod doesn't read
+    // an empty set before the KV view is open.
+    await this.initPromise?.catch(() => {});
+    if (!this.kv) return alive;
+    try {
+      const iter = await this.kv.keys();
+      for await (const key of iter) alive.add(key);
+    } catch {
+      // Empty bucket / transient read error → return whatever we have; callers
+      // treat a self-missing set as "unknown" and skip liveness-based actions.
+    }
+    return alive;
   }
 
   private startDeathWatcher(callback: (deadPodId: string) => void): void {


### PR DESCRIPTION
- Added `cancelDeadPodWorkflows` and `sweepOrphanedWorkflows` functions to handle orphaned DBOS workflows caused by pod deaths.
- Integrated these functions into the pod death handling logic to ensure timely cleanup of orphaned workflows.
- Enhanced `PodHeartbeat` interface with `listAlivePods` method to support accurate identification of live pods during recovery operations.
- Removed orphan cancellation logic from `reconcileAutomationSchedules` to streamline the reconciliation process.

This update improves the robustness of the system by preventing workflow accumulation that could lead to resource contention.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add orphan workflow recovery for dead pods to keep DBOS queues healthy and prevent frozen thread-gate partitions. Integrates pod-death cleanup and a boot-time sweep to safely cancel PENDING and ENQUEUED orphans.

- New Features
  - Cancel PENDING workflows for a dead pod on `podHeartbeat.onPodDeath`.
  - Boot-time sweep: cancel ENQUEUED rows with version drift and PENDING rows owned by non-alive executors (only when liveness is reliable).
  - `PodHeartbeat.listAlivePods()` to snapshot currently alive pods.

- Refactors
  - Removed orphan-cancel logic from `reconcileAutomationSchedules`; recovery now lives in `apps/mesh/src/dispatch-queue/dbos-orphan-recovery.ts`.

<sup>Written for commit e2cb4263361107d00fc20f064bd822451aef3b0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

