### PR TITLE
Config max memory clickhouse

### DIFF
--- a/apps/mesh/README.md
+++ b/apps/mesh/README.md
@@ -165,6 +165,7 @@ ENCRYPTION_KEY=<32 bytes>           # Credential vault key
 NATS_URL=nats://localhost:4222      # Optional: enable NATS notify strategy
 NODE_ENV=production                 # Production mode
 CLICKHOUSE_URL=http://localhost:8123  # Optional: remote ClickHouse for prod monitoring
+CLICKHOUSE_MAX_MEMORY_USAGE=4294967296  # Optional: per-query memory ceiling in bytes (default 4 GiB)
 ```
 
 Custom auth providers (Google, GitHub, SAML, magic-link, …) live in `auth-config.json`. See [`auth-config.example.json`](./auth-config.example.json) for the full shape.

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -1151,8 +1151,17 @@ export async function createStudioContextFactory(
     // OTel-native otel_logs table — provisioned manually, see
     // monitoring/clickhouse-setup.md). Metrics are derived from those same log
     // rows, so both factories point at the view.
-    monitoringEngine = new ClickHouseClientEngine(clickhouseUrl!);
-    metricEngine = new ClickHouseClientEngine(clickhouseUrl!);
+    const clickhouseEngineOptions = settings.clickhouseMaxMemoryUsage
+      ? { maxMemoryUsage: String(settings.clickhouseMaxMemoryUsage) }
+      : undefined;
+    monitoringEngine = new ClickHouseClientEngine(
+      clickhouseUrl!,
+      clickhouseEngineOptions,
+    );
+    metricEngine = new ClickHouseClientEngine(
+      clickhouseUrl!,
+      clickhouseEngineOptions,
+    );
     logSourceFactory = (_orgId: string) => "studio_monitoring_logs";
     metricSourceFactory = (_orgId: string) => "studio_monitoring_logs";
   } else if (isGcsOtlp) {

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -168,7 +168,10 @@ export class ClickHouseClientEngine implements QueryEngine {
     url: string,
     options?: { maxMemoryUsage?: string; maxExecutionTime?: number },
   ) {
-    this.maxMemoryUsage = options?.maxMemoryUsage ?? "200000000";
+    // 4 GiB. The monitoring view reads the entire `LogAttributes` map per row
+    // (incl. input/output blobs), so a tight cap OOMs on busy orgs. Override
+    // via CLICKHOUSE_MAX_MEMORY_USAGE on a memory-constrained ClickHouse.
+    this.maxMemoryUsage = options?.maxMemoryUsage ?? "4294967296";
     this.maxExecutionTime = options?.maxExecutionTime ?? 30;
     this.initPromise = import("@clickhouse/client").then(({ createClient }) => {
       this.client = createClient({ url });

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -96,6 +96,8 @@ export function resolveConfig(
 
     // Observability
     clickhouseUrl: envVars.CLICKHOUSE_URL,
+    clickhouseMaxMemoryUsage:
+      Number(envVars.CLICKHOUSE_MAX_MEMORY_USAGE) || undefined,
     monitoringOtlpEndpoint: envVars.MONITORING_OTLP_ENDPOINT,
     otelServiceName: envVars.OTEL_SERVICE_NAME || "studio",
 

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -31,6 +31,10 @@ export interface Settings {
   // derived from those rows) instead of the local NDJSON files via DuckDB.
   // Traces/metrics tables are not read.
   clickhouseUrl: string | undefined;
+  // Per-query memory ceiling (bytes) sent as ClickHouse `max_memory_usage`.
+  // The monitoring queries read the wide `LogAttributes` map, so the default
+  // must be generous; tune down only on a memory-constrained ClickHouse.
+  clickhouseMaxMemoryUsage: number | undefined;
   // Dedicated OTLP collector base URL for monitoring/audit logs. Falls back to
   // OTEL_EXPORTER_OTLP_ENDPOINT (shared with infra logs) when unset. The "/v1/logs"
   // signal path is appended automatically.


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make ClickHouse query memory limit configurable for monitoring and metrics. Default is now 4 GiB to reduce OOMs on wide log queries and allow tuning on constrained servers.

- **New Features**
  - Added `CLICKHOUSE_MAX_MEMORY_USAGE` to set per-query `max_memory_usage` (bytes).
  - Default increased to 4 GiB (was 200,000,000 bytes).
  - Wired through settings as `clickhouseMaxMemoryUsage` and applied by `ClickHouseClientEngine` for monitoring and metrics.

<sup>Written for commit 1055d26c006a289b81428c67d34f4e6819296910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

