### PR TITLE
perf(mesh): reduce event-loop blocking on hot paths

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1746,15 +1746,25 @@ export async function pullDispatch(
       // /_sandbox/dispatch (which re-inflates from messagesRef).
       let effectiveHarnessInput: WireHarnessInput = wireHarnessInput;
       let messagesRef: MessagesRef | null = null;
-      const encodedInput = JSON.stringify(wireHarnessInput);
-      if (shouldOffload(Buffer.byteLength(encodedInput, "utf8"))) {
+      // `messages` dominates the payload — serialize it once and reuse the same
+      // bytes for both the offload size-gate and the object-storage body,
+      // instead of stringifying the whole input and then the messages array
+      // again on the offload path.
+      const messagesBytes = new TextEncoder().encode(
+        JSON.stringify(wireHarnessInput.messages),
+      );
+      const inputByteLength =
+        messagesBytes.byteLength +
+        Buffer.byteLength(
+          JSON.stringify({ ...wireHarnessInput, messages: undefined }),
+          "utf8",
+        );
+      if (shouldOffload(inputByteLength)) {
         if (ctx.objectStorage) {
           try {
             const reqId = crypto.randomUUID();
-            const messagesJson = JSON.stringify(wireHarnessInput.messages);
-            const bytes = new TextEncoder().encode(messagesJson);
             const key = offloadKey(reqId);
-            await ctx.objectStorage.put(key, bytes, {
+            await ctx.objectStorage.put(key, messagesBytes, {
               contentType: "application/json",
             });
             const url = await ctx.objectStorage.presignedGetUrl(key, 600, {
@@ -1762,13 +1772,13 @@ export async function pullDispatch(
             });
             messagesRef = {
               url,
-              bytes: bytes.byteLength,
-              sha256: await sha256Hex(bytes),
+              bytes: messagesBytes.byteLength,
+              sha256: await sha256Hex(messagesBytes),
             };
             // Replace messages inline with [] — the real messages live at the ref.
             effectiveHarnessInput = { ...wireHarnessInput, messages: [] };
             console.log(
-              `[pullDispatch] offloaded messages to object storage key=${key} bytes=${bytes.byteLength} runId=${taskId}`,
+              `[pullDispatch] offloaded messages to object storage key=${key} bytes=${messagesBytes.byteLength} runId=${taskId}`,
             );
           } catch (err) {
             // Offload failed — fall through with the full payload and let

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -266,11 +266,21 @@ export class NatsStreamBuffer implements StreamBuffer {
 
     void (async () => {
       const reader = stream.getReader();
+      let sinceYield = 0;
       try {
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
           publishChunk(value);
+          // `reader.read()` normally yields to the event loop between chunks,
+          // but a producer with many buffered chunks can resolve reads
+          // synchronously in a burst — starving I/O (health checks, other
+          // streams' encodes). Yield via setImmediate every N chunks so the
+          // loop always gets a turn even under a synchronous burst.
+          if (++sinceYield >= 64) {
+            sinceYield = 0;
+            await new Promise<void>((resolve) => setImmediate(resolve));
+          }
         }
       } catch (err) {
         console.warn(

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -219,8 +219,9 @@ function checkApiKeyPermission(
       if (wildcardTools.includes("*")) {
         continue; // Wildcard grants all tools
       }
+      const wildcardSet = new Set(wildcardTools);
       for (const tool of tools) {
-        if (!wildcardTools.includes(tool)) {
+        if (!wildcardSet.has(tool)) {
           return false;
         }
       }
@@ -233,8 +234,9 @@ function checkApiKeyPermission(
     }
 
     // Check each requested tool
+    const grantedSet = new Set(grantedTools);
     for (const tool of tools) {
-      if (!grantedTools.includes(tool)) {
+      if (!grantedSet.has(tool)) {
         return false;
       }
     }


### PR DESCRIPTION
## Summary

Targeted CPU / event-loop optimizations in `apps/mesh`, found by a fan-out search of the codebase. Each reduces synchronous work on the shared multi-tenant event loop. Scope is deliberately narrow (3 files, no behavior change).

### Changes

1. **`nats-stream-buffer.ts` — stream pump yield.** The per-chunk `JSON.stringify({ p: value })` + encode is O(n) per chunk and `reader.read()` normally yields between chunks, but a producer with many buffered chunks can resolve reads synchronously in a burst and starve I/O (health checks, other streams' encodes). Added a `setImmediate` yield every 64 chunks. *(This is the path flagged in the long-standing "stream encode" lag investigation — the encode itself is inherently sync, so this bounds the burst rather than being an O(n²) fix.)*

2. **`dispatch-run.ts` — message offload double-serialize.** Was `JSON.stringify(wireHarnessInput)` for the size-gate, then `JSON.stringify(wireHarnessInput.messages)` again on the offload branch. Now serializes `messages` once and reuses the bytes for both the gate and the object-storage body.

3. **`context-factory.ts` — API-key permission check.** Replaced repeated `Array.includes` in the nested tool loop with `Set` lookups (auth hot path, runs per request).

### Deliberately not included
- **sandbox daemon `fs.ts`** — the daemon is single-tenant (one tool call at a time), so converting its `fs.*Sync` to async is low-value; dropped from this PR.
- **`git-sync.ts` (`spawnSync`)** — only fast *local* git plumbing reads; network ops already async via `runStep`. Async conversion risks `.git/index.lock` interleaving for ~zero gain.
- **`threads.ts` `JSON.stringify(parts)`** — unavoidable synchronous serialization for the DB insert.

## Testing
- `bun run check` (typecheck, all workspaces) ✅
- `bun run fmt` ✅
- No behavior change; no new tests added.