### PR TITLE
refactor: optimize UI message streaming in createSubtaskTool

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -162,26 +162,18 @@ export function createSubtaskTool(
           passthroughClient: mcpClient,
         });
 
-        // 4. Drain the UI stream so streamText runs to completion.
-        //    We intentionally don't yield each progressive UIMessage:
-        //      - AI SDK's executeTool helper reads only YIELDED values
-        //        (the generator's return value is discarded), so the
-        //        last yielded UIMessage would be what reaches
-        //        toModelOutput — losing our extracted text/error.
-        //      - Each progressive UIMessage from readUIMessageStream
-        //        carries the full accumulated state (incl. multi-MB
-        //        MCP tool outputs), causing per-chunk NATS payloads
-        //        to exceed the 1 MB default and be dropped silently.
-        //    Instead, we drain here and yield a single structured
-        //    object at the end (step 7).
-        const reader = handle.result.toUIMessageStream().getReader();
-        try {
-          while (true) {
-            const { done } = await reader.read();
-            if (done) break;
+        let streamedText = "";
+        let lastFlush = 0;
+        const FLUSH_MS = 200;
+        for await (const part of handle.result.fullStream) {
+          if (part.type === "text-delta") {
+            streamedText += part.text;
+            const now = performance.now();
+            if (now - lastFlush >= FLUSH_MS) {
+              lastFlush = now;
+              yield { text: streamedText };
+            }
           }
-        } finally {
-          reader.releaseLock();
         }
 
         // 5. Collect results from the resolved promises.


### PR DESCRIPTION
- Replaced the previous UI message draining logic with a more efficient streaming approach.
- Introduced a mechanism to yield accumulated text at regular intervals, improving performance and reducing payload size.
- Enhanced readability and maintainability of the code by simplifying the flow of message handling.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized UI message streaming in `createSubtaskTool` by switching to periodic text-delta flushing. This improves responsiveness, reduces payload size, and prevents dropped messages from oversized chunks.

- **Refactors**
  - Consume `handle.result.fullStream` and accumulate `text-delta`s.
  - Yield accumulated text every ~200 ms instead of draining UI messages.
  - Simplifies the message handling flow for better readability.

<sup>Written for commit efa5509b175e5231867071eb06f8837215c18715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

