### PR TITLE
feat(mcp-clients): disable MCP read/list caches by default (env-gated)

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -113,6 +113,7 @@ import {
   setMcpListCache,
   type McpListCache,
 } from "../mcp-clients/mcp-list-cache";
+import { isMcpCacheEnabled } from "../mcp-clients/mcp-read-cache";
 import {
   startMcpCacheInvalidation,
   teardownMcpCacheInvalidation,
@@ -878,7 +879,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   }
 
   let eventBus: EventBus;
-  let mcpListCache: McpListCache;
+  let mcpListCache: McpListCache | null;
   let connectionCircuitStore: ConnectionCircuitStore;
   // Model lists are public, low-stakes metadata cached per-replica with a TTL —
   // no NATS needed, so this is shared across the test and production branches.
@@ -948,10 +949,14 @@ export async function createApp(options: CreateAppOptions = {}) {
     natsProvider = createNatsConnectionProvider();
     natsProvider.init(getSettings().natsUrls);
 
-    const tlc = new JetStreamKVMcpListCache({
-      getJetStream: () => natsProvider!.getJetStream(),
-    });
-    tlc.init().catch(() => {});
+    // Cross-pod MCP list cache is opt-in (same flag as the read cache). When
+    // disabled, leave mcpListCache null so getMcpListCache() callers fetch live.
+    const tlc = isMcpCacheEnabled()
+      ? new JetStreamKVMcpListCache({
+          getJetStream: () => natsProvider!.getJetStream(),
+        })
+      : null;
+    tlc?.init().catch(() => {});
     mcpListCache = tlc;
 
     const ccs = new JetStreamKVConnectionCircuitStore({
@@ -991,7 +996,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
     // When NATS connects, (re-)initialize all deferred consumers
     natsProvider.onReady(() => {
-      tlc.init().catch((err: unknown) => {
+      tlc?.init().catch((err: unknown) => {
         console.error("[McpListCache] Deferred init failed:", err);
       });
       ccs.init().catch((err: unknown) => {
@@ -1214,7 +1219,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     asyncResearchJobSweeper.dispose();
     cancelBroadcast.stop().catch(() => {});
     streamBuffer.teardown();
-    mcpListCache.teardown();
+    mcpListCache?.teardown();
     modelListCache.teardown();
     providerKeyCache.teardown();
     teardownMcpCacheInvalidation();

--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -199,7 +199,10 @@ export function createLazyClient(
   // with a custom result schema bypass entirely. `options` (e.g. the timeout) is
   // forwarded to the live fetch but excluded from the cache key.
   const readCache = getMcpReadCache();
-  const cacheReads = connection.connection_type !== "VIRTUAL";
+  // Reads are only cached when the per-pod read cache is enabled (env-gated) and
+  // the connection isn't VIRTUAL (those compose other connections).
+  const cacheReads =
+    readCache !== null && connection.connection_type !== "VIRTUAL";
 
   placeholder.callTool = async (params, resultSchema, options) => {
     const toolName = (params as { name?: unknown })?.name;
@@ -214,7 +217,7 @@ export function createLazyClient(
       return real.callTool(params, resultSchema, options);
     }
 
-    const result = await readCache.fetch({
+    const result = await readCache!.fetch({
       type: "tools/call",
       connectionId: connection.id,
       scope: resolveReadCacheScope(),
@@ -239,7 +242,7 @@ export function createLazyClient(
       const real = await getRealClient();
       return real.getPrompt(params, options);
     }
-    const result = await readCache.fetch({
+    const result = await readCache!.fetch({
       type: "prompts/get",
       connectionId: connection.id,
       scope: resolveReadCacheScope(),
@@ -265,7 +268,7 @@ export function createLazyClient(
       const real = await getRealClient();
       return real.readResource(params, options);
     }
-    const result = await readCache.fetch({
+    const result = await readCache!.fetch({
       type: "resources/read",
       connectionId: connection.id,
       scope: resolveReadCacheScope(),

--- a/apps/mesh/src/mcp-clients/mcp-cache-invalidation.ts
+++ b/apps/mesh/src/mcp-clients/mcp-cache-invalidation.ts
@@ -28,7 +28,7 @@ let sub: Subscription | null = null;
 
 /** Drop this connection's per-pod cached read results (content + tool calls). */
 function evictLocal(connectionId: string): void {
-  getMcpReadCache().invalidate(connectionId);
+  getMcpReadCache()?.invalidate(connectionId);
 }
 
 /**

--- a/apps/mesh/src/mcp-clients/mcp-read-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-read-cache.ts
@@ -271,9 +271,20 @@ export class InMemoryMcpReadCache {
   }
 }
 
-// Per-pod singleton — pure in-memory, no external deps, always available.
+// Per-pod singleton — pure in-memory, no external deps.
 const readCache = new InMemoryMcpReadCache();
 
-export function getMcpReadCache(): InMemoryMcpReadCache {
-  return readCache;
+/**
+ * MCP read/result caching is OPT-IN: callers fall back to live upstream calls
+ * unless `MCP_CACHE_ENABLED=true`. Same flag gates the cross-pod list cache.
+ */
+export function isMcpCacheEnabled(): boolean {
+  return (
+    typeof process !== "undefined" && process.env?.MCP_CACHE_ENABLED === "true"
+  );
+}
+
+/** The per-pod read cache, or null when MCP caching is disabled. */
+export function getMcpReadCache(): InMemoryMcpReadCache | null {
+  return isMcpCacheEnabled() ? readCache : null;
 }


### PR DESCRIPTION
## Summary
Makes the MCP caching layer **opt-in** instead of always-on. Both caches now require `MCP_CACHE_ENABLED=true`; when unset (the new default) every caller falls through to a live upstream fetch.

Covers:
- **Per-pod read-result cache** (`mcp-read-cache.ts`) — results of read-only `tools/call`, `resources/read`, `prompts/get`.
- **Cross-pod NATS KV list cache** (`mcp-list-cache.ts`) — `tools` / `resources` / `prompts` lists.

## Changes
- `mcp-read-cache.ts`: add `isMcpCacheEnabled()` (reads `MCP_CACHE_ENABLED`); `getMcpReadCache()` now returns `InMemoryMcpReadCache | null` (null when disabled).
- `lazy-client.ts`: `cacheReads` is false when the read cache is null, so all read-only calls bypass to live fetch.
- `mcp-cache-invalidation.ts`: null-safe `getMcpReadCache()?.invalidate(...)`.
- `app.ts`: the NATS KV list cache is only constructed/inited when caching is enabled; otherwise `mcpListCache` stays null and `getMcpListCache()` callers fetch live (existing `fetchWithCache` null path + `?.invalidate`/`?.set` call sites already handle this).

## Behavior
- Default (no env var): no caching — same code paths as a cold/missing cache, fully live.
- `MCP_CACHE_ENABLED=true`: prior caching behavior (SWR read cache + NATS KV list cache) restored.

## Testing
- `bun run check` (mesh) — passes.
- `bun test` for `mcp-read-cache` + `mcp-list-cache` — 46 pass.
- `bun run fmt` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make MCP read and list caches opt-in via `MCP_CACHE_ENABLED`. By default caching is off, so read-only calls and list APIs fetch live.

- **Migration**
  - Set `MCP_CACHE_ENABLED=true` to restore the previous behavior (per-pod read-result cache and cross-pod NATS KV list cache).

<sup>Written for commit 6d725c033c0bf1c8669415f7b76872eb63e08b8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

