### PR TITLE
feat(observability): add benignPreview404 function and related tests

### DIFF
--- a/apps/mesh/src/observability/instrumentations/fetch.test.ts
+++ b/apps/mesh/src/observability/instrumentations/fetch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { __test } from "./fetch";
 
-const { benignSandbox4xx, isConnectionClosed } = __test;
+const { benignSandbox4xx, benignPreview404, isConnectionClosed } = __test;
 
 describe("benignSandbox4xx", () => {
   it("treats daemon 404 as gone", () => {
@@ -35,6 +35,23 @@ describe("benignSandbox4xx", () => {
 
   it("does not suppress a claim-path 409 (only 404 is benign there)", () => {
     expect(benignSandbox4xx(409, "/apis/x/sandboxclaims/foo")).toBeNull();
+  });
+});
+
+describe("benignPreview404", () => {
+  it("treats a 404 on the deco-site probe paths as not-a-deco-site", () => {
+    expect(benignPreview404(404, "/.decofile")).toBe("not_a_deco_site");
+    expect(benignPreview404(404, "/live/_meta")).toBe("not_a_deco_site");
+  });
+
+  it("does not suppress non-404 statuses on those paths", () => {
+    expect(benignPreview404(500, "/.decofile")).toBeNull();
+    expect(benignPreview404(403, "/live/_meta")).toBeNull();
+  });
+
+  it("does not suppress 404 on unrelated paths", () => {
+    expect(benignPreview404(404, "/live/_meta/extra")).toBeNull();
+    expect(benignPreview404(404, "/api/links/work")).toBeNull();
   });
 });
 

--- a/apps/mesh/src/observability/instrumentations/fetch.ts
+++ b/apps/mesh/src/observability/instrumentations/fetch.ts
@@ -56,6 +56,16 @@ function benignSandbox4xx(status: number, pathname: string): string | null {
   return null;
 }
 
+function benignPreview404(status: number, pathname: string): string | null {
+  if (
+    status === 404 &&
+    (pathname === "/.decofile" || pathname === "/live/_meta")
+  ) {
+    return "not_a_deco_site";
+  }
+  return null;
+}
+
 /**
  * Bun's `fetch` rejects with this shape when the peer closes the TCP
  * connection mid-request (e.g. an in-pod sandbox daemon torn down by idle
@@ -153,7 +163,17 @@ async function instrumentedFetch(
             ? benignSandbox4xx(response.status, url.pathname)
             : null;
 
-        if (response.status >= 400 && !isMcpSseProbe405 && !sandboxLifecycle) {
+        const previewProbe =
+          response.status >= 400
+            ? benignPreview404(response.status, url.pathname)
+            : null;
+
+        if (
+          response.status >= 400 &&
+          !isMcpSseProbe405 &&
+          !sandboxLifecycle &&
+          !previewProbe
+        ) {
           span.setStatus({
             code: SpanStatusCode.ERROR,
             message: `HTTP ${response.status}`,
@@ -161,6 +181,9 @@ async function instrumentedFetch(
         } else {
           if (sandboxLifecycle) {
             span.setAttribute("sandbox.lifecycle", sandboxLifecycle);
+          }
+          if (previewProbe) {
+            span.setAttribute("preview.probe", previewProbe);
           }
           span.setStatus({ code: SpanStatusCode.OK });
         }
@@ -207,4 +230,8 @@ export function enableFetchInstrumentation(): void {
 }
 
 /** Internal helpers exposed for unit tests only. */
-export const __test = { benignSandbox4xx, isConnectionClosed };
+export const __test = {
+  benignSandbox4xx,
+  benignPreview404,
+  isConnectionClosed,
+};


### PR DESCRIPTION
- Introduced `benignPreview404` to handle specific 404 responses for deco-site probe paths.
- Updated `instrumentedFetch` to utilize `benignPreview404` for enhanced error handling.
- Added unit tests for `benignPreview404` to verify its behavior with various status codes and paths.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle benign 404s on preview probe paths to avoid false error spans in fetch instrumentation. `instrumentedFetch` now uses `benignPreview404` to treat 404s on '/.decofile' and '/live/_meta' as "not_a_deco_site", tags spans with `preview.probe`, and includes unit tests.

<sup>Written for commit d3b78cca28b9a9a207c3e606d03b8ef52ecfae6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

