### PR TITLE
fix(recovery): add DBOS initialization checks in orphan workflow mana…

### DIFF
--- a/apps/mesh/src/dispatch-queue/dbos-orphan-recovery.ts
+++ b/apps/mesh/src/dispatch-queue/dbos-orphan-recovery.ts
@@ -75,6 +75,7 @@ async function cancelDeadExecutorPending(
 export async function cancelDeadPodWorkflows(
   deadPodId: string,
 ): Promise<number> {
+  if (!DBOS.isInitialized()) return 0;
   const rows = await DBOS.listWorkflows({
     status: ["PENDING"],
     executorId: deadPodId,
@@ -110,6 +111,10 @@ export async function sweepOrphanedWorkflows(
   alivePods: ReadonlySet<string>,
   selfPodId: string,
 ): Promise<SweepResult> {
+  if (!DBOS.isInitialized()) {
+    console.warn("[dbos-recovery] DBOS not launched yet; skipping boot sweep");
+    return { deadExecutor: 0, versionDrift: 0 };
+  }
   const versionDrift = await cancelVersionDriftedEnqueued();
 
   let deadExecutor = 0;


### PR DESCRIPTION
…gement

- Added checks to ensure DBOS is initialized before executing `cancelDeadPodWorkflows` and `sweepOrphanedWorkflows` functions.
- Included a warning log when DBOS is not launched, preventing potential errors during workflow management.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add initialization guards to orphan workflow recovery so checks only run after `DBOS` is launched. Prevents boot-time errors and safely no-ops when not ready.

- **Bug Fixes**
  - Guard `cancelDeadPodWorkflows` and `sweepOrphanedWorkflows` with `DBOS.isInitialized()`.
  - When not initialized, log a warning and return 0 counts instead of running a sweep.

<sup>Written for commit 401a13afe50ff680a4c70ff49124aeefaf6c46d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

