### PR TITLE
feat(sandbox): lazy file explorer tree with configurable glob limits

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -165,6 +165,18 @@ export function FileExplorer({
   const [loadedLazyDirs, setLoadedLazyDirs] = useState<Set<string>>(new Set());
   const [loadingDirs, setLoadingDirs] = useState<Set<string>>(new Set());
 
+  const treeGenerationRef = useRef(0);
+  const initialTreeLoadRef = useRef<Promise<void> | null>(null);
+  const filesRef = useRef<string[]>([]);
+  const directoriesRef = useRef<string[]>([]);
+  const loadedLazyDirsRef = useRef<Set<string>>(new Set());
+  const lazyLoadInflightRef = useRef<Map<string, Promise<boolean>>>(new Map());
+  const treeTruncatedRef = useRef(false);
+
+  filesRef.current = files;
+  directoriesRef.current = directories;
+  loadedLazyDirsRef.current = loadedLazyDirs;
+
   // File buffers: path -> { savedContent, editorValue, loaded }
   const [buffers, setBuffers] = useState<Map<string, FileBuffer>>(new Map());
 
@@ -441,7 +453,7 @@ export function FileExplorer({
   if (!loadTreeCalledRef.current) {
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- one-shot fetch trigger
     loadTreeCalledRef.current = true;
-    fetchFileTree();
+    initialTreeLoadRef.current = fetchFileTree();
   }
 
   // Deep-link: open the requested file when `openPath` is set or changes.
@@ -451,7 +463,11 @@ export function FileExplorer({
     const pathToOpen = openPath;
     queueMicrotask(() => {
       if (isSafeExplorerOpenPath(pathToOpen)) {
-        void handleFileClick(pathToOpen);
+        void handleFileClick(pathToOpen).catch((err) => {
+          toast.error(
+            err instanceof Error ? err.message : "Failed to open file",
+          );
+        });
       }
     });
   }
@@ -469,70 +485,115 @@ export function FileExplorer({
     };
   }
 
-  function applyGlobResult(result: GlobListResult, merge: boolean) {
+  function applyGlobResult(
+    result: GlobListResult,
+    merge: boolean,
+    generation: number,
+  ): boolean {
+    if (generation !== treeGenerationRef.current) return false;
+
     if (merge) {
-      const merged = mergeGlobLists(files, directories, result);
+      const merged = mergeGlobLists(
+        filesRef.current,
+        directoriesRef.current,
+        result,
+        treeTruncatedRef.current,
+      );
+      filesRef.current = merged.files;
+      directoriesRef.current = merged.directories;
+      treeTruncatedRef.current = Boolean(merged.truncated);
       setFiles(merged.files);
       setDirectories(merged.directories);
       if (merged.truncated) {
         toast.warning("File list truncated — some files may be hidden");
       }
-      return;
+      return Boolean(merged.truncated);
     }
+
+    filesRef.current = result.files;
+    directoriesRef.current = result.directories ?? [];
+    treeTruncatedRef.current = Boolean(result.truncated);
     setFiles(result.files);
     setDirectories(result.directories ?? []);
     if (result.truncated) {
       toast.warning("File list truncated — some files may be hidden");
     }
+    return Boolean(result.truncated);
   }
 
-  async function fetchDirChildren(dirPath: string) {
-    const result = await fetchGlob({
-      pattern: "**/*",
-      path: toDaemonPath(dirPath),
-      limit: EXPLORER_GLOB_LIMIT,
-    });
-    applyGlobResult(result, true);
-    setLoadedLazyDirs((prev) => {
-      const next = new Set(prev);
-      next.add(dirPath);
-      return next;
-    });
-  }
+  async function fetchDirChildren(dirPath: string): Promise<boolean> {
+    const inflight = lazyLoadInflightRef.current.get(dirPath);
+    if (inflight) return inflight;
 
-  async function ensureAncestorsLoaded(treePath: string) {
-    const loaded = new Set(loadedLazyDirs);
-    for (const dir of getAncestorDirectories(treePath)) {
-      if (!directoryNeedsLazyLoad(dir, loaded)) continue;
-      setLoadingDirs((prev) => new Set(prev).add(dir));
-      try {
-        await fetchDirChildren(dir);
-        loaded.add(dir);
-      } catch (err) {
-        toast.error(
-          err instanceof Error ? err.message : "Failed to load folder",
-        );
-        throw err;
-      } finally {
-        setLoadingDirs((prev) => {
+    const generation = treeGenerationRef.current;
+    const promise = (async () => {
+      const result = await fetchGlob({
+        pattern: "**/*",
+        path: toDaemonPath(dirPath),
+        limit: EXPLORER_GLOB_LIMIT,
+      });
+      const truncated = applyGlobResult(result, true, generation);
+      if (!truncated && generation === treeGenerationRef.current) {
+        setLoadedLazyDirs((prev) => {
           const next = new Set(prev);
-          next.delete(dir);
+          next.add(dirPath);
           return next;
         });
       }
+      return truncated;
+    })();
+
+    lazyLoadInflightRef.current.set(dirPath, promise);
+    try {
+      return await promise;
+    } finally {
+      lazyLoadInflightRef.current.delete(dirPath);
+    }
+  }
+
+  async function loadLazyDirectory(dirPath: string): Promise<boolean> {
+    if (!directoryNeedsLazyLoad(dirPath, loadedLazyDirsRef.current)) {
+      return false;
+    }
+    setLoadingDirs((prev) => new Set(prev).add(dirPath));
+    try {
+      return await fetchDirChildren(dirPath);
+    } finally {
+      setLoadingDirs((prev) => {
+        const next = new Set(prev);
+        next.delete(dirPath);
+        return next;
+      });
+    }
+  }
+
+  async function ensureAncestorsLoaded(treePath: string) {
+    const loaded = new Set(loadedLazyDirsRef.current);
+    for (const dir of getAncestorDirectories(treePath)) {
+      if (!directoryNeedsLazyLoad(dir, loaded)) continue;
+      const truncated = await loadLazyDirectory(dir);
+      if (truncated) {
+        throw new Error("Folder listing truncated — expand again to load more");
+      }
+      loaded.add(dir);
     }
   }
 
   async function fetchFileTree() {
+    const generation = ++treeGenerationRef.current;
+    lazyLoadInflightRef.current.clear();
+    treeTruncatedRef.current = false;
     setLoading(true);
     setLoadedLazyDirs(new Set());
+    setExpandedDirs(new Set());
+    setLoadingDirs(new Set());
     try {
       const result = await fetchGlob({
         pattern: "**/*",
         limit: EXPLORER_GLOB_LIMIT,
         maxDepth: EXPLORER_EAGER_DEPTH,
       });
-      applyGlobResult(result, false);
+      applyGlobResult(result, false, generation);
       setTreeLoaded(true);
     } catch {
       if (treeLoaded) {
@@ -668,21 +729,15 @@ export function FileExplorer({
   }
 
   async function expandDirectory(dirPath: string) {
-    if (directoryNeedsLazyLoad(dirPath, loadedLazyDirs)) {
-      setLoadingDirs((prev) => new Set(prev).add(dirPath));
+    if (directoryNeedsLazyLoad(dirPath, loadedLazyDirsRef.current)) {
       try {
-        await fetchDirChildren(dirPath);
+        const truncated = await loadLazyDirectory(dirPath);
+        if (truncated) return;
       } catch (err) {
         toast.error(
           err instanceof Error ? err.message : "Failed to load folder",
         );
         return;
-      } finally {
-        setLoadingDirs((prev) => {
-          const next = new Set(prev);
-          next.delete(dirPath);
-          return next;
-        });
       }
     }
     toggleDir(dirPath);
@@ -697,6 +752,7 @@ export function FileExplorer({
   }
 
   async function handleFileClick(path: string) {
+    await initialTreeLoadRef.current;
     await ensureAncestorsLoaded(path);
     const ancestors = getAncestorDirectories(path);
     setExpandedDirs((prev) => {

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -49,17 +49,22 @@ import { FileTreeRow } from "./file-tree-row";
 import {
   buildFileTree,
   decoBlockKeyFromTreePath,
+  directoryNeedsLazyLoad,
+  EXPLORER_EAGER_DEPTH,
+  EXPLORER_GLOB_LIMIT,
   flattenTree,
   getAncestorDirectories,
   getDirectoryContextPath,
   getLanguageFromPath,
   getParentTreePath,
   joinTreePath,
+  mergeGlobLists,
   pathExistsInFileList,
   stripLineNumbers,
   toDaemonPath,
   toTreePath,
   validateExplorerEntryName,
+  type GlobListResult,
 } from "./utils";
 
 // Configure Monaco CDN (shared with workflow editor)
@@ -157,6 +162,8 @@ export function FileExplorer({
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(false);
   const [treeLoaded, setTreeLoaded] = useState(false);
+  const [loadedLazyDirs, setLoadedLazyDirs] = useState<Set<string>>(new Set());
+  const [loadingDirs, setLoadingDirs] = useState<Set<string>>(new Set());
 
   // File buffers: path -> { savedContent, editorValue, loaded }
   const [buffers, setBuffers] = useState<Map<string, FileBuffer>>(new Map());
@@ -444,43 +451,93 @@ export function FileExplorer({
     const pathToOpen = openPath;
     queueMicrotask(() => {
       if (isSafeExplorerOpenPath(pathToOpen)) {
-        handleFileClick(pathToOpen);
+        void handleFileClick(pathToOpen);
       }
     });
   }
 
+  async function fetchGlob(
+    body: Record<string, unknown>,
+  ): Promise<GlobListResult> {
+    const data = (await postSandbox("glob", body)) as GlobListResult & {
+      error?: string;
+    };
+    return {
+      files: data.files ?? [],
+      directories: data.directories ?? [],
+      truncated: data.truncated,
+    };
+  }
+
+  function applyGlobResult(result: GlobListResult, merge: boolean) {
+    if (merge) {
+      const merged = mergeGlobLists(files, directories, result);
+      setFiles(merged.files);
+      setDirectories(merged.directories);
+      if (merged.truncated) {
+        toast.warning("File list truncated — some files may be hidden");
+      }
+      return;
+    }
+    setFiles(result.files);
+    setDirectories(result.directories ?? []);
+    if (result.truncated) {
+      toast.warning("File list truncated — some files may be hidden");
+    }
+  }
+
+  async function fetchDirChildren(dirPath: string) {
+    const result = await fetchGlob({
+      pattern: "**/*",
+      path: toDaemonPath(dirPath),
+      limit: EXPLORER_GLOB_LIMIT,
+    });
+    applyGlobResult(result, true);
+    setLoadedLazyDirs((prev) => {
+      const next = new Set(prev);
+      next.add(dirPath);
+      return next;
+    });
+  }
+
+  async function ensureAncestorsLoaded(treePath: string) {
+    const loaded = new Set(loadedLazyDirs);
+    for (const dir of getAncestorDirectories(treePath)) {
+      if (!directoryNeedsLazyLoad(dir, loaded)) continue;
+      setLoadingDirs((prev) => new Set(prev).add(dir));
+      try {
+        await fetchDirChildren(dir);
+        loaded.add(dir);
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to load folder",
+        );
+        throw err;
+      } finally {
+        setLoadingDirs((prev) => {
+          const next = new Set(prev);
+          next.delete(dir);
+          return next;
+        });
+      }
+    }
+  }
+
   async function fetchFileTree() {
     setLoading(true);
+    setLoadedLazyDirs(new Set());
     try {
-      const res = await fetch(
-        buildApiUrl(orgSlug, virtualMcpId, branch, "glob"),
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ pattern: "**/*" }),
-        },
-      );
-      if (!res.ok) {
-        if (treeLoaded) {
-          toast.error("Failed to refresh file tree");
-        }
-        return;
-      }
-      const data = (await res.json()) as {
-        files?: string[];
-        directories?: string[];
-      };
-      const nextFiles = data.files ?? [];
-      setFiles(nextFiles);
-      setDirectories((prev) => {
-        if (data.directories !== undefined) return data.directories;
-        // Legacy daemons omit `directories`; keep client-side empty dirs
-        // until the sandbox daemon is restarted with directory support.
-        return prev.filter(
-          (dir) => !pathExistsInFileList(toTreePath(dir), nextFiles),
-        );
+      const result = await fetchGlob({
+        pattern: "**/*",
+        limit: EXPLORER_GLOB_LIMIT,
+        maxDepth: EXPLORER_EAGER_DEPTH,
       });
+      applyGlobResult(result, false);
       setTreeLoaded(true);
+    } catch {
+      if (treeLoaded) {
+        toast.error("Failed to refresh file tree");
+      }
     } finally {
       setLoading(false);
     }
@@ -610,8 +667,37 @@ export function FileExplorer({
     });
   }
 
-  function handleFileClick(path: string) {
-    // Auto-expand ancestor directories
+  async function expandDirectory(dirPath: string) {
+    if (directoryNeedsLazyLoad(dirPath, loadedLazyDirs)) {
+      setLoadingDirs((prev) => new Set(prev).add(dirPath));
+      try {
+        await fetchDirChildren(dirPath);
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to load folder",
+        );
+        return;
+      } finally {
+        setLoadingDirs((prev) => {
+          const next = new Set(prev);
+          next.delete(dirPath);
+          return next;
+        });
+      }
+    }
+    toggleDir(dirPath);
+  }
+
+  async function handleDirectoryOpen(dirPath: string, isExpanded: boolean) {
+    if (isExpanded) {
+      toggleDir(dirPath);
+      return;
+    }
+    await expandDirectory(dirPath);
+  }
+
+  async function handleFileClick(path: string) {
+    await ensureAncestorsLoaded(path);
     const ancestors = getAncestorDirectories(path);
     setExpandedDirs((prev) => {
       const next = new Set(prev);
@@ -783,6 +869,7 @@ export function FileExplorer({
               const isExpanded = expandedDirs.has(node.path);
               const isSelected = selectedTreeNode?.path === node.path;
               const parentDir = getDirectoryContextPath(node.path, node.kind);
+              const isDirLoading = isDir && loadingDirs.has(node.path);
 
               return (
                 <FileTreeRow
@@ -791,13 +878,14 @@ export function FileExplorer({
                   depth={depth}
                   isExpanded={isExpanded}
                   isSelected={isSelected}
+                  isLoading={isDirLoading}
                   fileVisual={getFileVisual(node.name)}
                   onSelect={() => setSelectedTreeNode(node)}
                   onOpen={() => {
                     if (isDir) {
-                      toggleDir(node.path);
+                      void handleDirectoryOpen(node.path, isExpanded);
                     } else {
-                      handleFileClick(node.path);
+                      void handleFileClick(node.path);
                     }
                   }}
                   onNewFile={() =>

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -151,8 +151,12 @@ export function FileExplorer({
   openPath,
 }: FileExplorerProps) {
   // File tree state
-  const [files, setFiles] = useState<string[]>([]);
-  const [directories, setDirectories] = useState<string[]>([]);
+  const [treeLists, setTreeLists] = useState<{
+    files: string[];
+    directories: string[];
+    truncated: boolean;
+  }>({ files: [], directories: [], truncated: false });
+  const { files, directories } = treeLists;
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [selectedTreeNode, setSelectedTreeNode] = useState<TreeNode | null>(
@@ -162,20 +166,23 @@ export function FileExplorer({
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(false);
   const [treeLoaded, setTreeLoaded] = useState(false);
-  const [loadedLazyDirs, setLoadedLazyDirs] = useState<Set<string>>(new Set());
+  const [, setLoadedLazyDirs] = useState<Set<string>>(new Set());
   const [loadingDirs, setLoadingDirs] = useState<Set<string>>(new Set());
 
   const treeGenerationRef = useRef(0);
   const initialTreeLoadRef = useRef<Promise<void> | null>(null);
-  const filesRef = useRef<string[]>([]);
-  const directoriesRef = useRef<string[]>([]);
   const loadedLazyDirsRef = useRef<Set<string>>(new Set());
   const lazyLoadInflightRef = useRef<Map<string, Promise<boolean>>>(new Map());
-  const treeTruncatedRef = useRef(false);
 
-  filesRef.current = files;
-  directoriesRef.current = directories;
-  loadedLazyDirsRef.current = loadedLazyDirs;
+  function updateLoadedLazyDirs(
+    updater: Set<string> | ((prev: Set<string>) => Set<string>),
+  ) {
+    setLoadedLazyDirs((prev) => {
+      const next = typeof updater === "function" ? updater(prev) : updater;
+      loadedLazyDirsRef.current = next;
+      return next;
+    });
+  }
 
   // File buffers: path -> { savedContent, editorValue, loaded }
   const [buffers, setBuffers] = useState<Map<string, FileBuffer>>(new Map());
@@ -354,9 +361,12 @@ export function FileExplorer({
     }
     const daemonFolderPath = toDaemonPath(folderPath);
     await postSandbox("mkdir", { path: daemonFolderPath });
-    setDirectories((prev) =>
-      prev.includes(daemonFolderPath) ? prev : [...prev, daemonFolderPath],
-    );
+    setTreeLists((prev) => ({
+      ...prev,
+      directories: prev.directories.includes(daemonFolderPath)
+        ? prev.directories
+        : [...prev.directories, daemonFolderPath],
+    }));
     await fetchFileTree();
     await refreshGitStatus();
     setNameDialog(null);
@@ -453,6 +463,7 @@ export function FileExplorer({
   if (!loadTreeCalledRef.current) {
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- one-shot fetch trigger
     loadTreeCalledRef.current = true;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- one-shot fetch trigger
     initialTreeLoadRef.current = fetchFileTree();
   }
 
@@ -492,33 +503,26 @@ export function FileExplorer({
   ): boolean {
     if (generation !== treeGenerationRef.current) return false;
 
-    if (merge) {
-      const merged = mergeGlobLists(
-        filesRef.current,
-        directoriesRef.current,
-        result,
-        treeTruncatedRef.current,
-      );
-      filesRef.current = merged.files;
-      directoriesRef.current = merged.directories;
-      treeTruncatedRef.current = Boolean(merged.truncated);
-      setFiles(merged.files);
-      setDirectories(merged.directories);
-      if (merged.truncated) {
-        toast.warning("File list truncated — some files may be hidden");
-      }
-      return Boolean(merged.truncated);
-    }
-
-    filesRef.current = result.files;
-    directoriesRef.current = result.directories ?? [];
-    treeTruncatedRef.current = Boolean(result.truncated);
-    setFiles(result.files);
-    setDirectories(result.directories ?? []);
-    if (result.truncated) {
+    let truncated = false;
+    setTreeLists((prev) => {
+      const merged = merge
+        ? mergeGlobLists(prev.files, prev.directories, result, prev.truncated)
+        : {
+            files: result.files,
+            directories: result.directories ?? [],
+            truncated: Boolean(result.truncated),
+          };
+      truncated = Boolean(merged.truncated);
+      return {
+        files: merged.files,
+        directories: merged.directories,
+        truncated,
+      };
+    });
+    if (truncated) {
       toast.warning("File list truncated — some files may be hidden");
     }
-    return Boolean(result.truncated);
+    return truncated;
   }
 
   async function fetchDirChildren(dirPath: string): Promise<boolean> {
@@ -534,7 +538,7 @@ export function FileExplorer({
       });
       const truncated = applyGlobResult(result, true, generation);
       if (!truncated && generation === treeGenerationRef.current) {
-        setLoadedLazyDirs((prev) => {
+        updateLoadedLazyDirs((prev) => {
           const next = new Set(prev);
           next.add(dirPath);
           return next;
@@ -582,9 +586,8 @@ export function FileExplorer({
   async function fetchFileTree() {
     const generation = ++treeGenerationRef.current;
     lazyLoadInflightRef.current.clear();
-    treeTruncatedRef.current = false;
     setLoading(true);
-    setLoadedLazyDirs(new Set());
+    updateLoadedLazyDirs(new Set());
     setExpandedDirs(new Set());
     setLoadingDirs(new Set());
     try {

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-tree-row.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-tree-row.tsx
@@ -5,7 +5,12 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@deco/ui/components/context-menu.tsx";
-import { ChevronDown, ChevronRight, Folder } from "@untitledui/icons";
+import {
+  ChevronDown,
+  ChevronRight,
+  Folder,
+  Loading01,
+} from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.js";
 import type { TreeNode } from "./types";
 
@@ -22,6 +27,7 @@ export function FileTreeRow({
   depth,
   isExpanded,
   isSelected,
+  isLoading = false,
   fileVisual,
   onOpen,
   onSelect,
@@ -36,6 +42,7 @@ export function FileTreeRow({
   depth: number;
   isExpanded: boolean;
   isSelected: boolean;
+  isLoading?: boolean;
   fileVisual: { Icon: FileIcon; color: string };
   onOpen: () => void;
   onSelect: () => void;
@@ -66,7 +73,12 @@ export function FileTreeRow({
         >
           {isDir ? (
             <>
-              {isExpanded ? (
+              {isLoading ? (
+                <Loading01
+                  size={14}
+                  className="shrink-0 animate-spin text-muted-foreground"
+                />
+              ) : isExpanded ? (
                 <ChevronDown
                   size={14}
                   className="shrink-0 text-muted-foreground"

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -108,7 +108,12 @@ describe("file-explorer utils", () => {
 
   it("mergeGlobLists preserves truncated across merges", () => {
     expect(
-      mergeGlobLists(["a.ts"], ["src"], { files: [], truncated: true }, true),
+      mergeGlobLists(
+        ["a.ts"],
+        ["src"],
+        { files: [], directories: [], truncated: true },
+        true,
+      ),
     ).toEqual({
       files: ["a.ts"],
       directories: ["src"],

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "bun:test";
 import {
   buildFileTree,
   decoBlockKeyFromTreePath,
+  directoryNeedsLazyLoad,
+  EXPLORER_EAGER_DEPTH,
   flattenTree,
   getDirectoryContextPath,
   getParentTreePath,
+  getPathDepth,
   joinTreePath,
+  mergeGlobLists,
   pathExistsInFileList,
   toDaemonPath,
   toTreePath,
@@ -72,5 +76,35 @@ describe("file-explorer utils", () => {
     expect(toTreePath("src/index.ts")).toBe("/src/index.ts");
     expect(toTreePath("/src/index.ts")).toBe("/src/index.ts");
     expect(toTreePath("")).toBe("/");
+  });
+
+  it("getPathDepth counts tree path segments", () => {
+    expect(getPathDepth("/")).toBe(0);
+    expect(getPathDepth("/apps")).toBe(1);
+    expect(getPathDepth("/apps/mesh/src")).toBe(3);
+    expect(getPathDepth("/apps/mesh/src/index.ts")).toBe(4);
+  });
+
+  it("directoryNeedsLazyLoad is true at EXPLORER_EAGER_DEPTH and above", () => {
+    const loaded = new Set(["/apps/mesh/src"]);
+    expect(directoryNeedsLazyLoad("/apps", loaded)).toBe(false);
+    expect(directoryNeedsLazyLoad("/apps/mesh/src", loaded)).toBe(false);
+    expect(directoryNeedsLazyLoad("/apps/mesh/deep", loaded)).toBe(true);
+    expect(getPathDepth("/apps/mesh/deep")).toBeGreaterThanOrEqual(
+      EXPLORER_EAGER_DEPTH,
+    );
+  });
+
+  it("mergeGlobLists unions files and directories", () => {
+    expect(
+      mergeGlobLists(["a.ts"], ["src"], {
+        files: ["b.ts"],
+        directories: ["src/components"],
+      }),
+    ).toEqual({
+      files: ["a.ts", "b.ts"],
+      directories: ["src", "src/components"],
+      truncated: undefined,
+    });
   });
 });

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -3,7 +3,6 @@ import {
   buildFileTree,
   decoBlockKeyFromTreePath,
   directoryNeedsLazyLoad,
-  EXPLORER_EAGER_DEPTH,
   flattenTree,
   getDirectoryContextPath,
   getParentTreePath,
@@ -85,13 +84,12 @@ describe("file-explorer utils", () => {
     expect(getPathDepth("/apps/mesh/src/index.ts")).toBe(4);
   });
 
-  it("directoryNeedsLazyLoad is true at EXPLORER_EAGER_DEPTH and above", () => {
+  it("directoryNeedsLazyLoad is true only below eager depth boundary", () => {
     const loaded = new Set(["/apps/mesh/src"]);
     expect(directoryNeedsLazyLoad("/apps", loaded)).toBe(false);
     expect(directoryNeedsLazyLoad("/apps/mesh/src", loaded)).toBe(false);
-    expect(directoryNeedsLazyLoad("/apps/mesh/deep", loaded)).toBe(true);
-    expect(getPathDepth("/apps/mesh/deep")).toBeGreaterThanOrEqual(
-      EXPLORER_EAGER_DEPTH,
+    expect(directoryNeedsLazyLoad("/apps/mesh/src/components", loaded)).toBe(
+      true,
     );
   });
 
@@ -104,7 +102,17 @@ describe("file-explorer utils", () => {
     ).toEqual({
       files: ["a.ts", "b.ts"],
       directories: ["src", "src/components"],
-      truncated: undefined,
+      truncated: false,
+    });
+  });
+
+  it("mergeGlobLists preserves truncated across merges", () => {
+    expect(
+      mergeGlobLists(["a.ts"], ["src"], { files: [], truncated: true }, true),
+    ).toEqual({
+      files: ["a.ts"],
+      directories: ["src"],
+      truncated: true,
     });
   });
 });

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -80,11 +80,12 @@ export function mergeGlobLists(
   prevFiles: readonly string[],
   prevDirs: readonly string[],
   next: GlobListResult,
+  prevTruncated = false,
 ): GlobListResult {
   return {
     files: [...new Set([...prevFiles, ...next.files])],
     directories: [...new Set([...prevDirs, ...(next.directories ?? [])])],
-    truncated: next.truncated,
+    truncated: prevTruncated || Boolean(next.truncated),
   };
 }
 
@@ -93,7 +94,7 @@ export function directoryNeedsLazyLoad(
   loadedLazyDirs: ReadonlySet<string>,
 ): boolean {
   return (
-    getPathDepth(treePath) >= EXPLORER_EAGER_DEPTH &&
+    getPathDepth(treePath) > EXPLORER_EAGER_DEPTH &&
     !loadedLazyDirs.has(treePath)
   );
 }

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -1,5 +1,16 @@
 import type { FlatNode, TreeNode } from "./types";
 
+/** File explorer glob cap (agent default stays 1000 on the daemon). */
+export const EXPLORER_GLOB_LIMIT = 10_000;
+/** Eager-load directory depth; deeper paths load on expand. */
+export const EXPLORER_EAGER_DEPTH = 3;
+
+export type GlobListResult = {
+  files: string[];
+  directories: string[];
+  truncated?: boolean;
+};
+
 function normalizePath(path: string) {
   if (!path.trim()) {
     return "/";
@@ -57,6 +68,34 @@ export function validateExplorerEntryName(name: string): string | null {
     return "Name cannot start with a dot";
   }
   return null;
+}
+
+export function getPathDepth(treePath: string): number {
+  const daemonPath = toDaemonPath(treePath);
+  if (!daemonPath) return 0;
+  return daemonPath.split("/").filter(Boolean).length;
+}
+
+export function mergeGlobLists(
+  prevFiles: readonly string[],
+  prevDirs: readonly string[],
+  next: GlobListResult,
+): GlobListResult {
+  return {
+    files: [...new Set([...prevFiles, ...next.files])],
+    directories: [...new Set([...prevDirs, ...(next.directories ?? [])])],
+    truncated: next.truncated,
+  };
+}
+
+export function directoryNeedsLazyLoad(
+  treePath: string,
+  loadedLazyDirs: ReadonlySet<string>,
+): boolean {
+  return (
+    getPathDepth(treePath) >= EXPLORER_EAGER_DEPTH &&
+    !loadedLazyDirs.has(treePath)
+  );
 }
 
 /** Whether `treePath` already exists in the glob file list (file or directory). */

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -24,6 +24,7 @@ import {
   registerGlobAncestorDirectories,
   GLOB_RESULT_LIMIT,
   GLOB_MAX_RESULT_LIMIT,
+  resolveGlobResultLimit,
 } from "./fs";
 
 const hasRg = spawnSync("which", ["rg"]).status === 0;
@@ -348,23 +349,30 @@ describe("fs handlers", () => {
     expect(body.directories).toContain("a/b/c");
   });
 
-  it("glob: explicit limit is capped at GLOB_MAX_RESULT_LIMIT", async () => {
-    for (let i = 0; i < GLOB_MAX_RESULT_LIMIT + 5; i++) {
+  it("glob: explicit limit truncates results", async () => {
+    for (let i = 0; i < 7; i++) {
       writeFileSync(join(appRoot, `file-${i}.txt`), "");
     }
     const h = makeGlobHandler({ appRoot, repoDir: appRoot });
     const res = await h(
       post("/_sandbox/glob", {
         pattern: "*.txt",
-        limit: GLOB_MAX_RESULT_LIMIT + 999,
+        limit: 5,
       }),
     );
     const body = (await res.json()) as {
       files: string[];
       truncated?: boolean;
     };
-    expect(body.files.length).toBe(GLOB_MAX_RESULT_LIMIT);
+    expect(body.files.length).toBe(5);
     expect(body.truncated).toBe(true);
+  });
+
+  it("resolveGlobResultLimit caps at GLOB_MAX_RESULT_LIMIT", () => {
+    expect(resolveGlobResultLimit(undefined)).toBe(GLOB_RESULT_LIMIT);
+    expect(resolveGlobResultLimit(GLOB_MAX_RESULT_LIMIT + 999)).toBe(
+      GLOB_MAX_RESULT_LIMIT,
+    );
   });
 
   it("glob: default limit remains GLOB_RESULT_LIMIT for agents", async () => {
@@ -389,6 +397,12 @@ describe("fs handlers", () => {
   it("registerGlobAncestorDirectories adds ancestors up to maxDepth", () => {
     const dirs = new Set<string>();
     registerGlobAncestorDirectories("a/b/c/d.ts", 3, dirs, true);
+    expect([...dirs].sort()).toEqual(["a", "a/b", "a/b/c"]);
+  });
+
+  it("registerGlobAncestorDirectories handles directory paths", () => {
+    const dirs = new Set<string>();
+    registerGlobAncestorDirectories("a/b/c/d", 3, dirs, false);
     expect([...dirs].sort()).toEqual(["a", "a/b", "a/b/c"]);
   });
 

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -20,6 +20,10 @@ import {
   makeGrepHandler,
   makeGlobHandler,
   collectEmptyDirectories,
+  pathSegmentDepth,
+  registerGlobAncestorDirectories,
+  GLOB_RESULT_LIMIT,
+  GLOB_MAX_RESULT_LIMIT,
 } from "./fs";
 
 const hasRg = spawnSync("which", ["rg"]).status === 0;
@@ -325,6 +329,67 @@ describe("fs handlers", () => {
     const res = await h(post("/_sandbox/glob", { pattern: "**/*" }));
     const body = (await res.json()) as { files: string[] };
     expect(body.files).toContain("empty-dir/.gitkeep");
+  });
+
+  it("glob: maxDepth skips deeper files but registers ancestor directories", async () => {
+    mkdirSync(join(appRoot, "a/b/c/d"), { recursive: true });
+    writeFileSync(join(appRoot, "a/b/c/d/deep.txt"), "x");
+    writeFileSync(join(appRoot, "a/b/shallow.txt"), "y");
+    const h = makeGlobHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/glob", { pattern: "**/*", maxDepth: 3 }),
+    );
+    const body = (await res.json()) as {
+      files: string[];
+      directories: string[];
+    };
+    expect(body.files).toContain("a/b/shallow.txt");
+    expect(body.files).not.toContain("a/b/c/d/deep.txt");
+    expect(body.directories).toContain("a/b/c");
+  });
+
+  it("glob: explicit limit is capped at GLOB_MAX_RESULT_LIMIT", async () => {
+    for (let i = 0; i < GLOB_MAX_RESULT_LIMIT + 5; i++) {
+      writeFileSync(join(appRoot, `file-${i}.txt`), "");
+    }
+    const h = makeGlobHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/glob", {
+        pattern: "*.txt",
+        limit: GLOB_MAX_RESULT_LIMIT + 999,
+      }),
+    );
+    const body = (await res.json()) as {
+      files: string[];
+      truncated?: boolean;
+    };
+    expect(body.files.length).toBe(GLOB_MAX_RESULT_LIMIT);
+    expect(body.truncated).toBe(true);
+  });
+
+  it("glob: default limit remains GLOB_RESULT_LIMIT for agents", async () => {
+    for (let i = 0; i < GLOB_RESULT_LIMIT + 5; i++) {
+      writeFileSync(join(appRoot, `agent-${i}.txt`), "");
+    }
+    const h = makeGlobHandler({ appRoot, repoDir: appRoot });
+    const res = await h(post("/_sandbox/glob", { pattern: "agent-*.txt" }));
+    const body = (await res.json()) as {
+      files: string[];
+      truncated?: boolean;
+    };
+    expect(body.files.length).toBe(GLOB_RESULT_LIMIT);
+    expect(body.truncated).toBe(true);
+  });
+
+  it("pathSegmentDepth counts path segments", () => {
+    expect(pathSegmentDepth("a/b/c.ts")).toBe(3);
+    expect(pathSegmentDepth("README.md")).toBe(1);
+  });
+
+  it("registerGlobAncestorDirectories adds ancestors up to maxDepth", () => {
+    const dirs = new Set<string>();
+    registerGlobAncestorDirectories("a/b/c/d.ts", 3, dirs, true);
+    expect([...dirs].sort()).toEqual(["a", "a/b", "a/b/c"]);
   });
 
   it("collectEmptyDirectories ignores parents of nested directories", () => {

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -717,11 +717,81 @@ export function registerGlobAncestorDirectories(
   }
 }
 
-function resolveGlobResultLimit(limit: unknown): number {
+export function resolveGlobResultLimit(limit: unknown): number {
   if (limit === undefined || limit === null) return GLOB_RESULT_LIMIT;
   const n = typeof limit === "number" ? limit : Number(limit);
   if (!Number.isFinite(n) || n < 1) return GLOB_RESULT_LIMIT;
   return Math.min(Math.floor(n), GLOB_MAX_RESULT_LIMIT);
+}
+
+function repoRelativePrefix(searchPath: string, repoDir: string): string {
+  if (searchPath === repoDir) return "";
+  return path.relative(repoDir, searchPath).replace(/\\/g, "/");
+}
+
+function joinRepoRelative(prefix: string, name: string): string {
+  return prefix ? `${prefix}/${name}` : name;
+}
+
+type GlobScanState = {
+  filePaths: string[];
+  directoryPaths: Set<string>;
+  resultLimit: number;
+};
+
+/** Depth-bounded directory walk — avoids scanning the full tree for maxDepth. */
+function walkRepoWithinMaxDepth(
+  absDir: string,
+  repoRelDir: string,
+  maxDepth: number,
+  state: GlobScanState,
+): boolean {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  for (const entry of entries) {
+    const childRel = joinRepoRelative(repoRelDir, entry.name);
+    if (!isGlobPathAllowed(childRel)) continue;
+    if (entry.isSymbolicLink()) continue;
+
+    const depth = pathSegmentDepth(childRel);
+
+    if (entry.isDirectory()) {
+      if (depth > maxDepth) {
+        registerGlobAncestorDirectories(
+          childRel,
+          maxDepth,
+          state.directoryPaths,
+          false,
+        );
+        continue;
+      }
+      state.directoryPaths.add(childRel);
+      if (depth < maxDepth) {
+        const childAbs = path.join(absDir, entry.name);
+        if (walkRepoWithinMaxDepth(childAbs, childRel, maxDepth, state)) {
+          return true;
+        }
+      }
+    } else if (entry.isFile()) {
+      if (depth > maxDepth) {
+        registerGlobAncestorDirectories(
+          childRel,
+          maxDepth,
+          state.directoryPaths,
+          true,
+        );
+        continue;
+      }
+      state.filePaths.push(childRel);
+      if (state.filePaths.length >= state.resultLimit) return true;
+    }
+  }
+  return false;
 }
 
 function isGlobPathAllowed(rel: string): boolean {
@@ -814,44 +884,58 @@ export function makeGlobHandler(deps: FsDeps) {
 
     // Bun.Glob — no external binary dependency. Returns paths relative
     // to `cwd`, which we re-anchor to repoDir for consistent UX.
-    const glob = new Bun.Glob(body.pattern);
     const filePaths: string[] = [];
     const directoryPaths = new Set<string>();
     let truncated = false;
     try {
-      for await (const rel of glob.scan({
-        cwd: searchPath,
-        onlyFiles: false,
-        followSymlinks: false,
-        dot: true,
-      })) {
-        if (!isGlobPathAllowed(rel)) continue;
-        const abs = path.join(searchPath, rel);
-        let relPath: string;
-        try {
-          const stat = fs.statSync(abs);
-          relPath = toRepoRelativePath(abs, searchPath, deps.repoDir);
-          const depth = pathSegmentDepth(relPath);
-          if (maxDepth !== undefined && depth > maxDepth) {
-            registerGlobAncestorDirectories(
-              relPath,
-              maxDepth,
-              directoryPaths,
-              stat.isFile(),
-            );
+      if (maxDepth !== undefined && body.pattern === "**/*") {
+        const state: GlobScanState = {
+          filePaths,
+          directoryPaths,
+          resultLimit,
+        };
+        truncated = walkRepoWithinMaxDepth(
+          searchPath,
+          repoRelativePrefix(searchPath, deps.repoDir),
+          maxDepth,
+          state,
+        );
+      } else {
+        const glob = new Bun.Glob(body.pattern);
+        for await (const rel of glob.scan({
+          cwd: searchPath,
+          onlyFiles: false,
+          followSymlinks: false,
+          dot: true,
+        })) {
+          if (!isGlobPathAllowed(rel)) continue;
+          const abs = path.join(searchPath, rel);
+          let relPath: string;
+          try {
+            const stat = fs.statSync(abs);
+            relPath = toRepoRelativePath(abs, searchPath, deps.repoDir);
+            const depth = pathSegmentDepth(relPath);
+            if (maxDepth !== undefined && depth > maxDepth) {
+              registerGlobAncestorDirectories(
+                relPath,
+                maxDepth,
+                directoryPaths,
+                stat.isFile(),
+              );
+              continue;
+            }
+            if (stat.isDirectory()) {
+              directoryPaths.add(relPath);
+            } else if (stat.isFile()) {
+              filePaths.push(relPath);
+            }
+          } catch {
             continue;
           }
-          if (stat.isDirectory()) {
-            directoryPaths.add(relPath);
-          } else if (stat.isFile()) {
-            filePaths.push(relPath);
+          if (filePaths.length >= resultLimit) {
+            truncated = true;
+            break;
           }
-        } catch {
-          continue;
-        }
-        if (filePaths.length >= resultLimit) {
-          truncated = true;
-          break;
         }
       }
     } catch (e) {

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -694,7 +694,35 @@ const GLOB_EXCLUDE_DIRS = new Set([
   ".aws",
   ".gnupg",
 ]);
-const GLOB_RESULT_LIMIT = 1000;
+/** Default cap for agent glob calls. */
+export const GLOB_RESULT_LIMIT = 1000;
+/** Hard ceiling when callers pass an explicit `limit` (file explorer). */
+export const GLOB_MAX_RESULT_LIMIT = 10_000;
+
+export function pathSegmentDepth(relPath: string): number {
+  return relPath.split("/").filter(Boolean).length;
+}
+
+/** Register repo-relative ancestor directories up to `maxDepth`. */
+export function registerGlobAncestorDirectories(
+  repoRelativePath: string,
+  maxDepth: number,
+  directoryPaths: Set<string>,
+  isFile: boolean,
+): void {
+  const parts = repoRelativePath.split("/").filter(Boolean);
+  const dirParts = isFile ? parts.slice(0, -1) : parts;
+  for (let i = 1; i <= Math.min(dirParts.length, maxDepth); i++) {
+    directoryPaths.add(dirParts.slice(0, i).join("/"));
+  }
+}
+
+function resolveGlobResultLimit(limit: unknown): number {
+  if (limit === undefined || limit === null) return GLOB_RESULT_LIMIT;
+  const n = typeof limit === "number" ? limit : Number(limit);
+  if (!Number.isFinite(n) || n < 1) return GLOB_RESULT_LIMIT;
+  return Math.min(Math.floor(n), GLOB_MAX_RESULT_LIMIT);
+}
 
 function isGlobPathAllowed(rel: string): boolean {
   for (const seg of rel.split("/")) {
@@ -759,7 +787,12 @@ export function collectEmptyDirectories(
 
 export function makeGlobHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {
-    let body: { pattern?: string; path?: string };
+    let body: {
+      pattern?: string;
+      path?: string;
+      limit?: number;
+      maxDepth?: number;
+    };
     try {
       body = (await parseJsonBody(req)) as typeof body;
     } catch (e) {
@@ -773,11 +806,18 @@ export function makeGlobHandler(deps: FsDeps) {
     if (!searchPath)
       return jsonResponse({ error: "Path escapes app root" }, 400);
 
+    const resultLimit = resolveGlobResultLimit(body.limit);
+    const maxDepth =
+      body.maxDepth === undefined || body.maxDepth === null
+        ? undefined
+        : Math.max(1, Math.floor(body.maxDepth));
+
     // Bun.Glob — no external binary dependency. Returns paths relative
     // to `cwd`, which we re-anchor to repoDir for consistent UX.
     const glob = new Bun.Glob(body.pattern);
     const filePaths: string[] = [];
     const directoryPaths = new Set<string>();
+    let truncated = false;
     try {
       for await (const rel of glob.scan({
         cwd: searchPath,
@@ -791,6 +831,16 @@ export function makeGlobHandler(deps: FsDeps) {
         try {
           const stat = fs.statSync(abs);
           relPath = toRepoRelativePath(abs, searchPath, deps.repoDir);
+          const depth = pathSegmentDepth(relPath);
+          if (maxDepth !== undefined && depth > maxDepth) {
+            registerGlobAncestorDirectories(
+              relPath,
+              maxDepth,
+              directoryPaths,
+              stat.isFile(),
+            );
+            continue;
+          }
           if (stat.isDirectory()) {
             directoryPaths.add(relPath);
           } else if (stat.isFile()) {
@@ -799,12 +849,19 @@ export function makeGlobHandler(deps: FsDeps) {
         } catch {
           continue;
         }
-        if (filePaths.length >= GLOB_RESULT_LIMIT) break;
+        if (filePaths.length >= resultLimit) {
+          truncated = true;
+          break;
+        }
       }
     } catch (e) {
       return jsonResponse({ error: (e as Error).message }, 500);
     }
     const directories = collectEmptyDirectories(filePaths, [...directoryPaths]);
-    return jsonResponse({ files: filePaths, directories });
+    return jsonResponse({
+      files: filePaths,
+      directories,
+      ...(truncated ? { truncated: true } : {}),
+    });
   };
 }


### PR DESCRIPTION
## Summary
- Extend sandbox `/_sandbox/glob` with optional `limit` (default 1k for agents, max 10k) and `maxDepth`, plus a `truncated` flag when results are capped.
- File explorer uses a 10k limit with eager load through depth 3; deeper folders load on expand and deep-links prefetch lazy ancestors.
- Refresh after create/delete/rename resets lazy state and re-runs the depth-3 eager load.

## Test plan
- [x] `bun test packages/sandbox/daemon/routes/fs.test.ts`
- [x] `bun test apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts`
- [ ] Open sandbox file explorer on a large repo — top 3 levels appear without hitting the old 1k silent cap
- [ ] Expand a depth-3 folder — children load lazily (spinner, then contents)
- [ ] Create/delete a file — tree refreshes and lazy state resets
- [ ] Agent `glob` tool still defaults to 1k when no `limit` is passed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lazy-loaded file explorer tree with configurable glob limits so large repos load fast without silent truncation. Hardens loading, dedupes in-flight folder loads, and avoids full-tree scans with depth limits while keeping ancestor dirs visible.

- **New Features**
  - `/_sandbox/glob` now accepts `limit` (default `1000`, max `10000`) and `maxDepth`, returns `truncated` when capped, and registers ancestor directories when pruning by depth.
  - File explorer uses `EXPLORER_GLOB_LIMIT` `10000` and `EXPLORER_EAGER_DEPTH` `3`; deeper folders load on expand and deep-links wait for the initial tree load and prefetch ancestors.
  - Shows a spinner while folders load and a toast when results are truncated.
  - Refresh after create/delete/rename resets lazy and expanded state and re-runs the eager load.

- **Bug Fixes**
  - Prevent stale merges and race conditions in lazy loads using refs, generation tokens, deduped in-flight dir fetches, and a single `treeLists` state for atomic glob merges; update lazy-dir refs only inside `setState` callbacks.
  - Do not mark directories as loaded when a fetch is truncated.
  - Use a depth-bounded directory walk for `maxDepth` to avoid scanning the whole repo.

<sup>Written for commit d6c8af4698274bff93f5ef98cc1151b3ede6c35c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

