### PR TITLE
feat(observability): configure OTLP endpoints for DBOS integration

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -41,6 +41,11 @@ function withSslmode(url: string, ssl: boolean): string {
   }
   return u.toString();
 }
+// DBOS auto-builds OTel spans for every workflow/step but exports them via its
+// own pipeline, separate from observability/index.ts's NodeSDK. Point it at the
+// same collector as the rest of mesh. The OTLP proto exporter needs the full
+// per-signal URL, so derive it from the base OTEL_EXPORTER_OTLP_ENDPOINT.
+const otlpBase = process.env.OTEL_EXPORTER_OTLP_ENDPOINT?.replace(/\/$/, "");
 DBOS.setConfig({
   name: "decocms",
   systemDatabaseUrl: withSslmode(settings.databaseUrl, settings.databasePgSsl),
@@ -53,6 +58,13 @@ DBOS.setConfig({
   // over port 3001. Re-enable per-process once we need workflow admin HTTP.
   runAdminServer: false,
   executorID: settings.podName,
+  ...(otlpBase
+    ? {
+        enableOTLP: true,
+        otlpTracesEndpoints: [`${otlpBase}/v1/traces`],
+        otlpLogsEndpoints: [`${otlpBase}/v1/logs`],
+      }
+    : {}),
 });
 
 const { createApp } = await import("./api/app");


### PR DESCRIPTION
- Added configuration to enable OTLP tracing and logging endpoints in DBOS, pointing to the same collector as the rest of the mesh.
- Derived the OTLP base URL from the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` to ensure proper endpoint formatting.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure DBOS to export OpenTelemetry traces and logs to the same OTLP collector used by the mesh. Per-signal endpoints are derived from `OTEL_EXPORTER_OTLP_ENDPOINT` to produce correct `/v1/traces` and `/v1/logs` URLs.

- **New Features**
  - Activates only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set; otherwise no change.
  - Normalizes the base endpoint (removes trailing slash) before building per-signal URLs.

<sup>Written for commit 2604bfe776620587485bda9b4d35fb53a9f90776. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

