### PR TITLE
fix(cli): enhance Vite server configuration for sandbox environments

### DIFF
--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -95,10 +95,23 @@ function pipeToLogStore(stream: ReadableStream<Uint8Array>) {
 export async function startDevServer(
   options: DevOptions,
 ): Promise<{ port: number; process: Subprocess }> {
-  const { vitePort, baseUrl, noTui } = options;
+  const { baseUrl, noTui } = options;
+
+  // Sandbox preview: the daemon injects PORT and proxies the preview to it,
+  // expecting HTML at /. Mesh's dev front door is Vite (it serves the app and
+  // proxies /api → the Bun server); the Bun server alone 404s at / in dev. So
+  // in a sandbox we bind Vite to the injected PORT and move the Bun server to
+  // an internal port (Vite's proxy target follows PORT). The daemon sets
+  // HOST=0.0.0.0 (buildDevEnv) and local `bun run dev` never does, so that's
+  // our sandbox tell. Locally the conventional split is preserved (server on
+  // --port, Vite on --vite-port).
+  const inSandbox = process.env.HOST === "0.0.0.0" && Boolean(process.env.PORT);
+  const vitePort = inSandbox ? process.env.PORT! : options.vitePort;
   const publicBaseUrl = baseUrl || `http://localhost:${vitePort}`;
 
-  const port = await findAvailablePort(Number(options.port));
+  const port = inSandbox
+    ? await findAvailablePort(Number(vitePort) + 1)
+    : await findAvailablePort(Number(options.port));
 
   const { settings, services, managedServiceNames } = await buildSettings({
     port: String(port),

--- a/apps/mesh/vite.config.ts
+++ b/apps/mesh/vite.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
     __MESH_VERSION__: JSON.stringify(pkg.version),
   },
   server: {
+    // In a sandbox the daemon proxies the preview to Vite over IPv4
+    // (127.0.0.1); Vite otherwise binds IPv6-only (localhost → [::1]) and the
+    // proxy can't reach it. HOST=0.0.0.0 is the daemon's dev-env tell.
+    ...(process.env.HOST === "0.0.0.0" ? { host: true } : {}),
     hmr: {
       overlay: true,
       host: "localhost",

--- a/packages/sandbox/daemon/strip-bun-pragma.ts
+++ b/packages/sandbox/daemon/strip-bun-pragma.ts
@@ -1,0 +1,8 @@
+// Bun's `// @bun` fast-parse path rejects `using` declarations, which the
+// daemon graph uses (mcp-utils/sandbox/run-code.ts). Strip the pragma so Bun
+// transpiles on load instead. See packages/sandbox build script.
+const target = new URL("./dist/daemon.js", import.meta.url);
+const source = await Bun.file(target).text();
+if (source.startsWith("// @bun")) {
+  await Bun.write(target, source.replace(/^\/\/ @bun\n/, ""));
+}

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check": "tsc --noEmit",
     "test": "bun test",
-    "build": "bun build daemon/entry.ts --target=bun --outfile=daemon/dist/daemon.js --external node-pty",
+    "build": "bun build daemon/entry.ts --target=bun --outfile=daemon/dist/daemon.js --external node-pty && bun run daemon/strip-bun-pragma.ts",
     "dev:daemon": "bun run --watch daemon/entry.ts"
   },
   "exports": {


### PR DESCRIPTION
- Updated Vite configuration to conditionally bind the host to true when running in a sandbox environment (HOST=0.0.0.0).
- Modified the dev server startup logic to dynamically set the Vite port based on the sandbox environment, ensuring proper proxying to the Bun server.
- Added a new script to strip Bun's pragma from the daemon build output to prevent parsing issues.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox dev preview by making Vite listen on the injected host/port and moving the Bun server behind it, so the daemon proxy reaches the app. Also strips Bun’s fast-parse pragma from the sandbox daemon build to avoid `using` parse errors.

- **Bug Fixes**
  - Detect sandbox via `HOST=0.0.0.0` and `PORT`; run Vite on `PORT`, move the Bun server to the next free port.
  - In `vite.config.ts`, set `server.host = true` when `HOST=0.0.0.0` to allow IPv4 proxying.
  - Add `packages/sandbox/daemon/strip-bun-pragma.ts` and run it post-build to remove `// @bun` so Bun transpiles on load.

<sup>Written for commit bcd5c946c0644336e7a382e15fd2f7548303e00a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

