### PR TITLE
Enhance Decopilot built-in tools to support VM sandbox tools inheritance

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -7,7 +7,7 @@
 
 import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import { posthog } from "@/posthog";
-import type { UIMessageStreamWriter } from "ai";
+import type { ToolSet, UIMessageStreamWriter } from "ai";
 import {
   toolNeedsApproval,
   type ToolApprovalLevel,
@@ -200,6 +200,9 @@ async function buildAllTools(
   // share a single provisioning round-trip.
   const vmNeedsApproval =
     toolNeedsApproval(toolApprovalLevel, false, approvalOpts) !== false;
+  // Captured so a self-clone subtask can inherit the SAME sandbox tools (and
+  // therefore the same sandbox), letting it run bash / read-write files.
+  let vmTools: ToolSet | undefined;
   if (vmContext) {
     // The flat fs hooks (provider resolution + lazy handle + auto-restart retry
     // layer) are built by the cluster glue so the portable tools never import
@@ -210,20 +213,18 @@ async function buildAllTools(
       branch: vmContext.branch,
       userId: vmContext.userId,
     });
-    Object.assign(
-      tools,
-      createVmTools({
-        fs,
-        htmlPageBuffer,
-        toolOutputMap,
-        needsApproval: vmNeedsApproval,
-        pendingImages,
-        ctx,
-        threadId: vmContext.threadId,
-        virtualMcpId: vmContext.virtualMcpId,
-        orgFs: getSettings().orgFsClusterMounts,
-      }),
-    );
+    vmTools = createVmTools({
+      fs,
+      htmlPageBuffer,
+      toolOutputMap,
+      needsApproval: vmNeedsApproval,
+      pendingImages,
+      ctx,
+      threadId: vmContext.threadId,
+      virtualMcpId: vmContext.virtualMcpId,
+      orgFs: getSettings().orgFsClusterMounts,
+    }) as ToolSet;
+    Object.assign(tools, vmTools);
   }
   // subtask requires a provider (LLM calls) — skip when provider is null (Claude Code).
   if (provider) {
@@ -240,6 +241,9 @@ async function buildAllTools(
           toolNeedsApproval(toolApprovalLevel, false, approvalOpts) !== false,
         // Roll the child run's usage into the parent's accumulator (Task 17).
         onChildUsage,
+        // Self-clones inherit the parent's sandbox tools so they can run
+        // bash / file I/O against the SAME sandbox.
+        vmTools,
       },
       ctx,
     );

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -11,7 +11,7 @@
 
 import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import { resolveSubagent } from "../resolve-subagent";
-import type { UIMessageStreamWriter } from "ai";
+import type { ToolSet, UIMessageStreamWriter } from "ai";
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { MeshProvider } from "@/ai-providers/types";
@@ -87,6 +87,15 @@ export interface SubtaskParams {
     outputTokens: number;
     totalTokens: number;
   }) => void;
+  /**
+   * The parent's already-built VM sandbox tools (read/write/edit/grep/glob/
+   * bash/…), bound to the parent's sandbox via its fs hooks. Forwarded to a
+   * SELF-CLONE subagent so it works in the SAME sandbox — its file writes are
+   * visible to the parent. Absent for cross-agent delegation (different agent =
+   * different sandbox identity) and when the parent has no sandbox (no
+   * vmContext, e.g. Claude Code).
+   */
+  vmTools?: ToolSet;
 }
 
 /** Max chars of a tool call's args shown in the live subtask stream. */
@@ -119,8 +128,15 @@ export function createSubtaskTool(
   params: SubtaskParams,
   ctx: StudioContext,
 ) {
-  const { provider, organization, models, needsApproval, self, onChildUsage } =
-    params;
+  const {
+    provider,
+    organization,
+    models,
+    needsApproval,
+    self,
+    onChildUsage,
+    vmTools,
+  } = params;
 
   return tool({
     description: SUBTASK_DESCRIPTION,
@@ -230,6 +246,10 @@ export function createSubtaskTool(
           // (which is both the tool source AND the prompts source for the
           // target agent). This passes through to buildAgentSystemPrompt.
           passthroughClient: mcpClient,
+          // Self-clone only: inherit the parent's sandbox tools so the clone
+          // runs bash / file I/O against the SAME sandbox. A different agent
+          // has a different sandbox identity, so it must NOT inherit these.
+          extraTools: isSelf ? vmTools : undefined,
         });
 
         let streamedText = "";


### PR DESCRIPTION
- Updated `index.ts` and `subtask.ts` to include `ToolSet` type for VM tools, allowing self-clone subtasks to inherit the parent's sandbox tools.
- Modified `buildAllTools` function to create and assign `vmTools`, ensuring consistent access to the same sandbox environment for file operations.
- Adjusted `SubtaskParams` interface to include optional `vmTools`, facilitating the inheritance mechanism for self-clone subtasks.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-clone subtasks now inherit the parent’s VM sandbox tools so both run in the same sandbox for bash and file I/O. This keeps file changes visible across parent/subtask and avoids extra sandbox provisioning.

- New Features
  - Build and capture `vmTools` (typed as `ToolSet`) in `buildAllTools`, then merge into the parent tools.
  - Extend `SubtaskParams` with optional `vmTools`, passed only to self-clone subtasks.
  - When `isSelf`, provide `extraTools` with the inherited `vmTools` to preserve the same fs hooks and sandbox identity.

<sup>Written for commit 7fa9cf9419ec498876c0e0b20167b16409696fa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

