### PR TITLE
fix(mode-picker): restore !locked guard — label was showing on locked threads

### DIFF
--- a/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
@@ -222,7 +222,13 @@ export function ModePickerPure({
                 )}
               >
                 {icon}
-                <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[320px]/chat-bottom:max-w-32 @[320px]/chat-bottom:opacity-100">
+                <span
+                  className={cn(
+                    "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
+                    !locked &&
+                      "@[320px]/chat-bottom:max-w-32 @[320px]/chat-bottom:opacity-100",
+                  )}
+                >
                   {text}
                 </span>
                 {!locked && (


### PR DESCRIPTION
## Summary

- PR #3906 intended to make the locked `ModePicker` show icon-only (same as `BranchPill`), but the `mode-picker.tsx` change was **silently dropped** during GitHub's squash-merge — only `branch-pill.tsx` made it into squash commit `3435c17`.
- The label span was left with unconditional `@[320px]/chat-bottom:opacity-100` classes, so the "Claude Code" (or any mode name) text was still rendered visually on locked threads when the container was ≥320px wide.
- This single-line fix restores the `!locked &&` guard that was in the original commit but never reached `main`.

## What changed

`apps/mesh/src/web/components/chat/pills/mode-picker.tsx` — label span className converted from a static string to a `cn()` call with `!locked &&` guard:

```tsx
// before (on main — broken):
<span className="... max-w-0 opacity-0 @[320px]/chat-bottom:max-w-32 @[320px]/chat-bottom:opacity-100">

// after (this PR — correct):
<span className={cn("... max-w-0 opacity-0", !locked && "@[320px]/chat-bottom:max-w-32 @[320px]/chat-bottom:opacity-100")}>
```

## Test plan

- [ ] Locked thread (has messages or `harness_id` set): mode picker shows **icon only**, no label
- [ ] Unlocked thread (no messages, no harness): mode picker shows **icon + label** when container ≥320px
- [ ] All existing unit tests pass (`bun test`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the !locked guard in ModePicker so locked threads show icon-only. Prevents the mode label (e.g., "Claude Code") from appearing at ≥320px; unlocked threads still expand the label as expected.

<sup>Written for commit 6a6e78569c5d69a4fdf88f03e071eef1fb91cdef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

