### PR TITLE
Enhance memory usage profiling with safeMemoryUsage utility

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -101,6 +101,7 @@ import type { ThreadMessage } from "@/storage/types";
 import { getInternalUrl, getPublicUrl } from "@/core/server-constants";
 import { mintOrgFsConfigJson } from "@/file-storage/mount/provisioning";
 import { meter, traced } from "@/observability";
+import { safeMemoryUsage } from "@/observability/profiling/safe-memory";
 import { getPodId } from "@/core/pod-identity";
 import type { SSEEvent } from "@/event-bus";
 import { sleep } from "@decocms/std";
@@ -1375,7 +1376,7 @@ async function prepareRun(
               // event-loop stalls.
               await sleep(0);
 
-              const heapBefore = FINISH_TRACE ? process.memoryUsage() : null;
+              const heapBefore = FINISH_TRACE ? safeMemoryUsage() : null;
               const saveStart = performance.now();
 
               const threadStatus = resolveThreadStatus(
@@ -1397,7 +1398,7 @@ async function prepareRun(
               finishDurationHistogram.record(saveMs, { phase: "save" });
 
               if (FINISH_TRACE && heapBefore) {
-                const heapAfter = process.memoryUsage();
+                const heapAfter = safeMemoryUsage() ?? heapBefore;
                 let messageBytes = -1;
                 try {
                   messageBytes = JSON.stringify(responseMessage)?.length ?? -1;

--- a/apps/mesh/src/observability/profiling/event-loop.ts
+++ b/apps/mesh/src/observability/profiling/event-loop.ts
@@ -1,4 +1,5 @@
 import { meter } from "../index";
+import { safeMemoryUsage } from "./safe-memory";
 
 /**
  * Event-loop delay monitor (timer-drift technique).
@@ -69,16 +70,19 @@ export function startEventLoopMonitor(): () => void {
     delayHistogram.record(drift);
 
     if (drift > spikeMs) {
-      const m = process.memoryUsage();
+      // The lag is the signal worth keeping; memoryUsage() can throw under the
+      // very GC pressure that causes the stall, so read it defensively and omit
+      // the memory fields rather than crash the process logging a stall.
+      const m = safeMemoryUsage();
       console.warn(
         JSON.stringify({
           msg: "event-loop-stall",
           ts: new Date().toISOString(),
           lagMs: Math.round(drift),
-          rss: m.rss,
-          heapUsed: m.heapUsed,
-          heapTotal: m.heapTotal,
-          external: m.external,
+          rss: m?.rss,
+          heapUsed: m?.heapUsed,
+          heapTotal: m?.heapTotal,
+          external: m?.external,
         }),
       );
     }

--- a/apps/mesh/src/observability/profiling/heap.ts
+++ b/apps/mesh/src/observability/profiling/heap.ts
@@ -1,3 +1,5 @@
+import { safeMemoryUsage } from "./safe-memory";
+
 let timer: ReturnType<typeof setInterval> | undefined;
 
 export function startHeapWatch(): () => void {
@@ -5,7 +7,10 @@ export function startHeapWatch(): () => void {
   const intervalMs = Number(process.env.HEAP_WATCH_INTERVAL_MS ?? 60_000);
 
   const tick = async () => {
-    const m = process.memoryUsage();
+    const m = safeMemoryUsage();
+    // memoryUsage() can transiently throw under GC pressure (EINTR). Skip this
+    // tick rather than crash — the next one will capture the trend.
+    if (!m) return;
     let jsc: {
       objectCount?: number;
       heapSize?: number;
@@ -40,8 +45,11 @@ export function startHeapWatch(): () => void {
     );
   };
 
-  void tick();
-  timer = setInterval(() => void tick(), intervalMs);
+  // Backstop: profiling must never crash the process, so swallow any rejection
+  // (e.g. a Bun internal throw from heapStats) instead of leaking it as an
+  // unhandled rejection.
+  void tick().catch(() => {});
+  timer = setInterval(() => void tick().catch(() => {}), intervalMs);
   timer.unref?.();
 
   process.on("SIGUSR2", () => {

--- a/apps/mesh/src/observability/profiling/safe-memory.ts
+++ b/apps/mesh/src/observability/profiling/safe-memory.ts
@@ -1,0 +1,18 @@
+/**
+ * `process.memoryUsage()` can throw on Bun under load — observed as
+ * `SystemError: Failed to get memory usage, errno: 4` (EINTR, an interrupted
+ * syscall) while the process is under heavy GC pressure. Because the profiling
+ * tick runs unguarded, that throw became an `uncaughtException` and took the
+ * whole pod down — i.e. the observability tooling crashed the process under
+ * exactly the conditions it exists to observe.
+ *
+ * This wrapper makes the read non-fatal: callers degrade gracefully (skip a
+ * tick, omit memory fields) instead of crashing.
+ */
+export function safeMemoryUsage(): NodeJS.MemoryUsage | null {
+  try {
+    return process.memoryUsage();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
- Introduced `safeMemoryUsage` function to safely retrieve memory usage statistics, preventing crashes under heavy GC pressure.
- Updated `prepareRun`, `startEventLoopMonitor`, and `startHeapWatch` functions to utilize `safeMemoryUsage` instead of `process.memoryUsage`, ensuring more robust memory profiling.
- Added defensive checks to handle potential null values returned by `safeMemoryUsage`, maintaining stability during profiling operations.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents profiling-related crashes under GC pressure by introducing a safe memory usage helper and using it in finish tracing, the event-loop monitor, and heap watch. When memory reads fail, profiling skips the tick or omits memory fields, keeping the process stable.

- **Bug Fixes**
  - Added safeMemoryUsage wrapper around process.memoryUsage.
  - Updated prepareRun, startEventLoopMonitor, and startHeapWatch to use it.
  - Added null checks and wrapped tick calls to avoid unhandled rejections.

<sup>Written for commit 1b93a412b17efea98c22d66a1a3563c08f3898d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

