### PR TITLE
feat(database): enhance connection pooling metrics and logging

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -21,8 +21,19 @@ const queryDurationHistogram = meter.createHistogram("db.query.duration", {
   unit: "ms",
 });
 
+// Kysely's queryDurationMillis measures SQL execution only — the timer starts
+// after the connection is checked out of the pool. Pool-acquisition wait is
+// invisible to it, so we measure that separately to tell genuinely slow SQL
+// apart from pool-capacity contention.
+const poolAcquireHistogram = meter.createHistogram("db.pool.acquire.duration", {
+  description: "Time spent waiting to acquire a connection from the pool",
+  unit: "ms",
+});
+
 const SLOW_QUERY_TRESHOLD_MS = 400;
-const log = (event: LogEvent) => {
+const SLOW_ACQUIRE_THRESHOLD_MS = 100;
+
+const createLog = (pool: Pool) => (event: LogEvent) => {
   const attributes = {
     "db.statement": event.query.sql,
     "db.status": event.level === "error" ? "error" : "success",
@@ -32,6 +43,12 @@ const log = (event: LogEvent) => {
     console.error("Slow query detected:", {
       durationMs: event.queryDurationMillis,
       sql: event.query.sql,
+      pool: {
+        total: pool.totalCount,
+        idle: pool.idleCount,
+        waiting: pool.waitingCount,
+        max: getPoolMax(),
+      },
     });
   }
 
@@ -45,6 +62,43 @@ const log = (event: LogEvent) => {
     });
   }
 };
+
+/**
+ * Wrap pool.connect() to measure connection-acquisition wait and pool
+ * saturation. Kysely uses the promise form; the callback form is delegated
+ * untouched.
+ */
+function instrumentPool(pool: Pool): Pool {
+  const originalConnect = pool.connect.bind(pool);
+  // @ts-expect-error pg's connect has callback/promise overloads
+  pool.connect = (cb?: unknown) => {
+    if (typeof cb === "function") return originalConnect(cb as never);
+    const start = performance.now();
+    return originalConnect().then(
+      (client) => {
+        const waited = performance.now() - start;
+        poolAcquireHistogram.record(waited, { "db.pool.outcome": "acquired" });
+        if (waited > SLOW_ACQUIRE_THRESHOLD_MS) {
+          console.error("Slow pool acquire detected:", {
+            waitMs: waited,
+            total: pool.totalCount,
+            idle: pool.idleCount,
+            waiting: pool.waitingCount,
+            max: getPoolMax(),
+          });
+        }
+        return client;
+      },
+      (err) => {
+        poolAcquireHistogram.record(performance.now() - start, {
+          "db.pool.outcome": "error",
+        });
+        throw err;
+      },
+    );
+  };
+  return pool;
+}
 
 /**
  * PostgreSQL database connection.
@@ -85,15 +139,17 @@ function getPoolMax(): number {
 }
 
 function createPostgresDatabase(connectionString: string): StudioDatabase {
-  const pool = new Pool({
-    connectionString,
-    max: getPoolMax(),
-    ssl: getSsl(),
-    ...defaultPoolOptions,
-  });
+  const pool = instrumentPool(
+    new Pool({
+      connectionString,
+      max: getPoolMax(),
+      ssl: getSsl(),
+      ...defaultPoolOptions,
+    }),
+  );
 
   const dialect = new PostgresDialect({ pool });
-  const db = new Kysely<DatabaseSchema>({ dialect, log });
+  const db = new Kysely<DatabaseSchema>({ dialect, log: createLog(pool) });
 
   return { type: "postgres", db, pool };
 }


### PR DESCRIPTION
- Introduced a new histogram to measure connection acquisition time from the pool, allowing differentiation between slow SQL execution and pool contention.
- Updated logging to include pool status during slow query detection.
- Refactored the connection method to instrument pool connections, capturing wait times and logging slow acquisitions.
- Set a threshold for slow connection acquisitions to improve observability of database performance.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pool acquisition metrics and richer slow-query logging to distinguish slow SQL from pool contention. Instruments the DB pool to record wait times and flag slow acquisitions.

- **New Features**
  - Added histogram `db.pool.acquire.duration` to measure time waiting for a connection.
  - Slow-query logs now include pool status: total, idle, waiting, max.
  - Instrumented pool.connect to record acquire time/outcome and log waits over 100 ms.

<sup>Written for commit c955b66dd739129f4d7510f24d8b8c539fc01e09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

