### PR TITLE
feat(slides): built-in slides skill — deck runtime, templating CLI, live editable preview

### DIFF
--- a/apps/mesh/e2e/tests/deck-preview-edit.spec.ts
+++ b/apps/mesh/e2e/tests/deck-preview-edit.spec.ts
@@ -39,6 +39,9 @@ test.describe("deck preview tab", () => {
   test("renders the deck and persists an inline structural edit", async ({
     authedPage,
   }) => {
+    // Cold dev-server boot + iframe handshake + save debounces add up;
+    // triple the budget so a busy host doesn't flake the save poll.
+    test.slow();
     const { page, orgSlug } = authedPage;
     const api = page.context().request;
 

--- a/apps/mesh/e2e/tests/deck-preview-edit.spec.ts
+++ b/apps/mesh/e2e/tests/deck-preview-edit.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * E2E: the deck preview tab (`?main=deck:<encoded path>`) renders a deck
+ * stored in the org-fs home volume through the real `<deck-viewer>`
+ * runtime, and inline edits made in the sandboxed iframe round-trip back
+ * into the file via the DeckTab editor (op → applyDeckOp → org-fs PUT).
+ *
+ * No agent/sandbox involved — the deck is seeded straight through the
+ * org-fs HTTP API, which is the same surface the sandbox mount writes
+ * through.
+ */
+import { expect, test } from "../fixtures/test";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+
+const DECK_PATH = "decks/e2e-test.html";
+
+/** Minimal real deck: theme-less but uses the actual runtime script. */
+const DECK_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>E2E Deck</title>
+<style>
+  section { background: #fff; color: #111; padding: 120px; font-family: sans-serif; }
+  h1, h2 { font-size: 96px; margin: 0; }
+</style>
+</head>
+<body>
+<deck-viewer width="1920" height="1080">
+<section><h1>Alpha</h1></section>
+<section><h2>Beta</h2></section>
+<section><h2>Gamma</h2></section>
+</deck-viewer>
+<script src="/deck-runtime/v1/deck-viewer.js"></script>
+</body>
+</html>
+`;
+
+test.describe("deck preview tab", () => {
+  test("renders the deck and persists an inline structural edit", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+
+    // Seed the deck in the home volume (same write surface the sandbox
+    // mount uses).
+    const put = await api.put(
+      `/api/${orgSlug}/fs/home/file?path=${encodeURIComponent(DECK_PATH)}`,
+      {
+        data: DECK_HTML,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      },
+    );
+    expect(put.ok()).toBe(true);
+
+    // A thread context to host the main panel.
+    const agent = await callSelfMcpTool<{ item: { id: string } }>(
+      api,
+      orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      {
+        data: {
+          title: "deck e2e",
+          description: "deck preview spec",
+          status: "active",
+          pinned: false,
+          connections: [],
+        },
+      },
+    );
+    const thread = await callSelfMcpTool<{ item: { id: string } }>(
+      api,
+      orgSlug,
+      "COLLECTION_THREADS_CREATE",
+      { data: { virtual_mcp_id: agent.item.id } },
+    );
+
+    await page.goto(
+      `/${orgSlug}/${thread.item.id}?virtualmcpid=${agent.item.id}&main=deck:${encodeURIComponent(DECK_PATH)}`,
+    );
+
+    // The deck pill labels the tab with the deck name. Generous timeout:
+    // first paint pays the Vite dev-server cold transform.
+    await expect(page.getByText("e2e-test").first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // The runtime renders inside the sandboxed iframe (Playwright pierces
+    // the shadow DOM): slide 1 active, slide count in the rail.
+    const frame = page.frameLocator(`iframe[title="${DECK_PATH}"]`);
+    await expect(frame.locator("section[data-deck-active] h1")).toHaveText(
+      "Alpha",
+      { timeout: 15_000 },
+    );
+    await expect(frame.locator(".thumb")).toHaveCount(3);
+
+    // The floating release-announcement card (parent page, fixed bottom-
+    // right) overlaps the iframe and intercepts clicks aimed at in-iframe
+    // chrome — dismiss it if present.
+    const dismissRelease = page.getByRole("button", {
+      name: "Dismiss release announcement",
+    });
+    if (await dismissRelease.isVisible().catch(() => false)) {
+      await dismissRelease.click();
+    }
+
+    // Enter edit mode and delete slide 2 via the rail context menu.
+    await page.getByRole("button", { name: "Edit inline" }).click();
+    await expect(frame.locator("section[data-deck-active]")).toHaveAttribute(
+      "contenteditable",
+      "true",
+    );
+
+    await frame.locator(".thumb").nth(1).click({ button: "right" });
+    await frame.locator('[data-act="delete"]').click();
+    await frame.locator(".confirm .danger").click();
+
+    // Optimistic: the rail drops to 2 immediately.
+    await expect(frame.locator(".thumb")).toHaveCount(2);
+
+    // The op debounce-saves (400ms) into org-fs; poll the file until the
+    // section is gone from the source of truth.
+    await expect
+      .poll(
+        async () => {
+          const res = await api.get(
+            `/api/${orgSlug}/fs/home/read?path=${encodeURIComponent(DECK_PATH)}`,
+          );
+          return res.ok() ? await res.text() : "";
+        },
+        { timeout: 10_000 },
+      )
+      .not.toContain("Beta");
+
+    // The surviving slides are intact in the persisted HTML.
+    const saved = await (
+      await api.get(
+        `/api/${orgSlug}/fs/home/read?path=${encodeURIComponent(DECK_PATH)}`,
+      )
+    ).text();
+    expect(saved).toContain("Alpha");
+    expect(saved).toContain("Gamma");
+    expect(saved).toContain("deck-runtime/v1/deck-viewer.js");
+  });
+});

--- a/apps/mesh/public/deck-runtime/v1/deck-viewer.js
+++ b/apps/mesh/public/deck-runtime/v1/deck-viewer.js
@@ -1,0 +1,1516 @@
+/**
+ * <deck-viewer> — Studio's presentation deck runtime (v1).
+ *
+ * A deck is a single self-contained HTML file: a theme <style> in <head>,
+ * this script (classic, non-module — loaded no-cors so it works from the
+ * sandboxed preview iframe), and one <deck-viewer> element whose direct
+ * <section> children are the slides.
+ *
+ *   <deck-viewer width="1920" height="1080">
+ *     <section>…</section>
+ *     <section>…</section>
+ *   </deck-viewer>
+ *   <script src="/deck-runtime/v1/deck-viewer.js"></script>
+ *
+ * Features:
+ *  - Fixed design canvas (default 1920×1080) scaled with transform:scale()
+ *    to fit the viewport, letterboxed.
+ *  - Keyboard nav (←/→, PgUp/PgDn, Space, Home/End, digits, R), tap-halves
+ *    nav on touch, bottom-center overlay with prev/count/next/reset.
+ *  - Thumbnail rail (left column of static scaled clones); click to
+ *    navigate, drag to reorder, right-click for Skip / Move / Duplicate /
+ *    Delete — structural ops are only enabled in edit mode.
+ *  - Edit mode (host-toggled): slides become contenteditable; text edits
+ *    and structural ops self-apply optimistically AND are posted to the
+ *    parent window, which persists them to the source file.
+ *  - Print: one page per slide at design size (@page rule injected into
+ *    document head — @page is a no-op inside shadow DOM). Open with a
+ *    #print fragment to auto-trigger window.print() (PDF export path).
+ *
+ * postMessage protocol (v1) — all messages carry `v: 1`. The document may
+ * run in an opaque-origin sandboxed iframe, so both directions post with
+ * targetOrigin "*" and the parent validates event.source identity.
+ *
+ * runtime → parent:
+ *   { v, source: "deck-viewer", type: "ready", total, design: {width, height} }
+ *   { v, source: "deck-viewer", type: "state", index, total, skipped: number[] }
+ *   { v, source: "deck-viewer", type: "op", opId, witness: { childCount }, op }
+ *     op: { kind: "move", from, to } | { kind: "remove", at }
+ *       | { kind: "duplicate", at }
+ *       | { kind: "set-attr", at, name, value } | { kind: "remove-attr", at, name }
+ *       | { kind: "replace", at, html }   // contenteditable edit; cleaned outerHTML
+ *
+ * parent → runtime:
+ *   { v, type: "ack", opId, ok, error? }
+ *   { v, type: "set-edit-mode", enabled }
+ *   { v, type: "goto", index }
+ *   { v, type: "print" }
+ *
+ * Slide indices are positions in the light-DOM section list (including
+ * skipped slides) at the moment the op was emitted.
+ */
+
+(() => {
+  const PROTOCOL_V = 1;
+  const DESIGN_W_DEFAULT = 1920;
+  const DESIGN_H_DEFAULT = 1080;
+  const OVERLAY_HIDE_MS = 1800;
+  const ACK_TIMEOUT_MS = 5000;
+  const TEXT_EDIT_DEBOUNCE_MS = 800;
+  const RAIL_DEFAULT_W = 168;
+  const FINE_POINTER_MQ = matchMedia("(hover: hover) and (pointer: fine)");
+  const NARROW_MQ = matchMedia("(max-width: 640px)");
+  // Slide-authored controls that should keep a tap instead of navigating.
+  const INTERACTIVE_SEL =
+    'a[href], button, input, select, textarea, summary, label, video[controls], audio[controls], [role="button"], [onclick]';
+  // Attributes this runtime writes onto slides; stripped before any HTML
+  // leaves the component (replace ops, duplicate clones) so the persisted
+  // file stays clean.
+  const RUNTIME_ATTRS = [
+    "contenteditable",
+    "spellcheck",
+    "tabindex",
+    "aria-hidden",
+    "data-deck-active",
+    "data-deck-last-visible",
+  ];
+
+  const stylesheet = `
+    :host {
+      position: fixed;
+      inset: 0;
+      display: block;
+      background: #111;
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      overflow: hidden;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    .stage {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .canvas {
+      position: relative;
+      transform-origin: center center;
+      flex-shrink: 0;
+      background: #fff;
+      will-change: transform;
+    }
+
+    /* Slides live in light DOM (via <slot>) so authored CSS applies. Every
+       slotted child is absolutely positioned to stack; only the active one
+       is visible. Hidden, not unmounted — slide state survives nav. */
+    ::slotted(*) {
+      position: absolute !important;
+      inset: 0 !important;
+      width: 100% !important;
+      height: 100% !important;
+      box-sizing: border-box !important;
+      overflow: hidden;
+      opacity: 0;
+      pointer-events: none;
+      visibility: hidden;
+    }
+    ::slotted([data-deck-active]) {
+      opacity: 1;
+      pointer-events: auto;
+      visibility: visible;
+    }
+
+    .overlay {
+      position: fixed;
+      left: 50%;
+      bottom: 20px;
+      transform: translate(-50%, 6px);
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      padding: 4px;
+      background: rgba(0, 0, 0, 0.92);
+      color: #fff;
+      border-radius: 999px;
+      font-size: 12px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease, transform 200ms ease;
+      z-index: 100;
+      user-select: none;
+    }
+    .overlay[data-visible] {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translate(-50%, 0);
+    }
+    .btn {
+      appearance: none;
+      background: transparent;
+      border: 0;
+      margin: 0;
+      padding: 0;
+      color: rgba(255, 255, 255, 0.75);
+      font: inherit;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      height: 28px;
+      min-width: 28px;
+      border-radius: 999px;
+      cursor: pointer;
+    }
+    .btn:hover { background: rgba(255, 255, 255, 0.14); color: #fff; }
+    .btn svg { width: 14px; height: 14px; display: block; }
+    .count {
+      font-variant-numeric: tabular-nums;
+      padding: 0 8px;
+      min-width: 44px;
+      text-align: center;
+    }
+    .count .total { color: rgba(255, 255, 255, 0.55); }
+
+    /* ── Thumbnail rail ─────────────────────────────────────────────── */
+    .rail {
+      position: fixed;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: var(--deck-rail-w, ${RAIL_DEFAULT_W}px);
+      background: #1a1a1a;
+      border-right: 1px solid rgba(255, 255, 255, 0.08);
+      overflow-y: auto;
+      overflow-x: hidden;
+      padding: 12px 10px;
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      z-index: 50;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+    }
+    /* The rail is presentation chrome — hidden by default (a deck opened
+       in a fresh tab is presentation-first). The 'rail' URL-hash token or
+       the host's set-rail message opens it (data-rail-open). */
+    .rail, .rail-resize { display: none; }
+    :host([data-rail-open]) .rail { display: flex; }
+    :host([data-rail-open]) .rail-resize { display: block; }
+    :host([no-rail]) .rail, :host([no-rail]) .rail-resize { display: none !important; }
+    @media (max-width: 640px) {
+      .rail, .rail-resize { display: none !important; }
+    }
+    .thumb {
+      position: relative;
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      cursor: pointer;
+      user-select: none;
+      outline: none;
+    }
+    .thumb .num {
+      width: 16px;
+      flex-shrink: 0;
+      font-size: 11px;
+      text-align: right;
+      color: rgba(255, 255, 255, 0.55);
+      padding-top: 2px;
+      font-variant-numeric: tabular-nums;
+    }
+    .thumb .frame {
+      position: relative;
+      flex: 1;
+      min-width: 0;
+      aspect-ratio: var(--deck-aspect, 16 / 9);
+      background: #fff;
+      border-radius: 4px;
+      outline: 2px solid transparent;
+      overflow: hidden;
+      transition: outline-color 120ms ease;
+    }
+    .thumb:hover .frame { outline-color: rgba(255, 255, 255, 0.25); }
+    .thumb[data-current] .num { color: #fff; }
+    .thumb[data-current] .frame { outline-color: #6e8bff; }
+    .thumb[data-dragging] { opacity: 0.35; }
+    .thumb::before {
+      content: "";
+      position: absolute;
+      left: 24px;
+      right: 0;
+      height: 3px;
+      border-radius: 2px;
+      background: #6e8bff;
+      opacity: 0;
+      pointer-events: none;
+    }
+    .thumb[data-drop="before"]::before { top: -8px; opacity: 1; }
+    .thumb[data-drop="after"]::before { bottom: -8px; opacity: 1; }
+    .thumb[data-skip] .frame { opacity: 0.35; }
+    .thumb[data-skip] .frame::after {
+      content: "Skipped";
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.45);
+      color: #fff;
+      font-size: 10px;
+      letter-spacing: 0.04em;
+    }
+    .rail-resize {
+      position: fixed;
+      left: calc(var(--deck-rail-w, ${RAIL_DEFAULT_W}px) - 3px);
+      top: 0;
+      bottom: 0;
+      width: 6px;
+      cursor: col-resize;
+      z-index: 60;
+      touch-action: none;
+    }
+    .rail-resize:hover, .rail-resize[data-dragging] { background: rgba(255, 255, 255, 0.12); }
+
+    .ctxmenu {
+      position: fixed;
+      min-width: 150px;
+      padding: 4px;
+      background: #242424;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 7px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+      z-index: 120;
+      display: none;
+      font-size: 12px;
+    }
+    .ctxmenu[data-open] { display: block; }
+    .ctxmenu button {
+      display: block;
+      width: 100%;
+      appearance: none;
+      border: 0;
+      background: transparent;
+      color: #e8e8e8;
+      font: inherit;
+      text-align: left;
+      padding: 6px 10px;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .ctxmenu button:hover:not(:disabled) { background: rgba(255, 255, 255, 0.08); }
+    .ctxmenu button:disabled { opacity: 0.35; cursor: default; }
+    .ctxmenu hr { border: 0; border-top: 1px solid rgba(255, 255, 255, 0.1); margin: 4px 2px; }
+
+    .confirm-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.45);
+      z-index: 130;
+      display: none;
+      align-items: center;
+      justify-content: center;
+    }
+    .confirm-backdrop[data-open] { display: flex; }
+    .confirm {
+      width: 300px;
+      max-width: calc(100vw - 32px);
+      background: #2a2a2a;
+      color: #e8e8e8;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+    .confirm .body { padding: 18px 18px 14px; }
+    .confirm .title { font-size: 14px; font-weight: 600; margin-bottom: 4px; }
+    .confirm .msg { font-size: 13px; line-height: 1.5; color: rgba(255, 255, 255, 0.65); }
+    .confirm .footer {
+      padding: 12px 18px;
+      background: #1f1f1f;
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+    .confirm button {
+      appearance: none;
+      font: inherit;
+      font-size: 13px;
+      padding: 7px 14px;
+      border-radius: 8px;
+      cursor: pointer;
+      border: 0;
+    }
+    .confirm .cancel { background: transparent; color: rgba(255, 255, 255, 0.8); }
+    .confirm .cancel:hover { background: rgba(255, 255, 255, 0.08); }
+    .confirm .danger { background: #c0442c; color: #fff; }
+    .confirm .danger:hover { background: #ad3c26; }
+
+    .toast {
+      position: fixed;
+      left: 50%;
+      bottom: 64px;
+      transform: translateX(-50%);
+      background: #c0442c;
+      color: #fff;
+      font-size: 12px;
+      padding: 8px 14px;
+      border-radius: 8px;
+      z-index: 140;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .toast[data-visible] { opacity: 1; }
+
+    /* Edit-mode affordance: a subtle outline on the hovered/focused slide. */
+    :host([data-edit-mode]) ::slotted([data-deck-active]) {
+      outline: 1px dashed rgba(110, 139, 255, 0.5);
+      outline-offset: -1px;
+    }
+
+    /* ── Print: one page per slide, no chrome ───────────────────────────
+       Screen layout stacks slides inside a scaled canvas; for print they
+       go into document flow at the authored design size so the browser
+       paginates one slide per sheet. The @page rule is injected into
+       document <head> (no effect inside shadow DOM). */
+    @media print {
+      :host {
+        position: static;
+        inset: auto;
+        background: none;
+        overflow: visible;
+        color: inherit;
+      }
+      .stage { position: static; display: block; }
+      .canvas {
+        transform: none !important;
+        width: auto !important;
+        height: auto !important;
+        background: none;
+        will-change: auto;
+      }
+      ::slotted(*) {
+        position: relative !important;
+        inset: auto !important;
+        width: var(--deck-design-w) !important;
+        height: var(--deck-design-h) !important;
+        box-sizing: border-box !important;
+        opacity: 1 !important;
+        visibility: visible !important;
+        pointer-events: auto;
+        break-after: page;
+        page-break-after: always;
+        break-inside: avoid;
+        overflow: hidden;
+      }
+      /* The last *visible* slide must not force a trailing blank page —
+         :last-child alone misses the case where trailing slides are
+         skipped. _markLastVisible() maintains the attribute. */
+      ::slotted(*:last-child),
+      ::slotted([data-deck-last-visible]) {
+        break-after: auto;
+        page-break-after: auto;
+      }
+      ::slotted([data-deck-skip]) { display: none !important; }
+      .overlay, .rail, .rail-resize, .ctxmenu, .confirm-backdrop, .toast {
+        display: none !important;
+      }
+    }
+  `;
+
+  class DeckViewer extends HTMLElement {
+    static get observedAttributes() {
+      return ["width", "height", "no-rail"];
+    }
+
+    constructor() {
+      super();
+      this._root = this.attachShadow({ mode: "open" });
+      this._index = 0;
+      this._slides = [];
+      this._thumbs = [];
+      this._editMode = false;
+      this._railOpen = false;
+      this._opSeq = 0;
+      this._pendingAcks = new Map();
+      this._railLocked = false;
+      this._menuIndex = -1;
+      this._confirmIndex = -1;
+      this._dragFrom = null;
+      this._dropOn = null;
+      this._hideTimer = null;
+      this._printed = false;
+
+      this._onKey = this._onKey.bind(this);
+      this._onResize = this._onResize.bind(this);
+      this._onMessage = this._onMessage.bind(this);
+      this._onMouseMove = this._onMouseMove.bind(this);
+      this._onTap = this._onTap.bind(this);
+      this._onHashChange = this._onHashChange.bind(this);
+      this._onBeforePrint = this._onBeforePrint.bind(this);
+      this._onAfterPrint = this._onAfterPrint.bind(this);
+      this._onFocusIn = this._onFocusIn.bind(this);
+      this._onFocusOut = this._onFocusOut.bind(this);
+      this._onInput = this._onInput.bind(this);
+      this._onDocClick = (e) => {
+        if (this._menu && e.composedPath().includes(this._menu)) return;
+        this._closeMenu();
+      };
+    }
+
+    get designWidth() {
+      return parseInt(this.getAttribute("width"), 10) || DESIGN_W_DEFAULT;
+    }
+    get designHeight() {
+      return parseInt(this.getAttribute("height"), 10) || DESIGN_H_DEFAULT;
+    }
+
+    connectedCallback() {
+      this._render();
+      this._syncPrintPageRule();
+      window.addEventListener("keydown", this._onKey);
+      window.addEventListener("resize", this._onResize);
+      window.addEventListener("message", this._onMessage);
+      window.addEventListener("mousemove", this._onMouseMove, {
+        passive: true,
+      });
+      window.addEventListener("hashchange", this._onHashChange);
+      window.addEventListener("beforeprint", this._onBeforePrint);
+      window.addEventListener("afterprint", this._onAfterPrint);
+      window.addEventListener("click", this._onDocClick, true);
+      this.addEventListener("click", this._onTap);
+      this.addEventListener("focusin", this._onFocusIn);
+      this.addEventListener("focusout", this._onFocusOut);
+      this.addEventListener("input", this._onInput);
+      // Initial slide collection happens via slotchange (fires on mount).
+      this._maybeAutoPrint();
+    }
+
+    disconnectedCallback() {
+      window.removeEventListener("keydown", this._onKey);
+      window.removeEventListener("resize", this._onResize);
+      window.removeEventListener("message", this._onMessage);
+      window.removeEventListener("mousemove", this._onMouseMove);
+      window.removeEventListener("hashchange", this._onHashChange);
+      window.removeEventListener("beforeprint", this._onBeforePrint);
+      window.removeEventListener("afterprint", this._onAfterPrint);
+      window.removeEventListener("click", this._onDocClick, true);
+      this.removeEventListener("click", this._onTap);
+      this.removeEventListener("focusin", this._onFocusIn);
+      this.removeEventListener("focusout", this._onFocusOut);
+      this.removeEventListener("input", this._onInput);
+      if (this._hideTimer) clearTimeout(this._hideTimer);
+      if (this._textDebounce) clearTimeout(this._textDebounce);
+      this._pendingAcks.forEach((p) => clearTimeout(p.timer));
+      this._pendingAcks.clear();
+    }
+
+    attributeChangedCallback() {
+      if (!this._canvas) return;
+      this._applyDesignSize();
+      this._fit();
+      this._scaleThumbs();
+      this._syncPrintPageRule();
+    }
+
+    // ── Rendering ─────────────────────────────────────────────────────
+
+    _render() {
+      const style = document.createElement("style");
+      style.textContent = stylesheet;
+
+      const stage = document.createElement("div");
+      stage.className = "stage";
+      const canvas = document.createElement("div");
+      canvas.className = "canvas";
+      const slot = document.createElement("slot");
+      slot.addEventListener("slotchange", () => this._onSlotChange());
+      canvas.appendChild(slot);
+      stage.appendChild(canvas);
+
+      const overlay = document.createElement("div");
+      overlay.className = "overlay";
+      overlay.setAttribute("role", "toolbar");
+      overlay.setAttribute("aria-label", "Deck controls");
+      overlay.innerHTML = `
+        <button class="btn prev" type="button" aria-label="Previous slide" title="Previous (←)">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 3L5 8l5 5"/></svg>
+        </button>
+        <span class="count" aria-live="polite"><span class="current">1</span><span class="total"> / 1</span></span>
+        <button class="btn next" type="button" aria-label="Next slide" title="Next (→)">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3l5 5-5 5"/></svg>
+        </button>
+      `;
+      overlay
+        .querySelector(".prev")
+        .addEventListener("click", () => this._advance(-1));
+      overlay
+        .querySelector(".next")
+        .addEventListener("click", () => this._advance(1));
+
+      const rail = document.createElement("div");
+      rail.className = "rail";
+
+      const resize = document.createElement("div");
+      resize.className = "rail-resize";
+      resize.addEventListener("pointerdown", (e) => {
+        e.preventDefault();
+        resize.setPointerCapture(e.pointerId);
+        resize.setAttribute("data-dragging", "");
+        const move = (ev) => this._setRailWidth(ev.clientX);
+        const up = () => {
+          resize.removeEventListener("pointermove", move);
+          resize.removeEventListener("pointerup", up);
+          resize.removeEventListener("pointercancel", up);
+          resize.removeAttribute("data-dragging");
+          try {
+            localStorage.setItem("deck-viewer.railWidth", String(this._railPx));
+          } catch {
+            /* opaque origin */
+          }
+        };
+        resize.addEventListener("pointermove", move);
+        resize.addEventListener("pointerup", up);
+        resize.addEventListener("pointercancel", up);
+      });
+
+      const menu = document.createElement("div");
+      menu.className = "ctxmenu";
+      menu.innerHTML = `
+        <button type="button" data-act="skip">Skip slide</button>
+        <button type="button" data-act="up">Move up</button>
+        <button type="button" data-act="down">Move down</button>
+        <button type="button" data-act="duplicate">Duplicate slide</button>
+        <hr>
+        <button type="button" data-act="delete">Delete slide</button>
+      `;
+      menu.addEventListener("click", (e) => {
+        const act =
+          e.target instanceof Element && e.target.getAttribute("data-act");
+        if (!act) return;
+        const i = this._menuIndex;
+        this._closeMenu();
+        if (act === "skip") this._toggleSkip(i);
+        else if (act === "up") this._moveSlide(i, i - 1);
+        else if (act === "down") this._moveSlide(i, i + 1);
+        else if (act === "duplicate") this._duplicateSlide(i);
+        else if (act === "delete") this._openConfirm(i);
+      });
+      menu.addEventListener("contextmenu", (e) => e.preventDefault());
+
+      const confirm = document.createElement("div");
+      confirm.className = "confirm-backdrop";
+      confirm.innerHTML = `
+        <div class="confirm" role="dialog" aria-modal="true">
+          <div class="body">
+            <div class="title">Delete slide?</div>
+            <div class="msg">This slide will be removed from the deck.</div>
+          </div>
+          <div class="footer">
+            <button type="button" class="cancel">Cancel</button>
+            <button type="button" class="danger">Delete</button>
+          </div>
+        </div>
+      `;
+      confirm.addEventListener("click", (e) => {
+        if (e.target === confirm) this._closeConfirm();
+      });
+      confirm
+        .querySelector(".cancel")
+        .addEventListener("click", () => this._closeConfirm());
+      confirm.querySelector(".danger").addEventListener("click", () => {
+        const i = this._confirmIndex;
+        this._closeConfirm();
+        this._deleteSlide(i);
+      });
+
+      const toast = document.createElement("div");
+      toast.className = "toast";
+
+      this._root.append(
+        style,
+        rail,
+        resize,
+        stage,
+        overlay,
+        menu,
+        confirm,
+        toast,
+      );
+      this._canvas = canvas;
+      this._stage = stage;
+      this._overlay = overlay;
+      this._rail = rail;
+      this._menu = menu;
+      this._confirm = confirm;
+      this._toast = toast;
+      this._countEl = overlay.querySelector(".current");
+      this._totalEl = overlay.querySelector(".total");
+
+      this._applyDesignSize();
+      let rw = RAIL_DEFAULT_W;
+      try {
+        const s = localStorage.getItem("deck-viewer.railWidth");
+        if (s) rw = parseInt(s, 10) || rw;
+      } catch {
+        /* opaque origin */
+      }
+      this._setRailWidth(rw);
+    }
+
+    _applyDesignSize() {
+      this._canvas.style.width = `${this.designWidth}px`;
+      this._canvas.style.height = `${this.designHeight}px`;
+      this._canvas.style.setProperty(
+        "--deck-design-w",
+        `${this.designWidth}px`,
+      );
+      this._canvas.style.setProperty(
+        "--deck-design-h",
+        `${this.designHeight}px`,
+      );
+      if (this._rail) {
+        this._rail.style.setProperty(
+          "--deck-aspect",
+          `${this.designWidth} / ${this.designHeight}`,
+        );
+      }
+    }
+
+    _setRailWidth(px) {
+      const w = Math.max(110, Math.min(340, Math.round(px)));
+      this._railPx = w;
+      this.style.setProperty("--deck-rail-w", `${w}px`);
+      this._fit();
+      if (!this._scaleRaf) {
+        this._scaleRaf = requestAnimationFrame(() => {
+          this._scaleRaf = null;
+          this._scaleThumbs();
+        });
+      }
+    }
+
+    /** @page must live in the document stylesheet — it's a no-op inside
+     *  shadow DOM. One injected <head> style tag makes Print → Save as PDF
+     *  yield one slide per page at design size with no margins. */
+    _syncPrintPageRule() {
+      const id = "deck-viewer-print-page";
+      let tag = document.getElementById(id);
+      if (!tag) {
+        tag = document.createElement("style");
+        tag.id = id;
+        document.head.appendChild(tag);
+      }
+      tag.textContent =
+        `@page { size: ${this.designWidth}px ${this.designHeight}px; margin: 0; } ` +
+        "@media print { html, body { margin: 0 !important; padding: 0 !important; " +
+        "background: none !important; overflow: visible !important; height: auto !important; } " +
+        "* { -webkit-print-color-adjust: exact; print-color-adjust: exact; } " +
+        // Jump animations/transitions to their end state so print never
+        // captures a mid-entrance frame — pairs with the beforeprint
+        // handler that marks every slide active.
+        "*, *::before, *::after { animation-delay: -99s !important; " +
+        "animation-duration: 0.001s !important; animation-iteration-count: 1 !important; " +
+        "animation-fill-mode: both !important; transition-duration: 0s !important; } }";
+    }
+
+    // ── Slide collection & navigation ─────────────────────────────────
+
+    _onSlotChange() {
+      this._collectSlides();
+      // Deep-link hash applies only on the initial collection — later
+      // slotchanges come from structural edits that already adjusted
+      // _index, and the stale hash must not override them.
+      if (!this._readySent) this._applyHash({ initial: true });
+      this._applyIndex({ showOverlay: false });
+      this._fit();
+      if (!this._readySent) {
+        this._readySent = true;
+        this._post({
+          type: "ready",
+          total: this._slides.length,
+          design: { width: this.designWidth, height: this.designHeight },
+        });
+      }
+    }
+
+    _collectSlides() {
+      const assigned = this._root
+        .querySelector("slot")
+        .assignedElements({ flatten: true });
+      this._slides = assigned.filter(
+        (el) => !/^(TEMPLATE|SCRIPT|STYLE)$/.test(el.tagName),
+      );
+      if (this._index >= this._slides.length) {
+        this._index = Math.max(0, this._slides.length - 1);
+      }
+      if (this._totalEl)
+        this._totalEl.textContent = ` / ${this._slides.length || 1}`;
+      this._markLastVisible();
+      this._renderRail();
+      this._syncEditable();
+    }
+
+    _markLastVisible() {
+      let last = null;
+      for (const s of this._slides) {
+        s.removeAttribute("data-deck-last-visible");
+        if (!s.hasAttribute("data-deck-skip")) last = s;
+      }
+      if (last) last.setAttribute("data-deck-last-visible", "");
+    }
+
+    /** Hash grammar: comma/&-separated tokens — a 1-based number is the
+     *  slide deep-link, `rail` opens the thumbnail rail, `print` triggers
+     *  the PDF-export auto-print. Examples: #3, #rail, #3,rail, #print. */
+    _parseHash() {
+      const tokens = (location.hash || "")
+        .replace(/^#/, "")
+        .split(/[,&]/)
+        .filter(Boolean);
+      const out = { slide: null, rail: false, print: false };
+      for (const t of tokens) {
+        if (/^\d+$/.test(t)) out.slide = parseInt(t, 10) - 1;
+        else if (t === "rail") out.rail = true;
+        else if (t === "print") out.print = true;
+      }
+      return out;
+    }
+
+    /** Mirror slide + rail state into the hash so a copied/reloaded URL
+     *  restores the view. replaceState (no history entries, no hashchange
+     *  loop) — throws in the opaque-origin preview iframe, where the
+     *  host owns the state instead; safe to skip. */
+    _writeHash() {
+      const tokens = [String(this._index + 1)];
+      if (this._railOpen) tokens.push("rail");
+      try {
+        history.replaceState(null, "", `#${tokens.join(",")}`);
+      } catch {
+        /* sandboxed iframe */
+      }
+    }
+
+    _applyHash({ initial = false } = {}) {
+      const h = this._parseHash();
+      if (h.slide !== null && h.slide >= 0 && h.slide < this._slides.length) {
+        this._index = h.slide;
+      }
+      this._setRailOpen(h.rail, { writeHash: false });
+      if (!initial) this._applyIndex({ showOverlay: false });
+      if (h.print) this._maybeAutoPrint();
+    }
+
+    _setRailOpen(open, { writeHash = true } = {}) {
+      if (this._railOpen === open) return;
+      this._railOpen = open;
+      if (open) this.setAttribute("data-rail-open", "");
+      else this.removeAttribute("data-rail-open");
+      this._fit();
+      if (open) requestAnimationFrame(() => this._scaleThumbs());
+      if (writeHash) this._writeHash();
+    }
+
+    _applyIndex({ showOverlay = true } = {}) {
+      if (!this._slides.length) return;
+      const curr = this._index;
+      this._slides.forEach((s, i) => {
+        if (i === curr) s.setAttribute("data-deck-active", "");
+        else s.removeAttribute("data-deck-active");
+      });
+      if (this._countEl) this._countEl.textContent = String(curr + 1);
+      this._thumbs.forEach((t, i) => {
+        if (i === curr) {
+          t.thumb.setAttribute("data-current", "");
+          t.thumb.scrollIntoView({ block: "nearest" });
+        } else {
+          t.thumb.removeAttribute("data-current");
+        }
+      });
+      this._post({
+        type: "state",
+        index: curr,
+        total: this._slides.length,
+        skipped: this._skippedIndices(),
+      });
+      if (showOverlay) this._flashOverlay();
+    }
+
+    _skippedIndices() {
+      const out = [];
+      this._slides.forEach((s, i) => {
+        if (s.hasAttribute("data-deck-skip")) out.push(i);
+      });
+      return out;
+    }
+
+    _go(i, { showOverlay = true } = {}) {
+      if (!this._slides.length) return;
+      const clamped = Math.max(0, Math.min(this._slides.length - 1, i));
+      if (clamped === this._index) {
+        if (showOverlay) this._flashOverlay();
+        return;
+      }
+      this._index = clamped;
+      this._applyIndex({ showOverlay });
+      this._writeHash();
+    }
+
+    /** Step forward/back skipping data-deck-skip slides. */
+    _advance(dir) {
+      if (!this._slides.length) return;
+      let i = this._index + dir;
+      while (
+        i >= 0 &&
+        i < this._slides.length &&
+        this._slides[i].hasAttribute("data-deck-skip")
+      ) {
+        i += dir;
+      }
+      if (i < 0 || i >= this._slides.length) {
+        this._flashOverlay();
+        return;
+      }
+      this._go(i);
+    }
+
+    _flashOverlay() {
+      if (!this._overlay) return;
+      this._overlay.setAttribute("data-visible", "");
+      if (this._hideTimer) clearTimeout(this._hideTimer);
+      this._hideTimer = setTimeout(() => {
+        this._overlay.removeAttribute("data-visible");
+      }, OVERLAY_HIDE_MS);
+    }
+
+    _onMouseMove() {
+      this._flashOverlay();
+    }
+
+    _onResize() {
+      this._fit();
+      if (!this._scaleRaf) {
+        this._scaleRaf = requestAnimationFrame(() => {
+          this._scaleRaf = null;
+          this._scaleThumbs();
+        });
+      }
+    }
+
+    _railWidth() {
+      if (
+        !this._railOpen ||
+        this.hasAttribute("no-rail") ||
+        NARROW_MQ.matches
+      ) {
+        return 0;
+      }
+      return this._railPx || 0;
+    }
+
+    _fit() {
+      if (!this._canvas) return;
+      const rw = this._railWidth();
+      if (this._stage) this._stage.style.left = `${rw}px`;
+      if (this._overlay) this._overlay.style.marginLeft = `${rw / 2}px`;
+      const vw = window.innerWidth - rw;
+      const vh = window.innerHeight;
+      const s = Math.min(vw / this.designWidth, vh / this.designHeight);
+      this._canvas.style.transform = `scale(${s})`;
+    }
+
+    _onKey(e) {
+      const t = e.target;
+      // Don't steal keys while the user is typing (edit mode / inputs).
+      if (
+        t &&
+        (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))
+      )
+        return;
+      if (this._editingSlide) return;
+      if (this._confirm.hasAttribute("data-open")) {
+        if (e.key === "Escape") {
+          this._closeConfirm();
+          e.preventDefault();
+        }
+        return;
+      }
+      if (e.key === "Escape" && this._menu.hasAttribute("data-open")) {
+        this._closeMenu();
+        e.preventDefault();
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const key = e.key;
+      let handled = true;
+      if (key === "ArrowRight" || key === "PageDown" || key === " ")
+        this._advance(1);
+      else if (key === "ArrowLeft" || key === "PageUp") this._advance(-1);
+      else if (key === "Home") this._go(0);
+      else if (key === "End") this._go(this._slides.length - 1);
+      else if (key === "r" || key === "R") this._go(0);
+      else if (/^[0-9]$/.test(key)) {
+        const n = key === "0" ? 9 : parseInt(key, 10) - 1;
+        if (n < this._slides.length) this._go(n);
+        else handled = false;
+      } else handled = false;
+
+      if (handled) {
+        e.preventDefault();
+        this._flashOverlay();
+      }
+    }
+
+    _onTap(e) {
+      // Touch-only — keyboard + overlay cover desktop nav. Never navigate
+      // in edit mode (taps select text instead).
+      if (FINE_POINTER_MQ.matches || this._editMode) return;
+      const path = e.composedPath();
+      if (!this._stage || !path.includes(this._stage)) return;
+      if (e.defaultPrevented) return;
+      for (const n of path) {
+        if (n === this._stage) break;
+        if (n instanceof Element && n.matches(INTERACTIVE_SEL)) return;
+      }
+      e.preventDefault();
+      const rw = this._railWidth();
+      const mid = rw + (window.innerWidth - rw) / 2;
+      this._advance(e.clientX < mid ? -1 : 1);
+    }
+
+    // ── Print / PDF export ────────────────────────────────────────────
+
+    _maybeAutoPrint() {
+      if (!this._parseHash().print || this._printed) return;
+      this._printed = true;
+      // Wait for webfonts so the PDF gets the deck's real typography;
+      // capped so a broken font URL can't block export forever.
+      const go = () => setTimeout(() => window.print(), 50);
+      Promise.race([
+        document.fonts ? document.fonts.ready : Promise.resolve(),
+        new Promise((r) => setTimeout(r, 2000)),
+      ]).then(go, go);
+    }
+
+    _onHashChange() {
+      if (this._parseHash().print) this._printed = false;
+      this._applyHash();
+    }
+
+    _onBeforePrint() {
+      // Print lays every slide out as its own page, so [data-deck-active]-
+      // gated entrance styles need the attribute on every slide.
+      this._slides.forEach((s) => s.setAttribute("data-deck-active", ""));
+    }
+
+    _onAfterPrint() {
+      this._applyIndex({ showOverlay: false });
+    }
+
+    // ── postMessage protocol ──────────────────────────────────────────
+
+    _post(msg) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage(
+          { v: PROTOCOL_V, source: "deck-viewer", ...msg },
+          "*",
+        );
+      } catch {
+        /* parent gone */
+      }
+    }
+
+    _onMessage(e) {
+      const d = e.data;
+      if (!d || d.v !== PROTOCOL_V || typeof d.type !== "string") return;
+      if (d.type === "ack" && typeof d.opId === "string") {
+        const pending = this._pendingAcks.get(d.opId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this._pendingAcks.delete(d.opId);
+        if (pending.structural) this._railLocked = this._hasPendingStructural();
+        if (d.ok === false) {
+          this._showToast("Couldn't save the change — reload the preview.");
+        }
+      } else if (d.type === "set-edit-mode") {
+        this._setEditMode(Boolean(d.enabled));
+      } else if (d.type === "set-rail") {
+        this._setRailOpen(Boolean(d.open));
+      } else if (d.type === "goto" && typeof d.index === "number") {
+        this._go(d.index, { showOverlay: false });
+      } else if (d.type === "print") {
+        window.print();
+      }
+    }
+
+    _hasPendingStructural() {
+      for (const p of this._pendingAcks.values()) {
+        if (p.structural) return true;
+      }
+      return false;
+    }
+
+    /** Emit an op to the parent. Structural ops lock the rail until the
+     *  ack lands so a rapid second click can't address stale indices. */
+    _emitOp(op, { structural = false } = {}) {
+      const opId = `op-${++this._opSeq}`;
+      if (window.parent !== window) {
+        const timer = setTimeout(() => {
+          this._pendingAcks.delete(opId);
+          this._railLocked = this._hasPendingStructural();
+          this._showToast("Save timed out — reload the preview.");
+        }, ACK_TIMEOUT_MS);
+        this._pendingAcks.set(opId, { timer, structural });
+        if (structural) this._railLocked = true;
+      }
+      this._post({
+        type: "op",
+        opId,
+        witness: { childCount: this._slides.length },
+        op,
+      });
+    }
+
+    _showToast(text) {
+      if (!this._toast) return;
+      this._toast.textContent = text;
+      this._toast.setAttribute("data-visible", "");
+      clearTimeout(this._toastTimer);
+      this._toastTimer = setTimeout(() => {
+        this._toast.removeAttribute("data-visible");
+      }, 4000);
+    }
+
+    // ── Edit mode ─────────────────────────────────────────────────────
+
+    _setEditMode(enabled) {
+      if (this._editMode === enabled) return;
+      this._editMode = enabled;
+      if (enabled) this.setAttribute("data-edit-mode", "");
+      else this.removeAttribute("data-edit-mode");
+      // Structural ops (reorder/duplicate/delete/skip) live in the rail —
+      // editing without it would be a dead end.
+      if (enabled) this._setRailOpen(true);
+      this._syncEditable();
+      if (!enabled) {
+        this._flushTextEdit();
+        this._closeMenu();
+        this._closeConfirm();
+      }
+    }
+
+    _syncEditable() {
+      for (const s of this._slides) {
+        if (this._editMode) {
+          s.setAttribute("contenteditable", "true");
+          s.setAttribute("spellcheck", "false");
+        } else {
+          s.removeAttribute("contenteditable");
+          s.removeAttribute("spellcheck");
+        }
+      }
+    }
+
+    _onFocusIn(e) {
+      if (!this._editMode) return;
+      const slide = this._slideFromNode(e.target);
+      if (!slide) return;
+      if (this._editingSlide && this._editingSlide !== slide)
+        this._flushTextEdit();
+      this._editingSlide = slide;
+      this._editingSnapshot = slide.innerHTML;
+    }
+
+    _onFocusOut() {
+      if (!this._editingSlide) return;
+      // focusout fires before the new focus target settles; defer so a
+      // focus move WITHIN the same slide doesn't flush.
+      setTimeout(() => {
+        const active = document.activeElement;
+        if (active && this._slideFromNode(active) === this._editingSlide)
+          return;
+        this._flushTextEdit();
+      }, 0);
+    }
+
+    _onInput(e) {
+      if (!this._editMode) return;
+      const slide = this._slideFromNode(e.target);
+      if (!slide || slide !== this._editingSlide) return;
+      clearTimeout(this._textDebounce);
+      this._textDebounce = setTimeout(
+        () => this._flushTextEdit({ keepFocus: true }),
+        TEXT_EDIT_DEBOUNCE_MS,
+      );
+      // Live thumbnail update is cheap enough on the debounce flush only.
+    }
+
+    _slideFromNode(node) {
+      let n = node;
+      while (n && n.parentElement !== this) n = n.parentElement;
+      return n && this._slides.includes(n) ? n : null;
+    }
+
+    /** Post the edited slide's cleaned HTML if it changed. */
+    _flushTextEdit({ keepFocus = false } = {}) {
+      clearTimeout(this._textDebounce);
+      const slide = this._editingSlide;
+      if (!slide) return;
+      if (!keepFocus) {
+        this._editingSlide = null;
+      }
+      const snapshot = this._editingSnapshot;
+      if (slide.innerHTML === snapshot) return;
+      this._editingSnapshot = slide.innerHTML;
+      const at = this._slides.indexOf(slide);
+      if (at < 0) return;
+      this._emitOp({ kind: "replace", at, html: this._cleanSlideHtml(slide) });
+      this._refreshThumb(at);
+    }
+
+    /** Clone + strip runtime-managed attributes so persisted HTML is clean. */
+    _cleanSlideHtml(slide) {
+      const clone = slide.cloneNode(true);
+      for (const attr of RUNTIME_ATTRS) clone.removeAttribute(attr);
+      return clone.outerHTML;
+    }
+
+    // ── Structural ops (self-apply + emit) ────────────────────────────
+
+    _deleteSlide(i) {
+      if (this._railLocked) return;
+      const slide = this._slides[i];
+      if (!slide || this._slides.length <= 1) return;
+      const cur = this._index;
+      this._index =
+        i < cur || (i === cur && i === this._slides.length - 1) ? cur - 1 : cur;
+      this._emitOp({ kind: "remove", at: i }, { structural: true });
+      slide.remove(); // slotchange re-collects + re-renders the rail
+    }
+
+    _duplicateSlide(i) {
+      if (this._railLocked) return;
+      const slide = this._slides[i];
+      if (!slide) return;
+      this._emitOp({ kind: "duplicate", at: i }, { structural: true });
+      const copy = slide.cloneNode(true);
+      for (const attr of RUNTIME_ATTRS) copy.removeAttribute(attr);
+      copy.removeAttribute("id");
+      copy.querySelectorAll("[id]").forEach((el) => el.removeAttribute("id"));
+      this._index = i + 1;
+      this.insertBefore(copy, slide.nextSibling);
+    }
+
+    _moveSlide(i, j) {
+      if (this._railLocked || j < 0 || j >= this._slides.length || j === i)
+        return;
+      const cur = this._index;
+      this._index =
+        cur === i
+          ? j
+          : i < cur && j >= cur
+            ? cur - 1
+            : i > cur && j <= cur
+              ? cur + 1
+              : cur;
+      const slide = this._slides[i];
+      this._emitOp({ kind: "move", from: i, to: j }, { structural: true });
+      const ref = j < i ? this._slides[j] : this._slides[j].nextSibling;
+      this.insertBefore(slide, ref);
+    }
+
+    _toggleSkip(i) {
+      if (this._railLocked) return;
+      const slide = this._slides[i];
+      if (!slide) return;
+      const on = !slide.hasAttribute("data-deck-skip");
+      this._emitOp(
+        on
+          ? { kind: "set-attr", at: i, name: "data-deck-skip", value: "" }
+          : { kind: "remove-attr", at: i, name: "data-deck-skip" },
+        { structural: true },
+      );
+      if (on) slide.setAttribute("data-deck-skip", "");
+      else slide.removeAttribute("data-deck-skip");
+      this._markLastVisible();
+      const t = this._thumbs[i];
+      if (t) {
+        if (on) t.thumb.setAttribute("data-skip", "");
+        else t.thumb.removeAttribute("data-skip");
+      }
+      this._post({
+        type: "state",
+        index: this._index,
+        total: this._slides.length,
+        skipped: this._skippedIndices(),
+      });
+    }
+
+    // ── Thumbnail rail ────────────────────────────────────────────────
+    //
+    // Thumbs are static deep clones rendered inside a nested shadow root
+    // per frame. Custom properties inherit across shadow boundaries, and
+    // deck templates are inline-style-first, so cloning + a snapshot of
+    // the document's stylesheets covers authored styling without the
+    // :root-rewriting machinery a fully general solution would need.
+
+    _authorSheet() {
+      if (this._sheet !== undefined) return this._sheet;
+      const css = Array.from(document.styleSheets)
+        .map((sh) => {
+          try {
+            return Array.from(sh.cssRules)
+              .map((r) => r.cssText)
+              .join("\n");
+          } catch {
+            return ""; // cross-origin sheet
+          }
+        })
+        .join("\n");
+      try {
+        this._sheet = new CSSStyleSheet();
+        this._sheet.replaceSync(css);
+      } catch {
+        this._sheet = null;
+        this._sheetCss = css;
+      }
+      return this._sheet;
+    }
+
+    _renderRail() {
+      if (!this._rail) return;
+      const st = this._rail.scrollTop;
+      // Reconcile: reuse thumbs keyed by slide element.
+      const bySlide = new Map();
+      for (const t of this._thumbs) bySlide.set(t.slide, t);
+      const next = [];
+      for (const slide of this._slides) {
+        let t = bySlide.get(slide);
+        if (t) bySlide.delete(slide);
+        else t = this._makeThumb(slide);
+        next.push(t);
+      }
+      bySlide.forEach((t) => t.thumb.remove());
+      next.forEach((t, i) => {
+        const at = this._rail.children[i];
+        if (at !== t.thumb) this._rail.insertBefore(t.thumb, at || null);
+        t.i = i;
+        t.num.textContent = String(i + 1);
+        if (t.slide.hasAttribute("data-deck-skip"))
+          t.thumb.setAttribute("data-skip", "");
+        else t.thumb.removeAttribute("data-skip");
+      });
+      this._thumbs = next;
+      this._rail.scrollTop = st;
+      requestAnimationFrame(() => this._scaleThumbs());
+    }
+
+    _makeThumb(slide) {
+      const thumb = document.createElement("div");
+      thumb.className = "thumb";
+      thumb.tabIndex = 0;
+      const num = document.createElement("div");
+      num.className = "num";
+      const frame = document.createElement("div");
+      frame.className = "frame";
+      thumb.append(num, frame);
+
+      const entry = { thumb, num, frame, slide, clone: null, i: -1 };
+      const idx = () => entry.i;
+
+      thumb.addEventListener("click", () => this._go(idx()));
+      thumb.addEventListener("keydown", (e) => {
+        if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
+        e.preventDefault();
+        e.stopPropagation();
+        this._go(idx() + (e.key === "ArrowDown" ? 1 : -1));
+        const cur = this._thumbs[this._index];
+        if (cur) cur.thumb.focus({ preventScroll: true });
+      });
+      thumb.addEventListener("contextmenu", (e) => {
+        if (!this._editMode) return;
+        e.preventDefault();
+        this._openMenu(idx(), e.clientX, e.clientY);
+      });
+      thumb.draggable = true;
+      thumb.addEventListener("dragstart", (e) => {
+        if (!this._editMode || this._railLocked) {
+          e.preventDefault();
+          return;
+        }
+        this._dragFrom = idx();
+        thumb.setAttribute("data-dragging", "");
+        e.dataTransfer.effectAllowed = "move";
+        try {
+          e.dataTransfer.setData("text/plain", String(this._dragFrom));
+        } catch {
+          /* ignore */
+        }
+      });
+      thumb.addEventListener("dragend", () => {
+        thumb.removeAttribute("data-dragging");
+        this._clearDrop();
+        this._dragFrom = null;
+      });
+      thumb.addEventListener("dragover", (e) => {
+        if (this._dragFrom == null) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        const r = thumb.getBoundingClientRect();
+        this._setDrop(
+          idx(),
+          e.clientY < r.top + r.height / 2 ? "before" : "after",
+        );
+      });
+      thumb.addEventListener("drop", (e) => {
+        if (this._dragFrom == null) return;
+        e.preventDefault();
+        const i = idx();
+        const r = thumb.getBoundingClientRect();
+        let to = e.clientY >= r.top + r.height / 2 ? i + 1 : i;
+        if (this._dragFrom < to) to--;
+        const from = this._dragFrom;
+        this._clearDrop();
+        this._dragFrom = null;
+        if (to !== from) this._moveSlide(from, to);
+      });
+
+      this._materializeThumb(entry);
+      return entry;
+    }
+
+    _materializeThumb(entry) {
+      const dw = this.designWidth;
+      const dh = this.designHeight;
+      const clone = entry.slide.cloneNode(true);
+      for (const attr of RUNTIME_ATTRS) clone.removeAttribute(attr);
+      clone.removeAttribute("id");
+      clone.querySelectorAll("[id]").forEach((el) => el.removeAttribute("id"));
+      // Neuter heavy/stateful media in thumbnails.
+      clone
+        .querySelectorAll("iframe, audio, video, object, embed")
+        .forEach((el) => {
+          el.removeAttribute("src");
+          el.removeAttribute("srcdoc");
+          el.innerHTML = "";
+        });
+      clone.querySelectorAll("img").forEach((el) => {
+        el.loading = "lazy";
+        el.decoding = "async";
+      });
+      clone.style.cssText +=
+        ";position:absolute;top:0;left:0;transform-origin:0 0;pointer-events:none;" +
+        `width:${dw}px;height:${dh}px;box-sizing:border-box;overflow:hidden;` +
+        "visibility:visible;opacity:1;";
+      const host = document.createElement("div");
+      host.style.cssText = "position:absolute;inset:0;";
+      const sr = host.attachShadow({ mode: "open" });
+      const sheet = this._authorSheet();
+      if (sheet) {
+        sr.adoptedStyleSheets = [sheet];
+      } else if (this._sheetCss) {
+        const st = document.createElement("style");
+        st.textContent = this._sheetCss;
+        sr.appendChild(st);
+      }
+      sr.appendChild(clone);
+      entry.frame.textContent = "";
+      entry.frame.appendChild(host);
+      entry.clone = clone;
+      if (this._thumbScale)
+        clone.style.transform = `scale(${this._thumbScale})`;
+    }
+
+    _refreshThumb(i) {
+      const entry = this._thumbs[i];
+      if (entry) this._materializeThumb(entry);
+    }
+
+    _scaleThumbs() {
+      if (!this._thumbs.length) return;
+      const fw = this._thumbs[0].frame.offsetWidth;
+      if (!fw) return;
+      this._thumbScale = fw / this.designWidth;
+      for (const { clone } of this._thumbs) {
+        if (clone) clone.style.transform = `scale(${this._thumbScale})`;
+      }
+    }
+
+    _setDrop(i, where) {
+      const t = this._thumbs[i];
+      if (this._dropOn && this._dropOn !== t)
+        this._dropOn.thumb.removeAttribute("data-drop");
+      if (t) t.thumb.setAttribute("data-drop", where);
+      this._dropOn = t || null;
+    }
+
+    _clearDrop() {
+      if (this._dropOn) this._dropOn.thumb.removeAttribute("data-drop");
+      this._dropOn = null;
+    }
+
+    _openMenu(i, x, y) {
+      this._menuIndex = i;
+      const slide = this._slides[i];
+      const skip = slide && slide.hasAttribute("data-deck-skip");
+      this._menu.querySelector('[data-act="skip"]').textContent = skip
+        ? "Unskip slide"
+        : "Skip slide";
+      this._menu.querySelector('[data-act="up"]').disabled = i <= 0;
+      this._menu.querySelector('[data-act="down"]').disabled =
+        i >= this._slides.length - 1;
+      this._menu.querySelector('[data-act="delete"]').disabled =
+        this._slides.length <= 1;
+      this._menu.style.left = `${x}px`;
+      this._menu.style.top = `${y}px`;
+      this._menu.setAttribute("data-open", "");
+      const r = this._menu.getBoundingClientRect();
+      this._menu.style.left = `${Math.max(4, Math.min(x, window.innerWidth - r.width - 4))}px`;
+      this._menu.style.top = `${Math.max(4, Math.min(y, window.innerHeight - r.height - 4))}px`;
+    }
+
+    _closeMenu() {
+      this._menu.removeAttribute("data-open");
+      this._menuIndex = -1;
+    }
+
+    _openConfirm(i) {
+      this._confirmIndex = i;
+      this._confirm.querySelector(".title").textContent =
+        `Delete slide ${i + 1}?`;
+      this._confirm.setAttribute("data-open", "");
+      this._confirm.querySelector(".danger").focus();
+    }
+
+    _closeConfirm() {
+      this._confirm.removeAttribute("data-open");
+      this._confirmIndex = -1;
+    }
+
+    // ── Public API ────────────────────────────────────────────────────
+
+    get index() {
+      return this._index;
+    }
+    get length() {
+      return this._slides.length;
+    }
+    goTo(i) {
+      this._go(i);
+    }
+    next() {
+      this._advance(1);
+    }
+    prev() {
+      this._advance(-1);
+    }
+  }
+
+  if (!customElements.get("deck-viewer")) {
+    customElements.define("deck-viewer", DeckViewer);
+  }
+})();

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -234,10 +234,22 @@ export const createOrgFsRoutes = () => {
         return c.json({ url: await r.fs.presignRead(volume, path) });
       }
       const bytes = await r.fs.read(volume, path);
-      return c.body(Buffer.from(bytes), 200, {
-        "Content-Type": detectContentType(path),
+      const contentType = detectContentType(path);
+      const headers: Record<string, string> = {
+        "Content-Type": contentType,
         "Cache-Control": "private, max-age=0",
-      });
+      };
+      // Member-authored HTML (deck previews, generated pages) renders in
+      // sandboxed iframes AND can be opened top-level ("open in new tab",
+      // PDF export). CSP-sandbox the response so the top-level document
+      // also runs with an opaque origin — its scripts can't make
+      // credentialed same-origin calls. allow-modals keeps window.print()
+      // working for the deck PDF-export path.
+      if (contentType.startsWith("text/html")) {
+        headers["Content-Security-Policy"] =
+          "sandbox allow-scripts allow-modals";
+      }
+      return c.body(Buffer.from(bytes), 200, headers);
     } catch (err) {
       return fsErrorResponse(c, err);
     }

--- a/apps/mesh/src/file-storage/org-fs.ts
+++ b/apps/mesh/src/file-storage/org-fs.ts
@@ -392,6 +392,16 @@ export class OrgFs {
     };
   }
 
+  /** Latest change-feed cursor for a volume ("0" when empty). Use as the
+   *  starting point for "changes from now on" consumers. */
+  async latestSeq(volume: string): Promise<string> {
+    assertValidVolume(volume);
+    return this.manifest.latestSeq({
+      organizationId: this.organizationId,
+      volume,
+    });
+  }
+
   /**
    * Seed the manifest from objects already present in storage under a volume.
    * Idempotent — safe to re-run. Returns the number of file entries written.

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -37,6 +37,7 @@ import { createReadToolOutputTool } from "@decocms/harness/decopilot/built-in-to
 import { type VirtualClient } from "@decocms/harness/decopilot/built-in-tools/sandbox";
 import { createVmTools } from "@decocms/harness/decopilot/built-in-tools/vm-tools/index";
 import type { HtmlPageBuffer } from "./vm-tools/html-page-buffer";
+import type { DeckBuffer } from "@decocms/harness/decopilot/built-in-tools/vm-tools/types";
 import { buildClusterSandboxFs } from "./cluster-sandbox-fs";
 import { createSubtaskTool } from "./subtask";
 import { userAskTool } from "@decocms/harness/decopilot/built-in-tools/user-ask";
@@ -117,6 +118,8 @@ export interface BuiltinToolParams {
    * burst of edits collapses to one S3 PUT.
    */
   htmlPageBuffer: HtmlPageBuffer;
+  /** Per-turn deck fast-path mirror (see `DeckBuffer`). */
+  deckBuffer?: DeckBuffer;
   /** Thread (task) id of the current run — needed by tools that persist
    *  thread-scoped state (e.g. web_search reconnecting to Gemini Deep Research). */
   taskId: string;
@@ -159,6 +162,7 @@ async function buildAllTools(
     passthroughClient,
     vmContext,
     htmlPageBuffer,
+    deckBuffer,
     taskId,
     agentId,
     onChildUsage,
@@ -216,6 +220,7 @@ async function buildAllTools(
     vmTools = createVmTools({
       fs,
       htmlPageBuffer,
+      deckBuffer,
       toolOutputMap,
       needsApproval: vmNeedsApproval,
       pendingImages,

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-buffer.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-buffer.ts
@@ -1,0 +1,57 @@
+/**
+ * Deck buffer (cluster glue) — fast-path mirror for `write`/`edit` tool
+ * calls on `org/<slug>/decks/<name>.html`. The sandbox mount's vfs
+ * write-back takes seconds to reach org-fs; mirroring the tool's full
+ * content server-side at step end makes the deck preview (and the
+ * change-feed deck watcher, which emits the `data-deck-updated` part)
+ * see the bytes immediately. The mount's own later write-back uploads
+ * identical content, so the two paths converge.
+ *
+ * Coalesces per path like the html-page buffer: a burst of writes/edits
+ * to the same deck collapses to one org-fs write per step.
+ */
+
+import type { StudioContext } from "@/core/studio-context";
+import { homeMountPath } from "@/file-storage/home-mount";
+import { getSettings } from "@/settings";
+import { matchDeckToolPath } from "@decocms/harness/decopilot/built-in-tools/vm-tools/deck-paths";
+import type { DeckBuffer } from "@decocms/harness/decopilot/built-in-tools/vm-tools/types";
+
+const HOME_VOLUME = "home";
+
+const NOOP: DeckBuffer = { enqueue: () => {}, flush: async () => {} };
+
+export function createDeckBuffer(ctx: StudioContext): DeckBuffer {
+  const orgFs = getSettings().orgFsClusterMounts ? ctx.orgFs : null;
+  const orgSlug = ctx.organization?.slug ?? null;
+  const actor = ctx.auth?.user?.id ?? null;
+  if (!orgFs || !orgSlug || !actor) return NOOP;
+  const mountDir = homeMountPath(orgSlug);
+
+  const pending = new Map<string, string>();
+
+  return {
+    enqueue(rawPath, content) {
+      const deck = matchDeckToolPath(rawPath, mountDir);
+      if (!deck) return;
+      pending.set(deck.path, content);
+    },
+    async flush() {
+      if (pending.size === 0) return;
+      const entries = [...pending.entries()];
+      pending.clear();
+      await Promise.allSettled(
+        entries.map(async ([path, content]) => {
+          try {
+            await orgFs.write(HOME_VOLUME, path, content, {
+              actor,
+              contentType: "text/html; charset=utf-8",
+            });
+          } catch (err) {
+            console.error("[deck-buffer] org-fs write failed", { path }, err);
+          }
+        }),
+      );
+    },
+  };
+}

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-buffer.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-buffer.ts
@@ -4,8 +4,10 @@
  * write-back takes seconds to reach org-fs; mirroring the tool's full
  * content server-side at step end makes the deck preview (and the
  * change-feed deck watcher, which emits the `data-deck-updated` part)
- * see the bytes immediately. The mount's own later write-back uploads
- * identical content, so the two paths converge.
+ * see the bytes immediately. The mount's own later write-back re-uploads
+ * identical bytes — that echo still bumps the change feed (OrgFs.write
+ * doesn't compare contentHash), so the deck watcher dedupes emissions by
+ * content hash and the UI keys its cache marker on the hash too.
  *
  * Coalesces per path like the html-page buffer: a burst of writes/edits
  * to the same deck collapses to one org-fs write per step.

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-watcher.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-watcher.ts
@@ -1,0 +1,105 @@
+/**
+ * Deck watcher — detects presentation-deck writes (`decks/<name>.html` in
+ * the org home volume) during a run and emits `data-deck-updated` UI parts
+ * so the chat side panel opens/refreshes the live deck preview.
+ *
+ * Detection is change-feed based rather than tool-based: every sandbox
+ * write to the mounted `org/<slug>/` path flows through the WebDAV serve
+ * layer into `OrgFs.write` and the manifest change feed, so decks created
+ * via bash (the `slides-create` CLI) are caught the same as `write`-tool
+ * edits. The cursor snapshots at run start; `sweep()` is hooked into
+ * `onStepFinish` (and once more at run end — rclone's vfs write-back can
+ * land a few seconds after the file is closed in the sandbox).
+ *
+ * Parts use a stable `id` per deck path so the AI SDK reconciles repeated
+ * updates into one part per deck.
+ */
+
+import type { StudioContext } from "@/core/studio-context";
+import { homeMountPath } from "@/file-storage/home-mount";
+import { getSettings } from "@/settings";
+import { matchDeckEntryPath } from "@decocms/harness/decopilot/built-in-tools/vm-tools/deck-paths";
+import type { UIMessageStreamWriter } from "ai";
+
+const HOME_VOLUME = "home";
+const PAGE_SIZE = 200;
+
+export interface DeckWatcher {
+  /** Query the change feed since the last sweep and emit deck parts. */
+  sweep(): Promise<void>;
+}
+
+export interface DeckUpdatedData {
+  volume: string;
+  path: string;
+  name: string;
+  /** Mount-relative path the agent sees, for chat-row display. */
+  mountPath: string;
+}
+
+export function createDeckWatcher(
+  ctx: StudioContext,
+  writer: UIMessageStreamWriter,
+): DeckWatcher {
+  const orgFs = getSettings().orgFsClusterMounts ? ctx.orgFs : null;
+  const orgSlug = ctx.organization?.slug ?? null;
+  if (!orgFs || !orgSlug) {
+    return { sweep: async () => {} };
+  }
+  const mountDir = homeMountPath(orgSlug);
+
+  // Snapshot the cursor at run start so the first sweep only sees writes
+  // made during this run. Errors degrade to a dead watcher, never a
+  // failed run.
+  const cursorReady: Promise<string | null> = orgFs
+    .latestSeq(HOME_VOLUME)
+    .catch((err) => {
+      console.error("[deck-watcher] cursor snapshot failed", err);
+      return null;
+    });
+  let cursor: string | null = null;
+  let cursorInitialized = false;
+  let sweeping = false;
+
+  const sweep = async (): Promise<void> => {
+    if (sweeping) return; // sweeps are serialized; skip overlap
+    sweeping = true;
+    try {
+      if (!cursorInitialized) {
+        cursor = await cursorReady;
+        cursorInitialized = true;
+      }
+      if (cursor === null) return;
+      const updated = new Map<string, DeckUpdatedData>();
+      for (let pages = 0; pages < 20; pages++) {
+        const page = await orgFs.changes(HOME_VOLUME, cursor, PAGE_SIZE);
+        for (const entry of page.entries) {
+          if (entry.kind !== "file" || entry.deletedAt) continue;
+          const deck = matchDeckEntryPath(entry.path);
+          if (!deck) continue;
+          updated.set(deck.path, {
+            volume: HOME_VOLUME,
+            path: deck.path,
+            name: deck.name,
+            mountPath: `org/${mountDir}/${deck.path}`,
+          });
+        }
+        cursor = page.cursor;
+        if (!page.hasMore) break;
+      }
+      for (const data of updated.values()) {
+        writer.write({
+          type: "data-deck-updated",
+          id: data.path,
+          data,
+        });
+      }
+    } catch (err) {
+      console.error("[deck-watcher] sweep failed", err);
+    } finally {
+      sweeping = false;
+    }
+  };
+
+  return { sweep };
+}

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-watcher.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-watcher.ts
@@ -60,6 +60,11 @@ export function createDeckWatcher(
   let cursor: string | null = null;
   let cursorInitialized = false;
   let sweeping = false;
+  // Last emitted content hash per deck — the mount's vfs write-back
+  // re-writes the same bytes the fast-path mirror already stored, which
+  // bumps the change feed but changes nothing; skip those echoes so the
+  // UI doesn't reload/re-open the preview for identical content.
+  const emittedHash = new Map<string, string>();
 
   const sweep = async (): Promise<void> => {
     if (sweeping) return; // sweeps are serialized; skip overlap
@@ -77,6 +82,10 @@ export function createDeckWatcher(
           if (entry.kind !== "file" || entry.deletedAt) continue;
           const deck = matchDeckEntryPath(entry.path);
           if (!deck) continue;
+          if (entry.contentHash) {
+            if (emittedHash.get(deck.path) === entry.contentHash) continue;
+            emittedHash.set(deck.path, entry.contentHash);
+          }
           updated.set(deck.path, {
             volume: HOME_VOLUME,
             path: deck.path,

--- a/apps/mesh/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/mesh/src/harnesses/decopilot/harness-deps.ts
@@ -30,6 +30,8 @@ import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
 import type { SideChannelWriter } from "@decocms/harness/side-channel-writer";
 import { assembleDecopilotTools } from "./tools";
 import { buildClusterMcpToolHooks } from "@/api/routes/decopilot/cluster-mcp-tool-hooks";
+import { createDeckBuffer } from "./built-in-tools/vm-tools/deck-buffer";
+import { createDeckWatcher } from "./built-in-tools/vm-tools/deck-watcher";
 import { createHtmlPageBuffer } from "./built-in-tools/vm-tools/html-page-buffer";
 import type { PendingImage } from "./built-in-tools";
 import type {
@@ -112,6 +114,12 @@ export function buildClusterEnvironmentTools(args: {
 }): { toolRuntime: DecopilotToolRuntime; telemetry: DecopilotTelemetry } {
   const { ctx, organization, modelRuntime, sideChannel, cleanup } = args;
   const htmlPageBuffer = createHtmlPageBuffer(ctx, sideChannel.writer);
+  // Deck previews: change-feed watcher emitting `data-deck-updated` parts
+  // for `decks/<name>.html` writes in the org home volume (slides skill),
+  // plus the write/edit fast-path mirror that lands tool content in org-fs
+  // at step end (ahead of the mount's slow vfs write-back).
+  const deckWatcher = createDeckWatcher(ctx, sideChannel.writer);
+  const deckBuffer = createDeckBuffer(ctx);
 
   const toolRuntime: DecopilotToolRuntime = {
     buildEnvironmentTools: async ({ input: streamInput, onChildUsage }) => {
@@ -149,6 +157,7 @@ export function buildClusterEnvironmentTools(args: {
         deepResearchProvider:
           modelRuntime.deepResearch?.provider ?? modelRuntime.thinking.provider,
         htmlPageBuffer,
+        deckBuffer,
         // Roll subtask child usage into the parent run's accumulator
         // (Task 17). Threaded into the subtask tool via getBuiltInTools.
         onChildUsage,
@@ -170,6 +179,12 @@ export function buildClusterEnvironmentTools(args: {
           await htmlPageBuffer.flush().catch((err) => {
             console.error("[decopilot] html-page flush failed", err);
           });
+          // Deck fast-path mirror must land before the sweep so the
+          // change-feed entry it creates is picked up in the same step.
+          // Both swallow their own errors; late rclone write-backs are
+          // caught by the next step's sweep or the DeckTab stat poll.
+          await deckBuffer.flush();
+          await deckWatcher.sweep();
         },
         close: assembled.close,
       };

--- a/apps/mesh/src/harnesses/decopilot/tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/tools.ts
@@ -30,6 +30,7 @@ import {
   type VmContext,
 } from "./built-in-tools";
 import type { HtmlPageBuffer } from "./built-in-tools/vm-tools/html-page-buffer";
+import type { DeckBuffer } from "@decocms/harness/decopilot/built-in-tools/vm-tools/types";
 import type { ConnectionsBlockTool } from "@decocms/harness/decopilot/connections-block";
 import {
   toolsFromMCP,
@@ -111,6 +112,9 @@ export interface AssembleDecopilotToolsExtras {
    *  alongside `pendingOps` so the dispatch layer can also schedule a
    *  flush at step-end. */
   htmlPageBuffer: HtmlPageBuffer;
+  /** Per-turn deck fast-path mirror (`org/<slug>/decks/*.html`) — flushed
+   *  into org-fs at step-end by the dispatch layer. */
+  deckBuffer?: DeckBuffer;
   /** Usage roll-up sink (Task 17) — forwarded to the `subtask` built-in so a
    *  delegated child run's tokens fold into the parent run's accumulator. */
   onChildUsage?: (usage: {
@@ -305,6 +309,7 @@ export async function assembleDecopilotTools(
         passthroughClient,
         vmContext,
         htmlPageBuffer: extras.htmlPageBuffer,
+        deckBuffer: extras.deckBuffer,
         taskId: extras.threadId,
         agentId: input.agent.id,
         onChildUsage: extras.onChildUsage,

--- a/apps/mesh/src/storage/org-fs.ts
+++ b/apps/mesh/src/storage/org-fs.ts
@@ -424,6 +424,20 @@ export class OrgFsEntryStorage {
       .execute();
     return rows.map((r) => rowToEntry(r as OrgFsEntryRow));
   }
+
+  /** Latest change-feed cursor for a volume ("0" when empty). */
+  async latestSeq(params: {
+    organizationId: string;
+    volume: string;
+  }): Promise<string> {
+    const row = await this.db
+      .selectFrom("org_fs_entry")
+      .where("organization_id", "=", params.organizationId)
+      .where("volume", "=", params.volume)
+      .select(sql<string | null>`max(seq)`.as("seq"))
+      .executeTakeFirst();
+    return row?.seq ?? "0";
+  }
 }
 
 /** Escape LIKE wildcards in a literal path prefix. */

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -104,6 +104,7 @@ import { useLocalStorage } from "../../hooks/use-local-storage";
 import { chatModeForTransportRef } from "../../lib/chat-mode-sync";
 import { LOCALSTORAGE_KEYS } from "../../lib/localstorage-keys";
 import { KEYS } from "../../lib/query-keys";
+import { formatDeckTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import { useSimpleMode } from "../../hooks/use-organization-settings";
 
 // ============================================================================
@@ -842,6 +843,7 @@ export function ActiveTaskProvider({
     taskId,
     manager,
     navigate,
+    orgId: org.id,
     orgSlug: org.slug,
   });
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
@@ -852,6 +854,7 @@ export function ActiveTaskProvider({
     taskId,
     manager,
     navigate,
+    orgId: org.id,
     orgSlug: org.slug,
   };
 
@@ -885,6 +888,31 @@ export function ActiveTaskProvider({
             search: (prev: Record<string, unknown>) => ({
               ...prev,
               main: `web-page:${slug}`,
+            }),
+            replace: true,
+          });
+          return;
+        }
+        // Deck preview (slides skill): the harness emits `data-deck-updated`
+        // when `decks/<name>.html` changes in the org home volume. Refresh
+        // the stat (rolls the deck tab's cache-busted iframe src) and
+        // auto-open the tab — latest deck wins, like html pages above.
+        if (chunk.type === "data-deck-updated") {
+          const data = (chunk as unknown as { data: { path?: string } }).data;
+          if (!data?.path) return;
+          const path = data.path;
+          const cb = cbRef.current;
+          cb.queryClient.invalidateQueries({
+            queryKey: KEYS.orgFsStat(cb.orgId, "home", path),
+          });
+          cb.queryClient.invalidateQueries({
+            queryKey: KEYS.orgFsRecent(cb.orgId),
+          });
+          cb.navigate({
+            to: ".",
+            search: (prev: Record<string, unknown>) => ({
+              ...prev,
+              main: formatDeckTabId(path),
             }),
             replace: true,
           });

--- a/apps/mesh/src/web/components/chat/message/thread-html-previews.tsx
+++ b/apps/mesh/src/web/components/chat/message/thread-html-previews.tsx
@@ -92,10 +92,18 @@ export function ThreadHtmlPreviews() {
 
   if (chips.length === 0) return null;
 
+  const hasDecks = chips.some((c) => c.kind === "deck");
+  const hasPages = chips.some((c) => c.kind === "page");
+  const heading = hasDecks
+    ? hasPages
+      ? "Slides & pages in this chat"
+      : "Slides in this chat"
+    : "Pages in this chat";
+
   return (
     <div className="flex flex-col gap-1.5 py-2">
       <div className="text-[12px] text-muted-foreground/70 uppercase tracking-wide">
-        Pages in this chat
+        {heading}
       </div>
       <div className="flex flex-wrap gap-2">
         {chips.map((chip) => (

--- a/apps/mesh/src/web/components/chat/message/thread-html-previews.tsx
+++ b/apps/mesh/src/web/components/chat/message/thread-html-previews.tsx
@@ -1,16 +1,24 @@
 /**
- * ThreadHtmlPreviews — chips for every distinct HTML page the model
- * has produced via `write`/`edit` tools in this thread. Clicking a chip
- * sets `?main=web-page:<slug>` so the preview side-panel mounts.
+ * ThreadHtmlPreviews — chips for every distinct HTML artifact the model
+ * has produced in this thread: decks (slides skill, org-fs home volume)
+ * and legacy `pages/` HTML pages. Clicking a chip sets `?main=deck:<path>`
+ * / `?main=web-page:<slug>` so the preview side-panel mounts.
  *
  * Why this exists: the preview panel is opened solely by URL state, and
- * the `data-html-page-published` data part renders to null in the chat.
- * Once the panel is closed (reload, manual dismiss), there was no way
- * back without URL surgery. This row is the missing affordance.
+ * the `data-deck-updated` / `data-html-page-published` data parts render
+ * to null in the chat. Once the panel is closed (reload, manual dismiss),
+ * there was no way back without URL surgery. This row is the missing
+ * affordance.
+ *
+ * Sources: pages come from `write`/`edit` tool outputs (`htmlPreview`);
+ * decks come from the persisted `data-deck-updated` parts the deck
+ * watcher emits — decks can be created via bash (`slides-create`), so
+ * there is no tool output to scan for them.
  */
 
 import { useNavigate } from "@tanstack/react-router";
-import { Globe01 } from "@untitledui/icons";
+import { Globe01, Monitor01 } from "@untitledui/icons";
+import { formatDeckTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import { useOptionalChatStream } from "../context.tsx";
 
 interface HtmlPreviewRef {
@@ -20,11 +28,23 @@ interface HtmlPreviewRef {
   bytes: number;
 }
 
-function collectPreviews(
+interface DeckRef {
+  path: string;
+  name: string;
+}
+
+interface PreviewChip {
+  /** Tab id to navigate to (`deck:…` / `web-page:…`). */
+  tabId: string;
+  label: string;
+  kind: "deck" | "page";
+}
+
+function collectChips(
   messages: ReadonlyArray<{ parts?: ReadonlyArray<unknown> }>,
-): HtmlPreviewRef[] {
-  // Walk in reverse so the latest publish per slug wins on dedup.
-  const seen = new Map<string, HtmlPreviewRef>();
+): PreviewChip[] {
+  // Walk in reverse so the latest artifact per key wins on dedup.
+  const seen = new Map<string, PreviewChip>();
   for (let i = messages.length - 1; i >= 0; i--) {
     const parts = messages[i]?.parts;
     if (!parts) continue;
@@ -32,13 +52,34 @@ function collectPreviews(
       const p = raw as {
         type?: string;
         state?: string;
+        data?: unknown;
         output?: { htmlPreview?: HtmlPreviewRef };
       };
+      if (p.type === "data-deck-updated") {
+        const deck = p.data as DeckRef | undefined;
+        if (!deck?.path) continue;
+        const key = `deck:${deck.path}`;
+        if (!seen.has(key)) {
+          seen.set(key, {
+            tabId: formatDeckTabId(deck.path),
+            label: deck.name || deck.path,
+            kind: "deck",
+          });
+        }
+        continue;
+      }
       if (p.type !== "tool-edit" && p.type !== "tool-write") continue;
       if (p.state !== "output-available") continue;
       const preview = p.output?.htmlPreview;
       if (!preview?.slug) continue;
-      if (!seen.has(preview.slug)) seen.set(preview.slug, preview);
+      const key = `page:${preview.slug}`;
+      if (!seen.has(key)) {
+        seen.set(key, {
+          tabId: `web-page:${preview.slug}`,
+          label: preview.slug,
+          kind: "page",
+        });
+      }
     }
   }
   return Array.from(seen.values());
@@ -47,9 +88,9 @@ function collectPreviews(
 export function ThreadHtmlPreviews() {
   const navigate = useNavigate();
   const messages = useOptionalChatStream()?.messages ?? [];
-  const previews = collectPreviews(messages);
+  const chips = collectChips(messages);
 
-  if (previews.length === 0) return null;
+  if (chips.length === 0) return null;
 
   return (
     <div className="flex flex-col gap-1.5 py-2">
@@ -57,24 +98,28 @@ export function ThreadHtmlPreviews() {
         Pages in this chat
       </div>
       <div className="flex flex-wrap gap-2">
-        {previews.map((preview) => (
+        {chips.map((chip) => (
           <button
             type="button"
-            key={preview.slug}
+            key={chip.tabId}
             onClick={() =>
               navigate({
                 to: ".",
                 search: (prev: Record<string, unknown>) => ({
                   ...prev,
-                  main: `web-page:${preview.slug}`,
+                  main: chip.tabId,
                 }),
                 replace: true,
               })
             }
             className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border bg-muted/30 hover:bg-muted/60 text-[13px] transition-colors"
           >
-            <Globe01 className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className="font-medium text-foreground">{preview.slug}</span>
+            {chip.kind === "deck" ? (
+              <Monitor01 className="size-3.5 shrink-0 text-muted-foreground" />
+            ) : (
+              <Globe01 className="size-3.5 shrink-0 text-muted-foreground" />
+            )}
+            <span className="font-medium text-foreground">{chip.label}</span>
           </button>
         ))}
       </div>

--- a/apps/mesh/src/web/components/deck/deck-html-ops.test.ts
+++ b/apps/mesh/src/web/components/deck/deck-html-ops.test.ts
@@ -1,0 +1,123 @@
+import { setupComponentTest } from "../../../test/setup"; // happy-dom (DOMParser)
+setupComponentTest();
+import { describe, expect, test } from "bun:test";
+import { DeckOpError, applyDeckOp, countDeckSlides } from "./deck-html-ops";
+
+const DECK = `<!DOCTYPE html>
+<html lang="en"><head><title>T</title><style>section { color: red; }</style></head>
+<body>
+<deck-viewer width="1920" height="1080">
+<section class="a"><h1>One</h1></section>
+<section class="b"><h2>Two</h2></section>
+<section class="c"><h2>Three</h2></section>
+</deck-viewer>
+<script src="/deck-runtime/v1/deck-viewer.js"></script>
+</body></html>
+`;
+
+function headings(source: string): string[] {
+  const doc = new DOMParser().parseFromString(source, "text/html");
+  return [...doc.querySelectorAll("deck-viewer > section")].map(
+    (s) => s.textContent?.trim() ?? "",
+  );
+}
+
+describe("countDeckSlides", () => {
+  test("counts element children of deck-viewer", () => {
+    expect(countDeckSlides(DECK)).toBe(3);
+  });
+  test("null without a deck-viewer", () => {
+    expect(countDeckSlides("<html><body><p>x</p></body></html>")).toBeNull();
+  });
+});
+
+describe("applyDeckOp", () => {
+  test("remove", () => {
+    const out = applyDeckOp(DECK, { kind: "remove", at: 1 });
+    expect(headings(out)).toEqual(["One", "Three"]);
+    expect(out.startsWith("<!DOCTYPE html>")).toBe(true);
+    // The rest of the document survives the round-trip.
+    expect(out).toContain("section { color: red; }");
+    expect(out).toContain('script src="/deck-runtime/v1/deck-viewer.js"');
+  });
+
+  test("remove refuses the last slide", () => {
+    const one = `<deck-viewer><section><h1>Only</h1></section></deck-viewer>`;
+    expect(() => applyDeckOp(one, { kind: "remove", at: 0 })).toThrow(
+      DeckOpError,
+    );
+  });
+
+  test("duplicate strips ids", () => {
+    const src = DECK.replace(
+      '<section class="b">',
+      '<section class="b" id="x">',
+    );
+    const out = applyDeckOp(src, { kind: "duplicate", at: 1 });
+    expect(headings(out)).toEqual(["One", "Two", "Two", "Three"]);
+    const doc = new DOMParser().parseFromString(out, "text/html");
+    expect(doc.querySelectorAll("#x").length).toBe(1);
+  });
+
+  test("move down and up", () => {
+    expect(
+      headings(applyDeckOp(DECK, { kind: "move", from: 0, to: 2 })),
+    ).toEqual(["Two", "Three", "One"]);
+    expect(
+      headings(applyDeckOp(DECK, { kind: "move", from: 2, to: 0 })),
+    ).toEqual(["Three", "One", "Two"]);
+  });
+
+  test("set-attr / remove-attr (skip toggle)", () => {
+    const skipped = applyDeckOp(DECK, {
+      kind: "set-attr",
+      at: 1,
+      name: "data-deck-skip",
+      value: "",
+    });
+    expect(skipped).toContain("data-deck-skip");
+    const unskipped = applyDeckOp(skipped, {
+      kind: "remove-attr",
+      at: 1,
+      name: "data-deck-skip",
+    });
+    expect(unskipped).not.toContain("data-deck-skip");
+  });
+
+  test("replace swaps the section content", () => {
+    const out = applyDeckOp(DECK, {
+      kind: "replace",
+      at: 0,
+      html: '<section class="a"><h1>Edited</h1> <p>extra</p></section>',
+    });
+    expect(headings(out)).toEqual(["Edited extra", "Two", "Three"]);
+  });
+
+  test("stale index throws DeckOpError", () => {
+    expect(() => applyDeckOp(DECK, { kind: "remove", at: 9 })).toThrow(
+      DeckOpError,
+    );
+    try {
+      applyDeckOp(DECK, { kind: "remove", at: 9 });
+    } catch (err) {
+      expect((err as DeckOpError).code).toBe("stale-index");
+    }
+  });
+
+  test("missing deck-viewer throws", () => {
+    expect(() =>
+      applyDeckOp("<html><body></body></html>", { kind: "remove", at: 0 }),
+    ).toThrow(DeckOpError);
+  });
+
+  test("invalid attribute name rejected", () => {
+    expect(() =>
+      applyDeckOp(DECK, {
+        kind: "set-attr",
+        at: 0,
+        name: "on click",
+        value: "x",
+      }),
+    ).toThrow(DeckOpError);
+  });
+});

--- a/apps/mesh/src/web/components/deck/deck-html-ops.ts
+++ b/apps/mesh/src/web/components/deck/deck-html-ops.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure HTML-source transforms for deck edit ops.
+ *
+ * The DeckTab keeps the deck's HTML source as a string; each op from the
+ * preview iframe (which already self-applied the change to its own DOM)
+ * is replayed here against the source via DOMParser, then the result is
+ * PUT back to org-fs. Whole-document parse → mutate → serialize: decks
+ * are generated single-file HTML, so the round-trip is stable enough,
+ * and ops only ever touch `<deck-viewer>`'s element children.
+ *
+ * Throws `DeckOpError` when the source no longer matches the op (slide
+ * count drifted — e.g. the agent rewrote the file between iframe load
+ * and the user's edit). Callers should resync the iframe on that.
+ */
+
+import type { DeckOp } from "./deck-messages";
+
+export class DeckOpError extends Error {
+  constructor(
+    message: string,
+    readonly code: "no-viewer" | "stale-index" | "bad-op",
+  ) {
+    super(message);
+    this.name = "DeckOpError";
+  }
+}
+
+/** Slide elements = element children of <deck-viewer>, excluding non-slide
+ *  tags (mirrors the runtime's `_collectSlides`). */
+function slidesOf(viewer: Element): Element[] {
+  return [...viewer.children].filter(
+    (el) => !/^(TEMPLATE|SCRIPT|STYLE)$/.test(el.tagName),
+  );
+}
+
+export function countDeckSlides(source: string): number | null {
+  const doc = new DOMParser().parseFromString(source, "text/html");
+  const viewer = doc.querySelector("deck-viewer");
+  return viewer ? slidesOf(viewer).length : null;
+}
+
+export function applyDeckOp(source: string, op: DeckOp): string {
+  const doc = new DOMParser().parseFromString(source, "text/html");
+  const viewer = doc.querySelector("deck-viewer");
+  if (!viewer) {
+    throw new DeckOpError("no <deck-viewer> element in source", "no-viewer");
+  }
+  const slides = slidesOf(viewer);
+  const at = op.kind === "move" ? op.from : op.at;
+  const slide = slides[at];
+  if (!slide) {
+    throw new DeckOpError(
+      `slide index ${at} out of range (${slides.length})`,
+      "stale-index",
+    );
+  }
+
+  switch (op.kind) {
+    case "remove": {
+      if (slides.length <= 1) {
+        throw new DeckOpError("cannot remove the last slide", "bad-op");
+      }
+      slide.remove();
+      break;
+    }
+    case "duplicate": {
+      const copy = slide.cloneNode(true) as Element;
+      copy.removeAttribute("id");
+      for (const el of copy.querySelectorAll("[id]")) {
+        el.removeAttribute("id");
+      }
+      slide.after(copy);
+      break;
+    }
+    case "move": {
+      if (op.to < 0 || op.to >= slides.length) {
+        throw new DeckOpError(
+          `move target ${op.to} out of range`,
+          "stale-index",
+        );
+      }
+      if (op.to !== op.from) {
+        // Same semantics as the runtime: insert before the slide currently
+        // at `to` when moving up, after it when moving down.
+        const ref =
+          op.to < op.from ? slides[op.to]! : slides[op.to]!.nextSibling;
+        viewer.insertBefore(slide, ref);
+      }
+      break;
+    }
+    case "set-attr": {
+      if (!/^[a-zA-Z][\w-]*$/.test(op.name)) {
+        throw new DeckOpError(`invalid attribute name: ${op.name}`, "bad-op");
+      }
+      slide.setAttribute(op.name, op.value);
+      break;
+    }
+    case "remove-attr": {
+      slide.removeAttribute(op.name);
+      break;
+    }
+    case "replace": {
+      const fragment = new DOMParser().parseFromString(op.html, "text/html");
+      const replacement = fragment.body.firstElementChild;
+      if (!replacement) {
+        throw new DeckOpError("replace html has no root element", "bad-op");
+      }
+      slide.replaceWith(doc.importNode(replacement, true));
+      break;
+    }
+    default: {
+      throw new DeckOpError(
+        `unknown op kind: ${(op as { kind?: string }).kind}`,
+        "bad-op",
+      );
+    }
+  }
+
+  const doctype = source.trimStart().toLowerCase().startsWith("<!doctype")
+    ? "<!DOCTYPE html>\n"
+    : "";
+  return `${doctype}${doc.documentElement.outerHTML}\n`;
+}

--- a/apps/mesh/src/web/components/deck/deck-messages.ts
+++ b/apps/mesh/src/web/components/deck/deck-messages.ts
@@ -1,0 +1,84 @@
+/**
+ * postMessage protocol between the deck preview iframe (the standalone
+ * `<deck-viewer>` runtime served from /deck-runtime/v1/deck-viewer.js) and
+ * the DeckTab host. Keep in sync with the protocol block documented at the
+ * top of `apps/mesh/public/deck-runtime/v1/deck-viewer.js`.
+ *
+ * The iframe is sandboxed (`allow-scripts`, opaque origin), so:
+ *  - `event.origin` is the string "null" — identity is checked via
+ *    `event.source === iframe.contentWindow`, never via origin.
+ *  - both directions post with targetOrigin "*" and must carry no secrets.
+ */
+
+export const DECK_PROTOCOL_V = 1;
+
+/** Structural / text ops emitted by the runtime after optimistic
+ *  self-apply. Indices are positions in the slide list BEFORE the op. */
+export type DeckOp =
+  | { kind: "move"; from: number; to: number }
+  | { kind: "remove"; at: number }
+  | { kind: "duplicate"; at: number }
+  | { kind: "set-attr"; at: number; name: string; value: string }
+  | { kind: "remove-attr"; at: number; name: string }
+  | { kind: "replace"; at: number; html: string };
+
+export interface DeckOpMessage {
+  v: typeof DECK_PROTOCOL_V;
+  source: "deck-viewer";
+  type: "op";
+  opId: string;
+  witness: { childCount: number };
+  op: DeckOp;
+}
+
+export interface DeckReadyMessage {
+  v: typeof DECK_PROTOCOL_V;
+  source: "deck-viewer";
+  type: "ready";
+  total: number;
+  design: { width: number; height: number };
+}
+
+export interface DeckStateMessage {
+  v: typeof DECK_PROTOCOL_V;
+  source: "deck-viewer";
+  type: "state";
+  index: number;
+  total: number;
+  skipped: number[];
+}
+
+export type DeckRuntimeMessage =
+  | DeckOpMessage
+  | DeckReadyMessage
+  | DeckStateMessage;
+
+export type DeckHostMessage =
+  | {
+      v: typeof DECK_PROTOCOL_V;
+      type: "ack";
+      opId: string;
+      ok: boolean;
+      error?: string;
+    }
+  | { v: typeof DECK_PROTOCOL_V; type: "set-edit-mode"; enabled: boolean }
+  | { v: typeof DECK_PROTOCOL_V; type: "set-rail"; open: boolean }
+  | { v: typeof DECK_PROTOCOL_V; type: "goto"; index: number }
+  | { v: typeof DECK_PROTOCOL_V; type: "print" };
+
+export function parseDeckRuntimeMessage(
+  data: unknown,
+): DeckRuntimeMessage | null {
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    (data as { v?: unknown }).v !== DECK_PROTOCOL_V ||
+    (data as { source?: unknown }).source !== "deck-viewer"
+  ) {
+    return null;
+  }
+  const msg = data as DeckRuntimeMessage;
+  if (msg.type === "ready" || msg.type === "state") return msg;
+  if (msg.type === "op" && typeof msg.opId === "string" && msg.op) return msg;
+  return null;
+}

--- a/apps/mesh/src/web/components/deck/deck-toolbar.tsx
+++ b/apps/mesh/src/web/components/deck/deck-toolbar.tsx
@@ -27,18 +27,18 @@ import {
   LinkExternal01,
   RefreshCw01,
 } from "@untitledui/icons";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import type { DeckEditor } from "./use-deck-editor";
 
 export function DeckToolbar({
   readUrl,
   editor,
-  variant = "full",
+  trailing,
 }: {
   readUrl: string;
   editor: DeckEditor;
-  /** "controls" drops the URL row + copy/open (the host header has them). */
-  variant?: "full" | "controls";
+  /** Host-specific actions appended after the shared ones. */
+  trailing?: ReactNode;
 }) {
   const [copied, setCopied] = useState(false);
   const absoluteUrl = new URL(readUrl, window.location.origin).toString();
@@ -70,18 +70,14 @@ export function DeckToolbar({
           </TooltipContent>
         </Tooltip>
       )}
-      {variant === "full" ? (
-        <button
-          type="button"
-          onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
-          className="flex min-w-0 flex-1 items-center rounded-md px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title={absoluteUrl}
-        >
-          <span className="truncate">{absoluteUrl}</span>
-        </button>
-      ) : (
-        <div className="flex-1" />
-      )}
+      <button
+        type="button"
+        onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
+        className="flex min-w-0 flex-1 items-center rounded-md px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        title={absoluteUrl}
+      >
+        <span className="truncate">{absoluteUrl}</span>
+      </button>
 
       {editor.agentUpdated && (
         <Tooltip>
@@ -146,39 +142,36 @@ export function DeckToolbar({
         </Tooltip>
       )}
 
-      {variant === "full" && (
-        <>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Copy URL"
-                onClick={handleCopy}
-              >
-                {copied ? <Check size={14} /> : <Copy01 size={14} />}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {copied ? "Copied" : "Copy URL"}
-            </TooltipContent>
-          </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Copy URL"
+            onClick={handleCopy}
+          >
+            {copied ? <Check size={14} /> : <Copy01 size={14} />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {copied ? "Copied" : "Copy URL"}
+        </TooltipContent>
+      </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Open in new tab"
-                onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
-              >
-                <LinkExternal01 size={14} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Open in new tab</TooltipContent>
-          </Tooltip>
-        </>
-      )}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Open in new tab"
+            onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
+          >
+            <LinkExternal01 size={14} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open in new tab</TooltipContent>
+      </Tooltip>
+      {trailing}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/deck/deck-toolbar.tsx
+++ b/apps/mesh/src/web/components/deck/deck-toolbar.tsx
@@ -1,0 +1,163 @@
+/**
+ * DeckToolbar — header strip for the deck preview tab: URL/copy/open
+ * actions (mirrors WebPageTab's PreviewToolbar), the edit-mode toggle,
+ * the agent-updated reload badge, and PDF export.
+ *
+ * PDF export opens the deck's read URL with a `#print` fragment in a new
+ * tab: the deck-viewer runtime auto-triggers `window.print()` there and
+ * its print CSS lays one slide per page, so the browser's Save-as-PDF
+ * produces the export with zero server work.
+ */
+
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  Check,
+  Copy01,
+  Download01,
+  Edit03,
+  LayoutLeft,
+  LinkExternal01,
+  RefreshCw01,
+} from "@untitledui/icons";
+import { useState } from "react";
+import type { DeckEditor } from "./use-deck-editor";
+
+export function DeckToolbar({
+  readUrl,
+  editor,
+}: {
+  readUrl: string;
+  editor: DeckEditor;
+}) {
+  const [copied, setCopied] = useState(false);
+  const absoluteUrl = new URL(readUrl, window.location.origin).toString();
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(absoluteUrl);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border/60 px-2">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={editor.railOpen ? "secondary" : "ghost"}
+            size="icon"
+            aria-label={editor.railOpen ? "Hide slide list" : "Show slide list"}
+            onClick={() => editor.setRailOpen(!editor.railOpen)}
+          >
+            <LayoutLeft size={14} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {editor.railOpen ? "Hide slide list" : "Show slide list"}
+        </TooltipContent>
+      </Tooltip>
+      <button
+        type="button"
+        onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
+        className="flex min-w-0 flex-1 items-center rounded-md px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        title={absoluteUrl}
+      >
+        <span className="truncate">{absoluteUrl}</span>
+      </button>
+
+      {editor.agentUpdated && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 text-xs"
+              onClick={editor.reload}
+            >
+              <RefreshCw01 size={12} />
+              Agent updated — reload
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            The agent rewrote this deck while you were editing. Reloading
+            discards unsaved differences.
+          </TooltipContent>
+        </Tooltip>
+      )}
+
+      {editor.saving && (
+        <span className="px-1 text-xs text-muted-foreground">Saving…</span>
+      )}
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={editor.editMode ? "secondary" : "ghost"}
+            size="icon"
+            aria-label={editor.editMode ? "Done editing" : "Edit inline"}
+            className={cn(editor.editMode && "text-primary")}
+            onClick={() => editor.setEditMode(!editor.editMode)}
+          >
+            <Edit03 size={14} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {editor.editMode
+            ? "Done editing"
+            : "Edit inline (text, reorder, delete)"}
+        </TooltipContent>
+      </Tooltip>
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Export PDF"
+            onClick={() => window.open(`${absoluteUrl}#print`, "_blank")}
+          >
+            <Download01 size={14} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          Export PDF (opens print dialog)
+        </TooltipContent>
+      </Tooltip>
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Copy URL"
+            onClick={handleCopy}
+          >
+            {copied ? <Check size={14} /> : <Copy01 size={14} />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {copied ? "Copied" : "Copy URL"}
+        </TooltipContent>
+      </Tooltip>
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Open in new tab"
+            onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
+          >
+            <LinkExternal01 size={14} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open in new tab</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/deck/deck-toolbar.tsx
+++ b/apps/mesh/src/web/components/deck/deck-toolbar.tsx
@@ -1,7 +1,9 @@
 /**
- * DeckToolbar — header strip for the deck preview tab: URL/copy/open
- * actions (mirrors WebPageTab's PreviewToolbar), the edit-mode toggle,
- * the agent-updated reload badge, and PDF export.
+ * DeckToolbar — header strip for the HtmlPreviewPanel: URL/copy/open
+ * actions always; the slide-rail toggle, edit mode, and PDF export only
+ * after the framed document completes the deck-viewer handshake
+ * (editor.deckDetected) — a plain HTML preview shows none of them. Edit
+ * mode additionally requires a writable source.
  *
  * PDF export opens the deck's read URL with a `#print` fragment in a new
  * tab: the deck-viewer runtime auto-triggers `window.print()` there and
@@ -46,21 +48,25 @@ export function DeckToolbar({
 
   return (
     <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border/60 px-2">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant={editor.railOpen ? "secondary" : "ghost"}
-            size="icon"
-            aria-label={editor.railOpen ? "Hide slide list" : "Show slide list"}
-            onClick={() => editor.setRailOpen(!editor.railOpen)}
-          >
-            <LayoutLeft size={14} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {editor.railOpen ? "Hide slide list" : "Show slide list"}
-        </TooltipContent>
-      </Tooltip>
+      {editor.deckDetected && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={editor.railOpen ? "secondary" : "ghost"}
+              size="icon"
+              aria-label={
+                editor.railOpen ? "Hide slide list" : "Show slide list"
+              }
+              onClick={() => editor.setRailOpen(!editor.railOpen)}
+            >
+              <LayoutLeft size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {editor.railOpen ? "Hide slide list" : "Show slide list"}
+          </TooltipContent>
+        </Tooltip>
+      )}
       <button
         type="button"
         onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
@@ -94,40 +100,44 @@ export function DeckToolbar({
         <span className="px-1 text-xs text-muted-foreground">Saving…</span>
       )}
 
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant={editor.editMode ? "secondary" : "ghost"}
-            size="icon"
-            aria-label={editor.editMode ? "Done editing" : "Edit inline"}
-            className={cn(editor.editMode && "text-primary")}
-            onClick={() => editor.setEditMode(!editor.editMode)}
-          >
-            <Edit03 size={14} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {editor.editMode
-            ? "Done editing"
-            : "Edit inline (text, reorder, delete)"}
-        </TooltipContent>
-      </Tooltip>
+      {editor.deckDetected && editor.writable && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={editor.editMode ? "secondary" : "ghost"}
+              size="icon"
+              aria-label={editor.editMode ? "Done editing" : "Edit inline"}
+              className={cn(editor.editMode && "text-primary")}
+              onClick={() => editor.setEditMode(!editor.editMode)}
+            >
+              <Edit03 size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {editor.editMode
+              ? "Done editing"
+              : "Edit inline (text, reorder, delete)"}
+          </TooltipContent>
+        </Tooltip>
+      )}
 
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Export PDF"
-            onClick={() => window.open(`${absoluteUrl}#print`, "_blank")}
-          >
-            <Download01 size={14} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          Export PDF (opens print dialog)
-        </TooltipContent>
-      </Tooltip>
+      {editor.deckDetected && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Export PDF"
+              onClick={() => window.open(`${absoluteUrl}#print`, "_blank")}
+            >
+              <Download01 size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            Export PDF (opens print dialog)
+          </TooltipContent>
+        </Tooltip>
+      )}
 
       <Tooltip>
         <TooltipTrigger asChild>

--- a/apps/mesh/src/web/components/deck/deck-toolbar.tsx
+++ b/apps/mesh/src/web/components/deck/deck-toolbar.tsx
@@ -33,9 +33,12 @@ import type { DeckEditor } from "./use-deck-editor";
 export function DeckToolbar({
   readUrl,
   editor,
+  variant = "full",
 }: {
   readUrl: string;
   editor: DeckEditor;
+  /** "controls" drops the URL row + copy/open (the host header has them). */
+  variant?: "full" | "controls";
 }) {
   const [copied, setCopied] = useState(false);
   const absoluteUrl = new URL(readUrl, window.location.origin).toString();
@@ -67,14 +70,18 @@ export function DeckToolbar({
           </TooltipContent>
         </Tooltip>
       )}
-      <button
-        type="button"
-        onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
-        className="flex min-w-0 flex-1 items-center rounded-md px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        title={absoluteUrl}
-      >
-        <span className="truncate">{absoluteUrl}</span>
-      </button>
+      {variant === "full" ? (
+        <button
+          type="button"
+          onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
+          className="flex min-w-0 flex-1 items-center rounded-md px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          title={absoluteUrl}
+        >
+          <span className="truncate">{absoluteUrl}</span>
+        </button>
+      ) : (
+        <div className="flex-1" />
+      )}
 
       {editor.agentUpdated && (
         <Tooltip>
@@ -139,35 +146,39 @@ export function DeckToolbar({
         </Tooltip>
       )}
 
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Copy URL"
-            onClick={handleCopy}
-          >
-            {copied ? <Check size={14} /> : <Copy01 size={14} />}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {copied ? "Copied" : "Copy URL"}
-        </TooltipContent>
-      </Tooltip>
+      {variant === "full" && (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Copy URL"
+                onClick={handleCopy}
+              >
+                {copied ? <Check size={14} /> : <Copy01 size={14} />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {copied ? "Copied" : "Copy URL"}
+            </TooltipContent>
+          </Tooltip>
 
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Open in new tab"
-            onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
-          >
-            <LinkExternal01 size={14} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Open in new tab</TooltipContent>
-      </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Open in new tab"
+                onClick={() => window.open(absoluteUrl, "_blank", "noopener")}
+              >
+                <LinkExternal01 size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open in new tab</TooltipContent>
+          </Tooltip>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/deck/deck-toolbar.tsx
+++ b/apps/mesh/src/web/components/deck/deck-toolbar.tsx
@@ -13,6 +13,12 @@
 
 import { Button } from "@deco/ui/components/button.tsx";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -23,8 +29,10 @@ import {
   Copy01,
   Download01,
   Edit03,
+  File06,
   LayoutLeft,
   LinkExternal01,
+  Printer,
   RefreshCw01,
 } from "@untitledui/icons";
 import { type ReactNode, useState } from "react";
@@ -33,10 +41,13 @@ import type { DeckEditor } from "./use-deck-editor";
 export function DeckToolbar({
   readUrl,
   editor,
+  downloadName,
   trailing,
 }: {
   readUrl: string;
   editor: DeckEditor;
+  /** Filename for the Download action (`download` attribute). */
+  downloadName: string;
   /** Host-specific actions appended after the shared ones. */
   trailing?: ReactNode;
 }) {
@@ -124,21 +135,40 @@ export function DeckToolbar({
         </Tooltip>
       )}
 
-      {editor.deckDetected && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label="Export PDF"
-              onClick={() => window.open(`${absoluteUrl}#print`, "_blank")}
-            >
+      {editor.deckDetected ? (
+        // One download control: a deck exports as PDF (print) or as the
+        // raw HTML file. Plain pages get the simple download button below.
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="Download">
               <Download01 size={14} />
             </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onClick={() => window.open(`${absoluteUrl}#print`, "_blank")}
+            >
+              <Printer size={14} />
+              Export as PDF
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <a href={absoluteUrl} download={downloadName}>
+                <File06 size={14} />
+                Download HTML
+              </a>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="Download" asChild>
+              <a href={absoluteUrl} download={downloadName}>
+                <Download01 size={14} />
+              </a>
+            </Button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
-            Export PDF (opens print dialog)
-          </TooltipContent>
+          <TooltipContent side="bottom">Download</TooltipContent>
         </Tooltip>
       )}
 

--- a/apps/mesh/src/web/components/deck/deck-toolbar.tsx
+++ b/apps/mesh/src/web/components/deck/deck-toolbar.tsx
@@ -146,7 +146,9 @@ export function DeckToolbar({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem
-              onClick={() => window.open(`${absoluteUrl}#print`, "_blank")}
+              onClick={() =>
+                window.open(`${absoluteUrl}#print`, "_blank", "noopener")
+              }
             >
               <Printer size={14} />
               Export as PDF

--- a/apps/mesh/src/web/components/deck/html-preview-panel.tsx
+++ b/apps/mesh/src/web/components/deck/html-preview-panel.tsx
@@ -16,7 +16,7 @@
  */
 
 import { cn } from "@deco/ui/lib/utils.ts";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { DeckToolbar } from "./deck-toolbar";
 import { useDeckEditor } from "./use-deck-editor";
 
@@ -27,7 +27,7 @@ export function HtmlPreviewPanel({
   marker,
   title,
   savePath,
-  chrome = "full",
+  trailing,
 }: {
   readUrl: string;
   /** Content marker (org-fs `size-updatedAt` / publish byte count). */
@@ -35,10 +35,9 @@ export function HtmlPreviewPanel({
   title: string;
   /** Org-fs home-volume path for edit save-back; omit = read-only. */
   savePath?: string;
-  /** "full" = own toolbar with URL/copy/open. "controls" = the host
-   *  already has a header (e.g. the Library preview) — render only the
-   *  deck controls, and only once the handshake upgrades the panel. */
-  chrome?: "full" | "controls";
+  /** Host-specific actions appended to the (single) toolbar — e.g. the
+   *  Library's download/close buttons. Keeps every surface on one bar. */
+  trailing?: ReactNode;
 }) {
   const editor = useDeckEditor({ readUrl, statMarker: marker, savePath });
 
@@ -47,26 +46,22 @@ export function HtmlPreviewPanel({
 
   if (editor.displayedMarker === null) return null;
 
-  // Hash carries the runtime's view state (`#rail` opens the thumbnail
-  // rail) — kept out of the iframe `key` so toggling it is a fragment
-  // navigation inside the existing document, not a reload.
+  // Rail/edit state travels ONLY over postMessage — never the iframe
+  // src. Touching the src (even fragment-only: removing a fragment is a
+  // full navigation) reloads the document and resets the deck to slide 1.
   const sep = readUrl.includes("?") ? "&" : "?";
-  const baseSrc = `${readUrl}${sep}v=${encodeURIComponent(editor.displayedMarker)}`;
-  const src = editor.railOpen ? `${baseSrc}#rail` : baseSrc;
-  const iframeReady = readySrc === baseSrc;
+  const src = `${readUrl}${sep}v=${encodeURIComponent(editor.displayedMarker)}`;
+  const iframeReady = readySrc === src;
 
-  const showToolbar = chrome === "full" || editor.deckDetected;
   return (
     <div className="flex h-full w-full flex-col bg-background">
-      {showToolbar && (
-        <DeckToolbar readUrl={readUrl} editor={editor} variant={chrome} />
-      )}
+      <DeckToolbar readUrl={readUrl} editor={editor} trailing={trailing} />
       <div className="relative flex-1">
         <iframe
-          key={baseSrc}
+          key={src}
           ref={editor.iframeRef}
           src={src}
-          onLoad={() => setReadySrc(baseSrc)}
+          onLoad={() => setReadySrc(src)}
           sandbox="allow-scripts"
           className={cn(
             "absolute inset-0 block h-full w-full bg-white",

--- a/apps/mesh/src/web/components/deck/html-preview-panel.tsx
+++ b/apps/mesh/src/web/components/deck/html-preview-panel.tsx
@@ -1,0 +1,74 @@
+/**
+ * HtmlPreviewPanel — the ONE side-panel surface for previewing generated
+ * HTML, shared by the deck tab (org-fs files) and the legacy web-page tab
+ * (`pages/` object-storage mirrors).
+ *
+ * It always renders a sandboxed iframe of the given URL. If the framed
+ * document speaks the deck-viewer protocol (posts `ready`), the panel
+ * upgrades itself: the toolbar grows the slide-rail toggle and PDF
+ * export, and — when a `savePath` makes the source writable — the inline
+ * edit mode with op save-back. A plain HTML page never handshakes and
+ * stays a passive preview with copy/open actions.
+ *
+ * `marker` keys the iframe src (cache-bust); when it changes the editor
+ * hook decides whether to reload (suppressed mid-edit — see
+ * use-deck-editor.ts).
+ */
+
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useState } from "react";
+import { DeckToolbar } from "./deck-toolbar";
+import { useDeckEditor } from "./use-deck-editor";
+
+const FADE_MS = 300;
+
+export function HtmlPreviewPanel({
+  readUrl,
+  marker,
+  title,
+  savePath,
+}: {
+  readUrl: string;
+  /** Content marker (org-fs `size-updatedAt` / publish byte count). */
+  marker: string;
+  title: string;
+  /** Org-fs home-volume path for edit save-back; omit = read-only. */
+  savePath?: string;
+}) {
+  const editor = useDeckEditor({ readUrl, statMarker: marker, savePath });
+
+  // Fade the iframe in per loaded document; reset when the src rolls.
+  const [readySrc, setReadySrc] = useState<string | null>(null);
+
+  if (editor.displayedMarker === null) return null;
+
+  // Hash carries the runtime's view state (`#rail` opens the thumbnail
+  // rail) — kept out of the iframe `key` so toggling it is a fragment
+  // navigation inside the existing document, not a reload.
+  const sep = readUrl.includes("?") ? "&" : "?";
+  const baseSrc = `${readUrl}${sep}v=${encodeURIComponent(editor.displayedMarker)}`;
+  const src = editor.railOpen ? `${baseSrc}#rail` : baseSrc;
+  const iframeReady = readySrc === baseSrc;
+
+  return (
+    <div className="flex h-full w-full flex-col bg-background">
+      <DeckToolbar readUrl={readUrl} editor={editor} />
+      <div className="relative flex-1">
+        <iframe
+          key={baseSrc}
+          ref={editor.iframeRef}
+          src={src}
+          onLoad={() => setReadySrc(baseSrc)}
+          sandbox="allow-scripts"
+          className={cn(
+            "absolute inset-0 block h-full w-full bg-white",
+            "transition-opacity ease-out",
+            iframeReady ? "opacity-100" : "opacity-0",
+          )}
+          style={{ transitionDuration: `${FADE_MS}ms` }}
+          title={title}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/deck/html-preview-panel.tsx
+++ b/apps/mesh/src/web/components/deck/html-preview-panel.tsx
@@ -27,6 +27,7 @@ export function HtmlPreviewPanel({
   marker,
   title,
   savePath,
+  chrome = "full",
 }: {
   readUrl: string;
   /** Content marker (org-fs `size-updatedAt` / publish byte count). */
@@ -34,6 +35,10 @@ export function HtmlPreviewPanel({
   title: string;
   /** Org-fs home-volume path for edit save-back; omit = read-only. */
   savePath?: string;
+  /** "full" = own toolbar with URL/copy/open. "controls" = the host
+   *  already has a header (e.g. the Library preview) — render only the
+   *  deck controls, and only once the handshake upgrades the panel. */
+  chrome?: "full" | "controls";
 }) {
   const editor = useDeckEditor({ readUrl, statMarker: marker, savePath });
 
@@ -50,9 +55,12 @@ export function HtmlPreviewPanel({
   const src = editor.railOpen ? `${baseSrc}#rail` : baseSrc;
   const iframeReady = readySrc === baseSrc;
 
+  const showToolbar = chrome === "full" || editor.deckDetected;
   return (
     <div className="flex h-full w-full flex-col bg-background">
-      <DeckToolbar readUrl={readUrl} editor={editor} />
+      {showToolbar && (
+        <DeckToolbar readUrl={readUrl} editor={editor} variant={chrome} />
+      )}
       <div className="relative flex-1">
         <iframe
           key={baseSrc}

--- a/apps/mesh/src/web/components/deck/html-preview-panel.tsx
+++ b/apps/mesh/src/web/components/deck/html-preview-panel.tsx
@@ -55,7 +55,12 @@ export function HtmlPreviewPanel({
 
   return (
     <div className="flex h-full w-full flex-col bg-background">
-      <DeckToolbar readUrl={readUrl} editor={editor} trailing={trailing} />
+      <DeckToolbar
+        readUrl={readUrl}
+        editor={editor}
+        downloadName={title}
+        trailing={trailing}
+      />
       <div className="relative flex-1">
         <iframe
           key={src}

--- a/apps/mesh/src/web/components/deck/html-preview-panel.tsx
+++ b/apps/mesh/src/web/components/deck/html-preview-panel.tsx
@@ -58,7 +58,9 @@ export function HtmlPreviewPanel({
       <DeckToolbar
         readUrl={readUrl}
         editor={editor}
-        downloadName={title}
+        // Basename only — `title` can be a volume path ("decks/x.html")
+        // and browsers mangle slashes in the download attribute.
+        downloadName={title.split("/").pop() ?? title}
         trailing={trailing}
       />
       <div className="relative flex-1">

--- a/apps/mesh/src/web/components/deck/use-deck-editor.ts
+++ b/apps/mesh/src/web/components/deck/use-deck-editor.ts
@@ -96,6 +96,10 @@ export function useDeckEditor(args: {
   const [savePending, setSavePending] = useState(false);
   const [displayedMarker, setDisplayedMarker] = useState<string | null>(null);
   const [seenMarker, setSeenMarker] = useState<string | null>(null);
+  // Forces an iframe reload even when the server marker hasn't changed —
+  // reload() after a failed op/save must resync the (diverged) iframe to
+  // server truth, and the marker alone is an identical-state no-op then.
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   // Mutable op machinery — a stable plain object (lazy useState init, not
   // a ref, so no render-time .current access); mutated only from event
@@ -126,6 +130,7 @@ export function useDeckEditor(args: {
     machine.source = null;
     setAgentUpdated(false);
     if (seenMarker) setDisplayedMarker(seenMarker);
+    setReloadNonce((n) => n + 1);
     invalidateStat();
   };
 
@@ -311,7 +316,8 @@ export function useDeckEditor(args: {
     iframeRef,
     deckDetected,
     writable,
-    displayedMarker,
+    displayedMarker:
+      displayedMarker === null ? null : `${displayedMarker}.${reloadNonce}`,
     editMode,
     setEditMode,
     railOpen,

--- a/apps/mesh/src/web/components/deck/use-deck-editor.ts
+++ b/apps/mesh/src/web/components/deck/use-deck-editor.ts
@@ -25,7 +25,7 @@ import { useProjectContext } from "@decocms/mesh-sdk";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { KEYS } from "@/web/lib/query-keys";
-import { useOrgFsWriteText } from "@/web/hooks/use-org-fs";
+import { entryMarker, useOrgFsWriteText } from "@/web/hooks/use-org-fs";
 import {
   DECK_PROTOCOL_V,
   type DeckHostMessage,
@@ -168,14 +168,15 @@ export function useDeckEditor(args: {
         path: args.savePath!,
         body,
       });
-      machine.selfMarkers.add(`${entry.size}-${entry.updatedAt}`);
+      machine.selfMarkers.add(entryMarker(entry));
       invalidateStat();
     } catch (err) {
       console.error("[deck-editor] save failed", err);
       toast.error("Couldn't save deck edits — reloading the preview.");
-      machine.source = null;
-      setAgentUpdated(false);
-      invalidateStat();
+      // Same recovery as the op-failure path: the nonce in reload() forces
+      // the iframe roll even though the failed PUT left the server marker
+      // unchanged — otherwise the phantom edits would stay on screen.
+      latestRef.current.reload();
     } finally {
       setSaving(false);
       setSavePending(false);

--- a/apps/mesh/src/web/components/deck/use-deck-editor.ts
+++ b/apps/mesh/src/web/components/deck/use-deck-editor.ts
@@ -1,0 +1,300 @@
+/**
+ * useDeckEditor — host side of the deck inline-editing loop.
+ *
+ * The deck preview iframe self-applies every edit optimistically and posts
+ * the op here (see deck-messages.ts). This hook replays the op against a
+ * cached copy of the deck's HTML source (deck-html-ops.ts), acks the
+ * iframe, and debounce-saves the result to org-fs. Conflict policy is
+ * last-writer-wins:
+ *
+ *  - While the user is editing (edit mode on, or a save pending/in
+ *    flight), an agent rewrite does NOT reload the iframe — a toolbar
+ *    badge offers an explicit reload, and the user's next save wins.
+ *  - The hook's own saves are self-echo-suppressed: the PUT's returned
+ *    entry marker is remembered so the stat refresh it triggers doesn't
+ *    roll the iframe src.
+ *  - Any inconsistency (stale op index, fetch/save failure) drops the
+ *    cache and reloads the iframe from server truth.
+ *
+ * The iframe is sandboxed (opaque origin): identity is `event.source ===
+ * iframe.contentWindow`, and messages post with targetOrigin "*".
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { KEYS } from "@/web/lib/query-keys";
+import { useOrgFsWriteText } from "@/web/hooks/use-org-fs";
+import {
+  DECK_PROTOCOL_V,
+  type DeckHostMessage,
+  type DeckOpMessage,
+  parseDeckRuntimeMessage,
+} from "./deck-messages";
+import { DeckOpError, applyDeckOp, countDeckSlides } from "./deck-html-ops";
+
+const HOME_VOLUME = "home";
+const STRUCTURAL_SAVE_DEBOUNCE_MS = 400;
+const TEXT_SAVE_DEBOUNCE_MS = 800;
+
+export interface DeckEditor {
+  /** Ref callback for the preview iframe (attaches the message bridge). */
+  iframeRef: (el: HTMLIFrameElement | null) => void;
+  /** Marker (`size-updatedAt`) the iframe src should be keyed by. Null
+   *  until the file's stat has loaded once. */
+  displayedMarker: string | null;
+  editMode: boolean;
+  setEditMode: (enabled: boolean) => void;
+  /** Thumbnail-rail visibility inside the iframe (closed by default —
+   *  presentation-first). Edit mode opens it runtime-side. */
+  railOpen: boolean;
+  setRailOpen: (open: boolean) => void;
+  /** True while edits are being persisted. */
+  saving: boolean;
+  /** The agent rewrote the deck while the user was editing. */
+  agentUpdated: boolean;
+  /** Drop local state and reload the iframe at the latest server version. */
+  reload: () => void;
+  /** Post a host message into the iframe (print, goto). */
+  postToIframe: (msg: DeckHostMessage) => void;
+}
+
+interface Machine {
+  iframe: HTMLIFrameElement | null;
+  source: string | null;
+  queue: Promise<void>;
+  saveTimer: ReturnType<typeof setTimeout> | null;
+  selfMarkers: Set<string>;
+}
+
+export function useDeckEditor(args: {
+  path: string;
+  readUrl: string;
+  /** `size-updatedAt` of the current server stat, or null while absent. */
+  statMarker: string | null;
+}): DeckEditor {
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const writeText = useOrgFsWriteText(HOME_VOLUME);
+
+  const [editMode, setEditModeState] = useState(false);
+  const [railOpen, setRailOpenState] = useState(false);
+  const [agentUpdated, setAgentUpdated] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [savePending, setSavePending] = useState(false);
+  const [displayedMarker, setDisplayedMarker] = useState<string | null>(null);
+  const [seenMarker, setSeenMarker] = useState<string | null>(null);
+
+  // Mutable op machinery — a stable plain object (lazy useState init, not
+  // a ref, so no render-time .current access); mutated only from event
+  // handlers/timers.
+  const [machine] = useState<Machine>(() => ({
+    iframe: null,
+    source: null,
+    queue: Promise.resolve(),
+    saveTimer: null,
+    selfMarkers: new Set(),
+  }));
+
+  const isEditing = editMode || savePending || saving;
+
+  const invalidateStat = () => {
+    queryClient.invalidateQueries({
+      queryKey: KEYS.orgFsStat(org.id, HOME_VOLUME, args.path),
+    });
+    queryClient.invalidateQueries({ queryKey: KEYS.orgFsRecent(org.id) });
+  };
+
+  const postToIframe = (msg: DeckHostMessage) => {
+    machine.iframe?.contentWindow?.postMessage(msg, "*");
+  };
+
+  const reload = () => {
+    machine.source = null;
+    setAgentUpdated(false);
+    if (seenMarker) setDisplayedMarker(seenMarker);
+    invalidateStat();
+  };
+
+  // ── Stat-marker reconciliation (derived state during render) ────────
+  if (args.statMarker !== seenMarker) {
+    setSeenMarker(args.statMarker);
+    if (args.statMarker !== null) {
+      if (displayedMarker === null) {
+        // First stat — show the deck.
+        setDisplayedMarker(args.statMarker);
+      } else if (machine.selfMarkers.has(args.statMarker)) {
+        // Our own save echoing back — the iframe already shows this
+        // content (optimistic self-apply); don't reload it.
+      } else if (args.statMarker !== displayedMarker) {
+        if (isEditing) setAgentUpdated(true);
+        else {
+          machine.source = null;
+          setDisplayedMarker(args.statMarker);
+        }
+      }
+    }
+  }
+
+  // ── Saving ───────────────────────────────────────────────────────────
+  const flushSave = async () => {
+    machine.saveTimer = null;
+    const body = machine.source;
+    if (body === null) {
+      setSavePending(false);
+      return;
+    }
+    setSaving(true);
+    try {
+      const entry = await writeText.mutateAsync({ path: args.path, body });
+      machine.selfMarkers.add(`${entry.size}-${entry.updatedAt}`);
+      invalidateStat();
+    } catch (err) {
+      console.error("[deck-editor] save failed", err);
+      toast.error("Couldn't save deck edits — reloading the preview.");
+      machine.source = null;
+      setAgentUpdated(false);
+      invalidateStat();
+    } finally {
+      setSaving(false);
+      setSavePending(false);
+    }
+  };
+
+  const scheduleSave = (delayMs: number) => {
+    setSavePending(true);
+    if (machine.saveTimer) clearTimeout(machine.saveTimer);
+    machine.saveTimer = setTimeout(() => {
+      void latestRef.current.flushSave();
+    }, delayMs);
+  };
+
+  // ── Op handling ──────────────────────────────────────────────────────
+  const ack = (opId: string, ok: boolean, error?: string) => {
+    postToIframe({ v: DECK_PROTOCOL_V, type: "ack", opId, ok, error });
+  };
+
+  const handleOp = async (msg: DeckOpMessage) => {
+    try {
+      if (machine.source === null) {
+        const res = await fetch(args.readUrl, { credentials: "include" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        machine.source = await res.text();
+      }
+      const count = countDeckSlides(machine.source);
+      if (count === null || count !== msg.witness.childCount) {
+        throw new DeckOpError(
+          `slide count drifted (source ${count}, iframe ${msg.witness.childCount})`,
+          "stale-index",
+        );
+      }
+      machine.source = applyDeckOp(machine.source, msg.op);
+      ack(msg.opId, true);
+      scheduleSave(
+        msg.op.kind === "replace"
+          ? TEXT_SAVE_DEBOUNCE_MS
+          : STRUCTURAL_SAVE_DEBOUNCE_MS,
+      );
+    } catch (err) {
+      console.error("[deck-editor] op failed", msg.op, err);
+      ack(msg.opId, false, err instanceof Error ? err.message : String(err));
+      toast.error("That edit couldn't be saved — reloading the preview.");
+      latestRef.current.reload();
+    }
+  };
+
+  const onMessage = (e: MessageEvent) => {
+    if (!machine.iframe || e.source !== machine.iframe.contentWindow) return;
+    const msg = parseDeckRuntimeMessage(e.data);
+    if (!msg) return;
+    if (msg.type === "ready") {
+      // Re-assert host-held view state after every (re)load of the
+      // iframe document (the initial src hash only covers first paint).
+      if (latestRef.current.editMode) {
+        postToIframe({
+          v: DECK_PROTOCOL_V,
+          type: "set-edit-mode",
+          enabled: true,
+        });
+      } else if (latestRef.current.railOpen) {
+        postToIframe({ v: DECK_PROTOCOL_V, type: "set-rail", open: true });
+      }
+      return;
+    }
+    if (msg.type === "op") {
+      machine.queue = machine.queue
+        .then(() => latestRef.current.handleOp(msg))
+        .catch(() => {});
+    }
+  };
+
+  // Handlers close over per-render state; the stable window listener and
+  // save timers delegate through this ref so they always see the latest.
+  const latestRef = useRef({
+    onMessage,
+    handleOp,
+    flushSave,
+    reload,
+    editMode,
+    railOpen,
+  });
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- latest-handler mirror, same pattern as chat-context's cbRef
+  latestRef.current = {
+    onMessage,
+    handleOp,
+    flushSave,
+    reload,
+    editMode,
+    railOpen,
+  };
+
+  // Stable iframe ref callback: tracks the element and owns the window
+  // message listener for its lifetime (no useEffect — see lint rules).
+  const [iframeRef] = useState(() => {
+    let detach: (() => void) | null = null;
+    return (el: HTMLIFrameElement | null) => {
+      if (el) {
+        machine.iframe = el;
+        const listener = (e: MessageEvent) => latestRef.current.onMessage(e);
+        window.addEventListener("message", listener);
+        detach = () => window.removeEventListener("message", listener);
+      } else {
+        detach?.();
+        detach = null;
+        machine.iframe = null;
+      }
+    };
+  });
+
+  const setRailOpen = (open: boolean) => {
+    setRailOpenState(open);
+    postToIframe({ v: DECK_PROTOCOL_V, type: "set-rail", open });
+  };
+
+  const setEditMode = (enabled: boolean) => {
+    setEditModeState(enabled);
+    postToIframe({ v: DECK_PROTOCOL_V, type: "set-edit-mode", enabled });
+    // The runtime opens the rail when edit mode turns on (structural ops
+    // live there) — mirror that so the toolbar toggle stays in sync.
+    if (enabled) setRailOpenState(true);
+    if (!enabled && agentUpdated && !savePending && !saving) {
+      // Leaving edit mode with a pending agent update and nothing of ours
+      // left to save — adopt the agent's version.
+      reload();
+    }
+  };
+
+  return {
+    iframeRef,
+    displayedMarker,
+    editMode,
+    setEditMode,
+    railOpen,
+    setRailOpen,
+    saving,
+    agentUpdated,
+    reload,
+    postToIframe,
+  };
+}

--- a/apps/mesh/src/web/components/deck/use-deck-editor.ts
+++ b/apps/mesh/src/web/components/deck/use-deck-editor.ts
@@ -41,6 +41,12 @@ const TEXT_SAVE_DEBOUNCE_MS = 800;
 export interface DeckEditor {
   /** Ref callback for the preview iframe (attaches the message bridge). */
   iframeRef: (el: HTMLIFrameElement | null) => void;
+  /** The framed document completed the deck-viewer handshake (posted
+   *  `ready`) — gates the deck-specific toolbar controls. A plain HTML
+   *  page never posts it and stays a passive preview. */
+  deckDetected: boolean;
+  /** Edits can be persisted (an org-fs save path was provided). */
+  writable: boolean;
   /** Marker (`size-updatedAt`) the iframe src should be keyed by. Null
    *  until the file's stat has loaded once. */
   displayedMarker: string | null;
@@ -69,16 +75,21 @@ interface Machine {
 }
 
 export function useDeckEditor(args: {
-  path: string;
   readUrl: string;
-  /** `size-updatedAt` of the current server stat, or null while absent. */
+  /** Content marker the iframe src is keyed by (org-fs `size-updatedAt`,
+   *  or the publish event's byte count for read-only sources). */
   statMarker: string | null;
+  /** Org-fs home-volume path to persist edits to. Omit for read-only
+   *  sources (e.g. the legacy pages/ pipeline) — ops are then refused. */
+  savePath?: string;
 }): DeckEditor {
+  const writable = args.savePath !== undefined;
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
   const writeText = useOrgFsWriteText(HOME_VOLUME);
 
   const [editMode, setEditModeState] = useState(false);
+  const [deckDetected, setDeckDetected] = useState(false);
   const [railOpen, setRailOpenState] = useState(false);
   const [agentUpdated, setAgentUpdated] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -100,8 +111,9 @@ export function useDeckEditor(args: {
   const isEditing = editMode || savePending || saving;
 
   const invalidateStat = () => {
+    if (args.savePath === undefined) return;
     queryClient.invalidateQueries({
-      queryKey: KEYS.orgFsStat(org.id, HOME_VOLUME, args.path),
+      queryKey: KEYS.orgFsStat(org.id, HOME_VOLUME, args.savePath),
     });
     queryClient.invalidateQueries({ queryKey: KEYS.orgFsRecent(org.id) });
   };
@@ -147,7 +159,10 @@ export function useDeckEditor(args: {
     }
     setSaving(true);
     try {
-      const entry = await writeText.mutateAsync({ path: args.path, body });
+      const entry = await writeText.mutateAsync({
+        path: args.savePath!,
+        body,
+      });
       machine.selfMarkers.add(`${entry.size}-${entry.updatedAt}`);
       invalidateStat();
     } catch (err) {
@@ -176,6 +191,12 @@ export function useDeckEditor(args: {
   };
 
   const handleOp = async (msg: DeckOpMessage) => {
+    if (!writable) {
+      // Read-only source (no save path) — the edit affordances are hidden,
+      // but refuse defensively in case the framed document emits anyway.
+      ack(msg.opId, false, "read-only preview");
+      return;
+    }
     try {
       if (machine.source === null) {
         const res = await fetch(args.readUrl, { credentials: "include" });
@@ -209,6 +230,7 @@ export function useDeckEditor(args: {
     const msg = parseDeckRuntimeMessage(e.data);
     if (!msg) return;
     if (msg.type === "ready") {
+      setDeckDetected(true);
       // Re-assert host-held view state after every (re)load of the
       // iframe document (the initial src hash only covers first paint).
       if (latestRef.current.editMode) {
@@ -287,6 +309,8 @@ export function useDeckEditor(args: {
 
   return {
     iframeRef,
+    deckDetected,
+    writable,
     displayedMarker,
     editMode,
     setEditMode,

--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -20,6 +20,7 @@ export interface OrgFsEntry {
   kind: "file" | "dir";
   size: number;
   updatedAt: string;
+  contentHash?: string | null;
   /** Dir follows the Claude Code skill format (contains SKILL.md). */
   hasSkill?: boolean;
 }
@@ -32,6 +33,21 @@ export interface OrgFsUsage {
 /** A `/fs/recent` entry — cross-volume, so the volume rides along. */
 export interface OrgFsRecentEntry extends OrgFsEntry {
   volume: string;
+}
+
+/**
+ * Content marker for cache-busting previews. Prefer the content hash:
+ * the sandbox mount's vfs write-back re-PUTs identical bytes seconds
+ * after the deck fast-path mirror, bumping size-agnostic `updatedAt` —
+ * a hash-keyed marker doesn't roll on that echo (no spurious iframe
+ * reloads / stale-edit badges).
+ */
+export function entryMarker(entry: {
+  size: number;
+  updatedAt: string;
+  contentHash?: string | null;
+}): string {
+  return entry.contentHash ?? `${entry.size}-${entry.updatedAt}`;
 }
 
 function fsUrl(

--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -80,11 +80,21 @@ export function useOrgFsList(volume: string, path: string) {
 }
 
 /** Metadata for one entry — null when absent. Powers the Library preview. */
-export function useOrgFsStat(volume: string | null, path: string) {
+export function useOrgFsStat(
+  volume: string | null,
+  path: string,
+  opts?: { refetchIntervalWhenAbsent?: number },
+) {
   const { org } = useProjectContext();
   return useQuery({
     queryKey: KEYS.orgFsStat(org.id, volume ?? "", path),
     enabled: volume !== null,
+    // Optional poll while the entry doesn't exist yet (e.g. the deck tab
+    // waiting out the sandbox mount's write-back lag).
+    refetchInterval: opts?.refetchIntervalWhenAbsent
+      ? (query) =>
+          query.state.data ? false : (opts.refetchIntervalWhenAbsent ?? false)
+      : undefined,
     queryFn: async (): Promise<OrgFsEntry | null> => {
       const res = await fetch(fsUrl(org.slug, volume ?? "", "stat", { path }));
       if (res.status === 404) return null;
@@ -149,6 +159,35 @@ export function useOrgFsFileUrl() {
   const { org } = useProjectContext();
   return (volume: string, path: string) =>
     fsUrl(org.slug, volume, "read", { path });
+}
+
+/**
+ * Write a text file body to a volume path (deck inline editing). Returns
+ * the written entry (size/updatedAt) so callers can self-echo-suppress the
+ * stat refresh. Invalidation is the CALLER's job — the deck editor needs
+ * to record the entry BEFORE the stat query refetches.
+ */
+export function useOrgFsWriteText(volume: string) {
+  const { org } = useProjectContext();
+  return useMutation({
+    mutationFn: async (input: {
+      path: string;
+      body: string;
+      contentType?: string;
+    }): Promise<OrgFsEntry> => {
+      const res = await fsFetch(
+        fsUrl(org.slug, volume, "file", { path: input.path }),
+        {
+          method: "PUT",
+          headers: {
+            "content-type": input.contentType ?? "text/html; charset=utf-8",
+          },
+          body: input.body,
+        },
+      );
+      return ((await res.json()) as { entry: OrgFsEntry }).entry;
+    },
+  });
 }
 
 /** Upload/mkdir/delete; each invalidates the whole volume's listings+usage. */

--- a/apps/mesh/src/web/layouts/library/preview-dialog.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-dialog.tsx
@@ -23,7 +23,11 @@ import {
 } from "@/web/components/file-preview";
 import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
 import { FileTypeIcon } from "@/web/components/file-type-icon";
-import { useOrgFsDownloadUrl, useOrgFsStat } from "@/web/hooks/use-org-fs";
+import {
+  entryMarker,
+  useOrgFsDownloadUrl,
+  useOrgFsStat,
+} from "@/web/hooks/use-org-fs";
 import { basename, parseLibraryPath } from "./location";
 
 const isHtml = (name: string) => /\.html?$/i.test(name);
@@ -69,7 +73,7 @@ export function LibraryPreviewDialog({
             <HtmlPreviewPanel
               key={previewPath}
               readUrl={file.downloadUrl}
-              marker={`${entry.size}-${entry.updatedAt}`}
+              marker={entryMarker(entry)}
               title={filename}
               savePath={volume === "home" ? filePath : undefined}
               trailing={<div className="w-8 shrink-0" />}

--- a/apps/mesh/src/web/layouts/library/preview-dialog.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-dialog.tsx
@@ -21,9 +21,12 @@ import {
   FilePreviewShimmer,
   formatSize,
 } from "@/web/components/file-preview";
+import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
 import { FileTypeIcon } from "@/web/components/file-type-icon";
 import { useOrgFsDownloadUrl, useOrgFsStat } from "@/web/hooks/use-org-fs";
 import { basename, parseLibraryPath } from "./location";
+
+const isHtml = (name: string) => /\.html?$/i.test(name);
 
 export function LibraryPreviewDialog({
   previewPath,
@@ -102,7 +105,20 @@ export function LibraryPreviewDialog({
           )}
         </div>
         <div className="relative min-h-0 flex-1 bg-background">
-          {file ? (
+          {file && entry && isHtml(filename) ? (
+            // HTML goes through the shared handshake-upgrading panel: a
+            // deck gains the rail toggle / edit mode / PDF export; a plain
+            // page stays a passive preview. Public volumes are read-only.
+            <HtmlPreviewPanel
+              readUrl={file.downloadUrl}
+              marker={`${entry.size}-${entry.updatedAt}`}
+              title={filename}
+              // The editor hook persists to the HOME volume specifically
+              // (deck convention) — only home files are inline-editable.
+              savePath={volume === "home" ? filePath : undefined}
+              chrome="controls"
+            />
+          ) : file ? (
             <FilePreview file={file} />
           ) : isPending ? (
             <FilePreviewShimmer />

--- a/apps/mesh/src/web/layouts/library/preview-dialog.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-dialog.tsx
@@ -67,6 +67,7 @@ export function LibraryPreviewDialog({
           <>
             <DialogTitle className="sr-only">{filename}</DialogTitle>
             <HtmlPreviewPanel
+              key={previewPath}
               readUrl={file.downloadUrl}
               marker={`${entry.size}-${entry.updatedAt}`}
               title={filename}

--- a/apps/mesh/src/web/layouts/library/preview-dialog.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-dialog.tsx
@@ -60,77 +60,84 @@ export function LibraryPreviewDialog({
       }}
     >
       <DialogContent className="flex h-[88vh] w-[94vw] max-w-none! flex-col gap-0 overflow-hidden p-0 sm:max-w-5xl!">
-        <div className="flex h-11 shrink-0 items-center gap-1 border-b border-border/60 py-1 pr-12 pl-2">
-          <div className="flex min-w-0 flex-1 items-center gap-2 px-2">
-            <FileTypeIcon
-              filename={filename}
-              className="h-4.5 w-3.5 shrink-0"
-            />
-            <DialogTitle className="truncate text-xs font-medium text-foreground">
-              {filename}
-            </DialogTitle>
-            {file && (
-              <span className="shrink-0 text-xs text-muted-foreground">
-                {formatSize(file.size)}
-              </span>
-            )}
-          </div>
-          {file && (
-            <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button variant="ghost" size="icon" asChild>
-                    <a href={file.downloadUrl} download={file.filename}>
-                      <Download01 size={14} />
-                    </a>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Download</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() =>
-                      window.open(file.downloadUrl, "_blank", "noopener")
-                    }
-                  >
-                    <LinkExternal01 size={14} />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Open in new tab</TooltipContent>
-              </Tooltip>
-            </>
-          )}
-        </div>
-        <div className="relative min-h-0 flex-1 bg-background">
-          {file && entry && isHtml(filename) ? (
-            // HTML goes through the shared handshake-upgrading panel: a
-            // deck gains the rail toggle / edit mode / PDF export; a plain
-            // page stays a passive preview. Public volumes are read-only.
+        {file && entry && isHtml(filename) ? (
+          // HTML uses the shared handshake-upgrading panel (same single
+          // toolbar as the chat deck tab). sr-only title keeps the dialog
+          // accessible; the spacer clears the dialog's built-in close X.
+          <>
+            <DialogTitle className="sr-only">{filename}</DialogTitle>
             <HtmlPreviewPanel
               readUrl={file.downloadUrl}
               marker={`${entry.size}-${entry.updatedAt}`}
               title={filename}
-              // The editor hook persists to the HOME volume specifically
-              // (deck convention) — only home files are inline-editable.
               savePath={volume === "home" ? filePath : undefined}
-              chrome="controls"
+              trailing={<div className="w-8 shrink-0" />}
             />
-          ) : file ? (
-            <FilePreview file={file} />
-          ) : isPending ? (
-            <FilePreviewShimmer />
-          ) : (
-            <div className="flex h-full flex-col items-center justify-center gap-2">
-              <FileTypeIcon filename={filename} className="h-7.5 w-6" />
-              <span className="text-sm text-muted-foreground">
-                This file is no longer available.
-              </span>
+          </>
+        ) : (
+          <>
+            <div className="flex h-11 shrink-0 items-center gap-1 border-b border-border/60 py-1 pr-12 pl-2">
+              <div className="flex min-w-0 flex-1 items-center gap-2 px-2">
+                <FileTypeIcon
+                  filename={filename}
+                  className="h-4.5 w-3.5 shrink-0"
+                />
+                <DialogTitle className="truncate text-xs font-medium text-foreground">
+                  {filename}
+                </DialogTitle>
+                {file && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {formatSize(file.size)}
+                  </span>
+                )}
+              </div>
+              {file && (
+                <>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button variant="ghost" size="icon" asChild>
+                        <a href={file.downloadUrl} download={file.filename}>
+                          <Download01 size={14} />
+                        </a>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Download</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() =>
+                          window.open(file.downloadUrl, "_blank", "noopener")
+                        }
+                      >
+                        <LinkExternal01 size={14} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      Open in new tab
+                    </TooltipContent>
+                  </Tooltip>
+                </>
+              )}
             </div>
-          )}
-        </div>
+            <div className="relative min-h-0 flex-1 bg-background">
+              {file ? (
+                <FilePreview file={file} />
+              ) : isPending ? (
+                <FilePreviewShimmer />
+              ) : (
+                <div className="flex h-full flex-col items-center justify-center gap-2">
+                  <FileTypeIcon filename={filename} className="h-7.5 w-6" />
+                  <span className="text-sm text-muted-foreground">
+                    This file is no longer available.
+                  </span>
+                </div>
+              )}
+            </div>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/apps/mesh/src/web/layouts/library/preview-panel.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-panel.tsx
@@ -3,6 +3,12 @@
  * viewer, mirroring the chat's file tab (toolbar + preview). URL-driven
  * (`?preview=<browse path>`) so a preview link survives reload: the entry
  * is re-resolved via `stat`, not read off list caches.
+ *
+ * HTML files render the shared HtmlPreviewPanel instead — the SAME single
+ * toolbar the chat deck tab shows (URL/copy/open, upgrading with rail/
+ * edit/PDF on the deck-viewer handshake), with the Library's download and
+ * close actions appended via `trailing`. Only home-volume files get a
+ * savePath (the inline editor persists to the home volume).
  */
 
 import { Button } from "@deco/ui/components/button.tsx";
@@ -23,6 +29,39 @@ import { useOrgFsDownloadUrl, useOrgFsStat } from "@/web/hooks/use-org-fs";
 import { basename, parseLibraryPath } from "./location";
 
 const isHtml = (name: string) => /\.html?$/i.test(name);
+
+function PreviewActions({
+  downloadUrl,
+  filename,
+  onClose,
+}: {
+  downloadUrl: string;
+  filename: string;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="ghost" size="icon" asChild>
+            <a href={downloadUrl} download={filename}>
+              <Download01 size={14} />
+            </a>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Download</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="ghost" size="icon" onClick={onClose}>
+            <XClose size={14} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Close</TooltipContent>
+      </Tooltip>
+    </>
+  );
+}
 
 export function LibraryPreviewPanel({
   previewPath,
@@ -47,6 +86,26 @@ export function LibraryPreviewPanel({
           downloadUrl: downloadUrl(entry.path),
         }
       : null;
+
+  // HTML: hand the whole panel (toolbar included) to the shared surface so
+  // it is pixel-identical to the chat deck tab.
+  if (file && entry && isHtml(filename)) {
+    return (
+      <HtmlPreviewPanel
+        readUrl={file.downloadUrl}
+        marker={`${entry.size}-${entry.updatedAt}`}
+        title={filename}
+        savePath={volume === "home" ? filePath : undefined}
+        trailing={
+          <PreviewActions
+            downloadUrl={file.downloadUrl}
+            filename={filename}
+            onClose={onClose}
+          />
+        }
+      />
+    );
+  }
 
   return (
     <div className="flex h-full w-full flex-col bg-background">
@@ -100,20 +159,7 @@ export function LibraryPreviewPanel({
         </Tooltip>
       </div>
       <div className="relative min-h-0 flex-1">
-        {file && entry && isHtml(filename) ? (
-          // HTML goes through the shared handshake-upgrading panel: a deck
-          // gains the rail toggle / edit mode / PDF export; a plain page
-          // stays a passive preview. Public volumes are read-only.
-          <HtmlPreviewPanel
-            readUrl={file.downloadUrl}
-            marker={`${entry.size}-${entry.updatedAt}`}
-            title={filename}
-            // The editor hook persists to the HOME volume specifically
-            // (deck convention) — only home files are inline-editable.
-            savePath={volume === "home" ? filePath : undefined}
-            chrome="controls"
-          />
-        ) : file ? (
+        {file ? (
           <FilePreview file={file} />
         ) : isPending ? (
           <FilePreviewShimmer />

--- a/apps/mesh/src/web/layouts/library/preview-panel.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-panel.tsx
@@ -17,9 +17,12 @@ import {
   FilePreviewShimmer,
   formatSize,
 } from "@/web/components/file-preview";
+import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
 import { FileTypeIcon } from "@/web/components/file-type-icon";
 import { useOrgFsDownloadUrl, useOrgFsStat } from "@/web/hooks/use-org-fs";
 import { basename, parseLibraryPath } from "./location";
+
+const isHtml = (name: string) => /\.html?$/i.test(name);
 
 export function LibraryPreviewPanel({
   previewPath,
@@ -97,7 +100,20 @@ export function LibraryPreviewPanel({
         </Tooltip>
       </div>
       <div className="relative min-h-0 flex-1">
-        {file ? (
+        {file && entry && isHtml(filename) ? (
+          // HTML goes through the shared handshake-upgrading panel: a deck
+          // gains the rail toggle / edit mode / PDF export; a plain page
+          // stays a passive preview. Public volumes are read-only.
+          <HtmlPreviewPanel
+            readUrl={file.downloadUrl}
+            marker={`${entry.size}-${entry.updatedAt}`}
+            title={filename}
+            // The editor hook persists to the HOME volume specifically
+            // (deck convention) — only home files are inline-editable.
+            savePath={volume === "home" ? filePath : undefined}
+            chrome="controls"
+          />
+        ) : file ? (
           <FilePreview file={file} />
         ) : isPending ? (
           <FilePreviewShimmer />

--- a/apps/mesh/src/web/layouts/library/preview-panel.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-panel.tsx
@@ -72,7 +72,11 @@ export function LibraryPreviewPanel({
   // it is pixel-identical to the chat deck tab.
   if (file && entry && isHtml(filename)) {
     return (
+      // Keyed per file: the editor hook holds per-file state (source
+      // cache, debounced saves, handshake) that must never survive a
+      // ?preview= switch — a pending save would PUT to the new path.
       <HtmlPreviewPanel
+        key={previewPath}
         readUrl={file.downloadUrl}
         marker={`${entry.size}-${entry.updatedAt}`}
         title={filename}

--- a/apps/mesh/src/web/layouts/library/preview-panel.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-panel.tsx
@@ -26,7 +26,11 @@ import {
 } from "@/web/components/file-preview";
 import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
 import { FileTypeIcon } from "@/web/components/file-type-icon";
-import { useOrgFsDownloadUrl, useOrgFsStat } from "@/web/hooks/use-org-fs";
+import {
+  entryMarker,
+  useOrgFsDownloadUrl,
+  useOrgFsStat,
+} from "@/web/hooks/use-org-fs";
 import { basename, parseLibraryPath } from "./location";
 
 const isHtml = (name: string) => /\.html?$/i.test(name);
@@ -78,7 +82,7 @@ export function LibraryPreviewPanel({
       <HtmlPreviewPanel
         key={previewPath}
         readUrl={file.downloadUrl}
-        marker={`${entry.size}-${entry.updatedAt}`}
+        marker={entryMarker(entry)}
         title={filename}
         savePath={volume === "home" ? filePath : undefined}
         trailing={<PreviewClose onClose={onClose} />}

--- a/apps/mesh/src/web/layouts/library/preview-panel.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-panel.tsx
@@ -6,9 +6,10 @@
  *
  * HTML files render the shared HtmlPreviewPanel instead — the SAME single
  * toolbar the chat deck tab shows (URL/copy/open, upgrading with rail/
- * edit/PDF on the deck-viewer handshake), with the Library's download and
- * close actions appended via `trailing`. Only home-volume files get a
- * savePath (the inline editor persists to the home volume).
+ * edit/download on the deck-viewer handshake), with the Library's close
+ * action appended via `trailing` (download lives in the shared toolbar).
+ * Only home-volume files get a savePath (the inline editor persists to
+ * the home volume).
  */
 
 import { Button } from "@deco/ui/components/button.tsx";
@@ -30,36 +31,16 @@ import { basename, parseLibraryPath } from "./location";
 
 const isHtml = (name: string) => /\.html?$/i.test(name);
 
-function PreviewActions({
-  downloadUrl,
-  filename,
-  onClose,
-}: {
-  downloadUrl: string;
-  filename: string;
-  onClose: () => void;
-}) {
+function PreviewClose({ onClose }: { onClose: () => void }) {
   return (
-    <>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" asChild>
-            <a href={downloadUrl} download={filename}>
-              <Download01 size={14} />
-            </a>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Download</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" onClick={onClose}>
-            <XClose size={14} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Close</TooltipContent>
-      </Tooltip>
-    </>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" onClick={onClose}>
+          <XClose size={14} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Close</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -96,13 +77,7 @@ export function LibraryPreviewPanel({
         marker={`${entry.size}-${entry.updatedAt}`}
         title={filename}
         savePath={volume === "home" ? filePath : undefined}
-        trailing={
-          <PreviewActions
-            downloadUrl={file.downloadUrl}
-            filename={filename}
-            onClose={onClose}
-          />
-        }
+        trailing={<PreviewClose onClose={onClose} />}
       />
     );
   }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/deck-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/deck-tab.tsx
@@ -16,7 +16,11 @@
 
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
-import { useOrgFsDownloadUrl, useOrgFsStat } from "@/web/hooks/use-org-fs";
+import {
+  entryMarker,
+  useOrgFsDownloadUrl,
+  useOrgFsStat,
+} from "@/web/hooks/use-org-fs";
 
 const HOME_VOLUME = "home";
 
@@ -50,7 +54,7 @@ export function DeckTab({ path }: { path: string }) {
   return (
     <HtmlPreviewPanel
       readUrl={readUrl}
-      marker={`${stat.data.size}-${stat.data.updatedAt}`}
+      marker={entryMarker(stat.data)}
       title={path}
       savePath={path}
     />

--- a/apps/mesh/src/web/layouts/main-panel-tabs/deck-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/deck-tab.tsx
@@ -1,29 +1,24 @@
 /**
- * DeckTab — side-panel live preview + inline editor for a presentation
- * deck (`decks/<name>.html` in the org home volume, created by the
- * sandbox `slides` skill).
+ * DeckTab — side-panel preview/editor for an org-fs home-volume HTML file
+ * (`decks/<name>.html`, created by the sandbox `slides` skill).
  *
- * The deck HTML is served same-origin from the org-fs read route and
- * rendered in a sandboxed iframe (`allow-scripts`, no same-origin — the
- * deck is member-authored content). The iframe src is keyed by the
- * file's stat marker (`size-updatedAt`), so an agent rewrite mid-run
- * (signalled via `data-deck-updated` → stat invalidation in
- * chat-context) hard-reloads the preview — except while the user is
- * editing; `useDeckEditor` owns that policy.
+ * Thin adapter: resolves the same-origin read URL + stat marker and
+ * renders the shared HtmlPreviewPanel, which upgrades into the deck
+ * editor when the document completes the deck-viewer handshake. The
+ * `savePath` makes the source writable (inline edits PUT back to org-fs;
+ * a UI write reaches the sandbox mount in ~1s, so the agent sees it).
  *
- * While the file hasn't appeared yet (sandbox mount write-back takes a
- * few seconds for bash-created decks), the stat polls every 2s.
+ * Stat invalidation arrives from chat-context on `data-deck-updated`
+ * parts (agent rewrites mid-run); while the file hasn't appeared yet
+ * (sandbox mount write-back takes a few seconds for bash-created decks),
+ * the stat polls every 2s.
  */
 
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { useState } from "react";
-import { DeckToolbar } from "@/web/components/deck/deck-toolbar";
-import { useDeckEditor } from "@/web/components/deck/use-deck-editor";
+import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
 import { useOrgFsDownloadUrl, useOrgFsStat } from "@/web/hooks/use-org-fs";
 
 const HOME_VOLUME = "home";
-const FADE_MS = 300;
 
 function DeckShimmer({ label }: { label?: string }) {
   return (
@@ -35,56 +30,29 @@ function DeckShimmer({ label }: { label?: string }) {
 }
 
 export function DeckTab({ path }: { path: string }) {
-  // Poll while the deck hasn't reached org-fs yet (rclone write-back lag
-  // for bash-created decks). The query is cheap (one manifest row).
   const stat = useOrgFsStat(HOME_VOLUME, path, {
     refetchIntervalWhenAbsent: 2000,
   });
   const readUrl = useOrgFsDownloadUrl(HOME_VOLUME)(path);
 
-  const statMarker = stat.data
-    ? `${stat.data.size}-${stat.data.updatedAt}`
-    : null;
-  const editor = useDeckEditor({ path, readUrl, statMarker });
-
-  // Fade the iframe in per loaded document; reset when the src rolls.
-  const [readySrc, setReadySrc] = useState<string | null>(null);
-
-  const missing = !stat.isPending && !stat.data;
-  if (stat.isPending || editor.displayedMarker === null) {
+  if (stat.isPending || !stat.data) {
     return (
       <DeckShimmer
-        label={missing ? "Waiting for the deck to sync…" : undefined}
+        label={
+          !stat.isPending && !stat.data
+            ? "Waiting for the deck to sync…"
+            : undefined
+        }
       />
     );
   }
 
-  // Hash carries the runtime's view state (`#rail` opens the thumbnail
-  // rail) — kept out of the iframe `key` so toggling it is a fragment
-  // navigation inside the existing document, not a reload.
-  const baseSrc = `${readUrl}&v=${encodeURIComponent(editor.displayedMarker)}`;
-  const src = editor.railOpen ? `${baseSrc}#rail` : baseSrc;
-  const iframeReady = readySrc === baseSrc;
-
   return (
-    <div className="flex h-full w-full flex-col bg-background">
-      <DeckToolbar readUrl={readUrl} editor={editor} />
-      <div className="relative flex-1">
-        <iframe
-          key={baseSrc}
-          ref={editor.iframeRef}
-          src={src}
-          onLoad={() => setReadySrc(baseSrc)}
-          sandbox="allow-scripts"
-          className={cn(
-            "absolute inset-0 block h-full w-full bg-white",
-            "transition-opacity ease-out",
-            iframeReady ? "opacity-100" : "opacity-0",
-          )}
-          style={{ transitionDuration: `${FADE_MS}ms` }}
-          title={path}
-        />
-      </div>
-    </div>
+    <HtmlPreviewPanel
+      readUrl={readUrl}
+      marker={`${stat.data.size}-${stat.data.updatedAt}`}
+      title={path}
+      savePath={path}
+    />
   );
 }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/deck-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/deck-tab.tsx
@@ -1,0 +1,90 @@
+/**
+ * DeckTab — side-panel live preview + inline editor for a presentation
+ * deck (`decks/<name>.html` in the org home volume, created by the
+ * sandbox `slides` skill).
+ *
+ * The deck HTML is served same-origin from the org-fs read route and
+ * rendered in a sandboxed iframe (`allow-scripts`, no same-origin — the
+ * deck is member-authored content). The iframe src is keyed by the
+ * file's stat marker (`size-updatedAt`), so an agent rewrite mid-run
+ * (signalled via `data-deck-updated` → stat invalidation in
+ * chat-context) hard-reloads the preview — except while the user is
+ * editing; `useDeckEditor` owns that policy.
+ *
+ * While the file hasn't appeared yet (sandbox mount write-back takes a
+ * few seconds for bash-created decks), the stat polls every 2s.
+ */
+
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useState } from "react";
+import { DeckToolbar } from "@/web/components/deck/deck-toolbar";
+import { useDeckEditor } from "@/web/components/deck/use-deck-editor";
+import { useOrgFsDownloadUrl, useOrgFsStat } from "@/web/hooks/use-org-fs";
+
+const HOME_VOLUME = "home";
+const FADE_MS = 300;
+
+function DeckShimmer({ label }: { label?: string }) {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-background">
+      <Skeleton className="aspect-video w-2/3 max-w-xl" />
+      {label && <p className="text-xs text-muted-foreground">{label}</p>}
+    </div>
+  );
+}
+
+export function DeckTab({ path }: { path: string }) {
+  // Poll while the deck hasn't reached org-fs yet (rclone write-back lag
+  // for bash-created decks). The query is cheap (one manifest row).
+  const stat = useOrgFsStat(HOME_VOLUME, path, {
+    refetchIntervalWhenAbsent: 2000,
+  });
+  const readUrl = useOrgFsDownloadUrl(HOME_VOLUME)(path);
+
+  const statMarker = stat.data
+    ? `${stat.data.size}-${stat.data.updatedAt}`
+    : null;
+  const editor = useDeckEditor({ path, readUrl, statMarker });
+
+  // Fade the iframe in per loaded document; reset when the src rolls.
+  const [readySrc, setReadySrc] = useState<string | null>(null);
+
+  const missing = !stat.isPending && !stat.data;
+  if (stat.isPending || editor.displayedMarker === null) {
+    return (
+      <DeckShimmer
+        label={missing ? "Waiting for the deck to sync…" : undefined}
+      />
+    );
+  }
+
+  // Hash carries the runtime's view state (`#rail` opens the thumbnail
+  // rail) — kept out of the iframe `key` so toggling it is a fragment
+  // navigation inside the existing document, not a reload.
+  const baseSrc = `${readUrl}&v=${encodeURIComponent(editor.displayedMarker)}`;
+  const src = editor.railOpen ? `${baseSrc}#rail` : baseSrc;
+  const iframeReady = readySrc === baseSrc;
+
+  return (
+    <div className="flex h-full w-full flex-col bg-background">
+      <DeckToolbar readUrl={readUrl} editor={editor} />
+      <div className="relative flex-1">
+        <iframe
+          key={baseSrc}
+          ref={editor.iframeRef}
+          src={src}
+          onLoad={() => setReadySrc(baseSrc)}
+          sandbox="allow-scripts"
+          className={cn(
+            "absolute inset-0 block h-full w-full bg-white",
+            "transition-opacity ease-out",
+            iframeReady ? "opacity-100" : "opacity-0",
+          )}
+          style={{ transitionDuration: `${FADE_MS}ms` }}
+          title={path}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -18,9 +18,11 @@ import { AutomationTab } from "./automation-tab";
 import { AutomationsListTab } from "./automations-list-tab";
 import { WebPageTab } from "./web-page-tab";
 import { FileTab } from "./file-tab";
+import { DeckTab } from "./deck-tab";
 import { MainPanelLoading } from "./main-panel-loading";
 import {
   isLegacySettingsTab,
+  parseDeckTabId,
   parseFileTabId,
   parsePinnedViewTabId,
   parseWebPageTabId,
@@ -85,6 +87,11 @@ function TabBody({
   const webPage = parseWebPageTabId(activeTab);
   if (webPage) {
     return <WebPageTab slug={webPage.slug} />;
+  }
+
+  const deckTab = parseDeckTabId(activeTab);
+  if (deckTab) {
+    return <DeckTab key={deckTab.path} path={deckTab.path} />;
   }
 
   const fileTab = parseFileTabId(activeTab);

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+  formatDeckTabId,
   formatFileTabId,
   isLegacySettingsTab,
   isPerThreadTab,
   parseAutomationTabId,
+  parseDeckTabId,
   parseFileTabId,
   resolveDefaultTabId,
   resolveActiveTabAndOpen,
@@ -56,6 +58,29 @@ describe("file tab id", () => {
   test("file tabs are per-thread", () => {
     expect(isPerThreadTab(formatFileTabId("model-outputs/t/a.pdf"))).toBe(true);
     expect(isPerThreadTab("settings")).toBe(false);
+  });
+});
+
+describe("deck tab id", () => {
+  test("round-trips home-volume deck paths", () => {
+    for (const path of ["decks/q3-launch.html", "decks/My.Deck_2.html"]) {
+      expect(parseDeckTabId(formatDeckTabId(path))).toEqual({ path });
+    }
+  });
+
+  test("non-deck tab → null", () => {
+    expect(parseDeckTabId("settings")).toBeNull();
+    expect(parseDeckTabId("file:decks%2Fa.html")).toBeNull();
+    expect(parseDeckTabId(undefined)).toBeNull();
+    expect(parseDeckTabId("deck:")).toBeNull();
+  });
+
+  test("malformed percent-encoding → null, not a throw", () => {
+    expect(parseDeckTabId("deck:%E0%A4%A")).toBeNull();
+  });
+
+  test("deck tabs are per-thread", () => {
+    expect(isPerThreadTab(formatDeckTabId("decks/a.html"))).toBe(true);
   });
 });
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
@@ -10,6 +10,7 @@
  *   - Ephemeral automation: "automation:<id>"
  *   - Ephemeral web page: "web-page:<slug>" (web-developer agent preview)
  *   - Ephemeral file preview: "file:<encoded output key>" (thread output viewer)
+ *   - Ephemeral deck preview: "deck:<encoded home-volume path>" (slides skill)
  *   - "0" = closed sentinel (not an actual tab id)
  *
  * The "settings" tab bundles what used to be separate instructions,
@@ -82,6 +83,30 @@ export function parseWebPageTabId(
   return { slug };
 }
 
+export interface DeckTabParsed {
+  /** Home-volume-relative deck path, e.g. `decks/q3-launch.html`. */
+  path: string;
+}
+
+/** Paths carry `/`, so the tab id encodes them to keep the
+ *  `<kind>:<rest>` grammar unambiguous in the `?main=` URL param. */
+export function formatDeckTabId(path: string): string {
+  return `deck:${encodeURIComponent(path)}`;
+}
+
+export function parseDeckTabId(
+  tabId: string | undefined,
+): DeckTabParsed | null {
+  if (!tabId || !tabId.startsWith("deck:")) return null;
+  const encoded = tabId.slice("deck:".length);
+  if (!encoded) return null;
+  try {
+    return { path: decodeURIComponent(encoded) };
+  } catch {
+    return null;
+  }
+}
+
 export interface FileTabParsed {
   /** Thread-output key: an S3 key ("model-outputs/<threadId>/x.pdf") or an
    *  org-fs ref ("org-fs:outputs/<threadId>/x.pdf") — same shape the
@@ -125,13 +150,15 @@ const FIXED_SYSTEM_TAB_SET = new Set<string>(FIXED_SYSTEM_TABS);
  *   - "web-page:<slug>"               (ephemeral web preview)
  *   - "automation:<id>"               (ephemeral automation detail)
  *   - "file:<encoded key>"            (ephemeral thread-output file preview)
+ *   - "deck:<encoded path>"           (ephemeral deck preview/editor)
  */
 export function isPerThreadTab(tabId: string): boolean {
   return (
     tabId.startsWith("app:") ||
     tabId.startsWith("web-page:") ||
     tabId.startsWith("automation:") ||
-    tabId.startsWith("file:")
+    tabId.startsWith("file:") ||
+    tabId.startsWith("deck:")
   );
 }
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -12,6 +12,7 @@
 
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Monitor01 } from "@untitledui/icons";
 import { createElement, useSyncExternalStore } from "react";
 import {
   SELF_MCP_ALIAS_ID,
@@ -43,6 +44,7 @@ import { FileTypeIcon } from "@/web/components/file-type-icon";
 import {
   formatPinnedViewTabId,
   parseAutomationTabId,
+  parseDeckTabId,
   parseFileTabId,
   resolveActiveTabAndOpen,
   resolveDefaultTabId,
@@ -313,8 +315,28 @@ export function useMainPanelTabs(ctx: {
       ]
     : [];
 
+  // Ephemeral deck-preview tab (`?main=deck:<path>`): same pill semantics
+  // as file previews. Title is the deck name (file stem).
+  const deckTabParsed = parseDeckTabId(activeTab);
+  const deckTabs: Tab[] = deckTabParsed
+    ? [
+        {
+          id: activeTab,
+          title: (
+            deckTabParsed.path.split("/").pop() ?? deckTabParsed.path
+          ).replace(/\.html$/i, ""),
+          kind: "file",
+          icon: {
+            kind: "component",
+            Component: (props) => createElement(Monitor01, props),
+          },
+        },
+      ]
+    : [];
+
   const tabs: Tab[] = [
     ...fileTabs,
+    ...deckTabs,
     ...layoutTabs.map((t) => ({
       id: t.id,
       title: t.title,

--- a/apps/mesh/src/web/layouts/main-panel-tabs/web-page-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/web-page-tab.tsx
@@ -1,38 +1,28 @@
 /**
- * WebPageTab — side-panel preview of a generated HTML page.
+ * WebPageTab — side-panel preview of a generated HTML page (the legacy
+ * `pages/<slug>.html` pipeline).
  *
  * The HTML itself is NOT streamed through the chat. The model writes to
  * the sandbox; the wrapped `write`/`edit` tools enqueue the new content
- * into a per-turn buffer (`html-page-buffer`) and return `htmlPreview`
- * synchronously so the chat row paints "Page updated" immediately. The
- * actual S3 PUT happens once per step from `htmlPageBuffer.flush()`,
- * which is hooked into `onStepFinish` via `pendingOps` (awaited at
- * `onFinish` before the stream closes).
+ * into a per-turn buffer (`html-page-buffer`) and the actual S3 PUT
+ * happens once per step. This component waits for the
+ * `data-html-page-published` part emitted after the PUT lands (loading
+ * the URL straight from the tool result would race the deferred PUT),
+ * then renders the shared HtmlPreviewPanel.
  *
- * Iframe gating: this component does NOT load the URL straight from the
- * tool's `htmlPreview` — that would race the deferred PUT. Instead, it
- * waits for a `data-html-page-published` part emitted from the flush
- * after the PUT lands, then iframes the URL from that data event. While
- * waiting, the panel shows a shimmer.
+ * The panel is the same surface decks use: if the published page speaks
+ * the deck-viewer protocol it gains the rail toggle + PDF export. No
+ * `savePath` — this pipeline's source of truth is the sandbox file, and
+ * there is no write-back route to object storage, so the preview stays
+ * read-only (no inline edit affordance).
  *
- * Cache-bust: `?v=<bytes>` from the publish event forces the iframe to
- * refetch when the same slug is re-published with a different size, so
- * the browser doesn't serve a cached stale body.
+ * Cache-bust: the publish event's byte count is the content marker; a
+ * republished slug with a different size rolls the iframe src.
  */
 
-import { Button } from "@deco/ui/components/button.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Check, Copy01, LinkExternal01 } from "@untitledui/icons";
-import { useState } from "react";
 import { useOptionalChatStream } from "@/web/components/chat/context.tsx";
-
-const FADE_MS = 300;
+import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
 
 interface HtmlPagePublished {
   slug: string;
@@ -53,44 +43,6 @@ function PageShimmer() {
         </div>
         <Skeleton className="mt-2 h-8 w-24" />
       </div>
-    </div>
-  );
-}
-
-function PreviewSlot({ url, title }: { url: string; title: string }) {
-  const [iframeReady, setIframeReady] = useState(false);
-  const [shimmerMounted, setShimmerMounted] = useState(true);
-
-  return (
-    <div className="relative h-full w-full bg-background">
-      <iframe
-        src={url}
-        onLoad={() => setIframeReady(true)}
-        sandbox="allow-scripts"
-        className={cn(
-          "absolute inset-0 block w-full h-full bg-white",
-          "transition-opacity ease-out",
-          iframeReady ? "opacity-100" : "opacity-0",
-        )}
-        style={{ transitionDuration: `${FADE_MS}ms` }}
-        title={title}
-      />
-      {shimmerMounted && (
-        <div
-          className={cn(
-            "absolute inset-0 transition-opacity ease-out",
-            iframeReady ? "opacity-0 pointer-events-none" : "opacity-100",
-          )}
-          style={{ transitionDuration: `${FADE_MS}ms` }}
-          onTransitionEnd={(e) => {
-            if (e.propertyName === "opacity" && iframeReady) {
-              setShimmerMounted(false);
-            }
-          }}
-        >
-          <PageShimmer />
-        </div>
-      )}
     </div>
   );
 }
@@ -124,51 +76,6 @@ function findLatestPublished(
   return null;
 }
 
-function PreviewToolbar({ url }: { url: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(url);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
-  };
-
-  return (
-    <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border/60 px-2">
-      <button
-        type="button"
-        onClick={() => window.open(url, "_blank", "noopener")}
-        className="flex min-w-0 flex-1 items-center rounded-md px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        title={url}
-      >
-        <span className="truncate">{url}</span>
-      </button>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" onClick={handleCopy}>
-            {copied ? <Check size={14} /> : <Copy01 size={14} />}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {copied ? "Copied" : "Copy URL"}
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => window.open(url, "_blank", "noopener")}
-          >
-            <LinkExternal01 size={14} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Open in new tab</TooltipContent>
-      </Tooltip>
-    </div>
-  );
-}
-
 export function WebPageTab({ slug }: { slug: string }) {
   const stream = useOptionalChatStream();
   const messages = stream?.messages ?? [];
@@ -182,13 +89,11 @@ export function WebPageTab({ slug }: { slug: string }) {
     );
   }
 
-  const cacheBustedUrl = `${latest.url}${latest.url.includes("?") ? "&" : "?"}v=${latest.bytes}`;
   return (
-    <div className="flex h-full w-full flex-col bg-background">
-      <PreviewToolbar url={latest.url} />
-      <div className="relative flex-1">
-        <PreviewSlot url={cacheBustedUrl} title={`${slug}.html`} />
-      </div>
-    </div>
+    <HtmlPreviewPanel
+      readUrl={latest.url}
+      marker={String(latest.bytes)}
+      title={`${slug}.html`}
+    />
   );
 }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/web-page-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/web-page-tab.tsx
@@ -91,6 +91,7 @@ export function WebPageTab({ slug }: { slug: string }) {
 
   return (
     <HtmlPreviewPanel
+      key={slug}
       readUrl={latest.url}
       marker={String(latest.bytes)}
       title={`${slug}.html`}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -17,7 +17,10 @@
         "migrations/**/*.ts",
         "scripts/**/*.ts",
         // Dev-only module loaded via require() - needs explicit entry
-        "src/api/routes/dev-only.ts"
+        "src/api/routes/dev-only.ts",
+        // Browser asset served verbatim from the Vite public dir; deck HTML
+        // files reference it via <script src="/deck-runtime/v1/...">.
+        "public/deck-runtime/**/*.js"
       ],
       "ignore": ["src/api/index.ts"],
       "ignoreDependencies": [
@@ -37,8 +40,14 @@
       // daemon/entry.ts is bundled via `bun build` into a standalone binary
       // that runs inside sandbox VMs; org-fs/sidecar-main.ts likewise into
       // the orgfs-sidecar image (deploy/helm/sandbox-env/orgfs-sidecar).
+      // The skills *.mjs CLIs are COPY'd into the sandbox image and executed
+      // there via the _bin shims (e.g. `slides-create`), never imported.
       // Without marking them as entries, knip treats their graphs as unused.
-      "entry": ["daemon/entry.ts", "daemon/org-fs/sidecar-main.ts"]
+      "entry": [
+        "daemon/entry.ts",
+        "daemon/org-fs/sidecar-main.ts",
+        "image/skills/*/*.mjs"
+      ]
     },
     "packages/typegen": {}
   },

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/deck-paths.test.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/deck-paths.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { matchDeckEntryPath, matchDeckToolPath } from "./deck-paths";
+
+describe("matchDeckEntryPath", () => {
+  test("matches volume-relative deck paths", () => {
+    expect(matchDeckEntryPath("decks/q3-launch.html")).toEqual({
+      path: "decks/q3-launch.html",
+      name: "q3-launch",
+    });
+    expect(matchDeckEntryPath("decks/a.html")).toEqual({
+      path: "decks/a.html",
+      name: "a",
+    });
+    expect(matchDeckEntryPath("decks/My.Deck_2.HTML")).toEqual({
+      path: "decks/My.Deck_2.HTML",
+      name: "My.Deck_2",
+    });
+  });
+
+  test("rejects non-deck paths", () => {
+    expect(matchDeckEntryPath("decks/launch.md")).toBeNull();
+    expect(matchDeckEntryPath("decks/nested/launch.html")).toBeNull();
+    expect(matchDeckEntryPath("notes/launch.html")).toBeNull();
+    expect(matchDeckEntryPath("launch.html")).toBeNull();
+    expect(matchDeckEntryPath("decks/.hidden.html")).toBeNull();
+    expect(matchDeckEntryPath("")).toBeNull();
+  });
+});
+
+describe("matchDeckToolPath", () => {
+  test("matches mount-relative tool paths", () => {
+    expect(matchDeckToolPath("org/acme/decks/launch.html", "acme")).toEqual({
+      path: "decks/launch.html",
+      name: "launch",
+    });
+    expect(matchDeckToolPath("./org/acme/decks/launch.html", "acme")).toEqual({
+      path: "decks/launch.html",
+      name: "launch",
+    });
+    expect(
+      matchDeckToolPath("/app/repo/org/acme/decks/launch.html", "acme"),
+    ).toEqual({ path: "decks/launch.html", name: "launch" });
+  });
+
+  test("works with the reserved-slug fallback mount path", () => {
+    expect(matchDeckToolPath("org/home/decks/launch.html", "home")).toEqual({
+      path: "decks/launch.html",
+      name: "launch",
+    });
+  });
+
+  test("rejects other mounts, volumes, and traversal-ish paths", () => {
+    expect(matchDeckToolPath("org/other/decks/launch.html", "acme")).toBeNull();
+    expect(
+      matchDeckToolPath("org/upload/decks/launch.html", "acme"),
+    ).toBeNull();
+    expect(matchDeckToolPath("decks/launch.html", "acme")).toBeNull();
+    expect(matchDeckToolPath("xorg/acme/decks/launch.html", "acme")).toBeNull();
+    expect(matchDeckToolPath("org/acme/decks/launch.html", "")).toBeNull();
+    expect(
+      matchDeckToolPath("org/acme/decks/nested/launch.html", "acme"),
+    ).toBeNull();
+  });
+});

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/deck-paths.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/deck-paths.ts
@@ -1,0 +1,42 @@
+/**
+ * Deck path matching — pure logic shared by the cluster deck watcher (org-fs
+ * change-feed entries) and any tool-path detection.
+ *
+ * Convention: presentation decks live at `decks/<name>.html` inside the org
+ * home volume, which sandboxes see mounted at `org/<homeMountPath>/`. The
+ * `slides` sandbox skill writes there; the Studio web UI previews + edits
+ * the same file.
+ */
+
+const DECK_ENTRY_PATTERN = /^decks\/([a-z0-9][a-z0-9._-]*)\.html$/i;
+
+export interface DeckRef {
+  /** Volume-relative path, e.g. `decks/q3-launch.html`. */
+  path: string;
+  /** Deck name (file stem), e.g. `q3-launch`. */
+  name: string;
+}
+
+/** Match a HOME-VOLUME-relative entry path (org-fs change feed shape). */
+export function matchDeckEntryPath(entryPath: string): DeckRef | null {
+  const m = DECK_ENTRY_PATTERN.exec(entryPath);
+  if (!m) return null;
+  return { path: entryPath, name: m[1]! };
+}
+
+/**
+ * Match a SANDBOX tool path (`write`/`edit`/bash cwd-relative or absolute)
+ * against the mounted deck dir, e.g. `org/acme/decks/launch.html` or
+ * `/app/repo/org/acme/decks/launch.html`. Returns the volume-relative ref.
+ */
+export function matchDeckToolPath(
+  rawPath: string,
+  homeMountPath: string,
+): DeckRef | null {
+  if (!homeMountPath) return null;
+  const normalized = rawPath.replace(/^\.\//, "");
+  const marker = `org/${homeMountPath}/`;
+  const idx = normalized.indexOf(marker);
+  if (idx !== 0 && (idx < 0 || normalized[idx - 1] !== "/")) return null;
+  return matchDeckEntryPath(normalized.slice(idx + marker.length));
+}

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
@@ -107,6 +107,7 @@ export function createVmTools(params: VmToolsParams) {
   const {
     fs,
     htmlPageBuffer,
+    deckBuffer,
     toolOutputMap,
     needsApproval,
     pendingImages,
@@ -169,6 +170,9 @@ export function createVmTools(params: VmToolsParams) {
       // `htmlPageBuffer.flush()`, so a burst of writes/edits to the same
       // slug collapses to a single round-trip.
       const preview = htmlPageBuffer.enqueue(input.path, input.content);
+      // Deck fast path: mirror `org/<slug>/decks/*.html` content server-
+      // side at step end (skips the mount's slow vfs write-back).
+      deckBuffer?.enqueue(input.path, input.content);
       return preview
         ? { ...(daemonResult as object), htmlPreview: preview }
         : daemonResult;
@@ -189,6 +193,7 @@ export function createVmTools(params: VmToolsParams) {
       const { content: _omit, ...resultForClient } = daemonResult;
       if (typeof postEditContent !== "string") return resultForClient;
       const preview = htmlPageBuffer.enqueue(input.path, postEditContent);
+      deckBuffer?.enqueue(input.path, postEditContent);
       return preview
         ? { ...resultForClient, htmlPreview: preview }
         : resultForClient;

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -173,7 +173,8 @@ export function buildBashDescription(orgFs: boolean): string {
       : "") +
     "Pre-installed file-handling skills also live at " +
     "`/mnt/skills/public/<name>/SKILL.md` (pptx, docx, xlsx, pdf, " +
-    "file-reading). Run `ls /mnt/skills/public/` for that index." +
+    "file-reading, slides, templating). Run `ls /mnt/skills/public/` for " +
+    "that index. To make a presentation deck, read the `slides` skill first." +
     // Without org-fs there is no org/upload or org/output — the legacy
     // transfer tools (also only registered then) are the one way to move
     // files in and out.

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/types.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/types.ts
@@ -26,6 +26,19 @@ export interface HtmlPageBuffer {
   flush(): Promise<void>;
 }
 
+/**
+ * Fast-path mirror for presentation decks (`org/<slug>/decks/<name>.html`).
+ * `write`/`edit` enqueue the full post-write content; the cluster flush
+ * writes it server-side into org-fs, skipping the sandbox mount's multi-
+ * second vfs write-back so the preview (and the change-feed deck watcher)
+ * see the bytes at step end. Bash-created decks skip this and are caught
+ * by the watcher after write-back.
+ */
+export interface DeckBuffer {
+  enqueue(rawPath: string, content: string): void;
+  flush(): Promise<void>;
+}
+
 export interface VmToolsParams {
   /**
    * Flat sandbox filesystem hooks (read/write/edit/bash/glob/grep + the
@@ -43,6 +56,8 @@ export interface VmToolsParams {
    * `onStepFinish` so the iframe never races the write.
    */
   readonly htmlPageBuffer: HtmlPageBuffer;
+  /** Optional deck fast-path mirror (cluster-only; see `DeckBuffer`). */
+  readonly deckBuffer?: DeckBuffer;
   readonly toolOutputMap: Map<string, string>;
   readonly needsApproval: boolean;
   /**

--- a/packages/sandbox/image/skills-features.md
+++ b/packages/sandbox/image/skills-features.md
@@ -294,6 +294,28 @@ the image-size impact ahead of time.
 
 ---
 
+## templating
+
+- [x] **v1** `create-from-template` CLI — render any text file from a mustache template + JSON data (`--data` inline or `@file`, `--strict`, `--partials-dir`, `-f`)
+- [x] **v1** Vendored single-file mustache.js (MIT) at `templating/vendor/mustache.mjs`; other skills import it
+
+> **deps:** bun (already in the image); zero packages
+
+---
+
+## slides
+
+- [x] **v1** `slides-create` CLI — compose a deck from `deck.json` (slides by layout template) into a theme shell; `--theme`, `--templates-dir` for org brand templates
+- [x] **v1** Theme shells: `aurora-light`, `ink-dark`, `bold-gradient` (shared class contract, CSS custom-property theming)
+- [x] **v1** Slide templates: title, agenda, section-divider, bullets, two-column, quote, kpi-row, timeline, comparison, closing
+- [x] **v1** Decks are single self-contained HTML files driven by the mesh-served `/deck-runtime/v1/deck-viewer.js` (live preview, inline editing, and print-to-PDF live in the runtime/host, not the sandbox)
+- [ ] **v2** Image support inside decks (needs an unauthenticated org-asset route)
+- [ ] **v2** Speaker notes
+
+> **deps:** bun + the `templating` skill; zero packages
+
+---
+
 ## v1 summary — what we're shipping in the reading milestone
 
 In rough sequence:

--- a/packages/sandbox/image/skills/_bin/create-from-template
+++ b/packages/sandbox/image/skills/_bin/create-from-template
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec bun /mnt/skills/public/templating/create-from-template.mjs "$@"

--- a/packages/sandbox/image/skills/_bin/slides-create
+++ b/packages/sandbox/image/skills/_bin/slides-create
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec bun /mnt/skills/public/slides/slides-create.mjs "$@"

--- a/packages/sandbox/image/skills/slides/SKILL.md
+++ b/packages/sandbox/image/skills/slides/SKILL.md
@@ -1,0 +1,108 @@
+# slides — presentation decks
+
+Create and edit presentation decks as single self-contained HTML files,
+rendered by Studio's `<deck-viewer>` runtime. The user gets a live preview
+with inline editing, and exports PDF by printing (the deck ships print CSS
+— one page per slide; nothing for you to generate).
+
+## Quick reference
+
+| Task                      | How                                                                   |
+| ------------------------- | --------------------------------------------------------------------- |
+| Create a deck             | `slides-create --data @deck.json --output org/<slug>/decks/<name>.html` |
+| List themes / templates   | `slides-create --help`                                                 |
+| See a full data example   | `cat /mnt/skills/public/slides/examples/deck.json`                     |
+| Edit an existing deck     | `read` the HTML, edit the `<section>` slides, write it back            |
+| Org brand templates       | add `--templates-dir org/<slug>/templates/slides`                      |
+| PDF export                | user prints from the preview — no action needed                        |
+
+## Path convention
+
+Decks live at `org/<slug>/decks/<name>.html` (run `ls org/` for the org
+slug; `<name>` is lowercase kebab). Files written there sync to Studio
+near-instantly and the user sees a live preview that updates as you work.
+
+## Creating a deck
+
+1. Read `/mnt/skills/public/slides/examples/deck.json` once to learn the
+   data shapes.
+2. Author your own deck JSON (a file is easier to iterate than inline):
+   `{ "title": …, "theme": …, "slides": [ { "template": …, "data": … } ] }`
+3. Render: `slides-create --data @deck.json --output org/<slug>/decks/<name>.html`
+4. Iterate content by editing the **HTML output** (see lifecycle below),
+   or re-render with `-f` only while the user hasn't touched the deck.
+
+Themes (`--theme` or `"theme"` in data; default `aurora-light`):
+`aurora-light` (clean light, soft gradients), `ink-dark` (dark keynote,
+amber accents), `bold-gradient` (vivid full-bleed gradient, glass cards).
+
+`--theme` also accepts a **path to a custom theme file** — a complete deck
+shell HTML with a `{{{slides}}}` insertion point (copy a built-in from
+`/mnt/skills/public/slides/themes/` as the starting point and retune its
+CSS custom properties). Keep org brand themes in org-fs so they persist,
+e.g.:
+
+```sh
+slides-create --data @deck.json \
+  --theme org/<slug>/templates/slides/brand-theme.html \
+  --templates-dir org/<slug>/templates/slides \
+  --output org/<slug>/decks/q3.html
+```
+
+### Slide templates and their data
+
+| Template          | Data fields (`?` = optional)                                              |
+| ----------------- | ------------------------------------------------------------------------- |
+| `title`           | `heading`, `subheading?`, `eyebrow?`, `meta?`                              |
+| `agenda`          | `heading`, `items: [string]`, `eyebrow?`                                   |
+| `section-divider` | `heading`, `number?`, `subheading?`                                        |
+| `bullets`         | `heading`, `items: [string]`, `intro?`, `eyebrow?`                         |
+| `two-column`      | `heading`, `left/right: { title?, html }` (`html` is raw trusted HTML), `eyebrow?` |
+| `quote`           | `quote`, `attribution?`, `role?`                                           |
+| `kpi-row`         | `kpis: [{ value, label, delta? }]`, `heading?`, `eyebrow?` (3 KPIs fit best) |
+| `timeline`        | `heading`, `steps: [{ label, title, description? }]`, `eyebrow?` (3–4 steps) |
+| `comparison`      | `heading`, `columns: [{ title, items: [string] }]`, `eyebrow?` (2–3 columns) |
+| `closing`         | `heading`, `subheading?`, `cta?`                                           |
+
+This skill is built on the `templating` skill
+(`/mnt/skills/public/templating/SKILL.md`). For a one-off custom slide
+or deck template, render it directly with `create-from-template`; for an
+org's own slide layouts, keep them in `org/<slug>/templates/slides/` and
+pass `--templates-dir` — they resolve before the built-ins.
+
+## Lifecycle — templates create, edits go to the HTML
+
+Rendering is for **creation**. After that, the HTML file is the live
+artifact: **the user can edit it inline in the preview** (retype text,
+reorder/duplicate/delete/skip slides) and those edits are saved back into
+the same file. Therefore:
+
+- **Always re-read the deck file before editing it** — your last copy may
+  be stale.
+- Iterate with `read`/`edit` on the HTML, not by re-rendering;
+  `slides-create -f` overwrites the user's edits.
+
+## Editing slides by hand
+
+Slides are the direct `<section>` children of `<deck-viewer>`. Rules:
+
+- Fixed 1920×1080 canvas (the runtime scales it). Never set
+  `position`/`inset`/`width`/`height` on the `<section>` itself; lay out
+  inner elements freely.
+- Static HTML only — no JS-rendered text, no per-deck scripts. Inline
+  editing depends on the text being in the markup.
+- Reuse the theme's classes (`deck-h1`, `deck-h2`, `deck-sub`,
+  `deck-body`, `bullets`, `cols`, `card`, `kpi-value`, …) and tune the
+  look via the CSS custom properties in the theme `<style>` block rather
+  than scattering literal colors.
+- Entrance animations: gate on `section[data-deck-active]`, keep the
+  visible end state as the base state, respect
+  `prefers-reduced-motion` — required so print/PDF renders full content.
+- Images: absolute public URLs or data URIs only (relative paths do not
+  resolve when the deck is served). Prefer CSS shapes/gradients.
+- Content budget: a slide fits roughly one heading plus 5 bullets (or
+  3 cards). When in doubt, split into two slides.
+- `data-deck-skip` on a `<section>` hides it from presentation and print
+  without deleting it.
+- Never touch the `<script src="/deck-runtime/v1/deck-viewer.js">` tag or
+  rename `<deck-viewer>`.

--- a/packages/sandbox/image/skills/slides/examples/deck.json
+++ b/packages/sandbox/image/skills/slides/examples/deck.json
@@ -1,0 +1,147 @@
+{
+  "title": "Acme Q3 Launch",
+  "theme": "aurora-light",
+  "slides": [
+    {
+      "template": "title",
+      "data": {
+        "eyebrow": "Acme Inc",
+        "heading": "Q3 Launch Plan",
+        "subheading": "How we ship the new platform to every customer",
+        "meta": "Product Team · September 2026"
+      }
+    },
+    {
+      "template": "agenda",
+      "data": {
+        "heading": "What we'll cover",
+        "items": [
+          "Where we are today",
+          "The launch plan",
+          "Numbers that matter",
+          "Risks and mitigations",
+          "Next steps"
+        ]
+      }
+    },
+    {
+      "template": "section-divider",
+      "data": {
+        "number": "01",
+        "heading": "Where we are today",
+        "subheading": "Six months of groundwork, one quarter to ship"
+      }
+    },
+    {
+      "template": "bullets",
+      "data": {
+        "eyebrow": "Status",
+        "heading": "The platform is ready",
+        "intro": "Every workstream hit its August milestone.",
+        "items": [
+          "Core API stable since July — zero breaking changes in 8 weeks",
+          "Beta cohort of 40 customers using it daily",
+          "Support playbooks written and rehearsed",
+          "Pricing approved by finance and legal"
+        ]
+      }
+    },
+    {
+      "template": "two-column",
+      "data": {
+        "heading": "Beta vs. GA scope",
+        "left": {
+          "title": "In the beta",
+          "html": "Single-region deployments, manual onboarding, and a fixed integration catalog. Good enough to prove value with 40 teams."
+        },
+        "right": {
+          "title": "Added for GA",
+          "html": "Multi-region failover, <b>self-serve onboarding</b>, usage-based billing, and an open integration SDK."
+        }
+      }
+    },
+    {
+      "template": "kpi-row",
+      "data": {
+        "eyebrow": "Beta results",
+        "heading": "Numbers that matter",
+        "kpis": [
+          {
+            "value": "3.2x",
+            "label": "Faster onboarding vs. legacy",
+            "delta": "up from 2.1x in Q2"
+          },
+          { "value": "98.7%", "label": "30-day retention in beta cohort" },
+          {
+            "value": "$1.4M",
+            "label": "Pipeline attributed to beta",
+            "delta": "+$600k QoQ"
+          }
+        ]
+      }
+    },
+    {
+      "template": "timeline",
+      "data": {
+        "heading": "The launch plan",
+        "steps": [
+          {
+            "label": "Week 1–2",
+            "title": "Private GA",
+            "description": "Beta cohort upgrades in place; daily error budget review."
+          },
+          {
+            "label": "Week 3–4",
+            "title": "Public GA",
+            "description": "Self-serve signup opens; launch post and demo video go live."
+          },
+          {
+            "label": "Week 5–8",
+            "title": "Scale",
+            "description": "Migration tooling for legacy accounts; first partner integrations."
+          }
+        ]
+      }
+    },
+    {
+      "template": "comparison",
+      "data": {
+        "heading": "Risks and mitigations",
+        "columns": [
+          {
+            "title": "Top risks",
+            "items": [
+              "Migration load spikes on week one",
+              "Support volume beyond playbook capacity",
+              "One unresolved billing edge case"
+            ]
+          },
+          {
+            "title": "Mitigations",
+            "items": [
+              "Staged rollout with per-cohort rate limits",
+              "Two support engineers on rotation through GA",
+              "Billing fix ships before public GA gate"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "template": "quote",
+      "data": {
+        "quote": "We replaced three internal tools the first week. The team refuses to go back.",
+        "attribution": "Dana M.",
+        "role": "Engineering lead, beta customer"
+      }
+    },
+    {
+      "template": "closing",
+      "data": {
+        "heading": "Let's ship it",
+        "subheading": "Decision needed: green-light public GA for October 6",
+        "cta": "launch-q3@acme.com"
+      }
+    }
+  ]
+}

--- a/packages/sandbox/image/skills/slides/slide-templates/agenda.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/agenda.html
@@ -1,0 +1,8 @@
+<section>
+  <p class="eyebrow">{{#eyebrow}}{{eyebrow}}{{/eyebrow}}{{^eyebrow}}Agenda{{/eyebrow}}</p>
+  <h2 class="deck-h2">{{heading}}</h2>
+  <ol class="agenda">
+    {{#items}}<li>{{.}}</li>
+    {{/items}}
+  </ol>
+</section>

--- a/packages/sandbox/image/skills/slides/slide-templates/bullets.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/bullets.html
@@ -1,0 +1,9 @@
+<section>
+  {{#eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/eyebrow}}
+  <h2 class="deck-h2">{{heading}}</h2>
+  {{#intro}}<p class="deck-body intro">{{intro}}</p>{{/intro}}
+  <ul class="bullets">
+    {{#items}}<li>{{.}}</li>
+    {{/items}}
+  </ul>
+</section>

--- a/packages/sandbox/image/skills/slides/slide-templates/closing.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/closing.html
@@ -1,0 +1,5 @@
+<section class="slide-center">
+  <h2 class="deck-h1">{{heading}}</h2>
+  {{#subheading}}<p class="deck-sub">{{subheading}}</p>{{/subheading}}
+  {{#cta}}<p class="cta">{{cta}}</p>{{/cta}}
+</section>

--- a/packages/sandbox/image/skills/slides/slide-templates/comparison.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/comparison.html
@@ -1,0 +1,15 @@
+<section>
+  {{#eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/eyebrow}}
+  <h2 class="deck-h2">{{heading}}</h2>
+  <div class="cols">
+    {{#columns}}
+    <div class="card grow">
+      <h3 class="col-title">{{title}}</h3>
+      <ul class="bullets compact">
+        {{#items}}<li>{{.}}</li>
+        {{/items}}
+      </ul>
+    </div>
+    {{/columns}}
+  </div>
+</section>

--- a/packages/sandbox/image/skills/slides/slide-templates/kpi-row.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/kpi-row.html
@@ -1,0 +1,13 @@
+<section>
+  {{#eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/eyebrow}}
+  {{#heading}}<h2 class="deck-h2">{{heading}}</h2>{{/heading}}
+  <div class="cols kpis">
+    {{#kpis}}
+    <div class="card kpi grow">
+      <p class="kpi-value">{{value}}</p>
+      <p class="kpi-label">{{label}}</p>
+      {{#delta}}<p class="kpi-delta">{{delta}}</p>{{/delta}}
+    </div>
+    {{/kpis}}
+  </div>
+</section>

--- a/packages/sandbox/image/skills/slides/slide-templates/quote.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/quote.html
@@ -1,0 +1,4 @@
+<section class="slide-center">
+  <blockquote class="deck-quote">&ldquo;{{quote}}&rdquo;</blockquote>
+  {{#attribution}}<p class="attribution">{{attribution}}{{#role}} &middot; {{role}}{{/role}}</p>{{/attribution}}
+</section>

--- a/packages/sandbox/image/skills/slides/slide-templates/section-divider.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/section-divider.html
@@ -1,0 +1,5 @@
+<section class="slide-center divider">
+  {{#number}}<p class="giant-number">{{number}}</p>{{/number}}
+  <h2 class="deck-h1">{{heading}}</h2>
+  {{#subheading}}<p class="deck-sub">{{subheading}}</p>{{/subheading}}
+</section>

--- a/packages/sandbox/image/skills/slides/slide-templates/timeline.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/timeline.html
@@ -1,0 +1,13 @@
+<section>
+  {{#eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/eyebrow}}
+  <h2 class="deck-h2">{{heading}}</h2>
+  <div class="cols timeline">
+    {{#steps}}
+    <div class="step grow">
+      <p class="step-label">{{label}}</p>
+      <h3 class="col-title">{{title}}</h3>
+      {{#description}}<p class="deck-body">{{description}}</p>{{/description}}
+    </div>
+    {{/steps}}
+  </div>
+</section>

--- a/packages/sandbox/image/skills/slides/slide-templates/title.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/title.html
@@ -1,0 +1,6 @@
+<section class="slide-center">
+  {{#eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/eyebrow}}
+  <h1 class="deck-h1">{{heading}}</h1>
+  {{#subheading}}<p class="deck-sub">{{subheading}}</p>{{/subheading}}
+  {{#meta}}<p class="deck-meta">{{meta}}</p>{{/meta}}
+</section>

--- a/packages/sandbox/image/skills/slides/slide-templates/two-column.html
+++ b/packages/sandbox/image/skills/slides/slide-templates/two-column.html
@@ -1,0 +1,14 @@
+<section>
+  {{#eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/eyebrow}}
+  <h2 class="deck-h2">{{heading}}</h2>
+  <div class="cols">
+    <div class="card grow">
+      {{#left.title}}<h3 class="col-title">{{left.title}}</h3>{{/left.title}}
+      <div class="deck-body">{{{left.html}}}</div>
+    </div>
+    <div class="card grow">
+      {{#right.title}}<h3 class="col-title">{{right.title}}</h3>{{/right.title}}
+      <div class="deck-body">{{{right.html}}}</div>
+    </div>
+  </div>
+</section>

--- a/packages/sandbox/image/skills/slides/slides-create.mjs
+++ b/packages/sandbox/image/skills/slides/slides-create.mjs
@@ -1,0 +1,211 @@
+/**
+ * slides-create — compose a presentation deck from slide templates + data.
+ *
+ *   slides-create --data <json|@deck.json> --output <file>
+ *     [--theme <name>] [--templates-dir <dir>] [-f]
+ *
+ * The data describes the deck declaratively; each slide names a layout
+ * template and the values to fill in:
+ *
+ *   {
+ *     "title": "Q3 Launch",
+ *     "theme": "ink-dark",
+ *     "slides": [
+ *       { "template": "title",   "data": { "heading": "Q3 Launch" } },
+ *       { "template": "bullets", "data": { "heading": "Goals", "items": ["…"] } }
+ *     ]
+ *   }
+ *
+ * Slide templates are resolved from --templates-dir first (org-specific
+ * brand templates), then from this skill's slide-templates/ directory.
+ * The rendered deck is a single self-contained HTML file driven by
+ * Studio's /deck-runtime/v1/deck-viewer.js.
+ *
+ * Built on the `templating` skill's mustache engine — see
+ * /mnt/skills/public/templating/SKILL.md for the template syntax.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import Mustache from "../templating/vendor/mustache.mjs";
+
+const SKILL_DIR = dirname(fileURLToPath(import.meta.url));
+const THEMES_DIR = join(SKILL_DIR, "themes");
+const SLIDE_TEMPLATES_DIR = join(SKILL_DIR, "slide-templates");
+const DEFAULT_THEME = "aurora-light";
+
+function fail(message) {
+  console.error(`slides-create: ${message}`);
+  process.exit(1);
+}
+
+function usage() {
+  console.error(
+    [
+      "Usage: slides-create --data <json|@deck.json> --output <file>",
+      "         [--theme <name>] [--templates-dir <dir>] [-f]",
+      "",
+      "  --data           Deck description: inline JSON or @path/to/deck.json",
+      "  --output         Path to write the deck HTML (e.g. org/<slug>/decks/launch.html)",
+      "  --theme          Built-in theme name OR path to a custom theme .html",
+      '                   (overrides the data\'s "theme" field)',
+      "  --templates-dir  Extra directory to resolve slide templates from (checked first)",
+      "  -f               Overwrite the output file if it exists",
+      "",
+      `Themes: ${listNames(THEMES_DIR).join(", ")}`,
+      `Slide templates: ${listNames(SLIDE_TEMPLATES_DIR).join(", ")}`,
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+function listNames(dir) {
+  try {
+    return readdirSync(dir)
+      .filter((f) => f.endsWith(".html"))
+      .map((f) => f.replace(/\.html$/, ""))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function parseArgs(argv) {
+  const args = { force: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--data") args.data = argv[++i];
+    else if (a === "--output") args.output = argv[++i];
+    else if (a === "--theme") args.theme = argv[++i];
+    else if (a === "--templates-dir") args.templatesDir = argv[++i];
+    else if (a === "-f" || a === "--force") args.force = true;
+    else if (a === "-h" || a === "--help") usage();
+    else fail(`unknown argument: ${a} (try --help)`);
+  }
+  return args;
+}
+
+function loadDeckData(raw) {
+  let text = raw;
+  if (raw.startsWith("@")) {
+    const file = raw.slice(1);
+    if (!existsSync(file)) fail(`data file not found: ${file}`);
+    text = readFileSync(file, "utf8");
+  }
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch (err) {
+    fail(`--data is not valid JSON: ${err.message}`);
+  }
+  if (data === null || typeof data !== "object" || Array.isArray(data)) {
+    fail("--data must be a JSON object");
+  }
+  if (typeof data.title !== "string" || data.title.length === 0) {
+    fail('deck data needs a "title" string');
+  }
+  if (!Array.isArray(data.slides) || data.slides.length === 0) {
+    fail('deck data needs a non-empty "slides" array');
+  }
+  data.slides.forEach((slide, i) => {
+    if (
+      slide === null ||
+      typeof slide !== "object" ||
+      typeof slide.template !== "string"
+    ) {
+      fail(`slides[${i}] needs a "template" name`);
+    }
+    if (
+      slide.data !== undefined &&
+      (slide.data === null || typeof slide.data !== "object")
+    ) {
+      fail(`slides[${i}].data must be an object`);
+    }
+  });
+  return data;
+}
+
+function resolveSlideTemplate(name, templatesDir) {
+  if (!/^[\w-]+$/.test(name)) fail(`invalid slide template name: ${name}`);
+  const candidates = [];
+  if (templatesDir) candidates.push(join(templatesDir, `${name}.html`));
+  candidates.push(join(SLIDE_TEMPLATES_DIR, `${name}.html`));
+  for (const file of candidates) {
+    if (existsSync(file)) return readFileSync(file, "utf8");
+  }
+  const known = listNames(SLIDE_TEMPLATES_DIR);
+  fail(
+    `unknown slide template "${name}". Built-in templates: ${known.join(", ")}` +
+      (templatesDir ? ` (also searched ${templatesDir})` : ""),
+  );
+}
+
+/**
+ * `--theme` (or the data's "theme" field) accepts either a built-in name
+ * (`ink-dark`) or a path to a custom theme shell file — a complete deck
+ * HTML with a `{{{slides}}}` insertion point. Org brand themes live in
+ * org-fs (e.g. `org/<slug>/templates/slides/brand-theme.html`) and inject
+ * the same way slide templates do via --templates-dir.
+ */
+function resolveThemePath(value) {
+  if (value.includes("/") || value.toLowerCase().endsWith(".html")) {
+    const file = resolve(value);
+    if (!existsSync(file)) fail(`theme file not found: ${value}`);
+    return file;
+  }
+  const file = join(THEMES_DIR, `${value}.html`);
+  if (!/^[\w-]+$/.test(value) || !existsSync(file)) {
+    fail(
+      `unknown theme "${value}". Built-in themes: ${listNames(THEMES_DIR).join(", ")} ` +
+        "(or pass a path to a custom theme .html)",
+    );
+  }
+  return file;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.data || !args.output) usage();
+
+  const deck = loadDeckData(args.data);
+  if (deck.theme !== undefined && typeof deck.theme !== "string") {
+    fail('deck data "theme" must be a string');
+  }
+  const themePath = resolveThemePath(args.theme || deck.theme || DEFAULT_THEME);
+
+  const templatesDir = args.templatesDir
+    ? resolve(args.templatesDir)
+    : undefined;
+  if (templatesDir && !existsSync(templatesDir)) {
+    fail(`templates dir not found: ${args.templatesDir}`);
+  }
+
+  const sections = deck.slides.map((slide) => {
+    const template = resolveSlideTemplate(slide.template, templatesDir);
+    return Mustache.render(template, slide.data ?? {}).trim();
+  });
+
+  const outputPath = resolve(args.output);
+  if (existsSync(outputPath) && !args.force) {
+    fail(`output already exists: ${args.output} (pass -f to overwrite)`);
+  }
+
+  const theme = readFileSync(themePath, "utf8");
+  const html = Mustache.render(theme, {
+    title: deck.title,
+    slides: sections.join("\n\n"),
+  });
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, html);
+  console.log(outputPath);
+}
+
+main();

--- a/packages/sandbox/image/skills/slides/themes/aurora-light.html
+++ b/packages/sandbox/image/skills/slides/themes/aurora-light.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{title}}</title>
+<!--
+  Studio deck (deck-viewer v1). Authoring rules:
+  - Slides are the direct <section> children of <deck-viewer>; the canvas
+    is a fixed 1920x1080 the runtime scales. Do NOT set position/inset/
+    width/height on the <section> elements themselves.
+  - Keep slide content static HTML (users edit it inline in the preview).
+    No JS-rendered text. Re-read this file before editing it again.
+  - Theme is tuned via the CSS custom properties below.
+  - Images: absolute public URLs or data URIs only (relative paths do not
+    resolve when the deck is served).
+-->
+<style>
+  :root {
+    --deck-bg: #f7f7f9;
+    --deck-surface: #ffffff;
+    --deck-text: #1a1a21;
+    --deck-muted: #6f6f7c;
+    --deck-accent: #5151cd;
+    --deck-accent-2: #c2418f;
+    --deck-font-display: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --deck-font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --deck-radius: 28px;
+  }
+
+  section {
+    background:
+      radial-gradient(1100px 700px at 88% -12%, color-mix(in srgb, var(--deck-accent) 14%, transparent), transparent 70%),
+      radial-gradient(900px 600px at -8% 108%, color-mix(in srgb, var(--deck-accent-2) 10%, transparent), transparent 70%),
+      var(--deck-bg);
+    color: var(--deck-text);
+    font-family: var(--deck-font-body);
+    padding: 120px 150px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+  section.slide-center {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .eyebrow {
+    margin: 0 0 28px;
+    font-size: 26px;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--deck-accent);
+  }
+  .deck-h1 {
+    margin: 0;
+    font-family: var(--deck-font-display);
+    font-size: 132px;
+    font-weight: 700;
+    line-height: 1.04;
+    letter-spacing: -0.025em;
+    max-width: 1500px;
+  }
+  .deck-h2 {
+    margin: 0 0 56px;
+    font-family: var(--deck-font-display);
+    font-size: 84px;
+    font-weight: 700;
+    line-height: 1.06;
+    letter-spacing: -0.02em;
+    max-width: 1500px;
+  }
+  .deck-sub {
+    margin: 36px 0 0;
+    font-size: 44px;
+    line-height: 1.35;
+    color: var(--deck-muted);
+    max-width: 1300px;
+  }
+  .deck-meta {
+    margin: 56px 0 0;
+    font-size: 30px;
+    color: var(--deck-muted);
+  }
+  .deck-body {
+    font-size: 34px;
+    line-height: 1.45;
+    margin: 0;
+  }
+  .deck-body.intro {
+    margin: -16px 0 48px;
+    color: var(--deck-muted);
+    max-width: 1300px;
+  }
+
+  .bullets {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    font-size: 40px;
+    line-height: 1.35;
+    max-width: 1500px;
+  }
+  .bullets li {
+    padding-left: 56px;
+    position: relative;
+  }
+  .bullets li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.52em;
+    width: 22px;
+    height: 22px;
+    border-radius: 7px;
+    background: linear-gradient(135deg, var(--deck-accent), var(--deck-accent-2));
+  }
+  .bullets.compact {
+    gap: 22px;
+    font-size: 32px;
+  }
+  .bullets.compact li {
+    padding-left: 44px;
+  }
+  .bullets.compact li::before {
+    width: 16px;
+    height: 16px;
+    border-radius: 5px;
+  }
+
+  .agenda {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    counter-reset: agenda;
+    display: flex;
+    flex-direction: column;
+    gap: 36px;
+    font-size: 48px;
+    line-height: 1.25;
+  }
+  .agenda li {
+    counter-increment: agenda;
+    display: flex;
+    align-items: baseline;
+    gap: 36px;
+  }
+  .agenda li::before {
+    content: counter(agenda, decimal-leading-zero);
+    font-family: var(--deck-font-display);
+    font-size: 34px;
+    font-weight: 700;
+    color: var(--deck-accent);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .cols {
+    display: flex;
+    gap: 44px;
+    align-items: stretch;
+    width: 100%;
+  }
+  .grow { flex: 1; min-width: 0; }
+  .card {
+    background: var(--deck-surface);
+    border: 1px solid color-mix(in srgb, var(--deck-text) 8%, transparent);
+    border-radius: var(--deck-radius);
+    padding: 52px 56px;
+    box-shadow: 0 18px 50px color-mix(in srgb, var(--deck-text) 7%, transparent);
+  }
+  .col-title {
+    margin: 0 0 28px;
+    font-family: var(--deck-font-display);
+    font-size: 40px;
+    font-weight: 700;
+  }
+
+  .kpis { align-items: stretch; }
+  .kpi { text-align: left; }
+  .kpi-value {
+    margin: 0;
+    font-family: var(--deck-font-display);
+    font-size: 120px;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    background: linear-gradient(120deg, var(--deck-accent), var(--deck-accent-2));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .kpi-label {
+    margin: 24px 0 0;
+    font-size: 32px;
+    color: var(--deck-muted);
+  }
+  .kpi-delta {
+    margin: 14px 0 0;
+    font-size: 28px;
+    font-weight: 600;
+    color: var(--deck-accent);
+  }
+
+  .timeline { gap: 36px; }
+  .step {
+    border-top: 6px solid color-mix(in srgb, var(--deck-accent) 35%, transparent);
+    padding-top: 36px;
+  }
+  .step-label {
+    margin: 0 0 18px;
+    font-size: 26px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--deck-accent);
+  }
+  .step .deck-body {
+    margin-top: 18px;
+    font-size: 30px;
+    color: var(--deck-muted);
+  }
+
+  .deck-quote {
+    margin: 0;
+    font-family: var(--deck-font-display);
+    font-size: 76px;
+    font-weight: 600;
+    line-height: 1.22;
+    letter-spacing: -0.015em;
+    max-width: 1500px;
+  }
+  .attribution {
+    margin: 56px 0 0;
+    font-size: 36px;
+    color: var(--deck-muted);
+  }
+
+  .giant-number {
+    margin: 0 0 24px;
+    font-family: var(--deck-font-display);
+    font-size: 200px;
+    font-weight: 700;
+    line-height: 1;
+    background: linear-gradient(120deg, var(--deck-accent), var(--deck-accent-2));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .cta {
+    margin: 64px 0 0;
+    font-size: 38px;
+    font-weight: 600;
+    color: var(--deck-accent);
+  }
+
+  /* Entrance animation — base state is the visible end state so print
+     and reduced-motion render full content. */
+  @media (prefers-reduced-motion: no-preference) {
+    section[data-deck-active] > * {
+      animation: deck-rise 0.45s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+    }
+    section[data-deck-active] > :nth-child(2) { animation-delay: 70ms; }
+    section[data-deck-active] > :nth-child(3) { animation-delay: 140ms; }
+    section[data-deck-active] > :nth-child(4) { animation-delay: 210ms; }
+    section[data-deck-active] > :nth-child(5) { animation-delay: 280ms; }
+    section[data-deck-active] > :nth-child(n + 6) { animation-delay: 350ms; }
+    @keyframes deck-rise {
+      from {
+        opacity: 0;
+        transform: translateY(18px);
+      }
+    }
+  }
+</style>
+</head>
+<body>
+<deck-viewer width="1920" height="1080">
+{{{slides}}}
+</deck-viewer>
+<script src="/deck-runtime/v1/deck-viewer.js"></script>
+</body>
+</html>

--- a/packages/sandbox/image/skills/slides/themes/bold-gradient.html
+++ b/packages/sandbox/image/skills/slides/themes/bold-gradient.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{title}}</title>
+<!--
+  Studio deck (deck-viewer v1). Authoring rules:
+  - Slides are the direct <section> children of <deck-viewer>; the canvas
+    is a fixed 1920x1080 the runtime scales. Do NOT set position/inset/
+    width/height on the <section> elements themselves.
+  - Keep slide content static HTML (users edit it inline in the preview).
+    No JS-rendered text. Re-read this file before editing it again.
+  - Theme is tuned via the CSS custom properties below.
+  - Images: absolute public URLs or data URIs only (relative paths do not
+    resolve when the deck is served).
+-->
+<style>
+  :root {
+    --deck-bg-gradient: linear-gradient(135deg, #3527c0 0%, #8b22c4 52%, #d63d57 100%);
+    --deck-surface: rgba(255, 255, 255, 0.12);
+    --deck-text: #ffffff;
+    --deck-muted: rgba(255, 255, 255, 0.72);
+    --deck-accent: #ffd84d;
+    --deck-accent-2: #7df2c8;
+    --deck-font-display: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --deck-font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --deck-radius: 30px;
+  }
+
+  section {
+    background: var(--deck-bg-gradient);
+    color: var(--deck-text);
+    font-family: var(--deck-font-body);
+    padding: 120px 150px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+  section.slide-center {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .eyebrow {
+    margin: 0 0 28px;
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--deck-accent);
+  }
+  .deck-h1 {
+    margin: 0;
+    font-family: var(--deck-font-display);
+    font-size: 138px;
+    font-weight: 800;
+    line-height: 1.02;
+    letter-spacing: -0.03em;
+    max-width: 1500px;
+  }
+  .deck-h2 {
+    margin: 0 0 56px;
+    font-family: var(--deck-font-display);
+    font-size: 86px;
+    font-weight: 800;
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    max-width: 1500px;
+  }
+  .deck-sub {
+    margin: 36px 0 0;
+    font-size: 44px;
+    line-height: 1.35;
+    color: var(--deck-muted);
+    max-width: 1300px;
+  }
+  .deck-meta {
+    margin: 56px 0 0;
+    font-size: 30px;
+    color: var(--deck-muted);
+  }
+  .deck-body {
+    font-size: 34px;
+    line-height: 1.45;
+    margin: 0;
+  }
+  .deck-body.intro {
+    margin: -16px 0 48px;
+    color: var(--deck-muted);
+    max-width: 1300px;
+  }
+
+  .bullets {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    font-size: 40px;
+    line-height: 1.35;
+    max-width: 1500px;
+  }
+  .bullets li {
+    padding-left: 56px;
+    position: relative;
+  }
+  .bullets li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.5em;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--deck-accent);
+  }
+  .bullets.compact {
+    gap: 22px;
+    font-size: 32px;
+  }
+  .bullets.compact li {
+    padding-left: 44px;
+  }
+  .bullets.compact li::before {
+    width: 16px;
+    height: 16px;
+  }
+
+  .agenda {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    counter-reset: agenda;
+    display: flex;
+    flex-direction: column;
+    gap: 36px;
+    font-size: 48px;
+    line-height: 1.25;
+  }
+  .agenda li {
+    counter-increment: agenda;
+    display: flex;
+    align-items: baseline;
+    gap: 36px;
+  }
+  .agenda li::before {
+    content: counter(agenda, decimal-leading-zero);
+    font-family: var(--deck-font-display);
+    font-size: 34px;
+    font-weight: 800;
+    color: var(--deck-accent);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .cols {
+    display: flex;
+    gap: 44px;
+    align-items: stretch;
+    width: 100%;
+  }
+  .grow { flex: 1; min-width: 0; }
+  .card {
+    background: var(--deck-surface);
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: var(--deck-radius);
+    padding: 52px 56px;
+  }
+  .col-title {
+    margin: 0 0 28px;
+    font-family: var(--deck-font-display);
+    font-size: 40px;
+    font-weight: 800;
+  }
+
+  .kpis { align-items: stretch; }
+  .kpi { text-align: left; }
+  .kpi-value {
+    margin: 0;
+    font-family: var(--deck-font-display);
+    font-size: 124px;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    color: var(--deck-accent);
+    font-variant-numeric: tabular-nums;
+  }
+  .kpi-label {
+    margin: 24px 0 0;
+    font-size: 32px;
+    color: var(--deck-muted);
+  }
+  .kpi-delta {
+    margin: 14px 0 0;
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--deck-accent-2);
+  }
+
+  .timeline { gap: 36px; }
+  .step {
+    border-top: 6px solid rgba(255, 255, 255, 0.45);
+    padding-top: 36px;
+  }
+  .step-label {
+    margin: 0 0 18px;
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--deck-accent);
+  }
+  .step .deck-body {
+    margin-top: 18px;
+    font-size: 30px;
+    color: var(--deck-muted);
+  }
+
+  .deck-quote {
+    margin: 0;
+    font-family: var(--deck-font-display);
+    font-size: 78px;
+    font-weight: 700;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+    max-width: 1500px;
+  }
+  .attribution {
+    margin: 56px 0 0;
+    font-size: 36px;
+    color: var(--deck-muted);
+  }
+
+  .giant-number {
+    margin: 0 0 24px;
+    font-family: var(--deck-font-display);
+    font-size: 210px;
+    font-weight: 800;
+    line-height: 1;
+    color: var(--deck-accent);
+    font-variant-numeric: tabular-nums;
+  }
+  .cta {
+    margin: 64px 0 0;
+    font-size: 38px;
+    font-weight: 700;
+    color: var(--deck-accent);
+  }
+
+  /* Entrance animation — base state is the visible end state so print
+     and reduced-motion render full content. */
+  @media (prefers-reduced-motion: no-preference) {
+    section[data-deck-active] > * {
+      animation: deck-rise 0.45s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+    }
+    section[data-deck-active] > :nth-child(2) { animation-delay: 70ms; }
+    section[data-deck-active] > :nth-child(3) { animation-delay: 140ms; }
+    section[data-deck-active] > :nth-child(4) { animation-delay: 210ms; }
+    section[data-deck-active] > :nth-child(5) { animation-delay: 280ms; }
+    section[data-deck-active] > :nth-child(n + 6) { animation-delay: 350ms; }
+    @keyframes deck-rise {
+      from {
+        opacity: 0;
+        transform: translateY(18px);
+      }
+    }
+  }
+</style>
+</head>
+<body>
+<deck-viewer width="1920" height="1080">
+{{{slides}}}
+</deck-viewer>
+<script src="/deck-runtime/v1/deck-viewer.js"></script>
+</body>
+</html>

--- a/packages/sandbox/image/skills/slides/themes/ink-dark.html
+++ b/packages/sandbox/image/skills/slides/themes/ink-dark.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{title}}</title>
+<!--
+  Studio deck (deck-viewer v1). Authoring rules:
+  - Slides are the direct <section> children of <deck-viewer>; the canvas
+    is a fixed 1920x1080 the runtime scales. Do NOT set position/inset/
+    width/height on the <section> elements themselves.
+  - Keep slide content static HTML (users edit it inline in the preview).
+    No JS-rendered text. Re-read this file before editing it again.
+  - Theme is tuned via the CSS custom properties below.
+  - Images: absolute public URLs or data URIs only (relative paths do not
+    resolve when the deck is served).
+-->
+<style>
+  :root {
+    --deck-bg: #0e0f13;
+    --deck-surface: #191b22;
+    --deck-text: #f2f2ee;
+    --deck-muted: #9c9c94;
+    --deck-accent: #f5b83d;
+    --deck-accent-2: #4cc38a;
+    --deck-font-display: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --deck-font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --deck-radius: 24px;
+  }
+
+  section {
+    background:
+      radial-gradient(1300px 800px at 80% -20%, color-mix(in srgb, var(--deck-accent) 7%, transparent), transparent 70%),
+      var(--deck-bg);
+    color: var(--deck-text);
+    font-family: var(--deck-font-body);
+    padding: 120px 150px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+  section.slide-center {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .eyebrow {
+    margin: 0 0 28px;
+    font-size: 26px;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--deck-accent);
+  }
+  .deck-h1 {
+    margin: 0;
+    font-family: var(--deck-font-display);
+    font-size: 132px;
+    font-weight: 700;
+    line-height: 1.04;
+    letter-spacing: -0.025em;
+    max-width: 1500px;
+  }
+  .deck-h2 {
+    margin: 0 0 56px;
+    font-family: var(--deck-font-display);
+    font-size: 84px;
+    font-weight: 700;
+    line-height: 1.06;
+    letter-spacing: -0.02em;
+    max-width: 1500px;
+  }
+  .deck-sub {
+    margin: 36px 0 0;
+    font-size: 44px;
+    line-height: 1.35;
+    color: var(--deck-muted);
+    max-width: 1300px;
+  }
+  .deck-meta {
+    margin: 56px 0 0;
+    font-size: 30px;
+    color: var(--deck-muted);
+  }
+  .deck-body {
+    font-size: 34px;
+    line-height: 1.45;
+    margin: 0;
+  }
+  .deck-body.intro {
+    margin: -16px 0 48px;
+    color: var(--deck-muted);
+    max-width: 1300px;
+  }
+
+  .bullets {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    font-size: 40px;
+    line-height: 1.35;
+    max-width: 1500px;
+  }
+  .bullets li {
+    padding-left: 56px;
+    position: relative;
+  }
+  .bullets li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.55em;
+    width: 26px;
+    height: 8px;
+    border-radius: 4px;
+    background: var(--deck-accent);
+  }
+  .bullets.compact {
+    gap: 22px;
+    font-size: 32px;
+  }
+  .bullets.compact li {
+    padding-left: 44px;
+  }
+  .bullets.compact li::before {
+    width: 20px;
+    height: 6px;
+  }
+
+  .agenda {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    counter-reset: agenda;
+    display: flex;
+    flex-direction: column;
+    gap: 36px;
+    font-size: 48px;
+    line-height: 1.25;
+  }
+  .agenda li {
+    counter-increment: agenda;
+    display: flex;
+    align-items: baseline;
+    gap: 36px;
+  }
+  .agenda li::before {
+    content: counter(agenda, decimal-leading-zero);
+    font-family: var(--deck-font-display);
+    font-size: 34px;
+    font-weight: 700;
+    color: var(--deck-accent);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .cols {
+    display: flex;
+    gap: 44px;
+    align-items: stretch;
+    width: 100%;
+  }
+  .grow { flex: 1; min-width: 0; }
+  .card {
+    background: var(--deck-surface);
+    border: 1px solid color-mix(in srgb, var(--deck-text) 12%, transparent);
+    border-radius: var(--deck-radius);
+    padding: 52px 56px;
+  }
+  .col-title {
+    margin: 0 0 28px;
+    font-family: var(--deck-font-display);
+    font-size: 40px;
+    font-weight: 700;
+  }
+
+  .kpis { align-items: stretch; }
+  .kpi { text-align: left; }
+  .kpi-value {
+    margin: 0;
+    font-family: var(--deck-font-display);
+    font-size: 124px;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    color: var(--deck-accent);
+    font-variant-numeric: tabular-nums;
+  }
+  .kpi-label {
+    margin: 24px 0 0;
+    font-size: 32px;
+    color: var(--deck-muted);
+  }
+  .kpi-delta {
+    margin: 14px 0 0;
+    font-size: 28px;
+    font-weight: 600;
+    color: var(--deck-accent-2);
+  }
+
+  .timeline { gap: 36px; }
+  .step {
+    border-top: 6px solid color-mix(in srgb, var(--deck-accent) 45%, transparent);
+    padding-top: 36px;
+  }
+  .step-label {
+    margin: 0 0 18px;
+    font-size: 26px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--deck-accent);
+  }
+  .step .deck-body {
+    margin-top: 18px;
+    font-size: 30px;
+    color: var(--deck-muted);
+  }
+
+  .deck-quote {
+    margin: 0;
+    font-family: var(--deck-font-display);
+    font-size: 76px;
+    font-weight: 600;
+    line-height: 1.22;
+    letter-spacing: -0.015em;
+    max-width: 1500px;
+  }
+  .attribution {
+    margin: 56px 0 0;
+    font-size: 36px;
+    color: var(--deck-muted);
+  }
+
+  .giant-number {
+    margin: 0 0 24px;
+    font-family: var(--deck-font-display);
+    font-size: 200px;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--deck-accent);
+    font-variant-numeric: tabular-nums;
+  }
+  .cta {
+    margin: 64px 0 0;
+    font-size: 38px;
+    font-weight: 600;
+    color: var(--deck-accent);
+  }
+
+  /* Entrance animation — base state is the visible end state so print
+     and reduced-motion render full content. */
+  @media (prefers-reduced-motion: no-preference) {
+    section[data-deck-active] > * {
+      animation: deck-rise 0.45s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+    }
+    section[data-deck-active] > :nth-child(2) { animation-delay: 70ms; }
+    section[data-deck-active] > :nth-child(3) { animation-delay: 140ms; }
+    section[data-deck-active] > :nth-child(4) { animation-delay: 210ms; }
+    section[data-deck-active] > :nth-child(5) { animation-delay: 280ms; }
+    section[data-deck-active] > :nth-child(n + 6) { animation-delay: 350ms; }
+    @keyframes deck-rise {
+      from {
+        opacity: 0;
+        transform: translateY(18px);
+      }
+    }
+  }
+</style>
+</head>
+<body>
+<deck-viewer width="1920" height="1080">
+{{{slides}}}
+</deck-viewer>
+<script src="/deck-runtime/v1/deck-viewer.js"></script>
+</body>
+</html>

--- a/packages/sandbox/image/skills/templating/SKILL.md
+++ b/packages/sandbox/image/skills/templating/SKILL.md
@@ -1,0 +1,61 @@
+# templating — fill data into text-file templates
+
+Render any text file (HTML, markdown, config, SQL, email, …) from a
+mustache template plus JSON data. Use this whenever the shape of an output
+is known ahead of time and only the values change — it is faster and less
+error-prone than writing the file by hand.
+
+Other skills build on this one (e.g. `slides` composes presentation decks
+from slide templates).
+
+## Quick reference
+
+| Task                       | Command                                                                  |
+| -------------------------- | ------------------------------------------------------------------------ |
+| Render with inline data    | `create-from-template --template t.html --data '{"name":"Ada"}' --output out.html` |
+| Render with a data file    | `create-from-template --template t.html --data @data.json --output out.html` |
+| Fail on missing keys       | add `--strict`                                                            |
+| Overwrite existing output  | add `-f`                                                                  |
+| Use partials (`{{>name}}`) | add `--partials-dir ./partials`                                           |
+
+The command prints the absolute output path on success and exits non-zero
+with a message on any error (bad JSON, missing template, existing output
+without `-f`, missing keys under `--strict`).
+
+## Template syntax (mustache)
+
+| Syntax                | Meaning                                                       |
+| --------------------- | ------------------------------------------------------------- |
+| `{{name}}`            | Insert value, HTML-escaped                                    |
+| `{{{name}}}`          | Insert value raw (no escaping) — for trusted HTML fragments   |
+| `{{#items}}…{{/items}}` | Repeat block for each array item; also renders for truthy values |
+| `{{.}}`               | The current item inside a list block                          |
+| `{{^items}}…{{/items}}` | Render block only when the value is empty/falsy/missing     |
+| `{{user.name}}`       | Dotted path lookup                                            |
+| `{{>header}}`         | Include partial `header` (resolved from `--partials-dir` as `header` or `header.html`) |
+| `{{!comment}}`        | Comment, never rendered                                       |
+
+Example:
+
+```html
+<ul>
+  {{#items}}<li><b>{{label}}</b>: {{value}}</li>{{/items}}
+  {{^items}}<li>No items</li>{{/items}}
+</ul>
+```
+
+```sh
+create-from-template --template list.template.html \
+  --data '{"items":[{"label":"CPU","value":"42%"}]}' \
+  --output list.html
+```
+
+## Workflow tips
+
+- Keep data in a JSON file (`--data @data.json`) when it is more than a
+  couple of fields — easier to iterate on than a long inline string.
+- Use `--strict` while developing a template to catch typos in key names;
+  drop it when optional keys are intentional.
+- Templates are plain text files — author your own anywhere (the org home
+  folder under `org/<slug>/templates/` is a good durable place for
+  organization-wide templates).

--- a/packages/sandbox/image/skills/templating/create-from-template.mjs
+++ b/packages/sandbox/image/skills/templating/create-from-template.mjs
@@ -1,0 +1,178 @@
+/**
+ * create-from-template — render a mustache template file with JSON data.
+ *
+ *   create-from-template --template <file> --data <json|@file> --output <file>
+ *     [--partials-dir <dir>] [--strict] [-f]
+ *
+ * Works for any text file (HTML, markdown, config, SQL, email, …).
+ * Mustache semantics: {{var}} (HTML-escaped), {{{var}}} (raw),
+ * {{#list}}…{{/list}} (loops / conditionals), {{^empty}}…{{/empty}}
+ * (inverted), dotted paths ({{user.name}}), partials ({{>name}} resolved
+ * from --partials-dir as <name>.html or <name>).
+ *
+ * Exits non-zero with a clear message on bad input. Refuses to overwrite
+ * an existing output file unless -f is passed. Prints the output path on
+ * success so callers can chain on it.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import Mustache from "./vendor/mustache.mjs";
+
+function fail(message) {
+  console.error(`create-from-template: ${message}`);
+  process.exit(1);
+}
+
+function usage() {
+  console.error(
+    [
+      "Usage: create-from-template --template <file> --data <json|@file> --output <file>",
+      "         [--partials-dir <dir>] [--strict] [-f]",
+      "",
+      "  --template      Path to the mustache template file",
+      "  --data          Inline JSON object, or @path/to/data.json",
+      "  --output        Path to write the rendered result",
+      "  --partials-dir  Directory to resolve {{>partial}} references from",
+      "  --strict        Error when the template references a missing key",
+      "  -f              Overwrite the output file if it exists",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = { force: false, strict: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--template") args.template = argv[++i];
+    else if (a === "--data") args.data = argv[++i];
+    else if (a === "--output") args.output = argv[++i];
+    else if (a === "--partials-dir") args.partialsDir = argv[++i];
+    else if (a === "--strict") args.strict = true;
+    else if (a === "-f" || a === "--force") args.force = true;
+    else if (a === "-h" || a === "--help") usage();
+    else fail(`unknown argument: ${a} (try --help)`);
+  }
+  return args;
+}
+
+function loadData(raw) {
+  let text = raw;
+  if (raw.startsWith("@")) {
+    const file = raw.slice(1);
+    if (!existsSync(file)) fail(`data file not found: ${file}`);
+    text = readFileSync(file, "utf8");
+  }
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch (err) {
+    fail(`--data is not valid JSON: ${err.message}`);
+  }
+  if (data === null || typeof data !== "object" || Array.isArray(data)) {
+    fail("--data must be a JSON object");
+  }
+  return data;
+}
+
+/** Collect variable references ({{name}}, {{{name}}}, {{#section}}) the
+ *  data doesn't provide, so --strict can report them. Inverted sections
+ *  ({{^name}}) intentionally reference absent keys and are not counted,
+ *  but their bodies are still checked. */
+function missingKeys(template, data) {
+  const missing = new Set();
+  const lookup = (stack, name) => {
+    for (let s = stack.length - 1; s >= 0; s--) {
+      let ctx = stack[s];
+      const found = name.split(".").every((part) => {
+        if (ctx !== null && typeof ctx === "object" && part in ctx) {
+          ctx = ctx[part];
+          return true;
+        }
+        return false;
+      });
+      if (found) return { found: true, value: ctx };
+    }
+    return { found: false, value: undefined };
+  };
+  const walk = (tokens, stack) => {
+    for (const token of tokens) {
+      const [type, name] = token;
+      if (!/^(name|&|\{|#|\^)$/.test(type) || name === ".") continue;
+      const { found, value } = lookup(stack, name);
+      if (!found && type !== "^") missing.add(name);
+      // Only check section bodies that would actually render, with a
+      // representative child context for lists/objects.
+      if (type === "#" && token[4] && found) {
+        if (Array.isArray(value)) {
+          if (value.length > 0) walk(token[4], [...stack, value[0]]);
+        } else if (value) {
+          walk(token[4], typeof value === "object" ? [...stack, value] : stack);
+        }
+      } else if (type === "^" && token[4]) {
+        const empty =
+          !found || !value || (Array.isArray(value) && value.length === 0);
+        if (empty) walk(token[4], stack);
+      }
+    }
+  };
+  walk(Mustache.parse(template), [data]);
+  return [...missing];
+}
+
+function loadPartials(dir) {
+  return new Proxy(
+    {},
+    {
+      get(_target, name) {
+        if (typeof name !== "string") return undefined;
+        for (const candidate of [name, `${name}.html`]) {
+          const file = join(dir, candidate);
+          if (existsSync(file) && basename(file) === candidate) {
+            return readFileSync(file, "utf8");
+          }
+        }
+        return undefined;
+      },
+    },
+  );
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.template || !args.data || !args.output) usage();
+
+  const templatePath = resolve(args.template);
+  if (!existsSync(templatePath)) fail(`template not found: ${args.template}`);
+  const template = readFileSync(templatePath, "utf8");
+  const data = loadData(args.data);
+
+  if (args.strict) {
+    const missing = missingKeys(template, data);
+    if (missing.length > 0) {
+      fail(`missing data for: ${missing.join(", ")}`);
+    }
+  }
+
+  const outputPath = resolve(args.output);
+  if (existsSync(outputPath) && !args.force) {
+    fail(`output already exists: ${args.output} (pass -f to overwrite)`);
+  }
+
+  const partials = args.partialsDir
+    ? loadPartials(resolve(args.partialsDir))
+    : undefined;
+  let rendered;
+  try {
+    rendered = Mustache.render(template, data, partials);
+  } catch (err) {
+    fail(`render failed: ${err.message}`);
+  }
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, rendered);
+  console.log(outputPath);
+}
+
+if (import.meta.main) main();

--- a/packages/sandbox/image/skills/templating/vendor/mustache.mjs
+++ b/packages/sandbox/image/skills/templating/vendor/mustache.mjs
@@ -1,0 +1,858 @@
+/* oxlint-disable */
+/* vendored third-party file, kept byte-faithful */
+/*! vendored from mustache.js v4.2.0 (https://github.com/janl/mustache.js) — MIT License */
+/*!
+ * mustache.js - Logic-less {{mustache}} templates with JavaScript
+ * http://github.com/janl/mustache.js
+ */
+
+var objectToString = Object.prototype.toString;
+var isArray =
+  Array.isArray ||
+  function isArrayPolyfill(object) {
+    return objectToString.call(object) === "[object Array]";
+  };
+
+function isFunction(object) {
+  return typeof object === "function";
+}
+
+/**
+ * More correct typeof string handling array
+ * which normally returns typeof 'object'
+ */
+function typeStr(obj) {
+  return isArray(obj) ? "array" : typeof obj;
+}
+
+function escapeRegExp(string) {
+  return string.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
+}
+
+/**
+ * Null safe way of checking whether or not an object,
+ * including its prototype, has a given property
+ */
+function hasProperty(obj, propName) {
+  return obj != null && typeof obj === "object" && propName in obj;
+}
+
+/**
+ * Safe way of detecting whether or not the given thing is a primitive and
+ * whether it has the given property
+ */
+function primitiveHasOwnProperty(primitive, propName) {
+  return (
+    primitive != null &&
+    typeof primitive !== "object" &&
+    primitive.hasOwnProperty &&
+    primitive.hasOwnProperty(propName)
+  );
+}
+
+// Workaround for https://issues.apache.org/jira/browse/COUCHDB-577
+// See https://github.com/janl/mustache.js/issues/189
+var regExpTest = RegExp.prototype.test;
+function testRegExp(re, string) {
+  return regExpTest.call(re, string);
+}
+
+var nonSpaceRe = /\S/;
+function isWhitespace(string) {
+  return !testRegExp(nonSpaceRe, string);
+}
+
+var entityMap = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+  "/": "&#x2F;",
+  "`": "&#x60;",
+  "=": "&#x3D;",
+};
+
+function escapeHtml(string) {
+  return String(string).replace(/[&<>"'`=\/]/g, function fromEntityMap(s) {
+    return entityMap[s];
+  });
+}
+
+var whiteRe = /\s*/;
+var spaceRe = /\s+/;
+var equalsRe = /\s*=/;
+var curlyRe = /\s*\}/;
+var tagRe = /#|\^|\/|>|\{|&|=|!/;
+
+/**
+ * Breaks up the given `template` string into a tree of tokens. If the `tags`
+ * argument is given here it must be an array with two string values: the
+ * opening and closing tags used in the template (e.g. [ "<%", "%>" ]). Of
+ * course, the default is to use mustaches (i.e. mustache.tags).
+ *
+ * A token is an array with at least 4 elements. The first element is the
+ * mustache symbol that was used inside the tag, e.g. "#" or "&". If the tag
+ * did not contain a symbol (i.e. {{myValue}}) this element is "name". For
+ * all text that appears outside a symbol this element is "text".
+ *
+ * The second element of a token is its "value". For mustache tags this is
+ * whatever else was inside the tag besides the opening symbol. For text tokens
+ * this is the text itself.
+ *
+ * The third and fourth elements of the token are the start and end indices,
+ * respectively, of the token in the original template.
+ *
+ * Tokens that are the root node of a subtree contain two more elements: 1) an
+ * array of tokens in the subtree and 2) the index in the original template at
+ * which the closing tag for that section begins.
+ *
+ * Tokens for partials also contain two more elements: 1) a string value of
+ * indendation prior to that tag and 2) the index of that tag on that line -
+ * eg a value of 2 indicates the partial is the third tag on this line.
+ */
+function parseTemplate(template, tags) {
+  if (!template) return [];
+  var lineHasNonSpace = false;
+  var sections = []; // Stack to hold section tokens
+  var tokens = []; // Buffer to hold the tokens
+  var spaces = []; // Indices of whitespace tokens on the current line
+  var hasTag = false; // Is there a {{tag}} on the current line?
+  var nonSpace = false; // Is there a non-space char on the current line?
+  var indentation = ""; // Tracks indentation for tags that use it
+  var tagIndex = 0; // Stores a count of number of tags encountered on a line
+
+  // Strips all whitespace tokens array for the current line
+  // if there was a {{#tag}} on it and otherwise only space.
+  function stripSpace() {
+    if (hasTag && !nonSpace) {
+      while (spaces.length) delete tokens[spaces.pop()];
+    } else {
+      spaces = [];
+    }
+
+    hasTag = false;
+    nonSpace = false;
+  }
+
+  var openingTagRe, closingTagRe, closingCurlyRe;
+  function compileTags(tagsToCompile) {
+    if (typeof tagsToCompile === "string")
+      tagsToCompile = tagsToCompile.split(spaceRe, 2);
+
+    if (!isArray(tagsToCompile) || tagsToCompile.length !== 2)
+      throw new Error("Invalid tags: " + tagsToCompile);
+
+    openingTagRe = new RegExp(escapeRegExp(tagsToCompile[0]) + "\\s*");
+    closingTagRe = new RegExp("\\s*" + escapeRegExp(tagsToCompile[1]));
+    closingCurlyRe = new RegExp("\\s*" + escapeRegExp("}" + tagsToCompile[1]));
+  }
+
+  compileTags(tags || mustache.tags);
+
+  var scanner = new Scanner(template);
+
+  var start, type, value, chr, token, openSection;
+  while (!scanner.eos()) {
+    start = scanner.pos;
+
+    // Match any text between tags.
+    value = scanner.scanUntil(openingTagRe);
+
+    if (value) {
+      for (var i = 0, valueLength = value.length; i < valueLength; ++i) {
+        chr = value.charAt(i);
+
+        if (isWhitespace(chr)) {
+          spaces.push(tokens.length);
+          indentation += chr;
+        } else {
+          nonSpace = true;
+          lineHasNonSpace = true;
+          indentation += " ";
+        }
+
+        tokens.push(["text", chr, start, start + 1]);
+        start += 1;
+
+        // Check for whitespace on the current line.
+        if (chr === "\n") {
+          stripSpace();
+          indentation = "";
+          tagIndex = 0;
+          lineHasNonSpace = false;
+        }
+      }
+    }
+
+    // Match the opening tag.
+    if (!scanner.scan(openingTagRe)) break;
+
+    hasTag = true;
+
+    // Get the tag type.
+    type = scanner.scan(tagRe) || "name";
+    scanner.scan(whiteRe);
+
+    // Get the tag value.
+    if (type === "=") {
+      value = scanner.scanUntil(equalsRe);
+      scanner.scan(equalsRe);
+      scanner.scanUntil(closingTagRe);
+    } else if (type === "{") {
+      value = scanner.scanUntil(closingCurlyRe);
+      scanner.scan(curlyRe);
+      scanner.scanUntil(closingTagRe);
+      type = "&";
+    } else {
+      value = scanner.scanUntil(closingTagRe);
+    }
+
+    // Match the closing tag.
+    if (!scanner.scan(closingTagRe))
+      throw new Error("Unclosed tag at " + scanner.pos);
+
+    if (type == ">") {
+      token = [
+        type,
+        value,
+        start,
+        scanner.pos,
+        indentation,
+        tagIndex,
+        lineHasNonSpace,
+      ];
+    } else {
+      token = [type, value, start, scanner.pos];
+    }
+    tagIndex++;
+    tokens.push(token);
+
+    if (type === "#" || type === "^") {
+      sections.push(token);
+    } else if (type === "/") {
+      // Check section nesting.
+      openSection = sections.pop();
+
+      if (!openSection)
+        throw new Error('Unopened section "' + value + '" at ' + start);
+
+      if (openSection[1] !== value)
+        throw new Error(
+          'Unclosed section "' + openSection[1] + '" at ' + start,
+        );
+    } else if (type === "name" || type === "{" || type === "&") {
+      nonSpace = true;
+    } else if (type === "=") {
+      // Set the tags for the next time around.
+      compileTags(value);
+    }
+  }
+
+  stripSpace();
+
+  // Make sure there are no open sections when we're done.
+  openSection = sections.pop();
+
+  if (openSection)
+    throw new Error(
+      'Unclosed section "' + openSection[1] + '" at ' + scanner.pos,
+    );
+
+  return nestTokens(squashTokens(tokens));
+}
+
+/**
+ * Combines the values of consecutive text tokens in the given `tokens` array
+ * to a single token.
+ */
+function squashTokens(tokens) {
+  var squashedTokens = [];
+
+  var token, lastToken;
+  for (var i = 0, numTokens = tokens.length; i < numTokens; ++i) {
+    token = tokens[i];
+
+    if (token) {
+      if (token[0] === "text" && lastToken && lastToken[0] === "text") {
+        lastToken[1] += token[1];
+        lastToken[3] = token[3];
+      } else {
+        squashedTokens.push(token);
+        lastToken = token;
+      }
+    }
+  }
+
+  return squashedTokens;
+}
+
+/**
+ * Forms the given array of `tokens` into a nested tree structure where
+ * tokens that represent a section have two additional items: 1) an array of
+ * all tokens that appear in that section and 2) the index in the original
+ * template that represents the end of that section.
+ */
+function nestTokens(tokens) {
+  var nestedTokens = [];
+  var collector = nestedTokens;
+  var sections = [];
+
+  var token, section;
+  for (var i = 0, numTokens = tokens.length; i < numTokens; ++i) {
+    token = tokens[i];
+
+    switch (token[0]) {
+      case "#":
+      case "^":
+        collector.push(token);
+        sections.push(token);
+        collector = token[4] = [];
+        break;
+      case "/":
+        section = sections.pop();
+        section[5] = token[2];
+        collector =
+          sections.length > 0 ? sections[sections.length - 1][4] : nestedTokens;
+        break;
+      default:
+        collector.push(token);
+    }
+  }
+
+  return nestedTokens;
+}
+
+/**
+ * A simple string scanner that is used by the template parser to find
+ * tokens in template strings.
+ */
+function Scanner(string) {
+  this.string = string;
+  this.tail = string;
+  this.pos = 0;
+}
+
+/**
+ * Returns `true` if the tail is empty (end of string).
+ */
+Scanner.prototype.eos = function eos() {
+  return this.tail === "";
+};
+
+/**
+ * Tries to match the given regular expression at the current position.
+ * Returns the matched text if it can match, the empty string otherwise.
+ */
+Scanner.prototype.scan = function scan(re) {
+  var match = this.tail.match(re);
+
+  if (!match || match.index !== 0) return "";
+
+  var string = match[0];
+
+  this.tail = this.tail.substring(string.length);
+  this.pos += string.length;
+
+  return string;
+};
+
+/**
+ * Skips all text until the given regular expression can be matched. Returns
+ * the skipped string, which is the entire tail if no match can be made.
+ */
+Scanner.prototype.scanUntil = function scanUntil(re) {
+  var index = this.tail.search(re),
+    match;
+
+  switch (index) {
+    case -1:
+      match = this.tail;
+      this.tail = "";
+      break;
+    case 0:
+      match = "";
+      break;
+    default:
+      match = this.tail.substring(0, index);
+      this.tail = this.tail.substring(index);
+  }
+
+  this.pos += match.length;
+
+  return match;
+};
+
+/**
+ * Represents a rendering context by wrapping a view object and
+ * maintaining a reference to the parent context.
+ */
+function Context(view, parentContext) {
+  this.view = view;
+  this.cache = { ".": this.view };
+  this.parent = parentContext;
+}
+
+/**
+ * Creates a new context using the given view with this context
+ * as the parent.
+ */
+Context.prototype.push = function push(view) {
+  return new Context(view, this);
+};
+
+/**
+ * Returns the value of the given name in this context, traversing
+ * up the context hierarchy if the value is absent in this context's view.
+ */
+Context.prototype.lookup = function lookup(name) {
+  var cache = this.cache;
+
+  var value;
+  if (cache.hasOwnProperty(name)) {
+    value = cache[name];
+  } else {
+    var context = this,
+      intermediateValue,
+      names,
+      index,
+      lookupHit = false;
+
+    while (context) {
+      if (name.indexOf(".") > 0) {
+        intermediateValue = context.view;
+        names = name.split(".");
+        index = 0;
+
+        /**
+         * Using the dot notion path in `name`, we descend through the
+         * nested objects.
+         *
+         * To be certain that the lookup has been successful, we have to
+         * check if the last object in the path actually has the property
+         * we are looking for. We store the result in `lookupHit`.
+         *
+         * This is specially necessary for when the value has been set to
+         * `undefined` and we want to avoid looking up parent contexts.
+         *
+         * In the case where dot notation is used, we consider the lookup
+         * to be successful even if the last "object" in the path is
+         * not actually an object but a primitive (e.g., a string, or an
+         * integer), because it is sometimes useful to access a property
+         * of an autoboxed primitive, such as the length of a string.
+         **/
+        while (intermediateValue != null && index < names.length) {
+          if (index === names.length - 1)
+            lookupHit =
+              hasProperty(intermediateValue, names[index]) ||
+              primitiveHasOwnProperty(intermediateValue, names[index]);
+
+          intermediateValue = intermediateValue[names[index++]];
+        }
+      } else {
+        intermediateValue = context.view[name];
+
+        /**
+         * Only checking against `hasProperty`, which always returns `false` if
+         * `context.view` is not an object. Deliberately omitting the check
+         * against `primitiveHasOwnProperty` if dot notation is not used.
+         *
+         * Consider this example:
+         * ```
+         * Mustache.render("The length of a football field is {{#length}}{{length}}{{/length}}.", {length: "100 yards"})
+         * ```
+         *
+         * If we were to check also against `primitiveHasOwnProperty`, as we do
+         * in the dot notation case, then render call would return:
+         *
+         * "The length of a football field is 9."
+         *
+         * rather than the expected:
+         *
+         * "The length of a football field is 100 yards."
+         **/
+        lookupHit = hasProperty(context.view, name);
+      }
+
+      if (lookupHit) {
+        value = intermediateValue;
+        break;
+      }
+
+      context = context.parent;
+    }
+
+    cache[name] = value;
+  }
+
+  if (isFunction(value)) value = value.call(this.view);
+
+  return value;
+};
+
+/**
+ * A Writer knows how to take a stream of tokens and render them to a
+ * string, given a context. It also maintains a cache of templates to
+ * avoid the need to parse the same template twice.
+ */
+function Writer() {
+  this.templateCache = {
+    _cache: {},
+    set: function set(key, value) {
+      this._cache[key] = value;
+    },
+    get: function get(key) {
+      return this._cache[key];
+    },
+    clear: function clear() {
+      this._cache = {};
+    },
+  };
+}
+
+/**
+ * Clears all cached templates in this writer.
+ */
+Writer.prototype.clearCache = function clearCache() {
+  if (typeof this.templateCache !== "undefined") {
+    this.templateCache.clear();
+  }
+};
+
+/**
+ * Parses and caches the given `template` according to the given `tags` or
+ * `mustache.tags` if `tags` is omitted,  and returns the array of tokens
+ * that is generated from the parse.
+ */
+Writer.prototype.parse = function parse(template, tags) {
+  var cache = this.templateCache;
+  var cacheKey = template + ":" + (tags || mustache.tags).join(":");
+  var isCacheEnabled = typeof cache !== "undefined";
+  var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
+
+  if (tokens == undefined) {
+    tokens = parseTemplate(template, tags);
+    isCacheEnabled && cache.set(cacheKey, tokens);
+  }
+  return tokens;
+};
+
+/**
+ * High-level method that is used to render the given `template` with
+ * the given `view`.
+ *
+ * The optional `partials` argument may be an object that contains the
+ * names and templates of partials that are used in the template. It may
+ * also be a function that is used to load partial templates on the fly
+ * that takes a single argument: the name of the partial.
+ *
+ * If the optional `config` argument is given here, then it should be an
+ * object with a `tags` attribute or an `escape` attribute or both.
+ * If an array is passed, then it will be interpreted the same way as
+ * a `tags` attribute on a `config` object.
+ *
+ * The `tags` attribute of a `config` object must be an array with two
+ * string values: the opening and closing tags used in the template (e.g.
+ * [ "<%", "%>" ]). The default is to mustache.tags.
+ *
+ * The `escape` attribute of a `config` object must be a function which
+ * accepts a string as input and outputs a safely escaped string.
+ * If an `escape` function is not provided, then an HTML-safe string
+ * escaping function is used as the default.
+ */
+Writer.prototype.render = function render(template, view, partials, config) {
+  var tags = this.getConfigTags(config);
+  var tokens = this.parse(template, tags);
+  var context = view instanceof Context ? view : new Context(view, undefined);
+  return this.renderTokens(tokens, context, partials, template, config);
+};
+
+/**
+ * Low-level method that renders the given array of `tokens` using
+ * the given `context` and `partials`.
+ *
+ * Note: The `originalTemplate` is only ever used to extract the portion
+ * of the original template that was contained in a higher-order section.
+ * If the template doesn't use higher-order sections, this argument may
+ * be omitted.
+ */
+Writer.prototype.renderTokens = function renderTokens(
+  tokens,
+  context,
+  partials,
+  originalTemplate,
+  config,
+) {
+  var buffer = "";
+
+  var token, symbol, value;
+  for (var i = 0, numTokens = tokens.length; i < numTokens; ++i) {
+    value = undefined;
+    token = tokens[i];
+    symbol = token[0];
+
+    if (symbol === "#")
+      value = this.renderSection(
+        token,
+        context,
+        partials,
+        originalTemplate,
+        config,
+      );
+    else if (symbol === "^")
+      value = this.renderInverted(
+        token,
+        context,
+        partials,
+        originalTemplate,
+        config,
+      );
+    else if (symbol === ">")
+      value = this.renderPartial(token, context, partials, config);
+    else if (symbol === "&") value = this.unescapedValue(token, context);
+    else if (symbol === "name")
+      value = this.escapedValue(token, context, config);
+    else if (symbol === "text") value = this.rawValue(token);
+
+    if (value !== undefined) buffer += value;
+  }
+
+  return buffer;
+};
+
+Writer.prototype.renderSection = function renderSection(
+  token,
+  context,
+  partials,
+  originalTemplate,
+  config,
+) {
+  var self = this;
+  var buffer = "";
+  var value = context.lookup(token[1]);
+
+  // This function is used to render an arbitrary template
+  // in the current context by higher-order sections.
+  function subRender(template) {
+    return self.render(template, context, partials, config);
+  }
+
+  if (!value) return;
+
+  if (isArray(value)) {
+    for (var j = 0, valueLength = value.length; j < valueLength; ++j) {
+      buffer += this.renderTokens(
+        token[4],
+        context.push(value[j]),
+        partials,
+        originalTemplate,
+        config,
+      );
+    }
+  } else if (
+    typeof value === "object" ||
+    typeof value === "string" ||
+    typeof value === "number"
+  ) {
+    buffer += this.renderTokens(
+      token[4],
+      context.push(value),
+      partials,
+      originalTemplate,
+      config,
+    );
+  } else if (isFunction(value)) {
+    if (typeof originalTemplate !== "string")
+      throw new Error(
+        "Cannot use higher-order sections without the original template",
+      );
+
+    // Extract the portion of the original template that the section contains.
+    value = value.call(
+      context.view,
+      originalTemplate.slice(token[3], token[5]),
+      subRender,
+    );
+
+    if (value != null) buffer += value;
+  } else {
+    buffer += this.renderTokens(
+      token[4],
+      context,
+      partials,
+      originalTemplate,
+      config,
+    );
+  }
+  return buffer;
+};
+
+Writer.prototype.renderInverted = function renderInverted(
+  token,
+  context,
+  partials,
+  originalTemplate,
+  config,
+) {
+  var value = context.lookup(token[1]);
+
+  // Use JavaScript's definition of falsy. Include empty arrays.
+  // See https://github.com/janl/mustache.js/issues/186
+  if (!value || (isArray(value) && value.length === 0))
+    return this.renderTokens(
+      token[4],
+      context,
+      partials,
+      originalTemplate,
+      config,
+    );
+};
+
+Writer.prototype.indentPartial = function indentPartial(
+  partial,
+  indentation,
+  lineHasNonSpace,
+) {
+  var filteredIndentation = indentation.replace(/[^ \t]/g, "");
+  var partialByNl = partial.split("\n");
+  for (var i = 0; i < partialByNl.length; i++) {
+    if (partialByNl[i].length && (i > 0 || !lineHasNonSpace)) {
+      partialByNl[i] = filteredIndentation + partialByNl[i];
+    }
+  }
+  return partialByNl.join("\n");
+};
+
+Writer.prototype.renderPartial = function renderPartial(
+  token,
+  context,
+  partials,
+  config,
+) {
+  if (!partials) return;
+  var tags = this.getConfigTags(config);
+
+  var value = isFunction(partials) ? partials(token[1]) : partials[token[1]];
+  if (value != null) {
+    var lineHasNonSpace = token[6];
+    var tagIndex = token[5];
+    var indentation = token[4];
+    var indentedValue = value;
+    if (tagIndex == 0 && indentation) {
+      indentedValue = this.indentPartial(value, indentation, lineHasNonSpace);
+    }
+    var tokens = this.parse(indentedValue, tags);
+    return this.renderTokens(tokens, context, partials, indentedValue, config);
+  }
+};
+
+Writer.prototype.unescapedValue = function unescapedValue(token, context) {
+  var value = context.lookup(token[1]);
+  if (value != null) return value;
+};
+
+Writer.prototype.escapedValue = function escapedValue(token, context, config) {
+  var escape = this.getConfigEscape(config) || mustache.escape;
+  var value = context.lookup(token[1]);
+  if (value != null)
+    return typeof value === "number" && escape === mustache.escape
+      ? String(value)
+      : escape(value);
+};
+
+Writer.prototype.rawValue = function rawValue(token) {
+  return token[1];
+};
+
+Writer.prototype.getConfigTags = function getConfigTags(config) {
+  if (isArray(config)) {
+    return config;
+  } else if (config && typeof config === "object") {
+    return config.tags;
+  } else {
+    return undefined;
+  }
+};
+
+Writer.prototype.getConfigEscape = function getConfigEscape(config) {
+  if (config && typeof config === "object" && !isArray(config)) {
+    return config.escape;
+  } else {
+    return undefined;
+  }
+};
+
+var mustache = {
+  name: "mustache.js",
+  version: "4.2.0",
+  tags: ["{{", "}}"],
+  clearCache: undefined,
+  escape: undefined,
+  parse: undefined,
+  render: undefined,
+  Scanner: undefined,
+  Context: undefined,
+  Writer: undefined,
+  /**
+   * Allows a user to override the default caching strategy, by providing an
+   * object with set, get and clear methods. This can also be used to disable
+   * the cache by setting it to the literal `undefined`.
+   */
+  set templateCache(cache) {
+    defaultWriter.templateCache = cache;
+  },
+  /**
+   * Gets the default or overridden caching object from the default writer.
+   */
+  get templateCache() {
+    return defaultWriter.templateCache;
+  },
+};
+
+// All high-level mustache.* functions use this writer.
+var defaultWriter = new Writer();
+
+/**
+ * Clears all cached templates in the default writer.
+ */
+mustache.clearCache = function clearCache() {
+  return defaultWriter.clearCache();
+};
+
+/**
+ * Parses and caches the given template in the default writer and returns the
+ * array of tokens it contains. Doing this ahead of time avoids the need to
+ * parse templates on the fly as they are rendered.
+ */
+mustache.parse = function parse(template, tags) {
+  return defaultWriter.parse(template, tags);
+};
+
+/**
+ * Renders the `template` with the given `view`, `partials`, and `config`
+ * using the default writer.
+ */
+mustache.render = function render(template, view, partials, config) {
+  if (typeof template !== "string") {
+    throw new TypeError(
+      'Invalid template! Template should be a "string" ' +
+        'but "' +
+        typeStr(template) +
+        '" was given as the first ' +
+        "argument for mustache#render(template, view, partials)",
+    );
+  }
+
+  return defaultWriter.render(template, view, partials, config);
+};
+
+// Export the escaping function so that the user may override it.
+// See https://github.com/janl/mustache.js/issues/244
+mustache.escape = escapeHtml;
+
+// Export these mainly for testing, but also for advanced usage.
+mustache.Scanner = Scanner;
+mustache.Context = Context;
+mustache.Writer = Writer;
+
+export default mustache;


### PR DESCRIPTION
## What is this contribution about?

Agents can now produce **presentation decks** as a first-class artifact: single self-contained HTML files in the org-fs home volume (`org/<slug>/decks/<name>.html`), with an instant live preview in the chat side panel, **inline editing** (text + slide structure, saved back to the file so the agent sees user edits), org-injectable themes/templates, and PDF export.

### The pieces

- **`<deck-viewer>` runtime** (`apps/mesh/public/deck-runtime/v1/deck-viewer.js`) — vanilla-JS web component served as an unauthenticated static asset (classic script, loadable from the opaque-origin sandboxed iframe). Scaled 1920×1080 canvas, keyboard/touch nav, thumbnail rail (hidden by default — presentation-first; URL-hash `#3,rail` deep-links; host-toggled), host-gated edit mode (contenteditable + reorder/duplicate/delete/skip via rail context menu), optimistic ops over a versioned postMessage protocol, and `@media print` CSS (one slide per page → browser Save-as-PDF).
- **Two sandbox-image skills** (zero Dockerfile changes — `COPY image/skills` picks them up):
  - `templating` — generic `create-from-template --template <file> --data <json|@file> --output <file>` mustache CLI (vendored mustache.js, MIT). Works for any text file.
  - `slides` — `slides-create --data @deck.json --output …` composes a deck from 10 slide-layout templates into one of 3 themes (`aurora-light`, `ink-dark`, `bold-gradient`). `--theme` accepts a built-in name **or a path to a custom theme shell** and `--templates-dir` resolves org brand templates from org-fs.
- **Deck publish signal** — an org-fs change-feed watcher (`deck-watcher.ts`, new `OrgFs.latestSeq`) sweeps `decks/*.html` at each agent step and emits `data-deck-updated` parts (catches bash/CLI-created decks); the `write`/`edit` tools additionally fast-path mirror deck content server-side (`deck-buffer.ts`) ahead of the rclone mount's ~5s vfs write-back.
- **One preview surface, handshake-upgraded** — `HtmlPreviewPanel` renders every generated-HTML preview (chat `deck:` tab, legacy `web-page:` tab, Library html files). It's a plain sandboxed iframe until the framed document completes the deck-viewer `ready` handshake, then the toolbar grows the rail toggle, edit mode (writable org-fs sources only), and a Download dropdown (Export as PDF / Download HTML). Inline edits replay ops on the HTML source (pure `applyDeckOp`, DOMParser) and debounce-PUT to org-fs; conflicts are last-writer-wins with an "Agent updated — reload" badge.
- **Re-open affordance** — the thread artifacts row now shows deck chips (from persisted `data-deck-updated` parts), so a saved thread can re-open its deck panel.
- **Security hardening** — org-fs HTML reads now ship `Content-Security-Policy: sandbox allow-scripts allow-modals`, so top-level opens of member-authored HTML run with an opaque origin (no credentialed fetches); `allow-modals` keeps `window.print()` working.

### Notes
- The legacy `pages/` pipeline is untouched (still the only HTML preview for non-org-fs deployments and desktop); its tab now renders through the shared panel, so the eventual removal PR only deletes an adapter.
- Decks reference images via absolute public URLs / data URIs only (org-fs subresources can't carry cookies from the opaque-origin iframe) — documented in the SKILL.md; an unauthenticated asset route can lift this later.
- Shipping the skills requires the normal sandbox-image rebuild/release.

## Screenshots/Demonstration

Rendered themes (example deck, `slides-create --data @examples/deck.json`): aurora-light title + bullets slides, ink-dark KPI row, bold-gradient timeline — see `packages/sandbox/image/skills/slides/examples/deck.json` to reproduce locally in <1 min (instructions below).

## How to Test

1. `bun install && ORGFS_CLUSTER_MOUNTS=true bun run dev`
2. Render a demo deck and seed it: `bun packages/sandbox/image/skills/slides/slides-create.mjs --data @packages/sandbox/image/skills/slides/examples/deck.json --output /tmp/demo.html`, then PUT it to `/api/<org>/fs/home/file?path=decks/demo.html` (Library upload into a `decks/` folder works too).
3. Open the deck: Library → home volume → `decks/demo.html` (or `?main=deck:decks%2Fdemo.html` on a thread URL). Expect: deck renders, toolbar upgrades with rail/edit/download controls after load.
4. Toggle the rail (left toolbar button) — no reload, slide position preserved. Toggle edit mode → retype a heading, blur, wait ~1s → re-fetch the file and see the edit persisted. Right-click a thumbnail → duplicate/delete/skip.
5. Download ▾ → Export as PDF → print dialog shows one slide per page.
6. Agent flow (needs a sandbox image built from this branch): ask an agent to create a deck — the skill drives `slides-create`, and the preview auto-opens/refreshes mid-run; the thread shows a "Slides in this chat" chip afterwards.
7. `bun run fmt && bun run lint && bun run check && bun test <touched test files>`; e2e: `apps/mesh/e2e/tests/deck-preview-edit.spec.ts` (passes against dockerized postgres+NATS, see `.github/workflows/e2e.yml` env).

## Migration Notes

- New manifest query `OrgFsEntryStorage.latestSeq` (no schema change).
- Sandbox image rebuild required to ship `/mnt/skills/public/{slides,templating}`.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in slides skill and deck runtime so agents can create live‑editable presentation decks as single HTML files at org/<slug>/decks/<name>.html, with instant preview, inline edits saved back, and PDF export. Unifies HTML previews behind one panel that upgrades when a deck is detected.

- New Features
  - `<deck-viewer>` runtime served at `/deck-runtime/v1/deck-viewer.js`: 1920×1080 canvas, keyboard/touch nav, thumbnail rail, inline edit (reorder/duplicate/delete/skip), and print CSS for one‑slide‑per‑page PDFs.
  - Shared HtmlPreviewPanel for all HTML previews; on deck handshake it shows rail toggle, edit mode (writable sources), and a Download menu (Export as PDF / Download HTML). Edits apply via DOMParser ops and save to org‑fs (last‑writer‑wins with a reload badge on conflicts).
  - Sandbox skills: `slides` (CLI `slides-create`, 3 themes + 10 slide templates, supports custom theme path and `--templates-dir`) and `templating` (CLI `create-from-template`, mustache renderer).
  - Deck detection and refresh: change‑feed watcher emits `data-deck-updated`; a per‑step deck buffer mirrors `write`/`edit` content to org‑fs so previews update immediately; write‑back echoes are deduped by content hash, and preview cache markers key on `contentHash` to avoid spurious reloads or badges.
  - Chat and Library: deck chips in the thread artifacts row (`?main=deck:<path>` reopen), and Library HTML previews use the same upgraded panel with edit/PDF for home‑volume files.
  - Security: org‑fs HTML reads ship `Content-Security-Policy: sandbox allow-scripts allow-modals` to run with an opaque origin.
  - Stability/UX: one identical toolbar across chat and Library; rail/edit state syncs via postMessage (no iframe reloads); Download consolidated into a dropdown with HTML downloads using the file basename; per‑file panel keying prevents cross‑file saves; reload nonce forces a fresh load after failed ops or save failures; PDF export opens with `noopener`.

- Migration
  - Rebuild the sandbox image to ship `/mnt/skills/public/{slides,templating}`.
  - New manifest query `OrgFs.latestSeq` (no schema change).

<sup>Written for commit b9efc8dca4432c1bd63cb34e23de0c9f282abb35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

