### PR TITLE
feat(automations): add run stats tool and UI components

### DIFF
--- a/apps/mesh/src/storage/automations.ts
+++ b/apps/mesh/src/storage/automations.ts
@@ -107,6 +107,33 @@ export interface AutomationsStorage {
   markRunCompleted(taskId: string): Promise<void>;
   updateTriggerLastRunAt(triggerId: string, lastRunAt: string): Promise<void>;
   deactivateAutomation(id: string): Promise<void>;
+  /**
+   * Count run threads for an automation grouped into the run-lifecycle buckets,
+   * joining `threads` → `automation_triggers`. Backs the per-automation Runs
+   * stat cards (total + success rate).
+   */
+  getRunStats(
+    automationId: string,
+    organizationId: string,
+    opts?: { startDate?: string; endDate?: string },
+  ): Promise<AutomationRunStats>;
+  /**
+   * Most-recent run thread IDs for an automation (newest first), capped by
+   * `limit`. Used to aggregate token/cost usage for the stat cards via the
+   * monitoring store (keyed by `properties.thread_id`).
+   */
+  listRunThreadIds(
+    automationId: string,
+    organizationId: string,
+    opts?: { startDate?: string; endDate?: string; limit?: number },
+  ): Promise<string[]>;
+}
+
+export interface AutomationRunStats {
+  total: number;
+  completed: number;
+  failed: number;
+  inProgress: number;
 }
 
 // ============================================================================
@@ -615,6 +642,88 @@ class KyselyAutomationsStorage implements AutomationsStorage {
       .where("id", "=", id)
       .where("active", "=", true)
       .execute();
+  }
+
+  async getRunStats(
+    automationId: string,
+    organizationId: string,
+    opts?: { startDate?: string; endDate?: string },
+  ): Promise<AutomationRunStats> {
+    let query = this.db
+      .selectFrom("threads as th")
+      .innerJoin("automation_triggers as t", "t.id", "th.trigger_id")
+      .select("th.status")
+      .select((eb) => eb.fn.count("th.id").as("count"))
+      .where("t.automation_id", "=", automationId)
+      .where("th.organization_id", "=", organizationId)
+      .where("th.hidden", "=", false)
+      .groupBy("th.status");
+
+    if (opts?.startDate) {
+      query = query.where(
+        "th.created_at",
+        ">=",
+        opts.startDate as unknown as Date,
+      );
+    }
+    if (opts?.endDate) {
+      query = query.where(
+        "th.created_at",
+        "<=",
+        opts.endDate as unknown as Date,
+      );
+    }
+
+    const rows = await query.execute();
+
+    const stats: AutomationRunStats = {
+      total: 0,
+      completed: 0,
+      failed: 0,
+      inProgress: 0,
+    };
+    for (const row of rows) {
+      const count = Number(row.count);
+      stats.total += count;
+      if (row.status === "completed") stats.completed += count;
+      else if (row.status === "failed") stats.failed += count;
+      else if (row.status === "in_progress") stats.inProgress += count;
+    }
+    return stats;
+  }
+
+  async listRunThreadIds(
+    automationId: string,
+    organizationId: string,
+    opts?: { startDate?: string; endDate?: string; limit?: number },
+  ): Promise<string[]> {
+    let query = this.db
+      .selectFrom("threads as th")
+      .innerJoin("automation_triggers as t", "t.id", "th.trigger_id")
+      .select("th.id")
+      .where("t.automation_id", "=", automationId)
+      .where("th.organization_id", "=", organizationId)
+      .where("th.hidden", "=", false)
+      .orderBy("th.created_at", "desc")
+      .limit(opts?.limit ?? 500);
+
+    if (opts?.startDate) {
+      query = query.where(
+        "th.created_at",
+        ">=",
+        opts.startDate as unknown as Date,
+      );
+    }
+    if (opts?.endDate) {
+      query = query.where(
+        "th.created_at",
+        "<=",
+        opts.endDate as unknown as Date,
+      );
+    }
+
+    const rows = await query.execute();
+    return rows.map((row) => row.id);
   }
 }
 

--- a/apps/mesh/src/tools/automations/index.ts
+++ b/apps/mesh/src/tools/automations/index.ts
@@ -13,3 +13,4 @@ export { AUTOMATION_TRIGGER_ADD } from "./trigger-add";
 export { AUTOMATION_TRIGGER_REMOVE } from "./trigger-remove";
 export { AUTOMATION_TRIGGER_ROTATE_TOKEN } from "./trigger-rotate-token";
 export { AUTOMATION_RUN } from "./run";
+export { AUTOMATION_RUN_STATS } from "./run-stats";

--- a/apps/mesh/src/tools/automations/run-stats.ts
+++ b/apps/mesh/src/tools/automations/run-stats.ts
@@ -1,0 +1,126 @@
+/**
+ * AUTOMATION_RUN_STATS Tool
+ *
+ * Aggregate stats for a single automation's runs: run counts by lifecycle
+ * status (total / completed / failed / in-progress) plus LLM token + USD cost
+ * totals across the automation's run threads. Backs the per-automation Runs
+ * stat cards on the automation detail page and the Monitoring → Automations tab.
+ *
+ * Token/cost is aggregated over the most-recent run threads (capped at
+ * USAGE_SAMPLE_LIMIT); `usage.truncated` flags when more runs existed than were
+ * sampled, so the UI can label the figure as a partial total.
+ */
+
+import { z } from "zod";
+import { requireAuth, requireOrganization } from "@/core/studio-context";
+import { flushMonitoringData } from "@/observability";
+import { defineTool } from "../../core/define-tool";
+
+// Token/cost aggregation joins per-run threads to llm_call logs; bound the
+// thread-id set to keep the monitoring query cheap (matches the cap on
+// MONITORING_THREAD_USAGE).
+const USAGE_SAMPLE_LIMIT = 500;
+
+export const AUTOMATION_RUN_STATS = defineTool({
+  name: "AUTOMATION_RUN_STATS",
+  description:
+    "Aggregate run counts (by status) and LLM token/cost totals for a single automation.",
+  annotations: {
+    title: "Automation Run Stats",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({
+    automation_id: z.string(),
+    startDate: z
+      .string()
+      .datetime()
+      .optional()
+      .describe("Filter runs at or after this ISO timestamp"),
+    endDate: z
+      .string()
+      .datetime()
+      .optional()
+      .describe("Filter runs at or before this ISO timestamp"),
+  }),
+  outputSchema: z.object({
+    runs: z.object({
+      total: z.number(),
+      completed: z.number(),
+      failed: z.number(),
+      inProgress: z.number(),
+    }),
+    usage: z.object({
+      calls: z.number(),
+      inputTokens: z.number(),
+      outputTokens: z.number(),
+      totalTokens: z.number(),
+      costUsd: z.number(),
+      /** Number of run threads the token/cost totals were aggregated over. */
+      sampledRuns: z.number(),
+      /** True when more runs existed than were sampled for token/cost. */
+      truncated: z.boolean(),
+    }),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const organization = requireOrganization(ctx);
+    await ctx.access.check();
+    await flushMonitoringData();
+
+    const automation = await ctx.storage.automations.findById(
+      input.automation_id,
+      organization.id,
+    );
+    if (!automation) {
+      throw new Error("Automation not found");
+    }
+
+    const runs = await ctx.storage.automations.getRunStats(
+      input.automation_id,
+      organization.id,
+      { startDate: input.startDate, endDate: input.endDate },
+    );
+
+    const threadIds = await ctx.storage.automations.listRunThreadIds(
+      input.automation_id,
+      organization.id,
+      {
+        startDate: input.startDate,
+        endDate: input.endDate,
+        limit: USAGE_SAMPLE_LIMIT,
+      },
+    );
+
+    const usage = {
+      calls: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      sampledRuns: threadIds.length,
+      truncated: runs.total > threadIds.length,
+    };
+
+    if (threadIds.length > 0) {
+      const items = await ctx.storage.monitoring.queryThreadUsage({
+        organizationId: organization.id,
+        connectionId: "decopilot",
+        threadIds,
+        startDate: input.startDate ? new Date(input.startDate) : undefined,
+        endDate: input.endDate ? new Date(input.endDate) : undefined,
+      });
+      for (const item of items) {
+        usage.calls += item.calls;
+        usage.inputTokens += item.inputTokens;
+        usage.outputTokens += item.outputTokens;
+        usage.totalTokens += item.totalTokens;
+        usage.costUsd += item.costUsd;
+      }
+    }
+
+    return { runs, usage };
+  },
+});

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -135,6 +135,7 @@ const CORE_TOOLS = [
   AutomationTools.AUTOMATION_TRIGGER_REMOVE,
   AutomationTools.AUTOMATION_TRIGGER_ROTATE_TOKEN,
   AutomationTools.AUTOMATION_RUN,
+  AutomationTools.AUTOMATION_RUN_STATS,
 
   // Virtual MCP plugin config tools
   VirtualMCPTools.VIRTUAL_MCP_PLUGIN_CONFIG_GET,

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -125,6 +125,7 @@ const ALL_TOOL_NAMES = [
   "AUTOMATION_TRIGGER_REMOVE",
   "AUTOMATION_TRIGGER_ROTATE_TOKEN",
   "AUTOMATION_RUN",
+  "AUTOMATION_RUN_STATS",
   // Virtual MCP plugin config and pinned views tools
   "VIRTUAL_MCP_PLUGIN_CONFIG_GET",
   "VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE",
@@ -637,6 +638,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     description: "Manually trigger an automation run",
     category: "Automations",
   },
+  {
+    name: "AUTOMATION_RUN_STATS",
+    description: "View aggregated run counts and token/cost for an automation",
+    category: "Automations",
+  },
   // Virtual MCP plugin config and pinned views tools
   {
     name: "VIRTUAL_MCP_PLUGIN_CONFIG_GET",
@@ -1070,6 +1076,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       // View automations
       "AUTOMATION_GET",
       "AUTOMATION_LIST",
+      "AUTOMATION_RUN_STATS",
       // View AI providers (read-only — every member needs to know which
       // providers are configured so chat / agents can use them). KEY_LIST
       // returns metadata only (no secret material); CREDITS is the balance

--- a/apps/mesh/src/web/components/monitoring/types.tsx
+++ b/apps/mesh/src/web/components/monitoring/types.tsx
@@ -93,7 +93,7 @@ export interface MonitoringLogsResponse
 
 export interface MonitoringSearchParams {
   // Tab selection
-  tab?: "overview" | "audit" | "dashboards" | "threads";
+  tab?: "overview" | "audit" | "dashboards" | "threads" | "automations";
   // Time range using expressions (from/to)
   from?: string; // e.g., "now-24h", "now-7d", or ISO string
   to?: string; // e.g., "now" or ISO string

--- a/apps/mesh/src/web/hooks/use-automations.ts
+++ b/apps/mesh/src/web/hooks/use-automations.ts
@@ -217,6 +217,61 @@ export function useAutomation(id: string) {
 }
 
 // ============================================================================
+// Run stats hook
+// ============================================================================
+
+export interface AutomationRunStats {
+  runs: {
+    total: number;
+    completed: number;
+    failed: number;
+    inProgress: number;
+  };
+  usage: {
+    calls: number;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    costUsd: number;
+    sampledRuns: number;
+    truncated: boolean;
+  };
+}
+
+export function useAutomationRunStats(
+  automationId: string,
+  range?: { startDate?: string; endDate?: string },
+) {
+  const { org } = useProjectContext();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  return useQuery({
+    queryKey: KEYS.automationRunStats(
+      org.id,
+      automationId,
+      JSON.stringify(range ?? {}),
+    ),
+    queryFn: async () => {
+      const result = (await client.callTool({
+        name: "AUTOMATION_RUN_STATS",
+        arguments: {
+          automation_id: automationId,
+          ...(range?.startDate ? { startDate: range.startDate } : {}),
+          ...(range?.endDate ? { endDate: range.endDate } : {}),
+        },
+      })) as { structuredContent?: unknown };
+      return (result.structuredContent ?? result) as AutomationRunStats;
+    },
+    enabled: !!automationId,
+    staleTime: 30_000,
+  });
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -332,7 +332,9 @@ const monitoringRoute = createRoute({
   ),
   validateSearch: z.lazy(() =>
     z.object({
-      tab: z.enum(["overview", "audit", "threads"]).default("overview"),
+      tab: z
+        .enum(["overview", "audit", "threads", "automations"])
+        .default("overview"),
       from: z.string().default("now-30m"),
       to: z.string().default("now"),
       connectionId: z.array(z.string()).optional().default([]),

--- a/apps/mesh/src/web/layouts/main-panel-tabs/automation-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/automation-tab.tsx
@@ -1,10 +1,82 @@
 import { parseAutomationTabId } from "./tab-id";
 import { SettingsTab as AutomationInlineDetail } from "@/web/views/automations/automation-detail";
+import { AutomationRunsView } from "@/web/views/automations/automation-runs";
 import { useAutomation } from "@/web/hooks/use-automations";
 import { Page } from "@/web/components/page";
+import { Button } from "@deco/ui/components/button.tsx";
+import { CollectionTabs } from "@/web/components/collections/collection-tabs.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { ArrowLeft } from "@untitledui/icons";
 import { useNavigate } from "@tanstack/react-router";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { MainPanelLoading } from "./main-panel-loading";
+
+// Stat-card window options for the Runs tab. Anchored once at selection time so
+// the derived ISO range is stable across renders (avoids refetch loops).
+const WINDOW_OPTIONS = [
+  { key: "24h", label: "Last 24 hours", ms: 24 * 60 * 60 * 1000 },
+  { key: "7d", label: "Last 7 days", ms: 7 * 24 * 60 * 60 * 1000 },
+  { key: "30d", label: "Last 30 days", ms: 30 * 24 * 60 * 60 * 1000 },
+] as const;
+
+type WindowKey = (typeof WINDOW_OPTIONS)[number]["key"];
+
+function computeRange(key: WindowKey): { startDate: string; endDate: string } {
+  const ms = WINDOW_OPTIONS.find((o) => o.key === key)!.ms;
+  const now = Date.now();
+  return {
+    startDate: new Date(now - ms).toISOString(),
+    endDate: new Date(now).toISOString(),
+  };
+}
+
+function RunsTab({
+  automationId,
+  triggerIds,
+}: {
+  automationId: string;
+  triggerIds: string[];
+}) {
+  const [windowKey, setWindowKey] = useState<WindowKey>("30d");
+  const [range, setRange] = useState(() => computeRange("30d"));
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-center justify-end">
+        <Select
+          value={windowKey}
+          onValueChange={(v) => {
+            const key = v as WindowKey;
+            setWindowKey(key);
+            setRange(computeRange(key));
+          }}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {WINDOW_OPTIONS.map((o) => (
+              <SelectItem key={o.key} value={o.key}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <AutomationRunsView
+        automationId={automationId}
+        triggerIds={triggerIds}
+        range={range}
+      />
+    </div>
+  );
+}
 
 export function AutomationTab({ tabId }: { tabId: string }) {
   const parsed = parseAutomationTabId(tabId);
@@ -20,6 +92,7 @@ export function AutomationTab({ tabId }: { tabId: string }) {
 function AutomationTabInner({ id }: { id: string }) {
   const navigate = useNavigate();
   const { data: automation, isLoading } = useAutomation(id);
+  const [tab, setTab] = useState<"settings" | "runs">("settings");
 
   const onBack = () => {
     navigate({
@@ -44,15 +117,32 @@ function AutomationTabInner({ id }: { id: string }) {
     );
   }
 
+  const triggerIds = automation.triggers.map((t) => t.id);
+
   return (
     <Page>
       <Page.Content>
         <Page.Body>
-          <AutomationInlineDetail
-            automationId={id}
-            automation={automation}
-            onBack={onBack}
-          />
+          <div className="flex items-center justify-between pb-4 shrink-0">
+            <Button variant="ghost" size="sm" onClick={onBack}>
+              <ArrowLeft size={14} />
+              Back to list
+            </Button>
+            <CollectionTabs
+              tabs={[
+                { id: "settings", label: "Settings" },
+                { id: "runs", label: "Runs" },
+              ]}
+              activeTab={tab}
+              onTabChange={(t) => setTab(t as "settings" | "runs")}
+            />
+          </div>
+
+          {tab === "settings" ? (
+            <AutomationInlineDetail automationId={id} automation={automation} />
+          ) : (
+            <RunsTab automationId={id} triggerIds={triggerIds} />
+          )}
         </Page.Body>
       </Page.Content>
     </Page>

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -274,6 +274,12 @@ export const KEYS = {
       automationId,
       ...[...(triggerIds ?? [])].sort(),
     ] as const,
+  automationRunStats: (
+    organizationId: string,
+    automationId: string,
+    paramsKey: string,
+  ) =>
+    ["automation-run-stats", organizationId, automationId, paramsKey] as const,
 
   // Projects (scoped by organization)
   projects: (organizationId: string) => ["projects", organizationId] as const,

--- a/apps/mesh/src/web/routes/orgs/monitoring/automations.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/automations.tsx
@@ -1,0 +1,81 @@
+/**
+ * Automations Tab — pick an automation, see its runs + token/cost scoped to the
+ * dashboard time range. Reuses the shared AutomationRunsView.
+ */
+
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { EmptyState } from "@/web/components/empty-state.tsx";
+import { useAutomation, useAutomations } from "@/web/hooks/use-automations";
+import { AutomationRunsView } from "@/web/views/automations/automation-runs";
+import type { DateRange } from "./utils.ts";
+
+export function AutomationsTabContent({ dateRange }: { dateRange: DateRange }) {
+  const { data: automations = [], isLoading } = useAutomations(undefined);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const effectiveId = selectedId ?? automations[0]?.id ?? null;
+  const { data: automation } = useAutomation(effectiveId ?? "");
+
+  const range = {
+    startDate: dateRange.startDate.toISOString(),
+    endDate: dateRange.endDate.toISOString(),
+  };
+
+  return (
+    <div className="flex-1 flex flex-col overflow-auto min-w-0">
+      <div className="mx-auto w-full max-w-[1200px] px-4 md:px-10 flex flex-col flex-1 min-h-0 gap-5 pt-1">
+        {isLoading ? (
+          <div className="py-16 text-center text-sm text-muted-foreground">
+            Loading…
+          </div>
+        ) : automations.length === 0 ? (
+          <div className="py-16">
+            <EmptyState
+              title="No automations"
+              description="Create an automation to see its runs and usage here."
+            />
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-2">
+              <Select
+                value={effectiveId ?? ""}
+                onValueChange={(v) => setSelectedId(v)}
+              >
+                <SelectTrigger className="w-72">
+                  <SelectValue placeholder="Select an automation…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {automations.map((a) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      {a.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {automation ? (
+              <AutomationRunsView
+                automationId={automation.id}
+                triggerIds={automation.triggers.map((t) => t.id)}
+                range={range}
+              />
+            ) : (
+              <div className="py-16 text-center text-sm text-muted-foreground">
+                Loading…
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
@@ -71,6 +71,7 @@ import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { OverviewTabContent, OverviewTabSkeleton } from "./overview.tsx";
 import { AuditTabContent, MonitoringLogsTable } from "./audit.tsx";
 import { ThreadsTabContent, ThreadsFiltersPopover } from "./threads.tsx";
+import { AutomationsTabContent } from "./automations.tsx";
 import { getOrgMembers } from "./utils.ts";
 import { track } from "@/web/lib/posthog-client";
 
@@ -551,7 +552,7 @@ function FiltersPopover({
 // ============================================================================
 
 interface MonitoringDashboardContentProps {
-  tab: "overview" | "audit" | "threads";
+  tab: "overview" | "audit" | "threads" | "automations";
   dateRange: DateRange;
   displayDateRange: DateRange;
   connectionIds: string[];
@@ -568,7 +569,7 @@ interface MonitoringDashboardContentProps {
   onUpdateFilters: (updates: Partial<MonitoringSearchParams>) => void;
   onTimeRangeChange: (range: TimeRangeValue) => void;
   onStreamingToggle: () => void;
-  onTabChange: (tab: "overview" | "audit" | "threads") => void;
+  onTabChange: (tab: "overview" | "audit" | "threads" | "automations") => void;
 }
 
 function MonitoringDashboardContent({
@@ -697,6 +698,7 @@ function MonitoringDashboardContent({
     { id: "overview" as const, label: "Overview" },
     { id: "audit" as const, label: "Audit" },
     { id: "threads" as const, label: "Threads" },
+    { id: "automations" as const, label: "Automations" },
   ];
 
   return (
@@ -709,11 +711,13 @@ function MonitoringDashboardContent({
               tabs={tabs}
               activeTab={tab}
               onTabChange={(tabId) =>
-                onTabChange(tabId as "overview" | "audit" | "threads")
+                onTabChange(
+                  tabId as "overview" | "audit" | "threads" | "automations",
+                )
               }
             />
             <div className="flex items-center gap-2">
-              {tab !== "threads" && (
+              {(tab === "overview" || tab === "audit") && (
                 <>
                   <Button
                     variant={isStreaming ? "secondary" : "outline"}
@@ -800,7 +804,9 @@ function MonitoringDashboardContent({
         </div>
       </Page.Body>
 
-      {tab === "threads" ? (
+      {tab === "automations" ? (
+        <AutomationsTabContent dateRange={dateRange} />
+      ) : tab === "threads" ? (
         <ThreadsTabContent
           client={client}
           locator={locator}
@@ -953,11 +959,16 @@ export default function MonitoringDashboard() {
                         { id: "overview", label: "Overview" },
                         { id: "audit", label: "Audit" },
                         { id: "threads", label: "Threads" },
+                        { id: "automations", label: "Automations" },
                       ]}
                       activeTab={tab}
                       onTabChange={(tabId) =>
                         updateFilters({
-                          tab: tabId as "overview" | "audit" | "threads",
+                          tab: tabId as
+                            | "overview"
+                            | "audit"
+                            | "threads"
+                            | "automations",
                         })
                       }
                     />

--- a/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
@@ -71,7 +71,7 @@ import {
 
 // ── Per-thread usage (tokens + cost), keyed by thread id ────────────────────
 
-interface ThreadUsage {
+export interface ThreadUsage {
   calls: number;
   inputTokens: number;
   outputTokens: number;
@@ -83,7 +83,7 @@ type ThreadSortKey = "tokens" | "cost";
 
 // ── Thread types (pick only the fields we need from the server types) ───────
 
-type ThreadEntity = Pick<
+export type ThreadEntity = Pick<
   Thread,
   | "id"
   | "title"
@@ -506,7 +506,7 @@ function ThreadConversationPanel({
 
 // ── Thread sheet wrapper (renders header once, body swaps for loading/error) ─
 
-function ThreadSheetBody({
+export function ThreadSheetBody({
   thread,
   client,
   locator,

--- a/apps/mesh/src/web/views/automations/automation-runs.tsx
+++ b/apps/mesh/src/web/views/automations/automation-runs.tsx
@@ -1,0 +1,392 @@
+/**
+ * Automation Runs View
+ *
+ * Shared per-automation run history: stat cards (runs, success rate, tokens,
+ * cost) backed by AUTOMATION_RUN_STATS, plus a paginated runs table built from
+ * the automation's run threads (COLLECTION_THREADS_LIST filtered by the
+ * automation's trigger IDs, decorated with MONITORING_THREAD_USAGE). Clicking a
+ * run opens its conversation in a Sheet.
+ *
+ * Used both on the automation detail page ("Runs" tab) and the Monitoring →
+ * Automations tab. The Sheet (not the chat panel) is used so it works in the
+ * settings layout, which has no chat panel.
+ */
+
+import { useState } from "react";
+import {
+  useMCPClient,
+  useConnections,
+  useVirtualMCPs,
+  useProjectContext,
+  SELF_MCP_ALIAS_ID,
+} from "@decocms/mesh-sdk";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { Card } from "@deco/ui/components/card.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Sheet, SheetContent } from "@deco/ui/components/sheet.tsx";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@deco/ui/components/table.tsx";
+import { EmptyState } from "@/web/components/empty-state.tsx";
+import { useInfiniteScroll } from "@/web/hooks/use-infinite-scroll.ts";
+import { useMembers } from "@/web/hooks/use-members";
+import { KEYS } from "@/web/lib/query-keys";
+import { STATUS_CONFIG } from "@/web/lib/task-status";
+import { useAutomationRunStats } from "@/web/hooks/use-automations";
+import {
+  ThreadSheetBody,
+  type ThreadEntity,
+  type ThreadUsage,
+} from "@/web/routes/orgs/monitoring/threads.tsx";
+import {
+  formatCompactNumber,
+  formatUsd,
+} from "@/web/routes/orgs/monitoring/utils.ts";
+
+const RUNS_PAGE_SIZE = 50;
+
+// ── Stat cards ───────────────────────────────────────────────────────────────
+
+function StatCard({
+  title,
+  value,
+  subtitle,
+}: {
+  title: string;
+  value: string;
+  subtitle?: string;
+}) {
+  return (
+    <Card className="pt-4 px-4 pb-5 gap-1">
+      <span className="text-sm text-foreground/70">{title}</span>
+      <span className="text-3xl font-normal tabular-nums">{value}</span>
+      {subtitle && (
+        <span className="text-xs text-muted-foreground">{subtitle}</span>
+      )}
+    </Card>
+  );
+}
+
+function RunStatCards({
+  automationId,
+  range,
+}: {
+  automationId: string;
+  range: { startDate?: string; endDate?: string };
+}) {
+  const { data, isLoading } = useAutomationRunStats(automationId, range);
+
+  const runs = data?.runs;
+  const usage = data?.usage;
+  const successRate =
+    runs && runs.total > 0
+      ? `${Math.round((runs.completed / runs.total) * 100)}%`
+      : "—";
+  const usageSubtitle = usage
+    ? usage.truncated
+      ? `last ${usage.sampledRuns} runs`
+      : undefined
+    : undefined;
+
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      <StatCard
+        title="Runs"
+        value={isLoading ? "…" : (runs?.total.toLocaleString() ?? "0")}
+        subtitle={
+          runs
+            ? `${runs.completed} ok · ${runs.failed} failed${
+                runs.inProgress > 0 ? ` · ${runs.inProgress} running` : ""
+              }`
+            : undefined
+        }
+      />
+      <StatCard title="Success rate" value={isLoading ? "…" : successRate} />
+      <StatCard
+        title="Tokens"
+        value={isLoading ? "…" : formatCompactNumber(usage?.totalTokens ?? 0)}
+        subtitle={usageSubtitle}
+      />
+      <StatCard
+        title="Cost"
+        value={
+          isLoading
+            ? "…"
+            : usage && usage.costUsd > 0
+              ? formatUsd(usage.costUsd)
+              : "—"
+        }
+        subtitle={usageSubtitle}
+      />
+    </div>
+  );
+}
+
+// ── Runs table row ───────────────────────────────────────────────────────────
+
+function RunRow({
+  run,
+  usage,
+  onClick,
+  lastRowRef,
+}: {
+  run: ThreadEntity;
+  usage?: ThreadUsage;
+  onClick: () => void;
+  lastRowRef?: (node: HTMLTableRowElement | null) => void;
+}) {
+  const date = new Date(run.created_at);
+  const dateStr = date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+  const timeStr = date.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const statusCfg =
+    STATUS_CONFIG[run.status as keyof typeof STATUS_CONFIG] ??
+    STATUS_CONFIG.completed;
+  const StatusIcon = statusCfg.icon;
+
+  return (
+    <TableRow
+      ref={lastRowRef}
+      className="h-14 cursor-pointer hover:bg-muted/40 transition-colors border-b-0"
+      onClick={onClick}
+    >
+      <TableCell className="min-w-0 pr-2 pl-4 md:pr-4">
+        <div className="font-medium text-foreground truncate">{run.title}</div>
+      </TableCell>
+      <TableCell className="w-28 px-3">
+        <div className="flex items-center gap-1.5">
+          <StatusIcon size={14} className={statusCfg.iconClassName} />
+          <span className={cn("text-sm", statusCfg.labelColor)}>
+            {statusCfg.label}
+          </span>
+        </div>
+      </TableCell>
+      <TableCell className="w-24 px-3 text-right tabular-nums text-muted-foreground">
+        {usage ? formatCompactNumber(usage.totalTokens) : "—"}
+      </TableCell>
+      <TableCell className="w-24 px-3 text-right tabular-nums text-muted-foreground">
+        {usage && usage.costUsd > 0 ? formatUsd(usage.costUsd) : "—"}
+      </TableCell>
+      <TableCell className="w-32 px-3 pr-5 text-muted-foreground">
+        <div>{dateStr}</div>
+        <div className="text-xs text-muted-foreground/60">{timeStr}</div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+// ── Main view ────────────────────────────────────────────────────────────────
+
+export function AutomationRunsView({
+  automationId,
+  triggerIds,
+  range,
+}: {
+  automationId: string;
+  triggerIds: string[];
+  /** Window for the stat cards + table usage decoration. */
+  range: { startDate?: string; endDate?: string };
+}) {
+  const { org, locator } = useProjectContext();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const allConnections = useConnections();
+  const allVirtualMcps = useVirtualMCPs();
+  const { data: membersData } = useMembers();
+
+  const [selectedRunIndex, setSelectedRunIndex] = useState<number | null>(null);
+
+  const hasTriggers = triggerIds.length > 0;
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useInfiniteQuery({
+      queryKey: KEYS.automationRuns(org.id, automationId, triggerIds),
+      queryFn: async ({ pageParam = 0 }) => {
+        const result = (await client.callTool({
+          name: "COLLECTION_THREADS_LIST",
+          arguments: {
+            limit: RUNS_PAGE_SIZE,
+            offset: pageParam,
+            where: { trigger_ids: triggerIds },
+          },
+        })) as { structuredContent?: unknown };
+        return (result.structuredContent ?? result) as {
+          items: ThreadEntity[];
+          totalCount: number;
+          hasMore: boolean;
+        };
+      },
+      initialPageParam: 0 as number,
+      getNextPageParam: (lastPage, allPages) => {
+        const page = lastPage as { items?: ThreadEntity[] } | undefined;
+        const pages = allPages as Array<{ items?: ThreadEntity[] }>;
+        if ((page?.items?.length ?? 0) < RUNS_PAGE_SIZE) return undefined;
+        return pages.length * RUNS_PAGE_SIZE;
+      },
+      enabled: hasTriggers,
+      staleTime: 30_000,
+    });
+
+  const runs = (data?.pages ?? []).flatMap(
+    (p: { items?: ThreadEntity[] }) => p.items ?? [],
+  );
+
+  const threadIds = runs.map((r) => r.id);
+  const { data: usageData } = useQuery({
+    queryKey: KEYS.monitoringThreadUsage(
+      locator,
+      JSON.stringify({ ids: threadIds, ...range }),
+    ),
+    queryFn: async () => {
+      const result = (await client.callTool({
+        name: "MONITORING_THREAD_USAGE",
+        arguments: {
+          threadIds,
+          ...(range.startDate ? { startDate: range.startDate } : {}),
+          ...(range.endDate ? { endDate: range.endDate } : {}),
+        },
+      })) as { structuredContent?: unknown };
+      return (result.structuredContent ?? result) as {
+        items: Array<ThreadUsage & { threadId: string }>;
+      };
+    },
+    enabled: threadIds.length > 0,
+    staleTime: 30_000,
+  });
+
+  const usageMap = new Map<string, ThreadUsage>(
+    (usageData?.items ?? []).map((u) => [
+      u.threadId,
+      {
+        calls: u.calls,
+        inputTokens: u.inputTokens,
+        outputTokens: u.outputTokens,
+        totalTokens: u.totalTokens,
+        costUsd: u.costUsd,
+      },
+    ]),
+  );
+
+  const lastRowRef = useInfiniteScroll(
+    () => {
+      if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+    },
+    hasNextPage ?? false,
+    isFetchingNextPage,
+  );
+
+  const selectedRun =
+    selectedRunIndex !== null ? (runs[selectedRunIndex] ?? null) : null;
+
+  const handlePrev = () =>
+    setSelectedRunIndex((i) => (i !== null && i > 0 ? i - 1 : i));
+  const handleNext = () =>
+    setSelectedRunIndex((i) => (i !== null && i < runs.length - 1 ? i + 1 : i));
+
+  return (
+    <div className="flex flex-col gap-5">
+      <RunStatCards automationId={automationId} range={range} />
+
+      {!hasTriggers ? (
+        <div className="py-16">
+          <EmptyState
+            title="No starters yet"
+            description="Add a starter (cron, event, or webhook) to start collecting runs."
+          />
+        </div>
+      ) : isLoading ? (
+        <div className="py-16 text-center text-sm text-muted-foreground">
+          Loading runs…
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="py-16">
+          <EmptyState
+            title="No runs yet"
+            description="This automation hasn't run yet. Trigger it or wait for a starter to fire."
+          />
+        </div>
+      ) : (
+        <Table className="w-full border-collapse">
+          <TableHeader className="border-b-0">
+            <TableRow className="h-9 hover:bg-transparent border-b border-border">
+              <TableHead className="pl-4 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
+                Run
+              </TableHead>
+              <TableHead className="w-28 px-3 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
+                Status
+              </TableHead>
+              <TableHead className="w-24 px-3 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide text-right">
+                Tokens
+              </TableHead>
+              <TableHead className="w-24 px-3 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide text-right">
+                Cost
+              </TableHead>
+              <TableHead className="w-32 px-3 pr-5 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
+                Started
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {runs.map((run, idx) => (
+              <RunRow
+                key={run.id}
+                run={run}
+                usage={usageMap.get(run.id)}
+                onClick={() => setSelectedRunIndex(idx)}
+                lastRowRef={
+                  idx === runs.length - 1
+                    ? (lastRowRef as (node: HTMLTableRowElement | null) => void)
+                    : undefined
+                }
+              />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {isFetchingNextPage && (
+        <div className="py-4 text-center text-sm text-muted-foreground">
+          Loading more…
+        </div>
+      )}
+
+      <Sheet
+        open={selectedRunIndex !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedRunIndex(null);
+        }}
+      >
+        <SheetContent className="sm:max-w-2xl flex flex-col p-0 gap-0">
+          {selectedRun && selectedRunIndex !== null && (
+            <ThreadSheetBody
+              thread={selectedRun}
+              client={client}
+              locator={locator}
+              connections={allConnections}
+              virtualMcps={allVirtualMcps}
+              members={membersData}
+              selectedIndex={selectedRunIndex}
+              total={runs.length}
+              onPrev={handlePrev}
+              onNext={handleNext}
+            />
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}


### PR DESCRIPTION
- Introduced `AUTOMATION_RUN_STATS` tool to aggregate and display run statistics for automations, including total runs, success rates, and token/cost usage.
- Implemented new UI components for viewing automation run statistics, including a dedicated "Runs" tab in the automation detail page and a monitoring dashboard for automations.
- Enhanced the automation tab to allow users to select and view statistics for specific automations, improving monitoring capabilities.
- Updated relevant hooks and query keys to support the new run stats functionality.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `AUTOMATION_RUN_STATS` and a new UI to track automation runs, success rate, tokens, and cost. Includes a Runs tab on automation pages and an Automations tab in Monitoring for quick visibility.

- **New Features**
  - Added `AUTOMATION_RUN_STATS` tool returning run counts and aggregated token/cost totals (capped at 500 sampled runs with a `truncated` flag).
  - Storage: added `getRunStats` and `listRunThreadIds` with optional date filters.
  - UI: new Runs tab on automation detail with time-window selector; new Monitoring → Automations tab with automation picker; shared `AutomationRunsView` shows stat cards and a runs table with infinite scroll and a conversation sheet.
  - Hooks/keys: introduced `useAutomationRunStats` and `KEYS.automationRunStats`; updated monitoring search params and route validation to include `automations`.
  - Tool registry and permissions: registered `AUTOMATION_RUN_STATS` in core tools and metadata; enabled view access for members.

<sup>Written for commit 6089d48ae6d2ca83ee22015d137e0ff302bafcdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

