### PR TITLE
feat(database): refactor database metrics initialization and add even…

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -16,19 +16,26 @@ import { meter } from "../observability";
 // StudioDatabase Types
 // ============================================================================
 
-const queryDurationHistogram = meter.createHistogram("db.query.duration", {
-  description: "Database query execution duration in milliseconds",
-  unit: "ms",
-});
+// Created lazily, not at module top: `meter` is a no-op until
+// initObservability() reassigns it, and module-top capture binds the dead
+// pre-init meter (instruments never export). First use happens post-init.
+let _queryDurationHistogram: ReturnType<typeof meter.createHistogram>;
+const queryDurationHistogram = () =>
+  (_queryDurationHistogram ??= meter.createHistogram("db.query.duration", {
+    description: "Database query execution duration in milliseconds",
+    unit: "ms",
+  }));
 
 // Kysely's queryDurationMillis measures SQL execution only — the timer starts
 // after the connection is checked out of the pool. Pool-acquisition wait is
 // invisible to it, so we measure that separately to tell genuinely slow SQL
 // apart from pool-capacity contention.
-const poolAcquireHistogram = meter.createHistogram("db.pool.acquire.duration", {
-  description: "Time spent waiting to acquire a connection from the pool",
-  unit: "ms",
-});
+let _poolAcquireHistogram: ReturnType<typeof meter.createHistogram>;
+const poolAcquireHistogram = () =>
+  (_poolAcquireHistogram ??= meter.createHistogram("db.pool.acquire.duration", {
+    description: "Time spent waiting to acquire a connection from the pool",
+    unit: "ms",
+  }));
 
 const SLOW_QUERY_TRESHOLD_MS = 400;
 const SLOW_ACQUIRE_THRESHOLD_MS = 100;
@@ -52,7 +59,7 @@ const createLog = (pool: Pool) => (event: LogEvent) => {
     });
   }
 
-  queryDurationHistogram.record(event.queryDurationMillis, attributes);
+  queryDurationHistogram().record(event.queryDurationMillis, attributes);
 
   if (event.level === "error") {
     console.error("Query failed:", {
@@ -74,13 +81,17 @@ function instrumentPool(pool: Pool): Pool {
   pool.connect = (cb?: unknown) => {
     if (typeof cb === "function") return originalConnect(cb as never);
     const start = performance.now();
+    // Snapshot BEFORE waiting: pg hands out an idle client when one exists, so
+    // if any are idle here a slow resolve is event-loop lag (pg defers the
+    // handoff through process.nextTick), NOT pool-capacity contention. Only a
+    // full pool with zero idle is genuine contention.
     const max = getPoolMax();
     const contended = pool.idleCount === 0 && pool.totalCount >= max;
     const idleAtStart = pool.idleCount;
     return originalConnect().then(
       (client) => {
         const waited = performance.now() - start;
-        poolAcquireHistogram.record(waited, {
+        poolAcquireHistogram().record(waited, {
           "db.pool.outcome": contended ? "contended" : "available",
         });
         if (waited > SLOW_ACQUIRE_THRESHOLD_MS) {
@@ -93,6 +104,8 @@ function instrumentPool(pool: Pool): Pool {
               max,
             });
           } else {
+            // A connection was free; the delay is the event loop being blocked,
+            // not the DB pool. See observability/event-loop-delay.ts.
             console.warn("Slow pool acquire — event-loop lag (not pool):", {
               waitMs: waited,
               idleAtStart,
@@ -104,7 +117,7 @@ function instrumentPool(pool: Pool): Pool {
         return client;
       },
       (err) => {
-        poolAcquireHistogram.record(performance.now() - start, {
+        poolAcquireHistogram().record(performance.now() - start, {
           "db.pool.outcome": "error",
         });
         throw err;

--- a/apps/mesh/src/observability/event-loop-delay.ts
+++ b/apps/mesh/src/observability/event-loop-delay.ts
@@ -13,17 +13,20 @@ import { meter } from "./index";
  * process.nextTick, so a blocked loop inflates measured acquire time. Spikes
  * are logged with memory stats to correlate with GC pauses.
  */
-const delayHistogram = meter.createHistogram("eventloop.delay", {
-  description: "Event-loop lag measured as timer scheduling drift",
-  unit: "ms",
-});
-
 let timer: ReturnType<typeof setInterval> | undefined;
 
 export function startEventLoopMonitor(): () => void {
   if (process.env.EVENT_LOOP_MONITOR !== "1") return () => {};
   const intervalMs = Number(process.env.EVENT_LOOP_INTERVAL_MS ?? 250);
   const spikeMs = Number(process.env.EVENT_LOOP_SPIKE_MS ?? 100);
+
+  // Create the instrument here, not at module top: `meter` is a no-op until
+  // initObservability() reassigns it, and module-top capture binds the dead
+  // pre-init meter (instruments never export). This runs post-init.
+  const delayHistogram = meter.createHistogram("eventloop.delay", {
+    description: "Event-loop lag measured as timer scheduling drift",
+    unit: "ms",
+  });
 
   let expected = performance.now() + intervalMs;
   timer = setInterval(() => {
@@ -38,6 +41,7 @@ export function startEventLoopMonitor(): () => void {
       console.warn(
         JSON.stringify({
           msg: "event-loop-stall",
+          ts: new Date().toISOString(),
           lagMs: Math.round(drift),
           rss: m.rss,
           heapUsed: m.heapUsed,


### PR DESCRIPTION
…t-loop delay monitoring

- Changed the initialization of `queryDurationHistogram` and `poolAcquireHistogram` to be created lazily, ensuring they are only instantiated after observability is initialized.
- Updated the recording of query and pool acquisition durations to use the new lazy initialization.
- Introduced a new module for monitoring event-loop delays, providing insights into potential performance bottlenecks during database operations.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make database metrics lazy-initialized and add event-loop delay monitoring to improve accuracy and explain slow pool acquires. This reduces no-op instruments and clarifies whether delays are pool contention or event-loop lag.

- **Refactors**
  - Create `db.query.duration` and `db.pool.acquire.duration` histograms lazily after observability init; update all recording calls.
  - Pool acquire metrics snapshot idle/total counts at start to classify "contended" vs "available"/"error", and log when lag is from the event loop, not the pool.

- **New Features**
  - Add timer-drift event-loop monitor; its `eventloop.delay` histogram is created at start (post-init) to avoid no-op instruments.
  - JSON warnings include `ts` and memory stats; configurable via `EVENT_LOOP_MONITOR`, `EVENT_LOOP_INTERVAL_MS`, `EVENT_LOOP_SPIKE_MS`.

<sup>Written for commit 3578a6128aa42e05dd30ef38b66f0c4831477a80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

