### PR TITLE
feat(link): desktop onboarding, offline UX, and studio-side disconnect for local Claude Code

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1480,6 +1480,8 @@ export async function createApp(options: CreateAppOptions = {}) {
     providerKeyCache,
     memberRoleCache,
     linkClaimRegistry,
+    publishLinkControlFrame: (userSub, frame) =>
+      cancelBroadcast.publishControlFrame(userSub, frame),
   });
   ContextFactory.set(factory);
 

--- a/apps/mesh/src/api/routes/decopilot/control-frames.ts
+++ b/apps/mesh/src/api/routes/decopilot/control-frames.ts
@@ -16,6 +16,13 @@
  *                                  directly; the held control-poll is the only
  *                                  inbound signal it has.
  *   - `keep_alive` (Phase C)     — server heartbeat; ignored by the daemon.
+ *   - `shutdown`                 — disconnect requested from the Studio UI
+ *                                  (LINK_DISCONNECT tool); the daemon stops
+ *                                  polling and exits. Daemons predating this
+ *                                  frame fail schema validation and skip it
+ *                                  (logged, no crash) — for those the tool's
+ *                                  claim delete only flips the UI until their
+ *                                  next poll re-registers, which is accepted.
  *
  * Additional frame types (ensure_sandbox, delete_sandbox, approval) are deferred.
  */
@@ -25,6 +32,7 @@ export const controlFrameSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("cancel"), runId: z.string() }),
   z.object({ type: z.literal("cancel_req"), reqId: z.string() }),
   z.object({ type: z.literal("keep_alive") }),
+  z.object({ type: z.literal("shutdown") }),
 ]);
 
 export type ControlFrame = z.infer<typeof controlFrameSchema>;

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -125,6 +125,11 @@ export interface StudioContextConfig {
   /** Required for desktop sandbox auto-resolution; tests may omit. */
   linkClaimRegistry?: LinkClaimRegistry;
   /**
+   * Publishes a control frame to a user's link control channel (delegates to
+   * the app's CancelBroadcast). Required for LINK_DISCONNECT; tests may omit.
+   */
+  publishLinkControlFrame?: StudioContext["publishLinkControlFrame"];
+  /**
    * Test-only escape hatch: pre-built monitoring + metric engines. When
    * provided, skips the `@duckdb/node-api` import path that otherwise
    * runs in dev/test (when no `clickhouseUrl` is set). DuckDB's native
@@ -1401,6 +1406,7 @@ export async function createStudioContextFactory(
       },
       eventBus: config.eventBus,
       linkClaimRegistry: config.linkClaimRegistry,
+      publishLinkControlFrame: config.publishLinkControlFrame,
       aiProviders: aiProviderFactory,
       createMCPProxy: async (conn: string | ConnectionEntity) => {
         return await createMCPProxy(conn, ctx);

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -15,6 +15,7 @@ import type { Meter, Tracer } from "@opentelemetry/api";
 import type { Kysely } from "kysely";
 import type { LinkClaim } from "../links/link-claim-registry";
 import type { LinkClaimRegistry } from "@/links/link-claim-registry";
+import type { ControlFrame } from "@/api/routes/decopilot/control-frames";
 import type { CredentialVault } from "../encryption/credential-vault";
 import type { Database, Permission } from "../storage/types";
 import type { AccessControl } from "./access-control";
@@ -441,6 +442,16 @@ export interface StudioContext extends HarnessContext {
    * that don't supply a registry.
    */
   linkClaimRegistry?: LinkClaimRegistry;
+
+  /**
+   * Publish a control frame onto a user's link control channel
+   * (`links.control.<userSub>`), where the desktop daemon's long-poll picks
+   * it up. Fire-and-forget: a no-op when NATS is unavailable. Deliberately
+   * narrower than the CancelBroadcast it delegates to — tools only ever
+   * publish (LINK_DISCONNECT sends `shutdown`); start/stop/broadcast stay
+   * with the app wiring. Undefined in test contexts without a broadcast.
+   */
+  publishLinkControlFrame?: (userSub: string, frame: ControlFrame) => void;
 }
 
 // ============================================================================

--- a/apps/mesh/src/link-daemon/capabilities.test.ts
+++ b/apps/mesh/src/link-daemon/capabilities.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { detectCapabilities } from "./capabilities";
+import { sleep } from "@decocms/std";
+import type { Capability } from "@/links/protocol";
+import {
+  detectCapabilities,
+  mergeProbedCapabilities,
+  missingCliCapabilities,
+  startCapabilityReprobe,
+} from "./capabilities";
 
 describe("detectCapabilities", () => {
   it("always includes decopilot-sandbox and body-offload", async () => {
@@ -66,5 +73,87 @@ describe("detectCapabilities", () => {
       },
     });
     expect(caps).toEqual(["decopilot-sandbox", "body-offload"]);
+  });
+});
+
+describe("missingCliCapabilities", () => {
+  it("reports both CLIs missing on a bare daemon", () => {
+    expect(
+      missingCliCapabilities(["decopilot-sandbox", "body-offload"]),
+    ).toEqual(["claude-code", "codex"]);
+  });
+
+  it("reports nothing missing when both CLIs are present", () => {
+    expect(
+      missingCliCapabilities([
+        "decopilot-sandbox",
+        "body-offload",
+        "claude-code",
+        "codex",
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("mergeProbedCapabilities", () => {
+  it("grows the array in place with newly probed capabilities", () => {
+    const live: Capability[] = ["decopilot-sandbox", "body-offload"];
+    const added = mergeProbedCapabilities(live, [
+      "decopilot-sandbox",
+      "body-offload",
+      "claude-code",
+    ]);
+    expect(added).toEqual(["claude-code"]);
+    expect(live).toEqual(["decopilot-sandbox", "body-offload", "claude-code"]);
+  });
+
+  it("never removes a capability the probe stopped reporting (grow-only)", () => {
+    // A transient probe failure must not un-advertise a capability mid-run —
+    // dispatch routing would bounce threads that are actively streaming.
+    const live: Capability[] = [
+      "decopilot-sandbox",
+      "body-offload",
+      "claude-code",
+    ];
+    const added = mergeProbedCapabilities(live, [
+      "decopilot-sandbox",
+      "body-offload",
+    ]);
+    expect(added).toEqual([]);
+    expect(live).toContain("claude-code");
+  });
+});
+
+describe("startCapabilityReprobe", () => {
+  it("skips probing while no CLI capability is missing, probes and merges while one is", async () => {
+    const fullyEquipped: Capability[] = [
+      "decopilot-sandbox",
+      "body-offload",
+      "claude-code",
+      "codex",
+    ];
+    let probes = 0;
+    const stopFull = startCapabilityReprobe(fullyEquipped, {
+      intervalMs: 5,
+      detect: async () => {
+        probes++;
+        return fullyEquipped;
+      },
+    });
+    await sleep(25);
+    stopFull();
+    expect(probes).toBe(0);
+
+    const bare: Capability[] = ["decopilot-sandbox", "body-offload"];
+    const changes: Capability[][] = [];
+    const stopBare = startCapabilityReprobe(bare, {
+      intervalMs: 5,
+      detect: async () => ["decopilot-sandbox", "body-offload", "claude-code"],
+      onChange: (added) => changes.push(added),
+    });
+    await sleep(25);
+    stopBare();
+    expect(bare).toContain("claude-code");
+    expect(changes).toEqual([["claude-code"]]);
   });
 });

--- a/apps/mesh/src/link-daemon/capabilities.ts
+++ b/apps/mesh/src/link-daemon/capabilities.ts
@@ -32,7 +32,7 @@ export async function detectCapabilities(
 
 /** CLI-backed capabilities that can appear after daemon startup (the user
  * installs / signs into the CLI while the daemon is running). */
-export const CLI_CAPABILITIES: readonly Capability[] = ["claude-code", "codex"];
+const CLI_CAPABILITIES: readonly Capability[] = ["claude-code", "codex"];
 
 /** CLI capabilities not present in `current` — the re-probe targets. */
 export function missingCliCapabilities(

--- a/apps/mesh/src/link-daemon/capabilities.ts
+++ b/apps/mesh/src/link-daemon/capabilities.ts
@@ -1,7 +1,8 @@
 import type { Capability } from "@/links/protocol";
 
 /**
- * Detected once at daemon startup. The result rides the existing
+ * Detected at daemon startup and re-probed periodically while a CLI is
+ * missing (see `startCapabilityReprobe`). The result rides the existing
  * `capabilities: Capability[]` field on the registration payload, so the
  * cluster sees an accurate view of what this desktop can actually run.
  *
@@ -27,6 +28,68 @@ export async function detectCapabilities(
   if (hasClaudeCode) caps.push("claude-code");
   if (hasCodex) caps.push("codex");
   return caps;
+}
+
+/** CLI-backed capabilities that can appear after daemon startup (the user
+ * installs / signs into the CLI while the daemon is running). */
+export const CLI_CAPABILITIES: readonly Capability[] = ["claude-code", "codex"];
+
+/** CLI capabilities not present in `current` — the re-probe targets. */
+export function missingCliCapabilities(
+  current: readonly Capability[],
+): Capability[] {
+  return CLI_CAPABILITIES.filter((c) => !current.includes(c));
+}
+
+/**
+ * Grow-only merge of a re-probe result into the live capability array,
+ * IN PLACE — the same array reference is shared with the poll loops, which
+ * read it on every poll, so mutation is the propagation mechanism.
+ *
+ * Grow-only on purpose: a transient probe failure (CLI busy, SDK hiccup)
+ * must never un-advertise a capability mid-run — dispatch routing would
+ * start bouncing threads that are actively streaming. Returns the newly
+ * added capabilities (empty when nothing changed).
+ */
+export function mergeProbedCapabilities(
+  current: Capability[],
+  probed: readonly Capability[],
+): Capability[] {
+  const added = probed.filter((c) => !current.includes(c));
+  current.push(...added);
+  return added;
+}
+
+/**
+ * Re-probe CLI capabilities every `intervalMs` while at least one is
+ * missing, merging discoveries into `capabilities` in place. Probing stops
+ * being useful once every CLI capability is present, so those ticks are
+ * skipped (each claude-code probe spawns the agent SDK — not free).
+ * Returns a cancel function for daemon shutdown.
+ */
+export function startCapabilityReprobe(
+  capabilities: Capability[],
+  opts: {
+    intervalMs?: number;
+    detect?: () => Promise<Capability[]>;
+    onChange?: (added: Capability[]) => void;
+  } = {},
+): () => void {
+  const detect = opts.detect ?? (() => detectCapabilities());
+  const timer = setInterval(() => {
+    if (missingCliCapabilities(capabilities).length === 0) return;
+    void detect()
+      .then((probed) => {
+        const added = mergeProbedCapabilities(capabilities, probed);
+        if (added.length > 0) opts.onChange?.(added);
+      })
+      .catch(() => {
+        /* probe failures are expected while the CLI is absent */
+      });
+  }, opts.intervalMs ?? 60_000);
+  // Don't let the re-probe timer hold the process open on shutdown.
+  timer.unref?.();
+  return () => clearInterval(timer);
 }
 
 async function detectClaudeCode(): Promise<boolean> {

--- a/apps/mesh/src/link-daemon/cluster-connection-pull.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-pull.ts
@@ -99,6 +99,13 @@ export interface ClusterConnectionPullInput {
   /** Called once the pull loop has started (analogous to `onConnected` in the WS path). */
   onConnected?: () => void;
   /**
+   * Called when the cluster sends a `shutdown` control frame (LINK_DISCONNECT
+   * from the Studio UI). index.ts wires this to the daemon's shutdown so a
+   * web-side "Disconnect" actually stops the local daemon instead of letting
+   * its next poll re-register the presence claim the cluster just deleted.
+   */
+  onShutdown?: () => void;
+  /**
    * Durable chunk-relay outbox (spec §5.1). Opened once per daemon in index.ts
    * and shared across every dispatch; forwarded to `handleLocalDispatch` so the
    * relay survives a daemon restart mid-run.
@@ -356,6 +363,7 @@ export async function connectToClusterPull(
     onCancelReq: (reqId) => {
       proxyAbortRegistry.abort(reqId);
     },
+    onShutdown: input.onShutdown,
   });
 
   // Phase C-bis S2: the pull reverse-proxy loop (continuous-overlap GETs +

--- a/apps/mesh/src/link-daemon/control-poller.test.ts
+++ b/apps/mesh/src/link-daemon/control-poller.test.ts
@@ -126,4 +126,31 @@ describe("runControlPollLoop frame routing", () => {
       "https://cluster.example.com/api/links/control?timeout=15",
     );
   });
+
+  it("routes a shutdown frame to onShutdown and stops polling without abort", async () => {
+    // No ac.abort() here on purpose: the loop must RETURN on its own after a
+    // shutdown frame — one more long-poll would race the process exit and
+    // re-mint the presence claim the cluster just deleted.
+    const ac = new AbortController();
+    let shutdowns = 0;
+    let call = 0;
+    const fetchImpl = (async () => {
+      call++;
+      return jsonResponse(200, encodeControlFrame({ type: "shutdown" }));
+    }) as unknown as typeof fetch;
+
+    await runControlPollLoop({
+      baseUrl: BASE_URL,
+      getAccessToken: () => "tok",
+      signal: ac.signal,
+      fetchImpl,
+      onCancel: () => {},
+      onShutdown: () => {
+        shutdowns++;
+      },
+    });
+
+    expect(shutdowns).toBe(1);
+    expect(call).toBe(1);
+  });
 });

--- a/apps/mesh/src/link-daemon/control-poller.ts
+++ b/apps/mesh/src/link-daemon/control-poller.ts
@@ -53,6 +53,14 @@ export interface ControlPollerDeps {
    * optional so the WS-only paths / older callers compile unchanged.
    */
   onCancelReq?: (reqId: string) => void;
+  /**
+   * Called when a `shutdown` frame is received (LINK_DISCONNECT from the
+   * Studio UI). The daemon's shutdown function is the intended
+   * implementation. The loop RETURNS after dispatching — the process is on
+   * its way down, and one more long-poll would only race the exit and
+   * re-mint the presence claim the cluster just deleted.
+   */
+  onShutdown?: () => void;
 }
 
 const BASE_DELAY_MS = 1_000;
@@ -161,6 +169,16 @@ export async function runControlPollLoop(
         } catch (err) {
           console.error("[control-poller] onCancelReq threw (swallowed)", err);
         }
+      } else if (frame.type === "shutdown") {
+        console.log(
+          "[control-poller] shutdown frame received — stopping control poll",
+        );
+        try {
+          deps.onShutdown?.();
+        } catch (err) {
+          console.error("[control-poller] onShutdown threw (swallowed)", err);
+        }
+        return;
       }
       // keep_alive: no-op — continue to re-poll.
       continue;

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -244,6 +244,12 @@ export async function startLinkDaemon(
   // resend the unacked relay prefix.
   const outbox = openOutbox({ path: `${opts.dataDir}/link/outbox.sqlite` });
 
+  // `shutdown` is declared below (it needs `cluster` in scope); the control
+  // poller can in principle deliver a frame before that line runs, so route
+  // the callback through a mutable holder instead of capturing `shutdown`
+  // directly (TDZ).
+  let onRemoteShutdown: () => void = () => {};
+
   const cluster = await connectToClusterPull({
     clusterBaseUrl: opts.clusterBaseUrl,
     getAccessToken,
@@ -261,6 +267,7 @@ export async function startLinkDaemon(
       opts.monitor?.onCluster?.("linked");
       console.log(`Linked to ${opts.clusterBaseUrl} (pull transport)`);
     },
+    onShutdown: () => onRemoteShutdown(),
   });
 
   let resolveStopped!: (code: number) => void;
@@ -297,6 +304,12 @@ export async function startLinkDaemon(
   };
   process.on("SIGINT", () => void shutdown());
   process.on("SIGTERM", () => void shutdown());
+  onRemoteShutdown = () => {
+    console.log(
+      "Disconnect requested from the Studio web UI — shutting down. Run `bunx decocms link` to reconnect.",
+    );
+    void shutdown();
+  };
 
   void cluster.closed.then(() => {
     opts.monitor?.onCluster?.("closed");

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -24,7 +24,7 @@ import { createControlHandler } from "./control-handler";
 import { connectToClusterPull } from "./cluster-connection-pull";
 import { openOutbox } from "./outbox";
 import { startLocalIngress } from "./local-ingress";
-import { detectCapabilities } from "./capabilities";
+import { detectCapabilities, startCapabilityReprobe } from "./capabilities";
 import { loadOrCreateMachineId } from "./machine-id";
 import { getValidSession } from "../cli/lib/get-valid-session";
 import type { Session } from "../cli/lib/session";
@@ -226,6 +226,18 @@ export async function startLinkDaemon(
   const machineId = await loadOrCreateMachineId(opts.dataDir);
   const cliVersion = process.env.npm_package_version ?? "0.0.0";
   const capabilities = await detectCapabilities();
+  // While a CLI capability (claude-code / codex) is missing, re-probe every
+  // minute so installing or signing into the CLI after `decocms link` started
+  // is picked up without a daemon restart. The poll loops read the (shared,
+  // grow-only) array on every poll, so the next poll advertises the change
+  // and the cluster's presence claim follows.
+  const stopReprobe = startCapabilityReprobe(capabilities, {
+    onChange: (added) => {
+      console.log(
+        `[link-daemon] capabilities detected: +${added.join(",")} (now: ${capabilities.join(",")})`,
+      );
+    },
+  });
   // Durable uplink outbox (spec §5.1). One DB per daemon under the leaf data
   // dir (DATA_DIR is the leaf — do NOT append `.deco`; sandboxes live at
   // `$DATA_DIR/link/sandboxes/...`). Survives daemon restart so a reconnect can
@@ -260,6 +272,7 @@ export async function startLinkDaemon(
     if (shuttingDown) return;
     shuttingDown = true;
     console.log("\nShutting down…");
+    stopReprobe();
     try {
       await cluster.close();
     } catch {

--- a/apps/mesh/src/link-daemon/work-poller.test.ts
+++ b/apps/mesh/src/link-daemon/work-poller.test.ts
@@ -358,4 +358,40 @@ describe("runWorkPollLoop", () => {
 
     expect(received).toEqual(["run_A", "run_B", "run_C"]);
   });
+
+  it("advertises capabilities grown in place between polls (re-probe pickup)", async () => {
+    // The daemon's capability re-probe mutates the shared array after the
+    // loop has started; the NEXT poll must carry the updated header — that
+    // is the whole propagation mechanism (no restart, no re-registration).
+    const ac = new AbortController();
+    const capabilities: import("../links/protocol").Capability[] = [
+      "decopilot-sandbox",
+      "body-offload",
+    ];
+    const seenHeaders: (string | undefined)[] = [];
+
+    const fetchImpl = mock(async (_url: string, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string>;
+      seenHeaders.push(headers["x-link-capabilities"]);
+      if (seenHeaders.length === 1) {
+        // Simulate the re-probe discovering claude-code mid-loop.
+        capabilities.push("claude-code");
+        return makeResponse(204);
+      }
+      ac.abort();
+      return makeResponse(204);
+    });
+
+    await runWorkPollLoop({
+      baseUrl: BASE_URL,
+      onWork: async () => {},
+      getAccessToken: async () => "tok",
+      signal: ac.signal,
+      capabilities,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(seenHeaders[0]).toBe("decopilot-sandbox,body-offload");
+    expect(seenHeaders[1]).toBe("decopilot-sandbox,body-offload,claude-code");
+  });
 });

--- a/apps/mesh/src/link-daemon/work-poller.ts
+++ b/apps/mesh/src/link-daemon/work-poller.ts
@@ -60,6 +60,11 @@ export interface WorkPollerDeps {
    * header. The server mints the presence claim with these so
    * resolveDispatchTarget can route pull-transport threads correctly.
    * Mirrors the `capabilities` field in the WS hello frame.
+   *
+   * Read on EVERY poll (not snapshotted at loop start): the daemon re-probes
+   * CLI capabilities after startup, growing this array in place when a CLI
+   * (claude-code / codex) is installed while the daemon is running, and the
+   * next poll advertises the updated set without a restart.
    */
   capabilities?: Capability[];
   /**
@@ -106,12 +111,12 @@ export async function runWorkPollLoop(deps: WorkPollerDeps): Promise<void> {
   // Build the static presence headers once — these don't change between polls.
   // The protocol version is always sent so the cluster's 426 gate can tell a
   // current daemon from a stale one (absent header = pre-v2 daemon).
+  // `x-link-capabilities` is intentionally NOT in this static set — it is
+  // re-read from `deps.capabilities` on every poll so a post-startup CLI
+  // re-probe (capability array grown in place) reaches the presence claim.
   const presenceHeaders: Record<string, string> = {
     [LINK_PROTOCOL_HEADER]: String(LINK_PROTOCOL_VERSION),
   };
-  if (deps.capabilities && deps.capabilities.length > 0) {
-    presenceHeaders["x-link-capabilities"] = deps.capabilities.join(",");
-  }
   if (deps.machineId) {
     presenceHeaders["x-link-machine-id"] = deps.machineId;
   }
@@ -143,11 +148,20 @@ export async function runWorkPollLoop(deps: WorkPollerDeps): Promise<void> {
       continue;
     }
 
-    // Step 2: issue the long-poll request.
+    // Step 2: issue the long-poll request. Capabilities are joined here, per
+    // poll, so an in-place capability update is advertised on the next poll.
+    const capabilityHeader =
+      deps.capabilities && deps.capabilities.length > 0
+        ? { "x-link-capabilities": deps.capabilities.join(",") }
+        : undefined;
     let res: Response;
     try {
       res = await fetcher(url, {
-        headers: { Authorization: `Bearer ${token}`, ...presenceHeaders },
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...presenceHeaders,
+          ...capabilityHeader,
+        },
         signal,
       });
     } catch (err) {

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -190,6 +190,7 @@ const CORE_TOOLS = [
 
   // Link tools
   LinkTools.LINK_CURRENT_GET,
+  LinkTools.LINK_DISCONNECT,
 
   // Search tools
   SearchTools.GLOBAL_SEARCH,

--- a/apps/mesh/src/tools/links/disconnect.test.ts
+++ b/apps/mesh/src/tools/links/disconnect.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "bun:test";
+import type { ControlFrame } from "../../api/routes/decopilot/control-frames";
+import type { StudioContext } from "../../core/studio-context";
+import { createInMemoryLinkClaimRegistry } from "../../links/link-claim-registry";
+import type { LinkClaim } from "../../links/link-claim-registry";
+import { LINK_DISCONNECT } from "./disconnect";
+
+const STUB_CLAIM: LinkClaim = {
+  podId: "pod_1",
+  machineId: "machine_abc",
+  cliVersion: "1.2.3",
+  previewPort: 5174,
+  connectedAt: Date.now(),
+  capabilities: ["claude-code"],
+};
+
+const USER_ID = "user_1";
+
+function makeCtx(
+  overrides: Partial<
+    Pick<
+      StudioContext,
+      "linkClaimRegistry" | "publishLinkControlFrame" | "auth" | "access"
+    >
+  > = {},
+): StudioContext {
+  return {
+    auth: {
+      user: {
+        id: USER_ID,
+        email: "test@example.com",
+        name: "Test",
+        role: "user",
+      },
+    },
+    access: {
+      granted: () => true,
+      check: async () => {},
+      grant: () => {},
+      setToolName: () => {},
+    },
+    organization: { id: "org_1", slug: "test-org", name: "Test Org" },
+    storage: {} as never,
+    timings: {
+      measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
+    },
+    vault: null as never,
+    db: null as never,
+    authInstance: null as never,
+    boundAuth: null as never,
+    tracer: {
+      startActiveSpan: (
+        _name: string,
+        _opts: unknown,
+        fn: (span: unknown) => unknown,
+      ) =>
+        fn({
+          setStatus: () => {},
+          recordException: () => {},
+          end: () => {},
+        }),
+    } as never,
+    meter: {
+      createHistogram: () => ({ record: () => {} }),
+      createCounter: () => ({ add: () => {} }),
+    } as never,
+    baseUrl: "https://mesh.example.com",
+    metadata: { requestId: "req_1", timestamp: new Date() },
+    eventBus: null as never,
+    objectStorage: null as never,
+    aiProviders: null as never,
+    createMCPProxy: null as never,
+    getOrCreateClient: null as never,
+    pendingRevalidations: [],
+    monitoring: null as never,
+    ...overrides,
+  } as unknown as StudioContext;
+}
+
+describe("LINK_DISCONNECT", () => {
+  it("returns disconnected: false when no registry is wired", async () => {
+    const ctx = makeCtx({ linkClaimRegistry: undefined });
+    const result = await LINK_DISCONNECT.handler({}, ctx);
+    expect(result).toEqual({ disconnected: false });
+  });
+
+  it("returns disconnected: false and publishes nothing when no link is registered", async () => {
+    const published: ControlFrame[] = [];
+    const registry = createInMemoryLinkClaimRegistry();
+    const ctx = makeCtx({
+      linkClaimRegistry: registry,
+      publishLinkControlFrame: (_userSub, frame) => published.push(frame),
+    });
+
+    const result = await LINK_DISCONNECT.handler({}, ctx);
+
+    expect(result).toEqual({ disconnected: false });
+    expect(published).toEqual([]);
+  });
+
+  it("publishes a shutdown frame to the caller's channel and deletes the claim", async () => {
+    const published: Array<{ userSub: string; frame: ControlFrame }> = [];
+    const registry = createInMemoryLinkClaimRegistry();
+    await registry.put(USER_ID, STUB_CLAIM);
+    const ctx = makeCtx({
+      linkClaimRegistry: registry,
+      publishLinkControlFrame: (userSub, frame) =>
+        published.push({ userSub, frame }),
+    });
+
+    const result = await LINK_DISCONNECT.handler({}, ctx);
+
+    expect(result).toEqual({ disconnected: true });
+    expect(published).toEqual([
+      { userSub: USER_ID, frame: { type: "shutdown" } },
+    ]);
+    expect(await registry.get(USER_ID)).toBeNull();
+  });
+
+  it("still deletes the claim when no frame publisher is wired (test/no-NATS contexts)", async () => {
+    const registry = createInMemoryLinkClaimRegistry();
+    await registry.put(USER_ID, STUB_CLAIM);
+    const ctx = makeCtx({
+      linkClaimRegistry: registry,
+      publishLinkControlFrame: undefined,
+    });
+
+    const result = await LINK_DISCONNECT.handler({}, ctx);
+
+    expect(result).toEqual({ disconnected: true });
+    expect(await registry.get(USER_ID)).toBeNull();
+  });
+
+  it("throws when called without auth", async () => {
+    const ctx = makeCtx({ auth: {} });
+    await expect(LINK_DISCONNECT.handler({}, ctx)).rejects.toThrow(
+      "Authentication required",
+    );
+  });
+});

--- a/apps/mesh/src/tools/links/disconnect.ts
+++ b/apps/mesh/src/tools/links/disconnect.ts
@@ -1,0 +1,37 @@
+import z from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth } from "../../core/studio-context";
+
+export const LINK_DISCONNECT = defineTool({
+  name: "LINK_DISCONNECT",
+  description:
+    "Disconnect the calling user's desktop link from the Studio side: tells the linked daemon to shut down (via a `shutdown` control frame) and removes the presence claim. The user re-links by running `bunx decocms link` on the desktop.",
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    /**
+     * True when a registered link existed and was disconnected; false when
+     * there was nothing to disconnect (already offline / TTL expired).
+     */
+    disconnected: z.boolean(),
+  }),
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+
+    const userSub = ctx.auth.user!.id;
+    const registry = ctx.linkClaimRegistry;
+    const claim = registry ? await registry.get(userSub) : null;
+    if (!claim) return { disconnected: false };
+
+    // Order matters: tell the daemon to stop BEFORE deleting the claim. The
+    // frame is fire-and-forget (held control long-poll delivers it within
+    // the poll window); deleting first would still work, but a daemon that
+    // never receives the frame (pre-`shutdown` CLI, NATS hiccup) re-mints
+    // the claim on its next poll — the daemon stopping is what makes the
+    // disconnect stick, the delete just flips the UI immediately.
+    ctx.publishLinkControlFrame?.(userSub, { type: "shutdown" });
+    await registry!.delete(userSub);
+
+    return { disconnected: true };
+  },
+});

--- a/apps/mesh/src/tools/links/index.ts
+++ b/apps/mesh/src/tools/links/index.ts
@@ -1,1 +1,2 @@
 export { LINK_CURRENT_GET } from "./get-current";
+export { LINK_DISCONNECT } from "./disconnect";

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -212,6 +212,7 @@ const ALL_TOOL_NAMES = [
 
   // Link tools
   "LINK_CURRENT_GET",
+  "LINK_DISCONNECT",
 
   // Search tools
   "GLOBAL_SEARCH",
@@ -987,6 +988,12 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
       "Return the calling user's current desktop link status (online/offline, capabilities)",
     category: "Links",
   },
+  {
+    name: "LINK_DISCONNECT",
+    description:
+      "Disconnect the calling user's desktop link (stops the daemon, removes the presence claim)",
+    category: "Links",
+  },
   // Search tools
   {
     name: "GLOBAL_SEARCH",
@@ -1067,10 +1074,14 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       //   USER_GET     → resolve member display ("created by" on agents, etc.);
       //                  handler scopes to shared-org members, no secrets
       //   LINK_CURRENT_GET → caller's own desktop-link status (header poll)
+      //   LINK_DISCONNECT  → self-scoped: disconnects the CALLER's own
+      //                      desktop link only (handler keys everything off
+      //                      ctx.auth.user.id), so members keep it
       //   BRAND_CONTEXT_LIST → org branding for the chat empty state
       "ORGANIZATION_SETTINGS_GET",
       "USER_GET",
       "LINK_CURRENT_GET",
+      "LINK_DISCONNECT",
       "BRAND_CONTEXT_LIST",
       // Chat threads — talking to an agent is the most basic usage of the
       // product, so every member can CRUD their OWN threads. Per-thread access

--- a/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
@@ -9,8 +9,16 @@ import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Check, Copy01 } from "@untitledui/icons";
 import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
 import type { Capability } from "@/links/protocol";
 import { useCurrentLink } from "@/web/hooks/use-current-link";
+import { KEYS } from "@/web/lib/query-keys";
 
 const INSTALL_SNIPPET = "bunx decocms link";
 
@@ -36,7 +44,7 @@ export function visibleCapabilities(caps: readonly Capability[]): string[] {
  * Drives the remediation copy: the daemon re-probes every minute, so a
  * CLI installed (and signed into) after linking shows up here on its own.
  */
-export function missingCliLabels(caps: readonly Capability[]): string[] {
+function missingCliLabels(caps: readonly Capability[]): string[] {
   return (Object.keys(CAPABILITY_LABELS) as Capability[])
     .filter((c) => !caps.includes(c))
     .map((c) => CAPABILITY_LABELS[c])
@@ -54,6 +62,38 @@ export function ConnectDesktopDialog({
 }: ConnectDesktopDialogProps) {
   const link = useCurrentLink();
   const [copied, setCopied] = useState(false);
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  // Tells the linked daemon to shut down (a `shutdown` control frame rides
+  // its held control long-poll) and removes the presence claim, so the link
+  // flips offline immediately. The dialog then shows the reconnect snippet.
+  const disconnect = useMutation({
+    mutationFn: async () => {
+      const result = (await client.callTool({
+        name: "LINK_DISCONNECT",
+        arguments: {},
+      })) as { isError?: boolean; content?: { text?: string }[] };
+      if (result?.isError) {
+        throw new Error(
+          result.content?.[0]?.text ?? "Failed to disconnect desktop",
+        );
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: KEYS.currentLink(org.id),
+      });
+    },
+    onError: (err) => {
+      toast.error(`Disconnect failed: ${err.message}`);
+    },
+  });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -112,6 +152,18 @@ export function ConnectDesktopDialog({
                 — it appears here automatically within a minute.
               </p>
             )}
+            <div className="flex justify-end pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={disconnect.isPending}
+                onClick={() => disconnect.mutate()}
+                className="text-destructive hover:text-destructive"
+              >
+                {disconnect.isPending ? "Disconnecting…" : "Disconnect desktop"}
+              </Button>
+            </div>
           </div>
         )}
       </DialogContent>

--- a/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
@@ -31,6 +31,18 @@ export function visibleCapabilities(caps: readonly Capability[]): string[] {
     .filter((label): label is string => Boolean(label));
 }
 
+/**
+ * CLI agents the linked desktop does NOT advertise, as friendly labels.
+ * Drives the remediation copy: the daemon re-probes every minute, so a
+ * CLI installed (and signed into) after linking shows up here on its own.
+ */
+export function missingCliLabels(caps: readonly Capability[]): string[] {
+  return (Object.keys(CAPABILITY_LABELS) as Capability[])
+    .filter((c) => !caps.includes(c))
+    .map((c) => CAPABILITY_LABELS[c])
+    .filter((label): label is string => Boolean(label));
+}
+
 interface ConnectDesktopDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -88,6 +100,16 @@ export function ConnectDesktopDialog({
             {visibleCapabilities(link.capabilities).length > 0 && (
               <p className="text-muted-foreground">
                 Available: {visibleCapabilities(link.capabilities).join(", ")}
+              </p>
+            )}
+            {missingCliLabels(link.capabilities).length > 0 && (
+              <p className="text-muted-foreground">
+                {missingCliLabels(link.capabilities).join(" and ")}{" "}
+                {missingCliLabels(link.capabilities).length > 1
+                  ? "were"
+                  : "was"}{" "}
+                not detected on this desktop. Install the CLI and sign in there
+                — it appears here automatically within a minute.
               </p>
             )}
           </div>

--- a/apps/mesh/src/web/components/chat/desktop-offline-banner.tsx
+++ b/apps/mesh/src/web/components/chat/desktop-offline-banner.tsx
@@ -1,0 +1,63 @@
+/**
+ * DesktopOfflineBanner — proactive warning for threads pinned to the user's
+ * desktop (`sandbox_provider_kind = "user-desktop"`) while the link daemon is
+ * offline.
+ *
+ * Without it the user only learns at send time, via the POST /messages 409
+ * (`user_desktop_link_offline`) — after typing a whole message. The thread is
+ * permanently bound to the desktop runtime (harness lock), so the only
+ * remedy is bringing the link back; the banner says that up front and offers
+ * the connect-desktop flow.
+ *
+ * Self-contained on purpose (same pattern as TodosHighlight): reads the chat
+ * task context and link presence itself, renders nothing when the thread
+ * isn't desktop-pinned, the link state hasn't loaded yet, or the desktop is
+ * online. `useCurrentLink` polls LINK_CURRENT_GET, so the banner clears on
+ * its own once the daemon reconnects.
+ */
+
+import { useState } from "react";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Monitor01 } from "@untitledui/icons";
+import { useCurrentLink } from "@/web/hooks/use-current-link";
+import { useOptionalChatTask } from "./chat-context";
+import { ConnectDesktopDialog } from "./connect-desktop-dialog";
+import { CollapsibleHighlight } from "./highlight/collapsible-highlight";
+
+export function DesktopOfflineBanner() {
+  const taskCtx = useOptionalChatTask();
+  const link = useCurrentLink();
+  const [connectOpen, setConnectOpen] = useState(false);
+
+  const lockedToDesktop = taskCtx?.lockedSandbox === "user-desktop";
+  if (!lockedToDesktop || !link.ready || link.online) return null;
+
+  return (
+    <>
+      <CollapsibleHighlight
+        icon={<Monitor01 size={14} />}
+        label="Your desktop is offline"
+        title="This chat runs on your desktop, which isn't connected right now."
+        defaultExpanded={true}
+        variant="warning"
+        footerRight={
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 text-xs"
+            onClick={() => setConnectOpen(true)}
+          >
+            Reconnect desktop
+          </Button>
+        }
+      >
+        <p className="mx-4 text-xs text-muted-foreground">
+          Run <code className="font-mono">bunx decocms link</code> in a terminal
+          on that machine to bring it back. Messages you send while it's offline
+          will fail.
+        </p>
+      </CollapsibleHighlight>
+      <ConnectDesktopDialog open={connectOpen} onOpenChange={setConnectOpen} />
+    </>
+  );
+}

--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -14,6 +14,7 @@ import { UserAskQuestionHighlight } from "./user-ask-question";
 import { TodosHighlight } from "./todos";
 import { CollapsibleHighlight } from "./collapsible-highlight";
 import { CreditsExhaustedBanner } from "../credits-exhausted-banner";
+import { DesktopOfflineBanner } from "../desktop-offline-banner";
 import { useHighlightFlags } from "./use-highlight-count";
 import { parseErrorMessage } from "./parse-error-message";
 import type { UserAskToolPart } from "../types";
@@ -279,6 +280,7 @@ export function ChatHighlight() {
   return (
     <div className="absolute bottom-full left-0 right-0">
       <TodosHighlight />
+      <DesktopOfflineBanner />
       {showError && (
         <StatusHighlight
           variant="error"

--- a/apps/mesh/src/web/components/chat/highlight/parse-error-message.test.ts
+++ b/apps/mesh/src/web/components/chat/highlight/parse-error-message.test.ts
@@ -30,6 +30,25 @@ describe("parseErrorMessage", () => {
     expect(result.summary).toBe("That took longer than expected. Try again.");
   });
 
+  test("classifies a desktop-link-offline 409 body with a re-link CTA", () => {
+    // Shape POST /messages returns when the thread is pinned to user-desktop
+    // and resolveDispatchTarget finds no live link claim.
+    const raw =
+      '{"error":"link_unavailable","code":"user_desktop_link_offline"}';
+    const result = parseErrorMessage(raw);
+    expect(result.summary).toContain("desktop is offline");
+    expect(result.summary).toContain("bunx decocms link");
+    expect(result.rawDetails).toBe(raw);
+  });
+
+  test("classifies a capability-missing 409 body with install guidance", () => {
+    const raw =
+      '{"error":"link_unavailable","code":"user_desktop_link_capability_missing","activeCapabilities":["decopilot-sandbox"]}';
+    const result = parseErrorMessage(raw);
+    expect(result.summary).toContain("wasn't detected");
+    expect(result.rawDetails).toBe(raw);
+  });
+
   test("passes through a plain, short error message unchanged", () => {
     const result = parseErrorMessage("Something broke");
     expect(result.summary).toBe("Something broke");

--- a/apps/mesh/src/web/components/chat/highlight/parse-error-message.ts
+++ b/apps/mesh/src/web/components/chat/highlight/parse-error-message.ts
@@ -33,6 +33,26 @@ export function parseErrorMessage(message: string): {
     };
   }
 
+  // Desktop-link dispatch rejections: POST /messages answers 409 with a small
+  // JSON blob (`{"error":"link_unavailable","code":"user_desktop_link_…"}`)
+  // when the thread is pinned to the user's desktop and the link daemon is
+  // offline or lacks the CLI. Retrying won't help — the fix is on the user's
+  // desktop — so say exactly that instead of leaking raw JSON.
+  if (/link_unavailable|user_desktop_link_/i.test(trimmed)) {
+    if (/user_desktop_link_capability_missing/i.test(trimmed)) {
+      return {
+        summary:
+          "Your desktop is connected, but the CLI this chat uses wasn't detected there. Install it and sign in on your desktop, then try again.",
+        rawDetails: message,
+      };
+    }
+    return {
+      summary:
+        "Your desktop is offline. Run `bunx decocms link` in a terminal on it, then try again.",
+      rawDetails: message,
+    };
+  }
+
   if (isCloudflare || (looksLikeHtml && isTooLong)) {
     return {
       summary:

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.test.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.test.tsx
@@ -137,7 +137,9 @@ describe("ModePickerPure", () => {
     ]);
   });
 
-  it("omits local rows when user desktop is not linked", () => {
+  it("shows local rows as disabled connect-desktop teasers when user desktop is not linked", () => {
+    const onSelect = mock(() => {});
+    const onConnectDesktop = mock(() => {});
     const { getByRole, getAllByRole } = render(
       <ModePickerPure
         mode="cloud-decopilot"
@@ -148,18 +150,27 @@ describe("ModePickerPure", () => {
           codex: true,
         }}
         locked={false}
-        onSelect={() => {}}
+        onSelect={onSelect}
+        onConnectDesktop={onConnectDesktop}
       />,
     );
     fireEvent.click(getByRole("button", { name: /Cloud/i }));
+    // Local rows are teasers, not omitted — discoverability is the point.
     const items = getAllByRole("menuitem");
-    expect(items.map((i) => i.textContent)).toEqual([
-      expect.stringMatching(/Decopilot/),
-    ]);
+    expect(items).toHaveLength(4);
+
+    const claudeCode = getByRole("menuitem", { name: /Claude Code/ });
+    expect(claudeCode).toHaveAttribute("aria-disabled", "true");
+    expect(claudeCode).toHaveTextContent("Connect your desktop to enable");
+
+    // Clicking a teaser routes to the connect flow, never selects the mode.
+    fireEvent.click(claudeCode);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onConnectDesktop).toHaveBeenCalledTimes(1);
   });
 
   it("omits cloud decopilot when agent-sandbox is not configured", () => {
-    const { getByRole, getAllByRole } = render(
+    const { getByRole, getAllByRole, queryByRole } = render(
       <ModePickerPure
         mode="local-decopilot"
         availability={{
@@ -173,14 +184,19 @@ describe("ModePickerPure", () => {
       />,
     );
     fireEvent.click(getByRole("button", { name: /Decopilot/i }));
+    // Cloud row is gone (operator decision, not user-actionable); local rows
+    // all render — available Decopilot plus the two CLI teasers.
+    expect(queryByRole("menuitem", { name: /agent sandbox/i })).toBeNull();
     const items = getAllByRole("menuitem");
     expect(items.map((i) => i.textContent)).toEqual([
       expect.stringMatching(/Decopilot/),
+      expect.stringMatching(/Claude Code/),
+      expect.stringMatching(/Codex/),
     ]);
   });
 
-  it("omits unavailable CLIs", () => {
-    const { getByRole, queryByRole } = render(
+  it("shows unavailable CLIs as disabled rows with a not-detected hint", () => {
+    const { getByRole } = render(
       <ModePickerPure
         mode="cloud-decopilot"
         availability={{
@@ -194,8 +210,11 @@ describe("ModePickerPure", () => {
       />,
     );
     fireEvent.click(getByRole("button", { name: /Cloud/i }));
-    expect(queryByRole("menuitem", { name: /Claude Code/ })).toBeNull();
-    expect(queryByRole("menuitem", { name: /Codex/ })).toBeNull();
+    for (const name of [/Claude Code/, /Codex/]) {
+      const row = getByRole("menuitem", { name });
+      expect(row).toHaveAttribute("aria-disabled", "true");
+      expect(row).toHaveTextContent("Not detected on your desktop");
+    }
     expect(
       getByRole("menuitem", { name: /Runs on your desktop/ }),
     ).toHaveTextContent("Decopilot");

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
@@ -23,6 +23,7 @@ import { AgentAvatar } from "@/web/components/agent-icon";
 import { useSandboxStart } from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { track } from "@/web/lib/posthog-client";
 import { useOptionalChatTask } from "../chat-context";
+import { ConnectDesktopDialog } from "../connect-desktop-dialog";
 import { useAgentOptionAvailability } from "../use-agent-availability";
 import type { AgentOptionAvailability } from "./agent-options";
 import { ClaudeCodeIcon, CodexIcon } from "../agent-icons";
@@ -72,6 +73,13 @@ interface PureProps {
    */
   lockedHarness?: HarnessId | null;
   onSelect: (mode: AgentMode) => void;
+  /**
+   * Invoked when the user clicks an unavailable LOCAL row (desktop not
+   * linked, or linked without the CLI). The smart wrapper opens the
+   * connect-desktop dialog. Local rows are rendered as disabled teasers —
+   * not omitted — precisely so this path is discoverable.
+   */
+  onConnectDesktop?: () => void;
 }
 
 interface ModeRow {
@@ -162,19 +170,31 @@ export function ModePickerPure({
   locked,
   lockedHarness,
   onSelect,
+  onConnectDesktop,
 }: PureProps) {
   const [open, setOpen] = useState(false);
   const { icon, text } = pillLabel(mode);
   const isLocal = mode !== "cloud-decopilot";
   const isThreadLocked = locked && lockedHarness != null;
   const harnessLabel = lockedHarness ? HARNESS_LABEL[lockedHarness] : null;
-  const rows = ROWS.filter((row) => row.isAvailable(availability));
-  const cloudRows = rows.filter((row) => row.group === "cloud");
-  const localRows = rows.filter((row) => row.group === "local");
+  // Cloud rows hide when unavailable (a deployment without an agent sandbox
+  // is an operator decision, nothing the user can act on). Local rows always
+  // render: an unavailable one is a disabled teaser pointing at the
+  // connect-desktop flow — otherwise users never learn local Claude
+  // Code/Codex exists.
+  const cloudRows = ROWS.filter(
+    (row) => row.group === "cloud" && row.isAvailable(availability),
+  );
+  const localRows = ROWS.filter((row) => row.group === "local");
 
   const handleSelect = (m: AgentMode) => {
     onSelect(m);
     setOpen(false);
+  };
+
+  const handleConnectDesktop = () => {
+    setOpen(false);
+    onConnectDesktop?.();
   };
 
   return (
@@ -250,14 +270,25 @@ export function ModePickerPure({
               testId="local-section-header"
             />
           )}
-          {localRows.map((row) => (
-            <Row
-              key={row.mode}
-              row={row}
-              active={mode === row.mode}
-              onSelect={handleSelect}
-            />
-          ))}
+          {localRows.map((row) => {
+            const available = row.isAvailable(availability);
+            return (
+              <Row
+                key={row.mode}
+                row={row}
+                active={available && mode === row.mode}
+                onSelect={handleSelect}
+                unavailableHint={
+                  available
+                    ? undefined
+                    : availability.userDesktop
+                      ? "Not detected on your desktop"
+                      : "Connect your desktop to enable"
+                }
+                onUnavailableClick={handleConnectDesktop}
+              />
+            );
+          })}
         </div>
       </PopoverContent>
     </Popover>
@@ -295,25 +326,43 @@ function Row({
   row,
   active,
   onSelect,
+  unavailableHint,
+  onUnavailableClick,
 }: {
   row: ModeRow;
   active: boolean;
   onSelect: (mode: AgentMode) => void;
+  /**
+   * When set, the row is an unavailable teaser: dimmed, `aria-disabled`,
+   * and the hint replaces the description. It stays clickable — the click
+   * routes to `onUnavailableClick` (connect-desktop flow) instead of
+   * selecting the mode. A truly `disabled` button would swallow the one
+   * affordance that tells the user how to enable the feature.
+   */
+  unavailableHint?: string;
+  onUnavailableClick?: () => void;
 }) {
+  const unavailable = unavailableHint != null;
   return (
     <button
       type="button"
       role="menuitem"
-      onClick={() => onSelect(row.mode)}
+      aria-disabled={unavailable || undefined}
+      onClick={() =>
+        unavailable ? onUnavailableClick?.() : onSelect(row.mode)
+      }
       className={cn(
         "flex items-start gap-2 px-2 py-1.5 rounded-md text-left",
         "hover:bg-muted",
+        unavailable && "opacity-60",
       )}
     >
       <span className="shrink-0 text-muted-foreground mt-0.5">{row.icon}</span>
       <div className="flex-1">
         <div className="text-sm">{row.label}</div>
-        <div className="text-xs text-muted-foreground">{row.description}</div>
+        <div className="text-xs text-muted-foreground">
+          {unavailableHint ?? row.description}
+        </div>
       </div>
       {active && <Check size={14} className="text-foreground mt-0.5" />}
     </button>
@@ -358,6 +407,8 @@ export function ModePicker({
   const availability = useAgentOptionAvailability();
   const mode = fallbackMode(selectedMode, availability);
 
+  const [connectOpen, setConnectOpen] = useState(false);
+
   const handleSelect = (next: AgentMode) => {
     setAgentMode(next);
     track("agent_mode_selected", { mode: next });
@@ -374,12 +425,19 @@ export function ModePicker({
   };
 
   return (
-    <ModePickerPure
-      mode={mode}
-      availability={availability}
-      locked={locked}
-      lockedHarness={lockedHarness}
-      onSelect={handleSelect}
-    />
+    <>
+      <ModePickerPure
+        mode={mode}
+        availability={availability}
+        locked={locked}
+        lockedHarness={lockedHarness}
+        onSelect={handleSelect}
+        onConnectDesktop={() => {
+          track("agent_mode_connect_desktop_opened");
+          setConnectOpen(true);
+        }}
+      />
+      <ConnectDesktopDialog open={connectOpen} onOpenChange={setConnectOpen} />
+    </>
   );
 }

--- a/apps/mesh/src/web/hooks/use-current-link.ts
+++ b/apps/mesh/src/web/hooks/use-current-link.ts
@@ -14,9 +14,15 @@ export interface CurrentLink {
   hostname?: string;
   cliVersion?: string;
   capabilities: Capability[];
+  /**
+   * False until LINK_CURRENT_GET has resolved at least once this mount.
+   * Lets "the desktop is offline" surfaces (banner, teaser rows) hold back
+   * instead of flashing offline-state UI during the initial fetch.
+   */
+  ready: boolean;
 }
 
-const OFFLINE: CurrentLink = { online: false, capabilities: [] };
+const OFFLINE: CurrentLink = { online: false, capabilities: [], ready: false };
 
 export function useCurrentLink(): CurrentLink {
   const { org } = useProjectContext();
@@ -33,7 +39,8 @@ export function useCurrentLink(): CurrentLink {
         name: "LINK_CURRENT_GET",
         arguments: {},
       });
-      return unwrapToolResult<CurrentLink>(result) ?? OFFLINE;
+      const link = unwrapToolResult<Omit<CurrentLink, "ready">>(result);
+      return link ? { ...link, ready: true } : { ...OFFLINE, ready: true };
     },
     staleTime: 10_000,
     refetchInterval: 15_000,

--- a/apps/mesh/src/web/lib/agent-capabilities.test.ts
+++ b/apps/mesh/src/web/lib/agent-capabilities.test.ts
@@ -109,6 +109,7 @@ describe("hasLocalCliHarness", () => {
   const link = (overrides: Partial<CurrentLink> = {}): CurrentLink => ({
     online: false,
     capabilities: [],
+    ready: true,
     ...overrides,
   });
 


### PR DESCRIPTION
## Summary

Closes the product gaps around running chats on the user's desktop (local Claude Code / Codex via `decocms link`), now that #3742 landed the transport. Two areas:

### Onboarding + offline UX (`6d6f1e3`)
- **Mode picker discoverability**: unavailable LOCAL modes render as disabled teaser rows ("Connect your desktop to enable" / "Not detected on your desktop") that open the connect-desktop dialog, instead of being omitted — users can now discover local Claude Code exists. Cloud rows still hide when unavailable (operator decision, not user-actionable).
- **Desktop-offline banner**: threads pinned to `user-desktop` show a proactive warning with a reconnect CTA while the link is offline, instead of failing only at send time. Gated on a new `ready` flag on `useCurrentLink` so it doesn't flash during the initial fetch.
- **Honest 409s**: POST /messages `link_unavailable` bodies are classified into actionable copy (re-link command / install CLI) instead of raw JSON.
- **No-restart CLI pickup**: the daemon re-probes CLI capabilities every minute while one is missing (grow-only merge so a flaky probe never un-advertises mid-run), and the work poller sends `x-link-capabilities` per poll — installing/signing into Claude Code after linking no longer requires a daemon restart. The connect dialog explains missing CLIs accordingly.

### Studio-side disconnect (`faa0826`)
- **New `shutdown` control frame** on `links.control.<userSub>`: the daemon's control poller dispatches it to the daemon shutdown and stops polling (one more long-poll would re-mint the presence claim being deleted). Pre-frame daemons skip it on schema validation (logged, no crash) — degraded mode is claim-delete-only until they upgrade.
- **New `LINK_DISCONNECT` tool**: publishes the frame, then deletes the presence claim so the UI flips offline immediately. Self-scoped (caller's own link only), granted to members alongside `LINK_CURRENT_GET`. Tools reach the publisher via a narrow `publishLinkControlFrame` field on `StudioContext` delegating to the app's `CancelBroadcast`.
- **"Disconnect desktop" button** in the connect-desktop dialog (covers all entry points: header indicator, mode picker, offline banner); on success the link query invalidates and the dialog shows the reconnect snippet.

## Affected areas
- Web chat UI: `mode-picker`, `connect-desktop-dialog`, `desktop-offline-banner` (new), `parse-error-message`, `use-current-link`
- Link daemon: `capabilities` (re-probe), `work-poller` (per-poll capability header), `control-poller` (shutdown frame), `index`
- Cluster: `control-frames` (additive frame), `tools/links/disconnect` (new tool), `StudioContext`/`context-factory`/`app` (publisher wiring), `registry-metadata`

## Testing
- New unit tests: 409 classification, mode-picker teaser rows (click routes to connect flow, never selects), capability merge semantics (grow-only), re-probe skip-when-complete, per-poll capability header pickup, shutdown frame routing (stops loop without abort), `LINK_DISCONNECT` (publishes frame + deletes claim, no-op when offline, auth required).
- `bun run fmt`, `bun run lint`, `bun run knip`, `tsc --noEmit` (apps/mesh) all pass; touched suites green (`apps/mesh/src/link-daemon`, `tools/links`, `web/components/chat`, `web/lib`).
- Manual: run `bun run dev --local-sandbox-provider` + `bunx decocms link`, open the mode picker without/with the daemon, disconnect from the dialog and watch the daemon terminal exit with the reconnect hint.

## Notes
- The `shutdown` frame is additive to the control-frame schema — no protocol version bump needed (old daemons log-and-skip unknown frames).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves desktop onboarding and reliability for local Claude Code/Codex via `decocms link`. Adds a discoverable mode picker, proactive offline banner, per-poll capability updates, and a Studio-side disconnect that cleanly shuts down the daemon.

- **New Features**
  - Mode picker: unavailable LOCAL rows show as disabled teasers with hints and open the connect-desktop dialog; cloud rows still hide when unavailable.
  - Connect-desktop dialog: explains missing CLIs and adds a “Disconnect desktop” button that calls `LINK_DISCONNECT` and refreshes link state.
  - Desktop offline banner: shows for `user-desktop` threads when the link is offline, with a “Reconnect desktop” CTA; gated by `useCurrentLink.ready` to avoid flashing.
  - Error UX: classifies 409 `link_unavailable` bodies into clear messages (re-link command or install CLI) instead of raw JSON.
  - Daemon: re-probes CLI capabilities every minute until all are present (grow-only merge), and work poller sends `x-link-capabilities` on every poll to advertise updates without restart.
  - Control path: new `shutdown` control frame on `links.control.<userSub>`; control poller calls daemon shutdown and stops polling.
  - Tooling and wiring: new `LINK_DISCONNECT` tool (self-scoped) publishes `shutdown` then deletes the presence claim; exposed via `StudioContext.publishLinkControlFrame`.

<sup>Written for commit faa0826736fff20b7029a3110009690ce27295ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

