### PR TITLE
refactor(decopilot): enhance delegation error handling in subtask tool

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -110,14 +110,6 @@ export function createSubtaskTool(
         );
       }
 
-      // 1. Enforce the caller's sub-agent allowlist for cross-agent
-      //    delegation BEFORE resolving the target — a disallowed target must
-      //    not even cause a client to open. Delegating to SELF is always
-      //    allowed and never gated by the allowlist (an agent can always clone
-      //    itself), whether the id was omitted or passed explicitly. An empty
-      //    or absent allowlist means "all agents" (the default). This mirrors
-      //    the <available-agents> prompt filter — the model shouldn't even see
-      //    disallowed agents, but we re-check here as defense in depth.
       const isSelfTarget = !!self && targetId === self.id;
       if (!isSelf && !isSelfTarget && self) {
         const caller = await ctx.storage.virtualMcps.findById(
@@ -128,10 +120,9 @@ export function createSubtaskTool(
         // An allowlist array (even empty = itself only) gates cross-agent
         // delegation. A null/absent allowlist means all agents are allowed.
         if (Array.isArray(allow) && !allow.includes(targetId)) {
-          console.log(
-            `[subtask] delegation blocked by allowlist: caller=${self.id} target=${targetId} allow=${JSON.stringify(allow)} isSelf=${isSelf} agent_id=${agent_id ?? "(omitted)"}`,
+          throw new Error(
+            `Agent not available for delegation, blocked by allowlist. caller=${self.id} target=${targetId} allow=${JSON.stringify(allow)} isSelf=${isSelf} agent_id=${agent_id ?? "(omitted)"}`,
           );
-          throw new Error(`Agent not available for delegation, blocked by allowlist. caller=${self.id} target=${targetId} allow=${JSON.stringify(allow)} isSelf=${isSelf} agent_id=${agent_id ?? "(omitted)"}`);
         }
       }
 

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -112,11 +112,14 @@ export function createSubtaskTool(
 
       // 1. Enforce the caller's sub-agent allowlist for cross-agent
       //    delegation BEFORE resolving the target — a disallowed target must
-      //    not even cause a client to open. Self-clones are always allowed. An
-      //    empty or absent allowlist means "all agents" (the default). This
-      //    mirrors the <available-agents> prompt filter — the model shouldn't
-      //    even see disallowed agents, but we re-check here as defense in depth.
-      if (!isSelf && self) {
+      //    not even cause a client to open. Delegating to SELF is always
+      //    allowed and never gated by the allowlist (an agent can always clone
+      //    itself), whether the id was omitted or passed explicitly. An empty
+      //    or absent allowlist means "all agents" (the default). This mirrors
+      //    the <available-agents> prompt filter — the model shouldn't even see
+      //    disallowed agents, but we re-check here as defense in depth.
+      const isSelfTarget = !!self && targetId === self.id;
+      if (!isSelf && !isSelfTarget && self) {
         const caller = await ctx.storage.virtualMcps.findById(
           self.id,
           organization.id,
@@ -125,7 +128,10 @@ export function createSubtaskTool(
         // An allowlist array (even empty = itself only) gates cross-agent
         // delegation. A null/absent allowlist means all agents are allowed.
         if (Array.isArray(allow) && !allow.includes(targetId)) {
-          throw new Error("Agent not available for delegation");
+          console.log(
+            `[subtask] delegation blocked by allowlist: caller=${self.id} target=${targetId} allow=${JSON.stringify(allow)} isSelf=${isSelf} agent_id=${agent_id ?? "(omitted)"}`,
+          );
+          throw new Error(`Agent not available for delegation, blocked by allowlist. caller=${self.id} target=${targetId} allow=${JSON.stringify(allow)} isSelf=${isSelf} agent_id=${agent_id ?? "(omitted)"}`);
         }
       }
 


### PR DESCRIPTION
- Updated the subtask tool to improve the handling of delegation errors by adding detailed logging when an agent is blocked by the allowlist. This change ensures that the caller's sub-agent allowlist is enforced more clearly, providing better visibility into delegation failures.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve delegation error handling in the Decopilot `subtask` tool by explicitly allowing self-delegation and returning clearer errors when the allowlist blocks cross-agent delegation.

- **Refactors**
  - Added `isSelfTarget` to always allow self-clones and to gate cross-agent delegation before resolving the target.
  - When blocked by the allowlist, throw a descriptive error including caller, target, allowlist, `isSelf`, and `agent_id` for easier debugging.

<sup>Written for commit f29ae11af92be09bcf8a83897b364c329380c985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

