### PR TITLE
feat(sandbox): file explorer create/rename/delete and toolbar actions

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -358,6 +358,12 @@ export const createSandboxRoutes = () => {
   app.post("/:virtualMcpId/:branch/unlink", (c) =>
     proxyDaemon(c, "/_sandbox/unlink", { forwardJsonBody: true }),
   );
+  app.post("/:virtualMcpId/:branch/mkdir", (c) =>
+    proxyDaemon(c, "/_sandbox/mkdir", { forwardJsonBody: true }),
+  );
+  app.post("/:virtualMcpId/:branch/rename", (c) =>
+    proxyDaemon(c, "/_sandbox/rename", { forwardJsonBody: true }),
+  );
   app.post("/:virtualMcpId/:branch/read", (c) =>
     proxyDaemon(c, "/_sandbox/read", { forwardJsonBody: true }),
   );

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer-name-dialog.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer-name-dialog.tsx
@@ -1,0 +1,142 @@
+import { type FormEvent, useState } from "react";
+import { Loading01 } from "@untitledui/icons";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+
+export type FileExplorerNameDialogMode = "new-file" | "new-folder" | "rename";
+
+const MODE_COPY: Record<
+  FileExplorerNameDialogMode,
+  { title: string; description: string; submit: string; placeholder: string }
+> = {
+  "new-file": {
+    title: "New File",
+    description: "Enter a name for the new file.",
+    submit: "Create",
+    placeholder: "filename.ts",
+  },
+  "new-folder": {
+    title: "New Folder",
+    description: "Enter a name for the new folder.",
+    submit: "Create",
+    placeholder: "folder-name",
+  },
+  rename: {
+    title: "Rename",
+    description: "Enter a new name for this item.",
+    submit: "Rename",
+    placeholder: "new-name",
+  },
+};
+
+export function FileExplorerNameDialog({
+  open,
+  mode,
+  initialName = "",
+  parentLabel,
+  isPending = false,
+  onSubmit,
+  onOpenChange,
+}: {
+  open: boolean;
+  mode: FileExplorerNameDialogMode;
+  initialName?: string;
+  parentLabel?: string;
+  isPending?: boolean;
+  onSubmit: (name: string) => void | Promise<void>;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [name, setName] = useState(initialName);
+  const [prevOpen, setPrevOpen] = useState(open);
+  const copy = MODE_COPY[mode];
+
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setName(initialName);
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !isPending) onOpenChange(false);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || isPending) return;
+    await onSubmit(trimmed);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{copy.title}</DialogTitle>
+            <DialogDescription>{copy.description}</DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            {parentLabel && (
+              <div className="space-y-1.5">
+                <span className="text-xs font-medium text-muted-foreground">
+                  Location
+                </span>
+                <Input
+                  value={parentLabel}
+                  readOnly
+                  disabled
+                  className="font-mono text-xs"
+                />
+              </div>
+            )}
+            <div className="space-y-1.5">
+              <label
+                htmlFor="file-explorer-name"
+                className="text-xs font-medium text-muted-foreground"
+              >
+                Name
+              </label>
+              <Input
+                id="file-explorer-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={copy.placeholder}
+                autoFocus
+                disabled={isPending}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim() || isPending}>
+              {isPending ? (
+                <>
+                  <Loading01 size={14} className="animate-spin" />
+                  Saving…
+                </>
+              ) : (
+                copy.submit
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -4,18 +4,34 @@ import Editor, { loader } from "@monaco-editor/react";
 import type { OnMount } from "@monaco-editor/react";
 import {
   Brackets,
-  ChevronDown,
-  ChevronRight,
   File02,
   FileCode01,
-  Folder,
+  FilePlus01,
+  FolderPlus,
   Image01,
   Loading01,
   SearchSm,
   XClose,
 } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.js";
+import { Button } from "@deco/ui/components/button.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
+import { toast } from "sonner";
 import { useChatStream } from "@/web/components/chat/context";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { saveChangesDebug } from "../../../thread/github/save-changes-debug.ts";
@@ -23,13 +39,23 @@ import {
   fetchGitStatus,
   sandboxGitStatusQueryKey,
 } from "../../../thread/github/sandbox-git-api.ts";
-import type { FileBuffer } from "./types";
+import type { FileBuffer, TreeNode } from "./types";
+import {
+  FileExplorerNameDialog,
+  type FileExplorerNameDialogMode,
+} from "./file-explorer-name-dialog";
+import { FileTreeRow } from "./file-tree-row";
 import {
   buildFileTree,
   flattenTree,
   getAncestorDirectories,
+  getDirectoryContextPath,
   getLanguageFromPath,
+  getParentTreePath,
+  joinTreePath,
   stripLineNumbers,
+  toDaemonPath,
+  toTreePath,
 } from "./utils";
 
 // Configure Monaco CDN (shared with workflow editor)
@@ -60,11 +86,6 @@ function buildApiUrl(
   return `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/${endpoint}`;
 }
 
-/** The daemon expects relative paths (no leading slash). */
-function toDaemonPath(treePath: string) {
-  return treePath.startsWith("/") ? treePath.slice(1) : treePath;
-}
-
 /** Reject path traversal and absolute paths outside the workspace root. */
 function isSafeExplorerOpenPath(path: string): boolean {
   const normalized = toDaemonPath(path);
@@ -84,7 +105,6 @@ type FileIcon = React.ComponentType<{
 }>;
 
 /** Warm folder tone — reads well on both light and dark backgrounds. */
-const FOLDER_COLOR = "#d9a441";
 const DEFAULT_FILE_COLOR = "#94a3b8";
 
 /**
@@ -146,6 +166,177 @@ export function FileExplorer({
   const { sendMessage } = useChatStream();
   const { setChatOpen } = usePanelActions();
   const queryClient = useQueryClient();
+
+  const [nameDialog, setNameDialog] = useState<{
+    mode: FileExplorerNameDialogMode;
+    node: TreeNode;
+    parentDir: string;
+  } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<TreeNode | null>(null);
+  const [fsActionPending, setFsActionPending] = useState(false);
+
+  async function postSandbox(endpoint: string, body: Record<string, unknown>) {
+    const res = await fetch(
+      buildApiUrl(orgSlug, virtualMcpId, branch, endpoint),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!res.ok) {
+      const payload = await res.json().catch(() => ({}));
+      throw new Error(
+        (payload as { error?: string }).error ??
+          `Request failed (${res.status})`,
+      );
+    }
+    return res.json();
+  }
+
+  async function refreshGitStatus() {
+    void queryClient.invalidateQueries({
+      queryKey: sandboxGitStatusQueryKey(orgSlug, virtualMcpId, branch),
+    });
+  }
+
+  function copyText(label: string, value: string) {
+    void navigator.clipboard.writeText(value).then(
+      () => toast.success(`${label} copied`),
+      () => toast.error(`Failed to copy ${label.toLowerCase()}`),
+    );
+  }
+
+  function remapOpenPaths(remap: (path: string) => string | null) {
+    setOpenTabs((prev) =>
+      prev
+        .map((tab) => remap(tab))
+        .filter((tab): tab is string => tab !== null),
+    );
+    setSelectedFile((prev) => {
+      if (!prev) return prev;
+      const next = remap(prev);
+      return next;
+    });
+    setBuffers((prev) => {
+      const next = new Map<string, FileBuffer>();
+      for (const [path, buffer] of prev) {
+        const mapped = remap(path);
+        if (mapped) next.set(mapped, buffer);
+      }
+      return next;
+    });
+  }
+
+  function removeOpenPaths(prefix: string) {
+    const normalizedPrefix = toTreePath(prefix);
+    remapOpenPaths((path) => {
+      if (
+        path === normalizedPrefix ||
+        path.startsWith(`${normalizedPrefix}/`)
+      ) {
+        return null;
+      }
+      return path;
+    });
+  }
+
+  async function handleCreateFile(name: string) {
+    if (!nameDialog) return;
+    const filePath = joinTreePath(nameDialog.parentDir, name);
+    await postSandbox("write", {
+      path: toDaemonPath(filePath),
+      content: "",
+    });
+    await fetchFileTree();
+    await refreshGitStatus();
+    setNameDialog(null);
+    handleFileClick(filePath);
+  }
+
+  async function handleCreateFolder(name: string) {
+    if (!nameDialog) return;
+    const folderPath = joinTreePath(nameDialog.parentDir, name);
+    const gitkeepPath = joinTreePath(folderPath, ".gitkeep");
+    await postSandbox("mkdir", { path: toDaemonPath(folderPath) });
+    await postSandbox("write", {
+      path: toDaemonPath(gitkeepPath),
+      content: "",
+    });
+    await fetchFileTree();
+    await refreshGitStatus();
+    setNameDialog(null);
+    setExpandedDirs((prev) => {
+      const next = new Set(prev);
+      for (const dir of getAncestorDirectories(folderPath)) next.add(dir);
+      next.add(folderPath);
+      return next;
+    });
+  }
+
+  async function handleRename(name: string) {
+    if (!nameDialog) return;
+    const fromPath = nameDialog.node.path;
+    const parentDir = getParentTreePath(fromPath);
+    const toPath = joinTreePath(parentDir, name);
+    if (toPath === fromPath) {
+      setNameDialog(null);
+      return;
+    }
+    await postSandbox("rename", {
+      from: toDaemonPath(fromPath),
+      to: toDaemonPath(toPath),
+    });
+    remapOpenPaths((path) => {
+      if (path === fromPath) return toPath;
+      if (path.startsWith(`${fromPath}/`)) {
+        return joinTreePath(toPath, path.slice(fromPath.length + 1));
+      }
+      return path;
+    });
+    await fetchFileTree();
+    await refreshGitStatus();
+    setNameDialog(null);
+  }
+
+  async function handleDelete(node: TreeNode) {
+    setFsActionPending(true);
+    try {
+      await postSandbox("unlink", {
+        path: toDaemonPath(node.path),
+        recursive: node.kind === "directory",
+      });
+      removeOpenPaths(node.path);
+      await fetchFileTree();
+      await refreshGitStatus();
+      setDeleteTarget(null);
+      toast.success(`Deleted "${node.name}"`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setFsActionPending(false);
+    }
+  }
+
+  async function handleNameDialogSubmit(name: string) {
+    setFsActionPending(true);
+    try {
+      if (nameDialog?.mode === "new-file") {
+        await handleCreateFile(name);
+        toast.success(`Created "${name}"`);
+      } else if (nameDialog?.mode === "new-folder") {
+        await handleCreateFolder(name);
+        toast.success(`Created folder "${name}"`);
+      } else if (nameDialog?.mode === "rename") {
+        await handleRename(name);
+        toast.success(`Renamed to "${name}"`);
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Operation failed");
+    } finally {
+      setFsActionPending(false);
+    }
+  }
 
   // Load file tree on first render
   const loadTreeCalledRef = useRef(false);
@@ -317,6 +508,20 @@ export function FileExplorer({
     openFile(path);
   }
 
+  function openCreateDialog(mode: "new-file" | "new-folder") {
+    const parentDir = selectedFile ? getParentTreePath(selectedFile) : "/";
+    setNameDialog({
+      mode,
+      parentDir,
+      node: {
+        name: "",
+        path: parentDir,
+        kind: "directory",
+        children: [],
+      },
+    });
+  }
+
   const tree = buildFileTree(files);
   const flatNodes = flattenTree(tree, expandedDirs);
 
@@ -391,9 +596,9 @@ export function FileExplorer({
     <div className="flex h-full w-full overflow-hidden">
       {/* File tree sidebar */}
       <div className="w-64 shrink-0 border-r flex flex-col overflow-hidden">
-        {/* Search */}
-        <div className="p-2 border-b">
-          <div className="relative">
+        {/* Search + create */}
+        <div className="flex items-center gap-1 p-2 border-b">
+          <div className="relative min-w-0 flex-1">
             <SearchSm
               size={14}
               className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
@@ -403,9 +608,40 @@ export function FileExplorer({
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search files..."
+              aria-label="Search files"
               className="w-full rounded-md border border-input bg-transparent pl-7 pr-2 py-1.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
             />
           </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-7 shrink-0"
+                aria-label="New file"
+                onClick={() => openCreateDialog("new-file")}
+              >
+                <FilePlus01 size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">New file</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-7 shrink-0"
+                aria-label="New folder"
+                onClick={() => openCreateDialog("new-folder")}
+              >
+                <FolderPlus size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">New folder</TooltipContent>
+          </Tooltip>
         </div>
 
         {/* Tree */}
@@ -416,59 +652,50 @@ export function FileExplorer({
               const isDir = node.kind === "directory";
               const isExpanded = expandedDirs.has(node.path);
               const isSelected = selectedFile === node.path;
-
-              const { Icon: FileVisualIcon, color: fileColor } = getFileVisual(
-                node.name,
-              );
+              const parentDir = getDirectoryContextPath(node.path, node.kind);
 
               return (
-                <button
+                <FileTreeRow
                   key={node.path}
-                  type="button"
-                  className={cn(
-                    "flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-[13px] hover:bg-accent transition-colors",
-                    isSelected && "bg-accent",
-                  )}
-                  style={{ paddingLeft: `${depth * 14 + 8}px` }}
-                  onClick={() => {
+                  node={node}
+                  depth={depth}
+                  isExpanded={isExpanded}
+                  isSelected={isSelected}
+                  fileVisual={getFileVisual(node.name)}
+                  onOpen={() => {
                     if (isDir) {
                       toggleDir(node.path);
                     } else {
                       handleFileClick(node.path);
                     }
                   }}
-                >
-                  {isDir ? (
-                    <>
-                      {isExpanded ? (
-                        <ChevronDown
-                          size={14}
-                          className="shrink-0 text-muted-foreground"
-                        />
-                      ) : (
-                        <ChevronRight
-                          size={14}
-                          className="shrink-0 text-muted-foreground"
-                        />
-                      )}
-                      <Folder
-                        size={16}
-                        className="shrink-0"
-                        style={{ color: FOLDER_COLOR }}
-                      />
-                    </>
-                  ) : (
-                    <>
-                      <span className="w-3.5 shrink-0" />
-                      <FileVisualIcon
-                        size={16}
-                        className="shrink-0"
-                        style={{ color: fileColor }}
-                      />
-                    </>
-                  )}
-                  <span className="truncate">{node.name}</span>
-                </button>
+                  onNewFile={() =>
+                    setNameDialog({
+                      mode: "new-file",
+                      node,
+                      parentDir,
+                    })
+                  }
+                  onNewFolder={() =>
+                    setNameDialog({
+                      mode: "new-folder",
+                      node,
+                      parentDir,
+                    })
+                  }
+                  onCopyPath={() => copyText("Path", toTreePath(node.path))}
+                  onCopyRelativePath={() =>
+                    copyText("Relative path", toDaemonPath(node.path))
+                  }
+                  onRename={() =>
+                    setNameDialog({
+                      mode: "rename",
+                      node,
+                      parentDir,
+                    })
+                  }
+                  onDelete={() => setDeleteTarget(node)}
+                />
               );
             })}
             {treeLoaded && filteredNodes.length === 0 && (
@@ -662,6 +889,60 @@ export function FileExplorer({
           </div>
         )}
       </div>
+
+      <FileExplorerNameDialog
+        open={nameDialog !== null}
+        mode={nameDialog?.mode ?? "new-file"}
+        initialName={nameDialog?.mode === "rename" ? nameDialog.node.name : ""}
+        parentLabel={
+          nameDialog && nameDialog.mode !== "rename"
+            ? nameDialog.parentDir === "/"
+              ? "/"
+              : toDaemonPath(nameDialog.parentDir)
+            : undefined
+        }
+        isPending={fsActionPending}
+        onSubmit={handleNameDialogSubmit}
+        onOpenChange={(open) => {
+          if (!open && !fsActionPending) setNameDialog(null);
+        }}
+      />
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open && !fsActionPending) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {deleteTarget?.kind === "directory" ? "folder" : "file"}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete{" "}
+              <span className="font-mono">{deleteTarget?.name}</span>
+              {deleteTarget?.kind === "directory"
+                ? " and everything inside it."
+                : "."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={fsActionPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={fsActionPending || !deleteTarget}
+              onClick={(e) => {
+                e.preventDefault();
+                if (deleteTarget) void handleDelete(deleteTarget);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -147,6 +147,7 @@ export function FileExplorer({
 }: FileExplorerProps) {
   // File tree state
   const [files, setFiles] = useState<string[]>([]);
+  const [directories, setDirectories] = useState<string[]>([]);
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [selectedTreeNode, setSelectedTreeNode] = useState<TreeNode | null>(
@@ -313,7 +314,7 @@ export function FileExplorer({
   async function handleCreateFile(name: string) {
     if (!nameDialog) return;
     const filePath = joinTreePath(nameDialog.parentDir, name);
-    if (pathExistsInFileList(filePath, files)) {
+    if (pathExistsInFileList(filePath, files, directories)) {
       throw new Error(`"${name}" already exists`);
     }
     await postSandbox("write", {
@@ -329,27 +330,14 @@ export function FileExplorer({
   async function handleCreateFolder(name: string) {
     if (!nameDialog) return;
     const folderPath = joinTreePath(nameDialog.parentDir, name);
-    if (pathExistsInFileList(folderPath, files)) {
+    if (pathExistsInFileList(folderPath, files, directories)) {
       throw new Error(`"${name}" already exists`);
     }
-    const gitkeepPath = joinTreePath(folderPath, ".gitkeep");
-    await postSandbox("mkdir", { path: toDaemonPath(folderPath) });
-    try {
-      await postSandbox("write", {
-        path: toDaemonPath(gitkeepPath),
-        content: "",
-      });
-    } catch (err) {
-      try {
-        await postSandbox("unlink", {
-          path: toDaemonPath(folderPath),
-          recursive: true,
-        });
-      } catch {
-        // Best-effort rollback if the placeholder write fails.
-      }
-      throw err;
-    }
+    const daemonFolderPath = toDaemonPath(folderPath);
+    await postSandbox("mkdir", { path: daemonFolderPath });
+    setDirectories((prev) =>
+      prev.includes(daemonFolderPath) ? prev : [...prev, daemonFolderPath],
+    );
     await fetchFileTree();
     await refreshGitStatus();
     setNameDialog(null);
@@ -376,7 +364,7 @@ export function FileExplorer({
       setNameDialog(null);
       return;
     }
-    if (pathExistsInFileList(toPath, files)) {
+    if (pathExistsInFileList(toPath, files, directories)) {
       throw new Error(`"${name}" already exists`);
     }
     await postSandbox("rename", {
@@ -478,8 +466,20 @@ export function FileExplorer({
         }
         return;
       }
-      const data = (await res.json()) as { files?: string[] };
-      setFiles(data.files ?? []);
+      const data = (await res.json()) as {
+        files?: string[];
+        directories?: string[];
+      };
+      const nextFiles = data.files ?? [];
+      setFiles(nextFiles);
+      setDirectories((prev) => {
+        if (data.directories !== undefined) return data.directories;
+        // Legacy daemons omit `directories`; keep client-side empty dirs
+        // until the sandbox daemon is restarted with directory support.
+        return prev.filter(
+          (dir) => !pathExistsInFileList(toTreePath(dir), nextFiles),
+        );
+      });
       setTreeLoaded(true);
     } finally {
       setLoading(false);
@@ -648,7 +648,7 @@ export function FileExplorer({
     });
   }
 
-  const tree = buildFileTree(files);
+  const tree = buildFileTree(files, directories);
   const flatNodes = flattenTree(tree, expandedDirs);
 
   // Filter by search

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -34,6 +34,7 @@ import {
 import { toast } from "sonner";
 import { useChatStream } from "@/web/components/chat/context";
 import { usePanelActions } from "@/web/layouts/shell-layout";
+import { KEYS } from "@/web/lib/query-keys";
 import { saveChangesDebug } from "../../../thread/github/save-changes-debug.ts";
 import {
   fetchGitStatus,
@@ -47,15 +48,18 @@ import {
 import { FileTreeRow } from "./file-tree-row";
 import {
   buildFileTree,
+  decoBlockKeyFromTreePath,
   flattenTree,
   getAncestorDirectories,
   getDirectoryContextPath,
   getLanguageFromPath,
   getParentTreePath,
   joinTreePath,
+  pathExistsInFileList,
   stripLineNumbers,
   toDaemonPath,
   toTreePath,
+  validateExplorerEntryName,
 } from "./utils";
 
 // Configure Monaco CDN (shared with workflow editor)
@@ -145,6 +149,9 @@ export function FileExplorer({
   const [files, setFiles] = useState<string[]>([]);
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [selectedTreeNode, setSelectedTreeNode] = useState<TreeNode | null>(
+    null,
+  );
   const [openTabs, setOpenTabs] = useState<string[]>([]);
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(false);
@@ -207,6 +214,47 @@ export function FileExplorer({
     );
   }
 
+  function invalidateDecofileCacheForDeletedPath(treePath: string) {
+    const blockKey = decoBlockKeyFromTreePath(treePath);
+    if (!blockKey) return;
+    const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
+    queryClient.setQueryData(
+      KEYS.decofile(cacheKey),
+      (current: Record<string, unknown> | undefined) => {
+        if (!current) return current;
+        const { [blockKey]: _removed, ...rest } = current;
+        return rest;
+      },
+    );
+    void queryClient.invalidateQueries({ queryKey: KEYS.liveMeta(cacheKey) });
+  }
+
+  function invalidateDecofileCachesForDeletedNode(node: TreeNode) {
+    const pathsToInvalidate =
+      node.kind === "file"
+        ? [node.path]
+        : files
+            .filter((file) => file.startsWith(".deco/blocks/"))
+            .map((file) => toTreePath(file))
+            .filter(
+              (path) => path === node.path || path.startsWith(`${node.path}/`),
+            );
+    for (const path of pathsToInvalidate) {
+      invalidateDecofileCacheForDeletedPath(path);
+    }
+  }
+
+  function getDirtyOpenPathsUnder(prefix: string): string[] {
+    const normalizedPrefix = toTreePath(prefix);
+    return openTabs.filter((tab) => {
+      if (tab !== normalizedPrefix && !tab.startsWith(`${normalizedPrefix}/`)) {
+        return false;
+      }
+      const buf = buffers.get(tab);
+      return Boolean(buf?.loaded && buf.editorValue !== buf.savedContent);
+    });
+  }
+
   function remapOpenPaths(remap: (path: string) => string | null) {
     setOpenTabs((prev) =>
       prev
@@ -226,10 +274,31 @@ export function FileExplorer({
       }
       return next;
     });
+    setSelectedTreeNode((prev) => {
+      if (!prev) return prev;
+      const nextPath = remap(prev.path);
+      if (!nextPath) return null;
+      if (nextPath === prev.path) return prev;
+      return {
+        ...prev,
+        path: nextPath,
+        name: nextPath.split("/").pop() ?? nextPath,
+      };
+    });
   }
 
   function removeOpenPaths(prefix: string) {
     const normalizedPrefix = toTreePath(prefix);
+    setSelectedTreeNode((prev) => {
+      if (!prev) return prev;
+      if (
+        prev.path === normalizedPrefix ||
+        prev.path.startsWith(`${normalizedPrefix}/`)
+      ) {
+        return null;
+      }
+      return prev;
+    });
     remapOpenPaths((path) => {
       if (
         path === normalizedPrefix ||
@@ -244,6 +313,9 @@ export function FileExplorer({
   async function handleCreateFile(name: string) {
     if (!nameDialog) return;
     const filePath = joinTreePath(nameDialog.parentDir, name);
+    if (pathExistsInFileList(filePath, files)) {
+      throw new Error(`"${name}" already exists`);
+    }
     await postSandbox("write", {
       path: toDaemonPath(filePath),
       content: "",
@@ -257,12 +329,27 @@ export function FileExplorer({
   async function handleCreateFolder(name: string) {
     if (!nameDialog) return;
     const folderPath = joinTreePath(nameDialog.parentDir, name);
+    if (pathExistsInFileList(folderPath, files)) {
+      throw new Error(`"${name}" already exists`);
+    }
     const gitkeepPath = joinTreePath(folderPath, ".gitkeep");
     await postSandbox("mkdir", { path: toDaemonPath(folderPath) });
-    await postSandbox("write", {
-      path: toDaemonPath(gitkeepPath),
-      content: "",
-    });
+    try {
+      await postSandbox("write", {
+        path: toDaemonPath(gitkeepPath),
+        content: "",
+      });
+    } catch (err) {
+      try {
+        await postSandbox("unlink", {
+          path: toDaemonPath(folderPath),
+          recursive: true,
+        });
+      } catch {
+        // Best-effort rollback if the placeholder write fails.
+      }
+      throw err;
+    }
     await fetchFileTree();
     await refreshGitStatus();
     setNameDialog(null);
@@ -271,6 +358,12 @@ export function FileExplorer({
       for (const dir of getAncestorDirectories(folderPath)) next.add(dir);
       next.add(folderPath);
       return next;
+    });
+    setSelectedTreeNode({
+      name,
+      path: folderPath,
+      kind: "directory",
+      children: [],
     });
   }
 
@@ -282,6 +375,9 @@ export function FileExplorer({
     if (toPath === fromPath) {
       setNameDialog(null);
       return;
+    }
+    if (pathExistsInFileList(toPath, files)) {
+      throw new Error(`"${name}" already exists`);
     }
     await postSandbox("rename", {
       from: toDaemonPath(fromPath),
@@ -306,6 +402,7 @@ export function FileExplorer({
         path: toDaemonPath(node.path),
         recursive: node.kind === "directory",
       });
+      invalidateDecofileCachesForDeletedNode(node);
       removeOpenPaths(node.path);
       await fetchFileTree();
       await refreshGitStatus();
@@ -319,6 +416,11 @@ export function FileExplorer({
   }
 
   async function handleNameDialogSubmit(name: string) {
+    const validationError = validateExplorerEntryName(name);
+    if (validationError) {
+      toast.error(validationError);
+      return;
+    }
     setFsActionPending(true);
     try {
       if (nameDialog?.mode === "new-file") {
@@ -370,7 +472,12 @@ export function FileExplorer({
           body: JSON.stringify({ pattern: "**/*" }),
         },
       );
-      if (!res.ok) return;
+      if (!res.ok) {
+        if (treeLoaded) {
+          toast.error("Failed to refresh file tree");
+        }
+        return;
+      }
       const data = (await res.json()) as { files?: string[] };
       setFiles(data.files ?? []);
       setTreeLoaded(true);
@@ -463,6 +570,12 @@ export function FileExplorer({
 
   function openFile(path: string) {
     setSelectedFile(path);
+    setSelectedTreeNode({
+      name: path.split("/").pop() ?? path,
+      path,
+      kind: "file",
+      children: [],
+    });
     setAskAi(null);
     if (!openTabs.includes(path)) {
       setOpenTabs((prev) => [...prev, path]);
@@ -508,8 +621,21 @@ export function FileExplorer({
     openFile(path);
   }
 
+  function getCreateParentDir(): string {
+    if (selectedTreeNode?.kind === "directory") {
+      return selectedTreeNode.path;
+    }
+    if (selectedTreeNode?.kind === "file") {
+      return getParentTreePath(selectedTreeNode.path);
+    }
+    if (selectedFile) {
+      return getParentTreePath(selectedFile);
+    }
+    return "/";
+  }
+
   function openCreateDialog(mode: "new-file" | "new-folder") {
-    const parentDir = selectedFile ? getParentTreePath(selectedFile) : "/";
+    const parentDir = getCreateParentDir();
     setNameDialog({
       mode,
       parentDir,
@@ -536,6 +662,10 @@ export function FileExplorer({
   const isDirty =
     currentBuffer?.loaded &&
     currentBuffer.editorValue !== currentBuffer.savedContent;
+
+  const deleteDirtyPaths = deleteTarget
+    ? getDirtyOpenPathsUnder(deleteTarget.path)
+    : [];
 
   const handleEditorMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
@@ -651,7 +781,7 @@ export function FileExplorer({
               const { node, depth } = row;
               const isDir = node.kind === "directory";
               const isExpanded = expandedDirs.has(node.path);
-              const isSelected = selectedFile === node.path;
+              const isSelected = selectedTreeNode?.path === node.path;
               const parentDir = getDirectoryContextPath(node.path, node.kind);
 
               return (
@@ -662,6 +792,7 @@ export function FileExplorer({
                   isExpanded={isExpanded}
                   isSelected={isSelected}
                   fileVisual={getFileVisual(node.name)}
+                  onSelect={() => setSelectedTreeNode(node)}
                   onOpen={() => {
                     if (isDir) {
                       toggleDir(node.path);
@@ -925,6 +1056,14 @@ export function FileExplorer({
               {deleteTarget?.kind === "directory"
                 ? " and everything inside it."
                 : "."}
+              {deleteDirtyPaths.length > 0 && (
+                <>
+                  {" "}
+                  {deleteDirtyPaths.length === 1
+                    ? "One open file has unsaved changes that will be lost."
+                    : `${deleteDirtyPaths.length} open files have unsaved changes that will be lost.`}
+                </>
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-tree-row.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-tree-row.tsx
@@ -24,6 +24,7 @@ export function FileTreeRow({
   isSelected,
   fileVisual,
   onOpen,
+  onSelect,
   onNewFile,
   onNewFolder,
   onCopyPath,
@@ -37,6 +38,7 @@ export function FileTreeRow({
   isSelected: boolean;
   fileVisual: { Icon: FileIcon; color: string };
   onOpen: () => void;
+  onSelect: () => void;
   onNewFile: () => void;
   onNewFolder: () => void;
   onCopyPath: () => void;
@@ -57,7 +59,10 @@ export function FileTreeRow({
             isSelected && "bg-accent",
           )}
           style={{ paddingLeft: `${depth * 14 + 8}px` }}
-          onClick={onOpen}
+          onClick={() => {
+            onSelect();
+            onOpen();
+          }}
         >
           {isDir ? (
             <>

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-tree-row.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-tree-row.tsx
@@ -1,0 +1,110 @@
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@deco/ui/components/context-menu.tsx";
+import { ChevronDown, ChevronRight, Folder } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.js";
+import type { TreeNode } from "./types";
+
+type FileIcon = React.ComponentType<{
+  size?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}>;
+
+const FOLDER_COLOR = "#d9a441";
+
+export function FileTreeRow({
+  node,
+  depth,
+  isExpanded,
+  isSelected,
+  fileVisual,
+  onOpen,
+  onNewFile,
+  onNewFolder,
+  onCopyPath,
+  onCopyRelativePath,
+  onRename,
+  onDelete,
+}: {
+  node: TreeNode;
+  depth: number;
+  isExpanded: boolean;
+  isSelected: boolean;
+  fileVisual: { Icon: FileIcon; color: string };
+  onOpen: () => void;
+  onNewFile: () => void;
+  onNewFolder: () => void;
+  onCopyPath: () => void;
+  onCopyRelativePath: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  const isDir = node.kind === "directory";
+  const { Icon: FileVisualIcon, color: fileColor } = fileVisual;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-[13px] hover:bg-accent transition-colors",
+            isSelected && "bg-accent",
+          )}
+          style={{ paddingLeft: `${depth * 14 + 8}px` }}
+          onClick={onOpen}
+        >
+          {isDir ? (
+            <>
+              {isExpanded ? (
+                <ChevronDown
+                  size={14}
+                  className="shrink-0 text-muted-foreground"
+                />
+              ) : (
+                <ChevronRight
+                  size={14}
+                  className="shrink-0 text-muted-foreground"
+                />
+              )}
+              <Folder
+                size={16}
+                className="shrink-0"
+                style={{ color: FOLDER_COLOR }}
+              />
+            </>
+          ) : (
+            <>
+              <span className="w-3.5 shrink-0" />
+              <FileVisualIcon
+                size={16}
+                className="shrink-0"
+                style={{ color: fileColor }}
+              />
+            </>
+          )}
+          <span className="truncate">{node.name}</span>
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-52">
+        <ContextMenuItem onSelect={onNewFile}>New File</ContextMenuItem>
+        <ContextMenuItem onSelect={onNewFolder}>New Folder</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onCopyPath}>Copy Path</ContextMenuItem>
+        <ContextMenuItem onSelect={onCopyRelativePath}>
+          Copy Relative Path
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onRename}>Rename</ContextMenuItem>
+        <ContextMenuItem variant="destructive" onSelect={onDelete}>
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import {
+  decoBlockKeyFromTreePath,
+  getDirectoryContextPath,
+  getParentTreePath,
+  joinTreePath,
+  pathExistsInFileList,
+  toDaemonPath,
+  validateExplorerEntryName,
+} from "./utils";
+
+describe("file-explorer utils", () => {
+  it("joinTreePath joins under parent", () => {
+    expect(joinTreePath("/src", "index.ts")).toBe("/src/index.ts");
+    expect(joinTreePath("/", "README.md")).toBe("/README.md");
+  });
+
+  it("getDirectoryContextPath uses directory path for folders", () => {
+    expect(getDirectoryContextPath("/src", "directory")).toBe("/src");
+    expect(getDirectoryContextPath("/src/index.ts", "file")).toBe("/src");
+  });
+
+  it("validateExplorerEntryName rejects unsafe names", () => {
+    expect(validateExplorerEntryName("ok.ts")).toBeNull();
+    expect(validateExplorerEntryName("../evil")).toMatch(/cannot contain/);
+    expect(validateExplorerEntryName("a/b")).toMatch(/cannot contain/);
+    expect(validateExplorerEntryName(".env")).toMatch(
+      /cannot start with a dot/,
+    );
+    expect(validateExplorerEntryName("")).toMatch(/required/i);
+  });
+
+  it("pathExistsInFileList detects files and directories", () => {
+    const files = ["src/index.ts", "src/utils.ts", "README.md"];
+    expect(pathExistsInFileList("/src/index.ts", files)).toBe(true);
+    expect(pathExistsInFileList("/src", files)).toBe(true);
+    expect(pathExistsInFileList("/missing", files)).toBe(false);
+  });
+
+  it("decoBlockKeyFromTreePath decodes block keys", () => {
+    expect(decoBlockKeyFromTreePath("/.deco/blocks/Header.json")).toBe(
+      "Header",
+    );
+    expect(decoBlockKeyFromTreePath("/.deco/blocks/hello%20world.json")).toBe(
+      "hello world",
+    );
+    expect(decoBlockKeyFromTreePath("/src/index.ts")).toBeNull();
+  });
+
+  it("toDaemonPath strips leading slash", () => {
+    expect(toDaemonPath("/src/index.ts")).toBe("src/index.ts");
+    expect(getParentTreePath("/src/index.ts")).toBe("/src");
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import {
+  buildFileTree,
   decoBlockKeyFromTreePath,
+  flattenTree,
   getDirectoryContextPath,
   getParentTreePath,
   joinTreePath,
   pathExistsInFileList,
   toDaemonPath,
+  toTreePath,
   validateExplorerEntryName,
 } from "./utils";
 
@@ -32,9 +35,22 @@ describe("file-explorer utils", () => {
 
   it("pathExistsInFileList detects files and directories", () => {
     const files = ["src/index.ts", "src/utils.ts", "README.md"];
-    expect(pathExistsInFileList("/src/index.ts", files)).toBe(true);
-    expect(pathExistsInFileList("/src", files)).toBe(true);
-    expect(pathExistsInFileList("/missing", files)).toBe(false);
+    const directories = ["empty-dir"];
+    expect(pathExistsInFileList("/src/index.ts", files, directories)).toBe(
+      true,
+    );
+    expect(pathExistsInFileList("/src", files, directories)).toBe(true);
+    expect(pathExistsInFileList("/empty-dir", files, directories)).toBe(true);
+    expect(pathExistsInFileList("/missing", files, directories)).toBe(false);
+  });
+
+  it("buildFileTree includes empty directories", () => {
+    const tree = buildFileTree([], ["tavano-folder"]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.name).toBe("tavano-folder");
+    expect(tree[0]?.kind).toBe("directory");
+    const rows = flattenTree(tree, new Set());
+    expect(rows.some((row) => row.node.name === "tavano-folder")).toBe(true);
   });
 
   it("decoBlockKeyFromTreePath decodes block keys", () => {

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -67,4 +67,10 @@ describe("file-explorer utils", () => {
     expect(toDaemonPath("/src/index.ts")).toBe("src/index.ts");
     expect(getParentTreePath("/src/index.ts")).toBe("/src");
   });
+
+  it("toTreePath adds leading slash", () => {
+    expect(toTreePath("src/index.ts")).toBe("/src/index.ts");
+    expect(toTreePath("/src/index.ts")).toBe("/src/index.ts");
+    expect(toTreePath("")).toBe("/");
+  });
 });

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -41,6 +41,51 @@ export function getDirectoryContextPath(
   return kind === "directory" ? treePath : getParentTreePath(treePath);
 }
 
+/** Single-segment name validation for create/rename in the file explorer. */
+export function validateExplorerEntryName(name: string): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) return "Name is required";
+  if (
+    trimmed.includes("/") ||
+    trimmed.includes("\\") ||
+    trimmed.includes("..") ||
+    trimmed.includes("\0")
+  ) {
+    return "Name cannot contain /, \\, or ..";
+  }
+  if (trimmed.startsWith(".")) {
+    return "Name cannot start with a dot";
+  }
+  return null;
+}
+
+/** Whether `treePath` already exists in the glob file list (file or directory). */
+export function pathExistsInFileList(
+  treePath: string,
+  fileList: readonly string[],
+): boolean {
+  const daemonPath = toDaemonPath(treePath);
+  if (fileList.includes(daemonPath)) return true;
+  if (!daemonPath) return false;
+  const prefix = `${daemonPath}/`;
+  return fileList.some((file) => file.startsWith(prefix));
+}
+
+/** Extract decofile block key from `.deco/blocks/<key>.json`, if applicable. */
+export function decoBlockKeyFromTreePath(treePath: string): string | null {
+  const daemonPath = toDaemonPath(treePath);
+  const prefix = ".deco/blocks/";
+  if (!daemonPath.startsWith(prefix) || !daemonPath.endsWith(".json")) {
+    return null;
+  }
+  const stem = daemonPath.slice(prefix.length, -".json".length);
+  try {
+    return decodeURIComponent(stem);
+  } catch {
+    return stem;
+  }
+}
+
 export function getLanguageFromPath(filepath: string | null) {
   if (!filepath) return "plaintext";
 
@@ -136,6 +181,7 @@ export function flattenTree(
   const rows: FlatNode[] = [];
 
   for (const node of nodes) {
+    if (node.name === ".gitkeep") continue;
     rows.push({ node, depth });
 
     if (

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -63,12 +63,17 @@ export function validateExplorerEntryName(name: string): string | null {
 export function pathExistsInFileList(
   treePath: string,
   fileList: readonly string[],
+  directoryList: readonly string[] = [],
 ): boolean {
   const daemonPath = toDaemonPath(treePath);
   if (fileList.includes(daemonPath)) return true;
+  if (directoryList.includes(daemonPath)) return true;
   if (!daemonPath) return false;
   const prefix = `${daemonPath}/`;
-  return fileList.some((file) => file.startsWith(prefix));
+  return (
+    fileList.some((file) => file.startsWith(prefix)) ||
+    directoryList.some((dir) => dir.startsWith(prefix))
+  );
 }
 
 /** Extract decofile block key from `.deco/blocks/<key>.json`, if applicable. */
@@ -126,12 +131,39 @@ export function getAncestorDirectories(filepath: string) {
   return directories;
 }
 
-export function buildFileTree(files: string[]): TreeNode[] {
+export function buildFileTree(
+  files: string[],
+  directories: readonly string[] = [],
+): TreeNode[] {
   const root: TreeNode = {
     name: "/",
     path: "/",
     kind: "directory",
     children: [],
+  };
+
+  const ensureDirectory = (dirPath: string) => {
+    const normalized = normalizePath(dirPath);
+    const parts = normalized.split("/").filter(Boolean);
+    let current = root;
+    let currentPath = "";
+
+    for (const part of parts) {
+      currentPath += `/${part}`;
+      let child = current.children.find((entry) => entry.name === part);
+      if (!child) {
+        child = {
+          name: part,
+          path: currentPath,
+          kind: "directory",
+          children: [],
+        };
+        current.children.push(child);
+      } else if (child.kind === "file") {
+        child.kind = "directory";
+      }
+      current = child;
+    }
   };
 
   for (const rawFile of files) {
@@ -157,6 +189,10 @@ export function buildFileTree(files: string[]): TreeNode[] {
 
       current = child;
     });
+  }
+
+  for (const rawDirectory of directories) {
+    ensureDirectory(toTreePath(rawDirectory));
   }
 
   const sortNodes = (nodes: TreeNode[]) => {

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -8,6 +8,39 @@ function normalizePath(path: string) {
   return normalized.replace(/\/+/g, "/");
 }
 
+/** The daemon expects relative paths (no leading slash). */
+export function toDaemonPath(treePath: string) {
+  return treePath.startsWith("/") ? treePath.slice(1) : treePath;
+}
+
+/** Path as shown in the explorer tree (leading slash). */
+export function toTreePath(daemonPath: string) {
+  if (!daemonPath.trim()) return "/";
+  return daemonPath.startsWith("/") ? daemonPath : `/${daemonPath}`;
+}
+
+export function getParentTreePath(treePath: string): string {
+  const normalized = toTreePath(treePath);
+  if (normalized === "/") return "/";
+  const parts = normalized.split("/").filter(Boolean);
+  parts.pop();
+  return parts.length === 0 ? "/" : `/${parts.join("/")}`;
+}
+
+export function joinTreePath(parent: string, name: string): string {
+  const trimmedName = name.replace(/^\/+|\/+$/g, "");
+  if (!trimmedName) return toTreePath(parent);
+  const base = parent === "/" ? "" : parent;
+  return toTreePath(`${base}/${trimmedName}`);
+}
+
+export function getDirectoryContextPath(
+  treePath: string,
+  kind: TreeNode["kind"],
+): string {
+  return kind === "directory" ? treePath : getParentTreePath(treePath);
+}
+
 export function getLanguageFromPath(filepath: string | null) {
   if (!filepath) return "plaintext";
 

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -63,6 +63,8 @@ import {
   makeReadHandler,
   makeWriteHandler,
   makeUnlinkHandler,
+  makeMkdirHandler,
+  makeRenameHandler,
   makeEditHandler,
   makeGrepHandler,
   makeGlobHandler,
@@ -330,6 +332,8 @@ const fsDeps = {
 const readH = makeReadHandler(fsDeps);
 const writeH = makeWriteHandler(fsDeps);
 const unlinkH = makeUnlinkHandler(fsDeps);
+const mkdirH = makeMkdirHandler(fsDeps);
+const renameH = makeRenameHandler(fsDeps);
 const editH = makeEditHandler(fsDeps);
 const grepH = makeGrepHandler(fsDeps);
 const globH = makeGlobHandler(fsDeps);
@@ -579,6 +583,8 @@ const fsH: Record<string, (req: Request) => Response | Promise<Response>> = {
   "/read": readH,
   "/write": writeH,
   "/unlink": unlinkH,
+  "/mkdir": mkdirH,
+  "/rename": renameH,
   "/edit": editH,
   "/grep": grepH,
   "/glob": globH,

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach } from "bun:test";
 import {
   mkdtempSync,
   mkdirSync,
+  existsSync,
   rmSync,
   writeFileSync,
   readFileSync,
@@ -13,6 +14,8 @@ import {
   makeReadHandler,
   makeWriteHandler,
   makeUnlinkHandler,
+  makeMkdirHandler,
+  makeRenameHandler,
   makeEditHandler,
   makeGrepHandler,
   makeGlobHandler,
@@ -168,19 +171,50 @@ describe("fs handlers", () => {
     expect(body.existed).toBe(false);
   });
 
-  it("unlink: rejects paths outside .deco/blocks", async () => {
+  it("unlink: deletes any file under the workspace root", async () => {
     writeFileSync(join(appRoot, "secret.txt"), "x");
     const h = makeUnlinkHandler({ appRoot, repoDir: appRoot });
     const res = await h(post("/_sandbox/unlink", { path: "secret.txt" }));
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    expect(() => readFileSync(join(appRoot, "secret.txt"))).toThrow();
   });
 
-  it("unlink: refuses directories", async () => {
+  it("unlink: refuses directories without recursive", async () => {
     const blockDir = join(appRoot, ".deco", "blocks");
     mkdirSync(blockDir, { recursive: true });
     const h = makeUnlinkHandler({ appRoot, repoDir: appRoot });
     const res = await h(post("/_sandbox/unlink", { path: ".deco/blocks" }));
     expect(res.status).toBe(400);
+  });
+
+  it("unlink: deletes directories when recursive is true", async () => {
+    const dir = join(appRoot, "nested", "dir");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "a.txt"), "x");
+    const h = makeUnlinkHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/unlink", { path: "nested", recursive: true }),
+    );
+    expect(res.status).toBe(200);
+    expect(() => readFileSync(join(dir, "a.txt"))).toThrow();
+  });
+
+  it("mkdir: creates a directory", async () => {
+    const h = makeMkdirHandler({ appRoot, repoDir: appRoot });
+    const res = await h(post("/_sandbox/mkdir", { path: "new-dir/nested" }));
+    expect(res.status).toBe(200);
+    expect(existsSync(join(appRoot, "new-dir", "nested"))).toBe(true);
+  });
+
+  it("rename: moves a file", async () => {
+    writeFileSync(join(appRoot, "old.txt"), "hello");
+    const h = makeRenameHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/rename", { from: "old.txt", to: "new.txt" }),
+    );
+    expect(res.status).toBe(200);
+    expect(readFileSync(join(appRoot, "new.txt"), "utf-8")).toBe("hello");
+    expect(() => readFileSync(join(appRoot, "old.txt"))).toThrow();
   });
 
   it("edit: rejects when old_string doesn't match", async () => {

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -19,6 +19,7 @@ import {
   makeEditHandler,
   makeGrepHandler,
   makeGlobHandler,
+  collectEmptyDirectories,
 } from "./fs";
 
 const hasRg = spawnSync("which", ["rg"]).status === 0;
@@ -275,8 +276,12 @@ describe("fs handlers", () => {
     writeFileSync(join(appRoot, "x.txt"), "");
     const h = makeGlobHandler({ appRoot, repoDir: appRoot });
     const res = await h(post("/_sandbox/glob", { pattern: "*.txt" }));
-    const body = (await res.json()) as { files: string[] };
+    const body = (await res.json()) as {
+      files: string[];
+      directories?: string[];
+    };
     expect(body.files).toContain("x.txt");
+    expect(body.directories ?? []).toEqual([]);
   });
 
   it("glob: includes dot-directories such as .deco", async () => {
@@ -284,7 +289,10 @@ describe("fs handlers", () => {
     writeFileSync(join(appRoot, ".deco/blocks/foo.json"), "{}");
     const h = makeGlobHandler({ appRoot, repoDir: appRoot });
     const res = await h(post("/_sandbox/glob", { pattern: "**/*" }));
-    const body = (await res.json()) as { files: string[] };
+    const body = (await res.json()) as {
+      files: string[];
+      directories?: string[];
+    };
     expect(body.files).toContain(".deco/blocks/foo.json");
   });
 
@@ -299,13 +307,30 @@ describe("fs handlers", () => {
     expect(body.files).toContain(".deco/blocks/foo.json");
   });
 
-  it("glob: includes .gitkeep folder markers", async () => {
+  it("glob: includes empty directories without placeholder files", async () => {
+    mkdirSync(join(appRoot, "tavano-folder"), { recursive: true });
+    const h = makeGlobHandler({ appRoot, repoDir: appRoot });
+    const res = await h(post("/_sandbox/glob", { pattern: "**/*" }));
+    const body = (await res.json()) as {
+      files: string[];
+      directories: string[];
+    };
+    expect(body.directories).toContain("tavano-folder");
+  });
+
+  it("glob: includes .gitkeep folder markers in files", async () => {
     mkdirSync(join(appRoot, "empty-dir"), { recursive: true });
     writeFileSync(join(appRoot, "empty-dir", ".gitkeep"), "");
     const h = makeGlobHandler({ appRoot, repoDir: appRoot });
     const res = await h(post("/_sandbox/glob", { pattern: "**/*" }));
     const body = (await res.json()) as { files: string[] };
     expect(body.files).toContain("empty-dir/.gitkeep");
+  });
+
+  it("collectEmptyDirectories ignores parents of nested directories", () => {
+    expect(collectEmptyDirectories([], ["src", "src/components"])).toEqual([
+      "src/components",
+    ]);
   });
 
   it("unlink: refuses recursive delete of repository root", async () => {

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -298,4 +298,41 @@ describe("fs handlers", () => {
     expect(body.files).not.toContain(".env");
     expect(body.files).toContain(".deco/blocks/foo.json");
   });
+
+  it("glob: includes .gitkeep folder markers", async () => {
+    mkdirSync(join(appRoot, "empty-dir"), { recursive: true });
+    writeFileSync(join(appRoot, "empty-dir", ".gitkeep"), "");
+    const h = makeGlobHandler({ appRoot, repoDir: appRoot });
+    const res = await h(post("/_sandbox/glob", { pattern: "**/*" }));
+    const body = (await res.json()) as { files: string[] };
+    expect(body.files).toContain("empty-dir/.gitkeep");
+  });
+
+  it("unlink: refuses recursive delete of repository root", async () => {
+    const h = makeUnlinkHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/unlink", { path: ".", recursive: true }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("unlink: refuses deleting .git", async () => {
+    mkdirSync(join(appRoot, ".git"), { recursive: true });
+    writeFileSync(join(appRoot, ".git", "HEAD"), "ref: refs/heads/main\n");
+    const h = makeUnlinkHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/unlink", { path: ".git/HEAD", recursive: false }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rename: rejects destination that already exists", async () => {
+    writeFileSync(join(appRoot, "old.txt"), "hello");
+    writeFileSync(join(appRoot, "new.txt"), "taken");
+    const h = makeRenameHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/rename", { from: "old.txt", to: "new.txt" }),
+    );
+    expect(res.status).toBe(400);
+  });
 });

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -223,8 +223,12 @@ export function makeUnlinkHandler(deps: FsDeps) {
     if (!body.path || typeof body.path !== "string")
       return jsonResponse({ error: "path is required" }, 400);
     const normalized = body.path.replaceAll("\\", "/");
-    if (!normalized || normalized.includes("..")) {
-      return jsonResponse({ error: "Invalid path" }, 400);
+    const unlinkError = assertUnlinkAllowed(
+      normalized,
+      body.recursive === true,
+    );
+    if (unlinkError) {
+      return jsonResponse({ error: unlinkError }, 400);
     }
     const filePath = safePath(deps.appRoot, deps.repoDir, body.path);
     if (!filePath) return jsonResponse({ error: "Path escapes app root" }, 400);
@@ -695,10 +699,29 @@ const GLOB_RESULT_LIMIT = 1000;
 function isGlobPathAllowed(rel: string): boolean {
   for (const seg of rel.split("/")) {
     if (GLOB_EXCLUDE_DIRS.has(seg)) return false;
-    // Surface `.deco/**` without exposing other dotfiles (`.env`, `.npmrc`, …).
-    if (seg.startsWith(".") && seg !== ".deco") return false;
+    // Surface `.deco/**` and explorer `.gitkeep` folder markers without
+    // exposing other dotfiles (`.env`, `.npmrc`, …).
+    if (seg.startsWith(".") && seg !== ".deco" && seg !== ".gitkeep") {
+      return false;
+    }
   }
   return true;
+}
+
+/** Paths that must not be deleted via the sandbox unlink API. */
+function assertUnlinkAllowed(
+  normalized: string,
+  recursive: boolean,
+): string | null {
+  if (!normalized || normalized.includes("..")) return "Invalid path";
+  if (recursive && (normalized === "." || normalized === "")) {
+    return "Refusing to recursively delete the repository root";
+  }
+  const segments = normalized.split("/").filter(Boolean);
+  if (segments.includes(".git")) {
+    return "Refusing to delete .git";
+  }
+  return null;
 }
 
 export function makeGlobHandler(deps: FsDeps) {

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -724,6 +724,39 @@ function assertUnlinkAllowed(
   return null;
 }
 
+function toRepoRelativePath(
+  abs: string,
+  searchPath: string,
+  repoDir: string,
+): string {
+  return abs.startsWith(`${repoDir}/`)
+    ? abs.slice(repoDir.length + 1)
+    : abs.startsWith(`${searchPath}/`)
+      ? abs.slice(searchPath.length + 1)
+      : abs;
+}
+
+/** Empty directories have no nested files and no nested directories in the scan. */
+export function collectEmptyDirectories(
+  filePaths: readonly string[],
+  directoryPaths: readonly string[],
+): string[] {
+  const dirSet = new Set(directoryPaths);
+  const empty: string[] = [];
+  for (const dir of directoryPaths) {
+    if (!dir) continue;
+    const prefix = `${dir}/`;
+    const hasNestedFile = filePaths.some((file) => file.startsWith(prefix));
+    const hasNestedDirectory = [...dirSet].some(
+      (other) => other !== dir && other.startsWith(prefix),
+    );
+    if (!hasNestedFile && !hasNestedDirectory) {
+      empty.push(dir);
+    }
+  }
+  return empty;
+}
+
 export function makeGlobHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {
     let body: { pattern?: string; path?: string };
@@ -743,26 +776,35 @@ export function makeGlobHandler(deps: FsDeps) {
     // Bun.Glob — no external binary dependency. Returns paths relative
     // to `cwd`, which we re-anchor to repoDir for consistent UX.
     const glob = new Bun.Glob(body.pattern);
-    const files: string[] = [];
+    const filePaths: string[] = [];
+    const directoryPaths = new Set<string>();
     try {
       for await (const rel of glob.scan({
         cwd: searchPath,
-        onlyFiles: true,
+        onlyFiles: false,
         followSymlinks: false,
         dot: true,
       })) {
         if (!isGlobPathAllowed(rel)) continue;
         const abs = path.join(searchPath, rel);
-        files.push(
-          abs.startsWith(`${deps.repoDir}/`)
-            ? abs.slice(deps.repoDir.length + 1)
-            : abs,
-        );
-        if (files.length >= GLOB_RESULT_LIMIT) break;
+        let relPath: string;
+        try {
+          const stat = fs.statSync(abs);
+          relPath = toRepoRelativePath(abs, searchPath, deps.repoDir);
+          if (stat.isDirectory()) {
+            directoryPaths.add(relPath);
+          } else if (stat.isFile()) {
+            filePaths.push(relPath);
+          }
+        } catch {
+          continue;
+        }
+        if (filePaths.length >= GLOB_RESULT_LIMIT) break;
       }
     } catch (e) {
       return jsonResponse({ error: (e as Error).message }, 500);
     }
-    return jsonResponse({ files });
+    const directories = collectEmptyDirectories(filePaths, [...directoryPaths]);
+    return jsonResponse({ files: filePaths, directories });
   };
 }

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -207,12 +207,54 @@ export function makeWriteHandler(deps: FsDeps) {
 }
 
 /**
- * Delete a single file inside the workspace. Symmetric with `write` —
+ * Delete a file or directory inside the workspace. Symmetric with `write` —
  * same safePath clamp, same onWorkingTreeWrite signal so the branch
  * dirty-state recomputes. Idempotent (returns ok with `existed: false`
  * for a missing path) so the client can retry without races.
  */
 export function makeUnlinkHandler(deps: FsDeps) {
+  return async (req: Request): Promise<Response> => {
+    let body: { path?: string; recursive?: boolean };
+    try {
+      body = (await parseJsonBody(req)) as typeof body;
+    } catch (e) {
+      return jsonResponse({ error: (e as Error).message }, 400);
+    }
+    if (!body.path || typeof body.path !== "string")
+      return jsonResponse({ error: "path is required" }, 400);
+    const normalized = body.path.replaceAll("\\", "/");
+    if (!normalized || normalized.includes("..")) {
+      return jsonResponse({ error: "Invalid path" }, 400);
+    }
+    const filePath = safePath(deps.appRoot, deps.repoDir, body.path);
+    if (!filePath) return jsonResponse({ error: "Path escapes app root" }, 400);
+    let existed = true;
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.isDirectory()) {
+        if (!body.recursive) {
+          return jsonResponse(
+            { error: "Refusing to unlink directory without recursive: true" },
+            400,
+          );
+        }
+        fs.rmSync(filePath, { recursive: true, force: true });
+      } else {
+        fs.unlinkSync(filePath);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        existed = false;
+      } else {
+        return jsonResponse({ error: (err as Error).message }, 500);
+      }
+    }
+    if (existed) deps.onWorkingTreeWrite?.();
+    return jsonResponse({ ok: true, existed });
+  };
+}
+
+export function makeMkdirHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {
     let body: { path?: string };
     try {
@@ -223,33 +265,69 @@ export function makeUnlinkHandler(deps: FsDeps) {
     if (!body.path || typeof body.path !== "string")
       return jsonResponse({ error: "path is required" }, 400);
     const normalized = body.path.replaceAll("\\", "/");
-    if (
-      !normalized.startsWith(".deco/blocks/") ||
-      !normalized.endsWith(".json") ||
-      normalized.includes("..")
-    ) {
-      return jsonResponse(
-        { error: "path must be a .deco/blocks/<key>.json file" },
-        400,
-      );
+    if (!normalized || normalized.includes("..")) {
+      return jsonResponse({ error: "Invalid path" }, 400);
     }
-    const filePath = safePath(deps.appRoot, deps.repoDir, body.path);
-    if (!filePath) return jsonResponse({ error: "Path escapes app root" }, 400);
-    let existed = true;
+    const dirPath = safePath(deps.appRoot, deps.repoDir, body.path);
+    if (!dirPath) return jsonResponse({ error: "Path escapes app root" }, 400);
     try {
-      const stat = fs.statSync(filePath);
-      if (stat.isDirectory())
-        return jsonResponse({ error: "Refusing to unlink directory" }, 400);
-      fs.unlinkSync(filePath);
+      fs.mkdirSync(dirPath, { recursive: true });
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        existed = false;
-      } else {
+      return jsonResponse({ error: (err as Error).message }, 500);
+    }
+    deps.onWorkingTreeWrite?.();
+    return jsonResponse({ ok: true });
+  };
+}
+
+export function makeRenameHandler(deps: FsDeps) {
+  return async (req: Request): Promise<Response> => {
+    let body: { from?: string; to?: string };
+    try {
+      body = (await parseJsonBody(req)) as typeof body;
+    } catch (e) {
+      return jsonResponse({ error: (e as Error).message }, 400);
+    }
+    if (!body.from || typeof body.from !== "string")
+      return jsonResponse({ error: "from is required" }, 400);
+    if (!body.to || typeof body.to !== "string")
+      return jsonResponse({ error: "to is required" }, 400);
+    const fromNormalized = body.from.replaceAll("\\", "/");
+    const toNormalized = body.to.replaceAll("\\", "/");
+    if (
+      !fromNormalized ||
+      !toNormalized ||
+      fromNormalized.includes("..") ||
+      toNormalized.includes("..")
+    ) {
+      return jsonResponse({ error: "Invalid path" }, 400);
+    }
+    const fromPath = safePath(deps.appRoot, deps.repoDir, body.from);
+    const toPath = safePath(deps.appRoot, deps.repoDir, body.to);
+    if (!fromPath || !toPath) {
+      return jsonResponse({ error: "Path escapes app root" }, 400);
+    }
+    try {
+      fs.statSync(fromPath);
+    } catch {
+      return jsonResponse({ error: `Path not found: ${body.from}` }, 400);
+    }
+    try {
+      fs.statSync(toPath);
+      return jsonResponse({ error: `Path already exists: ${body.to}` }, 400);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         return jsonResponse({ error: (err as Error).message }, 500);
       }
     }
-    if (existed) deps.onWorkingTreeWrite?.();
-    return jsonResponse({ ok: true, existed });
+    try {
+      fs.mkdirSync(path.dirname(toPath), { recursive: true });
+      fs.renameSync(fromPath, toPath);
+    } catch (err) {
+      return jsonResponse({ error: (err as Error).message }, 500);
+    }
+    deps.onWorkingTreeWrite?.();
+    return jsonResponse({ ok: true });
   };
 }
 


### PR DESCRIPTION
## Summary
- Add **New file** and **New folder** icon buttons next to the file explorer search bar
- Support create, rename, and delete via context menu with name dialog and confirmation
- Expose `mkdir` and `rename` through the sandbox proxy and daemon FS routes

## Test plan
- [ ] Open preview → Code view → file explorer sidebar
- [ ] Click **New file** / **New folder** next to search; confirm dialog and creation work
- [ ] Right-click a file/folder → rename and delete
- [ ] Save a file (Cmd+S) and confirm git status updates


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add create, rename, and delete to the sandbox file explorer with toolbar buttons, a context menu, and safer FS ops. Empty folders now show up without placeholders, and deletes/renames keep tabs and buffers in sync.

- **New Features**
  - Toolbar: New file/folder buttons next to search with name dialog and confirm.
  - Context menu: New File, New Folder, Copy Path/Relative Path, Rename, Delete.
  - Tree UX: Creates target the selected folder; new folders auto-expand and appear immediately; selection persists; tabs/buffers remap on rename and close on delete.
  - Backend: Proxy/daemon routes `/_sandbox/mkdir`, `/_sandbox/rename`; `/_sandbox/unlink` supports directories via `recursive: true`; `/_sandbox/glob` returns `directories` with `files`.

- **Bug Fixes**
  - Empty folders are visible without `.gitkeep` (glob returns directory entries; `.gitkeep` is allowed but hidden in the tree).
  - Safer deletes: refuse repo-root recursive deletes and `.git` paths; warn on unsaved deletes; name validation and duplicate checks prevent bad writes.
  - Deleting `.deco/blocks/*` invalidates related decofile caches; live meta is refreshed.
  - Dev: Split-stack restored — forward `/oauth/callback*` to the Vite origin, build `@decocms/vite-plugin` before Vite/CI, pick browser base via `vitePort`, and only override OAuth redirect origin on `*.localhost` proxy hosts.
  - Tests: Cover `toTreePath` in file-explorer utils to fix the decocms check failure.

<sup>Written for commit 090c0486363327c80559454546feff1fc4d53967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

