### PR TITLE
fix(web): persist CONNECTIONS list so the home doesn't blank on reload

### DIFF
--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -43,8 +43,12 @@ const PERSISTED_KEY_HEADS = new Set([
 // collectionName, ...]` — the leading `client` serializes to a stable
 // `mcp-client:<org>:<conn>` string via its `toJSON` (use-mcp-client.ts), so the
 // hash survives reloads and the entry is safe to persist. Limited to the
-// collections the home bootstrap reads.
-const PERSISTED_COLLECTIONS = new Set(["VIRTUAL_MCP"]);
+// collections the home bootstrap reads: VIRTUAL_MCP (sidebar agents + displayed
+// agent) and CONNECTIONS (the composer's connection list — the one home-gating
+// suspense read that was previously cold on every reload, so the home blanked
+// until COLLECTION_CONNECTIONS_LIST returned). Both are org-scoped, non-secret
+// metadata (credentials live in the vault, never in the connection list).
+const PERSISTED_COLLECTIONS = new Set(["VIRTUAL_MCP", "CONNECTIONS"]);
 
 let cacheRestored = false;
 let orgCacheRestored = false;


### PR DESCRIPTION
## Summary

The org home (`/$org`) still showed a ~1–2s loading screen on a **full reload**, even after the org-list/SWR work. Measured on prod (`/deco`, 10 full reloads): FCP ~550ms but **LCP ~2.07s, dead consistent** — i.e. a deterministic gate, not jitter.

Traced it to a single blocking suspense query: the composer's **connection list** (`COLLECTION_CONNECTIONS_LIST` via `useConnections` → `useCollectionList` → `useSuspenseQuery`). It was the **only** home-gating self-MCP read missing from the localStorage persist allowlist (`PERSISTED_COLLECTIONS` had `VIRTUAL_MCP` but not `CONNECTIONS`). So on every full reload it hydrated **cold**, suspended, and the home background + greeting stayed blank until it returned — **~860ms cross-region**, the bulk of the residual LCP. The 40×40 `connection-icons` avatars are its payload.

Every other home bootstrap read (`organization-settings`, `ai-provider-keys`, the `VIRTUAL_MCP` collection) was already persisted and resolved instantly from the hydrated cache — confirmed via a warm **SPA remount**, which fires **zero** `self` calls. `CONNECTIONS` now joins them.

## Change

One line: add `"CONNECTIONS"` to `PERSISTED_COLLECTIONS` in `apps/mesh/src/web/lib/query-persist.ts`. It now hydrates stale-first like the other collections, so the home paints from cache immediately and revalidates in the background — collapsing warm-reload LCP toward FCP.

## Safety

Connection list entries are org-scoped, **non-secret** metadata (name/icon/slug); credentials live in the vault, never in the list — same sensitivity class as the `VIRTUAL_MCP` and `organization-settings` reads already persisted. The query key embeds the client's stable `toJSON` string, so the cache hash survives reloads (same mechanism that already works for `VIRTUAL_MCP`).

## Testing

- Verified on local dev: after the change the `CONNECTIONS` list is written to `mesh:rq-cache` and, on the next reload, resolves `status: success` with data from the hydrated cache (`fetchStatus: idle`) instead of cold-pending — i.e. no blocking suspense. `hydrateQueryClient` runs before render (providers.tsx), so the data is present at mount.
- Cold-cache (first-ever visit / cleared storage) is unchanged — still does the one fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the composer’s `CONNECTIONS` list by adding it to `PERSISTED_COLLECTIONS`, so the org home no longer blanks on full reload and paints from cache immediately. This removes the last blocking suspense query and pulls warm-reload LCP down toward FCP.

<sup>Written for commit 22118eb58be8b138f44f9861bb2a68ecc2acbd52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

