### PR TITLE
perf(sandbox): build WebSocket frames in a single allocation

### DIFF
--- a/packages/sandbox/proxy/websocket.ts
+++ b/packages/sandbox/proxy/websocket.ts
@@ -276,13 +276,23 @@ function encodeFrame(
     );
   }
 
+  // Write header + (mask) + payload into one allocation instead of concat'ing
+  // three buffers, masking in place for client frames.
+  const maskLen = isClient ? 4 : 0;
+  const frame = Buffer.allocUnsafe(header.length + maskLen + len);
+  let pos = 0;
+  for (let i = 0; i < header.length; i++) frame[pos++] = header[i]!;
   if (isClient) {
     const mask = randomBytes(4);
-    const masked = Buffer.alloc(len);
-    for (let i = 0; i < len; i++) masked[i] = payloadBuf[i]! ^ mask[i & 3]!;
-    return Buffer.concat([Buffer.from(header), mask, masked]);
+    frame[pos++] = mask[0]!;
+    frame[pos++] = mask[1]!;
+    frame[pos++] = mask[2]!;
+    frame[pos++] = mask[3]!;
+    for (let i = 0; i < len; i++) frame[pos++] = payloadBuf[i]! ^ mask[i & 3]!;
+  } else {
+    payloadBuf.copy(frame, pos);
   }
-  return Buffer.concat([Buffer.from(header), payloadBuf]);
+  return frame;
 }
 
 function decodeClosePayload(payload: ByteBuffer): {


### PR DESCRIPTION
## Summary
`encodeFrame` in `packages/sandbox/proxy/websocket.ts` allocated **4 buffers + 2 copies** per outbound frame: `Buffer.alloc(len)` for the masked payload, `Buffer.from(header)`, and a `Buffer.concat([...])` that allocates a fourth buffer and copies everything in.

This rewrites it to a **single `allocUnsafe`'d buffer**, writing the header, mask, and payload into their final positions. The client masking XOR now writes straight into the output (so that path has **0 extra copies**); unmasked server frames use one `payloadBuf.copy()`.

Net: **4 allocs + 2 copies → 1 alloc + ≤1 copy** per frame. `allocUnsafe` is safe here because every byte is written before the buffer escapes.

## Why only this change
This came out of an audit of all `Buffer` usage in the repo. Most call-sites are one-shot base64/utf8 conversions (pooling saves nothing) or stream chunks that escape (pooling would alias). The frame decoder already uses `subarray()` and the PTY reader already reuses a fixed buffer. `encodeFrame` was the one site with genuinely reducible allocations and no lifetime/aliasing risk.

## Testing
- Verified output is **byte-identical** to the previous implementation across payload sizes `0, 1, 125, 126, 65535, 65536, 70000` for both masked and unmasked paths.
- `tsc --noEmit` clean; existing `websocket.test.ts` passes; `bun run fmt` clean.

Note: this path serves the Vite HMR proxy, so the real-world win is modest — it's a clean, behavior-preserving allocation reduction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build WebSocket frames in a single buffer to cut allocations and copies in the sandbox proxy. Output stays byte-identical while reducing per-frame work from 4 allocations + 2 copies to 1 allocation with at most one copy.

- **Refactors**
  - Rewrote `encodeFrame` in `packages/sandbox/proxy/websocket.ts` to use one `Buffer.allocUnsafe`, writing header, mask, and payload directly instead of `Buffer.concat`.
  - Client frames mask in place; server frames do a single `payloadBuf.copy()`. Verified byte-identical output across edge sizes; tests pass.

<sup>Written for commit 3dcf595a1dacb04c75e2c2db2845ce876e4819b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

