### PR TITLE
Enhance housekeeper-sweep script to manage ReconcilerError handling

### DIFF
--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -22,6 +22,16 @@ DAEMON_PORT=9000
 IDLE_PATH="/_sandbox/idle"
 LEGACY_IDLE_PATH="/_decopilot_vm/idle"
 
+# A transient optimistic-concurrency conflict on the SandboxClaim status write
+# surfaces as Ready=False/reason=ReconcilerError for ~1s before the operator
+# retries and recovers (a concurrent reconcile still lands status.sandbox.name).
+# Don't force-delete on first sight — require the error to persist this long, so
+# we never delete a freshly-adopted claim out from under a client still inside
+# its adoption wait (the "did not record an adopted Sandbox within 60s" freeze).
+# Override via the CronJob env if needed.
+: "${RECONCILER_ERROR_GRACE_SEC:=120}"
+RECONCILER_ERROR_SINCE_ANNOTATION="studio.decocms.com/reconciler-error-since"
+
 now_iso()   { date -u +%Y-%m-%dT%H:%M:%SZ; }
 now_micro() { date -u +%Y-%m-%dT%H:%M:%S.000000Z; }
 
@@ -163,9 +173,11 @@ PODS_FILE=$(mktemp)
 ROUTES_FILE=$(mktemp)
 trap 'rm -f "$CLAIMS_FILE" "$PODS_FILE" "$ROUTES_FILE"' EXIT
 
-# Pipe-delimited so `read` can split without jq.
+# Pipe-delimited so `read` can split without jq. Trailing fields:
+#   status.sandbox.name      — adopted sandbox; non-empty means adoption landed
+#   reconciler-error-since    — our epoch stamp tracking a ReconcilerError streak
 kubectl get sandboxclaims -n "$NS" -l "$CLAIM_SELECTOR" \
-  -o jsonpath='{range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=="Ready")].status}|{.status.conditions[?(@.type=="Ready")].reason}{"\n"}{end}' \
+  -o jsonpath='{range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=="Ready")].status}|{.status.conditions[?(@.type=="Ready")].reason}|{.status.sandbox.name}|{.metadata.annotations.studio\.decocms\.com/reconciler-error-since}{"\n"}{end}' \
   > "$CLAIMS_FILE" 2>/dev/null || true
 
 # Selector-mismatch detector: silent `claims=0` hides a missing STUDIO_ENV
@@ -192,14 +204,48 @@ skipped=0
 
 # Redirect (not pipe) so the loop stays in the parent shell — pipe-into-
 # while subshells the body and counter mutations would be lost.
-while IFS='|' read -r CLAIM READY REASON; do
+while IFS='|' read -r CLAIM READY REASON SANDBOX_NAME ERROR_SINCE; do
   [ -z "$CLAIM" ] && continue
   total=$((total + 1))
 
   if [ "$READY" = "False" ] && [ "$REASON" = "ReconcilerError" ]; then
-    force_delete_claim "$CLAIM" "ReconcilerError" "operator failed to reconcile"
+    # Adoption that only failed to write status back is NOT a dead operator —
+    # the sandbox is already bound. Never delete it.
+    if [ -n "$SANDBOX_NAME" ]; then
+      log "skip claim=$CLAIM reason=reconciler-error-but-adopted sandbox=$SANDBOX_NAME"
+      skipped=$((skipped + 1))
+      continue
+    fi
+    now_s=$(date -u +%s)
+    # Treat an absent/garbage stamp as "first seen": start the grace clock and
+    # wait. A transient conflict clears well before the next 60s sweep.
+    case "$ERROR_SINCE" in
+      ''|*[!0-9]*)
+        kubectl annotate sandboxclaim "$CLAIM" -n "$NS" --overwrite \
+          "${RECONCILER_ERROR_SINCE_ANNOTATION}=${now_s}" >/dev/null 2>&1 || true
+        log "defer-delete claim=$CLAIM reason=ReconcilerError (first seen, grace ${RECONCILER_ERROR_GRACE_SEC}s)"
+        skipped=$((skipped + 1))
+        continue
+        ;;
+    esac
+    age_s=$((now_s - ERROR_SINCE))
+    if [ "$age_s" -lt "$RECONCILER_ERROR_GRACE_SEC" ]; then
+      log "defer-delete claim=$CLAIM reason=ReconcilerError age_s=$age_s grace_s=$RECONCILER_ERROR_GRACE_SEC"
+      skipped=$((skipped + 1))
+      continue
+    fi
+    # Error has persisted past the grace window — the operator really is stuck.
+    force_delete_claim "$CLAIM" "ReconcilerError" "persisted ${age_s}s past ${RECONCILER_ERROR_GRACE_SEC}s grace"
     reaped=$((reaped + 1))
     continue
+  fi
+
+  # Not in ReconcilerError this sweep — clear any stale streak stamp so a future
+  # transient error starts its grace window fresh (else a later blip would be
+  # judged against a long-expired timestamp and deleted immediately).
+  if [ -n "$ERROR_SINCE" ]; then
+    kubectl annotate sandboxclaim "$CLAIM" -n "$NS" \
+      "${RECONCILER_ERROR_SINCE_ANNOTATION}-" >/dev/null 2>&1 || true
   fi
 
   if [ "$READY" != "True" ]; then


### PR DESCRIPTION
- Introduced a grace period for transient ReconcilerErrors to prevent premature deletion of sandbox claims.
- Added logic to track the timestamp of ReconcilerErrors and defer deletion until the error persists beyond the grace period.
- Updated the output of `kubectl get sandboxclaims` to include additional fields for better error tracking.
- Improved logging for skipped claims and deferred deletions to enhance observability.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the housekeeper sweep resilient to transient ReconcilerError events so we don’t delete valid sandbox claims. Adds a grace window and tracking to defer deletion until the error truly persists.

- **Bug Fixes**
  - Defer deletion of ReconcilerError claims until they exceed `RECONCILER_ERROR_GRACE_SEC` (default 120s).
  - Track first-seen time in `studio.decocms.com/reconciler-error-since`; clear it when the claim recovers.
  - Never delete when `status.sandbox.name` is set (adopted, but status write failed).
  - Extend `kubectl get sandboxclaims` output and improve logs to show adoption state and defer reasons.

<sup>Written for commit 2ba08a38de767520c7abaa75ed4e8b654997fd31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

