### PR TITLE
Fix/decopilot eventloop stalls

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -91,6 +91,7 @@ import { mintOrgFsConfigJson } from "@/file-storage/mount/provisioning";
 import { meter, traced } from "@/observability";
 import { getPodId } from "@/core/pod-identity";
 import type { SSEEvent } from "@/event-bus";
+import { sleep } from "@decocms/std";
 
 // B5/I1: counter for message-save failures — tagged by org.id (low cardinality).
 // Incremented at every save .catch site inside dispatch-run.ts so the frequency
@@ -100,6 +101,22 @@ const saveErrorsCounter = meter.createCounter("decopilot.save.errors", {
     "Number of message-save failures during decopilot run dispatch (v1 and v2 paths)",
   unit: "{errors}",
 });
+
+// Attributes onFinish event-loop cost by phase (settle = awaiting the
+// accumulated pendingOps; save = the synchronous message-serialization +
+// DB write). The standalone eventloop.delay timer can't know what phase it
+// stalled in; this histogram closes that gap for the finish path.
+const finishDurationHistogram = meter.createHistogram(
+  "decopilot.finish.duration",
+  {
+    description: "Wall time of onFinish flush segments, tagged by phase",
+    unit: "ms",
+  },
+);
+
+// The per-finish payload-size probe re-stringifies the whole message (the very
+// cost we're characterizing), so the heavy trace is gated to a canary pod.
+const FINISH_TRACE = process.env.DECOPILOT_FINISH_TRACE === "1";
 
 /**
  * Process-wide progress-bump throttle (Task 9, A1/A2). One instance shared by
@@ -1278,8 +1295,22 @@ async function prepareRun(
           pendingOps.length,
         );
         streamFinished = true;
+        const pendingCount = pendingOps.length;
 
+        const settleStart = performance.now();
         await Promise.allSettled(pendingOps);
+        finishDurationHistogram.record(performance.now() - settleStart, {
+          phase: "settle",
+        });
+
+        // Yield a macrotask before the synchronous save serialization so the
+        // settle-burst of 35–55 pending-op continuations and the large
+        // JSON.stringify don't run in one tick — lets queued I/O (health
+        // probes) get a turn and caps the worst onFinish event-loop stalls.
+        await sleep(0);
+
+        const heapBefore = FINISH_TRACE ? process.memoryUsage() : null;
+        const saveStart = performance.now();
         if (partEmitter) {
           // v2: persist any remaining final parts + close the assistant
           // message with a finish anchor.
@@ -1288,6 +1319,31 @@ async function prepareRun(
           });
         } else {
           await saveMessagesToThread(responseMessage);
+        }
+        const saveMs = performance.now() - saveStart;
+        finishDurationHistogram.record(saveMs, { phase: "save" });
+
+        if (FINISH_TRACE && heapBefore) {
+          const heapAfter = process.memoryUsage();
+          let messageBytes = -1;
+          try {
+            messageBytes = JSON.stringify(responseMessage)?.length ?? -1;
+          } catch {
+            // circular/oversized — leave -1
+          }
+          console.warn(
+            JSON.stringify({
+              msg: "decopilot-finish-trace",
+              threadId: mem.thread.id,
+              pendingOps: pendingCount,
+              saveMs: Math.round(saveMs),
+              parts: responseMessage?.parts?.length ?? 0,
+              messageBytes,
+              rssDelta: heapAfter.rss - heapBefore.rss,
+              heapUsedDelta: heapAfter.heapUsed - heapBefore.heapUsed,
+              externalDelta: heapAfter.external - heapBefore.external,
+            }),
+          );
         }
 
         if (registrySignal.aborted) return;

--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -16,26 +16,27 @@ import { meter } from "../observability";
 // StudioDatabase Types
 // ============================================================================
 
-// Created lazily, not at module top: `meter` is a no-op until
-// initObservability() reassigns it, and module-top capture binds the dead
-// pre-init meter (instruments never export). First use happens post-init.
-let _queryDurationHistogram: ReturnType<typeof meter.createHistogram>;
+// Resolve the instrument on every record, never cached: the module-level
+// `meter` is the NoopMeter until initObservability() reassigns it, so caching
+// the first instance (e.g. when an early query races init) binds the dead meter
+// forever. createHistogram is idempotent — the meter memoizes by name — so this
+// is cheap and always hits the real post-init provider. Mirrors the working
+// pattern in mcp-clients/outbound/transports/monitoring.ts.
 const queryDurationHistogram = () =>
-  (_queryDurationHistogram ??= meter.createHistogram("db.query.duration", {
+  meter.createHistogram("db.query.duration", {
     description: "Database query execution duration in milliseconds",
     unit: "ms",
-  }));
+  });
 
 // Kysely's queryDurationMillis measures SQL execution only — the timer starts
 // after the connection is checked out of the pool. Pool-acquisition wait is
 // invisible to it, so we measure that separately to tell genuinely slow SQL
 // apart from pool-capacity contention.
-let _poolAcquireHistogram: ReturnType<typeof meter.createHistogram>;
 const poolAcquireHistogram = () =>
-  (_poolAcquireHistogram ??= meter.createHistogram("db.pool.acquire.duration", {
+  meter.createHistogram("db.pool.acquire.duration", {
     description: "Time spent waiting to acquire a connection from the pool",
     unit: "ms",
-  }));
+  });
 
 const SLOW_QUERY_TRESHOLD_MS = 400;
 const SLOW_ACQUIRE_THRESHOLD_MS = 100;

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { createConcurrencyGate } from "./subagent-concurrency";
+
+describe("createConcurrencyGate", () => {
+  it("allows up to `max` concurrent holders without waiting", async () => {
+    const gate = createConcurrencyGate(2);
+    await gate.acquire();
+    await gate.acquire();
+    expect(gate.active).toBe(2);
+    expect(gate.pending).toBe(0);
+  });
+
+  it("queues acquisitions past capacity and admits them on release", async () => {
+    const gate = createConcurrencyGate(1);
+    const r1 = await gate.acquire();
+
+    let admitted = false;
+    const p2 = gate.acquire().then((r) => {
+      admitted = true;
+      return r;
+    });
+
+    // Second acquire is parked, not granted.
+    await Promise.resolve();
+    expect(gate.active).toBe(1);
+    expect(gate.pending).toBe(1);
+    expect(admitted).toBe(false);
+
+    r1(); // free the slot
+    await p2;
+    expect(admitted).toBe(true);
+    expect(gate.active).toBe(1);
+    expect(gate.pending).toBe(0);
+  });
+
+  it("admits waiters in FIFO order", async () => {
+    const gate = createConcurrencyGate(1);
+    const r1 = await gate.acquire();
+    const order: number[] = [];
+    const p2 = gate.acquire().then((r) => {
+      order.push(2);
+      return r;
+    });
+    const p3 = gate.acquire().then((r) => {
+      order.push(3);
+      return r;
+    });
+
+    r1();
+    const r2 = await p2;
+    r2();
+    await p3;
+    expect(order).toEqual([2, 3]);
+  });
+
+  it("release is idempotent — a double-call frees only one slot", async () => {
+    const gate = createConcurrencyGate(2);
+    const r1 = await gate.acquire();
+    await gate.acquire();
+    r1();
+    r1(); // no-op
+    expect(gate.active).toBe(1);
+  });
+
+  it("coerces a sub-1 max up to 1", async () => {
+    const gate = createConcurrencyGate(0);
+    await gate.acquire();
+    expect(gate.active).toBe(1);
+    let admitted = false;
+    void gate.acquire().then(() => (admitted = true));
+    await Promise.resolve();
+    expect(admitted).toBe(false);
+  });
+});

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
@@ -1,0 +1,63 @@
+/**
+ * Process-wide gate on concurrent subagent streams.
+ *
+ * The `subtask` tool is documented to fan out ("launch multiple subtask calls
+ * in the same message"), and each call spawns a full nested agent stream
+ * (`runAgentLoop` + stream drain). With no bound, one busy session can start
+ * dozens of concurrent streams on a single pod; since the event loop is
+ * single-threaded, that pegs CPU and floods the microtask queue, starving
+ * everything else (pg pool acquires, even signal handlers). This caps how many
+ * run at once per process — excess calls queue and start as slots free.
+ *
+ * DRAFT: limit is read from the environment with a conservative default. If we
+ * keep this, move it into Settings (resolve-config.ts) so it's tunable per
+ * deployment without an env redeploy, and consider a per-run (not per-process)
+ * gate if cross-session head-of-line blocking becomes a concern.
+ */
+
+export interface ConcurrencyGate {
+  /**
+   * Acquire a slot, waiting if at capacity. Returns a release function; call it
+   * exactly once (idempotent) when the work is done, including on error/abort.
+   */
+  acquire(): Promise<() => void>;
+  /** Slots currently held (testing/observability). */
+  readonly active: number;
+  /** Callers waiting for a slot (testing/observability). */
+  readonly pending: number;
+}
+
+export function createConcurrencyGate(max: number): ConcurrencyGate {
+  const limit = Math.max(1, max);
+  let active = 0;
+  const waiters: Array<() => void> = [];
+
+  return {
+    async acquire() {
+      if (active >= limit) {
+        await new Promise<void>((resolve) => waiters.push(resolve));
+      }
+      active++;
+
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        active--;
+        waiters.shift()?.();
+      };
+    },
+    get active() {
+      return active;
+    },
+    get pending() {
+      return waiters.length;
+    },
+  };
+}
+
+const gate = createConcurrencyGate(
+  Number(process.env.DECOPILOT_MAX_CONCURRENT_SUBAGENTS ?? 4),
+);
+
+export const acquireSubagentSlot = (): Promise<() => void> => gate.acquire();

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -18,6 +18,7 @@ import type { MeshProvider } from "@/ai-providers/types";
 import type { ModelsConfig } from "../../../api/routes/decopilot/types";
 import { runAgentLoop } from "../run-agent-loop";
 import { SUBAGENT_STEP_LIMIT } from "../../../api/routes/decopilot/constants";
+import { acquireSubagentSlot } from "./subagent-concurrency";
 
 export const SubtaskInputSchema = z.object({
   prompt: z
@@ -174,6 +175,7 @@ export function createSubtaskTool(
       const { mcpClient, targetRef } = resolved;
       const targetLabel = targetRef.id;
 
+      const releaseSlot = await acquireSubagentSlot();
       try {
         // 3. Call runAgentLoop with subagent kind.
         const handle = await runAgentLoop({
@@ -248,6 +250,7 @@ export function createSubtaskTool(
         //    correct.
         yield { text: aggregatedText, error, finishReason };
       } finally {
+        releaseSlot();
         mcpClient.close().catch(() => {});
       }
     },

--- a/apps/mesh/src/harnesses/decopilot/run-stream.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-stream.ts
@@ -964,64 +964,46 @@ export async function* runDecopilotStream(
     | {
         kind: "queue";
         value: { done: false; value: UIMessageChunk } | { done: true };
-      }
-    | { kind: "title"; value: UIMessageChunk | null };
+      };
   const iter = uiMessageStream[Symbol.asyncIterator]();
   let mainDone = false;
   let titleDone = false;
+
+  const closeIfDone = () => {
+    if (mainDone && titleDone) chunkQueue.close();
+  };
+  void titlePromise.then((chunk) => {
+    titleDone = true;
+    if (chunk) chunkQueue.push(chunk);
+    closeIfDone();
+  });
+
   let mainPromise: Promise<Settled> = iter
     .next()
     .then((v) => ({ kind: "main" as const, value: v }));
   let queuePromise: Promise<Settled> = chunkQueue
     .next()
     .then((v) => ({ kind: "queue" as const, value: v }));
-  const titleResultPromise: Promise<Settled> = titlePromise.then((value) => ({
-    kind: "title" as const,
-    value,
-  }));
   try {
     while (true) {
-      if (mainDone && titleDone) {
-        // Main stream and title generation are both settled. Close the queue
-        // so the outstanding queue waiter resolves, then drain anything
-        // buffered by side-channel callbacks.
-        chunkQueue.close();
-        while (true) {
-          const remaining = await chunkQueue.next();
-          if (remaining.done) break;
-          yield remaining.value;
-        }
-        break;
-      }
-
-      const pending = [queuePromise];
+      const pending: Promise<Settled>[] = [queuePromise];
       if (!mainDone) pending.push(mainPromise);
-      if (!titleDone) pending.push(titleResultPromise);
 
       const settled = await Promise.race(pending);
       if (settled.kind === "main") {
         if (settled.value.done) {
           mainDone = true;
-          if (!titleDone) {
-            titleHandle.finish();
-          }
+          titleHandle.finish();
+          closeIfDone();
           continue;
         }
         yield settled.value.value;
         mainPromise = iter
           .next()
           .then((v) => ({ kind: "main" as const, value: v }));
-      } else if (settled.kind === "title") {
-        titleDone = true;
-        if (settled.value) yield settled.value;
       } else {
-        // Queue-side resolution. The queue is only closed by us
-        // (inside the main-done branch above), so a `done: true`
-        // here is unreachable during the main loop — the loop has
-        // already broken in that case.
-        if (!settled.value.done) {
-          yield settled.value.value;
-        }
+        if (settled.value.done) break;
+        yield settled.value.value;
         queuePromise = chunkQueue
           .next()
           .then((v) => ({ kind: "queue" as const, value: v }));

--- a/apps/mesh/src/tools/decopilot-mcp/subtask-tool.ts
+++ b/apps/mesh/src/tools/decopilot-mcp/subtask-tool.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { resolveSubagent } from "@/harnesses/decopilot/resolve-subagent";
 import { runAgentLoop } from "@/harnesses/decopilot/run-agent-loop";
+import { acquireSubagentSlot } from "@/harnesses/decopilot/built-in-tools/subagent-concurrency";
 import { SUBAGENT_STEP_LIMIT } from "@/api/routes/decopilot/constants";
 import type { ModelsConfig } from "@/api/routes/decopilot/types";
 import type { UIMessageStreamWriter } from "ai";
@@ -118,6 +119,7 @@ export const SUBTASK_MCP = defineTool({
       input.agent_id,
     );
 
+    const releaseSlot = await acquireSubagentSlot();
     try {
       const abortController = new AbortController();
 
@@ -167,6 +169,7 @@ export const SUBTASK_MCP = defineTool({
         finishReason: String(finishReason),
       };
     } finally {
+      releaseSlot();
       mcpClient.close().catch(() => {});
     }
   },


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Decopilot event-loop stalls on finish and prevents CPU spikes from subagent fan-out. Adds phase-level timing and optional memory tracing to make heavy saves visible and debuggable.

- **Bug Fixes**
  - Yield a macrotask before final message serialization/save and simplify stream/title closure to avoid long event-loop stalls.
  - Limit concurrent subagent streams per process (default 4 via `DECOPILOT_MAX_CONCURRENT_SUBAGENTS`) with acquire/release in both subtask tools; tests cover FIFO admission and idempotent release.

- **Observability**
  - Added `decopilot.finish.duration` histogram tagged by `phase` (`settle`, `save`) and optional finish tracing via `DECOPILOT_FINISH_TRACE` (includes message size and memory deltas).
  - Fixed DB query/pool duration histograms to always bind to the active meter post-init (no cached NoopMeter).

<sup>Written for commit 4cecc198d068d3c4bc8ed111d8cc617cb6cb2db2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

