### PR TITLE
fix(harness): correct claude-code opus-1m model alias

### DIFF
--- a/packages/harness/src/claude-code/model/index.ts
+++ b/packages/harness/src/claude-code/model/index.ts
@@ -75,11 +75,11 @@ export function createClaudeCodeModel(
  * "opus", "sonnet", and "haiku". Any other string is passed straight through to
  * the CLI's --model flag. For models not covered by a short alias (Fable 5,
  * Opus 4.8 1M) we therefore use the full CLI model ID so the CLI can resolve
- * it correctly.
+ * it correctly. For example, Opus 4.8 with 1M context uses `opus[1m]`.
  */
 const CLAUDE_CODE_SDK_MODELS: Record<string, string> = {
   "claude-code:opus": "opus",
-  "claude-code:opus-1m": "claude-opus-4.8-1m",
+  "claude-code:opus-1m": "opus[1m]",
   "claude-code:sonnet": "sonnet",
   "claude-code:haiku": "haiku",
   "claude-code:fable": "claude-fable-5",


### PR DESCRIPTION
## Summary

- Replace invalid `claude-opus-4.8-1m` with `opus[1m]` in the Claude Code model alias map
- `opus[1m]` is the bracket notation the Claude Code CLI actually recognises for Opus 4.8 with 1M context window (confirmed via `~/.claude/settings.json`)

## Test plan

- [ ] Start a session with `claude-code:opus-1m` model — should no longer throw `There's an issue with the selected model (claude-opus-4.8-1m)`
- [ ] Confirm the 1M context window is active in the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `claude-code:opus-1m` alias by mapping it to `opus[1m]`, which the Claude Code CLI recognizes for Opus 4.8 with a 1M context window. This removes the model selection error and enables the intended 1M context.

<sup>Written for commit 603accb0e1a2a5fce4fc3287a704bc05b04d5795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

