### PR TITLE
feat(files): proxy file bytes through mesh instead of redirecting to S3

### DIFF
--- a/apps/mesh/e2e/tests/file-serving.spec.ts
+++ b/apps/mesh/e2e/tests/file-serving.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * End-to-end coverage for the stable file-serving route
+ * (`GET /api/:org/files/*`), which proxies object bytes through mesh instead
+ * of 302-redirecting to a presigned S3 URL.
+ *
+ * The route has two byte-delivery paths and this spec exercises both depending
+ * on how the running app is configured (see e2e.yml):
+ *   - **dev (no S3):** DevObjectStorage hands back a `data:` URL → mesh decodes
+ *     it and serves the bytes inline.
+ *   - **S3 (CI MinIO):** mesh presigns a GET internally, fetches it, and streams
+ *     the body back — the signed URL / storage origin never reach the client.
+ *
+ * Bytes-back, content-type, CSP and auth assertions run in BOTH backends so the
+ * suite is meaningful on a plain `bun run test:e2e`. Range/conditional
+ * passthrough and the upstream-404→404 mapping are proxy-only behaviors, so
+ * they're gated behind a real S3 backend.
+ */
+
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+import type { APIRequestContext } from "@playwright/test";
+
+const s3Configured = !!(
+  process.env.S3_ENDPOINT &&
+  process.env.S3_BUCKET &&
+  process.env.S3_ACCESS_KEY_ID &&
+  process.env.S3_SECRET_ACCESS_KEY
+);
+
+const uniqueKey = (ext: string) =>
+  `e2e-files/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+
+/**
+ * Upload bytes to the org's storage via a presigned PUT URL. Works on both
+ * backends: S3 signs the content-type into the URL (so the PUT must replay it
+ * verbatim), and the dev backend ignores it — replaying it is harmless either
+ * way.
+ */
+async function uploadObject(
+  ctx: APIRequestContext,
+  orgSlug: string,
+  key: string,
+  contentType: string,
+  payload: Buffer,
+): Promise<void> {
+  const put = await callSelfMcpTool<{ url: string }>(
+    ctx,
+    orgSlug,
+    "PUT_PRESIGNED_URL",
+    { key, contentType },
+  );
+  const res = await ctx.fetch(put.url, {
+    method: "PUT",
+    data: payload,
+    headers: { "content-type": contentType },
+  });
+  expect(
+    res.ok(),
+    `upload failed: HTTP ${res.status()} — ${await res
+      .text()
+      .catch(() => "<unreadable>")}`,
+  ).toBe(true);
+}
+
+test.describe("File serving (/api/:org/files/*)", () => {
+  test("serves object bytes directly instead of redirecting", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const { orgSlug } = await signUpViaApi(ctx);
+
+    const key = uniqueKey("png");
+    // A clearly-binary payload (PNG magic + junk) so the dev backend's
+    // base64 data:-URL round-trip is exercised, not just the text path.
+    const payload = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      Buffer.from(`e2e-bytes-${key}`),
+    ]);
+    await uploadObject(ctx, orgSlug, key, "image/png", payload);
+
+    // maxRedirects: 0 is the regression guard — a 302 back to a presigned S3
+    // URL (the old behavior) would surface here as status 302, not 200.
+    const res = await ctx.get(`/api/${orgSlug}/files/${key}`, {
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toContain("image/png");
+    expect(res.headers()["cache-control"]).toContain("private");
+    const body = await res.body();
+    expect(body.equals(payload)).toBe(true);
+
+    await ctx.dispose();
+  });
+
+  test("sandboxes member-authored HTML served same-origin", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const { orgSlug } = await signUpViaApi(ctx);
+
+    const key = uniqueKey("html");
+    const html = Buffer.from(
+      "<!doctype html><title>e2e</title><p>hello</p>",
+      "utf-8",
+    );
+    await uploadObject(ctx, orgSlug, key, "text/html", html);
+
+    const res = await ctx.get(`/api/${orgSlug}/files/${key}`, {
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toContain("text/html");
+    // Now that HTML is served from mesh's own origin (not the storage origin
+    // after a redirect), it must run with an opaque origin so its scripts
+    // can't make credentialed same-origin calls.
+    expect(res.headers()["content-security-policy"]).toContain("sandbox");
+    expect((await res.body()).equals(html)).toBe(true);
+
+    await ctx.dispose();
+  });
+
+  test("rejects unauthenticated API clients with 401", async ({
+    playwright,
+  }) => {
+    // A valid org slug (so org resolution doesn't 404), hit by a fresh context
+    // carrying no session cookie. The auth check fires before any storage
+    // lookup, so the key need not exist.
+    const owner = await newApiContext(playwright);
+    const { orgSlug } = await signUpViaApi(owner);
+
+    const anon = await newApiContext(playwright);
+    const res = await anon.get(`/api/${orgSlug}/files/${uniqueKey("txt")}`, {
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBe(401);
+
+    await anon.dispose();
+    await owner.dispose();
+  });
+
+  test.describe("proxy-only behavior (real S3)", () => {
+    test.skip(
+      !s3Configured,
+      "requires S3 env (S3_ENDPOINT/S3_BUCKET/S3_ACCESS_KEY_ID/S3_SECRET_ACCESS_KEY); the dev backend serves bytes inline without proxying",
+    );
+
+    test("forwards Range requests and returns 206 Partial Content", async ({
+      playwright,
+    }) => {
+      const ctx = await newApiContext(playwright);
+      const { orgSlug } = await signUpViaApi(ctx);
+
+      const key = uniqueKey("bin");
+      const payload = Buffer.from("0123456789abcdefghijklmnopqrstuvwxyz");
+      await uploadObject(
+        ctx,
+        orgSlug,
+        key,
+        "application/octet-stream",
+        payload,
+      );
+
+      const res = await ctx.get(`/api/${orgSlug}/files/${key}`, {
+        headers: { Range: "bytes=0-3" },
+        maxRedirects: 0,
+      });
+      expect(res.status()).toBe(206);
+      expect(res.headers()["content-range"]).toContain("bytes 0-3/");
+      expect((await res.body()).equals(payload.subarray(0, 4))).toBe(true);
+
+      await ctx.dispose();
+    });
+
+    test("maps an upstream miss to 404", async ({ playwright }) => {
+      const ctx = await newApiContext(playwright);
+      const { orgSlug } = await signUpViaApi(ctx);
+
+      const res = await ctx.get(`/api/${orgSlug}/files/${uniqueKey("txt")}`, {
+        maxRedirects: 0,
+      });
+      expect(res.status()).toBe(404);
+
+      await ctx.dispose();
+    });
+  });
+});

--- a/apps/mesh/src/api/routes/files.ts
+++ b/apps/mesh/src/api/routes/files.ts
@@ -2,8 +2,8 @@
  * Files Route
  *
  * Serves org-scoped storage files via a stable, non-expiring URL.
- * Redirects to a fresh presigned GET URL on every request, so the
- * caller never needs to manage URL expiry.
+ * Proxies the object bytes through mesh on every request (presigning
+ * internally), so the caller never sees storage URLs or manages expiry.
  *
  * Route: GET /api/:org/files/:key
  *
@@ -25,6 +25,40 @@ import { isBrowserNavigation } from "../utils/browser-navigation";
 type Variables = { meshContext: StudioContext };
 
 const app = new Hono<{ Variables: Variables }>();
+
+/** Request headers forwarded to storage so Range requests (media seeking)
+ * and conditional revalidation keep working through the proxy. */
+const FORWARDED_REQUEST_HEADERS = [
+  "range",
+  "if-none-match",
+  "if-modified-since",
+] as const;
+
+/** Response headers passed through from storage to the client. */
+const FORWARDED_RESPONSE_HEADERS = [
+  "content-type",
+  "content-length",
+  "content-range",
+  "accept-ranges",
+  "etag",
+  "last-modified",
+] as const;
+
+/** Now that bytes are served same-origin (no more redirect to the storage
+ * domain), member-authored active content must not run with mesh's origin.
+ * CSP-sandbox it so scripts get an opaque origin and can't make credentialed
+ * same-origin calls (same posture as the org-fs /read route). */
+function applyContentPolicy(headers: Headers, contentType: string): void {
+  if (
+    contentType.startsWith("text/html") ||
+    contentType.startsWith("image/svg")
+  ) {
+    headers.set(
+      "Content-Security-Policy",
+      "sandbox allow-scripts allow-modals",
+    );
+  }
+}
 
 app.get("/:org/files/*", async (c) => {
   const ctx = c.get("meshContext");
@@ -59,8 +93,7 @@ app.get("/:org/files/*", async (c) => {
     throw new HTTPException(503, { message: "Object storage not configured" });
   }
 
-  // DevObjectStorage returns data: URIs which browsers can't follow as 302
-  // redirects. Serve the bytes inline instead.
+  // DevObjectStorage returns data: URIs — serve the bytes inline.
   if (presignedUrl.startsWith("data:") && usesLocalObjectStorage()) {
     const match = presignedUrl.match(/^data:([^;]+);base64,(.+)$/s);
     if (!match) {
@@ -70,13 +103,47 @@ app.get("/:org/files/*", async (c) => {
     }
     const [, contentType, base64] = match;
     const bytes = Buffer.from(base64!, "base64");
-    return c.body(bytes, 200, {
+    const headers = new Headers({
       "Content-Type": contentType!,
       "Cache-Control": "private, max-age=86400",
     });
+    applyContentPolicy(headers, contentType!);
+    return new Response(bytes, { status: 200, headers });
   }
 
-  return c.redirect(presignedUrl, 302);
+  // Proxy the object through mesh instead of redirecting: the storage origin
+  // and signed URLs never reach the client.
+  const upstreamHeaders = new Headers();
+  for (const name of FORWARDED_REQUEST_HEADERS) {
+    const value = c.req.header(name);
+    if (value) upstreamHeaders.set(name, value);
+  }
+
+  const upstream = await fetch(presignedUrl, { headers: upstreamHeaders });
+
+  // 200 OK / 206 Partial Content / 304 Not Modified / 416 Range Not
+  // Satisfiable pass through; storage 403/404 both mean "no such object"
+  // to the caller; anything else is a storage-side failure.
+  if (upstream.status === 403 || upstream.status === 404) {
+    throw new HTTPException(404, { message: "File not found" });
+  }
+  if (!upstream.ok && upstream.status !== 304 && upstream.status !== 416) {
+    console.error(
+      `[files] upstream storage error ${upstream.status} for key:`,
+      key,
+    );
+    throw new HTTPException(502, { message: "Upstream storage error" });
+  }
+
+  const headers = new Headers();
+  for (const name of FORWARDED_RESPONSE_HEADERS) {
+    const value = upstream.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  headers.set("Cache-Control", "private, max-age=86400");
+  applyContentPolicy(headers, headers.get("content-type") ?? "");
+
+  return new Response(upstream.body, { status: upstream.status, headers });
 });
 
 export default app;

--- a/apps/mesh/src/object-storage/dev-object-storage.ts
+++ b/apps/mesh/src/object-storage/dev-object-storage.ts
@@ -192,7 +192,7 @@ export class DevObjectStorage implements BoundObjectStorage {
    * AI SDK and vision models reject localhost URLs, so we inline the bytes
    * instead of generating an HMAC-signed redirect to /api/dev-assets/.
    * The /api/dev-assets/ route is still used by external clients (e.g. the UI)
-   * via the stable redirect endpoint (/api/:org/files/:key).
+   * via the stable files endpoint (/api/:org/files/:key).
    */
   async presignedGetUrl(
     key: string,

--- a/apps/mesh/src/object-storage/key-utils.ts
+++ b/apps/mesh/src/object-storage/key-utils.ts
@@ -62,9 +62,9 @@ export function buildS3Prefix(orgId: string, prefix?: string): string {
 
 /**
  * Build the stable, non-expiring URL the UI / tools use to read an object by
- * key. Backed by `GET /api/:org/files/*`, which 302-redirects to a fresh
- * presigned GET URL (or serves bytes inline in dev). Single source of truth
- * for this route shape.
+ * key. Backed by `GET /api/:org/files/*`, which proxies the object bytes
+ * through mesh (presigning internally). Single source of truth for this
+ * route shape.
  */
 export function toFilesUrl(
   baseUrl: string,

--- a/apps/mesh/src/web/components/file-preview.tsx
+++ b/apps/mesh/src/web/components/file-preview.tsx
@@ -5,7 +5,7 @@
  * (toolbar, close) and data fetching.
  *
  * Rendering strategy by extension:
- *   - image → <img> (same-origin URL or 302→presigned; no CORS needed)
+ *   - image → <img> (same-origin URL, bytes proxied by mesh; no CORS needed)
  *   - pdf   → <iframe> (browser-native viewer; NOT sandboxed — a sandbox
  *             without allow-scripts would disable Chrome's PDF plugin)
  *   - html  → <iframe sandbox="allow-scripts"> (untrusted, mirrors WebPageTab)
@@ -14,8 +14,7 @@
  *   - other (xlsx/pptx/zip/…) → download card fallback
  *
  * Text-ish fetches go through `fetch(credentials: "include")`; if that
- * fails (e.g. a cross-origin presigned redirect without CORS headers),
- * the component degrades to the download card rather than erroring.
+ * fails, the component degrades to the download card rather than erroring.
  */
 
 import { useQuery } from "@tanstack/react-query";


### PR DESCRIPTION
## What is this contribution about?
`GET /api/:org/files/*` previously answered with a 302 redirect to a fresh presigned S3 GET URL, leaking signed storage URLs to clients. It now proxies the object bytes through mesh: the route still presigns internally but fetches and streams the body, forwarding `Range`/`If-None-Match`/`If-Modified-Since` upstream and passing through `Content-Type`/`Content-Length`/`Content-Range`/`Accept-Ranges`/`ETag`/`Last-Modified`, so media seeking (206) and revalidation (304) keep working. Since content is now served same-origin (it used to execute on the S3 domain after the redirect), member-authored HTML/SVG responses get `Content-Security-Policy: sandbox allow-scripts allow-modals` — the same posture as the org-fs `/read` route — to avoid stored XSS with mesh's origin. Storage 403/404 surface as 404, other upstream failures as 502; stale comments describing the old redirect behavior were updated.

## How to Test
1. Upload a file in chat (or write a `pages/<slug>.html` page) and open its `/api/<org>/files/<key>` URL
2. Observe a direct 200 response with the file bytes (no 302 to an S3 domain in the network tab)
3. For a video/PDF, seek around — partial (206) responses should work; HTML pages should render with the CSP sandbox header

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve files via a same-origin proxy instead of redirecting to presigned S3 URLs. This hides storage URLs, keeps Range/304 working, and sandboxes active content.

- **New Features**
  - `GET /api/:org/files/*` streams bytes through mesh, forwarding `Range`/`If-None-Match`/`If-Modified-Since` and passing through `Content-Type`/`Content-Length`/`Content-Range`/`Accept-Ranges`/`ETag`/`Last-Modified`. Returns 200/206/304/416 as-is.
  - Adds `Content-Security-Policy: sandbox allow-scripts allow-modals` for `text/html` and `image/svg`.
  - Maps storage 403/404 to 404; other upstream failures to 502. Sets `Cache-Control: private, max-age=86400`.
  - Dev storage: serves `data:` URLs inline.
  - E2E tests cover dev + S3 backends: no redirect, content-type passthrough, CSP on HTML, 401 for unauth; S3-only asserts `Range`→206 and upstream miss→404.

<sup>Written for commit 0a33b87cc66655e1228938176d504aa967e157d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

