### PR TITLE
feat(monitoring): enhance PII redaction in emitMonitoringLog

### DIFF
--- a/apps/mesh/src/monitoring/emit.test.ts
+++ b/apps/mesh/src/monitoring/emit.test.ts
@@ -105,6 +105,25 @@ describe("emitMonitoringLog", () => {
     expect(input).toContain("[REDACTED:email]");
   });
 
+  it("should redact PII in nested values and object keys", () => {
+    emitMonitoringLog(
+      makeParams({
+        result: {
+          contact: { primary: "nested@example.com" },
+          "owner@example.com": "value",
+        },
+      }),
+    );
+
+    expect(emittedRecords.length).toBe(1);
+    const output = emittedRecords[0]!.attributes![
+      MONITORING_LOG_ATTR.OUTPUT
+    ] as string;
+    expect(output).not.toContain("nested@example.com");
+    expect(output).not.toContain("owner@example.com");
+    expect(output).toContain("[REDACTED:email]");
+  });
+
   it("should redact PII in error message", () => {
     emitMonitoringLog(
       makeParams({

--- a/apps/mesh/src/monitoring/emit.ts
+++ b/apps/mesh/src/monitoring/emit.ts
@@ -53,11 +53,20 @@ export function emitMonitoringLog(
   try {
     if (!params.organizationId) return;
 
-    // Apply PII redaction to input, output, and error message
-    const redactedInput = redactor.redact(params.toolArguments ?? {});
-    const redactedOutput = redactor.redact(params.result ?? {});
+    // Truncate BEFORE redacting so redaction cost is bounded by the storage
+    // cap (~64 KB) instead of the full object-graph size. Redacting the
+    // serialized + truncated string still covers both keys and values, since
+    // they all appear in the JSON text. Redacting the raw object first walked
+    // the entire (potentially multi-MB) result through 5 regexes synchronously,
+    // stalling the event loop before truncation threw most of it away.
+    const redactedInput = redactor.redactString(
+      truncateString(JSON.stringify(params.toolArguments ?? {})),
+    );
+    const redactedOutput = redactor.redactString(
+      truncateString(JSON.stringify(params.result ?? {})),
+    );
     const redactedErrorMessage = params.errorMessage
-      ? redactor.redactString(params.errorMessage)
+      ? redactor.redactString(truncateString(params.errorMessage))
       : "";
 
     getMonitoringLogger().emit({
@@ -72,12 +81,8 @@ export function emitMonitoringLog(
         [MONITORING_LOG_ATTR.CONNECTION_ID]: params.connectionId,
         [MONITORING_LOG_ATTR.CONNECTION_TITLE]: "",
         [MONITORING_LOG_ATTR.TOOL_NAME]: params.toolName,
-        [MONITORING_LOG_ATTR.INPUT]: truncateString(
-          JSON.stringify(redactedInput),
-        ),
-        [MONITORING_LOG_ATTR.OUTPUT]: truncateString(
-          JSON.stringify(redactedOutput),
-        ),
+        [MONITORING_LOG_ATTR.INPUT]: redactedInput,
+        [MONITORING_LOG_ATTR.OUTPUT]: redactedOutput,
         [MONITORING_LOG_ATTR.IS_ERROR]: params.isError,
         [MONITORING_LOG_ATTR.ERROR_MESSAGE]: redactedErrorMessage,
         [MONITORING_LOG_ATTR.DURATION_MS]: params.duration,


### PR DESCRIPTION
- Updated the emitMonitoringLog function to truncate input and output before redaction, improving performance by reducing the size of data processed.
- Added a new test case to verify that PII is correctly redacted in nested values and object keys, ensuring sensitive information is not logged.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `emitMonitoringLog` to serialize and truncate input/output before redaction, capping work and ensuring PII in object keys is also removed. Also truncates/redacts error messages and adds a test to verify redaction in nested values and keys.

<sup>Written for commit 3cc66fcf0b7808e47b616385d78e26b542a5e699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

