### PR TITLE
fix(decopilot): update agent delegation usage documentation and handling

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/agents-block.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/agents-block.test.ts
@@ -123,11 +123,12 @@ describe("buildAgentsBlock", () => {
       "vmcp_self",
       ["vmcp_does_not_exist"],
     );
-    // No matching agents → no table, but self-delegation usage still emitted.
-    // (The usage prose references <available-agents>, so assert on the table
-    // header instead of the tag.)
+    // No matching agents → no table, and the self-only usage must NOT dangle a
+    // pointer at <available-agents> (that's what makes the model invent ids).
     expect(result).not.toContain("id,name,description");
+    expect(result).not.toContain("<available-agents>");
     expect(result).toContain("<agents-usage>");
+    expect(result).toContain("NEVER pass agent_id");
   });
 
   test("includes <agents-usage> with subtask delegation guidance", () => {

--- a/apps/mesh/src/harnesses/decopilot/agents-block.ts
+++ b/apps/mesh/src/harnesses/decopilot/agents-block.ts
@@ -20,15 +20,7 @@ export interface AgentsBlockEntry {
   status: "active" | "inactive" | "error";
 }
 
-const SELF_USAGE = `<agents-usage>
-Delegate self-contained work to a subagent with the subtask tool.
-
-- subtask({ prompt }) — clone YOURSELF: a fresh subagent with your exact tools
-  and instructions but an empty context window.
-- subtask({ agent_id, prompt }) — delegate to a DIFFERENT agent (see
-  <available-agents>), which has its own tools and instructions.
-
-REACH FOR IT ON DISCOVERY: before an open-ended search, or before reading more
+const USAGE_TAIL = `REACH FOR IT ON DISCOVERY: before an open-ended search, or before reading more
 than ~3 files / resources / records to answer a question, run subtask FIRST so
 the digging burns the subagent's context, not yours. A single, targeted lookup
 you already know the shape of stays inline.
@@ -39,6 +31,31 @@ a raw dump); never use continuation phrases like "continue" or "as before".
 Launch multiple subtask calls in one message to run independent searches in
 parallel.
 </agents-usage>`;
+
+// Emitted when other delegable agents exist: documents both the self-clone and
+// the cross-agent form, and points at the <available-agents> catalog below.
+const FULL_USAGE = `<agents-usage>
+Delegate self-contained work to a subagent with the subtask tool.
+
+- subtask({ prompt }) — clone YOURSELF: a fresh subagent with your exact tools
+  and instructions but an empty context window.
+- subtask({ agent_id, prompt }) — delegate to a DIFFERENT agent (see
+  <available-agents>), which has its own tools and instructions.
+
+${USAGE_TAIL}`;
+
+// Emitted when there is NO catalog (self-only). Must NOT reference
+// <available-agents> or the agent_id form — that block isn't in context, and a
+// dangling pointer makes the model fabricate agent ids instead of just omitting
+// agent_id to clone itself.
+const SELF_ONLY_USAGE = `<agents-usage>
+Delegate self-contained work to a subagent with the subtask tool.
+
+- subtask({ prompt }) — clone YOURSELF: a fresh subagent with your exact tools
+  and instructions but an empty context window. This is your ONLY delegation
+  option: there are no other agents available, so NEVER pass agent_id.
+
+${USAGE_TAIL}`;
 
 function csvField(s: string | null | undefined): string {
   if (s == null || s === "") return "";
@@ -74,7 +91,7 @@ export function buildAgentsBlock(
   // emitted. The <available-agents> table is added only when other active
   // agents exist to delegate to.
   if (others.length === 0) {
-    return `\n\n${SELF_USAGE}`;
+    return `\n\n${SELF_ONLY_USAGE}`;
   }
 
   const rows = others.map((a) => {
@@ -84,6 +101,6 @@ export function buildAgentsBlock(
 
   return (
     `\n\n<available-agents>\nid,name,description\n${rows.join("\n")}\n</available-agents>` +
-    `\n\n${SELF_USAGE}`
+    `\n\n${FULL_USAGE}`
   );
 }

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -110,14 +110,18 @@ export function createSubtaskTool(
       // first yield kills the subtask with no guidance, so the model can't
       // self-correct and just repeats the mistake. A yielded error lets it
       // retry — usually by omitting agent_id to clone itself.
-      const selfHint = self
-        ? " Omit agent_id to clone yourself (a fresh subagent with your tools + instructions), or pass an agent id from <available-agents>."
+      // Base hint: always offer the self-clone path. The "pass an agent id from
+      // <available-agents>" pointer is appended ONLY when a catalog actually
+      // exists (see the allowlist branch below) — a dangling pointer is what
+      // makes the model fabricate agent ids instead of just omitting agent_id.
+      const cloneHint = self
+        ? " Omit agent_id to clone yourself (a fresh subagent with your tools + instructions)."
         : "";
 
       if (!targetId) {
         yield {
           text: "",
-          error: `agent_id is required here.${selfHint}`,
+          error: `agent_id is required here.${cloneHint}`,
           finishReason: "error",
         };
         return;
@@ -135,9 +139,16 @@ export function createSubtaskTool(
         // An allowlist array (even empty = itself only) gates cross-agent
         // delegation. A null/absent allowlist means all agents are allowed.
         if (Array.isArray(allow) && !allow.includes(targetId)) {
+          // Point at the catalog ONLY when the allowlist permits some other
+          // agent. An empty allowlist (self-only) has no <available-agents>
+          // table, so directing the model there just makes it invent ids.
+          const catalogHint =
+            allow.length > 0
+              ? " Or pass an agent id from <available-agents>."
+              : "";
           yield {
             text: "",
-            error: `Agent '${targetId}' is not in this agent's delegation allowlist (allow=${JSON.stringify(allow)}).${selfHint}`,
+            error: `Agent '${targetId}' is not in this agent's delegation allowlist (allow=${JSON.stringify(allow)}).${cloneHint}${catalogHint}`,
             finishReason: "error",
           };
           return;
@@ -155,7 +166,7 @@ export function createSubtaskTool(
       } catch (err) {
         yield {
           text: "",
-          error: `${(err as Error).message} (agent_id="${targetId}").${selfHint}`,
+          error: `${(err as Error).message} (agent_id="${targetId}").${cloneHint}`,
           finishReason: "error",
         };
         return;


### PR DESCRIPTION
- Refactored agent usage documentation to clarify self-delegation behavior when no other agents are available.
- Introduced distinct usage strings for self-only and full agent delegation scenarios, ensuring no dangling references to <available-agents> when self-only.
- Updated error messages in the subtask tool to provide clearer guidance on agent delegation options based on the context of available agents.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes self-delegation guidance and error messages so the model stops inventing agent IDs when no other agents are available. Usage now adapts to self-only vs. full delegation, and errors point to the right option for the context.

- **Bug Fixes**
  - Split usage into self-only and full forms: self-only omits `<available-agents>` and the `agent_id` path, and says “NEVER pass agent_id”.
  - Updated subtask tool errors: always suggest omitting `agent_id` to clone self; only reference `<available-agents>` when a real catalog exists.
  - Adjusted tests to assert no dangling `<available-agents>` in self-only mode and to expect the new guidance.

<sup>Written for commit f2d4ec496666ef958ae59763a9edfeeb498aac47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

