### PR TITLE
feat(connection-circuit): implement durable connection auto-disable m…

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -97,6 +97,12 @@ import {
   type McpListCache,
 } from "../mcp-clients/mcp-list-cache";
 import {
+  type ConnectionCircuitStore,
+  JetStreamKVConnectionCircuitStore,
+  NoopConnectionCircuitStore,
+  setConnectionCircuitStore,
+} from "../mcp-clients/connection-circuit-store";
+import {
   InMemoryModelListCache,
   type ModelListCache,
 } from "../ai-providers/model-list-cache";
@@ -850,6 +856,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   let eventBus: EventBus;
   let mcpListCache: McpListCache;
+  let connectionCircuitStore: ConnectionCircuitStore;
   // Model lists are public, low-stakes metadata cached per-replica with a TTL —
   // no NATS needed, so this is shared across the test and production branches.
   const modelListCache: ModelListCache = new InMemoryModelListCache();
@@ -874,6 +881,7 @@ export async function createApp(options: CreateAppOptions = {}) {
       invalidate: async () => {},
       teardown: () => {},
     };
+    connectionCircuitStore = new NoopConnectionCircuitStore();
     cancelBroadcast = {
       start: async () => {},
       broadcast: () => {},
@@ -919,6 +927,12 @@ export async function createApp(options: CreateAppOptions = {}) {
     tlc.init().catch(() => {});
     mcpListCache = tlc;
 
+    const ccs = new JetStreamKVConnectionCircuitStore({
+      getJetStream: () => natsProvider!.getJetStream(),
+    });
+    ccs.init().catch(() => {});
+    connectionCircuitStore = ccs;
+
     providerKeyCache = createProviderKeyCache({
       getConnection: () => natsProvider!.getConnection(),
     });
@@ -953,6 +967,9 @@ export async function createApp(options: CreateAppOptions = {}) {
       tlc.init().catch((err: unknown) => {
         console.error("[McpListCache] Deferred init failed:", err);
       });
+      ccs.init().catch((err: unknown) => {
+        console.error("[ConnectionCircuitStore] Deferred init failed:", err);
+      });
       // Subscribe to cross-replica key invalidations (idempotent).
       providerKeyCache.start();
       streamBuffer.init().catch((err: unknown) => {
@@ -984,6 +1001,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Set tool list cache after cleanup to avoid previous cleanup nulling the new cache
   setMcpListCache(mcpListCache);
+  setConnectionCircuitStore(connectionCircuitStore);
 
   const threadStorage = new SqlThreadStorage(database.db);
 
@@ -1073,7 +1091,9 @@ export async function createApp(options: CreateAppOptions = {}) {
     mcpListCache.teardown();
     modelListCache.teardown();
     providerKeyCache.teardown();
+    connectionCircuitStore.teardown();
     setMcpListCache(null);
+    setConnectionCircuitStore(null);
   };
 
   const app = new Hono<Env>();

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -27,6 +27,7 @@ import {
   recordFailure,
   recordSuccess,
 } from "@/mcp-clients/circuit-breaker";
+import { getConnectionCircuitStore } from "@/mcp-clients/connection-circuit-store";
 import { peekRpcMethod, probeDecision } from "./proxy-handshake";
 import { handleVirtualMcpRequest } from "./virtual-mcp";
 export { toServerClient, type MCPProxyClient } from "./mcp-proxy-factory";
@@ -187,6 +188,7 @@ export const createProxyRoutes = () => {
               try {
                 await clientFromConnection(connection, ctx, false);
                 recordSuccess(connectionId);
+                void getConnectionCircuitStore().recordSuccess(connectionId);
                 span.setStatus({ code: SpanStatusCode.OK });
               } catch (err) {
                 span.setStatus({
@@ -245,15 +247,23 @@ export const createProxyRoutes = () => {
             orgSlug: ctx.organization?.slug,
           });
           if (authResponse) {
+            // 401-style errors are user-recoverable (drive the OAuth popup) —
+            // they must NOT trip the breaker or disable the connection.
             return authResponse;
           }
-          const { shouldDisable } = recordFailure(connectionId);
+          // Non-auth failure (404 / 5xx / network) against a real downstream.
+          // Trip the per-replica breaker (latency guard) and the cross-replica
+          // failure window. Once failures are sustained fleet-wide, durably
+          // disable the connection so every replica stops probing it.
+          recordFailure(connectionId);
+          const { shouldDisable } =
+            await getConnectionCircuitStore().recordFailure(connectionId);
           if (shouldDisable && connection.status === "active") {
             await ctx.storage.connections.update(connectionId, {
               status: "error",
             });
             console.warn(
-              "[proxy] auto-disabled connection after repeated failures",
+              "[proxy] auto-disabled connection after sustained failures",
               {
                 connectionId,
                 org: ctx.organization?.slug,

--- a/apps/mesh/src/core/constants.ts
+++ b/apps/mesh/src/core/constants.ts
@@ -31,3 +31,23 @@ export const CIRCUIT_BREAKER_MAX_ENTRIES = 1000;
  * handshake on every refresh across all pods, until manually re-enabled.
  */
 export const CIRCUIT_BREAKER_DISABLE_AFTER_OPENS = 3;
+/*
+ * Durable connection auto-disable (cross-replica, via the shared circuit store).
+ *
+ * Distinct from the in-memory CIRCUIT_BREAKER_* guard above: that one fast-fails
+ * per replica to bound latency on a hung server. These govern when a connection's
+ * `status` is flipped to "error" so EVERY replica then stops probing a
+ * persistently-failing downstream (fast-fail via the cheap DB status gate).
+ */
+
+/** Non-auth failures (aggregated across replicas) before a connection is durably disabled. */
+export const CONNECTION_DISABLE_FAILURE_THRESHOLD = 5;
+
+/**
+ * Failures must be sustained at least this long before disabling. Filters out
+ * transient blips / thundering herds that spike the count in well under a window.
+ */
+export const CONNECTION_DISABLE_MIN_WINDOW_MS = 60_000; // 60 seconds
+
+/** TTL for shared failure-counter entries — a connection that stops failing self-resets. */
+export const CONNECTION_CIRCUIT_TTL_MS = 5 * 60_000; // 5 minutes

--- a/apps/mesh/src/mcp-clients/connection-circuit-store.test.ts
+++ b/apps/mesh/src/mcp-clients/connection-circuit-store.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import {
+  CONNECTION_DISABLE_FAILURE_THRESHOLD,
+  CONNECTION_DISABLE_MIN_WINDOW_MS,
+} from "../core/constants";
+import {
+  NoopConnectionCircuitStore,
+  shouldDisableForRecord,
+} from "./connection-circuit-store";
+
+const T = CONNECTION_DISABLE_FAILURE_THRESHOLD;
+const W = CONNECTION_DISABLE_MIN_WINDOW_MS;
+
+describe("shouldDisableForRecord", () => {
+  it("does not disable below the failure threshold", () => {
+    expect(
+      shouldDisableForRecord({
+        count: T - 1,
+        firstFailureAt: 0,
+        lastFailureAt: W,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not disable a burst that hasn't been sustained past the window", () => {
+    // Count is well over threshold, but all failures landed in < window —
+    // a thundering herd, not a sustained outage.
+    expect(
+      shouldDisableForRecord({
+        count: T * 10,
+        firstFailureAt: 0,
+        lastFailureAt: W - 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("disables once threshold is reached AND sustained past the window", () => {
+    expect(
+      shouldDisableForRecord({
+        count: T,
+        firstFailureAt: 0,
+        lastFailureAt: W,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("NoopConnectionCircuitStore", () => {
+  it("never signals disable", async () => {
+    const store = new NoopConnectionCircuitStore();
+    const decision = await store.recordFailure();
+    expect(decision.shouldDisable).toBe(false);
+    // recordSuccess / teardown are no-ops that must not throw
+    await store.recordSuccess();
+    store.teardown();
+  });
+});

--- a/apps/mesh/src/mcp-clients/connection-circuit-store.ts
+++ b/apps/mesh/src/mcp-clients/connection-circuit-store.ts
@@ -1,0 +1,173 @@
+/**
+ * Cross-replica failure counter for durable connection auto-disable.
+ *
+ * The in-memory circuit breaker (./circuit-breaker) fast-fails per replica to
+ * bound latency, but it can't decide to durably disable a connection: behind a
+ * load balancer each replica only sees a fraction of the traffic, so no single
+ * replica's count reflects the fleet. This store aggregates non-auth failures
+ * across ALL replicas in NATS JetStream KV, so any one replica can flip a
+ * persistently-failing connection to status="error" — after which every replica
+ * fast-fails via the cheap DB status gate, with no downstream handshake.
+ *
+ * Entries carry a bucket TTL, so a connection that stops failing has its window
+ * self-reset; a single success clears the counter immediately.
+ */
+
+import {
+  JSONCodec,
+  nanos,
+  StorageType,
+  type JetStreamClient,
+  type KV,
+} from "nats";
+import {
+  CONNECTION_CIRCUIT_TTL_MS,
+  CONNECTION_DISABLE_FAILURE_THRESHOLD,
+  CONNECTION_DISABLE_MIN_WINDOW_MS,
+} from "../core/constants";
+
+interface CircuitRecord {
+  count: number;
+  firstFailureAt: number;
+  lastFailureAt: number;
+}
+
+export interface FailureDecision {
+  /** Aggregated non-auth failure count within the current window. */
+  count: number;
+  /** True once failures crossed the threshold AND were sustained past the window. */
+  shouldDisable: boolean;
+}
+
+const NO_DISABLE: FailureDecision = { count: 0, shouldDisable: false };
+
+export interface ConnectionCircuitStore {
+  /** Record a non-auth failure and report whether the connection should be disabled. */
+  recordFailure(connectionId: string): Promise<FailureDecision>;
+  /** Clear a connection's failure window after a successful contact. */
+  recordSuccess(connectionId: string): Promise<void>;
+  teardown(): void;
+}
+
+/**
+ * Pure decision: does this accumulated record warrant a durable disable?
+ * Requires both a threshold count AND a sustained window so a brief burst can't
+ * trip it. Exported for unit testing.
+ */
+export function shouldDisableForRecord(record: CircuitRecord): boolean {
+  const sustainedMs = record.lastFailureAt - record.firstFailureAt;
+  return (
+    record.count >= CONNECTION_DISABLE_FAILURE_THRESHOLD &&
+    sustainedMs >= CONNECTION_DISABLE_MIN_WINDOW_MS
+  );
+}
+
+const KV_BUCKET = "DECOCMS_CONN_CIRCUIT";
+const MAX_CAS_ATTEMPTS = 5;
+
+export class JetStreamKVConnectionCircuitStore
+  implements ConnectionCircuitStore
+{
+  private kv: KV | null = null;
+  private readonly codec = JSONCodec<CircuitRecord>();
+
+  constructor(
+    private readonly options: { getJetStream: () => JetStreamClient | null },
+  ) {}
+
+  async init(): Promise<void> {
+    const js = this.options.getJetStream();
+    if (!js) return; // NATS not ready — disable accounting paused until re-init
+    this.kv = await js.views.kv(KV_BUCKET, {
+      storage: StorageType.Memory,
+      ttl: nanos(CONNECTION_CIRCUIT_TTL_MS),
+    });
+  }
+
+  async recordFailure(connectionId: string): Promise<FailureDecision> {
+    if (!this.kv) return NO_DISABLE;
+    const now = Date.now();
+    // Optimistic read-increment-write across replicas. create() rejects if a
+    // key already exists and update() rejects on a stale revision — either way
+    // another replica raced us, so we retry. Best-effort: after a few attempts
+    // we give up, since an occasional lost increment only slightly delays the
+    // disable, never causes a false one.
+    for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+      try {
+        const entry = await this.kv.get(connectionId);
+        const live =
+          entry &&
+          entry.operation !== "DEL" &&
+          entry.operation !== "PURGE" &&
+          entry.value?.length;
+
+        if (!live) {
+          const record: CircuitRecord = {
+            count: 1,
+            firstFailureAt: now,
+            lastFailureAt: now,
+          };
+          await this.kv.create(connectionId, this.codec.encode(record));
+          return { count: record.count, shouldDisable: false };
+        }
+
+        const prev = this.codec.decode(entry.value);
+        const record: CircuitRecord = {
+          count: prev.count + 1,
+          firstFailureAt: prev.firstFailureAt,
+          lastFailureAt: now,
+        };
+        await this.kv.update(
+          connectionId,
+          this.codec.encode(record),
+          entry.revision,
+        );
+        return {
+          count: record.count,
+          shouldDisable: shouldDisableForRecord(record),
+        };
+      } catch {
+        // create race / revision conflict — retry the read-modify-write
+      }
+    }
+    return NO_DISABLE;
+  }
+
+  async recordSuccess(connectionId: string): Promise<void> {
+    if (!this.kv) return;
+    try {
+      await this.kv.delete(connectionId);
+    } catch {
+      // best-effort, non-critical
+    }
+  }
+
+  teardown(): void {
+    this.kv = null;
+  }
+}
+
+/**
+ * No-op store for test / no-NATS mode. Durable cross-replica disable is paused;
+ * the per-replica in-memory circuit breaker still provides fast-fail.
+ */
+export class NoopConnectionCircuitStore implements ConnectionCircuitStore {
+  async recordFailure(): Promise<FailureDecision> {
+    return NO_DISABLE;
+  }
+  async recordSuccess(): Promise<void> {}
+  teardown(): void {}
+}
+
+// Module-level active store — set once at app startup, read by the proxy route.
+let activeStore: ConnectionCircuitStore = new NoopConnectionCircuitStore();
+
+export function setConnectionCircuitStore(
+  store: ConnectionCircuitStore | null,
+): void {
+  activeStore = store ?? new NoopConnectionCircuitStore();
+}
+
+export function getConnectionCircuitStore(): ConnectionCircuitStore {
+  return activeStore;
+}


### PR DESCRIPTION
…echanism

- Added `ConnectionCircuitStore` to aggregate non-auth failures across replicas, enabling durable connection disabling.
- Introduced `JetStreamKVConnectionCircuitStore` for persistent failure tracking using NATS JetStream KV.
- Implemented failure and success recording methods, with logic to determine when a connection should be disabled based on sustained failures.
- Updated `app.ts` to initialize and set the connection circuit store.
- Enhanced `proxy.ts` to utilize the circuit breaker for connection management, including success and failure recording.
- Added tests for the connection circuit store functionality to ensure correct behavior under various failure scenarios.
- Updated constants to define thresholds and TTL for connection failure tracking.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a durable, cross-replica connection auto-disable using a shared KV-backed circuit store, wired into the MCP proxy. This stops repeated probes to dead downstreams and returns 503 with Retry-After when the in-memory circuit is open.

- **New Features**
  - Added a `ConnectionCircuitStore` with a JetStream KV-backed implementation to aggregate non-auth failures across replicas (TTL-based) and a `NoopConnectionCircuitStore` fallback when NATS is unavailable.
  - Durable disable: flip connection `status: "error"` when failures meet `CONNECTION_DISABLE_FAILURE_THRESHOLD` and are sustained past `CONNECTION_DISABLE_MIN_WINDOW_MS`; windows self-reset via `CONNECTION_CIRCUIT_TTL_MS` or any success.
  - Proxy integration: on successful handshake, clear counters locally and in the shared store; on non-auth failures, record in both and auto-disable when signaled; auth failures are excluded.
  - App wiring: initialize/set the store at startup (with deferred init) and clean teardown on shutdown.
  - Tests for `shouldDisableForRecord` and the noop store; constants added for thresholds and TTL.

<sup>Written for commit fcbb5d236daa6e5501bb499532c5b9de626ef0ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

