### PR TITLE
Integrate shared JSON schema validator across MCP Client and Server i…

### DIFF
--- a/apps/mesh/src/api/routes/dev-assets-mcp.ts
+++ b/apps/mesh/src/api/routes/dev-assets-mcp.ts
@@ -33,6 +33,7 @@ import { join, relative } from "node:path";
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import type { StudioContext } from "../../core/studio-context";
 import { requireOrganization } from "../../core/studio-context";
 import { getContentType } from "./dev-assets";
@@ -491,7 +492,10 @@ export async function handleDevAssetsMcpRequest(
   // Create MCP server directly
   const server = new McpServer(
     { name: "dev-assets-mcp", version: "1.0.0" },
-    { capabilities: { tools: {} } },
+    {
+      capabilities: { tools: {} },
+      jsonSchemaValidator: sharedJsonSchemaValidator,
+    },
   );
 
   // Register each tool with the server

--- a/apps/mesh/src/api/routes/mcp-proxy-factory.ts
+++ b/apps/mesh/src/api/routes/mcp-proxy-factory.ts
@@ -17,6 +17,7 @@ import {
   createServerFromClient,
 } from "@decocms/mesh-sdk";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/core/constants";
 import type { StudioContext } from "../../core/studio-context";
 
@@ -131,10 +132,13 @@ async function createMCPProxyDoNotUseDirectly(
   await server.connect(serverTransport);
 
   // Create client and connect to client-side transport
-  const client = new Client({
-    name: "mcp-cms-proxy-client",
-    version: "1.0.0",
-  });
+  const client = new Client(
+    {
+      name: "mcp-cms-proxy-client",
+      version: "1.0.0",
+    },
+    { jsonSchemaValidator: sharedJsonSchemaValidator },
+  );
   await client.connect(clientTransport);
 
   // Return client as MCPProxyClient (backward compatible)

--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -9,6 +9,7 @@
  */
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
   GetPromptResult,
@@ -54,7 +55,7 @@ export function createLazyClient(
   // Placeholder client — never connects to anything
   const placeholder = new Client(
     { name: `lazy-${connection.id}`, version: "1.0.0" },
-    { capabilities: {} },
+    { capabilities: {}, jsonSchemaValidator: sharedJsonSchemaValidator },
   );
 
   // Shared promise for the real client (single-flight)

--- a/apps/mesh/src/mcp-clients/outbound/client-pool.ts
+++ b/apps/mesh/src/mcp-clients/outbound/client-pool.ts
@@ -11,6 +11,7 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 
 /**
  * Create a client pool
@@ -60,6 +61,7 @@ export function createClientPool(): (<T extends Transport>(
             requests: { tool: { call: {} } },
           },
         },
+        jsonSchemaValidator: sharedJsonSchemaValidator,
       },
     );
 

--- a/apps/mesh/src/tools/connection/fetch-tools.ts
+++ b/apps/mesh/src/tools/connection/fetch-tools.ts
@@ -6,6 +6,7 @@
  */
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -128,10 +129,13 @@ async function fetchToolsFromHttpMCP(
       { requestInit: { headers } },
     );
 
-    client = new Client({
-      name: "mcp-cms-tool-fetcher",
-      version: "1.0.0",
-    });
+    client = new Client(
+      {
+        name: "mcp-cms-tool-fetcher",
+        version: "1.0.0",
+      },
+      { jsonSchemaValidator: sharedJsonSchemaValidator },
+    );
 
     // Add timeout to prevent hanging connections
     const timeoutPromise = new Promise<never>((_, reject) => {
@@ -209,7 +213,10 @@ async function fetchToolsFromSSEMCP(
       { requestInit: { headers } },
     );
 
-    client = new Client({ name: "mcp-cms-tool-fetcher", version: "1.0.0" });
+    client = new Client(
+      { name: "mcp-cms-tool-fetcher", version: "1.0.0" },
+      { jsonSchemaValidator: sharedJsonSchemaValidator },
+    );
 
     const timeoutPromise = new Promise<never>((_, reject) => {
       setTimeout(() => reject(new Error("SSE connection timeout")), 15_000);
@@ -275,10 +282,13 @@ async function fetchToolsFromStdioMCP(
       cwd: stdioParams.cwd,
     });
 
-    client = new Client({
-      name: "mcp-cms-tool-fetcher",
-      version: "1.0.0",
-    });
+    client = new Client(
+      {
+        name: "mcp-cms-tool-fetcher",
+        version: "1.0.0",
+      },
+      { jsonSchemaValidator: sharedJsonSchemaValidator },
+    );
 
     // Add timeout to prevent hanging
     const timeoutPromise = new Promise<never>((_, reject) => {

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -16,6 +16,7 @@ import {
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import type { Tool as McpTool } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import * as ApiKeyTools from "./apiKeys";
@@ -249,7 +250,10 @@ export const managementMCP = async (ctx: StudioContext) => {
   // Create MCP server directly
   const server = new McpServer(
     { name: "mcp-cms-management", version: "1.0.0" },
-    { capabilities: { tools: {}, prompts: {}, resources: {} } },
+    {
+      capabilities: { tools: {}, prompts: {}, resources: {} },
+      jsonSchemaValidator: sharedJsonSchemaValidator,
+    },
   );
 
   // Register each tool with the server
@@ -460,7 +464,10 @@ export async function listManagementTools(
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
-  const client = new Client({ name: "tools-hydration", version: "1.0.0" });
+  const client = new Client(
+    { name: "tools-hydration", version: "1.0.0" },
+    { jsonSchemaValidator: sharedJsonSchemaValidator },
+  );
   try {
     await client.connect(clientTransport);
     const result = await client.listTools();

--- a/apps/mesh/src/tools/registry/discover-tools.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.ts
@@ -1,6 +1,7 @@
 import { defineTool } from "@/core/define-tool";
 import { requireOrganization } from "@/core/studio-context";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { z } from "zod";
@@ -213,7 +214,10 @@ export const REGISTRY_DISCOVER_TOOLS = defineTool({
     for (const attempt of attempts) {
       let client: Client | null = null;
       try {
-        client = new Client({ name: "registry-discover", version: "1.0.0" });
+        client = new Client(
+          { name: "registry-discover", version: "1.0.0" },
+          { jsonSchemaValidator: sharedJsonSchemaValidator },
+        );
 
         const transport =
           attempt.transport === "sse"

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.444.1",
+      "version": "3.2.4",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -199,13 +199,12 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "0.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.80",
         "@ai-sdk/google": "^3.0.80",
         "@ai-sdk/openai": "^3.0.65",
         "@ai-sdk/provider": "^3.0.10",
-        "@decocms/mcp-utils": "workspace:*",
         "@decocms/mesh-sdk": "workspace:*",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@openrouter/ai-sdk-provider": "^2.9.0",
@@ -224,6 +223,8 @@
       "version": "1.0.2",
       "dependencies": {
         "@decocms/std": "workspace:*",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
       },
       "devDependencies": {
         "@jitl/quickjs-wasmfile-release-sync": "0.31.0",
@@ -281,7 +282,7 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "1.6.5",
+      "version": "2.0.0",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.10",
         "@cloudflare/workers-types": "^4.20250617.0",
@@ -302,7 +303,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "0.21.0",
+      "version": "1.0.0",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/std": "workspace:*",

--- a/packages/mcp-utils/package.json
+++ b/packages/mcp-utils/package.json
@@ -13,7 +13,9 @@
     "./aggregate": "./src/aggregate/index.ts"
   },
   "dependencies": {
-    "@decocms/std": "workspace:*"
+    "@decocms/std": "workspace:*",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.27.0"

--- a/packages/mcp-utils/src/index.ts
+++ b/packages/mcp-utils/src/index.ts
@@ -1,4 +1,5 @@
 export type { IClient } from "./client-like.ts";
+export { sharedJsonSchemaValidator } from "./shared-schema-validator.ts";
 export {
   composeTransport,
   WrapperTransport,

--- a/packages/mcp-utils/src/server-from-client.ts
+++ b/packages/mcp-utils/src/server-from-client.ts
@@ -29,6 +29,7 @@
 
 import type { IClient } from "./client-like.ts";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { sharedJsonSchemaValidator } from "./shared-schema-validator.ts";
 import type {
   Implementation,
   ServerCapabilities,
@@ -85,6 +86,10 @@ export function createServerFromClient(
   const server = new McpServer(serverInfo, {
     capabilities,
     instructions,
+    // Share one content-memoized validator so the SDK doesn't mint a fresh Ajv
+    // (with an ever-growing compile cache) per server instance. See
+    // shared-schema-validator.ts.
+    jsonSchemaValidator: sharedJsonSchemaValidator,
   });
 
   // Set up request handlers that delegate to client methods

--- a/packages/mcp-utils/src/shared-schema-validator.ts
+++ b/packages/mcp-utils/src/shared-schema-validator.ts
@@ -1,9 +1,9 @@
-import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv.js";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
 import type {
   JsonSchemaType,
   JsonSchemaValidator,
   jsonSchemaValidator,
-} from "@modelcontextprotocol/sdk/validation/types.js";
+} from "@modelcontextprotocol/sdk/validation";
 
 /**
  * Shared, content-memoized JSON-schema validator for all MCP Client/Server

--- a/packages/mcp-utils/src/shared-schema-validator.ts
+++ b/packages/mcp-utils/src/shared-schema-validator.ts
@@ -1,9 +1,5 @@
-import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
-import type {
-  JsonSchemaType,
-  JsonSchemaValidator,
-  jsonSchemaValidator,
-} from "@modelcontextprotocol/sdk/validation";
+import Ajv, { type ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
 
 /**
  * Shared, content-memoized JSON-schema validator for all MCP Client/Server
@@ -16,10 +12,10 @@ import type {
  *      when none is injected. The mesh builds these per request / per Decopilot
  *      turn (proxy routes, passthrough aggregator, management server), so the
  *      Ajv instances pile up.
- *   2. `AjvJsonSchemaValidator.getValidator()` calls `ajv.compile(schema)` for
- *      every schema (MCP tool schemas have no `$id`), and Ajv keeps every
- *      compiled schema in its internal cache forever — no eviction. So the same
- *      tool schema is recompiled and retained on every request.
+ *   2. Ajv's `compile()` keeps every compiled schema in its internal cache
+ *      forever — no eviction — and the SDK calls it for every schema (MCP tool
+ *      schemas have no `$id`). So identical tool schemas are recompiled and
+ *      retained on every request.
  *
  * Heap snapshots showed the compiled-validator codegen (the dominant growing
  * object set — `Function`/`string`/`Object` in the millions) retained via
@@ -30,28 +26,63 @@ import type {
  * bounding total compiled validators to the number of distinct tool schemas
  * regardless of request volume — instead of one fresh Ajv + recompile per
  * request.
+ *
+ * Implemented against `ajv` directly (not the SDK's `AjvJsonSchemaValidator`)
+ * because that lives behind the SDK's `exports` map, which the package's
+ * classic module resolution can't reach; behaviour mirrors the SDK's provider.
  */
-class MemoizingJsonSchemaValidator implements jsonSchemaValidator {
-  // A single backing Ajv instance, compiled into once per distinct schema.
-  readonly #inner = new AjvJsonSchemaValidator();
-  readonly #cache = new Map<string, JsonSchemaValidator<unknown>>();
 
-  getValidator<T>(schema: JsonSchemaType): JsonSchemaValidator<T> {
+// Mirrors the SDK's JsonSchemaValidatorResult / JsonSchemaValidator types
+// structurally so the singleton is assignable to the `jsonSchemaValidator`
+// option on Client/Server without importing the SDK's exports-only types.
+type ValidatorResult<T> =
+  | { valid: true; data: T; errorMessage: undefined }
+  | { valid: false; data: undefined; errorMessage: string };
+
+type Validator<T> = (input: unknown) => ValidatorResult<T>;
+
+// Match the SDK's default Ajv configuration (server/index.js → AjvJsonSchemaValidator).
+function createAjv(): Ajv {
+  const ajv = new Ajv({
+    strict: false,
+    validateFormats: true,
+    validateSchema: false,
+    allErrors: true,
+  });
+  addFormats(ajv);
+  return ajv;
+}
+
+class MemoizingJsonSchemaValidator {
+  // One backing Ajv, compiled into once per distinct schema.
+  readonly #ajv = createAjv();
+  readonly #cache = new Map<string, ValidateFunction>();
+
+  getValidator<T>(schema: object): Validator<T> {
     const key = stableStringify(schema);
-    const cached = this.#cache.get(key);
-    if (cached) {
-      return cached as JsonSchemaValidator<T>;
+    let compiled = this.#cache.get(key);
+    if (!compiled) {
+      compiled = this.#ajv.compile(schema);
+      this.#cache.set(key, compiled);
     }
-    const created = this.#inner.getValidator<unknown>(schema);
-    this.#cache.set(key, created);
-    return created as JsonSchemaValidator<T>;
+    const validate = compiled;
+    return (input: unknown): ValidatorResult<T> => {
+      if (validate(input)) {
+        return { valid: true, data: input as T, errorMessage: undefined };
+      }
+      return {
+        valid: false,
+        data: undefined,
+        errorMessage: this.#ajv.errorsText(validate.errors),
+      };
+    };
   }
 }
 
 /**
  * Stable stringify: sort object keys so two structurally-identical schemas
  * serialized with different key order still hit the same cache entry. Tool
- * schemas are small, so the recursive walk is cheap relative to Ajv compilation.
+ * schemas are small, so the recursive walk is cheap relative to compilation.
  */
 function stableStringify(value: unknown): string {
   return JSON.stringify(value, (_key, val) => {
@@ -70,5 +101,4 @@ function stableStringify(value: unknown): string {
  * Process-wide singleton. Pass as `jsonSchemaValidator` to every `new Client`,
  * `new Server`, and `new McpServer` so they share one bounded validator cache.
  */
-export const sharedJsonSchemaValidator: jsonSchemaValidator =
-  new MemoizingJsonSchemaValidator();
+export const sharedJsonSchemaValidator = new MemoizingJsonSchemaValidator();

--- a/packages/mcp-utils/src/shared-schema-validator.ts
+++ b/packages/mcp-utils/src/shared-schema-validator.ts
@@ -1,0 +1,74 @@
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv.js";
+import type {
+  JsonSchemaType,
+  JsonSchemaValidator,
+  jsonSchemaValidator,
+} from "@modelcontextprotocol/sdk/validation/types.js";
+
+/**
+ * Shared, content-memoized JSON-schema validator for all MCP Client/Server
+ * instances in the mesh.
+ *
+ * Why this exists — a multi-hour leak hunt: MCP SDK ≥1.27 validates tool I/O
+ * with Ajv. Two compounding behaviours made this leak unboundedly under load:
+ *
+ *   1. Each `Client`/`Server` constructs its OWN `new AjvJsonSchemaValidator()`
+ *      when none is injected. The mesh builds these per request / per Decopilot
+ *      turn (proxy routes, passthrough aggregator, management server), so the
+ *      Ajv instances pile up.
+ *   2. `AjvJsonSchemaValidator.getValidator()` calls `ajv.compile(schema)` for
+ *      every schema (MCP tool schemas have no `$id`), and Ajv keeps every
+ *      compiled schema in its internal cache forever — no eviction. So the same
+ *      tool schema is recompiled and retained on every request.
+ *
+ * Heap snapshots showed the compiled-validator codegen (the dominant growing
+ * object set — `Function`/`string`/`Object` in the millions) retained via
+ * `_jsonSchemaValidator → _ajv` on accumulating Client/Server instances.
+ *
+ * Injecting this single provider into every Client/Server makes compilation
+ * happen ONCE per distinct schema across the whole process (content-keyed),
+ * bounding total compiled validators to the number of distinct tool schemas
+ * regardless of request volume — instead of one fresh Ajv + recompile per
+ * request.
+ */
+class MemoizingJsonSchemaValidator implements jsonSchemaValidator {
+  // A single backing Ajv instance, compiled into once per distinct schema.
+  readonly #inner = new AjvJsonSchemaValidator();
+  readonly #cache = new Map<string, JsonSchemaValidator<unknown>>();
+
+  getValidator<T>(schema: JsonSchemaType): JsonSchemaValidator<T> {
+    const key = stableStringify(schema);
+    const cached = this.#cache.get(key);
+    if (cached) {
+      return cached as JsonSchemaValidator<T>;
+    }
+    const created = this.#inner.getValidator<unknown>(schema);
+    this.#cache.set(key, created);
+    return created as JsonSchemaValidator<T>;
+  }
+}
+
+/**
+ * Stable stringify: sort object keys so two structurally-identical schemas
+ * serialized with different key order still hit the same cache entry. Tool
+ * schemas are small, so the recursive walk is cheap relative to Ajv compilation.
+ */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      return Object.fromEntries(
+        Object.keys(val as Record<string, unknown>)
+          .sort()
+          .map((k) => [k, (val as Record<string, unknown>)[k]]),
+      );
+    }
+    return val;
+  });
+}
+
+/**
+ * Process-wide singleton. Pass as `jsonSchemaValidator` to every `new Client`,
+ * `new Server`, and `new McpServer` so they share one bounded validator cache.
+ */
+export const sharedJsonSchemaValidator: jsonSchemaValidator =
+  new MemoizingJsonSchemaValidator();


### PR DESCRIPTION
…nstances

- Added `sharedJsonSchemaValidator` to various MCP Client and Server configurations to optimize JSON schema validation and reduce memory usage.
- Updated `dev-assets-mcp.ts`, `mcp-proxy-factory.ts`, `lazy-client.ts`, `client-pool.ts`, `index.ts`, `fetch-tools.ts`, and `discover-tools.ts` to utilize the shared validator.
- Introduced `shared-schema-validator.ts` to implement a memoizing JSON schema validator, ensuring efficient schema compilation across multiple instances.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share a single, memoized JSON Schema validator across all MCP clients and servers to stop duplicate Ajv compilations and lower memory under load. Exported `sharedJsonSchemaValidator` from `@decocms/mcp-utils` and wired it into every MCP entry point.

- **Refactors**
  - Added `shared-schema-validator.ts`, a content-keyed cache implemented directly with `ajv` + `ajv-formats` (no SDK wrapper).
  - Injected `sharedJsonSchemaValidator` into all `Client`/`McpServer` instances in dev-assets-mcp.ts, mcp-proxy-factory.ts, lazy-client.ts, client-pool.ts, tools/index.ts, fetch-tools.ts, discover-tools.ts, and server-from-client.ts; re-exported from `packages/mcp-utils/src/index.ts`.
  - No API changes.

- **Dependencies**
  - Added `ajv` and `ajv-formats` to `@decocms/mcp-utils`; bumped related workspace versions in `bun.lock`.

<sup>Written for commit fe88ff75d5c193c4a2c85ae72581d7a7c42ff0cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

