### PR TITLE
refactor(decopilot): improve error handling in subtask tool

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -104,14 +104,29 @@ export function createSubtaskTool(
       // identical tools + instructions but an empty context.
       const isSelf = !!self && (!agent_id || agent_id === self.id);
       const targetId = isSelf ? self!.id : agent_id;
+
+      // Recoverable failures yield a structured error (surfaced to the model
+      // via toModelOutput) and stop, instead of throwing. Throwing before the
+      // first yield kills the subtask with no guidance, so the model can't
+      // self-correct and just repeats the mistake. A yielded error lets it
+      // retry — usually by omitting agent_id to clone itself.
+      const selfHint = self
+        ? " Omit agent_id to clone yourself (a fresh subagent with your tools + instructions), or pass an agent id from <available-agents>."
+        : "";
+
       if (!targetId) {
-        throw new Error(
-          "agent_id is required: this agent cannot delegate to itself here.",
-        );
+        yield {
+          text: "",
+          error: `agent_id is required here.${selfHint}`,
+          finishReason: "error",
+        };
+        return;
       }
 
-      const isSelfTarget = !!self && targetId === self.id;
-      if (!isSelf && !isSelfTarget && self) {
+      // 1. Enforce the caller's sub-agent allowlist for cross-agent delegation
+      //    BEFORE resolving the target. Self-clones are always allowed (isSelf
+      //    short-circuits). An empty/absent allowlist means "all agents".
+      if (!isSelf && self) {
         const caller = await ctx.storage.virtualMcps.findById(
           self.id,
           organization.id,
@@ -120,20 +135,32 @@ export function createSubtaskTool(
         // An allowlist array (even empty = itself only) gates cross-agent
         // delegation. A null/absent allowlist means all agents are allowed.
         if (Array.isArray(allow) && !allow.includes(targetId)) {
-          throw new Error(
-            `Agent not available for delegation, blocked by allowlist. caller=${self.id} target=${targetId} allow=${JSON.stringify(allow)} isSelf=${isSelf} agent_id=${agent_id ?? "(omitted)"}`,
-          );
+          yield {
+            text: "",
+            error: `Agent '${targetId}' is not in this agent's delegation allowlist (allow=${JSON.stringify(allow)}).${selfHint}`,
+            finishReason: "error",
+          };
+          return;
         }
       }
 
       // 2. Validate the target and open its passthrough client. A self-clone
-      //    uses superUser so its tool scope mirrors the parent loop.
-      const { mcpClient, targetRef } = await resolveSubagent(
-        ctx,
-        organization.id,
-        targetId,
-        { superUser: isSelf },
-      );
+      //    uses superUser so its tool scope mirrors the parent loop. Resolution
+      //    errors ("Agent not found" / "not active") are also recoverable.
+      let resolved: Awaited<ReturnType<typeof resolveSubagent>>;
+      try {
+        resolved = await resolveSubagent(ctx, organization.id, targetId, {
+          superUser: isSelf,
+        });
+      } catch (err) {
+        yield {
+          text: "",
+          error: `${(err as Error).message} (agent_id="${targetId}").${selfHint}`,
+          finishReason: "error",
+        };
+        return;
+      }
+      const { mcpClient, targetRef } = resolved;
       const targetLabel = targetRef.id;
 
       try {


### PR DESCRIPTION
- Enhanced the subtask tool to yield structured error messages instead of throwing exceptions for recoverable failures, allowing the model to self-correct.
- Added hints for cloning self-agents and clarified delegation allowlist enforcement, improving user guidance during delegation errors.
- Updated error handling for agent resolution to provide more informative feedback when agents are not found or blocked by the allowlist.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the subtask tool to yield structured, recoverable errors instead of throwing, so the model can self-correct. Adds clear guidance for self-cloning and enforces the delegation allowlist before agent resolution.

- **Refactors**
  - Yield structured errors (finishReason "error") for missing `agent_id` and allowlist blocks, with a self-clone hint.
  - Enforce delegation allowlist before resolving the target; self-clones are always allowed.
  - Catch and surface `resolveSubagent` failures with agent_id context; self-clones continue to use `superUser`.

<sup>Written for commit bc91e8fc8ccfb811b823fd9d9e53f1c9a272b275. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

