### PR TITLE
feat(connections): surface enable/disable action for connections

### DIFF
--- a/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
@@ -3,7 +3,14 @@ import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import type { ConnectionEntity } from "@decocms/mesh-sdk";
-import { Loading01, Plus, Settings02, Trash01 } from "@untitledui/icons";
+import {
+  Loading01,
+  Plus,
+  Power01,
+  Settings02,
+  SlashCircle01,
+  Trash01,
+} from "@untitledui/icons";
 import { Suspense } from "react";
 
 interface ConnectionInstancesPanelProps {
@@ -11,6 +18,10 @@ interface ConnectionInstancesPanelProps {
   onConfigure: (instance: ConnectionEntity) => void;
   onAuthenticate: (instance: ConnectionEntity) => void;
   onDelete: (instance: ConnectionEntity) => void;
+  onToggleStatus: (
+    instance: ConnectionEntity,
+    status: "active" | "inactive",
+  ) => void;
   onAdd: () => void;
   isAdding?: boolean;
 }
@@ -20,22 +31,28 @@ function InstanceItem({
   onConfigure,
   onAuthenticate,
   onDelete,
+  onToggleStatus,
 }: {
   instance: ConnectionEntity;
   onConfigure: (instance: ConnectionEntity) => void;
   onAuthenticate: (instance: ConnectionEntity) => void;
   onDelete: (instance: ConnectionEntity) => void;
+  onToggleStatus: (
+    instance: ConnectionEntity,
+    status: "active" | "inactive",
+  ) => void;
 }) {
   const authStatus = useMCPAuthStatus({ connectionId: instance.id });
   const isVirtual = instance.connection_type === "VIRTUAL";
   const needsAuth =
     !isVirtual && authStatus.supportsOAuth && !authStatus.isAuthenticated;
+  const isDisabled = instance.status !== "active";
 
   return (
     <div
       className={cn(
         "flex items-center gap-3 rounded-lg border px-4 py-2.5 transition-colors",
-        needsAuth
+        needsAuth || isDisabled
           ? "border-destructive/50 bg-destructive/5"
           : "border-transparent",
       )}
@@ -48,11 +65,15 @@ function InstanceItem({
       />
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium truncate">{instance.title}</p>
-        {needsAuth && (
+        {needsAuth ? (
           <span className="text-xs text-destructive font-medium">
             Needs authorization
           </span>
-        )}
+        ) : isDisabled ? (
+          <span className="text-xs text-destructive font-medium">
+            {instance.status === "error" ? "Disabled (error)" : "Disabled"}
+          </span>
+        ) : null}
       </div>
       <div className="flex items-center gap-1 shrink-0">
         {needsAuth && (
@@ -63,6 +84,27 @@ function InstanceItem({
             onClick={() => onAuthenticate(instance)}
           >
             Authorize
+          </Button>
+        )}
+        {isDisabled ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs gap-1.5"
+            onClick={() => onToggleStatus(instance, "active")}
+          >
+            <Power01 size={13} />
+            Enable
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground"
+            onClick={() => onToggleStatus(instance, "inactive")}
+            title="Disable"
+          >
+            <SlashCircle01 size={13} />
           </Button>
         )}
         <Button
@@ -126,6 +168,7 @@ export function ConnectionInstancesPanel({
   onConfigure,
   onAuthenticate,
   onDelete,
+  onToggleStatus,
   onAdd,
   isAdding,
 }: ConnectionInstancesPanelProps) {
@@ -167,6 +210,7 @@ export function ConnectionInstancesPanel({
               onConfigure={onConfigure}
               onAuthenticate={onAuthenticate}
               onDelete={onDelete}
+              onToggleStatus={onToggleStatus}
             />
           </Suspense>
         ))}

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -561,6 +561,21 @@ function ConnectionInspectorViewWithConnection({
                   onConfigure={(inst) => setConfigureInstance(inst)}
                   onAuthenticate={(inst) => handleAuthenticateForId(inst.id)}
                   onDelete={(inst) => deleteConnection.requestDelete(inst)}
+                  onToggleStatus={async (inst, status) => {
+                    try {
+                      await connectionActions.update.mutateAsync({
+                        id: inst.id,
+                        data: { status },
+                      });
+                      toast.success(
+                        status === "active"
+                          ? "Connection enabled"
+                          : "Connection disabled",
+                      );
+                    } catch {
+                      toast.error("Failed to update connection");
+                    }
+                  }}
                   isAdding={isAddingInstance}
                   onAdd={async () => {
                     setIsAddingInstance(true);

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -97,6 +97,8 @@ import {
   Globe02,
   Loading01,
   Plus,
+  Power01,
+  SlashCircle01,
   Terminal,
   Trash01,
   XClose,
@@ -953,6 +955,21 @@ function ConnectionResults({
     exitSelectionMode();
   };
 
+  const handleToggleStatus = async (
+    id: string,
+    status: "active" | "inactive",
+  ) => {
+    try {
+      await actions.update.mutateAsync({ id, data: { status } });
+      invalidateConnections();
+      toast.success(
+        status === "active" ? "Connection enabled" : "Connection disabled",
+      );
+    } catch {
+      toast.error("Failed to update connection");
+    }
+  };
+
   const handleBulkToggleStatus = async (status: "active" | "inactive") => {
     const ids = [...selectedIds];
     track("connections_bulk_status_toggled", {
@@ -1192,6 +1209,34 @@ function ConnectionResults({
                                   Select
                                 </DropdownMenuItem>
                               )}
+                              {canManage &&
+                                (connection.status === "active" ? (
+                                  <DropdownMenuItem
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleToggleStatus(
+                                        connection.id,
+                                        "inactive",
+                                      );
+                                    }}
+                                  >
+                                    <SlashCircle01 size={16} />
+                                    Disable
+                                  </DropdownMenuItem>
+                                ) : (
+                                  <DropdownMenuItem
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleToggleStatus(
+                                        connection.id,
+                                        "active",
+                                      );
+                                    }}
+                                  >
+                                    <Power01 size={16} />
+                                    Enable
+                                  </DropdownMenuItem>
+                                ))}
                               {canManage && (
                                 <DropdownMenuItem
                                   variant="destructive"

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -76,6 +76,8 @@ import {
   Maximize01,
   Play,
   Plus,
+  Power01,
+  SlashCircle01,
   Stars01,
   Trash01,
   XClose,
@@ -263,6 +265,7 @@ function ConnectionItem({
         connectionDescription={connection.description}
         connectionIcon={connection.icon}
         connectionType={connection.connection_type}
+        connectionStatus={connection.status}
         slug={slug}
         orgSlug={org.slug}
         appName={connection.app_name}
@@ -406,6 +409,7 @@ function ConnectionItemWithAuth({
   connectionDescription,
   connectionIcon,
   connectionType,
+  connectionStatus,
   slug,
   orgSlug,
   appName,
@@ -421,6 +425,7 @@ function ConnectionItemWithAuth({
   connectionDescription?: string | null;
   connectionIcon?: string | null;
   connectionType: string;
+  connectionStatus: ConnectionEntity["status"];
   slug: string;
   orgSlug: string;
   appName?: string | null;
@@ -432,15 +437,33 @@ function ConnectionItemWithAuth({
   onNewInstance?: () => void;
 }) {
   const authStatus = useMCPAuthStatus({ connectionId: connection_id });
+  const connectionActions = useConnectionActions();
   const isVirtual = connectionType === "VIRTUAL";
   const needsAuth =
     !isVirtual && authStatus.supportsOAuth && !authStatus.isAuthenticated;
+  const isDisabled = connectionStatus !== "active";
+
+  const toggleStatus = async (status: "active" | "inactive") => {
+    try {
+      await connectionActions.update.mutateAsync({
+        id: connection_id,
+        data: { status },
+      });
+      toast.success(
+        status === "active" ? "Connection enabled" : "Connection disabled",
+      );
+    } catch {
+      toast.error("Failed to update connection");
+    }
+  };
 
   return (
     <div
       className={cn(
         "rounded-xl border overflow-hidden transition-colors",
-        needsAuth ? "border-destructive/50 bg-destructive/5" : "border-border",
+        needsAuth || isDisabled
+          ? "border-destructive/50 bg-destructive/5"
+          : "border-border",
       )}
     >
       {/* Body — clickable, navigates to connection detail */}
@@ -464,6 +487,10 @@ function ConnectionItemWithAuth({
             <span className="text-xs text-destructive font-medium">
               Needs authorization
             </span>
+          ) : isDisabled ? (
+            <span className="text-xs text-destructive font-medium">
+              {connectionStatus === "error" ? "Disabled (error)" : "Disabled"}
+            </span>
           ) : (
             connectionDescription && (
               <p className="text-xs text-muted-foreground truncate">
@@ -484,6 +511,20 @@ function ConnectionItemWithAuth({
             }}
           >
             Authorize
+          </Button>
+        ) : isDisabled ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs gap-1.5 shrink-0"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              toggleStatus("active");
+            }}
+          >
+            <Power01 size={13} />
+            Enable
           </Button>
         ) : (
           <Tooltip delayDuration={0}>
@@ -525,6 +566,22 @@ function ConnectionItemWithAuth({
             </TooltipTrigger>
             <TooltipContent side="bottom">Configure resources</TooltipContent>
           </Tooltip>
+          {!isDisabled && (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground"
+                  onClick={() => toggleStatus("inactive")}
+                  aria-label="Disable connection"
+                >
+                  <SlashCircle01 size={13} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Disable</TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip delayDuration={0}>
             <TooltipTrigger asChild>
               <Button


### PR DESCRIPTION
## Summary

Once a connection auto-disabled to `status="error"` (5 sustained non-auth failures over ≥60s, see `proxy.ts`), there was **no user-facing way to re-activate it**:
- The only `Enable` control lived in a floating bulk-action bar gated behind selection mode — and selection mode itself wasn't discoverable from a single connection.
- The connection detail page rendered a dead-end `ServerErrorState` ("try again later") with no action.

The recovery path already existed at the data layer (`COLLECTION_CONNECTIONS_UPDATE` accepts `status`, since the update schema is `ConnectionEntitySchema.partial()`), it just wasn't surfaced.

## Changes

Adds a discoverable enable/disable affordance in three places, all calling `COLLECTION_CONNECTIONS_UPDATE` with the target status:

- **Connections list** (`routes/orgs/connections.tsx`) — per-row `⋮` dropdown now has **Enable** (when not active) / **Disable** (when active), no longer locked behind selection mode.
- **Connection detail** (`connection-instances-panel.tsx` + `index.tsx`) — each instance row shows a `Disabled` / `Disabled (error)` label plus an **Enable** button (or a Disable icon when active).
- **Agent settings connection list** (`views/virtual-mcp/index.tsx`) — card body shows the disabled state with an **Enable** button, and a **Disable** toggle in the footer.

Disabled/errored connections now visually flag themselves (destructive border + label) so they're discoverable, not just actionable.

## Notes

- This is the **manual** recovery fix. Re-enabling sets `status="active"`; the cross-replica failure counter clears on the first success, so it sticks if the downstream is healthy and re-trips if it's still broken. There is still no *automatic* self-heal (the status gate in `proxy.ts` blocks any re-probe) — that'd be a separate change.

## Testing

- `bun run fmt`, `bun run --cwd=apps/mesh check`, and `bun run lint` pass for the touched files.
- UI-only change; manual verification recommended on an errored connection.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds enable/disable controls for connections across the app so users can re-activate errored or disabled connections and disable active ones. Disabled/errored connections are now clearly labeled and styled.

- **New Features**
  - Connections list: per-row menu now includes Enable/Disable (calls `COLLECTION_CONNECTIONS_UPDATE` with `status`).
  - Connection detail: each instance shows Disabled/Disabled (error) with an Enable button; active instances get a Disable icon.
  - Agent settings (Virtual MCP): card shows disabled state with an Enable button and a Disable toggle.

<sup>Written for commit 5ba67be0e2cde158faba0fe07648391e4576bbb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

