### PR TITLE
fix(openrouter): streamline model info extraction in listModels method

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/openrouter.ts
+++ b/apps/mesh/src/ai-providers/adapters/openrouter.ts
@@ -64,6 +64,13 @@ export const openrouterAdapter: ProviderAdapter = {
 
       async listModels(): Promise<ModelInfo[]> {
         const mapV1Model = (m: OpenRouterAPIModel): ModelInfo => {
+          const contextWindow = m.context_length ?? 0;
+          const reportedMaxOut = m.top_provider.max_completion_tokens || null;
+          const maxOutputTokens =
+            reportedMaxOut &&
+            (contextWindow === 0 || reportedMaxOut < contextWindow)
+              ? reportedMaxOut
+              : null;
           return {
             providerId: "openrouter",
             modelId: m.id,
@@ -87,8 +94,8 @@ export const openrouterAdapter: ProviderAdapter = {
               ]),
             ] as ModelCapability[],
             limits: {
-              contextWindow: m.context_length ?? 0,
-              maxOutputTokens: m.top_provider.max_completion_tokens || null,
+              contextWindow,
+              maxOutputTokens,
             },
             costs: {
               input: m.pricing.prompt ?? 0,


### PR DESCRIPTION
- Refactored the `listModels` method to simplify the extraction of `contextWindow` and `maxOutputTokens` from the model data.
- Improved readability by using intermediate variables for context length and maximum output tokens.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes max output token capping in `openrouter` model listing and simplifies limit extraction for clarity. `listModels` now sets `maxOutputTokens` only when the provider’s reported max is below the context window or when no context window is available.

- **Bug Fixes**
  - Prevents over-restricting completions by ignoring `max_completion_tokens` when it is greater than or equal to the context window (falls back to null).

<sup>Written for commit 04683a4e020774578b1ee917b3b34e900885e0a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

