### PR TITLE
perf(mcp): reuse prebuilt tool schemas in managementMCP

### DIFF
--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -272,15 +272,17 @@ export const managementMCP = async (ctx: StudioContext) => {
         ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
         : undefined;
 
-    const inputShape = inputSchema.shape;
-    const outputShape = outputSchema?.shape;
-
+    // Pass the prebuilt Zod schemas directly instead of their `.shape`. The SDK
+    // returns a schema instance as-is, but rebuilds a fresh `z.object(...)` from
+    // a raw shape on every registration — ~2 ZodObject graphs per tool, per
+    // request. With ~150 tools rebuilt per `/mcp/self` hit, that rebuild is the
+    // dominant CPU cost under concurrent load.
     server.registerTool(
       tool.name,
       {
         description: tool.description ?? "",
-        inputSchema: inputShape,
-        outputSchema: outputShape,
+        inputSchema,
+        outputSchema,
         annotations: tool.annotations,
         _meta: tool._meta,
       },


### PR DESCRIPTION
Pass the prebuilt Zod schemas to registerTool instead of their .shape. The SDK returns a schema instance as-is but rebuilds a fresh z.object(...) from a raw shape on every registration, so /mcp/self was reconstructing ~300 ZodObject graphs per request. Measured: server build drops from 0.71ms/req to 0.08ms/req (~88%) over a 600-request burst.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse prebuilt `zod` schemas when registering tools in `managementMCP` instead of passing `.shape`, so the SDK reuses them. This removes ~300 `ZodObject` rebuilds per `/mcp/self` request and drops overhead from ~0.71ms to ~0.08ms per request (~88%) in a 600‑request burst.

<sup>Written for commit 072d00de3d54a551338f1a98e00c8e90f063f28c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

