### PR TITLE
feat(org-fs): home volume — the org's shared folder, mounted as org/<slug>

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/decopilot/overview.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/decopilot/overview.mdx
@@ -68,7 +68,7 @@ Decopilot ships with tools for coordinating work across any scope:
 
 When an agent is backed by a sandbox (a linked GitHub repo), decopilot also gets six **VM tools** — `bash`, `read`, `write`, `edit`, `grep`, `glob` — so it can execute and modify code in that sandbox.
 
-Sandboxes also mount the **organization filesystem** under `org/`: `org/upload` holds the files attached to the current conversation (chat attachments land there automatically — no copy step), `org/output` is the current run's shared output folder, and `org/public/<set>` exposes curated read-only skill sets synced from versioned repositories. Files written to `org/output` sync to your organization's cloud storage and are visible to every member and agent; external changes appear inside the sandbox within about a second.
+Sandboxes also mount the **organization filesystem** under `org/`: a folder named after your organization (e.g. `org/acme/`) is the org's shared home — editable, free-form, shared across every member, agent, and run, where agents record durable knowledge and check for context before starting work; `org/upload` holds the files attached to the current conversation (chat attachments land there automatically — no copy step); `org/output` is the current run's shared output folder; and `org/public/<set>` exposes curated read-only skill sets synced from versioned repositories. Files written to the home folder and `org/output` sync to your organization's cloud storage and are visible to every member and agent; external changes appear inside the sandbox within about a second.
 
 <Callout type="info">
   **macOS desktop links:** when a sandbox runs on your machine (`deco link`),

--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -145,6 +145,7 @@ export function buildOrgFilesystemPrompt(publicSets: string[]): string {
       : "No sets are configured on this deployment.";
   return `<organization-filesystem>
 The organization filesystem is mounted at \`org/\` in your sandbox (when available):
+- the folder named after your organization (its slug — run \`ls org/\` to see it) — the org's shared home folder, editable and shared across every agent, member, and run. Organize it freely with subfolders. Check it for relevant context before starting non-trivial work, and record durable knowledge as you learn it: decisions, preferences, project facts, gotchas. Prefer small focused markdown files over one big log, and update stale notes instead of appending duplicates.
 - \`org/public/<set>/\` — curated read-only skill sets. ${sets} Each skill is a folder with a SKILL.md — read it before applying the skill.
 - \`org/upload/\` — files the user attached to this conversation are already here; read them directly (no copy step needed).
 - \`org/output/\` — write final deliverables here; they are shared back to the organization under this run's folder.

--- a/apps/mesh/src/file-storage/home-mount.ts
+++ b/apps/mesh/src/file-storage/home-mount.ts
@@ -1,0 +1,22 @@
+/**
+ * Mount path for the org's `home` volume — shared by sandbox provisioning
+ * (the actual mount) and the Library UI (the card label), so the name the
+ * user sees always matches the path the agent sees. Dependency-free on
+ * purpose: the web bundle imports this directly.
+ */
+
+/** Other names that live directly under `org/` — a slug matching one of
+ *  these would shadow it. */
+const RESERVED_HOME_PATHS = new Set(["output", "upload", "public", "home"]);
+/** One safe path segment, no traversal/hidden dirs (mirrors thread-links). */
+const SAFE_MOUNT_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** The org's own slug (immutable), so the agent sees `org/<slug>/`. Falls
+ *  back to a literal `home` when the slug would collide with another `org/`
+ *  entry or isn't a safe segment. */
+export function homeMountPath(orgSlug: string): string {
+  if (RESERVED_HOME_PATHS.has(orgSlug) || !SAFE_MOUNT_SEGMENT.test(orgSlug)) {
+    return "home";
+  }
+  return orgSlug;
+}

--- a/apps/mesh/src/file-storage/mount/provisioning.test.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { buildOrgFsConfig } from "./provisioning";
+import { buildOrgFsConfig, homeMountPath } from "./provisioning";
 
 describe("buildOrgFsConfig", () => {
-  it("returns the hardcoded outputs + uploads mounts with the given identity", () => {
+  it("returns home (slug-mounted) + outputs + uploads with the given identity", () => {
     const c = buildOrgFsConfig({
       baseUrl: "https://cluster.example",
       orgSlug: "acme",
@@ -11,6 +11,7 @@ describe("buildOrgFsConfig", () => {
     expect(c.orgSlug).toBe("acme");
     expect(c.token).toBe("tok_abc");
     expect(c.mounts).toEqual([
+      { volume: "home", path: "acme" },
       { volume: "outputs", path: ".outputs" },
       { volume: "uploads", path: ".uploads" },
     ]);
@@ -21,5 +22,21 @@ describe("buildOrgFsConfig", () => {
       buildOrgFsConfig({ baseUrl: "http://x/", orgSlug: "o", token: "t" })
         .baseUrl,
     ).toBe("http://x");
+  });
+});
+
+describe("homeMountPath", () => {
+  it("uses the org slug as the mount path", () => {
+    expect(homeMountPath("acme")).toBe("acme");
+    expect(homeMountPath("my-org.2")).toBe("my-org.2");
+  });
+
+  it("falls back to 'home' for reserved or unsafe slugs", () => {
+    for (const bad of ["output", "upload", "public", "home"]) {
+      expect(homeMountPath(bad)).toBe("home");
+    }
+    for (const bad of [".hidden", "a/b", "", "..", "with space"]) {
+      expect(homeMountPath(bad)).toBe("home");
+    }
   });
 });

--- a/apps/mesh/src/file-storage/mount/provisioning.test.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { buildOrgFsConfig, homeMountPath } from "./provisioning";
+import { homeMountPath } from "../home-mount";
+import { buildOrgFsConfig } from "./provisioning";
 
 describe("buildOrgFsConfig", () => {
   it("returns home (slug-mounted) + outputs + uploads with the given identity", () => {

--- a/apps/mesh/src/file-storage/mount/provisioning.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.ts
@@ -23,6 +23,7 @@
  *     folder appear in the sandbox with no copy step.
  */
 
+import { homeMountPath } from "../home-mount";
 import { getPublicSets, publicVolumeForSet } from "../public-sets";
 
 /** Shape the daemon parses from ORGFS_CONFIG (mirrors OrgFsMountConfig). */
@@ -43,22 +44,6 @@ const DEFAULT_MOUNTS: ReadonlyArray<{ volume: string; path: string }> = [
   { volume: "outputs", path: ORG_FS_OUTPUTS_MOUNT_PATH },
   { volume: "uploads", path: ORG_FS_UPLOADS_MOUNT_PATH },
 ];
-
-/** Other names that live directly under `org/` — a slug matching one of
- *  these would shadow it. */
-const RESERVED_HOME_PATHS = new Set(["output", "upload", "public", "home"]);
-/** One safe path segment, no traversal/hidden dirs (mirrors thread-links). */
-const SAFE_MOUNT_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
-
-/** Mount path for the org's home volume: the org's own slug (immutable),
- *  so the agent sees `org/<slug>/`. Falls back to a literal `home` when the
- *  slug would collide with another `org/` entry or isn't a safe segment. */
-export function homeMountPath(orgSlug: string): string {
-  if (RESERVED_HOME_PATHS.has(orgSlug) || !SAFE_MOUNT_SEGMENT.test(orgSlug)) {
-    return "home";
-  }
-  return orgSlug;
-}
 
 export function buildOrgFsConfig(opts: {
   baseUrl: string;

--- a/apps/mesh/src/file-storage/mount/provisioning.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.ts
@@ -4,9 +4,15 @@
  * (packages/sandbox/daemon/org-fs/config.ts) validates this shape.
  *
  * The mounted set is hardcoded for now (per the team decision); later this
- * becomes per-agent configurable. Two volumes (org skills are deliberately
+ * becomes per-agent configurable. Three volumes (org skills are deliberately
  * NOT a cloud volume — skills belong in versioned repos, surfaced through
  * the read-only public sets):
+ *   - `home`    → mounted at `<appRoot>/org/<orgSlug>` (visible, editable):
+ *     the org's shared home folder, free-form — members and agents organize
+ *     it with whatever subfolders they want, and knowledge accumulates
+ *     across every run (no per-thread scoping). The volume NAME is the
+ *     stable `home` (uniform keyspace across orgs); only the mount path
+ *     carries the slug, which is immutable by design (see CLAUDE.md).
  *   - `outputs` → mounted at `<appRoot>/org/.outputs` (hidden); the daemon
  *     repoints a per-run symlink `<appRoot>/org/output → .outputs/<threadId>`
  *     so the agent sees a bare `output/` that is, externally, that thread's
@@ -38,6 +44,22 @@ const DEFAULT_MOUNTS: ReadonlyArray<{ volume: string; path: string }> = [
   { volume: "uploads", path: ORG_FS_UPLOADS_MOUNT_PATH },
 ];
 
+/** Other names that live directly under `org/` — a slug matching one of
+ *  these would shadow it. */
+const RESERVED_HOME_PATHS = new Set(["output", "upload", "public", "home"]);
+/** One safe path segment, no traversal/hidden dirs (mirrors thread-links). */
+const SAFE_MOUNT_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Mount path for the org's home volume: the org's own slug (immutable),
+ *  so the agent sees `org/<slug>/`. Falls back to a literal `home` when the
+ *  slug would collide with another `org/` entry or isn't a safe segment. */
+export function homeMountPath(orgSlug: string): string {
+  if (RESERVED_HOME_PATHS.has(orgSlug) || !SAFE_MOUNT_SEGMENT.test(orgSlug)) {
+    return "home";
+  }
+  return orgSlug;
+}
+
 export function buildOrgFsConfig(opts: {
   baseUrl: string;
   orgSlug: string;
@@ -50,6 +72,8 @@ export function buildOrgFsConfig(opts: {
     orgSlug: opts.orgSlug,
     token: opts.token,
     mounts: [
+      // The org's home folder mounts under the org's own name.
+      { volume: "home", path: homeMountPath(opts.orgSlug) },
       ...DEFAULT_MOUNTS.map((m) => ({ ...m })),
       ...(opts.publicSets ?? []).map((set) => ({
         volume: publicVolumeForSet(set),

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -159,6 +159,10 @@ export function buildBashDescription(orgFs: boolean): string {
     "Working directory is the project root. Timeout default 30s, max 2min.\n\n" +
     (orgFs
       ? "The organization filesystem is mounted at `org/` (when available):\n" +
+        "- `org/<your-org-slug>/` — the org's shared home folder (editable, " +
+        "shared across runs; `ls org/` shows the actual name). Organize it " +
+        "freely; check it before non-trivial work and record durable facts, " +
+        "decisions, and learnings as small markdown files.\n" +
         "- `org/public/<set>/` — curated read-only skill sets. Run " +
         "`ls org/public/` for the sets and `cat org/public/<set>/<name>/SKILL.md` " +
         "before using a skill.\n" +

--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -47,6 +47,7 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { homeMountPath } from "@/file-storage/home-mount";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { KEYS } from "@/web/lib/query-keys";
 import {
@@ -277,9 +278,13 @@ function RootView({
             <VolumeFolderCard
               key={v.id}
               volume={v.id}
-              // The home volume presents as the org itself (mirrors the
-              // sandbox mount at org/<slug>).
-              displayName={v.id === "home" ? org.slug : undefined}
+              // The home volume presents as the org itself — through the same
+              // helper provisioning uses, so the label always matches the
+              // sandbox mount (incl. the reserved-slug fallback to "home",
+              // which avoids two cards both named e.g. "public").
+              displayName={
+                v.id === "home" ? homeMountPath(org.slug) : undefined
+              }
               description={v.description}
               glyph={v.glyph}
               onOpen={() => onOpenDir(v.id)}

--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -19,6 +19,7 @@ import {
   ChevronRight,
   Eye,
   Globe01,
+  Home01,
   Plus,
   RefreshCw01,
   Stars01,
@@ -78,6 +79,7 @@ import { SkillPreviewDialog } from "./skill-preview-dialog";
  *  deliberately absent — they live in versioned repos (public sets), not as
  *  an editable cloud volume. */
 const VOLUMES = [
+  { id: "home", description: "Your organization's home folder", glyph: Home01 },
   { id: "uploads", description: "Files your team uploads", glyph: Upload01 },
   { id: "outputs", description: "Agent run outputs", glyph: Stars01 },
 ] as const;
@@ -147,11 +149,14 @@ function FolderFilterPills() {
 
 function VolumeFolderCard({
   volume,
+  displayName,
   description,
   glyph,
   onOpen,
 }: {
   volume: string;
+  /** Card label when it differs from the volume id (home shows the slug). */
+  displayName?: string;
   description: string;
   glyph?: ComponentType<SVGProps<SVGSVGElement>>;
   onOpen: () => void;
@@ -159,7 +164,7 @@ function VolumeFolderCard({
   const usage = useOrgFsUsage(volume);
   return (
     <FolderCard
-      name={volume}
+      name={displayName ?? volume}
       meta={usage.data ? `${usage.data.files} files` : undefined}
       subtitle={description}
       glyph={glyph}
@@ -223,6 +228,7 @@ function RootView({
   onOpenFile: (previewPath: string) => void;
   onDelete: (pending: PendingDelete) => void;
 }) {
+  const { org } = useProjectContext();
   const recent = useOrgFsRecent();
   const publicSets = useOrgFsPublicSets();
   const fileUrl = useOrgFsFileUrl();
@@ -271,6 +277,9 @@ function RootView({
             <VolumeFolderCard
               key={v.id}
               volume={v.id}
+              // The home volume presents as the org itself (mirrors the
+              // sandbox mount at org/<slug>).
+              displayName={v.id === "home" ? org.slug : undefined}
               description={v.description}
               glyph={v.glyph}
               onOpen={() => onOpenDir(v.id)}


### PR DESCRIPTION
## Summary

Adds a third default org-fs volume, **`home`** — the organization's free-form shared folder, mounted visible + editable in every sandbox **under the org's own slug** (`org/acme/`). It reads as "the org's drive": members and agents create whatever subfolders they want, and knowledge accumulates across every run (no per-thread scoping).

> Reworked from the earlier "memory volume" cut of this PR: instead of a purpose-named `memory` folder, one open home folder named after the org — memory usage is encouraged by the prompt, structure is up to each org.

| Piece | Change |
|---|---|
| `provisioning.ts` | `home` volume mounted at `homeMountPath(orgSlug)` — the slug (immutable by design) unless it collides with another `org/` entry (`output`/`upload`/`public`/`home`) or isn't a safe path segment, then a literal `home`. The volume NAME stays `home`, so the keyspace is uniform across orgs; only the mount path carries the slug. Direct mount, no symlink → **no daemon/image change** |
| System prompt + bash description | Teach the home folder: *check it for relevant context before non-trivial work; record durable knowledge — decisions, preferences, project facts, gotchas — as small focused markdown files; update stale notes instead of duplicating*. Worded slug-generically (`ls org/` reveals the name) so the prompt stays deployment-stable (cached prefix) |
| Library | `home` card labeled with the **org slug** (Home01 glyph), first in the volumes row |
| Docs | decopilot overview `org/` section |

## Notes

- Lazily materialized — an org that never touches it costs nothing
- Members edit it in the Library; agents read/write the same files at `org/<slug>/` — bidirectional shared memory
- Browse URL uses the stable volume id (`?path=home/...`) while the card shows the slug
- Rollout: pure mesh change — flows with the next mesh image bump (no chart or runner-image dependency)

## Testing

- `bun run lint` 0/0, `tsc` clean
- Unit: mounts shape (home@slug + outputs + uploads) and `homeMountPath` fallbacks (reserved names, hidden/multi-segment/empty/space slugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)