### PR TITLE
Enhance live subtask stream by formatting tool call outputs

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -89,6 +89,24 @@ export interface SubtaskParams {
   }) => void;
 }
 
+/** Max chars of a tool call's args shown in the live subtask stream. */
+const TOOL_CALL_ARG_CAP = 80;
+
+/** Render a subagent tool call as a short, capped one-liner for the stream. */
+function formatToolCall(toolName: string, input: unknown): string {
+  let args = "";
+  try {
+    args = typeof input === "string" ? input : JSON.stringify(input ?? {});
+  } catch {
+    args = "";
+  }
+  if (args === "{}") args = "";
+  if (args.length > TOOL_CALL_ARG_CAP) {
+    args = args.slice(0, TOOL_CALL_ARG_CAP) + "…";
+  }
+  return args ? `${toolName} ${args}` : toolName;
+}
+
 const SUBTASK_ANNOTATIONS = {
   readOnlyHint: false,
   destructiveHint: false,
@@ -225,6 +243,16 @@ export function createSubtaskTool(
               lastFlush = now;
               yield { text: streamedText };
             }
+          } else if (part.type === "tool-call") {
+            // Surface the subagent's tool executions in the live stream so the
+            // UI shows progress even while the subagent is working silently
+            // (calling tools, not emitting text). Args are capped to a few
+            // tokens — enough to identify the call, not a full dump.
+            const sep =
+              streamedText && !streamedText.endsWith("\n") ? "\n" : "";
+            streamedText += `${sep}↳ ${formatToolCall(part.toolName, part.input)}\n`;
+            lastFlush = performance.now();
+            yield { text: streamedText };
           }
         }
 

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.tsx
@@ -101,9 +101,14 @@ function useSubtaskShellConfig({
         ? prompt.slice(0, 120) + "…"
         : prompt;
 
-  const response = isError
+  const extracted = isError
     ? getToolPartErrorText(part)
-    : (extractSubtaskResponse(part.output) ?? "No output available");
+    : extractSubtaskResponse(part.output);
+  // While the subtask is still streaming but no chunk has arrived yet, show
+  // nothing rather than "No output available" — that text is for a genuinely
+  // empty completed result, not for the in-flight gap before the first chunk.
+  const isStreaming = isInputStreaming || isOutputStreaming;
+  const response = extracted ?? (isStreaming ? "" : "No output available");
   const detail = `# Task\n${part.input?.prompt ?? "No prompt provided"}\n\n# ${isError ? "Error" : "Result"}\n${response}`;
 
   return {


### PR DESCRIPTION
- Introduced a new function `formatToolCall` to render tool call arguments as concise one-liners in the live subtask stream, capping the displayed characters for clarity.
- Updated the subtask tool creation logic to include formatted tool call outputs, improving the visibility of subagent tool executions during processing.
- Adjusted the response handling in the chat component to prevent displaying "No output available" during streaming, enhancing user experience.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show subagent tool calls in the live subtask stream as short, readable lines so progress is visible while tools run. Also, don’t show “No output available” until the subtask finishes with no output.

- New Features
  - Stream tool-call entries as capped one-liners (80 chars) using `formatToolCall` to surface subagent activity.

- Bug Fixes
  - Suppress “No output available” during in-flight streaming; only show it for truly empty completed results.

<sup>Written for commit 77222b7307f579268d623cb6ccf4bc827313706e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

