### PR TITLE
fix(dev): bind Vite to :4000 after removing deco plugin

### DIFF
--- a/apps/mesh/vite.config.ts
+++ b/apps/mesh/vite.config.ts
@@ -2,9 +2,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
-import deco from "@decocms/vite-plugin";
 import pkg from "./package.json" with { type: "json" };
 
+const vitePort = parseInt(process.env.VITE_PORT || "4000", 10);
 const bunServerTarget = `http://localhost:${process.env.PORT || "3000"}`;
 
 // IMPORTANT: the dev server must run under Node, NOT Bun (`vite dev`, never
@@ -22,6 +22,10 @@ export default defineConfig({
     __MESH_VERSION__: JSON.stringify(pkg.version),
   },
   server: {
+    // Previously set by @decocms/vite-plugin's baseDecoPlugin; keep the same
+    // defaults so the link daemon and dev CLI can reach Vite on :4000.
+    port: vitePort,
+    strictPort: true,
     // In a sandbox the daemon proxies the preview to Vite over IPv4
     // (127.0.0.1); Vite otherwise binds IPv6-only (localhost → [::1]) and the
     // proxy can't reach it. HOST=0.0.0.0 is the daemon's dev-env tell.
@@ -29,7 +33,7 @@ export default defineConfig({
     hmr: {
       overlay: true,
       host: "localhost",
-      clientPort: parseInt(process.env.VITE_PORT || "4000", 10),
+      clientPort: vitePort,
     },
     proxy: {
       "/api": {
@@ -73,8 +77,5 @@ export default defineConfig({
     react({ babel: { plugins: ["babel-plugin-react-compiler"] } }),
     tailwindcss(),
     tsconfigPaths({ root: "." }),
-    deco({
-      target: "bun",
-    }),
   ],
 });


### PR DESCRIPTION
## Summary
- Remove `@decocms/vite-plugin` from `vite.config.ts` and inline the port settings it previously provided (`port: 4000`, `strictPort: true`).
- Fixes link daemon `ConnectionRefused` errors on `/api/links/proxy`, `/api/links/control`, and `/api/links/work` during local dev — the daemon polls Vite on `:4000`, but without the plugin Vite was binding to the default `:5173`.

## Test plan
- [ ] Run `bun run dev` (or `bun run dev:servers` with `VITE_PORT=4000 PORT=3000`)
- [ ] Confirm Vite listens on `http://localhost:4000`
- [ ] Confirm link daemon connects without repeated `ConnectionRefused` errors
- [ ] Confirm the UI loads and `/api` proxy routes work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the Vite dev server to port 4000 after removing `@decocms/vite-plugin` so the link daemon and dev CLI can reach it. Fixes ConnectionRefused errors on `/api/links/proxy`, `/api/links/control`, and `/api/links/work` during local dev.

- **Bug Fixes**
  - Configure `server.port` from `VITE_PORT` (default 4000) with `strictPort: true`.
  - Use the same port for HMR `clientPort`; keep IPv4 host behavior when `HOST=0.0.0.0`.
  - Remove `@decocms/vite-plugin` and inline its port behavior.

<sup>Written for commit ef8ef109af4554b9f49b1041247171ae0523156f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

