### PR TITLE
feat(automation): add max agent steps configuration for automations

### DIFF
--- a/apps/mesh/migrations/108-automation-max-agent-steps.ts
+++ b/apps/mesh/migrations/108-automation-max-agent-steps.ts
@@ -1,0 +1,21 @@
+import { type Kysely } from "kysely";
+
+/**
+ * Per-automation agent step limit. Caps the parent agent loop's number of
+ * reasoning/tool steps (the AI SDK `stopWhen: stepCountIs(...)` value). `null`
+ * (the default) means "use the platform default" (`PARENT_STEP_LIMIT`), so
+ * existing automations are untouched.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("automations")
+    .addColumn("max_agent_steps", "integer") // null = PARENT_STEP_LIMIT default
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("automations")
+    .dropColumn("max_agent_steps")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -106,6 +106,7 @@ import * as migration104agentsandboxproviderkind from "./104-agent-sandbox-provi
 import * as migration105orgfs from "./105-org-fs.ts";
 import * as migration106automationtools from "./106-automation-tools.ts";
 import * as migration107orgfspublicorg from "./107-org-fs-public-org.ts";
+import * as migration108automationmaxagentsteps from "./108-automation-max-agent-steps.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -234,6 +235,7 @@ const migrations: Record<string, Migration> = {
   "105-org-fs": migration105orgfs,
   "106-automation-tools": migration106automationtools,
   "107-org-fs-public-org": migration107orgfspublicorg,
+  "108-automation-max-agent-steps": migration108automationmaxagentsteps,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -392,6 +392,12 @@ export interface DispatchRunInput {
    * pin a specific subset of tools.
    */
   toolAllowlist?: string[] | null;
+  /**
+   * Parent agent-loop step cap (AI SDK `stopWhen`). Omitted leaves the loop
+   * on its `PARENT_STEP_LIMIT` default. Set by automations that need a higher
+   * (or lower) ceiling than the platform default.
+   */
+  maxAgentSteps?: number;
   /** Chat mode — plan, forced web search / image, or default */
   mode: ChatMode;
   organizationId: string;
@@ -1053,6 +1059,7 @@ async function prepareRun(
       temperature: input.temperature,
       toolApprovalLevel: input.toolApprovalLevel,
       toolAllowlist: input.toolAllowlist ?? null,
+      maxAgentSteps: input.maxAgentSteps,
       user: { id: input.userId, email: ctx.auth.user?.email ?? "" },
       organizationId: input.organizationId,
       projectSlug: organization.slug,

--- a/apps/mesh/src/automations/automation-event-dispatcher.test.ts
+++ b/apps/mesh/src/automations/automation-event-dispatcher.test.ts
@@ -26,6 +26,7 @@ function makeAutomation(overrides?: Partial<Automation>): Automation {
     models: JSON.stringify({ tier: "smart" }),
     tools: null,
     temperature: 0.5,
+    max_agent_steps: null,
     virtual_mcp_id: "agent_1",
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",

--- a/apps/mesh/src/automations/build-stream-request.test.ts
+++ b/apps/mesh/src/automations/build-stream-request.test.ts
@@ -18,6 +18,7 @@ function makeAutomation(overrides?: Partial<Automation>): Automation {
     models: JSON.stringify({ tier: "smart" }),
     tools: null,
     temperature: 0.7,
+    max_agent_steps: null,
     virtual_mcp_id: "agent_1",
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
@@ -210,5 +211,25 @@ describe("buildStreamRequest", () => {
       makeResolvedModel(),
     );
     expect(result.toolAllowlist).toBeNull();
+  });
+
+  it("leaves maxAgentSteps undefined when not configured", () => {
+    const result = buildStreamRequest(
+      makeAutomation({ max_agent_steps: null }),
+      null,
+      "thrd_1",
+      makeResolvedModel(),
+    );
+    expect(result.maxAgentSteps).toBeUndefined();
+  });
+
+  it("forwards a configured maxAgentSteps", () => {
+    const result = buildStreamRequest(
+      makeAutomation({ max_agent_steps: 50 }),
+      null,
+      "thrd_1",
+      makeResolvedModel(),
+    );
+    expect(result.maxAgentSteps).toBe(50);
   });
 });

--- a/apps/mesh/src/automations/build-stream-request.ts
+++ b/apps/mesh/src/automations/build-stream-request.ts
@@ -84,6 +84,9 @@ export function buildStreamRequest(
     // Per-automation tool allowlist (model-facing tool names). null/absent
     // leaves the run with the bound agent's full toolset.
     toolAllowlist: parseToolAllowlist(automation.tools),
+    // Per-automation parent step cap. undefined leaves runAgentLoop on its
+    // PARENT_STEP_LIMIT default.
+    maxAgentSteps: automation.max_agent_steps ?? undefined,
     temperature: automation.temperature ?? 0.5,
     toolApprovalLevel: "auto",
     mode: "default",

--- a/apps/mesh/src/harnesses/decopilot/agents-block.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/agents-block.test.ts
@@ -76,6 +76,60 @@ describe("buildAgentsBlock", () => {
     expect(result).toContain(`vmcp_c,C,"Has, a comma"`);
   });
 
+  test("restricts the catalog to a non-empty allowlist", () => {
+    const result = buildAgentsBlock(
+      [
+        entry("vmcp_self", "Self", "Self"),
+        entry("vmcp_a", "Agent A", "Does A things"),
+        entry("vmcp_b", "Agent B", "Does B things"),
+      ],
+      "vmcp_self",
+      ["vmcp_a"],
+    );
+    expect(result).toContain("vmcp_a");
+    expect(result).not.toContain("vmcp_b");
+  });
+
+  test("treats a null/undefined allowlist as all agents", () => {
+    const agents = [
+      entry("vmcp_self", "Self", "Self"),
+      entry("vmcp_a", "Agent A", "Does A things"),
+      entry("vmcp_b", "Agent B", "Does B things"),
+    ];
+    for (const allowed of [null, undefined]) {
+      const result = buildAgentsBlock(agents, "vmcp_self", allowed);
+      expect(result).toContain("vmcp_a");
+      expect(result).toContain("vmcp_b");
+    }
+  });
+
+  test("treats an empty allowlist as itself only (no catalog)", () => {
+    const result = buildAgentsBlock(
+      [
+        entry("vmcp_self", "Self", "Self"),
+        entry("vmcp_a", "Agent A", "Does A things"),
+      ],
+      "vmcp_self",
+      [],
+    );
+    // No other agents permitted, but self-delegation usage stays.
+    expect(result).not.toContain("id,name,description");
+    expect(result).toContain("<agents-usage>");
+  });
+
+  test("omits the catalog when the allowlist excludes every other agent", () => {
+    const result = buildAgentsBlock(
+      [entry("vmcp_self", "Self", "Self"), entry("vmcp_a", "Agent A", "x")],
+      "vmcp_self",
+      ["vmcp_does_not_exist"],
+    );
+    // No matching agents → no table, but self-delegation usage still emitted.
+    // (The usage prose references <available-agents>, so assert on the table
+    // header instead of the tag.)
+    expect(result).not.toContain("id,name,description");
+    expect(result).toContain("<agents-usage>");
+  });
+
   test("includes <agents-usage> with subtask delegation guidance", () => {
     const result = buildAgentsBlock(
       [entry("vmcp_self", "Self", "Self"), entry("vmcp_a", "A", "x")],

--- a/apps/mesh/src/harnesses/decopilot/agents-block.ts
+++ b/apps/mesh/src/harnesses/decopilot/agents-block.ts
@@ -56,10 +56,19 @@ function truncate(s: string, max: number): string {
 export function buildAgentsBlock(
   agents: AgentsBlockEntry[],
   currentVirtualMcpId: string,
+  allowedIds?: string[] | null,
 ): string {
-  const others = agents.filter(
+  let others = agents.filter(
     (a) => a.id !== currentVirtualMcpId && a.status === "active",
   );
+
+  // An allowlist (any array, even empty) restricts delegation to exactly those
+  // agents — an empty array means "itself only" (no cross-agent delegation).
+  // A null/absent allowlist means "all active agents" (the default behavior).
+  if (allowedIds) {
+    const allow = new Set(allowedIds);
+    others = others.filter((a) => allow.has(a.id));
+  }
 
   // Self-delegation is always available, so the usage guidance is always
   // emitted. The <available-agents> table is added only when other active

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -123,6 +123,24 @@ export function createSubtaskTool(
         throw new Error("Agent is not active");
       }
 
+      // 1b. Enforce the caller's sub-agent allowlist for cross-agent
+      //     delegation. Self-clones are always allowed. An empty or absent
+      //     allowlist means "all agents" (the default). This mirrors the
+      //     <available-agents> prompt filter — the model shouldn't even see
+      //     disallowed agents, but we re-check here as defense in depth.
+      if (!isSelf && self) {
+        const caller = await ctx.storage.virtualMcps.findById(
+          self.id,
+          organization.id,
+        );
+        const allow = caller?.metadata?.subAgents;
+        // An allowlist array (even empty = itself only) gates cross-agent
+        // delegation. A null/absent allowlist means all agents are allowed.
+        if (Array.isArray(allow) && !allow.includes(targetId)) {
+          throw new Error("Agent not available for delegation");
+        }
+      }
+
       // 2. Open an MCP client for the target. A self-clone uses superUser so
       //    its tool scope mirrors the parent loop's passthrough client.
       const mcpClient = (await createVirtualClientFrom(

--- a/apps/mesh/src/harnesses/decopilot/prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/prompt.ts
@@ -56,6 +56,9 @@ export async function listAgentsBlock(
   currentVirtualMcpId?: string,
 ): Promise<string | null> {
   const virtualMcpList = await ctx.storage.virtualMcps.list(org.id);
+  const current = currentVirtualMcpId
+    ? virtualMcpList.find((vm) => vm.id === currentVirtualMcpId)
+    : undefined;
   return buildAgentsBlock(
     virtualMcpList.map((vm) => ({
       id: vm.id,
@@ -64,6 +67,7 @@ export async function listAgentsBlock(
       status: vm.status,
     })),
     currentVirtualMcpId ?? "",
+    current?.metadata?.subAgents ?? null,
   );
 }
 
@@ -150,6 +154,7 @@ export async function assembleDecopilotPrompt(
     })(),
   ]);
 
+  const currentAgent = virtualMcpList.find((vm) => vm.id === input.agent.id);
   const agentsBlock = buildAgentsBlock(
     virtualMcpList.map((vm) => ({
       id: vm.id,
@@ -158,6 +163,7 @@ export async function assembleDecopilotPrompt(
       status: vm.status,
     })),
     input.agent.id,
+    currentAgent?.metadata?.subAgents ?? null,
   );
 
   const promptsBlock = buildPromptsBlock(

--- a/apps/mesh/src/harnesses/decopilot/run-stream.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-stream.ts
@@ -610,6 +610,8 @@ export async function* runDecopilotStream(
     models: input.models,
     messages: processedMessages,
     abortSignal: registrySignal,
+    // Per-automation override; undefined → runAgentLoop's PARENT_STEP_LIMIT.
+    stepLimit: input.maxAgentSteps,
     temperature: input.temperature,
     planMode: modeConfig.isPlanMode,
     isDecopilot: isDecopilot(input.agent.id) !== null,

--- a/apps/mesh/src/harnesses/types.ts
+++ b/apps/mesh/src/harnesses/types.ts
@@ -242,6 +242,12 @@ export interface HarnessStreamInput {
    * specific subset of tools.
    */
   toolAllowlist?: string[] | null;
+  /**
+   * Parent agent-loop step cap (AI SDK `stopWhen: stepCountIs(...)`). Absent
+   * leaves the decopilot harness on its `PARENT_STEP_LIMIT` default. Set by
+   * automations that pin a custom ceiling.
+   */
+  maxAgentSteps?: number;
 
   // ===== Identity context (for prompts, audit) =====
   user: { id: string; email: string };

--- a/apps/mesh/src/links/protocol/schemas.ts
+++ b/apps/mesh/src/links/protocol/schemas.ts
@@ -79,6 +79,8 @@ export const harnessStreamInputSchema = z
     toolApprovalLevel: z.string(),
     // Per-run tool allowlist (model-facing names). null/absent = full toolset.
     toolAllowlist: z.array(z.string()).nullable().optional(),
+    // Per-run parent agent-loop step cap. absent = PARENT_STEP_LIMIT default.
+    maxAgentSteps: z.number().int().optional(),
     user: z.object({ id: z.string(), email: z.string() }),
     organizationId: z.string(),
     organizationSlug: z.string().optional(),

--- a/apps/mesh/src/storage/automations.ts
+++ b/apps/mesh/src/storage/automations.ts
@@ -27,6 +27,7 @@ export interface CreateAutomationInput {
   models: string; // JSON
   tools?: string | null; // JSON string[] | null = all tools
   temperature?: number;
+  max_agent_steps?: number | null; // null = PARENT_STEP_LIMIT default
   virtual_mcp_id: string;
 }
 
@@ -37,6 +38,7 @@ export interface UpdateAutomationInput {
   models?: string;
   tools?: string | null;
   temperature?: number;
+  max_agent_steps?: number | null;
 }
 
 export interface CreateTriggerInput {
@@ -125,6 +127,7 @@ function automationFromDbRow(row: {
   models: string;
   tools: string | null;
   temperature: number;
+  max_agent_steps: number | null;
   virtual_mcp_id: string;
   created_at: Date | string;
   updated_at: Date | string;
@@ -139,6 +142,7 @@ function automationFromDbRow(row: {
     models: row.models,
     tools: row.tools ?? null,
     temperature: row.temperature,
+    max_agent_steps: row.max_agent_steps ?? null,
     virtual_mcp_id: row.virtual_mcp_id,
     created_at: toIsoString(row.created_at),
     updated_at: toIsoString(row.updated_at),
@@ -187,6 +191,7 @@ const TRIGGER_JOIN_AUTOMATION_COLUMNS = [
   "a.models as a_models",
   "a.tools as a_tools",
   "a.temperature as a_temperature",
+  "a.max_agent_steps as a_max_agent_steps",
   "a.virtual_mcp_id as a_virtual_mcp_id",
   "a.created_at as a_created_at",
   "a.updated_at as a_updated_at",
@@ -202,6 +207,7 @@ function automationFromAliasedRow(row: {
   a_models: string;
   a_tools: string | null;
   a_temperature: number;
+  a_max_agent_steps: number | null;
   a_virtual_mcp_id: string;
   a_created_at: Date | string;
   a_updated_at: Date | string;
@@ -216,6 +222,7 @@ function automationFromAliasedRow(row: {
     models: row.a_models,
     tools: row.a_tools,
     temperature: row.a_temperature,
+    max_agent_steps: row.a_max_agent_steps,
     virtual_mcp_id: row.a_virtual_mcp_id,
     created_at: row.a_created_at,
     updated_at: row.a_updated_at,
@@ -243,6 +250,7 @@ class KyselyAutomationsStorage implements AutomationsStorage {
       models: input.models,
       tools: input.tools ?? null,
       temperature: input.temperature ?? 0.5,
+      max_agent_steps: input.max_agent_steps ?? null,
       virtual_mcp_id: input.virtual_mcp_id,
       created_at: now,
       updated_at: now,
@@ -299,6 +307,7 @@ class KyselyAutomationsStorage implements AutomationsStorage {
         "a.models",
         "a.tools",
         "a.temperature",
+        "a.max_agent_steps",
         "a.virtual_mcp_id",
         "a.created_at",
         "a.updated_at",
@@ -322,6 +331,7 @@ class KyselyAutomationsStorage implements AutomationsStorage {
         "a.models",
         "a.tools",
         "a.temperature",
+        "a.max_agent_steps",
         "a.virtual_mcp_id",
         "a.created_at",
         "a.updated_at",
@@ -353,6 +363,8 @@ class KyselyAutomationsStorage implements AutomationsStorage {
     if (input.tools !== undefined) updateData.tools = input.tools;
     if (input.temperature !== undefined)
       updateData.temperature = input.temperature;
+    if (input.max_agent_steps !== undefined)
+      updateData.max_agent_steps = input.max_agent_steps;
 
     await this.db
       .updateTable("automations")

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1207,6 +1207,8 @@ export interface AutomationTable {
   // null = all of the bound agent's tools (default / pre-existing behavior).
   tools: string | null;
   temperature: number;
+  // Parent agent-loop step cap (AI SDK stopWhen). null = PARENT_STEP_LIMIT.
+  max_agent_steps: number | null;
   virtual_mcp_id: string;
   created_at: ColumnType<Date, Date | string, never>;
   updated_at: ColumnType<Date, Date | string, Date | string>;
@@ -1225,6 +1227,7 @@ export interface Automation {
   models: string;
   tools: string | null;
   temperature: number;
+  max_agent_steps: number | null;
   virtual_mcp_id: string;
   created_at: string;
   updated_at: string;

--- a/apps/mesh/src/tools/automations/create.ts
+++ b/apps/mesh/src/tools/automations/create.ts
@@ -53,6 +53,10 @@ export const AUTOMATION_CREATE = defineTool({
     // Allowlist of model-facing tool names the run is restricted to.
     // null/omitted = all of the bound agent's tools (default behavior).
     tools: z.array(z.string()).nullable().optional(),
+    // Parent agent-loop step cap. null/omitted = platform default
+    // (PARENT_STEP_LIMIT). Raise it for automations that legitimately need
+    // more reasoning/tool steps before stopping.
+    maxAgentSteps: z.number().int().min(1).max(100).nullable().optional(),
     temperature: z.number().default(0.5),
     active: z.boolean().default(true),
   }),
@@ -84,6 +88,7 @@ export const AUTOMATION_CREATE = defineTool({
         input.tools === undefined || input.tools === null
           ? null
           : JSON.stringify(input.tools),
+      max_agent_steps: input.maxAgentSteps ?? null,
       temperature: input.temperature,
       active: input.active,
       virtual_mcp_id: input.virtual_mcp_id,

--- a/apps/mesh/src/tools/automations/get.ts
+++ b/apps/mesh/src/tools/automations/get.ts
@@ -34,6 +34,7 @@ export const AUTOMATION_GET = defineTool({
         messages: z.unknown(),
         models: z.unknown(),
         tools: z.array(z.string()).nullable(),
+        maxAgentSteps: z.number().nullable(),
         temperature: z.number(),
         triggers: z.array(
           z.object({
@@ -79,6 +80,7 @@ export const AUTOMATION_GET = defineTool({
         messages: JSON.parse(automation.messages),
         models: JSON.parse(automation.models),
         tools: automation.tools ? JSON.parse(automation.tools) : null,
+        maxAgentSteps: automation.max_agent_steps,
         temperature: automation.temperature,
         triggers: triggers.map((t) => ({
           id: t.id,

--- a/apps/mesh/src/tools/automations/update.ts
+++ b/apps/mesh/src/tools/automations/update.ts
@@ -52,6 +52,9 @@ export const AUTOMATION_UPDATE = defineTool({
     // null clears the allowlist (= all tools); an array sets it; omitting
     // leaves the stored value untouched.
     tools: z.array(z.string()).nullable().optional(),
+    // Parent agent-loop step cap. null resets to the platform default
+    // (PARENT_STEP_LIMIT); a number sets it; omitting leaves it untouched.
+    maxAgentSteps: z.number().int().min(1).max(100).nullable().optional(),
     temperature: z.number().optional(),
   }),
   outputSchema: z.object({
@@ -89,6 +92,8 @@ export const AUTOMATION_UPDATE = defineTool({
         input.tools === null ? null : JSON.stringify(input.tools);
     if (input.temperature !== undefined)
       updateData.temperature = input.temperature;
+    if (input.maxAgentSteps !== undefined)
+      updateData.max_agent_steps = input.maxAgentSteps;
     const automation = await ctx.storage.automations.update(
       input.id,
       organization.id,

--- a/apps/mesh/src/web/hooks/use-automations.ts
+++ b/apps/mesh/src/web/hooks/use-automations.ts
@@ -151,6 +151,8 @@ export interface AutomationDetail {
   // Tool allowlist (model-facing/raw tool names). null = all of the agent's
   // tools.
   tools: string[] | null;
+  // Parent agent-loop step cap. null = platform default (PARENT_STEP_LIMIT).
+  maxAgentSteps: number | null;
   temperature: number;
   triggers: AutomationTrigger[];
 }

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -19,6 +19,11 @@ import {
 } from "@/web/hooks/use-automations";
 import { useChatTask, useChatStream } from "@/web/components/chat/context";
 import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@deco/ui/components/collapsible.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Switch } from "@deco/ui/components/switch.tsx";
 import {
@@ -36,6 +41,7 @@ import { buildImprovePromptDoc } from "@/web/components/chat/tiptap/build-improv
 import {
   ArrowLeft,
   ArrowUp,
+  ChevronDown,
   Clock,
   Loading01,
   Stars01,
@@ -69,7 +75,13 @@ interface SettingsFormData {
   modelOverride: AutomationModelOverride | null;
   // Tool allowlist (null = all of the agent's tools).
   tools: string[] | null;
+  // Parent agent-loop step cap (null = platform default).
+  maxAgentSteps: number | null;
 }
+
+// Platform default for the parent agent loop (PARENT_STEP_LIMIT) — shown as
+// the placeholder when no per-automation override is set.
+const DEFAULT_MAX_AGENT_STEPS = 30;
 
 type EditSession = {
   start: number;
@@ -345,6 +357,7 @@ export function SettingsTab({
   const [tiptapDoc, setTiptapDocRaw] =
     useState<Metadata["tiptapDoc"]>(initialTiptapDoc);
   const [starterOpen, setStarterOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [showCustomCron, setShowCustomCron] = useState(false);
   const [cronInput, setCronInput] = useState("");
   const [showEventForm, setShowEventForm] = useState(false);
@@ -413,6 +426,7 @@ export function SettingsTab({
       tier: defaultTier,
       modelOverride: defaultModelOverride,
       tools: automation.tools ?? null,
+      maxAgentSteps: automation.maxAgentSteps ?? null,
     },
   });
 
@@ -482,6 +496,7 @@ export function SettingsTab({
       active: formData.active,
       models,
       tools: formData.tools,
+      maxAgentSteps: formData.maxAgentSteps,
       messages: tiptapDocToMessages(tiptapDoc),
       temperature: 0,
     };
@@ -787,25 +802,6 @@ export function SettingsTab({
           />
         </div>
 
-        {/* Section: Model & Tools */}
-        <div className="flex flex-col gap-5">
-          <AutomationModelControl
-            tier={form.watch("tier")}
-            onTierChange={(tier) =>
-              form.setValue("tier", tier, { shouldDirty: true })
-            }
-            override={form.watch("modelOverride")}
-            onOverrideChange={(o) =>
-              form.setValue("modelOverride", o, { shouldDirty: true })
-            }
-          />
-          <AutomationToolsControl
-            agentId={agentId || null}
-            value={form.watch("tools")}
-            onChange={(v) => form.setValue("tools", v, { shouldDirty: true })}
-          />
-        </div>
-
         {/* Section: Instructions */}
         <div className="flex flex-col gap-2.5">
           <div className="flex items-center justify-between">
@@ -854,6 +850,62 @@ export function SettingsTab({
             </div>
           </TiptapProvider>
         </div>
+
+        {/* Section: Advanced (Model, Tools, Max steps) */}
+        <Collapsible
+          open={advancedOpen}
+          onOpenChange={setAdvancedOpen}
+          className="flex flex-col gap-2.5"
+        >
+          <CollapsibleTrigger className="group flex w-fit cursor-pointer items-center gap-1.5">
+            <span className="text-xs font-semibold text-muted-foreground/60">
+              Advanced
+            </span>
+            <ChevronDown
+              size={14}
+              className="text-muted-foreground/60 transition-transform group-data-[state=open]:rotate-180"
+            />
+          </CollapsibleTrigger>
+          <CollapsibleContent className="flex flex-col gap-5 pt-0.5">
+            <AutomationModelControl
+              tier={form.watch("tier")}
+              onTierChange={(tier) =>
+                form.setValue("tier", tier, { shouldDirty: true })
+              }
+              override={form.watch("modelOverride")}
+              onOverrideChange={(o) =>
+                form.setValue("modelOverride", o, { shouldDirty: true })
+              }
+            />
+            <AutomationToolsControl
+              agentId={agentId || null}
+              value={form.watch("tools")}
+              onChange={(v) => form.setValue("tools", v, { shouldDirty: true })}
+            />
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-semibold text-muted-foreground/60">
+                Max steps
+              </span>
+              <Input
+                type="number"
+                min={1}
+                max={100}
+                className="w-40"
+                placeholder={`${DEFAULT_MAX_AGENT_STEPS} (default)`}
+                value={form.watch("maxAgentSteps") ?? ""}
+                onChange={(e) => {
+                  const raw = e.target.value.trim();
+                  const next = raw === "" ? null : Number(raw);
+                  form.setValue(
+                    "maxAgentSteps",
+                    next === null || Number.isNaN(next) ? null : next,
+                    { shouldDirty: true },
+                  );
+                }}
+              />
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       </div>
     </>
   );

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -88,6 +88,7 @@ import { IconPicker } from "../../components/icon-picker";
 import { SimpleIconPicker } from "../../components/simple-icon-picker";
 import { Page } from "@/web/components/page";
 import { AddConnectionDialog } from "./add-connection-dialog";
+import { SubAgentsSection } from "./sub-agents-section";
 import { track } from "@/web/lib/posthog-client";
 import { DependencySelectionDialog } from "./dependency-selection-dialog";
 import { ALL_ITEMS_SELECTED } from "./selection-utils";
@@ -1756,6 +1757,22 @@ Define step-by-step how the agent should handle requests.
                 )}
               </div>
             </section>
+
+            {/* Sub-agents section — delegation allowlist for the subtask tool */}
+            <ErrorBoundary fallback={() => null}>
+              <Suspense
+                fallback={
+                  <section className="flex flex-col gap-3">
+                    <h2 className="text-sm font-medium text-foreground">
+                      Sub-agents
+                    </h2>
+                    <div className="h-16 rounded-lg border border-dashed border-border animate-pulse" />
+                  </section>
+                }
+              >
+                <SubAgentsSection form={form} currentAgentId={virtualMcp.id} />
+              </Suspense>
+            </ErrorBoundary>
 
             {/* Instructions section */}
             <section className="flex flex-col gap-3">

--- a/apps/mesh/src/web/views/virtual-mcp/sub-agents-section.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/sub-agents-section.tsx
@@ -2,9 +2,10 @@
  * Sub-agents section for the agent (Virtual MCP) settings page.
  *
  * Controls which other agents this one may delegate to via the `subtask`
- * tool. The allowlist is stored on `metadata.subAgents` (an array of Virtual
- * MCP IDs). An empty/absent list means "all active org agents" — the default
- * behavior — so selecting specific agents is what restricts delegation.
+ * tool. The allowlist is stored on `metadata.subAgents`:
+ *   - null/absent  → "Any agent" (delegate to all active org agents)
+ *   - [ids...]     → "Specific agents" (only those)
+ *   - []           → "Only itself" (no cross-agent delegation)
  */
 
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
@@ -18,10 +19,24 @@ import {
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
 import { SearchInput } from "@deco/ui/components/search-input.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
 import { useProjectContext, useVirtualMCPs } from "@decocms/mesh-sdk";
 import { Plus, XClose } from "@untitledui/icons";
 import { useState } from "react";
 import type { VirtualMcpFormReturn } from "./types";
+
+type Mode = "all" | "selected" | "self";
+
+function modeOf(value: string[] | null | undefined): Mode {
+  if (value == null) return "all";
+  return value.length === 0 ? "self" : "selected";
+}
 
 export function SubAgentsSection({
   form,
@@ -34,14 +49,14 @@ export function SubAgentsSection({
   const allAgents = useVirtualMCPs();
   const [pickerOpen, setPickerOpen] = useState(false);
 
-  // Local optimistic mirror of the allowlist. This field is edited only here,
-  // so local state owns the UI source of truth — clicks update instantly,
-  // decoupled from the form-watch subscription and the autosave's query
-  // invalidation — while form.setValue persists it in the background.
-  const [selectedIds, setSelectedIds] = useState<string[]>(
-    () => form.getValues("metadata.subAgents") ?? [],
-  );
-  const isRestricted = selectedIds.length > 0;
+  // Local optimistic state. This field is edited only here, so local state
+  // owns the UI source of truth — clicks update instantly, decoupled from the
+  // form-watch subscription and the autosave's query invalidation — while
+  // form.setValue persists in the background. Mode is tracked explicitly so
+  // "Specific agents" with nothing selected yet doesn't collapse to "self".
+  const initial = form.getValues("metadata.subAgents") ?? null;
+  const [mode, setMode] = useState<Mode>(() => modeOf(initial));
+  const [selectedIds, setSelectedIds] = useState<string[]>(initial ?? []);
 
   // Candidates: active agents in the org, excluding this agent itself and the
   // org-admin agent (whose id equals the org id).
@@ -51,86 +66,115 @@ export function SubAgentsSection({
 
   const selectedAgents = candidates.filter((a) => selectedIds.includes(a.id));
 
-  // Empty array collapses to null — both mean "all agents".
-  const setSubAgents = (ids: string[]) => {
-    setSelectedIds(ids);
-    form.setValue("metadata.subAgents", ids.length > 0 ? ids : null, {
-      shouldDirty: true,
-    });
+  const persist = (nextMode: Mode, nextIds: string[]) =>
+    form.setValue(
+      "metadata.subAgents",
+      nextMode === "all" ? null : nextMode === "self" ? [] : nextIds,
+      { shouldDirty: true },
+    );
+
+  const handleModeChange = (next: Mode) => {
+    setMode(next);
+    persist(next, selectedIds);
   };
 
-  const handleToggle = (id: string) =>
-    setSubAgents(
-      selectedIds.includes(id)
-        ? selectedIds.filter((x) => x !== id)
-        : [...selectedIds, id],
-    );
+  const handleToggle = (id: string) => {
+    const next = selectedIds.includes(id)
+      ? selectedIds.filter((x) => x !== id)
+      : [...selectedIds, id];
+    setSelectedIds(next);
+    persist("selected", next);
+  };
 
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-3">
         <h2 className="text-sm font-medium text-foreground">Sub-agents</h2>
-        {isRestricted && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPickerOpen(true)}
-          >
-            <Plus size={14} />
-            Add sub-agent
-          </Button>
-        )}
-      </div>
-      <div className="flex flex-col gap-2">
-        {!isRestricted ? (
-          <button
-            type="button"
-            onClick={() => setPickerOpen(true)}
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-dashed border-border hover:bg-accent/50 transition-colors w-full text-left cursor-pointer"
-          >
-            <div className="flex items-center justify-center size-8 rounded-md text-muted-foreground/75 border border-dashed border-border shrink-0">
-              <Plus size={16} />
-            </div>
-            <span className="text-sm text-muted-foreground">
-              Can delegate to any agent in the organization. Choose specific
-              agents to restrict.
-            </span>
-          </button>
-        ) : selectedAgents.length > 0 ? (
-          selectedAgents.map((agent) => (
-            <div
-              key={agent.id}
-              className="flex items-center gap-3 px-4 py-3 rounded-xl border bg-background"
+        <div className="flex items-center gap-2">
+          {mode === "selected" && selectedAgents.length > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPickerOpen(true)}
             >
-              <IntegrationIcon
-                icon={agent.icon}
-                name={agent.title}
-                size="sm"
-                className="shrink-0"
-              />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium truncate">{agent.title}</p>
-                {agent.description && (
-                  <p className="text-xs text-muted-foreground truncate">
-                    {agent.description}
-                  </p>
-                )}
-              </div>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => handleToggle(agent.id)}
-              >
-                <XClose size={16} />
-              </Button>
-            </div>
-          ))
-        ) : (
+              <Plus size={14} />
+              Add sub-agent
+            </Button>
+          )}
+          <Select
+            value={mode}
+            onValueChange={(v) => handleModeChange(v as Mode)}
+          >
+            <SelectTrigger size="sm" className="w-auto">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="end">
+              <SelectItem value="all">Any agent</SelectItem>
+              <SelectItem value="selected">Specific agents</SelectItem>
+              <SelectItem value="self">Only itself</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {mode === "all" && (
           <p className="text-sm text-muted-foreground px-1">
-            The selected sub-agents are no longer available — delegation falls
-            back to all agents.
+            Can delegate to any agent in the organization.
           </p>
         )}
+
+        {mode === "self" && (
+          <p className="text-sm text-muted-foreground px-1">
+            Can only delegate to a fresh copy of itself — no other agents.
+          </p>
+        )}
+
+        {mode === "selected" &&
+          (selectedAgents.length > 0 ? (
+            selectedAgents.map((agent) => (
+              <div
+                key={agent.id}
+                className="flex items-center gap-3 px-4 py-3 rounded-xl border bg-background"
+              >
+                <IntegrationIcon
+                  icon={agent.icon}
+                  name={agent.title}
+                  size="sm"
+                  className="shrink-0"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{agent.title}</p>
+                  {agent.description && (
+                    <p className="text-xs text-muted-foreground truncate">
+                      {agent.description}
+                    </p>
+                  )}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleToggle(agent.id)}
+                >
+                  <XClose size={16} />
+                </Button>
+              </div>
+            ))
+          ) : (
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-dashed border-border hover:bg-accent/50 transition-colors w-full text-left cursor-pointer"
+            >
+              <div className="flex items-center justify-center size-8 rounded-md text-muted-foreground/75 border border-dashed border-border shrink-0">
+                <Plus size={16} />
+              </div>
+              <span className="text-sm text-muted-foreground">
+                No sub-agents selected yet. Add one — until then this agent can
+                only delegate to itself.
+              </span>
+            </button>
+          ))}
       </div>
 
       <SubAgentsPickerDialog

--- a/apps/mesh/src/web/views/virtual-mcp/sub-agents-section.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/sub-agents-section.tsx
@@ -1,0 +1,219 @@
+/**
+ * Sub-agents section for the agent (Virtual MCP) settings page.
+ *
+ * Controls which other agents this one may delegate to via the `subtask`
+ * tool. The allowlist is stored on `metadata.subAgents` (an array of Virtual
+ * MCP IDs). An empty/absent list means "all active org agents" — the default
+ * behavior — so selecting specific agents is what restricts delegation.
+ */
+
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import type { VirtualMCPEntity } from "@/tools/virtual/schema";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { SearchInput } from "@deco/ui/components/search-input.tsx";
+import { useProjectContext, useVirtualMCPs } from "@decocms/mesh-sdk";
+import { Plus, XClose } from "@untitledui/icons";
+import { useState } from "react";
+import type { VirtualMcpFormReturn } from "./types";
+
+export function SubAgentsSection({
+  form,
+  currentAgentId,
+}: {
+  form: VirtualMcpFormReturn;
+  currentAgentId: string;
+}) {
+  const { org } = useProjectContext();
+  const allAgents = useVirtualMCPs();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  // Local optimistic mirror of the allowlist. This field is edited only here,
+  // so local state owns the UI source of truth — clicks update instantly,
+  // decoupled from the form-watch subscription and the autosave's query
+  // invalidation — while form.setValue persists it in the background.
+  const [selectedIds, setSelectedIds] = useState<string[]>(
+    () => form.getValues("metadata.subAgents") ?? [],
+  );
+  const isRestricted = selectedIds.length > 0;
+
+  // Candidates: active agents in the org, excluding this agent itself and the
+  // org-admin agent (whose id equals the org id).
+  const candidates = allAgents.filter(
+    (a) => a.id !== currentAgentId && a.id !== org.id && a.status === "active",
+  );
+
+  const selectedAgents = candidates.filter((a) => selectedIds.includes(a.id));
+
+  // Empty array collapses to null — both mean "all agents".
+  const setSubAgents = (ids: string[]) => {
+    setSelectedIds(ids);
+    form.setValue("metadata.subAgents", ids.length > 0 ? ids : null, {
+      shouldDirty: true,
+    });
+  };
+
+  const handleToggle = (id: string) =>
+    setSubAgents(
+      selectedIds.includes(id)
+        ? selectedIds.filter((x) => x !== id)
+        : [...selectedIds, id],
+    );
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-sm font-medium text-foreground">Sub-agents</h2>
+        {isRestricted && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPickerOpen(true)}
+          >
+            <Plus size={14} />
+            Add sub-agent
+          </Button>
+        )}
+      </div>
+      <div className="flex flex-col gap-2">
+        {!isRestricted ? (
+          <button
+            type="button"
+            onClick={() => setPickerOpen(true)}
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-dashed border-border hover:bg-accent/50 transition-colors w-full text-left cursor-pointer"
+          >
+            <div className="flex items-center justify-center size-8 rounded-md text-muted-foreground/75 border border-dashed border-border shrink-0">
+              <Plus size={16} />
+            </div>
+            <span className="text-sm text-muted-foreground">
+              Can delegate to any agent in the organization. Choose specific
+              agents to restrict.
+            </span>
+          </button>
+        ) : selectedAgents.length > 0 ? (
+          selectedAgents.map((agent) => (
+            <div
+              key={agent.id}
+              className="flex items-center gap-3 px-4 py-3 rounded-xl border bg-background"
+            >
+              <IntegrationIcon
+                icon={agent.icon}
+                name={agent.title}
+                size="sm"
+                className="shrink-0"
+              />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{agent.title}</p>
+                {agent.description && (
+                  <p className="text-xs text-muted-foreground truncate">
+                    {agent.description}
+                  </p>
+                )}
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => handleToggle(agent.id)}
+              >
+                <XClose size={16} />
+              </Button>
+            </div>
+          ))
+        ) : (
+          <p className="text-sm text-muted-foreground px-1">
+            The selected sub-agents are no longer available — delegation falls
+            back to all agents.
+          </p>
+        )}
+      </div>
+
+      <SubAgentsPickerDialog
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        candidates={candidates}
+        selectedIds={selectedIds}
+        onToggle={handleToggle}
+      />
+    </section>
+  );
+}
+
+function SubAgentsPickerDialog({
+  open,
+  onOpenChange,
+  candidates,
+  selectedIds,
+  onToggle,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  candidates: VirtualMCPEntity[];
+  selectedIds: string[];
+  onToggle: (id: string) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const lower = search.toLowerCase();
+  const filtered = candidates.filter(
+    (a) =>
+      a.title.toLowerCase().includes(lower) ||
+      a.description?.toLowerCase().includes(lower),
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Sub-agents</DialogTitle>
+        </DialogHeader>
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Search agents..."
+          className="w-full"
+        />
+        <div className="flex flex-col gap-1 max-h-80 overflow-y-auto">
+          {filtered.length === 0 ? (
+            <p className="text-sm text-muted-foreground px-1 py-4 text-center">
+              No agents found.
+            </p>
+          ) : (
+            filtered.map((agent) => (
+              <button
+                key={agent.id}
+                type="button"
+                onClick={() => onToggle(agent.id)}
+                className="flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-accent/50 transition-colors cursor-pointer w-full text-left"
+              >
+                <Checkbox
+                  checked={selectedIds.includes(agent.id)}
+                  className="pointer-events-none"
+                  tabIndex={-1}
+                />
+                <IntegrationIcon
+                  icon={agent.icon}
+                  name={agent.title}
+                  size="sm"
+                  className="shrink-0"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{agent.title}</p>
+                  {agent.description && (
+                    <p className="text-xs text-muted-foreground truncate">
+                      {agent.description}
+                    </p>
+                  )}
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -507,6 +507,13 @@ export const VirtualMCPEntitySchema = z.object({
         .nullable()
         .optional()
         .describe("List of enabled plugin IDs"),
+      subAgents: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe(
+          "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
+        ),
       ui: VirtualMcpUISchema.nullable()
         .optional()
         .describe("UI customization settings"),
@@ -564,6 +571,13 @@ export const VirtualMCPCreateDataSchema = z.object({
         .nullable()
         .optional()
         .describe("List of enabled plugin IDs"),
+      subAgents: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe(
+          "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
+        ),
       ui: VirtualMcpUISchema.nullable()
         .optional()
         .describe("UI customization settings"),
@@ -617,6 +631,13 @@ export const VirtualMCPUpdateDataSchema = z.object({
         .nullable()
         .optional()
         .describe("List of enabled plugin IDs"),
+      subAgents: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe(
+          "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
+        ),
       ui: VirtualMcpUISchema.nullable()
         .optional()
         .describe("UI customization settings"),


### PR DESCRIPTION
- Introduced a new migration to add `max_agent_steps` column to the `automations` table, allowing per-automation control over the maximum number of reasoning/tool steps.
- Updated relevant interfaces and types to include `maxAgentSteps` for input and output in various components, including API routes and storage.
- Enhanced UI components to support configuration of `maxAgentSteps`, with appropriate defaults and validation.
- Added tests to ensure correct behavior of the new feature in automation settings and agent delegation.

This change allows automations to specify a custom step limit, improving flexibility in agent behavior.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per‑automation control of the parent agent’s max step count and a sub‑agent delegation allowlist for Virtual MCPs, with UI to configure, prompt filtering, and runtime enforcement. This lets teams bound agent loop length and safely control cross‑agent delegation.

- **New Features**
  - Automations: Added `max_agent_steps` (null uses `PARENT_STEP_LIMIT`). Wired through storage, API schemas, dispatch route, and `HarnessStreamInput` as `maxAgentSteps`, passed to decopilot as `stepLimit`. Tools: `create`/`get`/`update` support `maxAgentSteps`.
  - UI: Automation detail → Advanced “Max steps” field (1–100, placeholder 30, autosave).
  - Virtual MCPs: New “Sub‑agents” section with modes “Any agent”, “Specific agents”, “Only itself”, plus picker to add/remove allowed agents. Stored in `metadata.subAgents` and reflected in SDK types.
  - Prompt/runtime: Agents catalog filtered by the allowlist; `subtask` enforces it (self‑delegation always allowed). Empty allowlist hides the catalog. Tests cover defaults, forwarding, and edge cases.

- **Migration**
  - Run DB migrations to add `automations.max_agent_steps`. Existing automations keep the default unless a custom limit is set.

<sup>Written for commit f105b78242c66124229e3f1fce9716c0439de41b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

