### PR TITLE
feat(profiling): add stall-stack watchdog for event loop monitoring

### DIFF
--- a/apps/mesh/src/observability/profiling/index.ts
+++ b/apps/mesh/src/observability/profiling/index.ts
@@ -1,18 +1,24 @@
 import { logCpuProfilingStatus } from "./cpu";
 import { startEventLoopMonitor } from "./event-loop";
 import { startHeapWatch } from "./heap";
+import { startStallWatchdog } from "./stall-stack";
 
 /**
  * Single entry point for the profiling stack:
  * - CPU profiling status (Bun `--cpu-prof` launch flag — see cpu.ts)
  * - heap watch + on-demand snapshots (HEAP_WATCH — see heap.ts)
  * - event-loop delay monitor (EVENT_LOOP_MONITOR — see event-loop.ts)
+ * - stall-stack watchdog (STALL_WATCHDOG — see stall-stack.ts)
  *
  * Returns a stop function that tears down every monitor it started.
  */
 export function startProfiling(): () => void {
   logCpuProfilingStatus();
-  const stops = [startHeapWatch(), startEventLoopMonitor()];
+  const stops = [
+    startHeapWatch(),
+    startEventLoopMonitor(),
+    startStallWatchdog(),
+  ];
   return () => {
     for (const stop of stops) stop();
   };

--- a/apps/mesh/src/observability/profiling/stall-stack.ts
+++ b/apps/mesh/src/observability/profiling/stall-stack.ts
@@ -1,0 +1,113 @@
+import * as bunJsc from "bun:jsc";
+
+/**
+ * Stall-stack watchdog — names the JS frame that blocks the event loop.
+ *
+ * Every static guess for the prod loop stalls (JSON.stringify, stream encode,
+ * the MCP-server leak's GC, DBOS conductor) has been refuted by measurement.
+ * The only way left is to sample the main thread DURING a freeze. `bun:jsc`'s
+ * sampling profiler runs on a SEPARATE thread, so it keeps sampling even while
+ * the main loop is frozen — the one technique that survives a blocked loop.
+ *
+ * Mechanism: drain the profiler's sample buffer every tick. While the loop is
+ * frozen it can't tick, so the batch drained on the first post-freeze tick IS
+ * the set of stacks sampled during the frozen window — no timestamp math. On a
+ * tick whose scheduling drift exceeds the threshold, aggregate those stacks by
+ * innermost real JS frame and log the hottest ones as `stall-stack`.
+ *
+ * Gated by STALL_WATCHDOG=1 (off by default — the sampling profiler has a small
+ * always-on cost). STALL_WATCHDOG_MS sets the drift threshold (default 100ms,
+ * matching the event-loop-stall log threshold so every logged stall gets a
+ * stack). Logs flow to stdout → VictoriaLogs, same as event-loop-stall.
+ */
+interface SampledFrame {
+  name?: string;
+  sourceURL?: string;
+  line?: number;
+  category?: string;
+}
+interface SampledTrace {
+  frames: SampledFrame[];
+}
+
+// The runtime exports these (verified live on Bun 1.3.11 + 1.3.14) but
+// @types/bun omits them from the "bun:jsc" declarations.
+const { startSamplingProfiler, samplingProfilerStackTraces } =
+  bunJsc as unknown as {
+    startSamplingProfiler: () => void;
+    samplingProfilerStackTraces: () => { traces?: SampledTrace[] };
+  };
+
+export function startStallWatchdog(): () => void {
+  if (process.env.STALL_WATCHDOG !== "1") return () => {};
+
+  const stallMs = Number(process.env.STALL_WATCHDOG_MS ?? 100);
+  const tickMs = Number(process.env.STALL_WATCHDOG_TICK_MS ?? 50);
+
+  try {
+    startSamplingProfiler();
+  } catch (err) {
+    console.error("[stall-watchdog] failed to start sampling profiler:", err);
+    return () => {};
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let expected = performance.now() + tickMs;
+
+  const tick = () => {
+    const now = performance.now();
+    const drift = now - expected;
+    expected = now + tickMs;
+
+    // Drain every tick so the buffer stays bounded and the post-freeze batch is
+    // exactly the freeze window's samples.
+    let batch: SampledTrace[] = [];
+    try {
+      batch = samplingProfilerStackTraces()?.traces ?? [];
+    } catch {
+      // profiler buffer read can race; skip this window
+    }
+
+    if (drift > stallMs && batch.length > 0) {
+      const counts = new Map<string, number>();
+      for (const t of batch) {
+        // innermost meaningful JS frame = first with a real sourceURL
+        const f =
+          t.frames.find(
+            (fr) =>
+              fr.sourceURL && !/Unknown Executable/.test(fr.category ?? ""),
+          ) ?? t.frames[0];
+        if (!f) continue;
+        const src = (f.sourceURL ?? "?").replace(
+          /^.*\/node_modules\//,
+          "node_modules/",
+        );
+        const key = `${f.name ?? "?"} @ ${src}:${f.line ?? "?"}`;
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+      }
+      const top = [...counts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 8)
+        .map(([frame, count]) => ({ frame, count }));
+      console.warn(
+        JSON.stringify({
+          msg: "stall-stack",
+          ts: new Date().toISOString(),
+          lagMs: Math.round(drift),
+          samplesInWindow: batch.length,
+          top,
+        }),
+      );
+    }
+
+    timer = setTimeout(tick, tickMs);
+    timer.unref?.();
+  };
+
+  timer = setTimeout(tick, tickMs);
+  timer.unref?.();
+
+  return () => {
+    if (timer) clearTimeout(timer);
+  };
+}


### PR DESCRIPTION
- Introduced a new `startStallWatchdog` function to monitor and log JS frames that block the event loop, utilizing Bun's sampling profiler.
- Updated the `startProfiling` function to include the stall-stack watchdog in the profiling stack, enhancing observability of performance issues.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a stall-stack watchdog that samples JS stacks during event-loop stalls using `bun:jsc`, and logs the hottest frames as JSON. Integrated into `startProfiling` (opt-in via `STALL_WATCHDOG`) to pinpoint what blocks the loop.

- **New Features**
  - Added `startStallWatchdog()` that drains the sampling profiler each tick and, on drift > threshold, logs top blocking frames.
  - Controlled by env vars: `STALL_WATCHDOG=1` to enable; `STALL_WATCHDOG_MS` (default 100); `STALL_WATCHDOG_TICK_MS` (default 50).
  - Logs JSON to stdout: `msg: "stall-stack"`, `lagMs`, `samplesInWindow`, and `top` frames with counts.
  - Included in `startProfiling()` and returns a stop function.

<sup>Written for commit 6a537a51b175e1a157cc05feac291d9b055e31a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

