### PR TITLE
feat(circuit-breaker): enhance circuit management with failure tracking

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -21,6 +21,12 @@ import { managementMCP } from "../../tools";
 import { guardResponseStream } from "../utils/stream-guard";
 import { handleAuthError } from "./oauth-proxy";
 import { getMcpListCache } from "@/mcp-clients/mcp-list-cache";
+import {
+  assertCircuitClosed,
+  CircuitOpenError,
+  recordFailure,
+  recordSuccess,
+} from "@/mcp-clients/circuit-breaker";
 import { peekRpcMethod, probeDecision } from "./proxy-handshake";
 import { handleVirtualMcpRequest } from "./virtual-mcp";
 export { toServerClient, type MCPProxyClient } from "./mcp-proxy-factory";
@@ -33,6 +39,10 @@ type Variables = {
 type ProxyEnv = { Variables: Variables };
 
 const handleError = (err: Error, c: Context) => {
+  if (err instanceof CircuitOpenError) {
+    c.header("Retry-After", String(Math.ceil(err.cooldownRemainingMs / 1000)));
+    return c.json({ error: err.message }, 503);
+  }
   if (err.message.includes("not found")) {
     return c.json({ error: err.message }, 404);
   }
@@ -163,6 +173,7 @@ export const createProxyRoutes = () => {
             : true;
         }
         if (connection.connection_url && probe) {
+          assertCircuitClosed(connectionId);
           await ctx.tracer.startActiveSpan(
             "studio.connection.handshake",
             {
@@ -175,6 +186,7 @@ export const createProxyRoutes = () => {
               startTime(c, "mcp.client_handshake");
               try {
                 await clientFromConnection(connection, ctx, false);
+                recordSuccess(connectionId);
                 span.setStatus({ code: SpanStatusCode.OK });
               } catch (err) {
                 span.setStatus({
@@ -214,6 +226,9 @@ export const createProxyRoutes = () => {
         endTime(c, "mcp.handle_request");
         return guardResponseStream(response, `mcp:${connectionId}`);
       } catch (error) {
+        if (error instanceof CircuitOpenError) {
+          throw error;
+        }
         // Check if this is an auth error - if so, return appropriate 401
         // Note: This only applies to HTTP connections
         const connection = await ctx.storage.connections.findById(
@@ -231,6 +246,20 @@ export const createProxyRoutes = () => {
           });
           if (authResponse) {
             return authResponse;
+          }
+          const { shouldDisable } = recordFailure(connectionId);
+          if (shouldDisable && connection.status === "active") {
+            await ctx.storage.connections.update(connectionId, {
+              status: "error",
+            });
+            console.warn(
+              "[proxy] auto-disabled connection after repeated failures",
+              {
+                connectionId,
+                org: ctx.organization?.slug,
+                error: (error as Error).message,
+              },
+            );
           }
         }
         throw error;

--- a/apps/mesh/src/core/constants.ts
+++ b/apps/mesh/src/core/constants.ts
@@ -22,3 +22,12 @@ export const CIRCUIT_BREAKER_COOLDOWN_MS = 30_000; // 30 seconds
 
 /** Maximum number of circuit breaker entries to retain in memory */
 export const CIRCUIT_BREAKER_MAX_ENTRIES = 1000;
+
+/**
+ * Number of times a connection's circuit may re-open before it is durably
+ * disabled (connection.status → "error"). The in-memory breaker fast-fails for
+ * a 30s cooldown and auto-recovers; if the downstream keeps failing across this
+ * many open cycles, the connection is persisted as "error" so it stops paying a
+ * handshake on every refresh across all pods, until manually re-enabled.
+ */
+export const CIRCUIT_BREAKER_DISABLE_AFTER_OPENS = 3;

--- a/apps/mesh/src/mcp-clients/circuit-breaker.test.ts
+++ b/apps/mesh/src/mcp-clients/circuit-breaker.test.ts
@@ -82,6 +82,49 @@ describe("circuit-breaker", () => {
     expect(() => assertCircuitClosed("conn_a")).toThrow(CircuitOpenError);
   });
 
+  it("reports openCount and does not signal disable on the first open", () => {
+    const r1 = recordFailure("conn_a");
+    expect(r1.shouldDisable).toBe(false);
+    const r2 = recordFailure("conn_a");
+    expect(r2.shouldDisable).toBe(false);
+    // Third failure crosses the failure threshold → first OPEN cycle.
+    const r3 = recordFailure("conn_a");
+    expect(r3.state).toBe("OPEN");
+    expect(r3.openCount).toBe(1);
+    expect(r3.shouldDisable).toBe(false);
+  });
+
+  it("signals disable after re-opening across cooldown cycles", () => {
+    // First open cycle.
+    for (let i = 0; i < 3; i++) recordFailure("conn_a");
+    expect(_getCircuitForTest("conn_a")!.openCount).toBe(1);
+
+    // Each cooldown→HALF_OPEN→failed-probe re-opens the circuit once.
+    const reopen = () => {
+      const circuit = _getCircuitForTest("conn_a")!;
+      circuit.lastFailureTime = Date.now() - 60_000;
+      assertCircuitClosed("conn_a"); // → HALF_OPEN, probe allowed
+      return recordFailure("conn_a"); // probe fails → OPEN again
+    };
+
+    const second = reopen();
+    expect(second.openCount).toBe(2);
+    expect(second.shouldDisable).toBe(false);
+
+    const third = reopen();
+    expect(third.openCount).toBe(3);
+    expect(third.shouldDisable).toBe(true);
+  });
+
+  it("success clears the open-cycle counter", () => {
+    for (let i = 0; i < 3; i++) recordFailure("conn_a");
+    recordSuccess("conn_a");
+    // Counter resets — a fresh failure burst starts the cycle count over.
+    const r = recordFailure("conn_a");
+    expect(r.openCount).toBe(0);
+    expect(r.shouldDisable).toBe(false);
+  });
+
   it("includes retry info in error message", () => {
     for (let i = 0; i < 3; i++) recordFailure("conn_a");
     let thrown: unknown;

--- a/apps/mesh/src/mcp-clients/circuit-breaker.ts
+++ b/apps/mesh/src/mcp-clients/circuit-breaker.ts
@@ -12,6 +12,7 @@
 
 import {
   CIRCUIT_BREAKER_COOLDOWN_MS,
+  CIRCUIT_BREAKER_DISABLE_AFTER_OPENS,
   CIRCUIT_BREAKER_FAILURE_THRESHOLD,
   CIRCUIT_BREAKER_MAX_ENTRIES,
 } from "../core/constants";
@@ -23,17 +24,26 @@ interface CircuitEntry {
   consecutiveFailures: number;
   lastFailureTime: number;
   halfOpenInFlight: boolean;
+  openCount: number;
+}
+
+export interface FailureOutcome {
+  state: CircuitState;
+  openCount: number;
+  shouldDisable: boolean;
 }
 
 const circuits = new Map<string, CircuitEntry>();
 
 export class CircuitOpenError extends Error {
+  readonly cooldownRemainingMs: number;
   constructor(connectionId: string, cooldownRemainingMs: number) {
     super(
       `Connection ${connectionId} circuit breaker is open — downstream server unreachable. ` +
         `Retry in ${Math.ceil(cooldownRemainingMs / 1000)}s.`,
     );
     this.name = "CircuitOpenError";
+    this.cooldownRemainingMs = cooldownRemainingMs;
   }
 }
 
@@ -77,27 +87,39 @@ export function recordSuccess(connectionId: string): void {
 /**
  * Record a failed connection. Increments failures and opens circuit after threshold.
  */
-export function recordFailure(connectionId: string): void {
-  const circuit = circuits.get(connectionId);
+export function recordFailure(connectionId: string): FailureOutcome {
+  let circuit = circuits.get(connectionId);
 
   if (!circuit) {
     evictIfNeeded();
-    circuits.set(connectionId, {
-      state: 1 >= CIRCUIT_BREAKER_FAILURE_THRESHOLD ? "OPEN" : "CLOSED",
-      consecutiveFailures: 1,
-      lastFailureTime: Date.now(),
+    circuit = {
+      state: "CLOSED",
+      consecutiveFailures: 0,
+      lastFailureTime: 0,
       halfOpenInFlight: false,
-    });
-    return;
+      openCount: 0,
+    };
+    circuits.set(connectionId, circuit);
   }
 
+  const wasOpen = circuit.state === "OPEN";
   circuit.consecutiveFailures++;
   circuit.lastFailureTime = Date.now();
   circuit.halfOpenInFlight = false;
 
-  if (circuit.consecutiveFailures >= CIRCUIT_BREAKER_FAILURE_THRESHOLD) {
+  if (
+    circuit.consecutiveFailures >= CIRCUIT_BREAKER_FAILURE_THRESHOLD &&
+    !wasOpen
+  ) {
     circuit.state = "OPEN";
+    circuit.openCount++;
   }
+
+  return {
+    state: circuit.state,
+    openCount: circuit.openCount,
+    shouldDisable: circuit.openCount >= CIRCUIT_BREAKER_DISABLE_AFTER_OPENS,
+  };
 }
 
 /**


### PR DESCRIPTION
- Introduced new logic to track connection failures and manage circuit states, including a mechanism to disable connections after repeated failures.
- Updated `recordFailure` and `recordSuccess` functions to return detailed outcomes, including open count and disable status.
- Enhanced error handling in proxy routes to provide retry information and manage circuit states effectively.
- Added tests to validate the new failure tracking and disabling behavior of the circuit breaker.

This change improves the resilience of the system by preventing repeated attempts on failing connections and providing clearer feedback on circuit states.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add failure-cycle tracking to the circuit breaker and auto-disable flapping connections after repeated open cycles. Proxy returns 503 with Retry-After when a circuit is open and skips handshakes during cooldown.

- **New Features**
  - `recordFailure`/`recordSuccess` now return a `FailureOutcome` with `state`, `openCount`, and `shouldDisable`.
  - Added `CircuitOpenError` (includes cooldown) and `assertCircuitClosed` checks before handshakes; on success we call `recordSuccess`.
  - Auto-disable connections after repeated re-opens by setting `status: "error"` when `shouldDisable` is true, controlled by `CIRCUIT_BREAKER_DISABLE_AFTER_OPENS = 3`.
  - Proxy maps open-circuit errors to 503 and sets `Retry-After`; tests cover open counts, disable signaling, and reset on success.

<sup>Written for commit edb9e37d06f3008ff0a2b81435fef8fc97b4af96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

