### PR TITLE
feat(permission): implement wildcard permission handling and add tests

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -54,6 +54,7 @@ import { TagStorage } from "../storage/tags";
 import type { Database, Permission } from "../storage/types";
 import { UserStorage } from "../storage/user";
 import { AccessControl } from "./access-control";
+import { buildWildcardPermission } from "./permission-wildcard";
 import { isOrgArchived } from "./org-archived";
 import type {
   BetterAuthInstance,
@@ -316,11 +317,12 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
         }
 
         // Check wildcard permission: { resource: ["*"] }
-        // Better Auth may not handle wildcards, so we check explicitly
-        const wildcardPermission: Permission = {};
-        for (const resource of Object.keys(requestedPermission)) {
-          wildcardPermission[resource] = ["*"];
-        }
+        // Better Auth's authorize() matches actions literally with no wildcard
+        // expansion, so the `*` grant on a (custom) role is only reachable by
+        // probing for the literal `"*"` action — a SEPARATE call from the exact
+        // probe above (a merged array would be AND-matched and fail both). See
+        // permission-wildcard.ts.
+        const wildcardPermission = buildWildcardPermission(requestedPermission);
 
         const wildcardResult = await hasPermissionApi({
           headers,

--- a/apps/mesh/src/core/permission-wildcard.test.ts
+++ b/apps/mesh/src/core/permission-wildcard.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { createAccessControl } from "@decocms/better-auth/plugins/access";
+import { buildWildcardPermission } from "./permission-wildcard";
+
+// Pure-logic unit test (TESTING.md unit tier). No mocks: `createAccessControl`
+// is the REAL Better Auth access-control matcher (a third-party dependency,
+// exercised in-process), so these assertions verify the helper against the
+// actual `authorize()` semantics the production `hasPermission` call relies on
+// — not a fiction we typed. There is no HTTP/DB/auth-session here; the endpoint
+// wrapper around `authorize` is what e2e covers.
+
+describe("buildWildcardPermission", () => {
+  it("maps every resource to the literal `*` action", () => {
+    expect(buildWildcardPermission({ self: ["TOOL_A"] })).toEqual({
+      self: ["*"],
+    });
+    expect(
+      buildWildcardPermission({ conn_abc: ["SEND_MESSAGE"], self: ["X"] }),
+    ).toEqual({ conn_abc: ["*"], self: ["*"] });
+  });
+
+  it("preserves resource keys and ignores the requested actions", () => {
+    expect(buildWildcardPermission({ conn_abc: ["A", "B", "C"] })).toEqual({
+      conn_abc: ["*"],
+    });
+  });
+
+  it("returns an empty map for an empty request", () => {
+    expect(buildWildcardPermission({})).toEqual({});
+  });
+});
+
+// These tests pin the EXACT Better Auth semantics that justify keeping the
+// exact probe and the wildcard probe as two separate calls. They are the
+// reason the double `hasPermission` call cannot be collapsed into one.
+describe("Better Auth authorize() — wildcard is literal, not expanded", () => {
+  const ac = createAccessControl({ self: [] as string[] });
+  const wildcardRole = ac.newRole({ self: ["*"] });
+  const exactRole = ac.newRole({ self: ["TOOL_A"] });
+
+  it("a `*` role is NOT matched by an exact request (needs the wildcard probe)", () => {
+    expect(wildcardRole.authorize({ self: ["TOOL_A"] }).success).toBe(false);
+    expect(
+      wildcardRole.authorize(buildWildcardPermission({ self: ["TOOL_A"] }))
+        .success,
+    ).toBe(true);
+  });
+
+  it("an exact role is NOT matched by the wildcard request (needs the exact probe)", () => {
+    expect(exactRole.authorize({ self: ["TOOL_A"] }).success).toBe(true);
+    expect(
+      exactRole.authorize(buildWildcardPermission({ self: ["TOOL_A"] }))
+        .success,
+    ).toBe(false);
+  });
+
+  it("a merged single array is AND-matched and fails BOTH roles — proving the calls cannot be merged", () => {
+    const merged = { self: ["TOOL_A", "*"] };
+    expect(wildcardRole.authorize(merged).success).toBe(false);
+    expect(exactRole.authorize(merged).success).toBe(false);
+  });
+});

--- a/apps/mesh/src/core/permission-wildcard.ts
+++ b/apps/mesh/src/core/permission-wildcard.ts
@@ -1,0 +1,33 @@
+import type { Permission } from "../storage/types";
+
+/**
+ * Better Auth's access-control `authorize()` matches requested actions
+ * LITERALLY against a role's stored statement
+ * (`allowedActions.includes(requestedAction)` — see
+ * `@decocms/better-auth` `dist/access-*.mjs`, `function role()`). It performs
+ * NO wildcard expansion: a request for `{ self: ["SOME_TOOL"] }` matches only a
+ * role whose `self` statement literally contains `"SOME_TOOL"`, and a request
+ * for `{ self: ["*"] }` matches only a role whose `self` literally contains
+ * `"*"`. The two are disjoint OR-branches.
+ *
+ * Because the wildcard lives on the role-statement side, the only way to grant
+ * "this member holds a `*` on this resource" through Better Auth's
+ * `hasPermission` endpoint is to probe for the literal `"*"` action. This
+ * builder turns an exact permission request (`{ resource: [tool] }`) into its
+ * wildcard counterpart (`{ resource: ["*"] }`) for that second probe.
+ *
+ * It must stay a SEPARATE probe from the exact one: a single merged array
+ * `{ resource: [tool, "*"] }` would be AND-matched by `authorize`
+ * (`requestedActions.every(...)`) and therefore fail for both an exact-only and
+ * a wildcard-only role — denying access that should be granted. See
+ * `permission-wildcard.test.ts`.
+ */
+export function buildWildcardPermission(
+  requestedPermission: Permission,
+): Permission {
+  const wildcardPermission: Permission = {};
+  for (const resource of Object.keys(requestedPermission)) {
+    wildcardPermission[resource] = ["*"];
+  }
+  return wildcardPermission;
+}


### PR DESCRIPTION
- Added `buildWildcardPermission` function to convert exact permission requests into wildcard counterparts for Better Auth's access control.
- Updated `createBoundAuthClient` to utilize the new wildcard permission handling.
- Introduced unit tests for `buildWildcardPermission` to ensure correct mapping of resources to wildcard actions and validate access control behavior.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds wildcard permission handling to ensure roles with "*" are correctly authorized. Also adds tests to pin `@decocms/better-auth`'s literal action matching and avoid regressions.

- **New Features**
  - Added `buildWildcardPermission` to turn exact requests into `{ resource: ["*"] }`.
  - Updated `createBoundAuthClient` to run a second `hasPermission` probe with the wildcard map.
  - Added unit tests for the helper and to confirm that merged requests (e.g., `["TOOL_A", "*"]`) fail, justifying separate probes.

<sup>Written for commit 9175bd13b85435bc4fca5943c767178984e8cd14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

