### PR TITLE
feat(monitoring): add max_threads configuration and tighten thread us…

### DIFF
--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -194,6 +194,7 @@ export class ClickHouseClientEngine implements QueryEngine {
         max_bytes_before_external_sort: String(
           Math.floor(Number(this.maxMemoryUsage) / 2),
         ),
+        max_threads: 1,
       },
     });
     return await result.json<Record<string, unknown>>();

--- a/apps/mesh/src/storage/monitoring-sql.ts
+++ b/apps/mesh/src/storage/monitoring-sql.ts
@@ -401,6 +401,14 @@ function tsLte(
  */
 const DEFAULT_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
 
+/**
+ * Tighter lookback for thread-usage queries. These always target a specific,
+ * recent set of decopilot thread IDs, so the 30-day default just scans (and
+ * materializes the wide `LogAttributes`/`properties` column for) weeks of
+ * irrelevant rows — the dominant cost behind the queryThreadUsage OOMs.
+ */
+const THREAD_USAGE_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
+
 function applyStartDateBound(
   where: string[],
   startDate: Date | undefined,
@@ -811,7 +819,13 @@ LIMIT ${topN}`;
       `connection_id = '${esc(params.connectionId)}'`,
       `${threadExpr} IN (${ids})`,
     ];
-    applyStartDateBound(where, params.startDate, dialect);
+    // ClickHouse-only tighter default: applyStartDateBound otherwise falls back
+    // to the 30-day DEFAULT_LOOKBACK_MS, which scans far more of otel_logs than
+    // these recent-thread lookups ever need. DuckDB stays unbounded (local files).
+    const startDate =
+      params.startDate ??
+      (isCh ? new Date(Date.now() - THREAD_USAGE_LOOKBACK_MS) : undefined);
+    applyStartDateBound(where, startDate, dialect);
     if (params.endDate) {
       where.push(tsLte(params.endDate, dialect));
     }


### PR DESCRIPTION
…age lookback

- Introduced a new `max_threads` setting in the ClickHouse client engine to optimize query performance.
- Updated the thread usage queries to use a tighter lookback period of 7 days, reducing unnecessary data scans and improving efficiency.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set ClickHouse `max_threads` to 1 and tightened thread-usage query lookback to 7 days to reduce scans and stabilize monitoring query performance.

- **New Features**
  - Added `max_threads: 1` to the ClickHouse client to limit query parallelism and lower memory use.
  - For ClickHouse thread-usage queries, default lookback is now 7 days when no `startDate` is provided; DuckDB remains unbounded.

<sup>Written for commit 2e9e6d9ff595f3996424ab176c263757601d5158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

