### PR TITLE
feat(virtual-mcp): enhance plugin management and performance

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -16,7 +16,10 @@ import { CredentialVault } from "../encryption/credential-vault";
 import { getSettings } from "../settings";
 import { getBaseUrl } from "./server-constants";
 import { ConnectionStorage } from "../storage/connection";
-import { VirtualMCPStorage } from "../storage/virtual";
+import {
+  createRequestCachedVirtualMcps,
+  VirtualMCPStorage,
+} from "../storage/virtual";
 import {
   SqlMonitoringStorage,
   type SqlDialect,
@@ -1319,6 +1322,7 @@ export async function createStudioContextFactory(
 
     const storage = {
       ...baseStorage,
+      virtualMcps: createRequestCachedVirtualMcps(baseStorage.virtualMcps),
       threads: new OrgScopedThreadStorage(threadDb, organization?.id),
       asyncResearchJobs: new OrgScopedAsyncResearchJobStorage(
         asyncResearchJobDb,

--- a/apps/mesh/src/core/plugin-loader.ts
+++ b/apps/mesh/src/core/plugin-loader.ts
@@ -50,15 +50,9 @@ async function isPluginEnabledForOrg(
   }
 
   // Check all virtual MCPs in the org
-  const virtualMcps = await ctx.storage.virtualMcps.list(orgId);
-  for (const virtualMcp of virtualMcps) {
-    const enabledPlugins = virtualMcp.metadata?.enabled_plugins;
-    if (Array.isArray(enabledPlugins) && enabledPlugins.includes(pluginId)) {
-      return true;
-    }
-  }
-
-  return false;
+  const virtualMcpPlugins =
+    await ctx.storage.virtualMcps.listEnabledPlugins(orgId);
+  return virtualMcpPlugins.includes(pluginId);
 }
 
 /**

--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -11,6 +11,7 @@ import { Pool } from "pg";
 import type { Database as DatabaseSchema } from "../storage/types";
 import { getSettings } from "../settings";
 import { meter } from "../observability";
+import { getEventLoopLagMs } from "../observability/event-loop-delay";
 
 // ============================================================================
 // StudioDatabase Types
@@ -48,16 +49,30 @@ const createLog = (pool: Pool) => (event: LogEvent) => {
   };
 
   if (event.queryDurationMillis > SLOW_QUERY_TRESHOLD_MS) {
-    console.error("Slow query detected:", {
-      durationMs: event.queryDurationMillis,
-      sql: event.query.sql,
-      pool: {
-        total: pool.totalCount,
-        idle: pool.idleCount,
-        waiting: pool.waitingCount,
-        max: getPoolMax(),
+    // Kysely's queryDurationMillis is measured in JS: the timer starts when the
+    // query is dispatched and stops in the result callback, so a blocked event
+    // loop inflates the figure even when Postgres answered in sub-ms. When
+    // recent loop lag is on the same order as the "slow" duration, the SQL is
+    // almost certainly fast and the loop is the real bottleneck — say so
+    // instead of blaming the DB. See observability/event-loop-delay.ts.
+    const eventLoopLagMs = getEventLoopLagMs();
+    const likelyEventLoopLag = eventLoopLagMs > SLOW_QUERY_TRESHOLD_MS / 2;
+    console.error(
+      likelyEventLoopLag
+        ? "Slow query measurement — likely event-loop lag, not slow SQL:"
+        : "Slow query detected:",
+      {
+        durationMs: event.queryDurationMillis,
+        eventLoopLagMs: Math.round(eventLoopLagMs),
+        sql: event.query.sql,
+        pool: {
+          total: pool.totalCount,
+          idle: pool.idleCount,
+          waiting: pool.waitingCount,
+          max: getPoolMax(),
+        },
       },
-    });
+    );
   }
 
   queryDurationHistogram().record(event.queryDurationMillis, attributes);

--- a/apps/mesh/src/observability/event-loop-delay.ts
+++ b/apps/mesh/src/observability/event-loop-delay.ts
@@ -15,7 +15,39 @@ import { meter } from "./index";
  */
 let timer: ReturnType<typeof setInterval> | undefined;
 
+// Always-on, ultra-cheap lag sampler (independent of EVENT_LOOP_MONITOR) so
+// other subsystems can tell event-loop stalls apart from genuinely slow work.
+// The slow-query log uses it to avoid blaming Postgres for time the query
+// callback actually spent queued behind a blocked main thread.
+let lagSampler: ReturnType<typeof setInterval> | undefined;
+let lastLagMs = 0;
+const LAG_SAMPLE_INTERVAL_MS = 500;
+
+function startLagSampler(): void {
+  if (lagSampler) return;
+  let expected = performance.now() + LAG_SAMPLE_INTERVAL_MS;
+  lagSampler = setInterval(() => {
+    const now = performance.now();
+    lastLagMs = Math.max(0, now - expected);
+    expected = now + LAG_SAMPLE_INTERVAL_MS;
+  }, LAG_SAMPLE_INTERVAL_MS);
+  lagSampler.unref?.();
+}
+
+/**
+ * Most recent event-loop lag sample in ms (timer scheduling drift). Lazily
+ * starts the sampler on first read, so callers don't need init wiring.
+ */
+export function getEventLoopLagMs(): number {
+  startLagSampler();
+  return lastLagMs;
+}
+
 export function startEventLoopMonitor(): () => void {
+  // Start the lightweight sampler eagerly at boot so the first slow query
+  // already has lag data to classify against.
+  startLagSampler();
+
   if (process.env.EVENT_LOOP_MONITOR !== "1") return () => {};
   const intervalMs = Number(process.env.EVENT_LOOP_INTERVAL_MS ?? 250);
   const spikeMs = Number(process.env.EVENT_LOOP_SPIKE_MS ?? 100);

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -574,6 +574,7 @@ export interface VirtualMCPStoragePort {
     options?: { pinnedOnly?: boolean },
   ): Promise<VirtualMCPEntity[]>;
   listByIds(organizationId: string, ids: string[]): Promise<VirtualMCPEntity[]>;
+  listEnabledPlugins(organizationId: string): Promise<string[]>;
   listByConnectionId(
     organizationId: string,
     connectionId: string,

--- a/apps/mesh/src/storage/virtual.ts
+++ b/apps/mesh/src/storage/virtual.ts
@@ -239,6 +239,45 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
     );
   }
 
+  /**
+   * Union of `metadata.enabled_plugins` across all VIRTUAL connections in the
+   * org. Projects only the `metadata` column — no aggregations join, no
+   * full-entity deserialization — because the callers (management-tool
+   * filtering, plugin-enablement checks) need just the plugin ids, not whole
+   * virtual-MCP rows. The full `list()` pulls every column (configs run to
+   * ~16 KB) for hundreds of rows, so reusing it here is what put `select *`
+   * on the hot path.
+   */
+  async listEnabledPlugins(organizationId: string): Promise<string[]> {
+    const rows = await this.db
+      .selectFrom("connections")
+      .select("metadata")
+      .where("organization_id", "=", organizationId)
+      .where("connection_type", "=", "VIRTUAL")
+      .execute();
+
+    const plugins = new Set<string>();
+    for (const row of rows) {
+      if (!row.metadata) continue;
+      let metadata: Record<string, unknown>;
+      try {
+        metadata =
+          typeof row.metadata === "string"
+            ? JSON.parse(row.metadata)
+            : (row.metadata as Record<string, unknown>);
+      } catch {
+        continue;
+      }
+      const enabled = metadata?.enabled_plugins;
+      if (Array.isArray(enabled)) {
+        for (const pluginId of enabled) {
+          if (typeof pluginId === "string") plugins.add(pluginId);
+        }
+      }
+    }
+    return [...plugins];
+  }
+
   async listByIds(
     organizationId: string,
     ids: string[],
@@ -613,4 +652,55 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
     }
     return value as T;
   }
+}
+
+/**
+ * Wrap a (singleton) VirtualMCPStorage so `list` and `listEnabledPlugins` are
+ * memoized for the lifetime of one request. A single MCP/decopilot request
+ * fans out to several independent callers — management-tool filtering, plugin
+ * enablement checks, decopilot prompt assembly — that each re-read the org's
+ * virtual MCPs; without this they issue the same query 3+ times. Concurrent
+ * callers share the in-flight promise. Any write through this wrapper clears
+ * the cache, so a mutate-then-read within the same request stays correct.
+ */
+export function createRequestCachedVirtualMcps(
+  base: VirtualMCPStorage,
+): VirtualMCPStorage {
+  const cache = new Map<string, Promise<unknown>>();
+  const memoize = <T>(key: string, fn: () => Promise<T>): Promise<T> => {
+    const hit = cache.get(key);
+    if (hit) return hit as Promise<T>;
+    const promise = fn();
+    cache.set(key, promise);
+    return promise;
+  };
+
+  return new Proxy(base, {
+    get(target, prop, receiver) {
+      if (prop === "list") {
+        return (organizationId: string, options?: { pinnedOnly?: boolean }) =>
+          memoize(`list:${organizationId}:${options?.pinnedOnly ? 1 : 0}`, () =>
+            target.list(organizationId, options),
+          );
+      }
+      if (prop === "listEnabledPlugins") {
+        return (organizationId: string) =>
+          memoize(`plugins:${organizationId}`, () =>
+            target.listEnabledPlugins(organizationId),
+          );
+      }
+      if (
+        prop === "create" ||
+        prop === "update" ||
+        prop === "delete" ||
+        prop === "removeConnectionReferences"
+      ) {
+        return (...args: unknown[]) => {
+          cache.clear();
+          return (target[prop] as (...a: unknown[]) => unknown)(...args);
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
 }

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -241,16 +241,13 @@ export const managementMCP = async (ctx: StudioContext) => {
     const settings = await ctx.storage.organizationSettings.get(
       ctx.organization.id,
     );
-    const virtualMcps = await ctx.storage.virtualMcps.list(ctx.organization.id);
+    const virtualMcpPlugins = await ctx.storage.virtualMcps.listEnabledPlugins(
+      ctx.organization.id,
+    );
     // Merge enabled plugins from org settings + all virtual MCPs
     const merged = new Set<string>(settings?.enabled_plugins ?? []);
-    for (const virtualMcp of virtualMcps) {
-      const enabledPlugins = virtualMcp.metadata?.enabled_plugins;
-      if (enabledPlugins && Array.isArray(enabledPlugins)) {
-        for (const pluginId of enabledPlugins) {
-          merged.add(pluginId);
-        }
-      }
+    for (const pluginId of virtualMcpPlugins) {
+      merged.add(pluginId);
     }
     enabledPlugins = merged.size > 0 ? [...merged] : null;
   }


### PR DESCRIPTION
- Introduced `listEnabledPlugins` method in `VirtualMCPStorage` to efficiently retrieve enabled plugins across all virtual connections for an organization.
- Updated `plugin-loader` and `managementMCP` to utilize the new method, improving performance by reducing redundant queries.
- Implemented `createRequestCachedVirtualMcps` to cache results for virtual MCP requests, optimizing data retrieval during concurrent operations.
- Added event-loop lag monitoring to distinguish between slow queries and event-loop stalls, enhancing observability in database operations.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up virtual MCP plugin checks by querying only enabled plugin IDs and memoizing results per request. Add event-loop lag monitoring to tell slow SQL from event-loop stalls and improve slow-query logs.

- New Features
  - Added `VirtualMCPStorage.listEnabledPlugins` to return the union of enabled plugin IDs across an org’s virtual connections.
  - Introduced `createRequestCachedVirtualMcps` to memoize `list` and `listEnabledPlugins` per request; cache clears on writes.
  - Updated `plugin-loader` and `managementMCP` to use the new method, removing redundant reads.

- Observability
  - Added lightweight event-loop lag sampler and `getEventLoopLagMs`.
  - Slow-query logging now includes `eventLoopLagMs` and flags likely event-loop lag instead of blaming SQL.

<sup>Written for commit c8261eb515a90082d77e9e1ce6da543423ba824f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

