### PR TITLE
fix(mesh): cut release to rebundle harness opus-1m alias fix

### DIFF
--- a/apps/mesh/scripts/bundle-server-script.ts
+++ b/apps/mesh/scripts/bundle-server-script.ts
@@ -397,6 +397,11 @@ async function pruneNodeModules(): Promise<Set<string>> {
     // Workspace packages stay inlined (bun build will pull source directly).
     // @decocms/better-auth is the one published @decocms/* dep, so it ships
     // like any other.
+    //
+    // Because workspace deps (e.g. @decocms/harness) are inlined from source
+    // rather than read from npm at runtime, the published `decocms` CLI only
+    // picks up a harness change when mesh itself re-releases and re-bundles.
+    // A harness-only version bump does NOT reach `decocms@latest` on its own.
     if (
       packageName.startsWith("@decocms/") &&
       packageName !== "@decocms/better-auth"


### PR DESCRIPTION
## Summary

#3911 corrected the claude-code `opus-1m` model alias in `@decocms/harness`, but that fix is **not yet in the published `decocms` CLI**. The harness is inlined from source into the `decocms` server bundle at build time (`bundle-server-script.ts` → `📦 Bundling inline (workspace)`), so it only reaches `decocms@latest` when **mesh itself re-releases and re-bundles**. A harness-only version bump (1.4.0 → 1.4.1) does nothing for the CLI on its own.

This PR documents that coupling at the inline-bundling site and exists to **cut a mesh release** so the opus-1m fix ships to `decocms@latest`.

## Mechanics

- No functional change — comment only.
- On merge, the release bot bumps `apps/mesh/package.json` (patch) → triggers `release-mesh.yaml` → rebuilds the bundle from current `main` (which already includes the harness fix) → publishes the new `decocms`.

## Testing

- `bun run fmt` ✅ (comment-only change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut a mesh patch release to rebundle the `@decocms/harness` fix for the claude-code `opus-1m` alias into the published `decocms` CLI. Adds a comment in `apps/mesh/scripts/bundle-server-script.ts` explaining that workspace deps are inlined, so harness changes only reach `decocms@latest` when mesh re-releases.

<sup>Written for commit d1ba23124eb522e126b5c7f049f2f6f2c9e4cceb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

