### PR TITLE
feat(observability): integrate heap watch functionality and ensure pr…

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -9,6 +9,7 @@
 import { sleep } from "@decocms/std";
 import { getSettings } from "./settings";
 import { initObservability } from "./observability";
+import { startHeapWatch } from "./observability/heap-watch";
 
 const settings = getSettings();
 
@@ -199,6 +200,8 @@ const server = Bun.serve({
   development: false,
 });
 
+const stopHeapWatch = startHeapWatch();
+
 // Local mode: seed admin user + organization after server is listening
 // This must run after Bun.serve() so that the org seed can fetch tools
 // from the self MCP endpoint (http://localhost:PORT/mcp/self).
@@ -273,6 +276,8 @@ async function gracefulShutdown(signal: string) {
 
   let exitCode = 0;
   try {
+    stopHeapWatch();
+
     // 1. Mark as shutting down — readiness returns 503 immediately
     app.markShuttingDown();
 

--- a/apps/mesh/src/observability/heap-watch.ts
+++ b/apps/mesh/src/observability/heap-watch.ts
@@ -1,0 +1,62 @@
+let timer: ReturnType<typeof setInterval> | undefined;
+
+export function startHeapWatch(): () => void {
+  if (process.env.HEAP_WATCH !== "1") return () => {};
+  const intervalMs = Number(process.env.HEAP_WATCH_INTERVAL_MS ?? 60_000);
+
+  const tick = async () => {
+    const m = process.memoryUsage();
+    let jsc: {
+      objectCount?: number;
+      heapSize?: number;
+      top?: Record<string, number>;
+    } = {};
+    try {
+      const { heapStats } = await import("bun:jsc");
+      const s = heapStats();
+      const top = Object.entries(s.objectTypeCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 20);
+      jsc = {
+        objectCount: s.objectCount,
+        heapSize: s.heapSize,
+        top: Object.fromEntries(top),
+      };
+    } catch {
+      // not running under Bun — memoryUsage() alone still tracks the trend
+    }
+    console.log(
+      JSON.stringify({
+        msg: "heap-watch",
+        ts: new Date().toISOString(),
+        uptimeS: Math.round(process.uptime()),
+        rss: m.rss,
+        heapUsed: m.heapUsed,
+        heapTotal: m.heapTotal,
+        external: m.external,
+        arrayBuffers: m.arrayBuffers,
+        ...jsc,
+      }),
+    );
+  };
+
+  void tick();
+  timer = setInterval(() => void tick(), intervalMs);
+  timer.unref?.();
+
+  process.on("SIGUSR2", () => {
+    try {
+      const snap = Bun.generateHeapSnapshot("v8");
+      const data = typeof snap === "string" ? snap : JSON.stringify(snap);
+      const path = `/tmp/heap-${process.pid}-${Date.now()}.heapsnapshot`;
+      void Bun.write(path, data);
+      console.log(JSON.stringify({ msg: "heap-snapshot-written", path }));
+    } catch (err) {
+      console.error("[heap-watch] snapshot failed:", err);
+    }
+  });
+
+  return () => {
+    if (timer) clearInterval(timer);
+  };
+}


### PR DESCRIPTION
…oper shutdown handling

- Added `startHeapWatch` to monitor memory usage, enhancing observability.
- Implemented `stopHeapWatch` in the graceful shutdown process to ensure memory monitoring is properly terminated.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a heap memory watcher to improve production observability and clean shutdown. It logs periodic memory stats and supports on-demand heap snapshots.

- **New Features**
  - Added `startHeapWatch()` to log `process.memoryUsage()` and `bun:jsc` heap stats (top object types).
  - Gated by `HEAP_WATCH=1`; interval via `HEAP_WATCH_INTERVAL_MS` (default 60s); immediate first tick; timer is unref’d.
  - `SIGUSR2` writes a heap snapshot to `/tmp/heap-<pid>-<ts>.heapsnapshot` and logs the path.
  - Integrated into server lifecycle: started on boot and stopped during graceful shutdown to avoid dangling timers.

- **Migration**
  - Set `HEAP_WATCH=1` to enable; optionally set `HEAP_WATCH_INTERVAL_MS`.
  - Send `SIGUSR2` to the process to generate a snapshot; ensure write access to `/tmp`.

<sup>Written for commit cfa6f6d9330d76a8a604307db276a7dd5c263d27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

