### PR TITLE
feat(observability): add unit tests for fetch instrumentation functions

### DIFF
--- a/apps/mesh/src/observability/instrumentations/fetch.test.ts
+++ b/apps/mesh/src/observability/instrumentations/fetch.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { __test } from "./fetch";
+
+const { benignSandbox4xx, isConnectionClosed } = __test;
+
+describe("benignSandbox4xx", () => {
+  it("treats daemon 404 as gone", () => {
+    expect(benignSandbox4xx(404, "/_sandbox/git/status")).toBe("daemon_gone");
+  });
+
+  it("treats daemon 409 as not-ready", () => {
+    expect(benignSandbox4xx(409, "/_sandbox/git/status")).toBe(
+      "daemon_not_ready",
+    );
+    expect(benignSandbox4xx(409, "/_sandbox/events")).toBe("daemon_not_ready");
+  });
+
+  it("treats a GC'd sandbox claim 404 as gone", () => {
+    expect(
+      benignSandbox4xx(
+        404,
+        "/apis/extensions.agents.x-k8s.io/v1alpha1/namespaces/agent-sandbox-system/sandboxclaims/tawny-spark",
+      ),
+    ).toBe("claim_gone");
+  });
+
+  it("does not suppress non-lifecycle statuses on daemon paths", () => {
+    expect(benignSandbox4xx(500, "/_sandbox/git/status")).toBeNull();
+    expect(benignSandbox4xx(403, "/_sandbox/git/status")).toBeNull();
+  });
+
+  it("does not suppress 409 outside the daemon", () => {
+    expect(benignSandbox4xx(409, "/api/links/work")).toBeNull();
+  });
+
+  it("does not suppress a claim-path 409 (only 404 is benign there)", () => {
+    expect(benignSandbox4xx(409, "/apis/x/sandboxclaims/foo")).toBeNull();
+  });
+});
+
+describe("isConnectionClosed", () => {
+  it("matches Bun's socket-closed message", () => {
+    expect(
+      isConnectionClosed(
+        new Error(
+          "The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches reset / broken-pipe codes", () => {
+    const reset = Object.assign(new Error("read"), { code: "ECONNRESET" });
+    const pipe = Object.assign(new Error("write"), { code: "EPIPE" });
+    expect(isConnectionClosed(reset)).toBe(true);
+    expect(isConnectionClosed(pipe)).toBe(true);
+  });
+
+  it("ignores unrelated errors and non-errors", () => {
+    expect(isConnectionClosed(new Error("ENOTFOUND"))).toBe(false);
+    expect(
+      isConnectionClosed(
+        Object.assign(new Error("x"), { code: "ECONNREFUSED" }),
+      ),
+    ).toBe(false);
+    expect(isConnectionClosed("nope")).toBe(false);
+    expect(isConnectionClosed(null)).toBe(false);
+  });
+});

--- a/apps/mesh/src/observability/instrumentations/fetch.ts
+++ b/apps/mesh/src/observability/instrumentations/fetch.ts
@@ -45,6 +45,31 @@ function classifyAbort(
   return null;
 }
 
+function benignSandbox4xx(status: number, pathname: string): string | null {
+  if (pathname.startsWith("/_sandbox/")) {
+    if (status === 404) return "daemon_gone";
+    if (status === 409) return "daemon_not_ready";
+  }
+  if (status === 404 && pathname.includes("/sandboxclaims/")) {
+    return "claim_gone";
+  }
+  return null;
+}
+
+/**
+ * Bun's `fetch` rejects with this shape when the peer closes the TCP
+ * connection mid-request (e.g. an in-pod sandbox daemon torn down by idle
+ * eviction). Distinct from an abort — nobody cancelled, the socket just went
+ * away. Matched on message + the common reset/broken-pipe codes since Bun
+ * gives these no stable error `name`.
+ */
+function isConnectionClosed(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.message.includes("socket connection was closed")) return true;
+  const code = (error as { code?: string }).code;
+  return code === "ECONNRESET" || code === "EPIPE";
+}
+
 /**
  * Instrumented fetch that creates spans for outbound requests
  * and propagates trace context.
@@ -120,25 +145,23 @@ async function instrumentedFetch(
           method === "GET" &&
           (headers.get("accept") ?? "").includes("text/event-stream");
 
-        // A 404 on the in-pod daemon (`/_sandbox/*`) means the sandbox handle
-        // is gone (idle-evicted). That's expected control flow — the proxy maps
-        // it to 410/`gone` and the UI self-heals — not a failure. Open Studio
-        // tabs poll `/events` + `/git/status` against reaped sandboxes, so
-        // marking these ERROR floods the error dashboard with benign 404s.
-        const isDaemonSandboxGone404 =
-          response.status === 404 && url.pathname.startsWith("/_sandbox/");
+        // Sandbox lifecycle churn (reaped/booting daemon, GC'd claim) is
+        // expected control flow the caller self-heals — not a failure. See
+        // benignSandbox4xx; marking these ERROR floods the error dashboard.
+        const sandboxLifecycle =
+          response.status >= 400
+            ? benignSandbox4xx(response.status, url.pathname)
+            : null;
 
-        if (
-          response.status >= 400 &&
-          !isMcpSseProbe405 &&
-          !isDaemonSandboxGone404
-        ) {
+        if (response.status >= 400 && !isMcpSseProbe405 && !sandboxLifecycle) {
           span.setStatus({
             code: SpanStatusCode.ERROR,
             message: `HTTP ${response.status}`,
           });
         } else {
-          if (isDaemonSandboxGone404) span.setAttribute("sandbox.gone", true);
+          if (sandboxLifecycle) {
+            span.setAttribute("sandbox.lifecycle", sandboxLifecycle);
+          }
           span.setStatus({ code: SpanStatusCode.OK });
         }
 
@@ -154,6 +177,11 @@ async function instrumentedFetch(
           // and distinguishable in traces. We still re-throw — control flow is
           // the caller's concern, untouched.
           span.setAttribute("abort.reason", abortReason);
+        } else if (
+          isConnectionClosed(error) &&
+          url.pathname.startsWith("/_sandbox/")
+        ) {
+          span.setAttribute("sandbox.lifecycle", "connection_closed");
         } else {
           // Record exception and set error status
           span.recordException(error as Exception);
@@ -177,3 +205,6 @@ export function enableFetchInstrumentation(): void {
   // @ts-expect-error - Bun's fetch has extra properties like preconnect
   globalThis.fetch = instrumentedFetch;
 }
+
+/** Internal helpers exposed for unit tests only. */
+export const __test = { benignSandbox4xx, isConnectionClosed };


### PR DESCRIPTION
- Introduced tests for `benignSandbox4xx` to validate handling of specific HTTP status codes related to sandbox lifecycle.
- Added tests for `isConnectionClosed` to ensure correct identification of closed socket connections and error handling.
- Implemented internal helper functions for testing purposes in `fetch.ts` to facilitate unit testing.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for fetch instrumentation and improve how sandbox lifecycle errors are tagged. This reduces false ERROR spans and noise in traces.

- **Bug Fixes**
  - Treat 404/409 on `/_sandbox/*` and 404 on `*/sandboxclaims/*` as benign; set `sandbox.lifecycle` to "daemon_gone", "daemon_not_ready", or "claim_gone" and keep span OK.
  - Detect closed connections (Bun “socket connection was closed”, `ECONNRESET`, `EPIPE`) on `/_sandbox/*` and tag `sandbox.lifecycle=connection_closed` instead of marking an error.
  - Keep `abort.reason` tagging and rethrow behavior unchanged.

- **New Features**
  - Expose internal helpers via `__test` and add unit tests for `benignSandbox4xx` and `isConnectionClosed` in `fetch.test.ts`.

<sup>Written for commit 03a25bac075e8b4fdecb2c357cad6e7eb9826d3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

