### PR TITLE
feat(library): skill preview redesign, richer file thumbnails & side-panel preview

### DIFF
--- a/apps/mesh/src/web/components/code-viewer.tsx
+++ b/apps/mesh/src/web/components/code-viewer.tsx
@@ -9,6 +9,7 @@
 import Editor, { loader } from "@monaco-editor/react";
 import { Loading01 } from "@untitledui/icons";
 import { getLanguageFromPath } from "@/web/components/sandbox/preview/file-explorer/utils";
+import { usePreferences } from "@/web/hooks/use-preferences";
 
 // Load Monaco from the same CDN as the other editors (idempotent — the
 // config is global and every consumer points at the same version).
@@ -25,17 +26,20 @@ export function CodeViewer({
   value: string;
   filename: string;
 }) {
+  const [preferences] = usePreferences();
+  const isDark =
+    preferences.theme === "dark" ||
+    (preferences.theme === "system" &&
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+
   return (
     <Editor
       key={filename}
       path={filename}
       language={getLanguageFromPath(filename)}
       value={value}
-      theme={
-        document.documentElement.classList.contains("dark")
-          ? "vs-dark"
-          : "light"
-      }
+      theme={isDark ? "vs-dark" : "light"}
       loading={
         <div className="flex h-full w-full items-center justify-center">
           <Loading01 size={20} className="animate-spin text-muted-foreground" />

--- a/apps/mesh/src/web/components/code-viewer.tsx
+++ b/apps/mesh/src/web/components/code-viewer.tsx
@@ -1,0 +1,64 @@
+/**
+ * CodeViewer — read-only Monaco viewer for source files, sharing the same
+ * editor (and CDN-loaded engine) the sandbox file explorer uses so code
+ * renders with real syntax highlighting and line numbers instead of a bare
+ * <pre>. Not editable: `readOnly` + `domReadOnly` disable input and the
+ * cursor, leaving selection/scroll/copy intact.
+ */
+
+import Editor, { loader } from "@monaco-editor/react";
+import { Loading01 } from "@untitledui/icons";
+import { getLanguageFromPath } from "@/web/components/sandbox/preview/file-explorer/utils";
+
+// Load Monaco from the same CDN as the other editors (idempotent — the
+// config is global and every consumer points at the same version).
+loader.config({
+  paths: {
+    vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs",
+  },
+});
+
+export function CodeViewer({
+  value,
+  filename,
+}: {
+  value: string;
+  filename: string;
+}) {
+  return (
+    <Editor
+      key={filename}
+      path={filename}
+      language={getLanguageFromPath(filename)}
+      value={value}
+      theme={
+        document.documentElement.classList.contains("dark")
+          ? "vs-dark"
+          : "light"
+      }
+      loading={
+        <div className="flex h-full w-full items-center justify-center">
+          <Loading01 size={20} className="animate-spin text-muted-foreground" />
+        </div>
+      }
+      options={{
+        readOnly: true,
+        domReadOnly: true,
+        fontSize: 13,
+        scrollBeyondLastLine: false,
+        automaticLayout: true,
+        lineNumbersMinChars: 3,
+        wordWrap: "on",
+        minimap: { enabled: false },
+        padding: { top: 12, bottom: 12 },
+        renderLineHighlight: "none",
+        scrollbar: {
+          vertical: "auto",
+          horizontal: "auto",
+          verticalScrollbarSize: 8,
+          horizontalScrollbarSize: 8,
+        },
+      }}
+    />
+  );
+}

--- a/apps/mesh/src/web/components/file-preview.tsx
+++ b/apps/mesh/src/web/components/file-preview.tsx
@@ -23,7 +23,7 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { Download01 } from "@untitledui/icons";
 import { KEYS } from "@/web/lib/query-keys";
-import { CodeViewer } from "@/web/components/code-viewer";
+import { ReadOnlyCodeViewer } from "@/web/components/read-only-code-viewer";
 import { FileTypeIcon } from "@/web/components/file-type-icon";
 import { MemoizedMarkdown } from "@/web/components/chat/markdown.tsx";
 
@@ -170,7 +170,7 @@ function TextPreview({
       </div>
     );
   }
-  return <CodeViewer value={data} filename={file.filename} />;
+  return <ReadOnlyCodeViewer value={data} filename={file.filename} />;
 }
 
 export function FilePreview({ file }: { file: PreviewableFile }) {

--- a/apps/mesh/src/web/components/file-preview.tsx
+++ b/apps/mesh/src/web/components/file-preview.tsx
@@ -10,7 +10,7 @@
  *             without allow-scripts would disable Chrome's PDF plugin)
  *   - html  → <iframe sandbox="allow-scripts"> (untrusted, mirrors WebPageTab)
  *   - md    → fetched and rendered through the chat markdown renderer
- *   - text  → fetched and rendered in a <pre>
+ *   - text  → fetched and rendered in a read-only Monaco code viewer
  *   - other (xlsx/pptx/zip/…) → download card fallback
  *
  * Text-ish fetches go through `fetch(credentials: "include")`; if that
@@ -23,6 +23,7 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { Download01 } from "@untitledui/icons";
 import { KEYS } from "@/web/lib/query-keys";
+import { CodeViewer } from "@/web/components/code-viewer";
 import { FileTypeIcon } from "@/web/components/file-type-icon";
 import { MemoizedMarkdown } from "@/web/components/chat/markdown.tsx";
 
@@ -169,13 +170,7 @@ function TextPreview({
       </div>
     );
   }
-  return (
-    <div className="h-full overflow-auto">
-      <pre className="px-6 py-4 font-mono text-xs leading-relaxed whitespace-pre-wrap break-words text-foreground">
-        {data}
-      </pre>
-    </div>
-  );
+  return <CodeViewer value={data} filename={file.filename} />;
 }
 
 export function FilePreview({ file }: { file: PreviewableFile }) {

--- a/apps/mesh/src/web/components/read-only-code-viewer.tsx
+++ b/apps/mesh/src/web/components/read-only-code-viewer.tsx
@@ -1,9 +1,11 @@
 /**
- * CodeViewer — read-only Monaco viewer for source files, sharing the same
- * editor (and CDN-loaded engine) the sandbox file explorer uses so code
+ * ReadOnlyCodeViewer — read-only Monaco viewer for source files, sharing the
+ * same editor (and CDN-loaded engine) the sandbox file explorer uses so code
  * renders with real syntax highlighting and line numbers instead of a bare
- * <pre>. Not editable: `readOnly` + `domReadOnly` disable input and the
- * cursor, leaving selection/scroll/copy intact.
+ * <pre>. Distinct from the editable MonacoCodeEditor (workflow): this is a
+ * pure viewer — `readOnly` + `domReadOnly` disable input and the cursor,
+ * leaving selection/scroll/copy intact, and it carries none of the editor's
+ * Prettier/TS-diagnostics/save machinery.
  */
 
 import Editor, { loader } from "@monaco-editor/react";
@@ -19,7 +21,7 @@ loader.config({
   },
 });
 
-export function CodeViewer({
+export function ReadOnlyCodeViewer({
   value,
   filename,
 }: {

--- a/apps/mesh/src/web/layouts/library/cards.tsx
+++ b/apps/mesh/src/web/layouts/library/cards.tsx
@@ -8,7 +8,7 @@
  * else gets a large type icon. Real xlsx/pptx renders are phase 3.
  */
 
-import type { ComponentType, SVGProps } from "react";
+import type { ComponentType, ReactNode, SVGProps } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   DotsVertical,
@@ -42,13 +42,13 @@ const IMAGE_EXTS = new Set([
   "svg",
   "avif",
 ]);
+const CSV_EXTS = new Set(["csv", "tsv"]);
+const VIDEO_EXTS = new Set(["mp4", "webm", "mov", "m4v"]);
 const TEXT_THUMB_EXTS = new Set([
   "txt",
   "md",
   "markdown",
   "json",
-  "csv",
-  "tsv",
   "log",
   "yaml",
   "yml",
@@ -391,6 +391,57 @@ function TextThumb({ url }: { url: string }) {
   );
 }
 
+function CsvThumb({ url, ext }: { url: string; ext: string }) {
+  const { data } = useQuery({
+    queryKey: KEYS.csvThumb(url),
+    queryFn: async () => {
+      const res = await fetch(url, {
+        credentials: "include",
+        headers: { Range: "bytes=0-8191" },
+      });
+      if (!res.ok && res.status !== 206)
+        throw new Error(`fetch failed: ${res.status}`);
+      return res.text();
+    },
+    staleTime: 60_000,
+    retry: false,
+  });
+  if (!data) return null;
+  const sep = ext === "tsv" ? "\t" : ",";
+  const rows = data
+    .split("\n")
+    .filter(Boolean)
+    .slice(0, 7)
+    .map((line) =>
+      line
+        .split(sep)
+        .slice(0, 6)
+        .map((cell) => cell.trim().replace(/^"|"$/g, "")),
+    );
+  if (rows.length === 0) return null;
+  return (
+    <div className="pointer-events-none h-full w-full overflow-hidden bg-background p-2 select-none">
+      <table className="w-full border-collapse">
+        <tbody>
+          {rows.map((row, ri) => (
+            <tr key={ri} className={cn(ri === 0 && "bg-muted/50 font-medium")}>
+              {row.map((cell, ci) => (
+                <td
+                  key={ci}
+                  className="max-w-[56px] overflow-hidden border border-border/30 px-1 py-px text-[7px] leading-[1.4] text-muted-foreground"
+                  style={{ maxWidth: 56 }}
+                >
+                  <span className="block truncate">{cell}</span>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 function Thumb({
   filename,
   size,
@@ -401,20 +452,47 @@ function Thumb({
   downloadUrl: string;
 }) {
   const ext = extOf(filename);
-  const inner = IMAGE_EXTS.has(ext) ? (
-    <img
-      src={downloadUrl}
-      alt=""
-      loading="lazy"
-      className="h-full w-full object-cover"
-    />
-  ) : TEXT_THUMB_EXTS.has(ext) && size <= MAX_TEXT_THUMB_BYTES ? (
-    <TextThumb url={downloadUrl} />
-  ) : (
-    <div className="flex h-full w-full items-center justify-center">
-      <FileTypeIcon filename={filename} className="h-14 w-11 opacity-60" />
-    </div>
-  );
+  let inner: ReactNode;
+  if (IMAGE_EXTS.has(ext)) {
+    inner = (
+      <img
+        src={downloadUrl}
+        alt=""
+        loading="lazy"
+        className="h-full w-full object-cover"
+      />
+    );
+  } else if (VIDEO_EXTS.has(ext)) {
+    // `#t=0.1` + preload="metadata" makes the browser paint the first frame
+    // without downloading the whole file.
+    inner = (
+      <video
+        src={`${downloadUrl}#t=0.1`}
+        preload="metadata"
+        muted
+        playsInline
+        className="pointer-events-none h-full w-full object-cover"
+      />
+    );
+  } else if (ext === "pdf") {
+    inner = (
+      <embed
+        src={`${downloadUrl}#toolbar=0&navpanes=0&scrollbar=0`}
+        type="application/pdf"
+        className="pointer-events-none h-full w-full"
+      />
+    );
+  } else if (CSV_EXTS.has(ext)) {
+    inner = <CsvThumb url={downloadUrl} ext={ext} />;
+  } else if (TEXT_THUMB_EXTS.has(ext) && size <= MAX_TEXT_THUMB_BYTES) {
+    inner = <TextThumb url={downloadUrl} />;
+  } else {
+    inner = (
+      <div className="flex h-full w-full items-center justify-center">
+        <FileTypeIcon filename={filename} className="h-14 w-11 opacity-60" />
+      </div>
+    );
+  }
   return (
     <div className="aspect-[400/265] w-full overflow-hidden rounded-lg border border-border/60 bg-muted/30">
       {inner}

--- a/apps/mesh/src/web/layouts/library/cards.tsx
+++ b/apps/mesh/src/web/layouts/library/cards.tsx
@@ -9,6 +9,7 @@
  */
 
 import type { ComponentType, ReactNode, SVGProps } from "react";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   DotsVertical,
@@ -372,6 +373,31 @@ export function SkillCard({
   );
 }
 
+/**
+ * Defers rendering children until the sentinel div enters the viewport.
+ * Prevents N parallel network requests when many thumbnails mount at once.
+ * The `setVisible` setter is stable across renders so capturing it in the
+ * lazy initializer is safe without a ref.
+ */
+function LazyThumb({ children }: { children: ReactNode }) {
+  const [visible, setVisible] = useState(false);
+  const [attachSentinel] = useState(() => (node: HTMLDivElement | null) => {
+    if (!node) return;
+    const obs = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setVisible(true);
+          obs.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    obs.observe(node);
+  });
+  if (visible) return <>{children}</>;
+  return <div ref={attachSentinel} className="h-full w-full" />;
+}
+
 function TextThumb({ url }: { url: string }) {
   const { data } = useQuery({
     queryKey: KEYS.fileText(url),
@@ -399,8 +425,7 @@ function CsvThumb({ url, ext }: { url: string; ext: string }) {
         credentials: "include",
         headers: { Range: "bytes=0-8191" },
       });
-      if (!res.ok && res.status !== 206)
-        throw new Error(`fetch failed: ${res.status}`);
+      if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
       return res.text();
     },
     staleTime: 60_000,
@@ -463,29 +488,39 @@ function Thumb({
       />
     );
   } else if (VIDEO_EXTS.has(ext)) {
-    // `#t=0.1` + preload="metadata" makes the browser paint the first frame
-    // without downloading the whole file.
+    // `#t=0.1` + preload="metadata" paints the first frame without a full
+    // download — but only when the card is actually visible.
     inner = (
-      <video
-        src={`${downloadUrl}#t=0.1`}
-        preload="metadata"
-        muted
-        playsInline
-        className="pointer-events-none h-full w-full object-cover"
-      />
+      <LazyThumb>
+        <video
+          src={`${downloadUrl}#t=0.1`}
+          preload="metadata"
+          muted
+          playsInline
+          className="pointer-events-none h-full w-full object-cover"
+        />
+      </LazyThumb>
     );
   } else if (ext === "pdf") {
+    // Full PDF embed is too heavy for a card thumbnail; show the type icon
+    // and let the preview panel handle the real render.
     inner = (
-      <embed
-        src={`${downloadUrl}#toolbar=0&navpanes=0&scrollbar=0`}
-        type="application/pdf"
-        className="pointer-events-none h-full w-full"
-      />
+      <div className="flex h-full w-full items-center justify-center">
+        <FileTypeIcon filename={filename} className="h-14 w-11 opacity-60" />
+      </div>
     );
   } else if (CSV_EXTS.has(ext)) {
-    inner = <CsvThumb url={downloadUrl} ext={ext} />;
+    inner = (
+      <LazyThumb>
+        <CsvThumb url={downloadUrl} ext={ext} />
+      </LazyThumb>
+    );
   } else if (TEXT_THUMB_EXTS.has(ext) && size <= MAX_TEXT_THUMB_BYTES) {
-    inner = <TextThumb url={downloadUrl} />;
+    inner = (
+      <LazyThumb>
+        <TextThumb url={downloadUrl} />
+      </LazyThumb>
+    );
   } else {
     inner = (
       <div className="flex h-full w-full items-center justify-center">

--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -49,6 +49,9 @@ import { Input } from "@deco/ui/components/input.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { homeMountPath } from "@/file-storage/home-mount";
 import { ErrorBoundary } from "@/web/components/error-boundary";
+import { FileTypeIcon } from "@/web/components/file-type-icon";
+import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
+import { HeaderTabButton } from "@/web/layouts/main-panel-tabs/header-tab-button";
 import { KEYS } from "@/web/lib/query-keys";
 import {
   type OrgFsEntry,
@@ -72,7 +75,13 @@ import {
   type LibraryLocation,
   parseLibraryPath,
 } from "./location";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/web/components/resizable";
 import { LibraryPreviewDialog } from "./preview-dialog";
+import { LibraryPreviewPanel } from "./preview-panel";
 import { SkillPreviewDialog } from "./skill-preview-dialog";
 
 /** The volumes every sandbox mounts (see file-storage/mount/provisioning.ts).
@@ -117,35 +126,6 @@ function GridSkeleton({ rows = 1 }: { rows?: number }) {
 
 function EmptyNote({ children }: { children: React.ReactNode }) {
   return <p className="text-sm text-muted-foreground">{children}</p>;
-}
-
-/** Folder filter pills — Shared/Private are a pending product decision. */
-function FolderFilterPills() {
-  return (
-    <div className="flex items-center gap-1">
-      <Button variant="secondary" size="sm" className="h-7 px-2.5 text-xs">
-        All
-      </Button>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-7 px-2.5 text-xs"
-        disabled
-        title="Coming soon"
-      >
-        Shared
-      </Button>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-7 px-2.5 text-xs"
-        disabled
-        title="Coming soon"
-      >
-        Private
-      </Button>
-    </div>
-  );
 }
 
 function VolumeFolderCard({
@@ -272,7 +252,6 @@ function RootView({
 
       <div className="flex flex-col gap-3">
         <SectionLabel>Folders</SectionLabel>
-        <FolderFilterPills />
         <CardsGrid>
           {VOLUMES.map((v) => (
             <VolumeFolderCard
@@ -460,6 +439,7 @@ function LibraryPage() {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const search = useSearch({ strict: false }) as {
     path?: string;
     preview?: string;
@@ -484,17 +464,6 @@ function LibraryPage() {
   const onOpenFile = (previewPath: string) =>
     setSearchParam("preview", previewPath);
   const onOpenSkill = (skillPath: string) => setSearchParam("skill", skillPath);
-  // "Browse files" from inside the skill preview: jump the page to the
-  // skill's folder and drop the overlay in one navigation.
-  const onBrowseSkill = (browsePath: string) =>
-    navigate({
-      to: ".",
-      search: (prev: Record<string, unknown>) => ({
-        ...prev,
-        path: browsePath,
-        skill: undefined,
-      }),
-    });
 
   const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(
     null,
@@ -648,19 +617,21 @@ function LibraryPage() {
         )}
       </div>
 
-      {/* Preview wins over skill: opening a bundled file stacks on top of the
-          skill dialog; closing it falls back to the still-set ?skill=. */}
+      {/* Preview wins over skill: opening a bundled file hides the skill
+          dialog; closing it falls back to the still-set ?skill=. On desktop
+          the preview renders as a side panel (in the outer Library), so only
+          mobile uses the dialog here. */}
       {search.preview ? (
-        <LibraryPreviewDialog
-          previewPath={search.preview}
-          onClose={() => setSearchParam("preview", null)}
-        />
+        isMobile && (
+          <LibraryPreviewDialog
+            previewPath={search.preview}
+            onClose={() => setSearchParam("preview", null)}
+          />
+        )
       ) : search.skill ? (
         <SkillPreviewDialog
           skillPath={search.skill}
           onClose={() => setSearchParam("skill", null)}
-          onOpenFile={onOpenFile}
-          onBrowse={onBrowseSkill}
         />
       ) : null}
 
@@ -726,6 +697,20 @@ function LibraryPage() {
 
 export default function Library() {
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as { preview?: string };
+  const previewPath = search.preview;
+  const previewName = previewPath
+    ? basename(parseLibraryPath(previewPath).dirPath)
+    : "";
+  const closePreview = () =>
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        preview: undefined,
+      }),
+    });
 
   if (isMobile) {
     return (
@@ -737,15 +722,54 @@ export default function Library() {
     );
   }
 
+  // Desktop: chat-style two-panel group — Library on the left and, when a
+  // file is open (`?preview=`), its preview as a tab-like panel on the right.
   return (
-    <div className="min-h-0 flex-1 pt-0 pr-1 pb-1 pl-0">
-      <div className="h-full p-0.5 pt-0.25">
-        <div className="card-shadow flex h-full flex-col overflow-hidden rounded-[0.75rem] bg-background">
-          <ErrorBoundary>
-            <LibraryPage />
-          </ErrorBoundary>
+    <ResizablePanelGroup
+      direction="horizontal"
+      className="min-h-0 flex-1 pt-0 pr-1 pb-1 pl-0"
+    >
+      <ResizablePanel order={1} minSize={30} defaultSize={55}>
+        <div className="h-full p-0.5 pt-0.25">
+          <div className="card-shadow flex h-full flex-col overflow-hidden rounded-[0.75rem] bg-background">
+            <ErrorBoundary>
+              <LibraryPage />
+            </ErrorBoundary>
+          </div>
         </div>
-      </div>
-    </div>
+      </ResizablePanel>
+      {previewPath && (
+        <>
+          {/* Mirror the chat: an open file surfaces as a pill in the shared
+              top-right tab slot; clicking it closes the preview. */}
+          <Toolbar.Tabs>
+            <HeaderTabButton
+              title={previewName}
+              icon={{
+                kind: "component",
+                Component: (props) => (
+                  <FileTypeIcon filename={previewName} {...props} />
+                ),
+              }}
+              active
+              onClick={closePreview}
+            />
+          </Toolbar.Tabs>
+          <ResizableHandle className="bg-sidebar" />
+          <ResizablePanel order={2} minSize={25} defaultSize={45}>
+            <div className="h-full p-0.5 pt-0.25">
+              <div className="card-shadow flex h-full flex-col overflow-hidden rounded-[0.75rem] bg-background">
+                <ErrorBoundary>
+                  <LibraryPreviewPanel
+                    previewPath={previewPath}
+                    onClose={closePreview}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </ResizablePanel>
+        </>
+      )}
+    </ResizablePanelGroup>
   );
 }

--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -630,6 +630,7 @@ function LibraryPage() {
         )
       ) : search.skill ? (
         <SkillPreviewDialog
+          key={search.skill}
           skillPath={search.skill}
           onClose={() => setSearchParam("skill", null)}
         />
@@ -700,9 +701,7 @@ export default function Library() {
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as { preview?: string };
   const previewPath = search.preview;
-  const previewName = previewPath
-    ? basename(parseLibraryPath(previewPath).dirPath)
-    : "";
+  const previewName = previewPath ? basename(previewPath) : "";
   const closePreview = () =>
     navigate({
       to: ".",

--- a/apps/mesh/src/web/layouts/library/preview-panel.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-panel.tsx
@@ -1,0 +1,115 @@
+/**
+ * Library file preview panel — right-side panel over the shared FilePreview
+ * viewer, mirroring the chat's file tab (toolbar + preview). URL-driven
+ * (`?preview=<browse path>`) so a preview link survives reload: the entry
+ * is re-resolved via `stat`, not read off list caches.
+ */
+
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { Download01, LinkExternal01, XClose } from "@untitledui/icons";
+import {
+  FilePreview,
+  FilePreviewShimmer,
+  formatSize,
+} from "@/web/components/file-preview";
+import { FileTypeIcon } from "@/web/components/file-type-icon";
+import { useOrgFsDownloadUrl, useOrgFsStat } from "@/web/hooks/use-org-fs";
+import { basename, parseLibraryPath } from "./location";
+
+export function LibraryPreviewPanel({
+  previewPath,
+  onClose,
+}: {
+  /** Browse-grammar path of the open file ("<volume>/<path...>"). */
+  previewPath: string;
+  onClose: () => void;
+}) {
+  const location = parseLibraryPath(previewPath);
+  const { volume, dirPath: filePath } = location;
+  const { data: entry, isPending } = useOrgFsStat(volume, filePath);
+  const downloadUrl = useOrgFsDownloadUrl(volume ?? "");
+  const filename = basename(filePath);
+
+  const file =
+    entry && entry.kind === "file"
+      ? {
+          key: previewPath,
+          filename,
+          size: entry.size,
+          downloadUrl: downloadUrl(entry.path),
+        }
+      : null;
+
+  return (
+    <div className="flex h-full w-full flex-col bg-background">
+      <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border/60 px-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-2">
+          <FileTypeIcon filename={filename} className="h-4.5 w-3.5 shrink-0" />
+          <span className="truncate text-xs font-medium text-foreground">
+            {filename}
+          </span>
+          {file && (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {formatSize(file.size)}
+            </span>
+          )}
+        </div>
+        {file && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon" asChild>
+                  <a href={file.downloadUrl} download={file.filename}>
+                    <Download01 size={14} />
+                  </a>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Download</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() =>
+                    window.open(file.downloadUrl, "_blank", "noopener")
+                  }
+                >
+                  <LinkExternal01 size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Open in new tab</TooltipContent>
+            </Tooltip>
+          </>
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" onClick={onClose}>
+              <XClose size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Close</TooltipContent>
+        </Tooltip>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        {file ? (
+          <FilePreview file={file} />
+        ) : isPending ? (
+          <FilePreviewShimmer />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-2">
+            <FileTypeIcon filename={filename} className="h-7.5 w-6" />
+            <span className="text-sm text-muted-foreground">
+              This file is no longer available.
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/library/skill-preview-dialog.tsx
+++ b/apps/mesh/src/web/layouts/library/skill-preview-dialog.tsx
@@ -1,41 +1,38 @@
 /**
  * Skill preview — a dedicated dialog for Claude Code skill dirs
- * (`?skill=<browse path>`): frontmatter name/description as the header,
- * the SKILL.md body rendered as markdown, and the bundled files listed
- * below with click-through to the regular file preview. URL-driven, so a
- * skill link survives reload.
+ * (`?skill=<browse path>`): a file sidebar on the left (SKILL.md plus the
+ * bundled files) and the selected file's preview on the right. SKILL.md
+ * renders as description + markdown; everything else goes through the
+ * shared FilePreview viewer. URL-driven, so a skill link survives reload.
  */
 
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { Folder, Zap } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { X, Zap } from "@untitledui/icons";
 import { MemoizedMarkdown } from "@/web/components/chat/markdown.tsx";
-import { formatSize } from "@/web/components/file-preview";
+import { FilePreview } from "@/web/components/file-preview";
 import { FileTypeIcon } from "@/web/components/file-type-icon";
 import { useOrgFsFileUrl, useOrgFsList } from "@/web/hooks/use-org-fs";
 import { KEYS } from "@/web/lib/query-keys";
-import { basename, browsePathFor, parseLibraryPath } from "./location";
+import { basename, parseLibraryPath } from "./location";
 import { parseSkillMd } from "./skill";
 
 export function SkillPreviewDialog({
   skillPath,
   onClose,
-  onOpenFile,
-  onBrowse,
 }: {
   /** Browse-grammar path of the skill dir ("<volume>/<dir...>"). */
   skillPath: string;
   onClose: () => void;
-  /** Open a bundled file in the regular file preview. */
-  onOpenFile: (previewPath: string) => void;
-  /** Navigate the Library to the underlying folder. */
-  onBrowse: (browsePath: string) => void;
 }) {
   const location = parseLibraryPath(skillPath);
   const { volume, dirPath } = location;
@@ -56,9 +53,22 @@ export function SkillPreviewDialog({
 
   const dirName = basename(dirPath);
   const meta = md.data ? parseSkillMd(md.data) : null;
-  const bundled = (listing.data ?? []).filter(
-    (e) => e.kind === "file" && basename(e.path) !== "SKILL.md",
-  );
+  const isSkillMd = (path: string) => basename(path) === "SKILL.md";
+  // SKILL.md is the entry point, so it always leads the list.
+  const files = (listing.data ?? [])
+    .filter((e) => e.kind === "file")
+    .sort((a, b) => {
+      if (isSkillMd(a.path)) return -1;
+      if (isSkillMd(b.path)) return 1;
+      return basename(a.path).localeCompare(basename(b.path));
+    });
+
+  // null = SKILL.md (the default view); otherwise the selected entry's path.
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const selected =
+    selectedPath === null
+      ? null
+      : (files.find((e) => e.path === selectedPath) ?? null);
 
   return (
     <Dialog
@@ -67,78 +77,111 @@ export function SkillPreviewDialog({
         if (!open) onClose();
       }}
     >
-      <DialogContent className="flex h-[85vh] w-[92vw] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl!">
-        <div className="flex shrink-0 items-start gap-3 border-b border-border/60 py-4 pr-12 pl-5">
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
-            <Zap size={20} />
+      <DialogContent
+        className="flex h-[88vh] w-[94vw] max-w-none! flex-col gap-0 overflow-hidden p-0 sm:max-w-5xl!"
+        closeButtonClassName="hidden"
+      >
+        {/* Header */}
+        <div className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-full border border-border bg-violet-100 text-violet-600">
+            <Zap size={18} />
           </div>
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <DialogTitle className="truncate text-sm font-medium text-foreground">
-              {meta?.name ?? dirName}
-            </DialogTitle>
-            <p className="line-clamp-2 text-xs text-muted-foreground">
-              {meta?.description ?? "Claude Code skill"}
-            </p>
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="shrink-0"
-            onClick={() => onBrowse(skillPath)}
-          >
-            <Folder size={14} />
-            Browse files
-          </Button>
+          <DialogTitle className="flex-1 truncate text-base font-medium text-foreground">
+            {meta?.name ?? dirName}
+          </DialogTitle>
+          <DialogClose asChild>
+            <Button variant="ghost" size="icon" className="size-8 shrink-0">
+              <X size={16} />
+            </Button>
+          </DialogClose>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto">
-          {md.isPending ? (
-            <div className="flex flex-col gap-2 p-6">
-              <Skeleton className="h-5 w-1/2" />
-              <Skeleton className="h-3 w-full" />
-              <Skeleton className="h-3 w-5/6" />
-              <Skeleton className="h-3 w-2/3" />
-            </div>
-          ) : md.isError || !meta ? (
-            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-              This skill is no longer available.
-            </div>
-          ) : (
-            <div className="prose prose-sm dark:prose-invert max-w-none px-6 py-5">
-              <MemoizedMarkdown
-                id={`skill-preview-${skillPath}`}
-                text={meta.body}
+        {/* Two-column body */}
+        <div className="flex min-h-0 flex-1">
+          {/* Left sidebar — Files */}
+          <div className="flex w-[220px] shrink-0 flex-col gap-1 overflow-y-auto border-r border-border bg-muted p-3">
+            <p className="px-2 py-1.5 text-sm font-medium text-foreground">
+              Files
+            </p>
+            {listing.isPending ? (
+              <Skeleton className="mx-2 h-4 w-24" />
+            ) : (
+              files.map((e) => {
+                const active = isSkillMd(e.path)
+                  ? selected === null
+                  : selectedPath === e.path;
+                return (
+                  <button
+                    key={e.path}
+                    type="button"
+                    onClick={() =>
+                      setSelectedPath(isSkillMd(e.path) ? null : e.path)
+                    }
+                    className={cn(
+                      "flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-left",
+                      active ? "bg-background shadow-sm" : "hover:bg-muted/60",
+                    )}
+                  >
+                    <FileTypeIcon
+                      filename={basename(e.path)}
+                      className="h-6 w-5 shrink-0"
+                    />
+                    <span
+                      className={cn(
+                        "truncate text-sm",
+                        active ? "text-foreground" : "text-muted-foreground",
+                      )}
+                    >
+                      {basename(e.path)}
+                    </span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+
+          {/* Right content — selected file preview */}
+          <div className="relative flex min-w-0 flex-1 flex-col overflow-y-auto">
+            {selected ? (
+              <FilePreview
+                file={{
+                  key: selected.path,
+                  filename: basename(selected.path),
+                  size: selected.size,
+                  downloadUrl: fileUrl(volume ?? "", selected.path),
+                }}
               />
-            </div>
-          )}
-        </div>
-
-        {bundled.length > 0 && (
-          <div className="flex max-h-44 shrink-0 flex-col gap-1 overflow-y-auto border-t border-border/60 px-3 py-2.5">
-            <p className="px-2 text-xs text-muted-foreground">
-              Files in this skill
-            </p>
-            {bundled.map((e) => (
-              <button
-                key={e.path}
-                type="button"
-                onClick={() => onOpenFile(browsePathFor(location, e.path))}
-                className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-left hover:bg-muted/60"
-              >
-                <FileTypeIcon
-                  filename={basename(e.path)}
-                  className="h-5 w-4 shrink-0"
-                />
-                <span className="min-w-0 flex-1 truncate text-[13px] text-foreground">
-                  {basename(e.path)}
-                </span>
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {formatSize(e.size)}
-                </span>
-              </button>
-            ))}
+            ) : md.isPending ? (
+              <div className="flex flex-col gap-2 p-6">
+                <Skeleton className="h-4 w-1/3" />
+                <Skeleton className="h-3 w-full" />
+                <Skeleton className="h-3 w-5/6" />
+                <Skeleton className="h-3 w-2/3" />
+              </div>
+            ) : md.isError || !meta ? (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                This skill is no longer available.
+              </div>
+            ) : (
+              <>
+                <div className="flex flex-col gap-4 border-b border-border p-6">
+                  <p className="text-sm font-medium text-foreground">
+                    Description
+                  </p>
+                  <p className="text-base text-muted-foreground">
+                    {meta.description ?? "Claude Code skill"}
+                  </p>
+                </div>
+                <div className="prose prose-sm dark:prose-invert max-w-none p-6">
+                  <MemoizedMarkdown
+                    id={`skill-preview-${skillPath}`}
+                    text={meta.body}
+                  />
+                </div>
+              </>
+            )}
           </div>
-        )}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/apps/mesh/src/web/layouts/library/skill-preview-dialog.tsx
+++ b/apps/mesh/src/web/layouts/library/skill-preview-dialog.tsx
@@ -83,7 +83,7 @@ export function SkillPreviewDialog({
       >
         {/* Header */}
         <div className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-3">
-          <div className="flex size-9 shrink-0 items-center justify-center rounded-full border border-border bg-violet-100 text-violet-600">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
             <Zap size={18} />
           </div>
           <DialogTitle className="flex-1 truncate text-base font-medium text-foreground">

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -190,6 +190,8 @@ export const KEYS = {
   threadOutputs: (threadId: string) => ["thread-outputs", threadId] as const,
   // Fetched text content of a previewed file (FilePreview), keyed by URL.
   fileText: (downloadUrl: string) => ["file-text", downloadUrl] as const,
+  // First bytes of a CSV/TSV file for the card thumbnail (range request).
+  csvThumb: (downloadUrl: string) => ["csv-thumb", downloadUrl] as const,
 
   // Virtual MCP tools (for tool definition lookup in chat)
   // null virtualMcpId means default virtual MCP


### PR DESCRIPTION
## Summary

Improvements to the Library / skills experience in the mesh web app.

### Skill preview dialog
- Two-column layout: a **file sidebar** on the left (SKILL.md always first, rest alphabetized) and the selected file's preview on the right.
- Clicking a file in the sidebar previews it inline via the shared `FilePreview` (no more stacked dialogs). SKILL.md shows description + rendered markdown.
- Wider dialog, original-case filenames, larger file icons, slimmer header.

### Richer file thumbnails (Recently added cards)
- **CSV / TSV** → mini table preview (range-fetches only the first 8 KB, so size no longer matters).
- **Video** (mp4/webm/mov/m4v) → first frame via `<video preload="metadata">`.
- **PDF** → native `<embed>` first-page render.

### Code rendering
- The text branch of `FilePreview` now uses a **read-only Monaco viewer** (`code-viewer.tsx`) — same engine/CDN as the sandbox file explorer — giving real syntax highlighting + line numbers. Applies everywhere `FilePreview` is used (skill dialog, library panel, chat file tabs).

### Library file preview as a side panel
- On desktop, opening a file opens it in a **resizable right-side panel** (chat-style) instead of a modal, with a **tab pill** in the shared top-right tab slot (reuses `HeaderTabButton` / `Toolbar.Tabs`). Clicking the pill toggles it closed. Mobile keeps the dialog.

### Cleanup
- Removed the unused All / Shared / Private folder filter pills.

## Testing
- `bun run fmt`, `bun run check`, `bun run lint` all pass.
- Manual UI verification recommended for the Monaco viewer, video/PDF/CSV thumbnails, and the side-panel + tab-pill flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Library skill and file preview to make browsing faster and more visual. Adds a two-column skill dialog, richer thumbnails, and a desktop side-panel preview with syntax-highlighted code.

- **New Features**
  - Skill preview: two-column layout with a file sidebar (SKILL.md first) and inline `FilePreview`.
  - Thumbnails: CSV/TSV mini table (first 8 KB via range request) and video first frame; PDFs use an icon thumbnail (full render in preview).
  - Code: read-only Monaco `ReadOnlyCodeViewer` with real syntax highlighting and line numbers used by `FilePreview`.
  - Desktop preview: opens files in a resizable right-side panel with a top-right tab pill via `Toolbar.Tabs`; mobile keeps the dialog.

- **Bug Fixes**
  - Performance: lazy-load CSV/video/text thumbnails with an IntersectionObserver so cards fetch only when visible.
  - Correctness/UX: reset selected file when switching skills; Monaco theme follows `usePreferences` and is SSR-safe; simplified preview tab title; updated to design tokens; removed PDF embeds from thumbnails.
  - Cleanup: removed the unused All/Shared/Private folder filter pills.

<sup>Written for commit 1f061659b07f391dd86b754233735dfc5ede7644. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

