### PR TITLE
feat(language-model): enhance model creation with fallback for OpenRo…

### DIFF
--- a/apps/mesh/src/ai-providers/language-model.ts
+++ b/apps/mesh/src/ai-providers/language-model.ts
@@ -17,19 +17,39 @@
 import type { MeshProvider } from "./types";
 import type { ModelInfo } from "../api/routes/decopilot/types";
 
+const FREE_FALLBACK_MODEL = "openrouter/free";
+
+const OPENROUTER_FAMILY = new Set(["openrouter", "deco"]);
+
 /**
- * Creates a language model from the provider, enabling reasoning when the
- * model advertises the "reasoning" capability (e.g. OpenRouter thinking models).
+ * Creates a language model from the provider.
+ *
+ * - Enables reasoning when the model advertises the "reasoning" capability
+ *   (e.g. OpenRouter thinking models).
+ * - For OpenRouter-family providers, attaches a native model-fallback list
+ *   (`models: [primary, openrouter/free]`). When the primary fails for ANY
+ *   reason — rate-limit, downtime, context-length, or a budget/credit
+ *   rejection — OpenRouter retries on the free model instead of surfacing a
+ *   hard error to the user. The response's `model` field reports whichever
+ *   model actually served the request.
  */
 export function createLanguageModel(provider: MeshProvider, model: ModelInfo) {
+  const settings: Record<string, unknown> = {};
+
   if (model.capabilities?.reasoning !== false) {
-    // Provider-specific settings (e.g. OpenRouter reasoning) are not part of
-    // the generic ProviderV3 interface, so we cast to pass them through.
-    // biome-ignore lint/complexity/noBannedTypes: pass-through provider settings
-    const lm = (provider.aiSdk.languageModel as Function)(model.id, {
-      reasoning: { enabled: true, effort: "medium" },
-    });
-    return lm as ReturnType<typeof provider.aiSdk.languageModel>;
+    settings.reasoning = { enabled: true, effort: "medium" };
   }
-  return provider.aiSdk.languageModel(model.id);
+  if (
+    OPENROUTER_FAMILY.has(provider.info.id) &&
+    model.id !== FREE_FALLBACK_MODEL
+  ) {
+    settings.models = [model.id, FREE_FALLBACK_MODEL];
+  }
+
+  if (Object.keys(settings).length === 0) {
+    return provider.aiSdk.languageModel(model.id);
+  }
+
+  const lm = (provider.aiSdk.languageModel as Function)(model.id, settings);
+  return lm as ReturnType<typeof provider.aiSdk.languageModel>;
 }


### PR DESCRIPTION
…uter family

- Introduced a fallback mechanism for OpenRouter-family providers, allowing automatic retries on a free model when the primary model fails due to various issues (e.g., rate limits, downtime).
- Updated the createLanguageModel function to include reasoning capabilities and handle provider-specific settings more effectively.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic fallback to `openrouter/free` in `createLanguageModel` for OpenRouter-family providers and enables reasoning when supported. Improves reliability by retrying instead of failing on rate limits, downtime, or budget errors.

- **New Features**
  - For providers with id `openrouter` or `deco`, pass `models: [primary, "openrouter/free"]`; the response `model` shows which served the request.
  - Enable reasoning with `reasoning: { enabled: true, effort: "medium" }` when `capabilities.reasoning !== false`.

<sup>Written for commit a0c052f4717f270f15e23fb58f55b52599bdec15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

