### PR TITLE
Feat/permanent run error

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -23,6 +23,7 @@
  */
 
 import type { StudioContext } from "@/core/studio-context";
+import { PermanentRunError } from "@/core/dispatch-errors";
 import { posthog } from "@/posthog";
 import { type UIMessageChunk, createUIMessageStream } from "ai";
 import type { MeshProvider } from "@/ai-providers/types";
@@ -812,7 +813,7 @@ async function prepareRun(
       : null;
 
     if (!virtualMcp) {
-      throw new Error("Agent not found");
+      throw new PermanentRunError("agent_not_found", "Agent not found");
     }
 
     // 3. Dispatch START or RESUME
@@ -906,7 +907,8 @@ async function prepareRun(
 
     if (!input.isResume) {
       if (!materializedRequestMessage) {
-        throw new Error(
+        throw new PermanentRunError(
+          "empty_request",
           "No user message found in input — expected at least one non-system message",
         );
       }

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -46,6 +46,7 @@ import {
   resolveTier,
   tryResolveTier,
 } from "@/core/resolve-tier";
+import { isPermanentRunError } from "@/core/dispatch-errors";
 import type { AutomationsStorage } from "@/storage/automations";
 import type { Automation } from "@/storage/types";
 import type { SimpleModeTier } from "@/tools/organization/schema";
@@ -344,6 +345,15 @@ async function markRunFailedStep(taskId: string): Promise<void> {
   }
 }
 
+async function deactivateAutomationStep(automationId: string): Promise<void> {
+  const rt = requireRuntime();
+  try {
+    await rt.storage.deactivateAutomation(automationId);
+  } catch {
+    // best-effort
+  }
+}
+
 // Split into steps so a crash-recovery replay doesn't duplicate the
 // `threads` row inserted by `createRunThread`.
 async function fireAutomationWorkflowFn(
@@ -402,6 +412,18 @@ async function fireAutomationWorkflowFn(
     });
   } catch (err) {
     const runError = err instanceof Error ? err.message : String(err);
+    if (isPermanentRunError(err)) {
+      console.warn(
+        `[fireAutomationWorkflow] deactivating "${prep.automation.name}" (${prep.automation.id}) — permanent dispatch error, will not fire again: ${runError}`,
+      );
+      await DBOS.runStep(() => deactivateAutomationStep(prep.automation.id), {
+        name: "deactivateAutomation",
+      });
+      await DBOS.runStep(() => markRunFailedStep(taskId), {
+        name: "markRunFailed",
+      });
+      return { taskId, error: runError };
+    }
     console.error(
       `[fireAutomationWorkflow] ERROR "${prep.automation.name}" taskId=${taskId}:`,
       runError,

--- a/apps/mesh/src/core/dispatch-errors.test.ts
+++ b/apps/mesh/src/core/dispatch-errors.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { PermanentRunError, isPermanentRunError } from "./dispatch-errors";
+
+describe("isPermanentRunError", () => {
+  it("matches a PermanentRunError instance", () => {
+    expect(
+      isPermanentRunError(new PermanentRunError("empty_request", "no msg")),
+    ).toBe(true);
+    expect(
+      isPermanentRunError(new PermanentRunError("agent_not_found", "gone")),
+    ).toBe(true);
+  });
+
+  it("matches the deserialized shape (flag, not instanceof)", () => {
+    const deserialized = Object.assign(new Error("Agent not found"), {
+      name: "PermanentRunError",
+      permanent: true,
+      code: "agent_not_found",
+    });
+    expect(deserialized instanceof PermanentRunError).toBe(false);
+    expect(isPermanentRunError(deserialized)).toBe(true);
+  });
+
+  it("rejects ordinary errors and non-errors", () => {
+    expect(isPermanentRunError(new Error("transient db blip"))).toBe(false);
+    expect(isPermanentRunError({ permanent: false })).toBe(false);
+    expect(isPermanentRunError(null)).toBe(false);
+    expect(isPermanentRunError("Agent not found")).toBe(false);
+  });
+});

--- a/apps/mesh/src/core/dispatch-errors.ts
+++ b/apps/mesh/src/core/dispatch-errors.ts
@@ -1,0 +1,22 @@
+export type PermanentRunErrorCode = "empty_request" | "agent_not_found";
+
+export class PermanentRunError extends Error {
+  /** Own-enumerable so it survives DBOS error (de)serialization. */
+  readonly permanent = true as const;
+  readonly code: PermanentRunErrorCode;
+
+  constructor(code: PermanentRunErrorCode, message: string) {
+    super(message);
+    this.name = "PermanentRunError";
+    this.code = code;
+  }
+}
+
+export function isPermanentRunError(err: unknown): boolean {
+  return (
+    err instanceof PermanentRunError ||
+    (typeof err === "object" &&
+      err !== null &&
+      (err as { permanent?: unknown }).permanent === true)
+  );
+}


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `PermanentRunError` to flag non‑retryable dispatch failures. The automation workflow now deactivates automations on these errors to stop repeated firing.

- **New Features**
  - Introduced `PermanentRunError` with codes `empty_request` and `agent_not_found`, plus `isPermanentRunError` for safe checks after serialization.
  - Run preparation now throws `PermanentRunError` for missing agent and empty user input.
  - Added tests for identifying permanent errors, including deserialized shapes.

- **Bug Fixes**
  - Workflow detects permanent dispatch errors, deactivates the automation, marks the run failed, and returns early instead of retrying.

<sup>Written for commit f0d31a45b9e7229f9c936782f9edaeba4014e1ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

