### PR TITLE
feat(decopilot): implement shared subagent resolution logic

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -10,8 +10,7 @@
  */
 
 import type { StudioContext, OrganizationScope } from "@/core/studio-context";
-import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
-import type { PassthroughClient } from "@/mcp-clients/virtual-mcp/passthrough-client";
+import { resolveSubagent } from "../resolve-subagent";
 import type { UIMessageStreamWriter } from "ai";
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
@@ -111,23 +110,12 @@ export function createSubtaskTool(
         );
       }
 
-      // 1. Validate the target agent.
-      const virtualMcp = await ctx.storage.virtualMcps.findById(
-        targetId,
-        organization.id,
-      );
-      if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
-        throw new Error("Agent not found");
-      }
-      if (virtualMcp.status !== "active") {
-        throw new Error("Agent is not active");
-      }
-
-      // 1b. Enforce the caller's sub-agent allowlist for cross-agent
-      //     delegation. Self-clones are always allowed. An empty or absent
-      //     allowlist means "all agents" (the default). This mirrors the
-      //     <available-agents> prompt filter — the model shouldn't even see
-      //     disallowed agents, but we re-check here as defense in depth.
+      // 1. Enforce the caller's sub-agent allowlist for cross-agent
+      //    delegation BEFORE resolving the target — a disallowed target must
+      //    not even cause a client to open. Self-clones are always allowed. An
+      //    empty or absent allowlist means "all agents" (the default). This
+      //    mirrors the <available-agents> prompt filter — the model shouldn't
+      //    even see disallowed agents, but we re-check here as defense in depth.
       if (!isSelf && self) {
         const caller = await ctx.storage.virtualMcps.findById(
           self.id,
@@ -141,22 +129,17 @@ export function createSubtaskTool(
         }
       }
 
-      // 2. Open an MCP client for the target. A self-clone uses superUser so
-      //    its tool scope mirrors the parent loop's passthrough client.
-      const mcpClient = (await createVirtualClientFrom(
-        virtualMcp,
+      // 2. Validate the target and open its passthrough client. A self-clone
+      //    uses superUser so its tool scope mirrors the parent loop.
+      const { mcpClient, targetRef } = await resolveSubagent(
         ctx,
-        "passthrough",
-        isSelf,
-      )) as PassthroughClient;
-      const targetLabel = virtualMcp.id;
+        organization.id,
+        targetId,
+        { superUser: isSelf },
+      );
+      const targetLabel = targetRef.id;
 
       try {
-        const targetRef = {
-          id: virtualMcp.id,
-          instructions: mcpClient.getInstructions(),
-          repo: virtualMcp.metadata?.githubRepo ?? undefined,
-        };
         // 3. Call runAgentLoop with subagent kind.
         const handle = await runAgentLoop({
           kind: "subagent",

--- a/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
+++ b/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
@@ -9,6 +9,7 @@
  * on the error strings (`"Agent not found"` / `"Agent is not active"`) or the
  * targetRef shape.
  */
+import type { GithubRepo } from "@decocms/mesh-sdk";
 import type { StudioContext } from "@/core/studio-context";
 import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
 import type { PassthroughClient } from "@/mcp-clients/virtual-mcp/passthrough-client";
@@ -18,7 +19,7 @@ export interface ResolvedSubagent {
   targetRef: {
     id: string;
     instructions: string | undefined;
-    repo: string | undefined;
+    repo: GithubRepo | undefined;
   };
 }
 

--- a/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
+++ b/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared delegation-target resolution for the two `subtask` surfaces:
+ * the in-process `subtask` built-in (`built-in-tools/subtask.ts`) and the
+ * cluster-side `SUBTASK_MCP` tool (`tools/decopilot-mcp/subtask-tool.ts`).
+ *
+ * Both validate the target Virtual MCP identically (existence + org scope +
+ * active status), open a passthrough client, and build the `targetRef` that
+ * `runAgentLoop` expects. Keeping it here stops the two surfaces from drifting
+ * on the error strings (`"Agent not found"` / `"Agent is not active"`) or the
+ * targetRef shape.
+ */
+import type { StudioContext } from "@/core/studio-context";
+import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
+import type { PassthroughClient } from "@/mcp-clients/virtual-mcp/passthrough-client";
+
+export interface ResolvedSubagent {
+  mcpClient: PassthroughClient;
+  targetRef: {
+    id: string;
+    instructions: string | undefined;
+    repo: string | undefined;
+  };
+}
+
+/**
+ * Validate a delegation target, open a passthrough client for it, and build the
+ * targetRef. `superUser` mirrors the parent loop's passthrough scope (used by
+ * self-clones); leave it false for cross-agent delegation.
+ *
+ * @throws Error("Agent not found") when the id doesn't resolve in the org.
+ * @throws Error("Agent is not active") when the agent exists but is inactive.
+ */
+export async function resolveSubagent(
+  ctx: StudioContext,
+  organizationId: string,
+  agentId: string,
+  { superUser = false }: { superUser?: boolean } = {},
+): Promise<ResolvedSubagent> {
+  const virtualMcp = await ctx.storage.virtualMcps.findById(
+    agentId,
+    organizationId,
+  );
+  if (!virtualMcp || virtualMcp.organization_id !== organizationId) {
+    throw new Error("Agent not found");
+  }
+  if (virtualMcp.status !== "active") {
+    throw new Error("Agent is not active");
+  }
+
+  const mcpClient = await createVirtualClientFrom(
+    virtualMcp,
+    ctx,
+    "passthrough",
+    superUser,
+  );
+
+  return {
+    mcpClient,
+    targetRef: {
+      id: virtualMcp.id,
+      instructions: mcpClient.getInstructions(),
+      repo: virtualMcp.metadata?.githubRepo ?? undefined,
+    },
+  };
+}

--- a/apps/mesh/src/tools/decopilot-mcp/subtask-tool.ts
+++ b/apps/mesh/src/tools/decopilot-mcp/subtask-tool.ts
@@ -18,7 +18,7 @@
  */
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
-import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
+import { resolveSubagent } from "@/harnesses/decopilot/resolve-subagent";
 import { runAgentLoop } from "@/harnesses/decopilot/run-agent-loop";
 import { SUBAGENT_STEP_LIMIT } from "@/api/routes/decopilot/constants";
 import type { ModelsConfig } from "@/api/routes/decopilot/types";
@@ -111,23 +111,11 @@ export const SUBTASK_MCP = defineTool({
         : {}),
     };
 
-    // 3. Validate the target agent.
-    const virtualMcp = await ctx.storage.virtualMcps.findById(
-      input.agent_id,
-      organization.id,
-    );
-    if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
-      throw new Error("Agent not found");
-    }
-    if (virtualMcp.status !== "active") {
-      throw new Error("Agent is not active");
-    }
-
-    // 4. Create MCP client for the target agent.
-    const mcpClient = await createVirtualClientFrom(
-      virtualMcp,
+    // 3. Validate the target agent and open its passthrough client.
+    const { mcpClient, targetRef } = await resolveSubagent(
       ctx,
-      "passthrough",
+      organization.id,
+      input.agent_id,
     );
 
     try {
@@ -140,11 +128,7 @@ export const SUBTASK_MCP = defineTool({
         kind: "subagent",
         ctx,
         organization,
-        virtualMcp: {
-          id: virtualMcp.id,
-          instructions: mcpClient.getInstructions(),
-          repo: virtualMcp.metadata?.githubRepo ?? undefined,
-        },
+        virtualMcp: targetRef,
         mcpClient,
         provider,
         models,


### PR DESCRIPTION
- Added `resolveSubagent` function to validate delegation targets and open passthrough clients, ensuring consistent error handling and target reference structure across built-in and cluster-side subtask tools.
- Refactored `subtask` and `subtask-tool` to utilize the new resolution logic, improving code maintainability and reducing duplication of validation logic.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented shared subagent resolution for Decopilot by adding `resolveSubagent` and refactoring both `subtask` surfaces to use it. This standardizes target validation, error messages, and the `targetRef` used by `runAgentLoop`, and fixes the `repo` type to `GithubRepo`.

- **Refactors**
  - Added `resolveSubagent` to validate agents, open a passthrough client, and build `targetRef`.
  - Updated built-in `subtask` and cluster-side `SUBTASK_MCP` to use the shared logic.
  - Unified errors ("Agent not found", "Agent is not active") and the `targetRef` shape for `runAgentLoop`.
  - Self-clone delegations now pass `superUser` to mirror the parent loop’s scope.

- **Bug Fixes**
  - Enforce the caller’s sub-agent allowlist before resolving targets in the built-in `subtask`, preventing clients from opening for disallowed agents.
  - Set `targetRef.repo` to `GithubRepo` for correct typing and consistency.

<sup>Written for commit fc036a0b544c9e67f9dab2a5c2c60c62543f180f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

