### PR TITLE
Improve logging messages for database pool acquisition in index.ts

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -112,7 +112,7 @@ function instrumentPool(pool: Pool): Pool {
         });
         if (waited > SLOW_ACQUIRE_THRESHOLD_MS) {
           if (contended) {
-            console.error("Slow pool acquire — pool saturated:", {
+            console.error("Slow db pool acquire — pool saturated:", {
               waitMs: waited,
               total: pool.totalCount,
               idle: pool.idleCount,
@@ -122,7 +122,7 @@ function instrumentPool(pool: Pool): Pool {
           } else {
             // A connection was free; the delay is the event loop being blocked,
             // not the DB pool. See observability/profiling/event-loop.ts.
-            console.warn("Slow pool acquire — event-loop lag (not pool):", {
+            console.warn("Slow db pool acquire — event-loop lag (not pool):", {
               waitMs: waited,
               idleAtStart,
               total: pool.totalCount,


### PR DESCRIPTION
- Updated error and warning messages to specify "db pool" for clarity in logging slow acquisition scenarios, enhancing observability and debugging capabilities.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified slow acquisition logs for the database connection pool to improve debugging and on-call triage. Error and warning messages now say "Slow db pool acquire", clearly differentiating pool saturation from event-loop lag.

<sup>Written for commit f3b56100bd16e5930649512ed40db4edbc4190a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

