### PR TITLE
fix(decopilot): enhance error handling and credit message detection

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -163,7 +163,7 @@ function classifyStreamError(
     error instanceof Error ? error.message : stringifyError(error)
   ).toLowerCase();
   if (
-    /insufficient|no credits|out of credits|balance|payment|quota exceeded|402/i.test(
+    /insufficient|no credits|out of credits|balance|payment|quota exceeded|key limit|402/i.test(
       msg,
     )
   ) {

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -232,6 +232,16 @@ export async function runAgentLoop(
         span.setStatus({ code: SpanStatusCode.OK });
       }
     })
+    .catch((err: unknown) => {
+      const message =
+        err instanceof Error
+          ? err.message
+          : typeof err === "string"
+            ? err
+            : `${err}`;
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      finalizeError(message);
+    })
     .finally(() => span.end());
 
   return { result, error: errorPromise, span };

--- a/apps/mesh/src/harnesses/decopilot/run-stream.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-stream.ts
@@ -781,93 +781,100 @@ export async function* runDecopilotStream(
   // we must register this watcher before we start draining the stream
   // below. We do NOT await it here — we just attach the handler so it
   // fires whenever the abort resolves.
-  handle.error.then(async (_errMsg) => {
-    // Only fire the abort metrics path if the signal was aborted AND
-    // we haven't already logged metrics via the onFinish path.
-    if (!registrySignal.aborted || llmCallLogged) return;
-    const steps = await result.steps;
-    if (!steps.length || llmCallLogged) return;
-    llmCallLogged = true;
-    const durationMs = Date.now() - (llmCallStartTime ?? Date.now());
-    const abortTotalUsage = steps.reduce(
-      (acc, s) => ({
-        inputTokens: acc.inputTokens + (s.usage.inputTokens ?? 0),
-        outputTokens: acc.outputTokens + (s.usage.outputTokens ?? 0),
-        totalTokens: acc.totalTokens + (s.usage.totalTokens ?? 0),
-      }),
-      { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-    );
-    const lastStepUsage = steps[steps.length - 1]!.usage;
-    const cacheTotalsOnAbort = usageAcc.cacheTotals();
-    recordLlmCallMetrics({
-      ctx,
-      organizationId: input.organizationId,
-      modelId: input.models.thinking.id,
-      durationMs,
-      isError: false,
-      inputTokens: abortTotalUsage.inputTokens,
-      outputTokens: abortTotalUsage.outputTokens,
-      cacheReadTokens: cacheTotalsOnAbort.read,
-      cacheWriteTokens: cacheTotalsOnAbort.write,
-    });
-    monitorLlmCall({
-      ctx,
-      organizationId: input.organizationId,
-      agentId: input.agent.id,
-      modelId: input.models.thinking.id,
-      modelTitle: input.models.thinking.title ?? input.models.thinking.id,
-      credentialId: input.models.credentialId,
-      taskId: threadId,
-      durationMs,
-      isError: false,
-      finishReason: "abort",
-      usage: {
-        inputTokens: lastStepUsage.inputTokens ?? 0,
-        outputTokens: lastStepUsage.outputTokens ?? 0,
-        totalTokens: lastStepUsage.totalTokens ?? 0,
-      },
-      totalUsage: abortTotalUsage,
-      cost: usageAcc.cost(),
-      request: undefined,
-      response: undefined,
-      userId: input.user.id,
-      requestId: ctx.metadata.requestId,
-      userAgent: ctx.metadata.userAgent ?? null,
-    });
-
-    // Re-push accumulated usage to the client. On abort the SDK
-    // resets message.metadata to its pre-stream state, so we
-    // explicitly emit it here before the stream closes.
-    if (abortTotalUsage.totalTokens > 0) {
-      const cost = usageAcc.cost();
-      chunkQueue.push({
-        type: "message-metadata",
-        messageMetadata: {
-          usage: {
-            inputTokens: abortTotalUsage.inputTokens,
-            outputTokens: abortTotalUsage.outputTokens,
-            totalTokens: abortTotalUsage.totalTokens,
-            cachedInputTokens: cacheTotalsOnAbort.read,
-            inputTokenDetails: {
-              cacheReadTokens: cacheTotalsOnAbort.read,
-              cacheWriteTokens: cacheTotalsOnAbort.write,
-              noCacheTokens:
-                abortTotalUsage.inputTokens -
-                cacheTotalsOnAbort.read -
-                cacheTotalsOnAbort.write,
-            },
-            ...(cost > 0 && {
-              providerMetadata: {
-                openrouter: {
-                  usage: { cost },
-                },
-              },
-            }),
-          },
-        },
+  handle.error
+    .then(async (_errMsg) => {
+      // Only fire the abort metrics path if the signal was aborted AND
+      // we haven't already logged metrics via the onFinish path.
+      if (!registrySignal.aborted || llmCallLogged) return;
+      const steps = await result.steps;
+      if (!steps.length || llmCallLogged) return;
+      llmCallLogged = true;
+      const durationMs = Date.now() - (llmCallStartTime ?? Date.now());
+      const abortTotalUsage = steps.reduce(
+        (acc, s) => ({
+          inputTokens: acc.inputTokens + (s.usage.inputTokens ?? 0),
+          outputTokens: acc.outputTokens + (s.usage.outputTokens ?? 0),
+          totalTokens: acc.totalTokens + (s.usage.totalTokens ?? 0),
+        }),
+        { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      );
+      const lastStepUsage = steps[steps.length - 1]!.usage;
+      const cacheTotalsOnAbort = usageAcc.cacheTotals();
+      recordLlmCallMetrics({
+        ctx,
+        organizationId: input.organizationId,
+        modelId: input.models.thinking.id,
+        durationMs,
+        isError: false,
+        inputTokens: abortTotalUsage.inputTokens,
+        outputTokens: abortTotalUsage.outputTokens,
+        cacheReadTokens: cacheTotalsOnAbort.read,
+        cacheWriteTokens: cacheTotalsOnAbort.write,
       });
-    }
-  });
+      monitorLlmCall({
+        ctx,
+        organizationId: input.organizationId,
+        agentId: input.agent.id,
+        modelId: input.models.thinking.id,
+        modelTitle: input.models.thinking.title ?? input.models.thinking.id,
+        credentialId: input.models.credentialId,
+        taskId: threadId,
+        durationMs,
+        isError: false,
+        finishReason: "abort",
+        usage: {
+          inputTokens: lastStepUsage.inputTokens ?? 0,
+          outputTokens: lastStepUsage.outputTokens ?? 0,
+          totalTokens: lastStepUsage.totalTokens ?? 0,
+        },
+        totalUsage: abortTotalUsage,
+        cost: usageAcc.cost(),
+        request: undefined,
+        response: undefined,
+        userId: input.user.id,
+        requestId: ctx.metadata.requestId,
+        userAgent: ctx.metadata.userAgent ?? null,
+      });
+
+      // Re-push accumulated usage to the client. On abort the SDK
+      // resets message.metadata to its pre-stream state, so we
+      // explicitly emit it here before the stream closes.
+      if (abortTotalUsage.totalTokens > 0) {
+        const cost = usageAcc.cost();
+        chunkQueue.push({
+          type: "message-metadata",
+          messageMetadata: {
+            usage: {
+              inputTokens: abortTotalUsage.inputTokens,
+              outputTokens: abortTotalUsage.outputTokens,
+              totalTokens: abortTotalUsage.totalTokens,
+              cachedInputTokens: cacheTotalsOnAbort.read,
+              inputTokenDetails: {
+                cacheReadTokens: cacheTotalsOnAbort.read,
+                cacheWriteTokens: cacheTotalsOnAbort.write,
+                noCacheTokens:
+                  abortTotalUsage.inputTokens -
+                  cacheTotalsOnAbort.read -
+                  cacheTotalsOnAbort.write,
+              },
+              ...(cost > 0 && {
+                providerMetadata: {
+                  openrouter: {
+                    usage: { cost },
+                  },
+                },
+              }),
+            },
+          },
+        });
+      }
+    })
+    .catch((err) => {
+      console.error(
+        "[decopilot:stream] abort-metrics handler failed",
+        stringifyError(err),
+      );
+    });
 
   // Posthog: emit `chat_message_completed`/`chat_message_aborted`/
   // `chat_message_failed` is the caller's responsibility (it lives in

--- a/apps/mesh/src/harnesses/decopilot/stream-error.ts
+++ b/apps/mesh/src/harnesses/decopilot/stream-error.ts
@@ -48,13 +48,14 @@ export function sanitizeStreamError(error: unknown): string {
       msg.includes("insufficient balance") ||
       msg.includes("billing") ||
       msg.includes("quota exceeded") ||
+      msg.includes("key limit") ||
       msg.includes("payment required")
     ) {
       // Prefix with [CREDITS] so the frontend can detect credit errors
       // without fragile string matching on provider-specific messages.
       return `[CREDITS] ${stripProviderSpecificDetails(error.message)}`;
     }
-    return error.message;
+    return stripProviderSpecificDetails(error.message);
   }
   return stringifyError(error);
 }


### PR DESCRIPTION
- Updated error classification in `classifyStreamError` to include "key limit" in credit-related messages.
- Improved error handling in `runAgentLoop` to capture and log error messages more effectively.
- Refactored `runDecopilotStream` to ensure proper error handling during abort metrics processing, including logging failures.
- Enhanced `sanitizeStreamError` to strip provider-specific details from error messages consistently.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Decopilot error handling and credit detection for clearer user errors and more reliable abort metrics. Detects “key limit” as a credit issue and consistently strips provider-specific provider details from messages.

- **Bug Fixes**
  - Treat “key limit” as a credit-related error in `classifyStreamError`; prefix credit messages with `[CREDITS]`.
  - Catch and log errors in `runAgentLoop`, set span status, and finalize the error message.
  - Harden abort-metrics handling in `runDecopilotStream`, log handler failures, and re-emit usage on abort when present.
  - Sanitize errors in `sanitizeStreamError` by removing provider-specific details for consistent messaging.

<sup>Written for commit 154884af99494738be5630daa4c2ad0ab330d72b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

