### PR TITLE
fix: enhance error handling and retry logic in fetch requests for dec…

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -22,12 +22,20 @@ export function useDecofile(
       const res = await fetch(
         `/api/${params!.orgSlug}/sandbox/${encodeURIComponent(params!.virtualMcpId)}/${encodeURIComponent(params!.branch)}/preview-fetch?${search.toString()}`,
       );
-      if (!res.ok) throw new Error(`Failed to fetch decofile: ${res.status}`);
+      if (!res.ok) {
+        const err = new Error(`Failed to fetch decofile: ${res.status}`);
+        (err as { status?: number }).status = res.status;
+        throw err;
+      }
       return (await res.json()) as Record<string, unknown>;
     },
     enabled: !!params && fetchEnabled,
     staleTime: 30_000,
-    retry: 3,
+    // 502 = preview unreachable (sandbox starting or down). The SSE lifecycle
+    // re-enables this query when the preview is back, so retrying just hammers
+    // a known-down endpoint and spams 5xx logs.
+    retry: (failureCount, error) =>
+      (error as { status?: number }).status !== 502 && failureCount < 2,
     retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 5000),
   });
 }

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -23,12 +23,20 @@ export function useLiveMeta(
       const res = await fetch(
         `/api/${params!.orgSlug}/sandbox/${encodeURIComponent(params!.virtualMcpId)}/${encodeURIComponent(params!.branch)}/preview-fetch?${search.toString()}`,
       );
-      if (!res.ok) throw new Error(`Failed to fetch live meta: ${res.status}`);
+      if (!res.ok) {
+        const err = new Error(`Failed to fetch live meta: ${res.status}`);
+        (err as { status?: number }).status = res.status;
+        throw err;
+      }
       return (await res.json()) as LiveMeta;
     },
     enabled: !!params && fetchEnabled,
     staleTime: 300_000,
-    retry: 3,
+    // 502 = preview unreachable (sandbox starting or down). The SSE lifecycle
+    // re-enables this query when the preview is back, so retrying just hammers
+    // a known-down endpoint and spams 5xx logs.
+    retry: (failureCount, error) =>
+      (error as { status?: number }).status !== 502 && failureCount < 3,
     retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 5000),
   });
 }


### PR DESCRIPTION
…ofile and live meta

- Updated error handling to attach the response status to the thrown error for better debugging.
- Modified retry logic to prevent unnecessary retries on 502 errors, reducing log spam during sandbox downtime.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve sandbox preview fetchers to attach HTTP status to errors and skip retries on 502. This reduces log spam during sandbox downtime and makes debugging easier.

- **Bug Fixes**
  - In `useDecofile` and `useLiveMeta`, include `status` on thrown fetch errors for clearer diagnostics.
  - Update retry logic: no retries on 502; otherwise retry up to 1 time for decofile and 2 times for live meta, with exponential backoff capped at 5s.

<sup>Written for commit d1fdbfd7ba734c07061cd1e2f2009269b77b7abb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

