### PR TITLE
refactor(database): improve histogram creation for query and pool acq…

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -16,26 +16,27 @@ import { meter } from "../observability";
 // StudioDatabase Types
 // ============================================================================
 
-// Created lazily, not at module top: `meter` is a no-op until
-// initObservability() reassigns it, and module-top capture binds the dead
-// pre-init meter (instruments never export). First use happens post-init.
-let _queryDurationHistogram: ReturnType<typeof meter.createHistogram>;
+// Resolve the instrument on every record, never cached: the module-level
+// `meter` is the NoopMeter until initObservability() reassigns it, so caching
+// the first instance (e.g. when an early query races init) binds the dead meter
+// forever. createHistogram is idempotent — the meter memoizes by name — so this
+// is cheap and always hits the real post-init provider. Mirrors the working
+// pattern in mcp-clients/outbound/transports/monitoring.ts.
 const queryDurationHistogram = () =>
-  (_queryDurationHistogram ??= meter.createHistogram("db.query.duration", {
+  meter.createHistogram("db.query.duration", {
     description: "Database query execution duration in milliseconds",
     unit: "ms",
-  }));
+  });
 
 // Kysely's queryDurationMillis measures SQL execution only — the timer starts
 // after the connection is checked out of the pool. Pool-acquisition wait is
 // invisible to it, so we measure that separately to tell genuinely slow SQL
 // apart from pool-capacity contention.
-let _poolAcquireHistogram: ReturnType<typeof meter.createHistogram>;
 const poolAcquireHistogram = () =>
-  (_poolAcquireHistogram ??= meter.createHistogram("db.pool.acquire.duration", {
+  meter.createHistogram("db.pool.acquire.duration", {
     description: "Time spent waiting to acquire a connection from the pool",
     unit: "ms",
-  }));
+  });
 
 const SLOW_QUERY_TRESHOLD_MS = 400;
 const SLOW_ACQUIRE_THRESHOLD_MS = 100;


### PR DESCRIPTION
…uisition metrics

- Updated the initialization of `queryDurationHistogram` and `poolAcquireHistogram` to avoid caching the NoopMeter, ensuring they always reference the active meter post-initialization.
- Simplified the creation logic for both histograms, enhancing clarity and maintaining performance.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor histogram creation for DB query and pool acquisition metrics to always bind to the active meter. This avoids capturing the pre-init NoopMeter and restores reliable metric export after observability init.

- **Refactors**
  - Replace cached `_queryDurationHistogram` and `_poolAcquireHistogram` with accessors that call `meter.createHistogram` each time, relying on name-based memoization for zero overhead.

<sup>Written for commit c86b9332ac7012c8e7a46e3541ac3778747dd9df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

