### PR TITLE
fix(observability): handle 404 responses for idle-evicted sandboxes

### DIFF
--- a/apps/mesh/src/observability/instrumentations/fetch.ts
+++ b/apps/mesh/src/observability/instrumentations/fetch.ts
@@ -120,12 +120,25 @@ async function instrumentedFetch(
           method === "GET" &&
           (headers.get("accept") ?? "").includes("text/event-stream");
 
-        if (response.status >= 400 && !isMcpSseProbe405) {
+        // A 404 on the in-pod daemon (`/_sandbox/*`) means the sandbox handle
+        // is gone (idle-evicted). That's expected control flow — the proxy maps
+        // it to 410/`gone` and the UI self-heals — not a failure. Open Studio
+        // tabs poll `/events` + `/git/status` against reaped sandboxes, so
+        // marking these ERROR floods the error dashboard with benign 404s.
+        const isDaemonSandboxGone404 =
+          response.status === 404 && url.pathname.startsWith("/_sandbox/");
+
+        if (
+          response.status >= 400 &&
+          !isMcpSseProbe405 &&
+          !isDaemonSandboxGone404
+        ) {
           span.setStatus({
             code: SpanStatusCode.ERROR,
             message: `HTTP ${response.status}`,
           });
         } else {
+          if (isDaemonSandboxGone404) span.setAttribute("sandbox.gone", true);
           span.setStatus({ code: SpanStatusCode.OK });
         }
 

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -66,11 +66,14 @@ class SandboxGitError extends Error {
 }
 
 /** The sandbox is gone / has no runner — polling it again won't help until
- *  it's re-provisioned, so stop the interval rather than flood 503s. */
+ *  it's re-provisioned, so back off the interval rather than flood errors.
+ *  404 is the daemon's "sandbox not found" (handle idle-evicted); without it
+ *  the status poll keeps hammering `/git/status` every 3s against a sandbox
+ *  that no longer exists. 503 = no runner, 410 = handle gone. */
 export function isSandboxUnreachable(error: unknown): boolean {
   return (
     error instanceof SandboxGitError &&
-    (error.status === 503 || error.status === 410)
+    (error.status === 503 || error.status === 410 || error.status === 404)
   );
 }
 


### PR DESCRIPTION
Updated the fetch instrumentation to treat 404 responses from the in-pod daemon as expected control flow, preventing unnecessary error logging. Adjusted the error handling logic to differentiate between 404 (sandbox not found) and other error statuses, ensuring the UI can self-heal without flooding the error dashboard. Enhanced the isSandboxUnreachable function to account for 404 status in addition to existing 503 and 410 checks.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle 404 responses from the in-pod daemon for idle-evicted sandboxes without logging errors. This reduces observability noise and lets the UI back off polling and recover cleanly.

- Bug Fixes
  - Fetch instrumentation treats 404s on `/_sandbox/*` as expected and sets a `sandbox.gone` span attribute instead of marking spans as errors.
  - `isSandboxUnreachable` now includes 404 (alongside 503/410), so status polling backs off and avoids flooding `/events` and `/git/status` with requests.

<sup>Written for commit a003373b7d2848a8472ae20db2b49574c593237b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

