### PR TITLE
feat(dispatch-errors): introduce PermanentRunError for better error h…

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -23,6 +23,7 @@
  */
 
 import type { StudioContext } from "@/core/studio-context";
+import { PermanentRunError } from "@/core/dispatch-errors";
 import { posthog } from "@/posthog";
 import { type UIMessageChunk, createUIMessageStream } from "ai";
 import type { MeshProvider } from "@/ai-providers/types";
@@ -812,7 +813,7 @@ async function prepareRun(
       : null;
 
     if (!virtualMcp) {
-      throw new Error("Agent not found");
+      throw new PermanentRunError("agent_not_found", "Agent not found");
     }
 
     // 3. Dispatch START or RESUME
@@ -906,7 +907,8 @@ async function prepareRun(
 
     if (!input.isResume) {
       if (!materializedRequestMessage) {
-        throw new Error(
+        throw new PermanentRunError(
+          "empty_request",
           "No user message found in input — expected at least one non-system message",
         );
       }

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -46,6 +46,7 @@ import {
   resolveTier,
   tryResolveTier,
 } from "@/core/resolve-tier";
+import { isPermanentRunError } from "@/core/dispatch-errors";
 import type { AutomationsStorage } from "@/storage/automations";
 import type { Automation } from "@/storage/types";
 import type { SimpleModeTier } from "@/tools/organization/schema";
@@ -344,6 +345,15 @@ async function markRunFailedStep(taskId: string): Promise<void> {
   }
 }
 
+async function deactivateAutomationStep(automationId: string): Promise<void> {
+  const rt = requireRuntime();
+  try {
+    await rt.storage.deactivateAutomation(automationId);
+  } catch {
+    // best-effort
+  }
+}
+
 // Split into steps so a crash-recovery replay doesn't duplicate the
 // `threads` row inserted by `createRunThread`.
 async function fireAutomationWorkflowFn(
@@ -402,6 +412,18 @@ async function fireAutomationWorkflowFn(
     });
   } catch (err) {
     const runError = err instanceof Error ? err.message : String(err);
+    if (isPermanentRunError(err)) {
+      console.warn(
+        `[fireAutomationWorkflow] deactivating "${prep.automation.name}" (${prep.automation.id}) — permanent dispatch error, will not fire again: ${runError}`,
+      );
+      await DBOS.runStep(() => deactivateAutomationStep(prep.automation.id), {
+        name: "deactivateAutomation",
+      });
+      await DBOS.runStep(() => markRunFailedStep(taskId), {
+        name: "markRunFailed",
+      });
+      return { taskId, error: runError };
+    }
     console.error(
       `[fireAutomationWorkflow] ERROR "${prep.automation.name}" taskId=${taskId}:`,
       runError,

--- a/apps/mesh/src/core/dispatch-errors.ts
+++ b/apps/mesh/src/core/dispatch-errors.ts
@@ -1,0 +1,22 @@
+export type PermanentRunErrorCode = "empty_request" | "agent_not_found";
+
+export class PermanentRunError extends Error {
+  /** Own-enumerable so it survives DBOS error (de)serialization. */
+  readonly permanent = true as const;
+  readonly code: PermanentRunErrorCode;
+
+  constructor(code: PermanentRunErrorCode, message: string) {
+    super(message);
+    this.name = "PermanentRunError";
+    this.code = code;
+  }
+}
+
+export function isPermanentRunError(err: unknown): boolean {
+  return (
+    err instanceof PermanentRunError ||
+    (typeof err === "object" &&
+      err !== null &&
+      (err as { permanent?: unknown }).permanent === true)
+  );
+}


### PR DESCRIPTION
…andling

- Added PermanentRunError class to encapsulate specific error codes ("empty_request", "agent_not_found") for permanent errors in dispatch processes.
- Updated error handling in dispatch-run.ts to throw PermanentRunError instead of generic Error for improved clarity and consistency.
- Enhanced automation workflow to handle PermanentRunError, ensuring proper deactivation of automations on permanent errors.

This change improves error management and provides clearer feedback in the dispatch and automation workflows.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies permanent dispatch failures with a new `PermanentRunError`, and updates automations to stop retrying and auto-deactivate on these errors. This gives clearer feedback and prevents repeated runs on unrecoverable issues.

- **New Features**
  - Added `PermanentRunError` (codes: `empty_request`, `agent_not_found`) and `isPermanentRunError` in `@/core/dispatch-errors`.
  - `dispatch-run.ts`: throws `PermanentRunError` for missing agent and empty user message.
  - `dbos-workflow.ts`: on permanent errors, deactivates the automation, marks the run failed, and stops re-firing.

<sup>Written for commit 822c8b5751a828f63cf4d522d0fcae789eeb58bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

