### PR TITLE
fix(sandbox): disable Bun fetch timeout on K8s watch streams

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -214,6 +214,14 @@ interface KubeFetchInit {
    *                         (and optionally `force=true`) to `path`.
    */
   patchType?: "merge" | "strategic-merge" | "apply";
+  /**
+   * Long-lived streaming request (a K8s `watch`). Disables Bun's default
+   * per-request fetch timeout — otherwise Bun aborts the idle stream between
+   * events with "The operation timed out", forcing a needless reconnect every
+   * few minutes. Watch lifetime is bounded by the caller's `signal` and the
+   * API server's own watch timeout instead.
+   */
+  stream?: boolean;
 }
 
 /**
@@ -246,12 +254,13 @@ export async function kubeFetch(
   } else if (init.body !== undefined && !("content-type" in headers)) {
     headers["content-type"] = "application/json";
   }
-  const reqInit: RequestInit & { tls?: typeof auth.tls } = {
+  const reqInit: RequestInit & { tls?: typeof auth.tls; timeout?: boolean } = {
     method: init.method,
     headers,
     body: init.body === undefined ? undefined : JSON.stringify(init.body),
     signal: init.signal,
     tls: auth.tls,
+    ...(init.stream ? { timeout: false } : {}),
   };
   return fetch(`${auth.server}${init.path}`, reqInit as RequestInit);
 }
@@ -781,6 +790,7 @@ export function waitForSandboxReady(
         path,
         signal: controller.signal,
         headers: { accept: "application/json" },
+        stream: true,
       });
     } catch (err) {
       settleWith(() =>

--- a/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
@@ -748,6 +748,7 @@ async function runWatch<T>(opts: RunWatchOpts<T>): Promise<void> {
         path,
         signal,
         headers: { accept: "application/json" },
+        stream: true,
       });
       if (!resp.ok || !resp.body) {
         // Drain body before throwing so the connection can be reused.


### PR DESCRIPTION
## Summary

K8s `watch` streams are long-lived and sit idle between events. Bun's default per-request `fetch` timeout aborts them with `The operation timed out`, which surfaces as repeated:

```
[lifecycle-watcher] sandboxclaim-reaper watch ended: The operation timed out.
```

Each timeout makes `runWatch` log, back off, and reconnect — every few minutes, indefinitely, even when nothing is wrong. The reaper watch in particular only ever sees traffic on a SandboxClaim *delete*, so it's idle ~all the time and trips the timeout on a steady cadence.

This is a **client-side Bun timeout**, not Kubernetes closing the stream (the API server's watch timeout is randomized around `--min-request-timeout`, default 30 min).

## Fix

Thread a `stream` flag through `kubeFetch` that sets Bun's `timeout: false` for the two streaming watch call sites:

- `runWatch` in `lifecycle-watcher.ts` (pod / sandbox / event watches + the `sandboxclaim-reaper` deletion watch)
- `waitForSandboxReady`'s readiness watch in `client.ts`

Watch lifetime stays bounded by the caller's `AbortSignal` and the API server's own watch timeout. One-shot requests (GET/POST/PATCH) are unchanged and keep Bun's default timeout as a safety net. The readiness watch additionally already has its own 180s `setTimeout`+`AbortController`, so it remains bounded — this only removes Bun's redundant timeout.

## Testing

- `bun test packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.test.ts` — 18 pass
- `tsc --noEmit` on `packages/sandbox` — clean
- `bun run fmt` — clean

> Note: confirming the full default-timeout duration empirically requires ~5 min of idle stream per cycle; the fix relies on Bun's documented `timeout: false` behavior and the matching `The operation timed out` error string. The `timeout` option is accepted by Bun's `fetch` (verified on Bun 1.3.11).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Bun’s per-request fetch timeout for Kubernetes watch streams to stop idle aborts and reconnect loops in sandbox lifecycle and readiness watches. Adds a `stream` flag to `kubeFetch` that sets `timeout: false`; non-stream requests are unchanged.

- **Bug Fixes**
  - Applied `stream: true` to `runWatch` and `waitForSandboxReady` watch calls.
  - Watch lifetime is now bounded by the caller `AbortSignal` and the API server’s watch timeout, eliminating periodic “watch ended: The operation timed out” log spam.

<sup>Written for commit ef7ca70b81a5fc7ee93f7561ff6ed13a422f5154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

