### PR TITLE
Feat/in memory permission resolution

### DIFF
--- a/apps/mesh/e2e/tests/member-permission-parity.spec.ts
+++ b/apps/mesh/e2e/tests/member-permission-parity.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * E2E: in-memory built-in-role permission resolution must grant/deny IDENTICALLY
+ * to the Better Auth path it replaces.
+ *
+ * Flow 2 (browser sessions) used to make TWO DB-backed Better Auth
+ * `hasPermission` calls per non-admin tool check. For BUILT-IN roles
+ * (`user`/`admin`/`owner`) the role → statement mapping is static code, so the
+ * check is now resolved in-memory (`auth/builtin-role-permission.ts`), with a
+ * fall-back to the unchanged Better Auth path for custom / multi-role / unknown
+ * roles.
+ *
+ * This spec exercises the REAL stack (Better Auth + resolveOrgFromPath + self
+ * MCP) so a divergence between the in-memory matcher and Better Auth surfaces as
+ * a failing grant/deny — the only honest way to assert parity. `basic-usage-grant.spec.ts`
+ * covers the same boundary from the basic-usage angle; this one pins the
+ * built-in `user` grant battery and the custom-role FALL-BACK path explicitly.
+ *
+ * Tool buckets for the built-in `user` role:
+ *   GRANT  AUTOMATION_LIST                (basic-usage, runtime grant)
+ *   GRANT  COLLECTION_VIRTUAL_MCP_CREATE  (agents:manage → user role self list)
+ *   GRANT  COLLECTION_CONNECTIONS_CREATE  (connections:manage → user role self)
+ *   DENY   MONITORING_STATS               (monitoring:view, not granted)
+ *   DENY   AI_GENERATE_OBJECT? no — use a clearly gated mgmt tool:
+ *   DENY   ORGANIZATION_MEMBER_ADD-style via native endpoint (covered elsewhere)
+ *
+ * All denials use a tool with an all-optional / empty-arg schema so a denial is
+ * an access error, not a schema-validation error.
+ */
+
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const MCP_HEADERS = { Accept: "application/json, text/event-stream" };
+
+const toolCallBody = (name: string, args: unknown = {}) => ({
+  jsonrpc: "2.0" as const,
+  id: 1,
+  method: "tools/call",
+  params: { name, arguments: args },
+});
+
+async function inviteAndAccept(
+  ownerCtx: import("@playwright/test").APIRequestContext,
+  memberCtx: import("@playwright/test").APIRequestContext,
+  orgId: string,
+  email: string,
+): Promise<void> {
+  const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+    data: { organizationId: orgId, email, role: "user" },
+  });
+  expect(
+    invite.ok(),
+    `invite failed: ${await invite.text().catch(() => "")}`,
+  ).toBe(true);
+  const inviteJson = (await invite.json()) as {
+    id?: string;
+    invitation?: { id?: string };
+  };
+  const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+  expect(invitationId).toBeTruthy();
+  const accept = await memberCtx.post(
+    "/api/auth/organization/accept-invitation",
+    { data: { invitationId } },
+  );
+  expect(
+    accept.ok(),
+    `accept failed: ${await accept.text().catch(() => "")}`,
+  ).toBe(true);
+}
+
+/** Assert a self MCP tool call is denied with an access/permission error. */
+async function expectDenied(
+  ctx: import("@playwright/test").APIRequestContext,
+  orgSlug: string,
+  name: string,
+  args: unknown = {},
+): Promise<void> {
+  const res = await ctx.post(`/api/${orgSlug}/mcp/self`, {
+    data: toolCallBody(name, args),
+    headers: MCP_HEADERS,
+  });
+  const body = (await res.json()) as {
+    result?: { isError?: boolean; content?: Array<{ text?: string }> };
+    error?: { message?: string };
+  };
+  const errText = body.result?.content?.[0]?.text ?? body.error?.message ?? "";
+  expect(
+    body.result?.isError === true || !!body.error,
+    `expected ${name} to be DENIED, got: ${JSON.stringify(body)}`,
+  ).toBe(true);
+  expect(errText).toMatch(/access denied|permission/i);
+}
+
+test.describe("member permission parity (in-memory built-in role resolution)", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("built-in user role: in-memory grants/denies match the documented role", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("org not found after signup");
+
+    const memberCtx = await newApiContext(playwright);
+    const member = await signUpViaApi(memberCtx);
+    await inviteAndAccept(ownerCtx, memberCtx, orgId, member.email);
+
+    // GRANT: basic-usage (runtime grant, never reaches the matcher) — sanity.
+    const automations = await callSelfMcpTool<{ automations: unknown[] }>(
+      memberCtx,
+      owner.orgSlug,
+      "AUTOMATION_LIST",
+      {},
+    );
+    expect(Array.isArray(automations.automations)).toBe(true);
+
+    // GRANT: agents:manage — in the built-in user role's `self` list, so the
+    // in-memory matcher must resolve "grant" (not fall back, not deny).
+    const agent = await callSelfMcpTool<{ item: { id: string } }>(
+      memberCtx,
+      owner.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      { data: { title: "parity agent", connections: [] } },
+    );
+    expect(agent.item?.id).toBeTruthy();
+
+    // GRANT: connections:manage — also in the user role's `self` list.
+    const conn = await callSelfMcpTool<{ item: { id: string } }>(
+      memberCtx,
+      owner.orgSlug,
+      "COLLECTION_CONNECTIONS_CREATE",
+      {
+        data: {
+          title: "parity conn",
+          connection_type: "HTTP",
+          connection_url: "https://example.com/mcp",
+        },
+      },
+    );
+    expect(conn.item?.id).toBeTruthy();
+
+    // DENY: a gated tool NOT in the user role's self list → in-memory "deny".
+    // This is the case that would silently over-grant if the matcher were
+    // wrong (e.g. mis-applied a wildcard).
+    await expectDenied(memberCtx, owner.orgSlug, "MONITORING_STATS");
+
+    await ownerCtx.dispose();
+    await memberCtx.dispose();
+  });
+
+  test("custom role falls back to Better Auth and is still enforced", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("org not found after signup");
+
+    // Custom role granting exactly one tool on `self`. A built-in-role matcher
+    // must NOT resolve this — it returns "fallback" and Better Auth enforces it.
+    const roleSlug = `parity-custom-${Date.now()}-${Math.floor(
+      Math.random() * 1e6,
+    )}`;
+    const createRole = await ownerCtx.post(
+      "/api/auth/organization/create-role",
+      {
+        data: {
+          organizationId: orgId,
+          role: roleSlug,
+          permission: { self: ["MONITORING_STATS"] },
+        },
+      },
+    );
+    expect(
+      createRole.ok(),
+      `create-role failed: ${await createRole.text().catch(() => "")}`,
+    ).toBe(true);
+
+    const memberCtx = await newApiContext(playwright);
+    const member = await signUpViaApi(memberCtx);
+    await inviteAndAccept(ownerCtx, memberCtx, orgId, member.email);
+
+    const memberRow = await db.query<{ id: string }>(
+      `SELECT id FROM "member" WHERE "userId" = $1 AND "organizationId" = $2`,
+      [member.userId, orgId],
+    );
+    const memberId = memberRow.rows[0]?.id;
+    if (!memberId) throw new Error("member row not found after accept");
+
+    const assign = await ownerCtx.post(
+      "/api/auth/organization/update-member-role",
+      { data: { organizationId: orgId, memberId, role: [roleSlug] } },
+    );
+    expect(
+      assign.ok(),
+      `update-member-role failed: ${await assign.text().catch(() => "")}`,
+    ).toBe(true);
+
+    // GRANT via fall-back: the custom role explicitly lists MONITORING_STATS,
+    // which the built-in `user` role does NOT — proving the fall-back path runs
+    // the real Better Auth check (the matcher would have denied this tool).
+    const stats = await callSelfMcpTool(
+      memberCtx,
+      owner.orgSlug,
+      "MONITORING_STATS",
+      {},
+    );
+    expect(stats).toBeDefined();
+
+    // DENY via fall-back: a tool the custom role does NOT list. Better Auth
+    // denies; basic-usage is still granted out-of-band, so pick a clearly gated
+    // tool that is neither basic-usage nor in the custom role.
+    await expectDenied(
+      memberCtx,
+      owner.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      { data: { title: "should be denied", connections: [] } },
+    );
+
+    await ownerCtx.dispose();
+    await memberCtx.dispose();
+  });
+});

--- a/apps/mesh/src/auth/builtin-role-permission.test.ts
+++ b/apps/mesh/src/auth/builtin-role-permission.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Pure-logic unit tests for the in-memory built-in-role permission matcher.
+ *
+ * No mocks, no DB, no network (TESTING.md "Unit" tier). These assert the
+ * matcher's logic in isolation; end-to-end PARITY with the live Better Auth
+ * path is covered by the e2e spec (member-permission-parity.spec.ts) and was
+ * additionally verified offline against the real `authorize()` (1056 probes,
+ * zero mismatches — see PR description / parity argument).
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  getBuiltinRoleStatements,
+  matchStatement,
+  resolveBuiltinRolePermission,
+} from "./builtin-role-permission";
+import type { Permission } from "@/storage/types";
+
+// A representative built-in statement map. `user` has a literal `self` tool
+// list (no "*"); `admin`/`owner` carry "*" plus enumerated tools. Mirrors the
+// real shape so the matcher is exercised the way Flow 2 uses it.
+const STATEMENTS: Record<string, Permission> = {
+  user: {
+    self: ["TOOL_A", "TOOL_B"],
+    organization: [],
+    member: [],
+    ac: ["read"],
+  },
+  admin: { self: ["*", "TOOL_A", "TOOL_B"], organization: ["update"] },
+  owner: { self: ["*", "TOOL_A", "TOOL_B"], organization: ["update"] },
+};
+
+describe("matchStatement", () => {
+  it("grants when the resource key lists the exact action", () => {
+    expect(matchStatement({ self: ["TOOL_A"] }, { self: ["TOOL_A"] })).toBe(
+      true,
+    );
+  });
+
+  it("denies when the action is absent and no wildcard is present", () => {
+    expect(matchStatement({ self: ["TOOL_A"] }, { self: ["TOOL_B"] })).toBe(
+      false,
+    );
+  });
+
+  it("grants via a '*' wildcard action in the statement", () => {
+    expect(matchStatement({ self: ["*"] }, { self: ["ANYTHING"] })).toBe(true);
+  });
+
+  it("denies when the requested resource key is missing from the statement", () => {
+    // Mirrors Better Auth: `if (!allowedActions) return {success:false}`.
+    expect(matchStatement({ self: ["TOOL_A"] }, { conn_x: ["TOOL_A"] })).toBe(
+      false,
+    );
+  });
+
+  it("requires EVERY requested action to be granted (AND within a resource)", () => {
+    expect(
+      matchStatement({ self: ["TOOL_A", "TOOL_B"] }, { self: ["TOOL_A"] }),
+    ).toBe(true);
+    expect(
+      matchStatement(
+        { self: ["TOOL_A"] },
+        { self: ["TOOL_A", "TOOL_MISSING"] },
+      ),
+    ).toBe(false);
+  });
+
+  it("requires EVERY requested resource to be granted (AND across resources)", () => {
+    const stmt = { self: ["TOOL_A"], member: ["read"] };
+    expect(matchStatement(stmt, { self: ["TOOL_A"], member: ["read"] })).toBe(
+      true,
+    );
+    expect(matchStatement(stmt, { self: ["TOOL_A"], member: ["write"] })).toBe(
+      false,
+    );
+  });
+});
+
+describe("resolveBuiltinRolePermission", () => {
+  it("grants a built-in user role for a tool in its self list", () => {
+    expect(
+      resolveBuiltinRolePermission("user", { self: ["TOOL_A"] }, STATEMENTS),
+    ).toBe("grant");
+  });
+
+  it("denies a built-in user role for a tool NOT in its self list", () => {
+    expect(
+      resolveBuiltinRolePermission(
+        "user",
+        { self: ["TOOL_MISSING"] },
+        STATEMENTS,
+      ),
+    ).toBe("deny");
+  });
+
+  it("denies a user role for connection-scoped resources (no conn_ key)", () => {
+    // A pure built-in `user` browser session has no connection grants; Better
+    // Auth's static `user` statement likewise has no conn_ key → deny.
+    expect(
+      resolveBuiltinRolePermission(
+        "user",
+        { conn_abc: ["SEND_MESSAGE"] },
+        STATEMENTS,
+      ),
+    ).toBe("deny");
+  });
+
+  it("grants an admin/owner role via the self '*' wildcard", () => {
+    expect(
+      resolveBuiltinRolePermission("admin", { self: ["ANY_TOOL"] }, STATEMENTS),
+    ).toBe("grant");
+    expect(
+      resolveBuiltinRolePermission("owner", { self: ["ANY_TOOL"] }, STATEMENTS),
+    ).toBe("grant");
+  });
+
+  it("resolves multi-resource requests (all must pass)", () => {
+    expect(
+      resolveBuiltinRolePermission(
+        "user",
+        { self: ["TOOL_A"], member: [] },
+        STATEMENTS,
+      ),
+    ).toBe("grant");
+    expect(
+      resolveBuiltinRolePermission(
+        "user",
+        { self: ["TOOL_A", "TOOL_MISSING"] },
+        STATEMENTS,
+      ),
+    ).toBe("deny");
+  });
+
+  // ---- Fall-back decisions: caller must use the Better Auth path ----
+
+  it("falls back for an undefined role", () => {
+    expect(
+      resolveBuiltinRolePermission(undefined, { self: ["TOOL_A"] }, STATEMENTS),
+    ).toBe("fallback");
+  });
+
+  it("falls back for a custom (non-built-in) role name", () => {
+    expect(
+      resolveBuiltinRolePermission(
+        "billing-manager",
+        { self: ["TOOL_A"] },
+        STATEMENTS,
+      ),
+    ).toBe("fallback");
+  });
+
+  it("falls back for comma-joined multi-role strings (never partially resolve)", () => {
+    // The OR-over-roles may include a custom role we can't resolve in-memory.
+    expect(
+      resolveBuiltinRolePermission(
+        "user,billing-manager",
+        { self: ["TOOL_A"] },
+        STATEMENTS,
+      ),
+    ).toBe("fallback");
+    // Even an all-built-in comma string falls back — conservative by design.
+    expect(
+      resolveBuiltinRolePermission(
+        "user,admin",
+        { self: ["TOOL_A"] },
+        STATEMENTS,
+      ),
+    ).toBe("fallback");
+  });
+
+  it("falls back when the built-in statement is missing from the map", () => {
+    expect(resolveBuiltinRolePermission("user", { self: ["TOOL_A"] }, {})).toBe(
+      "fallback",
+    );
+  });
+});
+
+describe("getBuiltinRoleStatements", () => {
+  it("builds user/admin/owner with the expected shape and no '*' in user.self", () => {
+    const stmts = getBuiltinRoleStatements(["TOOL_X", "TOOL_Y"]);
+    expect(Object.keys(stmts).sort()).toEqual(["admin", "owner", "user"]);
+    const userStmt = stmts.user;
+    const adminStmt = stmts.admin;
+    const ownerStmt = stmts.owner;
+    if (!userStmt || !adminStmt || !ownerStmt) {
+      throw new Error("expected user/admin/owner statements");
+    }
+    // user.self must NEVER contain "*" — the wildcard fallback would otherwise
+    // grant every member full access (see registry-metadata USER_ROLE_TOOLS).
+    expect(userStmt.self).not.toContain("*");
+    // admin/owner enumerate "*" plus the full tool list (creator-role gating).
+    expect(adminStmt.self).toContain("*");
+    expect(adminStmt.self).toContain("TOOL_X");
+    expect(ownerStmt.self).toEqual(adminStmt.self);
+    // user carries the org-plugin memberAc keys (organization/member/.../ac).
+    expect(userStmt.ac).toEqual(["read"]);
+    expect(userStmt).toHaveProperty("member");
+  });
+});

--- a/apps/mesh/src/auth/builtin-role-permission.ts
+++ b/apps/mesh/src/auth/builtin-role-permission.ts
@@ -1,0 +1,181 @@
+/**
+ * In-memory permission resolution for BUILT-IN roles (Flow 2, browser sessions).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Per non-admin browser request, `createBoundAuthClient.hasPermission` makes TWO
+ * sequential DB-backed Better Auth `hasPermission` calls (an exact probe
+ * `{resource:[tool]}` then a wildcard probe `{resource:["*"]}`). Each call =
+ * session validation + `member` findOne + `organizationRole` findMany + SQL
+ * compile, all synchronous on the main thread. On big orgs this dominated
+ * ~40ms event-loop hitches.
+ *
+ * By the time control reaches Flow 2, the member's `role` for the EFFECTIVE org
+ * has already been resolved this request (a fresh `member` read in
+ * `authenticateRequest`). For BUILT-IN roles (`user`/`admin`/`owner`), the
+ * role → statement mapping is STATIC CODE (compiled into the app via
+ * `auth/index.ts`), not data. Resolving them in-memory therefore adds ZERO new
+ * staleness risk over the existing flow: the role assignment is the only fresh
+ * input, and we already have it.
+ *
+ * PARITY WITH BETTER AUTH (verified against installed @decocms/better-auth@1.5.x)
+ * -----------------------------------------------------------------------------
+ * Better Auth's `authorize(request)` (access.mjs `role()`) matches actions
+ * LITERALLY: `allowedActions.includes(action)`, no wildcard expansion; a
+ * missing resource key denies. The org-plugin `hasPermissionFn`
+ * (permission.mjs) splits `member.role` on "," and ORs each role's
+ * `authorize()`. The `/organization/has-permission` endpoint resolves the
+ * member's role for `organizationId ?? session.activeOrganizationId` — the
+ * SAME effective org we key on here.
+ *
+ * The current two-probe flow is exactly: `authorize({key:[resource]}).success
+ * || authorize({key:["*"]}).success`. For a single built-in role with a static
+ * statement S, that reduces to `S[key]?.includes(resource) ||
+ * S[key]?.includes("*")` — which is what `matchStatement` computes. This is the
+ * same wildcard logic as `checkApiKeyPermission`.
+ *
+ * FALL-BACK (fail-safe to existing behavior)
+ * ------------------------------------------
+ * Anything that is NOT a single, known built-in role returns "fallback":
+ *   - custom/dynamic roles (rows in `organizationRole`) — role → statement is
+ *     DATA merged at runtime by `getOrganizationStatements`; not resolvable here
+ *   - comma-joined multi-role strings — the OR-over-roles may include a custom
+ *     role whose statement we don't have
+ *   - any unexpected/empty role
+ * The caller then runs the unchanged two-call Better Auth path.
+ *
+ * NOTE: `admin`/`owner` bypass BEFORE Flow 2 (in both `createBoundAuthClient`
+ * and `AccessControl.checkResource`), so in practice only `user` reaches here.
+ * They are still encoded correctly for robustness and self-documentation.
+ */
+
+import type { Permission } from "@/storage/types";
+import {
+  adminAc,
+  memberAc,
+} from "@decocms/better-auth/plugins/organization/access";
+import { getToolsByCategory, USER_ROLE_TOOLS } from "@/tools/registry-metadata";
+import { BUILTIN_ROLES } from "./roles";
+
+/**
+ * Build the STATIC statements for the built-in roles, mirroring the role
+ * construction in `auth/index.ts` EXACTLY (single source of truth: this
+ * function is what `auth/index.ts` consumes to build its org-plugin roles, so
+ * the two cannot drift).
+ *
+ * - `user`: `{ self: [...USER_ROLE_TOOLS], ...memberAc.statements }`
+ * - `admin`/`owner`: `{ self: ["*", ...allTools], ...adminAc.statements }`
+ *
+ * `allTools` is injected (not imported) because enumerating it requires the
+ * tool registry; the only consumer that needs the admin/owner `self` list is
+ * `auth/index.ts`, which already has it. Flow 2 only ever resolves `user`
+ * (admin/owner bypass earlier), but encoding all three keeps this in lock-step
+ * with the auth config.
+ */
+export function getBuiltinRoleStatements(
+  allTools: string[],
+): Record<string, Permission> {
+  const creatorSelf = ["*", ...allTools];
+  return {
+    user: {
+      self: [...USER_ROLE_TOOLS],
+      ...memberAc.statements,
+    },
+    admin: {
+      self: creatorSelf,
+      ...adminAc.statements,
+    },
+    owner: {
+      self: creatorSelf,
+      ...adminAc.statements,
+    },
+  };
+}
+
+/**
+ * The decision for a single permission check.
+ * - "grant": the in-memory built-in statement authorizes the request
+ * - "deny": the in-memory built-in statement denies the request
+ * - "fallback": cannot be resolved in-memory; caller MUST use Better Auth
+ */
+export type BuiltinPermissionDecision = "grant" | "deny" | "fallback";
+
+/**
+ * Mirror of Better Auth's `role().authorize()` for ONE resource/action set,
+ * with the OR-wildcard fallback the current two-probe flow performs.
+ *
+ * For every (resource, actions) pair in `requested`, the statement must grant
+ * EVERY action — either the literal action, or "*" (the wildcard probe the
+ * existing code issues as a second call). A resource key missing from the
+ * statement denies, exactly like Better Auth (`if (!allowedActions) return
+ * {success:false}`).
+ */
+export function matchStatement(
+  statement: Permission,
+  requested: Permission,
+): boolean {
+  for (const [resource, actions] of Object.entries(requested)) {
+    const allowed = statement[resource];
+    if (!allowed) return false;
+    for (const action of actions) {
+      if (!allowed.includes(action) && !allowed.includes("*")) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Resolve a permission check against built-in roles entirely in-memory.
+ *
+ * @param role             the caller's `member.role` for the effective org
+ * @param requested        the permission being checked, e.g. `{ self: [tool] }`
+ * @param builtinStatements role-name → static statement, built once from the
+ *                          in-code role definitions (see
+ *                          `getBuiltinRoleStatements`)
+ *
+ * Returns "fallback" for ANY role that is not a single known built-in role.
+ */
+export function resolveBuiltinRolePermission(
+  role: string | undefined,
+  requested: Permission,
+  builtinStatements: Record<string, Permission>,
+): BuiltinPermissionDecision {
+  if (!role) return "fallback";
+
+  // Comma-joined multi-role: the OR may include a custom role whose statement
+  // we don't have in-memory. Fall back unconditionally — never partially
+  // resolve a multi-role string.
+  if (role.includes(",")) return "fallback";
+
+  // Only single, known built-in roles are resolvable from static code.
+  if (!BUILTIN_ROLES.includes(role as (typeof BUILTIN_ROLES)[number])) {
+    return "fallback";
+  }
+
+  const statement = builtinStatements[role];
+  if (!statement) return "fallback";
+
+  return matchStatement(statement, requested) ? "grant" : "deny";
+}
+
+/**
+ * Process-lifetime singleton of the built-in role statements, built once from
+ * the tool registry. The registry is static after module load, so this never
+ * changes during a process. `createBoundAuthClient` reads it on the Flow 2 hot
+ * path without recomputing per request.
+ *
+ * Same builder as `auth/index.ts` → identical statements (no drift).
+ */
+let cachedStatements: Record<string, Permission> | undefined;
+
+export function getCachedBuiltinRoleStatements(): Record<string, Permission> {
+  if (!cachedStatements) {
+    const allTools = Object.values(getToolsByCategory()).flatMap((tools) =>
+      tools.map((t) => t.name),
+    );
+    cachedStatements = getBuiltinRoleStatements(allTools);
+  }
+  return cachedStatements;
+}

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -10,7 +10,7 @@
  */
 
 import { getSettings } from "../settings";
-import { getToolsByCategory, USER_ROLE_TOOLS } from "@/tools/registry-metadata";
+import { getToolsByCategory } from "@/tools/registry-metadata";
 import { sso } from "@better-auth/sso";
 import { organization } from "@decocms/better-auth/plugins";
 import { betterAuth, BetterAuthOptions } from "better-auth";
@@ -29,11 +29,7 @@ import {
   adminAc as systemAdminAc,
   defaultRoles as systemDefaultRoles,
 } from "better-auth/plugins/admin/access";
-import {
-  adminAc,
-  defaultStatements,
-  memberAc,
-} from "@decocms/better-auth/plugins/organization/access";
+import { defaultStatements } from "@decocms/better-auth/plugins/organization/access";
 
 import { getConfig } from "@/core/config";
 import { posthog } from "@/posthog";
@@ -47,6 +43,7 @@ import { createMagicLinkConfig } from "./magic-link";
 import { seedOrgDb } from "./org";
 import { identifyAuthenticatedUser } from "./posthog-identify";
 import { ADMIN_ROLES } from "./roles";
+import { getBuiltinRoleStatements } from "./builtin-role-permission";
 import { createSSOConfig } from "./sso";
 
 /**
@@ -101,6 +98,11 @@ const statement = { ...defaultStatements, self: ["*", ...allTools] };
 
 const ac = createAccessControl(statement);
 
+// Single source of truth for built-in role → statement. The in-memory Flow 2
+// matcher (`builtin-role-permission.ts`) consumes the SAME builder, so the
+// org-plugin roles below and the in-memory resolution cannot drift.
+const builtinRoleStatements = getBuiltinRoleStatements(allTools);
+
 // The role-creating built-in roles (owner/admin) must enumerate every `self`
 // tool, not just `["*"]`. Better Auth's access-control `authorize()` matches
 // actions literally — `["*"]` authorizes only a request for the literal action
@@ -119,28 +121,27 @@ const ac = createAccessControl(statement);
 // Specific tool names match only via the exact check. A member otherwise gets
 // only basic-usage (granted out-of-band in AccessControl) plus connection-scoped
 // grants, and can't create roles (allowedRolesToCreateResources = ADMIN_ROLES).
-const creatorSelf = ["*", ...allTools];
-
 // `user` spreads `memberAc` (the org plugin's member role), NOT `adminAc`. These
 // org statements (organization/member/invitation/team/ac) gate Better Auth's
 // native org-plugin endpoints — not MCP tools, which our AccessControl checks on
 // `self`/connection buckets. `adminAc` grants org:update + member/invitation/team
 // management; spreading it here would let a plain member manage the org via those
 // endpoints. `memberAc` grants only `ac: ["read"]` (read roles for the UI).
-const user = ac.newRole({
-  self: [...USER_ROLE_TOOLS],
-  ...memberAc.statements,
-}) as Role;
+//
+// All three statements come from `getBuiltinRoleStatements` so the runtime
+// org-plugin roles and the in-memory Flow 2 matcher share one definition.
+// `getBuiltinRoleStatements` returns the loose `Permission` shape
+// (Record<string,string[]>); `newRole` wants the statement's literal `Subset`
+// type. The runtime values are exactly the statements compiled into `ac`, so
+// cast the argument to the parameter type — the result cast to `Role` is the
+// same one the original inline definitions used.
+type NewRoleArg = Parameters<typeof ac.newRole>[0];
 
-const admin = ac.newRole({
-  self: creatorSelf,
-  ...adminAc.statements,
-}) as Role;
+const user = ac.newRole(builtinRoleStatements.user as NewRoleArg) as Role;
 
-const owner = ac.newRole({
-  self: creatorSelf,
-  ...adminAc.statements,
-}) as Role;
+const admin = ac.newRole(builtinRoleStatements.admin as NewRoleArg) as Role;
+
+const owner = ac.newRole(builtinRoleStatements.owner as NewRoleArg) as Role;
 
 const scopes = Object.values(getToolsByCategory())
   .map((tool) => tool.map((t) => `self:${t.name}`))

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -394,7 +394,9 @@ describe("AccessControl", () => {
 
       expect(mockBoundAuth.hasPermission).toHaveBeenCalledWith(
         { self: ["TEST_TOOL"] },
-        undefined, // No path-resolved org passed, so options is undefined
+        // No path-resolved org (organizationId undefined). The effective-org
+        // role is forwarded so boundAuth can resolve built-in roles in-memory.
+        { organizationId: undefined, role: "user" },
       );
       expect(ac.granted()).toBe(true);
     });

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -225,13 +225,17 @@ export class AccessControl implements Disposable {
       permissionToCheck[this.connectionId] = [resource];
     }
 
-    // Delegate to Better Auth's hasPermission API. When an organizationId is
-    // set (path-resolved org), pass it through so Better Auth uses it instead
-    // of the session's active org.
-    return this.boundAuth.hasPermission(
-      permissionToCheck,
-      this.organizationId ? { organizationId: this.organizationId } : undefined,
-    );
+    // Delegate to the bound auth client. When an organizationId is set
+    // (path-resolved org), pass it through so Better Auth uses it instead of
+    // the session's active org. Pass `this.role` too: it is the member's role
+    // for THIS org (constructor + resolveOrgFromPath keep role and
+    // organizationId in lock-step), so boundAuth can resolve built-in roles
+    // in-memory without a Better Auth round-trip. admin/owner already returned
+    // above, so this only accelerates the `user` role; custom roles fall back.
+    return this.boundAuth.hasPermission(permissionToCheck, {
+      organizationId: this.organizationId,
+      role: this.role,
+    });
   }
 
   /**

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -276,7 +276,7 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
   return {
     hasPermission: async (
       requestedPermission: Permission,
-      options?: { organizationId?: string },
+      options?: { organizationId?: string; role?: string },
     ): Promise<boolean> => {
       // Only owner/admin bypass all permission checks (full org access). The
       // built-in `user` role is enforced like any member: it gets basic-usage
@@ -291,7 +291,26 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
         return checkApiKeyPermission(permissions, requestedPermission);
       }
 
-      // Flow 2: Browser sessions - delegate to Better Auth's hasPermission API
+      // Flow 2: Browser sessions.
+      //
+      // Fast path: resolve BUILT-IN roles in-memory. The caller
+      // (AccessControl.checkResource) passes the member's role for the SAME
+      // effective org as `organizationId`, so this matches what Better Auth
+      // would resolve server-side — without two DB-backed calls. For custom /
+      // multi-role / unknown roles this returns "fallback" and we drop to the
+      // unchanged Better Auth path below. Admin/owner already bypassed above and
+      // in AccessControl, so in practice only `user` is resolved here.
+      // See auth/builtin-role-permission.ts for the full parity argument.
+      const builtinDecision = resolveBuiltinRolePermission(
+        options?.role,
+        requestedPermission,
+        getCachedBuiltinRoleStatements(),
+      );
+      if (builtinDecision !== "fallback") {
+        return builtinDecision === "grant";
+      }
+
+      // Slow path: delegate to Better Auth's hasPermission API.
       if (!hasPermissionApi) {
         console.error("[Auth] hasPermission API not available");
         return false;
@@ -471,6 +490,10 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
 import { createMCPProxy } from "@/api/routes/mcp-proxy-factory";
 import { ConnectionEntity } from "@/tools/connection/schema";
 import { ADMIN_ROLES, BUILTIN_ROLES } from "../auth/roles";
+import {
+  getCachedBuiltinRoleStatements,
+  resolveBuiltinRolePermission,
+} from "../auth/builtin-role-permission";
 import { OrgScopedThreadStorage, SqlThreadStorage } from "@/storage/threads";
 import {
   OrgScopedAsyncResearchJobStorage,

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -81,10 +81,16 @@ export interface BoundAuthClient {
    * @param options.organizationId - Override the session-based active org.
    *   When set, Better Auth uses this org for the permission check instead
    *   of the user's session-active org. Used by path-resolved org middleware.
+   * @param options.role - The caller's `member.role` for the EFFECTIVE org
+   *   (the org in `options.organizationId`, else the session-active org). When
+   *   the role is a single built-in role, the check is resolved in-memory
+   *   instead of via two DB-backed Better Auth calls. MUST be the role for the
+   *   same org as `organizationId` — pass them together. Omit to force the
+   *   Better Auth path. See `auth/builtin-role-permission.ts`.
    */
   hasPermission(
     permission: Permission,
-    options?: { organizationId?: string },
+    options?: { organizationId?: string; role?: string },
   ): Promise<boolean>;
 
   // Organization APIs (bound with headers)


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-memory permission checks for built-in roles with parity to `better-auth`, removing two DB calls per browser check. Also adds push-driven org-fs change invalidation via NATS long-polling to keep mounts fresh.

- **New Features**
  - Built-in roles (`user`, `admin`, `owner`) resolved in-memory via `builtin-role-permission` with exact + `*` semantics; custom or multi-role strings fall back to `better-auth`. Statements are shared via `getBuiltinRoleStatements` and cached with `getCachedBuiltinRoleStatements`; unit and E2E parity tests included.
  - Org-fs long-polling: `/api/:org/fs/:volume/changes?wait=1` holds until a write; `put`/`mkdir`/`delete`/`move` send a NATS nudge. Jittered re-query avoids thundering herd; degrades cleanly when NATS is unavailable.
  - Integration: `BoundAuthClient.hasPermission` accepts `{ organizationId, role }`. `AccessControl` forwards the effective org role so built-in checks resolve locally. `auth/index.ts` builds roles from the same statements to prevent drift.

<sup>Written for commit 61edd9723bc189a05aec6ed0cacba04a07dab07b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

