### PR TITLE
fix(web): render home tile chrome without waiting on the tile's MCP connect

### DIFF
--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -177,11 +177,6 @@ function AgentUITile({
   tileWidth: number;
 }) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: tile.connectionId,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
   const { open, startBlank, dialog, starting } = usePromptEntryAction(
     tile.agentId,
   );
@@ -213,21 +208,16 @@ function AgentUITile({
       </button>
       <div className="flex min-h-0 flex-1 gap-3 overflow-hidden">
         <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border">
-          {/* Inner boundary so the slow resource read only blocks the embedded
-              panel — the tile chrome (agent name, Open chat, prompt chips)
-              renders immediately and stays interactive while the app loads. */}
+          {/* Inner boundary so the connect + resource read only block the
+              embedded panel — the tile chrome (agent name, Open chat, prompt
+              chips) renders immediately from cached tile data and stays
+              interactive while the connection establishes and the app loads.
+              The useMCPClient connect lives in TileAppPanel (below this
+              boundary) on purpose: hoisting it to the tile root would suspend
+              the whole tile on every reload, re-introducing a full-tile
+              skeleton even though the chrome needs no live connection. */}
           <Suspense fallback={<TilePanelSkeleton />}>
-            <MCPAppRenderer
-              resourceURI={tile.resourceUri}
-              orgId={org.id}
-              orgSlug={org.slug}
-              connectionId={tile.connectionId}
-              client={client}
-              displayMode="fullscreen"
-              minHeight={tile.minHeight ?? 200}
-              maxHeight={tile.maxHeight ?? 4000}
-              className="h-full"
-            />
+            <TileAppPanel tile={tile} orgId={org.id} orgSlug={org.slug} />
           </Suspense>
         </div>
         {promptChips.length > 0 && !isEditMode && tileWidth >= 2 && (
@@ -251,6 +241,37 @@ function AgentUITile({
       </div>
       {dialog}
     </div>
+  );
+}
+
+/** Owns the tile's live MCP connection so the connect suspends only the
+ *  embedded panel (via the inner boundary above), not the whole tile. */
+function TileAppPanel({
+  tile,
+  orgId,
+  orgSlug,
+}: {
+  tile: HomeTileEntry;
+  orgId: string;
+  orgSlug: string;
+}) {
+  const client = useMCPClient({
+    connectionId: tile.connectionId,
+    orgId,
+    orgSlug,
+  });
+  return (
+    <MCPAppRenderer
+      resourceURI={tile.resourceUri}
+      orgId={orgId}
+      orgSlug={orgSlug}
+      connectionId={tile.connectionId}
+      client={client}
+      displayMode="fullscreen"
+      minHeight={tile.minHeight ?? 200}
+      maxHeight={tile.maxHeight ?? 4000}
+      className="h-full"
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #3893 / #3894 (which persist the home's *data* so the grid-level skeleton + reflow are gone). The remaining visible loading state on reload was the **per-tile** skeleton: each home tile flashed a full-tile `TileLoadingFallback`.

Cause: `AgentUITile` called `useMCPClient(tile.connectionId)` at its **root**, so the tile's *live* MCP connect suspended the **whole tile** (caught by the outer boundary) on every reload — even though the tile chrome (agent avatar, name, "Open chat", inline prompt chips) needs **no** live connection, only the cached tile metadata. The inner `<Suspense>` was meant to scope loading to just the embedded panel, but the connect sat above it, so the intent wasn't realized.

## Change

Move the `useMCPClient` connect into a small `TileAppPanel` rendered **inside** the existing inner `<Suspense fallback={TilePanelSkeleton}>`. Now:
- **Tile chrome** (avatar, name, Open chat, prompt chips) paints **immediately** from cached `home-next-actions` data and is interactive right away.
- Only the **embedded UI panel** waits on the connect + resource read, showing the small `TilePanelSkeleton` within the tile.

Net: no more full-tile skeleton flicker on reload; the home looks "done" as soon as the cached data renders, and the live widget content streams into each panel behind its own boundary.

## Testing

- `tsc --noEmit` clean.
- Local dev: home renders with all tile chrome (agent names, "Open chat", prompt chips) present and interactive; embedded panels fill in behind the inner boundary. No runtime errors.

## Toward "instant"

With #3893/#3894 (data hydrates from cache) + this (tile chrome decoupled from connect), the only remaining reload gate is the top-level `useMCPClient(self)` suspense in `HomePage` (~280ms live connect). Decoupling that one too is the next step toward zero loading state except a genuinely cold path (first-ever org visit / cleared cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render home tile chrome immediately by moving the MCP connect inside the embedded panel, so only the panel suspends and the per-tile skeleton flicker on reload is gone.

- **Bug Fixes**
  - Moved `useMCPClient` from `AgentUITile` to a new `TileAppPanel` rendered under the inner `<Suspense>`.
  - Tile chrome (avatar, name, Open chat, prompt chips) now paints from cached data and stays interactive.
  - Only the embedded panel waits on connect + resource read, showing `TilePanelSkeleton` instead of a full-tile fallback.

<sup>Written for commit 431b8526aaf57da56bb413f2dc95ad03bb0aa5fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

