### PR TITLE
refactor(chat): unify branch and mode picker locked states

### DIFF
--- a/apps/mesh/e2e/tests/chat-locked-thread.spec.ts
+++ b/apps/mesh/e2e/tests/chat-locked-thread.spec.ts
@@ -14,7 +14,7 @@
  *     after sending a conflicting body.
  *
  *   - Task 5 / Task 6 (UI affordance): on a locked thread the harness pill
- *     and branch chip render as `harness-picker-locked` /
+ *     and branch chip render as `mode-picker-locked` /
  *     `branch-picker-locked` with the original values, and the same is true
  *     after a hard reload.
  *
@@ -251,7 +251,7 @@ test.describe("Thread runtime is locked after first message", () => {
     try {
       // Seed an AI provider key so the thread route renders the
       // composer instead of `NoAiProviderEmptyState`. Without this,
-      // `harness-picker-locked` never mounts because the chat input
+      // `mode-picker-locked` never mounts because the chat input
       // itself is short-circuited away.
       await seedAiProviderKey(api, orgSlug);
 
@@ -282,13 +282,13 @@ test.describe("Thread runtime is locked after first message", () => {
       // harness/branch pickers entirely.
       await page.goto(`/${orgSlug}/${threadId}?virtualmcpid=${agentId}`);
 
-      const lockedHarness = page.getByTestId("harness-picker-locked");
+      const lockedHarness = page.getByTestId("mode-picker-locked");
       await expect(lockedHarness).toBeVisible({ timeout: 60_000 });
       await expect(lockedHarness).toHaveAccessibleName(/claude code/i);
 
       // The unlocked-state harness trigger must NOT be present — that
       // would mean the lock chip is shadowed by the live picker.
-      await expect(page.getByTestId("harness-picker")).toHaveCount(0);
+      await expect(page.getByTestId("mode-picker")).toHaveCount(0);
 
       // Note: the branch-picker-locked chip is intentionally not asserted
       // here. `ChatModeRow` gates `BranchPill` on
@@ -303,7 +303,7 @@ test.describe("Thread runtime is locked after first message", () => {
 
       // Hard reload — locked affordance must survive a fresh mount.
       await page.reload();
-      await expect(page.getByTestId("harness-picker-locked")).toBeVisible({
+      await expect(page.getByTestId("mode-picker-locked")).toBeVisible({
         timeout: 60_000,
       });
     } finally {

--- a/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
+++ b/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
@@ -6,7 +6,6 @@ import {
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { GitBranch01 } from "@untitledui/icons";
-import { useOptionalChatTask } from "../chat-context";
 import { BranchPicker } from "../../thread/github/branch-picker";
 
 interface Props {
@@ -30,20 +29,15 @@ interface Props {
  * Button + Tooltip when disabled — the user just can't open the
  * popover.
  *
- * When the active thread is *thread-locked* (i.e. `thread.harness_id` is
- * captured on the server row) we replace the picker with a
- * non-clickable lock chip. Any branch change on a locked thread is a
- * no-op on submit (see `applyThreadLock`), so we surface that to the
- * user instead of silently ignoring the click.
+ * When `locked` is true (chat has messages or is a thread-locked thread)
+ * we replace the picker with a non-clickable lock chip so the user can
+ * see the active branch without being able to change it.
  */
-export function BranchPill({ locked, placement, ...props }: Props) {
-  const taskCtx = useOptionalChatTask();
-  const isThreadLocked = taskCtx?.isThreadLocked ?? false;
-  const lockedBranch = taskCtx?.lockedBranch ?? null;
+export function BranchPill({ locked, placement, value, ...props }: Props) {
   const isHeader = placement === "header";
 
-  if (isThreadLocked) {
-    const branchLabel = lockedBranch ?? "(no branch)";
+  if (locked) {
+    const branchLabel = value ?? "(no branch)";
     return (
       <Tooltip>
         <TooltipTrigger asChild>
@@ -79,5 +73,12 @@ export function BranchPill({ locked, placement, ...props }: Props) {
     );
   }
 
-  return <BranchPicker {...props} disabled={locked} placement={placement} />;
+  return (
+    <BranchPicker
+      {...props}
+      value={value}
+      disabled={locked}
+      placement={placement}
+    />
+  );
 }

--- a/apps/mesh/src/web/components/chat/pills/chat-mode-row.test.tsx
+++ b/apps/mesh/src/web/components/chat/pills/chat-mode-row.test.tsx
@@ -13,6 +13,7 @@ mock.module("../../thread/github/branch-picker", () => ({
 
 import { ChatModeRowPure } from "./chat-mode-row";
 import { BranchPill } from "./branch-pill";
+import { ModePickerPure } from "./mode-picker";
 
 describe("ChatModeRowPure", () => {
   it("returns null when both pills are null", () => {
@@ -89,5 +90,40 @@ describe("BranchPill", () => {
       <BranchPill {...BRANCH_PILL_PROPS} locked={false} />,
     );
     expect(getByRole("button")).toBeInTheDocument();
+  });
+});
+
+describe("ChatModeRow integration", () => {
+  it("renders both pills as non-interactive when locked=true", () => {
+    const { getByTestId, queryAllByRole } = render(
+      <ChatModeRowPure
+        branchPill={
+          <BranchPill {...BRANCH_PILL_PROPS} locked={true} value="main" />
+        }
+        modePicker={
+          <ModePickerPure
+            mode="cloud-decopilot"
+            availability={{
+              agentSandbox: true,
+              userDesktop: false,
+              claudeCode: false,
+              codex: false,
+            }}
+            locked={true}
+            onSelect={mock(() => {})}
+          />
+        }
+      />,
+    );
+
+    // Both locked elements are present
+    expect(getByTestId("branch-picker-locked")).toBeInTheDocument();
+    expect(getByTestId("mode-picker-locked")).toBeInTheDocument();
+
+    // No interactive (enabled) buttons should be present
+    const buttons = queryAllByRole("button");
+    for (const btn of buttons) {
+      expect(btn).toBeDisabled();
+    }
   });
 });

--- a/apps/mesh/src/web/components/chat/pills/chat-mode-row.test.tsx
+++ b/apps/mesh/src/web/components/chat/pills/chat-mode-row.test.tsx
@@ -1,9 +1,18 @@
 import { setupComponentTest } from "../../../../test/setup"; // happy-dom + jest-dom matchers
 setupComponentTest();
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
+
+// Mock BranchPicker so BranchPill tests don't pull in its heavy
+// network/hook dependencies. The mock just renders a plain <button>
+// so tests can assert the unlocked path forwards to BranchPicker.
+mock.module("../../thread/github/branch-picker", () => ({
+  BranchPicker: () => <button type="button">branch-picker</button>,
+}));
+
 import { ChatModeRowPure } from "./chat-mode-row";
+import { BranchPill } from "./branch-pill";
 
 describe("ChatModeRowPure", () => {
   it("returns null when both pills are null", () => {
@@ -51,5 +60,34 @@ describe("ChatModeRowPure", () => {
     expect(
       mode.compareDocumentPosition(branch) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+});
+
+const BRANCH_PILL_PROPS = {
+  orgId: "org-1",
+  orgSlug: "my-org",
+  userId: "user-1",
+  virtualMcpId: "vmcp-1",
+  connectionId: "conn-1",
+  owner: "acme",
+  repo: "monorepo",
+  sandboxMap: undefined,
+  value: "main",
+  onChange: () => {},
+} as const;
+
+describe("BranchPill", () => {
+  it("renders the lock chip when locked=true", () => {
+    const { getByTestId } = render(
+      <BranchPill {...BRANCH_PILL_PROPS} locked={true} />,
+    );
+    expect(getByTestId("branch-picker-locked")).toBeInTheDocument();
+  });
+
+  it("renders BranchPicker (a button) when locked=false", () => {
+    const { getByRole } = render(
+      <BranchPill {...BRANCH_PILL_PROPS} locked={false} />,
+    );
+    expect(getByRole("button")).toBeInTheDocument();
   });
 });

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.test.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.test.tsx
@@ -113,6 +113,83 @@ describe("ModePickerPure", () => {
     expect(button).toBeDisabled();
   });
 
+  it("locked=true gives the button data-testid='mode-picker-locked' and disabled", () => {
+    const { getByTestId } = render(
+      <ModePickerPure
+        mode="cloud-decopilot"
+        availability={{
+          agentSandbox: true,
+          userDesktop: true,
+          claudeCode: true,
+          codex: true,
+        }}
+        locked={true}
+        onSelect={() => {}}
+      />,
+    );
+    const button = getByTestId("mode-picker-locked");
+    expect(button).toBeDisabled();
+  });
+
+  it("locked=false gives the button data-testid='mode-picker' and not disabled", () => {
+    const { getByTestId } = render(
+      <ModePickerPure
+        mode="cloud-decopilot"
+        availability={{
+          agentSandbox: true,
+          userDesktop: true,
+          claudeCode: true,
+          codex: true,
+        }}
+        locked={false}
+        onSelect={() => {}}
+      />,
+    );
+    const button = getByTestId("mode-picker");
+    expect(button).not.toBeDisabled();
+  });
+
+  it("locked=true with lockedHarness='claude-code' uses harness-specific aria-label", () => {
+    const { getByTestId } = render(
+      <ModePickerPure
+        mode="local-claude-code"
+        availability={{
+          agentSandbox: true,
+          userDesktop: true,
+          claudeCode: true,
+          codex: true,
+        }}
+        locked={true}
+        lockedHarness="claude-code"
+        onSelect={() => {}}
+      />,
+    );
+    const button = getByTestId("mode-picker-locked");
+    expect(button).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Claude Code"),
+    );
+  });
+
+  it("locked=true with lockedHarness=null uses mode text as aria-label", () => {
+    const { getByTestId } = render(
+      <ModePickerPure
+        mode="cloud-decopilot"
+        availability={{
+          agentSandbox: true,
+          userDesktop: true,
+          claudeCode: true,
+          codex: true,
+        }}
+        locked={true}
+        lockedHarness={null}
+        onSelect={() => {}}
+      />,
+    );
+    const button = getByTestId("mode-picker-locked");
+    expect(button).toHaveAttribute("aria-label", "Cloud");
+  });
+
   it("opens the popover and shows stitched rows in order", () => {
     const { getByRole, getAllByRole } = render(
       <ModePickerPure

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
@@ -175,7 +175,7 @@ export function ModePickerPure({
   const [open, setOpen] = useState(false);
   const { icon, text } = pillLabel(mode);
   const isLocal = mode !== "cloud-decopilot";
-  const isThreadLocked = locked && lockedHarness != null;
+  const showHarnessLabel = lockedHarness != null;
   const harnessLabel = lockedHarness ? HARNESS_LABEL[lockedHarness] : null;
   // Cloud rows hide when unavailable (a deployment without an agent sandbox
   // is an operator decision, nothing the user can act on). Local rows always
@@ -208,14 +208,12 @@ export function ModePickerPure({
                 variant="ghost"
                 size="default"
                 aria-label={
-                  isThreadLocked && harnessLabel
+                  showHarnessLabel && harnessLabel
                     ? `This chat is using ${harnessLabel}. Start a new chat to use a different runtime.`
                     : text
                 }
                 disabled={locked}
-                data-testid={
-                  isThreadLocked ? "harness-picker-locked" : "harness-picker"
-                }
+                data-testid={locked ? "mode-picker-locked" : "mode-picker"}
                 className={cn(
                   baseClasses,
                   isLocal && localPreviewClasses,
@@ -224,13 +222,7 @@ export function ModePickerPure({
                 )}
               >
                 {icon}
-                <span
-                  className={cn(
-                    "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
-                    !locked &&
-                      "@[320px]/chat-bottom:max-w-32 @[320px]/chat-bottom:opacity-100",
-                  )}
-                >
+                <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[320px]/chat-bottom:max-w-32 @[320px]/chat-bottom:opacity-100">
                   {text}
                 </span>
                 {!locked && (
@@ -244,7 +236,7 @@ export function ModePickerPure({
           </span>
         </TooltipTrigger>
         <TooltipContent>
-          {isThreadLocked && harnessLabel
+          {showHarnessLabel && harnessLabel
             ? `This chat is using ${harnessLabel}. Start a new chat to use a different runtime.`
             : text}
         </TooltipContent>

--- a/apps/mesh/src/web/components/thread/github/branch-picker.tsx
+++ b/apps/mesh/src/web/components/thread/github/branch-picker.tsx
@@ -157,11 +157,7 @@ export function BranchPicker({
                     "min-w-0 truncate",
                     isHeader
                       ? ""
-                      : cn(
-                          "transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
-                          !disabled &&
-                            "@[320px]/chat-bottom:max-w-[200px] @[320px]/chat-bottom:opacity-100",
-                        ),
+                      : "transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[320px]/chat-bottom:max-w-[200px] @[320px]/chat-bottom:opacity-100",
                   )}
                 >
                   {label}


### PR DESCRIPTION
## Summary

- **Problem:** `BranchPill` and `ModePicker` had two separate locked rendering paths — a new chat after message submission showed icon-only (disabled picker), while an older/finalized chat showed the full branch name (lock chip with responsive visibility). Same container width, different UI.
- **Root cause:** `BranchPill` was checking `isThreadLocked` from React context independently of the `locked` prop, resulting in two code paths with inconsistent responsive behavior.
- **Solution:** Removed the secondary context checks from both `BranchPill` and `ModePickerPure`. Both now trust the pre-computed `locked` prop from `ChatModeRow` (which already unifies `messages.length > 0 || isThreadLocked`). Both always render the lock chip when locked, with consistent `@[320px]/chat-bottom` responsive label visibility.

## Changes

- `branch-pill.tsx` — removed `useOptionalChatTask` dependency; uses `locked` prop + `value` prop for label
- `branch-picker.tsx` — removed `!disabled &&` guard on responsive classes; label now always shows if container ≥ 320px
- `mode-picker.tsx` — replaced `isThreadLocked` variable with `showHarnessLabel`; removed `!locked &&` guard on label span; updated `data-testid` to `mode-picker-locked`/`mode-picker`
- `chat-mode-row.test.tsx` — added BranchPill locked/unlocked tests + ChatModeRow integration test
- `mode-picker.test.tsx` — added unified locked behavior tests (testid, disabled, aria-label)

## Test Plan

- [x] `bun test apps/mesh/src/web/components/chat/pills/` — 38/38 pass
- [x] `bun run check` — no TypeScript errors
- [x] `bun run lint` — 0 errors (2 pre-existing warnings in unrelated file)
- [ ] Visual: verify both new and old chats render branch pill identically after message submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies locked-state rendering for `BranchPill` and `ModePicker` so both show a disabled lock chip with a responsive label when a chat is locked, driven by a single `locked` prop from `ChatModeRow`.

- **Bug Fixes**
  - Fixed mismatch where new chats showed icon-only while older/finalized chats showed a full label.
  - Updated e2e test to assert `mode-picker-locked` and remove `harness-picker-*` selectors.

- **Refactors**
  - `BranchPill`: removed context dependency; when `locked`, render a non-clickable lock chip using `value`; otherwise forward `value` to `BranchPicker`.
  - `BranchPicker`/`ModePicker`: always apply responsive label at `@[320px]/chat-bottom` regardless of disabled/locked.
  - `ModePicker`: `data-testid` is `mode-picker`/`mode-picker-locked`; aria-label uses `lockedHarness` when present.
  - Tests: added unit and integration tests for unified locked behavior.

<sup>Written for commit c33158810da14832e58e0ad02ff69a84dfaaf299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

