### PR TITLE
Feat/mcp tool result cache

### DIFF
--- a/apps/mesh/e2e/tests/member-permission-parity.spec.ts
+++ b/apps/mesh/e2e/tests/member-permission-parity.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * E2E: in-memory built-in-role permission resolution must grant/deny IDENTICALLY
+ * to the Better Auth path it replaces.
+ *
+ * Flow 2 (browser sessions) used to make TWO DB-backed Better Auth
+ * `hasPermission` calls per non-admin tool check. For BUILT-IN roles
+ * (`user`/`admin`/`owner`) the role → statement mapping is static code, so the
+ * check is now resolved in-memory (`auth/builtin-role-permission.ts`), with a
+ * fall-back to the unchanged Better Auth path for custom / multi-role / unknown
+ * roles.
+ *
+ * This spec exercises the REAL stack (Better Auth + resolveOrgFromPath + self
+ * MCP) so a divergence between the in-memory matcher and Better Auth surfaces as
+ * a failing grant/deny — the only honest way to assert parity. `basic-usage-grant.spec.ts`
+ * covers the same boundary from the basic-usage angle; this one pins the
+ * built-in `user` grant battery and the custom-role FALL-BACK path explicitly.
+ *
+ * Tool buckets for the built-in `user` role:
+ *   GRANT  AUTOMATION_LIST                (basic-usage, runtime grant)
+ *   GRANT  COLLECTION_VIRTUAL_MCP_CREATE  (agents:manage → user role self list)
+ *   GRANT  COLLECTION_CONNECTIONS_CREATE  (connections:manage → user role self)
+ *   DENY   MONITORING_STATS               (monitoring:view, not granted)
+ *   DENY   AI_GENERATE_OBJECT? no — use a clearly gated mgmt tool:
+ *   DENY   ORGANIZATION_MEMBER_ADD-style via native endpoint (covered elsewhere)
+ *
+ * All denials use a tool with an all-optional / empty-arg schema so a denial is
+ * an access error, not a schema-validation error.
+ */
+
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const MCP_HEADERS = { Accept: "application/json, text/event-stream" };
+
+const toolCallBody = (name: string, args: unknown = {}) => ({
+  jsonrpc: "2.0" as const,
+  id: 1,
+  method: "tools/call",
+  params: { name, arguments: args },
+});
+
+async function inviteAndAccept(
+  ownerCtx: import("@playwright/test").APIRequestContext,
+  memberCtx: import("@playwright/test").APIRequestContext,
+  orgId: string,
+  email: string,
+): Promise<void> {
+  const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+    data: { organizationId: orgId, email, role: "user" },
+  });
+  expect(
+    invite.ok(),
+    `invite failed: ${await invite.text().catch(() => "")}`,
+  ).toBe(true);
+  const inviteJson = (await invite.json()) as {
+    id?: string;
+    invitation?: { id?: string };
+  };
+  const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+  expect(invitationId).toBeTruthy();
+  const accept = await memberCtx.post(
+    "/api/auth/organization/accept-invitation",
+    { data: { invitationId } },
+  );
+  expect(
+    accept.ok(),
+    `accept failed: ${await accept.text().catch(() => "")}`,
+  ).toBe(true);
+}
+
+/** Assert a self MCP tool call is denied with an access/permission error. */
+async function expectDenied(
+  ctx: import("@playwright/test").APIRequestContext,
+  orgSlug: string,
+  name: string,
+  args: unknown = {},
+): Promise<void> {
+  const res = await ctx.post(`/api/${orgSlug}/mcp/self`, {
+    data: toolCallBody(name, args),
+    headers: MCP_HEADERS,
+  });
+  const body = (await res.json()) as {
+    result?: { isError?: boolean; content?: Array<{ text?: string }> };
+    error?: { message?: string };
+  };
+  const errText = body.result?.content?.[0]?.text ?? body.error?.message ?? "";
+  expect(
+    body.result?.isError === true || !!body.error,
+    `expected ${name} to be DENIED, got: ${JSON.stringify(body)}`,
+  ).toBe(true);
+  expect(errText).toMatch(/access denied|permission/i);
+}
+
+test.describe("member permission parity (in-memory built-in role resolution)", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("built-in user role: in-memory grants/denies match the documented role", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("org not found after signup");
+
+    const memberCtx = await newApiContext(playwright);
+    const member = await signUpViaApi(memberCtx);
+    await inviteAndAccept(ownerCtx, memberCtx, orgId, member.email);
+
+    // GRANT: basic-usage (runtime grant, never reaches the matcher) — sanity.
+    const automations = await callSelfMcpTool<{ automations: unknown[] }>(
+      memberCtx,
+      owner.orgSlug,
+      "AUTOMATION_LIST",
+      {},
+    );
+    expect(Array.isArray(automations.automations)).toBe(true);
+
+    // GRANT: agents:manage — in the built-in user role's `self` list, so the
+    // in-memory matcher must resolve "grant" (not fall back, not deny).
+    const agent = await callSelfMcpTool<{ item: { id: string } }>(
+      memberCtx,
+      owner.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      { data: { title: "parity agent", connections: [] } },
+    );
+    expect(agent.item?.id).toBeTruthy();
+
+    // GRANT: connections:manage — also in the user role's `self` list.
+    const conn = await callSelfMcpTool<{ item: { id: string } }>(
+      memberCtx,
+      owner.orgSlug,
+      "COLLECTION_CONNECTIONS_CREATE",
+      {
+        data: {
+          title: "parity conn",
+          connection_type: "HTTP",
+          connection_url: "https://example.com/mcp",
+        },
+      },
+    );
+    expect(conn.item?.id).toBeTruthy();
+
+    // DENY: a gated tool NOT in the user role's self list → in-memory "deny".
+    // This is the case that would silently over-grant if the matcher were
+    // wrong (e.g. mis-applied a wildcard).
+    await expectDenied(memberCtx, owner.orgSlug, "MONITORING_STATS");
+
+    await ownerCtx.dispose();
+    await memberCtx.dispose();
+  });
+
+  test("custom role falls back to Better Auth and is still enforced", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("org not found after signup");
+
+    // Custom role granting exactly one tool on `self`. A built-in-role matcher
+    // must NOT resolve this — it returns "fallback" and Better Auth enforces it.
+    const roleSlug = `parity-custom-${Date.now()}-${Math.floor(
+      Math.random() * 1e6,
+    )}`;
+    const createRole = await ownerCtx.post(
+      "/api/auth/organization/create-role",
+      {
+        data: {
+          organizationId: orgId,
+          role: roleSlug,
+          permission: { self: ["MONITORING_STATS"] },
+        },
+      },
+    );
+    expect(
+      createRole.ok(),
+      `create-role failed: ${await createRole.text().catch(() => "")}`,
+    ).toBe(true);
+
+    const memberCtx = await newApiContext(playwright);
+    const member = await signUpViaApi(memberCtx);
+    await inviteAndAccept(ownerCtx, memberCtx, orgId, member.email);
+
+    const memberRow = await db.query<{ id: string }>(
+      `SELECT id FROM "member" WHERE "userId" = $1 AND "organizationId" = $2`,
+      [member.userId, orgId],
+    );
+    const memberId = memberRow.rows[0]?.id;
+    if (!memberId) throw new Error("member row not found after accept");
+
+    const assign = await ownerCtx.post(
+      "/api/auth/organization/update-member-role",
+      { data: { organizationId: orgId, memberId, role: [roleSlug] } },
+    );
+    expect(
+      assign.ok(),
+      `update-member-role failed: ${await assign.text().catch(() => "")}`,
+    ).toBe(true);
+
+    // GRANT via fall-back: the custom role explicitly lists MONITORING_STATS,
+    // which the built-in `user` role does NOT — proving the fall-back path runs
+    // the real Better Auth check (the matcher would have denied this tool).
+    const stats = await callSelfMcpTool(
+      memberCtx,
+      owner.orgSlug,
+      "MONITORING_STATS",
+      {},
+    );
+    expect(stats).toBeDefined();
+
+    // DENY via fall-back: a tool the custom role does NOT list. Better Auth
+    // denies; basic-usage is still granted out-of-band, so pick a clearly gated
+    // tool that is neither basic-usage nor in the custom role.
+    await expectDenied(
+      memberCtx,
+      owner.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      { data: { title: "should be denied", connections: [] } },
+    );
+
+    await ownerCtx.dispose();
+    await memberCtx.dispose();
+  });
+});

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decocms",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "Deco CMS — Self-hostable MCP Gateway for managing AI connections and tools",
   "author": "Deco team",
   "repository": {

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decocms",
-  "version": "3.10.3",
+  "version": "3.11.0",
   "description": "Deco CMS — Self-hostable MCP Gateway for managing AI connections and tools",
   "author": "Deco team",
   "repository": {

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decocms",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Deco CMS — Self-hostable MCP Gateway for managing AI connections and tools",
   "author": "Deco team",
   "repository": {

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -114,6 +114,10 @@ import {
   type McpListCache,
 } from "../mcp-clients/mcp-list-cache";
 import {
+  startMcpCacheInvalidation,
+  teardownMcpCacheInvalidation,
+} from "../mcp-clients/mcp-cache-invalidation";
+import {
   type ConnectionCircuitStore,
   JetStreamKVConnectionCircuitStore,
   NoopConnectionCircuitStore,
@@ -995,6 +999,8 @@ export async function createApp(options: CreateAppOptions = {}) {
       });
       // Subscribe to cross-replica key invalidations (idempotent).
       providerKeyCache.start();
+      // Subscribe to cross-replica MCP read/result cache invalidations.
+      startMcpCacheInvalidation(() => natsProvider!.getConnection());
       streamBuffer.init().catch((err: unknown) => {
         console.warn(
           "[StreamBuffer] Deferred init failed, late-join disabled:",
@@ -1211,6 +1217,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     mcpListCache.teardown();
     modelListCache.teardown();
     providerKeyCache.teardown();
+    teardownMcpCacheInvalidation();
     connectionCircuitStore.teardown();
     setMcpListCache(null);
     setConnectionCircuitStore(null);

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -128,6 +128,8 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   // --- MCP routes need mcpAuth in addition to resolveOrgFromPath ---
   // Order matters (preserve from legacy): virtual-mcp → self → proxy
   app.use("/mcp/:connectionId?", deps.mcpAuth);
+  // The single-segment matcher above does not cover the deeper UI-resource GET.
+  app.use("/mcp/:connectionId/ui-resource", deps.mcpAuth);
   app.use("/mcp/gateway/:virtualMcpId?", deps.mcpAuth);
   app.use("/mcp/virtual-mcp/:virtualMcpId?", deps.mcpAuth);
   app.use("/mcp/self", deps.mcpAuth);

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -21,6 +21,9 @@ import { managementContextStore, managementMCP } from "../../tools";
 import { serveMcpRequest } from "../utils/serve-mcp";
 import { handleAuthError } from "./oauth-proxy";
 import { getMcpListCache } from "@/mcp-clients/mcp-list-cache";
+import { createLazyClient } from "@/mcp-clients/lazy-client";
+import { injectCSP } from "@/mcp-apps/csp-injector";
+import type { McpUiResourceCsp } from "@/mcp-apps/types";
 import {
   assertCircuitClosed,
   CircuitOpenError,
@@ -71,6 +74,87 @@ export const createProxyRoutes = () => {
    */
   app.all("/", async (c) => {
     return handleVirtualMcpRequest(c, undefined);
+  });
+
+  /**
+   * Cacheable GET for a connection's UI resource HTML (MCP-apps).
+   *
+   * Route: GET /mcp/:connectionId/ui-resource?uri=<resource uri>
+   *
+   * Reads the resource through the lazy client (so the per-pod read cache + SWR
+   * apply — no upstream call on a warm hit), then serves the content with an
+   * `ETag` so the browser HTTP-caches it: a matching `If-None-Match` returns 304
+   * with no body, so the (often multi-MiB) HTML only re-transfers when it
+   * actually changes. `private` because the content is org/auth-scoped.
+   *
+   * This is the GET counterpart to the JSON-RPC `resources/read` POST, which is
+   * inherently uncacheable by the browser. The frontend renders the bytes into
+   * an iframe `srcDoc` exactly as before (CSP injection + app bridge unchanged).
+   */
+  app.get("/:connectionId/ui-resource", async (c) => {
+    const ctx = c.get("meshContext");
+    const connectionId = c.req.param("connectionId");
+    const uri = c.req.query("uri");
+    if (!uri) return c.json({ error: "uri query param is required" }, 400);
+    if (!ctx.organization?.id) {
+      return c.json({ error: "Organization context is required" }, 403);
+    }
+
+    const connection = await ctx.storage.connections.findById(
+      connectionId,
+      ctx.organization.id,
+    );
+    if (!connection || connection.organization_id !== ctx.organization.id) {
+      return c.json({ error: "Connection not found" }, 404);
+    }
+
+    const client = createLazyClient(
+      connection,
+      ctx,
+      false,
+      getMcpListCache() ?? undefined,
+    );
+    let text: string | undefined;
+    let resourceCsp: McpUiResourceCsp | undefined;
+    try {
+      const result = (await client.readResource({ uri })) as {
+        contents?: Array<{
+          text?: string;
+          _meta?: { ui?: { csp?: McpUiResourceCsp } };
+        }>;
+      };
+      const content = result.contents?.[0];
+      text = content?.text;
+      resourceCsp = content?._meta?.ui?.csp;
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 502);
+    } finally {
+      await client.close().catch(() => {});
+    }
+    if (typeof text !== "string") {
+      return c.json({ error: "Resource has no text content" }, 404);
+    }
+
+    // Inject CSP server-side so the cached bytes are render-ready — the frontend
+    // just drops the response into an iframe `srcDoc` (no client-side rewrite).
+    const html = injectCSP(text, { resourceCsp });
+    // ETag over the final HTML; a matching If-None-Match returns 304 (no body),
+    // so the multi-MiB payload only re-transfers when the content changes.
+    const etag = `"${Bun.hash(html).toString(36)}"`;
+    const cacheControl = "private, max-age=30, must-revalidate";
+    if (c.req.header("if-none-match") === etag) {
+      return new Response(null, {
+        status: 304,
+        headers: { ETag: etag, "Cache-Control": cacheControl },
+      });
+    }
+    return new Response(html, {
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        ETag: etag,
+        "Cache-Control": cacheControl,
+      },
+    });
   });
 
   /**

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -17,7 +17,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { Context, Hono } from "hono";
 import { endTime, startTime } from "hono/timing";
 import type { StudioContext } from "../../core/studio-context";
-import { managementMCP } from "../../tools";
+import { managementContextStore, managementMCP } from "../../tools";
 import { serveMcpRequest } from "../utils/serve-mcp";
 import { handleAuthError } from "./oauth-proxy";
 import { getMcpListCache } from "@/mcp-clients/mcp-list-cache";
@@ -97,11 +97,15 @@ export const createProxyRoutes = () => {
           false,
       });
       await server.connect(transport);
-      return serveMcpRequest(
-        server,
-        transport,
-        c.req.raw,
-        `mcp:self:${connectionId}`,
+      // Tool handlers read ctx from the ALS store, so the request must run
+      // inside its scope.
+      return managementContextStore.run(ctx, () =>
+        serveMcpRequest(
+          server,
+          transport,
+          c.req.raw,
+          `mcp:self:${connectionId}`,
+        ),
       );
     }
 

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -140,8 +140,12 @@ export const createProxyRoutes = () => {
     const html = injectCSP(text, { resourceCsp });
     // ETag over the final HTML; a matching If-None-Match returns 304 (no body),
     // so the multi-MiB payload only re-transfers when the content changes.
+    // `no-cache` = the browser may store it but MUST revalidate before use, so a
+    // server-side invalidation (connection update/delete clears the read cache)
+    // is picked up on the next use instead of being masked by a max-age window.
+    // React Query's staleTime gates how often that revalidation actually fires.
     const etag = `"${Bun.hash(html).toString(36)}"`;
-    const cacheControl = "private, max-age=30, must-revalidate";
+    const cacheControl = "private, no-cache";
     if (c.req.header("if-none-match") === etag) {
       return new Response(null, {
         status: 304,

--- a/apps/mesh/src/api/routes/self.ts
+++ b/apps/mesh/src/api/routes/self.ts
@@ -7,7 +7,7 @@
 import { Hono } from "hono";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { StudioContext } from "../../core/studio-context";
-import { managementMCP } from "../../tools";
+import { managementContextStore, managementMCP } from "../../tools";
 import { serveMcpRequest } from "../utils/serve-mcp";
 
 // Define Hono variables type
@@ -27,13 +27,18 @@ export const createSelfRoutes = () => {
    * Exposes all PROJECT_* and CONNECTION_* tools via MCP protocol
    */
   app.all("/", async (c) => {
-    const server = await managementMCP(c.get("meshContext"));
+    const ctx = c.get("meshContext");
+    const server = await managementMCP(ctx);
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse:
         c.req.raw.headers.get("Accept")?.includes("application/json") ?? false,
     });
     await server.connect(transport);
-    return serveMcpRequest(server, transport, c.req.raw, "mcp:self");
+    // Tool handlers read ctx from the ALS store, so the request must run inside
+    // its scope.
+    return managementContextStore.run(ctx, () =>
+      serveMcpRequest(server, transport, c.req.raw, "mcp:self"),
+    );
   });
 
   return app;

--- a/apps/mesh/src/auth/builtin-role-permission.test.ts
+++ b/apps/mesh/src/auth/builtin-role-permission.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Pure-logic unit tests for the in-memory built-in-role permission matcher.
+ *
+ * No mocks, no DB, no network (TESTING.md "Unit" tier). These assert the
+ * matcher's logic in isolation; end-to-end PARITY with the live Better Auth
+ * path is covered by the e2e spec (member-permission-parity.spec.ts) and was
+ * additionally verified offline against the real `authorize()` (1056 probes,
+ * zero mismatches — see PR description / parity argument).
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  getBuiltinRoleStatements,
+  matchStatement,
+  resolveBuiltinRolePermission,
+} from "./builtin-role-permission";
+import type { Permission } from "@/storage/types";
+
+// A representative built-in statement map. `user` has a literal `self` tool
+// list (no "*"); `admin`/`owner` carry "*" plus enumerated tools. Mirrors the
+// real shape so the matcher is exercised the way Flow 2 uses it.
+const STATEMENTS: Record<string, Permission> = {
+  user: {
+    self: ["TOOL_A", "TOOL_B"],
+    organization: [],
+    member: [],
+    ac: ["read"],
+  },
+  admin: { self: ["*", "TOOL_A", "TOOL_B"], organization: ["update"] },
+  owner: { self: ["*", "TOOL_A", "TOOL_B"], organization: ["update"] },
+};
+
+describe("matchStatement", () => {
+  it("grants when the resource key lists the exact action", () => {
+    expect(matchStatement({ self: ["TOOL_A"] }, { self: ["TOOL_A"] })).toBe(
+      true,
+    );
+  });
+
+  it("denies when the action is absent and no wildcard is present", () => {
+    expect(matchStatement({ self: ["TOOL_A"] }, { self: ["TOOL_B"] })).toBe(
+      false,
+    );
+  });
+
+  it("grants via a '*' wildcard action in the statement", () => {
+    expect(matchStatement({ self: ["*"] }, { self: ["ANYTHING"] })).toBe(true);
+  });
+
+  it("denies when the requested resource key is missing from the statement", () => {
+    // Mirrors Better Auth: `if (!allowedActions) return {success:false}`.
+    expect(matchStatement({ self: ["TOOL_A"] }, { conn_x: ["TOOL_A"] })).toBe(
+      false,
+    );
+  });
+
+  it("requires EVERY requested action to be granted (AND within a resource)", () => {
+    expect(
+      matchStatement({ self: ["TOOL_A", "TOOL_B"] }, { self: ["TOOL_A"] }),
+    ).toBe(true);
+    expect(
+      matchStatement(
+        { self: ["TOOL_A"] },
+        { self: ["TOOL_A", "TOOL_MISSING"] },
+      ),
+    ).toBe(false);
+  });
+
+  it("requires EVERY requested resource to be granted (AND across resources)", () => {
+    const stmt = { self: ["TOOL_A"], member: ["read"] };
+    expect(matchStatement(stmt, { self: ["TOOL_A"], member: ["read"] })).toBe(
+      true,
+    );
+    expect(matchStatement(stmt, { self: ["TOOL_A"], member: ["write"] })).toBe(
+      false,
+    );
+  });
+});
+
+describe("resolveBuiltinRolePermission", () => {
+  it("grants a built-in user role for a tool in its self list", () => {
+    expect(
+      resolveBuiltinRolePermission("user", { self: ["TOOL_A"] }, STATEMENTS),
+    ).toBe("grant");
+  });
+
+  it("denies a built-in user role for a tool NOT in its self list", () => {
+    expect(
+      resolveBuiltinRolePermission(
+        "user",
+        { self: ["TOOL_MISSING"] },
+        STATEMENTS,
+      ),
+    ).toBe("deny");
+  });
+
+  it("denies a user role for connection-scoped resources (no conn_ key)", () => {
+    // A pure built-in `user` browser session has no connection grants; Better
+    // Auth's static `user` statement likewise has no conn_ key → deny.
+    expect(
+      resolveBuiltinRolePermission(
+        "user",
+        { conn_abc: ["SEND_MESSAGE"] },
+        STATEMENTS,
+      ),
+    ).toBe("deny");
+  });
+
+  it("grants an admin/owner role via the self '*' wildcard", () => {
+    expect(
+      resolveBuiltinRolePermission("admin", { self: ["ANY_TOOL"] }, STATEMENTS),
+    ).toBe("grant");
+    expect(
+      resolveBuiltinRolePermission("owner", { self: ["ANY_TOOL"] }, STATEMENTS),
+    ).toBe("grant");
+  });
+
+  it("resolves multi-resource requests (all must pass)", () => {
+    expect(
+      resolveBuiltinRolePermission(
+        "user",
+        { self: ["TOOL_A"], member: [] },
+        STATEMENTS,
+      ),
+    ).toBe("grant");
+    expect(
+      resolveBuiltinRolePermission(
+        "user",
+        { self: ["TOOL_A", "TOOL_MISSING"] },
+        STATEMENTS,
+      ),
+    ).toBe("deny");
+  });
+
+  // ---- Fall-back decisions: caller must use the Better Auth path ----
+
+  it("falls back for an undefined role", () => {
+    expect(
+      resolveBuiltinRolePermission(undefined, { self: ["TOOL_A"] }, STATEMENTS),
+    ).toBe("fallback");
+  });
+
+  it("falls back for a custom (non-built-in) role name", () => {
+    expect(
+      resolveBuiltinRolePermission(
+        "billing-manager",
+        { self: ["TOOL_A"] },
+        STATEMENTS,
+      ),
+    ).toBe("fallback");
+  });
+
+  it("falls back for comma-joined multi-role strings (never partially resolve)", () => {
+    // The OR-over-roles may include a custom role we can't resolve in-memory.
+    expect(
+      resolveBuiltinRolePermission(
+        "user,billing-manager",
+        { self: ["TOOL_A"] },
+        STATEMENTS,
+      ),
+    ).toBe("fallback");
+    // Even an all-built-in comma string falls back — conservative by design.
+    expect(
+      resolveBuiltinRolePermission(
+        "user,admin",
+        { self: ["TOOL_A"] },
+        STATEMENTS,
+      ),
+    ).toBe("fallback");
+  });
+
+  it("falls back when the built-in statement is missing from the map", () => {
+    expect(resolveBuiltinRolePermission("user", { self: ["TOOL_A"] }, {})).toBe(
+      "fallback",
+    );
+  });
+});
+
+describe("getBuiltinRoleStatements", () => {
+  it("builds user/admin/owner with the expected shape and no '*' in user.self", () => {
+    const stmts = getBuiltinRoleStatements(["TOOL_X", "TOOL_Y"]);
+    expect(Object.keys(stmts).sort()).toEqual(["admin", "owner", "user"]);
+    const userStmt = stmts.user;
+    const adminStmt = stmts.admin;
+    const ownerStmt = stmts.owner;
+    if (!userStmt || !adminStmt || !ownerStmt) {
+      throw new Error("expected user/admin/owner statements");
+    }
+    // user.self must NEVER contain "*" — the wildcard fallback would otherwise
+    // grant every member full access (see registry-metadata USER_ROLE_TOOLS).
+    expect(userStmt.self).not.toContain("*");
+    // admin/owner enumerate "*" plus the full tool list (creator-role gating).
+    expect(adminStmt.self).toContain("*");
+    expect(adminStmt.self).toContain("TOOL_X");
+    expect(ownerStmt.self).toEqual(adminStmt.self);
+    // user carries the org-plugin memberAc keys (organization/member/.../ac).
+    expect(userStmt.ac).toEqual(["read"]);
+    expect(userStmt).toHaveProperty("member");
+  });
+});

--- a/apps/mesh/src/auth/builtin-role-permission.ts
+++ b/apps/mesh/src/auth/builtin-role-permission.ts
@@ -1,0 +1,181 @@
+/**
+ * In-memory permission resolution for BUILT-IN roles (Flow 2, browser sessions).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Per non-admin browser request, `createBoundAuthClient.hasPermission` makes TWO
+ * sequential DB-backed Better Auth `hasPermission` calls (an exact probe
+ * `{resource:[tool]}` then a wildcard probe `{resource:["*"]}`). Each call =
+ * session validation + `member` findOne + `organizationRole` findMany + SQL
+ * compile, all synchronous on the main thread. On big orgs this dominated
+ * ~40ms event-loop hitches.
+ *
+ * By the time control reaches Flow 2, the member's `role` for the EFFECTIVE org
+ * has already been resolved this request (a fresh `member` read in
+ * `authenticateRequest`). For BUILT-IN roles (`user`/`admin`/`owner`), the
+ * role → statement mapping is STATIC CODE (compiled into the app via
+ * `auth/index.ts`), not data. Resolving them in-memory therefore adds ZERO new
+ * staleness risk over the existing flow: the role assignment is the only fresh
+ * input, and we already have it.
+ *
+ * PARITY WITH BETTER AUTH (verified against installed @decocms/better-auth@1.5.x)
+ * -----------------------------------------------------------------------------
+ * Better Auth's `authorize(request)` (access.mjs `role()`) matches actions
+ * LITERALLY: `allowedActions.includes(action)`, no wildcard expansion; a
+ * missing resource key denies. The org-plugin `hasPermissionFn`
+ * (permission.mjs) splits `member.role` on "," and ORs each role's
+ * `authorize()`. The `/organization/has-permission` endpoint resolves the
+ * member's role for `organizationId ?? session.activeOrganizationId` — the
+ * SAME effective org we key on here.
+ *
+ * The current two-probe flow is exactly: `authorize({key:[resource]}).success
+ * || authorize({key:["*"]}).success`. For a single built-in role with a static
+ * statement S, that reduces to `S[key]?.includes(resource) ||
+ * S[key]?.includes("*")` — which is what `matchStatement` computes. This is the
+ * same wildcard logic as `checkApiKeyPermission`.
+ *
+ * FALL-BACK (fail-safe to existing behavior)
+ * ------------------------------------------
+ * Anything that is NOT a single, known built-in role returns "fallback":
+ *   - custom/dynamic roles (rows in `organizationRole`) — role → statement is
+ *     DATA merged at runtime by `getOrganizationStatements`; not resolvable here
+ *   - comma-joined multi-role strings — the OR-over-roles may include a custom
+ *     role whose statement we don't have
+ *   - any unexpected/empty role
+ * The caller then runs the unchanged two-call Better Auth path.
+ *
+ * NOTE: `admin`/`owner` bypass BEFORE Flow 2 (in both `createBoundAuthClient`
+ * and `AccessControl.checkResource`), so in practice only `user` reaches here.
+ * They are still encoded correctly for robustness and self-documentation.
+ */
+
+import type { Permission } from "@/storage/types";
+import {
+  adminAc,
+  memberAc,
+} from "@decocms/better-auth/plugins/organization/access";
+import { getToolsByCategory, USER_ROLE_TOOLS } from "@/tools/registry-metadata";
+import { BUILTIN_ROLES } from "./roles";
+
+/**
+ * Build the STATIC statements for the built-in roles, mirroring the role
+ * construction in `auth/index.ts` EXACTLY (single source of truth: this
+ * function is what `auth/index.ts` consumes to build its org-plugin roles, so
+ * the two cannot drift).
+ *
+ * - `user`: `{ self: [...USER_ROLE_TOOLS], ...memberAc.statements }`
+ * - `admin`/`owner`: `{ self: ["*", ...allTools], ...adminAc.statements }`
+ *
+ * `allTools` is injected (not imported) because enumerating it requires the
+ * tool registry; the only consumer that needs the admin/owner `self` list is
+ * `auth/index.ts`, which already has it. Flow 2 only ever resolves `user`
+ * (admin/owner bypass earlier), but encoding all three keeps this in lock-step
+ * with the auth config.
+ */
+export function getBuiltinRoleStatements(
+  allTools: string[],
+): Record<string, Permission> {
+  const creatorSelf = ["*", ...allTools];
+  return {
+    user: {
+      self: [...USER_ROLE_TOOLS],
+      ...memberAc.statements,
+    },
+    admin: {
+      self: creatorSelf,
+      ...adminAc.statements,
+    },
+    owner: {
+      self: creatorSelf,
+      ...adminAc.statements,
+    },
+  };
+}
+
+/**
+ * The decision for a single permission check.
+ * - "grant": the in-memory built-in statement authorizes the request
+ * - "deny": the in-memory built-in statement denies the request
+ * - "fallback": cannot be resolved in-memory; caller MUST use Better Auth
+ */
+export type BuiltinPermissionDecision = "grant" | "deny" | "fallback";
+
+/**
+ * Mirror of Better Auth's `role().authorize()` for ONE resource/action set,
+ * with the OR-wildcard fallback the current two-probe flow performs.
+ *
+ * For every (resource, actions) pair in `requested`, the statement must grant
+ * EVERY action — either the literal action, or "*" (the wildcard probe the
+ * existing code issues as a second call). A resource key missing from the
+ * statement denies, exactly like Better Auth (`if (!allowedActions) return
+ * {success:false}`).
+ */
+export function matchStatement(
+  statement: Permission,
+  requested: Permission,
+): boolean {
+  for (const [resource, actions] of Object.entries(requested)) {
+    const allowed = statement[resource];
+    if (!allowed) return false;
+    for (const action of actions) {
+      if (!allowed.includes(action) && !allowed.includes("*")) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Resolve a permission check against built-in roles entirely in-memory.
+ *
+ * @param role             the caller's `member.role` for the effective org
+ * @param requested        the permission being checked, e.g. `{ self: [tool] }`
+ * @param builtinStatements role-name → static statement, built once from the
+ *                          in-code role definitions (see
+ *                          `getBuiltinRoleStatements`)
+ *
+ * Returns "fallback" for ANY role that is not a single known built-in role.
+ */
+export function resolveBuiltinRolePermission(
+  role: string | undefined,
+  requested: Permission,
+  builtinStatements: Record<string, Permission>,
+): BuiltinPermissionDecision {
+  if (!role) return "fallback";
+
+  // Comma-joined multi-role: the OR may include a custom role whose statement
+  // we don't have in-memory. Fall back unconditionally — never partially
+  // resolve a multi-role string.
+  if (role.includes(",")) return "fallback";
+
+  // Only single, known built-in roles are resolvable from static code.
+  if (!BUILTIN_ROLES.includes(role as (typeof BUILTIN_ROLES)[number])) {
+    return "fallback";
+  }
+
+  const statement = builtinStatements[role];
+  if (!statement) return "fallback";
+
+  return matchStatement(statement, requested) ? "grant" : "deny";
+}
+
+/**
+ * Process-lifetime singleton of the built-in role statements, built once from
+ * the tool registry. The registry is static after module load, so this never
+ * changes during a process. `createBoundAuthClient` reads it on the Flow 2 hot
+ * path without recomputing per request.
+ *
+ * Same builder as `auth/index.ts` → identical statements (no drift).
+ */
+let cachedStatements: Record<string, Permission> | undefined;
+
+export function getCachedBuiltinRoleStatements(): Record<string, Permission> {
+  if (!cachedStatements) {
+    const allTools = Object.values(getToolsByCategory()).flatMap((tools) =>
+      tools.map((t) => t.name),
+    );
+    cachedStatements = getBuiltinRoleStatements(allTools);
+  }
+  return cachedStatements;
+}

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -10,7 +10,7 @@
  */
 
 import { getSettings } from "../settings";
-import { getToolsByCategory, USER_ROLE_TOOLS } from "@/tools/registry-metadata";
+import { getToolsByCategory } from "@/tools/registry-metadata";
 import { sso } from "@better-auth/sso";
 import { organization } from "@decocms/better-auth/plugins";
 import { betterAuth, BetterAuthOptions } from "better-auth";
@@ -29,11 +29,7 @@ import {
   adminAc as systemAdminAc,
   defaultRoles as systemDefaultRoles,
 } from "better-auth/plugins/admin/access";
-import {
-  adminAc,
-  defaultStatements,
-  memberAc,
-} from "@decocms/better-auth/plugins/organization/access";
+import { defaultStatements } from "@decocms/better-auth/plugins/organization/access";
 
 import { getConfig } from "@/core/config";
 import { posthog } from "@/posthog";
@@ -47,6 +43,7 @@ import { createMagicLinkConfig } from "./magic-link";
 import { seedOrgDb } from "./org";
 import { identifyAuthenticatedUser } from "./posthog-identify";
 import { ADMIN_ROLES } from "./roles";
+import { getBuiltinRoleStatements } from "./builtin-role-permission";
 import { createSSOConfig } from "./sso";
 
 /**
@@ -101,6 +98,11 @@ const statement = { ...defaultStatements, self: ["*", ...allTools] };
 
 const ac = createAccessControl(statement);
 
+// Single source of truth for built-in role → statement. The in-memory Flow 2
+// matcher (`builtin-role-permission.ts`) consumes the SAME builder, so the
+// org-plugin roles below and the in-memory resolution cannot drift.
+const builtinRoleStatements = getBuiltinRoleStatements(allTools);
+
 // The role-creating built-in roles (owner/admin) must enumerate every `self`
 // tool, not just `["*"]`. Better Auth's access-control `authorize()` matches
 // actions literally — `["*"]` authorizes only a request for the literal action
@@ -119,28 +121,27 @@ const ac = createAccessControl(statement);
 // Specific tool names match only via the exact check. A member otherwise gets
 // only basic-usage (granted out-of-band in AccessControl) plus connection-scoped
 // grants, and can't create roles (allowedRolesToCreateResources = ADMIN_ROLES).
-const creatorSelf = ["*", ...allTools];
-
 // `user` spreads `memberAc` (the org plugin's member role), NOT `adminAc`. These
 // org statements (organization/member/invitation/team/ac) gate Better Auth's
 // native org-plugin endpoints — not MCP tools, which our AccessControl checks on
 // `self`/connection buckets. `adminAc` grants org:update + member/invitation/team
 // management; spreading it here would let a plain member manage the org via those
 // endpoints. `memberAc` grants only `ac: ["read"]` (read roles for the UI).
-const user = ac.newRole({
-  self: [...USER_ROLE_TOOLS],
-  ...memberAc.statements,
-}) as Role;
+//
+// All three statements come from `getBuiltinRoleStatements` so the runtime
+// org-plugin roles and the in-memory Flow 2 matcher share one definition.
+// `getBuiltinRoleStatements` returns the loose `Permission` shape
+// (Record<string,string[]>); `newRole` wants the statement's literal `Subset`
+// type. The runtime values are exactly the statements compiled into `ac`, so
+// cast the argument to the parameter type — the result cast to `Role` is the
+// same one the original inline definitions used.
+type NewRoleArg = Parameters<typeof ac.newRole>[0];
 
-const admin = ac.newRole({
-  self: creatorSelf,
-  ...adminAc.statements,
-}) as Role;
+const user = ac.newRole(builtinRoleStatements.user as NewRoleArg) as Role;
 
-const owner = ac.newRole({
-  self: creatorSelf,
-  ...adminAc.statements,
-}) as Role;
+const admin = ac.newRole(builtinRoleStatements.admin as NewRoleArg) as Role;
+
+const owner = ac.newRole(builtinRoleStatements.owner as NewRoleArg) as Role;
 
 const scopes = Object.values(getToolsByCategory())
   .map((tool) => tool.map((t) => `self:${t.name}`))

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -394,7 +394,9 @@ describe("AccessControl", () => {
 
       expect(mockBoundAuth.hasPermission).toHaveBeenCalledWith(
         { self: ["TEST_TOOL"] },
-        undefined, // No path-resolved org passed, so options is undefined
+        // No path-resolved org (organizationId undefined). The effective-org
+        // role is forwarded so boundAuth can resolve built-in roles in-memory.
+        { organizationId: undefined, role: "user" },
       );
       expect(ac.granted()).toBe(true);
     });

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -225,13 +225,17 @@ export class AccessControl implements Disposable {
       permissionToCheck[this.connectionId] = [resource];
     }
 
-    // Delegate to Better Auth's hasPermission API. When an organizationId is
-    // set (path-resolved org), pass it through so Better Auth uses it instead
-    // of the session's active org.
-    return this.boundAuth.hasPermission(
-      permissionToCheck,
-      this.organizationId ? { organizationId: this.organizationId } : undefined,
-    );
+    // Delegate to the bound auth client. When an organizationId is set
+    // (path-resolved org), pass it through so Better Auth uses it instead of
+    // the session's active org. Pass `this.role` too: it is the member's role
+    // for THIS org (constructor + resolveOrgFromPath keep role and
+    // organizationId in lock-step), so boundAuth can resolve built-in roles
+    // in-memory without a Better Auth round-trip. admin/owner already returned
+    // above, so this only accelerates the `user` role; custom roles fall back.
+    return this.boundAuth.hasPermission(permissionToCheck, {
+      organizationId: this.organizationId,
+      role: this.role,
+    });
   }
 
   /**

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -276,7 +276,7 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
   return {
     hasPermission: async (
       requestedPermission: Permission,
-      options?: { organizationId?: string },
+      options?: { organizationId?: string; role?: string },
     ): Promise<boolean> => {
       // Only owner/admin bypass all permission checks (full org access). The
       // built-in `user` role is enforced like any member: it gets basic-usage
@@ -291,7 +291,26 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
         return checkApiKeyPermission(permissions, requestedPermission);
       }
 
-      // Flow 2: Browser sessions - delegate to Better Auth's hasPermission API
+      // Flow 2: Browser sessions.
+      //
+      // Fast path: resolve BUILT-IN roles in-memory. The caller
+      // (AccessControl.checkResource) passes the member's role for the SAME
+      // effective org as `organizationId`, so this matches what Better Auth
+      // would resolve server-side — without two DB-backed calls. For custom /
+      // multi-role / unknown roles this returns "fallback" and we drop to the
+      // unchanged Better Auth path below. Admin/owner already bypassed above and
+      // in AccessControl, so in practice only `user` is resolved here.
+      // See auth/builtin-role-permission.ts for the full parity argument.
+      const builtinDecision = resolveBuiltinRolePermission(
+        options?.role,
+        requestedPermission,
+        getCachedBuiltinRoleStatements(),
+      );
+      if (builtinDecision !== "fallback") {
+        return builtinDecision === "grant";
+      }
+
+      // Slow path: delegate to Better Auth's hasPermission API.
       if (!hasPermissionApi) {
         console.error("[Auth] hasPermission API not available");
         return false;
@@ -471,6 +490,10 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
 import { createMCPProxy } from "@/api/routes/mcp-proxy-factory";
 import { ConnectionEntity } from "@/tools/connection/schema";
 import { ADMIN_ROLES, BUILTIN_ROLES } from "../auth/roles";
+import {
+  getCachedBuiltinRoleStatements,
+  resolveBuiltinRolePermission,
+} from "../auth/builtin-role-permission";
 import { OrgScopedThreadStorage, SqlThreadStorage } from "@/storage/threads";
 import {
   OrgScopedAsyncResearchJobStorage,

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -81,10 +81,16 @@ export interface BoundAuthClient {
    * @param options.organizationId - Override the session-based active org.
    *   When set, Better Auth uses this org for the permission check instead
    *   of the user's session-active org. Used by path-resolved org middleware.
+   * @param options.role - The caller's `member.role` for the EFFECTIVE org
+   *   (the org in `options.organizationId`, else the session-active org). When
+   *   the role is a single built-in role, the check is resolved in-memory
+   *   instead of via two DB-backed Better Auth calls. MUST be the role for the
+   *   same org as `organizationId` — pass them together. Omit to force the
+   *   Better Auth path. See `auth/builtin-role-permission.ts`.
    */
   hasPermission(
     permission: Permission,
-    options?: { organizationId?: string },
+    options?: { organizationId?: string; role?: string },
   ): Promise<boolean>;
 
   // Organization APIs (bound with headers)

--- a/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
+++ b/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@deco/ui/lib/utils.ts";
-import { useMCPReadResource } from "@decocms/mesh-sdk";
+import { useMCPReadResource, useUiResourceHtml } from "@decocms/mesh-sdk";
 import type {
   McpUiDisplayMode,
   McpUiHostContext,
@@ -18,7 +18,7 @@ import { track } from "../web/lib/posthog-client";
 const openedMcpApps = new Set<string>();
 
 // ---------------------------------------------------------------------------
-// useResourceHtml
+// useResourceHtml — client-side CSP injection for the JSON-RPC read path
 // ---------------------------------------------------------------------------
 
 type ReadResourceData = {
@@ -45,6 +45,14 @@ function useResourceHtml(data: ReadResourceData | undefined): string | null {
 interface MCPAppRendererProps {
   resourceURI: string;
   orgId?: string;
+  /**
+   * When both `orgSlug` and `connectionId` are provided, the HTML is fetched
+   * via the cacheable GET endpoint (browser HTTP-caches it, ETag-revalidated,
+   * CSP injected server-side). Otherwise it falls back to the JSON-RPC
+   * `resources/read` path via `client`.
+   */
+  orgSlug?: string;
+  connectionId?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;
@@ -64,11 +72,12 @@ interface MCPAppRendererProps {
 }
 
 // ---------------------------------------------------------------------------
-// Component
+// Frame — shared presentation + app bridge (identical for both data paths)
 // ---------------------------------------------------------------------------
 
-export function MCPAppRenderer({
-  resourceURI: uri,
+function MCPAppFrame({
+  html,
+  uri,
   orgId,
   toolInfo,
   toolInput,
@@ -82,13 +91,12 @@ export function MCPAppRenderer({
   onTeardown,
   onRequestDisplayMode,
   className,
-}: MCPAppRendererProps) {
-  const { data } = useMCPReadResource({ client, uri, staleTime: 30_000 });
-  const html = useResourceHtml(data);
-
+}: Omit<MCPAppRendererProps, "resourceURI" | "orgSlug" | "connectionId"> & {
+  html: string | null;
+  uri: string;
+}) {
   // Fire mcp_app_opened once per (page session × resource URI) — render-time
-  // dedupe via module Set. Display mode distinguishes inline (shown inside
-  // chat messages) from fullscreen (opened as a view panel).
+  // dedupe via module Set.
   if (uri && !openedMcpApps.has(uri)) {
     openedMcpApps.add(uri);
     track("mcp_app_opened", {
@@ -154,4 +162,56 @@ export function MCPAppRenderer({
       />
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Data paths
+// ---------------------------------------------------------------------------
+
+// Cacheable GET path: browser HTTP-caches the (server-CSP-injected) HTML.
+function MCPAppRendererViaGet({
+  resourceURI,
+  orgSlug,
+  connectionId,
+  ...frameProps
+}: MCPAppRendererProps & { orgSlug: string; connectionId: string }) {
+  const html = useUiResourceHtml({
+    orgSlug,
+    connectionId,
+    uri: resourceURI,
+    staleTime: 30_000,
+  });
+  return <MCPAppFrame html={html.data} uri={resourceURI} {...frameProps} />;
+}
+
+// JSON-RPC `resources/read` path (CSP injected client-side). Used wherever the
+// caller can't supply orgSlug + connectionId.
+function MCPAppRendererViaClient({
+  resourceURI,
+  ...frameProps
+}: MCPAppRendererProps) {
+  const { data } = useMCPReadResource({
+    client: frameProps.client,
+    uri: resourceURI,
+    staleTime: 30_000,
+  });
+  const html = useResourceHtml(data);
+  return <MCPAppFrame html={html} uri={resourceURI} {...frameProps} />;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function MCPAppRenderer(props: MCPAppRendererProps) {
+  if (props.orgSlug && props.connectionId) {
+    return (
+      <MCPAppRendererViaGet
+        {...props}
+        orgSlug={props.orgSlug}
+        connectionId={props.connectionId}
+      />
+    );
+  }
+  return <MCPAppRendererViaClient {...props} />;
 }

--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -34,7 +34,44 @@ import {
   type McpListCache,
   REVALIDATE_MIN_INTERVAL_MS,
 } from "./mcp-list-cache";
-import { getMcpReadCache } from "./mcp-read-cache";
+import { getMcpReadCache, type ReadCacheScope } from "./mcp-read-cache";
+
+/**
+ * A read-only tool is eligible for result caching. We trust the upstream's
+ * `annotations.readOnlyHint` (surfaced in the cached tool list); a tool we
+ * can't confirm read-only is never cached.
+ */
+async function isReadOnlyTool(
+  cache: McpListCache | undefined,
+  connectionId: string,
+  toolName: string,
+): Promise<boolean> {
+  if (!cache) return false;
+  const tools = await cache.get("tools", connectionId).catch(() => null);
+  if (!tools) return false;
+  for (const t of tools) {
+    if (
+      typeof t === "object" &&
+      t !== null &&
+      (t as { name?: unknown }).name === toolName
+    ) {
+      return (
+        (t as { annotations?: { readOnlyHint?: boolean } }).annotations
+          ?.readOnlyHint === true
+      );
+    }
+  }
+  return false;
+}
+
+/**
+ * Cache scope for a connection's read-only results. Defaults to "org" (shared
+ * across all members). The per-connection "user" opt-out (key by principal) is
+ * a follow-up; the cache already keys by scope, so it's a resolver change only.
+ */
+function resolveReadCacheScope(): ReadCacheScope {
+  return { kind: "org" };
+}
 
 /**
  * Create a lazy-connecting client wrapper for a connection.
@@ -155,41 +192,91 @@ export function createLazyClient(
     (cached) => ({ prompts: cached as ListPromptsResult["prompts"] }),
   );
 
-  // Proxy non-list operations to the real client (always needs a connection)
-  placeholder.callTool = async (params, resultSchema, options) => {
-    const real = await getRealClient();
-    return real.callTool(params, resultSchema, options);
-  };
-
-  // Read-content cache (resources/read, prompts/get): per-pod TTL+LRU, shared
-  // across org members. VIRTUAL connections bypass (they compose other conns).
+  // Read-only results (tools/call for read-only tools, resources/read,
+  // prompts/get) are served stale-while-revalidate from the per-pod read cache,
+  // org-scoped by default and shared across org members. Writes, tools we can't
+  // confirm read-only, VIRTUAL connections (they compose other conns), and calls
+  // with a custom result schema bypass entirely. `options` (e.g. the timeout) is
+  // forwarded to the live fetch but excluded from the cache key.
   const readCache = getMcpReadCache();
   const cacheReads = connection.connection_type !== "VIRTUAL";
 
+  placeholder.callTool = async (params, resultSchema, options) => {
+    const toolName = (params as { name?: unknown })?.name;
+    const cacheable =
+      cacheReads &&
+      !resultSchema &&
+      typeof toolName === "string" &&
+      (await isReadOnlyTool(cache, connection.id, toolName));
+
+    if (!cacheable) {
+      const real = await getRealClient();
+      return real.callTool(params, resultSchema, options);
+    }
+
+    const result = await readCache.fetch({
+      type: "tools/call",
+      connectionId: connection.id,
+      scope: resolveReadCacheScope(),
+      params: {
+        name: toolName,
+        arguments: (params as { arguments?: unknown })?.arguments,
+      },
+      fetchLive: async () => {
+        const real = await getRealClient();
+        return real.callTool(params, resultSchema, options);
+      },
+      // Never cache error results — they're returned to the caller but not stored.
+      shouldCache: (value) =>
+        (value as { isError?: boolean })?.isError !== true,
+      onRevalidation: (p) => ctx.pendingRevalidations.push(p),
+    });
+    return result as Awaited<ReturnType<Client["callTool"]>>;
+  };
+
   placeholder.getPrompt = async (params, options) => {
-    if (cacheReads) {
-      const hit = readCache.get("prompts/get", connection.id, params);
-      if (hit !== null) return hit as GetPromptResult;
+    if (!cacheReads) {
+      const real = await getRealClient();
+      return real.getPrompt(params, options);
     }
-    const real = await getRealClient();
-    const result = await real.getPrompt(params, options);
-    if (cacheReads) {
-      readCache.set("prompts/get", connection.id, params, result);
-    }
-    return result;
+    const result = await readCache.fetch({
+      type: "prompts/get",
+      connectionId: connection.id,
+      scope: resolveReadCacheScope(),
+      params,
+      fetchLive: async () => {
+        const real = await getRealClient();
+        return real.getPrompt(params, options);
+      },
+      onRevalidation: (p) => ctx.pendingRevalidations.push(p),
+    });
+    return result as GetPromptResult;
   };
 
   placeholder.readResource = async (params, options) => {
-    if (cacheReads) {
-      const hit = readCache.get("resources/read", connection.id, params);
-      if (hit !== null) return hit as ReadResourceResult;
+    if (!cacheReads) {
+      if (process.env?.MCP_CACHE_DEBUG) {
+        console.log(
+          "[mcp-read-cache] BYPASS (VIRTUAL)",
+          connection.id,
+          "resources/read",
+        );
+      }
+      const real = await getRealClient();
+      return real.readResource(params, options);
     }
-    const real = await getRealClient();
-    const result = await real.readResource(params, options);
-    if (cacheReads) {
-      readCache.set("resources/read", connection.id, params, result);
-    }
-    return result;
+    const result = await readCache.fetch({
+      type: "resources/read",
+      connectionId: connection.id,
+      scope: resolveReadCacheScope(),
+      params,
+      fetchLive: async () => {
+        const real = await getRealClient();
+        return real.readResource(params, options);
+      },
+      onRevalidation: (p) => ctx.pendingRevalidations.push(p),
+    });
+    return result as ReadResourceResult;
   };
 
   placeholder.listResourceTemplates = async (params, options) => {

--- a/apps/mesh/src/mcp-clients/mcp-cache-invalidation.ts
+++ b/apps/mesh/src/mcp-clients/mcp-cache-invalidation.ts
@@ -1,0 +1,85 @@
+/**
+ * Cross-replica invalidation for the per-pod MCP caches.
+ *
+ * The read-content cache (mcp-read-cache) and tool-result cache
+ * (mcp-result-cache) are in-memory per-pod singletons, so evicting them locally
+ * only clears the pod that handled the mutation — every other replica keeps
+ * serving stale (possibly now-unauthorized) responses until TTL. On a
+ * connection change we therefore evict locally AND broadcast over NATS so the
+ * other replicas drop their copies near-instantly. TTL is the worst-case floor:
+ * if NATS is mid-hiccup and a broadcast is lost, each replica still expires the
+ * entry within its TTL.
+ *
+ * (The tool/resource/prompt *list* cache is NATS JetStream KV — already
+ * cross-pod — so it is invalidated directly by its callers, not here.)
+ */
+
+import type { NatsConnection, Subscription } from "nats";
+import { getMcpReadCache } from "./mcp-read-cache";
+
+const INVALIDATE_SUBJECT = "studio.mcp-cache.invalidate";
+
+const originId = crypto.randomUUID();
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+let getConnection: (() => NatsConnection | null) | undefined;
+let sub: Subscription | null = null;
+
+/** Drop this connection's per-pod cached read results (content + tool calls). */
+function evictLocal(connectionId: string): void {
+  getMcpReadCache().invalidate(connectionId);
+}
+
+/**
+ * Evict this connection's per-pod caches on every replica: locally now, and on
+ * the others via a NATS broadcast. Falls back to local-only (covered by TTL)
+ * when NATS is unavailable — e.g. single-pod local mode.
+ */
+export function invalidateConnectionCaches(connectionId: string): void {
+  evictLocal(connectionId);
+  const nc = getConnection?.();
+  if (!nc) return; // NATS not ready — local eviction only, TTL covers the rest
+  try {
+    nc.publish(
+      INVALIDATE_SUBJECT,
+      encoder.encode(JSON.stringify({ connectionId, originId })),
+    );
+  } catch (err) {
+    console.warn("[McpCacheInvalidation] publish failed (non-critical):", err);
+  }
+}
+
+/**
+ * Subscribe to cross-replica invalidations. Idempotent; call once after NATS is
+ * ready (re-attempted on each NATS-ready callback).
+ */
+export function startMcpCacheInvalidation(
+  getConn: () => NatsConnection | null,
+): void {
+  getConnection = getConn;
+  if (sub) return;
+  const nc = getConn();
+  if (!nc) return; // retried on the next NATS-ready callback
+  sub = nc.subscribe(INVALIDATE_SUBJECT);
+  (async () => {
+    for await (const msg of sub!) {
+      try {
+        const parsed = JSON.parse(decoder.decode(msg.data)) as {
+          connectionId: string;
+          originId?: string;
+        };
+        if (parsed.originId === originId) continue; // our own broadcast
+        evictLocal(parsed.connectionId);
+      } catch {
+        // Ignore malformed messages
+      }
+    }
+  })().catch(console.error);
+}
+
+export function teardownMcpCacheInvalidation(): void {
+  sub?.unsubscribe();
+  sub = null;
+  getConnection = undefined;
+}

--- a/apps/mesh/src/mcp-clients/mcp-read-cache.test.ts
+++ b/apps/mesh/src/mcp-clients/mcp-read-cache.test.ts
@@ -1,84 +1,478 @@
-import { describe, expect, it } from "bun:test";
-import { InMemoryMcpReadCache } from "./mcp-read-cache";
+/**
+ * Read cache: SWR semantics, single-flight revalidation, scope + type + param
+ * keying, staleness bounds, the no-cache guard, oversized rejection, and
+ * per-type config. Pure in-memory logic with an injected clock — no DB, no
+ * network.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  InMemoryMcpReadCache,
+  type McpReadType,
+  type ReadCacheScope,
+} from "./mcp-read-cache";
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const ORG: ReadCacheScope = { kind: "org" };
+const CONN = "conn_a";
+const TOOL: McpReadType = "tools/call";
+
+function configFor(
+  revalidateAfterMs: number,
+  maxStaleMs: number,
+  maxValueBytes: number,
+): Record<
+  McpReadType,
+  {
+    revalidateAfterMs: number;
+    maxStaleMs: number;
+    maxValueBytes: number;
+  }
+> {
+  const c = { revalidateAfterMs, maxStaleMs, maxValueBytes };
+  return { "tools/call": c, "resources/read": c, "prompts/get": c };
+}
+
+function newCache(opts?: {
+  revalidateAfterMs?: number;
+  maxStaleMs?: number;
+  maxValueBytes?: number;
+  maxEntries?: number;
+  maxTotalBytes?: number;
+}) {
+  let now = 1_000;
+  const cache = new InMemoryMcpReadCache(
+    configFor(
+      opts?.revalidateAfterMs ?? 30_000,
+      opts?.maxStaleMs ?? 300_000,
+      opts?.maxValueBytes ?? 2 * 1024 * 1024,
+    ),
+    opts?.maxEntries ?? 2000,
+    () => now,
+    opts?.maxTotalBytes ?? 256 * 1024 * 1024,
+  );
+  return { cache, advance: (ms: number) => (now += ms) };
+}
 
 describe("InMemoryMcpReadCache", () => {
-  it("returns null on miss and the value after set", () => {
-    const cache = new InMemoryMcpReadCache();
-    const params = { uri: "file://a" };
-    expect(cache.get("resources/read", "c1", params)).toBeNull();
-    cache.set("resources/read", "c1", params, { contents: [1] });
-    expect(cache.get("resources/read", "c1", params)).toEqual({
-      contents: [1],
+  test("miss fetches live, stores, and returns; hit reuses it", async () => {
+    const { cache } = newCache();
+    let calls = 0;
+    const fetchLive = async () => ({ value: `v${++calls}` });
+
+    const r1 = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: { a: 1 },
+      fetchLive,
     });
+    const r2 = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: { a: 1 },
+      fetchLive,
+    });
+
+    expect(r1).toEqual({ value: "v1" });
+    expect(r2).toEqual({ value: "v1" });
+    expect(calls).toBe(1);
   });
 
-  it("hashes params order-independently", () => {
-    const cache = new InMemoryMcpReadCache();
-    cache.set(
-      "prompts/get",
-      "c1",
-      { name: "p", arguments: { a: 1, b: 2 } },
-      {
-        v: 1,
-      },
-    );
-    // Same params, keys in different order — must hit the same entry.
+  test("param equality is order-independent", async () => {
+    const { cache } = newCache();
+    let calls = 0;
+    const fetchLive = async () => ({ calls: ++calls });
+    await cache.fetch({
+      type: "prompts/get",
+      connectionId: CONN,
+      scope: ORG,
+      params: { name: "p", arguments: { a: 1, b: 2 } },
+      fetchLive,
+    });
+    const r = await cache.fetch({
+      type: "prompts/get",
+      connectionId: CONN,
+      scope: ORG,
+      params: { arguments: { b: 2, a: 1 }, name: "p" },
+      fetchLive,
+    });
+    expect(r).toEqual({ calls: 1 });
+    expect(calls).toBe(1);
+  });
+
+  test("isolates by connection, type, scope, and params", async () => {
+    const { cache } = newCache();
+    const live = (tag: string) => async () => ({ tag });
+    const base = {
+      connectionId: CONN,
+      scope: ORG,
+      params: { uri: "file://a" },
+    } as const;
+
+    await cache.fetch({
+      ...base,
+      type: "resources/read",
+      fetchLive: live("a"),
+    });
+    // Different connection / type / scope / params all miss (distinct keys).
     expect(
-      cache.get("prompts/get", "c1", { arguments: { b: 2, a: 1 }, name: "p" }),
-    ).toEqual({ v: 1 });
+      await cache.fetch({
+        ...base,
+        connectionId: "conn_b",
+        type: "resources/read",
+        fetchLive: live("conn_b"),
+      }),
+    ).toEqual({ tag: "conn_b" });
+    expect(
+      await cache.fetch({
+        ...base,
+        type: "prompts/get",
+        fetchLive: live("pg"),
+      }),
+    ).toEqual({ tag: "pg" });
+    expect(
+      await cache.fetch({
+        ...base,
+        scope: { kind: "user", userId: "u1" },
+        type: "resources/read",
+        fetchLive: live("user"),
+      }),
+    ).toEqual({ tag: "user" });
+    expect(
+      await cache.fetch({
+        ...base,
+        type: "resources/read",
+        params: { uri: "file://b" },
+        fetchLive: live("b"),
+      }),
+    ).toEqual({ tag: "b" });
+    // Original still cached.
+    expect(
+      await cache.fetch({
+        ...base,
+        type: "resources/read",
+        fetchLive: live("SHOULD_NOT_RUN"),
+      }),
+    ).toEqual({ tag: "a" });
   });
 
-  it("isolates by connection, type, and params", () => {
-    const cache = new InMemoryMcpReadCache();
-    const params = { uri: "file://a" };
-    cache.set("resources/read", "c1", params, { v: "c1" });
-    expect(cache.get("resources/read", "c2", params)).toBeNull();
-    expect(cache.get("prompts/get", "c1", params)).toBeNull();
-    expect(cache.get("resources/read", "c1", { uri: "file://b" })).toBeNull();
+  test("stale hit serves immediately and revalidates once in the background", async () => {
+    const { cache, advance } = newCache({ revalidateAfterMs: 30_000 });
+    let calls = 0;
+    const fetchLive = async () => ({ value: `v${++calls}` });
+
+    const first = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    expect(first).toEqual({ value: "v1" });
+
+    advance(31_000);
+
+    let bg: Promise<void> | undefined;
+    const stale = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+      onRevalidation: (p) => {
+        bg = p;
+      },
+    });
+    expect(stale).toEqual({ value: "v1" }); // served stale synchronously
+    expect(bg).toBeDefined();
+    await bg;
+    expect(calls).toBe(2); // refreshed in background
+
+    const fresh = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    expect(fresh).toEqual({ value: "v2" });
   });
 
-  it("expires entries after the TTL", async () => {
-    const cache = new InMemoryMcpReadCache(5 /* ttlMs */);
-    const params = { uri: "file://a" };
-    cache.set("resources/read", "c1", params, { v: 1 });
-    expect(cache.get("resources/read", "c1", params)).toEqual({ v: 1 });
-    await sleep(15);
-    expect(cache.get("resources/read", "c1", params)).toBeNull();
+  test("single-flight: concurrent stale hits trigger one revalidation", async () => {
+    const { cache, advance } = newCache({ revalidateAfterMs: 10_000 });
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const fetchLive = async () => {
+      calls++;
+      if (calls > 1) await gate;
+      return { calls };
+    };
+
+    await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    advance(11_000);
+
+    const bgs: Promise<void>[] = [];
+    const reads = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        cache.fetch({
+          type: TOOL,
+          connectionId: CONN,
+          scope: ORG,
+          params: {},
+          fetchLive,
+          onRevalidation: (p) => bgs.push(p),
+        }),
+      ),
+    );
+    for (const r of reads) expect(r).toEqual({ calls: 1 });
+    expect(bgs.length).toBe(1);
+    release();
+    await Promise.all(bgs);
+    expect(calls).toBe(2);
   });
 
-  it("evicts the least-recently-used entry past capacity", () => {
-    const cache = new InMemoryMcpReadCache(60_000, 2 /* maxEntries */);
-    cache.set("resources/read", "c", { uri: "a" }, { v: "a" });
-    cache.set("resources/read", "c", { uri: "b" }, { v: "b" });
-    // Touch "a" so "b" becomes the LRU eviction candidate.
-    cache.get("resources/read", "c", { uri: "a" });
-    cache.set("resources/read", "c", { uri: "d" }, { v: "d" });
-
-    expect(cache.get("resources/read", "c", { uri: "a" })).toEqual({ v: "a" });
-    expect(cache.get("resources/read", "c", { uri: "b" })).toBeNull();
-    expect(cache.get("resources/read", "c", { uri: "d" })).toEqual({ v: "d" });
+  test("past maxStale, a hit becomes a blocking miss", async () => {
+    const { cache, advance } = newCache({
+      revalidateAfterMs: 10_000,
+      maxStaleMs: 60_000,
+    });
+    let calls = 0;
+    const fetchLive = async () => ({ value: `v${++calls}` });
+    await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    advance(61_000);
+    const r = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    expect(r).toEqual({ value: "v2" });
+    expect(calls).toBe(2);
   });
 
-  it("invalidate drops only the target connection's entries", () => {
-    const cache = new InMemoryMcpReadCache();
-    cache.set("resources/read", "c1", { uri: "a" }, { v: 1 });
-    cache.set("prompts/get", "c1", { name: "p" }, { v: 2 });
-    cache.set("resources/read", "c2", { uri: "a" }, { v: 3 });
+  test("shouldCache=false returns the value but does not store it", async () => {
+    const { cache } = newCache();
+    let calls = 0;
+    const fetchLive = async () => ({ isError: true, calls: ++calls });
+    const shouldCache = (v: unknown) =>
+      (v as { isError?: boolean }).isError !== true;
 
-    cache.invalidate("c1");
-
-    expect(cache.get("resources/read", "c1", { uri: "a" })).toBeNull();
-    expect(cache.get("prompts/get", "c1", { name: "p" })).toBeNull();
-    expect(cache.get("resources/read", "c2", { uri: "a" })).toEqual({ v: 3 });
+    const r1 = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+      shouldCache,
+    });
+    const r2 = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+      shouldCache,
+    });
+    expect(r1).toEqual({ isError: true, calls: 1 });
+    expect(r2).toEqual({ isError: true, calls: 2 }); // not cached
+    expect(calls).toBe(2);
   });
 
-  it("does not cache oversized results", () => {
-    const cache = new InMemoryMcpReadCache();
-    const params = { uri: "file://big" };
-    const big = { blob: "x".repeat(3 * 1024 * 1024) }; // > 2 MiB cap
-    cache.set("resources/read", "c1", params, big);
-    expect(cache.get("resources/read", "c1", params)).toBeNull();
+  test("does not cache oversized results", async () => {
+    const { cache } = newCache({ maxValueBytes: 64 });
+    let calls = 0;
+    const fetchLive = async () => ({ blob: "x".repeat(1000), calls: ++calls });
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: { uri: "big" },
+      fetchLive,
+    });
+    const r = await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: { uri: "big" },
+      fetchLive,
+    });
+    expect(calls).toBe(2); // never stored → refetched
+    expect((r as { calls: number }).calls).toBe(2);
+  });
+
+  test("evicts the least-recently-used entry past capacity", async () => {
+    const { cache } = newCache({ maxEntries: 2 });
+    // Count live fetches per key; a hit (bump) does not fetch, an evicted key
+    // refetches. Asserting on counts avoids perturbing LRU order with reads.
+    const counts: Record<string, number> = {};
+    const read = (uri: string) =>
+      cache.fetch({
+        type: "resources/read",
+        connectionId: CONN,
+        scope: ORG,
+        params: { uri },
+        fetchLive: async () => {
+          counts[uri] = (counts[uri] ?? 0) + 1;
+          return { uri };
+        },
+      });
+
+    await read("a"); // miss → {a}
+    await read("b"); // miss → {a,b}
+    await read("a"); // HIT (bump a) → {b,a}; no fetch
+    await read("c"); // miss → evicts LRU "b" → {a,c}
+    await read("b"); // miss again (was evicted) → refetch
+
+    // "a" fetched once (the second read was a hit), "b" twice (evicted by "c").
+    expect(counts).toEqual({ a: 1, b: 2, c: 1 });
+  });
+
+  test("evicts by total-byte budget even under the entry-count cap", async () => {
+    // ~102-byte values; budget of 250 holds two, so the third evicts the LRU
+    // even though the entry-count cap (1000) is nowhere near hit.
+    const { cache } = newCache({ maxEntries: 1000, maxTotalBytes: 250 });
+    const counts: Record<string, number> = {};
+    const read = (uri: string) =>
+      cache.fetch({
+        type: "resources/read",
+        connectionId: CONN,
+        scope: ORG,
+        params: { uri },
+        fetchLive: async () => {
+          counts[uri] = (counts[uri] ?? 0) + 1;
+          return "x".repeat(100);
+        },
+      });
+
+    await read("a"); // {a}
+    await read("b"); // {a,b} ~204b
+    await read("c"); // 306b > 250 → evict LRU "a" → {b,c}
+    await read("a"); // evicted by bytes → refetch
+
+    expect(counts).toEqual({ a: 2, b: 1, c: 1 });
+  });
+
+  test("invalidate drops only the target connection's entries", async () => {
+    const { cache } = newCache();
+    let calls = 0;
+    const fetchLive = async () => ({ calls: ++calls });
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: { uri: "a" },
+      fetchLive,
+    });
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: "conn_b",
+      scope: ORG,
+      params: { uri: "a" },
+      fetchLive,
+    });
+
+    cache.invalidate(CONN);
+
+    // conn_a refetches, conn_b still cached.
+    expect(
+      await cache.fetch({
+        type: "resources/read",
+        connectionId: CONN,
+        scope: ORG,
+        params: { uri: "a" },
+        fetchLive,
+      }),
+    ).toEqual({ calls: 3 });
+    expect(
+      await cache.fetch({
+        type: "resources/read",
+        connectionId: "conn_b",
+        scope: ORG,
+        params: { uri: "a" },
+        fetchLive,
+      }),
+    ).toEqual({ calls: 2 });
+  });
+
+  test("config is per-type: one type can be stale while another is fresh", async () => {
+    let now = 1_000;
+    const cache = new InMemoryMcpReadCache(
+      {
+        "tools/call": {
+          revalidateAfterMs: 10_000,
+          maxStaleMs: 300_000,
+          maxValueBytes: 1024,
+        },
+        "resources/read": {
+          revalidateAfterMs: 100_000,
+          maxStaleMs: 300_000,
+          maxValueBytes: 1024,
+        },
+        "prompts/get": {
+          revalidateAfterMs: 100_000,
+          maxStaleMs: 300_000,
+          maxValueBytes: 1024,
+        },
+      },
+      2000,
+      () => now,
+    );
+    const live = async () => ({ ok: true });
+    await cache.fetch({
+      type: "tools/call",
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive: live,
+    });
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive: live,
+    });
+
+    now += 50_000; // past tools/call revalidate (10s), before resources/read (100s)
+
+    let toolBg = false;
+    await cache.fetch({
+      type: "tools/call",
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive: live,
+      onRevalidation: () => {
+        toolBg = true;
+      },
+    });
+    let resBg = false;
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive: live,
+      onRevalidation: () => {
+        resBg = true;
+      },
+    });
+
+    expect(toolBg).toBe(true); // stale → revalidated
+    expect(resBg).toBe(false); // still fresh → not revalidated
   });
 });

--- a/apps/mesh/src/mcp-clients/mcp-read-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-read-cache.ts
@@ -48,25 +48,26 @@ interface TypeConfig {
   maxValueBytes: number;
 }
 
-const MIB = 1024 * 1024;
+const KiB = 1024 as const;
+const MiB = KiB * KiB;
 
 /** Per-method tuning. Content reads are slow-changing and can be large; tool
  * results change faster, so refresh sooner and cap their size tighter. */
-export const DEFAULT_READ_CACHE_CONFIG: Record<McpReadType, TypeConfig> = {
+const DEFAULT_READ_CACHE_CONFIG: Record<McpReadType, TypeConfig> = {
   "tools/call": {
     revalidateAfterMs: 30_000,
     maxStaleMs: 5 * 60_000,
-    maxValueBytes: 512 * 1024,
+    maxValueBytes: 512 * KiB,
   },
   "resources/read": {
     revalidateAfterMs: 60_000,
     maxStaleMs: 5 * 60_000,
-    maxValueBytes: 5 * MIB,
+    maxValueBytes: 4 * MiB,
   },
   "prompts/get": {
     revalidateAfterMs: 60_000,
     maxStaleMs: 5 * 60_000,
-    maxValueBytes: 2 * MIB,
+    maxValueBytes: 512 * KiB,
   },
 };
 
@@ -74,7 +75,7 @@ const READ_CACHE_MAX_ENTRIES = 2000;
 // Hard ceiling on aggregate cached bytes (per pod). With multi-MiB entries the
 // entry-count cap alone isn't enough — evict LRU until under this too, so the
 // cache can't grow into the heap-pressure territory that OOM'd pods before.
-const READ_CACHE_MAX_TOTAL_BYTES = 256 * MIB;
+const READ_CACHE_MAX_TOTAL_BYTES = 256 * MiB;
 
 // Opt-in tracing: `MCP_CACHE_DEBUG=1` logs every fetch outcome + store skip so
 // we can see hit/miss/stale and oversize rejections live. Temporary diagnostic.

--- a/apps/mesh/src/mcp-clients/mcp-read-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-read-cache.ts
@@ -1,37 +1,90 @@
 /**
- * MCP Read Cache
+ * MCP Read Cache (stale-while-revalidate)
  *
- * Per-pod in-memory TTL+LRU cache for read-only MCP content methods that take
- * parameters: `resources/read` and `prompts/get`. The list cache
- * (mcp-list-cache.ts, NATS KV) covers tools/resources/prompts *lists*; this
- * covers the *content* reads those lists point at.
+ * Per-pod TTL+LRU cache for the results of READ-ONLY MCP methods that take
+ * parameters: `tools/call` (read-only tools), `resources/read`, `prompts/get`.
+ * The list cache (mcp-list-cache, NATS KV) covers tool/resource/prompt *lists*;
+ * this covers the per-call *results* those lists point at.
  *
- * Scope: keyed by (connectionId, method, params) only — NOT by principal. This
- * is a deliberate choice (shared across org members) and assumes a connection's
- * read responses are the same for every member. It would leak content between
- * users if an upstream personalizes `resources/read` / `prompts/get` per caller.
- * Invalidated on connection update/delete.
+ * Semantics: stale-while-revalidate. A hit returns immediately; once older than
+ * the type's `revalidateAfterMs`, a single-flight background revalidation
+ * refreshes it (a stampede of concurrent callers triggers at most one upstream
+ * call). Past `maxStaleMs` a hit is treated as a miss and the caller blocks on a
+ * live fetch.
+ *
+ * Scope (two tiers):
+ *  - "org" (default): the key omits the principal, so the result is shared
+ *    across every org member. This assumes the result does NOT depend on the
+ *    caller — only valid for upstreams that ignore the per-user identity
+ *    (`x-mesh-token`).
+ *  - "user": the key includes the principal, so a result is never shared across
+ *    users. Safe for any read-only operation.
+ *
+ * Caller invariants (lazy-client): only read-only operations reach here; tool
+ * error results (`isError`) are never stored (via `shouldCache`); the
+ * org-ownership check precedes this cache. Per-pod, so a connection change
+ * invalidates it across replicas via a NATS broadcast (mcp-cache-invalidation);
+ * TTL is the worst-case floor if a broadcast is lost.
  */
 
 import { meter } from "../observability";
 
 const cacheCounter = meter.createCounter("mcp_read_cache.fetches", {
-  description: "MCP read cache fetch outcomes (hit, miss)",
+  description: "MCP read cache outcomes (hit, stale, miss, error)",
   unit: "{fetches}",
 });
 
-/** Long TTL — read content is treated as slow-changing (see module note). */
-const READ_CACHE_TTL_MS = 5 * 60_000;
-/** LRU cap to bound memory; oldest entries evicted first. */
-const READ_CACHE_MAX_ENTRIES = 1000;
-/** Skip caching results larger than this (avoid pinning huge file blobs). */
-const READ_CACHE_MAX_VALUE_BYTES = 2 * 1024 * 1024; // 2 MiB
+export type McpReadType = "tools/call" | "resources/read" | "prompts/get";
 
-export type McpReadType = "resources/read" | "prompts/get";
+/** Cache scope: org-shared (default) or isolated per principal. */
+export type ReadCacheScope = { kind: "org" } | { kind: "user"; userId: string };
 
-interface CacheEntry {
-  value: unknown;
-  expiresAt: number;
+interface TypeConfig {
+  /** Serve a hit immediately; revalidate in the background past this age. */
+  revalidateAfterMs: number;
+  /** Past this age a hit is a miss — block on a live fetch instead of serving. */
+  maxStaleMs: number;
+  /** Skip caching results larger than this (avoid pinning huge payloads). */
+  maxValueBytes: number;
+}
+
+const MIB = 1024 * 1024;
+
+/** Per-method tuning. Content reads are slow-changing and can be large; tool
+ * results change faster, so refresh sooner and cap their size tighter. */
+export const DEFAULT_READ_CACHE_CONFIG: Record<McpReadType, TypeConfig> = {
+  "tools/call": {
+    revalidateAfterMs: 30_000,
+    maxStaleMs: 5 * 60_000,
+    maxValueBytes: 512 * 1024,
+  },
+  "resources/read": {
+    revalidateAfterMs: 60_000,
+    maxStaleMs: 5 * 60_000,
+    maxValueBytes: 5 * MIB,
+  },
+  "prompts/get": {
+    revalidateAfterMs: 60_000,
+    maxStaleMs: 5 * 60_000,
+    maxValueBytes: 2 * MIB,
+  },
+};
+
+const READ_CACHE_MAX_ENTRIES = 2000;
+// Hard ceiling on aggregate cached bytes (per pod). With multi-MiB entries the
+// entry-count cap alone isn't enough — evict LRU until under this too, so the
+// cache can't grow into the heap-pressure territory that OOM'd pods before.
+const READ_CACHE_MAX_TOTAL_BYTES = 256 * MIB;
+
+// Opt-in tracing: `MCP_CACHE_DEBUG=1` logs every fetch outcome + store skip so
+// we can see hit/miss/stale and oversize rejections live. Temporary diagnostic.
+const DEBUG = typeof process !== "undefined" && !!process.env?.MCP_CACHE_DEBUG;
+function debug(...args: unknown[]): void {
+  if (DEBUG) console.log("[mcp-read-cache]", ...args);
+}
+
+function scopeKey(scope: ReadCacheScope): string {
+  return scope.kind === "org" ? "org" : `u:${scope.userId}`;
 }
 
 /** Deterministic stringify (sorted keys) so equivalent params hash identically. */
@@ -53,74 +106,166 @@ function stableStringify(value: unknown): string {
     .join(",")}}`;
 }
 
+interface CacheEntry {
+  value: unknown;
+  storedAt: number;
+  bytes: number;
+}
+
 export class InMemoryMcpReadCache {
   // Map preserves insertion order — first key is the LRU eviction candidate.
   private readonly store = new Map<string, CacheEntry>();
+  // Keys with an in-flight background revalidation (single-flight guard).
+  private readonly revalidating = new Set<string>();
+  // Running sum of cached entry bytes, kept in lockstep with the store.
+  private totalBytes = 0;
 
   constructor(
-    private readonly ttlMs: number = READ_CACHE_TTL_MS,
+    private readonly config: Record<
+      McpReadType,
+      TypeConfig
+    > = DEFAULT_READ_CACHE_CONFIG,
     private readonly maxEntries: number = READ_CACHE_MAX_ENTRIES,
+    // Injectable clock for deterministic tests; defaults to wall time.
+    private readonly now: () => number = () => Date.now(),
+    private readonly maxTotalBytes: number = READ_CACHE_MAX_TOTAL_BYTES,
   ) {}
+
+  /** Delete a key and keep the byte accounting in sync. */
+  private deleteKey(key: string): void {
+    const e = this.store.get(key);
+    if (e) {
+      this.store.delete(key);
+      this.totalBytes -= e.bytes;
+    }
+  }
 
   private key(
     type: McpReadType,
     connectionId: string,
+    scope: ReadCacheScope,
     params: unknown,
   ): string {
-    return `${connectionId}:${type}:${stableStringify(params)}`;
+    return `${connectionId}:${scopeKey(scope)}:${type}:${stableStringify(
+      params,
+    )}`;
   }
 
-  get(
-    type: McpReadType,
-    connectionId: string,
-    params: unknown,
-  ): unknown | null {
-    const key = this.key(type, connectionId, params);
+  private storeSet(
+    key: string,
+    value: unknown,
+    now: number,
+    maxValueBytes: number,
+  ): void {
+    // Skip oversized results so a single large payload can't pin memory.
+    let bytes: number;
+    try {
+      bytes = JSON.stringify(value).length;
+    } catch {
+      debug("SKIP non-serializable", key);
+      return; // non-serializable — don't cache
+    }
+    if (bytes > maxValueBytes) {
+      debug("SKIP oversize", key, `${bytes}b > cap ${maxValueBytes}b`);
+      return;
+    }
+    // Drop any existing entry's bytes before re-inserting.
+    this.deleteKey(key);
+    // Evict LRU (oldest-first) until there's room by BOTH count and bytes.
+    while (
+      this.store.size > 0 &&
+      (this.store.size >= this.maxEntries ||
+        this.totalBytes + bytes > this.maxTotalBytes)
+    ) {
+      const oldest = this.store.keys().next().value;
+      if (oldest === undefined) break;
+      this.deleteKey(oldest);
+    }
+    this.store.set(key, { value, storedAt: now, bytes });
+    this.totalBytes += bytes;
+  }
+
+  /**
+   * Stale-while-revalidate fetch for a read-only MCP method result.
+   *
+   * @param fetchLive Performs the live upstream call. MUST reject (not return)
+   *   on error.
+   * @param shouldCache Decide whether a freshly fetched value may be stored.
+   *   Returning false still returns the value but skips the cache — used to keep
+   *   `isError` tool results out of the cache. Defaults to caching everything.
+   * @param onRevalidation Receives the background revalidation promise so the
+   *   request lifecycle can await it (e.g. `ctx.pendingRevalidations`).
+   */
+  async fetch(params: {
+    type: McpReadType;
+    connectionId: string;
+    scope: ReadCacheScope;
+    params: unknown;
+    fetchLive: () => Promise<unknown>;
+    shouldCache?: (value: unknown) => boolean;
+    onRevalidation?: (promise: Promise<void>) => void;
+  }): Promise<unknown> {
+    const {
+      type,
+      connectionId,
+      scope,
+      params: callParams,
+      fetchLive,
+      shouldCache,
+      onRevalidation,
+    } = params;
+    const cfg = this.config[type];
+    const key = this.key(type, connectionId, scope, callParams);
+    const now = this.now();
     const entry = this.store.get(key);
-    if (!entry) {
+    const age = entry ? now - entry.storedAt : Infinity;
+
+    // Miss, or stale past the hard limit: block on a live fetch.
+    if (!entry || age > cfg.maxStaleMs) {
       cacheCounter.add(1, { type, outcome: "miss" });
-      return null;
+      debug(entry ? "EXPIRED" : "MISS", key);
+      const value = await fetchLive();
+      if (shouldCache?.(value) ?? true) {
+        this.storeSet(key, value, this.now(), cfg.maxValueBytes);
+      } else {
+        debug("NOT-CACHED (shouldCache=false)", key);
+      }
+      return value;
     }
-    if (entry.expiresAt <= Date.now()) {
-      this.store.delete(key);
-      cacheCounter.add(1, { type, outcome: "miss" });
-      return null;
-    }
-    // LRU bump: re-insert to move to the most-recent position.
+
+    // LRU bump.
     this.store.delete(key);
     this.store.set(key, entry);
-    cacheCounter.add(1, { type, outcome: "hit" });
+
+    if (age > cfg.revalidateAfterMs && !this.revalidating.has(key)) {
+      cacheCounter.add(1, { type, outcome: "stale" });
+      debug("STALE → serve + revalidate", key, `age=${age}ms`);
+      this.revalidating.add(key);
+      const revalidation = fetchLive()
+        .then((value) => {
+          if (shouldCache?.(value) ?? true) {
+            this.storeSet(key, value, this.now(), cfg.maxValueBytes);
+          }
+        })
+        .catch(() => {
+          // Best-effort: keep serving the existing entry until maxStaleMs.
+          cacheCounter.add(1, { type, outcome: "error" });
+        })
+        .finally(() => this.revalidating.delete(key));
+      onRevalidation?.(revalidation);
+    } else {
+      cacheCounter.add(1, { type, outcome: "hit" });
+      debug("HIT", key, `age=${age}ms`);
+    }
+
     return entry.value;
   }
 
-  set(
-    type: McpReadType,
-    connectionId: string,
-    params: unknown,
-    value: unknown,
-  ): void {
-    // Skip oversized results so a single large resource can't pin memory.
-    try {
-      if (JSON.stringify(value).length > READ_CACHE_MAX_VALUE_BYTES) return;
-    } catch {
-      return; // non-serializable — don't cache
-    }
-
-    const key = this.key(type, connectionId, params);
-    if (this.store.has(key)) {
-      this.store.delete(key);
-    } else if (this.store.size >= this.maxEntries) {
-      const oldest = this.store.keys().next().value;
-      if (oldest !== undefined) this.store.delete(oldest);
-    }
-    this.store.set(key, { value, expiresAt: Date.now() + this.ttlMs });
-  }
-
-  /** Drop every cached read for a connection (config/auth may have changed). */
+  /** Drop every cached result for a connection (config/auth may have changed). */
   invalidate(connectionId: string): void {
-    const prefix = `${connectionId}:`; //
-    for (const key of this.store.keys()) {
-      if (key.startsWith(prefix)) this.store.delete(key);
+    const prefix = `${connectionId}:`;
+    for (const key of [...this.store.keys()]) {
+      if (key.startsWith(prefix)) this.deleteKey(key);
     }
   }
 }

--- a/apps/mesh/src/tools/connection/delete.ts
+++ b/apps/mesh/src/tools/connection/delete.ts
@@ -17,7 +17,7 @@ import {
   requireOrganization,
 } from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
-import { getMcpReadCache } from "../../mcp-clients/mcp-read-cache";
+import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
 import { ConnectionEntitySchema } from "./schema";
 
 const ConnectionDeleteInputSchema = CollectionDeleteInputSchema.extend({
@@ -113,8 +113,9 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
     getMcpListCache()
       ?.invalidate(input.id)
       .catch(() => {});
-    // Drop cached read content for this connection
-    getMcpReadCache().invalidate(input.id);
+    // Drop cached read content and tool results for this connection across ALL
+    // replicas (per-pod caches → NATS broadcast).
+    invalidateConnectionCaches(input.id);
 
     const userId = getUserId(ctx);
     if (userId) {

--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -20,7 +20,7 @@ import {
   requireOrganization,
 } from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
-import { getMcpReadCache } from "../../mcp-clients/mcp-read-cache";
+import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
 import { fetchToolsFromMCP } from "./fetch-tools";
 import { prop } from "./json-path";
 import {
@@ -292,9 +292,10 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
         ?.set("tools", id, tools as Tool[])
         .catch(() => {});
     }
-    // Config/auth/url may have changed — drop cached read content so stale
-    // (possibly long-TTL) responses aren't served against the new config.
-    getMcpReadCache().invalidate(id);
+    // Config/auth/url may have changed — drop cached read content and tool
+    // results across ALL replicas (per-pod caches → NATS broadcast) so stale
+    // (possibly now-unauthorized) responses aren't served against the new config.
+    invalidateConnectionCaches(id);
 
     // Invoke ON_MCP_CONFIGURATION callback if configuration was updated
     // Ignore errors but await for the response before responding

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -7,7 +7,6 @@
  * Plugin tools are collected at startup and combined with core tools.
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
 import type { ToolAnnotations } from "@/core/define-tool";
 import { StudioContext } from "@/core/studio-context";
 import {
@@ -36,6 +35,8 @@ import * as SecretsTools from "./secrets";
 import * as FileConfigTools from "./file-configs";
 import { ORG_FS_PUBLIC_SETS_SYNC } from "./org-fs/sync-public-sets";
 import { getPrompts, getResources } from "./guides";
+import { getToolRegistration } from "./management-registration";
+export { managementContextStore } from "./management-registration";
 import * as ObjectStorageTools from "./object-storage";
 import * as RegistryTools from "./registry/index";
 import * as SandboxTools from "./sandbox";
@@ -225,89 +226,6 @@ export type MCPMeshTools = typeof ALL_TOOLS;
 
 // Derive tool name type from ALL_TOOLS
 export type ToolNameFromTools = (typeof ALL_TOOLS)[number]["name"];
-
-/**
- * Per-request StudioContext for the management server's tool handlers.
- *
- * The serving routes build a fresh `McpServer` per request, but the tool
- * registrations below are built once and shared across every server: the
- * handler reads its `ctx` from this store at call time instead of closing over
- * it. A request runs its handler inside `managementContextStore.run(ctx, ...)`.
- * This keeps a server that survives `close()` (the production leak) from
- * pinning that request's ctx graph — the only heavy per-request state a tool
- * handler used to capture.
- */
-export const managementContextStore = new AsyncLocalStorage<StudioContext>();
-
-/**
- * Cache of per-tool MCP registrations (config + ctx-free handler), keyed by the
- * static tool object. Built lazily on first use and reused for the life of the
- * process, so the static tool set is never re-derived per request — only the
- * tiny `registerTool` map insertion happens on each `/mcp/self` build.
- */
-const toolRegistrationCache = new Map<
-  CombinedTool,
-  ReturnType<typeof buildToolRegistration>
->();
-
-function buildToolRegistration(tool: CombinedTool) {
-  const inputSchema =
-    tool.inputSchema &&
-    typeof tool.inputSchema === "object" &&
-    "shape" in tool.inputSchema
-      ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
-      : z.object({});
-  const outputSchema =
-    tool.outputSchema &&
-    typeof tool.outputSchema === "object" &&
-    "shape" in tool.outputSchema
-      ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
-      : undefined;
-
-  return {
-    config: {
-      description: tool.description ?? "",
-      inputSchema,
-      outputSchema,
-      annotations: tool.annotations,
-      _meta: tool._meta,
-    },
-    handler: async (args: unknown) => {
-      const ctx = managementContextStore.getStore();
-      if (!ctx) {
-        throw new Error(
-          `[managementMCP] tool ${tool.name} invoked outside a request context`,
-        );
-      }
-      ctx.access.setToolName(tool.name);
-      try {
-        const result = await tool.execute(args, ctx);
-        const modelText = tool.modelSummary
-          ? tool.modelSummary(result)
-          : JSON.stringify(result);
-        return {
-          content: [{ type: "text" as const, text: modelText }],
-          structuredContent: result as { [x: string]: unknown },
-        };
-      } catch (error) {
-        const err = error as Error;
-        return {
-          content: [{ type: "text" as const, text: `Error: ${err.message}` }],
-          isError: true,
-        };
-      }
-    },
-  };
-}
-
-function getToolRegistration(tool: CombinedTool) {
-  let registration = toolRegistrationCache.get(tool);
-  if (!registration) {
-    registration = buildToolRegistration(tool);
-    toolRegistrationCache.set(tool, registration);
-  }
-  return registration;
-}
 
 export const managementMCP = async (ctx: StudioContext) => {
   // Get enabled plugins for this organization to filter plugin tools

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -7,7 +7,6 @@
  * Plugin tools are collected at startup and combined with core tools.
  */
 
-import { AsyncLocalStorage } from "node:async_hooks";
 import type { ToolAnnotations } from "@/core/define-tool";
 import { StudioContext } from "@/core/studio-context";
 import {
@@ -227,89 +226,6 @@ export type MCPMeshTools = typeof ALL_TOOLS;
 
 // Derive tool name type from ALL_TOOLS
 export type ToolNameFromTools = (typeof ALL_TOOLS)[number]["name"];
-
-/**
- * Per-request StudioContext for the management server's tool handlers.
- *
- * The serving routes build a fresh `McpServer` per request, but the tool
- * registrations below are built once and shared across every server: the
- * handler reads its `ctx` from this store at call time instead of closing over
- * it. A request runs its handler inside `managementContextStore.run(ctx, ...)`.
- * This keeps a server that survives `close()` (the production leak) from
- * pinning that request's ctx graph — the only heavy per-request state a tool
- * handler used to capture.
- */
-export const managementContextStore = new AsyncLocalStorage<StudioContext>();
-
-/**
- * Cache of per-tool MCP registrations (config + ctx-free handler), keyed by the
- * static tool object. Built lazily on first use and reused for the life of the
- * process, so the static tool set is never re-derived per request — only the
- * tiny `registerTool` map insertion happens on each `/mcp/self` build.
- */
-const toolRegistrationCache = new Map<
-  CombinedTool,
-  ReturnType<typeof buildToolRegistration>
->();
-
-function buildToolRegistration(tool: CombinedTool) {
-  const inputSchema =
-    tool.inputSchema &&
-    typeof tool.inputSchema === "object" &&
-    "shape" in tool.inputSchema
-      ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
-      : z.object({});
-  const outputSchema =
-    tool.outputSchema &&
-    typeof tool.outputSchema === "object" &&
-    "shape" in tool.outputSchema
-      ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
-      : undefined;
-
-  return {
-    config: {
-      description: tool.description ?? "",
-      inputSchema,
-      outputSchema,
-      annotations: tool.annotations,
-      _meta: tool._meta,
-    },
-    handler: async (args: unknown) => {
-      const ctx = managementContextStore.getStore();
-      if (!ctx) {
-        throw new Error(
-          `[managementMCP] tool ${tool.name} invoked outside a request context`,
-        );
-      }
-      ctx.access.setToolName(tool.name);
-      try {
-        const result = await tool.execute(args, ctx);
-        const modelText = tool.modelSummary
-          ? tool.modelSummary(result)
-          : JSON.stringify(result);
-        return {
-          content: [{ type: "text" as const, text: modelText }],
-          structuredContent: result as { [x: string]: unknown },
-        };
-      } catch (error) {
-        const err = error as Error;
-        return {
-          content: [{ type: "text" as const, text: `Error: ${err.message}` }],
-          isError: true,
-        };
-      }
-    },
-  };
-}
-
-function getToolRegistration(tool: CombinedTool) {
-  let registration = toolRegistrationCache.get(tool);
-  if (!registration) {
-    registration = buildToolRegistration(tool);
-    toolRegistrationCache.set(tool, registration);
-  }
-  return registration;
-}
 
 export const managementMCP = async (ctx: StudioContext) => {
   // Get enabled plugins for this organization to filter plugin tools

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -7,6 +7,7 @@
  * Plugin tools are collected at startup and combined with core tools.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { ToolAnnotations } from "@/core/define-tool";
 import { StudioContext } from "@/core/studio-context";
 import {
@@ -226,6 +227,89 @@ export type MCPMeshTools = typeof ALL_TOOLS;
 
 // Derive tool name type from ALL_TOOLS
 export type ToolNameFromTools = (typeof ALL_TOOLS)[number]["name"];
+
+/**
+ * Per-request StudioContext for the management server's tool handlers.
+ *
+ * The serving routes build a fresh `McpServer` per request, but the tool
+ * registrations below are built once and shared across every server: the
+ * handler reads its `ctx` from this store at call time instead of closing over
+ * it. A request runs its handler inside `managementContextStore.run(ctx, ...)`.
+ * This keeps a server that survives `close()` (the production leak) from
+ * pinning that request's ctx graph — the only heavy per-request state a tool
+ * handler used to capture.
+ */
+export const managementContextStore = new AsyncLocalStorage<StudioContext>();
+
+/**
+ * Cache of per-tool MCP registrations (config + ctx-free handler), keyed by the
+ * static tool object. Built lazily on first use and reused for the life of the
+ * process, so the static tool set is never re-derived per request — only the
+ * tiny `registerTool` map insertion happens on each `/mcp/self` build.
+ */
+const toolRegistrationCache = new Map<
+  CombinedTool,
+  ReturnType<typeof buildToolRegistration>
+>();
+
+function buildToolRegistration(tool: CombinedTool) {
+  const inputSchema =
+    tool.inputSchema &&
+    typeof tool.inputSchema === "object" &&
+    "shape" in tool.inputSchema
+      ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
+      : z.object({});
+  const outputSchema =
+    tool.outputSchema &&
+    typeof tool.outputSchema === "object" &&
+    "shape" in tool.outputSchema
+      ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
+      : undefined;
+
+  return {
+    config: {
+      description: tool.description ?? "",
+      inputSchema,
+      outputSchema,
+      annotations: tool.annotations,
+      _meta: tool._meta,
+    },
+    handler: async (args: unknown) => {
+      const ctx = managementContextStore.getStore();
+      if (!ctx) {
+        throw new Error(
+          `[managementMCP] tool ${tool.name} invoked outside a request context`,
+        );
+      }
+      ctx.access.setToolName(tool.name);
+      try {
+        const result = await tool.execute(args, ctx);
+        const modelText = tool.modelSummary
+          ? tool.modelSummary(result)
+          : JSON.stringify(result);
+        return {
+          content: [{ type: "text" as const, text: modelText }],
+          structuredContent: result as { [x: string]: unknown },
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [{ type: "text" as const, text: `Error: ${err.message}` }],
+          isError: true,
+        };
+      }
+    },
+  };
+}
+
+function getToolRegistration(tool: CombinedTool) {
+  let registration = toolRegistrationCache.get(tool);
+  if (!registration) {
+    registration = buildToolRegistration(tool);
+    toolRegistrationCache.set(tool, registration);
+  }
+  return registration;
+}
 
 export const managementMCP = async (ctx: StudioContext) => {
   // Get enabled plugins for this organization to filter plugin tools

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -7,6 +7,7 @@
  * Plugin tools are collected at startup and combined with core tools.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { ToolAnnotations } from "@/core/define-tool";
 import { StudioContext } from "@/core/studio-context";
 import {
@@ -225,6 +226,89 @@ export type MCPMeshTools = typeof ALL_TOOLS;
 // Derive tool name type from ALL_TOOLS
 export type ToolNameFromTools = (typeof ALL_TOOLS)[number]["name"];
 
+/**
+ * Per-request StudioContext for the management server's tool handlers.
+ *
+ * The serving routes build a fresh `McpServer` per request, but the tool
+ * registrations below are built once and shared across every server: the
+ * handler reads its `ctx` from this store at call time instead of closing over
+ * it. A request runs its handler inside `managementContextStore.run(ctx, ...)`.
+ * This keeps a server that survives `close()` (the production leak) from
+ * pinning that request's ctx graph — the only heavy per-request state a tool
+ * handler used to capture.
+ */
+export const managementContextStore = new AsyncLocalStorage<StudioContext>();
+
+/**
+ * Cache of per-tool MCP registrations (config + ctx-free handler), keyed by the
+ * static tool object. Built lazily on first use and reused for the life of the
+ * process, so the static tool set is never re-derived per request — only the
+ * tiny `registerTool` map insertion happens on each `/mcp/self` build.
+ */
+const toolRegistrationCache = new Map<
+  CombinedTool,
+  ReturnType<typeof buildToolRegistration>
+>();
+
+function buildToolRegistration(tool: CombinedTool) {
+  const inputSchema =
+    tool.inputSchema &&
+    typeof tool.inputSchema === "object" &&
+    "shape" in tool.inputSchema
+      ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
+      : z.object({});
+  const outputSchema =
+    tool.outputSchema &&
+    typeof tool.outputSchema === "object" &&
+    "shape" in tool.outputSchema
+      ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
+      : undefined;
+
+  return {
+    config: {
+      description: tool.description ?? "",
+      inputSchema,
+      outputSchema,
+      annotations: tool.annotations,
+      _meta: tool._meta,
+    },
+    handler: async (args: unknown) => {
+      const ctx = managementContextStore.getStore();
+      if (!ctx) {
+        throw new Error(
+          `[managementMCP] tool ${tool.name} invoked outside a request context`,
+        );
+      }
+      ctx.access.setToolName(tool.name);
+      try {
+        const result = await tool.execute(args, ctx);
+        const modelText = tool.modelSummary
+          ? tool.modelSummary(result)
+          : JSON.stringify(result);
+        return {
+          content: [{ type: "text" as const, text: modelText }],
+          structuredContent: result as { [x: string]: unknown },
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [{ type: "text" as const, text: `Error: ${err.message}` }],
+          isError: true,
+        };
+      }
+    },
+  };
+}
+
+function getToolRegistration(tool: CombinedTool) {
+  let registration = toolRegistrationCache.get(tool);
+  if (!registration) {
+    registration = buildToolRegistration(tool);
+    toolRegistrationCache.set(tool, registration);
+  }
+  return registration;
+}
+
 export const managementMCP = async (ctx: StudioContext) => {
   // Get enabled plugins for this organization to filter plugin tools
   // Check both org settings (legacy) and all virtual MCPs
@@ -257,55 +341,12 @@ export const managementMCP = async (ctx: StudioContext) => {
     },
   );
 
-  // Register each tool with the server
+  // Register each tool from its shared, prebuilt registration (config carries
+  // the prebuilt Zod schemas; the handler reads ctx from the ALS store at call
+  // time rather than capturing it). Only the map insertion is per-request.
   for (const tool of filteredTools) {
-    const inputSchema =
-      tool.inputSchema &&
-      typeof tool.inputSchema === "object" &&
-      "shape" in tool.inputSchema
-        ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
-        : z.object({});
-    const outputSchema =
-      tool.outputSchema &&
-      typeof tool.outputSchema === "object" &&
-      "shape" in tool.outputSchema
-        ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
-        : undefined;
-
-    // Pass the prebuilt Zod schemas directly instead of their `.shape`. The SDK
-    // returns a schema instance as-is, but rebuilds a fresh `z.object(...)` from
-    // a raw shape on every registration — ~2 ZodObject graphs per tool, per
-    // request. With ~150 tools rebuilt per `/mcp/self` hit, that rebuild is the
-    // dominant CPU cost under concurrent load.
-    server.registerTool(
-      tool.name,
-      {
-        description: tool.description ?? "",
-        inputSchema,
-        outputSchema,
-        annotations: tool.annotations,
-        _meta: tool._meta,
-      },
-      async (args) => {
-        ctx.access.setToolName(tool.name);
-        try {
-          const result = await tool.execute(args, ctx);
-          const modelText = tool.modelSummary
-            ? tool.modelSummary(result)
-            : JSON.stringify(result);
-          return {
-            content: [{ type: "text" as const, text: modelText }],
-            structuredContent: result as { [x: string]: unknown },
-          };
-        } catch (error) {
-          const err = error as Error;
-          return {
-            content: [{ type: "text" as const, text: `Error: ${err.message}` }],
-            isError: true,
-          };
-        }
-      },
-    );
+    const { config, handler } = getToolRegistration(tool);
+    server.registerTool(tool.name, config, handler);
   }
 
   // Register action prompts

--- a/apps/mesh/src/tools/management-registration.test.ts
+++ b/apps/mesh/src/tools/management-registration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Multi-tenant isolation of the shared, ctx-free management tool handler.
+ *
+ * The registration (config + handler) is built ONCE and shared across every
+ * per-request server; the handler reads its StudioContext from an
+ * AsyncLocalStorage store rather than capturing it. This test proves that
+ * concurrent requests from different tenants each see ONLY their own ctx — both
+ * at handler entry and after the handler is suspended mid-execution while every
+ * other tenant's handler runs.
+ *
+ * Why a barrier: a test that just fires N requests and checks results can pass
+ * even with a broken (module-global) implementation, because the requests may
+ * never overlap at the dangerous moment. The barrier forces ALL N handlers to
+ * be suspended simultaneously, each having read its ctx, so a global-variable
+ * implementation would have its "current ctx" clobbered by later arrivals and
+ * every handler would read the last tenant's id — failing the assertion. With
+ * real ALS, each handler's context is restored on resume regardless of what ran
+ * in between.
+ *
+ * It drives the REAL SDK dispatch path (handleRequest -> microtask -> handler),
+ * since that microtask hop is exactly where async-context propagation could
+ * break.
+ */
+import { describe, expect, test } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import type { StudioContext } from "@/core/studio-context";
+import {
+  buildToolRegistration,
+  managementContextStore,
+  type RegistrableTool,
+} from "./management-registration";
+
+const N = 32;
+
+function fakeCtx(tenantId: string): StudioContext {
+  // The handler only touches `.access.setToolName`; the tool reads `.tenantId`.
+  return {
+    tenantId,
+    access: { setToolName: () => {} },
+  } as unknown as StudioContext;
+}
+
+function callToolRequest(id: number): Request {
+  return new Request("http://test.local/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      "mcp-protocol-version": "2025-11-25",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name: "BARRIER", arguments: {} },
+    }),
+  });
+}
+
+describe("management tool ctx isolation (AsyncLocalStorage)", () => {
+  test("concurrent tenants each read only their own ctx under forced interleaving", async () => {
+    // Barrier: release only once all N handlers have entered and read their
+    // ctx, guaranteeing every handler is suspended mid-execution at the same
+    // time (maximal interleaving).
+    let arrived = 0;
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    // Fail loudly instead of hanging if some handler never arrives.
+    const watchdog = setTimeout(() => releaseGate(), 10_000);
+
+    const barrierTool: RegistrableTool = {
+      name: "BARRIER",
+      description: "test barrier tool",
+      inputSchema: undefined,
+      outputSchema: undefined,
+      execute: async (_args, ctx) => {
+        // ctx the handler read from ALS at entry and forwarded here.
+        const entryId = (ctx as unknown as { tenantId: string }).tenantId;
+        arrived++;
+        if (arrived === N) releaseGate();
+        // Suspend while every other tenant's handler runs.
+        await gate;
+        // Re-read the store AFTER suspension: with a broken (global) impl this
+        // would now hold the last-arrived tenant's ctx for everyone.
+        const afterId = (
+          managementContextStore.getStore() as unknown as {
+            tenantId: string;
+          }
+        )?.tenantId;
+        return { entryId, afterId };
+      },
+    };
+
+    // Built ONCE, shared across all per-request servers — exactly like prod.
+    const { config, handler } = buildToolRegistration(barrierTool);
+
+    const results = await Promise.all(
+      Array.from({ length: N }, async (_unused, i) => {
+        const tenantId = `tenant-${i}`;
+        // Fresh server + transport per request (production shape), reusing the
+        // shared config + handler.
+        const server = new McpServer(
+          { name: "test", version: "1.0.0" },
+          { capabilities: { tools: {} } },
+        );
+        server.registerTool("BARRIER", config, handler);
+        const transport = new WebStandardStreamableHTTPServerTransport({
+          enableJsonResponse: true,
+        });
+        await server.connect(transport);
+
+        const response = await managementContextStore.run(
+          fakeCtx(tenantId),
+          () => transport.handleRequest(callToolRequest(i)),
+        );
+        const body = (await response.json()) as {
+          result?: {
+            structuredContent?: { entryId?: string; afterId?: string };
+          };
+          error?: unknown;
+        };
+        return { tenantId, body };
+      }),
+    );
+
+    clearTimeout(watchdog);
+
+    // The barrier must have actually fired — all N were in-flight together.
+    expect(arrived).toBe(N);
+
+    for (const { tenantId, body } of results) {
+      expect(body.error).toBeUndefined();
+      const sc = body.result?.structuredContent;
+      expect(sc).toBeDefined();
+      // ctx read at handler entry belongs to this tenant.
+      expect(sc?.entryId).toBe(tenantId);
+      // ctx read after suspension (while all siblings ran) still this tenant.
+      expect(sc?.afterId).toBe(tenantId);
+    }
+
+    // Every tenant id appears exactly once — no duplication / bleed.
+    const seen = results.map((r) => r.body.result?.structuredContent?.afterId);
+    expect(new Set(seen).size).toBe(N);
+  }, 20_000);
+
+  test("handler invoked outside a request context throws", async () => {
+    const tool: RegistrableTool = {
+      name: "NO_CTX",
+      description: "test",
+      inputSchema: undefined,
+      outputSchema: undefined,
+      execute: async () => ({ ok: true }),
+    };
+    const { handler } = buildToolRegistration(tool);
+    // Not wrapped in managementContextStore.run(...) — getStore() is undefined.
+    expect(handler({})).rejects.toThrow(/outside a request context/);
+  });
+});

--- a/apps/mesh/src/tools/management-registration.ts
+++ b/apps/mesh/src/tools/management-registration.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared, ctx-free registration for the management MCP server's tools.
+ *
+ * The serving routes build a fresh `McpServer` per request, but the per-tool
+ * registration (config + handler) is built once and shared across every
+ * server. The handler reads its `StudioContext` from `managementContextStore`
+ * at call time instead of capturing it, so a server that survives `close()`
+ * (the production leak) no longer pins a request's ctx graph — the only heavy
+ * per-request state a tool handler used to capture.
+ *
+ * A request must run inside `managementContextStore.run(ctx, ...)` for its tool
+ * handlers to find their ctx.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ToolAnnotations } from "@/core/define-tool";
+import type { StudioContext } from "@/core/studio-context";
+import { z } from "zod";
+
+export const managementContextStore = new AsyncLocalStorage<StudioContext>();
+
+/** The slice of a tool the shared handler actually needs. */
+export interface RegistrableTool {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  outputSchema: unknown;
+  annotations?: ToolAnnotations;
+  _meta?: Record<string, unknown>;
+  modelSummary?: (result: unknown) => string;
+  execute: (input: unknown, ctx: StudioContext) => Promise<unknown>;
+}
+
+export function buildToolRegistration(tool: RegistrableTool) {
+  const inputSchema =
+    tool.inputSchema &&
+    typeof tool.inputSchema === "object" &&
+    "shape" in tool.inputSchema
+      ? (tool.inputSchema as z.ZodObject<z.ZodRawShape>)
+      : z.object({});
+  const outputSchema =
+    tool.outputSchema &&
+    typeof tool.outputSchema === "object" &&
+    "shape" in tool.outputSchema
+      ? (tool.outputSchema as z.ZodObject<z.ZodRawShape>)
+      : undefined;
+
+  return {
+    config: {
+      description: tool.description ?? "",
+      inputSchema,
+      outputSchema,
+      annotations: tool.annotations,
+      _meta: tool._meta,
+    },
+    handler: async (args: unknown) => {
+      const ctx = managementContextStore.getStore();
+      if (!ctx) {
+        throw new Error(
+          `[managementMCP] tool ${tool.name} invoked outside a request context`,
+        );
+      }
+      ctx.access.setToolName(tool.name);
+      try {
+        const result = await tool.execute(args, ctx);
+        const modelText = tool.modelSummary
+          ? tool.modelSummary(result)
+          : JSON.stringify(result);
+        return {
+          content: [{ type: "text" as const, text: modelText }],
+          structuredContent: result as { [x: string]: unknown },
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [{ type: "text" as const, text: `Error: ${err.message}` }],
+          isError: true,
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Per-process cache of tool registrations keyed by the static tool object.
+ * Built lazily, reused for the life of the process, so the static tool set is
+ * never re-derived per request — only the tiny `registerTool` map insertion
+ * happens on each server build.
+ */
+const toolRegistrationCache = new Map<
+  RegistrableTool,
+  ReturnType<typeof buildToolRegistration>
+>();
+
+export function getToolRegistration(tool: RegistrableTool) {
+  let registration = toolRegistrationCache.get(tool);
+  if (!registration) {
+    registration = buildToolRegistration(tool);
+    toolRegistrationCache.set(tool, registration);
+  }
+  return registration;
+}

--- a/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
@@ -3,7 +3,14 @@ import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import type { ConnectionEntity } from "@decocms/mesh-sdk";
-import { Loading01, Plus, Settings02, Trash01 } from "@untitledui/icons";
+import {
+  Loading01,
+  Plus,
+  Power01,
+  Settings02,
+  SlashCircle01,
+  Trash01,
+} from "@untitledui/icons";
 import { Suspense } from "react";
 
 interface ConnectionInstancesPanelProps {
@@ -11,6 +18,10 @@ interface ConnectionInstancesPanelProps {
   onConfigure: (instance: ConnectionEntity) => void;
   onAuthenticate: (instance: ConnectionEntity) => void;
   onDelete: (instance: ConnectionEntity) => void;
+  onToggleStatus: (
+    instance: ConnectionEntity,
+    status: "active" | "inactive",
+  ) => void;
   onAdd: () => void;
   isAdding?: boolean;
 }
@@ -20,22 +31,28 @@ function InstanceItem({
   onConfigure,
   onAuthenticate,
   onDelete,
+  onToggleStatus,
 }: {
   instance: ConnectionEntity;
   onConfigure: (instance: ConnectionEntity) => void;
   onAuthenticate: (instance: ConnectionEntity) => void;
   onDelete: (instance: ConnectionEntity) => void;
+  onToggleStatus: (
+    instance: ConnectionEntity,
+    status: "active" | "inactive",
+  ) => void;
 }) {
   const authStatus = useMCPAuthStatus({ connectionId: instance.id });
   const isVirtual = instance.connection_type === "VIRTUAL";
   const needsAuth =
     !isVirtual && authStatus.supportsOAuth && !authStatus.isAuthenticated;
+  const isDisabled = instance.status !== "active";
 
   return (
     <div
       className={cn(
         "flex items-center gap-3 rounded-lg border px-4 py-2.5 transition-colors",
-        needsAuth
+        needsAuth || isDisabled
           ? "border-destructive/50 bg-destructive/5"
           : "border-transparent",
       )}
@@ -48,11 +65,15 @@ function InstanceItem({
       />
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium truncate">{instance.title}</p>
-        {needsAuth && (
+        {needsAuth ? (
           <span className="text-xs text-destructive font-medium">
             Needs authorization
           </span>
-        )}
+        ) : isDisabled ? (
+          <span className="text-xs text-destructive font-medium">
+            {instance.status === "error" ? "Disabled (error)" : "Disabled"}
+          </span>
+        ) : null}
       </div>
       <div className="flex items-center gap-1 shrink-0">
         {needsAuth && (
@@ -63,6 +84,27 @@ function InstanceItem({
             onClick={() => onAuthenticate(instance)}
           >
             Authorize
+          </Button>
+        )}
+        {isDisabled ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs gap-1.5"
+            onClick={() => onToggleStatus(instance, "active")}
+          >
+            <Power01 size={13} />
+            Enable
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground"
+            onClick={() => onToggleStatus(instance, "inactive")}
+            title="Disable"
+          >
+            <SlashCircle01 size={13} />
           </Button>
         )}
         <Button
@@ -126,6 +168,7 @@ export function ConnectionInstancesPanel({
   onConfigure,
   onAuthenticate,
   onDelete,
+  onToggleStatus,
   onAdd,
   isAdding,
 }: ConnectionInstancesPanelProps) {
@@ -167,6 +210,7 @@ export function ConnectionInstancesPanel({
               onConfigure={onConfigure}
               onAuthenticate={onAuthenticate}
               onDelete={onDelete}
+              onToggleStatus={onToggleStatus}
             />
           </Suspense>
         ))}

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -561,6 +561,21 @@ function ConnectionInspectorViewWithConnection({
                   onConfigure={(inst) => setConfigureInstance(inst)}
                   onAuthenticate={(inst) => handleAuthenticateForId(inst.id)}
                   onDelete={(inst) => deleteConnection.requestDelete(inst)}
+                  onToggleStatus={async (inst, status) => {
+                    try {
+                      await connectionActions.update.mutateAsync({
+                        id: inst.id,
+                        data: { status },
+                      });
+                      toast.success(
+                        status === "active"
+                          ? "Connection enabled"
+                          : "Connection disabled",
+                      );
+                    } catch {
+                      toast.error("Failed to update connection");
+                    }
+                  }}
                   isAdding={isAddingInstance}
                   onAdd={async () => {
                     setIsAddingInstance(true);

--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -220,6 +220,8 @@ function AgentUITile({
             <MCPAppRenderer
               resourceURI={tile.resourceUri}
               orgId={org.id}
+              orgSlug={org.slug}
+              connectionId={tile.connectionId}
               client={client}
               displayMode="fullscreen"
               minHeight={tile.minHeight ?? 200}

--- a/apps/mesh/src/web/hooks/use-delete-connection.ts
+++ b/apps/mesh/src/web/hooks/use-delete-connection.ts
@@ -1,5 +1,6 @@
 import {
   SELF_MCP_ALIAS_ID,
+  UI_RESOURCE_HTML_KEY,
   useMCPClient,
   useProjectContext,
   type ConnectionEntity,
@@ -7,6 +8,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
+import { clearHtmlResourceCacheForConnection } from "@/web/lib/html-resource-persist";
 
 export type DeleteConnectionState =
   | { mode: "idle" }
@@ -59,8 +61,18 @@ export function useDeleteConnection({
     });
   };
 
-  const handleSuccess = () => {
+  const evictUiResourceCache = (connectionId: string) => {
+    void clearHtmlResourceCacheForConnection(connectionId);
+    queryClient.invalidateQueries({
+      predicate: (query) =>
+        query.queryKey[1] === UI_RESOURCE_HTML_KEY &&
+        query.queryKey[3] === connectionId,
+    });
+  };
+
+  const handleSuccess = (connectionId: string) => {
     invalidateConnections();
+    evictUiResourceCache(connectionId);
     toast.success("Connection deleted successfully");
     setDeleteState({ mode: "idle" });
     onSuccess?.();
@@ -111,7 +123,7 @@ export function useDeleteConnection({
         return;
       }
 
-      handleSuccess();
+      handleSuccess(connection.id);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       toast.error(`Failed to delete connection: ${message}`);
@@ -135,7 +147,7 @@ export function useDeleteConnection({
         return;
       }
 
-      handleSuccess();
+      handleSuccess(id);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       toast.error(`Failed to delete connection: ${message}`);

--- a/apps/mesh/src/web/lib/html-resource-persist.ts
+++ b/apps/mesh/src/web/lib/html-resource-persist.ts
@@ -1,0 +1,195 @@
+/**
+ * IndexedDB persistence for MCP-app UI-resource HTML queries.
+ *
+ * UI-resource HTML is large (multi-MiB self-contained bundles), so it must NOT
+ * go through the localStorage bootstrap cache (query-persist.ts) — localStorage
+ * is ~5 MB and synchronous. This persists ONLY the `ui-resource-html` queries
+ * to IndexedDB (async, large quota), so they survive reloads / brief offline:
+ * on boot we restore them into the query cache (best-effort warm start), and on
+ * every successful read we write the latest HTML back.
+ *
+ * The GET endpoint already gives the browser HTTP cache (ETag + max-age), so
+ * this is the "instant cross-session / offline" layer on top of that.
+ */
+
+import type { QueryClient } from "@tanstack/react-query";
+import { UI_RESOURCE_HTML_KEY } from "@decocms/mesh-sdk";
+
+const DB_NAME = "mesh-ui-resources";
+const STORE = "html";
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const MAX_ENTRIES = 50; // bound the store; prune oldest beyond this on restore
+const MAX_VALUE_BYTES = 16 * 1024 * 1024; // mirror the server-side resources/read cap
+
+interface StoredHtml {
+  html: string;
+  updatedAt: number;
+  /** Build version, so a deploy invalidates stale cached HTML. */
+  buster: string;
+}
+
+function version(): string {
+  return typeof __MESH_VERSION__ === "string" ? __MESH_VERSION__ : "dev";
+}
+
+function isHtmlResourceKey(key: readonly unknown[]): boolean {
+  return key[0] === "mcp" && key[1] === UI_RESOURCE_HTML_KEY;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) {
+        req.result.createObjectStore(STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function tx(db: IDBDatabase, mode: IDBTransactionMode): IDBObjectStore {
+  return db.transaction(STORE, mode).objectStore(STORE);
+}
+
+function reqToPromise<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Restore persisted UI-resource HTML into the query cache before the app reads
+ * it (best-effort: IndexedDB is async, so a query that runs first just fetches —
+ * which is HTTP-cached anyway). Prunes expired / over-budget / stale-version
+ * entries. Safe to call once at startup.
+ */
+export async function restoreHtmlResourceCache(
+  queryClient: QueryClient,
+): Promise<void> {
+  if (typeof indexedDB === "undefined") return;
+  try {
+    const db = await openDb();
+    const store = tx(db, "readonly");
+    const keys = (await reqToPromise(store.getAllKeys())) as IDBValidKey[];
+    const values = (await reqToPromise(store.getAll())) as StoredHtml[];
+    const now = Date.now();
+    const ver = version();
+
+    // Pair + sort newest-first so over-budget pruning drops the oldest.
+    const entries = keys
+      .map((key, i) => ({ key, value: values[i] }))
+      .sort((a, b) => (b.value?.updatedAt ?? 0) - (a.value?.updatedAt ?? 0));
+
+    const stale: IDBValidKey[] = [];
+    let kept = 0;
+    for (const { key, value } of entries) {
+      const expired =
+        !value ||
+        value.buster !== ver ||
+        now - value.updatedAt > MAX_AGE_MS ||
+        kept >= MAX_ENTRIES;
+      if (expired) {
+        stale.push(key);
+        continue;
+      }
+      kept++;
+      try {
+        const queryKey = JSON.parse(String(key)) as unknown[];
+        if (queryClient.getQueryData(queryKey) === undefined) {
+          // Restore with the original timestamp so an entry older than the
+          // query's staleTime revalidates immediately on mount (instant render
+          // from IDB + background refresh) instead of being treated as fresh.
+          queryClient.setQueryData(queryKey, value.html, {
+            updatedAt: value.updatedAt,
+          });
+        }
+      } catch {
+        stale.push(key);
+      }
+    }
+
+    if (stale.length > 0) {
+      const wstore = tx(db, "readwrite");
+      for (const key of stale) wstore.delete(key);
+    }
+  } catch {
+    // IndexedDB unavailable / blocked / corrupt — non-fatal, fall back to fetch.
+  }
+}
+
+/**
+ * Subscribe to the query cache and write successful UI-resource HTML reads to
+ * IndexedDB. Returns the unsubscribe fn.
+ */
+export function persistHtmlResourceCache(queryClient: QueryClient): () => void {
+  if (typeof indexedDB === "undefined") return () => {};
+  const dbPromise = openDb().catch(() => null);
+
+  return queryClient.getQueryCache().subscribe((event) => {
+    const query = event.query;
+    if (!Array.isArray(query.queryKey) || !isHtmlResourceKey(query.queryKey)) {
+      return;
+    }
+    if (query.state.status !== "success") return;
+    const html = query.state.data;
+    if (typeof html !== "string" || html.length > MAX_VALUE_BYTES) return;
+
+    void dbPromise.then((db) => {
+      if (!db) return;
+      try {
+        tx(db, "readwrite").put(
+          {
+            html,
+            updatedAt: Date.now(),
+            buster: version(),
+          } satisfies StoredHtml,
+          JSON.stringify(query.queryKey),
+        );
+      } catch {
+        // best-effort
+      }
+    });
+  });
+}
+
+/** Drop all persisted UI-resource HTML (call on sign-out). */
+export function clearHtmlResourceCache(): void {
+  if (typeof indexedDB === "undefined") return;
+  void openDb()
+    .then((db) => tx(db, "readwrite").clear())
+    .catch(() => {});
+}
+
+/**
+ * Drop persisted HTML for a single connection. Call when a connection is
+ * updated/deleted so the editing client doesn't restore stale HTML on its next
+ * reload (other clients self-heal via the no-cache GET on their next read).
+ * Keys are `JSON.stringify(["mcp","ui-resource-html", orgSlug, connectionId, uri])`.
+ */
+export async function clearHtmlResourceCacheForConnection(
+  connectionId: string,
+): Promise<void> {
+  if (typeof indexedDB === "undefined") return;
+  try {
+    const db = await openDb();
+    const keys = (await reqToPromise(
+      tx(db, "readonly").getAllKeys(),
+    )) as IDBValidKey[];
+    const wstore = tx(db, "readwrite");
+    for (const key of keys) {
+      try {
+        const parsed = JSON.parse(String(key)) as unknown[];
+        if (parsed[1] === UI_RESOURCE_HTML_KEY && parsed[3] === connectionId) {
+          wstore.delete(key);
+        }
+      } catch {
+        // skip unparseable keys
+      }
+    }
+  } catch {
+    // non-fatal
+  }
+}

--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -13,6 +13,7 @@
  */
 
 import { type QueryClient, dehydrate, hydrate } from "@tanstack/react-query";
+import { clearHtmlResourceCache } from "./html-resource-persist";
 
 const STORAGE_KEY = "mesh:rq-cache";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
@@ -157,6 +158,8 @@ export function writeCachedOrg(
 
 /** Wipe all persisted caches. Call on sign-out so the next user starts clean. */
 export function clearPersistedQueryCache(): void {
+  // Drop the IndexedDB UI-resource HTML store too (org-scoped UI shells).
+  clearHtmlResourceCache();
   if (typeof window === "undefined") return;
   try {
     window.localStorage.removeItem(STORAGE_KEY);

--- a/apps/mesh/src/web/providers/providers.tsx
+++ b/apps/mesh/src/web/providers/providers.tsx
@@ -10,6 +10,10 @@ import {
   hydrateQueryClient,
   persistQueryClient,
 } from "@/web/lib/query-persist";
+import {
+  persistHtmlResourceCache,
+  restoreHtmlResourceCache,
+} from "@/web/lib/html-resource-persist";
 import { Toaster } from "sonner";
 
 const queryClient = new QueryClient({
@@ -31,6 +35,10 @@ const queryClient = new QueryClient({
 
 hydrateQueryClient(queryClient);
 persistQueryClient(queryClient);
+// Large UI-resource HTML goes to IndexedDB (not the localStorage cache above):
+// warm-start from it, then keep it written on successful reads.
+void restoreHtmlResourceCache(queryClient);
+persistHtmlResourceCache(queryClient);
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -97,6 +97,8 @@ import {
   Globe02,
   Loading01,
   Plus,
+  Power01,
+  SlashCircle01,
   Terminal,
   Trash01,
   XClose,
@@ -953,6 +955,21 @@ function ConnectionResults({
     exitSelectionMode();
   };
 
+  const handleToggleStatus = async (
+    id: string,
+    status: "active" | "inactive",
+  ) => {
+    try {
+      await actions.update.mutateAsync({ id, data: { status } });
+      invalidateConnections();
+      toast.success(
+        status === "active" ? "Connection enabled" : "Connection disabled",
+      );
+    } catch {
+      toast.error("Failed to update connection");
+    }
+  };
+
   const handleBulkToggleStatus = async (status: "active" | "inactive") => {
     const ids = [...selectedIds];
     track("connections_bulk_status_toggled", {
@@ -1192,6 +1209,34 @@ function ConnectionResults({
                                   Select
                                 </DropdownMenuItem>
                               )}
+                              {canManage &&
+                                (connection.status === "active" ? (
+                                  <DropdownMenuItem
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleToggleStatus(
+                                        connection.id,
+                                        "inactive",
+                                      );
+                                    }}
+                                  >
+                                    <SlashCircle01 size={16} />
+                                    Disable
+                                  </DropdownMenuItem>
+                                ) : (
+                                  <DropdownMenuItem
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleToggleStatus(
+                                        connection.id,
+                                        "active",
+                                      );
+                                    }}
+                                  >
+                                    <Power01 size={16} />
+                                    Enable
+                                  </DropdownMenuItem>
+                                ))}
                               {canManage && (
                                 <DropdownMenuItem
                                   variant="destructive"

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -76,6 +76,7 @@ function ConnectionRow({
   const updateAuth = useUpdateMonitorConnectionAuth();
   const { updateMutation } = useRegistryMutations();
   const { org } = useProjectContext();
+  const queryClient = useQueryClient();
   const connectionId = entry.mapping.connection_id;
   const authStatus = entry.mapping.auth_status;
   const title = entry.item?.title ?? entry.mapping.item_id;

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -2,9 +2,11 @@ import { useState } from "react";
 import {
   authenticateMcp,
   isConnectionAuthenticated,
+  UI_RESOURCE_HTML_KEY,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { clearHtmlResourceCacheForConnection } from "@/web/lib/html-resource-persist";
 import { Badge } from "@deco/ui/components/badge.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Card } from "@deco/ui/components/card.tsx";
@@ -242,6 +244,14 @@ function ConnectionRow({
       setIsReplacingToken(false);
       setTokenValue("");
       markAuthenticated();
+      // Auth changed → upstream may return different content; drop cached UI
+      // HTML for this connection (IDB + in-memory query) so it re-reads fresh.
+      void clearHtmlResourceCacheForConnection(connectionId);
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[1] === UI_RESOURCE_HTML_KEY &&
+          query.queryKey[3] === connectionId,
+      });
       await probeQuery.refetch();
     } catch (err) {
       toast.error(

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -76,6 +76,8 @@ import {
   Maximize01,
   Play,
   Plus,
+  Power01,
+  SlashCircle01,
   Stars01,
   Trash01,
   XClose,
@@ -263,6 +265,7 @@ function ConnectionItem({
         connectionDescription={connection.description}
         connectionIcon={connection.icon}
         connectionType={connection.connection_type}
+        connectionStatus={connection.status}
         slug={slug}
         orgSlug={org.slug}
         appName={connection.app_name}
@@ -406,6 +409,7 @@ function ConnectionItemWithAuth({
   connectionDescription,
   connectionIcon,
   connectionType,
+  connectionStatus,
   slug,
   orgSlug,
   appName,
@@ -421,6 +425,7 @@ function ConnectionItemWithAuth({
   connectionDescription?: string | null;
   connectionIcon?: string | null;
   connectionType: string;
+  connectionStatus: ConnectionEntity["status"];
   slug: string;
   orgSlug: string;
   appName?: string | null;
@@ -432,15 +437,33 @@ function ConnectionItemWithAuth({
   onNewInstance?: () => void;
 }) {
   const authStatus = useMCPAuthStatus({ connectionId: connection_id });
+  const connectionActions = useConnectionActions();
   const isVirtual = connectionType === "VIRTUAL";
   const needsAuth =
     !isVirtual && authStatus.supportsOAuth && !authStatus.isAuthenticated;
+  const isDisabled = connectionStatus !== "active";
+
+  const toggleStatus = async (status: "active" | "inactive") => {
+    try {
+      await connectionActions.update.mutateAsync({
+        id: connection_id,
+        data: { status },
+      });
+      toast.success(
+        status === "active" ? "Connection enabled" : "Connection disabled",
+      );
+    } catch {
+      toast.error("Failed to update connection");
+    }
+  };
 
   return (
     <div
       className={cn(
         "rounded-xl border overflow-hidden transition-colors",
-        needsAuth ? "border-destructive/50 bg-destructive/5" : "border-border",
+        needsAuth || isDisabled
+          ? "border-destructive/50 bg-destructive/5"
+          : "border-border",
       )}
     >
       {/* Body — clickable, navigates to connection detail */}
@@ -464,6 +487,10 @@ function ConnectionItemWithAuth({
             <span className="text-xs text-destructive font-medium">
               Needs authorization
             </span>
+          ) : isDisabled ? (
+            <span className="text-xs text-destructive font-medium">
+              {connectionStatus === "error" ? "Disabled (error)" : "Disabled"}
+            </span>
           ) : (
             connectionDescription && (
               <p className="text-xs text-muted-foreground truncate">
@@ -484,6 +511,20 @@ function ConnectionItemWithAuth({
             }}
           >
             Authorize
+          </Button>
+        ) : isDisabled ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs gap-1.5 shrink-0"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              toggleStatus("active");
+            }}
+          >
+            <Power01 size={13} />
+            Enable
           </Button>
         ) : (
           <Tooltip delayDuration={0}>
@@ -525,6 +566,22 @@ function ConnectionItemWithAuth({
             </TooltipTrigger>
             <TooltipContent side="bottom">Configure resources</TooltipContent>
           </Tooltip>
+          {!isDisabled && (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground"
+                  onClick={() => toggleStatus("inactive")}
+                  aria-label="Disable connection"
+                >
+                  <SlashCircle01 size={13} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Disable</TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip delayDuration={0}>
             <TooltipTrigger asChild>
               <Button

--- a/packages/mesh-sdk/src/hooks/index.ts
+++ b/packages/mesh-sdk/src/hooks/index.ts
@@ -53,9 +53,12 @@ export {
   useMCPResourcesList,
   useMCPResourcesListQuery,
   useMCPReadResource,
+  useUiResourceHtml,
+  UI_RESOURCE_HTML_KEY,
   type UseMcpResourcesListOptions,
   type UseMcpResourcesListQueryOptions,
   type UseMcpReadResourceOptions,
+  type UseUiResourceHtmlOptions,
 } from "./use-mcp-resources";
 
 // MCP prompts hooks and helpers

--- a/packages/mesh-sdk/src/hooks/use-mcp-resources.ts
+++ b/packages/mesh-sdk/src/hooks/use-mcp-resources.ts
@@ -136,3 +136,60 @@ export function useMCPReadResource({
     retry: false,
   });
 }
+
+/**
+ * Query-key discriminator (segment [1]) for cached UI-resource HTML. Exported
+ * so a persister can select only these entries — the HTML is large, so it goes
+ * to IndexedDB, never the localStorage bootstrap cache.
+ */
+export const UI_RESOURCE_HTML_KEY = "ui-resource-html" as const;
+
+export interface UseUiResourceHtmlOptions
+  extends Omit<UseSuspenseQueryOptions<string, Error>, "queryKey" | "queryFn"> {
+  /** Org slug (the `:org` path segment). */
+  orgSlug: string;
+  /** Connection id serving the resource. */
+  connectionId: string;
+  /** Resource URI (e.g. `ui://...`). */
+  uri: string;
+  /** Base mesh URL; defaults to the current origin. */
+  meshUrl?: string;
+}
+
+/**
+ * Read a connection's UI-resource HTML via the cacheable GET endpoint
+ * (`/api/:org/mcp/:connectionId/ui-resource`) instead of the JSON-RPC
+ * `resources/read` POST. The GET carries an ETag + `Cache-Control`, so the
+ * browser HTTP-caches the (often multi-MiB) HTML and revalidates with cheap
+ * 304s — and the response is already CSP-injected server-side, ready for an
+ * iframe `srcDoc`.
+ */
+export function useUiResourceHtml({
+  orgSlug,
+  connectionId,
+  uri,
+  meshUrl,
+  ...queryOptions
+}: UseUiResourceHtmlOptions): UseSuspenseQueryResult<string, Error> {
+  return useSuspenseQuery<string, Error>({
+    ...queryOptions,
+    queryKey: KEYS.mcpUiResourceHtml(orgSlug, connectionId, uri),
+    queryFn: async () => {
+      const base =
+        meshUrl ??
+        (typeof window !== "undefined" ? window.location.origin : "");
+      const url = `${base}/api/${encodeURIComponent(
+        orgSlug,
+      )}/mcp/${encodeURIComponent(
+        connectionId,
+      )}/ui-resource?uri=${encodeURIComponent(uri)}`;
+      const res = await fetch(url, { credentials: "include" });
+      if (!res.ok) {
+        throw new Error(`Failed to read UI resource (${res.status})`);
+      }
+      return res.text();
+    },
+    staleTime: queryOptions.staleTime ?? 30000,
+    retry: false,
+  });
+}

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -57,9 +57,12 @@ export {
   useMCPResourcesList,
   useMCPResourcesListQuery,
   useMCPReadResource,
+  useUiResourceHtml,
+  UI_RESOURCE_HTML_KEY,
   type UseMcpResourcesListOptions,
   type UseMcpResourcesListQueryOptions,
   type UseMcpReadResourceOptions,
+  type UseUiResourceHtmlOptions,
   // MCP prompts hooks and helpers
   listPrompts,
   getPrompt,

--- a/packages/mesh-sdk/src/lib/query-keys.ts
+++ b/packages/mesh-sdk/src/lib/query-keys.ts
@@ -66,6 +66,10 @@ export const KEYS = {
     ["mcp", "client", client, "prompts"] as const,
   mcpReadResource: (client: unknown, uri: string) =>
     ["mcp", "client", client, "resource", uri] as const,
+  // UI-resource HTML fetched via the cacheable GET endpoint. Keyed by
+  // (org, connection, uri) — NOT the client — so a persister can select it.
+  mcpUiResourceHtml: (orgSlug: string, connectionId: string, uri: string) =>
+    ["mcp", "ui-resource-html", orgSlug, connectionId, uri] as const,
   mcpGetPrompt: (client: unknown, name: string, argsKey: string) =>
     ["mcp", "client", client, "prompt", name, argsKey] as const,
   mcpToolCall: (client: unknown, toolName: string, argsKey: string) =>

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {

--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -214,6 +214,14 @@ interface KubeFetchInit {
    *                         (and optionally `force=true`) to `path`.
    */
   patchType?: "merge" | "strategic-merge" | "apply";
+  /**
+   * Long-lived streaming request (a K8s `watch`). Disables Bun's default
+   * per-request fetch timeout — otherwise Bun aborts the idle stream between
+   * events with "The operation timed out", forcing a needless reconnect every
+   * few minutes. Watch lifetime is bounded by the caller's `signal` and the
+   * API server's own watch timeout instead.
+   */
+  stream?: boolean;
 }
 
 /**
@@ -246,12 +254,13 @@ export async function kubeFetch(
   } else if (init.body !== undefined && !("content-type" in headers)) {
     headers["content-type"] = "application/json";
   }
-  const reqInit: RequestInit & { tls?: typeof auth.tls } = {
+  const reqInit: RequestInit & { tls?: typeof auth.tls; timeout?: boolean } = {
     method: init.method,
     headers,
     body: init.body === undefined ? undefined : JSON.stringify(init.body),
     signal: init.signal,
     tls: auth.tls,
+    ...(init.stream ? { timeout: false } : {}),
   };
   return fetch(`${auth.server}${init.path}`, reqInit as RequestInit);
 }
@@ -781,6 +790,7 @@ export function waitForSandboxReady(
         path,
         signal: controller.signal,
         headers: { accept: "application/json" },
+        stream: true,
       });
     } catch (err) {
       settleWith(() =>

--- a/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
@@ -748,6 +748,7 @@ async function runWatch<T>(opts: RunWatchOpts<T>): Promise<void> {
         path,
         signal,
         headers: { accept: "application/json" },
+        stream: true,
       });
       if (!resp.ok || !resp.body) {
         // Drain body before throwing so the connection can be reused.


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read-only MCP result caching with cross-replica invalidation and a cacheable UI-resource GET path to cut latency and bandwidth. Also adds in-memory permission checks for built‑in roles and moves management tool registration to a shared, context‑isolated flow for correctness under concurrency and lower CPU.

- **New Features**
  - Cache read‑only `tools/call`, `resources/read`, and `prompts/get` with stale‑while‑revalidate, single‑flight, size caps, and no error caching (org‑scoped by default).
  - Cross‑pod invalidation over NATS for read‑content and tool‑result caches; triggered on connection update/delete (and auth changes) so stale or unauthorized data isn’t served.
  - Cacheable UI‑resource endpoint: `GET /mcp/:connectionId/ui-resource?uri=…` returns CSP‑injected HTML with `ETag` and `Cache-Control`; `useUiResourceHtml` prefers this when `orgSlug` + `connectionId` are available and persists large HTML to IndexedDB; caches are cleared on connection delete/update/auth changes.
  - UI: Enable/disable connections from lists and details; disabled and needs‑auth states are surfaced.
  - Auth: Built‑in role (`user`/`admin`/`owner`) permission checks resolved in‑memory with parity tests; fewer Better Auth DB calls on browser requests.

- **Refactors**
  - Introduced `managementContextStore` (AsyncLocalStorage) and shared tool registration; `proxy` and `self` routes run inside this scope. Adds tests proving tenant isolation under concurrency.
  - `createLazyClient` consults tool `annotations.readOnlyHint` to cache read‑only results, bypasses VIRTUAL connections and custom result schemas, and pushes revalidations to the request lifecycle.
  - Read cache internals now have per‑type tuning, LRU with byte budget, optional user scope, and improved metrics; cross‑replica invalidation wired into app startup/shutdown.

<sup>Written for commit 2e36a1ef1164ac6010f989150e21e0a3fda6e072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

