### PR TITLE
fix(connection): auto-disable connections after repeated decryption failures

### DIFF
--- a/apps/mesh/src/core/constants.ts
+++ b/apps/mesh/src/core/constants.ts
@@ -23,6 +23,14 @@ export const CIRCUIT_BREAKER_COOLDOWN_MS = 30_000; // 30 seconds
 /** Maximum number of circuit breaker entries to retain in memory */
 export const CIRCUIT_BREAKER_MAX_ENTRIES = 1000;
 
+/**
+ * Consecutive credential-decryption failures (per replica) before a connection
+ * is durably disabled (status="error"). A decrypt failure is deterministic — the
+ * same key never recovers — so a small buffer is enough; it only guards against a
+ * transient key-load race at boot. Mirrors CIRCUIT_BREAKER_FAILURE_THRESHOLD.
+ */
+export const CONNECTION_DECRYPT_DISABLE_THRESHOLD = 3;
+
 /*
  * Durable connection auto-disable (cross-replica, via the shared circuit store).
  *

--- a/apps/mesh/src/storage/connection.ts
+++ b/apps/mesh/src/storage/connection.ts
@@ -31,6 +31,13 @@ import {
   isDecopilot,
 } from "@decocms/mesh-sdk";
 import { getConnectionSlug } from "@/shared/utils/connection-slug";
+import { CONNECTION_DECRYPT_DISABLE_THRESHOLD } from "../core/constants";
+import {
+  isDecryptDisabled,
+  markDecryptDisabled,
+  recordDecryptFailure,
+  recordDecryptSuccess,
+} from "./decrypt-failure-tracker";
 import type { ConnectionStoragePort } from "./ports";
 import type { Database } from "./types";
 
@@ -471,20 +478,72 @@ export class ConnectionStorage implements ConnectionStoragePort {
   }
 
   /**
+   * Handle one or more credential-decryption failures for a connection.
+   *
+   * Logs each failure until CONNECTION_DECRYPT_DISABLE_THRESHOLD consecutive
+   * failures are reached, then durably disables the connection (status="error")
+   * and suppresses further logs. Already-disabled connections (this replica or a
+   * non-active DB status from a prior disable) are suppressed immediately.
+   */
+  private async handleDecryptFailures(
+    row: RawConnectionRow,
+    failures: Array<{ label: string; error: unknown }>,
+  ): Promise<void> {
+    const context = `connection ${row.id} (org: ${row.organization_id}, type: ${row.connection_type}, title: ${row.title})`;
+
+    // Already disabled in this replica — stay quiet.
+    if (isDecryptDisabled(row.id)) return;
+
+    // Disabled in a prior run (or paused by a user): sync local state and suppress.
+    if (row.status !== "active") {
+      markDecryptDisabled(row.id);
+      return;
+    }
+
+    const { thresholdCrossed } = recordDecryptFailure(row.id);
+
+    if (!thresholdCrossed) {
+      for (const { label, error } of failures) {
+        console.error(`Failed to decrypt ${label} for ${context}:`, error);
+      }
+      return;
+    }
+
+    // Threshold reached — disable durably, then mark suppressed only on success
+    // so a failed write is retried on the next read instead of silently dropped.
+    try {
+      await this.db
+        .updateTable("connections")
+        .set({ status: "error" })
+        .where("id", "=", row.id)
+        .execute();
+      markDecryptDisabled(row.id);
+      console.error(
+        `Disabled ${context} after ${CONNECTION_DECRYPT_DISABLE_THRESHOLD} consecutive decryption failures.`,
+        failures[0]?.error,
+      );
+    } catch (err) {
+      console.error(
+        `Failed to disable ${context} after decryption failures:`,
+        err,
+      );
+    }
+  }
+
+  /**
    * Deserialize database row to entity
    */
   private async deserializeConnection(
     row: RawConnectionRow,
   ): Promise<ConnectionEntity> {
+    const decryptErrors: Array<{ label: string; error: unknown }> = [];
+
     let decryptedToken: string | null = null;
     if (row.connection_token) {
       try {
         decryptedToken = await this.vault.decrypt(row.connection_token);
       } catch (error) {
-        console.error(
-          `Failed to decrypt connection token for connection ${row.id} (org: ${row.organization_id}, type: ${row.connection_type}, title: ${row.title}):`,
-          error,
-        );
+        decryptErrors.push({ label: "connection token", error });
       }
     }
 
@@ -495,11 +554,14 @@ export class ConnectionStorage implements ConnectionStoragePort {
         const decryptedJson = await this.vault.decrypt(row.configuration_state);
         decryptedConfigState = JSON.parse(decryptedJson);
       } catch (error) {
-        console.error(
-          `Failed to decrypt configuration state for connection ${row.id} (org: ${row.organization_id}, type: ${row.connection_type}, title: ${row.title}):`,
-          error,
-        );
+        decryptErrors.push({ label: "configuration state", error });
       }
+    }
+
+    if (decryptErrors.length > 0) {
+      await this.handleDecryptFailures(row, decryptErrors);
+    } else if (row.connection_token || row.configuration_state) {
+      recordDecryptSuccess(row.id);
     }
 
     // Parse and decrypt connection_headers

--- a/apps/mesh/src/storage/decrypt-failure-tracker.test.ts
+++ b/apps/mesh/src/storage/decrypt-failure-tracker.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { CONNECTION_DECRYPT_DISABLE_THRESHOLD } from "../core/constants";
+import {
+  isDecryptDisabled,
+  markDecryptDisabled,
+  recordDecryptFailure,
+  recordDecryptSuccess,
+  resetAll,
+} from "./decrypt-failure-tracker";
+
+describe("decrypt-failure-tracker", () => {
+  afterEach(() => resetAll());
+
+  it("crosses the threshold only after N consecutive failures", () => {
+    const id = "conn_a";
+    for (let i = 1; i < CONNECTION_DECRYPT_DISABLE_THRESHOLD; i++) {
+      const r = recordDecryptFailure(id);
+      expect(r.consecutiveFailures).toBe(i);
+      expect(r.thresholdCrossed).toBe(false);
+    }
+    const crossing = recordDecryptFailure(id);
+    expect(crossing.consecutiveFailures).toBe(CONNECTION_DECRYPT_DISABLE_THRESHOLD);
+    expect(crossing.thresholdCrossed).toBe(true);
+  });
+
+  it("success clears the failure window", () => {
+    const id = "conn_b";
+    recordDecryptFailure(id);
+    recordDecryptFailure(id);
+    recordDecryptSuccess(id);
+    expect(recordDecryptFailure(id).consecutiveFailures).toBe(1);
+  });
+
+  it("marks and reports disabled state without re-enabling on success", () => {
+    const id = "conn_c";
+    expect(isDecryptDisabled(id)).toBe(false);
+    markDecryptDisabled(id);
+    expect(isDecryptDisabled(id)).toBe(true);
+    // success clears the entry; a disabled connection is re-flagged on the next
+    // failure but is never auto-re-enabled by the tracker (non-self-healing).
+    recordDecryptSuccess(id);
+    expect(isDecryptDisabled(id)).toBe(false);
+  });
+
+  it("tracks connections independently", () => {
+    recordDecryptFailure("conn_x");
+    const y = recordDecryptFailure("conn_y");
+    expect(y.consecutiveFailures).toBe(1);
+  });
+});

--- a/apps/mesh/src/storage/decrypt-failure-tracker.test.ts
+++ b/apps/mesh/src/storage/decrypt-failure-tracker.test.ts
@@ -19,7 +19,9 @@ describe("decrypt-failure-tracker", () => {
       expect(r.thresholdCrossed).toBe(false);
     }
     const crossing = recordDecryptFailure(id);
-    expect(crossing.consecutiveFailures).toBe(CONNECTION_DECRYPT_DISABLE_THRESHOLD);
+    expect(crossing.consecutiveFailures).toBe(
+      CONNECTION_DECRYPT_DISABLE_THRESHOLD,
+    );
     expect(crossing.thresholdCrossed).toBe(true);
   });
 

--- a/apps/mesh/src/storage/decrypt-failure-tracker.ts
+++ b/apps/mesh/src/storage/decrypt-failure-tracker.ts
@@ -1,0 +1,101 @@
+/**
+ * Per-replica tracker for credential-decryption failures.
+ *
+ * A connection whose `connection_token` or `configuration_state` ciphertext can't
+ * be authenticated ("Unsupported state or unable to authenticate data") fails
+ * deterministically — the same vault key never recovers. Left alone it spams the
+ * log on every read path. After CONNECTION_DECRYPT_DISABLE_THRESHOLD consecutive
+ * failures the connection is durably disabled (status="error"); this tracker
+ * dampens the count and suppresses repeat logs until then.
+ *
+ * Unlike ./mcp-clients/connection-circuit-store, this needs no cross-replica
+ * aggregation: a decrypt failure trips on every read on every replica, so each
+ * replica reaches the threshold on its own. It is intentionally NOT self-healing
+ * — a disabled connection requires manual re-enable.
+ */
+
+import {
+  CIRCUIT_BREAKER_MAX_ENTRIES,
+  CONNECTION_DECRYPT_DISABLE_THRESHOLD,
+} from "../core/constants";
+
+interface DecryptFailureEntry {
+  consecutiveFailures: number;
+  disabled: boolean;
+  lastFailureAt: number;
+}
+
+const entries = new Map<string, DecryptFailureEntry>();
+
+function evictIfNeeded(): void {
+  if (entries.size < CIRCUIT_BREAKER_MAX_ENTRIES) return;
+  let oldestId: string | null = null;
+  let oldestTime = Infinity;
+  for (const [id, entry] of entries) {
+    if (entry.lastFailureAt < oldestTime) {
+      oldestTime = entry.lastFailureAt;
+      oldestId = id;
+    }
+  }
+  if (oldestId) entries.delete(oldestId);
+}
+
+/**
+ * Record a decrypt failure for a connection. Returns the running consecutive
+ * count so the caller can decide whether the disable threshold was crossed.
+ */
+export function recordDecryptFailure(connectionId: string): {
+  consecutiveFailures: number;
+  thresholdCrossed: boolean;
+} {
+  const entry = entries.get(connectionId);
+  if (!entry) {
+    evictIfNeeded();
+    entries.set(connectionId, {
+      consecutiveFailures: 1,
+      disabled: false,
+      lastFailureAt: Date.now(),
+    });
+    return {
+      consecutiveFailures: 1,
+      thresholdCrossed: 1 >= CONNECTION_DECRYPT_DISABLE_THRESHOLD,
+    };
+  }
+  entry.consecutiveFailures++;
+  entry.lastFailureAt = Date.now();
+  return {
+    consecutiveFailures: entry.consecutiveFailures,
+    thresholdCrossed:
+      entry.consecutiveFailures >= CONNECTION_DECRYPT_DISABLE_THRESHOLD,
+  };
+}
+
+/** Mark a connection as disabled so further failures are suppressed (no log, no re-disable). */
+export function markDecryptDisabled(connectionId: string): void {
+  const entry = entries.get(connectionId);
+  if (entry) {
+    entry.disabled = true;
+    return;
+  }
+  evictIfNeeded();
+  entries.set(connectionId, {
+    consecutiveFailures: CONNECTION_DECRYPT_DISABLE_THRESHOLD,
+    disabled: true,
+    lastFailureAt: Date.now(),
+  });
+}
+
+/** True once the connection has been disabled in this replica. */
+export function isDecryptDisabled(connectionId: string): boolean {
+  return entries.get(connectionId)?.disabled ?? false;
+}
+
+/** Clear the failure window after a successful decrypt. Does NOT re-enable a disabled connection. */
+export function recordDecryptSuccess(connectionId: string): void {
+  entries.delete(connectionId);
+}
+
+/** Reset all tracked state. Exposed for testing only. */
+export function resetAll(): void {
+  entries.clear();
+}


### PR DESCRIPTION
## Summary

A connection whose `connection_token` or `configuration_state` ciphertext can't be authenticated — `Error: Unsupported state or unable to authenticate data` — fails **deterministically** (the same vault key never recovers). Left alone it spams the log on *every* read path (UI lists included) and only eventually trips the downstream breaker indirectly.

This auto-disables such connections after **3 consecutive** decrypt failures (per replica), setting `status="error"` and suppressing further logs.

## Changes

- **`storage/decrypt-failure-tracker.ts`** (new) — per-replica in-memory failure tracker. No cross-replica aggregation needed (unlike `connection-circuit-store`): a decrypt failure trips on every read on every replica, so each reaches the threshold on its own.
- **`storage/connection.ts`** — `deserializeConnection` collects decrypt failures for `connection_token` + `configuration_state`, then `handleDecryptFailures`:
  - logs each failure (preserving existing message text) until the threshold,
  - then sets `status="error"` and logs **one** "Disabled connection …" line,
  - treats an already-non-active row (disabled before a restart) as suppressed immediately, so the spam doesn't return on every pod restart,
  - marks suppressed only *after* the DB write succeeds (a failed write retries next read),
  - a clean decrypt clears the in-memory window but does **not** re-enable.
- **`core/constants.ts`** — `CONNECTION_DECRYPT_DISABLE_THRESHOLD = 3`.
- **`storage/decrypt-failure-tracker.test.ts`** (new) — unit tests.

## Design notes

- Uses **`status="error"`** to match the existing auto-disable convention (`proxy.ts` after sustained downstream failures); the `status !== "active"` gate already stops usage.
- **Not self-healing** — manual re-enable required.
- ⚠️ Known limitation (by design): a wrong/rotated `ENCRYPTION_KEY` would mass-disable every connection over a few reads, and `"error"` does not auto-recover after the key is fixed.

## Testing

- `bun test apps/mesh/src/storage/decrypt-failure-tracker.test.ts` — 4 pass
- `tsc --noEmit` clean on touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-disable connections after 3 consecutive decryption failures to stop error spam and prevent use of broken credentials.

- **Bug Fixes**
  - Disable connection (`status="error"`) after 3 consecutive decrypt failures per replica and suppress repeat logs.
  - Add in-memory failure tracker; clears on successful decrypt; not self-healing (manual re-enable required).
  - Update `deserializeConnection` to batch failures, suppress already non-active rows, and emit a single “Disabled connection …” message; add `CONNECTION_DECRYPT_DISABLE_THRESHOLD = 3` and unit tests.

<sup>Written for commit 66d9abae4ab2c5cd71dc403b0b53aa2365f25e67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

