### PR TITLE
feat(mcp-clients): mutation tools invalidate read cache across pods

### DIFF
--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -29,6 +29,7 @@ import {
   recordSuccess,
 } from "./circuit-breaker";
 import { clientFromConnection } from "./client";
+import { invalidateConnectionCaches } from "./mcp-cache-invalidation";
 import {
   fetchWithCache,
   type McpListCache,
@@ -204,35 +205,52 @@ export function createLazyClient(
 
   placeholder.callTool = async (params, resultSchema, options) => {
     const toolName = (params as { name?: unknown })?.name;
-    const cacheable =
+    const readOnly =
       cacheReads &&
-      !resultSchema &&
       typeof toolName === "string" &&
       (await isReadOnlyTool(cache, connection.id, toolName));
 
-    if (!readCache || !cacheable) {
-      const real = await getRealClient();
-      return real.callTool(params, resultSchema, options);
+    // Read-only tools are served stale-while-revalidate from the per-pod read
+    // cache (when caching is enabled). A custom result schema bypasses caching
+    // (the value is reshaped).
+    if (readCache && readOnly && !resultSchema) {
+      const result = await readCache.fetch({
+        type: "tools/call",
+        connectionId: connection.id,
+        scope: resolveReadCacheScope(),
+        params: {
+          name: toolName,
+          arguments: (params as { arguments?: unknown })?.arguments,
+        },
+        fetchLive: async () => {
+          const real = await getRealClient();
+          return real.callTool(params, resultSchema, options);
+        },
+        // Never cache error results — returned to the caller but not stored.
+        shouldCache: (value) =>
+          (value as { isError?: boolean })?.isError !== true,
+        onRevalidation: (p) => ctx.pendingRevalidations.push(p),
+      });
+      return result as Awaited<ReturnType<Client["callTool"]>>;
     }
 
-    const result = await readCache.fetch({
-      type: "tools/call",
-      connectionId: connection.id,
-      scope: resolveReadCacheScope(),
-      params: {
-        name: toolName,
-        arguments: (params as { arguments?: unknown })?.arguments,
-      },
-      fetchLive: async () => {
-        const real = await getRealClient();
-        return real.callTool(params, resultSchema, options);
-      },
-      // Never cache error results — they're returned to the caller but not stored.
-      shouldCache: (value) =>
-        (value as { isError?: boolean })?.isError !== true,
-      onRevalidation: (p) => ctx.pendingRevalidations.push(p),
-    });
-    return result as Awaited<ReturnType<Client["callTool"]>>;
+    const real = await getRealClient();
+
+    // Any tool we can't confirm read-only is treated as a mutation: after the
+    // call, evict this connection's cached read results on every replica so the
+    // next read sees fresh data. Invalidate even on throw — a partial mutation
+    // may have landed. Only when caching is enabled (readCache present) and the
+    // connection caches reads; VIRTUAL connections route through the upstream
+    // connections' own lazy clients, which invalidate themselves.
+    if (readCache && cacheReads && !readOnly) {
+      try {
+        return await real.callTool(params, resultSchema, options);
+      } finally {
+        invalidateConnectionCaches(connection.id);
+      }
+    }
+
+    return real.callTool(params, resultSchema, options);
   };
 
   placeholder.getPrompt = async (params, options) => {


### PR DESCRIPTION
## Summary

We already serve **read-only** MCP tool calls (and `resources/read` / `prompts/get`) stale-while-revalidate from the per-pod read cache. This PR closes the coherence gap on the write side.

Any tool call we **cannot confirm is read-only** (no `readOnlyHint`, unknown tool, etc.) is now treated as a **mutation**. After such a call runs, we evict the connection's cached read-only results on **every replica** via the existing cross-pod primitive `invalidateConnectionCaches(connectionId)` (local evict + NATS broadcast on `studio.mcp-cache.invalidate`). Subsequent reads then fetch fresh data instead of serving the now-stale SWR cache.

## Behavior

- **Read-only tools** (`annotations.readOnlyHint === true`) → unchanged stale-while-revalidate.
- **Mutation tools** → run live, then invalidate the connection's read cache across all pods. Invalidation runs in a `finally` so a partial mutation that throws still busts the cache.
- Gated on caching being enabled (`readCache` present) and non-`VIRTUAL` connections. VIRTUAL connections route through the upstream connections' own lazy clients, which invalidate themselves — so no double work.
- The **list cache** (NATS KV — tool/resource/prompt *lists*) is intentionally left alone: a mutation tool changes data, not the tool list.

## Testing

- `bun test apps/mesh/src/mcp-clients/lazy-client.test.ts` → 7 pass
- `tsc --noEmit` clean for the touched files
- `biome format` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats any non-read-only MCP tool call as a mutation and, after it runs, evicts the connection’s read cache across pods so future reads return fresh data. Read-only tools keep their stale-while-revalidate behavior.

- **New Features**
  - Read-only tools (`readOnlyHint === true`) still use SWR read cache; custom `resultSchema` skips caching.
  - Mutation tools invalidate the connection’s cached read results via `invalidateConnectionCaches(connectionId)`; runs in a `finally` to handle errors.
  - Only applies when caching is enabled and the connection is not `VIRTUAL`.
  - Tool/resource/prompt list cache remains unchanged.

<sup>Written for commit f9e8af345bba820f76034210f8382b6dda383fd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

