### PR TITLE
fix(web): persist home-next-actions so the home grid doesn't flicker on reload

### DIFF
--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -26,6 +26,12 @@ const WRITE_DEBOUNCE_MS = 1000;
 //   - publicConfig          theme/styling — identical for every user
 //   - ai-provider-keys      AI_PROVIDER_KEY_LIST — metadata only, never secrets
 //   - organization-settings ORGANIZATION_SETTINGS_GET — sidebar/plugins/config
+//   - home-next-actions     the home grid's tiles + prompt chips. Plain (non-
+//                           suspense) query with staleTime 0, so without
+//                           hydration HomeGrid shows PromptChipsRowSkeleton and
+//                           the board reflows once it lands — the reload flicker.
+//                           Hydrated, it renders the prior grid instantly and
+//                           revalidates in the background.
 // plus the VIRTUAL_MCP collection reads (the home's displayed agent), matched
 // by key shape below.
 //
@@ -37,6 +43,7 @@ const PERSISTED_KEY_HEADS = new Set([
   "publicConfig",
   "ai-provider-keys",
   "organization-settings",
+  "home-next-actions",
 ]);
 
 // Collection reads are keyed by `[client, orgId, scopeKey, "collection",


### PR DESCRIPTION
## Summary

Follow-up to #3893 (persisted `CONNECTIONS`). On every full reload the home grid still **flickered**: a loading skeleton, then a layout reflow as the real tiles dropped in.

Cause: `home-next-actions` (the query feeding the home grid's tiles + prompt chips) is a plain `useQuery` with `staleTime: 0` and was **not** in the persist allowlist. So it was cold on every reload → `HomeGrid` rendered `PromptChipsRowSkeleton` until it landed, then the board reflowed when the real tiles replaced the skeleton.

## Change

Add `"home-next-actions"` to `PERSISTED_KEY_HEADS`. It now hydrates from `localStorage` and renders the prior grid **instantly**, revalidating in the background (`staleTime: 0` keeps it SWR-fresh, so content is never shown stale beyond the first revalidation after mount). Org-scoped, non-secret data — same class as the other persisted bootstrap reads.

## Testing

Verified on local dev: after the change `home-next-actions` is written to `mesh:rq-cache` and, on the next reload, the query resolves `status: success` with data from the hydrated cache (no cold `pending`) — so `HomeGrid`'s `isLoading` is false at mount and the grid skeleton + reflow are gone.

Note: a separate per-tile `TileLoadingFallback` can still appear briefly while each tile's live MCP connection re-establishes — tracked separately; this PR removes the grid-level skeleton/reflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted the `home-next-actions` query by adding it to `PERSISTED_KEY_HEADS` so the home grid no longer flickers on reload. It now hydrates from `localStorage` to render previous tiles and chips instantly, then revalidates in the background (`staleTime: 0`).

<sup>Written for commit bd904b0363a49cf454ef9ed15224dc711522536e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

