### PR TITLE
fix(link-daemon): recover transient cluster-relay resets; split + label logs

### DIFF
--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -151,12 +151,18 @@ export async function runLinkCommand(
         setMachine,
       } = await import("../link-store");
 
-      // Combined log file: both the parent's intercepted console output and
-      // every spawned sandbox daemon's stdout/stderr land here, keeping the
-      // Ink canvas clean. Append mode so it survives across restarts.
+      // link.log — the daemon's own intercepted console (cluster connection,
+      // work/control/proxy polls, [user-desktop] lifecycle, dispatch +
+      // chunk-relay diagnostics). The transport log. Opened with "w"
+      // (truncate) — RECREATED every restart; the previous "a" (append) is what
+      // let it balloon to 100+ MB across sessions.
+      //
+      // Each spawned sandbox daemon's (very noisy) stdout/stderr goes to its
+      // OWN `<workdir>/tmp/daemon.log` instead (see `perSandboxLogs` below), so
+      // this file stays a legible transport timeline.
       mkdirSync(dataDir, { recursive: true });
       const logPath = join(dataDir, "link.log");
-      logFd = openSync(logPath, "a");
+      logFd = openSync(logPath, "w");
       setLogPath(logPath);
 
       setClusterUrl(clusterBaseUrl);
@@ -174,6 +180,11 @@ export async function runLinkCommand(
       printBanner(opts.version ?? "0.0.0");
     }
 
+    // Standalone `deco link` isolates each sandbox daemon's output into its own
+    // `<workdir>/tmp/daemon.log`. The managed/dev daemon leaves it off so its
+    // sandboxes' output streams to the parent `dev`/`serve` process instead.
+    const perSandboxLogs = process.env.DECOCMS_LINK_MANAGED !== "1";
+
     const handle = await startLinkDaemon({
       port,
       clusterBaseUrl,
@@ -181,6 +192,7 @@ export async function runLinkCommand(
       session,
       monitor,
       logFd,
+      perSandboxLogs,
       hotReload: opts.hotReload,
     });
     return await handle.stopped;

--- a/apps/mesh/src/link-daemon/chunk-relay.test.ts
+++ b/apps/mesh/src/link-daemon/chunk-relay.test.ts
@@ -293,6 +293,28 @@ describe("relayDispatchSSEAsChunkStream", () => {
     expect(postCalls).toBe(1);
   });
 
+  it("retries a network drop (no status) up to the configured maxAttempts, then gives up", async () => {
+    // ECONNRESET-style failure: no `.status` → retriable. The widened retry
+    // budget is what lets a transient cluster/edge reset recover; here we use a
+    // small override and assert the relay honors it exactly before failing.
+    let postCalls = 0;
+
+    await expect(
+      relayDispatchSSEAsChunkStream({
+        dispatchBody: sseBody([CHUNK_A, DONE]),
+        runId: "run_econnreset",
+        retry: { maxAttempts: 4, minTimeout: 1, maxTimeout: 2, jitter: 0 },
+        post: async (body): Promise<RelayPostResult> => {
+          postCalls += 1;
+          await readAllLines(body);
+          throw new Error("The socket connection was closed unexpectedly");
+        },
+      }),
+    ).rejects.toThrow("socket connection was closed");
+
+    expect(postCalls).toBe(4);
+  });
+
   it("throws when the relay buffer exceeds RELAY_BUFFER_MAX_BYTES", async () => {
     // Enough 1 MiB deltas to push the serialized lines past the cap.
     const deltaBytes = 1024 * 1024;
@@ -389,6 +411,9 @@ describe("relayDispatchSSEAsChunkStream + durable outbox", () => {
       runId: "run_crash",
       fenceToken: FENCE,
       outbox,
+      // Fast retry budget — this test asserts on-disk durability after the
+      // budget is exhausted, not the (widened) production timing.
+      retry: { maxAttempts: 2, minTimeout: 1, maxTimeout: 2, jitter: 0 },
       post: async (body): Promise<RelayPostResult> => {
         for await (const _line of ndjsonLines(
           body as ReadableStream<Uint8Array>,

--- a/apps/mesh/src/link-daemon/chunk-relay.ts
+++ b/apps/mesh/src/link-daemon/chunk-relay.ts
@@ -80,6 +80,20 @@ export interface RelayDispatchSSEAsChunkStreamInput {
    * opened once per daemon.
    */
   outbox?: Outbox;
+  /**
+   * Retry policy for the streaming POST. The defaults widen the window to
+   * ~2.5 min (vs the old 5-attempt/~8s budget) so a TRANSIENT cluster/edge
+   * reset — confirmed in the field as a fast `ECONNRESET` with no response,
+   * where all retries fall inside one brief reset window — is recovered
+   * instead of failing the run. `jitter` de-synchronizes concurrent runs so
+   * they don't retry in lockstep into the same window. Tests/ops override.
+   */
+  retry?: {
+    maxAttempts?: number;
+    minTimeout?: number;
+    maxTimeout?: number;
+    jitter?: number;
+  };
 }
 
 const encoder = new TextEncoder();
@@ -165,6 +179,16 @@ export async function relayDispatchSSEAsChunkStream(
   })().catch((err: unknown) => {
     pumpError =
       err ?? new Error(`[chunk-relay] runId=${input.runId}: chunk pump failed`);
+    // `rootCause === null` ⇒ this leg failed FIRST, so it is the real root.
+    // (A poster failure aborts `internal`, which cancels the SSE reader and
+    // lands here too — but then rootCause is already set, so we stay quiet.)
+    if (rootCause === null) {
+      // ROOT = SANDBOX leg: the loopback dispatch SSE broke (sandbox daemon
+      // closed the stream / died → "socket connection closed unexpectedly").
+      console.error(
+        `[relay-diag] ROOT=SANDBOX-SSE-pump runId=${input.runId} name=${pumpError instanceof Error ? pumpError.name : typeof pumpError} msg=${pumpError instanceof Error ? pumpError.message : String(pumpError)}`,
+      );
+    }
     signalChange(); // wake attempt bodies so they error out promptly
     failWith(pumpError);
     throw pumpError;
@@ -241,19 +265,35 @@ export async function relayDispatchSSEAsChunkStream(
     outbox.truncateRun({ runId: input.runId, fenceToken });
   };
 
+  // Widened defaults (see the `retry` field doc): ~2.5 min total window so a
+  // brief ECONNRESET reset window can't swallow the whole budget.
   const posterPromise = retry(postOnce, {
-    maxAttempts: 5,
-    minTimeout: 250,
-    maxTimeout: 5_000,
+    maxAttempts: input.retry?.maxAttempts ?? 12,
+    minTimeout: input.retry?.minTimeout ?? 250,
+    maxTimeout: input.retry?.maxTimeout ?? 30_000,
+    jitter: input.retry?.jitter ?? 0.5,
     signal: internal.signal,
     isRetriable: (err) => {
       // A pump failure is the root cause — retrying the POST cannot fix it.
       if (pumpError !== null && err === pumpError) return false;
       const status = (err as { status?: number }).status;
+      // Network drops (ECONNRESET etc.) carry no `.status` → retriable; a 4xx
+      // (fence/cancel) is permanent; 5xx is retriable.
       return status === undefined || status >= 500;
     },
   }).catch((err: unknown) => {
     const cause = err instanceof RetryError ? err.cause : err;
+    // Only the FIRST failure is the root (see the pump catch above). A pump
+    // failure that aborts an in-flight POST also lands here, but by then
+    // rootCause is already set, so we don't mislabel it as a cluster fault.
+    if (rootCause === null) {
+      // ROOT = CLUSTER-RELAY leg: the streaming POST to the cluster failed
+      // (after exhausting the retry budget) — socket reset, non-2xx, or ack
+      // mismatch.
+      console.error(
+        `[relay-diag] ROOT=CLUSTER-RELAY runId=${input.runId} retried=${err instanceof RetryError} name=${cause instanceof Error ? cause.name : typeof cause} msg=${cause instanceof Error ? cause.message : String(cause)}`,
+      );
+    }
     failWith(cause);
     throw cause;
   });

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
@@ -652,6 +652,9 @@ describe("handleLocalDispatch", () => {
       getClusterToken: async () => CLUSTER_TOKEN,
       fetchImpl: fetchImpl as unknown as typeof fetch,
       outbox,
+      // Fast budget — this test asserts durability after exhaustion, not the
+      // (widened) production retry window.
+      relayRetry: { maxAttempts: 2, minTimeout: 1, maxTimeout: 2, jitter: 0 },
     }).catch(() => {}); // expected to fail after retries
 
     outbox.close();

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.ts
@@ -52,6 +52,18 @@ import type { Outbox } from "./outbox";
 const DISPATCH_START_TIMEOUT_MS = 15_000;
 
 /**
+ * Relay retry budget, env-tunable for ops without a rebuild (undefined → the
+ * widened chunk-relay defaults: 12 attempts / 30s max backoff ≈ 2.5 min). The
+ * wide window lets a transient cluster/edge ECONNRESET recover instead of
+ * exhausting the budget and failing the run. `Number("")`/`Number(undefined)`
+ * collapse to NaN → `|| undefined`, so an unset/blank env keeps the defaults.
+ */
+const RELAY_MAX_ATTEMPTS =
+  Number(process.env.DECO_LINK_RELAY_MAX_ATTEMPTS) || undefined;
+const RELAY_MAX_TIMEOUT_MS =
+  Number(process.env.DECO_LINK_RELAY_MAX_TIMEOUT_MS) || undefined;
+
+/**
  * Relay a synthesized terminal failure for a work item that cannot run
  * (expired credentials, etc.) over the normal /chunks channel, so the
  * cluster kernel persists the failure and the gate unblocks.
@@ -153,6 +165,18 @@ export interface LocalDispatchDeps {
    * production durability is never silently lost to the in-memory fallback.
    */
   outbox: Outbox;
+  /**
+   * Override the chunk-relay retry budget. Production leaves this unset → the
+   * env-tunable widened defaults apply (so a transient ECONNRESET recovers).
+   * Tests inject a fast budget to exercise retry-exhaustion without waiting on
+   * the ~2.5 min production window.
+   */
+  relayRetry?: {
+    maxAttempts?: number;
+    minTimeout?: number;
+    maxTimeout?: number;
+    jitter?: number;
+  };
 }
 
 /**
@@ -254,6 +278,15 @@ export async function handleLocalDispatch(
         { cause: err },
       );
     }
+    // SANDBOX leg: opening the loopback dispatch SSE threw (e.g. the sandbox
+    // daemon died / reset → "socket connection closed unexpectedly"). Label it
+    // so it's distinguishable from a CLUSTER-RELAY failure in link.log. Quiet
+    // on an intentional abort (cancel/shutdown).
+    if (!deps.signal?.aborted) {
+      console.error(
+        `[relay-diag] SANDBOX dispatch-open threw runId=${work.runId} url=${deps.sandboxDispatchUrl}/_sandbox/dispatch name=${err instanceof Error ? err.name : typeof err} msg=${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
     throw err;
   } finally {
     if (timeoutId !== undefined) {
@@ -294,8 +327,23 @@ export async function handleLocalDispatch(
     fenceToken: work.runFenceToken,
     outbox: deps.outbox,
     signal: deps.signal,
+    // Injected budget wins (tests); else env-tunable widened defaults. Either
+    // way, undefined entries fall back to chunk-relay's defaults.
+    retry: deps.relayRetry ?? {
+      maxAttempts: RELAY_MAX_ATTEMPTS,
+      maxTimeout: RELAY_MAX_TIMEOUT_MS,
+    },
     post: async (body, fromSeq) => {
-      const res = await fetcher(chunksUrl, {
+      // Bun-specific fetch options absent from the DOM RequestInit typings:
+      //  - `duplex: "half"` — required by the Fetch spec for streaming request
+      //    bodies; supported by Node/Bun/undici. Verified on Bun 1.3.14: the
+      //    upload is delivered incrementally.
+      //  - `verbose` — env-gated (DECO_LINK_FETCH_VERBOSE=1). Prints Bun's
+      //    HTTP/connection transcript to stderr so a "socket connection closed
+      //    unexpectedly" reveals its real cause (HTTP/2 GOAWAY / idle timeout /
+      //    RST) on the next relay reset. Noisy (fires on every POST) — keep off
+      //    by default; flip it on only while hunting a relay-reset.
+      const init: RequestInit & { duplex: "half"; verbose?: boolean } = {
         method: "POST",
         headers: {
           authorization: `Bearer ${clusterToken}`,
@@ -304,14 +352,40 @@ export async function handleLocalDispatch(
           "x-relay-from": String(fromSeq),
         },
         body,
-        // @ts-expect-error — `duplex: "half"` is required by the Fetch spec
-        // for streaming request bodies; supported by Node/Bun/undici but not
-        // yet in TS DOM typings (same pattern as proxy-poller.ts). Verified
-        // on Bun 1.3.14: the upload is delivered incrementally.
         duplex: "half",
         signal: deps.signal,
-      });
+        ...(process.env.DECO_LINK_FETCH_VERBOSE === "1"
+          ? { verbose: true }
+          : {}),
+      };
+      let res: Response;
+      try {
+        res = await fetcher(chunksUrl, init);
+      } catch (err) {
+        // The streaming POST to the cluster threw (e.g. "socket connection
+        // closed unexpectedly"). This is per-ATTEMPT and factual (the POST to
+        // chunksUrl errored), but it can ALSO fire as downstream fallout when
+        // the SANDBOX leg failed first — the errored request body propagates
+        // here. chunk-relay's `[relay-diag] ROOT=...` line is the definitive
+        // leg. Re-thrown so chunk-relay's retry/backoff still applies.
+        const e = err as {
+          name?: string;
+          message?: string;
+          code?: string;
+          errno?: number;
+          cause?: unknown;
+        };
+        const causeStr =
+          e?.cause instanceof Error ? e.cause.message : String(e?.cause ?? "?");
+        console.error(
+          `[relay-diag] cluster-POST attempt errored runId=${work.runId} fromSeq=${fromSeq} url=${chunksUrl} name=${e?.name ?? typeof err} code=${e?.code ?? "?"} errno=${e?.errno ?? "?"} cause=${causeStr} msg=${e?.message ?? String(err)}`,
+        );
+        throw err;
+      }
       if (!res.ok) {
+        console.error(
+          `[relay-diag] CLUSTER-RELAY POST non-ok runId=${work.runId} fromSeq=${fromSeq} url=${chunksUrl} status=${res.status}`,
+        );
         const err = new Error(
           `[handleLocalDispatch] relay failed (${res.status})`,
         );

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -58,12 +58,21 @@ export interface StartLinkDaemonOptions {
   /** Optional TUI hooks. Omitted in --no-tui mode. */
   monitor?: LinkDaemonMonitor;
   /**
-   * When set, spawned sandbox daemons write stdout/stderr to this file
-   * descriptor (the `deco link` log file) instead of inheriting the
-   * terminal. Omitted in `--no-tui` / managed mode so their output streams
-   * to the parent process.
+   * The daemon's own log file descriptor (`link.log`). The parent process
+   * intercepts `console.*` onto this fd before calling us, so daemon-level
+   * logs (cluster connection, polls, dispatch/relay diagnostics) land here.
+   * Also the fallback stdio for spawned sandbox daemons when `perSandboxLogs`
+   * is off (managed/dev mode) — otherwise each sandbox logs to its own file.
    */
   logFd?: number;
+  /**
+   * When true, each spawned sandbox daemon writes its stdout/stderr to its own
+   * `<workdir>/tmp/daemon.log` (truncated on every spawn) instead of `logFd` /
+   * the terminal — keeping the (very noisy) per-sandbox vite/harness output
+   * isolated and co-located with that sandbox's `repo/`. Off in managed/dev
+   * mode so the output streams to the parent process.
+   */
+  perSandboxLogs?: boolean;
   /** Hot-reload sandbox daemons spawned from source. */
   hotReload?: boolean;
 }
@@ -80,7 +89,10 @@ export async function startLinkDaemon(
   opts.monitor?.onMachine?.(hostname ?? "this machine");
 
   const innerSpawn = createDefaultDaemonSpawn(opts.dataDir, {
+    // Per-sandbox `<workdir>/tmp/daemon.log` when enabled; otherwise fall back
+    // to the daemon's log fd / terminal inherit (managed/dev mode).
     outFd: opts.logFd,
+    perSandboxLog: opts.perSandboxLogs,
     hotReload: opts.hotReload,
   });
   // Forward declaration so `resolvePreviewUrl` can read the ingress port

--- a/packages/sandbox/server/daemon-spawn.test.ts
+++ b/packages/sandbox/server/daemon-spawn.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   buildSandboxDaemonSpawnCommand,
   resolveDaemonStdio,
+  sandboxDaemonLogPath,
 } from "./daemon-spawn";
 
 describe("resolveDaemonStdio", () => {
@@ -12,6 +13,22 @@ describe("resolveDaemonStdio", () => {
 
   it("returns the provided fd so the child writes to the log file", () => {
     expect(resolveDaemonStdio(7)).toBe(7);
+  });
+});
+
+describe("sandboxDaemonLogPath", () => {
+  it("co-locates the per-sandbox daemon log under the sandbox's tmp/", () => {
+    expect(
+      sandboxDaemonLogPath("/Users/me/deco/sandboxes/thin-crest-abc123"),
+    ).toBe("/Users/me/deco/sandboxes/thin-crest-abc123/tmp/daemon.log");
+  });
+
+  it("is a sibling of the sandbox repo/, not inside it", () => {
+    const workdir = "/data/sandboxes/h1";
+    expect(sandboxDaemonLogPath(workdir)).not.toContain("/repo/");
+    expect(sandboxDaemonLogPath(workdir)).toBe(
+      "/data/sandboxes/h1/tmp/daemon.log",
+    );
   });
 });
 

--- a/packages/sandbox/server/daemon-spawn.ts
+++ b/packages/sandbox/server/daemon-spawn.ts
@@ -21,9 +21,9 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { mkdir, rename, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export interface DaemonProcess {
@@ -97,6 +97,16 @@ export function resolveDaemonStdio(outFd?: number): "inherit" | number {
   return outFd ?? "inherit";
 }
 
+/**
+ * Per-sandbox daemon log path: `<workdir>/tmp/daemon.log`. Each spawned sandbox
+ * daemon writes its stdout/stderr here — co-located with the sandbox's `repo/`
+ * and isolated from every other sandbox (the old single combined file
+ * interleaved them all). Truncated on every spawn (see `createDefaultDaemonSpawn`).
+ */
+export function sandboxDaemonLogPath(workdir: string): string {
+  return join(workdir, "tmp", "daemon.log");
+}
+
 export function canHotReloadDaemon(opts: {
   daemonExec: string;
   sourceDaemonPath: string;
@@ -123,7 +133,7 @@ export function buildSandboxDaemonSpawnCommand(opts: {
  */
 export function createDefaultDaemonSpawn(
   homeDir: string,
-  opts: { outFd?: number; hotReload?: boolean } = {},
+  opts: { outFd?: number; perSandboxLog?: boolean; hotReload?: boolean } = {},
 ): SpawnDaemonFn {
   return async (args) => {
     const daemonExec = await resolveDaemonExec(homeDir);
@@ -133,7 +143,22 @@ export function createDefaultDaemonSpawn(
     const nodePath = existingNodePath
       ? `${ptyNodeModulesDir}:${existingNodePath}`
       : ptyNodeModulesDir;
-    const stdio = resolveDaemonStdio(opts.outFd);
+    // Per-sandbox log: open `<workdir>/tmp/daemon.log` (truncate every spawn)
+    // and point this sandbox daemon's stdout/stderr at it, so each sandbox's
+    // (noisy) output is isolated + co-located with its repo. Falls back to
+    // `outFd`/terminal-inherit for managed/dev mode, where output is meant to
+    // stream to the parent process.
+    let perSandboxFd: number | undefined;
+    let stdio: "inherit" | number;
+    if (opts.perSandboxLog) {
+      const logPath = sandboxDaemonLogPath(args.workdir);
+      mkdirSync(dirname(logPath), { recursive: true });
+      perSandboxFd = openSync(logPath, "w");
+      stdio = perSandboxFd;
+      console.log(`[user-desktop] sandbox daemon logs → ${logPath}`);
+    } else {
+      stdio = resolveDaemonStdio(opts.outFd);
+    }
     const proc = Bun.spawn({
       cmd: buildSandboxDaemonSpawnCommand({
         daemonExec,
@@ -149,6 +174,18 @@ export function createDefaultDaemonSpawn(
       stderr: stdio,
       stdin: "ignore",
     });
+    // Close the parent's copy of the log fd once the child exits — the child
+    // holds its own dup for its lifetime, so this only releases our handle.
+    if (perSandboxFd !== undefined) {
+      const fd = perSandboxFd;
+      void proc.exited.finally(() => {
+        try {
+          closeSync(fd);
+        } catch {
+          /* already closed */
+        }
+      });
+    }
     return {
       pid: proc.pid,
       kill: (sig) => {


### PR DESCRIPTION
## Problem

The desktop link daemon streams harness output back to the cluster `/chunks` endpoint as a single long-lived streaming POST. Against studio-stg this **intermittently fails with a fast `ECONNRESET`** (TCP reset, no HTTP response) at the edge. The old retry budget (**5 attempts / ~8s**) was too short and clustered, so all retries fell inside one brief reset window → the run failed terminally with the harness output **undelivered** — the long-standing "harness isn't responding / 2nd message doesn't answer" symptom.

This was diagnosed live against studio-stg with the instrumentation in this PR: the harness ran fine (`stream start` → output produced), but the relay POST got `ECONNRESET` on all 5 attempts → `ROOT=CLUSTER-RELAY` → `local dispatch failed`.

## Changes

- **Mitigation (the fix):** `chunk-relay` retry budget widened to **12 attempts / 30s max backoff (~2.5 min)** with **jitter**, so a transient reset window is outlasted instead of exhausting the budget. Env-tunable (`DECO_LINK_RELAY_MAX_ATTEMPTS`, `DECO_LINK_RELAY_MAX_TIMEOUT_MS`) and dep-injectable for tests.
- **Diagnostics:** rootCause-guarded `[relay-diag] ROOT=SANDBOX-SSE-pump | ROOT=CLUSTER-RELAY` leg labels, per-attempt `code`/`errno`/`cause`, and an env-gated fetch `verbose` — so a "socket closed" failure names the exact leg and cause instead of being opaque.
- **Log layout:** `link.log` is now the link-daemon transport log only; each sandbox daemon's noisy stdout/stderr goes to its own `<workdir>/tmp/daemon.log`. Both are **recreated on restart** (`link.log` was append-only and ballooned to 100+ MB).

## Testing

- `bun test` (link-daemon + sandbox): 33 pass, incl. new coverage for the configurable retry budget and the per-sandbox log path.
- `bun run check` (typecheck), `bun run fmt`, `bun run lint`: clean.
- Verified live against studio-stg: per-sandbox `tmp/daemon.log` created fresh per spawn; `link.log` stays clean of sandbox internals; the `ROOT=CLUSTER-RELAY` failure was captured with `code=ECONNRESET`.

> Note: branch was based on a commit ~52 behind `main` (main moved ahead during the debugging session); none of these 8 files were touched on `main`, so the change is conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover transient `/chunks` stream resets by widening the `chunk-relay` retry window and adding jitter. Split and label logs so failures name the exact leg, and keep `link.log` small and readable.

- **Bug Fixes**
  - Expanded retry policy to 12 attempts with 30s max backoff (~2.5 min) and jitter; env-tunable via `DECO_LINK_RELAY_MAX_ATTEMPTS` and `DECO_LINK_RELAY_MAX_TIMEOUT_MS`, and injectable for tests.
  - Network drops with no status are retriable; 4xx are permanent; 5xx retriable.
  
- **Diagnostics & Logging**
  - Added `[relay-diag] ROOT=SANDBOX-SSE-pump` and `ROOT=CLUSTER-RELAY` labels, per-attempt `code`/`errno`/`cause`, and optional fetch `verbose` via `DECO_LINK_FETCH_VERBOSE=1`.
  - `link.log` now captures only link-daemon transport logs and is recreated on restart.
  - Each sandbox daemon logs to its own `<workdir>/tmp/daemon.log` (truncated on spawn); controlled by `perSandboxLogs` (on for standalone `deco link`, off for managed/dev).

<sup>Written for commit b6df428d00536a2b984dc3a02909a93c99153000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

