### PR TITLE
feat(dev): hot reload local daemons

### DIFF
--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -61,6 +61,10 @@ const { values, positionals } = parseArgs({
       type: "boolean",
       default: false,
     },
+    hot: {
+      type: "boolean",
+      default: false,
+    },
     target: { type: "string" },
     env: { type: "string", short: "e" },
     "dry-run": {
@@ -102,6 +106,7 @@ Dev Options:
   --vite-port <port>            Vite dev server port (default: 4000)
   --base-url <url>              Base URL for the server
   --local-sandbox-provider      Auto-spawn the local link daemon (desktop sandbox provider)
+  --hot                         Hot-reload managed link and sandbox daemons in dev
 
 Auth Options:
   --target <url>        Decocms target (default: https://studio.decocms.com)
@@ -306,6 +311,7 @@ if (command === "link") {
     clusterBaseUrl: studioUrl,
     tui,
     version: await getVersion(),
+    hotReload: values.hot === true,
     // Managed daemons (dev / npx --local-sandbox-provider) suppress the
     // banner — the parent dev/serve process already renders one.
     banner: process.env.DECOCMS_LINK_MANAGED !== "1",
@@ -336,6 +342,7 @@ if (command === "dev") {
     noTui,
     localMode: values["no-local-mode"] !== true,
     localSandboxProvider,
+    hotReload: values.hot === true,
   };
 
   if (noTui) {

--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -30,6 +30,8 @@ export interface DevOptions {
    *  desktop sandbox provider has a live target. Default false —
    *  `dev:conductor` opts in. */
   localSandboxProvider: boolean;
+  /** When true, hot-reload the managed link daemon and sandbox daemons. */
+  hotReload?: boolean;
 }
 
 // Strip ANSI escape codes from a string
@@ -237,6 +239,7 @@ export async function startDevServer(
           clusterUrl: serverUrl,
           linkDataDir,
           repoRoot,
+          hotReload: options.hotReload,
           signal: linkAbort.signal,
           stdio: [
             "inherit",

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -33,6 +33,8 @@ export interface LinkCommandOptions {
    * `dev`/`serve` TUI.
    */
   banner?: boolean;
+  /** Hot-reload sandbox daemons spawned by this link process. */
+  hotReload?: boolean;
 }
 
 /**
@@ -179,6 +181,7 @@ export async function runLinkCommand(
       session,
       monitor,
       logFd,
+      hotReload: opts.hotReload,
     });
     return await handle.stopped;
   } catch (err) {

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -62,6 +62,8 @@ export interface StartLinkDaemonOptions {
    * to the parent process.
    */
   logFd?: number;
+  /** Hot-reload sandbox daemons spawned from source. */
+  hotReload?: boolean;
 }
 
 export interface LinkDaemonHandle {
@@ -77,6 +79,7 @@ export async function startLinkDaemon(
 
   const innerSpawn = createDefaultDaemonSpawn(opts.dataDir, {
     outFd: opts.logFd,
+    hotReload: opts.hotReload,
   });
   // Forward declaration so `resolvePreviewUrl` can read the ingress port
   // once the ingress finishes binding (the ingress's `lookupSandboxPort`

--- a/apps/mesh/src/services/ensure-services.test.ts
+++ b/apps/mesh/src/services/ensure-services.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { minioArtifactName, minioDownloadUrl } from "./ensure-services";
+import {
+  buildManagedLinkSpawnCommand,
+  minioArtifactName,
+  minioDownloadUrl,
+} from "./ensure-services";
 
 describe("minioArtifactName", () => {
   it("returns the bare executable on unix platforms", () => {
@@ -35,5 +39,49 @@ describe("minioDownloadUrl", () => {
     expect(() => minioDownloadUrl("sunos", "sparc")).toThrow(
       /Unsupported platform for MinIO/,
     );
+  });
+});
+
+describe("buildManagedLinkSpawnCommand", () => {
+  it("adds Bun hot reload and forwards --hot to the link command", () => {
+    expect(
+      buildManagedLinkSpawnCommand({
+        clusterUrl: "http://lagos.localhost",
+        port: 5174,
+        hotReload: true,
+      }),
+    ).toEqual([
+      "bun",
+      "--hot",
+      "run",
+      "--cwd=apps/mesh",
+      "src/cli.ts",
+      "link",
+      "http://lagos.localhost",
+      "--port",
+      "5174",
+      "--no-tui",
+      "--hot",
+    ]);
+  });
+
+  it("keeps the existing link command shape when hot reload is disabled", () => {
+    expect(
+      buildManagedLinkSpawnCommand({
+        clusterUrl: "http://lagos.localhost",
+        port: 5174,
+        hotReload: false,
+      }),
+    ).toEqual([
+      "bun",
+      "run",
+      "--cwd=apps/mesh",
+      "src/cli.ts",
+      "link",
+      "http://lagos.localhost",
+      "--port",
+      "5174",
+      "--no-tui",
+    ]);
   });
 });

--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -1016,6 +1016,8 @@ export interface EnsureLinkInputs {
   linkDataDir: string;
   /** Repo root — `cwd` for the spawned `bun run --cwd=apps/mesh …`. */
   repoRoot: string;
+  /** Enable Bun hot reload for the managed link and its sandbox daemons. */
+  hotReload?: boolean;
   /**
    * Called only when a fresh link daemon needs to be spawned (i.e. not when
    * an existing managed link is reused). Use this to await prerequisites
@@ -1042,6 +1044,32 @@ export interface EnsureLinkResult {
   info: ServiceInfo;
   /** The spawned subprocess, or null when reusing an existing managed link. */
   proc: ReturnType<typeof Bun.spawn> | null;
+}
+
+export function buildManagedLinkSpawnCommand(opts: {
+  clusterUrl: string;
+  port: number;
+  hotReload?: boolean;
+}): string[] {
+  const bunRuntimeArgs = opts.hotReload === true ? ["--hot"] : [];
+  const forwardedLinkArgs = opts.hotReload === true ? ["--hot"] : [];
+
+  return [
+    "bun",
+    ...bunRuntimeArgs,
+    "run",
+    "--cwd=apps/mesh",
+    "src/cli.ts",
+    "link",
+    // Required positional: the studio to link against.
+    opts.clusterUrl,
+    "--port",
+    String(opts.port),
+    // Managed background daemon: never render the Ink TUI (it would paint
+    // over the parent dev/serve terminal when stdio is inherited).
+    "--no-tui",
+    ...forwardedLinkArgs,
+  ];
 }
 
 async function ensureLink(inputs: EnsureLinkInputs): Promise<EnsureLinkResult> {
@@ -1071,20 +1099,11 @@ async function ensureLink(inputs: EnsureLinkInputs): Promise<EnsureLinkResult> {
   info.port = port;
 
   const proc = Bun.spawn(
-    [
-      "bun",
-      "run",
-      "--cwd=apps/mesh",
-      "src/cli.ts",
-      "link",
-      // Required positional: the studio to link against.
-      inputs.clusterUrl,
-      "--port",
-      String(port),
-      // Managed background daemon: never render the Ink TUI (it would paint
-      // over the parent dev/serve terminal when stdio is inherited).
-      "--no-tui",
-    ],
+    buildManagedLinkSpawnCommand({
+      clusterUrl: inputs.clusterUrl,
+      port,
+      hotReload: inputs.hotReload,
+    }),
     {
       cwd: inputs.repoRoot,
       env: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "dev": "bun run --env-file=.env scripts/dev.ts",
     "dev:worktree": "bun run scripts/dev-worktree.ts",
-    "dev:conductor": "WORKTREE_SLUG=$CONDUCTOR_WORKSPACE_NAME bun run dev:worktree -- --local-sandbox-provider",
+    "dev:conductor": "WORKTREE_SLUG=$CONDUCTOR_WORKSPACE_NAME bun run dev:worktree -- --local-sandbox-provider --hot",
     "fmt": "biome format --write",
     "lint": "oxlint",
     "check": "bun run --workspaces check",

--- a/packages/sandbox/server/daemon-spawn.test.ts
+++ b/packages/sandbox/server/daemon-spawn.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { resolveDaemonStdio } from "./daemon-spawn";
+import {
+  buildSandboxDaemonSpawnCommand,
+  resolveDaemonStdio,
+} from "./daemon-spawn";
 
 describe("resolveDaemonStdio", () => {
   it("inherits the parent fds when no log fd is given", () => {
@@ -9,5 +12,32 @@ describe("resolveDaemonStdio", () => {
 
   it("returns the provided fd so the child writes to the log file", () => {
     expect(resolveDaemonStdio(7)).toBe(7);
+  });
+});
+
+describe("buildSandboxDaemonSpawnCommand", () => {
+  it("adds Bun hot reload when the daemon is running from source", () => {
+    expect(
+      buildSandboxDaemonSpawnCommand({
+        daemonExec: "/repo/packages/sandbox/daemon/entry.ts",
+        sourceDaemonPath: "/repo/packages/sandbox/daemon/entry.ts",
+        hotReload: true,
+      }),
+    ).toEqual([
+      "bun",
+      "--hot",
+      "run",
+      "/repo/packages/sandbox/daemon/entry.ts",
+    ]);
+  });
+
+  it("does not add Bun hot reload for a materialized daemon bundle", () => {
+    expect(
+      buildSandboxDaemonSpawnCommand({
+        daemonExec: "/tmp/cache/sandbox-daemon-deadbeef.js",
+        sourceDaemonPath: "/repo/packages/sandbox/daemon/entry.ts",
+        hotReload: true,
+      }),
+    ).toEqual(["bun", "run", "/tmp/cache/sandbox-daemon-deadbeef.js"]);
   });
 });

--- a/packages/sandbox/server/daemon-spawn.ts
+++ b/packages/sandbox/server/daemon-spawn.ts
@@ -97,16 +97,37 @@ export function resolveDaemonStdio(outFd?: number): "inherit" | number {
   return outFd ?? "inherit";
 }
 
+export function canHotReloadDaemon(opts: {
+  daemonExec: string;
+  sourceDaemonPath: string;
+  hotReload?: boolean;
+}): boolean {
+  return (
+    opts.hotReload === true &&
+    resolve(opts.daemonExec) === resolve(opts.sourceDaemonPath)
+  );
+}
+
+export function buildSandboxDaemonSpawnCommand(opts: {
+  daemonExec: string;
+  sourceDaemonPath: string;
+  hotReload?: boolean;
+}): string[] {
+  const hotFromSource = canHotReloadDaemon(opts);
+  return ["bun", ...(hotFromSource ? ["--hot"] : []), "run", opts.daemonExec];
+}
+
 /**
  * Default Bun.spawn-based daemon launcher. `homeDir` is the DATA_DIR
  * root used to materialize the daemon bundle when running from a bundle.
  */
 export function createDefaultDaemonSpawn(
   homeDir: string,
-  opts: { outFd?: number } = {},
+  opts: { outFd?: number; hotReload?: boolean } = {},
 ): SpawnDaemonFn {
   return async (args) => {
     const daemonExec = await resolveDaemonExec(homeDir);
+    const sourceDaemonPath = resolveSourceDaemonPath();
     const ptyNodeModulesDir = resolveNodePtyNodeModulesDir();
     const existingNodePath = process.env.NODE_PATH;
     const nodePath = existingNodePath
@@ -114,7 +135,11 @@ export function createDefaultDaemonSpawn(
       : ptyNodeModulesDir;
     const stdio = resolveDaemonStdio(opts.outFd);
     const proc = Bun.spawn({
-      cmd: ["bun", "run", daemonExec],
+      cmd: buildSandboxDaemonSpawnCommand({
+        daemonExec,
+        sourceDaemonPath,
+        hotReload: opts.hotReload,
+      }),
       env: {
         ...process.env,
         NODE_PATH: nodePath,


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hot reload for the local link daemon and sandbox daemons during development. Use the new --hot flag to reload on code changes without manual restarts.

- **New Features**
  - `dev` and `link` now accept `--hot` to hot-reload the managed link daemon and local sandbox daemons.
  - Spawns use `bun --hot run` when enabled; sandbox daemons hot-reload only when running from source (not from a bundled file).
  - Updated tests cover the new spawn command builders.

- **Migration**
  - Use `--hot` with your local `dev` or `link` commands.
  - `dev:conductor` now enables `--hot` by default.

<sup>Written for commit 5c854926954b0b8181aa5ce17a51c005d5b320b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

