### PR TITLE
fix(web): center shell loading spinner

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -76,6 +76,7 @@ import { VirtualMcpHeaderInfo } from "../../views/virtual-mcp/header-info.tsx";
 import { SandboxEventsProvider } from "@/web/components/sandbox/hooks/sandbox-events-context.tsx";
 import { SandboxLifecycleProvider } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 import { useEnsureTask } from "@/web/hooks/use-ensure-task";
+import { ShellRouteLoading } from "@/web/layouts/shell-route-loading";
 
 // ---------------------------------------------------------------------------
 // Types & Context
@@ -539,13 +540,7 @@ function AgentInsetProvider() {
 
 export default function AgentShellLayout() {
   return (
-    <Suspense
-      fallback={
-        <div className="flex-1 flex items-center justify-center">
-          <Loading01 size={20} className="animate-spin text-muted-foreground" />
-        </div>
-      }
-    >
+    <Suspense fallback={<ShellRouteLoading />}>
       <AgentInsetProvider />
     </Suspense>
   );

--- a/apps/mesh/src/web/layouts/main-panel-tabs/automation-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/automation-tab.tsx
@@ -2,33 +2,18 @@ import { parseAutomationTabId } from "./tab-id";
 import { SettingsTab as AutomationInlineDetail } from "@/web/views/automations/automation-detail";
 import { useAutomation } from "@/web/hooks/use-automations";
 import { Page } from "@/web/components/page";
-import { Loading01 } from "@untitledui/icons";
 import { useNavigate } from "@tanstack/react-router";
 import { Suspense } from "react";
+import { MainPanelLoading } from "./main-panel-loading";
 
 export function AutomationTab({ tabId }: { tabId: string }) {
   const parsed = parseAutomationTabId(tabId);
   if (!parsed) return null;
 
   return (
-    <Page>
-      <Page.Content>
-        <Page.Body>
-          <Suspense
-            fallback={
-              <div className="flex-1 flex items-center justify-center">
-                <Loading01
-                  size={20}
-                  className="animate-spin text-muted-foreground"
-                />
-              </div>
-            }
-          >
-            <AutomationTabInner id={parsed.id} />
-          </Suspense>
-        </Page.Body>
-      </Page.Content>
-    </Page>
+    <Suspense fallback={<MainPanelLoading />}>
+      <AutomationTabInner id={parsed.id} />
+    </Suspense>
   );
 }
 
@@ -48,26 +33,28 @@ function AutomationTabInner({ id }: { id: string }) {
   };
 
   if (isLoading) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <Loading01 size={20} className="animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <MainPanelLoading />;
   }
 
   if (!automation) {
     return (
-      <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+      <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
         Automation not found
       </div>
     );
   }
 
   return (
-    <AutomationInlineDetail
-      automationId={id}
-      automation={automation}
-      onBack={onBack}
-    />
+    <Page>
+      <Page.Content>
+        <Page.Body>
+          <AutomationInlineDetail
+            automationId={id}
+            automation={automation}
+            onBack={onBack}
+          />
+        </Page.Body>
+      </Page.Content>
+    </Page>
   );
 }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/automations-list-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/automations-list-tab.tsx
@@ -1,16 +1,10 @@
 import { Suspense } from "react";
-import { Loading01 } from "@untitledui/icons";
 import { AutomationsList } from "@/web/views/automations/automations-list";
+import { MainPanelLoading } from "./main-panel-loading";
 
 export function AutomationsListTab({ virtualMcpId }: { virtualMcpId: string }) {
   return (
-    <Suspense
-      fallback={
-        <div className="flex-1 flex items-center justify-center">
-          <Loading01 size={20} className="animate-spin text-muted-foreground" />
-        </div>
-      }
-    >
+    <Suspense fallback={<MainPanelLoading />}>
       <AutomationsList virtualMcpId={virtualMcpId} />
     </Suspense>
   );

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -9,7 +9,6 @@
  */
 
 import { Suspense, lazy } from "react";
-import { Loading01 } from "@untitledui/icons";
 import { useMainPanelTabs } from "./use-main-panel-tabs";
 import { SettingsTab } from "./settings-tab";
 import { GitTab } from "@/web/components/thread/github/git-tab";
@@ -18,6 +17,7 @@ import { ContentTab } from "./content-tab";
 import { AutomationTab } from "./automation-tab";
 import { AutomationsListTab } from "./automations-list-tab";
 import { WebPageTab } from "./web-page-tab";
+import { MainPanelLoading } from "./main-panel-loading";
 import {
   isLegacySettingsTab,
   parsePinnedViewTabId,
@@ -91,16 +91,7 @@ function TabBody({
         t.toolName === pinnedView.toolName,
     );
     return (
-      <Suspense
-        fallback={
-          <div className="h-full w-full flex items-center justify-center">
-            <Loading01
-              size={20}
-              className="animate-spin text-muted-foreground"
-            />
-          </div>
-        }
-      >
+      <Suspense fallback={<MainPanelLoading />}>
         <AppViewContent
           key={activeTab}
           connectionId={pinnedView.connectionId}
@@ -114,16 +105,7 @@ function TabBody({
   const agentTab = layoutTabs.find((t) => t.id === activeTab);
   if (agentTab) {
     return (
-      <Suspense
-        fallback={
-          <div className="h-full w-full flex items-center justify-center">
-            <Loading01
-              size={20}
-              className="animate-spin text-muted-foreground"
-            />
-          </div>
-        }
-      >
+      <Suspense fallback={<MainPanelLoading />}>
         <AppViewContent
           key={activeTab}
           connectionId={agentTab.view.appId}
@@ -152,16 +134,7 @@ export function MainPanelContent({
 
   return (
     <ErrorBoundary key={activeTab}>
-      <Suspense
-        fallback={
-          <div className="h-full w-full flex items-center justify-center">
-            <Loading01
-              size={20}
-              className="animate-spin text-muted-foreground"
-            />
-          </div>
-        }
-      >
+      <Suspense fallback={<MainPanelLoading />}>
         <TabBody
           activeTab={activeTab}
           virtualMcpId={virtualMcpId}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-loading.test.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-loading.test.tsx
@@ -1,0 +1,21 @@
+import { setupComponentTest } from "../../../test/setup";
+setupComponentTest();
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "bun:test";
+import { MainPanelLoading } from "./main-panel-loading";
+
+describe("MainPanelLoading", () => {
+  it("centers the spinner across the full panel", () => {
+    const { getByTestId } = render(<MainPanelLoading />);
+
+    expect(getByTestId("main-panel-loading")).toHaveClass(
+      "flex",
+      "h-full",
+      "w-full",
+      "items-center",
+      "justify-center",
+    );
+  });
+});

--- a/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-loading.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-loading.tsx
@@ -1,0 +1,12 @@
+import { Loading01 } from "@untitledui/icons";
+
+export function MainPanelLoading() {
+  return (
+    <div
+      data-testid="main-panel-loading"
+      className="flex h-full w-full items-center justify-center"
+    >
+      <Loading01 size={20} className="animate-spin text-muted-foreground" />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -23,7 +23,6 @@ import {
   SidebarProvider,
 } from "@deco/ui/components/sidebar.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
-import { Loading01 } from "@untitledui/icons";
 import { Outlet } from "@tanstack/react-router";
 import { SidebarResizeHandle } from "@/web/components/sidebar/sidebar-resize-handle";
 import { useSidebarResize } from "@/web/hooks/use-sidebar-resize";
@@ -37,15 +36,12 @@ import {
   SidebarTriggerButton,
 } from "@/web/layouts/shell-controls";
 import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import { ShellRouteLoading } from "@/web/layouts/shell-route-loading";
 
 const SIDEBAR_OPEN_STORAGE_KEY = "sidebar.open";
 
 function RouteFallback() {
-  return (
-    <div className="flex-1 flex items-center justify-center">
-      <Loading01 size={20} className="animate-spin text-muted-foreground" />
-    </div>
-  );
+  return <ShellRouteLoading />;
 }
 
 export default function OrgShellLayout() {
@@ -107,7 +103,7 @@ export default function OrgShellLayout() {
                   }}
                 >
                   <div className="flex flex-col h-full min-h-0">
-                    <div className="flex-1 min-h-0 flex flex-row">
+                    <div className="relative flex-1 min-h-0 flex flex-row">
                       <Suspense fallback={<RouteFallback />}>
                         <Outlet />
                       </Suspense>

--- a/apps/mesh/src/web/layouts/shell-route-loading.test.tsx
+++ b/apps/mesh/src/web/layouts/shell-route-loading.test.tsx
@@ -1,0 +1,21 @@
+import { setupComponentTest } from "../../test/setup";
+setupComponentTest();
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "bun:test";
+import { ShellRouteLoading } from "./shell-route-loading";
+
+describe("ShellRouteLoading", () => {
+  it("centers route loading across the whole routed content area", () => {
+    const { getByTestId } = render(<ShellRouteLoading />);
+
+    expect(getByTestId("shell-route-loading")).toHaveClass(
+      "absolute",
+      "inset-0",
+      "flex",
+      "items-center",
+      "justify-center",
+    );
+  });
+});

--- a/apps/mesh/src/web/layouts/shell-route-loading.tsx
+++ b/apps/mesh/src/web/layouts/shell-route-loading.tsx
@@ -1,0 +1,12 @@
+import { Loading01 } from "@untitledui/icons";
+
+export function ShellRouteLoading() {
+  return (
+    <div
+      data-testid="shell-route-loading"
+      className="absolute inset-0 flex items-center justify-center"
+    >
+      <Loading01 size={20} className="animate-spin text-muted-foreground" />
+    </div>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -17,21 +17,6 @@
         "worktree-devservers": "0.3.1",
       },
     },
-    "apps/benchmark": {
-      "name": "@decocms/benchmark",
-      "version": "1.0.0",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "1.29.0",
-        "@openrouter/ai-sdk-provider": "^2.9.0",
-        "ai": "^6.0.191",
-        "decocms": "workspace:*",
-        "hono": "^4.10.7",
-      },
-      "devDependencies": {
-        "@types/bun": "^1.3.1",
-        "typescript": "^5.9.3",
-      },
-    },
     "apps/docs": {
       "name": "@decocms/docs",
       "version": "1.0.0",
@@ -53,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.407.2",
+      "version": "2.419.1",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -257,7 +242,7 @@
     },
     "packages/mesh-sdk": {
       "name": "@decocms/mesh-sdk",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.1",
         "@decocms/mcp-utils": "workspace:*",
@@ -276,7 +261,7 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "1.6.3",
+      "version": "1.6.5",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.10",
         "@cloudflare/workers-types": "^4.20250617.0",
@@ -297,7 +282,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "0.7.3",
+      "version": "0.15.0",
       "dependencies": {
         "@decocms/std": "workspace:*",
         "@kubernetes/client-node": "^1.4.0",
@@ -665,8 +650,6 @@
     "@dbos-inc/dbos-sdk": ["@dbos-inc/dbos-sdk@4.17.6", "", { "dependencies": { "commander": "12.0.0", "pg": "8.11.3", "serialize-error": "8.1.0", "superjson": "^1.13.3", "ws": "^8.18.1", "yaml": "^2.8.3" }, "bin": { "dbos": "dist/src/cli/cli.js", "dbos-sdk": "dist/src/cli/cli.js" } }, "sha512-1wt9eESm1AHKnmCWG9pOrzsmroJYLiujVKldi/hlyDXeCAyYmdKRcERtEzUZgPN2zOOSNJcsdf9ItWUacSnROQ=="],
 
     "@deco/ui": ["@deco/ui@workspace:packages/ui"],
-
-    "@decocms/benchmark": ["@decocms/benchmark@workspace:apps/benchmark"],
 
     "@decocms/better-auth": ["@decocms/better-auth@1.5.17", "", { "dependencies": { "@better-auth/core": "1.4.6-beta.3", "@better-auth/telemetry": "1.4.6-beta.3", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.5", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "ms": "4.0.0-nightly.202508271359", "nanostores": "^1.0.1", "zod": "^4.1.12" }, "peerDependencies": { "@lynx-js/react": "*", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@sveltejs/kit", "@tanstack/react-start", "next", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-7AiNXIX51oYMUeNSPNLHDcr/uvQEs+acAfoD2g41Rv+u9DKbOZy6Vh869yAcUNNqzRMWmF4RqvRK3woVUzM5ww=="],
 
@@ -3380,8 +3363,6 @@
 
     "@dbos-inc/dbos-sdk/pg": ["pg@8.11.3", "", { "dependencies": { "buffer-writer": "2.0.0", "packet-reader": "1.0.0", "pg-connection-string": "^2.6.2", "pg-pool": "^3.6.1", "pg-protocol": "^1.6.0", "pg-types": "^2.1.0", "pgpass": "1.x" }, "optionalDependencies": { "pg-cloudflare": "^1.1.1" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g=="],
 
-    "@decocms/benchmark/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
     "@decocms/better-auth/better-call": ["better-call@1.1.5", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.7.10", "set-cookie-parser": "^2.7.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-nQJ3S87v6wApbDwbZ++FrQiSiVxWvZdjaO+2v6lZJAG2WWggkB2CziUDjPciz3eAt9TqfRursIQMZIcpkBnvlw=="],
 
     "@decocms/runtime/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
@@ -3827,8 +3808,6 @@
     "@better-auth/sso/better-auth/@better-auth/telemetry": ["@better-auth/telemetry@1.4.5", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.18" }, "peerDependencies": { "@better-auth/core": "1.4.5" } }, "sha512-r3NyksbaBYA10SC86JA6QwmZfHwFutkUGcphgWGfu6MVx1zutYmZehIeC8LxTjOWZqqF9FI8vLjglWBHvPQeTg=="],
 
     "@better-auth/sso/better-auth/better-call": ["better-call@1.1.4", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.7.10", "set-cookie-parser": "^2.7.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-NJouLY6IVKv0nDuFoc6FcbKDFzEnmgMNofC9F60Mwx1Ecm7X6/Ecyoe5b+JSVZ42F/0n46/M89gbYP1ZCVv8xQ=="],
-
-    "@decocms/benchmark/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@decocms/better-auth/better-call/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 


### PR DESCRIPTION
## Summary
- Add shared shell and main-panel loading components with full-area centering.
- Use the shell loader for org/agent route Suspense fallbacks so loading centers after the sidebar renders.
- Reuse the main-panel loader across tab and automation loading states.

## Test Plan
- [x] bun test apps/mesh/src/web/layouts/shell-route-loading.test.tsx apps/mesh/src/web/layouts/main-panel-tabs/main-panel-loading.test.tsx
- [x] bun run lint -- apps/mesh/src/web/layouts/shell-route-loading.tsx apps/mesh/src/web/layouts/shell-route-loading.test.tsx apps/mesh/src/web/layouts/org-shell-layout/index.tsx apps/mesh/src/web/layouts/agent-shell-layout/index.tsx apps/mesh/src/web/layouts/main-panel-tabs/main-panel-loading.tsx apps/mesh/src/web/layouts/main-panel-tabs/main-panel-loading.test.tsx apps/mesh/src/web/layouts/main-panel-tabs/index.tsx apps/mesh/src/web/layouts/main-panel-tabs/automation-tab.tsx apps/mesh/src/web/layouts/main-panel-tabs/automations-list-tab.tsx
- [x] bun run --cwd=apps/mesh check
- [x] bun run fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers all shell and main panel loading spinners by introducing shared loaders, fixing off-center states and ensuring the spinner overlays the correct content area after the sidebar renders.
Improves consistency and removes duplicate `Suspense` fallback code.

- **Bug Fixes**
  - Shell routes now use a full-coverage overlay loader so the spinner centers over routed content and appears after the sidebar.
  - Main panel tabs and automation views show a full-area centered loader.

- **Refactors**
  - Replaced inline loaders with shared `ShellRouteLoading` and `MainPanelLoading` components; set the shell content wrapper to `relative` for correct overlay positioning.
  - Added tests for both loaders to lock in centering; cleaned up `bun.lock` with internal version bumps.

<sup>Written for commit d38f706a6933747d866f4303ff397ac60d8cbb6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

