### PR TITLE
feat(web): tasks board — org tasks as kanban/list with prompt-first create

### DIFF
--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -4,7 +4,7 @@ import type {
   SidebarSection,
 } from "@/web/components/sidebar/types";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { Folder, Home01 } from "@untitledui/icons";
+import { Columns03, Folder, Home01 } from "@untitledui/icons";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -32,6 +32,16 @@ export function useProjectSidebarItems(): SidebarSection[] {
     },
   };
 
+  const tasksItem: NavigationSidebarItem = {
+    key: "tasks",
+    label: "Tasks",
+    icon: <Columns03 className="size-4!" />,
+    isActive: pathname.startsWith(`/${slug}/tasks`),
+    onClick: () => {
+      navigate({ to: "/$org/tasks", params: { org: slug } });
+    },
+  };
+
   const filesItem: NavigationSidebarItem = {
     key: "files",
     label: "Library",
@@ -43,7 +53,7 @@ export function useProjectSidebarItems(): SidebarSection[] {
   };
 
   const sections: SidebarSection[] = [
-    { type: "items", items: [homeItem, filesItem] },
+    { type: "items", items: [homeItem, tasksItem, filesItem] },
   ];
 
   if (isCollapsed) {

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -254,6 +254,15 @@ const libraryRoute = createRoute({
   component: lazyRouteComponent(() => import("./layouts/library/index.tsx")),
 });
 
+// Tasks board (/$org/tasks) — the org's tasks as a kanban or list.
+const tasksRoute = createRoute({
+  getParentRoute: () => orgShellLayout,
+  path: "/tasks",
+  component: lazyRouteComponent(
+    () => import("./layouts/tasks-board/index.tsx"),
+  ),
+});
+
 // ============================================
 // SETTINGS LAYOUT (/$org/settings)
 // ============================================
@@ -615,6 +624,7 @@ const agentShellWithChildren = agentShellLayout.addChildren([
 const orgShellWithChildren = orgShellLayout.addChildren([
   orgIndexRoute,
   libraryRoute,
+  tasksRoute,
   agentShellWithChildren,
 ]);
 

--- a/apps/mesh/src/web/layouts/tasks-board/index.tsx
+++ b/apps/mesh/src/web/layouts/tasks-board/index.tsx
@@ -1,0 +1,515 @@
+/**
+ * Tasks board (/$org/tasks) — the org's tasks (threads) as a kanban or list.
+ *
+ * Columns are the real thread statuses (in progress, needs review, done,
+ * failed) and dragging a card to another column persists the status via
+ * ThreadManager. Data comes from the same `useThreads()` store the sidebar
+ * uses, so rows stay live as runs progress. Filters narrow by agent and by
+ * origin (manual vs automation-triggered).
+ */
+
+import { useState } from "react";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useProjectContext, useVirtualMCPs } from "@decocms/mesh-sdk";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import {
+  Columns03,
+  CpuChip01,
+  List,
+  Loading01,
+  Plus,
+  X,
+  Zap,
+} from "@untitledui/icons";
+import { AgentAvatar } from "@/web/components/agent-icon";
+import { useThreads } from "@/web/components/chat/store/hooks";
+import type { Task } from "@/web/components/chat/task/types";
+import { useThreadActions } from "@/web/components/chat/store/hooks";
+import { formatTimeAgo } from "@/web/lib/format-time";
+import { getStatusConfig } from "@/web/lib/task-status";
+import { isSyntheticBranch } from "@/shared/is-synthetic-branch";
+import { NewTaskDialog } from "./new-task-dialog";
+
+type Lane = "in_progress" | "requires_action" | "completed" | "failed";
+
+const LANES: Lane[] = ["in_progress", "requires_action", "completed", "failed"];
+
+/** Buckets a thread's display status into one of the four columns.
+ *  `expired` is a virtual read-time status for stale runs — it lives in the
+ *  failed column but is never written back. */
+function laneFor(status: Task["status"]): Lane {
+  switch (status) {
+    case "in_progress":
+      return "in_progress";
+    case "requires_action":
+      return "requires_action";
+    case "failed":
+    case "expired":
+      return "failed";
+    case "completed":
+    case undefined:
+      return "completed";
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+type Layout = "kanban" | "list";
+
+export default function TasksBoard() {
+  const navigate = useNavigate();
+  const { org } = useParams({ strict: false }) as { org?: string };
+  const { org: organization } = useProjectContext();
+  const { threads, status, hasMore, isFetchingMore, fetchNextPage } =
+    useThreads();
+  const actions = useThreadActions();
+  const agents = useVirtualMCPs();
+
+  const [layout, setLayout] = useState<Layout>("kanban");
+  const [newTaskOpen, setNewTaskOpen] = useState(false);
+  const [agentSel, setAgentSel] = useState<Set<string>>(new Set());
+  const [originSel, setOriginSel] = useState<Set<string>>(new Set());
+
+  const visibleThreads = threads.filter((t) => !t.hidden);
+
+  // Agent options come from the agents actually present on the board, so the
+  // menu never lists agents with nothing to filter.
+  const agentById = new Map(agents.map((a) => [a.id, a]));
+  const agentOptions = [
+    ...new Set(
+      visibleThreads.flatMap((t) =>
+        t.virtual_mcp_id ? [t.virtual_mcp_id] : [],
+      ),
+    ),
+  ].map((id) => ({ key: id, label: agentById.get(id)?.title ?? "Decopilot" }));
+
+  const matchesFilters = (t: Task) =>
+    (agentSel.size === 0 ||
+      (!!t.virtual_mcp_id && agentSel.has(t.virtual_mcp_id))) &&
+    (originSel.size === 0 ||
+      originSel.has(t.trigger_id ? "automation" : "manual"));
+
+  const items = visibleThreads
+    .filter(matchesFilters)
+    .sort(
+      (a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+    );
+
+  const anyFilter = agentSel.size + originSel.size > 0;
+  const toggleIn =
+    (set: Set<string>, update: (next: Set<string>) => void) =>
+    (key: string) => {
+      const next = new Set(set);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      update(next);
+    };
+
+  const open = (taskId: string, virtualMcpId?: string) => {
+    if (!org) return;
+    navigate({
+      to: "/$org/$taskId",
+      params: { org, taskId },
+      search: virtualMcpId ? { virtualmcpid: virtualMcpId } : {},
+    });
+  };
+
+  if (status.kind === "loading" && threads.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Loading01 size={20} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div
+        className={cn(
+          "mx-auto flex w-full flex-col gap-6 px-10 pt-10 pb-16",
+          layout === "kanban" ? "max-w-[1400px]" : "max-w-[900px]",
+        )}
+      >
+        <h1 className="text-xl font-medium text-foreground">Tasks</h1>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button size="sm" onClick={() => setNewTaskOpen(true)}>
+            <Plus size={16} />
+            New task
+          </Button>
+
+          <FilterMenu
+            label="Agent"
+            icon={CpuChip01}
+            options={agentOptions}
+            selected={agentSel}
+            onToggle={toggleIn(agentSel, setAgentSel)}
+          />
+          <FilterMenu
+            label="Origin"
+            icon={Zap}
+            options={[
+              { key: "manual", label: "Started by a person" },
+              { key: "automation", label: "Automation-triggered" },
+            ]}
+            selected={originSel}
+            onToggle={toggleIn(originSel, setOriginSel)}
+          />
+          {anyFilter && (
+            <button
+              type="button"
+              onClick={() => {
+                setAgentSel(new Set());
+                setOriginSel(new Set());
+              }}
+              className="inline-flex items-center gap-1 rounded-full px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <X size={12} />
+              Clear
+            </button>
+          )}
+
+          <div className="ml-auto inline-flex rounded-lg bg-muted p-0.5">
+            <LayoutToggle
+              active={layout === "list"}
+              onClick={() => setLayout("list")}
+              icon={List}
+              label="List"
+            />
+            <LayoutToggle
+              active={layout === "kanban"}
+              onClick={() => setLayout("kanban")}
+              icon={Columns03}
+              label="Board"
+            />
+          </div>
+        </div>
+
+        {items.length === 0 ? (
+          <div className="rounded-xl border border-border bg-card px-4 py-12 text-center text-sm text-muted-foreground">
+            No tasks yet. Start one with New task.
+          </div>
+        ) : layout === "kanban" ? (
+          <KanbanBoard
+            items={items}
+            agentById={agentById}
+            onOpen={open}
+            onMove={(id, lane) => void actions.setStatus(id, lane)}
+          />
+        ) : (
+          <div className="flex flex-col gap-2">
+            {items.map((t) => (
+              <ListRow
+                key={t.id}
+                task={t}
+                agent={
+                  t.virtual_mcp_id ? agentById.get(t.virtual_mcp_id) : undefined
+                }
+                onOpen={() => open(t.id, t.virtual_mcp_id)}
+              />
+            ))}
+          </div>
+        )}
+
+        {hasMore && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="self-center"
+            disabled={isFetchingMore}
+            onClick={() => void fetchNextPage()}
+          >
+            {isFetchingMore ? (
+              <Loading01 size={14} className="animate-spin" />
+            ) : null}
+            Load more
+          </Button>
+        )}
+      </div>
+
+      <NewTaskDialog
+        open={newTaskOpen}
+        onClose={() => setNewTaskOpen(false)}
+        orgName={organization.name}
+        orgLogo={organization.logo ?? null}
+      />
+    </div>
+  );
+}
+
+/** A Linear-style multi-select filter chip: a dropdown of checkbox options.
+ *  Selecting keeps the menu open; the chip shows the active count. */
+function FilterMenu({
+  label,
+  icon: Icon,
+  options,
+  selected,
+  onToggle,
+}: {
+  label: string;
+  icon: typeof Zap;
+  options: { key: string; label: string }[];
+  selected: Set<string>;
+  onToggle: (key: string) => void;
+}) {
+  if (options.length === 0) return null;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full border border-dashed border-border px-2.5 py-1.5 text-xs transition-colors hover:bg-accent/50",
+            selected.size > 0
+              ? "border-solid text-foreground"
+              : "text-muted-foreground",
+          )}
+        >
+          <Icon size={13} />
+          {label}
+          {selected.size > 0 && (
+            <span className="rounded-full bg-foreground/10 px-1.5 text-[10px]">
+              {selected.size}
+            </span>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        {options.map((o) => (
+          <DropdownMenuCheckboxItem
+            key={o.key}
+            checked={selected.has(o.key)}
+            onCheckedChange={() => onToggle(o.key)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            <span className="truncate">{o.label}</span>
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function LayoutToggle({
+  active,
+  onClick,
+  icon: Icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: typeof List;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`${label} view`}
+      aria-pressed={active}
+      className={cn(
+        "flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors",
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <Icon size={14} />
+      {label}
+    </button>
+  );
+}
+
+/** The board: threads bucketed by status. Dragging a card to another column
+ *  persists that status through the thread store (optimistic + server). */
+function KanbanBoard({
+  items,
+  agentById,
+  onOpen,
+  onMove,
+}: {
+  items: Task[];
+  agentById: Map<string, { id: string; title: string; icon?: string | null }>;
+  onOpen: (taskId: string, virtualMcpId?: string) => void;
+  onMove: (id: string, lane: Lane) => void;
+}) {
+  const [overLane, setOverLane] = useState<Lane | null>(null);
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {LANES.map((lane) => {
+        const laneItems = items.filter((t) => laneFor(t.status) === lane);
+        const config = getStatusConfig(lane);
+        const LaneIcon = config.icon;
+        return (
+          <div
+            key={lane}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setOverLane(lane);
+            }}
+            onDragLeave={(e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                setOverLane(null);
+              }
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              const id = e.dataTransfer.getData("text/plain");
+              if (id) onMove(id, lane);
+              setOverLane(null);
+            }}
+            className={cn(
+              "flex flex-col rounded-xl p-1 transition-colors",
+              overLane === lane && "bg-muted/50",
+            )}
+          >
+            <div className="flex items-center gap-2 p-2">
+              <LaneIcon
+                size={14}
+                className={cn("shrink-0", config.iconClassName)}
+              />
+              <span className="text-xs text-foreground">{config.label}</span>
+              <span className="text-[11px] text-muted-foreground">
+                {laneItems.length}
+              </span>
+            </div>
+            <div className="flex min-h-12 flex-col gap-2">
+              {laneItems.map((t) => (
+                <KanbanCard
+                  key={t.id}
+                  task={t}
+                  agent={
+                    t.virtual_mcp_id
+                      ? agentById.get(t.virtual_mcp_id)
+                      : undefined
+                  }
+                  onOpen={() => onOpen(t.id, t.virtual_mcp_id)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function TaskMetaLine({ task }: { task: Task }) {
+  return (
+    <span className="flex min-w-0 items-center gap-1 text-[11px] text-muted-foreground/70">
+      {task.branch && !isSyntheticBranch(task.branch) && (
+        <>
+          <span className="truncate font-mono">{task.branch}</span>
+          <span className="shrink-0">·</span>
+        </>
+      )}
+      <span className="shrink-0">
+        {formatTimeAgo(new Date(task.updated_at))}
+      </span>
+    </span>
+  );
+}
+
+function KanbanCard({
+  task,
+  agent,
+  onOpen,
+}: {
+  task: Task;
+  agent?: { title: string; icon?: string | null };
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.setData("text/plain", task.id);
+        e.dataTransfer.effectAllowed = "move";
+      }}
+      onClick={onOpen}
+      className="flex cursor-grab flex-col gap-3 rounded-[10px] border border-border bg-card px-3.5 py-3 text-left transition-colors hover:border-ring/40 active:cursor-grabbing"
+    >
+      <div className="flex items-start gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+          {task.trigger_id && (
+            <Zap
+              size={12}
+              aria-label="Automation-triggered"
+              className="shrink-0 text-blue-500"
+            />
+          )}
+          <span className="truncate text-[13px] font-medium leading-snug text-foreground">
+            {task.title || "Untitled task"}
+          </span>
+        </div>
+        <AgentAvatar
+          icon={agent?.icon ?? null}
+          name={agent?.title ?? "Decopilot"}
+          size="2xs"
+        />
+      </div>
+      <TaskMetaLine task={task} />
+    </button>
+  );
+}
+
+function ListRow({
+  task,
+  agent,
+  onOpen,
+}: {
+  task: Task;
+  agent?: { title: string; icon?: string | null };
+  onOpen: () => void;
+}) {
+  const config = getStatusConfig(task.status);
+  const StatusIcon = config.icon;
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 text-left transition-colors hover:border-ring/40"
+    >
+      <StatusIcon
+        size={15}
+        className={cn(
+          "shrink-0",
+          config.iconClassName,
+          task.status === "in_progress" && "animate-spin",
+        )}
+      />
+      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+        {task.trigger_id && (
+          <Zap
+            size={12}
+            aria-label="Automation-triggered"
+            className="shrink-0 text-blue-500"
+          />
+        )}
+        <span className="truncate text-sm font-medium text-foreground">
+          {task.title || "Untitled task"}
+        </span>
+      </div>
+      <span className={cn("shrink-0 text-xs", config.labelColor)}>
+        {config.label}
+      </span>
+      <AgentAvatar
+        icon={agent?.icon ?? null}
+        name={agent?.title ?? "Decopilot"}
+        size="2xs"
+      />
+      <TaskMetaLine task={task} />
+    </button>
+  );
+}

--- a/apps/mesh/src/web/layouts/tasks-board/index.tsx
+++ b/apps/mesh/src/web/layouts/tasks-board/index.tsx
@@ -65,7 +65,21 @@ function laneFor(status: Task["status"]): Lane {
 
 type Layout = "kanban" | "list";
 
+/** Route component — the same rounded content card every routed page sits in
+ *  (see Library): sidebar-colored gutter, then the card with the board. */
 export default function TasksBoard() {
+  return (
+    <div className="min-h-0 flex-1 pt-0 pr-1 pb-1 pl-0">
+      <div className="h-full p-0.5 pt-0.25">
+        <div className="card-shadow flex h-full flex-col overflow-hidden rounded-[0.75rem] bg-background">
+          <TasksBoardPage />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TasksBoardPage() {
   const navigate = useNavigate();
   const { org } = useParams({ strict: false }) as { org?: string };
   const { org: organization } = useProjectContext();

--- a/apps/mesh/src/web/layouts/tasks-board/new-task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/tasks-board/new-task-dialog.tsx
@@ -1,0 +1,207 @@
+/**
+ * New task — a prompt-first create dialog. The prompt is the task: it is
+ * handed to the new thread via the autosend channel (the same handoff the
+ * chat uses for follow-up tasks), so the agent starts working immediately.
+ * An agent picker chooses which vMCP runs it (default: Decopilot).
+ */
+
+import { useState } from "react";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import {
+  getWellKnownDecopilotVirtualMCP,
+  useProjectContext,
+  useVirtualMCPs,
+} from "@decocms/mesh-sdk";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { ChevronRight, Cube01, X } from "@untitledui/icons";
+import { AgentAvatar } from "@/web/components/agent-icon";
+import { useThreadActions } from "@/web/components/chat/store/hooks";
+import type { TiptapDoc } from "@/web/components/chat/types";
+import { AUTOSEND_QUERY_VALUE, writeStoredAutosend } from "@/web/lib/autosend";
+
+function promptDoc(text: string): TiptapDoc {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+export function NewTaskDialog({
+  open,
+  onClose,
+  orgName,
+  orgLogo,
+}: {
+  open: boolean;
+  onClose: () => void;
+  orgName: string;
+  orgLogo: string | null;
+}) {
+  const navigate = useNavigate();
+  const { org } = useParams({ strict: false }) as { org?: string };
+  const { org: organization, locator } = useProjectContext();
+  const actions = useThreadActions();
+  const agents = useVirtualMCPs();
+  const decopilot = getWellKnownDecopilotVirtualMCP(organization.id);
+
+  const [prompt, setPrompt] = useState("");
+  const [agentId, setAgentId] = useState<string>(decopilot.id);
+  const [creating, setCreating] = useState(false);
+
+  const agentOptions = [
+    { id: decopilot.id, title: decopilot.title, icon: decopilot.icon },
+    ...agents.map((a) => ({ id: a.id, title: a.title, icon: a.icon })),
+  ];
+  const selectedAgent =
+    agentOptions.find((a) => a.id === agentId) ?? agentOptions[0]!;
+
+  const reset = () => {
+    setPrompt("");
+    setAgentId(decopilot.id);
+    setCreating(false);
+  };
+
+  const submit = async () => {
+    const text = prompt.trim();
+    if (!text || !org || creating) return;
+    setCreating(true);
+    const taskId = crypto.randomUUID();
+    // Stage the message first so the new task's chat finds it on mount even
+    // if navigation lands before the create round-trip settles.
+    writeStoredAutosend(sessionStorage, locator, taskId, {
+      tiptapDoc: promptDoc(text),
+    });
+    try {
+      await actions.create({ id: taskId, virtual_mcp_id: agentId });
+    } finally {
+      setCreating(false);
+    }
+    reset();
+    onClose();
+    navigate({
+      to: "/$org/$taskId",
+      params: { org, taskId },
+      search: { virtualmcpid: agentId, autosend: AUTOSEND_QUERY_VALUE },
+    });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          reset();
+          onClose();
+        }
+      }}
+    >
+      <DialogContent
+        className="gap-0 overflow-hidden p-0 sm:max-w-[640px]"
+        closeButtonClassName="hidden"
+      >
+        <DialogTitle className="sr-only">New task</DialogTitle>
+
+        {/* Header — org breadcrumb + close. */}
+        <div className="flex items-center gap-2 px-4 pt-4">
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs font-medium text-foreground">
+            {orgLogo ? (
+              <img
+                src={orgLogo}
+                alt=""
+                className="size-3.5 rounded-sm object-cover"
+              />
+            ) : (
+              <Cube01 size={13} className="text-muted-foreground" />
+            )}
+            {orgName}
+          </span>
+          <ChevronRight size={14} className="text-muted-foreground" />
+          <span className="text-sm text-muted-foreground">New task</span>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={() => {
+              reset();
+              onClose();
+            }}
+            className="ml-auto grid size-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Prompt — the task is described like a chat message. */}
+        <div className="px-4 pt-3">
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void submit();
+              }
+            }}
+            placeholder="Describe the task…"
+            aria-label="Task prompt"
+            autoFocus
+            className="min-h-[96px] w-full resize-none border-0 bg-transparent text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/70"
+          />
+        </div>
+
+        {/* Footer — agent picker + create. */}
+        <div className="flex items-center gap-3 border-t border-border px-4 py-3">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground transition-colors hover:bg-muted"
+              >
+                <AgentAvatar
+                  icon={selectedAgent.icon ?? null}
+                  name={selectedAgent.title}
+                  size="2xs"
+                />
+                {selectedAgent.title}
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-56">
+              {agentOptions.map((a) => (
+                <DropdownMenuItem
+                  key={a.id}
+                  onSelect={() => setAgentId(a.id)}
+                  className="gap-2"
+                >
+                  <AgentAvatar
+                    icon={a.icon ?? null}
+                    name={a.title}
+                    size="2xs"
+                  />
+                  <span className="truncate">{a.title}</span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button
+            size="sm"
+            className="ml-auto"
+            disabled={!prompt.trim() || creating}
+            onClick={() => void submit()}
+          >
+            Create task
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **Tasks board** at `/$org/tasks` showing the org's tasks (threads) as a kanban or list, driven entirely by real data — no mocks.

- **Columns are the real thread statuses**: in progress, needs review, done, failed (the virtual `expired` status buckets into failed but is never written back). Status icons/colors reuse `lib/task-status.ts` so the board speaks the same language as the tasks panel.
- **Drag to move**: dropping a card on another column persists the status through `ThreadManager.setStatus` (optimistic + server).
- **Live data**: reads the same `useThreads()` store the sidebar uses, so cards update as runs progress; "Load more" pages through history.
- **Filters**: Linear-style multi-select chips for Agent (from the agents actually present on the board) and Origin (started by a person vs automation-triggered), plus a list/board layout toggle.
- **New task**: a prompt-first dialog — describe the task, pick the agent (defaults to Decopilot), and the prompt is handed to a freshly created thread via the autosend channel (the same handoff the chat uses for follow-up tasks), so the agent starts working immediately.
- Sidebar gets a **Tasks** entry between Home and Library.

## Testing

- `bun run check`, `bun run lint`, `bun run fmt` all pass (the 2 lint warnings are pre-existing on main in `packages/sandbox/daemon/org-fs`).
- UI extracted from the product-redesign mockup branch and rewired onto real threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tasks board at /$org/tasks to view and manage org tasks as a kanban or list. Supports live updates, drag-and-drop status changes, filters, and a prompt-first flow to create and start tasks immediately.

- **New Features**
  - Tasks board with real statuses as columns (in progress, needs review, done, failed; `expired` shows under failed but isn’t persisted).
  - Drag a card between columns to persist status via the thread store (optimistic + server).
  - Live data from `useThreads()` with “Load more” pagination.
  - Filters: Agent (from agents on the board) and Origin (manual vs automation). Toggle between list and board.
  - New task dialog: write a prompt, pick an agent (defaults to Decopilot), create a thread, and autosend the prompt so work starts right away.

- **Bug Fixes**
  - Wrapped the board in the routed content card so it renders inside the standard page chrome (not on the sidebar background).

<sup>Written for commit 852279aad9cfcd1dd0395c8a762ccb96c87d88b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

