### PR TITLE
refactor(oauth): improve token refresh error handling and backoff logic

### DIFF
--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -169,18 +169,14 @@ async function _buildRequestHeaders(
 
     if (tokenResult.accessToken) {
       accessToken = tokenResult.accessToken;
-    } else {
-      if (tokenResult.state === "expired_without_refresh") {
-        console.warn(
-          `[Proxy] Token expired for ${connectionId} with no refresh capability`,
-        );
-      } else if (tokenResult.state === "refresh_failed") {
-        console.error("[Proxy] token refresh failed", {
-          connectionId,
-          tokenState: tokenResult.state,
-        });
-      }
+    } else if (tokenResult.state === "expired_without_refresh") {
+      console.warn(
+        `[Proxy] Token expired for ${connectionId} with no refresh capability`,
+      );
     }
+    // `refresh_failed` is already logged (once per backoff window) by the
+    // refresh primitive with full detail; the proxy falls back to the
+    // connection token below, so no second log here.
   }
 
   // Fall back to connection token if no cached token

--- a/apps/mesh/src/oauth/refresh-access-token.ts
+++ b/apps/mesh/src/oauth/refresh-access-token.ts
@@ -115,14 +115,22 @@ export async function refreshAccessToken(
         !!errorCode &&
         PERMANENT_REFRESH_ERROR_CODES.has(errorCode);
 
-      console.error("[TokenRefresh] refresh failed", {
-        connectionId: token.connectionId,
-        tokenEndpoint: token.tokenEndpoint,
-        status: response.status,
-        errorCode,
-        errorDescription,
-        permanent,
-      });
+      // Permanent failures (dead refresh_token) are actionable → error.
+      // Transient ones (5xx, non-spec codes like Cloudflare 525) are upstream
+      // blips the proxy recovers from → warn. The caller's backoff
+      // (refreshAndStore) rate-limits this so a down endpoint logs once per
+      // window, not once per request.
+      (permanent ? console.error : console.warn)(
+        "[TokenRefresh] refresh failed",
+        {
+          connectionId: token.connectionId,
+          tokenEndpoint: token.tokenEndpoint,
+          status: response.status,
+          errorCode,
+          errorDescription,
+          permanent,
+        },
+      );
 
       return {
         success: false,
@@ -152,7 +160,8 @@ export async function refreshAccessToken(
       scope: data.scope,
     };
   } catch (error) {
-    console.error("[TokenRefresh] network/parse error", {
+    // Network/parse errors are transient upstream failures → warn (see above).
+    console.warn("[TokenRefresh] network/parse error", {
       connectionId: token.connectionId,
       tokenEndpoint: token.tokenEndpoint,
       message: error instanceof Error ? error.message : String(error),

--- a/apps/mesh/src/oauth/token-refresh.integration.test.ts
+++ b/apps/mesh/src/oauth/token-refresh.integration.test.ts
@@ -29,7 +29,9 @@ mock.module("./refresh-access-token", () => ({
   refreshAccessToken: mockRefreshAccessToken,
 }));
 
-const { refreshAndStore } = await import("./token-refresh");
+const { refreshAndStore, clearRefreshBackoff } = await import(
+  "./token-refresh"
+);
 
 let database: StudioDatabase;
 let vault: CredentialVault;
@@ -62,6 +64,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   mockRefreshAccessToken.mockReset();
+  clearRefreshBackoff();
   await tokenStorage.delete(connectionId);
   await tokenStorage.upsert({
     connectionId,
@@ -177,6 +180,84 @@ describe("refreshAndStore", () => {
     await expect(first).resolves.toBe("fresh-single-flight");
     await expect(second).resolves.toBe("fresh-single-flight");
     expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses a re-attempt after a failure (backoff window)", async () => {
+    // First sequential call fails transiently → opens a backoff window.
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      permanent: false,
+      status: 525,
+      error: "Origin SSL handshake failed",
+    });
+
+    const token = await tokenStorage.get(connectionId);
+    expect(await refreshAndStore(token!, tokenStorage)).toBeNull();
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+
+    // Second sequential call within the window must NOT hit the endpoint.
+    expect(await refreshAndStore(token!, tokenStorage)).toBeNull();
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-attempts once the backoff window is cleared", async () => {
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      permanent: false,
+      status: 525,
+      error: "Origin SSL handshake failed",
+    });
+    const token = await tokenStorage.get(connectionId);
+    await refreshAndStore(token!, tokenStorage);
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+
+    // Simulate the window elapsing (or a manual reconnect clearing it).
+    clearRefreshBackoff(connectionId);
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh-after-backoff",
+      refreshToken: "rt",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+    expect(await refreshAndStore(token!, tokenStorage)).toBe(
+      "fresh-after-backoff",
+    );
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the backoff window after a successful refresh", async () => {
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      permanent: false,
+      status: 525,
+      error: "Origin SSL handshake failed",
+    });
+    const token = await tokenStorage.get(connectionId);
+    await refreshAndStore(token!, tokenStorage);
+
+    clearRefreshBackoff(connectionId);
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh",
+      refreshToken: "rt",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+    await refreshAndStore(token!, tokenStorage);
+
+    // A subsequent failure should be allowed to hit the endpoint immediately
+    // (the prior success reset the attempt counter / window).
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      permanent: false,
+      status: 525,
+      error: "Origin SSL handshake failed",
+    });
+    const after = await tokenStorage.get(connectionId);
+    expect(await refreshAndStore(after!, tokenStorage)).toBeNull();
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/apps/mesh/src/oauth/token-refresh.ts
+++ b/apps/mesh/src/oauth/token-refresh.ts
@@ -11,6 +11,7 @@
  * `refreshAndStore` here — same-module references cannot be mocked.
  */
 
+import { exponentialBackoffWithJitter } from "@decocms/std";
 import type { DownstreamToken } from "../storage/types";
 import type { DownstreamTokenStorage } from "../storage/downstream-token";
 import { refreshAccessToken } from "./refresh-access-token";
@@ -28,6 +29,30 @@ export function canRefresh(token: DownstreamToken): boolean {
 }
 
 const inflightRefreshes = new Map<string, Promise<string | null>>();
+
+/**
+ * Negative-cache for failed refreshes, keyed by connection. Single-flight
+ * (`inflightRefreshes`) only collapses *concurrent* refreshes; without this a
+ * down token endpoint (e.g. an upstream Cloudflare 525) is re-hit on every
+ * *sequential* proxy request — N requests = N network calls + N error logs.
+ * After a failure we suppress further attempts for an exponentially growing
+ * window so one broken upstream doesn't get hammered (and doesn't spam logs).
+ * Cleared on the next successful refresh. A freshly reconnected token is
+ * `valid` for ~1h, far past any cooldown, so it never refreshes through here
+ * while suppressed — no prod reset needed.
+ */
+const REFRESH_BACKOFF_BASE_MS = 30_000;
+const REFRESH_BACKOFF_CAP_MS = 5 * 60 * 1000;
+const refreshBackoff = new Map<
+  string,
+  { attempt: number; nextAttemptAt: number }
+>();
+
+/** Drop the suppression window for a connection (or all). Test/reconnect hook. */
+export function clearRefreshBackoff(connectionId?: string): void {
+  if (connectionId) refreshBackoff.delete(connectionId);
+  else refreshBackoff.clear();
+}
 
 async function refreshAndStoreOnce(
   token: DownstreamToken,
@@ -67,9 +92,36 @@ export function refreshAndStore(
   const existing = inflightRefreshes.get(token.connectionId);
   if (existing) return existing;
 
-  const refresh = refreshAndStoreOnce(token, tokenStorage).finally(() => {
-    inflightRefreshes.delete(token.connectionId);
-  });
+  const backoff = refreshBackoff.get(token.connectionId);
+  if (backoff && Date.now() < backoff.nextAttemptAt) {
+    // Still inside the suppression window from a recent failure — skip the
+    // network call (and its log) and report failure to the caller as usual.
+    return Promise.resolve(null);
+  }
+
+  const refresh = refreshAndStoreOnce(token, tokenStorage)
+    .then((accessToken) => {
+      if (accessToken) {
+        refreshBackoff.delete(token.connectionId);
+      } else {
+        const attempt = refreshBackoff.get(token.connectionId)?.attempt ?? 0;
+        const delay = exponentialBackoffWithJitter(
+          REFRESH_BACKOFF_CAP_MS,
+          REFRESH_BACKOFF_BASE_MS,
+          attempt,
+          2,
+          0.5,
+        );
+        refreshBackoff.set(token.connectionId, {
+          attempt: attempt + 1,
+          nextAttemptAt: Date.now() + delay,
+        });
+      }
+      return accessToken;
+    })
+    .finally(() => {
+      inflightRefreshes.delete(token.connectionId);
+    });
   inflightRefreshes.set(token.connectionId, refresh);
   return refresh;
 }


### PR DESCRIPTION
- Simplified logging for token refresh failures, differentiating between permanent and transient errors.
- Introduced a backoff mechanism to suppress repeated refresh attempts after failures, reducing unnecessary network calls and log spam.
- Added a `clearRefreshBackoff` function to manage the suppression window, allowing for manual resets during testing or reconnections.
- Enhanced integration tests to verify the new backoff behavior and ensure correct handling of refresh attempts after failures.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves OAuth token refresh reliability by adding exponential backoff with jitter and clearer logging. Prevents repeated refresh attempts and duplicate logs when an upstream token endpoint is down.

- **Refactors**
  - Permanent refresh failures log as errors; transient/network issues log as warnings.
  - Adds suppression window with exponential backoff + jitter via `@decocms/std`; window clears on success and skips network calls while active.
  - Exports `clearRefreshBackoff(connectionId?)` to reset the window for tests or reconnections.
  - Keeps single-flight for concurrent refreshes and now suppresses sequential retries during outages.
  - Removes extra `refresh_failed` logging in headers; proxy falls back to the connection token.
  - Extends integration tests to verify backoff, clearing, and success reset.

<sup>Written for commit 1cd0387468f161998e44985aaed73cc3119ef353. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

