### PR TITLE
refactor(mcp): integrate managementContextStore for request context h…

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -17,7 +17,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { Context, Hono } from "hono";
 import { endTime, startTime } from "hono/timing";
 import type { StudioContext } from "../../core/studio-context";
-import { managementMCP } from "../../tools";
+import { managementContextStore, managementMCP } from "../../tools";
 import { serveMcpRequest } from "../utils/serve-mcp";
 import { handleAuthError } from "./oauth-proxy";
 import { getMcpListCache } from "@/mcp-clients/mcp-list-cache";
@@ -97,11 +97,15 @@ export const createProxyRoutes = () => {
           false,
       });
       await server.connect(transport);
-      return serveMcpRequest(
-        server,
-        transport,
-        c.req.raw,
-        `mcp:self:${connectionId}`,
+      // Tool handlers read ctx from the ALS store, so the request must run
+      // inside its scope.
+      return managementContextStore.run(ctx, () =>
+        serveMcpRequest(
+          server,
+          transport,
+          c.req.raw,
+          `mcp:self:${connectionId}`,
+        ),
       );
     }
 

--- a/apps/mesh/src/api/routes/self.ts
+++ b/apps/mesh/src/api/routes/self.ts
@@ -7,7 +7,7 @@
 import { Hono } from "hono";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { StudioContext } from "../../core/studio-context";
-import { managementMCP } from "../../tools";
+import { managementContextStore, managementMCP } from "../../tools";
 import { serveMcpRequest } from "../utils/serve-mcp";
 
 // Define Hono variables type
@@ -27,13 +27,18 @@ export const createSelfRoutes = () => {
    * Exposes all PROJECT_* and CONNECTION_* tools via MCP protocol
    */
   app.all("/", async (c) => {
-    const server = await managementMCP(c.get("meshContext"));
+    const ctx = c.get("meshContext");
+    const server = await managementMCP(ctx);
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse:
         c.req.raw.headers.get("Accept")?.includes("application/json") ?? false,
     });
     await server.connect(transport);
-    return serveMcpRequest(server, transport, c.req.raw, "mcp:self");
+    // Tool handlers read ctx from the ALS store, so the request must run inside
+    // its scope.
+    return managementContextStore.run(ctx, () =>
+      serveMcpRequest(server, transport, c.req.raw, "mcp:self"),
+    );
   });
 
   return app;

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -7,7 +7,6 @@
  * Plugin tools are collected at startup and combined with core tools.
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
 import type { ToolAnnotations } from "@/core/define-tool";
 import { StudioContext } from "@/core/studio-context";
 import {
@@ -36,6 +35,8 @@ import * as SecretsTools from "./secrets";
 import * as FileConfigTools from "./file-configs";
 import { ORG_FS_PUBLIC_SETS_SYNC } from "./org-fs/sync-public-sets";
 import { getPrompts, getResources } from "./guides";
+import { getToolRegistration } from "./management-registration";
+export { managementContextStore } from "./management-registration";
 import * as ObjectStorageTools from "./object-storage";
 import * as RegistryTools from "./registry/index";
 import * as SandboxTools from "./sandbox";
@@ -225,89 +226,6 @@ export type MCPMeshTools = typeof ALL_TOOLS;
 
 // Derive tool name type from ALL_TOOLS
 export type ToolNameFromTools = (typeof ALL_TOOLS)[number]["name"];
-
-/**
- * Per-request StudioContext for the management server's tool handlers.
- *
- * The serving routes build a fresh `McpServer` per request, but the tool
- * registrations below are built once and shared across every server: the
- * handler reads its `ctx` from this store at call time instead of closing over
- * it. A request runs its handler inside `managementContextStore.run(ctx, ...)`.
- * This keeps a server that survives `close()` (the production leak) from
- * pinning that request's ctx graph — the only heavy per-request state a tool
- * handler used to capture.
- */
-export const managementContextStore = new AsyncLocalStorage<StudioContext>();
-
-/**
- * Cache of per-tool MCP registrations (config + ctx-free handler), keyed by the
- * static tool object. Built lazily on first use and reused for the life of the
- * process, so the static tool set is never re-derived per request — only the
- * tiny `registerTool` map insertion happens on each `/mcp/self` build.
- */
-const toolRegistrationCache = new Map<
-  CombinedTool,
-  ReturnType<typeof buildToolRegistration>
->();
-
-function buildToolRegistration(tool: CombinedTool) {
-  const inputSchema =
-    tool.inputSchema &&
-    typeof tool.inputSchema === "object" &&
-    "shape" in tool.inputSchema
-      ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
-      : z.object({});
-  const outputSchema =
-    tool.outputSchema &&
-    typeof tool.outputSchema === "object" &&
-    "shape" in tool.outputSchema
-      ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
-      : undefined;
-
-  return {
-    config: {
-      description: tool.description ?? "",
-      inputSchema,
-      outputSchema,
-      annotations: tool.annotations,
-      _meta: tool._meta,
-    },
-    handler: async (args: unknown) => {
-      const ctx = managementContextStore.getStore();
-      if (!ctx) {
-        throw new Error(
-          `[managementMCP] tool ${tool.name} invoked outside a request context`,
-        );
-      }
-      ctx.access.setToolName(tool.name);
-      try {
-        const result = await tool.execute(args, ctx);
-        const modelText = tool.modelSummary
-          ? tool.modelSummary(result)
-          : JSON.stringify(result);
-        return {
-          content: [{ type: "text" as const, text: modelText }],
-          structuredContent: result as { [x: string]: unknown },
-        };
-      } catch (error) {
-        const err = error as Error;
-        return {
-          content: [{ type: "text" as const, text: `Error: ${err.message}` }],
-          isError: true,
-        };
-      }
-    },
-  };
-}
-
-function getToolRegistration(tool: CombinedTool) {
-  let registration = toolRegistrationCache.get(tool);
-  if (!registration) {
-    registration = buildToolRegistration(tool);
-    toolRegistrationCache.set(tool, registration);
-  }
-  return registration;
-}
 
 export const managementMCP = async (ctx: StudioContext) => {
   // Get enabled plugins for this organization to filter plugin tools

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -7,6 +7,7 @@
  * Plugin tools are collected at startup and combined with core tools.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { ToolAnnotations } from "@/core/define-tool";
 import { StudioContext } from "@/core/studio-context";
 import {
@@ -225,6 +226,89 @@ export type MCPMeshTools = typeof ALL_TOOLS;
 // Derive tool name type from ALL_TOOLS
 export type ToolNameFromTools = (typeof ALL_TOOLS)[number]["name"];
 
+/**
+ * Per-request StudioContext for the management server's tool handlers.
+ *
+ * The serving routes build a fresh `McpServer` per request, but the tool
+ * registrations below are built once and shared across every server: the
+ * handler reads its `ctx` from this store at call time instead of closing over
+ * it. A request runs its handler inside `managementContextStore.run(ctx, ...)`.
+ * This keeps a server that survives `close()` (the production leak) from
+ * pinning that request's ctx graph — the only heavy per-request state a tool
+ * handler used to capture.
+ */
+export const managementContextStore = new AsyncLocalStorage<StudioContext>();
+
+/**
+ * Cache of per-tool MCP registrations (config + ctx-free handler), keyed by the
+ * static tool object. Built lazily on first use and reused for the life of the
+ * process, so the static tool set is never re-derived per request — only the
+ * tiny `registerTool` map insertion happens on each `/mcp/self` build.
+ */
+const toolRegistrationCache = new Map<
+  CombinedTool,
+  ReturnType<typeof buildToolRegistration>
+>();
+
+function buildToolRegistration(tool: CombinedTool) {
+  const inputSchema =
+    tool.inputSchema &&
+    typeof tool.inputSchema === "object" &&
+    "shape" in tool.inputSchema
+      ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
+      : z.object({});
+  const outputSchema =
+    tool.outputSchema &&
+    typeof tool.outputSchema === "object" &&
+    "shape" in tool.outputSchema
+      ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
+      : undefined;
+
+  return {
+    config: {
+      description: tool.description ?? "",
+      inputSchema,
+      outputSchema,
+      annotations: tool.annotations,
+      _meta: tool._meta,
+    },
+    handler: async (args: unknown) => {
+      const ctx = managementContextStore.getStore();
+      if (!ctx) {
+        throw new Error(
+          `[managementMCP] tool ${tool.name} invoked outside a request context`,
+        );
+      }
+      ctx.access.setToolName(tool.name);
+      try {
+        const result = await tool.execute(args, ctx);
+        const modelText = tool.modelSummary
+          ? tool.modelSummary(result)
+          : JSON.stringify(result);
+        return {
+          content: [{ type: "text" as const, text: modelText }],
+          structuredContent: result as { [x: string]: unknown },
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [{ type: "text" as const, text: `Error: ${err.message}` }],
+          isError: true,
+        };
+      }
+    },
+  };
+}
+
+function getToolRegistration(tool: CombinedTool) {
+  let registration = toolRegistrationCache.get(tool);
+  if (!registration) {
+    registration = buildToolRegistration(tool);
+    toolRegistrationCache.set(tool, registration);
+  }
+  return registration;
+}
+
 export const managementMCP = async (ctx: StudioContext) => {
   // Get enabled plugins for this organization to filter plugin tools
   // Check both org settings (legacy) and all virtual MCPs
@@ -257,55 +341,12 @@ export const managementMCP = async (ctx: StudioContext) => {
     },
   );
 
-  // Register each tool with the server
+  // Register each tool from its shared, prebuilt registration (config carries
+  // the prebuilt Zod schemas; the handler reads ctx from the ALS store at call
+  // time rather than capturing it). Only the map insertion is per-request.
   for (const tool of filteredTools) {
-    const inputSchema =
-      tool.inputSchema &&
-      typeof tool.inputSchema === "object" &&
-      "shape" in tool.inputSchema
-        ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
-        : z.object({});
-    const outputSchema =
-      tool.outputSchema &&
-      typeof tool.outputSchema === "object" &&
-      "shape" in tool.outputSchema
-        ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
-        : undefined;
-
-    // Pass the prebuilt Zod schemas directly instead of their `.shape`. The SDK
-    // returns a schema instance as-is, but rebuilds a fresh `z.object(...)` from
-    // a raw shape on every registration — ~2 ZodObject graphs per tool, per
-    // request. With ~150 tools rebuilt per `/mcp/self` hit, that rebuild is the
-    // dominant CPU cost under concurrent load.
-    server.registerTool(
-      tool.name,
-      {
-        description: tool.description ?? "",
-        inputSchema,
-        outputSchema,
-        annotations: tool.annotations,
-        _meta: tool._meta,
-      },
-      async (args) => {
-        ctx.access.setToolName(tool.name);
-        try {
-          const result = await tool.execute(args, ctx);
-          const modelText = tool.modelSummary
-            ? tool.modelSummary(result)
-            : JSON.stringify(result);
-          return {
-            content: [{ type: "text" as const, text: modelText }],
-            structuredContent: result as { [x: string]: unknown },
-          };
-        } catch (error) {
-          const err = error as Error;
-          return {
-            content: [{ type: "text" as const, text: `Error: ${err.message}` }],
-            isError: true,
-          };
-        }
-      },
-    );
+    const { config, handler } = getToolRegistration(tool);
+    server.registerTool(tool.name, config, handler);
   }
 
   // Register action prompts

--- a/apps/mesh/src/tools/management-registration.test.ts
+++ b/apps/mesh/src/tools/management-registration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Multi-tenant isolation of the shared, ctx-free management tool handler.
+ *
+ * The registration (config + handler) is built ONCE and shared across every
+ * per-request server; the handler reads its StudioContext from an
+ * AsyncLocalStorage store rather than capturing it. This test proves that
+ * concurrent requests from different tenants each see ONLY their own ctx — both
+ * at handler entry and after the handler is suspended mid-execution while every
+ * other tenant's handler runs.
+ *
+ * Why a barrier: a test that just fires N requests and checks results can pass
+ * even with a broken (module-global) implementation, because the requests may
+ * never overlap at the dangerous moment. The barrier forces ALL N handlers to
+ * be suspended simultaneously, each having read its ctx, so a global-variable
+ * implementation would have its "current ctx" clobbered by later arrivals and
+ * every handler would read the last tenant's id — failing the assertion. With
+ * real ALS, each handler's context is restored on resume regardless of what ran
+ * in between.
+ *
+ * It drives the REAL SDK dispatch path (handleRequest -> microtask -> handler),
+ * since that microtask hop is exactly where async-context propagation could
+ * break.
+ */
+import { describe, expect, test } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import type { StudioContext } from "@/core/studio-context";
+import {
+  buildToolRegistration,
+  managementContextStore,
+  type RegistrableTool,
+} from "./management-registration";
+
+const N = 32;
+
+function fakeCtx(tenantId: string): StudioContext {
+  // The handler only touches `.access.setToolName`; the tool reads `.tenantId`.
+  return {
+    tenantId,
+    access: { setToolName: () => {} },
+  } as unknown as StudioContext;
+}
+
+function callToolRequest(id: number): Request {
+  return new Request("http://test.local/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      "mcp-protocol-version": "2025-11-25",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name: "BARRIER", arguments: {} },
+    }),
+  });
+}
+
+describe("management tool ctx isolation (AsyncLocalStorage)", () => {
+  test("concurrent tenants each read only their own ctx under forced interleaving", async () => {
+    // Barrier: release only once all N handlers have entered and read their
+    // ctx, guaranteeing every handler is suspended mid-execution at the same
+    // time (maximal interleaving).
+    let arrived = 0;
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    // Fail loudly instead of hanging if some handler never arrives.
+    const watchdog = setTimeout(() => releaseGate(), 10_000);
+
+    const barrierTool: RegistrableTool = {
+      name: "BARRIER",
+      description: "test barrier tool",
+      inputSchema: undefined,
+      outputSchema: undefined,
+      execute: async (_args, ctx) => {
+        // ctx the handler read from ALS at entry and forwarded here.
+        const entryId = (ctx as unknown as { tenantId: string }).tenantId;
+        arrived++;
+        if (arrived === N) releaseGate();
+        // Suspend while every other tenant's handler runs.
+        await gate;
+        // Re-read the store AFTER suspension: with a broken (global) impl this
+        // would now hold the last-arrived tenant's ctx for everyone.
+        const afterId = (
+          managementContextStore.getStore() as unknown as {
+            tenantId: string;
+          }
+        )?.tenantId;
+        return { entryId, afterId };
+      },
+    };
+
+    // Built ONCE, shared across all per-request servers — exactly like prod.
+    const { config, handler } = buildToolRegistration(barrierTool);
+
+    const results = await Promise.all(
+      Array.from({ length: N }, async (_unused, i) => {
+        const tenantId = `tenant-${i}`;
+        // Fresh server + transport per request (production shape), reusing the
+        // shared config + handler.
+        const server = new McpServer(
+          { name: "test", version: "1.0.0" },
+          { capabilities: { tools: {} } },
+        );
+        server.registerTool("BARRIER", config, handler);
+        const transport = new WebStandardStreamableHTTPServerTransport({
+          enableJsonResponse: true,
+        });
+        await server.connect(transport);
+
+        const response = await managementContextStore.run(
+          fakeCtx(tenantId),
+          () => transport.handleRequest(callToolRequest(i)),
+        );
+        const body = (await response.json()) as {
+          result?: {
+            structuredContent?: { entryId?: string; afterId?: string };
+          };
+          error?: unknown;
+        };
+        return { tenantId, body };
+      }),
+    );
+
+    clearTimeout(watchdog);
+
+    // The barrier must have actually fired — all N were in-flight together.
+    expect(arrived).toBe(N);
+
+    for (const { tenantId, body } of results) {
+      expect(body.error).toBeUndefined();
+      const sc = body.result?.structuredContent;
+      expect(sc).toBeDefined();
+      // ctx read at handler entry belongs to this tenant.
+      expect(sc?.entryId).toBe(tenantId);
+      // ctx read after suspension (while all siblings ran) still this tenant.
+      expect(sc?.afterId).toBe(tenantId);
+    }
+
+    // Every tenant id appears exactly once — no duplication / bleed.
+    const seen = results.map((r) => r.body.result?.structuredContent?.afterId);
+    expect(new Set(seen).size).toBe(N);
+  }, 20_000);
+
+  test("handler invoked outside a request context throws", async () => {
+    const tool: RegistrableTool = {
+      name: "NO_CTX",
+      description: "test",
+      inputSchema: undefined,
+      outputSchema: undefined,
+      execute: async () => ({ ok: true }),
+    };
+    const { handler } = buildToolRegistration(tool);
+    // Not wrapped in managementContextStore.run(...) — getStore() is undefined.
+    expect(handler({})).rejects.toThrow(/outside a request context/);
+  });
+});

--- a/apps/mesh/src/tools/management-registration.ts
+++ b/apps/mesh/src/tools/management-registration.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared, ctx-free registration for the management MCP server's tools.
+ *
+ * The serving routes build a fresh `McpServer` per request, but the per-tool
+ * registration (config + handler) is built once and shared across every
+ * server. The handler reads its `StudioContext` from `managementContextStore`
+ * at call time instead of capturing it, so a server that survives `close()`
+ * (the production leak) no longer pins a request's ctx graph — the only heavy
+ * per-request state a tool handler used to capture.
+ *
+ * A request must run inside `managementContextStore.run(ctx, ...)` for its tool
+ * handlers to find their ctx.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ToolAnnotations } from "@/core/define-tool";
+import type { StudioContext } from "@/core/studio-context";
+import { z } from "zod";
+
+export const managementContextStore = new AsyncLocalStorage<StudioContext>();
+
+/** The slice of a tool the shared handler actually needs. */
+export interface RegistrableTool {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  outputSchema: unknown;
+  annotations?: ToolAnnotations;
+  _meta?: Record<string, unknown>;
+  modelSummary?: (result: unknown) => string;
+  execute: (input: unknown, ctx: StudioContext) => Promise<unknown>;
+}
+
+export function buildToolRegistration(tool: RegistrableTool) {
+  const inputSchema =
+    tool.inputSchema &&
+    typeof tool.inputSchema === "object" &&
+    "shape" in tool.inputSchema
+      ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
+      : z.object({});
+  const outputSchema =
+    tool.outputSchema &&
+    typeof tool.outputSchema === "object" &&
+    "shape" in tool.outputSchema
+      ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
+      : undefined;
+
+  return {
+    config: {
+      description: tool.description ?? "",
+      inputSchema,
+      outputSchema,
+      annotations: tool.annotations,
+      _meta: tool._meta,
+    },
+    handler: async (args: unknown) => {
+      const ctx = managementContextStore.getStore();
+      if (!ctx) {
+        throw new Error(
+          `[managementMCP] tool ${tool.name} invoked outside a request context`,
+        );
+      }
+      ctx.access.setToolName(tool.name);
+      try {
+        const result = await tool.execute(args, ctx);
+        const modelText = tool.modelSummary
+          ? tool.modelSummary(result)
+          : JSON.stringify(result);
+        return {
+          content: [{ type: "text" as const, text: modelText }],
+          structuredContent: result as { [x: string]: unknown },
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [{ type: "text" as const, text: `Error: ${err.message}` }],
+          isError: true,
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Per-process cache of tool registrations keyed by the static tool object.
+ * Built lazily, reused for the life of the process, so the static tool set is
+ * never re-derived per request — only the tiny `registerTool` map insertion
+ * happens on each server build.
+ */
+const toolRegistrationCache = new Map<
+  RegistrableTool,
+  ReturnType<typeof buildToolRegistration>
+>();
+
+export function getToolRegistration(tool: RegistrableTool) {
+  let registration = toolRegistrationCache.get(tool);
+  if (!registration) {
+    registration = buildToolRegistration(tool);
+    toolRegistrationCache.set(tool, registration);
+  }
+  return registration;
+}


### PR DESCRIPTION
…andling

- Updated proxy and self route handlers to utilize managementContextStore for managing request context, ensuring tool handlers operate within the correct context scope.
- Enhanced managementMCP to leverage prebuilt tool registrations, improving performance by reducing per-request overhead during tool registration.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared `management-registration` module and an AsyncLocalStorage-based `managementContextStore` so MCP tool handlers resolve `StudioContext` per request, isolate tenants, and cut per-request registration work.

- **Refactors**
  - Wraps `proxy` and `self` routes with `managementContextStore.run(ctx, ...)` so handlers read context from ALS.
  - Registers tools via `getToolRegistration(...)` (prebuilt config + ctx-free handler); only the name→config/handler map insertion happens per request.
  - Reuses Zod schemas in the shared registration config; handler looks up ctx at call time and throws if invoked outside a request.
  - Adds tests that force concurrent interleaving to verify per-tenant context isolation.

<sup>Written for commit 9cf33a21fbde63362dd31160ab011d9c63fd398f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

