### PR TITLE
feat(channels): WhatsApp concierge channel (shared number + phone routing)

### DIFF
--- a/apps/mesh/migrations/109-channels.ts
+++ b/apps/mesh/migrations/109-channels.ts
@@ -2,9 +2,11 @@ import { type Kysely, sql } from "kysely";
 
 /**
  * Org-chat channels. Each row is one configured chat-platform integration
- * (Microsoft Teams, Discord, ...) that registers a synthetic bot org-member.
- * Inbound platform messages run a Decopilot agent turn and the reply is posted
- * back to the platform.
+ * (Microsoft Teams, Discord, WhatsApp, ...). For per-org bot platforms
+ * (Teams/Discord) the row registers a synthetic bot org-member; for the shared
+ * WhatsApp concierge there is no bot (the real verified user answers), so
+ * `bot_user_id` is nullable. Inbound messages run a Decopilot agent turn and the
+ * reply is posted back to the platform.
  *
  * Mirrors the AI-provider-keys shape: org-scoped, secrets vault-encrypted into a
  * single opaque blob (`encrypted_credentials`), never columnized. `metadata`
@@ -30,9 +32,10 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     // virtual_mcp_id of the Decopilot agent the bot runs. Nullable: bound during
     // setup; runChannelTurn falls back to the org default home agent when unset.
     .addColumn("agent_id", "text")
-    // Synthetic bot org-member (user.id). Managed by the app (no FK cascade so
+    // Synthetic bot org-member (user.id) for Teams/Discord. Null for WhatsApp
+    // (no bot — the real verified user answers). App-managed (no FK cascade so
     // the bot user/member teardown stays explicit in CHANNEL_DELETE).
-    .addColumn("bot_user_id", "text", (col) => col.notNull())
+    .addColumn("bot_user_id", "text")
     // JSON, non-secret display metadata (e.g. bot display name surfaced by TEST).
     .addColumn("metadata", "text")
     // 'draft' | 'active' | 'error' | 'disabled'

--- a/apps/mesh/migrations/110-user-phones.ts
+++ b/apps/mesh/migrations/110-user-phones.ts
@@ -1,0 +1,51 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Verified WhatsApp phone link per user (for the shared concierge number).
+ *
+ * Verification is inbound-only: Studio issues a unique `code`, the user sends it
+ * from their WhatsApp to the concierge number, and the inbound proves ownership
+ * — so `phone` is null until the code arrives and `verified_at` is stamped then.
+ * One link per user; a verified phone maps to exactly one user.
+ * `selected_organization_id` remembers which org answers when the user belongs
+ * to several WhatsApp-enabled orgs.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("user_phones")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("user_id", "text", (col) =>
+      col.notNull().references("user.id").onDelete("cascade").unique(),
+    )
+    // Canonical E.164 digits (no '+'); null until the verification code arrives.
+    .addColumn("phone", "text")
+    .addColumn("verified_at", "timestamptz")
+    // Studio-issued pending code the user must send to verify (then cleared).
+    .addColumn("code", "text")
+    .addColumn("code_expires_at", "timestamptz")
+    .addColumn("selected_organization_id", "text", (col) =>
+      col.references("organization.id").onDelete("set null"),
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  // Codes are matched against inbound message text — must be unique & indexed.
+  await sql`
+    CREATE UNIQUE INDEX idx_user_phones_code
+    ON user_phones (code)
+    WHERE code IS NOT NULL
+  `.execute(db);
+
+  // A verified phone resolves to exactly one user (inbound routing key).
+  await sql`
+    CREATE UNIQUE INDEX idx_user_phones_verified
+    ON user_phones (phone)
+    WHERE verified_at IS NOT NULL
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("user_phones").execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -108,6 +108,7 @@ import * as migration106automationtools from "./106-automation-tools.ts";
 import * as migration107orgfspublicorg from "./107-org-fs-public-org.ts";
 import * as migration108automationmaxagentsteps from "./108-automation-max-agent-steps.ts";
 import * as migration109channels from "./109-channels.ts";
+import * as migration110userphones from "./110-user-phones.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -238,6 +239,7 @@ const migrations: Record<string, Migration> = {
   "107-org-fs-public-org": migration107orgfspublicorg,
   "108-automation-max-agent-steps": migration108automationmaxagentsteps,
   "109-channels": migration109channels,
+  "110-user-phones": migration110userphones,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -55,6 +55,7 @@ import {
 import { handleApiError } from "./error-handler";
 import { resolveOrgFromPath } from "./middleware/resolve-org-from-path";
 import { createOrgScopedApi } from "./routes/org-scoped";
+import { createWhatsappIngestRoutes } from "./routes/whatsapp-ingest";
 import { createLinkWorkRoutes } from "./routes/decopilot/link-work-routes";
 import { createLinkControlRoutes } from "./routes/decopilot/link-control-routes";
 import { createLinkProxyRoutes } from "./routes/decopilot/link-proxy-routes";
@@ -2146,6 +2147,10 @@ export async function createApp(options: CreateAppOptions = {}) {
     watchHandler,
     betterAuthProtectedResourceHandler,
   });
+  // WhatsApp concierge ingest is global (routes by phone, not org). Mount BEFORE
+  // the `/api/:org` catch-all so `/api/whatsapp/ingest` isn't treated as an org
+  // slug.
+  app.route("/api/whatsapp", createWhatsappIngestRoutes({ db: database.db }));
   app.route("/api/:org", orgScopedApi);
 
   // ============================================================================

--- a/apps/mesh/src/api/routes/channel-webhooks.ts
+++ b/apps/mesh/src/api/routes/channel-webhooks.ts
@@ -105,6 +105,17 @@ export function createChannelWebhookRoutes() {
       return ackResponse(c, parsed.ackResponse);
     }
 
+    // Teams/Discord channels always have a synthetic bot member; the agent runs
+    // as that bot. (WhatsApp — which has no bot — uses the global ingest route,
+    // not this per-org webhook.)
+    const botUserId = info.botUserId;
+    if (!botUserId) {
+      console.warn(
+        `[channel-webhook] channel ${channelId} has no bot user — skipping`,
+      );
+      return ackResponse(c, parsed.ackResponse);
+    }
+
     const { message } = parsed;
     const threadId = threadIdFor(channelId, message.conversationKey);
 
@@ -115,7 +126,7 @@ export function createChannelWebhookRoutes() {
       try {
         const { replyText } = await runChannelTurn({
           organizationId: orgId,
-          botUserId: info.botUserId,
+          userId: botUserId,
           agentId,
           threadId,
           userText: message.text,

--- a/apps/mesh/src/api/routes/whatsapp-ingest.test.ts
+++ b/apps/mesh/src/api/routes/whatsapp-ingest.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { resolveTargetOrg, type WhatsappEnabledOrg } from "./whatsapp-ingest";
+
+const A: WhatsappEnabledOrg = { orgId: "o-a", orgName: "Alpha", agentId: "ag" };
+const B: WhatsappEnabledOrg = { orgId: "o-b", orgName: "Beta", agentId: "ag" };
+const C: WhatsappEnabledOrg = { orgId: "o-c", orgName: "Gamma", agentId: "ag" };
+
+describe("resolveTargetOrg", () => {
+  it("none when the user has no enabled orgs", () => {
+    expect(
+      resolveTargetOrg({ text: "hi", orgs: [], selectedOrgId: null }),
+    ).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("routes straight through with a single org", () => {
+    expect(
+      resolveTargetOrg({ text: "hello", orgs: [A], selectedOrgId: null }),
+    ).toEqual({ kind: "route", org: A });
+  });
+
+  it("routes to the remembered selection when still enabled", () => {
+    expect(
+      resolveTargetOrg({ text: "hello", orgs: [A, B], selectedOrgId: "o-b" }),
+    ).toEqual({ kind: "route", org: B });
+  });
+
+  it("asks the user to pick when multiple and none selected", () => {
+    expect(
+      resolveTargetOrg({ text: "hello", orgs: [A, B], selectedOrgId: null }),
+    ).toEqual({ kind: "pick" });
+  });
+
+  it("selects by a bare number against the sorted list", () => {
+    expect(
+      resolveTargetOrg({ text: "2", orgs: [A, B, C], selectedOrgId: null }),
+    ).toEqual({ kind: "select", org: B });
+  });
+
+  it("ignores out-of-range numbers (still pick)", () => {
+    expect(
+      resolveTargetOrg({ text: "9", orgs: [A, B], selectedOrgId: null }),
+    ).toEqual({ kind: "pick" });
+  });
+
+  it("treats numeric input as chat once an org is selected (route, not re-select)", () => {
+    expect(
+      resolveTargetOrg({ text: "2", orgs: [A, B], selectedOrgId: "o-a" }),
+    ).toEqual({ kind: "route", org: A });
+  });
+
+  it("recognizes switch commands (case-insensitive)", () => {
+    for (const t of ["switch", "/switch", "Orgs", " /orgs "]) {
+      expect(
+        resolveTargetOrg({ text: t, orgs: [A, B], selectedOrgId: "o-a" }),
+      ).toEqual({ kind: "switch" });
+    }
+  });
+});

--- a/apps/mesh/src/api/routes/whatsapp-ingest.ts
+++ b/apps/mesh/src/api/routes/whatsapp-ingest.ts
@@ -1,0 +1,257 @@
+/**
+ * WhatsApp Concierge Ingest
+ *
+ * Global (NOT org-scoped) endpoint the deployed WhatsApp worker calls for every
+ * inbound message. Routing is by the sender's verified phone, so the org is
+ * resolved here — not from the URL.
+ *
+ *   POST /api/whatsapp/ingest   (Authorization: Bearer WHATSAPP_INGEST_SECRET)
+ *   { phone, text, messageId?, name? }  ->  202 (processed async)
+ *
+ * Flow: verify pending code (inbound verification) → resolve phone→user →
+ * resolve target org (selected / single / in-chat pick-list) → run the agent as
+ * the real user → deliver the reply via the worker's /send.
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { Kysely } from "kysely";
+import { getBaseUrl } from "@/core/server-constants";
+import { canonicalizePhone } from "@/channels/phone";
+import { runChannelTurn } from "@/channels/run-channel-turn";
+import { sendWhatsApp } from "@/channels/whatsapp-worker";
+import { getSettings } from "@/settings";
+import { UserPhoneStorage } from "@/storage/user-phones";
+import type { Database } from "@/storage/types";
+
+const MAX_BODY_SIZE = 262_144; // 256KB
+
+export interface WhatsappEnabledOrg {
+  orgId: string;
+  orgName: string;
+  agentId: string | null;
+}
+
+export type OrgResolution =
+  | { kind: "none" }
+  | { kind: "switch" }
+  | { kind: "pick" }
+  | { kind: "route"; org: WhatsappEnabledOrg }
+  | { kind: "select"; org: WhatsappEnabledOrg };
+
+const SWITCH_COMMANDS = new Set(["switch", "/switch", "orgs", "/orgs"]);
+
+/**
+ * Pure resolver for which org should answer. Exported for unit testing.
+ * `orgs` must be sorted deterministically (e.g. by channel created_at).
+ */
+export function resolveTargetOrg(args: {
+  text: string;
+  orgs: WhatsappEnabledOrg[];
+  selectedOrgId: string | null;
+}): OrgResolution {
+  const { text, orgs, selectedOrgId } = args;
+  if (orgs.length === 0) return { kind: "none" };
+  if (SWITCH_COMMANDS.has(text.trim().toLowerCase())) return { kind: "switch" };
+  if (orgs.length === 1) return { kind: "route", org: orgs[0]! };
+
+  const selected = selectedOrgId
+    ? orgs.find((o) => o.orgId === selectedOrgId)
+    : undefined;
+  if (selected) return { kind: "route", org: selected };
+
+  // No active selection + multiple orgs: a bare number picks from the list.
+  const n = Number(text.trim());
+  const picked = Number.isInteger(n) ? orgs[n - 1] : undefined;
+  if (picked) return { kind: "select", org: picked };
+  return { kind: "pick" };
+}
+
+function pickListText(orgs: WhatsappEnabledOrg[]): string {
+  const lines = orgs.map((o, i) => `${i + 1}. ${o.orgName}`);
+  return [
+    "You're in more than one organization on WhatsApp. Reply with a number to choose which one I should talk to:",
+    ...lines,
+    "(send 'switch' anytime to change)",
+  ].join("\n");
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function threadIdFor(phone: string, orgId: string): string {
+  const hash = createHash("sha1")
+    .update(`${phone}:${orgId}`)
+    .digest("hex")
+    .slice(0, 24);
+  return `thrd_wa_${hash}`;
+}
+
+async function listEnabledOrgs(
+  db: Kysely<Database>,
+  userId: string,
+): Promise<WhatsappEnabledOrg[]> {
+  const rows = await db
+    .selectFrom("channels")
+    .innerJoin("organization", "organization.id", "channels.organization_id")
+    .innerJoin("member", "member.organizationId", "channels.organization_id")
+    .where("member.userId", "=", userId)
+    .where("channels.channel_type", "=", "whatsapp")
+    .where("channels.status", "=", "active")
+    .select([
+      "organization.id as orgId",
+      "organization.name as orgName",
+      "channels.agent_id as agentId",
+    ])
+    .orderBy("channels.created_at", "asc")
+    .execute();
+  return rows.map((r) => ({
+    orgId: r.orgId,
+    orgName: r.orgName,
+    agentId: r.agentId,
+  }));
+}
+
+export function createWhatsappIngestRoutes(deps: { db: Kysely<Database> }) {
+  const app = new Hono();
+  const userPhones = new UserPhoneStorage(deps.db);
+
+  const limit = bodyLimit({
+    maxSize: MAX_BODY_SIZE,
+    onError: (c) => c.json({ error: "Payload too large" }, 413),
+  });
+
+  app.post("/ingest", limit, async (c) => {
+    const secret = getSettings().whatsappIngestSecret;
+    if (!secret) return c.json({ error: "WhatsApp not configured" }, 503);
+
+    const header = c.req.header("authorization") ?? "";
+    const token = header.startsWith("Bearer ") ? header.slice(7).trim() : "";
+    if (!constantTimeEqual(token, secret)) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    let body: { phone?: string; text?: string; name?: string };
+    try {
+      body = (await c.req.json()) as typeof body;
+    } catch {
+      return c.json({ error: "Invalid JSON" }, 400);
+    }
+    const phone = canonicalizePhone(body.phone);
+    const text = (body.text ?? "").trim();
+    const name = body.name?.trim() || phone;
+    if (!phone) return c.json({ error: "phone required" }, 400);
+
+    // ACK now; process out of band (agent runs can take a while).
+    void handleInbound({ db: deps.db, userPhones, phone, text, name }).catch(
+      (err) =>
+        console.error(
+          "[whatsapp-ingest] processing failed:",
+          err instanceof Error ? err.message : err,
+        ),
+    );
+
+    return c.json({ ok: true }, 202);
+  });
+
+  return app;
+}
+
+async function handleInbound(args: {
+  db: Kysely<Database>;
+  userPhones: UserPhoneStorage;
+  phone: string;
+  text: string;
+  name: string;
+}): Promise<void> {
+  const { db, userPhones, phone, text, name } = args;
+
+  // 1) Verification: a Studio-issued code sent BY the user proves ownership.
+  const codeCandidate = text.toUpperCase().replace(/\s+/g, "");
+  const pending = codeCandidate
+    ? await userPhones.findPendingByCode(codeCandidate)
+    : null;
+  if (pending) {
+    const result = await userPhones.bindVerified(pending.userId, phone);
+    await sendWhatsApp(
+      phone,
+      result.ok
+        ? "✅ Your number is now linked to deco."
+        : "This number is already linked to another deco account.",
+    );
+    return;
+  }
+
+  // 2) Resolve the sender to a verified user.
+  const link = await userPhones.findVerifiedByPhone(phone);
+  if (!link) {
+    await sendWhatsApp(
+      phone,
+      `This number isn't linked to a deco account yet. Link it from your profile at ${getBaseUrl()}.`,
+    );
+    return;
+  }
+
+  // 3) Resolve the target organization.
+  const orgs = await listEnabledOrgs(db, link.userId);
+  const resolution = resolveTargetOrg({
+    text,
+    orgs,
+    selectedOrgId: link.selectedOrganizationId,
+  });
+
+  let target: WhatsappEnabledOrg;
+  switch (resolution.kind) {
+    case "none":
+      await sendWhatsApp(
+        phone,
+        "No organization has WhatsApp enabled for you yet.",
+      );
+      return;
+    case "switch":
+      await userPhones.setSelectedOrg(link.userId, null);
+      await sendWhatsApp(phone, pickListText(orgs));
+      return;
+    case "pick":
+      await sendWhatsApp(phone, pickListText(orgs));
+      return;
+    case "select":
+      await userPhones.setSelectedOrg(link.userId, resolution.org.orgId);
+      target = resolution.org;
+      break;
+    case "route":
+      target = resolution.org;
+      if (orgs.length === 1) {
+        await userPhones.setSelectedOrg(link.userId, target.orgId);
+      }
+      break;
+  }
+
+  if (!target.agentId) {
+    await sendWhatsApp(
+      phone,
+      `WhatsApp isn't fully set up for ${target.orgName} yet (no agent selected).`,
+    );
+    return;
+  }
+
+  // 4) Run the agent AS the real user, in a stable per-user+org thread.
+  const { replyText } = await runChannelTurn({
+    organizationId: target.orgId,
+    userId: link.userId,
+    agentId: target.agentId,
+    threadId: threadIdFor(phone, target.orgId),
+    userText: text,
+    sender: { platform: "whatsapp", senderId: phone, senderName: name },
+  });
+
+  await sendWhatsApp(
+    phone,
+    replyText || "I wasn't able to produce a response. Please try again.",
+  );
+}

--- a/apps/mesh/src/channels/phone.test.ts
+++ b/apps/mesh/src/channels/phone.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { canonicalizePhone, displayPhone, maskPhone } from "./phone";
+
+describe("canonicalizePhone", () => {
+  it("strips '+', spaces and punctuation to bare digits", () => {
+    expect(canonicalizePhone("+55 (11) 99888-7777")).toBe("5511998887777");
+    expect(canonicalizePhone("5511998887777")).toBe("5511998887777");
+    expect(canonicalizePhone(null)).toBe("");
+    expect(canonicalizePhone(undefined)).toBe("");
+  });
+});
+
+describe("displayPhone / maskPhone", () => {
+  it("adds a leading '+' for display", () => {
+    expect(displayPhone("5511998887777")).toBe("+5511998887777");
+    expect(displayPhone("")).toBe("");
+  });
+  it("masks all but the last 4 digits", () => {
+    expect(maskPhone("5511998887777")).toMatch(/7777$/);
+    expect(maskPhone("5511998887777")).not.toContain("5511");
+    expect(maskPhone("")).toBe("");
+  });
+});

--- a/apps/mesh/src/channels/phone.ts
+++ b/apps/mesh/src/channels/phone.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonical phone form used for matching/storage: digits only, no '+', spaces,
+ * or punctuation. WhatsApp/WABA delivers the sender `from` in E.164 **without**
+ * a leading '+', so we normalize both the inbound number and any UI-entered
+ * number to the same digit string before comparing or persisting.
+ */
+export function canonicalizePhone(input: string | null | undefined): string {
+  return (input ?? "").replace(/\D/g, "");
+}
+
+/** Display form: leading '+' on the canonical digits (or "" when empty). */
+export function displayPhone(canonical: string): string {
+  return canonical ? `+${canonical}` : "";
+}
+
+/** Mask all but the last 4 digits for previews (e.g. "+•••••••1234"). */
+export function maskPhone(canonical: string): string {
+  if (!canonical) return "";
+  if (canonical.length <= 4) return `+${canonical}`;
+  return `+${"•".repeat(Math.max(2, canonical.length - 4))}${canonical.slice(-4)}`;
+}

--- a/apps/mesh/src/channels/registry.ts
+++ b/apps/mesh/src/channels/registry.ts
@@ -4,20 +4,34 @@ import { teamsAdapter } from "./adapters/teams";
 import type { ChannelAdapter } from "./types";
 
 /**
- * Registry of supported chat-channel adapters, keyed by channel type. Mirrors
- * `getProviders()` in the AI-providers feature. Add new platforms here.
+ * Channel types that use the per-org webhook + credentials adapter model.
+ * WhatsApp is intentionally excluded — it's a shared-number, enable-only channel
+ * with a global ingest route, no per-org credentials, and no adapter.
  */
-export function getChannelAdapters(): Record<ChannelType, ChannelAdapter> {
+export type WebhookChannelType = "teams" | "discord";
+
+/**
+ * Registry of per-org webhook channel adapters. Mirrors `getProviders()` in the
+ * AI-providers feature. Add new credential-based platforms here.
+ */
+export function getChannelAdapters(): Record<
+  WebhookChannelType,
+  ChannelAdapter
+> {
   return {
     teams: teamsAdapter,
     discord: discordAdapter,
   };
 }
 
+/** True for channel types backed by a per-org webhook adapter (not WhatsApp). */
+function isWebhookChannelType(type: ChannelType): type is WebhookChannelType {
+  return type === "teams" || type === "discord";
+}
+
 export function getChannelAdapter(type: ChannelType): ChannelAdapter {
-  const adapter = getChannelAdapters()[type];
-  if (!adapter) {
-    throw new Error(`Unsupported channel type: ${type}`);
+  if (!isWebhookChannelType(type)) {
+    throw new Error(`Channel type "${type}" has no webhook adapter`);
   }
-  return adapter;
+  return getChannelAdapters()[type];
 }

--- a/apps/mesh/src/channels/run-channel-turn.ts
+++ b/apps/mesh/src/channels/run-channel-turn.ts
@@ -22,7 +22,7 @@ import { requireChannelRuntime } from "./runtime";
  */
 export async function runChannelTurn(params: {
   organizationId: string;
-  botUserId: string;
+  userId: string;
   agentId: string;
   threadId: string;
   userText: string;
@@ -30,7 +30,7 @@ export async function runChannelTurn(params: {
   tier?: SimpleModeTier;
 }): Promise<{ taskId: string; replyText: string }> {
   const { meshContextFactory } = requireChannelRuntime();
-  const ctx = await meshContextFactory(params.organizationId, params.botUserId);
+  const ctx = await meshContextFactory(params.organizationId, params.userId);
   if (!ctx) {
     throw new Error(
       "Channel bot is not a member of the organization — cannot run agent turn",
@@ -44,7 +44,7 @@ export async function runChannelTurn(params: {
       title: `${params.sender.platform} · ${params.sender.senderName}`,
       status: "in_progress",
       virtual_mcp_id: params.agentId,
-      created_by: params.botUserId,
+      created_by: params.userId,
     });
   }
 
@@ -79,7 +79,7 @@ export async function runChannelTurn(params: {
     toolApprovalLevel: "auto",
     mode: "default",
     organizationId: params.organizationId,
-    userId: params.botUserId,
+    userId: params.userId,
     taskId: params.threadId,
   };
 

--- a/apps/mesh/src/channels/whatsapp-worker.ts
+++ b/apps/mesh/src/channels/whatsapp-worker.ts
@@ -1,0 +1,49 @@
+import { getSettings } from "@/settings";
+
+/**
+ * Studio → WhatsApp worker calls. The deployed Cloudflare Worker owns the WABA
+ * connection and exposes a `/send` endpoint; Studio calls it to deliver agent
+ * replies, org pick-lists, and verification confirmations. (Verification codes
+ * flow the other way — the user sends them to the number.)
+ */
+
+/** Whether the WhatsApp concierge is configured (all required settings present). */
+export function isWhatsappConfigured(): boolean {
+  const s = getSettings();
+  return Boolean(
+    s.whatsappWorkerUrl &&
+      s.whatsappWorkerToken &&
+      s.whatsappIngestSecret &&
+      s.whatsappConciergeNumber,
+  );
+}
+
+export function getConciergeNumber(): string | undefined {
+  return getSettings().whatsappConciergeNumber;
+}
+
+/** Send a WhatsApp message via the worker. `phone` is canonical digits (no '+'). */
+export async function sendWhatsApp(phone: string, text: string): Promise<void> {
+  const s = getSettings();
+  if (!s.whatsappWorkerUrl || !s.whatsappWorkerToken) {
+    throw new Error("WhatsApp worker is not configured");
+  }
+  const url = `${s.whatsappWorkerUrl.replace(/\/$/, "")}/send`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${s.whatsappWorkerToken}`,
+    },
+    body: JSON.stringify({ phone, text }),
+  });
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = await res.text();
+    } catch {
+      // ignore
+    }
+    throw new Error(`WhatsApp worker send failed: ${res.status} ${detail}`);
+  }
+}

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -469,6 +469,7 @@ import {
 import { createClientPool } from "@/mcp-clients/outbound/client-pool";
 import { AIProviderKeyStorage } from "@/storage/ai-provider-keys";
 import { ChannelStorage } from "@/storage/channels";
+import { UserPhoneStorage } from "@/storage/user-phones";
 import { SecretStorage } from "@/storage/secrets";
 import { OrgFileConfigStorage } from "@/storage/org-file-configs";
 import { OrgFsEntryStorage } from "@/storage/org-fs";
@@ -1201,6 +1202,7 @@ export async function createStudioContextFactory(
       config.providerKeyCache,
     ),
     channels: new ChannelStorage(config.db, vault),
+    userPhones: new UserPhoneStorage(config.db),
     secrets: new SecretStorage(config.db, vault),
     orgFileConfigs: new OrgFileConfigStorage(config.db, vault),
     orgFsEntries: new OrgFsEntryStorage(config.db),

--- a/apps/mesh/src/core/define-tool.test.ts
+++ b/apps/mesh/src/core/define-tool.test.ts
@@ -54,6 +54,7 @@ const createMockContext = (): StudioContext => ({
     virtualMcpPluginConfigs: null as never,
     aiProviderKeys: null as never,
     channels: null as never,
+    userPhones: null as never,
     secrets: null as never,
     orgFileConfigs: null as never,
     orgFsEntries: null as never,

--- a/apps/mesh/src/core/studio-context.test.ts
+++ b/apps/mesh/src/core/studio-context.test.ts
@@ -30,6 +30,7 @@ const createMockContext = (
     virtualMcpPluginConfigs: null as never,
     aiProviderKeys: null as never,
     channels: null as never,
+    userPhones: null as never,
     secrets: null as never,
     orgFileConfigs: null as never,
     orgFsEntries: null as never,

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -267,6 +267,7 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { AIProviderKeyStorage } from "@/storage/ai-provider-keys";
 import { ChannelStorage } from "@/storage/channels";
+import { UserPhoneStorage } from "@/storage/user-phones";
 import { SecretStorage } from "@/storage/secrets";
 import { OrgFileConfigStorage } from "@/storage/org-file-configs";
 import type { OrgFsEntryStorage } from "@/storage/org-fs";
@@ -302,6 +303,7 @@ export interface MeshStorage {
   tags: TagStorage;
   aiProviderKeys: AIProviderKeyStorage;
   channels: ChannelStorage;
+  userPhones: UserPhoneStorage;
   secrets: SecretStorage;
   orgFileConfigs: OrgFileConfigStorage;
   orgFsEntries: OrgFsEntryStorage;

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -146,6 +146,12 @@ export function resolveConfig(
     decoSupabaseUrl: envVars.DECO_SUPABASE_URL,
     decoSupabaseServiceKey: envVars.DECO_SUPABASE_SERVICE_KEY,
     firecrawlApiKey: envVars.FIRECRAWL_API_KEY,
+
+    // WhatsApp concierge channel
+    whatsappWorkerUrl: envVars.WHATSAPP_WORKER_URL,
+    whatsappWorkerToken: envVars.WHATSAPP_WORKER_TOKEN,
+    whatsappIngestSecret: envVars.WHATSAPP_INGEST_SECRET,
+    whatsappConciergeNumber: envVars.WHATSAPP_CONCIERGE_NUMBER,
   };
 
   return {

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -88,6 +88,13 @@ export interface Settings {
   decoSupabaseUrl: string | undefined;
   decoSupabaseServiceKey: string | undefined;
   firecrawlApiKey: string | undefined;
+
+  // WhatsApp concierge (shared-number channel). All four must be set for the
+  // WhatsApp channel + phone verification to be available.
+  whatsappWorkerUrl: string | undefined; // base URL of the deployed WABA worker
+  whatsappWorkerToken: string | undefined; // Studio→worker auth (its /send endpoint)
+  whatsappIngestSecret: string | undefined; // worker→Studio auth (/api/whatsapp/ingest)
+  whatsappConciergeNumber: string | undefined; // display number users text to verify/chat
 }
 
 export interface CliFlags {

--- a/apps/mesh/src/shared/utils/generate-id.ts
+++ b/apps/mesh/src/shared/utils/generate-id.ts
@@ -21,7 +21,8 @@ type IdPrefixes =
   | "vpc"
   | "tile"
   | "fcfg"
-  | "chan";
+  | "chan"
+  | "uph";
 
 export function generatePrefixedId(prefix: IdPrefixes) {
   return `${prefix}_${nanoid()}`;

--- a/apps/mesh/src/storage/channels.ts
+++ b/apps/mesh/src/storage/channels.ts
@@ -21,7 +21,7 @@ interface ChannelRow {
   channel_type: string;
   label: string;
   agent_id: string | null;
-  bot_user_id: string;
+  bot_user_id: string | null;
   metadata: string | null;
   status: string;
   created_by: string;
@@ -77,7 +77,7 @@ export class ChannelStorage {
     id?: string;
     channelType: ChannelType;
     label: string;
-    botUserId: string;
+    botUserId: string | null;
     agentId?: string | null;
     credentials?: ChannelCredentials | null;
     metadata?: Record<string, unknown> | null;

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -277,10 +277,10 @@ export interface ProviderKeyInfo {
 }
 
 // ============================================================================
-// Channels (org-chat integrations: Microsoft Teams, Discord)
+// Channels (org-chat integrations: Microsoft Teams, Discord, WhatsApp)
 // ============================================================================
 
-export type ChannelType = "teams" | "discord";
+export type ChannelType = "teams" | "discord" | "whatsapp";
 export type ChannelStatus = "draft" | "active" | "error" | "disabled";
 
 export interface ChannelTable {
@@ -292,8 +292,8 @@ export interface ChannelTable {
   encrypted_credentials: string | null;
   /** virtual_mcp_id of the Decopilot agent the bot runs. */
   agent_id: string | null;
-  /** Synthetic bot org-member (user.id). */
-  bot_user_id: string;
+  /** Synthetic bot org-member (user.id) for Teams/Discord; null for WhatsApp. */
+  bot_user_id: string | null;
   /** JSON, non-secret display metadata. */
   metadata: string | null;
   status: string; // ChannelStatus
@@ -307,12 +307,28 @@ export interface ChannelInfo {
   channelType: ChannelType;
   label: string;
   agentId: string | null;
-  botUserId: string;
+  botUserId: string | null;
   metadata: Record<string, unknown> | null;
   status: ChannelStatus;
   organizationId: string;
   createdBy: string;
   createdAt: string;
+}
+
+// ============================================================================
+// User phone links (WhatsApp concierge — verified phone → user)
+// ============================================================================
+
+export interface UserPhoneTable {
+  id: string;
+  user_id: string;
+  /** Canonical E.164 digits (no '+'); null until the verification code arrives. */
+  phone: string | null;
+  verified_at: ColumnType<Date, Date | string, Date | string> | null;
+  code: string | null;
+  code_expires_at: ColumnType<Date, Date | string, Date | string> | null;
+  selected_organization_id: string | null;
+  created_at: ColumnType<Date, Date | string, never>;
 }
 
 export type SecretScopeKind = "user" | "organization";
@@ -1469,8 +1485,11 @@ export interface Database {
   // AI Provider keys tables
   ai_provider_keys: AIProviderKeyTable;
 
-  // Org-chat channel integrations (Teams, Discord)
+  // Org-chat channel integrations (Teams, Discord, WhatsApp)
   channels: ChannelTable;
+
+  // Verified WhatsApp phone links (concierge routing)
+  user_phones: UserPhoneTable;
 
   // Generic secrets vault (org and user scoped)
   secrets: SecretTable;

--- a/apps/mesh/src/storage/user-phones.ts
+++ b/apps/mesh/src/storage/user-phones.ts
@@ -1,0 +1,154 @@
+import type { Kysely } from "kysely";
+import type { Database } from "./types";
+import { generatePrefixedId } from "@/shared/utils/generate-id";
+
+export type PhoneLinkStatus = "none" | "pending" | "verified";
+
+export interface UserPhoneLink {
+  userId: string;
+  phone: string | null;
+  status: PhoneLinkStatus;
+  /** Pending verification code (only while not yet verified). */
+  code: string | null;
+  selectedOrganizationId: string | null;
+}
+
+function toIso(v: Date | string | null): string | null {
+  if (v == null) return null;
+  return v instanceof Date ? v.toISOString() : String(v);
+}
+
+/**
+ * Storage for the WhatsApp concierge phone links. Verification is inbound-only:
+ * `issueCode` stores a pending code (no phone yet); the matching inbound message
+ * is resolved via `findPendingByCode`, and `bindVerified` stamps the sender's
+ * number once ownership is proven.
+ */
+export class UserPhoneStorage {
+  constructor(private db: Kysely<Database>) {}
+
+  /** Issue/refresh a pending verification code for a user (upsert by user_id). */
+  async issueCode(userId: string, code: string, ttlMs: number): Promise<void> {
+    const expires = new Date(Date.now() + ttlMs).toISOString();
+    await this.db
+      .insertInto("user_phones")
+      .values({
+        id: generatePrefixedId("uph"),
+        user_id: userId,
+        phone: null,
+        verified_at: null,
+        code,
+        code_expires_at: expires,
+        selected_organization_id: null,
+        created_at: new Date().toISOString(),
+      })
+      .onConflict((oc) =>
+        oc.column("user_id").doUpdateSet({
+          code,
+          code_expires_at: expires,
+        }),
+      )
+      .execute();
+  }
+
+  /** Resolve a non-expired pending code to its owning user. */
+  async findPendingByCode(code: string): Promise<{ userId: string } | null> {
+    const row = await this.db
+      .selectFrom("user_phones")
+      .select(["user_id", "code_expires_at"])
+      .where("code", "=", code)
+      .executeTakeFirst();
+    if (!row) return null;
+    const exp = toIso(row.code_expires_at ?? null);
+    if (exp && new Date(exp).getTime() < Date.now()) return null;
+    return { userId: row.user_id };
+  }
+
+  /**
+   * Bind a verified phone to the user (clears the pending code). Returns
+   * `{ ok: false, reason: "taken" }` if the phone is already verified to a
+   * different user.
+   */
+  async bindVerified(
+    userId: string,
+    phone: string,
+  ): Promise<{ ok: true } | { ok: false; reason: "taken" }> {
+    const owner = await this.db
+      .selectFrom("user_phones")
+      .select(["user_id"])
+      .where("phone", "=", phone)
+      .where("verified_at", "is not", null)
+      .executeTakeFirst();
+    if (owner && owner.user_id !== userId) {
+      return { ok: false, reason: "taken" };
+    }
+    await this.db
+      .updateTable("user_phones")
+      .set({
+        phone,
+        verified_at: new Date().toISOString(),
+        code: null,
+        code_expires_at: null,
+      })
+      .where("user_id", "=", userId)
+      .execute();
+    return { ok: true };
+  }
+
+  async getByUser(userId: string): Promise<UserPhoneLink | null> {
+    const row = await this.db
+      .selectFrom("user_phones")
+      .select([
+        "user_id",
+        "phone",
+        "verified_at",
+        "code",
+        "selected_organization_id",
+      ])
+      .where("user_id", "=", userId)
+      .executeTakeFirst();
+    if (!row) return null;
+    return {
+      userId: row.user_id,
+      phone: row.phone,
+      status: row.verified_at ? "verified" : "pending",
+      code: row.verified_at ? null : row.code,
+      selectedOrganizationId: row.selected_organization_id,
+    };
+  }
+
+  /** Resolve a verified phone to its user (inbound routing key). */
+  async findVerifiedByPhone(
+    phone: string,
+  ): Promise<{ userId: string; selectedOrganizationId: string | null } | null> {
+    const row = await this.db
+      .selectFrom("user_phones")
+      .select(["user_id", "selected_organization_id"])
+      .where("phone", "=", phone)
+      .where("verified_at", "is not", null)
+      .executeTakeFirst();
+    if (!row) return null;
+    return {
+      userId: row.user_id,
+      selectedOrganizationId: row.selected_organization_id,
+    };
+  }
+
+  async setSelectedOrg(
+    userId: string,
+    organizationId: string | null,
+  ): Promise<void> {
+    await this.db
+      .updateTable("user_phones")
+      .set({ selected_organization_id: organizationId })
+      .where("user_id", "=", userId)
+      .execute();
+  }
+
+  async delete(userId: string): Promise<void> {
+    await this.db
+      .deleteFrom("user_phones")
+      .where("user_id", "=", userId)
+      .execute();
+  }
+}

--- a/apps/mesh/src/tools/channels/channel-create.ts
+++ b/apps/mesh/src/tools/channels/channel-create.ts
@@ -28,8 +28,39 @@ export const CHANNEL_CREATE = defineTool({
     const org = requireOrganization(ctx);
     await ctx.access.check();
 
-    const adapter = getChannelAdapter(input.channelType);
     const channelId = generatePrefixedId("chan");
+
+    // WhatsApp is a shared-number, enable-only channel: no synthetic bot, no
+    // credentials/endpoint/test — the real verified user answers. It requires an
+    // agent and goes straight to `active`.
+    if (input.channelType === "whatsapp") {
+      if (!input.agentId) {
+        throw new Error("WhatsApp channels require an agent");
+      }
+      const info = await ctx.storage.channels.create({
+        id: channelId,
+        channelType: "whatsapp",
+        label: input.label ?? "WhatsApp",
+        botUserId: null,
+        agentId: input.agentId,
+        status: "active",
+        organizationId: org.id,
+        createdBy: ctx.auth.user!.id,
+      });
+      posthog.capture({
+        distinctId: ctx.auth.user!.id,
+        event: "channel_created",
+        groups: { organization: org.id },
+        properties: {
+          organization_id: org.id,
+          channel_id: info.id,
+          channel_type: info.channelType,
+        },
+      });
+      return toChannelOutput(info, org.slug ?? org.id);
+    }
+
+    const adapter = getChannelAdapter(input.channelType);
     const label = input.label ?? `${adapter.info.name} bot`;
 
     const { botUserId } = await ensureChannelBot({

--- a/apps/mesh/src/tools/channels/channel-delete.ts
+++ b/apps/mesh/src/tools/channels/channel-delete.ts
@@ -21,11 +21,14 @@ export const CHANNEL_DELETE = defineTool({
     }
 
     await ctx.storage.channels.delete(input.id, org.id);
-    await removeChannelBot({
-      db: ctx.db,
-      organizationId: org.id,
-      botUserId: existing.botUserId,
-    });
+    // WhatsApp channels have no synthetic bot to tear down.
+    if (existing.botUserId) {
+      await removeChannelBot({
+        db: ctx.db,
+        organizationId: org.id,
+        botUserId: existing.botUserId,
+      });
+    }
 
     posthog.capture({
       distinctId: ctx.auth.user!.id,

--- a/apps/mesh/src/tools/channels/channels-list.ts
+++ b/apps/mesh/src/tools/channels/channels-list.ts
@@ -2,58 +2,91 @@ import z from "zod";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { getChannelAdapters } from "@/channels/registry";
+import { isWhatsappConfigured } from "@/channels/whatsapp-worker";
 import { CHANNEL_TYPES } from "./shared";
+
+const platformSchema = z.object({
+  id: z.enum(CHANNEL_TYPES),
+  name: z.string(),
+  description: z.string(),
+  logo: z.string().optional(),
+  setupKind: z.enum(["credentials", "shared"]),
+  credentialFields: z.array(
+    z.object({
+      key: z.string(),
+      label: z.string(),
+      placeholder: z.string().optional(),
+      secret: z.boolean().optional(),
+      optional: z.boolean().optional(),
+      help: z.string().optional(),
+    }),
+  ),
+  setupInstructions: z.array(
+    z.object({
+      title: z.string(),
+      description: z.string(),
+      link: z.object({ label: z.string(), url: z.string() }).optional(),
+    }),
+  ),
+});
 
 /**
  * Static list of supported chat-channel platforms and their setup metadata.
- * Drives the wizard's platform grid, credential form, and instructions.
+ * Drives the page's per-platform "Add" buttons + the wizard.
+ *
+ * `setupKind`:
+ *  - "credentials" — per-org webhook platforms (Teams, Discord): paste creds,
+ *    set an endpoint, test.
+ *  - "shared" — the WhatsApp concierge: enable-only (pick an agent); members
+ *    verify their phone in their profile. Only listed when configured.
  */
 export const CHANNELS_LIST = defineTool({
   name: "CHANNELS_LIST",
   description:
-    "List supported chat channel platforms (Teams, Discord) with their setup instructions and credential fields.",
+    "List supported chat channel platforms (Teams, Discord, WhatsApp) with their setup instructions and credential fields.",
   annotations: { readOnlyHint: true, idempotentHint: true },
   inputSchema: z.object({}),
   outputSchema: z.object({
-    platforms: z.array(
-      z.object({
-        id: z.enum(CHANNEL_TYPES),
-        name: z.string(),
-        description: z.string(),
-        logo: z.string().optional(),
-        credentialFields: z.array(
-          z.object({
-            key: z.string(),
-            label: z.string(),
-            placeholder: z.string().optional(),
-            secret: z.boolean().optional(),
-            optional: z.boolean().optional(),
-            help: z.string().optional(),
-          }),
-        ),
-        setupInstructions: z.array(
-          z.object({
-            title: z.string(),
-            description: z.string(),
-            link: z.object({ label: z.string(), url: z.string() }).optional(),
-          }),
-        ),
-      }),
-    ),
+    platforms: z.array(platformSchema),
   }),
   handler: async (_input, ctx) => {
     requireAuth(ctx);
     requireOrganization(ctx);
     await ctx.access.check();
 
-    const platforms = Object.values(getChannelAdapters()).map((adapter) => ({
+    const platforms: Array<z.infer<typeof platformSchema>> = Object.values(
+      getChannelAdapters(),
+    ).map((adapter) => ({
       id: adapter.info.id,
       name: adapter.info.name,
       description: adapter.info.description,
       logo: adapter.info.logo,
+      setupKind: "credentials",
       credentialFields: adapter.credentialFields,
       setupInstructions: adapter.setupInstructions,
     }));
+
+    // WhatsApp is a shared-number, enable-only channel — listed only when the
+    // concierge worker is configured for this deployment.
+    if (isWhatsappConfigured()) {
+      platforms.push({
+        id: "whatsapp",
+        name: "WhatsApp",
+        description:
+          "Let members chat with an agent over the shared decoCMS WhatsApp number.",
+        logo: "whatsapp",
+        setupKind: "shared",
+        credentialFields: [],
+        setupInstructions: [
+          {
+            title: "Pick the agent that answers",
+            description:
+              "Choose the Decopilot agent that will respond to your members on WhatsApp. Members link their phone in their profile, then message the concierge number — it runs this agent as that member.",
+          },
+        ],
+      });
+    }
+
     return { platforms };
   },
 });

--- a/apps/mesh/src/tools/channels/shared.ts
+++ b/apps/mesh/src/tools/channels/shared.ts
@@ -2,7 +2,7 @@ import z from "zod";
 import { getBaseUrl } from "@/core/server-constants";
 import type { ChannelInfo, ChannelType } from "@/storage/types";
 
-export const CHANNEL_TYPES = ["teams", "discord"] as const;
+export const CHANNEL_TYPES = ["teams", "discord", "whatsapp"] as const;
 
 export const channelStatusSchema = z.enum([
   "draft",
@@ -17,7 +17,7 @@ export const channelOutputSchema = z.object({
   channelType: z.enum(CHANNEL_TYPES),
   label: z.string(),
   agentId: z.string().nullable(),
-  botUserId: z.string(),
+  botUserId: z.string().nullable(),
   status: channelStatusSchema,
   webhookUrl: z.string(),
   metadata: z.record(z.string(), z.unknown()).nullable(),

--- a/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
@@ -86,6 +86,7 @@ describe("Connection Tools", () => {
         virtualMcpPluginConfigs: null as never,
         aiProviderKeys: null as never,
         channels: null as never,
+        userPhones: null as never,
         secrets: null as never,
         orgFileConfigs: null as never,
         orgFsEntries: null as never,

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -31,6 +31,7 @@ import * as AutomationTools from "./automations";
 import * as UserTools from "./user";
 import * as AiProvidersTools from "./ai-providers";
 import * as ChannelsTools from "./channels";
+import * as ProfileTools from "./profile";
 import * as SecretsTools from "./secrets";
 import * as FileConfigTools from "./file-configs";
 import { ORG_FS_PUBLIC_SETS_SYNC } from "./org-fs/sync-public-sets";
@@ -164,6 +165,9 @@ const CORE_TOOLS = [
   ChannelsTools.CHANNEL_PREVIEW,
   ChannelsTools.CHANNEL_TEST,
   ChannelsTools.CHANNEL_DELETE,
+  ProfileTools.PHONE_LINK_START,
+  ProfileTools.PHONE_GET,
+  ProfileTools.PHONE_DELETE,
   // Secrets tools
   SecretsTools.SECRET_CREATE,
   SecretsTools.SECRET_LIST,

--- a/apps/mesh/src/tools/organization/organization-tools.test.ts
+++ b/apps/mesh/src/tools/organization/organization-tools.test.ts
@@ -198,6 +198,7 @@ const createMockContext = (
       virtualMcpPluginConfigs: null as never,
       aiProviderKeys: null as never,
       channels: null as never,
+      userPhones: null as never,
       secrets: null as never,
       orgFileConfigs: null as never,
       orgFsEntries: null as never,

--- a/apps/mesh/src/tools/organization/settings-tools.test.ts
+++ b/apps/mesh/src/tools/organization/settings-tools.test.ts
@@ -78,6 +78,7 @@ const createMockContext = (
       virtualMcpPluginConfigs: null as never,
       aiProviderKeys: null as never,
       channels: null as never,
+      userPhones: null as never,
       secrets: null as never,
       orgFileConfigs: null as never,
       orgFsEntries: null as never,

--- a/apps/mesh/src/tools/profile/index.ts
+++ b/apps/mesh/src/tools/profile/index.ts
@@ -1,0 +1,3 @@
+export { PHONE_LINK_START } from "./phone-link-start";
+export { PHONE_GET } from "./phone-get";
+export { PHONE_DELETE } from "./phone-delete";

--- a/apps/mesh/src/tools/profile/phone-delete.ts
+++ b/apps/mesh/src/tools/profile/phone-delete.ts
@@ -1,0 +1,18 @@
+import z from "zod";
+import { defineTool } from "../../core/define-tool";
+import { getUserId, requireAuth } from "../../core/studio-context";
+
+/** Unlink the caller's WhatsApp number. */
+export const PHONE_DELETE = defineTool({
+  name: "PHONE_DELETE",
+  description: "Unlink the caller's WhatsApp number.",
+  inputSchema: z.object({}),
+  outputSchema: z.object({ ok: z.boolean() }),
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    const userId = getUserId(ctx);
+    if (!userId) throw new Error("Authentication required");
+    await ctx.storage.userPhones.delete(userId);
+    return { ok: true };
+  },
+});

--- a/apps/mesh/src/tools/profile/phone-get.ts
+++ b/apps/mesh/src/tools/profile/phone-get.ts
@@ -1,0 +1,47 @@
+import z from "zod";
+import { defineTool } from "../../core/define-tool";
+import { getUserId, requireAuth } from "../../core/studio-context";
+import { maskPhone } from "@/channels/phone";
+import {
+  getConciergeNumber,
+  isWhatsappConfigured,
+} from "@/channels/whatsapp-worker";
+
+/**
+ * Current WhatsApp link state for the caller. The profile UI polls this so it
+ * flips to "verified" once the user's code arrives via the ingest route.
+ */
+export const PHONE_GET = defineTool({
+  name: "PHONE_GET",
+  description: "Get the caller's WhatsApp phone link status.",
+  annotations: { readOnlyHint: true },
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    configured: z.boolean(),
+    status: z.enum(["none", "pending", "verified"]),
+    code: z.string().optional(),
+    conciergeNumber: z.string().optional(),
+    maskedPhone: z.string().optional(),
+    selectedOrganizationId: z.string().nullable().optional(),
+  }),
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    const userId = getUserId(ctx);
+    if (!userId) throw new Error("Authentication required");
+
+    const configured = isWhatsappConfigured();
+    const link = await ctx.storage.userPhones.getByUser(userId);
+
+    return {
+      configured,
+      status: link?.status ?? "none",
+      code: link?.status === "pending" ? (link.code ?? undefined) : undefined,
+      conciergeNumber: getConciergeNumber(),
+      maskedPhone:
+        link?.status === "verified" && link.phone
+          ? maskPhone(link.phone)
+          : undefined,
+      selectedOrganizationId: link?.selectedOrganizationId ?? null,
+    };
+  },
+});

--- a/apps/mesh/src/tools/profile/phone-link-start.ts
+++ b/apps/mesh/src/tools/profile/phone-link-start.ts
@@ -1,0 +1,48 @@
+import { randomInt } from "node:crypto";
+import z from "zod";
+import { defineTool } from "../../core/define-tool";
+import { getUserId, requireAuth } from "../../core/studio-context";
+import {
+  getConciergeNumber,
+  isWhatsappConfigured,
+} from "@/channels/whatsapp-worker";
+
+// Distinctive, unambiguous alphabet (no 0/O/1/I/L) so codes are easy to type
+// and unlikely to collide with a normal chat message.
+const ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+const CODE_TTL_MS = 15 * 60_000;
+
+function generateCode(): string {
+  let body = "";
+  for (let i = 0; i < 6; i++) body += ALPHABET[randomInt(ALPHABET.length)];
+  return `DECO-${body}`;
+}
+
+/**
+ * Begin linking the caller's WhatsApp number. Studio issues a one-time code;
+ * the user proves ownership by sending it FROM their WhatsApp to the concierge
+ * number (verification completes in the ingest route, not here).
+ */
+export const PHONE_LINK_START = defineTool({
+  name: "PHONE_LINK_START",
+  description:
+    "Start linking your WhatsApp number: returns a code to send to the concierge number.",
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    code: z.string(),
+    conciergeNumber: z.string(),
+  }),
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    const userId = getUserId(ctx);
+    if (!userId) throw new Error("Authentication required");
+    if (!isWhatsappConfigured()) {
+      throw new Error("WhatsApp is not configured for this deployment");
+    }
+
+    const code = generateCode();
+    await ctx.storage.userPhones.issueCode(userId, code, CODE_TTL_MS);
+
+    return { code, conciergeNumber: getConciergeNumber() ?? "" };
+  },
+});

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -155,6 +155,11 @@ const ALL_TOOL_NAMES = [
   "CHANNEL_TEST",
   "CHANNEL_DELETE",
 
+  // Profile / self WhatsApp phone linking
+  "PHONE_LINK_START",
+  "PHONE_GET",
+  "PHONE_DELETE",
+
   // Secrets vault tools
   "SECRET_CREATE",
   "SECRET_LIST",
@@ -1124,6 +1129,10 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "COLLECTION_THREADS_UPDATE",
       "COLLECTION_THREADS_DELETE",
       "COLLECTION_THREAD_MESSAGES_LIST",
+      // Self-service WhatsApp phone linking (a member manages their OWN phone)
+      "PHONE_LINK_START",
+      "PHONE_GET",
+      "PHONE_DELETE",
     ],
   },
   // Organization

--- a/apps/mesh/src/web/hooks/collections/use-channels.ts
+++ b/apps/mesh/src/web/hooks/collections/use-channels.ts
@@ -17,7 +17,7 @@ import {
 } from "@tanstack/react-query";
 import { KEYS } from "../../lib/query-keys";
 
-export type ChannelType = "teams" | "discord";
+export type ChannelType = "teams" | "discord" | "whatsapp";
 export type ChannelStatus = "draft" | "active" | "error" | "disabled";
 
 export interface ChannelCredentialField {
@@ -35,11 +35,15 @@ export interface ChannelSetupStep {
   link?: { label: string; url: string };
 }
 
+export type ChannelSetupKind = "credentials" | "shared";
+
 export interface ChannelPlatform {
   id: ChannelType;
   name: string;
   description: string;
   logo?: string;
+  /** "credentials" = wizard (Teams/Discord); "shared" = enable-only (WhatsApp). */
+  setupKind: ChannelSetupKind;
   credentialFields: ChannelCredentialField[];
   setupInstructions: ChannelSetupStep[];
 }
@@ -49,7 +53,7 @@ export interface ChannelInstance {
   channelType: ChannelType;
   label: string;
   agentId: string | null;
-  botUserId: string;
+  botUserId: string | null;
   status: ChannelStatus;
   webhookUrl: string;
   metadata: Record<string, unknown> | null;
@@ -138,4 +142,41 @@ export function useChannelClient() {
 export function invalidateChannels(queryClient: QueryClient, orgId: string) {
   queryClient.invalidateQueries({ queryKey: KEYS.orgChannels(orgId) });
   queryClient.invalidateQueries({ queryKey: KEYS.channelPlatforms(orgId) });
+}
+
+// ---------------------------------------------------------------------------
+// WhatsApp phone linking (profile)
+// ---------------------------------------------------------------------------
+
+export interface UserPhoneState {
+  configured: boolean;
+  status: "none" | "pending" | "verified";
+  code?: string;
+  conciergeNumber?: string;
+  maskedPhone?: string;
+  selectedOrganizationId?: string | null;
+}
+
+/**
+ * Poll the caller's WhatsApp link status. While `pending`, refetch every few
+ * seconds so the UI flips to `verified` once the user's code arrives via the
+ * ingest route (effect-free — driven by `refetchInterval`).
+ */
+export function useUserPhone(userId: string) {
+  const { client } = useSelfClient();
+  return useQuery({
+    queryKey: KEYS.userPhone(userId),
+    staleTime: 10_000,
+    refetchInterval: (q) =>
+      (q.state.data as UserPhoneState | undefined)?.status === "pending"
+        ? 3000
+        : false,
+    queryFn: async (): Promise<UserPhoneState> => {
+      const result = (await client.callTool({
+        name: "PHONE_GET",
+        arguments: {},
+      })) as { structuredContent?: UserPhoneState };
+      return result.structuredContent ?? { configured: false, status: "none" };
+    },
+  });
 }

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -319,6 +319,8 @@ export const KEYS = {
   // Connections offered as agent bindings in the channel wizard
   channelAgentOptions: (orgId: string) =>
     ["channel-agent-options", orgId] as const,
+  // Caller's WhatsApp phone link status (profile)
+  userPhone: (userId: string) => ["user-phone", userId] as const,
 
   // Secrets (scoped by org; user-scope filtering happens server-side)
   secrets: (orgId: string) => ["secrets", orgId] as const,

--- a/apps/mesh/src/web/views/settings/channels/connected-channels-section.tsx
+++ b/apps/mesh/src/web/views/settings/channels/connected-channels-section.tsx
@@ -25,6 +25,7 @@ import {
   useChannelClient,
   useChannelPlatforms,
   type ChannelInstance,
+  type ChannelPlatform,
   type ChannelStatus,
   type ChannelType,
 } from "@/web/hooks/collections/use-channels";
@@ -52,7 +53,7 @@ export function PlatformAddButtons({
   onAdd,
   busy,
 }: {
-  onAdd: (platform: ChannelType) => void;
+  onAdd: (platform: ChannelPlatform) => void;
   busy: boolean;
 }) {
   const platforms = useChannelPlatforms();
@@ -64,7 +65,7 @@ export function PlatformAddButtons({
           size="sm"
           variant="outline"
           disabled={busy}
-          onClick={() => onAdd(p.id)}
+          onClick={() => onAdd(p)}
         >
           <Plus size={14} /> Add {p.name}
         </Button>
@@ -80,7 +81,7 @@ export function ConnectedChannelsSection({
   busy,
 }: {
   channels: ChannelInstance[];
-  onAdd: (platform: ChannelType) => void;
+  onAdd: (platform: ChannelPlatform) => void;
   onResume: (target: WizardTarget) => void;
   busy: boolean;
 }) {
@@ -168,7 +169,8 @@ function ChannelRow({
               >
                 <PlayCircle size={14} /> Resume setup
               </Button>
-            ) : (
+            ) : channel.channelType === "whatsapp" ? null : (
+              // WhatsApp has no wizard to edit; change the agent by re-adding.
               <Button
                 variant="ghost"
                 size="icon"

--- a/apps/mesh/src/web/views/settings/channels/index.tsx
+++ b/apps/mesh/src/web/views/settings/channels/index.tsx
@@ -10,6 +10,7 @@ import {
   invalidateChannels,
   useChannelClient,
   useOrgChannels,
+  type ChannelPlatform,
   type ChannelType,
 } from "@/web/hooks/collections/use-channels";
 import {
@@ -18,6 +19,7 @@ import {
   type WizardTarget,
 } from "./connected-channels-section";
 import { SetupWizardDialog } from "./setup-wizard-dialog";
+import { WhatsAppEnableDialog } from "./whatsapp-enable-dialog";
 
 function ErrorFallback({ error }: { error: Error }) {
   return (
@@ -34,7 +36,7 @@ function EmptyState({
   onAdd,
   busy,
 }: {
-  onAdd: (platform: ChannelType) => void;
+  onAdd: (platform: ChannelPlatform) => void;
   busy: boolean;
 }) {
   return (
@@ -57,6 +59,7 @@ function OrgChannelsContent() {
   const { org, client } = useChannelClient();
   const queryClient = useQueryClient();
   const [target, setTarget] = useState<WizardTarget | null>(null);
+  const [whatsappOpen, setWhatsappOpen] = useState(false);
 
   // Create the draft channel (+ its bot) on click, then open the wizard at the
   // first step. Done here (not in the dialog) so platform selection is a plain
@@ -83,17 +86,23 @@ function OrgChannelsContent() {
     onError: (err) => toast.error(`Failed to start setup: ${err.message}`),
   });
 
+  // WhatsApp is enable-only (no wizard); everything else is the draft→wizard flow.
+  const handleAdd = (platform: ChannelPlatform) => {
+    if (platform.setupKind === "shared") {
+      setWhatsappOpen(true);
+      return;
+    }
+    createDraft.mutate(platform.id);
+  };
+
   return (
     <>
       {channels.length === 0 ? (
-        <EmptyState
-          onAdd={(p) => createDraft.mutate(p)}
-          busy={createDraft.isPending}
-        />
+        <EmptyState onAdd={handleAdd} busy={createDraft.isPending} />
       ) : (
         <ConnectedChannelsSection
           channels={channels}
-          onAdd={(p) => createDraft.mutate(p)}
+          onAdd={handleAdd}
           onResume={setTarget}
           busy={createDraft.isPending}
         />
@@ -106,6 +115,10 @@ function OrgChannelsContent() {
           target={target}
           onOpenChange={(o) => !o && setTarget(null)}
         />
+      )}
+
+      {whatsappOpen && (
+        <WhatsAppEnableDialog open onOpenChange={setWhatsappOpen} />
       )}
     </>
   );

--- a/apps/mesh/src/web/views/settings/channels/whatsapp-enable-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/channels/whatsapp-enable-dialog.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import {
+  invalidateChannels,
+  useAgentOptions,
+  useChannelClient,
+} from "@/web/hooks/collections/use-channels";
+
+/**
+ * WhatsApp is a shared-number, enable-only channel — no wizard. Pick the agent
+ * that answers and activate. Members link their phone in their own profile.
+ */
+export function WhatsAppEnableDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { org, client } = useChannelClient();
+  const agentOptions = useAgentOptions();
+  const queryClient = useQueryClient();
+  const [agentId, setAgentId] = useState("");
+
+  const enable = useMutation({
+    mutationFn: async () => {
+      await client.callTool({
+        name: "CHANNEL_CREATE",
+        arguments: { channelType: "whatsapp", agentId },
+      });
+    },
+    onSuccess: () => {
+      invalidateChannels(queryClient, org.id);
+      toast.success("WhatsApp enabled");
+      onOpenChange(false);
+    },
+    onError: (err) => toast.error(`Failed to enable WhatsApp: ${err.message}`),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onOpenChange(false)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Enable WhatsApp</DialogTitle>
+          <DialogDescription>
+            Members chat with this agent over the shared decoCMS WhatsApp
+            number. They link their phone in their profile, then message the
+            concierge number.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">
+            Agent that answers
+          </Label>
+          <Select value={agentId} onValueChange={setAgentId}>
+            <SelectTrigger className="h-8 text-sm">
+              <SelectValue placeholder="Select an agent…" />
+            </SelectTrigger>
+            <SelectContent>
+              {agentOptions.map((a) => (
+                <SelectItem key={a.id} value={a.id}>
+                  {a.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            disabled={!agentId || enable.isPending}
+            onClick={() => enable.mutate()}
+          >
+            {enable.isPending ? "Enabling…" : "Enable"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -1,6 +1,16 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Check, Copy01 } from "@untitledui/icons";
 import { Page } from "@/web/components/page";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { Switch } from "@deco/ui/components/switch.tsx";
+import { KEYS } from "@/web/lib/query-keys";
+import {
+  useChannelClient,
+  useUserPhone,
+} from "@/web/hooks/collections/use-channels";
 import {
   Select,
   SelectContent,
@@ -125,6 +135,108 @@ function ProfileSection() {
             <span className="text-sm text-muted-foreground">{user?.email}</span>
           }
         />
+      </SettingsCard>
+    </SettingsSection>
+  );
+}
+
+function WhatsAppLinkSection() {
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id ?? "";
+  const { client } = useChannelClient();
+  const queryClient = useQueryClient();
+  const { data: phone } = useUserPhone(userId);
+  const [copied, setCopied] = useState(false);
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: KEYS.userPhone(userId) });
+
+  const start = useMutation({
+    mutationFn: async () => {
+      await client.callTool({ name: "PHONE_LINK_START", arguments: {} });
+    },
+    onSuccess: invalidate,
+    onError: (err) => toast.error(`Failed to start linking: ${err.message}`),
+  });
+
+  const remove = useMutation({
+    mutationFn: async () => {
+      await client.callTool({ name: "PHONE_DELETE", arguments: {} });
+    },
+    onSuccess: invalidate,
+    onError: (err) => toast.error(`Failed to unlink: ${err.message}`),
+  });
+
+  // Hidden entirely when the deployment has no WhatsApp concierge configured.
+  if (!phone || !phone.configured) return null;
+
+  const conciergeDisplay = phone.conciergeNumber
+    ? `+${phone.conciergeNumber.replace(/\D/g, "")}`
+    : "the concierge number";
+
+  return (
+    <SettingsSection
+      title="WhatsApp"
+      description="Link your number to chat with your organizations' agents over WhatsApp."
+    >
+      <SettingsCard>
+        {phone.status === "verified" ? (
+          <SettingsCardItem
+            title="WhatsApp number"
+            description={`Linked${phone.maskedPhone ? ` · ${phone.maskedPhone}` : ""}`}
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={remove.isPending}
+                onClick={() => remove.mutate()}
+              >
+                Remove
+              </Button>
+            }
+          />
+        ) : phone.status === "pending" && phone.code ? (
+          <SettingsCardItem
+            title="Verify your number"
+            description={`Send the code below to ${conciergeDisplay} on WhatsApp. This page updates automatically once it arrives.`}
+            action={
+              <div className="flex items-center gap-2">
+                <code className="rounded-md bg-muted px-2 py-1.5 text-xs">
+                  {phone.code}
+                </code>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => {
+                    navigator.clipboard.writeText(phone.code ?? "").then(() => {
+                      setCopied(true);
+                      toast.success("Code copied");
+                      setTimeout(() => setCopied(false), 1500);
+                    });
+                  }}
+                >
+                  {copied ? <Check size={14} /> : <Copy01 size={14} />}
+                </Button>
+                <Spinner size="sm" />
+              </div>
+            }
+          />
+        ) : (
+          <SettingsCardItem
+            title="WhatsApp number"
+            description="Not linked yet."
+            action={
+              <Button
+                size="sm"
+                disabled={start.isPending}
+                onClick={() => start.mutate()}
+              >
+                {start.isPending ? "Starting…" : "Link WhatsApp"}
+              </Button>
+            }
+          />
+        )}
       </SettingsCard>
     </SettingsSection>
   );
@@ -296,6 +408,7 @@ export function ProfilePreferencesPage() {
           <SettingsPage>
             <Page.Title>Profile & Preferences</Page.Title>
             <ProfileSection />
+            <WhatsAppLinkSection />
             <PreferencesSection />
           </SettingsPage>
         </Page.Body>


### PR DESCRIPTION
## Summary

Adds **WhatsApp** as a third channel, **stacked on the Teams/Discord channels PR** (#3749 — this PR's base is `vibegui/org-chat-integration`, so the diff is WhatsApp-only). Merge #3749 first.

Unlike the per-org Teams/Discord bots, WhatsApp uses **one shared decoCMS concierge number**. A user verifies their phone once in their profile; inbound messages route **by phone → user → org** and the org's agent answers **as that real user**.

## How it works
- **Verification (inbound-only):** Studio issues a code shown in the user's profile; the user texts it to the concierge number; that inbound proves ownership and links the number. No phone typing, no Studio→worker send for verification.
- **Routing:** global `POST /api/whatsapp/ingest` (shared-secret auth, async) — verify code → resolve phone→user → pick the target org (saved default + in-chat numbered pick-list / `switch`) → run the agent as the real user → reply via the worker's `/send`.
- **Identity:** one verified phone → one Studio user, across all their orgs.
- **Enable-only channel:** no per-org credentials/bot — `CHANNELS_LIST` advertises WhatsApp (`setupKind: "shared"`), `CHANNEL_CREATE` activates immediately with a chosen agent. Only available when `WHATSAPP_WORKER_URL/TOKEN`, `WHATSAPP_INGEST_SECRET`, `WHATSAPP_CONCIERGE_NUMBER` are set.
- The deployed Cloudflare worker (`mangabeira`) stays the WABA owner and becomes a thin relay — integration prompt in `.context/whatsapp-worker-integration-prompt.md`.

## Key pieces
- `migration 110-user-phones`; `109-channels.bot_user_id` made nullable
- `UserPhoneStorage` + phone canonicalization; `whatsapp-worker` client; `whatsapp-ingest` route
- `runChannelTurn` generalized (`botUserId`→`userId`) so the real user can answer
- profile tools `PHONE_LINK_START / PHONE_GET / PHONE_DELETE` (basic-usage)
- profile "Link WhatsApp" UI + "Add WhatsApp" enable dialog

## Testing
- `bun run check` / `lint` / `fmt:check` / `knip` clean; `build:server` ok.
- Unit tests: org-selection resolver + phone canonicalization (+ existing channel adapter tests).
- Manual: `curl` the ingest endpoint with a mock worker `/send`, or wire the real worker per the prompt. Run `bun run --cwd=apps/mesh migrate` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WhatsApp as a shared-number concierge channel. Members link their phone once; inbound messages route phone → user → org, and the agent runs as the real user.

- **New Features**
  - Global ingest endpoint with secret auth; verifies one-time codes, resolves phone → user → org (remembered org, number pick-list, or `switch`).
  - Runs agent turns as the real user (`runChannelTurn` now uses `userId`) and replies via the WhatsApp worker `/send`.
  - Enable-only channel: listed when configured, created without a bot or credentials, activates immediately with a chosen agent.
  - Profile tools and UI for phone linking: `PHONE_LINK_START`, `PHONE_GET`, `PHONE_DELETE`; “Link WhatsApp” in profile with live polling.
  - Settings UI: “Enable WhatsApp” dialog to pick the answering agent.
  - Storage and utils: `UserPhoneStorage`, phone canonicalization/masking, and unit tests for org selection and phone utils.

- **Migration**
  - DB: new `user_phones` table; `channels.bot_user_id` is nullable for WhatsApp.
  - Config: set `WHATSAPP_WORKER_URL`, `WHATSAPP_WORKER_TOKEN`, `WHATSAPP_INGEST_SECRET`, `WHATSAPP_CONCIERGE_NUMBER`.
  - Deploy/enable the WhatsApp worker, then run migrations and enable WhatsApp per org by selecting an agent. Members link their phone from their profile.

<sup>Written for commit 6dfad8706439c35ecbad1b2e46d327233416469a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

