### PR TITLE
feat(agent-sandbox): add claim deletion watch to manage resource cleanup

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
@@ -682,6 +682,44 @@ async function watchEvents(
   });
 }
 
+/**
+ * Namespace-wide watch of mesh-managed SandboxClaims that invokes `onDelete`
+ * with the claim handle (== claim `metadata.name`) whenever a claim is removed.
+ * The long-lived runner uses this to drop its cached record + close the
+ * port-forwarder the instant the operator idle-reaps the backing pod, instead
+ * of waiting for a later request to that handle to fail — which, on prod
+ * hot-paths that bypass the records cache, may never happen, leaking the
+ * forwarder (a listening net.Server + FD) for the process lifetime.
+ *
+ * Reconnects with backoff via `runWatch`; resolves only when `signal` aborts.
+ */
+export async function watchClaimDeletions(opts: {
+  kc: KubeConfig;
+  namespace: string;
+  /** Pins the watch to this deployment's claims (managed-by + optional env). */
+  labelSelector: string;
+  signal: AbortSignal;
+  onDelete: (handle: string) => void;
+}): Promise<void> {
+  const { kc, namespace, labelSelector, signal, onDelete } = opts;
+  const path =
+    `/apis/${K8S_CONSTANTS.CLAIM_API_GROUP}/${K8S_CONSTANTS.CLAIM_API_VERSION}` +
+    `/namespaces/${encodeURIComponent(namespace)}/${K8S_CONSTANTS.CLAIM_PLURAL}` +
+    `?watch=true&labelSelector=${encodeURIComponent(labelSelector)}`;
+
+  return runWatch<{ metadata?: { name?: string } }>({
+    kc,
+    path,
+    signal,
+    label: "sandboxclaim-reaper",
+    onEvent: (envelope) => {
+      if (envelope.type !== "DELETED") return;
+      const handle = envelope.object.metadata?.name;
+      if (handle) onDelete(handle);
+    },
+  });
+}
+
 interface RunWatchOpts<T> {
   kc: KubeConfig;
   path: string;

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -82,7 +82,7 @@ import {
   SandboxAlreadyExistsError,
   SandboxError,
 } from "./constants";
-import { watchClaimLifecycle } from "./lifecycle-watcher";
+import { watchClaimDeletions, watchClaimLifecycle } from "./lifecycle-watcher";
 import type { ClaimPhase } from "../lifecycle-types";
 
 const RUNNER_KIND = "agent-sandbox" as const;
@@ -405,6 +405,8 @@ export class AgentSandboxProvider implements SandboxProvider {
    */
   private readonly sentinelToken: string | null;
   private closed = false;
+  /** Aborts the background SandboxClaim-deletion watch on `close()`. */
+  private readonly claimWatchAbort = new AbortController();
 
   constructor(opts: AgentSandboxProviderOptions = {}) {
     this.stateStore = opts.stateStore ?? null;
@@ -429,6 +431,30 @@ export class AgentSandboxProvider implements SandboxProvider {
         : null;
     const trimmedSentinel = opts.sentinelToken?.trim() ?? "";
     this.sentinelToken = trimmedSentinel.length > 0 ? trimmedSentinel : null;
+    this.startClaimReaper();
+  }
+
+  /**
+   * Drops the cached record + closes its forwarder the moment the operator
+   * reaps a claim (idle-TTL or explicit delete). Without this, a record for a
+   * sandbox that's used once then abandoned lingers — with its listening
+   * net.Server port-forwarder (an active libuv handle + FD that GC can't
+   * reclaim) — until a later request to that exact handle happens to fail,
+   * which on cache-bypassing prod hot-paths may never occur.
+   */
+  private startClaimReaper(): void {
+    const labelSelector = [
+      "app.kubernetes.io/managed-by=studio",
+      "app.kubernetes.io/name=studio-sandbox",
+      ...(this.envName ? [`${LABEL_KEYS.env}=${this.envName}`] : []),
+    ].join(",");
+    void watchClaimDeletions({
+      kc: this.kubeConfig,
+      namespace: this.namespace,
+      labelSelector,
+      signal: this.claimWatchAbort.signal,
+      onDelete: (handle) => this.invalidateRecord(handle),
+    });
   }
 
   // ---- SandboxProvider surface ------------------------------------------------
@@ -1003,7 +1029,11 @@ export class AgentSandboxProvider implements SandboxProvider {
     patchTtl: boolean,
     outcome: "fresh" | "resume" | "adopt",
   ): Promise<Sandbox> {
-    const wasCached = this.records.has(rec.handle);
+    const prev = this.records.get(rec.handle);
+    const wasCached = prev !== undefined;
+    if (prev && prev.daemonForward !== rec.daemonForward) {
+      this.closeForwarder(prev.daemonForward);
+    }
     this.records.set(rec.handle, rec);
     if (persistNow) await this.persist(ops, rec);
     // Fresh provision set a shutdownTime in the claim spec already; resumes
@@ -1918,6 +1948,7 @@ export class AgentSandboxProvider implements SandboxProvider {
   close(): void {
     if (this.closed) return;
     this.closed = true;
+    this.claimWatchAbort.abort();
     for (const rec of this.records.values()) {
       this.closeForwarder(rec.daemonForward);
     }


### PR DESCRIPTION
- Implemented `watchClaimDeletions` function to monitor and handle deletion events for mesh-managed SandboxClaims, allowing immediate cleanup of resources.
- Integrated the claim deletion watch into the `AgentSandboxProvider` to ensure timely invalidation of cached records and closure of associated port-forwarders.
- Enhanced resource management by preventing leaks from abandoned claims, improving overall system efficiency.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a namespace-wide deletion watch for mesh-managed SandboxClaims and wires it into `AgentSandboxProvider` to immediately invalidate cache and close port-forwarders when a claim is deleted. Prevents leaks from abandoned claims and improves long‑runner stability.

- New Features
  - Added `watchClaimDeletions` that reconnects with backoff and emits handles on `DELETED` events using a label selector.
  - Integrated into `AgentSandboxProvider` to drop cached records and close forwarders; starts on init and aborts on `close()`.

- Bug Fixes
  - Close the previous port-forwarder when replacing a record with a different `daemonForward`.
  - Eliminate lingering resources from claims reaped by the operator, instead of waiting for a later request to fail.

<sup>Written for commit 4f1a1938fd0460272dc146242dd1c3fc6eeac54a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

