### PR TITLE
feat(mcp): add leak gauge for MCP servers and implement abort handling

### DIFF
--- a/apps/mesh/src/api/utils/serve-mcp.ts
+++ b/apps/mesh/src/api/utils/serve-mcp.ts
@@ -39,6 +39,74 @@ interface ServeMcpOptions {
   onClose?: () => void | Promise<void>;
 }
 
+/**
+ * Leak gauge for per-request MCP servers. `built` counts servers entering
+ * `serveMcpRequest`, `closed` counts completed teardowns, `collected` counts
+ * servers the GC actually reclaimed (via FinalizationRegistry). A rising
+ * `built - collected` floor under steady traffic means servers are being
+ * pinned after close — the production leak signature — and tells us so
+ * without needing a heap snapshot.
+ */
+const gauge = {
+  built: 0,
+  closed: 0,
+  collected: 0,
+};
+const collectedRegistry = new FinalizationRegistry<null>(() => {
+  gauge.collected++;
+});
+const GAUGE_INTERVAL_MS = 60_000;
+const gaugeTimer = setInterval(() => {
+  if (gauge.built === 0) return;
+  console.log(
+    JSON.stringify({
+      msg: "mcp-server-gauge",
+      ts: new Date().toISOString(),
+      built: gauge.built,
+      closed: gauge.closed,
+      collected: gauge.collected,
+      alive: gauge.built - gauge.collected,
+    }),
+  );
+}, GAUGE_INTERVAL_MS);
+gaugeTimer.unref?.();
+
+/**
+ * The SDK transport's JSON-response mode returns a Promise from
+ * `handleRequest` that is resolved only by `send()` delivering the final
+ * response. `transport.close()` does NOT settle it (cleanup just deletes the
+ * stream mapping — verified through SDK 1.29), so a request that aborts
+ * mid-handler leaves `handleRequest` pending forever. Awaiting it would pin
+ * this frame — and through it the server, transport, request, and every tool
+ * schema — as a permanent GC root. Race it against the abort signal so the
+ * frame always settles.
+ */
+function raceAbort(
+  promise: Promise<Response>,
+  signal: AbortSignal | undefined,
+): Promise<Response> {
+  if (!signal) return promise;
+  if (signal.aborted) {
+    return Promise.resolve(new Response(null, { status: 499 }));
+  }
+  return new Promise<Response>((resolve, reject) => {
+    const onAbort = () => {
+      resolve(new Response(null, { status: 499 }));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (res) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(res);
+      },
+      (err) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
 export async function serveMcpRequest(
   server: CloseableServer,
   transport: RequestTransport,
@@ -48,12 +116,16 @@ export async function serveMcpRequest(
 ): Promise<Response> {
   const signal = request.signal;
 
+  gauge.built++;
+  collectedRegistry.register(server, null);
+
   // Idempotent: the abort listener and the stream guard's onDone can both fire
   // (e.g. disconnect racing body-complete) — teardown must run exactly once.
   let closed = false;
   const close = () => {
     if (closed) return;
     closed = true;
+    gauge.closed++;
     signal?.removeEventListener("abort", close);
     void server.close().catch((err) => {
       console.error(`[serve-mcp] ${label} server close failed:`, err);
@@ -78,10 +150,14 @@ export async function serveMcpRequest(
 
   let response: Response;
   try {
-    response = await transport.handleRequest(request);
+    response = await raceAbort(transport.handleRequest(request), signal);
   } catch (err) {
     close();
     throw err;
+  }
+  if (signal?.aborted) {
+    close();
+    return response;
   }
   return guardResponseStream(response, label, close);
 }


### PR DESCRIPTION
- Introduced a gauge to track the number of MCP servers built, closed, and collected by the garbage collector, aiding in memory leak detection.
- Implemented `raceAbort` function to handle request abort signals, ensuring proper cleanup and preventing memory retention of server instances.
- Updated `serveMcpRequest` to utilize the new abort handling mechanism, enhancing resource management during request processing.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a leak gauge for per-request MCP servers and add abort-safe request handling to prevent pinned server instances. This improves cleanup on aborted requests and surfaces leak signals via periodic logs.

- **New Features**
  - Leak gauge: tracks built/closed/collected servers; logs JSON every 60s; uses `FinalizationRegistry` to count collections.
  - Abort handling: `raceAbort` returns 499 on abort and ensures `serveMcpRequest` closes exactly once, avoiding memory retention.

<sup>Written for commit 520b21231a25d9c685c92e53fb4ab32cfe6a5b9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

