### PR TITLE
feat(pages): standalone pages live in the org home volume

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-watcher.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-watcher.ts
@@ -1,7 +1,8 @@
 /**
- * Deck watcher — detects presentation-deck writes (`decks/<name>.html` in
- * the org home volume) during a run and emits `data-deck-updated` UI parts
- * so the chat side panel opens/refreshes the live deck preview.
+ * Deck watcher — detects live-HTML writes in the org home volume
+ * (`decks/<name>.html` presentation decks, `pages/<name>.html` standalone
+ * pages) during a run and emits `data-deck-updated` UI parts so the chat
+ * side panel opens/refreshes the live preview.
  *
  * Detection is change-feed based rather than tool-based: every sandbox
  * write to the mounted `org/<slug>/` path flows through the WebDAV serve
@@ -33,6 +34,8 @@ export interface DeckUpdatedData {
   volume: string;
   path: string;
   name: string;
+  /** `deck` (decks/) or `page` (pages/) — drives chip icons. */
+  kind: "deck" | "page";
   /** Mount-relative path the agent sees, for chat-row display. */
   mountPath: string;
 }
@@ -90,6 +93,7 @@ export function createDeckWatcher(
             volume: HOME_VOLUME,
             path: deck.path,
             name: deck.name,
+            kind: deck.kind,
             mountPath: `org/${mountDir}/${deck.path}`,
           });
         }

--- a/apps/mesh/src/web/components/chat/message/thread-html-previews.tsx
+++ b/apps/mesh/src/web/components/chat/message/thread-html-previews.tsx
@@ -31,6 +31,8 @@ interface HtmlPreviewRef {
 interface DeckRef {
   path: string;
   name: string;
+  /** `deck` (decks/) or `page` (pages/); older parts may omit it. */
+  kind?: "deck" | "page";
 }
 
 interface PreviewChip {
@@ -63,7 +65,7 @@ function collectChips(
           seen.set(key, {
             tabId: formatDeckTabId(deck.path),
             label: deck.name || deck.path,
-            kind: "deck",
+            kind: deck.kind === "page" ? "page" : "deck",
           });
         }
         continue;

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -12,7 +12,7 @@
 
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Monitor01 } from "@untitledui/icons";
+import { Globe01, Monitor01 } from "@untitledui/icons";
 import { createElement, useSyncExternalStore } from "react";
 import {
   SELF_MCP_ALIAS_ID,
@@ -315,8 +315,9 @@ export function useMainPanelTabs(ctx: {
       ]
     : [];
 
-  // Ephemeral deck-preview tab (`?main=deck:<path>`): same pill semantics
-  // as file previews. Title is the deck name (file stem).
+  // Ephemeral live-HTML preview tab (`?main=deck:<path>` — decks AND
+  // standalone pages from the org home volume): same pill semantics as
+  // file previews. Title is the file stem; icon follows the artifact dir.
   const deckTabParsed = parseDeckTabId(activeTab);
   const deckTabs: Tab[] = deckTabParsed
     ? [
@@ -328,7 +329,11 @@ export function useMainPanelTabs(ctx: {
           kind: "file",
           icon: {
             kind: "component",
-            Component: (props) => createElement(Monitor01, props),
+            Component: (props) =>
+              createElement(
+                deckTabParsed.path.startsWith("pages/") ? Globe01 : Monitor01,
+                props,
+              ),
           },
         },
       ]

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/deck-paths.test.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/deck-paths.test.ts
@@ -6,14 +6,25 @@ describe("matchDeckEntryPath", () => {
     expect(matchDeckEntryPath("decks/q3-launch.html")).toEqual({
       path: "decks/q3-launch.html",
       name: "q3-launch",
+      kind: "deck",
     });
     expect(matchDeckEntryPath("decks/a.html")).toEqual({
       path: "decks/a.html",
       name: "a",
+      kind: "deck",
     });
     expect(matchDeckEntryPath("decks/My.Deck_2.HTML")).toEqual({
       path: "decks/My.Deck_2.HTML",
       name: "My.Deck_2",
+      kind: "deck",
+    });
+  });
+
+  test("matches standalone pages with kind page", () => {
+    expect(matchDeckEntryPath("pages/landing.html")).toEqual({
+      path: "pages/landing.html",
+      name: "landing",
+      kind: "page",
     });
   });
 
@@ -32,20 +43,28 @@ describe("matchDeckToolPath", () => {
     expect(matchDeckToolPath("org/acme/decks/launch.html", "acme")).toEqual({
       path: "decks/launch.html",
       name: "launch",
+      kind: "deck",
     });
     expect(matchDeckToolPath("./org/acme/decks/launch.html", "acme")).toEqual({
       path: "decks/launch.html",
       name: "launch",
+      kind: "deck",
     });
     expect(
       matchDeckToolPath("/app/repo/org/acme/decks/launch.html", "acme"),
-    ).toEqual({ path: "decks/launch.html", name: "launch" });
+    ).toEqual({ path: "decks/launch.html", name: "launch", kind: "deck" });
+    expect(matchDeckToolPath("org/acme/pages/landing.html", "acme")).toEqual({
+      path: "pages/landing.html",
+      name: "landing",
+      kind: "page",
+    });
   });
 
   test("works with the reserved-slug fallback mount path", () => {
     expect(matchDeckToolPath("org/home/decks/launch.html", "home")).toEqual({
       path: "decks/launch.html",
       name: "launch",
+      kind: "deck",
     });
   });
 

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/deck-paths.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/deck-paths.ts
@@ -1,27 +1,34 @@
 /**
- * Deck path matching — pure logic shared by the cluster deck watcher (org-fs
- * change-feed entries) and any tool-path detection.
+ * Live-HTML path matching — pure logic shared by the cluster deck watcher
+ * (org-fs change-feed entries) and any tool-path detection.
  *
- * Convention: presentation decks live at `decks/<name>.html` inside the org
- * home volume, which sandboxes see mounted at `org/<homeMountPath>/`. The
- * `slides` sandbox skill writes there; the Studio web UI previews + edits
- * the same file.
+ * Convention: HTML artifacts the user should see live in the org home
+ * volume, which sandboxes see mounted at `org/<homeMountPath>/`:
+ *   - `decks/<name>.html` — presentation decks (the `slides` skill)
+ *   - `pages/<name>.html` — standalone pages (landing pages, one-pagers)
+ * The Studio web UI previews (and for decks, edits) the same files.
  */
 
-const DECK_ENTRY_PATTERN = /^decks\/([a-z0-9][a-z0-9._-]*)\.html$/i;
+const DECK_ENTRY_PATTERN = /^(decks|pages)\/([a-z0-9][a-z0-9._-]*)\.html$/i;
 
 export interface DeckRef {
   /** Volume-relative path, e.g. `decks/q3-launch.html`. */
   path: string;
-  /** Deck name (file stem), e.g. `q3-launch`. */
+  /** File stem, e.g. `q3-launch`. */
   name: string;
+  /** Which artifact dir matched. */
+  kind: "deck" | "page";
 }
 
 /** Match a HOME-VOLUME-relative entry path (org-fs change feed shape). */
 export function matchDeckEntryPath(entryPath: string): DeckRef | null {
   const m = DECK_ENTRY_PATTERN.exec(entryPath);
   if (!m) return null;
-  return { path: entryPath, name: m[1]! };
+  return {
+    path: entryPath,
+    name: m[2]!,
+    kind: m[1]!.toLowerCase() === "decks" ? "deck" : "page",
+  };
 }
 
 /**

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -137,19 +137,26 @@ export function buildWriteDescription(orgFs: boolean): string {
     "Write content to a file in the VM's project directory. " +
     "Creates parent directories if needed. Overwrites existing files entirely.\n\n" +
     (orgFs
-      ? "PRESENTATION DECKS / SLIDES: never `pages/` — read " +
-        "`/mnt/skills/public/slides/SKILL.md` and write the deck to " +
-        "`org/<your-org-slug>/decks/<name>.html` (lowercase kebab). That " +
-        "path gets a live preview with inline editing and persists in the " +
-        "org's shared folder.\n\n"
-      : "") +
-    "Reserved path — `pages/<slug>.html`: writes to this prefix are " +
-    "automatically published to the org's object storage and rendered as a " +
-    "live preview in the chat side panel. Use this for one-off viewable " +
-    "HTML pages (landing pages, brand kits, one-pagers)" +
-    (orgFs ? " — NOT for slides/decks (see above)" : "") +
-    ". Slug must be lowercase kebab (e.g. `pages/landing.html`). HTML " +
-    "written elsewhere stays sandbox-only and will not render a preview."
+      ? // Org-fs deployments: every live-preview HTML artifact lives in the
+        // org home volume (durable, Library-visible, deck editing). The
+        // legacy root `pages/` pipeline is intentionally not advertised.
+        "Viewable HTML artifacts get a LIVE PREVIEW in the chat side panel " +
+        "and persist in the org's shared folder when written under " +
+        "`org/<your-org-slug>/` (lowercase-kebab names):\n" +
+        "- Presentation decks / slides → `org/<your-org-slug>/decks/<name>.html` " +
+        "— read `/mnt/skills/public/slides/SKILL.md` FIRST and create the " +
+        "deck with its CLI.\n" +
+        "- Standalone pages (landing pages, brand kits, one-pagers) → " +
+        "`org/<your-org-slug>/pages/<name>.html` — single self-contained " +
+        "HTML file.\n" +
+        "HTML written anywhere else will not render a preview."
+      : "Reserved path — `pages/<slug>.html`: writes to this prefix are " +
+        "automatically published to the org's object storage and rendered " +
+        "as a live preview in the chat side panel. Use this whenever the " +
+        "user wants a viewable HTML page (landing pages, brand kits, " +
+        "one-pagers). Slug must be lowercase kebab (e.g. " +
+        "`pages/landing.html`). HTML written elsewhere stays sandbox-only " +
+        "and will not render a preview.")
   );
 }
 


### PR DESCRIPTION
## What is this contribution about?

Phase 1 of retiring the legacy root `pages/` pipeline (sandbox-local + object-storage mirror: invisible in the Library, dies with the sandbox, and was stealing slide requests until #3871).

With org-fs mounted, **all live-preview HTML now lives in the org home volume**:

- decks → `org/<slug>/decks/<name>.html` (slides skill, unchanged)
- standalone pages → `org/<slug>/pages/<name>.html` (new convention)

Both flow through the same pipeline shipped in #3868: deck-watcher change-feed sweep → `data-deck-updated` part (now with `kind: "deck" | "page"`) → auto-open in the side panel → `HtmlPreviewPanel` (a page is a passive preview; deck controls only appear on the deck-viewer handshake). Pages are durable, show in the Library, and download/copy/open like any org file. Thread chips and the tab pill pick a globe icon for pages.

The legacy pipeline is **no longer advertised** in the write tool when org-fs is mounted, but stays intact for desktop and non-org-fs deployments (their only HTML preview). Phases 2/3 (museum-mode WebPageTab, then deletion) are tracked separately and blocked on the desktop/org-fs decision.

## How to Test

1. `ORGFS_CLUSTER_MOUNTS=true bun run dev`, ask an agent for a landing page.
2. Expected: file lands at `org/<slug>/pages/<name>.html`, the preview panel auto-opens on the right (passive toolbar — no rail/edit), the file is in the Library, and the thread shows a globe chip. Nothing in root `pages/`.
3. Slides flow unchanged (deck e2e passes: `e2e/tests/deck-preview-edit.spec.ts`).
4. `bun run fmt && bun run lint && bun run check` green; unit tests cover the `(decks|pages)` matcher + kind.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves standalone page previews into the org home volume and unifies the live-HTML pipeline. All live-preview HTML now lives at `org/<slug>/{decks|pages}/<name>.html`, making pages durable and Library-visible.

- **New Features**
  - Route standalone pages to `org/<slug>/pages/<name>.html`; decks remain in `org/<slug>/decks/`.
  - Unify watcher/preview flow and include `kind: "deck" | "page"` to drive chips and tab icons (`Globe01` for pages).
  - Update write tool guidance for org-fs; stop advertising legacy root `pages/` (still used on desktop/non-org-fs).
  - Add matcher and tool-path tests; minor UI tweaks for preview tabs and thread chips.

<sup>Written for commit 75552da2ccac15e6b4601798d3dc6d1142f24415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

