### PR TITLE
refactor(circuit-breaker): remove open count tracking and related tests

### DIFF
--- a/apps/mesh/src/core/constants.ts
+++ b/apps/mesh/src/core/constants.ts
@@ -23,14 +23,6 @@ export const CIRCUIT_BREAKER_COOLDOWN_MS = 30_000; // 30 seconds
 /** Maximum number of circuit breaker entries to retain in memory */
 export const CIRCUIT_BREAKER_MAX_ENTRIES = 1000;
 
-/**
- * Number of times a connection's circuit may re-open before it is durably
- * disabled (connection.status → "error"). The in-memory breaker fast-fails for
- * a 30s cooldown and auto-recovers; if the downstream keeps failing across this
- * many open cycles, the connection is persisted as "error" so it stops paying a
- * handshake on every refresh across all pods, until manually re-enabled.
- */
-export const CIRCUIT_BREAKER_DISABLE_AFTER_OPENS = 3;
 /*
  * Durable connection auto-disable (cross-replica, via the shared circuit store).
  *

--- a/apps/mesh/src/mcp-clients/circuit-breaker.test.ts
+++ b/apps/mesh/src/mcp-clients/circuit-breaker.test.ts
@@ -82,49 +82,6 @@ describe("circuit-breaker", () => {
     expect(() => assertCircuitClosed("conn_a")).toThrow(CircuitOpenError);
   });
 
-  it("reports openCount and does not signal disable on the first open", () => {
-    const r1 = recordFailure("conn_a");
-    expect(r1.shouldDisable).toBe(false);
-    const r2 = recordFailure("conn_a");
-    expect(r2.shouldDisable).toBe(false);
-    // Third failure crosses the failure threshold → first OPEN cycle.
-    const r3 = recordFailure("conn_a");
-    expect(r3.state).toBe("OPEN");
-    expect(r3.openCount).toBe(1);
-    expect(r3.shouldDisable).toBe(false);
-  });
-
-  it("signals disable after re-opening across cooldown cycles", () => {
-    // First open cycle.
-    for (let i = 0; i < 3; i++) recordFailure("conn_a");
-    expect(_getCircuitForTest("conn_a")!.openCount).toBe(1);
-
-    // Each cooldown→HALF_OPEN→failed-probe re-opens the circuit once.
-    const reopen = () => {
-      const circuit = _getCircuitForTest("conn_a")!;
-      circuit.lastFailureTime = Date.now() - 60_000;
-      assertCircuitClosed("conn_a"); // → HALF_OPEN, probe allowed
-      return recordFailure("conn_a"); // probe fails → OPEN again
-    };
-
-    const second = reopen();
-    expect(second.openCount).toBe(2);
-    expect(second.shouldDisable).toBe(false);
-
-    const third = reopen();
-    expect(third.openCount).toBe(3);
-    expect(third.shouldDisable).toBe(true);
-  });
-
-  it("success clears the open-cycle counter", () => {
-    for (let i = 0; i < 3; i++) recordFailure("conn_a");
-    recordSuccess("conn_a");
-    // Counter resets — a fresh failure burst starts the cycle count over.
-    const r = recordFailure("conn_a");
-    expect(r.openCount).toBe(0);
-    expect(r.shouldDisable).toBe(false);
-  });
-
   it("includes retry info in error message", () => {
     for (let i = 0; i < 3; i++) recordFailure("conn_a");
     let thrown: unknown;

--- a/apps/mesh/src/mcp-clients/circuit-breaker.ts
+++ b/apps/mesh/src/mcp-clients/circuit-breaker.ts
@@ -12,7 +12,6 @@
 
 import {
   CIRCUIT_BREAKER_COOLDOWN_MS,
-  CIRCUIT_BREAKER_DISABLE_AFTER_OPENS,
   CIRCUIT_BREAKER_FAILURE_THRESHOLD,
   CIRCUIT_BREAKER_MAX_ENTRIES,
 } from "../core/constants";
@@ -24,13 +23,6 @@ interface CircuitEntry {
   consecutiveFailures: number;
   lastFailureTime: number;
   halfOpenInFlight: boolean;
-  openCount: number;
-}
-
-export interface FailureOutcome {
-  state: CircuitState;
-  openCount: number;
-  shouldDisable: boolean;
 }
 
 const circuits = new Map<string, CircuitEntry>();
@@ -87,39 +79,27 @@ export function recordSuccess(connectionId: string): void {
 /**
  * Record a failed connection. Increments failures and opens circuit after threshold.
  */
-export function recordFailure(connectionId: string): FailureOutcome {
-  let circuit = circuits.get(connectionId);
+export function recordFailure(connectionId: string): void {
+  const circuit = circuits.get(connectionId);
 
   if (!circuit) {
     evictIfNeeded();
-    circuit = {
-      state: "CLOSED",
-      consecutiveFailures: 0,
-      lastFailureTime: 0,
+    circuits.set(connectionId, {
+      state: 1 >= CIRCUIT_BREAKER_FAILURE_THRESHOLD ? "OPEN" : "CLOSED",
+      consecutiveFailures: 1,
+      lastFailureTime: Date.now(),
       halfOpenInFlight: false,
-      openCount: 0,
-    };
-    circuits.set(connectionId, circuit);
+    });
+    return;
   }
 
-  const wasOpen = circuit.state === "OPEN";
   circuit.consecutiveFailures++;
   circuit.lastFailureTime = Date.now();
   circuit.halfOpenInFlight = false;
 
-  if (
-    circuit.consecutiveFailures >= CIRCUIT_BREAKER_FAILURE_THRESHOLD &&
-    !wasOpen
-  ) {
+  if (circuit.consecutiveFailures >= CIRCUIT_BREAKER_FAILURE_THRESHOLD) {
     circuit.state = "OPEN";
-    circuit.openCount++;
   }
-
-  return {
-    state: circuit.state,
-    openCount: circuit.openCount,
-    shouldDisable: circuit.openCount >= CIRCUIT_BREAKER_DISABLE_AFTER_OPENS,
-  };
 }
 
 /**


### PR DESCRIPTION
- Eliminated the `CIRCUIT_BREAKER_DISABLE_AFTER_OPENS` constant and associated logic from the circuit breaker implementation.
- Updated `recordFailure` function to simplify failure handling by removing open count tracking.
- Removed related tests that checked for open count and disable signaling after multiple failures, streamlining the test suite.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the circuit breaker by removing open-cycle counting and durable-disable logic. `recordFailure` now only tracks consecutive failures and opens the circuit at the threshold.

- **Refactors**
  - Removed `CIRCUIT_BREAKER_DISABLE_AFTER_OPENS` and all `openCount` logic; deleted related tests.
  - Dropped `FailureOutcome`; `recordFailure` now returns `void`.
  - New entries start with one failure and open immediately if the threshold is 1.

- **Migration**
  - Stop reading `openCount` or `shouldDisable` from `recordFailure`; no return value.
  - Use `assertCircuitClosed` and circuit state to gate retries instead of a disable signal.

<sup>Written for commit 96df9e47148c33e394ff538672d79a462972cf62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

