### PR TITLE
feat(mcp): implement cross-replica cache invalidation and UI resource…

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -114,6 +114,10 @@ import {
   type McpListCache,
 } from "../mcp-clients/mcp-list-cache";
 import {
+  startMcpCacheInvalidation,
+  teardownMcpCacheInvalidation,
+} from "../mcp-clients/mcp-cache-invalidation";
+import {
   type ConnectionCircuitStore,
   JetStreamKVConnectionCircuitStore,
   NoopConnectionCircuitStore,
@@ -995,6 +999,8 @@ export async function createApp(options: CreateAppOptions = {}) {
       });
       // Subscribe to cross-replica key invalidations (idempotent).
       providerKeyCache.start();
+      // Subscribe to cross-replica MCP read/result cache invalidations.
+      startMcpCacheInvalidation(() => natsProvider!.getConnection());
       streamBuffer.init().catch((err: unknown) => {
         console.warn(
           "[StreamBuffer] Deferred init failed, late-join disabled:",
@@ -1211,6 +1217,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     mcpListCache.teardown();
     modelListCache.teardown();
     providerKeyCache.teardown();
+    teardownMcpCacheInvalidation();
     connectionCircuitStore.teardown();
     setMcpListCache(null);
     setConnectionCircuitStore(null);

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -128,6 +128,8 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   // --- MCP routes need mcpAuth in addition to resolveOrgFromPath ---
   // Order matters (preserve from legacy): virtual-mcp → self → proxy
   app.use("/mcp/:connectionId?", deps.mcpAuth);
+  // The single-segment matcher above does not cover the deeper UI-resource GET.
+  app.use("/mcp/:connectionId/ui-resource", deps.mcpAuth);
   app.use("/mcp/gateway/:virtualMcpId?", deps.mcpAuth);
   app.use("/mcp/virtual-mcp/:virtualMcpId?", deps.mcpAuth);
   app.use("/mcp/self", deps.mcpAuth);

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -21,6 +21,9 @@ import { managementContextStore, managementMCP } from "../../tools";
 import { serveMcpRequest } from "../utils/serve-mcp";
 import { handleAuthError } from "./oauth-proxy";
 import { getMcpListCache } from "@/mcp-clients/mcp-list-cache";
+import { createLazyClient } from "@/mcp-clients/lazy-client";
+import { injectCSP } from "@/mcp-apps/csp-injector";
+import type { McpUiResourceCsp } from "@/mcp-apps/types";
 import {
   assertCircuitClosed,
   CircuitOpenError,
@@ -71,6 +74,84 @@ export const createProxyRoutes = () => {
    */
   app.all("/", async (c) => {
     return handleVirtualMcpRequest(c, undefined);
+  });
+
+  /**
+   * Cacheable GET for a connection's UI resource HTML (MCP-apps).
+   *
+   * Route: GET /mcp/:connectionId/ui-resource?uri=<resource uri>
+   *
+   * Reads the resource through the lazy client (so the per-pod read cache + SWR
+   * apply — no upstream call on a warm hit), injects CSP server-side, then
+   * serves the HTML with an `ETag`: a matching `If-None-Match` returns 304 with
+   * no body, so the (often multi-MiB) HTML only re-transfers when it changes.
+   * `no-cache` makes the browser revalidate before use, so a server-side
+   * invalidation is picked up promptly. `private` because it's org/auth-scoped.
+   *
+   * This is the GET counterpart to the JSON-RPC `resources/read` POST, which is
+   * inherently uncacheable by the browser. The frontend renders the bytes into
+   * an iframe `srcDoc` (CSP already injected here).
+   */
+  app.get("/:connectionId/ui-resource", async (c) => {
+    const ctx = c.get("meshContext");
+    const connectionId = c.req.param("connectionId");
+    const uri = c.req.query("uri");
+    if (!uri) return c.json({ error: "uri query param is required" }, 400);
+    if (!ctx.organization?.id) {
+      return c.json({ error: "Organization context is required" }, 403);
+    }
+
+    const connection = await ctx.storage.connections.findById(
+      connectionId,
+      ctx.organization.id,
+    );
+    if (!connection || connection.organization_id !== ctx.organization.id) {
+      return c.json({ error: "Connection not found" }, 404);
+    }
+
+    const client = createLazyClient(
+      connection,
+      ctx,
+      false,
+      getMcpListCache() ?? undefined,
+    );
+    let text: string | undefined;
+    let resourceCsp: McpUiResourceCsp | undefined;
+    try {
+      const result = (await client.readResource({ uri })) as {
+        contents?: Array<{
+          text?: string;
+          _meta?: { ui?: { csp?: McpUiResourceCsp } };
+        }>;
+      };
+      const content = result.contents?.[0];
+      text = content?.text;
+      resourceCsp = content?._meta?.ui?.csp;
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 502);
+    } finally {
+      await client.close().catch(() => {});
+    }
+    if (typeof text !== "string") {
+      return c.json({ error: "Resource has no text content" }, 404);
+    }
+
+    const html = injectCSP(text, { resourceCsp });
+    const etag = `"${Bun.hash(html).toString(36)}"`;
+    const cacheControl = "private, no-cache";
+    if (c.req.header("if-none-match") === etag) {
+      return new Response(null, {
+        status: 304,
+        headers: { ETag: etag, "Cache-Control": cacheControl },
+      });
+    }
+    return new Response(html, {
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        ETag: etag,
+        "Cache-Control": cacheControl,
+      },
+    });
   });
 
   /**

--- a/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
+++ b/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@deco/ui/lib/utils.ts";
-import { useMCPReadResource } from "@decocms/mesh-sdk";
+import { useMCPReadResource, useUiResourceHtml } from "@decocms/mesh-sdk";
 import type {
   McpUiDisplayMode,
   McpUiHostContext,
@@ -18,7 +18,7 @@ import { track } from "../web/lib/posthog-client";
 const openedMcpApps = new Set<string>();
 
 // ---------------------------------------------------------------------------
-// useResourceHtml
+// useResourceHtml — client-side CSP injection for the JSON-RPC read path
 // ---------------------------------------------------------------------------
 
 type ReadResourceData = {
@@ -45,6 +45,14 @@ function useResourceHtml(data: ReadResourceData | undefined): string | null {
 interface MCPAppRendererProps {
   resourceURI: string;
   orgId?: string;
+  /**
+   * When both `orgSlug` and `connectionId` are provided, the HTML is fetched
+   * via the cacheable GET endpoint (browser HTTP-caches it, ETag-revalidated,
+   * CSP injected server-side). Otherwise it falls back to the JSON-RPC
+   * `resources/read` path via `client`.
+   */
+  orgSlug?: string;
+  connectionId?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;
@@ -64,11 +72,12 @@ interface MCPAppRendererProps {
 }
 
 // ---------------------------------------------------------------------------
-// Component
+// Frame — shared presentation + app bridge (identical for both data paths)
 // ---------------------------------------------------------------------------
 
-export function MCPAppRenderer({
-  resourceURI: uri,
+function MCPAppFrame({
+  html,
+  uri,
   orgId,
   toolInfo,
   toolInput,
@@ -82,13 +91,12 @@ export function MCPAppRenderer({
   onTeardown,
   onRequestDisplayMode,
   className,
-}: MCPAppRendererProps) {
-  const { data } = useMCPReadResource({ client, uri, staleTime: 30_000 });
-  const html = useResourceHtml(data);
-
+}: Omit<MCPAppRendererProps, "resourceURI" | "orgSlug" | "connectionId"> & {
+  html: string | null;
+  uri: string;
+}) {
   // Fire mcp_app_opened once per (page session × resource URI) — render-time
-  // dedupe via module Set. Display mode distinguishes inline (shown inside
-  // chat messages) from fullscreen (opened as a view panel).
+  // dedupe via module Set.
   if (uri && !openedMcpApps.has(uri)) {
     openedMcpApps.add(uri);
     track("mcp_app_opened", {
@@ -154,4 +162,56 @@ export function MCPAppRenderer({
       />
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Data paths
+// ---------------------------------------------------------------------------
+
+// Cacheable GET path: browser HTTP-caches the (server-CSP-injected) HTML.
+function MCPAppRendererViaGet({
+  resourceURI,
+  orgSlug,
+  connectionId,
+  ...frameProps
+}: MCPAppRendererProps & { orgSlug: string; connectionId: string }) {
+  const html = useUiResourceHtml({
+    orgSlug,
+    connectionId,
+    uri: resourceURI,
+    staleTime: 30_000,
+  });
+  return <MCPAppFrame html={html.data} uri={resourceURI} {...frameProps} />;
+}
+
+// JSON-RPC `resources/read` path (CSP injected client-side). Used wherever the
+// caller can't supply orgSlug + connectionId.
+function MCPAppRendererViaClient({
+  resourceURI,
+  ...frameProps
+}: MCPAppRendererProps) {
+  const { data } = useMCPReadResource({
+    client: frameProps.client,
+    uri: resourceURI,
+    staleTime: 30_000,
+  });
+  const html = useResourceHtml(data);
+  return <MCPAppFrame html={html} uri={resourceURI} {...frameProps} />;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function MCPAppRenderer(props: MCPAppRendererProps) {
+  if (props.orgSlug && props.connectionId) {
+    return (
+      <MCPAppRendererViaGet
+        {...props}
+        orgSlug={props.orgSlug}
+        connectionId={props.connectionId}
+      />
+    );
+  }
+  return <MCPAppRendererViaClient {...props} />;
 }

--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -34,7 +34,44 @@ import {
   type McpListCache,
   REVALIDATE_MIN_INTERVAL_MS,
 } from "./mcp-list-cache";
-import { getMcpReadCache } from "./mcp-read-cache";
+import { getMcpReadCache, type ReadCacheScope } from "./mcp-read-cache";
+
+/**
+ * A read-only tool is eligible for result caching. We trust the upstream's
+ * `annotations.readOnlyHint` (surfaced in the cached tool list); a tool we
+ * can't confirm read-only is never cached.
+ */
+async function isReadOnlyTool(
+  cache: McpListCache | undefined,
+  connectionId: string,
+  toolName: string,
+): Promise<boolean> {
+  if (!cache) return false;
+  const tools = await cache.get("tools", connectionId).catch(() => null);
+  if (!tools) return false;
+  for (const t of tools) {
+    if (
+      typeof t === "object" &&
+      t !== null &&
+      (t as { name?: unknown }).name === toolName
+    ) {
+      return (
+        (t as { annotations?: { readOnlyHint?: boolean } }).annotations
+          ?.readOnlyHint === true
+      );
+    }
+  }
+  return false;
+}
+
+/**
+ * Cache scope for a connection's read-only results. Defaults to "org" (shared
+ * across all members). The per-connection "user" opt-out (key by principal) is
+ * a follow-up; the cache already keys by scope, so it's a resolver change only.
+ */
+function resolveReadCacheScope(): ReadCacheScope {
+  return { kind: "org" };
+}
 
 /**
  * Create a lazy-connecting client wrapper for a connection.
@@ -155,41 +192,91 @@ export function createLazyClient(
     (cached) => ({ prompts: cached as ListPromptsResult["prompts"] }),
   );
 
-  // Proxy non-list operations to the real client (always needs a connection)
-  placeholder.callTool = async (params, resultSchema, options) => {
-    const real = await getRealClient();
-    return real.callTool(params, resultSchema, options);
-  };
-
-  // Read-content cache (resources/read, prompts/get): per-pod TTL+LRU, shared
-  // across org members. VIRTUAL connections bypass (they compose other conns).
+  // Read-only results (tools/call for read-only tools, resources/read,
+  // prompts/get) are served stale-while-revalidate from the per-pod read cache,
+  // org-scoped by default and shared across org members. Writes, tools we can't
+  // confirm read-only, VIRTUAL connections (they compose other conns), and calls
+  // with a custom result schema bypass entirely. `options` (e.g. the timeout) is
+  // forwarded to the live fetch but excluded from the cache key.
   const readCache = getMcpReadCache();
   const cacheReads = connection.connection_type !== "VIRTUAL";
 
+  placeholder.callTool = async (params, resultSchema, options) => {
+    const toolName = (params as { name?: unknown })?.name;
+    const cacheable =
+      cacheReads &&
+      !resultSchema &&
+      typeof toolName === "string" &&
+      (await isReadOnlyTool(cache, connection.id, toolName));
+
+    if (!cacheable) {
+      const real = await getRealClient();
+      return real.callTool(params, resultSchema, options);
+    }
+
+    const result = await readCache.fetch({
+      type: "tools/call",
+      connectionId: connection.id,
+      scope: resolveReadCacheScope(),
+      params: {
+        name: toolName,
+        arguments: (params as { arguments?: unknown })?.arguments,
+      },
+      fetchLive: async () => {
+        const real = await getRealClient();
+        return real.callTool(params, resultSchema, options);
+      },
+      // Never cache error results — they're returned to the caller but not stored.
+      shouldCache: (value) =>
+        (value as { isError?: boolean })?.isError !== true,
+      onRevalidation: (p) => ctx.pendingRevalidations.push(p),
+    });
+    return result as Awaited<ReturnType<Client["callTool"]>>;
+  };
+
   placeholder.getPrompt = async (params, options) => {
-    if (cacheReads) {
-      const hit = readCache.get("prompts/get", connection.id, params);
-      if (hit !== null) return hit as GetPromptResult;
+    if (!cacheReads) {
+      const real = await getRealClient();
+      return real.getPrompt(params, options);
     }
-    const real = await getRealClient();
-    const result = await real.getPrompt(params, options);
-    if (cacheReads) {
-      readCache.set("prompts/get", connection.id, params, result);
-    }
-    return result;
+    const result = await readCache.fetch({
+      type: "prompts/get",
+      connectionId: connection.id,
+      scope: resolveReadCacheScope(),
+      params,
+      fetchLive: async () => {
+        const real = await getRealClient();
+        return real.getPrompt(params, options);
+      },
+      onRevalidation: (p) => ctx.pendingRevalidations.push(p),
+    });
+    return result as GetPromptResult;
   };
 
   placeholder.readResource = async (params, options) => {
-    if (cacheReads) {
-      const hit = readCache.get("resources/read", connection.id, params);
-      if (hit !== null) return hit as ReadResourceResult;
+    if (!cacheReads) {
+      if (process.env?.MCP_CACHE_DEBUG) {
+        console.log(
+          "[mcp-read-cache] BYPASS (VIRTUAL)",
+          connection.id,
+          "resources/read",
+        );
+      }
+      const real = await getRealClient();
+      return real.readResource(params, options);
     }
-    const real = await getRealClient();
-    const result = await real.readResource(params, options);
-    if (cacheReads) {
-      readCache.set("resources/read", connection.id, params, result);
-    }
-    return result;
+    const result = await readCache.fetch({
+      type: "resources/read",
+      connectionId: connection.id,
+      scope: resolveReadCacheScope(),
+      params,
+      fetchLive: async () => {
+        const real = await getRealClient();
+        return real.readResource(params, options);
+      },
+      onRevalidation: (p) => ctx.pendingRevalidations.push(p),
+    });
+    return result as ReadResourceResult;
   };
 
   placeholder.listResourceTemplates = async (params, options) => {

--- a/apps/mesh/src/mcp-clients/mcp-cache-invalidation.ts
+++ b/apps/mesh/src/mcp-clients/mcp-cache-invalidation.ts
@@ -1,0 +1,85 @@
+/**
+ * Cross-replica invalidation for the per-pod MCP caches.
+ *
+ * The read-content cache (mcp-read-cache) and tool-result cache
+ * (mcp-result-cache) are in-memory per-pod singletons, so evicting them locally
+ * only clears the pod that handled the mutation — every other replica keeps
+ * serving stale (possibly now-unauthorized) responses until TTL. On a
+ * connection change we therefore evict locally AND broadcast over NATS so the
+ * other replicas drop their copies near-instantly. TTL is the worst-case floor:
+ * if NATS is mid-hiccup and a broadcast is lost, each replica still expires the
+ * entry within its TTL.
+ *
+ * (The tool/resource/prompt *list* cache is NATS JetStream KV — already
+ * cross-pod — so it is invalidated directly by its callers, not here.)
+ */
+
+import type { NatsConnection, Subscription } from "nats";
+import { getMcpReadCache } from "./mcp-read-cache";
+
+const INVALIDATE_SUBJECT = "studio.mcp-cache.invalidate";
+
+const originId = crypto.randomUUID();
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+let getConnection: (() => NatsConnection | null) | undefined;
+let sub: Subscription | null = null;
+
+/** Drop this connection's per-pod cached read results (content + tool calls). */
+function evictLocal(connectionId: string): void {
+  getMcpReadCache().invalidate(connectionId);
+}
+
+/**
+ * Evict this connection's per-pod caches on every replica: locally now, and on
+ * the others via a NATS broadcast. Falls back to local-only (covered by TTL)
+ * when NATS is unavailable — e.g. single-pod local mode.
+ */
+export function invalidateConnectionCaches(connectionId: string): void {
+  evictLocal(connectionId);
+  const nc = getConnection?.();
+  if (!nc) return; // NATS not ready — local eviction only, TTL covers the rest
+  try {
+    nc.publish(
+      INVALIDATE_SUBJECT,
+      encoder.encode(JSON.stringify({ connectionId, originId })),
+    );
+  } catch (err) {
+    console.warn("[McpCacheInvalidation] publish failed (non-critical):", err);
+  }
+}
+
+/**
+ * Subscribe to cross-replica invalidations. Idempotent; call once after NATS is
+ * ready (re-attempted on each NATS-ready callback).
+ */
+export function startMcpCacheInvalidation(
+  getConn: () => NatsConnection | null,
+): void {
+  getConnection = getConn;
+  if (sub) return;
+  const nc = getConn();
+  if (!nc) return; // retried on the next NATS-ready callback
+  sub = nc.subscribe(INVALIDATE_SUBJECT);
+  (async () => {
+    for await (const msg of sub!) {
+      try {
+        const parsed = JSON.parse(decoder.decode(msg.data)) as {
+          connectionId: string;
+          originId?: string;
+        };
+        if (parsed.originId === originId) continue; // our own broadcast
+        evictLocal(parsed.connectionId);
+      } catch {
+        // Ignore malformed messages
+      }
+    }
+  })().catch(console.error);
+}
+
+export function teardownMcpCacheInvalidation(): void {
+  sub?.unsubscribe();
+  sub = null;
+  getConnection = undefined;
+}

--- a/apps/mesh/src/mcp-clients/mcp-read-cache.test.ts
+++ b/apps/mesh/src/mcp-clients/mcp-read-cache.test.ts
@@ -1,84 +1,478 @@
-import { describe, expect, it } from "bun:test";
-import { InMemoryMcpReadCache } from "./mcp-read-cache";
+/**
+ * Read cache: SWR semantics, single-flight revalidation, scope + type + param
+ * keying, staleness bounds, the no-cache guard, oversized rejection, and
+ * per-type config. Pure in-memory logic with an injected clock — no DB, no
+ * network.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  InMemoryMcpReadCache,
+  type McpReadType,
+  type ReadCacheScope,
+} from "./mcp-read-cache";
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const ORG: ReadCacheScope = { kind: "org" };
+const CONN = "conn_a";
+const TOOL: McpReadType = "tools/call";
+
+function configFor(
+  revalidateAfterMs: number,
+  maxStaleMs: number,
+  maxValueBytes: number,
+): Record<
+  McpReadType,
+  {
+    revalidateAfterMs: number;
+    maxStaleMs: number;
+    maxValueBytes: number;
+  }
+> {
+  const c = { revalidateAfterMs, maxStaleMs, maxValueBytes };
+  return { "tools/call": c, "resources/read": c, "prompts/get": c };
+}
+
+function newCache(opts?: {
+  revalidateAfterMs?: number;
+  maxStaleMs?: number;
+  maxValueBytes?: number;
+  maxEntries?: number;
+  maxTotalBytes?: number;
+}) {
+  let now = 1_000;
+  const cache = new InMemoryMcpReadCache(
+    configFor(
+      opts?.revalidateAfterMs ?? 30_000,
+      opts?.maxStaleMs ?? 300_000,
+      opts?.maxValueBytes ?? 2 * 1024 * 1024,
+    ),
+    opts?.maxEntries ?? 2000,
+    () => now,
+    opts?.maxTotalBytes ?? 256 * 1024 * 1024,
+  );
+  return { cache, advance: (ms: number) => (now += ms) };
+}
 
 describe("InMemoryMcpReadCache", () => {
-  it("returns null on miss and the value after set", () => {
-    const cache = new InMemoryMcpReadCache();
-    const params = { uri: "file://a" };
-    expect(cache.get("resources/read", "c1", params)).toBeNull();
-    cache.set("resources/read", "c1", params, { contents: [1] });
-    expect(cache.get("resources/read", "c1", params)).toEqual({
-      contents: [1],
+  test("miss fetches live, stores, and returns; hit reuses it", async () => {
+    const { cache } = newCache();
+    let calls = 0;
+    const fetchLive = async () => ({ value: `v${++calls}` });
+
+    const r1 = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: { a: 1 },
+      fetchLive,
     });
+    const r2 = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: { a: 1 },
+      fetchLive,
+    });
+
+    expect(r1).toEqual({ value: "v1" });
+    expect(r2).toEqual({ value: "v1" });
+    expect(calls).toBe(1);
   });
 
-  it("hashes params order-independently", () => {
-    const cache = new InMemoryMcpReadCache();
-    cache.set(
-      "prompts/get",
-      "c1",
-      { name: "p", arguments: { a: 1, b: 2 } },
-      {
-        v: 1,
-      },
-    );
-    // Same params, keys in different order — must hit the same entry.
+  test("param equality is order-independent", async () => {
+    const { cache } = newCache();
+    let calls = 0;
+    const fetchLive = async () => ({ calls: ++calls });
+    await cache.fetch({
+      type: "prompts/get",
+      connectionId: CONN,
+      scope: ORG,
+      params: { name: "p", arguments: { a: 1, b: 2 } },
+      fetchLive,
+    });
+    const r = await cache.fetch({
+      type: "prompts/get",
+      connectionId: CONN,
+      scope: ORG,
+      params: { arguments: { b: 2, a: 1 }, name: "p" },
+      fetchLive,
+    });
+    expect(r).toEqual({ calls: 1 });
+    expect(calls).toBe(1);
+  });
+
+  test("isolates by connection, type, scope, and params", async () => {
+    const { cache } = newCache();
+    const live = (tag: string) => async () => ({ tag });
+    const base = {
+      connectionId: CONN,
+      scope: ORG,
+      params: { uri: "file://a" },
+    } as const;
+
+    await cache.fetch({
+      ...base,
+      type: "resources/read",
+      fetchLive: live("a"),
+    });
+    // Different connection / type / scope / params all miss (distinct keys).
     expect(
-      cache.get("prompts/get", "c1", { arguments: { b: 2, a: 1 }, name: "p" }),
-    ).toEqual({ v: 1 });
+      await cache.fetch({
+        ...base,
+        connectionId: "conn_b",
+        type: "resources/read",
+        fetchLive: live("conn_b"),
+      }),
+    ).toEqual({ tag: "conn_b" });
+    expect(
+      await cache.fetch({
+        ...base,
+        type: "prompts/get",
+        fetchLive: live("pg"),
+      }),
+    ).toEqual({ tag: "pg" });
+    expect(
+      await cache.fetch({
+        ...base,
+        scope: { kind: "user", userId: "u1" },
+        type: "resources/read",
+        fetchLive: live("user"),
+      }),
+    ).toEqual({ tag: "user" });
+    expect(
+      await cache.fetch({
+        ...base,
+        type: "resources/read",
+        params: { uri: "file://b" },
+        fetchLive: live("b"),
+      }),
+    ).toEqual({ tag: "b" });
+    // Original still cached.
+    expect(
+      await cache.fetch({
+        ...base,
+        type: "resources/read",
+        fetchLive: live("SHOULD_NOT_RUN"),
+      }),
+    ).toEqual({ tag: "a" });
   });
 
-  it("isolates by connection, type, and params", () => {
-    const cache = new InMemoryMcpReadCache();
-    const params = { uri: "file://a" };
-    cache.set("resources/read", "c1", params, { v: "c1" });
-    expect(cache.get("resources/read", "c2", params)).toBeNull();
-    expect(cache.get("prompts/get", "c1", params)).toBeNull();
-    expect(cache.get("resources/read", "c1", { uri: "file://b" })).toBeNull();
+  test("stale hit serves immediately and revalidates once in the background", async () => {
+    const { cache, advance } = newCache({ revalidateAfterMs: 30_000 });
+    let calls = 0;
+    const fetchLive = async () => ({ value: `v${++calls}` });
+
+    const first = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    expect(first).toEqual({ value: "v1" });
+
+    advance(31_000);
+
+    let bg: Promise<void> | undefined;
+    const stale = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+      onRevalidation: (p) => {
+        bg = p;
+      },
+    });
+    expect(stale).toEqual({ value: "v1" }); // served stale synchronously
+    expect(bg).toBeDefined();
+    await bg;
+    expect(calls).toBe(2); // refreshed in background
+
+    const fresh = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    expect(fresh).toEqual({ value: "v2" });
   });
 
-  it("expires entries after the TTL", async () => {
-    const cache = new InMemoryMcpReadCache(5 /* ttlMs */);
-    const params = { uri: "file://a" };
-    cache.set("resources/read", "c1", params, { v: 1 });
-    expect(cache.get("resources/read", "c1", params)).toEqual({ v: 1 });
-    await sleep(15);
-    expect(cache.get("resources/read", "c1", params)).toBeNull();
+  test("single-flight: concurrent stale hits trigger one revalidation", async () => {
+    const { cache, advance } = newCache({ revalidateAfterMs: 10_000 });
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const fetchLive = async () => {
+      calls++;
+      if (calls > 1) await gate;
+      return { calls };
+    };
+
+    await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    advance(11_000);
+
+    const bgs: Promise<void>[] = [];
+    const reads = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        cache.fetch({
+          type: TOOL,
+          connectionId: CONN,
+          scope: ORG,
+          params: {},
+          fetchLive,
+          onRevalidation: (p) => bgs.push(p),
+        }),
+      ),
+    );
+    for (const r of reads) expect(r).toEqual({ calls: 1 });
+    expect(bgs.length).toBe(1);
+    release();
+    await Promise.all(bgs);
+    expect(calls).toBe(2);
   });
 
-  it("evicts the least-recently-used entry past capacity", () => {
-    const cache = new InMemoryMcpReadCache(60_000, 2 /* maxEntries */);
-    cache.set("resources/read", "c", { uri: "a" }, { v: "a" });
-    cache.set("resources/read", "c", { uri: "b" }, { v: "b" });
-    // Touch "a" so "b" becomes the LRU eviction candidate.
-    cache.get("resources/read", "c", { uri: "a" });
-    cache.set("resources/read", "c", { uri: "d" }, { v: "d" });
-
-    expect(cache.get("resources/read", "c", { uri: "a" })).toEqual({ v: "a" });
-    expect(cache.get("resources/read", "c", { uri: "b" })).toBeNull();
-    expect(cache.get("resources/read", "c", { uri: "d" })).toEqual({ v: "d" });
+  test("past maxStale, a hit becomes a blocking miss", async () => {
+    const { cache, advance } = newCache({
+      revalidateAfterMs: 10_000,
+      maxStaleMs: 60_000,
+    });
+    let calls = 0;
+    const fetchLive = async () => ({ value: `v${++calls}` });
+    await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    advance(61_000);
+    const r = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+    });
+    expect(r).toEqual({ value: "v2" });
+    expect(calls).toBe(2);
   });
 
-  it("invalidate drops only the target connection's entries", () => {
-    const cache = new InMemoryMcpReadCache();
-    cache.set("resources/read", "c1", { uri: "a" }, { v: 1 });
-    cache.set("prompts/get", "c1", { name: "p" }, { v: 2 });
-    cache.set("resources/read", "c2", { uri: "a" }, { v: 3 });
+  test("shouldCache=false returns the value but does not store it", async () => {
+    const { cache } = newCache();
+    let calls = 0;
+    const fetchLive = async () => ({ isError: true, calls: ++calls });
+    const shouldCache = (v: unknown) =>
+      (v as { isError?: boolean }).isError !== true;
 
-    cache.invalidate("c1");
-
-    expect(cache.get("resources/read", "c1", { uri: "a" })).toBeNull();
-    expect(cache.get("prompts/get", "c1", { name: "p" })).toBeNull();
-    expect(cache.get("resources/read", "c2", { uri: "a" })).toEqual({ v: 3 });
+    const r1 = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+      shouldCache,
+    });
+    const r2 = await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive,
+      shouldCache,
+    });
+    expect(r1).toEqual({ isError: true, calls: 1 });
+    expect(r2).toEqual({ isError: true, calls: 2 }); // not cached
+    expect(calls).toBe(2);
   });
 
-  it("does not cache oversized results", () => {
-    const cache = new InMemoryMcpReadCache();
-    const params = { uri: "file://big" };
-    const big = { blob: "x".repeat(3 * 1024 * 1024) }; // > 2 MiB cap
-    cache.set("resources/read", "c1", params, big);
-    expect(cache.get("resources/read", "c1", params)).toBeNull();
+  test("does not cache oversized results", async () => {
+    const { cache } = newCache({ maxValueBytes: 64 });
+    let calls = 0;
+    const fetchLive = async () => ({ blob: "x".repeat(1000), calls: ++calls });
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: { uri: "big" },
+      fetchLive,
+    });
+    const r = await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: { uri: "big" },
+      fetchLive,
+    });
+    expect(calls).toBe(2); // never stored → refetched
+    expect((r as { calls: number }).calls).toBe(2);
+  });
+
+  test("evicts the least-recently-used entry past capacity", async () => {
+    const { cache } = newCache({ maxEntries: 2 });
+    // Count live fetches per key; a hit (bump) does not fetch, an evicted key
+    // refetches. Asserting on counts avoids perturbing LRU order with reads.
+    const counts: Record<string, number> = {};
+    const read = (uri: string) =>
+      cache.fetch({
+        type: "resources/read",
+        connectionId: CONN,
+        scope: ORG,
+        params: { uri },
+        fetchLive: async () => {
+          counts[uri] = (counts[uri] ?? 0) + 1;
+          return { uri };
+        },
+      });
+
+    await read("a"); // miss → {a}
+    await read("b"); // miss → {a,b}
+    await read("a"); // HIT (bump a) → {b,a}; no fetch
+    await read("c"); // miss → evicts LRU "b" → {a,c}
+    await read("b"); // miss again (was evicted) → refetch
+
+    // "a" fetched once (the second read was a hit), "b" twice (evicted by "c").
+    expect(counts).toEqual({ a: 1, b: 2, c: 1 });
+  });
+
+  test("evicts by total-byte budget even under the entry-count cap", async () => {
+    // ~102-byte values; budget of 250 holds two, so the third evicts the LRU
+    // even though the entry-count cap (1000) is nowhere near hit.
+    const { cache } = newCache({ maxEntries: 1000, maxTotalBytes: 250 });
+    const counts: Record<string, number> = {};
+    const read = (uri: string) =>
+      cache.fetch({
+        type: "resources/read",
+        connectionId: CONN,
+        scope: ORG,
+        params: { uri },
+        fetchLive: async () => {
+          counts[uri] = (counts[uri] ?? 0) + 1;
+          return "x".repeat(100);
+        },
+      });
+
+    await read("a"); // {a}
+    await read("b"); // {a,b} ~204b
+    await read("c"); // 306b > 250 → evict LRU "a" → {b,c}
+    await read("a"); // evicted by bytes → refetch
+
+    expect(counts).toEqual({ a: 2, b: 1, c: 1 });
+  });
+
+  test("invalidate drops only the target connection's entries", async () => {
+    const { cache } = newCache();
+    let calls = 0;
+    const fetchLive = async () => ({ calls: ++calls });
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: { uri: "a" },
+      fetchLive,
+    });
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: "conn_b",
+      scope: ORG,
+      params: { uri: "a" },
+      fetchLive,
+    });
+
+    cache.invalidate(CONN);
+
+    // conn_a refetches, conn_b still cached.
+    expect(
+      await cache.fetch({
+        type: "resources/read",
+        connectionId: CONN,
+        scope: ORG,
+        params: { uri: "a" },
+        fetchLive,
+      }),
+    ).toEqual({ calls: 3 });
+    expect(
+      await cache.fetch({
+        type: "resources/read",
+        connectionId: "conn_b",
+        scope: ORG,
+        params: { uri: "a" },
+        fetchLive,
+      }),
+    ).toEqual({ calls: 2 });
+  });
+
+  test("config is per-type: one type can be stale while another is fresh", async () => {
+    let now = 1_000;
+    const cache = new InMemoryMcpReadCache(
+      {
+        "tools/call": {
+          revalidateAfterMs: 10_000,
+          maxStaleMs: 300_000,
+          maxValueBytes: 1024,
+        },
+        "resources/read": {
+          revalidateAfterMs: 100_000,
+          maxStaleMs: 300_000,
+          maxValueBytes: 1024,
+        },
+        "prompts/get": {
+          revalidateAfterMs: 100_000,
+          maxStaleMs: 300_000,
+          maxValueBytes: 1024,
+        },
+      },
+      2000,
+      () => now,
+    );
+    const live = async () => ({ ok: true });
+    await cache.fetch({
+      type: "tools/call",
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive: live,
+    });
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive: live,
+    });
+
+    now += 50_000; // past tools/call revalidate (10s), before resources/read (100s)
+
+    let toolBg = false;
+    await cache.fetch({
+      type: "tools/call",
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive: live,
+      onRevalidation: () => {
+        toolBg = true;
+      },
+    });
+    let resBg = false;
+    await cache.fetch({
+      type: "resources/read",
+      connectionId: CONN,
+      scope: ORG,
+      params: {},
+      fetchLive: live,
+      onRevalidation: () => {
+        resBg = true;
+      },
+    });
+
+    expect(toolBg).toBe(true); // stale → revalidated
+    expect(resBg).toBe(false); // still fresh → not revalidated
   });
 });

--- a/apps/mesh/src/mcp-clients/mcp-read-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-read-cache.ts
@@ -1,37 +1,91 @@
 /**
- * MCP Read Cache
+ * MCP Read Cache (stale-while-revalidate)
  *
- * Per-pod in-memory TTL+LRU cache for read-only MCP content methods that take
- * parameters: `resources/read` and `prompts/get`. The list cache
- * (mcp-list-cache.ts, NATS KV) covers tools/resources/prompts *lists*; this
- * covers the *content* reads those lists point at.
+ * Per-pod TTL+LRU cache for the results of READ-ONLY MCP methods that take
+ * parameters: `tools/call` (read-only tools), `resources/read`, `prompts/get`.
+ * The list cache (mcp-list-cache, NATS KV) covers tool/resource/prompt *lists*;
+ * this covers the per-call *results* those lists point at.
  *
- * Scope: keyed by (connectionId, method, params) only — NOT by principal. This
- * is a deliberate choice (shared across org members) and assumes a connection's
- * read responses are the same for every member. It would leak content between
- * users if an upstream personalizes `resources/read` / `prompts/get` per caller.
- * Invalidated on connection update/delete.
+ * Semantics: stale-while-revalidate. A hit returns immediately; once older than
+ * the type's `revalidateAfterMs`, a single-flight background revalidation
+ * refreshes it (a stampede of concurrent callers triggers at most one upstream
+ * call). Past `maxStaleMs` a hit is treated as a miss and the caller blocks on a
+ * live fetch.
+ *
+ * Scope (two tiers):
+ *  - "org" (default): the key omits the principal, so the result is shared
+ *    across every org member. This assumes the result does NOT depend on the
+ *    caller — only valid for upstreams that ignore the per-user identity
+ *    (`x-mesh-token`).
+ *  - "user": the key includes the principal, so a result is never shared across
+ *    users. Safe for any read-only operation.
+ *
+ * Caller invariants (lazy-client): only read-only operations reach here; tool
+ * error results (`isError`) are never stored (via `shouldCache`); the
+ * org-ownership check precedes this cache. Per-pod, so a connection change
+ * invalidates it across replicas via a NATS broadcast (mcp-cache-invalidation);
+ * TTL is the worst-case floor if a broadcast is lost.
  */
 
 import { meter } from "../observability";
 
 const cacheCounter = meter.createCounter("mcp_read_cache.fetches", {
-  description: "MCP read cache fetch outcomes (hit, miss)",
+  description: "MCP read cache outcomes (hit, stale, miss, error)",
   unit: "{fetches}",
 });
 
-/** Long TTL — read content is treated as slow-changing (see module note). */
-const READ_CACHE_TTL_MS = 5 * 60_000;
-/** LRU cap to bound memory; oldest entries evicted first. */
-const READ_CACHE_MAX_ENTRIES = 1000;
-/** Skip caching results larger than this (avoid pinning huge file blobs). */
-const READ_CACHE_MAX_VALUE_BYTES = 2 * 1024 * 1024; // 2 MiB
+export type McpReadType = "tools/call" | "resources/read" | "prompts/get";
 
-export type McpReadType = "resources/read" | "prompts/get";
+/** Cache scope: org-shared (default) or isolated per principal. */
+export type ReadCacheScope = { kind: "org" } | { kind: "user"; userId: string };
 
-interface CacheEntry {
-  value: unknown;
-  expiresAt: number;
+interface TypeConfig {
+  /** Serve a hit immediately; revalidate in the background past this age. */
+  revalidateAfterMs: number;
+  /** Past this age a hit is a miss — block on a live fetch instead of serving. */
+  maxStaleMs: number;
+  /** Skip caching results larger than this (avoid pinning huge payloads). */
+  maxValueBytes: number;
+}
+
+const KiB = 1024 as const;
+const MiB = KiB * KiB;
+
+/** Per-method tuning. Content reads are slow-changing and can be large; tool
+ * results change faster, so refresh sooner and cap their size tighter. */
+const DEFAULT_READ_CACHE_CONFIG: Record<McpReadType, TypeConfig> = {
+  "tools/call": {
+    revalidateAfterMs: 30_000,
+    maxStaleMs: 5 * 60_000,
+    maxValueBytes: 512 * KiB,
+  },
+  "resources/read": {
+    revalidateAfterMs: 60_000,
+    maxStaleMs: 5 * 60_000,
+    maxValueBytes: 4 * MiB,
+  },
+  "prompts/get": {
+    revalidateAfterMs: 60_000,
+    maxStaleMs: 5 * 60_000,
+    maxValueBytes: 512 * KiB,
+  },
+};
+
+const READ_CACHE_MAX_ENTRIES = 2000;
+// Hard ceiling on aggregate cached bytes (per pod). With multi-MiB entries the
+// entry-count cap alone isn't enough — evict LRU until under this too, so the
+// cache can't grow into the heap-pressure territory that OOM'd pods before.
+const READ_CACHE_MAX_TOTAL_BYTES = 256 * MiB;
+
+// Opt-in tracing: `MCP_CACHE_DEBUG=1` logs every fetch outcome + store skip so
+// we can see hit/miss/stale and oversize rejections live. Temporary diagnostic.
+const DEBUG = typeof process !== "undefined" && !!process.env?.MCP_CACHE_DEBUG;
+function debug(...args: unknown[]): void {
+  if (DEBUG) console.log("[mcp-read-cache]", ...args);
+}
+
+function scopeKey(scope: ReadCacheScope): string {
+  return scope.kind === "org" ? "org" : `u:${scope.userId}`;
 }
 
 /** Deterministic stringify (sorted keys) so equivalent params hash identically. */
@@ -53,74 +107,166 @@ function stableStringify(value: unknown): string {
     .join(",")}}`;
 }
 
+interface CacheEntry {
+  value: unknown;
+  storedAt: number;
+  bytes: number;
+}
+
 export class InMemoryMcpReadCache {
   // Map preserves insertion order — first key is the LRU eviction candidate.
   private readonly store = new Map<string, CacheEntry>();
+  // Keys with an in-flight background revalidation (single-flight guard).
+  private readonly revalidating = new Set<string>();
+  // Running sum of cached entry bytes, kept in lockstep with the store.
+  private totalBytes = 0;
 
   constructor(
-    private readonly ttlMs: number = READ_CACHE_TTL_MS,
+    private readonly config: Record<
+      McpReadType,
+      TypeConfig
+    > = DEFAULT_READ_CACHE_CONFIG,
     private readonly maxEntries: number = READ_CACHE_MAX_ENTRIES,
+    // Injectable clock for deterministic tests; defaults to wall time.
+    private readonly now: () => number = () => Date.now(),
+    private readonly maxTotalBytes: number = READ_CACHE_MAX_TOTAL_BYTES,
   ) {}
+
+  /** Delete a key and keep the byte accounting in sync. */
+  private deleteKey(key: string): void {
+    const e = this.store.get(key);
+    if (e) {
+      this.store.delete(key);
+      this.totalBytes -= e.bytes;
+    }
+  }
 
   private key(
     type: McpReadType,
     connectionId: string,
+    scope: ReadCacheScope,
     params: unknown,
   ): string {
-    return `${connectionId}:${type}:${stableStringify(params)}`;
+    return `${connectionId}:${scopeKey(scope)}:${type}:${stableStringify(
+      params,
+    )}`;
   }
 
-  get(
-    type: McpReadType,
-    connectionId: string,
-    params: unknown,
-  ): unknown | null {
-    const key = this.key(type, connectionId, params);
+  private storeSet(
+    key: string,
+    value: unknown,
+    now: number,
+    maxValueBytes: number,
+  ): void {
+    // Skip oversized results so a single large payload can't pin memory.
+    let bytes: number;
+    try {
+      bytes = JSON.stringify(value).length;
+    } catch {
+      debug("SKIP non-serializable", key);
+      return; // non-serializable — don't cache
+    }
+    if (bytes > maxValueBytes) {
+      debug("SKIP oversize", key, `${bytes}b > cap ${maxValueBytes}b`);
+      return;
+    }
+    // Drop any existing entry's bytes before re-inserting.
+    this.deleteKey(key);
+    // Evict LRU (oldest-first) until there's room by BOTH count and bytes.
+    while (
+      this.store.size > 0 &&
+      (this.store.size >= this.maxEntries ||
+        this.totalBytes + bytes > this.maxTotalBytes)
+    ) {
+      const oldest = this.store.keys().next().value;
+      if (oldest === undefined) break;
+      this.deleteKey(oldest);
+    }
+    this.store.set(key, { value, storedAt: now, bytes });
+    this.totalBytes += bytes;
+  }
+
+  /**
+   * Stale-while-revalidate fetch for a read-only MCP method result.
+   *
+   * @param fetchLive Performs the live upstream call. MUST reject (not return)
+   *   on error.
+   * @param shouldCache Decide whether a freshly fetched value may be stored.
+   *   Returning false still returns the value but skips the cache — used to keep
+   *   `isError` tool results out of the cache. Defaults to caching everything.
+   * @param onRevalidation Receives the background revalidation promise so the
+   *   request lifecycle can await it (e.g. `ctx.pendingRevalidations`).
+   */
+  async fetch(params: {
+    type: McpReadType;
+    connectionId: string;
+    scope: ReadCacheScope;
+    params: unknown;
+    fetchLive: () => Promise<unknown>;
+    shouldCache?: (value: unknown) => boolean;
+    onRevalidation?: (promise: Promise<void>) => void;
+  }): Promise<unknown> {
+    const {
+      type,
+      connectionId,
+      scope,
+      params: callParams,
+      fetchLive,
+      shouldCache,
+      onRevalidation,
+    } = params;
+    const cfg = this.config[type];
+    const key = this.key(type, connectionId, scope, callParams);
+    const now = this.now();
     const entry = this.store.get(key);
-    if (!entry) {
+    const age = entry ? now - entry.storedAt : Infinity;
+
+    // Miss, or stale past the hard limit: block on a live fetch.
+    if (!entry || age > cfg.maxStaleMs) {
       cacheCounter.add(1, { type, outcome: "miss" });
-      return null;
+      debug(entry ? "EXPIRED" : "MISS", key);
+      const value = await fetchLive();
+      if (shouldCache?.(value) ?? true) {
+        this.storeSet(key, value, this.now(), cfg.maxValueBytes);
+      } else {
+        debug("NOT-CACHED (shouldCache=false)", key);
+      }
+      return value;
     }
-    if (entry.expiresAt <= Date.now()) {
-      this.store.delete(key);
-      cacheCounter.add(1, { type, outcome: "miss" });
-      return null;
-    }
-    // LRU bump: re-insert to move to the most-recent position.
+
+    // LRU bump.
     this.store.delete(key);
     this.store.set(key, entry);
-    cacheCounter.add(1, { type, outcome: "hit" });
+
+    if (age > cfg.revalidateAfterMs && !this.revalidating.has(key)) {
+      cacheCounter.add(1, { type, outcome: "stale" });
+      debug("STALE → serve + revalidate", key, `age=${age}ms`);
+      this.revalidating.add(key);
+      const revalidation = fetchLive()
+        .then((value) => {
+          if (shouldCache?.(value) ?? true) {
+            this.storeSet(key, value, this.now(), cfg.maxValueBytes);
+          }
+        })
+        .catch(() => {
+          // Best-effort: keep serving the existing entry until maxStaleMs.
+          cacheCounter.add(1, { type, outcome: "error" });
+        })
+        .finally(() => this.revalidating.delete(key));
+      onRevalidation?.(revalidation);
+    } else {
+      cacheCounter.add(1, { type, outcome: "hit" });
+      debug("HIT", key, `age=${age}ms`);
+    }
+
     return entry.value;
   }
 
-  set(
-    type: McpReadType,
-    connectionId: string,
-    params: unknown,
-    value: unknown,
-  ): void {
-    // Skip oversized results so a single large resource can't pin memory.
-    try {
-      if (JSON.stringify(value).length > READ_CACHE_MAX_VALUE_BYTES) return;
-    } catch {
-      return; // non-serializable — don't cache
-    }
-
-    const key = this.key(type, connectionId, params);
-    if (this.store.has(key)) {
-      this.store.delete(key);
-    } else if (this.store.size >= this.maxEntries) {
-      const oldest = this.store.keys().next().value;
-      if (oldest !== undefined) this.store.delete(oldest);
-    }
-    this.store.set(key, { value, expiresAt: Date.now() + this.ttlMs });
-  }
-
-  /** Drop every cached read for a connection (config/auth may have changed). */
+  /** Drop every cached result for a connection (config/auth may have changed). */
   invalidate(connectionId: string): void {
-    const prefix = `${connectionId}:`; //
-    for (const key of this.store.keys()) {
-      if (key.startsWith(prefix)) this.store.delete(key);
+    const prefix = `${connectionId}:`;
+    for (const key of [...this.store.keys()]) {
+      if (key.startsWith(prefix)) this.deleteKey(key);
     }
   }
 }

--- a/apps/mesh/src/tools/connection/delete.ts
+++ b/apps/mesh/src/tools/connection/delete.ts
@@ -17,7 +17,7 @@ import {
   requireOrganization,
 } from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
-import { getMcpReadCache } from "../../mcp-clients/mcp-read-cache";
+import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
 import { ConnectionEntitySchema } from "./schema";
 
 const ConnectionDeleteInputSchema = CollectionDeleteInputSchema.extend({
@@ -113,8 +113,9 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
     getMcpListCache()
       ?.invalidate(input.id)
       .catch(() => {});
-    // Drop cached read content for this connection
-    getMcpReadCache().invalidate(input.id);
+    // Drop cached read content and tool results for this connection across ALL
+    // replicas (per-pod caches → NATS broadcast).
+    invalidateConnectionCaches(input.id);
 
     const userId = getUserId(ctx);
     if (userId) {

--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -20,7 +20,7 @@ import {
   requireOrganization,
 } from "../../core/studio-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
-import { getMcpReadCache } from "../../mcp-clients/mcp-read-cache";
+import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
 import { fetchToolsFromMCP } from "./fetch-tools";
 import { prop } from "./json-path";
 import {
@@ -292,9 +292,10 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
         ?.set("tools", id, tools as Tool[])
         .catch(() => {});
     }
-    // Config/auth/url may have changed — drop cached read content so stale
-    // (possibly long-TTL) responses aren't served against the new config.
-    getMcpReadCache().invalidate(id);
+    // Config/auth/url may have changed — drop cached read content and tool
+    // results across ALL replicas (per-pod caches → NATS broadcast) so stale
+    // (possibly now-unauthorized) responses aren't served against the new config.
+    invalidateConnectionCaches(id);
 
     // Invoke ON_MCP_CONFIGURATION callback if configuration was updated
     // Ignore errors but await for the response before responding

--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -220,6 +220,8 @@ function AgentUITile({
             <MCPAppRenderer
               resourceURI={tile.resourceUri}
               orgId={org.id}
+              orgSlug={org.slug}
+              connectionId={tile.connectionId}
               client={client}
               displayMode="fullscreen"
               minHeight={tile.minHeight ?? 200}

--- a/apps/mesh/src/web/hooks/use-delete-connection.ts
+++ b/apps/mesh/src/web/hooks/use-delete-connection.ts
@@ -1,5 +1,6 @@
 import {
   SELF_MCP_ALIAS_ID,
+  UI_RESOURCE_HTML_KEY,
   useMCPClient,
   useProjectContext,
   type ConnectionEntity,
@@ -7,6 +8,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
+import { clearHtmlResourceCacheForConnection } from "@/web/lib/html-resource-persist";
 
 export type DeleteConnectionState =
   | { mode: "idle" }
@@ -59,8 +61,18 @@ export function useDeleteConnection({
     });
   };
 
-  const handleSuccess = () => {
+  const evictUiResourceCache = (connectionId: string) => {
+    void clearHtmlResourceCacheForConnection(connectionId);
+    queryClient.invalidateQueries({
+      predicate: (query) =>
+        query.queryKey[1] === UI_RESOURCE_HTML_KEY &&
+        query.queryKey[3] === connectionId,
+    });
+  };
+
+  const handleSuccess = (connectionId: string) => {
     invalidateConnections();
+    evictUiResourceCache(connectionId);
     toast.success("Connection deleted successfully");
     setDeleteState({ mode: "idle" });
     onSuccess?.();
@@ -111,7 +123,7 @@ export function useDeleteConnection({
         return;
       }
 
-      handleSuccess();
+      handleSuccess(connection.id);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       toast.error(`Failed to delete connection: ${message}`);
@@ -135,7 +147,7 @@ export function useDeleteConnection({
         return;
       }
 
-      handleSuccess();
+      handleSuccess(id);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       toast.error(`Failed to delete connection: ${message}`);

--- a/apps/mesh/src/web/lib/html-resource-persist.ts
+++ b/apps/mesh/src/web/lib/html-resource-persist.ts
@@ -1,0 +1,195 @@
+/**
+ * IndexedDB persistence for MCP-app UI-resource HTML queries.
+ *
+ * UI-resource HTML is large (multi-MiB self-contained bundles), so it must NOT
+ * go through the localStorage bootstrap cache (query-persist.ts) — localStorage
+ * is ~5 MB and synchronous. This persists ONLY the `ui-resource-html` queries
+ * to IndexedDB (async, large quota), so they survive reloads / brief offline:
+ * on boot we restore them into the query cache (best-effort warm start), and on
+ * every successful read we write the latest HTML back.
+ *
+ * The GET endpoint already gives the browser HTTP cache (ETag + max-age), so
+ * this is the "instant cross-session / offline" layer on top of that.
+ */
+
+import type { QueryClient } from "@tanstack/react-query";
+import { UI_RESOURCE_HTML_KEY } from "@decocms/mesh-sdk";
+
+const DB_NAME = "mesh-ui-resources";
+const STORE = "html";
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const MAX_ENTRIES = 50; // bound the store; prune oldest beyond this on restore
+const MAX_VALUE_BYTES = 16 * 1024 * 1024; // mirror the server-side resources/read cap
+
+interface StoredHtml {
+  html: string;
+  updatedAt: number;
+  /** Build version, so a deploy invalidates stale cached HTML. */
+  buster: string;
+}
+
+function version(): string {
+  return typeof __MESH_VERSION__ === "string" ? __MESH_VERSION__ : "dev";
+}
+
+function isHtmlResourceKey(key: readonly unknown[]): boolean {
+  return key[0] === "mcp" && key[1] === UI_RESOURCE_HTML_KEY;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) {
+        req.result.createObjectStore(STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function tx(db: IDBDatabase, mode: IDBTransactionMode): IDBObjectStore {
+  return db.transaction(STORE, mode).objectStore(STORE);
+}
+
+function reqToPromise<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Restore persisted UI-resource HTML into the query cache before the app reads
+ * it (best-effort: IndexedDB is async, so a query that runs first just fetches —
+ * which is HTTP-cached anyway). Prunes expired / over-budget / stale-version
+ * entries. Safe to call once at startup.
+ */
+export async function restoreHtmlResourceCache(
+  queryClient: QueryClient,
+): Promise<void> {
+  if (typeof indexedDB === "undefined") return;
+  try {
+    const db = await openDb();
+    const store = tx(db, "readonly");
+    const keys = (await reqToPromise(store.getAllKeys())) as IDBValidKey[];
+    const values = (await reqToPromise(store.getAll())) as StoredHtml[];
+    const now = Date.now();
+    const ver = version();
+
+    // Pair + sort newest-first so over-budget pruning drops the oldest.
+    const entries = keys
+      .map((key, i) => ({ key, value: values[i] }))
+      .sort((a, b) => (b.value?.updatedAt ?? 0) - (a.value?.updatedAt ?? 0));
+
+    const stale: IDBValidKey[] = [];
+    let kept = 0;
+    for (const { key, value } of entries) {
+      const expired =
+        !value ||
+        value.buster !== ver ||
+        now - value.updatedAt > MAX_AGE_MS ||
+        kept >= MAX_ENTRIES;
+      if (expired) {
+        stale.push(key);
+        continue;
+      }
+      kept++;
+      try {
+        const queryKey = JSON.parse(String(key)) as unknown[];
+        if (queryClient.getQueryData(queryKey) === undefined) {
+          // Restore with the original timestamp so an entry older than the
+          // query's staleTime revalidates immediately on mount (instant render
+          // from IDB + background refresh) instead of being treated as fresh.
+          queryClient.setQueryData(queryKey, value.html, {
+            updatedAt: value.updatedAt,
+          });
+        }
+      } catch {
+        stale.push(key);
+      }
+    }
+
+    if (stale.length > 0) {
+      const wstore = tx(db, "readwrite");
+      for (const key of stale) wstore.delete(key);
+    }
+  } catch {
+    // IndexedDB unavailable / blocked / corrupt — non-fatal, fall back to fetch.
+  }
+}
+
+/**
+ * Subscribe to the query cache and write successful UI-resource HTML reads to
+ * IndexedDB. Returns the unsubscribe fn.
+ */
+export function persistHtmlResourceCache(queryClient: QueryClient): () => void {
+  if (typeof indexedDB === "undefined") return () => {};
+  const dbPromise = openDb().catch(() => null);
+
+  return queryClient.getQueryCache().subscribe((event) => {
+    const query = event.query;
+    if (!Array.isArray(query.queryKey) || !isHtmlResourceKey(query.queryKey)) {
+      return;
+    }
+    if (query.state.status !== "success") return;
+    const html = query.state.data;
+    if (typeof html !== "string" || html.length > MAX_VALUE_BYTES) return;
+
+    void dbPromise.then((db) => {
+      if (!db) return;
+      try {
+        tx(db, "readwrite").put(
+          {
+            html,
+            updatedAt: Date.now(),
+            buster: version(),
+          } satisfies StoredHtml,
+          JSON.stringify(query.queryKey),
+        );
+      } catch {
+        // best-effort
+      }
+    });
+  });
+}
+
+/** Drop all persisted UI-resource HTML (call on sign-out). */
+export function clearHtmlResourceCache(): void {
+  if (typeof indexedDB === "undefined") return;
+  void openDb()
+    .then((db) => tx(db, "readwrite").clear())
+    .catch(() => {});
+}
+
+/**
+ * Drop persisted HTML for a single connection. Call when a connection is
+ * updated/deleted so the editing client doesn't restore stale HTML on its next
+ * reload (other clients self-heal via the no-cache GET on their next read).
+ * Keys are `JSON.stringify(["mcp","ui-resource-html", orgSlug, connectionId, uri])`.
+ */
+export async function clearHtmlResourceCacheForConnection(
+  connectionId: string,
+): Promise<void> {
+  if (typeof indexedDB === "undefined") return;
+  try {
+    const db = await openDb();
+    const keys = (await reqToPromise(
+      tx(db, "readonly").getAllKeys(),
+    )) as IDBValidKey[];
+    const wstore = tx(db, "readwrite");
+    for (const key of keys) {
+      try {
+        const parsed = JSON.parse(String(key)) as unknown[];
+        if (parsed[1] === UI_RESOURCE_HTML_KEY && parsed[3] === connectionId) {
+          wstore.delete(key);
+        }
+      } catch {
+        // skip unparseable keys
+      }
+    }
+  } catch {
+    // non-fatal
+  }
+}

--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -13,6 +13,7 @@
  */
 
 import { type QueryClient, dehydrate, hydrate } from "@tanstack/react-query";
+import { clearHtmlResourceCache } from "./html-resource-persist";
 
 const STORAGE_KEY = "mesh:rq-cache";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
@@ -157,6 +158,8 @@ export function writeCachedOrg(
 
 /** Wipe all persisted caches. Call on sign-out so the next user starts clean. */
 export function clearPersistedQueryCache(): void {
+  // Drop the IndexedDB UI-resource HTML store too (org-scoped UI shells).
+  clearHtmlResourceCache();
   if (typeof window === "undefined") return;
   try {
     window.localStorage.removeItem(STORAGE_KEY);

--- a/apps/mesh/src/web/providers/providers.tsx
+++ b/apps/mesh/src/web/providers/providers.tsx
@@ -10,6 +10,10 @@ import {
   hydrateQueryClient,
   persistQueryClient,
 } from "@/web/lib/query-persist";
+import {
+  persistHtmlResourceCache,
+  restoreHtmlResourceCache,
+} from "@/web/lib/html-resource-persist";
 import { Toaster } from "sonner";
 
 const queryClient = new QueryClient({
@@ -31,6 +35,10 @@ const queryClient = new QueryClient({
 
 hydrateQueryClient(queryClient);
 persistQueryClient(queryClient);
+// Large UI-resource HTML goes to IndexedDB (not the localStorage cache above):
+// warm-start from it, then keep it written on successful reads.
+void restoreHtmlResourceCache(queryClient);
+persistHtmlResourceCache(queryClient);
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -2,9 +2,11 @@ import { useState } from "react";
 import {
   authenticateMcp,
   isConnectionAuthenticated,
+  UI_RESOURCE_HTML_KEY,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { clearHtmlResourceCacheForConnection } from "@/web/lib/html-resource-persist";
 import { Badge } from "@deco/ui/components/badge.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Card } from "@deco/ui/components/card.tsx";
@@ -74,6 +76,7 @@ function ConnectionRow({
   const updateAuth = useUpdateMonitorConnectionAuth();
   const { updateMutation } = useRegistryMutations();
   const { org } = useProjectContext();
+  const queryClient = useQueryClient();
   const connectionId = entry.mapping.connection_id;
   const authStatus = entry.mapping.auth_status;
   const title = entry.item?.title ?? entry.mapping.item_id;
@@ -242,6 +245,14 @@ function ConnectionRow({
       setIsReplacingToken(false);
       setTokenValue("");
       markAuthenticated();
+      // Auth changed → upstream may return different content; drop cached UI
+      // HTML for this connection (IDB + in-memory query) so it re-reads fresh.
+      void clearHtmlResourceCacheForConnection(connectionId);
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[1] === UI_RESOURCE_HTML_KEY &&
+          query.queryKey[3] === connectionId,
+      });
       await probeQuery.refetch();
     } catch (err) {
       toast.error(

--- a/packages/mesh-sdk/src/hooks/index.ts
+++ b/packages/mesh-sdk/src/hooks/index.ts
@@ -53,9 +53,12 @@ export {
   useMCPResourcesList,
   useMCPResourcesListQuery,
   useMCPReadResource,
+  useUiResourceHtml,
+  UI_RESOURCE_HTML_KEY,
   type UseMcpResourcesListOptions,
   type UseMcpResourcesListQueryOptions,
   type UseMcpReadResourceOptions,
+  type UseUiResourceHtmlOptions,
 } from "./use-mcp-resources";
 
 // MCP prompts hooks and helpers

--- a/packages/mesh-sdk/src/hooks/use-mcp-resources.ts
+++ b/packages/mesh-sdk/src/hooks/use-mcp-resources.ts
@@ -136,3 +136,60 @@ export function useMCPReadResource({
     retry: false,
   });
 }
+
+/**
+ * Query-key discriminator (segment [1]) for cached UI-resource HTML. Exported
+ * so a persister can select only these entries — the HTML is large, so it goes
+ * to IndexedDB, never the localStorage bootstrap cache.
+ */
+export const UI_RESOURCE_HTML_KEY = "ui-resource-html" as const;
+
+export interface UseUiResourceHtmlOptions
+  extends Omit<UseSuspenseQueryOptions<string, Error>, "queryKey" | "queryFn"> {
+  /** Org slug (the `:org` path segment). */
+  orgSlug: string;
+  /** Connection id serving the resource. */
+  connectionId: string;
+  /** Resource URI (e.g. `ui://...`). */
+  uri: string;
+  /** Base mesh URL; defaults to the current origin. */
+  meshUrl?: string;
+}
+
+/**
+ * Read a connection's UI-resource HTML via the cacheable GET endpoint
+ * (`/api/:org/mcp/:connectionId/ui-resource`) instead of the JSON-RPC
+ * `resources/read` POST. The GET carries an ETag + `Cache-Control`, so the
+ * browser HTTP-caches the (often multi-MiB) HTML and revalidates with cheap
+ * 304s — and the response is already CSP-injected server-side, ready for an
+ * iframe `srcDoc`.
+ */
+export function useUiResourceHtml({
+  orgSlug,
+  connectionId,
+  uri,
+  meshUrl,
+  ...queryOptions
+}: UseUiResourceHtmlOptions): UseSuspenseQueryResult<string, Error> {
+  return useSuspenseQuery<string, Error>({
+    ...queryOptions,
+    queryKey: KEYS.mcpUiResourceHtml(orgSlug, connectionId, uri),
+    queryFn: async () => {
+      const base =
+        meshUrl ??
+        (typeof window !== "undefined" ? window.location.origin : "");
+      const url = `${base}/api/${encodeURIComponent(
+        orgSlug,
+      )}/mcp/${encodeURIComponent(
+        connectionId,
+      )}/ui-resource?uri=${encodeURIComponent(uri)}`;
+      const res = await fetch(url, { credentials: "include" });
+      if (!res.ok) {
+        throw new Error(`Failed to read UI resource (${res.status})`);
+      }
+      return res.text();
+    },
+    staleTime: queryOptions.staleTime ?? 30000,
+    retry: false,
+  });
+}

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -57,9 +57,12 @@ export {
   useMCPResourcesList,
   useMCPResourcesListQuery,
   useMCPReadResource,
+  useUiResourceHtml,
+  UI_RESOURCE_HTML_KEY,
   type UseMcpResourcesListOptions,
   type UseMcpResourcesListQueryOptions,
   type UseMcpReadResourceOptions,
+  type UseUiResourceHtmlOptions,
   // MCP prompts hooks and helpers
   listPrompts,
   getPrompt,

--- a/packages/mesh-sdk/src/lib/query-keys.ts
+++ b/packages/mesh-sdk/src/lib/query-keys.ts
@@ -66,6 +66,10 @@ export const KEYS = {
     ["mcp", "client", client, "prompts"] as const,
   mcpReadResource: (client: unknown, uri: string) =>
     ["mcp", "client", client, "resource", uri] as const,
+  // UI-resource HTML fetched via the cacheable GET endpoint. Keyed by
+  // (org, connection, uri) — NOT the client — so a persister can select it.
+  mcpUiResourceHtml: (orgSlug: string, connectionId: string, uri: string) =>
+    ["mcp", "ui-resource-html", orgSlug, connectionId, uri] as const,
   mcpGetPrompt: (client: unknown, name: string, argsKey: string) =>
     ["mcp", "client", client, "prompt", name, argsKey] as const,
   mcpToolCall: (client: unknown, toolName: string, argsKey: string) =>


### PR DESCRIPTION
… handling

- Added `mcp-cache-invalidation.ts` for managing cross-replica cache invalidation via NATS, ensuring timely updates across pods.
- Integrated cache invalidation in connection update and delete operations to maintain cache consistency.
- Introduced `html-resource-persist.ts` for IndexedDB persistence of UI-resource HTML, allowing for offline access and improved performance.
- Updated `MCPAppRenderer` to utilize the new cache mechanism for rendering UI resources, enhancing the user experience.
- Enhanced query cache management to include UI-resource HTML, ensuring efficient data retrieval and storage.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-replica invalidation for MCP read/result caches and a cacheable UI‑resource HTML flow (server ETag+CSP + client IndexedDB) to keep UI fast and consistent across pods. Also upgrades the read cache to SWR with single‑flight and read‑only tool call caching, and routes the UI through the new GET path when possible.

- **New Features**
  - Cross-replica cache invalidation via NATS for per-pod MCP caches; start/teardown wired in app lifecycle and used on connection update/delete.
  - Cacheable UI-resource HTML endpoint: `GET /mcp/:connectionId/ui-resource?uri=...` with server-side CSP injection, `ETag`, and `Cache-Control`; added `mcpAuth` guard for this path.
  - Read cache rebuilt with SWR semantics, single-flight revalidation, per-type tuning, LRU + total-bytes budget, and oversize-skips; now caches read-only `tools/call` results in addition to `resources/read` and `prompts/get`; org-scoped by default with invalidate-by-connection.
  - UI integration: new `useUiResourceHtml` hook and `UI_RESOURCE_HTML_KEY`; `MCPAppRenderer` uses the GET path when `orgSlug` + `connectionId` are provided, otherwise falls back to `useMCPReadResource`.
  - IndexedDB persistence for UI-resource HTML (`html-resource-persist.ts`): restore on boot, persist on success, and clear on sign-out, connection delete/update, or auth changes.
  - Expanded tests for the new read-cache behavior (SWR, staleness bounds, single-flight, scoping, LRU/byte eviction).

<sup>Written for commit 68843bb26ce0158ed82c5656c0cc17ca9b7414be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

