### PR TITLE
Revert "Feat/reapply apply http route"

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
-version: 0.7.5
+version: 0.7.4
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.5.7"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
@@ -69,15 +69,12 @@ rules:
   # `istio-system` (or wherever `previewGateway.namespace` points) can
   # route `<handle>.<domain>` traffic directly to the operator-created
   # headless Service — bypassing mesh as a proxy. `delete` mirrors the
-  # claim teardown path. `patch` is required because the runner upserts
-  # the route via Server-Side Apply (`applyHttpRoute`) — apply-patch is a
-  # content type, but the verb on the resource is still PATCH. Without it
-  # every route write 403s, so re-adoption can't re-point the backendRef
-  # and the preview hostname serves an empty 500. `get`/`create` remain
-  # for the legacy-claim backfill path in `adopt()`.
+  # claim teardown path. `get` is used for the create-if-missing branch
+  # in `adopt()` so legacy claims (provisioned before this rolled out)
+  # get their HTTPRoute backfilled.
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
-    verbs: ["get", "create", "delete", "patch"]
+    verbs: ["get", "create", "delete"]
   # Per-claim Service port ownership. agent-sandbox v0.4.x creates the
   # Service for each Sandbox with `spec.ports: []` (the operator's
   # contract is that callers reach pods via direct pod-IP DNS). Istio's

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -40,7 +40,7 @@ image:
   # instead of silently moving with `:latest`. Bump in lockstep with
   # packages/sandbox/package.json — release-studio-sandbox.yaml tags
   # images using that version. NEVER set this to "latest" in prod.
-  tag: "0.14.2"
+  tag: "0.5.7"
   # Override to Never on local kind clusters that load via `kind load`.
   pullPolicy: IfNotPresent
 

--- a/packages/sandbox/server/provider/agent-sandbox/client.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.test.ts
@@ -5,12 +5,10 @@ import {
   SandboxTimeoutError,
 } from "./constants";
 import {
-  applyHttpRoute,
   createSandboxClaim,
   deleteSandboxClaim,
   ensureServicePort,
   getSandboxClaim,
-  type HttpRoute,
   patchSandboxClaimShutdown,
   type SandboxClaim,
   type SandboxResource,
@@ -456,75 +454,6 @@ describe("ensureServicePort", () => {
         targetPort: 9000,
       }),
     ).rejects.toThrow(/Failed to apply Service ports: missing/);
-  });
-});
-
-describe("applyHttpRoute", () => {
-  const route: HttpRoute = {
-    apiVersion: "gateway.networking.k8s.io/v1",
-    kind: "HTTPRoute",
-    metadata: { name: "solar-vale", namespace: NS },
-    spec: {
-      parentRefs: [
-        {
-          kind: "Gateway",
-          group: "gateway.networking.k8s.io",
-          name: "agent-sandbox-preview-prod",
-          namespace: NS,
-        },
-      ],
-      hostnames: ["solar-vale.preview-studio.decocms.com"],
-      rules: [
-        {
-          backendRefs: [
-            {
-              group: "",
-              kind: "Service",
-              name: "studio-sandbox-prod-7nt7m",
-              port: 9000,
-            },
-          ],
-        },
-      ],
-    },
-  };
-
-  it("upserts via server-side apply to the named route path with force", async () => {
-    fetchImpl = async () => jsonResponse(200, { kind: "HTTPRoute" });
-    await applyHttpRoute(makeKc(), NS, route);
-
-    expect(fetchCalls).toHaveLength(1);
-    const [call] = fetchCalls;
-    const url = new URL(call!.url);
-    // SSA targets the named resource (not the collection) so the same call
-    // creates-or-updates — this is what re-points a surviving route's
-    // backendRef at the freshly adopted Service instead of 409-swallowing.
-    expect(url.pathname).toBe(
-      `/apis/gateway.networking.k8s.io/v1/namespaces/${NS}/httproutes/solar-vale`,
-    );
-    expect(url.searchParams.get("fieldManager")).toBe("mesh-sandbox-runner");
-    expect(url.searchParams.get("force")).toBe("true");
-
-    expect(call!.init.method).toBe("PATCH");
-    const headers = call!.init.headers as Record<string, string>;
-    expect(headers["content-type"]).toBe("application/apply-patch+yaml");
-
-    const body = JSON.parse(String(call!.init.body));
-    expect(body.spec.rules[0].backendRefs[0].name).toBe(
-      "studio-sandbox-prod-7nt7m",
-    );
-  });
-
-  it("wraps non-2xx errors in SandboxError with the route name", async () => {
-    fetchImpl = async () =>
-      jsonResponse(403, {
-        kind: "Status",
-        reason: "Forbidden",
-        message: "forbidden",
-      });
-    await expect(applyHttpRoute(makeKc(), NS, route)).rejects.toThrow(
-      /Failed to apply HTTPRoute: solar-vale/,
-    );
   });
 });
 

--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -557,45 +557,33 @@ function httpRoutePath(namespace: string, routeName: string): string {
   return `${HTTPROUTE_PATH_PREFIX}/${encodeURIComponent(namespace)}/${HTTPROUTE_PLURAL}/${encodeURIComponent(routeName)}`;
 }
 
+function httpRouteCollectionPath(namespace: string): string {
+  return `${HTTPROUTE_PATH_PREFIX}/${encodeURIComponent(namespace)}/${HTTPROUTE_PLURAL}`;
+}
+
 /**
- * Upsert an HTTPRoute via Server-Side Apply. Creates the route when absent
- * and — crucially — rewrites `spec.rules[].backendRefs` when it already
- * exists, so a route minted for an earlier sandbox re-points at the freshly
- * adopted Service instead of an orphaned one.
- *
- * The route name is stable per handle, so the runner calls this from both
- * the fresh-provision and adopt-backfill paths. The old POST-create path
- * swallowed the resulting 409, which left the backendRef pinned to a
- * since-deleted Service: Envoy then serves an empty-body 500 for the preview
- * hostname (see `ensureServicePort` for the same no-upstream signature) until
- * the next teardown happened to delete the route. SSA with a stable field
- * manager makes the write idempotent AND mutating — re-applying the same body
- * is a no-op, re-applying a changed backendRef updates it in place.
- *
- * `force=true` so we take ownership even when the route was first created by
- * the legacy POST path under the default field manager.
+ * Create an HTTPRoute. 409 (AlreadyExists) is swallowed because the runner
+ * calls this from both the fresh-provision path and the adopt-backfill
+ * path — a pre-existing route from an earlier provision attempt is the
+ * intended steady state, not an error.
  */
-export async function applyHttpRoute(
+export async function createHttpRoute(
   kc: KubeConfig,
   namespace: string,
   route: HttpRoute,
 ): Promise<void> {
-  const query = new URLSearchParams({
-    fieldManager: SSA_FIELD_MANAGER,
-    force: "true",
-  });
-  const path = `${httpRoutePath(namespace, route.metadata.name)}?${query}`;
   try {
     const resp = await kubeFetch(kc, {
-      method: "PATCH",
-      path,
-      patchType: "apply",
+      method: "POST",
+      path: httpRouteCollectionPath(namespace),
       body: route,
     });
-    await ensureOk(resp, "applyHttpRoute");
+    if (resp.status === 409) return;
+    await ensureOk(resp, "createHttpRoute");
   } catch (error) {
+    if (error instanceof KubeHttpError && error.status === 409) return;
     throw new SandboxError(
-      `Failed to apply HTTPRoute: ${route.metadata.name}`,
+      `Failed to create HTTPRoute: ${route.metadata.name}`,
       error,
     );
   }

--- a/packages/sandbox/server/provider/agent-sandbox/index.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/index.ts
@@ -3,7 +3,7 @@
 export { KubeConfig } from "@kubernetes/client-node";
 export { K8S_CONSTANTS, SandboxError, SandboxTimeoutError } from "./constants";
 export {
-  applyHttpRoute,
+  createHttpRoute,
   createSandboxClaim,
   deleteHttpRoute,
   deleteSandboxClaim,

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -62,7 +62,7 @@ import type {
   Workload,
 } from "../types";
 import {
-  applyHttpRoute,
+  createHttpRoute,
   createSandboxClaim,
   deleteHttpRoute,
   deleteSandboxClaim,
@@ -1386,11 +1386,10 @@ export class AgentSandboxProvider implements SandboxProvider {
   }
 
   /**
-   * No-op when `previewGateway` isn't configured. Otherwise upsert (SSA)
+   * No-op when `previewGateway` isn't configured. Otherwise PUT-or-create
    * an HTTPRoute that maps `<handle>.<base>` → Service `<adoptedSandboxName>`
-   * port 9000. applyHttpRoute is idempotent and mutating, so calling it from
-   * the adopt path re-points the backendRef at the newly bound pool pod
-   * rather than leaving it on the previous (deleted) Service.
+   * port 9000. createHttpRoute swallows 409, so this is safe to call from
+   * both fresh-provision and adopt-backfill paths.
    *
    * Route name and hostname stay tied to `handle` so the public preview
    * URL is stable across pool re-adoptions and so cleanup
@@ -1449,7 +1448,7 @@ export class AgentSandboxProvider implements SandboxProvider {
         ],
       },
     };
-    await applyHttpRoute(this.kubeConfig, this.namespace, route);
+    await createHttpRoute(this.kubeConfig, this.namespace, route);
   }
 
   /** No-op when `previewGateway` isn't configured. 404-tolerant otherwise. */
@@ -1575,11 +1574,9 @@ export class AgentSandboxProvider implements SandboxProvider {
 
     const tenant = readClaimTenant(claim);
     // Backfill the Service port + HTTPRoute for legacy claims provisioned
-    // before per-claim routing existed. Both calls are idempotent SSA upserts
-    // — the Service patch is a no-op once `port: 9000` is declared, and
-    // applyHttpRoute re-points the backendRef at this adoption's Service even
-    // when a route from a prior pool pod survives. Failures here don't block
-    // adoption:
+    // before per-claim routing existed. Both calls are idempotent — Service
+    // patch is a no-op once `port: 9000` is already declared, and
+    // createHttpRoute swallows 409. Failures here don't block adoption:
     // preview traffic stays unrouted until the next ensure() picks it up;
     // the rest of the sandbox surface (exec, port-forward) is unaffected.
     // Service patch first so that, if the route is missing, recreating it


### PR DESCRIPTION
Reverts decocms/studio#3791

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the server‑side apply flow for preview routing and restores create‑only `HTTPRoute` handling in `agent-sandbox`. Also rolls back `sandbox-env` chart and image versions and simplifies RBAC.

- **Refactors**
  - Replaced `applyHttpRoute` (SSA PATCH) with `createHttpRoute` (POST) that swallows 409; updated exports and runner usage.
  - Removed `patch` from HTTPRoute RBAC; kept `get`, `create`, `delete`.
  - Deleted tests tied to `applyHttpRoute`.

- **Dependencies**
  - Rolled back `deploy/helm/sandbox-env` chart version to 0.7.4.
  - Reset image tag to `0.5.7` in values to match the app version.

<sup>Written for commit 6190b8e5b474dea5f9312d96bac76feb94298b40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

