### PR TITLE
feat(mcp): introduce mcpClientQueryOptions for improved client connec…

### DIFF
--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -12,7 +12,9 @@ import { readCachedOrg, writeCachedOrg } from "@/web/lib/query-persist";
 import { PostHogGroupSync } from "@/web/providers/posthog-group-sync";
 import {
   getWellKnownDecopilotVirtualMCP,
+  mcpClientQueryOptions,
   ProjectContextProvider,
+  SELF_MCP_ALIAS_ID,
   useProjectContext,
 } from "@decocms/mesh-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
@@ -295,6 +297,20 @@ function ShellLayoutContent() {
   const orgId = activeOrg?.id;
   const orgSlug = activeOrg?.slug;
   const { data: ssoStatus } = useOrgSsoStatus(orgId, orgSlug);
+
+  // Warm the self-MCP connection in parallel with the rest of shell bootstrap,
+  // so the home's useMCPClient resolves without waiting on a fresh connect()
+  // round-trip after it mounts. Non-suspense (useQuery) — this only pre-warms
+  // the shared cache entry (same key as useMCPClient via mcpClientQueryOptions);
+  // it never blocks paint, and no-ops if the connect doesn't finish first.
+  useQuery({
+    ...mcpClientQueryOptions({
+      connectionId: SELF_MCP_ALIAS_ID,
+      orgId: orgId ?? "",
+      orgSlug: orgSlug ?? "",
+    }),
+    enabled: !!orgId && !!orgSlug,
+  });
 
   if (!activeOrg) {
     // Not a member: figure out which screen to show (no-access / pending

--- a/packages/mesh-sdk/src/hooks/index.ts
+++ b/packages/mesh-sdk/src/hooks/index.ts
@@ -25,6 +25,7 @@ export {
 // MCP client hook and factory
 export {
   createMCPClient,
+  mcpClientQueryOptions,
   useMCPClient,
   useMCPClientOptional,
   type CreateMcpClientOptions,

--- a/packages/mesh-sdk/src/hooks/use-mcp-client.ts
+++ b/packages/mesh-sdk/src/hooks/use-mcp-client.ts
@@ -112,37 +112,39 @@ export async function createMCPClient({
 }
 
 /**
+ * React Query options for an MCP client connection. Single source of truth for
+ * the client query key + connect behavior, so a suspense consumer
+ * (`useMCPClient`) and a non-suspense pre-warm (e.g. the shell starting the self
+ * connection in parallel with the rest of bootstrap) target the EXACT same
+ * cache entry — the key cannot drift between them.
+ */
+export function mcpClientQueryOptions(options: UseMcpClientOptions) {
+  const { connectionId, token, meshUrl, orgId } = options;
+  return {
+    queryKey: KEYS.mcpClient(
+      orgId,
+      connectionId ?? "self",
+      token ?? "",
+      meshUrl ?? "",
+    ),
+    queryFn: () => createMCPClient(options),
+    staleTime: Infinity, // Keep client alive while query is active
+    // Keep the client cached for a minute after the last subscriber detaches so
+    // brief unmount/remount transitions (sidebar collapse toggle, popover open,
+    // etc.) re-use the same transport instead of re-establishing it.
+    gcTime: 60_000,
+  };
+}
+
+/**
  * Hook to create and manage an MCP client with Streamable HTTP transport.
  * Uses Suspense - must be used within a Suspense boundary.
  *
  * @param options - Configuration for the MCP client
  * @returns The MCP client instance (never null - suspends until ready)
  */
-export function useMCPClient({
-  connectionId,
-  orgId,
-  orgSlug,
-  token,
-  meshUrl,
-}: UseMcpClientOptions): Client {
-  const queryKey = KEYS.mcpClient(
-    orgId,
-    connectionId ?? "self",
-    token ?? "",
-    meshUrl ?? "",
-  );
-
-  const { data: client } = useSuspenseQuery({
-    queryKey,
-    queryFn: () =>
-      createMCPClient({ connectionId, orgId, orgSlug, token, meshUrl }),
-    staleTime: Infinity, // Keep client alive while query is active
-    // Keep the client cached for a minute after the last subscriber detaches so
-    // brief unmount/remount transitions (sidebar collapse toggle, popover open,
-    // etc.) re-use the same transport instead of re-establishing it.
-    gcTime: 60_000,
-  });
-
+export function useMCPClient(options: UseMcpClientOptions): Client {
+  const { data: client } = useSuspenseQuery(mcpClientQueryOptions(options));
   return client!;
 }
 

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -35,6 +35,7 @@ export {
   type UseConnectionsOptions,
   // MCP client hook and factory
   createMCPClient,
+  mcpClientQueryOptions,
   useMCPClient,
   useMCPClientOptional,
   type CreateMcpClientOptions,


### PR DESCRIPTION
…tion management

- Added mcpClientQueryOptions to streamline the configuration of MCP client connections, ensuring consistent query behavior across suspense and non-suspense contexts.
- Updated ShellLayoutContent to pre-warm the self-MCP connection during shell bootstrap, enhancing performance by reducing wait times for client resolution.
- Refactored useMCPClient to utilize the new mcpClientQueryOptions, maintaining the same cache entry for both suspense and non-suspense consumers.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `mcpClientQueryOptions` to unify MCP client connection config and cache keys, and pre-warm the self-MCP connection during shell bootstrap to cut wait time and avoid redundant connects.

- **New Features**
  - Added `mcpClientQueryOptions` and exported it from `mesh-sdk`; `useMCPClient` now uses it to keep a single query key and GC policy across consumers.

- **Performance**
  - `ShellLayoutContent` pre-warms the self-MCP connection (`SELF_MCP_ALIAS_ID`) with `useQuery` during bootstrap, reusing the exact cache entry used by `useMCPClient` so home mounts don’t wait on a fresh connect.

<sup>Written for commit f66d7ce3dba17108bb7da28582291f91a079bcff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

