### PR TITLE
feat(studio-pack): add Usage Manager introspection agent

### DIFF
--- a/apps/mesh/src/auth/install-studio-pack-workflow.ts
+++ b/apps/mesh/src/auth/install-studio-pack-workflow.ts
@@ -77,15 +77,24 @@ const installStudioPackWorkflow = DBOS.registerWorkflow(
 );
 
 /**
+ * Bump when STUDIO_PACK_AGENTS (or what the workflow writes) changes.
+ * OAOO dedupes on the workflow ID, so a completed run under the old
+ * version would otherwise block the startup backfill from installing
+ * newly added agents in existing orgs.
+ * v2: added Usage Manager.
+ */
+const INSTALL_VERSION = "v2";
+
+/**
  * Fire-and-forget enqueue from the Better Auth org.afterCreate callback.
- * Workflow ID is deterministic per org so an accidental double-fire
- * collapses onto the same workflow via OAOO.
+ * Workflow ID is deterministic per org+version so an accidental
+ * double-fire collapses onto the same workflow via OAOO.
  */
 export async function enqueueInstallStudioPack(
   input: InstallStudioPackInput,
 ): Promise<void> {
   await DBOS.startWorkflow(installStudioPackWorkflow, {
-    workflowID: `install-studio-pack:${input.orgId}`,
+    workflowID: `install-studio-pack:${INSTALL_VERSION}:${input.orgId}`,
   })(input);
 }
 

--- a/apps/mesh/src/tools/virtual/studio-pack.integration.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack.integration.test.ts
@@ -78,7 +78,7 @@ describe("installStudioPack", () => {
     await closeTestPgDatabase(database);
   });
 
-  test("creates all four studio-pack agents on a fresh org", async () => {
+  test("creates the studio-pack agents on a fresh org", async () => {
     await installStudioPack(orgId, userId, virtualMcpStorage);
 
     for (const getId of [
@@ -86,6 +86,7 @@ describe("installStudioPack", () => {
       StudioPackAgentId.AUTOMATION_MANAGER,
       StudioPackAgentId.CONNECTION_MANAGER,
       StudioPackAgentId.STORE_MANAGER,
+      StudioPackAgentId.USAGE_MANAGER,
     ]) {
       const found = await virtualMcpStorage.findById(getId(orgId), orgId);
       expect(found).not.toBeNull();

--- a/apps/mesh/src/tools/virtual/studio-pack/index.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/index.ts
@@ -5,6 +5,7 @@ import { automationManagerAgent } from "./automation-manager";
 import { brandManagerAgent } from "./brand-manager";
 import { connectionManagerAgent } from "./connection-manager";
 import { storeManagerAgent } from "./store-manager";
+import { usageManagerAgent } from "./usage-manager";
 import type {
   ChecklistContext,
   ResolvedChecklistItem,
@@ -30,6 +31,7 @@ export const STUDIO_PACK_AGENTS = [
   automationManagerAgent,
   connectionManagerAgent,
   storeManagerAgent,
+  usageManagerAgent,
 ] as const;
 
 type StudioPackAgent = (typeof STUDIO_PACK_AGENTS)[number];

--- a/apps/mesh/src/tools/virtual/studio-pack/usage-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/usage-manager.ts
@@ -1,0 +1,80 @@
+import { StudioPackAgentId } from "@decocms/mesh-sdk";
+import type { StudioPackConnectionKey } from "./types";
+
+const INSTRUCTIONS = `<role>
+You are the Usage Manager. You analyze how this workspace is actually used — which agents and connections get traffic, who uses them, what it costs — and help clean up what's idle.
+</role>
+
+<capabilities>
+- Report tool-call volume, error rates, and latency for the org (summary or timeseries).
+- Rank agents by usage and surface idle ones (no recent threads or tool calls).
+- Rank users by activity and LLM token/cost consumption.
+- Audit connections for staleness (no recent calls) or poor health (high error rate).
+- Inspect individual tool-call logs to debug failures.
+- Delete idle agents and connections after explicit user confirmation.
+</capabilities>
+
+<constraints>
+- You are an analyst first. Never delete anything without showing the evidence (last-used date, call counts in the window) and getting explicit confirmation.
+- Never delete Studio Pack agents (Agent Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Usage Manager) or well-known connections (ids ending in _self, _registry, _community-registry, _dev-assets).
+- Resolve user IDs to names with ORGANIZATION_MEMBER_LIST before presenting per-user numbers; never show raw user IDs to the user.
+- Always state the time window behind any "unused" or "top" claim. Default to the last 30 days when the user doesn't specify one.
+- Lead with the top 5 rows of any ranking and offer to expand.
+</constraints>
+
+<workflows>
+1. Org usage overview (first-contact default):
+   a. MONITORING_STATS without interval for the window → total calls, error rate, avg duration.
+   b. MONITORING_STATS with interval (e.g. "1d") and topN 10 → traffic trend and top tools.
+   c. COLLECTION_VIRTUAL_MCP_LIST, then VIRTUAL_MCP_LAST_USED_LIST with all agent ids → active vs. idle agents.
+   d. Summarize: trend, top tools, busiest agents, and anything stale or erroring worth a follow-up.
+
+2. Ranking agents by usage:
+   a. List agents with COLLECTION_VIRTUAL_MCP_LIST.
+   b. For each agent, MONITORING_LOGS_LIST with virtualMcpId, the date range, and limit 1 — read \`total\` as the call count.
+   c. Cross-check recency with VIRTUAL_MCP_LAST_USED_LIST.
+   d. Present a table: agent, calls in window, last used, last used by.
+
+3. Ranking users by activity and cost:
+   a. ORGANIZATION_MEMBER_LIST to map user ids to names.
+   b. MONITORING_STATS with llmUsage true, an interval, and userIds per member → token and USD cost totals (decopilot/LLM usage).
+   c. For tool-call activity, MONITORING_LOGS_LIST over the window (limit up to 1000) and group by userId; state the sample size if you hit the limit.
+   d. Present a table sorted by the metric the user asked about.
+
+4. Cleanup audit (agents and connections):
+   a. Agents: COLLECTION_VIRTUAL_MCP_LIST + VIRTUAL_MCP_LAST_USED_LIST + per-agent call counts (workflow 2). Flag agents with no threads and no calls in the window.
+   b. Connections: COLLECTION_CONNECTIONS_LIST, then MONITORING_LOGS_LIST with connectionId and limit 1 per connection — \`total\` 0 in the window means stale. Also check which agents reference it (COLLECTION_VIRTUAL_MCP_LIST filtering by connection_id).
+   c. Present cleanup candidates with the evidence and wait for explicit confirmation.
+   d. Delete confirmed items with COLLECTION_VIRTUAL_MCP_DELETE / COLLECTION_CONNECTIONS_DELETE. For connections still referenced by agents, warn first and only use force after the user acknowledges.
+
+5. Investigating errors:
+   a. MONITORING_STATS with status "error" and an interval → where and when errors spike.
+   b. MONITORING_LOGS_LIST with isError true (plus connectionId/toolName/virtualMcpId filters) → failing calls.
+   c. MONITORING_LOG_GET on specific log ids for full input/output when the error message isn't enough.
+   d. Report the failing tool/connection, error pattern, and suggest the fix or owner.
+</workflows>`;
+
+export const usageManagerAgent = {
+  id: "studio-usage-manager",
+  title: "Usage Manager",
+  icon: "icon://BarChart10?color=blue",
+  description: "Analyze usage, costs, and clean up idle agents and connections",
+  selectedTools: [
+    "MONITORING_STATS",
+    "MONITORING_LOGS_LIST",
+    "MONITORING_LOG_GET",
+    "MONITORING_THREAD_USAGE",
+    "COLLECTION_VIRTUAL_MCP_LIST",
+    "COLLECTION_VIRTUAL_MCP_GET",
+    "COLLECTION_VIRTUAL_MCP_DELETE",
+    "VIRTUAL_MCP_LAST_USED_LIST",
+    "COLLECTION_CONNECTIONS_LIST",
+    "COLLECTION_CONNECTIONS_GET",
+    "COLLECTION_CONNECTIONS_DELETE",
+    "ORGANIZATION_MEMBER_LIST",
+  ] as readonly string[] | null,
+  selectedConnections: null as readonly StudioPackConnectionKey[] | null,
+  selectedPrompts: [] as readonly string[],
+  instructions: INSTRUCTIONS,
+  getId: StudioPackAgentId.USAGE_MANAGER,
+} as const;

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -318,6 +318,7 @@ export const StudioPackAgentId = {
   CONNECTION_MANAGER: (orgId: string) => `studio-connection-manager_${orgId}`,
   STORE_MANAGER: (orgId: string) => `studio-store-manager_${orgId}`,
   BRAND_MANAGER: (orgId: string) => `studio-brand-manager_${orgId}`,
+  USAGE_MANAGER: (orgId: string) => `studio-usage-manager_${orgId}`,
 } as const;
 
 /**
@@ -330,7 +331,8 @@ export function isStudioPackAgent(id: string | null | undefined): boolean {
     id.startsWith("studio-automation-manager_") ||
     id.startsWith("studio-connection-manager_") ||
     id.startsWith("studio-store-manager_") ||
-    id.startsWith("studio-brand-manager_")
+    id.startsWith("studio-brand-manager_") ||
+    id.startsWith("studio-usage-manager_")
   );
 }
 


### PR DESCRIPTION
## What is this contribution about?
Adds a new built-in Studio Pack agent, **Usage Manager** (`studio-usage-manager`), giving the Studio introspection over its own usage: org-wide traffic overview, ranking agents by usage, ranking users by activity and LLM token/cost, auditing stale agents/connections, and guided cleanup (delete only after showing evidence and getting explicit confirmation). It binds to the `self` connection with the existing `MONITORING_*`, `COLLECTION_VIRTUAL_MCP_*`, `COLLECTION_CONNECTIONS_*`, `VIRTUAL_MCP_LAST_USED_LIST`, and `ORGANIZATION_MEMBER_LIST` tools — no new tools needed. The install workflow ID is versioned (`install-studio-pack:v2:<orgId>`) because DBOS OAOO dedupes on the ID: orgs whose install workflow already completed would otherwise never receive newly added agents from the startup backfill (the install itself is idempotent, so re-running only creates what's missing).

## Screenshots/Demonstration
No UI changes — the agent appears alongside the other Studio Pack managers.

## How to Test
1. `bun run dev`, open an org — the startup backfill (or org creation) installs the **Usage Manager** agent.
2. Chat with it: ask "which agent has the most usage?" or "which connections are unused?" and verify it queries monitoring tools and presents ranked tables with the time window stated.
3. Ask it to clean up an idle agent/connection — it must show evidence and ask for confirmation before deleting, and refuse to delete Studio Pack agents or well-known connections.
4. `bun test apps/mesh/src/tools/virtual/studio-pack.integration.test.ts` against a real Postgres (4 pass).

## Migration Notes
No DB migrations. Existing orgs get the agent automatically via the startup backfill thanks to the workflow ID version bump.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the new `studio-usage-manager` agent to analyze org-wide usage, costs, and stale resources, plus guided cleanup with confirmation. Also versions the Studio Pack install workflow so existing orgs receive the new agent.

- New Features
  - New built-in agent: Usage Manager.
  - Uses existing monitoring/collection tools on the `self` connection; no new tools.
  - Ranks agents/users, audits stale agents/connections, and investigates errors.
  - Cleanup requires evidence and explicit confirmation; protects Studio Pack agents and well-known connections.
  - Registered in `STUDIO_PACK_AGENTS` and `StudioPackAgentId`; test updated to include it.

- Migration
  - No DB migrations.
  - Install workflow ID bumped to `install-studio-pack:v2:<orgId>` so startup backfill re-runs for existing orgs; install remains idempotent.

<sup>Written for commit 93185093532e4899566cbf420ced6a8cf4749e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

