### PR TITLE
perf(mesh): share Ajv validator on public-MCP-server & bindings-client hot paths

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "3.2.4",
+      "version": "3.18.5",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -177,8 +177,9 @@
     },
     "packages/bindings": {
       "name": "@decocms/bindings",
-      "version": "1.4.2",
+      "version": "1.4.5",
       "dependencies": {
+        "@decocms/mcp-utils": "^1.0.5",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@tanstack/react-router": "1.169.2",
         "react": "^19.2.6",
@@ -199,7 +200,7 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "1.1.1",
+      "version": "1.4.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.80",
         "@ai-sdk/google": "^3.0.80",
@@ -220,7 +221,7 @@
     },
     "packages/mcp-utils": {
       "name": "@decocms/mcp-utils",
-      "version": "1.0.2",
+      "version": "1.0.5",
       "dependencies": {
         "@decocms/std": "workspace:*",
         "ajv": "^8.20.0",
@@ -263,7 +264,7 @@
     },
     "packages/mesh-sdk": {
       "name": "@decocms/mesh-sdk",
-      "version": "1.5.0",
+      "version": "1.8.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.1",
         "@decocms/mcp-utils": "workspace:*",
@@ -282,11 +283,12 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.10",
         "@cloudflare/workers-types": "^4.20250617.0",
         "@decocms/bindings": "^1.0.7",
+        "@decocms/mcp-utils": "^1.0.5",
         "@modelcontextprotocol/sdk": "1.29.0",
         "jose": "^6.0.11",
         "zod": "^4.0.0",
@@ -303,7 +305,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.0.0",
+      "version": "1.2.4",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/std": "workspace:*",
@@ -323,7 +325,7 @@
     },
     "packages/typegen": {
       "name": "@decocms/typegen",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "typegen": "./dist/cli.js",
       },

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -7,6 +7,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@decocms/mcp-utils": "^1.0.5",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@tanstack/react-router": "1.169.2",
     "react": "^19.2.6",

--- a/packages/bindings/src/core/client/mcp-client.ts
+++ b/packages/bindings/src/core/client/mcp-client.ts
@@ -14,6 +14,7 @@ import {
   ListToolsResult,
   ListToolsResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import { MCPConnection } from "../connection";
 import { HTTPClientTransport } from "./http-client-transport";
 
@@ -26,7 +27,10 @@ import { HTTPClientTransport } from "./http-client-transport";
  */
 class Client extends BaseClient {
   constructor(_clientInfo: Implementation, options?: ClientOptions) {
-    super(_clientInfo, options);
+    super(_clientInfo, {
+      jsonSchemaValidator: sharedJsonSchemaValidator,
+      ...options,
+    });
   }
 
   override async listTools(

--- a/packages/mcp-utils/package.json
+++ b/packages/mcp-utils/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.5",
   "description": "Primitives for building MCP proxies, gateways, and sandboxes",
   "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "check": "tsc --noEmit",
     "test": "bun test"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20250617.0",
     "@decocms/bindings": "^1.0.7",
+    "@decocms/mcp-utils": "^1.0.5",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@ai-sdk/provider": "^3.0.10",
     "jose": "^6.0.11",

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -5,6 +5,7 @@ import {
   OnEventsOutputSchema,
   type EventBusBindingClient,
 } from "@decocms/bindings";
+import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport as HttpServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type {
@@ -1086,6 +1087,7 @@ export const createMCPServer = <
       },
       {
         capabilities: { tools: {}, prompts: {}, resources: {} },
+        jsonSchemaValidator: sharedJsonSchemaValidator,
         ...(instructions && { instructions }),
       },
     );


### PR DESCRIPTION
## Summary

Follow-up to #3910. Two **request-path** MCP constructions bypassed the process-wide `sharedJsonSchemaValidator`, so each spun up its own Ajv instance and **recompiled every tool schema cold on every request**:

- **`packages/runtime/src/tools.ts:1081`** — `createServer()` is called inside `fetch`, i.e. per request (mounted as the public MCP handler via `createPublicMCPHandler`), constructing a fresh `new McpServer` with no validator.
- **`packages/bindings/src/core/client/mcp-client.ts:62`** — `createServerClient` builds a `new Client` with no validator.

Every Client/Server in `apps/mesh/src` already injects the shared validator; these two were the remaining gaps, and both sit on hot paths.

## Why this matters (event-loop lag)

In `deco-studio` prod, the in-process `stall-stack` sampler shows synchronous **Ajv `compile()` codegen** (`getValidator` → `render`/`get names`/`encode`) as the dominant frame during event-loop freezes — bursty stalls of p90 ~1.2s, max ~2.3s. These freezes fail liveness/readiness probes and contribute to the pod-kill pattern.

Local benchmark (real Ajv config, 30-tool server = 60 schemas):

| path | cost |
|---|---|
| single cold compile | ~9 ms |
| **bypass** (fresh Ajv/req, recompile all) | **20 reqs = 946 ms sync, ~47 ms/req** |
| **shared** (compile-once) | warmup ~37 ms, then **~0.08 ms/req** |

A burst of ~25–40 concurrent requests through a bypass path = 1.2–1.9s of synchronous loop blocking, matching the observed prod distribution. (Bench is on a fast arm64 Mac; prod's shared-CPU containers make each compile slower, so this is a floor.)

## Changes

- Inject `jsonSchemaValidator: sharedJsonSchemaValidator` at both construction sites (bindings injects it as the `Client` constructor default, so all uses inherit it; callers can still override).
- Add `@decocms/mcp-utils` dep to `runtime` and `bindings`. No dependency cycle — `mcp-utils` only depends on `@decocms/std` + `ajv`.
- Add `main`/`types` to `mcp-utils/package.json` (mirroring `@decocms/std`) so it resolves under bindings' classic `node` moduleResolution.

## Testing

- `bun run check` — clean across all workspaces.
- `bun test packages/mcp-utils` (92 pass) and `packages/bindings` (3 pass).
- `bun run fmt` applied.

## Verification after deploy

Not live until a new `mesh:` image ships to `deco-studio`. Post-deploy, the `getValidator`/Ajv-codegen frames should drop out of `stall-stack` bursts. Open question (doesn't block — fix is correct either way): whether these bypass paths are the *dominant* prod traffic vs. the shared path also seeing genuinely-new schemas; a compile-vs-cache-hit counter on `getValidator` would settle it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares a single Ajv validator across the public MCP server and the `bindings` client hot paths to remove per-request schema compiles and event-loop stalls. Uses `sharedJsonSchemaValidator` so compiles happen once (~37ms warmup), then ~0.08 ms/req instead of ~47 ms/req.

- **Refactors**
  - Inject `jsonSchemaValidator: sharedJsonSchemaValidator` in `packages/runtime/src/tools.ts` server creation and `packages/bindings/src/core/client/mcp-client.ts` client constructor. Callers can still override.

- **Dependencies**
  - Add `@decocms/mcp-utils` to `@decocms/runtime` and `@decocms/bindings`.
  - Expose `main` and `types` in `@decocms/mcp-utils`.

<sup>Written for commit c5fbc1615bc8a6f5a20d489b6bef205fe5c1130c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

