### PR TITLE
Stream sandbox daemon events from preview

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.test.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildDirectDaemonEventsUrl,
+  isDirectDaemonEventsGoneStatus,
+} from "./sandbox-events-context";
+
+describe("buildDirectDaemonEventsUrl", () => {
+  test("routes daemon events through the preview origin root", () => {
+    expect(
+      buildDirectDaemonEventsUrl("https://abc.preview.example.com/app/page"),
+    ).toBe("https://abc.preview.example.com/_sandbox/events");
+  });
+
+  test("preserves local desktop preview origin", () => {
+    expect(buildDirectDaemonEventsUrl("http://h1.localhost:4000")).toBe(
+      "http://h1.localhost:4000/_sandbox/events",
+    );
+  });
+
+  test("returns null for missing or invalid preview URLs", () => {
+    expect(buildDirectDaemonEventsUrl(null)).toBeNull();
+    expect(buildDirectDaemonEventsUrl("not a url")).toBeNull();
+  });
+});
+
+describe("isDirectDaemonEventsGoneStatus", () => {
+  test("maps preview 404 to sandbox gone", () => {
+    expect(isDirectDaemonEventsGoneStatus(404)).toBe(true);
+  });
+
+  test("does not map transient preview errors to sandbox gone", () => {
+    expect(isDirectDaemonEventsGoneStatus(429)).toBe(false);
+    expect(isDirectDaemonEventsGoneStatus(502)).toBe(false);
+    expect(isDirectDaemonEventsGoneStatus(503)).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -114,6 +114,7 @@ class ChunkBuffer {
 
 const BASE_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
+const DIRECT_EVENTS_PROBE_TIMEOUT_MS = 3_000;
 
 const DAEMON_EVENT_TYPES: readonly DaemonEventName[] = [
   "lifecycle",
@@ -126,14 +127,45 @@ const DAEMON_EVENT_TYPES: readonly DaemonEventName[] = [
 // `log` is broadcast separately — same SSE stream, different shape.
 const LOG_EVENT = "log" as const;
 
+export function buildDirectDaemonEventsUrl(
+  previewUrl: string | null | undefined,
+): string | null {
+  if (!previewUrl) return null;
+  try {
+    return new URL("/_sandbox/events", previewUrl).href;
+  } catch {
+    return null;
+  }
+}
+
+export function isDirectDaemonEventsGoneStatus(status: number): boolean {
+  return status === 404;
+}
+
+async function probeDirectDaemonEventsGone(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: "text/event-stream" },
+      cache: "no-store",
+      signal: AbortSignal.timeout(DIRECT_EVENTS_PROBE_TIMEOUT_MS),
+    });
+    await response.body?.cancel().catch(() => {});
+    return isDirectDaemonEventsGoneStatus(response.status);
+  } catch {
+    return false;
+  }
+}
+
 export function SandboxEventsProvider({
   virtualMcpId,
   branch,
+  previewUrl = null,
   enabled = true,
   children,
 }: {
   virtualMcpId: string | null;
   branch: string | null;
+  previewUrl?: string | null;
   /**
    * Open the events stream only when a sandbox exists (or is about to) for
    * this (virtualMcpId, branch). Mounting the provider with `enabled={false}`
@@ -161,6 +193,7 @@ export function SandboxEventsProvider({
   const chunkHandlers = useRef(new Set<ChunkHandler>());
   const reloadHandlers = useRef(new Set<ReloadHandler>());
   const prevPortRef = useRef<number | null>(null);
+  const directDaemonEventsUrl = buildDirectDaemonEventsUrl(previewUrl);
 
   const getOrCreateBuffer = (source: string) => {
     let buf = buffers.current.get(source);
@@ -191,7 +224,8 @@ export function SandboxEventsProvider({
     let disposed = false;
     let reconnectAttempt = 0;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-    let es: EventSource | null = null;
+    let studioEs: EventSource | null = null;
+    let directEs: EventSource | null = null;
 
     const handleClaimPhase = (e: MessageEvent) => {
       try {
@@ -204,6 +238,9 @@ export function SandboxEventsProvider({
         if (next.kind !== "failed") {
           setNotFound(false);
           reconnectAttempt = 0;
+        }
+        if (next.kind === "ready") {
+          connectDirectDaemonEvents();
         }
       } catch (err) {
         console.warn("[vm-events] bad phase payload", err);
@@ -317,10 +354,11 @@ export function SandboxEventsProvider({
       }
     };
 
-    function connect() {
+    function connectStudioEvents() {
       if (disposed) return;
 
-      es = new EventSource(sseUrl);
+      const candidate = new EventSource(sseUrl);
+      studioEs = candidate;
 
       // NOTE: deliberately do NOT reset `reconnectAttempt` here. A connection
       // that opens, immediately receives `gone` (handle evicted), and closes
@@ -329,22 +367,75 @@ export function SandboxEventsProvider({
       // data/phase progress arrives (see handleLog/handleDaemonEvent/
       // handleClaimPhase), so repeated `gone`-only reconnects ramp toward the
       // 30s cap instead of hammering.
-      es.onopen = () => {};
+      candidate.onopen = () => {};
 
-      es.onerror = () => {
-        if (es?.readyState !== EventSource.CLOSED) return;
-        scheduleReconnect();
+      candidate.onerror = () => {
+        if (studioEs !== candidate) return;
+        if (candidate.readyState !== EventSource.CLOSED) return;
+        scheduleReconnect("studio");
       };
 
-      es.addEventListener("phase", handleClaimPhase);
-      es.addEventListener("gone", handleGone);
-      es.addEventListener(LOG_EVENT, handleLog);
+      candidate.addEventListener("phase", handleClaimPhase);
+      candidate.addEventListener("gone", handleGone);
+      candidate.addEventListener(LOG_EVENT, handleLog);
       for (const type of DAEMON_EVENT_TYPES) {
-        es.addEventListener(type, handleDaemonEvent);
+        candidate.addEventListener(type, handleDaemonEvent);
       }
     }
 
-    function scheduleReconnect() {
+    function connectDirectDaemonEvents() {
+      if (disposed || !directDaemonEventsUrl || directEs) return;
+
+      const candidate = new EventSource(directDaemonEventsUrl);
+      directEs = candidate;
+      let opened = false;
+
+      candidate.onopen = () => {
+        if (disposed || directEs !== candidate) return;
+        opened = true;
+        reconnectAttempt = 0;
+        const previousStudio = studioEs;
+        studioEs = null;
+        previousStudio?.close();
+      };
+
+      candidate.onerror = () => {
+        if (directEs !== candidate) return;
+        if (candidate.readyState !== EventSource.CLOSED) return;
+        void handleDirectDaemonEventsClosed(candidate, opened);
+      };
+
+      candidate.addEventListener(LOG_EVENT, handleLog);
+      for (const type of DAEMON_EVENT_TYPES) {
+        candidate.addEventListener(type, handleDaemonEvent);
+      }
+    }
+
+    async function handleDirectDaemonEventsClosed(
+      candidate: EventSource,
+      opened: boolean,
+    ) {
+      const gone = directDaemonEventsUrl
+        ? await probeDirectDaemonEventsGone(directDaemonEventsUrl)
+        : false;
+      if (disposed || directEs !== candidate) return;
+
+      candidate.close();
+      directEs = null;
+
+      if (gone) {
+        handleGone();
+        if (!studioEs) connectStudioEvents();
+        return;
+      }
+
+      if (opened) {
+        scheduleReconnect("direct");
+      }
+      // If direct never opened, leave the Studio stream alive as fallback.
+    }
+
+    function scheduleReconnect(target: "studio" | "direct") {
       if (disposed || reconnectTimer) return;
 
       const delay = Math.min(
@@ -356,19 +447,27 @@ export function SandboxEventsProvider({
       reconnectTimer = setTimeout(() => {
         reconnectTimer = null;
         if (disposed) return;
-        es?.close();
-        connect();
+        if (target === "direct") {
+          directEs?.close();
+          directEs = null;
+          connectDirectDaemonEvents();
+          return;
+        }
+        studioEs?.close();
+        studioEs = null;
+        connectStudioEvents();
       }, delay);
     }
 
-    connect();
+    connectStudioEvents();
 
     return () => {
       disposed = true;
-      es?.close();
+      studioEs?.close();
+      directEs?.close();
       if (reconnectTimer) clearTimeout(reconnectTimer);
     };
-  }, [virtualMcpId, branch, org.slug, enabled]);
+  }, [virtualMcpId, branch, org.slug, enabled, directDaemonEventsUrl]);
 
   const value: SandboxEventsValue = {
     phase,

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -74,7 +74,11 @@ import { MainPanelTabsBar } from "@/web/layouts/main-panel-tabs/main-panel-tabs-
 import { MainPanelWithDrawer } from "@/web/layouts/main-panel-tabs/main-panel-with-drawer";
 import { VirtualMcpHeaderInfo } from "../../views/virtual-mcp/header-info.tsx";
 import { SandboxEventsProvider } from "@/web/components/sandbox/hooks/sandbox-events-context.tsx";
-import { SandboxLifecycleProvider } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
+import {
+  SandboxLifecycleProvider,
+  selectVmEntry,
+  type BranchMapEntryLike,
+} from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 import { useEnsureTask } from "@/web/hooks/use-ensure-task";
 import { ShellRouteLoading } from "@/web/layouts/shell-route-loading";
 
@@ -227,14 +231,20 @@ function VmEventsBridge({
   );
   const branchMap =
     userId && currentBranch
-      ? parseBranchMap(sandboxMap?.[userId]?.[currentBranch])
+      ? (parseBranchMap(sandboxMap?.[userId]?.[currentBranch]) as Record<
+          string,
+          BranchMapEntryLike
+        >)
       : {};
+  const vmEntry = selectVmEntry(branchMap);
+  const previewUrl = vmEntry?.previewUrl ?? null;
   const shouldConnect = Object.keys(branchMap).length > 0 || isStartPending;
 
   return (
     <SandboxEventsProvider
       virtualMcpId={virtualMcpId}
       branch={currentBranch ?? null}
+      previewUrl={previewUrl}
       enabled={shouldConnect}
     >
       <SandboxLifecycleProvider


### PR DESCRIPTION
## What is this contribution about?
Moves sandbox daemon SSE consumption to the browser after Studio reports lifecycle ready, using the sandbox preview origin’s `/_sandbox/events` endpoint. Studio remains the lifecycle/fallback stream and reopens when a direct 404 indicates the sandbox is gone.

## Screenshots/Demonstration
Not applicable; no visual UI change.

## How to Test
1. Open a started sandbox preview and confirm logs/status continue updating after lifecycle ready.
2. Verify the browser connects to `<previewUrl>/_sandbox/events` while Studio remains the fallback path.
3. Run `bun test apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.test.ts`, `bun run check`, `bun run lint`, and `bun run fmt`.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stream sandbox daemon SSE directly from the browser preview after lifecycle is ready, with Studio SSE as a safe fallback. Treats preview 404 as sandbox gone, reducing reliance on Studio.

- **New Features**
  - Switch to the preview’s `/_sandbox/events` once lifecycle is ready; keep Studio SSE until direct opens, then close it. If direct never opens, Studio stays as fallback.
  - On direct close, probe the endpoint (3s). 404 => sandbox gone; other errors are transient and Studio remains fallback.
  - Exponential backoff per stream (1s–30s) to avoid repeated gone-only reconnects.
  - Added `buildDirectDaemonEventsUrl` and `isDirectDaemonEventsGoneStatus` with tests; thread `previewUrl` from `selectVmEntry` to `SandboxEventsProvider`.
  - No UI changes.

<sup>Written for commit fe67164768539d17ce12b7fb9721b19743b9e6fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

