### PR TITLE
Refactor MCP request handling to use centralized serveMcpRequest utility

### DIFF
--- a/apps/mesh/src/api/routes/dev-assets-mcp.ts
+++ b/apps/mesh/src/api/routes/dev-assets-mcp.ts
@@ -11,6 +11,7 @@
  */
 
 import { getSettings } from "../../settings";
+import { serveMcpRequest } from "../utils/serve-mcp";
 import {
   type DeleteObjectInput,
   type DeleteObjectOutput,
@@ -537,7 +538,7 @@ export async function handleDevAssetsMcpRequest(
       req.headers.get("Accept")?.includes("application/json") ?? false,
   });
   await server.connect(transport);
-  return transport.handleRequest(req);
+  return serveMcpRequest(server, transport, req, "mcp:dev-assets");
 }
 
 /**

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -18,7 +18,7 @@ import { Context, Hono } from "hono";
 import { endTime, startTime } from "hono/timing";
 import type { StudioContext } from "../../core/studio-context";
 import { managementMCP } from "../../tools";
-import { guardResponseStream } from "../utils/stream-guard";
+import { serveMcpRequest } from "../utils/serve-mcp";
 import { handleAuthError } from "./oauth-proxy";
 import { getMcpListCache } from "@/mcp-clients/mcp-list-cache";
 import {
@@ -97,8 +97,12 @@ export const createProxyRoutes = () => {
           false,
       });
       await server.connect(transport);
-      const selfResponse = await transport.handleRequest(c.req.raw);
-      return guardResponseStream(selfResponse, `mcp:self:${connectionId}`);
+      return serveMcpRequest(
+        server,
+        transport,
+        c.req.raw,
+        `mcp:self:${connectionId}`,
+      );
     }
 
     try {
@@ -224,9 +228,14 @@ export const createProxyRoutes = () => {
 
         // Handle request and cleanup
         startTime(c, "mcp.handle_request");
-        const response = await transport.handleRequest(c.req.raw);
+        const response = await serveMcpRequest(
+          server,
+          transport,
+          c.req.raw,
+          `mcp:${connectionId}`,
+        );
         endTime(c, "mcp.handle_request");
-        return guardResponseStream(response, `mcp:${connectionId}`);
+        return response;
       } catch (error) {
         if (error instanceof CircuitOpenError) {
           throw error;

--- a/apps/mesh/src/api/routes/self.ts
+++ b/apps/mesh/src/api/routes/self.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { StudioContext } from "../../core/studio-context";
 import { managementMCP } from "../../tools";
+import { serveMcpRequest } from "../utils/serve-mcp";
 
 // Define Hono variables type
 type Variables = {
@@ -32,7 +33,7 @@ export const createSelfRoutes = () => {
         c.req.raw.headers.get("Accept")?.includes("application/json") ?? false,
     });
     await server.connect(transport);
-    return transport.handleRequest(c.req.raw);
+    return serveMcpRequest(server, transport, c.req.raw, "mcp:self");
   });
 
   return app;

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -22,7 +22,7 @@ import type { StudioContext } from "../../core/studio-context";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/core/constants";
 import { createVirtualClientFrom } from "../../mcp-clients/virtual-mcp";
 import type { Env } from "../hono-env";
-import { guardResponseStream } from "../utils/stream-guard";
+import { serveMcpRequest } from "../utils/serve-mcp";
 
 // ============================================================================
 // Route Handler (shared between /gateway and /virtual-mcp endpoints for backward compat)
@@ -193,9 +193,10 @@ export async function handleVirtualMcpRequest(
     // Connect server to transport
     await server.connect(transport);
 
-    const response = await transport.handleRequest(c.req.raw);
-    return guardResponseStream(
-      response,
+    return await serveMcpRequest(
+      server,
+      transport,
+      c.req.raw,
       `virtual-mcp:${virtualMcp.id ?? "decopilot"}`,
     );
   } catch (error) {

--- a/apps/mesh/src/api/utils/serve-mcp.ts
+++ b/apps/mesh/src/api/utils/serve-mcp.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-request MCP server lifecycle.
+ *
+ * Routes that serve MCP over HTTP build a fresh `McpServer` + transport per
+ * request (stateless mode). The SDK does not tear these down on its own: each
+ * registered tool handler closes over the server (and the request's
+ * StudioContext), so a server that is never `close()`d stays reachable
+ * forever. In production this leaked thousands of fully-populated servers
+ * (~4.6k in a 5-minute heap snapshot — every tool's Zod schemas + handler
+ * closures + the captured ctx), filling the heap until GC pegged the CPU and
+ * the pod was OOMKilled.
+ *
+ * `serveMcpRequest` is the one place that gets this right: handle the
+ * request, stream the body through the guard, and close the server (which
+ * closes its transport) exactly once — after the body is fully delivered,
+ * on client cancel, or on a handler throw.
+ */
+import { guardResponseStream } from "./stream-guard";
+
+interface CloseableServer {
+  close(): Promise<void>;
+}
+
+interface RequestTransport {
+  handleRequest(req: Request): Promise<Response>;
+}
+
+export async function serveMcpRequest(
+  server: CloseableServer,
+  transport: RequestTransport,
+  request: Request,
+  label: string,
+): Promise<Response> {
+  // Closing the server cascades into its own transport only — bridge servers
+  // delegate to their client via request handlers, so a shared/pooled client
+  // is never closed from here.
+  const close = () => {
+    void server.close().catch((err) => {
+      console.error(`[serve-mcp] ${label} server close failed:`, err);
+    });
+  };
+
+  let response: Response;
+  try {
+    response = await transport.handleRequest(request);
+  } catch (err) {
+    close();
+    throw err;
+  }
+  return guardResponseStream(response, label, close);
+}

--- a/apps/mesh/src/api/utils/stream-guard.ts
+++ b/apps/mesh/src/api/utils/stream-guard.ts
@@ -12,12 +12,32 @@
  * The guard catches the error, logs it for the operator, and closes the
  * controller cleanly. The client receives a well-formed but truncated SSE
  * response and can recover via its own retry/reconnect logic.
+ *
+ * `onDone`, when provided, fires exactly once when the response is finished —
+ * body fully streamed, errored, or cancelled by the client (or immediately for
+ * a body-less response). Use it to release per-request resources whose
+ * lifetime must span the full body, e.g. closing a per-request MCP server.
  */
 export function guardResponseStream(
   response: Response,
   label: string,
+  onDone?: () => void,
 ): Response {
-  if (!response.body) return response;
+  let doneFired = false;
+  const fireDone = () => {
+    if (doneFired) return;
+    doneFired = true;
+    try {
+      onDone?.();
+    } catch (err) {
+      console.error(`[stream-guard] ${label} onDone threw:`, err);
+    }
+  };
+
+  if (!response.body) {
+    fireDone();
+    return response;
+  }
 
   const source = response.body;
   let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
@@ -34,6 +54,7 @@ export function guardResponseStream(
       } catch (err) {
         console.error(`[stream-guard] ${label} stream errored:`, err);
       } finally {
+        fireDone();
         try {
           controller.close();
         } catch {
@@ -49,6 +70,7 @@ export function guardResponseStream(
       } else {
         await source.cancel(reason).catch(() => {});
       }
+      fireDone();
     },
   });
 

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -480,5 +480,6 @@ export async function listManagementTools(
     return result.tools;
   } finally {
     await client.close().catch(() => {});
+    await server.close().catch(() => {});
   }
 }


### PR DESCRIPTION
- Replaced direct transport request handling with serveMcpRequest in multiple routes: dev-assets-mcp, proxy, self, and virtual-mcp.
- Introduced serveMcpRequest utility to manage server lifecycle and response streaming, ensuring proper resource cleanup.
- Updated stream-guard to support onDone callback for resource management after response completion.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized MCP request handling with `serveMcpRequest` to ensure proper server cleanup and safe response streaming. Fixes per-request server leaks and improves stability under load.

- **Refactors**
  - Switched routes (`dev-assets-mcp`, `proxy`, `self`, `virtual-mcp`) to use `serveMcpRequest` instead of direct `transport.handleRequest`.
  - Added `serveMcpRequest` to close the MCP server after streaming completes, errors, or client cancel.
  - Extended `guardResponseStream` with an `onDone` callback and integrated it to trigger server cleanup.
  - Ensured management tooling closes both `client` and `server` in `tools/index.ts`.

<sup>Written for commit 0252988c9ace217ef7020697431be0bd7d019219. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

