### PR TITLE
Revert "feat(observability): configure OTLP endpoints for DBOS integration"

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -41,11 +41,6 @@ function withSslmode(url: string, ssl: boolean): string {
   }
   return u.toString();
 }
-// DBOS auto-builds OTel spans for every workflow/step but exports them via its
-// own pipeline, separate from observability/index.ts's NodeSDK. Point it at the
-// same collector as the rest of mesh. The OTLP proto exporter needs the full
-// per-signal URL, so derive it from the base OTEL_EXPORTER_OTLP_ENDPOINT.
-const otlpBase = process.env.OTEL_EXPORTER_OTLP_ENDPOINT?.replace(/\/$/, "");
 DBOS.setConfig({
   name: "decocms",
   systemDatabaseUrl: withSslmode(settings.databaseUrl, settings.databasePgSsl),
@@ -58,13 +53,6 @@ DBOS.setConfig({
   // over port 3001. Re-enable per-process once we need workflow admin HTTP.
   runAdminServer: false,
   executorID: settings.podName,
-  ...(otlpBase
-    ? {
-        enableOTLP: true,
-        otlpTracesEndpoints: [`${otlpBase}/v1/traces`],
-        otlpLogsEndpoints: [`${otlpBase}/v1/logs`],
-      }
-    : {}),
 });
 
 const { createApp } = await import("./api/app");


### PR DESCRIPTION
Reverts decocms/studio#3803

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the OTLP endpoint configuration for `DBOS` in apps/mesh/src/index.ts, removing custom traces/logs exporter URLs so telemetry falls back to default behavior. Restores prior observability behavior by dropping `enableOTLP`, `otlpTracesEndpoints`, and `otlpLogsEndpoints`.

<sup>Written for commit 714be4ce39315e4b6bc186987ff5d67ce1fac99e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

