### PR TITLE
feat(sandbox): enhance SSE handling with exponential backoff and clie…

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-events-handler.ts
+++ b/apps/mesh/src/api/routes/sandbox-events-handler.ts
@@ -14,7 +14,7 @@ import {
   type SandboxProviderKind,
   type SandboxProvider,
 } from "@decocms/sandbox/provider";
-import { delay } from "@decocms/std";
+import { delay, exponentialBackoffWithJitter } from "@decocms/std";
 import { subscribeLifecycle } from "../../sandbox/lifecycle";
 import type { StudioContext } from "../../core/studio-context";
 import { KyselySandboxProviderStateStore } from "../../storage/sandbox-runner-state";
@@ -43,6 +43,14 @@ const HEARTBEAT_MS = 15_000;
  */
 const PROXY_OPEN_RETRY_BUDGET_MS = 60_000;
 const PROXY_OPEN_RETRY_DELAY_MS = 500;
+/**
+ * Cap for the exponential backoff applied to transient upstream statuses (429 /
+ * 5xx). 429 means "too many SSE clients on the daemon" — retrying every 500ms
+ * (let alone instantly ending the stream so the client's EventSource reconnects
+ * at once) is exactly the storm that pins the daemon at MAX_SSE_CLIENTS and
+ * floods logs with `bad status 429`. Back off hard instead.
+ */
+const PROXY_BACKOFF_CAP_MS = 10_000;
 
 export interface VmEventsHandlerArgs {
   ctx: StudioContext;
@@ -269,6 +277,7 @@ async function proxyDaemonEvents(args: {
 
   const openedAt = Date.now();
   let upstream: Response | null = null;
+  let badStatusAttempt = 0;
 
   while (!signal.aborted) {
     let attempt: Response | null = null;
@@ -320,9 +329,25 @@ async function proxyDaemonEvents(args: {
       } catch {
         /* ignore */
       }
-      // Transient upstream error — end the stream and let the client reconnect.
+      if (Date.now() - openedAt < PROXY_OPEN_RETRY_BUDGET_MS) {
+        console.warn(
+          `[vm-events] upstream daemon SSE bad status ${status} for ${claimName} (attempt ${
+            badStatusAttempt + 1
+          }, backing off)`,
+        );
+        const backoff = exponentialBackoffWithJitter(
+          PROXY_BACKOFF_CAP_MS,
+          PROXY_OPEN_RETRY_DELAY_MS,
+          badStatusAttempt++,
+          2,
+          0.5,
+        );
+        await delay(backoff, { signal }).catch(() => {});
+        continue;
+      }
+      // Past budget — end the stream and let the client reconnect fresh.
       console.warn(
-        `[vm-events] upstream daemon SSE bad status ${status} for ${claimName}`,
+        `[vm-events] upstream daemon SSE bad status ${status} for ${claimName} past budget; ending stream`,
       );
       return;
     }

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -624,7 +624,7 @@ async function vmRouteH(
   prefix: string,
 ): Promise<Response> {
   if (method === "GET" && vmPath === "/idle") return idleH();
-  if (method === "GET" && vmPath === "/events") return eventsH();
+  if (method === "GET" && vmPath === "/events") return eventsH(req);
   if (method === "GET" && vmPath === "/scripts") return scriptsHandler();
   if (method === "OPTIONS")
     return new Response(null, { status: 204, headers: CORS_HEADERS });

--- a/packages/sandbox/daemon/events/broadcast.test.ts
+++ b/packages/sandbox/daemon/events/broadcast.test.ts
@@ -28,6 +28,19 @@ describe("Broadcaster", () => {
     b.emit("intent", { state: "running" });
   });
 
+  it("reaps a controller that throws on enqueue so it frees its slot", () => {
+    const b = new Broadcaster(100);
+    b.register({
+      enqueue: () => {
+        throw new Error("closed");
+      },
+    } as unknown as ReadableStreamDefaultController<Uint8Array>);
+    expect(b.size()).toBe(1);
+    b.emit("intent", { state: "running" });
+    // Dead controller dropped — would otherwise leak against MAX_SSE_CLIENTS.
+    expect(b.size()).toBe(0);
+  });
+
   it("records chunks into its replay buffer", () => {
     const b = new Broadcaster(100);
     b.broadcastChunk("setup", "abc");

--- a/packages/sandbox/daemon/events/broadcast.ts
+++ b/packages/sandbox/daemon/events/broadcast.ts
@@ -48,12 +48,14 @@ export class Broadcaster {
   }
 
   private fan(bytes: Uint8Array): void {
+    let dead: Controller[] | null = null;
     for (const c of this.clients) {
       try {
         c.enqueue(bytes);
       } catch {
-        // Swallow — controller closed under our feet.
+        (dead ??= []).push(c);
       }
     }
+    if (dead) for (const c of dead) this.clients.delete(c);
   }
 }

--- a/packages/sandbox/daemon/events/sse.test.ts
+++ b/packages/sandbox/daemon/events/sse.test.ts
@@ -33,6 +33,29 @@ describe("makeSseStream", () => {
     await reader.cancel();
   });
 
+  it("unregisters the client when the request signal aborts", async () => {
+    const b = new Broadcaster(100);
+    const ctl = new AbortController();
+    const stream = makeSseStream({ ...mkDeps(b), signal: ctl.signal })!;
+    const reader = stream.getReader();
+    await reader.read(); // drive start() so the controller registers
+    expect(b.size()).toBe(1);
+    ctl.abort();
+    expect(b.size()).toBe(0);
+    await reader.cancel();
+  });
+
+  it("does not register when the signal is already aborted", async () => {
+    const b = new Broadcaster(100);
+    const ctl = new AbortController();
+    ctl.abort();
+    const stream = makeSseStream({ ...mkDeps(b), signal: ctl.signal })!;
+    const reader = stream.getReader();
+    await reader.read();
+    expect(b.size()).toBe(0);
+    await reader.cancel();
+  });
+
   it("emits status event in handshake", async () => {
     const b = new Broadcaster(100);
     const stream = makeSseStream(mkDeps(b))!;

--- a/packages/sandbox/daemon/events/sse.ts
+++ b/packages/sandbox/daemon/events/sse.ts
@@ -17,6 +17,7 @@ export interface SseHandshakeDeps {
   getStatus: () => DaemonStatus;
   getBranchMeta: () => BranchMeta;
   maxClients: number;
+  signal?: AbortSignal;
 }
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
@@ -33,6 +34,15 @@ export function makeSseStream(
 
   let controller!: ReadableStreamDefaultController<Uint8Array>;
   let keepAlive: ReturnType<typeof setInterval> | null = null;
+  let cleanedUp = false;
+
+  function cleanup() {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    if (keepAlive) clearInterval(keepAlive);
+    deps.broadcaster.unregister(controller);
+    deps.signal?.removeEventListener("abort", cleanup);
+  }
 
   function frame<K extends DaemonEventName>(
     name: K,
@@ -65,19 +75,25 @@ export function makeSseStream(
 
       deps.broadcaster.register(controller);
 
+      if (deps.signal) {
+        if (deps.signal.aborted) {
+          cleanup();
+          return;
+        }
+        deps.signal.addEventListener("abort", cleanup, { once: true });
+      }
+
       keepAlive = setInterval(() => {
         try {
           c.enqueue(frame("lifecycle", { state: deps.getLifecycle() }));
         } catch {
-          if (keepAlive) clearInterval(keepAlive);
-          deps.broadcaster.unregister(controller);
+          cleanup();
         }
       }, HEARTBEAT_INTERVAL_MS);
     },
 
     cancel() {
-      if (keepAlive) clearInterval(keepAlive);
-      deps.broadcaster.unregister(controller);
+      cleanup();
     },
   });
 }

--- a/packages/sandbox/daemon/routes/events-stream.ts
+++ b/packages/sandbox/daemon/routes/events-stream.ts
@@ -3,10 +3,16 @@ import { makeSseStream, type SseHandshakeDeps } from "../events/sse";
 import { MAX_SSE_CLIENTS } from "../constants";
 
 export function makeEventsHandler(
-  deps: Omit<SseHandshakeDeps, "maxClients"> & { broadcaster: Broadcaster },
+  deps: Omit<SseHandshakeDeps, "maxClients" | "signal"> & {
+    broadcaster: Broadcaster;
+  },
 ) {
-  return async (): Promise<Response> => {
-    const stream = makeSseStream({ ...deps, maxClients: MAX_SSE_CLIENTS });
+  return async (req?: Request): Promise<Response> => {
+    const stream = makeSseStream({
+      ...deps,
+      maxClients: MAX_SSE_CLIENTS,
+      signal: req?.signal,
+    });
     if (!stream) {
       return new Response("Too many connections", {
         status: 429,


### PR DESCRIPTION
…nt cleanup

- Introduced exponential backoff for handling transient upstream errors (429/5xx) in the SSE proxy, improving resilience against server overload.
- Updated the events handler to accept request signals for better client management, allowing for automatic unregistration on abort.
- Added tests to ensure proper cleanup of clients and handling of closed controllers in the Broadcaster class, preventing resource leaks.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves sandbox SSE reliability with exponential backoff on 429/5xx and automatic client cleanup to avoid overload and leaked connections. Propagates request abort signals through the daemon to unregister clients promptly.

- **New Features**
  - Add exponential backoff with jitter (capped at 10s) for upstream 429/5xx in the SSE proxy using `exponentialBackoffWithJitter`.
  - Pass the request `AbortSignal` to the daemon events stream (`eventsH` → `makeSseStream`) for better client lifecycle handling.

- **Bug Fixes**
  - Reap controllers that throw on `enqueue` in `Broadcaster` to free `MAX_SSE_CLIENTS` slots and prevent leaks.
  - Skip registration when the provided signal is already aborted; auto-unregister on abort and on heartbeat failures in `makeSseStream`.
  - Add tests covering controller cleanup and signal-driven unregistration.

<sup>Written for commit bb39132ec00dddff5a818563ae8c61a721e75c73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

