### PR TITLE
feat(api): add health path check and utility function

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -75,7 +75,11 @@ import publicConfigRoutes from "./routes/public-config";
 import filesRoutes from "./routes/files";
 import { createThreadOutputsRoutes } from "./routes/thread-outputs";
 import { createSelfRoutes } from "./routes/self";
-import { shouldSkipStudioContext, SYSTEM_PATHS } from "./utils/paths";
+import {
+  isHealthPath,
+  shouldSkipStudioContext,
+  SYSTEM_PATHS,
+} from "./utils/paths";
 import {
   mountPluginRoutes,
   initializePluginStorage,
@@ -1127,6 +1131,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Log response body for 5xx errors
   app.use("*", async (c, next) => {
     await next();
+    if (isHealthPath(c.req.path)) return;
     if (c.res.status >= 500) {
       const clonedRes = c.res.clone();
       const body = await clonedRes.text();

--- a/apps/mesh/src/api/utils/paths.ts
+++ b/apps/mesh/src/api/utils/paths.ts
@@ -30,6 +30,14 @@ const PATH_PREFIXES = {
 const STATIC_FILE_PATTERN =
   /\.(html|css|js|ico|svg|png|jpg|jpeg|gif|webp|woff|woff2)$/;
 
+export function isHealthPath(path: string): boolean {
+  return (
+    path === SYSTEM_PATHS.HEALTH ||
+    path === SYSTEM_PATHS.HEALTH_LIVE ||
+    path === SYSTEM_PATHS.HEALTH_READY
+  );
+}
+
 /** Check if a path is a system endpoint (health, metrics, well-known) */
 function isSystemPath(path: string): boolean {
   return (

--- a/apps/mesh/src/observability/middleware.ts
+++ b/apps/mesh/src/observability/middleware.ts
@@ -14,12 +14,17 @@ import {
   setCorrelationIdHeader,
 } from "./index";
 import type { Env } from "../api/hono-env";
+import { isHealthPath } from "../api/utils/paths";
 
 /**
  * Tracing middleware that creates a span for each request
  * with common HTTP attributes and mesh-specific context.
  */
 export const tracingMiddleware: MiddlewareHandler<Env> = async (c, next) => {
+  if (isHealthPath(c.req.path)) {
+    return next();
+  }
+
   const req = c.req.raw;
   const url = new URL(req.url);
 


### PR DESCRIPTION
- Introduced `isHealthPath` utility function to determine if a request path corresponds to health check endpoints.
- Updated middleware to skip processing for health paths, improving performance and reducing unnecessary logging for health checks.
- Refactored imports in `app.ts` to include the new utility function.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `isHealthPath` and skips tracing and error-body logging for health endpoints to reduce noise and improve performance.

- **New Features**
  - Added `isHealthPath` in `api/utils/paths` to detect `SYSTEM_PATHS.HEALTH`, `SYSTEM_PATHS.HEALTH_LIVE`, and `SYSTEM_PATHS.HEALTH_READY`.
  - Updated observability middleware to bypass tracing for health paths.
  - Skips 5xx response body logging in `app.ts` when the request path is a health endpoint.

<sup>Written for commit abe64ffba861b5ca7a07b8bd5d69135130989828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

