### PR TITLE
feat(ci): enhance multi-arch Docker build and manifest merging

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -165,26 +165,41 @@ jobs:
       - name: Publish to NPM
         run: npm publish decocms-*.tgz --access public --tag ${{ needs.prepare.outputs.npm-tag }} --provenance
 
-  # Single-job multi-arch build. Pushes the final tagged manifest directly to
-  # GHCR. arm64 is built under QEMU on an amd64 runner; only node-pty compiles
-  # natively, which is small enough to keep the simpler topology.
+  # Multi-arch build split across NATIVE runners — amd64 on ubuntu-latest,
+  # arm64 on ubuntu-24.04-arm — instead of emulating arm64 under QEMU on amd64.
+  # The expensive `bun add /tmp/decocms.tgz` layer ran ~5x slower under QEMU
+  # (~64s vs ~13s) and is a guaranteed cache miss every release (the tarball
+  # content changes each version), so we paid the full emulation tax every time.
+  # Each leg builds + pushes its single-arch image BY DIGEST (no tags), and the
+  # merge-docker job below assembles the tagged manifest list from both digests.
+  #
   # Consumes the tarball built by build-dist (NOT the npm registry): the
   # Dockerfile does `bun add /tmp/decocms.tgz`, so there is no registry read to
   # race against publish-npm. Runs in PARALLEL with publish-npm — both gate only
   # on build-dist and install the same tarball, so the image stays byte-identical
   # to the published package.
   build-docker:
-    name: Build & push Docker (multi-arch)
+    name: Build Docker (${{ matrix.arch }})
     needs: [prepare, build-dist]
     if: |
       always() &&
       needs.prepare.outputs.image-exists == 'false' &&
       needs.build-dist.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
         with:
@@ -195,7 +210,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Download package artifact into build context
         uses: actions/download-artifact@v4
@@ -204,7 +218,71 @@ jobs:
           path: docker-context
       - name: Normalize tarball filename
         run: mv docker-context/decocms-*.tgz docker-context/decocms.tgz
-      - name: Extract metadata (tags, labels)
+      - name: Image labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # push-by-digest=true publishes a single-arch image addressable only by
+      # digest (no tag); merge-docker stitches the per-arch digests into the
+      # tagged manifest list. provenance:false keeps each pushed digest a plain
+      # single-platform image — provenance attestations turn it into a nested
+      # index that `buildx imagetools create` can't merge cleanly.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker-context
+          file: ./apps/mesh/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=mesh-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=mesh-${{ matrix.arch }}
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests pushed by build-docker into one tagged
+  # multi-arch manifest list and push it to GHCR. This is the job that makes
+  # `ghcr.io/.../mesh:<version>` resolve to both amd64 + arm64.
+  merge-docker:
+    name: Merge & push Docker manifest
+    needs: [prepare, build-docker]
+    if: |
+      always() &&
+      needs.prepare.outputs.image-exists == 'false' &&
+      needs.build-docker.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Extract metadata (tags)
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -213,27 +291,25 @@ jobs:
             type=semver,pattern={{version}},value=${{ needs.prepare.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.prepare.outputs.version }}
             type=raw,value=latest
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./docker-context
-          file: ./apps/mesh/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=mesh
-          cache-to: type=gha,mode=max,scope=mesh
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
 
   release:
     name: GitHub Release + Deployment
-    needs: [prepare, build-dist, publish-npm, build-docker]
+    needs: [prepare, build-dist, publish-npm, merge-docker]
     if: |
       always() &&
       (needs.prepare.outputs.version-changed == 'true' || needs.prepare.outputs.image-exists == 'false') &&
       (needs.build-dist.result == 'success' || needs.build-dist.result == 'skipped') &&
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
-      (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped')
+      (needs.merge-docker.result == 'success' || needs.merge-docker.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -299,15 +375,15 @@ jobs:
   # ---------------------------------------------------------------------------
   bump-deco-apps-cd:
     name: Trigger deco-apps-cd bump
-    needs: [prepare, build-dist, publish-npm, build-docker]
+    needs: [prepare, build-dist, publish-npm, merge-docker]
     # Only bump when this release is fully consistent across the artifact pair:
     #   * a VALID image for this version exists (either already published, so
-    #     build-docker is skipped, or freshly built), AND
-    #   * the npm side didn't fail. publish-npm is gated separately because
-    #     build-docker is now parallel to it — without this clause, an npm
-    #     failure could still ship an image to prod whose `bunx @decocms/mesh@X`
+    #     merge-docker is skipped, or freshly built + merged), AND
+    #   * the npm side didn't fail. publish-npm is gated separately because the
+    #     docker build is parallel to it — without this clause, an npm failure
+    #     could still ship an image to prod whose `bunx @decocms/mesh@X`
     #     wouldn't resolve, leaving the two artifacts inconsistent.
-    # A skipped publish-npm (version already on npm) or skipped build-docker
+    # A skipped publish-npm (version already on npm) or skipped merge-docker
     # (image already in GHCR) is fine — those mean "nothing to do", not failure.
     if: |
       always() &&
@@ -315,7 +391,7 @@ jobs:
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
       (
         needs.prepare.outputs.image-exists == 'true' ||
-        needs.build-docker.result == 'success'
+        needs.merge-docker.result == 'success'
       )
     runs-on: ubuntu-latest
     # Reuses DEPLOY_REPO_TOKEN — the decobot machine-user PAT already used to

--- a/apps/mesh/scripts/bundle-server-script.ts
+++ b/apps/mesh/scripts/bundle-server-script.ts
@@ -12,7 +12,7 @@
  */
 
 import { nodeFileTrace } from "@vercel/nft";
-import { cp, mkdir, readFile, stat } from "fs/promises";
+import { cp, mkdir, readFile, rm, stat } from "fs/promises";
 import { dirname, join, resolve } from "path";
 import { existsSync } from "fs";
 import { $ } from "bun";
@@ -97,6 +97,22 @@ const ALWAYS_EXCLUDE = [
   "@duckdb/node-bindings",
   "react-devtools-core",
 ];
+
+// Package-name prefixes whose packages nft DOES trace but we must NOT copy into
+// dist/server/node_modules. Unlike ALWAYS_EXCLUDE (which only adds `--external`
+// to the bun build), this filters the prune/copy step.
+//
+// @embedded-postgres/<platform> ships a ~144MB platform-specific Postgres
+// binary. `embedded-postgres` (a runtime dependency, kept external) resolves
+// the matching one with a dynamic `import("@embedded-postgres/<platform>")` at
+// runtime, and that package is installed per-platform via embedded-postgres'
+// own optionalDependencies when a consumer runs `bun add decocms`. nft, run on
+// the BUILD HOST, traces only the host's binary — so bundling it is both dead
+// weight on every other platform AND wrong-platform for the published package
+// (CI builds linux-x64; a Mac/arm consumer's runtime never loads it, and the
+// Docker `bun add` already installs the correct linux-<arch> binary per image).
+// Skipping the copy lets the consumer's install supply the right binary.
+const EXCLUDE_COPY_PREFIXES = ["@embedded-postgres/"];
 
 // Parse command line arguments
 function parseArgs() {
@@ -386,6 +402,15 @@ async function pruneNodeModules(): Promise<Set<string>> {
       packageName !== "@decocms/better-auth"
     ) {
       console.log(`📦 Bundling inline (workspace): ${packageName}`);
+      continue;
+    }
+
+    // Platform-specific binaries resolved from the consumer's install at
+    // runtime (see EXCLUDE_COPY_PREFIXES). Don't ship the build host's copy.
+    if (EXCLUDE_COPY_PREFIXES.some((p) => packageName.startsWith(p))) {
+      console.log(
+        `⏭️  Skipping copy (resolved from consumer install): ${packageName}`,
+      );
       continue;
     }
 
@@ -833,6 +858,39 @@ async function verifyBundlesShipExternals() {
   );
 }
 
+// Strip files the JS runtime never loads from the copied node_modules:
+// source maps (debug-only) and TypeScript declarations (the published package
+// is a runnable bundle, not a typed library). These are ~45MB of pure dead
+// weight in the tarball/image and slow down every npm pack / publish / docker
+// `bun add` / artifact transfer. We deliberately do NOT strip *.development.js
+// (react-dom's exports map can resolve to it depending on NODE_ENV) or *.ts
+// source (a few packages route exports through it).
+async function stripNonRuntimeFiles() {
+  console.log("🧹 Stripping non-runtime files (.map / .d.ts) from bundle...");
+  const nodeModules = join(OUTPUT_DIR, "node_modules");
+  if (!existsSync(nodeModules)) return;
+
+  const patterns = ["**/*.map", "**/*.d.ts", "**/*.d.cts", "**/*.d.mts"];
+  let removed = 0;
+  let freedBytes = 0;
+  for (const pattern of patterns) {
+    const glob = new Bun.Glob(pattern);
+    for await (const rel of glob.scan({ cwd: nodeModules, onlyFiles: true })) {
+      const abs = join(nodeModules, rel);
+      try {
+        freedBytes += (await stat(abs)).size;
+        await rm(abs);
+        removed++;
+      } catch {
+        // best-effort: a missing/locked file just stays
+      }
+    }
+  }
+  console.log(
+    `✅ Stripped ${removed} files, freed ${(freedBytes / 1048576).toFixed(1)} MB`,
+  );
+}
+
 async function main() {
   // Build sandbox daemon bundle so runner.ts's text-import has a file to embed.
   await buildSandboxDaemon();
@@ -850,6 +908,9 @@ async function main() {
 
   // Copy QuickJS WASM alongside bundles as a safety net for path resolution
   await copyQuickjsWasm();
+
+  // Drop debug-only / type-only files the runtime never loads (~45MB).
+  await stripNonRuntimeFiles();
 
   // Defense in depth: fail the build if any external import points at a
   // package that isn't on disk. See verifyBundlesShipExternals for context.


### PR DESCRIPTION
- Updated the GitHub Actions workflow to support multi-architecture builds using native runners for amd64 and arm64, improving build performance significantly.
- Removed QEMU emulation to avoid slow build times and cache misses.
- Introduced a new job to merge per-architecture digests into a tagged multi-arch manifest for GitHub Container Registry.
- Added functionality to strip non-runtime files from the node_modules directory to reduce package size.
- Enhanced the bundle server script to exclude specific packages from being copied into the distribution.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up Docker releases by building amd64 and arm64 natively and then merging digests into a single multi-arch image on GHCR. Also trims the server bundle by skipping platform binaries and stripping non-runtime files to shrink images and tarballs.

- **New Features**
  - Split multi-arch build into native jobs (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm), pushing single-arch images by digest with per-arch caches; removed QEMU.
  - New merge job creates and pushes the tagged multi-arch manifest (`latest`, version, major.minor) to GHCR from the per-arch digests.
  - Bundle script skips copying `@embedded-postgres/*` platform binaries; they resolve from the consumer install at runtime.
  - Strips `.map` and `.d.ts` files from bundled `node_modules`, cutting ~45 MB of dead weight.

<sup>Written for commit d2958b9a634b729da123d5682d7d6350aec9dbce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

