### PR TITLE
feat(mcp-clients): MCP cache on by default, off in dev, env-gated

### DIFF
--- a/apps/mesh/playwright.config.ts
+++ b/apps/mesh/playwright.config.ts
@@ -19,7 +19,11 @@ export function resolvePlaywrightDevServerConfig(
 
   return {
     appOrigin,
-    webServerCommand: `BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run dev:servers`,
+    // e2e exercises production-like behavior; the MCP read/list cache is on in
+    // prod but defaults off under NODE_ENV=development (which `dev:server` sets),
+    // so opt it back in here. Without this, cache-dependent specs (e.g. proxy
+    // roundtrip's no-re-handshake assertion) fail against the dev server.
+    webServerCommand: `MCP_CACHE_ENABLED=true BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run dev:servers`,
   };
 }
 

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -113,6 +113,7 @@ import {
   setMcpListCache,
   type McpListCache,
 } from "../mcp-clients/mcp-list-cache";
+import { isMcpCacheEnabled } from "../mcp-clients/mcp-read-cache";
 import {
   startMcpCacheInvalidation,
   teardownMcpCacheInvalidation,
@@ -878,7 +879,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   }
 
   let eventBus: EventBus;
-  let mcpListCache: McpListCache;
+  let mcpListCache: McpListCache | null;
   let connectionCircuitStore: ConnectionCircuitStore;
   // Model lists are public, low-stakes metadata cached per-replica with a TTL —
   // no NATS needed, so this is shared across the test and production branches.
@@ -948,10 +949,14 @@ export async function createApp(options: CreateAppOptions = {}) {
     natsProvider = createNatsConnectionProvider();
     natsProvider.init(getSettings().natsUrls);
 
-    const tlc = new JetStreamKVMcpListCache({
-      getJetStream: () => natsProvider!.getJetStream(),
-    });
-    tlc.init().catch(() => {});
+    // Cross-pod MCP list cache is gated by the same flag as the read cache.
+    // When disabled, leave mcpListCache null so getMcpListCache() callers fetch live.
+    const tlc = isMcpCacheEnabled()
+      ? new JetStreamKVMcpListCache({
+          getJetStream: () => natsProvider!.getJetStream(),
+        })
+      : null;
+    tlc?.init().catch(() => {});
     mcpListCache = tlc;
 
     const ccs = new JetStreamKVConnectionCircuitStore({
@@ -991,7 +996,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
     // When NATS connects, (re-)initialize all deferred consumers
     natsProvider.onReady(() => {
-      tlc.init().catch((err: unknown) => {
+      tlc?.init().catch((err: unknown) => {
         console.error("[McpListCache] Deferred init failed:", err);
       });
       ccs.init().catch((err: unknown) => {
@@ -1214,7 +1219,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     asyncResearchJobSweeper.dispose();
     cancelBroadcast.stop().catch(() => {});
     streamBuffer.teardown();
-    mcpListCache.teardown();
+    mcpListCache?.teardown();
     modelListCache.teardown();
     providerKeyCache.teardown();
     teardownMcpCacheInvalidation();

--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -198,6 +198,7 @@ export function createLazyClient(
   // confirm read-only, VIRTUAL connections (they compose other conns), and calls
   // with a custom result schema bypass entirely. `options` (e.g. the timeout) is
   // forwarded to the live fetch but excluded from the cache key.
+  // null when MCP caching is disabled (settings-gated).
   const readCache = getMcpReadCache();
   const cacheReads = connection.connection_type !== "VIRTUAL";
 
@@ -209,7 +210,7 @@ export function createLazyClient(
       typeof toolName === "string" &&
       (await isReadOnlyTool(cache, connection.id, toolName));
 
-    if (!cacheable) {
+    if (!readCache || !cacheable) {
       const real = await getRealClient();
       return real.callTool(params, resultSchema, options);
     }
@@ -235,7 +236,7 @@ export function createLazyClient(
   };
 
   placeholder.getPrompt = async (params, options) => {
-    if (!cacheReads) {
+    if (!readCache || !cacheReads) {
       const real = await getRealClient();
       return real.getPrompt(params, options);
     }
@@ -254,7 +255,7 @@ export function createLazyClient(
   };
 
   placeholder.readResource = async (params, options) => {
-    if (!cacheReads) {
+    if (!readCache || !cacheReads) {
       if (process.env?.MCP_CACHE_DEBUG) {
         console.log(
           "[mcp-read-cache] BYPASS (VIRTUAL)",

--- a/apps/mesh/src/mcp-clients/mcp-cache-invalidation.ts
+++ b/apps/mesh/src/mcp-clients/mcp-cache-invalidation.ts
@@ -28,7 +28,7 @@ let sub: Subscription | null = null;
 
 /** Drop this connection's per-pod cached read results (content + tool calls). */
 function evictLocal(connectionId: string): void {
-  getMcpReadCache().invalidate(connectionId);
+  getMcpReadCache()?.invalidate(connectionId);
 }
 
 /**

--- a/apps/mesh/src/mcp-clients/mcp-read-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-read-cache.ts
@@ -28,6 +28,7 @@
  */
 
 import { meter } from "../observability";
+import { getSettings } from "../settings";
 
 const cacheCounter = meter.createCounter("mcp_read_cache.fetches", {
   description: "MCP read cache outcomes (hit, stale, miss, error)",
@@ -271,9 +272,19 @@ export class InMemoryMcpReadCache {
   }
 }
 
-// Per-pod singleton — pure in-memory, no external deps, always available.
+// Per-pod singleton — pure in-memory, no external deps.
 const readCache = new InMemoryMcpReadCache();
 
-export function getMcpReadCache(): InMemoryMcpReadCache {
-  return readCache;
+/**
+ * MCP read/list caching. On by default in production, off in development;
+ * MCP_CACHE_ENABLED overrides either way (resolved in settings). Same flag
+ * gates the cross-pod NATS KV list cache.
+ */
+export function isMcpCacheEnabled(): boolean {
+  return getSettings().mcpCacheEnabled;
+}
+
+/** The per-pod read cache, or null when MCP caching is disabled. */
+export function getMcpReadCache(): InMemoryMcpReadCache | null {
+  return isMcpCacheEnabled() ? readCache : null;
 }

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -13,6 +13,15 @@ function toBool(value: string | undefined): boolean {
   return value === "true" || value === "1";
 }
 
+/** Tri-state flag: unset/empty → `fallback`, otherwise parse as boolean. */
+function toBoolWithDefault(
+  value: string | undefined,
+  fallback: boolean,
+): boolean {
+  if (value === undefined || value === "") return fallback;
+  return value === "true" || value === "1";
+}
+
 /**
  * Determine if a URL points to a non-local host (i.e., an external service).
  * Returns the URL string if external, null if local or not set.
@@ -110,6 +119,12 @@ export function resolveConfig(
 
     // Feature Flags
     enableDecoImport: toBool(envVars.ENABLE_DECO_IMPORT),
+    // MCP caching is on by default in production, off in development. Set
+    // MCP_CACHE_ENABLED=false to disable in prod, =true to enable in dev.
+    mcpCacheEnabled: toBoolWithDefault(
+      envVars.MCP_CACHE_ENABLED,
+      nodeEnv !== "development",
+    ),
     orgFsClusterMounts: toBool(envVars.ORGFS_CLUSTER_MOUNTS),
     orgFsPublicSetsJson: envVars.ORGFS_PUBLIC_SETS,
 

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -53,6 +53,9 @@ export interface Settings {
 
   // Feature Flags
   enableDecoImport: boolean;
+  /** MCP read/list caching. On by default in production, off in development;
+   *  MCP_CACHE_ENABLED explicitly overrides either default. */
+  mcpCacheEnabled: boolean;
   /** Mint org-fs tokens for hosted (agent-sandbox) pods too — only useful
    *  when the sandbox-env chart runs the org-fs sidecar (orgFs.enabled). */
   orgFsClusterMounts: boolean;


### PR DESCRIPTION
## Summary
Inverts the gating from #3902. MCP read/list caching is now **enabled by default in production** and **disabled by default in development**, with a single env flag (`MCP_CACHE_ENABLED`) that explicitly overrides either default.

The flag is resolved once through the **settings util** (`resolve-config.ts` → `getSettings().mcpCacheEnabled`) instead of reading `process.env` directly inside the cache module.

## Behavior
| Environment | `MCP_CACHE_ENABLED` | Caching |
|---|---|---|
| production | unset | **on** (default) |
| production | `false` / `0` | off |
| development | unset | **off** (default) |
| development | `true` / `1` | on |

## Changes
- `settings/types.ts`: add `mcpCacheEnabled: boolean` to `Settings`.
- `settings/resolve-config.ts`: add `toBoolWithDefault()` tri-state helper; resolve `mcpCacheEnabled` (default `nodeEnv !== "development"`, overridable by `MCP_CACHE_ENABLED`).
- `mcp-read-cache.ts`: `isMcpCacheEnabled()` now reads `getSettings().mcpCacheEnabled` (no direct `process.env`); `getMcpReadCache()` returns `InMemoryMcpReadCache | null`.
- `lazy-client.ts`: bypass to live fetch when the read cache is null — guards narrow on `readCache` directly (no non-null assertions).
- `mcp-cache-invalidation.ts`: null-safe `getMcpReadCache()?.invalidate(...)`.
- `app.ts`: the NATS KV list cache is only constructed/inited when caching is enabled; `mcpListCache` is `McpListCache | null` with null-safe init/teardown.

## Testing
- `bun run check` (mesh) — passes.
- `bun test` for `mcp-read-cache` + `mcp-list-cache` — 46 pass.
- `bun run fmt` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable MCP read/list caching by default in production and disable it by default in development. E2E dev server now sets `MCP_CACHE_ENABLED=true` to mirror production behavior.

- **New Features**
  - Centralized flag via `getSettings().mcpCacheEnabled` in `resolve-config.ts` using `toBoolWithDefault()`.
  - Read cache is nullable: `getMcpReadCache()` returns `InMemoryMcpReadCache | null`; added `isMcpCacheEnabled()`.
  - Cross-pod NATS KV list cache and invalidation are gated and null-safe (init/teardown guarded).
  - Playwright e2e server opts into caching with `MCP_CACHE_ENABLED=true` to keep cache-dependent specs stable.

- **Migration**
  - Production: no change needed (caching stays on). Set `MCP_CACHE_ENABLED=false` to disable.
  - Development: no change needed (caching stays off). Set `MCP_CACHE_ENABLED=true` to enable.

<sup>Written for commit db1cbf72aace6e04ae41008ff82aba0ad9ec3fef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

