### PR TITLE
feat(mcp): register observability metrics for MCP server lifecycle

### DIFF
--- a/apps/mesh/src/api/utils/serve-mcp.ts
+++ b/apps/mesh/src/api/utils/serve-mcp.ts
@@ -16,6 +16,7 @@
  * on client cancel, on client disconnect (request abort), or on a handler
  * throw.
  */
+import { meter } from "../../observability";
 import { guardResponseStream } from "./stream-guard";
 
 interface CloseableServer {
@@ -58,18 +59,43 @@ const collectedRegistry = new FinalizationRegistry<null>(() => {
 const GAUGE_INTERVAL_MS = 60_000;
 const gaugeTimer = setInterval(() => {
   if (gauge.built === 0) return;
-  console.log(
-    JSON.stringify({
-      msg: "mcp-server-gauge",
-      ts: new Date().toISOString(),
-      built: gauge.built,
-      closed: gauge.closed,
-      collected: gauge.collected,
-      alive: gauge.built - gauge.collected,
-    }),
-  );
 }, GAUGE_INTERVAL_MS);
 gaugeTimer.unref?.();
+
+/**
+ * Export the gauge to OTLP/Grafana as metrics. `meter` is a live binding that
+ * is a Noop until `initObservability()` runs after SDK start, so register the
+ * instruments lazily on first request (the SDK is up by the time traffic
+ * arrives). `mcp.server.alive` is the leak indicator; built/collected are
+ * monotonic counters for rate/gap analysis.
+ */
+let metricsRegistered = false;
+function ensureGaugeMetrics(): void {
+  if (metricsRegistered) return;
+  metricsRegistered = true;
+  try {
+    const alive = meter.createObservableGauge("mcp.server.alive", {
+      description:
+        "Per-request MCP servers built but not yet GC-collected (rising floor = leak)",
+      unit: "{server}",
+    });
+    alive.addCallback((r) => r.observe(gauge.built - gauge.collected));
+
+    const built = meter.createObservableCounter("mcp.server.built", {
+      description: "Total per-request MCP servers constructed",
+      unit: "{server}",
+    });
+    built.addCallback((r) => r.observe(gauge.built));
+
+    const collected = meter.createObservableCounter("mcp.server.collected", {
+      description: "Total per-request MCP servers reclaimed by GC",
+      unit: "{server}",
+    });
+    collected.addCallback((r) => r.observe(gauge.collected));
+  } catch (err) {
+    console.error("[serve-mcp] failed to register gauge metrics:", err);
+  }
+}
 
 /**
  * The SDK transport's JSON-response mode returns a Promise from
@@ -116,6 +142,7 @@ export async function serveMcpRequest(
 ): Promise<Response> {
   const signal = request.signal;
 
+  ensureGaugeMetrics();
   gauge.built++;
   collectedRegistry.register(server, null);
 


### PR DESCRIPTION
- Added metrics to track the number of MCP servers built, collected, and alive, aiding in memory leak detection.
- Implemented lazy registration of metrics to ensure observability is initialized before traffic arrives.
- Enhanced error handling during metric registration to improve robustness.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OTLP metrics for the MCP server lifecycle to detect leaks and track server churn. Metrics register lazily on first request and replace the old console gauge logging.

- **New Features**
  - `mcp.server.alive` ObservableGauge (built - collected).
  - `mcp.server.built` and `mcp.server.collected` ObservableCounters.
  - Lazy, one-time metric registration with error handling.

<sup>Written for commit 4667140ad10e76a55d1649fd826660f52f3778dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

