### PR TITLE
fix(org-fs): run public skill-set sync as a DBOS scheduled workflow

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -9,7 +9,11 @@
  */
 
 import { getSettings } from "../settings";
-import { startPublicSetsSync } from "../file-storage/skill-set-sync";
+import {
+  kickPublicSetsBootSync,
+  registerPublicSetsSyncWorkflow,
+  setPublicSetsSyncRuntime,
+} from "../file-storage/dbos-public-sets-sync";
 import { getPublicUrl } from "@/core/server-constants";
 import { usesLocalObjectStorage } from "../tools/connection/dev-assets";
 import { DECO_STORE_URL, isDecoHostedMcp } from "@/core/deco-constants";
@@ -1368,9 +1372,10 @@ export async function createApp(options: CreateAppOptions = {}) {
       console.error("[EventBus] Error during startup:", error);
     });
 
-  // Public skill sets: sync the configured GitHub-sourced shared volumes on
-  // boot and on an interval (no-op when ORGFS_PUBLIC_SETS is unset).
-  startPublicSetsSync(database.db, { baseUrl: getPublicUrl() });
+  // Public skill sets: synced by a DBOS scheduled workflow (one pod per tick
+  // instead of every pod racing its own loop). This only stashes deps — the
+  // workflow no-ops when ORGFS_PUBLIC_SETS is unset.
+  setPublicSetsSyncRuntime({ db: database.db, baseUrl: getPublicUrl() });
 
   // ============================================================================
   // Automation Runtime — wire storage + streaming into the DBOS workflow
@@ -1418,6 +1423,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Must run before DBOS.launch() (which fires in index.ts after createApp).
   registerMonitoringRetentionWorkflow();
+  registerPublicSetsSyncWorkflow();
 
   const automationRunner: StudioContext["automationRunner"] = async (
     automationId,
@@ -2224,6 +2230,12 @@ export async function createApp(options: CreateAppOptions = {}) {
     // replicas/workers all enqueueing in parallel collapse via OAOO.
     backfillStudioPackForAllOrgs().catch((err) => {
       console.error("[studio-pack-backfill] failed:", err);
+    });
+
+    // Fire-and-forget immediate public-sets sync (hour-bucketed workflow ID,
+    // so parallel-booting replicas collapse via OAOO).
+    kickPublicSetsBootSync().catch((err) => {
+      console.error("[org-fs] public-sets boot sync kick failed:", err);
     });
   };
 

--- a/apps/mesh/src/file-storage/dbos-public-sets-sync.ts
+++ b/apps/mesh/src/file-storage/dbos-public-sets-sync.ts
@@ -1,0 +1,99 @@
+/**
+ * DBOS scheduled workflow for the public skill-set sync.
+ *
+ * Replaces the per-pod boot loop: N replicas each ran their own 10-minute
+ * interval, so every tick fetched N tarballs and raced the same
+ * delete-before-write sequence against the shared volumes. The DBOS scheduler
+ * coordinates through the system DB (deterministic workflow ID per tick), so
+ * exactly one pod owns a tick; per-set steps journal progress, so a pod death
+ * mid-sweep resumes from the failed set instead of refetching everything.
+ *
+ * Runtime deps (db, baseUrl) are looked up via a module-level registry wired
+ * by app boot via `setPublicSetsSyncRuntime` BEFORE `DBOS.launch()` — same
+ * pattern as automations/dbos-workflow.ts.
+ */
+
+import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
+import type { Kysely } from "kysely";
+import type { Database } from "../storage/types";
+import { getPublicSets } from "./public-sets";
+import { syncPublicSetSafe } from "./skill-set-sync";
+
+/** Every 10 minutes, off the :00 boundary to avoid colliding with hourly tasks. */
+const PUBLIC_SETS_SYNC_CRONTAB = "4-59/10 * * * *";
+
+export interface PublicSetsSyncRuntime {
+  db: Kysely<Database>;
+  baseUrl: string;
+}
+
+let runtime: PublicSetsSyncRuntime | null = null;
+
+/** Wire deps for the workflow body. Safe to call before `DBOS.launch()`:
+ *  it only writes a module-level pointer, no DBOS API calls. */
+export function setPublicSetsSyncRuntime(rt: PublicSetsSyncRuntime): void {
+  runtime = rt;
+}
+
+function requireRuntime(): PublicSetsSyncRuntime {
+  if (!runtime) {
+    throw new Error(
+      "[org-fs] public-sets sync runtime not initialized — setPublicSetsSyncRuntime() must run before the workflow fires",
+    );
+  }
+  return runtime;
+}
+
+async function publicSetsSyncWorkflowFn(
+  _scheduledTime: Date,
+  _currentTime: Date,
+): Promise<void> {
+  // Env-derived config, identical on every pod — deterministic across replays.
+  for (const source of getPublicSets()) {
+    const result = await DBOS.runStep(
+      () => {
+        const rt = requireRuntime();
+        return syncPublicSetSafe(rt.db, source, { baseUrl: rt.baseUrl });
+      },
+      { name: `syncPublicSet:${source.set}` },
+    );
+    if ("error" in result) {
+      console.warn(
+        `[org-fs] public set "${result.set}" sync failed: ${result.error}`,
+      );
+    } else if (result.written || result.deleted) {
+      console.log(
+        `[org-fs] public set "${result.set}" synced: +${result.written} -${result.deleted} (=${result.unchanged})`,
+      );
+    }
+  }
+}
+
+let registeredWorkflow: typeof publicSetsSyncWorkflowFn | null = null;
+
+// Must run before DBOS.launch(). Guarded so HMR repeats don't re-register.
+export function registerPublicSetsSyncWorkflow(): void {
+  if (registeredWorkflow) return;
+  registeredWorkflow = DBOS.registerWorkflow(publicSetsSyncWorkflowFn, {
+    name: "publicSetsSyncWorkflow",
+  });
+  DBOS.registerScheduled(registeredWorkflow, {
+    name: "publicSetsSyncWorkflow",
+    crontab: PUBLIC_SETS_SYNC_CRONTAB,
+    mode: SchedulerMode.ExactlyOncePerIntervalWhenActive,
+  });
+}
+
+/**
+ * Boot kick: one immediate sync per boot wave so a fresh deployment doesn't
+ * serve empty volumes until the first cron tick. The hour-bucketed workflow
+ * ID collapses N replicas booting together via OAOO; a redeploy later in the
+ * same hour skips it, which is fine — the schedule covers it within 10
+ * minutes. Must run AFTER `DBOS.launch()`.
+ */
+export async function kickPublicSetsBootSync(): Promise<void> {
+  if (getPublicSets().length === 0 || !registeredWorkflow) return;
+  const now = new Date();
+  const workflowID = `public-sets-sync-boot:${now.toISOString().slice(0, 13)}`;
+  await DBOS.startWorkflow(registeredWorkflow, { workflowID })(now, now);
+}

--- a/apps/mesh/src/file-storage/skill-set-sync.ts
+++ b/apps/mesh/src/file-storage/skill-set-sync.ts
@@ -9,14 +9,13 @@
  * written and only vanished ones deleted. Running sandboxes pick changes up
  * in ~1s via the change feed (the mount invalidator).
  *
- * Runs from server boot on an interval (the cron-shaped safety net) and on
- * demand via the ORG_FS_PUBLIC_SETS_SYNC tool.
+ * Runs on a DBOS scheduled workflow (dbos-public-sets-sync.ts) so exactly one
+ * pod owns each tick, and on demand via the ORG_FS_PUBLIC_SETS_SYNC tool.
  */
 
 import { createHash } from "node:crypto";
 import { gunzipSync } from "node:zlib";
 import type { Kysely } from "kysely";
-import { sleep } from "@decocms/std";
 import type { Database } from "../storage/types";
 import { OrgFsEntryStorage } from "../storage/org-fs";
 import { createBoundObjectStorage } from "../object-storage/bound-object-storage";
@@ -278,6 +277,22 @@ async function syncPublicSet(
   return { set: source.set, written, deleted, unchanged };
 }
 
+/** `syncPublicSet` with failure folded into the result (never throws). */
+export async function syncPublicSetSafe(
+  db: Kysely<Database>,
+  source: PublicSkillSetSource,
+  opts: { baseUrl: string },
+): Promise<SyncResult | { set: string; error: string }> {
+  try {
+    return await syncPublicSet(db, source, opts);
+  } catch (err) {
+    return {
+      set: source.set,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 /** Sync every configured set; failures are per-set (one bad repo never
  *  blocks the others). Returns per-set results or error messages. */
 export async function syncAllPublicSets(
@@ -286,45 +301,7 @@ export async function syncAllPublicSets(
 ): Promise<Array<SyncResult | { set: string; error: string }>> {
   const results: Array<SyncResult | { set: string; error: string }> = [];
   for (const source of getPublicSets()) {
-    try {
-      results.push(await syncPublicSet(db, source, opts));
-    } catch (err) {
-      results.push({
-        set: source.set,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+    results.push(await syncPublicSetSafe(db, source, opts));
   }
   return results;
-}
-
-const DEFAULT_SYNC_INTERVAL_MS = 10 * 60 * 1000;
-
-/** Boot-time loop: initial sync, then every `intervalMs`. Never throws. */
-export function startPublicSetsSync(
-  db: Kysely<Database>,
-  opts: { baseUrl: string; intervalMs?: number; signal?: AbortSignal },
-): void {
-  if (getPublicSets().length === 0) return;
-  const intervalMs = opts.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
-  void (async () => {
-    while (!opts.signal?.aborted) {
-      const results = await syncAllPublicSets(db, opts).catch((err) => {
-        console.warn("[org-fs] public set sync failed", err);
-        return [];
-      });
-      for (const r of results) {
-        if ("error" in r) {
-          console.warn(
-            `[org-fs] public set "${r.set}" sync failed: ${r.error}`,
-          );
-        } else if (r.written || r.deleted) {
-          console.log(
-            `[org-fs] public set "${r.set}" synced: +${r.written} -${r.deleted} (=${r.unchanged})`,
-          );
-        }
-      }
-      await sleep(intervalMs, { signal: opts.signal }).catch(() => {});
-    }
-  })();
 }


### PR DESCRIPTION
## Summary

The public skill-set sync (`ORGFS_PUBLIC_SETS` → shared org-fs volumes) ran as a per-pod boot loop: every replica fetched the tarballs and ran the same delete-before-write sequence against the shared volumes every 10 minutes, concurrently. This moves it to a DBOS scheduled workflow so exactly one pod owns each tick.

## Changes

- **New `file-storage/dbos-public-sets-sync.ts`** — scheduled workflow (`4-59/10 * * * *`, `ExactlyOncePerIntervalWhenActive`, same pattern as `monitoring/dbos-retention-workflow.ts`). Each configured set syncs as its own `DBOS.runStep`, so a pod death mid-sweep replays from the failed set instead of refetching everything. Runtime deps (db, baseUrl) wired via a module registry before `DBOS.launch()`, same as `automations/dbos-workflow.ts`.
- **Boot kick** in `initDbos` (post-launch): one immediate fire-and-forget sync per boot wave with an hour-bucketed workflow ID, so fresh deployments don't serve empty volumes until the first cron tick and parallel-booting replicas collapse via OAOO.
- **`skill-set-sync.ts`** — extracted `syncPublicSetSafe` (per-set try/catch, shared by the workflow and `syncAllPublicSets`); removed the `startPublicSetsSync` boot loop.
- `ORG_FS_PUBLIC_SETS_SYNC` admin tool unchanged.

## Testing

- `bun test apps/mesh/src/file-storage/skill-set-sync.test.ts` — 7/7 pass
- `bun run check`, `bun run lint`, `bun run fmt`, knip — clean
- Pre-existing ECONNREFUSED failures in `file-storage/` integration tests are identical on a clean tree (require a running server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved public skill‑set sync to a `@dbos-inc/dbos-sdk` scheduled workflow so only one pod runs each tick. This removes multi‑pod races and redundant downloads, and adds safe resume on failure.

- **Refactors**
  - Replaced per‑pod loop with a DBOS scheduled workflow (`ExactlyOncePerIntervalWhenActive`, every 10m).
  - Each set sync runs as its own `DBOS.runStep`, so crashes resume from the failed set only.
  - Added a post‑launch boot kick with an hour‑bucketed workflow ID to avoid empty volumes on fresh deploys (OAOO across replicas).
  - Extracted `syncPublicSetSafe`; removed `startPublicSetsSync`. On‑demand `ORG_FS_PUBLIC_SETS_SYNC` tool stays the same.
  - Runtime wiring via `setPublicSetsSyncRuntime` and `registerPublicSetsSyncWorkflow` before launch; `kickPublicSetsBootSync()` after launch. No‑ops when `ORGFS_PUBLIC_SETS` is unset.

<sup>Written for commit b4c3a251be2c2e5958643f4f6ae9291c3ccddb0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

