### PR TITLE
Fix/persist connections list

### DIFF
--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -26,6 +26,12 @@ const WRITE_DEBOUNCE_MS = 1000;
 //   - publicConfig          theme/styling — identical for every user
 //   - ai-provider-keys      AI_PROVIDER_KEY_LIST — metadata only, never secrets
 //   - organization-settings ORGANIZATION_SETTINGS_GET — sidebar/plugins/config
+//   - home-next-actions     the home grid's tiles + prompt chips. Plain (non-
+//                           suspense) query with staleTime 0, so without
+//                           hydration HomeGrid shows PromptChipsRowSkeleton and
+//                           the board reflows once it lands — the reload flicker.
+//                           Hydrated, it renders the prior grid instantly and
+//                           revalidates in the background.
 // plus the VIRTUAL_MCP collection reads (the home's displayed agent), matched
 // by key shape below.
 //
@@ -37,6 +43,7 @@ const PERSISTED_KEY_HEADS = new Set([
   "publicConfig",
   "ai-provider-keys",
   "organization-settings",
+  "home-next-actions",
 ]);
 
 // Collection reads are keyed by `[client, orgId, scopeKey, "collection",

--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -43,8 +43,12 @@ const PERSISTED_KEY_HEADS = new Set([
 // collectionName, ...]` — the leading `client` serializes to a stable
 // `mcp-client:<org>:<conn>` string via its `toJSON` (use-mcp-client.ts), so the
 // hash survives reloads and the entry is safe to persist. Limited to the
-// collections the home bootstrap reads.
-const PERSISTED_COLLECTIONS = new Set(["VIRTUAL_MCP"]);
+// collections the home bootstrap reads: VIRTUAL_MCP (sidebar agents + displayed
+// agent) and CONNECTIONS (the composer's connection list — the one home-gating
+// suspense read that was previously cold on every reload, so the home blanked
+// until COLLECTION_CONNECTIONS_LIST returned). Both are org-scoped, non-secret
+// metadata (credentials live in the vault, never in the connection list).
+const PERSISTED_COLLECTIONS = new Set(["VIRTUAL_MCP", "CONNECTIONS"]);
 
 let cacheRestored = false;
 let orgCacheRestored = false;


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted the composer’s connection list (`CONNECTIONS`) and `home-next-actions` so the home no longer blanks or flickers on reload. Data now hydrates from localStorage and revalidates in the background.

- **Bug Fixes**
  - Added `CONNECTIONS` to persisted collections to stop home from suspending on reload.
  - Added `home-next-actions` to persisted keys to render the previous grid instantly (no skeleton flicker), with SWR revalidation.

<sup>Written for commit d3ed31bf84434544472615caf4f88ba3297096d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

