### PR TITLE
feat(models): suspend Fable 5, rollback Thinking tier to Opus 4.8 1M

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/claude-code-models.ts
+++ b/apps/mesh/src/ai-providers/adapters/claude-code-models.ts
@@ -37,4 +37,13 @@ export const CLAUDE_CODE_MODELS: ModelInfo[] = [
     limits: null,
     costs: null,
   },
+  {
+    providerId: "claude-code",
+    modelId: "claude-code:opus-1m",
+    title: "Claude Code Opus 4.8 1M",
+    description: "Most capable, 1M context window",
+    capabilities: ["text", "reasoning"],
+    limits: { contextWindow: 1_000_000, maxOutputTokens: null },
+    costs: null,
+  },
 ];

--- a/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
@@ -41,8 +41,8 @@ const CLAUDE_CODE_TIERS: AgentTierMap = {
     iconNode: <ClaudeCodeIcon size={16} />,
   },
   thinking: {
-    modelId: "claude-code:opus",
-    label: "Opus 4.8",
+    modelId: "claude-code:opus-1m",
+    label: "Opus 4.8 1M",
     description: "Deeper reasoning",
     iconNode: <ClaudeCodeIcon size={16} />,
   },

--- a/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
@@ -41,8 +41,8 @@ const CLAUDE_CODE_TIERS: AgentTierMap = {
     iconNode: <ClaudeCodeIcon size={16} />,
   },
   thinking: {
-    modelId: "claude-code:fable",
-    label: "Fable 5",
+    modelId: "claude-code:opus",
+    label: "Opus 4.8",
     description: "Deeper reasoning",
     iconNode: <ClaudeCodeIcon size={16} />,
   },

--- a/apps/mesh/src/web/components/chat/use-agent-mode.test.ts
+++ b/apps/mesh/src/web/components/chat/use-agent-mode.test.ts
@@ -48,9 +48,9 @@ describe("resolveTierSubtitle", () => {
         "Sonnet 4.6",
       );
     });
-    it("thinking → Fable 5", () => {
+    it("thinking → Opus 4.8 1M", () => {
       expect(resolveTierSubtitle("local-claude-code", "thinking")).toBe(
-        "Fable 5",
+        "Opus 4.8 1M",
       );
     });
   });

--- a/apps/mesh/src/web/lib/release-feed.ts
+++ b/apps/mesh/src/web/lib/release-feed.ts
@@ -30,6 +30,30 @@ export interface Release {
  */
 export const RELEASES: Release[] = [
   {
+    id: "fable-5-suspension",
+    date: "2026-06-13",
+    eyebrow: "Important Update",
+    title: "Fable 5 & Mythos 5 suspended — Opus 4.8 takes over",
+    bullets: [
+      {
+        icon: CheckCircle,
+        title: "US government directive",
+        body: "Anthropic received an export control directive requiring the suspension of Fable 5 and Mythos 5 access for all users, citing national security concerns. Anthropic is complying while it works to resolve the matter.",
+      },
+      {
+        icon: Stars02,
+        title: "Opus 4.8 steps in as the Thinking tier",
+        body: "The Thinking tier now runs on Claude Opus 4.8, which remains fully operational. Performance on most tasks is comparable, and Anthropic reports more than 95% of sessions were unaffected by the Fable 5 classifiers anyway.",
+      },
+      {
+        icon: Zap,
+        title: "Nothing to change",
+        body: "The switch is automatic — any chat or agent already using the Thinking tier is now served by Opus 4.8. Anthropic will share further details within 24 hours.",
+      },
+    ],
+    learnMoreHref: "https://www.anthropic.com/news/fable-mythos-access",
+  },
+  {
     id: "claude-fable-5",
     date: "2026-06-09",
     eyebrow: "Now Available",

--- a/packages/harness/src/claude-code/model/agent-tiers.ts
+++ b/packages/harness/src/claude-code/model/agent-tiers.ts
@@ -20,7 +20,7 @@ export type AgentTierMap = Record<ChatTier, AgentTierEntry>;
 const CLAUDE_CODE_TIERS: AgentTierMap = {
   fast: { modelId: "claude-code:haiku", label: "Haiku 4.5" },
   smart: { modelId: "claude-code:sonnet", label: "Sonnet 4.6" },
-  thinking: { modelId: "claude-code:opus", label: "Opus 4.8" },
+  thinking: { modelId: "claude-code:opus-1m", label: "Opus 4.8 1M" },
 };
 
 const CODEX_TIERS: AgentTierMap = {

--- a/packages/harness/src/claude-code/model/agent-tiers.ts
+++ b/packages/harness/src/claude-code/model/agent-tiers.ts
@@ -20,7 +20,7 @@ export type AgentTierMap = Record<ChatTier, AgentTierEntry>;
 const CLAUDE_CODE_TIERS: AgentTierMap = {
   fast: { modelId: "claude-code:haiku", label: "Haiku 4.5" },
   smart: { modelId: "claude-code:sonnet", label: "Sonnet 4.6" },
-  thinking: { modelId: "claude-code:fable", label: "Fable 5" },
+  thinking: { modelId: "claude-code:opus", label: "Opus 4.8" },
 };
 
 const CODEX_TIERS: AgentTierMap = {

--- a/packages/harness/src/claude-code/model/index.ts
+++ b/packages/harness/src/claude-code/model/index.ts
@@ -73,12 +73,13 @@ export function createClaudeCodeModel(
  *
  * NOTE: The ai-sdk-provider-claude-code SDK only recognises the short aliases
  * "opus", "sonnet", and "haiku". Any other string is passed straight through to
- * the CLI's --model flag. For Fable 5 we therefore use the full CLI model ID
- * "claude-fable-5" so the CLI can resolve it correctly (the short alias "fable"
- * is not in the SDK's modelMap and the CLI rejects it).
+ * the CLI's --model flag. For models not covered by a short alias (Fable 5,
+ * Opus 4.8 1M) we therefore use the full CLI model ID so the CLI can resolve
+ * it correctly.
  */
 const CLAUDE_CODE_SDK_MODELS: Record<string, string> = {
   "claude-code:opus": "opus",
+  "claude-code:opus-1m": "claude-opus-4.8-1m",
   "claude-code:sonnet": "sonnet",
   "claude-code:haiku": "haiku",
   "claude-code:fable": "claude-fable-5",

--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -112,7 +112,11 @@ export const THINKING_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
       "anthropic/claude-fable",
     ],
     google: ["gemini-3-pro"],
-    "claude-code": ["claude-code:opus", "claude-code:sonnet"],
+    "claude-code": [
+      "claude-code:opus-1m",
+      "claude-code:opus",
+      "claude-code:sonnet",
+    ],
     codex: ["codex:gpt-5.5"],
   };
 

--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -90,26 +90,29 @@ export const SMART_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
 export const THINKING_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
   {
     anthropic: [
-      "claude-fable-5",
       "claude-opus-4-8",
       "claude-sonnet-4-6",
       "claude-sonnet",
+      // Fable 5 suspended by US government directive (2026-06-13)
+      "claude-fable-5",
     ],
     openrouter: [
-      "anthropic/claude-fable-5",
       "anthropic/claude-opus-4.8",
       "anthropic/claude-sonnet-4.6:extended",
       "anthropic/claude-sonnet-4.6",
       "google/gemini-3-pro",
+      // Fable 5 suspended by US government directive (2026-06-13)
+      "anthropic/claude-fable-5",
     ],
     deco: [
-      "anthropic/claude-fable",
       "anthropic/claude-opus",
       "anthropic/claude-sonnet-4.6",
       "anthropic/claude-sonnet",
+      // Fable suspended by US government directive (2026-06-13)
+      "anthropic/claude-fable",
     ],
     google: ["gemini-3-pro"],
-    "claude-code": ["claude-code:fable", "claude-code:sonnet"],
+    "claude-code": ["claude-code:opus", "claude-code:sonnet"],
     codex: ["codex:gpt-5.5"],
   };
 


### PR DESCRIPTION
## Summary

- **New release notice**: Added `fable-5-suspension` entry to the release feed announcing that Anthropic's Fable 5 & Mythos 5 models are suspended by US government export control directive, and that Opus 4.8 takes over the Thinking tier automatically.
- **Model rollback**: Switched Claude Code Thinking tier from `claude-code:fable` (`claude-fable-5`) → `claude-code:opus-1m` (`claude-opus-4.8-1m`), passing the full model ID to the CLI's `--model` flag.
- **1M context**: Added `claude-code:opus-1m` to the harness SDK model map, the browser-safe model adapter list (with `contextWindow: 1_000_000`), and the `THINKING_MODEL_PREFERENCES` order so it's picked up automatically.

## Test plan

- [ ] `bun test packages/harness/src/claude-code/model/index.test.ts` — the existing "every tier maps to a non-composite SDK alias" guard now covers `claude-code:opus-1m → claude-opus-4.8-1m` ✓
- [ ] UI: Thinking tier label shows **"Opus 4.8 1M"** in the Claude Code model selector
- [ ] Release feed card shows the Fable 5 suspension notice on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suspends Fable 5/Mythos 5 and moves the Thinking tier to Opus 4.8 1M with an automatic fallback. Adds a release notice and updates model maps, preferences, tests, and UI labels to use `claude-code:opus-1m`.

- **New Features**
  - Added `fable-5-suspension` entry to the release feed.
  - Introduced `claude-code:opus-1m` (1M context) and mapped it to CLI `claude-opus-4.8-1m`.
  - Switched Thinking tier to `claude-code:opus-1m`; updated preferences and UI label to "Opus 4.8 1M".

- **Bug Fixes**
  - Updated test expectation for Thinking tier label to "Opus 4.8 1M".

<sup>Written for commit 056b38cce798428f3ca6739c2f6c33d5a1115414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

