### PR TITLE
fix(dev): build vite plugin to dist for local mesh dev

### DIFF
--- a/.github/workflows/publish-vite-plugin-npm.yaml
+++ b/.github/workflows/publish-vite-plugin-npm.yaml
@@ -58,6 +58,11 @@ jobs:
           fi
         working-directory: packages/vite-plugin-deco
 
+      - name: Build package
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: bun run build
+        working-directory: packages/vite-plugin-deco
+
       - name: Publish to npm
         if: steps.version-check.outputs.version-changed == 'true'
         run: npm publish --access public --tag ${{ steps.version-check.outputs.npm-tag }} --provenance

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decocms",
-  "version": "2.430.0",
+  "version": "2.419.1",
   "description": "Deco CMS — Self-hostable MCP Gateway for managing AI connections and tools",
   "author": "Deco team",
   "repository": {
@@ -19,11 +19,11 @@
     "dist/**/*"
   ],
   "scripts": {
-    "dev": "bun run migrate && concurrently \"bun run dev:client\" \"bun run dev:server\"",
-    "dev:servers": "concurrently \"bun run dev:client\" \"bun run dev:server\"",
-    "dev:client": "vite dev",
+    "dev": "bun run migrate && bun run dev:servers",
+    "dev:servers": "BASE_URL=http://localhost:4000 PORT=3000 VITE_PORT=4000 concurrently \"bun run dev:client\" \"bun run dev:server\"",
+    "dev:client": "bun run --cwd=../../packages/vite-plugin-deco build && vite dev",
     "dev:server": "bun run --cwd=../../packages/sandbox build && NODE_ENV=development bun --env-file=.env --hot run src/index.ts",
-    "build:client": "bun --bun vite build",
+    "build:client": "bun run --cwd=../../packages/vite-plugin-deco build && bun --bun vite build",
     "build:server": "bun run scripts/bundle-server-script.ts --dist ./dist/server",
     "db:migrate": "bun run ./dist/server/migrate.js",
     "check": "tsc --noEmit",

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -9,7 +9,16 @@
  */
 
 import { getSettings } from "../settings";
-import { getBaseUrl, isSplitDevStack } from "../core/server-constants";
+import {
+  kickPublicSetsBootSync,
+  registerPublicSetsSyncWorkflow,
+  setPublicSetsSyncRuntime,
+} from "../file-storage/dbos-public-sets-sync";
+import {
+  getPublicUrl,
+  getBaseUrl,
+  isSplitDevStack,
+} from "@/core/server-constants";
 import { usesLocalObjectStorage } from "../tools/connection/dev-assets";
 import { DECO_STORE_URL, isDecoHostedMcp } from "@/core/deco-constants";
 import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
@@ -58,6 +67,7 @@ import {
   createDecoSitesOrgRoutes,
   createDecoSitesUserRoutes,
 } from "./routes/deco-sites";
+import { createDecoAppsRoutes } from "./routes/deco-apps";
 import { createVirtualMcpRoutes } from "./routes/virtual-mcp";
 import {
   createLegacyWellKnownProtectedResourceRoutes,
@@ -74,7 +84,11 @@ import publicConfigRoutes from "./routes/public-config";
 import filesRoutes from "./routes/files";
 import { createThreadOutputsRoutes } from "./routes/thread-outputs";
 import { createSelfRoutes } from "./routes/self";
-import { shouldSkipStudioContext, SYSTEM_PATHS } from "./utils/paths";
+import {
+  isHealthPath,
+  shouldSkipStudioContext,
+  SYSTEM_PATHS,
+} from "./utils/paths";
 import {
   mountPluginRoutes,
   initializePluginStorage,
@@ -91,6 +105,12 @@ import {
   setMcpListCache,
   type McpListCache,
 } from "../mcp-clients/mcp-list-cache";
+import {
+  type ConnectionCircuitStore,
+  JetStreamKVConnectionCircuitStore,
+  NoopConnectionCircuitStore,
+  setConnectionCircuitStore,
+} from "../mcp-clients/connection-circuit-store";
 import {
   InMemoryModelListCache,
   type ModelListCache,
@@ -845,6 +865,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   let eventBus: EventBus;
   let mcpListCache: McpListCache;
+  let connectionCircuitStore: ConnectionCircuitStore;
   // Model lists are public, low-stakes metadata cached per-replica with a TTL —
   // no NATS needed, so this is shared across the test and production branches.
   const modelListCache: ModelListCache = new InMemoryModelListCache();
@@ -869,6 +890,7 @@ export async function createApp(options: CreateAppOptions = {}) {
       invalidate: async () => {},
       teardown: () => {},
     };
+    connectionCircuitStore = new NoopConnectionCircuitStore();
     cancelBroadcast = {
       start: async () => {},
       broadcast: () => {},
@@ -914,6 +936,12 @@ export async function createApp(options: CreateAppOptions = {}) {
     tlc.init().catch(() => {});
     mcpListCache = tlc;
 
+    const ccs = new JetStreamKVConnectionCircuitStore({
+      getJetStream: () => natsProvider!.getJetStream(),
+    });
+    ccs.init().catch(() => {});
+    connectionCircuitStore = ccs;
+
     providerKeyCache = createProviderKeyCache({
       getConnection: () => natsProvider!.getConnection(),
     });
@@ -948,6 +976,9 @@ export async function createApp(options: CreateAppOptions = {}) {
       tlc.init().catch((err: unknown) => {
         console.error("[McpListCache] Deferred init failed:", err);
       });
+      ccs.init().catch((err: unknown) => {
+        console.error("[ConnectionCircuitStore] Deferred init failed:", err);
+      });
       // Subscribe to cross-replica key invalidations (idempotent).
       providerKeyCache.start();
       streamBuffer.init().catch((err: unknown) => {
@@ -979,6 +1010,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Set tool list cache after cleanup to avoid previous cleanup nulling the new cache
   setMcpListCache(mcpListCache);
+  setConnectionCircuitStore(connectionCircuitStore);
 
   const threadStorage = new SqlThreadStorage(database.db);
 
@@ -1068,7 +1100,9 @@ export async function createApp(options: CreateAppOptions = {}) {
     mcpListCache.teardown();
     modelListCache.teardown();
     providerKeyCache.teardown();
+    connectionCircuitStore.teardown();
     setMcpListCache(null);
+    setConnectionCircuitStore(null);
   };
 
   const app = new Hono<Env>();
@@ -1128,6 +1162,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Log response body for 5xx errors
   app.use("*", async (c, next) => {
     await next();
+    if (isHealthPath(c.req.path)) return;
     if (c.res.status >= 500) {
       const clonedRes = c.res.clone();
       const body = await clonedRes.text();
@@ -1364,6 +1399,11 @@ export async function createApp(options: CreateAppOptions = {}) {
       console.error("[EventBus] Error during startup:", error);
     });
 
+  // Public skill sets: synced by a DBOS scheduled workflow (one pod per tick
+  // instead of every pod racing its own loop). This only stashes deps — the
+  // workflow no-ops when ORGFS_PUBLIC_SETS is unset.
+  setPublicSetsSyncRuntime({ db: database.db, baseUrl: getPublicUrl() });
+
   // ============================================================================
   // Automation Runtime — wire storage + streaming into the DBOS workflow
   // ============================================================================
@@ -1410,6 +1450,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Must run before DBOS.launch() (which fires in index.ts after createApp).
   registerMonitoringRetentionWorkflow();
+  registerPublicSetsSyncWorkflow();
 
   const automationRunner: StudioContext["automationRunner"] = async (
     automationId,
@@ -2023,6 +2064,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // /profile is user-scoped (no org), stays mounted permanently — no
   // deprecation log.
   app.route("/api/deco-sites", createDecoSitesUserRoutes());
+  app.route("/api/deco-apps", createDecoAppsRoutes());
 
   // Org-scoped deco-sites routes (GET /, POST /connection). Currently mounted
   // at /api/deco-sites with a deprecation log; the new /api/:org/deco-sites
@@ -2236,6 +2278,12 @@ export async function createApp(options: CreateAppOptions = {}) {
     // replicas/workers all enqueueing in parallel collapse via OAOO.
     backfillStudioPackForAllOrgs().catch((err) => {
       console.error("[studio-pack-backfill] failed:", err);
+    });
+
+    // Fire-and-forget immediate public-sets sync (hour-bucketed workflow ID,
+    // so parallel-booting replicas collapse via OAOO).
+    kickPublicSetsBootSync().catch((err) => {
+      console.error("[org-fs] public-sets boot sync kick failed:", err);
     });
   };
 

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -9,12 +9,7 @@
  */
 
 import { getSettings } from "../settings";
-import {
-  kickPublicSetsBootSync,
-  registerPublicSetsSyncWorkflow,
-  setPublicSetsSyncRuntime,
-} from "../file-storage/dbos-public-sets-sync";
-import { getPublicUrl } from "@/core/server-constants";
+import { getBaseUrl, isSplitDevStack } from "../core/server-constants";
 import { usesLocalObjectStorage } from "../tools/connection/dev-assets";
 import { DECO_STORE_URL, isDecoHostedMcp } from "@/core/deco-constants";
 import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
@@ -63,7 +58,6 @@ import {
   createDecoSitesOrgRoutes,
   createDecoSitesUserRoutes,
 } from "./routes/deco-sites";
-import { createDecoAppsRoutes } from "./routes/deco-apps";
 import { createVirtualMcpRoutes } from "./routes/virtual-mcp";
 import {
   createLegacyWellKnownProtectedResourceRoutes,
@@ -80,11 +74,7 @@ import publicConfigRoutes from "./routes/public-config";
 import filesRoutes from "./routes/files";
 import { createThreadOutputsRoutes } from "./routes/thread-outputs";
 import { createSelfRoutes } from "./routes/self";
-import {
-  isHealthPath,
-  shouldSkipStudioContext,
-  SYSTEM_PATHS,
-} from "./utils/paths";
+import { shouldSkipStudioContext, SYSTEM_PATHS } from "./utils/paths";
 import {
   mountPluginRoutes,
   initializePluginStorage,
@@ -101,12 +91,6 @@ import {
   setMcpListCache,
   type McpListCache,
 } from "../mcp-clients/mcp-list-cache";
-import {
-  type ConnectionCircuitStore,
-  JetStreamKVConnectionCircuitStore,
-  NoopConnectionCircuitStore,
-  setConnectionCircuitStore,
-} from "../mcp-clients/connection-circuit-store";
 import {
   InMemoryModelListCache,
   type ModelListCache,
@@ -861,7 +845,6 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   let eventBus: EventBus;
   let mcpListCache: McpListCache;
-  let connectionCircuitStore: ConnectionCircuitStore;
   // Model lists are public, low-stakes metadata cached per-replica with a TTL —
   // no NATS needed, so this is shared across the test and production branches.
   const modelListCache: ModelListCache = new InMemoryModelListCache();
@@ -886,7 +869,6 @@ export async function createApp(options: CreateAppOptions = {}) {
       invalidate: async () => {},
       teardown: () => {},
     };
-    connectionCircuitStore = new NoopConnectionCircuitStore();
     cancelBroadcast = {
       start: async () => {},
       broadcast: () => {},
@@ -932,12 +914,6 @@ export async function createApp(options: CreateAppOptions = {}) {
     tlc.init().catch(() => {});
     mcpListCache = tlc;
 
-    const ccs = new JetStreamKVConnectionCircuitStore({
-      getJetStream: () => natsProvider!.getJetStream(),
-    });
-    ccs.init().catch(() => {});
-    connectionCircuitStore = ccs;
-
     providerKeyCache = createProviderKeyCache({
       getConnection: () => natsProvider!.getConnection(),
     });
@@ -972,9 +948,6 @@ export async function createApp(options: CreateAppOptions = {}) {
       tlc.init().catch((err: unknown) => {
         console.error("[McpListCache] Deferred init failed:", err);
       });
-      ccs.init().catch((err: unknown) => {
-        console.error("[ConnectionCircuitStore] Deferred init failed:", err);
-      });
       // Subscribe to cross-replica key invalidations (idempotent).
       providerKeyCache.start();
       streamBuffer.init().catch((err: unknown) => {
@@ -1006,7 +979,6 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Set tool list cache after cleanup to avoid previous cleanup nulling the new cache
   setMcpListCache(mcpListCache);
-  setConnectionCircuitStore(connectionCircuitStore);
 
   const threadStorage = new SqlThreadStorage(database.db);
 
@@ -1096,9 +1068,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     mcpListCache.teardown();
     modelListCache.teardown();
     providerKeyCache.teardown();
-    connectionCircuitStore.teardown();
     setMcpListCache(null);
-    setConnectionCircuitStore(null);
   };
 
   const app = new Hono<Env>();
@@ -1156,7 +1126,6 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Log response body for 5xx errors
   app.use("*", async (c, next) => {
     await next();
-    if (isHealthPath(c.req.path)) return;
     if (c.res.status >= 500) {
       const clonedRes = c.res.clone();
       const body = await clonedRes.text();
@@ -1393,11 +1362,6 @@ export async function createApp(options: CreateAppOptions = {}) {
       console.error("[EventBus] Error during startup:", error);
     });
 
-  // Public skill sets: synced by a DBOS scheduled workflow (one pod per tick
-  // instead of every pod racing its own loop). This only stashes deps — the
-  // workflow no-ops when ORGFS_PUBLIC_SETS is unset.
-  setPublicSetsSyncRuntime({ db: database.db, baseUrl: getPublicUrl() });
-
   // ============================================================================
   // Automation Runtime — wire storage + streaming into the DBOS workflow
   // ============================================================================
@@ -1444,7 +1408,6 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Must run before DBOS.launch() (which fires in index.ts after createApp).
   registerMonitoringRetentionWorkflow();
-  registerPublicSetsSyncWorkflow();
 
   const automationRunner: StudioContext["automationRunner"] = async (
     automationId,
@@ -2058,7 +2021,6 @@ export async function createApp(options: CreateAppOptions = {}) {
   // /profile is user-scoped (no org), stays mounted permanently — no
   // deprecation log.
   app.route("/api/deco-sites", createDecoSitesUserRoutes());
-  app.route("/api/deco-apps", createDecoAppsRoutes());
 
   // Org-scoped deco-sites routes (GET /, POST /connection). Currently mounted
   // at /api/deco-sites with a deprecation log; the new /api/:org/deco-sites
@@ -2153,6 +2115,26 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mountPluginRoutes(app, { db: database.db as any, vault });
+
+  // Split dev stack: OAuth redirect URIs may target the API port (plain
+  // localhost) while the callback page is served by Vite. Forward to the
+  // browser-facing origin so the SPA can handle the popup callback.
+  if (isSplitDevStack()) {
+    app.get("/oauth/callback", (c) => {
+      const target = new URL(getBaseUrl());
+      const reqUrl = new URL(c.req.url);
+      target.pathname = reqUrl.pathname;
+      target.search = reqUrl.search;
+      return c.redirect(target.toString(), 302);
+    });
+    app.get("/oauth/callback/ai-provider", (c) => {
+      const target = new URL(getBaseUrl());
+      const reqUrl = new URL(c.req.url);
+      target.pathname = reqUrl.pathname;
+      target.search = reqUrl.search;
+      return c.redirect(target.toString(), 302);
+    });
+  }
 
   // ============================================================================
   // 404 Handler
@@ -2252,12 +2234,6 @@ export async function createApp(options: CreateAppOptions = {}) {
     // replicas/workers all enqueueing in parallel collapse via OAOO.
     backfillStudioPackForAllOrgs().catch((err) => {
       console.error("[studio-pack-backfill] failed:", err);
-    });
-
-    // Fire-and-forget immediate public-sets sync (hour-bucketed workflow ID,
-    // so parallel-booting replicas collapse via OAOO).
-    kickPublicSetsBootSync().catch((err) => {
-      console.error("[org-fs] public-sets boot sync kick failed:", err);
     });
   };
 

--- a/apps/mesh/src/core/server-constants.ts
+++ b/apps/mesh/src/core/server-constants.ts
@@ -19,7 +19,25 @@ export function getBaseUrl(): string {
   if (settings.baseUrl) {
     return settings.baseUrl;
   }
+  // Split dev stack: Vite serves the SPA on vitePort; the Bun API listens on
+  // port. OAuth callbacks and Better Auth redirects must target the browser
+  // origin (Vite), not the API port.
+  if (settings.nodeEnv === "development" && settings.vitePort) {
+    const apiPort = settings.port ?? 3000;
+    if (Number(settings.vitePort) !== Number(apiPort)) {
+      return `http://localhost:${settings.vitePort}`;
+    }
+  }
   return `http://localhost:${settings.port ?? 3000}`;
+}
+
+/** True when Vite (SPA) and the Bun API listen on different ports in dev. */
+export function isSplitDevStack(): boolean {
+  const settings = getSettings();
+  if (settings.nodeEnv !== "development") return false;
+  const vitePort = settings.vitePort;
+  if (!vitePort) return false;
+  return Number(vitePort) !== Number(settings.port ?? 3000);
 }
 
 /**

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -141,6 +141,7 @@ export function resolveConfig(
     sandboxProviderKind: resolveSandboxProviderKind(
       envVars.STUDIO_SANDBOX_PROVIDER,
     ),
+    vitePort: flags.vitePort || envVars.VITE_PORT,
 
     // External service credentials
     decoSupabaseUrl: envVars.DECO_SUPABASE_URL,

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -83,6 +83,8 @@ export interface Settings {
   noTui: boolean;
   podName: string;
   sandboxProviderKind: "agent-sandbox" | "user-desktop";
+  /** Vite dev-server port when split from the Bun API (dev:servers). */
+  vitePort?: string;
 
   // External service credentials (optional)
   decoSupabaseUrl: string | undefined;

--- a/apps/mesh/src/web/providers/theme-provider.tsx
+++ b/apps/mesh/src/web/providers/theme-provider.tsx
@@ -83,9 +83,18 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const [preferences] = usePreferences();
 
-  // Set OAuth redirect origin for proxy environments (e.g. tokyo.localhost → localhost:3000)
+  // Set OAuth redirect origin for *.localhost proxy dev (e.g. tokyo.localhost).
+  // External OAuth providers often reject those hostnames but accept plain
+  // localhost — so MCP OAuth registers localhost:API_PORT as redirect_uri and
+  // the API forwards to the browser-facing origin. On plain localhost:4000 dev
+  // the callback page lives on Vite; window.location.origin is already correct.
   if (publicConfig.internalUrl) {
-    setOAuthRedirectOrigin(publicConfig.internalUrl);
+    const { hostname } = window.location;
+    const isProxyLocalhost =
+      hostname.endsWith(".localhost") && hostname !== "localhost";
+    if (isProxyLocalhost) {
+      setOAuthRedirectOrigin(publicConfig.internalUrl);
+    }
   }
 
   // Inject theme variables synchronously before paint to avoid FOUC

--- a/bun.lock
+++ b/bun.lock
@@ -242,7 +242,7 @@
     },
     "packages/mesh-sdk": {
       "name": "@decocms/mesh-sdk",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.1",
         "@decocms/mcp-utils": "workspace:*",
@@ -282,7 +282,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "0.15.0",
+      "version": "0.19.0",
       "dependencies": {
         "@decocms/std": "workspace:*",
         "@kubernetes/client-node": "^1.4.0",
@@ -380,6 +380,9 @@
       "dependencies": {
         "@cloudflare/vite-plugin": "^1.13.4",
         "vite": "^7.2.1",
+      },
+      "devDependencies": {
+        "tsup": "^8.5.0",
       },
     },
   },

--- a/packages/vite-plugin-deco/package.json
+++ b/packages/vite-plugin-deco/package.json
@@ -2,15 +2,27 @@
   "name": "@decocms/vite-plugin",
   "version": "1.0.0-alpha.2",
   "type": "module",
+  "files": [
+    "dist/**/*"
+  ],
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "source": "./index.ts",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
+    "build": "tsup",
+    "prepublishOnly": "npm run build",
     "check": "tsc --noEmit"
   },
   "dependencies": {
     "vite": "^7.2.1",
     "@cloudflare/vite-plugin": "^1.13.4"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.0"
   },
   "repository": {
     "type": "git",

--- a/packages/vite-plugin-deco/tsup.config.ts
+++ b/packages/vite-plugin-deco/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, type Options } from "tsup";
+
+const config: Options = {
+  entry: {
+    index: "index.ts",
+  },
+  format: ["esm"],
+  target: "es2022",
+  bundle: true,
+  sourcemap: true,
+  clean: true,
+  dts: true,
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  shims: true,
+};
+
+export default defineConfig(config);


### PR DESCRIPTION
## Summary
- Add a `tsup` build for `@decocms/vite-plugin` and export compiled `dist/index.js` so Node-based Vite can load the plugin (fixes `ERR_UNKNOWN_FILE_EXTENSION` on `index.ts`).
- Build the plugin before `dev:client` and `build:client`; wire split-stack dev env (`BASE_URL` on :4000, API on :3000).
- Forward `/oauth/callback` from the API port to Vite in dev; only override OAuth redirect origin on `*.localhost` proxy hosts.
- Run `bun run build` in the vite-plugin npm publish workflow before publish.

## Test plan
- [x] `bun run --cwd=packages/vite-plugin-deco build`
- [x] `bun run --cwd=apps/mesh build:client`
- [ ] `bun run dev` from repo root — Vite on http://localhost:4000, API on :3000, no plugin load error
- [ ] OAuth login completes in split dev stack


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds `@decocms/vite-plugin` to `dist/` so Node-based Vite can load it in local dev, and wires split-stack dev (Vite :4000, API :3000) with correct OAuth redirects.

- **Bug Fixes**
  - Compile plugin with `tsup` and point package `exports` to `dist/index.js` (fixes Node ERR_UNKNOWN_FILE_EXTENSION).
  - Build the plugin before `dev:client` and `build:client`, and set `BASE_URL`/`PORT`/`VITE_PORT` in `dev:servers` for split dev.
  - In dev, forward `/oauth/callback` and `/oauth/callback/ai-provider` to the browser origin; `getBaseUrl()` prefers `VITE_PORT` and `vitePort` is added to Settings/resolve-config; reapply redirects on top of current `app.ts` wiring.
  - Only override OAuth redirect origin on `*.localhost` proxy hosts.

- **Dependencies**
  - Add `tsup` and `tsup.config.ts` to `@decocms/vite-plugin`; build on publish via `prepublishOnly` and CI.

<sup>Written for commit d22f3b2d600aca0349548bdeb710cde3f52c9146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

