### PR TITLE
feat(sandbox): co-author Studio user on VM git commits and PRs

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1629,6 +1629,16 @@ async function resolvePullSandboxConfig(
     handle: sandboxHandle,
     ...(repo ? { repo } : {}),
     ...(workload ? { workload } : {}),
+    ...(ctx.auth.user?.name?.trim()
+      ? {
+          operator: {
+            userName: ctx.auth.user.name.trim(),
+            ...(ctx.auth.user.email?.trim()
+              ? { userEmail: ctx.auth.user.email.trim() }
+              : {}),
+          },
+        }
+      : {}),
     ...(offloadAllowedHosts !== undefined ? { offloadAllowedHosts } : {}),
     ...(offloadAllowSameHostDev !== undefined
       ? { offloadAllowSameHostDev }

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -39,6 +39,7 @@ import { ensureSandbox } from "@/tools/sandbox/start";
 import { buildDesktopProvider } from "@/sandbox/lifecycle";
 import { computeClaimHandle } from "@/sandbox/claim-handle";
 import { composeSandboxRef } from "@decocms/sandbox/provider";
+import { normalizeCoAuthorIdentity } from "@decocms/sandbox/shared";
 import {
   buildAnonymousCloneInfo,
   buildCloneInfo,
@@ -1625,20 +1626,16 @@ async function resolvePullSandboxConfig(
       })
     : undefined;
 
+  const operator = normalizeCoAuthorIdentity({
+    userName: ctx.auth.user?.name,
+    userEmail: ctx.auth.user?.email,
+  });
+
   return {
     handle: sandboxHandle,
     ...(repo ? { repo } : {}),
     ...(workload ? { workload } : {}),
-    ...(ctx.auth.user?.name?.trim()
-      ? {
-          operator: {
-            userName: ctx.auth.user.name.trim(),
-            ...(ctx.auth.user.email?.trim()
-              ? { userEmail: ctx.auth.user.email.trim() }
-              : {}),
-          },
-        }
-      : {}),
+    ...(operator ? { operator } : {}),
     ...(offloadAllowedHosts !== undefined ? { offloadAllowedHosts } : {}),
     ...(offloadAllowSameHostDev !== undefined
       ? { offloadAllowSameHostDev }

--- a/apps/mesh/src/api/routes/decopilot/link-work-queue.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-work-queue.ts
@@ -75,11 +75,17 @@ const workItemWorkloadSchema = z.object({
  * not be resolved at dispatch time (back-compat: daemons that already have
  * a running sandbox for the handle still succeed via the cache-hit path).
  */
+const workItemOperatorSchema = z.object({
+  userName: z.string(),
+  userEmail: z.string().optional(),
+});
+
 const workItemSandboxSchema = z.object({
   /** The stable sandbox handle — `computeHandle(sandboxId, branch)`. */
   handle: z.string(),
   repo: workItemRepoSchema.optional(),
   workload: workItemWorkloadSchema.optional(),
+  operator: workItemOperatorSchema.optional(),
   /**
    * Message-offload SSRF allowlist. Derived cluster-side from the object-
    * storage config (never a request frame). Empty = daemon fails closed.

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -17,7 +17,6 @@ import { streamSSE } from "hono/streaming";
 import { createMiddleware } from "hono/factory";
 import { composeSandboxRef } from "@decocms/sandbox/provider";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
-import { appendCoAuthorTrailer } from "@decocms/sandbox/shared";
 import type { ClaimPhase } from "@decocms/sandbox/provider/agent-sandbox";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
@@ -27,7 +26,7 @@ import {
   requireOrganization,
 } from "../../core/studio-context";
 import type { Env } from "../hono-env";
-import type { StudioContext } from "../../core/studio-context";
+import { patchSandboxOperator } from "../../tools/sandbox/patch-sandbox-operator";
 import { handleVmEvents } from "./sandbox-events-handler";
 import { resolveAndPushEnv } from "../../tools/sandbox/resolve-env";
 import { readValidatedRuntimeEnv } from "../../tools/sandbox/helpers";
@@ -81,13 +80,6 @@ function assertSandboxBranchParam(branch: string): void {
 
 const SUGGEST_COMMIT_MAX_BODY_BYTES = 512 * 1024;
 const PREVIEW_INVOKE_MAX_BODY_BYTES = 64 * 1024;
-
-function coAuthorFromContext(ctx: StudioContext) {
-  const name = ctx.auth.user?.name?.trim();
-  if (!name) return null;
-  const email = ctx.auth.user?.email?.trim();
-  return { userName: name, ...(email ? { userEmail: email } : {}) };
-}
 
 // ---- Shared middleware ------------------------------------------------------
 
@@ -511,6 +503,7 @@ export const createSandboxRoutes = () => {
     const ctx = c.var.meshContext;
 
     try {
+      await patchSandboxOperator(ctx, runner, claimName);
       const githubRepo = parseGithubRepoFromMetadata(
         virtualMcpMetadata,
         connectionIds,
@@ -526,16 +519,8 @@ export const createSandboxRoutes = () => {
       return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
     }
 
-    const raw = (await c.req.json().catch(() => ({}))) as {
-      message?: string;
-    };
-    const message = appendCoAuthorTrailer(
-      typeof raw.message === "string" ? raw.message : "",
-      coAuthorFromContext(ctx),
-    );
-
     return proxyDaemon(c, "/_sandbox/git/publish", {
-      jsonBody: JSON.stringify({ message }),
+      forwardJsonBody: true,
       map404to410: true,
     });
   });
@@ -545,12 +530,25 @@ export const createSandboxRoutes = () => {
       map404to410: true,
     }),
   );
-  app.post("/:virtualMcpId/:branch/git/rebase", (c) =>
-    proxyDaemon(c, "/_sandbox/git/rebase", {
+  app.post("/:virtualMcpId/:branch/git/rebase", async (c) => {
+    const runner = requireRunner(c);
+    if (runner instanceof Response) return runner;
+
+    const { claimName } = c.get("vmClaim");
+    const ctx = c.var.meshContext;
+
+    try {
+      await patchSandboxOperator(ctx, runner, claimName);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
+    }
+
+    return proxyDaemon(c, "/_sandbox/git/rebase", {
       forwardJsonBody: true,
       map404to410: true,
-    }),
-  );
+    });
+  });
   app.post(
     "/:virtualMcpId/:branch/git/suggest-commit",
     bodyLimit({

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -17,6 +17,7 @@ import { streamSSE } from "hono/streaming";
 import { createMiddleware } from "hono/factory";
 import { composeSandboxRef } from "@decocms/sandbox/provider";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
+import { appendCoAuthorTrailer } from "@decocms/sandbox/shared";
 import type { ClaimPhase } from "@decocms/sandbox/provider/agent-sandbox";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
@@ -26,6 +27,7 @@ import {
   requireOrganization,
 } from "../../core/studio-context";
 import type { Env } from "../hono-env";
+import type { StudioContext } from "../../core/studio-context";
 import { handleVmEvents } from "./sandbox-events-handler";
 import { resolveAndPushEnv } from "../../tools/sandbox/resolve-env";
 import { readValidatedRuntimeEnv } from "../../tools/sandbox/helpers";
@@ -79,6 +81,13 @@ function assertSandboxBranchParam(branch: string): void {
 
 const SUGGEST_COMMIT_MAX_BODY_BYTES = 512 * 1024;
 const PREVIEW_INVOKE_MAX_BODY_BYTES = 64 * 1024;
+
+function coAuthorFromContext(ctx: StudioContext) {
+  const name = ctx.auth.user?.name?.trim();
+  if (!name) return null;
+  const email = ctx.auth.user?.email?.trim();
+  return { userName: name, ...(email ? { userEmail: email } : {}) };
+}
 
 // ---- Shared middleware ------------------------------------------------------
 
@@ -196,6 +205,8 @@ async function proxyDaemon(
   opts?: {
     method?: "GET" | "POST" | "PUT";
     forwardJsonBody?: boolean;
+    /** When set, sent instead of reading the request body. */
+    jsonBody?: string;
     signal?: AbortSignal;
     /** Map 404 to 410 (sandbox needs re-provision). */
     map404to410?: boolean;
@@ -209,7 +220,10 @@ async function proxyDaemon(
   let body: string | null = null;
   const headers = new Headers();
 
-  if (opts?.forwardJsonBody) {
+  if (opts?.jsonBody !== undefined) {
+    body = opts.jsonBody;
+    headers.set("content-type", "application/json");
+  } else if (opts?.forwardJsonBody) {
     body = await c.req.text();
     headers.set("content-type", "application/json");
   }
@@ -512,8 +526,16 @@ export const createSandboxRoutes = () => {
       return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
     }
 
+    const raw = (await c.req.json().catch(() => ({}))) as {
+      message?: string;
+    };
+    const message = appendCoAuthorTrailer(
+      typeof raw.message === "string" ? raw.message : "",
+      coAuthorFromContext(ctx),
+    );
+
     return proxyDaemon(c, "/_sandbox/git/publish", {
-      forwardJsonBody: true,
+      jsonBody: JSON.stringify({ message }),
       map404to410: true,
     });
   });

--- a/apps/mesh/src/lib/co-author-identity.test.ts
+++ b/apps/mesh/src/lib/co-author-identity.test.ts
@@ -19,11 +19,11 @@ describe("coAuthorFromSessionUser", () => {
 });
 
 describe("coAuthorFromStudioContext", () => {
-  it("returns null when auth user has no display name", () => {
+  it("returns undefined when auth user has no display name", () => {
     expect(
       coAuthorFromStudioContext({
         auth: { user: { id: "u1", email: "jane@example.com" } },
       } as never),
-    ).toBeNull();
+    ).toBeUndefined();
   });
 });

--- a/apps/mesh/src/lib/co-author-identity.test.ts
+++ b/apps/mesh/src/lib/co-author-identity.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import {
+  coAuthorFromSessionUser,
+  coAuthorFromStudioContext,
+} from "./co-author-identity";
+
+describe("coAuthorFromSessionUser", () => {
+  it("normalizes display name and email", () => {
+    expect(
+      coAuthorFromSessionUser({
+        name: " Jane ",
+        email: " jane@example.com ",
+      }),
+    ).toEqual({
+      userName: "Jane",
+      userEmail: "jane@example.com",
+    });
+  });
+});
+
+describe("coAuthorFromStudioContext", () => {
+  it("returns null when auth user has no display name", () => {
+    expect(
+      coAuthorFromStudioContext({
+        auth: { user: { id: "u1", email: "jane@example.com" } },
+      } as never),
+    ).toBeNull();
+  });
+});

--- a/apps/mesh/src/lib/co-author-identity.ts
+++ b/apps/mesh/src/lib/co-author-identity.ts
@@ -6,18 +6,22 @@ import type { StudioContext } from "../core/studio-context";
 
 export function coAuthorFromStudioContext(
   ctx: StudioContext,
-): CoAuthorIdentity | null {
-  return normalizeCoAuthorIdentity({
-    userName: ctx.auth.user?.name,
-    userEmail: ctx.auth.user?.email,
-  });
+): CoAuthorIdentity | undefined {
+  return (
+    normalizeCoAuthorIdentity({
+      userName: ctx.auth.user?.name,
+      userEmail: ctx.auth.user?.email,
+    }) ?? undefined
+  );
 }
 
 export function coAuthorFromSessionUser(
   user: { name?: string | null; email?: string | null } | null | undefined,
-): CoAuthorIdentity | null {
-  return normalizeCoAuthorIdentity({
-    userName: user?.name,
-    userEmail: user?.email,
-  });
+): CoAuthorIdentity | undefined {
+  return (
+    normalizeCoAuthorIdentity({
+      userName: user?.name,
+      userEmail: user?.email,
+    }) ?? undefined
+  );
 }

--- a/apps/mesh/src/lib/co-author-identity.ts
+++ b/apps/mesh/src/lib/co-author-identity.ts
@@ -1,0 +1,23 @@
+import {
+  normalizeCoAuthorIdentity,
+  type CoAuthorIdentity,
+} from "@decocms/sandbox/shared";
+import type { StudioContext } from "../core/studio-context";
+
+export function coAuthorFromStudioContext(
+  ctx: StudioContext,
+): CoAuthorIdentity | null {
+  return normalizeCoAuthorIdentity({
+    userName: ctx.auth.user?.name,
+    userEmail: ctx.auth.user?.email,
+  });
+}
+
+export function coAuthorFromSessionUser(
+  user: { name?: string | null; email?: string | null } | null | undefined,
+): CoAuthorIdentity | null {
+  return normalizeCoAuthorIdentity({
+    userName: user?.name,
+    userEmail: user?.email,
+  });
+}

--- a/apps/mesh/src/link-daemon/cluster-connection-pull.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-pull.ts
@@ -179,6 +179,9 @@ export async function connectToClusterPull(
             ...(item.sandbox.workload
               ? { workload: item.sandbox.workload }
               : {}),
+            ...(item.sandbox.operator
+              ? { operator: item.sandbox.operator }
+              : {}),
             ...(item.sandbox.offloadAllowedHosts !== undefined
               ? { offloadAllowedHosts: item.sandbox.offloadAllowedHosts }
               : {}),

--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -35,6 +35,10 @@ interface EnsureSandboxBody {
   handle: string;
   repo?: RepoRef;
   workload?: Workload;
+  operator?: {
+    userName: string;
+    userEmail?: string;
+  };
   /** Message-offload SSRF allowlist pushed by the cluster (trusted config,
    *  never a request frame). Threaded into the spawned daemon's boot env so
    *  it can fetch offloaded `messagesRef` payloads from these hosts only. */

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -17,6 +17,7 @@ import {
   postConfig as daemonPostConfig,
   waitForDaemonReady,
 } from "@decocms/sandbox/daemon-client";
+import { normalizeCoAuthorIdentity } from "@decocms/sandbox/shared";
 import { createDefaultDaemonSpawn } from "@decocms/sandbox/daemon-spawn";
 import { ensureRclone } from "./ensure-rclone";
 import { createControlHandler } from "./control-handler";
@@ -146,13 +147,9 @@ export async function startLinkDaemon(
         };
       }
       const payload: Record<string, unknown> = { application };
-      if (config.operator?.userName) {
-        payload.operator = {
-          userName: config.operator.userName,
-          ...(config.operator.userEmail
-            ? { userEmail: config.operator.userEmail }
-            : {}),
-        };
+      const operator = normalizeCoAuthorIdentity(config.operator ?? null);
+      if (operator) {
+        payload.operator = operator;
       }
       if (config.repo) {
         payload.git = {

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -146,6 +146,14 @@ export async function startLinkDaemon(
         };
       }
       const payload: Record<string, unknown> = { application };
+      if (config.operator?.userName) {
+        payload.operator = {
+          userName: config.operator.userName,
+          ...(config.operator.userEmail
+            ? { userEmail: config.operator.userEmail }
+            : {}),
+        };
+      }
       if (config.repo) {
         payload.git = {
           repository: {

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -80,6 +80,11 @@ export interface EnsureSandboxInput {
   handle: string;
   repo?: RepoRef;
   workload?: Workload;
+  /** Studio user operating the sandbox — co-authored on git commits. */
+  operator?: {
+    userName: string;
+    userEmail?: string;
+  };
   /**
    * Message-offload SSRF allowlist, pushed by the cluster from its OWN trusted
    * S3 config (never a request frame). Threaded into the spawned daemon's boot
@@ -154,7 +159,11 @@ export interface DesktopSandboxProviderDeps {
   postConfig: (
     port: number,
     devPort: number,
-    config: { repo?: RepoRef; workload?: Workload },
+    config: {
+      repo?: RepoRef;
+      workload?: Workload;
+      operator?: EnsureSandboxInput["operator"];
+    },
     daemonToken: string,
   ) => Promise<void>;
   waitForHealth: (port: number) => Promise<void>;
@@ -370,7 +379,11 @@ export function createDesktopSandboxProvider(
         await deps.postConfig(
           port,
           devPort,
-          { repo: input.repo, workload: input.workload },
+          {
+            repo: input.repo,
+            workload: input.workload,
+            operator: input.operator,
+          },
           daemonToken,
         );
       } catch (err) {

--- a/apps/mesh/src/tools/sandbox/patch-sandbox-operator.ts
+++ b/apps/mesh/src/tools/sandbox/patch-sandbox-operator.ts
@@ -1,0 +1,26 @@
+import type { SandboxProvider } from "@decocms/sandbox/provider";
+import { coAuthorFromStudioContext } from "../../lib/co-author-identity";
+import type { StudioContext } from "../../core/studio-context";
+
+/** Sync the authenticated Studio user into daemon tenant config for co-author. */
+export async function patchSandboxOperator(
+  ctx: StudioContext,
+  runner: SandboxProvider,
+  handle: string,
+): Promise<void> {
+  const operator = coAuthorFromStudioContext(ctx);
+  if (!operator) return;
+
+  const res = await runner.proxyDaemonRequest(handle, "/_sandbox/config", {
+    method: "PUT",
+    headers: new Headers({ "content-type": "application/json" }),
+    body: JSON.stringify({ operator }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => res.statusText);
+    throw new Error(
+      `Failed to patch sandbox operator (${res.status}): ${body}`,
+    );
+  }
+}

--- a/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
@@ -2,6 +2,7 @@ import type { GithubRepo } from "@decocms/mesh-sdk/types";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import type { StudioContext } from "../../core/studio-context";
 import { RECONNECT_ERROR } from "../../oauth/token-refresh";
+import { coAuthorFromStudioContext } from "../../lib/co-author-identity";
 import {
   buildCloneInfo,
   ensureGithubCloneToken,
@@ -65,6 +66,8 @@ export async function refreshSandboxGitCredentials(
     ctx.vault,
   );
 
+  const operator = coAuthorFromStudioContext(ctx);
+
   const res = await runner.proxyDaemonRequest(handle, "/_sandbox/config", {
     method: "PUT",
     headers: new Headers({ "content-type": "application/json" }),
@@ -73,6 +76,7 @@ export async function refreshSandboxGitCredentials(
         repository: { cloneUrl },
         identity: { userName: gitUserName, userEmail: gitUserEmail },
       },
+      ...(operator ? { operator } : {}),
     }),
   });
 

--- a/apps/mesh/src/web/components/thread/github/github-pr-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-api.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./extract-tool-json.ts";
 import {
   findOpenPullRequestForBranch,
+  openPullRequestForBranch,
   parseCreatedPullRequestResult,
   squashMergePullRequest,
 } from "./github-pr-api.ts";
@@ -141,5 +142,70 @@ describe("squashMergePullRequest", () => {
         pullNumber: 1,
       }),
     ).rejects.toThrow("Failed to merge pull request");
+  });
+
+  test("appends co-author to squash commit message", async () => {
+    let args: Record<string, unknown> | undefined;
+    const client = {
+      callTool: async (req: {
+        name: string;
+        arguments: Record<string, unknown>;
+      }) => {
+        args = req.arguments;
+        return {
+          content: [{ type: "text", text: JSON.stringify({ merged: true }) }],
+        };
+      },
+    };
+
+    await squashMergePullRequest(client, {
+      owner: "o",
+      repo: "r",
+      pullNumber: 1,
+      commitMessage: "feat: ship it",
+      coAuthor: { userName: "Jane Doe", userEmail: "jane@example.com" },
+    });
+
+    expect(args?.commit_message).toBe(
+      "feat: ship it\n\nCo-authored-by: Jane Doe <jane@example.com>",
+    );
+  });
+});
+
+describe("openPullRequestForBranch", () => {
+  test("does not create a co-author-only PR body", async () => {
+    let args: Record<string, unknown> | undefined;
+    const client = {
+      callTool: async (req: {
+        name: string;
+        arguments: Record<string, unknown>;
+      }) => {
+        if (req.name === "list_pull_requests") {
+          return { content: [{ type: "text", text: "[]" }] };
+        }
+        args = req.arguments;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                url: "https://github.com/o/r/pull/2",
+              }),
+            },
+          ],
+        };
+      },
+    };
+
+    await openPullRequestForBranch(client, {
+      owner: "o",
+      repo: "r",
+      branch: "feat/x",
+      title: "feat: x",
+      base: "main",
+      coAuthor: { userName: "Jane Doe", userEmail: "jane@example.com" },
+    });
+
+    expect(args?.body).toBeUndefined();
   });
 });

--- a/apps/mesh/src/web/components/thread/github/github-pr-api.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-api.ts
@@ -3,7 +3,12 @@ import {
   pullNumberFromUrl,
   pullRequestFromToolText,
 } from "./extract-tool-json.ts";
-import { appendCoAuthorTrailer } from "@decocms/sandbox/shared";
+import {
+  appendCoAuthorToPullRequestBody,
+  appendCoAuthorTrailer,
+  normalizeCoAuthorIdentity,
+  type CoAuthorIdentity,
+} from "@decocms/sandbox/shared";
 
 type GithubMcpClient = {
   callTool: (req: {
@@ -34,7 +39,7 @@ export interface OpenPullRequestArgs {
   title: string;
   body?: string;
   base: string;
-  coAuthor?: { userName: string; userEmail?: string };
+  coAuthor?: CoAuthorIdentity;
 }
 
 function toolErrorMessage(result: unknown): string | null {
@@ -194,6 +199,37 @@ export async function findOpenPullRequestForBranch(
   return null;
 }
 
+async function ensureExistingPullRequestCoAuthor(
+  client: GithubMcpClient,
+  args: {
+    owner: string;
+    repo: string;
+    pullNumber: number;
+    body?: string;
+    coAuthor?: CoAuthorIdentity;
+  },
+): Promise<void> {
+  const body = appendCoAuthorToPullRequestBody(
+    args.body,
+    normalizeCoAuthorIdentity(args.coAuthor),
+  );
+  if (!body) return;
+
+  try {
+    await client.callTool({
+      name: "update_pull_request",
+      arguments: {
+        owner: args.owner,
+        repo: args.repo,
+        pullNumber: args.pullNumber,
+        body,
+      },
+    });
+  } catch {
+    // Best-effort when the GitHub MCP tool is unavailable or rejects the update.
+  }
+}
+
 async function createPullRequest(
   client: GithubMcpClient,
   args: {
@@ -203,14 +239,13 @@ async function createPullRequest(
     body?: string;
     head: string;
     base: string;
-    coAuthor?: OpenPullRequestArgs["coAuthor"];
+    coAuthor?: CoAuthorIdentity;
   },
 ): Promise<CreatedPullRequest> {
-  const body = args.body
-    ? appendCoAuthorTrailer(args.body, args.coAuthor)
-    : args.coAuthor
-      ? appendCoAuthorTrailer("", args.coAuthor)
-      : undefined;
+  const body = appendCoAuthorToPullRequestBody(
+    args.body,
+    normalizeCoAuthorIdentity(args.coAuthor),
+  );
   const result = await client.callTool({
     name: "create_pull_request",
     arguments: {
@@ -236,7 +271,16 @@ export async function openPullRequestForBranch(
     repo: args.repo,
     branch: args.branch,
   });
-  if (existing) return existing;
+  if (existing) {
+    await ensureExistingPullRequestCoAuthor(client, {
+      owner: args.owner,
+      repo: args.repo,
+      pullNumber: existing.number,
+      body: args.body,
+      coAuthor: args.coAuthor,
+    });
+    return existing;
+  }
 
   try {
     return await createPullRequest(client, {
@@ -269,14 +313,13 @@ export async function squashMergePullRequest(
     pullNumber: number;
     commitTitle?: string;
     commitMessage?: string;
-    coAuthor?: OpenPullRequestArgs["coAuthor"];
+    coAuthor?: CoAuthorIdentity;
   },
 ): Promise<MergedPullRequest> {
-  const commitMessage = args.commitMessage
-    ? appendCoAuthorTrailer(args.commitMessage, args.coAuthor)
-    : args.coAuthor
-      ? appendCoAuthorTrailer("", args.coAuthor)
-      : undefined;
+  const normalized = normalizeCoAuthorIdentity(args.coAuthor);
+  const commitMessage = normalized
+    ? appendCoAuthorTrailer(args.commitMessage?.trim() ?? "", normalized)
+    : args.commitMessage?.trim() || undefined;
   const result = await client.callTool({
     name: "merge_pull_request",
     arguments: {

--- a/apps/mesh/src/web/components/thread/github/github-pr-api.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-api.ts
@@ -3,6 +3,7 @@ import {
   pullNumberFromUrl,
   pullRequestFromToolText,
 } from "./extract-tool-json.ts";
+import { appendCoAuthorTrailer } from "@decocms/sandbox/shared";
 
 type GithubMcpClient = {
   callTool: (req: {
@@ -33,6 +34,7 @@ export interface OpenPullRequestArgs {
   title: string;
   body?: string;
   base: string;
+  coAuthor?: { userName: string; userEmail?: string };
 }
 
 function toolErrorMessage(result: unknown): string | null {
@@ -201,15 +203,21 @@ async function createPullRequest(
     body?: string;
     head: string;
     base: string;
+    coAuthor?: OpenPullRequestArgs["coAuthor"];
   },
 ): Promise<CreatedPullRequest> {
+  const body = args.body
+    ? appendCoAuthorTrailer(args.body, args.coAuthor)
+    : args.coAuthor
+      ? appendCoAuthorTrailer("", args.coAuthor)
+      : undefined;
   const result = await client.callTool({
     name: "create_pull_request",
     arguments: {
       owner: args.owner,
       repo: args.repo,
       title: args.title,
-      body: args.body,
+      body: body || undefined,
       head: args.head,
       base: args.base,
     },
@@ -238,6 +246,7 @@ export async function openPullRequestForBranch(
       body: args.body,
       head: args.branch,
       base: args.base,
+      coAuthor: args.coAuthor,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -259,8 +268,15 @@ export async function squashMergePullRequest(
     repo: string;
     pullNumber: number;
     commitTitle?: string;
+    commitMessage?: string;
+    coAuthor?: OpenPullRequestArgs["coAuthor"];
   },
 ): Promise<MergedPullRequest> {
+  const commitMessage = args.commitMessage
+    ? appendCoAuthorTrailer(args.commitMessage, args.coAuthor)
+    : args.coAuthor
+      ? appendCoAuthorTrailer("", args.coAuthor)
+      : undefined;
   const result = await client.callTool({
     name: "merge_pull_request",
     arguments: {
@@ -269,6 +285,7 @@ export async function squashMergePullRequest(
       pullNumber: args.pullNumber,
       merge_method: "squash",
       ...(args.commitTitle ? { commit_title: args.commitTitle } : {}),
+      ...(commitMessage ? { commit_message: commitMessage } : {}),
     },
   });
 

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -236,10 +236,19 @@ export function HeaderActions({ virtualMcpId }: Props) {
     if (!githubRepo?.connectionId || githubActionPending) return;
     setGithubActionPending(true);
     try {
+      const coAuthor = session?.user?.name?.trim()
+        ? {
+            userName: session.user.name.trim(),
+            ...(session.user.email?.trim()
+              ? { userEmail: session.user.email.trim() }
+              : {}),
+          }
+        : undefined;
       await squashMergePullRequest(githubClient, {
         owner: githubRepo.owner,
         repo: githubRepo.name,
         pullNumber,
+        coAuthor,
       });
       toast.success(`Published PR #${pullNumber}`);
       await refreshPrState();

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -15,7 +15,7 @@ import {
 import { useState, useRef } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/web/lib/auth-client.ts";
-import { coAuthorFromSessionUser } from "@/web/lib/co-author-identity.ts";
+import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
 import { getActiveGithubRepo } from "@/web/lib/github-repo.ts";
 import { generateBranchName } from "@/shared/branch-name";
 import { useChatStream } from "../../chat/chat-context.tsx";

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -15,6 +15,7 @@ import {
 import { useState, useRef } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/web/lib/auth-client.ts";
+import { coAuthorFromSessionUser } from "@/web/lib/co-author-identity.ts";
 import { getActiveGithubRepo } from "@/web/lib/github-repo.ts";
 import { generateBranchName } from "@/shared/branch-name";
 import { useChatStream } from "../../chat/chat-context.tsx";
@@ -236,14 +237,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
     if (!githubRepo?.connectionId || githubActionPending) return;
     setGithubActionPending(true);
     try {
-      const coAuthor = session?.user?.name?.trim()
-        ? {
-            userName: session.user.name.trim(),
-            ...(session.user.email?.trim()
-              ? { userEmail: session.user.email.trim() }
-              : {}),
-          }
-        : undefined;
+      const coAuthor = coAuthorFromSessionUser(session?.user);
       await squashMergePullRequest(githubClient, {
         owner: githubRepo.owner,
         repo: githubRepo.name,

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -24,6 +24,7 @@ import {
 } from "@untitledui/icons";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
+import { authClient } from "@/web/lib/auth-client.ts";
 import { GitDiffList } from "./git-diff-list.tsx";
 import {
   openPullRequestForBranch,
@@ -139,7 +140,17 @@ function PublishDialogBody({
     orgId,
     orgSlug,
   });
+  const { data: session } = authClient.useSession();
   const startSandbox = useSandboxStart(selfClient);
+
+  const coAuthor = session?.user?.name?.trim()
+    ? {
+        userName: session.user.name.trim(),
+        ...(session.user.email?.trim()
+          ? { userEmail: session.user.email.trim() }
+          : {}),
+      }
+    : undefined;
 
   const commitToOpenPr = openPullRequest?.state === "open";
   /** Header "Save changes" — commit/push only, no new PR / merge. */
@@ -349,6 +360,7 @@ function PublishDialogBody({
           title: prTitle,
           body: prBody,
           base: baseBranch,
+          coAuthor,
         });
       } catch (error) {
         throw new PublishFlowError(
@@ -365,6 +377,8 @@ function PublishDialogBody({
           repo,
           pullNumber: openedPr.number,
           commitTitle: prTitle,
+          commitMessage: prBody,
+          coAuthor,
         });
       } catch (error) {
         throw new PublishFlowError(
@@ -469,6 +483,7 @@ function PublishDialogBody({
         title: prTitle,
         body: prBody,
         base: baseBranch,
+        coAuthor,
       });
 
       toast.success(`Submitted pull request #${pr.number} for review`, {

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -25,6 +25,7 @@ import {
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/web/lib/auth-client.ts";
+import { coAuthorFromSessionUser } from "@/web/lib/co-author-identity.ts";
 import { GitDiffList } from "./git-diff-list.tsx";
 import {
   openPullRequestForBranch,
@@ -143,14 +144,7 @@ function PublishDialogBody({
   const { data: session } = authClient.useSession();
   const startSandbox = useSandboxStart(selfClient);
 
-  const coAuthor = session?.user?.name?.trim()
-    ? {
-        userName: session.user.name.trim(),
-        ...(session.user.email?.trim()
-          ? { userEmail: session.user.email.trim() }
-          : {}),
-      }
-    : undefined;
+  const coAuthor = coAuthorFromSessionUser(session?.user);
 
   const commitToOpenPr = openPullRequest?.state === "open";
   /** Header "Save changes" — commit/push only, no new PR / merge. */

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -25,7 +25,7 @@ import {
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/web/lib/auth-client.ts";
-import { coAuthorFromSessionUser } from "@/web/lib/co-author-identity.ts";
+import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
 import { GitDiffList } from "./git-diff-list.tsx";
 import {
   openPullRequestForBranch,

--- a/packages/sandbox/daemon/config-store/merge.test.ts
+++ b/packages/sandbox/daemon/config-store/merge.test.ts
@@ -33,6 +33,26 @@ describe("deepMerge", () => {
     expect(merged.application?.packageManager?.name).toBe("pnpm");
   });
 
+  it("preserves operator when git patch omits it", () => {
+    const merged = deepMerge(
+      {
+        operator: { userName: "Jane Doe", userEmail: "jane@example.com" },
+        git: { repository: { cloneUrl: "old" } },
+      },
+      {
+        git: {
+          repository: { cloneUrl: "new" },
+          identity: { userName: "Bot", userEmail: "bot@example.com" },
+        },
+      },
+    );
+    expect(merged.operator).toEqual({
+      userName: "Jane Doe",
+      userEmail: "jane@example.com",
+    });
+    expect(merged.git?.repository?.cloneUrl).toBe("new");
+  });
+
   it("absent fields don't overwrite existing ones", () => {
     const current: TenantConfig = {
       application: {

--- a/packages/sandbox/daemon/config-store/merge.ts
+++ b/packages/sandbox/daemon/config-store/merge.ts
@@ -18,6 +18,7 @@ export function deepMerge(
   const base: TenantConfig = current ?? {};
   return {
     git: mergeOptional(base.git, patch.git),
+    operator: mergeOptional(base.operator, patch.operator),
     application: mergeOptional(base.application, patch.application),
     env: mergeEnv(base.env, patch.env),
   };

--- a/packages/sandbox/daemon/config-store/store.ts
+++ b/packages/sandbox/daemon/config-store/store.ts
@@ -183,6 +183,7 @@ export class TenantConfigStore {
 function plainConfig(enriched: EnrichedTenantConfig): TenantConfig {
   return {
     git: enriched.git,
+    operator: enriched.operator,
     application: enriched.application,
     env: enriched.env,
   };

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -350,6 +350,7 @@ const gitDeps = {
   appRoot,
   repoDir,
   getCloneUrl: () => store.read()?.git?.repository?.cloneUrl ?? null,
+  getOperator: () => store.read()?.operator ?? null,
 };
 const gitStatusH = makeGitStatusHandler(gitDeps);
 const gitDiffH = makeGitDiffHandler(gitDeps);

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -1,9 +1,11 @@
 import fs, { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { appendCoAuthorTrailer } from "../../git-co-author";
 import { gitSync as rawGitSync } from "./git-sync";
 import { parsePorcelainEntry } from "./porcelain";
 import { assertValidRemoteBranchName } from "./ref-name";
+import type { OperatorIdentity } from "../types";
 
 const MAX_CONFLICT_RESOLUTION_ATTEMPTS = 50;
 
@@ -15,6 +17,7 @@ let rebaseGitAsUser = true;
 
 export interface RebaseOntoBaseOptions {
   asUser?: boolean;
+  operator?: OperatorIdentity;
 }
 
 function gitEnv(repoDir: string): Record<string, string> {
@@ -119,7 +122,10 @@ const NON_INTERACTIVE_ENV: Record<string, string> = {
   EDITOR: "true",
 };
 
-function commitBeforeRebase(repoDir: string): void {
+function commitBeforeRebase(
+  repoDir: string,
+  operator?: OperatorIdentity,
+): void {
   const porcelain = tryGit(repoDir, ["status", "--porcelain"]);
   if (!porcelain?.trim()) return;
 
@@ -134,7 +140,7 @@ function commitBeforeRebase(repoDir: string): void {
       // hook failures clearly in the publish UI instead of opaque daemon errors.
       "--no-verify",
       "-m",
-      "Before rebase",
+      appendCoAuthorTrailer("Before rebase", operator),
     ],
     { env: SKIP_HOOKS_ENV },
   );
@@ -304,7 +310,7 @@ export function rebaseOntoBase(
   const previousAsUser = rebaseGitAsUser;
   rebaseGitAsUser = options?.asUser ?? true;
   try {
-    return rebaseOntoBaseInner(repoDir, base);
+    return rebaseOntoBaseInner(repoDir, base, options?.operator);
   } finally {
     rebaseGitAsUser = previousAsUser;
   }
@@ -313,6 +319,7 @@ export function rebaseOntoBase(
 function rebaseOntoBaseInner(
   repoDir: string,
   base: string,
+  operator?: OperatorIdentity,
 ): { rebased: boolean } {
   assertValidRemoteBranchName(base);
 
@@ -338,7 +345,7 @@ function rebaseOntoBaseInner(
     throw new Error(`Base branch '${base}' not found on origin`);
   }
 
-  commitBeforeRebase(repoDir);
+  commitBeforeRebase(repoDir, operator);
 
   try {
     runGit(repoDir, ["rebase", "-X", "theirs", upstream]);

--- a/packages/sandbox/daemon/routes/config.ts
+++ b/packages/sandbox/daemon/routes/config.ts
@@ -159,6 +159,7 @@ function stripDerived(
   if (!enriched) return null;
   return {
     git: enriched.git,
+    operator: enriched.operator,
     application: enriched.application,
   };
 }

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -245,6 +245,31 @@ describe("git routes", () => {
     });
   });
 
+  it("publish appends operator co-author trailer", async () => {
+    const { appRoot, repoDir } = initRepo();
+    writeFileSync(join(repoDir, "README.md"), "updated\n");
+    const handler = makeGitPublishHandler({
+      appRoot,
+      repoDir,
+      getOperator: () => ({
+        userName: "Studio User",
+        userEmail: "studio@example.com",
+      }),
+    });
+    const res = await handler(
+      new Request("http://x/git/publish", {
+        method: "POST",
+        body: JSON.stringify({ message: "update readme" }),
+      }),
+    );
+    expect([200, 500]).toContain(res.status);
+    const log = gitSync(["log", "-1", "--pretty=%B"], {
+      cwd: repoDir,
+      asUser: false,
+    });
+    expect(log).toContain("Co-authored-by: Studio User <studio@example.com>");
+  });
+
   it("publish commits staged changes", async () => {
     const { appRoot, repoDir } = initRepo();
     writeFileSync(join(repoDir, "README.md"), "updated\n");

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -1,6 +1,7 @@
 import fs, { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { appendCoAuthorTrailer } from "../../git-co-author";
 import { computeBranchDivergence } from "../git/branch-divergence";
 import { parsePorcelainFiles } from "../git/porcelain";
 import { rebaseOntoBase } from "../git/rebase-onto-base";
@@ -9,6 +10,7 @@ import {
   InvalidRemoteBranchNameError,
 } from "../git/ref-name";
 import { safePath } from "../paths";
+import type { OperatorIdentity } from "../types";
 import { git } from "../setup/git";
 import { jsonResponse, parseJsonBody } from "./body-parser";
 
@@ -17,6 +19,8 @@ export interface GitDeps {
   repoDir: string;
   /** Authenticated clone URL from daemon config (may embed OAuth token). */
   getCloneUrl?: () => string | null | undefined;
+  /** Studio user operating the sandbox — co-authored on commits. */
+  getOperator?: () => OperatorIdentity | null | undefined;
 }
 
 function gitEnv(repoDir: string): Record<string, string> {
@@ -387,8 +391,10 @@ export function publish(deps: GitDeps, message: string): { pushed: boolean } {
   const hasStagedChanges =
     tryGit(repoDir, ["diff", "--cached", "--quiet"]) === null;
   if (hasStagedChanges) {
-    const commitMsg =
-      message.trim().length > 0 ? message.trim() : "Update from sandbox";
+    const commitMsg = appendCoAuthorTrailer(
+      message.trim().length > 0 ? message.trim() : "Update from sandbox",
+      deps.getOperator?.(),
+    );
     // Sandbox repos often ship lefthook/husky hooks (deno fmt, lint, check)
     // that need a full dev toolchain + network. Push still runs normal hooks
     // (e.g. pre-push branch protection); only this commit skips them.
@@ -574,7 +580,11 @@ export function makeGitRebaseHandler(deps: GitDeps) {
       return jsonResponse({ error: "base is required" }, 400);
     }
     try {
-      return jsonResponse(rebaseOntoBase(deps.repoDir, base));
+      return jsonResponse(
+        rebaseOntoBase(deps.repoDir, base, {
+          operator: deps.getOperator?.() ?? undefined,
+        }),
+      );
     } catch (err) {
       if (err instanceof InvalidRemoteBranchNameError) {
         return jsonResponse({ error: err.message }, 400);

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -27,6 +27,12 @@ export interface GitIdentity {
   readonly userEmail: string;
 }
 
+/** Studio user operating the sandbox — appended as git co-author on commits. */
+export interface OperatorIdentity {
+  readonly userName: string;
+  readonly userEmail?: string;
+}
+
 export interface GitRepository {
   readonly cloneUrl: string;
   readonly branch?: string;
@@ -59,6 +65,7 @@ export interface Application {
  */
 export interface TenantConfig {
   readonly git?: GitConfig;
+  readonly operator?: OperatorIdentity;
   readonly application?: Application;
   readonly env?: Readonly<Record<string, string>>;
 }

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -27,8 +27,10 @@ export interface GitIdentity {
   readonly userEmail: string;
 }
 
+import type { CoAuthorIdentity } from "../git-co-author";
+
 /** Studio user operating the sandbox — appended as git co-author on commits. */
-export type { CoAuthorIdentity as OperatorIdentity } from "../../git-co-author";
+export type OperatorIdentity = CoAuthorIdentity;
 
 export interface GitRepository {
   readonly cloneUrl: string;

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -28,10 +28,7 @@ export interface GitIdentity {
 }
 
 /** Studio user operating the sandbox — appended as git co-author on commits. */
-export interface OperatorIdentity {
-  readonly userName: string;
-  readonly userEmail?: string;
-}
+export type { CoAuthorIdentity as OperatorIdentity } from "../../git-co-author";
 
 export interface GitRepository {
   readonly cloneUrl: string;

--- a/packages/sandbox/daemon/validate.test.ts
+++ b/packages/sandbox/daemon/validate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { validateTenantConfig } from "./validate";
+
+describe("validateTenantConfig operator", () => {
+  it("accepts a valid operator", () => {
+    expect(
+      validateTenantConfig({
+        operator: { userName: "Jane Doe", userEmail: "jane@example.com" },
+      }),
+    ).toEqual({ kind: "ok" });
+  });
+
+  it("rejects unsafe display names", () => {
+    expect(
+      validateTenantConfig({
+        operator: { userName: "Jane\nEvil" },
+      }),
+    ).toEqual({ kind: "invalid", reason: "operator.userName is required" });
+  });
+
+  it("rejects invalid emails", () => {
+    expect(
+      validateTenantConfig({
+        operator: { userName: "Jane Doe", userEmail: "not-an-email" },
+      }),
+    ).toEqual({ kind: "invalid", reason: "operator.userEmail is invalid" });
+  });
+});

--- a/packages/sandbox/daemon/validate.ts
+++ b/packages/sandbox/daemon/validate.ts
@@ -1,4 +1,5 @@
 import { isSyntheticBranch } from "./constants";
+import { normalizeCoAuthorIdentity } from "../git-co-author";
 import type { PackageManager, RuntimeName, TenantConfig } from "./types";
 
 const VALID_RUNTIMES: ReadonlySet<RuntimeName> = new Set([
@@ -149,21 +150,22 @@ function validateApplication(
 function validateOperator(
   operator: NonNullable<TenantConfig["operator"]>,
 ): ValidationResult {
-  if (
-    typeof operator.userName !== "string" ||
-    operator.userName.trim().length === 0
-  ) {
+  if (typeof operator.userName !== "string") {
+    return { kind: "invalid", reason: "operator.userName is required" };
+  }
+  const normalized = normalizeCoAuthorIdentity({
+    userName: operator.userName,
+    userEmail: operator.userEmail,
+  });
+  if (!normalized) {
     return { kind: "invalid", reason: "operator.userName is required" };
   }
   if (operator.userEmail !== undefined) {
-    if (
-      typeof operator.userEmail !== "string" ||
-      operator.userEmail.trim().length === 0
-    ) {
-      return {
-        kind: "invalid",
-        reason: "operator.userEmail must be non-empty",
-      };
+    if (typeof operator.userEmail !== "string") {
+      return { kind: "invalid", reason: "operator.userEmail must be a string" };
+    }
+    if (operator.userEmail.trim().length > 0 && !normalized.userEmail) {
+      return { kind: "invalid", reason: "operator.userEmail is invalid" };
     }
   }
   return { kind: "ok" };

--- a/packages/sandbox/daemon/validate.ts
+++ b/packages/sandbox/daemon/validate.ts
@@ -42,6 +42,10 @@ export function validateTenantConfig(config: TenantConfig): ValidationResult {
     const v = validateEnv(config.env);
     if (v.kind === "invalid") return v;
   }
+  if (config.operator !== undefined) {
+    const v = validateOperator(config.operator);
+    if (v.kind === "invalid") return v;
+  }
   return { kind: "ok" };
 }
 
@@ -138,6 +142,29 @@ function validateApplication(
       kind: "invalid",
       reason: `port invalid: ${app.port}`,
     };
+  }
+  return { kind: "ok" };
+}
+
+function validateOperator(
+  operator: NonNullable<TenantConfig["operator"]>,
+): ValidationResult {
+  if (
+    typeof operator.userName !== "string" ||
+    operator.userName.trim().length === 0
+  ) {
+    return { kind: "invalid", reason: "operator.userName is required" };
+  }
+  if (operator.userEmail !== undefined) {
+    if (
+      typeof operator.userEmail !== "string" ||
+      operator.userEmail.trim().length === 0
+    ) {
+      return {
+        kind: "invalid",
+        reason: "operator.userEmail must be non-empty",
+      };
+    }
   }
   return { kind: "ok" };
 }

--- a/packages/sandbox/git-co-author.test.ts
+++ b/packages/sandbox/git-co-author.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { appendCoAuthorTrailer } from "./git-co-author";
+
+describe("appendCoAuthorTrailer", () => {
+  it("appends co-author with display name and email", () => {
+    expect(
+      appendCoAuthorTrailer("feat: update hero", {
+        userName: "Jane Doe",
+        userEmail: "jane@example.com",
+      }),
+    ).toBe("feat: update hero\n\nCo-authored-by: Jane Doe <jane@example.com>");
+  });
+
+  it("uses display name only when email is absent", () => {
+    expect(appendCoAuthorTrailer("fix: typo", { userName: "Jane Doe" })).toBe(
+      "fix: typo\n\nCo-authored-by: Jane Doe",
+    );
+  });
+
+  it("is idempotent when the trailer is already present", () => {
+    const message =
+      "feat: update hero\n\nCo-authored-by: Jane Doe <jane@example.com>";
+    expect(
+      appendCoAuthorTrailer(message, {
+        userName: "Jane Doe",
+        userEmail: "jane@example.com",
+      }),
+    ).toBe(message);
+  });
+
+  it("returns the original message when operator is missing", () => {
+    expect(appendCoAuthorTrailer("feat: noop", null)).toBe("feat: noop");
+  });
+});

--- a/packages/sandbox/git-co-author.test.ts
+++ b/packages/sandbox/git-co-author.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { appendCoAuthorTrailer } from "./git-co-author";
+import {
+  appendCoAuthorTrailer,
+  normalizeCoAuthorIdentity,
+  stripCoAuthorTrailers,
+} from "./git-co-author";
 
 describe("appendCoAuthorTrailer", () => {
   it("appends co-author with display name and email", () => {
@@ -30,5 +34,56 @@ describe("appendCoAuthorTrailer", () => {
 
   it("returns the original message when operator is missing", () => {
     expect(appendCoAuthorTrailer("feat: noop", null)).toBe("feat: noop");
+  });
+
+  it("replaces client-supplied co-author trailers with the trusted one", () => {
+    expect(
+      appendCoAuthorTrailer(
+        "feat: update\n\nCo-authored-by: Attacker <evil@example.com>",
+        { userName: "Jane Doe", userEmail: "jane@example.com" },
+      ),
+    ).toBe("feat: update\n\nCo-authored-by: Jane Doe <jane@example.com>");
+  });
+
+  it("stays idempotent across proxy and daemon append passes", () => {
+    const operator = {
+      userName: "Jane Doe",
+      userEmail: "jane@example.com",
+    };
+    const afterProxy = appendCoAuthorTrailer("feat: update hero", operator);
+    const afterDaemon = appendCoAuthorTrailer(afterProxy, operator);
+    expect(afterDaemon).toBe(
+      "feat: update hero\n\nCo-authored-by: Jane Doe <jane@example.com>",
+    );
+  });
+
+  it("rejects unsafe display names", () => {
+    expect(
+      appendCoAuthorTrailer("feat: update", {
+        userName: "Jane\nCo-authored-by: Evil <evil@example.com>",
+        userEmail: "jane@example.com",
+      }),
+    ).toBe("feat: update");
+  });
+});
+
+describe("normalizeCoAuthorIdentity", () => {
+  it("trims and drops invalid emails", () => {
+    expect(
+      normalizeCoAuthorIdentity({
+        userName: " Jane ",
+        userEmail: "not-an-email",
+      }),
+    ).toEqual({ userName: "Jane" });
+  });
+});
+
+describe("stripCoAuthorTrailers", () => {
+  it("removes co-author lines only", () => {
+    expect(
+      stripCoAuthorTrailers(
+        "feat: x\n\nCo-authored-by: A <a@example.com>\nCo-authored-by: B",
+      ),
+    ).toBe("feat: x");
   });
 });

--- a/packages/sandbox/git-co-author.ts
+++ b/packages/sandbox/git-co-author.ts
@@ -3,7 +3,37 @@ export interface CoAuthorIdentity {
   readonly userEmail?: string;
 }
 
-const CO_AUTHOR_LINE_RE = /^Co-authored-by:\s/m;
+const INVALID_CO_AUTHOR_CHARS = /[\r\n<>]/;
+const EMAIL_RE = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
+
+export function normalizeCoAuthorIdentity(
+  input:
+    | {
+        userName?: string | null;
+        userEmail?: string | null;
+      }
+    | null
+    | undefined,
+): CoAuthorIdentity | null {
+  const userName = input?.userName?.trim();
+  if (!userName || INVALID_CO_AUTHOR_CHARS.test(userName)) return null;
+
+  const rawEmail = input?.userEmail?.trim();
+  if (!rawEmail || INVALID_CO_AUTHOR_CHARS.test(rawEmail)) {
+    return { userName };
+  }
+  if (!EMAIL_RE.test(rawEmail)) return { userName };
+  return { userName, userEmail: rawEmail };
+}
+
+/** Remove client-supplied co-author trailers before appending a trusted one. */
+export function stripCoAuthorTrailers(message: string): string {
+  return message
+    .split("\n")
+    .filter((line) => !/^Co-authored-by:\s/i.test(line))
+    .join("\n")
+    .trimEnd();
+}
 
 function formatCoAuthorLine(identity: CoAuthorIdentity): string {
   const name = identity.userName.trim();
@@ -17,15 +47,23 @@ export function appendCoAuthorTrailer(
   message: string,
   operator: CoAuthorIdentity | null | undefined,
 ): string {
-  if (!operator?.userName?.trim()) return message;
-  const line = formatCoAuthorLine(operator);
-  if (message.includes(line)) return message;
-  if (
-    CO_AUTHOR_LINE_RE.test(message) &&
-    message.includes(operator.userName.trim())
-  ) {
-    return message;
-  }
-  const trimmed = message.trimEnd();
+  const normalized = normalizeCoAuthorIdentity(operator);
+  if (!normalized) return message;
+
+  const withoutTrailers = stripCoAuthorTrailers(message);
+  const line = formatCoAuthorLine(normalized);
+  if (withoutTrailers.includes(line)) return withoutTrailers;
+
+  const trimmed = withoutTrailers.trimEnd();
   return trimmed.length > 0 ? `${trimmed}\n\n${line}` : line;
+}
+
+/** Append co-author to PR description text; skip when body is empty. */
+export function appendCoAuthorToPullRequestBody(
+  body: string | undefined,
+  operator: CoAuthorIdentity | null | undefined,
+): string | undefined {
+  const trimmed = body?.trim();
+  if (!trimmed) return trimmed || undefined;
+  return appendCoAuthorTrailer(trimmed, operator);
 }

--- a/packages/sandbox/git-co-author.ts
+++ b/packages/sandbox/git-co-author.ts
@@ -1,0 +1,31 @@
+export interface CoAuthorIdentity {
+  readonly userName: string;
+  readonly userEmail?: string;
+}
+
+const CO_AUTHOR_LINE_RE = /^Co-authored-by:\s/m;
+
+function formatCoAuthorLine(identity: CoAuthorIdentity): string {
+  const name = identity.userName.trim();
+  const email = identity.userEmail?.trim();
+  if (email) return `Co-authored-by: ${name} <${email}>`;
+  return `Co-authored-by: ${name}`;
+}
+
+/** Append a GitHub co-author trailer when the operator is known. Idempotent. */
+export function appendCoAuthorTrailer(
+  message: string,
+  operator: CoAuthorIdentity | null | undefined,
+): string {
+  if (!operator?.userName?.trim()) return message;
+  const line = formatCoAuthorLine(operator);
+  if (message.includes(line)) return message;
+  if (
+    CO_AUTHOR_LINE_RE.test(message) &&
+    message.includes(operator.userName.trim())
+  ) {
+    return message;
+  }
+  const trimmed = message.trimEnd();
+  return trimmed.length > 0 ? `${trimmed}\n\n${line}` : line;
+}

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1293,6 +1293,7 @@ export class AgentSandboxProvider implements SandboxProvider {
         : null,
       repo: opts?.repo ?? null,
       port: opts?.workload?.devPort ?? DEFAULT_DEV_PORT,
+      tenant: opts?.tenant ?? undefined,
     });
   }
 

--- a/packages/sandbox/server/provider/desktop/runner.ts
+++ b/packages/sandbox/server/provider/desktop/runner.ts
@@ -135,6 +135,16 @@ export class DesktopSandboxProvider implements SandboxProvider {
       repo: opts.repo,
       branch,
       ...(opts.workload ? { workload: opts.workload } : {}),
+      ...(opts.tenant?.userName
+        ? {
+            operator: {
+              userName: opts.tenant.userName,
+              ...(opts.tenant.userEmail
+                ? { userEmail: opts.tenant.userEmail }
+                : {}),
+            },
+          }
+        : {}),
       // Message-offload SSRF allowlist, derived cluster-side from the
       // cluster's own trusted S3 config and pushed down here so the spawned
       // daemon can fetch offloaded `messagesRef` payloads. The daemon fails

--- a/packages/sandbox/server/provider/desktop/runner.ts
+++ b/packages/sandbox/server/provider/desktop/runner.ts
@@ -17,6 +17,7 @@
  */
 
 import { computeHandle } from "../shared";
+import { normalizeCoAuthorIdentity } from "../../../git-co-author";
 import type { ClaimPhase } from "../lifecycle-types";
 import type { RunnerStateStoreOps } from "../state-store";
 import type {
@@ -130,21 +131,16 @@ export class DesktopSandboxProvider implements SandboxProvider {
     // falls through to lockfile autodetect, which on a repo with
     // `yarn.lock` picks yarn — and the desktop daemon can't reliably
     // shim a yarn binary into PATH.
+    const operator = normalizeCoAuthorIdentity({
+      userName: opts.tenant?.userName,
+      userEmail: opts.tenant?.userEmail,
+    });
     const body = JSON.stringify({
       handle,
       repo: opts.repo,
       branch,
       ...(opts.workload ? { workload: opts.workload } : {}),
-      ...(opts.tenant?.userName
-        ? {
-            operator: {
-              userName: opts.tenant.userName,
-              ...(opts.tenant.userEmail
-                ? { userEmail: opts.tenant.userEmail }
-                : {}),
-            },
-          }
-        : {}),
+      ...(operator ? { operator } : {}),
       // Message-offload SSRF allowlist, derived cluster-side from the
       // cluster's own trusted S3 config and pushed down here so the spawned
       // daemon can fetch offloaded `messagesRef` payloads. The daemon fails

--- a/packages/sandbox/server/provider/shared/build-config-payload.test.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { buildConfigPayload } from "./build-config-payload";
+
+describe("buildConfigPayload", () => {
+  it("maps tenant identity to operator", () => {
+    const payload = buildConfigPayload({
+      runtime: "node",
+      packageManager: null,
+      repo: null,
+      tenant: {
+        orgId: "org",
+        userId: "user",
+        userName: " Jane Doe ",
+        userEmail: " jane@example.com ",
+      },
+    });
+
+    expect(payload?.operator).toEqual({
+      userName: "Jane Doe",
+      userEmail: "jane@example.com",
+    });
+  });
+
+  it("returns operator-only payload when repo and application are absent", () => {
+    const payload = buildConfigPayload({
+      runtime: "node",
+      packageManager: null,
+      repo: null,
+      tenant: {
+        orgId: "org",
+        userId: "user",
+        userName: "Jane Doe",
+      },
+    });
+
+    expect(payload).toEqual({
+      operator: { userName: "Jane Doe" },
+    });
+  });
+});

--- a/packages/sandbox/server/provider/shared/build-config-payload.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.ts
@@ -1,4 +1,5 @@
 import type { PackageManagerConfig, TenantConfig } from "../../../daemon/types";
+import { normalizeCoAuthorIdentity } from "../../../git-co-author";
 import type { EnsureOptions } from "../types";
 
 /**
@@ -29,14 +30,11 @@ export function buildConfigPayload(args: {
     : undefined;
 
   const tenant = args.tenant;
-  const operator = tenant?.userName?.trim()
-    ? {
-        userName: tenant.userName.trim(),
-        ...(tenant.userEmail?.trim()
-          ? { userEmail: tenant.userEmail.trim() }
-          : {}),
-      }
-    : undefined;
+  const operator =
+    normalizeCoAuthorIdentity({
+      userName: tenant?.userName,
+      userEmail: tenant?.userEmail,
+    }) ?? undefined;
 
   const packageManager = args.packageManager
     ? {

--- a/packages/sandbox/server/provider/shared/build-config-payload.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.ts
@@ -11,6 +11,7 @@ export function buildConfigPayload(args: {
   packageManager: PackageManagerConfig | null;
   port?: number;
   repo: NonNullable<EnsureOptions["repo"]> | null;
+  tenant?: EnsureOptions["tenant"];
 }): Partial<TenantConfig> | null {
   const repo = args.repo;
   const git = repo
@@ -24,6 +25,16 @@ export function buildConfigPayload(args: {
           userName: repo.userName,
           userEmail: repo.userEmail,
         },
+      }
+    : undefined;
+
+  const tenant = args.tenant;
+  const operator = tenant?.userName?.trim()
+    ? {
+        userName: tenant.userName.trim(),
+        ...(tenant.userEmail?.trim()
+          ? { userEmail: tenant.userEmail.trim() }
+          : {}),
       }
     : undefined;
 
@@ -42,9 +53,10 @@ export function buildConfigPayload(args: {
       }
     : undefined;
 
-  if (!git && !application) return null;
+  if (!git && !application && !operator) return null;
   return {
     ...(git ? { git } : {}),
+    ...(operator ? { operator } : {}),
     ...(application ? { application } : {}),
   };
 }

--- a/packages/sandbox/shared.ts
+++ b/packages/sandbox/shared.ts
@@ -31,6 +31,11 @@ export function gitIdentityScript(userName: string, userEmail: string): string {
   return `git config --global user.name ${shellQuote(userName)} && git config --global user.email ${shellQuote(userEmail)}`;
 }
 
+export {
+  appendCoAuthorTrailer,
+  type CoAuthorIdentity,
+} from "./git-co-author";
+
 /**
  * Injected into proxied dev-server HTML. Two jobs:
  * 1. WebSocket rewriter — Vite/Fresh/Next/Webpack/Bun bake the dev WS URL

--- a/packages/sandbox/shared.ts
+++ b/packages/sandbox/shared.ts
@@ -32,7 +32,10 @@ export function gitIdentityScript(userName: string, userEmail: string): string {
 }
 
 export {
+  appendCoAuthorToPullRequestBody,
   appendCoAuthorTrailer,
+  normalizeCoAuthorIdentity,
+  stripCoAuthorTrailers,
   type CoAuthorIdentity,
 } from "./git-co-author";
 


### PR DESCRIPTION
## Summary
- Adds `Co-authored-by` trailers with the logged-in Studio user's display name (and email when available) on sandbox git commits and PR flows.
- Stores `operator` identity in daemon tenant config at sandbox start (agent-sandbox, desktop, and pull-dispatch paths).
- Appends co-author on publish/rebase in the daemon, on publish via the mesh proxy fallback, and on open PR / squash merge in the GitHub UI.

## Test plan
- [ ] Start a sandbox with a linked GitHub repo, save changes, and verify the pushed commit includes `Co-authored-by: <display name>`.
- [ ] Submit for review / open PR and confirm the PR body includes the co-author trailer.
- [ ] Squash merge and confirm the merge commit message includes co-author attribution.
- [x] `bun test packages/sandbox/git-co-author.test.ts packages/sandbox/daemon/routes/git.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds "Co-authored-by" attribution using the logged-in Studio user on sandbox git commits and PRs, now hardened to prevent spoofing and persist the operator across config updates.

- **New Features**
  - Store `operator` in daemon tenant config at sandbox start and persist through config merges/PUTs; expose via `/config`.
  - Append co-author on: daemon publish and rebase (including the pre-rebase commit), mesh-proxy publish/rebase (after patching operator), PR open (body), and squash merge (commit message).
  - Add `normalizeCoAuthorIdentity`, `appendCoAuthorTrailer`, and `appendCoAuthorToPullRequestBody` (idempotent, sanitized) in `packages/sandbox`; re-export from `@decocms/sandbox/shared`.
  - Thread `operator` through `sandbox-proxy`, `link-daemon`, desktop/agent providers, and `build-config-payload`; update schemas/APIs to accept `operator`.

- **Bug Fixes**
  - Strip client-supplied co-author trailers before appending the trusted one to prevent spoofing; normalize name/email.
  - Update existing PRs to include co-author when missing; skip creating a PR body if it would only contain the co-author line.
  - Validate `operator` in daemon config and tests; preserve `operator` when applying git config patches.
  - Fix UI imports to `@/lib/co-author-identity` and align `OperatorIdentity` types to ensure TS/Vite resolution.

<sup>Written for commit ecf0d81d9196db037d57b3f93d898bd22397f9bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

