### PR TITLE
feat(web): thread file outputs — files panel, artifact viewer tab, per-turn rows

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1111,11 +1111,13 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   app.use("*", async (c, next) => {
     await next();
-    // Org-scoped /files/* serves user content (HTML pages written by the
-    // web-developer agent, uploaded images, etc.) that we deliberately
-    // iframe back into the app. Same-origin only — auth middleware still
+    // Org-scoped /files/* and org-fs /fs/:volume/read serve user content
+    // (HTML pages written by the web-developer agent, uploaded images,
+    // thread outputs, etc.) that we deliberately iframe back into the app
+    // (pages preview, FileTab). Same-origin only — auth middleware still
     // gates access — and consumers are expected to sandbox the iframe.
     if (c.req.path.includes("/files/")) return;
+    if (c.req.path.includes("/fs/") && c.req.path.endsWith("/read")) return;
     c.header("X-Frame-Options", "DENY");
     c.header("Content-Security-Policy", "frame-ancestors 'none'");
   });

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -30,7 +30,7 @@ import {
 } from "./parts/tool-call-part/index.ts";
 import { NextActionChip } from "./next-action-chip.tsx";
 import { ThreadHtmlPreviews } from "./thread-html-previews.tsx";
-import { ThreadOutputs } from "./thread-outputs.tsx";
+import { MessageProducedFiles } from "./thread-outputs.tsx";
 import {
   type DataParts,
   type RenderItem,
@@ -774,13 +774,15 @@ export function MessageAssistant({
               renderOrder,
             });
           })}
+          {taskId && (
+            <MessageProducedFiles threadId={taskId} message={message!} />
+          )}
           {isLast && isLoading && startedAt !== null && (
             <GeneratingFooter startedAt={startedAt} />
           )}
           {isLast && !isLoading && taskId && (
             <>
               <ThreadHtmlPreviews />
-              <ThreadOutputs threadId={taskId} />
               {isTerminallyDone && <NextActionChip />}
             </>
           )}

--- a/apps/mesh/src/web/components/chat/message/thread-outputs.tsx
+++ b/apps/mesh/src/web/components/chat/message/thread-outputs.tsx
@@ -1,113 +1,81 @@
 /**
- * ThreadOutputs — download chips for files the model has shared back
- * to the user via the `share_with_user` tool. Files live under
- * `model-outputs/<thread_id>/` and are listed by
- * `GET /api/:org/threads/:threadId/outputs`. The query is invalidated on
- * assistant-turn completion (see chat onFinish).
+ * MessageProducedFiles — file rows under the assistant message that
+ * PRODUCED them (replacing the old thread-aggregate "files shared in this
+ * chat" block that always sat under the last message).
  *
- * The fetch is gated on whether any message in the thread has a
- * `tool-share_with_user` part with `state: "output-available"` — threads
- * that never shared a file pay zero network. The companion invalidation in
- * chat-context's onFinish handler refreshes the cache only when a new
- * share appears, so the round-trip count is exactly one per produced file.
+ * Attribution is client-side: the message's own tool parts name the files
+ * it produced — `share_with_user` returns `{ filename }`, and `write`
+ * calls targeting the org-output mount carry the path in their input.
+ * Those names are matched against the thread-outputs listing (shared
+ * `useThreadOutputs` query) to get key/size/downloadUrl. Files produced
+ * invisibly (e.g. `bash` cp into org/output) can't be attributed to a
+ * turn and surface only in ThreadFilesPanel.
  *
- * Attribution caveat: outputs are aggregated under the *last* assistant
- * message of the thread rather than per-producing-message. Future
- * iterations can encode the message id in the storage key to attribute
- * each chip to its producing turn.
+ * Caveat: the match is by filename, so a file re-written in a later turn
+ * shows on every producing turn (it IS the same output). Encoding the
+ * message id in the storage key is the future per-turn-exact fix.
  */
 
-import { useQuery } from "@tanstack/react-query";
-import { Download01 } from "@untitledui/icons";
-import { useProjectContext } from "@decocms/mesh-sdk";
-import { KEYS } from "../../../lib/query-keys";
-import { useOptionalChatStream } from "../context.tsx";
+import { useThreadOutputs } from "../use-thread-outputs.ts";
+import { OutputFileRow } from "../output-file-row.tsx";
 
-interface ThreadOutput {
-  key: string;
-  filename: string;
-  size: number;
-  uploadedAt?: string;
-  downloadUrl: string;
+interface MessageLike {
+  parts?: ReadonlyArray<unknown>;
 }
 
-interface ThreadOutputsResponse {
-  objects: ThreadOutput[];
+function basename(p: string): string {
+  return p.split("/").pop() ?? p;
 }
 
-async function fetchThreadOutputs(
-  threadId: string,
-  orgSlug: string,
-): Promise<ThreadOutput[]> {
-  const res = await fetch(
-    `/api/${orgSlug}/threads/${encodeURIComponent(threadId)}/outputs`,
-    {
-      credentials: "include",
-    },
-  );
-  if (!res.ok) {
-    throw new Error(`Failed to fetch thread outputs: ${res.status}`);
+/** Matches sandbox paths under the org-output mount: `output/x`,
+ *  `org/output/x`, `/app/org/output/x`. */
+const OUTPUT_PATH_RE = /(^|\/)output\//;
+
+function collectProducedFilenames(message: MessageLike): Set<string> {
+  const names = new Set<string>();
+  for (const raw of message.parts ?? []) {
+    const part = raw as {
+      type?: string;
+      state?: string;
+      input?: { path?: string; source?: string; name?: string };
+      output?: { filename?: string };
+    };
+    if (part.state !== "output-available") continue;
+    if (part.type === "tool-share_with_user") {
+      const name =
+        part.output?.filename ??
+        part.input?.name ??
+        (part.input?.source ? basename(part.input.source) : null);
+      if (name) names.add(name);
+    } else if (part.type === "tool-write") {
+      const path = part.input?.path;
+      if (path && OUTPUT_PATH_RE.test(path)) names.add(basename(path));
+    }
   }
-  const body = (await res.json()) as ThreadOutputsResponse;
-  return body.objects ?? [];
+  return names;
 }
 
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-export function ThreadOutputs({ threadId }: { threadId: string }) {
-  const { org } = useProjectContext();
-  const messages = useOptionalChatStream()?.messages ?? [];
-  // Only fetch when the thread could have produced a downloadable file:
-  // an explicit share_with_user, or sandbox file work (bash/write can drop
-  // results into `org/output/`). Pure-chat threads stay silent — no GET.
-  const hasSharedFile = messages.some((m) =>
-    m.parts?.some((p) => {
-      const part = p as { type: string; state?: string };
-      return (
-        (part.type === "tool-share_with_user" ||
-          part.type === "tool-bash" ||
-          part.type === "tool-write") &&
-        part.state === "output-available"
-      );
-    }),
-  );
-  const { data: outputs } = useQuery({
-    queryKey: KEYS.threadOutputs(threadId),
-    queryFn: () => fetchThreadOutputs(threadId, org.slug),
-    enabled: hasSharedFile,
-    // Stale immediately so refetch on invalidation is fresh.
-    staleTime: 0,
+export function MessageProducedFiles({
+  threadId,
+  message,
+}: {
+  threadId: string;
+  message: MessageLike;
+}) {
+  const produced = collectProducedFilenames(message);
+  const { data: outputs } = useThreadOutputs(threadId, {
+    enabled: produced.size > 0,
   });
 
-  if (!outputs || outputs.length === 0) return null;
+  if (produced.size === 0) return null;
+  const files = (outputs ?? []).filter((o) => produced.has(o.filename));
+  if (files.length === 0) return null;
 
   return (
     <div className="flex flex-col gap-1.5 py-2">
-      <div className="text-[12px] text-muted-foreground/70 uppercase tracking-wide">
-        Files shared in this chat
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {outputs.map((file) => (
-          <a
-            key={file.key}
-            href={file.downloadUrl}
-            download={file.filename}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border bg-muted/30 hover:bg-muted/60 text-[13px] transition-colors"
-          >
-            <Download01 className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className="font-medium text-foreground">{file.filename}</span>
-            <span className="text-muted-foreground">
-              {formatSize(file.size)}
-            </span>
-          </a>
-        ))}
-      </div>
+      {files.map((file) => (
+        <OutputFileRow key={file.key} file={file} />
+      ))}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/chat/output-file-row.tsx
+++ b/apps/mesh/src/web/components/chat/output-file-row.tsx
@@ -1,0 +1,57 @@
+/**
+ * OutputFileRow — one thread-output file: icon, name, hover download,
+ * "Open" button → file-preview main-panel tab. Shared by the floating
+ * "Files in this task" panel and the per-turn rows under the producing
+ * assistant message, so the two surfaces stay visually identical.
+ */
+
+import { useNavigate } from "@tanstack/react-router";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Download01 } from "@untitledui/icons";
+import { FileTypeIcon } from "@/web/components/file-type-icon";
+import { formatFileTabId } from "@/web/layouts/main-panel-tabs/tab-id";
+import type { ThreadOutput } from "./use-thread-outputs.ts";
+
+export function OutputFileRow({ file }: { file: ThreadOutput }) {
+  const navigate = useNavigate();
+  const open = () =>
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        main: formatFileTabId(file.key),
+      }),
+      replace: true,
+    });
+
+  return (
+    <div className="group flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2">
+      <FileTypeIcon filename={file.filename} className="h-5 w-4 shrink-0" />
+      <button
+        type="button"
+        onClick={open}
+        className="min-w-0 flex-1 truncate text-left text-[13px] font-medium text-foreground hover:underline"
+        title={file.filename}
+      >
+        {file.filename}
+      </button>
+      <a
+        href={file.downloadUrl}
+        download={file.filename}
+        className="hidden shrink-0 text-muted-foreground hover:text-foreground group-hover:block"
+        title="Download"
+        aria-label={`Download ${file.filename}`}
+      >
+        <Download01 className="size-3.5" />
+      </a>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 shrink-0 px-2.5 text-xs"
+        onClick={open}
+      >
+        Open
+      </Button>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -11,6 +11,7 @@ import { Chat } from "./index";
 import { useChatStream, useChatPrefs } from "./context";
 import { ChatContextPanel } from "./context-panel";
 import { CenteredComposer } from "./centered-composer";
+import { ThreadFilesPanel } from "./thread-files-panel";
 import { wasCreditsEmptyDismissed } from "./credits-empty-state";
 
 import {
@@ -86,8 +87,14 @@ function ChatPanelContent() {
           </Chat.Main>
         ) : (
           <>
-            <Chat.Main>
-              <Chat.Messages />
+            {/* @container: the files panel floats in the right gutter on
+                wide chats and becomes an in-flow topbar (flex row above
+                the scroller) when the gutter can't fit it */}
+            <Chat.Main className="relative flex flex-col overflow-hidden @container">
+              <ThreadFilesPanel />
+              <div className="min-h-0 flex-1">
+                <Chat.Messages />
+              </div>
             </Chat.Main>
             <Chat.Footer>
               <Chat.Input

--- a/apps/mesh/src/web/components/chat/thread-files-panel.tsx
+++ b/apps/mesh/src/web/components/chat/thread-files-panel.tsx
@@ -1,0 +1,107 @@
+/**
+ * ThreadFilesPanel — "Files in this task" accordion listing every file the
+ * thread has produced (same `threadOutputs` query as the per-turn rows;
+ * unlike those, this catches files the per-turn attribution can't see,
+ * e.g. bash writing into org/output).
+ *
+ * Two placements, switched by container query (needs `@container` on the
+ * chat main wrapper in side-panel-chat.tsx):
+ *   - Wide chat (≥1280px): floating card in the right gutter beside the
+ *     centered max-w-2xl message column (672px + ~304px gutter each
+ *     side) — the Figma layout. Expanded by default.
+ *   - Narrow chat: flat in-flow topbar above the messages (real layout
+ *     row closed by a border-b, so it can never overlap a message),
+ *     collapsed by default to a slim bar; expanding pushes content like
+ *     a normal accordion.
+ */
+
+import { useState } from "react";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { ChevronDown } from "@untitledui/icons";
+import { useOptionalChatTask } from "./context.tsx";
+import { OutputFileRow } from "./output-file-row.tsx";
+import {
+  useThreadHasFileWork,
+  useThreadOutputs,
+  type ThreadOutput,
+} from "./use-thread-outputs.ts";
+
+function FilesAccordion({
+  outputs,
+  collapsed,
+  onToggle,
+  variant,
+}: {
+  outputs: ThreadOutput[];
+  collapsed: boolean;
+  onToggle: () => void;
+  variant: "card" | "bar";
+}) {
+  return (
+    <div
+      className={cn(
+        variant === "card"
+          ? "rounded-xl border border-border bg-muted/95 shadow-sm backdrop-blur-sm"
+          : "border-b border-border bg-background",
+      )}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between px-3 py-2.5 text-left"
+      >
+        <span className="text-sm font-medium text-foreground">
+          Files in this task
+        </span>
+        <ChevronDown
+          className={cn(
+            "size-4 text-muted-foreground transition-transform",
+            collapsed && "-rotate-90",
+          )}
+        />
+      </button>
+      {!collapsed && (
+        <div className="flex max-h-72 flex-col gap-1.5 overflow-y-auto px-2 pb-2">
+          {outputs.map((file) => (
+            <OutputFileRow key={file.key} file={file} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ThreadFilesPanel() {
+  const taskId = useOptionalChatTask()?.taskId ?? null;
+  const hasFileWork = useThreadHasFileWork();
+  const { data: outputs } = useThreadOutputs(taskId, { enabled: hasFileWork });
+  // Independent defaults per placement (only one is visible at a time):
+  // the gutter has room to spare, the topbar starts as a slim bar.
+  const [gutterCollapsed, setGutterCollapsed] = useState(false);
+  const [barCollapsed, setBarCollapsed] = useState(true);
+
+  if (!taskId || !outputs || outputs.length === 0) return null;
+
+  return (
+    <>
+      {/* Wide: floating in the right gutter (never reaches the column) */}
+      <div className="absolute top-2 right-2 z-10 hidden w-72 @[1280px]:block">
+        <FilesAccordion
+          variant="card"
+          outputs={outputs}
+          collapsed={gutterCollapsed}
+          onToggle={() => setGutterCollapsed((c) => !c)}
+        />
+      </div>
+      {/* Narrow: flat topbar above the messages, closed by a border-b */}
+      <div className="shrink-0 @[1280px]:hidden">
+        <FilesAccordion
+          variant="bar"
+          outputs={outputs}
+          collapsed={barCollapsed}
+          onToggle={() => setBarCollapsed((c) => !c)}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/mesh/src/web/components/chat/use-thread-outputs.ts
+++ b/apps/mesh/src/web/components/chat/use-thread-outputs.ts
@@ -1,0 +1,87 @@
+/**
+ * useThreadOutputs — shared query for the files a thread has produced
+ * (share_with_user uploads under `model-outputs/<threadId>/` merged with
+ * org-fs `outputs/<threadId>/` writes), served by
+ * `GET /api/:org/threads/:threadId/outputs`.
+ *
+ * Consumed by the per-turn rows (MessageProducedFiles), the
+ * "Files in this task" pill (ThreadFilesPanel), and the file-preview tab
+ * (FileTab), so all three render the same list and share one cache entry.
+ * The fetch is gated on the thread having any file-producing tool part —
+ * pure-chat threads pay zero network. The companion invalidation lives in
+ * chat-context's onFinish handler.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { KEYS } from "../../lib/query-keys";
+import { useOptionalChatStream } from "./context.tsx";
+
+export interface ThreadOutput {
+  key: string;
+  filename: string;
+  size: number;
+  uploadedAt?: string;
+  downloadUrl: string;
+}
+
+interface ThreadOutputsResponse {
+  objects: ThreadOutput[];
+}
+
+async function fetchThreadOutputs(
+  threadId: string,
+  orgSlug: string,
+): Promise<ThreadOutput[]> {
+  const res = await fetch(
+    `/api/${orgSlug}/threads/${encodeURIComponent(threadId)}/outputs`,
+    {
+      credentials: "include",
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch thread outputs: ${res.status}`);
+  }
+  const body = (await res.json()) as ThreadOutputsResponse;
+  return body.objects ?? [];
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * True when any message has a tool part that could have produced a file:
+ * an explicit share_with_user, or sandbox file work (bash/write can drop
+ * results into `org/output/`).
+ */
+export function useThreadHasFileWork(): boolean {
+  const messages = useOptionalChatStream()?.messages ?? [];
+  return messages.some((m) =>
+    m.parts?.some((p) => {
+      const part = p as { type: string; state?: string };
+      return (
+        (part.type === "tool-share_with_user" ||
+          part.type === "tool-bash" ||
+          part.type === "tool-write") &&
+        part.state === "output-available"
+      );
+    }),
+  );
+}
+
+export function useThreadOutputs(
+  threadId: string | null,
+  opts?: { enabled?: boolean },
+) {
+  const { org } = useProjectContext();
+  return useQuery({
+    queryKey: KEYS.threadOutputs(threadId ?? ""),
+    queryFn: () => fetchThreadOutputs(threadId ?? "", org.slug),
+    enabled: Boolean(threadId) && (opts?.enabled ?? true),
+    // Stale immediately so refetch on invalidation is fresh.
+    staleTime: 0,
+  });
+}

--- a/apps/mesh/src/web/components/file-type-icon.tsx
+++ b/apps/mesh/src/web/components/file-type-icon.tsx
@@ -1,0 +1,130 @@
+/**
+ * FileTypeIcon — Untitled UI-style file icon: file body with a folded
+ * corner plus a colored extension badge (PDF red, XLS green, …).
+ * Parametric SVG instead of vendored per-type assets, so any extension
+ * renders; unknown ones get a gray badge, extension-less names get the
+ * plain file shape. Body uses design tokens (dark-mode aware); badge
+ * colors are brand constants by type bucket.
+ */
+
+import type { SVGProps } from "react";
+
+const BADGE_COLORS: Record<string, string> = {
+  // documents
+  pdf: "#D92D20",
+  doc: "#155EEF",
+  docx: "#155EEF",
+  txt: "#475467",
+  md: "#475467",
+  // spreadsheets / data
+  xls: "#099250",
+  xlsx: "#099250",
+  csv: "#099250",
+  tsv: "#099250",
+  json: "#475467",
+  xml: "#475467",
+  yaml: "#475467",
+  yml: "#475467",
+  // presentations
+  ppt: "#DC6803",
+  pptx: "#DC6803",
+  key: "#DC6803",
+  // images
+  png: "#7F56D9",
+  jpg: "#7F56D9",
+  jpeg: "#7F56D9",
+  gif: "#7F56D9",
+  webp: "#7F56D9",
+  svg: "#7F56D9",
+  avif: "#7F56D9",
+  // audio / video
+  mp3: "#DD2590",
+  wav: "#DD2590",
+  mp4: "#DD2590",
+  mov: "#DD2590",
+  webm: "#DD2590",
+  // archives
+  zip: "#475467",
+  tar: "#475467",
+  gz: "#475467",
+  rar: "#475467",
+  // web / code
+  html: "#DC6803",
+  htm: "#DC6803",
+  css: "#155EEF",
+  js: "#155EEF",
+  jsx: "#155EEF",
+  ts: "#155EEF",
+  tsx: "#155EEF",
+  py: "#155EEF",
+  sql: "#155EEF",
+  sh: "#475467",
+};
+
+const DEFAULT_BADGE_COLOR = "#475467";
+
+function extensionOf(filename: string): string | null {
+  const dot = filename.lastIndexOf(".");
+  if (dot <= 0 || dot === filename.length - 1) return null;
+  const ext = filename.slice(dot + 1).toLowerCase();
+  // Anything longer than 4 chars stops reading as an extension badge.
+  if (ext.length > 4 || !/^[a-z0-9]+$/.test(ext)) return null;
+  return ext;
+}
+
+export function FileTypeIcon({
+  filename,
+  ...props
+}: { filename: string } & SVGProps<SVGSVGElement>) {
+  const ext = extensionOf(filename);
+  const color = ext ? (BADGE_COLORS[ext] ?? DEFAULT_BADGE_COLOR) : null;
+  const label = ext?.toUpperCase() ?? "";
+  // Badge hugs its text: ~4.6 units/char + padding, never past the body.
+  const badgeWidth = Math.min(8 + label.length * 4.6, 28);
+
+  return (
+    <svg
+      viewBox="0 0 32 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      {/* file body with folded top-right corner */}
+      <path
+        d="M19.5 1H8a4 4 0 0 0-4 4v30a4 4 0 0 0 4 4h16a4 4 0 0 0 4-4V9.5L19.5 1Z"
+        className="fill-background stroke-border"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M19.5 1v4.5a4 4 0 0 0 4 4H28"
+        className="stroke-border"
+        strokeWidth="1.5"
+      />
+      {ext && color && (
+        <>
+          <rect
+            x="1"
+            y="20"
+            width={badgeWidth}
+            height="12"
+            rx="3"
+            fill={color}
+          />
+          <text
+            x={1 + badgeWidth / 2}
+            y="29"
+            textAnchor="middle"
+            fontSize="7"
+            fontWeight="700"
+            letterSpacing="0.2"
+            fill="#FFFFFF"
+            style={{ fontFamily: "inherit" }}
+          >
+            {label}
+          </text>
+        </>
+      )}
+    </svg>
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/file-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/file-tab.tsx
@@ -1,0 +1,323 @@
+/**
+ * FileTab — main-panel preview of a file the thread produced
+ * (`?main=file:<encoded key>`).
+ *
+ * The tab id only carries the output `key`; the file's URL/name/size are
+ * resolved from the same `threadOutputs` query the chips and the
+ * "Files in this task" panel use, so the server stays the single source
+ * of truth for download-URL construction and the three surfaces share one
+ * cache entry.
+ *
+ * Rendering strategy by extension:
+ *   - image → <img> (same-origin URL or 302→presigned; no CORS needed)
+ *   - pdf   → <iframe> (browser-native viewer; NOT sandboxed — a sandbox
+ *             without allow-scripts would disable Chrome's PDF plugin)
+ *   - html  → <iframe sandbox="allow-scripts"> (untrusted, mirrors WebPageTab)
+ *   - md    → fetched and rendered through the chat markdown renderer
+ *   - text  → fetched and rendered in a <pre>
+ *   - other (xlsx/pptx/zip/…) → download card fallback
+ *
+ * Text-ish fetches go through `fetch(credentials: "include")`; if that
+ * fails (e.g. a cross-origin presigned redirect without CORS headers),
+ * the component degrades to the download card rather than erroring.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { Download01, LinkExternal01, XClose } from "@untitledui/icons";
+import { KEYS } from "@/web/lib/query-keys";
+import { FileTypeIcon } from "@/web/components/file-type-icon";
+import { MemoizedMarkdown } from "@/web/components/chat/markdown.tsx";
+import {
+  formatSize,
+  useThreadOutputs,
+  type ThreadOutput,
+} from "@/web/components/chat/use-thread-outputs.ts";
+
+const IMAGE_EXTS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "avif",
+]);
+const TEXT_EXTS = new Set([
+  "txt",
+  "json",
+  "csv",
+  "tsv",
+  "log",
+  "yaml",
+  "yml",
+  "xml",
+  "toml",
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "py",
+  "rb",
+  "go",
+  "rs",
+  "java",
+  "sh",
+  "sql",
+]);
+// Beyond this we don't buffer text into the DOM — download card instead.
+const MAX_TEXT_PREVIEW_BYTES = 2 * 1024 * 1024;
+
+type PreviewKind = "image" | "pdf" | "html" | "markdown" | "text" | "download";
+
+function previewKind(filename: string, size: number): PreviewKind {
+  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+  if (IMAGE_EXTS.has(ext)) return "image";
+  if (ext === "pdf") return "pdf";
+  if (ext === "html" || ext === "htm") return "html";
+  if (ext === "md" || ext === "markdown") {
+    return size <= MAX_TEXT_PREVIEW_BYTES ? "markdown" : "download";
+  }
+  if (TEXT_EXTS.has(ext)) {
+    return size <= MAX_TEXT_PREVIEW_BYTES ? "text" : "download";
+  }
+  return "download";
+}
+
+function FileShimmer() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="flex w-3/4 max-w-md flex-col gap-3 p-6">
+        <Skeleton className="h-6 w-2/3" />
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-5/6" />
+          <Skeleton className="h-3 w-2/3" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DownloadCard({ file, note }: { file: ThreadOutput; note?: string }) {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="flex flex-col items-center gap-3 rounded-xl border border-border bg-muted/30 px-10 py-8">
+        <FileTypeIcon filename={file.filename} className="h-12 w-10" />
+        <div className="flex flex-col items-center gap-0.5">
+          <span className="text-sm font-medium text-foreground">
+            {file.filename}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {formatSize(file.size)}
+            {note ? ` · ${note}` : ""}
+          </span>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <a href={file.downloadUrl} download={file.filename}>
+            <Download01 size={14} />
+            Download
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function TextPreview({
+  file,
+  markdown,
+}: {
+  file: ThreadOutput;
+  markdown: boolean;
+}) {
+  const { data, isPending, isError } = useQuery({
+    queryKey: KEYS.threadOutputText(file.downloadUrl),
+    queryFn: async () => {
+      const res = await fetch(file.downloadUrl, { credentials: "include" });
+      if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+      return res.text();
+    },
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  if (isPending) return <FileShimmer />;
+  if (isError || data === undefined) {
+    return <DownloadCard file={file} note="preview unavailable" />;
+  }
+
+  if (markdown) {
+    return (
+      <div className="h-full overflow-y-auto">
+        <div className="prose prose-sm dark:prose-invert mx-auto max-w-3xl px-6 py-6">
+          <MemoizedMarkdown id={`file-preview-${file.key}`} text={data} />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="h-full overflow-auto">
+      <pre className="px-6 py-4 font-mono text-xs leading-relaxed whitespace-pre-wrap break-words text-foreground">
+        {data}
+      </pre>
+    </div>
+  );
+}
+
+function PreviewBody({ file }: { file: ThreadOutput }) {
+  const kind = previewKind(file.filename, file.size);
+
+  switch (kind) {
+    case "image":
+      return (
+        <div className="flex h-full w-full items-center justify-center overflow-auto bg-muted/30 p-4">
+          <img
+            src={file.downloadUrl}
+            alt={file.filename}
+            className="max-h-full max-w-full rounded-lg object-contain"
+          />
+        </div>
+      );
+    case "pdf":
+      return (
+        <iframe
+          src={file.downloadUrl}
+          title={file.filename}
+          className="block h-full w-full bg-white"
+        />
+      );
+    case "html":
+      return (
+        <iframe
+          src={file.downloadUrl}
+          title={file.filename}
+          sandbox="allow-scripts"
+          className="block h-full w-full bg-white"
+        />
+      );
+    case "markdown":
+      return <TextPreview file={file} markdown />;
+    case "text":
+      return <TextPreview file={file} markdown={false} />;
+    default:
+      return <DownloadCard file={file} />;
+  }
+}
+
+function FileToolbar({
+  file,
+  onClose,
+}: {
+  file: ThreadOutput;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border/60 px-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2 px-2">
+        <FileTypeIcon
+          filename={file.filename}
+          className="h-4.5 w-3.5 shrink-0"
+        />
+        <span className="truncate text-xs font-medium text-foreground">
+          {file.filename}
+        </span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {formatSize(file.size)}
+        </span>
+      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="ghost" size="icon" asChild>
+            <a href={file.downloadUrl} download={file.filename}>
+              <Download01 size={14} />
+            </a>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Download</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => window.open(file.downloadUrl, "_blank", "noopener")}
+          >
+            <LinkExternal01 size={14} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open in new tab</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="ghost" size="icon" onClick={onClose}>
+            <XClose size={14} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Close</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+export function FileTab({
+  fileKey,
+  taskId,
+}: {
+  fileKey: string;
+  taskId: string;
+}) {
+  const navigate = useNavigate();
+  // Always enabled while the tab is open — on a fresh page load the
+  // message-scan gate (useThreadHasFileWork) may not have hydrated yet,
+  // and an open file tab is itself proof the thread produced files.
+  const { data: outputs, isPending } = useThreadOutputs(taskId);
+  const file = outputs?.find((o) => o.key === fileKey) ?? null;
+
+  const handleClose = () =>
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, main: "0" }),
+      replace: true,
+    });
+
+  if (!file) {
+    if (isPending) {
+      return (
+        <div className="h-full w-full bg-background">
+          <FileShimmer />
+        </div>
+      );
+    }
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2 bg-background">
+        <FileTypeIcon
+          filename={fileKey.split("/").pop() ?? fileKey}
+          className="h-7.5 w-6"
+        />
+        <span className="text-sm text-muted-foreground">
+          This file is no longer available.
+        </span>
+        <Button variant="ghost" size="sm" onClick={handleClose}>
+          Close
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col bg-background">
+      <FileToolbar file={file} onClose={handleClose} />
+      <div className="relative min-h-0 flex-1">
+        <PreviewBody file={file} />
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -17,9 +17,11 @@ import { ContentTab } from "./content-tab";
 import { AutomationTab } from "./automation-tab";
 import { AutomationsListTab } from "./automations-list-tab";
 import { WebPageTab } from "./web-page-tab";
+import { FileTab } from "./file-tab";
 import { MainPanelLoading } from "./main-panel-loading";
 import {
   isLegacySettingsTab,
+  parseFileTabId,
   parsePinnedViewTabId,
   parseWebPageTabId,
 } from "./tab-id";
@@ -34,12 +36,14 @@ const AppViewContent = lazy(() =>
 function TabBody({
   activeTab,
   virtualMcpId,
+  taskId,
   layoutTabs,
   expandedTools,
   automationTabParsed,
 }: {
   activeTab: string;
   virtualMcpId: string;
+  taskId: string;
   layoutTabs: ReturnType<typeof useMainPanelTabs>["layoutTabs"];
   expandedTools: ReturnType<typeof useMainPanelTabs>["expandedTools"];
   automationTabParsed: ReturnType<
@@ -81,6 +85,11 @@ function TabBody({
   const webPage = parseWebPageTabId(activeTab);
   if (webPage) {
     return <WebPageTab slug={webPage.slug} />;
+  }
+
+  const fileTab = parseFileTabId(activeTab);
+  if (fileTab) {
+    return <FileTab fileKey={fileTab.key} taskId={taskId} />;
   }
 
   const pinnedView = parsePinnedViewTabId(activeTab);
@@ -138,6 +147,7 @@ export function MainPanelContent({
         <TabBody
           activeTab={activeTab}
           virtualMcpId={virtualMcpId}
+          taskId={taskId}
           layoutTabs={layoutTabs}
           expandedTools={expandedTools}
           automationTabParsed={automationTabParsed}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/resolve-tab-icon.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/resolve-tab-icon.ts
@@ -10,7 +10,7 @@ import { getIconComponent, parseIconString } from "../../components/agent-icon";
 
 export type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
-export type TabKind = "system" | "agent" | "expanded";
+export type TabKind = "system" | "agent" | "expanded" | "file";
 
 export type TabIcon =
   | { kind: "component"; Component: IconComponent }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  formatFileTabId,
   isLegacySettingsTab,
+  isPerThreadTab,
   parseAutomationTabId,
+  parseFileTabId,
   resolveDefaultTabId,
   resolveActiveTabAndOpen,
   resolveTabClickTarget,
@@ -25,6 +28,34 @@ describe("parseAutomationTabId", () => {
 
   test("automation: with empty id → null", () => {
     expect(parseAutomationTabId("automation:")).toBeNull();
+  });
+});
+
+describe("file tab id", () => {
+  test("round-trips S3 and org-fs keys (slashes, colons, spaces)", () => {
+    for (const key of [
+      "model-outputs/thread-1/report final.pdf",
+      "org-fs:outputs/thread-1/nested/dir/data.csv",
+      "model-outputs/t/weird?#&name.txt",
+    ]) {
+      expect(parseFileTabId(formatFileTabId(key))).toEqual({ key });
+    }
+  });
+
+  test("non-file tab → null", () => {
+    expect(parseFileTabId("settings")).toBeNull();
+    expect(parseFileTabId("web-page:home")).toBeNull();
+    expect(parseFileTabId(undefined)).toBeNull();
+    expect(parseFileTabId("file:")).toBeNull();
+  });
+
+  test("malformed percent-encoding → null, not a throw", () => {
+    expect(parseFileTabId("file:%E0%A4%A")).toBeNull();
+  });
+
+  test("file tabs are per-thread", () => {
+    expect(isPerThreadTab(formatFileTabId("model-outputs/t/a.pdf"))).toBe(true);
+    expect(isPerThreadTab("settings")).toBe(false);
   });
 });
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
@@ -9,6 +9,7 @@
  *   - Pinned view: "app:<connectionId>:<toolName>" (from metadata.ui.pinnedViews)
  *   - Ephemeral automation: "automation:<id>"
  *   - Ephemeral web page: "web-page:<slug>" (web-developer agent preview)
+ *   - Ephemeral file preview: "file:<encoded output key>" (thread output viewer)
  *   - "0" = closed sentinel (not an actual tab id)
  *
  * The "settings" tab bundles what used to be separate instructions,
@@ -81,6 +82,32 @@ export function parseWebPageTabId(
   return { slug };
 }
 
+export interface FileTabParsed {
+  /** Thread-output key: an S3 key ("model-outputs/<threadId>/x.pdf") or an
+   *  org-fs ref ("org-fs:outputs/<threadId>/x.pdf") — same shape the
+   *  thread-outputs endpoint returns. */
+  key: string;
+}
+
+/** Keys carry `/` and `:`, so the tab id encodes them to keep the
+ *  `<kind>:<rest>` grammar unambiguous in the `?main=` URL param. */
+export function formatFileTabId(key: string): string {
+  return `file:${encodeURIComponent(key)}`;
+}
+
+export function parseFileTabId(
+  tabId: string | undefined,
+): FileTabParsed | null {
+  if (!tabId || !tabId.startsWith("file:")) return null;
+  const encoded = tabId.slice("file:".length);
+  if (!encoded) return null;
+  try {
+    return { key: decodeURIComponent(encoded) };
+  } catch {
+    return null;
+  }
+}
+
 export const FIXED_SYSTEM_TABS = [
   "settings",
   "automations",
@@ -97,12 +124,14 @@ const FIXED_SYSTEM_TAB_SET = new Set<string>(FIXED_SYSTEM_TABS);
  *   - "app:<connectionId>:<toolName>"  (expanded tool / pinned view)
  *   - "web-page:<slug>"               (ephemeral web preview)
  *   - "automation:<id>"               (ephemeral automation detail)
+ *   - "file:<encoded key>"            (ephemeral thread-output file preview)
  */
 export function isPerThreadTab(tabId: string): boolean {
   return (
     tabId.startsWith("app:") ||
     tabId.startsWith("web-page:") ||
-    tabId.startsWith("automation:")
+    tabId.startsWith("automation:") ||
+    tabId.startsWith("file:")
   );
 }
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -12,7 +12,7 @@
 
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useSyncExternalStore } from "react";
+import { createElement, useSyncExternalStore } from "react";
 import {
   SELF_MCP_ALIAS_ID,
   useConnections,
@@ -39,9 +39,11 @@ import type {
   ThreadMetadata,
 } from "../../../storage/types";
 import type { Task } from "@/web/components/chat/task/types";
+import { FileTypeIcon } from "@/web/components/file-type-icon";
 import {
   formatPinnedViewTabId,
   parseAutomationTabId,
+  parseFileTabId,
   resolveActiveTabAndOpen,
   resolveDefaultTabId,
   resolveTabClickTarget,
@@ -288,7 +290,31 @@ export function useMainPanelTabs(ctx: {
     });
   }
 
+  // Ephemeral file-preview tab (`?main=file:<key>`): surfaces as a pill
+  // while open — like the Figma artifact pill — so the open file is
+  // visible in the bar and click-to-toggle closes it. Not persisted:
+  // once closed, recovery is via the chat's file rows / files panel.
+  const fileTabParsed = parseFileTabId(activeTab);
+  const fileTabName = fileTabParsed
+    ? (fileTabParsed.key.split("/").pop() ?? fileTabParsed.key)
+    : null;
+  const fileTabs: Tab[] = fileTabName
+    ? [
+        {
+          id: activeTab,
+          title: fileTabName,
+          kind: "file",
+          icon: {
+            kind: "component",
+            Component: (props) =>
+              createElement(FileTypeIcon, { filename: fileTabName, ...props }),
+          },
+        },
+      ]
+    : [];
+
   const tabs: Tab[] = [
+    ...fileTabs,
     ...layoutTabs.map((t) => ({
       id: t.id,
       title: t.title,

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -188,6 +188,8 @@ export const KEYS = {
   threadSandbox: (orgKey: string, taskId: string | undefined) =>
     ["thread-sandbox", "v2", orgKey, taskId] as const,
   threadOutputs: (threadId: string) => ["thread-outputs", threadId] as const,
+  threadOutputText: (downloadUrl: string) =>
+    ["thread-output-text", downloadUrl] as const,
 
   // Virtual MCP tools (for tool definition lookup in chat)
   // null virtualMcpId means default virtual MCP


### PR DESCRIPTION
## Summary

Phase 1 of the Files UI revamp (per the Figma designs): chat-side UX for the files a thread produces — org-fs `outputs/` writes merged with legacy `model-outputs/` shares.

- **Artifact viewer tab** (`?main=file:<key>`): opens in the main panel like the Figma artifact pill. Renders pdf/html (iframe), images, markdown (chat renderer), text (`<pre>`, 2MB cap); everything else (xlsx/zip/…) gets a download card. Shows as a header tab pill with the file's type icon while open; click-to-toggle closes.
- **"Files in this task" accordion**: floating card in the right gutter when the chat container is ≥1280px (Figma layout); flat in-flow topbar (border-b, collapsed by default) on narrower chats — by construction it can never overlap a message. This is the affordance that catches files per-turn attribution can't see (e.g. `bash` cp into `org/output/`).
- **Per-turn file rows** under the producing assistant message (replaces the old thread-aggregate chips under the last message). Attribution is client-side from `share_with_user` outputs and `write` paths under the org-output mount.
- **FileTypeIcon**: parametric Untitled UI-style file icon (colored extension badge by type bucket) shared by rows, viewer toolbar, download card, and the header tab pill — one SVG instead of vendored per-type assets.
- All three surfaces share a single `threadOutputs` query (`use-thread-outputs.ts`); the existing onFinish invalidation sweeps refresh everything together. No backend data changes.
- **api**: `/fs/:volume/read` joins the existing `/files/*` exemption from the frame-blocking headers (X-Frame-Options/frame-ancestors) so the viewer iframes work. Same gating (session auth, same-origin) and the HTML preview iframe is sandboxed (`allow-scripts`, opaque origin — no app DOM/cookie access).

## Testing

- `bun test` (tab-id grammar round-trip incl. malformed percent-encoding), `bun run check`, `bun run lint`, `bun run fmt` — all green.
- Manual on the local kind rig: csv/md/pdf/html/image previews, per-turn rows, accordion at both container widths, tab pill toggle, frame-header exemption verified live (`/fs/.../read` clean, other API routes still DENY).

## Follow-ups

- Phase 2: Library home redesign (cards, recently added via change-feed, Shared/Private filter).
- Use `FileTypeIcon` on the settings Files page (`org-files.tsx`).
- Exact per-turn attribution by encoding message id in the storage key (#19 ties in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new files experience in chat: a file preview tab, a responsive “Files in this task” panel, and per-turn file rows, all backed by a shared thread outputs query. Also updates headers so org-fs reads can load in iframes.

- **New Features**
  - File preview tab in the main panel (`?main=file:<encoded-key>`). Supports images/PDF/HTML/markdown/text (2MB cap), with a download fallback. Shows as a header pill and click-to-close.
  - “Files in this task” accordion. Floats in the right gutter on wide chats (≥1280px) and becomes a topbar on narrow chats. Lists all thread outputs, including ones not attributable to a single turn.
  - Per-turn file rows under the producing assistant message. Attribution from `share_with_user` and `write` paths under the org-output mount.
  - Shared data via `useThreadOutputs`; existing onFinish invalidation refreshes all surfaces together. No backend data shape changes.
  - `FileTypeIcon`: single SVG with colored extension badges used across rows, viewer toolbar, and the tab pill.
  - API header update: `/fs/:volume/read` joins `/files/*` in being exempt from frame-blocking headers so iframes work. Same auth gating; HTML previews are sandboxed.

<sup>Written for commit f95bdfb84e2b017ed4968a2b88a897c9388fecba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

