### PR TITLE
feat(org-fs): push-driven change invalidation, eliminate steady-state…

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -2246,6 +2246,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     eventsHandler,
     watchHandler,
     betterAuthProtectedResourceHandler,
+    getNatsConnection: () => natsProvider?.getConnection() ?? null,
   });
   app.route("/api/:org", orgScopedApi);
 

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -26,6 +26,7 @@
  * with no route changes. See `.context/org-filesystem-proposal.md`.
  */
 
+import { exponentialBackoffWithJitter, sleep } from "@decocms/std";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
@@ -63,6 +64,12 @@ const MAX_RECENT_LIMIT = 200;
 const DEFAULT_RECENT_LIMIT = 50;
 /** Long-poll hold time, just under the usual 30s gateway/proxy timeout. */
 const CHANGES_LONG_POLL_MS = 28_000;
+/**
+ * Spread window for the post-nudge re-query. One write fans out to every mount
+ * watching that (org, volume); jittering keeps a herd from hitting the change
+ * feed in the same tick. Small enough to be invisible to file freshness.
+ */
+const CHANGES_NUDGE_JITTER_MS = 250;
 
 type Resolved =
   | { ok: true; ctx: StudioContext; fs: OrgFs }
@@ -106,6 +113,7 @@ async function waitForChanges(
       // ignore
     }
   };
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     const first = await query();
     if (first.entries.length > 0) return first;
@@ -115,26 +123,38 @@ async function waitForChanges(
         once: true,
       });
 
-    await Promise.race([
+    // Wins as `true` on a nudge, `false` on the hold timeout (or when the
+    // subscription is closed by an abort). `.unref()` so a parked timer never
+    // keeps the process from exiting.
+    const nudged = await Promise.race([
       (async () => {
-        for await (const _msg of sub) return;
+        for await (const _msg of sub) return true;
+        return false;
       })(),
-      new Promise<void>((resolve) => {
-        setTimeout(() => {
-          try {
-            sub.unsubscribe();
-          } catch {
-            // ignore
-          }
-          resolve();
-        }, CHANGES_LONG_POLL_MS);
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), CHANGES_LONG_POLL_MS);
+        timer.unref?.();
       }),
     ]);
 
-    // A nudge may be coalesced/foreign, so the re-query can still be empty —
-    // that's fine, the daemon just loops and waits again.
+    if (!nudged) return first;
+
+    await sleep(
+      exponentialBackoffWithJitter(
+        CHANGES_NUDGE_JITTER_MS,
+        CHANGES_NUDGE_JITTER_MS,
+        0,
+        1,
+        1,
+      ),
+      {
+        signal: reqSignal ?? undefined,
+      },
+    ).catch(() => {});
+    if (reqSignal?.aborted) return first;
     return query();
   } finally {
+    if (timer) clearTimeout(timer);
     if (reqSignal && !reqSignal.aborted) {
       reqSignal.removeEventListener("abort", abortListener);
     }

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -29,6 +29,7 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import type { NatsConnection } from "nats";
 import { ForbiddenError, UnauthorizedError } from "@/core/access-control";
 import type { StudioContext } from "@/core/studio-context";
 import type { OrgFs } from "@/file-storage/org-fs";
@@ -37,6 +38,10 @@ import {
   OrgFsQuotaError,
   OrgFsValidationError,
 } from "@/file-storage/org-fs";
+import {
+  notifyOrgFsChange,
+  orgFsChangeSubject,
+} from "@/file-storage/org-fs-notify";
 import { isValidVolume } from "@/file-storage/org-fs-path";
 import {
   buildPublicOrgFs,
@@ -56,6 +61,8 @@ const MAX_CHANGES_LIMIT = 1000;
 const DEFAULT_CHANGES_LIMIT = 500;
 const MAX_RECENT_LIMIT = 200;
 const DEFAULT_RECENT_LIMIT = 50;
+/** Long-poll hold time, just under the usual 30s gateway/proxy timeout. */
+const CHANGES_LONG_POLL_MS = 28_000;
 
 type Resolved =
   | { ok: true; ctx: StudioContext; fs: OrgFs }
@@ -73,8 +80,84 @@ function fsErrorResponse(c: Ctx, err: unknown): Response {
   throw err;
 }
 
-export const createOrgFsRoutes = () => {
+/**
+ * Long-poll the change feed: return immediately if there's already data,
+ * otherwise hold until a NATS nudge for this volume or the hold timeout, then
+ * re-query once. Subscribes BEFORE the first query so a write landing in
+ * between can't be missed (NATS buffers it for the active subscription). Falls
+ * back to a plain immediate query when NATS is unavailable.
+ */
+async function waitForChanges(
+  c: Ctx,
+  fs: OrgFs,
+  nc: NatsConnection | null,
+  q: { orgId: string; volume: string; since: string; limit: number },
+): Promise<Awaited<ReturnType<OrgFs["changes"]>>> {
+  const query = () => fs.changes(q.volume, q.since, q.limit);
+  const subject = nc ? orgFsChangeSubject(q.orgId, q.volume) : null;
+  if (!nc || !subject) return query();
+
+  const sub = nc.subscribe(subject, { max: 1 });
+  const reqSignal = c.req.raw.signal;
+  const abortListener = () => {
+    try {
+      sub.unsubscribe();
+    } catch {
+      // ignore
+    }
+  };
+  try {
+    const first = await query();
+    if (first.entries.length > 0) return first;
+    if (reqSignal?.aborted) return first;
+    if (reqSignal)
+      reqSignal.addEventListener("abort", abortListener, {
+        once: true,
+      });
+
+    await Promise.race([
+      (async () => {
+        for await (const _msg of sub) return;
+      })(),
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          try {
+            sub.unsubscribe();
+          } catch {
+            // ignore
+          }
+          resolve();
+        }, CHANGES_LONG_POLL_MS);
+      }),
+    ]);
+
+    // A nudge may be coalesced/foreign, so the re-query can still be empty —
+    // that's fine, the daemon just loops and waits again.
+    return query();
+  } finally {
+    if (reqSignal && !reqSignal.aborted) {
+      reqSignal.removeEventListener("abort", abortListener);
+    }
+    try {
+      sub.unsubscribe();
+    } catch {
+      // ignore double-unsubscribe
+    }
+  }
+}
+
+export interface OrgFsRoutesDeps {
+  /**
+   * Shared NATS connection (null until connected / when unconfigured). Powers
+   * the `/changes?wait=1` long-poll and the post-write wake-up nudge. Without
+   * it, `/changes` stays a plain immediate-return feed.
+   */
+  getConnection?: () => NatsConnection | null;
+}
+
+export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   const app = new Hono<{ Variables: Variables }>();
+  const getConnection = deps.getConnection ?? (() => null);
 
   /** access.check with the thrown auth errors mapped to explicit responses. */
   const checkPermission = async (
@@ -256,6 +339,13 @@ export const createOrgFsRoutes = () => {
   });
 
   // Change feed since a cursor ("0" = from the beginning).
+  //
+  // `?wait=1` long-polls: if nothing has changed since the cursor, the request
+  // is held open (subscribed to the volume's NATS notify) until a write nudges
+  // it or the hold time expires, then re-queried. This lets the mount
+  // invalidator wake instantly on writes instead of polling on a timer. Without
+  // a NATS connection it degrades to an immediate return (the daemon's own
+  // poll-timeout floor backs off so it never busy-loops).
   app.get("/:volume/changes", async (c) => {
     const volume = c.req.param("volume");
     const r = await resolve(c, volume, "ORG_FS_READ");
@@ -265,8 +355,19 @@ export const createOrgFsRoutes = () => {
       Math.max(Number(c.req.query("limit")) || DEFAULT_CHANGES_LIMIT, 1),
       MAX_CHANGES_LIMIT,
     );
+    const wait = c.req.query("wait") === "1" || c.req.query("wait") === "true";
     try {
-      return c.json(await r.fs.changes(volume, since, limit));
+      if (!wait) {
+        return c.json(await r.fs.changes(volume, since, limit));
+      }
+      return c.json(
+        await waitForChanges(c, r.fs, getConnection(), {
+          orgId: r.ctx.organization!.id,
+          volume,
+          since,
+          limit,
+        }),
+      );
     } catch (err) {
       return fsErrorResponse(c, err);
     }
@@ -309,6 +410,7 @@ export const createOrgFsRoutes = () => {
               ? contentType
               : undefined,
         });
+        notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
         return c.json({ entry });
       } catch (err) {
         return fsErrorResponse(c, err);
@@ -325,6 +427,7 @@ export const createOrgFsRoutes = () => {
       await r.fs.mkdir(volume, c.req.query("path") ?? "", {
         actor: r.ctx.auth!.user!.id,
       });
+      notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
       return c.json({ ok: true });
     } catch (err) {
       return fsErrorResponse(c, err);
@@ -340,6 +443,7 @@ export const createOrgFsRoutes = () => {
       await r.fs.delete(volume, c.req.query("path") ?? "", {
         actor: r.ctx.auth!.user!.id,
       });
+      notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
       return c.json({ ok: true });
     } catch (err) {
       return fsErrorResponse(c, err);
@@ -375,6 +479,7 @@ export const createOrgFsRoutes = () => {
         await r.fs.move(volume, body.from, body.to, {
           actor: r.ctx.auth!.user!.id,
         });
+        notifyOrgFsChange(getConnection(), r.ctx.organization!.id, volume);
         return c.json({ ok: true });
       } catch (err) {
         return fsErrorResponse(c, err);

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { MiddlewareHandler } from "hono";
+import type { NatsConnection } from "nats";
 import type { AutomationEventDispatcher } from "@/automations/automation-event-dispatcher";
 import type { CancelBroadcast } from "@/api/routes/decopilot/cancel-broadcast";
 import type { RunRegistry } from "@/api/routes/decopilot/run-registry";
@@ -72,6 +73,11 @@ interface OrgScopedDeps {
    * `/api/:org/mcp/:gateway?/:connectionId/.well-known/oauth-protected-resource/*`.
    */
   betterAuthProtectedResourceHandler: MiddlewareHandler<Env>;
+  /**
+   * Shared NATS connection accessor (null until connected). Powers the org-fs
+   * `/changes?wait=1` long-poll + post-write wake-up nudge.
+   */
+  getNatsConnection: () => NatsConnection | null;
 }
 
 export const createOrgScopedApi = (deps: OrgScopedDeps) => {
@@ -86,7 +92,10 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   app.route("/", createObjectStorageRoutes()); // /api/:org/object-storage/*
   app.route("/", createKVRoutes({ kvStorage: deps.kvStorage }));
   app.route("/", createFileUploadRoutes()); // /api/:org/file-configs/:id/upload
-  app.route("/fs", createOrgFsRoutes()); // /api/:org/fs/:volume/...
+  app.route(
+    "/fs",
+    createOrgFsRoutes({ getConnection: deps.getNatsConnection }),
+  ); // /api/:org/fs/:volume/...
   app.route("/sandbox", createSandboxRoutes()); // /api/:org/sandbox/:virtualMcpId/:branch/*
   app.route("/", createHomeNextActionsRoutes());
   app.route("/deco-sites", createDecoSitesOrgRoutes()); // /api/:org/deco-sites

--- a/apps/mesh/src/file-storage/mount/client.ts
+++ b/apps/mesh/src/file-storage/mount/client.ts
@@ -182,13 +182,21 @@ export class OrgFsClient implements OrgFsApi {
   }
 
   /**
-   * Poll the change feed from `since` ("0" = beginning). Drives the mount's
+   * Read the change feed from `since` ("0" = beginning). Drives the mount's
    * cache invalidation (see the daemon invalidator) — not part of OrgFsApi
    * since the WebDAV serve layer never needs it.
+   *
+   * `wait: true` long-polls: the server holds the request open until a write
+   * nudges it or its hold timeout elapses, so the invalidator wakes on writes
+   * instead of polling on a timer.
    */
-  async changes(since: string, limit?: number): Promise<OrgFsChangePage> {
+  async changes(
+    since: string,
+    opts?: { limit?: number; wait?: boolean },
+  ): Promise<OrgFsChangePage> {
     const params: Record<string, string> = { since };
-    if (limit != null) params.limit = String(limit);
+    if (opts?.limit != null) params.limit = String(opts.limit);
+    if (opts?.wait) params.wait = "1";
     const res = await this.fetch(this.url("changes", params), {
       headers: this.headers,
     });

--- a/apps/mesh/src/file-storage/org-fs-notify.ts
+++ b/apps/mesh/src/file-storage/org-fs-notify.ts
@@ -1,0 +1,50 @@
+/**
+ * Wake-up nudge for the org-fs change feed.
+ *
+ * The mount invalidator (daemon side) long-polls `/api/:org/fs/:volume/changes`
+ * to learn about external writes. Rather than poll on a timer, the server holds
+ * each request open and publishes a per-(org, volume) NATS notify on every
+ * write, waking the long-poll instantly. This is the same NatsNotify +
+ * poll-timeout safety-net pattern the event bus uses.
+ *
+ * The payload is intentionally empty: the daemon re-queries the change feed on
+ * wake, so a nudge only needs to signal "something changed for this volume".
+ */
+
+import type { NatsConnection } from "nats";
+
+const SUBJECT_PREFIX = "mesh.org-fs.changes";
+
+/**
+ * NATS subject for a volume's change notifications, or null if either token
+ * contains a character that isn't safe in a subject (`.`, `*`, `>`, ws). Volume
+ * is already validated upstream; orgId is server-controlled — the guard is
+ * defensive, and a null subject just means the long-poll falls back to its
+ * timeout safety net.
+ */
+export function orgFsChangeSubject(
+  orgId: string,
+  volume: string,
+): string | null {
+  if (/[.*>\s]/.test(orgId) || /[.*>\s]/.test(volume)) return null;
+  return `${SUBJECT_PREFIX}.${orgId}.${volume}`;
+}
+
+/**
+ * Best-effort wake-up after a write. Never throws — if NATS is down the
+ * daemon's long-poll timeout still picks the change up on its next cycle.
+ */
+export function notifyOrgFsChange(
+  nc: NatsConnection | null,
+  orgId: string,
+  volume: string,
+): void {
+  if (!nc) return;
+  const subject = orgFsChangeSubject(orgId, volume);
+  if (!subject) return;
+  try {
+    nc.publish(subject);
+  } catch {
+    // best-effort
+  }
+}

--- a/packages/sandbox/daemon/org-fs/invalidator.ts
+++ b/packages/sandbox/daemon/org-fs/invalidator.ts
@@ -15,10 +15,12 @@
  * macOS NFS: hung writer + an empty flushed file). Refresh re-lists in place;
  * open handles and dirty cache entries survive.
  *
- * Result: external changes surface in ~1 poll interval instead of a dir-cache
- * TTL. The poll is the interim trigger; a NATS nudge can later wake this loop
- * instantly (the codebase's NatsNotify + polling-safety-net pattern), removing
- * the steady-state poll without changing the refresh logic.
+ * The change feed is long-polled (`changes` blocks server-side until a write
+ * nudge or its hold timeout), so steady state is push-driven: no timer poll
+ * while idle, and external changes surface as soon as the write commits. The
+ * `pollMs` floor only kicks in if the server returns fast with nothing — i.e.
+ * long-poll isn't available (NATS down) — so the loop degrades to timer polling
+ * instead of busy-looping.
  *
  * Deps are injected so the loop is unit-testable without a real mesh or rclone.
  */
@@ -26,7 +28,10 @@
 import { sleep } from "@decocms/std";
 
 export interface InvalidatorDeps {
-  /** Poll the change feed from `since` ("0" = beginning). */
+  /**
+   * Read the change feed from `since` ("0" = beginning). Long-polls: the call
+   * blocks until a change or the server's hold timeout.
+   */
   changes: (since: string) => Promise<{
     entries: { parent: string }[];
     cursor: string;
@@ -36,7 +41,7 @@ export interface InvalidatorDeps {
   refresh: (dir: string) => Promise<void>;
   /** Aborts the loop (mount teardown). */
   signal: AbortSignal;
-  /** Idle poll interval; default 1s. */
+  /** Floor between cycles when the long-poll returns fast-empty; default 1s. */
   pollMs?: number;
   log?: (msg: string, err?: unknown) => void;
 }
@@ -55,6 +60,7 @@ export async function runInvalidator(deps: InvalidatorDeps): Promise<void> {
   let primed = false;
 
   while (!deps.signal.aborted) {
+    const startedAt = Date.now();
     let page: Awaited<ReturnType<InvalidatorDeps["changes"]>>;
     try {
       page = await deps.changes(since);
@@ -81,7 +87,17 @@ export async function runInvalidator(deps: InvalidatorDeps): Promise<void> {
     since = page.cursor;
     if (!page.hasMore) {
       primed = true; // caught up to head; everything after this is a real change
-      await sleep(pollMs, { signal: deps.signal }).catch(() => {});
+      // Long-poll already absorbs the idle wait, so don't sleep on top of it.
+      // Only back off when it returned fast-empty (long-poll unavailable / NATS
+      // down) — that prevents a busy loop without delaying real changes.
+      if (page.entries.length === 0) {
+        const elapsed = Date.now() - startedAt;
+        if (elapsed < pollMs) {
+          await sleep(pollMs - elapsed, { signal: deps.signal }).catch(
+            () => {},
+          );
+        }
+      }
     }
     // hasMore → loop immediately to drain the backlog.
   }

--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -74,7 +74,9 @@ const defaultInvalidatorFactory: InvalidatorFactory = ({
 }) => {
   const ac = new AbortController();
   void runInvalidator({
-    changes: (since) => client.changes(since),
+    // wait: true → server holds the request open until a write nudge or its
+    // hold timeout, so this is push-driven with the poll floor as a safety net.
+    changes: (since) => client.changes(since, { wait: true }),
     refresh: makeRcRefresh(rcUrl),
     signal: ac.signal,
     log,


### PR DESCRIPTION
… polling

Long-poll the org-fs change feed (`/changes?wait=1`): the server holds the request open (subscribed to the volume's NATS notify) until a write nudges it or the hold timeout elapses, then re-queries. Writes (put/mkdir/delete/move) publish a NATS nudge so the mount invalidator wakes instantly instead of polling on a timer; the poll floor only kicks in as a busy-loop guard when the long-poll returns fast-empty (NATS down).

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make org-fs change invalidation push-driven with long-polling and NATS nudges so mounts refresh immediately on writes, eliminating steady-state polling. Falls back to immediate queries with a short backoff if NATS is unavailable.

- **New Features**
  - `GET /api/:org/fs/:volume/changes?wait=1` long-polls (up to ~28s), subscribes before the first query, and re-queries on nudge with a small jitter (≤250ms) to avoid thundering herds.
  - Writes (`put`, `mkdir`, `delete`, `move`) publish a per-volume nudge via `notifyOrgFsChange`.
  - `OrgFsClient.changes(since, { wait, limit })` adds a `wait: true` option.

- **Refactors**
  - Invalidator now long-polls; sleeps only on fast-empty responses; no idle timer.
  - Mount manager calls `client.changes(since, { wait: true })`.
  - Plumbed `getNatsConnection` into org-scoped and org-fs routes; added `org-fs-notify` helpers.

<sup>Written for commit 009b4eb7fb36a1230285b5b4f602acf1b988531e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

