### PR TITLE
Enhance MCP request handling and resource management

### DIFF
--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -198,6 +198,11 @@ export async function handleVirtualMcpRequest(
       transport,
       c.req.raw,
       `virtual-mcp:${virtualMcp.id ?? "decopilot"}`,
+      // `client` is built fresh per request and is NOT pooled; the bridge
+      // server delegates to it but never closes it. Close it here or the
+      // PassthroughClient + every downstream lazy/real client + their
+      // transports leak (GatewayClient.close() cascades to all children).
+      { onClose: () => client.close() },
     );
   } catch (error) {
     const err = error as Error;

--- a/apps/mesh/src/api/utils/serve-mcp.ts
+++ b/apps/mesh/src/api/utils/serve-mcp.ts
@@ -13,7 +13,8 @@
  * `serveMcpRequest` is the one place that gets this right: handle the
  * request, stream the body through the guard, and close the server (which
  * closes its transport) exactly once — after the body is fully delivered,
- * on client cancel, or on a handler throw.
+ * on client cancel, on client disconnect (request abort), or on a handler
+ * throw.
  */
 import { guardResponseStream } from "./stream-guard";
 
@@ -25,20 +26,55 @@ interface RequestTransport {
   handleRequest(req: Request): Promise<Response>;
 }
 
+interface ServeMcpOptions {
+  /**
+   * Extra teardown to run exactly once when the response is done, alongside
+   * `server.close()`. Closing the server cascades into its own transport only;
+   * a bridge server delegates to a client via request handlers and does NOT
+   * close it. For a **per-request, non-pooled** client (e.g. the
+   * PassthroughClient a virtual-MCP route builds fresh) pass
+   * `() => client.close()` here, or the client + its downstream
+   * connections/transports leak.
+   */
+  onClose?: () => void | Promise<void>;
+}
+
 export async function serveMcpRequest(
   server: CloseableServer,
   transport: RequestTransport,
   request: Request,
   label: string,
+  options?: ServeMcpOptions,
 ): Promise<Response> {
-  // Closing the server cascades into its own transport only — bridge servers
-  // delegate to their client via request handlers, so a shared/pooled client
-  // is never closed from here.
+  const signal = request.signal;
+
+  // Idempotent: the abort listener and the stream guard's onDone can both fire
+  // (e.g. disconnect racing body-complete) — teardown must run exactly once.
+  let closed = false;
   const close = () => {
+    if (closed) return;
+    closed = true;
+    signal?.removeEventListener("abort", close);
     void server.close().catch((err) => {
       console.error(`[serve-mcp] ${label} server close failed:`, err);
     });
+    if (options?.onClose) {
+      void Promise.resolve()
+        .then(options.onClose)
+        .catch((err) => {
+          console.error(`[serve-mcp] ${label} onClose failed:`, err);
+        });
+    }
   };
+
+  // Backstop for the SSE-pinning leak: a long-lived MCP stream keeps the
+  // per-request server (its tool Zod graph + transport) alive via the guard's
+  // suspended read loop. On client disconnect the runtime may stop reading
+  // WITHOUT cancelling the stream, so the guard's onDone never fires. The
+  // request's AbortSignal does fire on disconnect — close on it too.
+  if (signal && !signal.aborted) {
+    signal.addEventListener("abort", close, { once: true });
+  }
 
   let response: Response;
   try {

--- a/apps/mesh/src/mcp-clients/server.ts
+++ b/apps/mesh/src/mcp-clients/server.ts
@@ -118,5 +118,18 @@ export function serverFromConnection(
     },
   );
 
+  // The bridge created by `createServerFromClient` does NOT close the client it
+  // delegates to (a generic bridge can't assume it owns a possibly-shared
+  // client). This `client` IS owned by this per-request server, so cascade:
+  // closing the server (e.g. via `serveMcpRequest` on stream-done/disconnect)
+  // must close the lazy client too, or it + its real downstream connection +
+  // transport leak. The lazy client's own `close()` is a no-op if it never
+  // connected (list cache hits), so this is cheap on the warm path.
+  const closeServer = server.close.bind(server);
+  server.close = async () => {
+    await closeServer();
+    await client.close().catch(() => {});
+  };
+
   return server;
 }

--- a/packages/bindings/src/core/client/proxy.ts
+++ b/packages/bindings/src/core/client/proxy.ts
@@ -20,6 +20,25 @@ type Tool = {
 
 const toolsMap = new Map<string, Promise<Array<Tool>>>();
 
+// Memoize JSON-schema → Zod conversion by schema content. Zod v4 schemas carry
+// their methods per-instance, so a freshly-converted schema is ~18 Function/
+// AsyncFunction nodes; `mapTool` runs on EVERY `asCallableTools()`/`asTool()`
+// call, so without this an MCP server's whole tool set was re-minted into a new
+// Zod graph per call and retained by whatever held the result — a dominant
+// heap-leak vector server-side (runtime/workflows/sandbox hit this path). The
+// conversion is pure and Zod schemas are immutable after build, so sharing one
+// instance per distinct schema is safe. Distinct schema contents are bounded by
+// the tool catalogue, so no eviction is needed (mirrors sharedJsonSchemaValidator).
+const zodSchemaCache = new Map<string, unknown>();
+const cachedConvertJsonSchemaToZod = (schema: any) => {
+  const key = JSON.stringify(schema);
+  const hit = zodSchemaCache.get(key);
+  if (hit !== undefined) return hit;
+  const zod = convertJsonSchemaToZod(schema);
+  zodSchemaCache.set(key, zod);
+  return zod;
+};
+
 const mapTool = (
   tool: Tool,
   callToolFn: (input: any, toolName?: string) => Promise<any>,
@@ -28,10 +47,10 @@ const mapTool = (
     ...tool,
     id: tool.name,
     inputSchema: tool.inputSchema
-      ? convertJsonSchemaToZod(tool.inputSchema)
+      ? cachedConvertJsonSchemaToZod(tool.inputSchema)
       : undefined,
     outputSchema: tool.outputSchema
-      ? convertJsonSchemaToZod(tool.outputSchema)
+      ? cachedConvertJsonSchemaToZod(tool.outputSchema)
       : undefined,
     execute: (input: any) => {
       return callToolFn(input.context, tool.name);


### PR DESCRIPTION
- Updated `serveMcpRequest` to include an `onClose` option for additional teardown logic, ensuring proper resource cleanup for non-pooled clients.
- Improved handling of client disconnects and request aborts to prevent resource leaks.
- Memoized JSON-schema to Zod conversion in `proxy.ts` to optimize performance and reduce heap usage, addressing a significant memory leak issue.
- Adjusted server closing logic in `server.ts` to ensure lazy clients are closed appropriately, preventing downstream connection leaks.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves MCP teardown to stop leaks on disconnects and non-pooled clients. Memoizes JSON Schema → Zod conversion to fix a major memory leak and reduce heap growth.

- New Features
  - `serveMcpRequest` now accepts `onClose` for extra teardown (e.g., `client.close()`).

- Bug Fixes
  - Close the server on request abort/disconnect and ensure teardown runs exactly once.
  - Cascade `server.close()` to the lazy MCP client to prevent downstream connection/transport leaks.
  - Memoize JSON-schema → Zod conversion in `proxy.ts` to reuse schemas and eliminate repeated Zod graph allocations.

<sup>Written for commit 0e5fa4939110737132b5042f5dbb19b89bdb2040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

