### PR TITLE
fix(mesh): auto-recover MCP connections from status="error"

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -31,6 +31,7 @@ import {
   recordSuccess,
 } from "@/mcp-clients/circuit-breaker";
 import { getConnectionCircuitStore } from "@/mcp-clients/connection-circuit-store";
+import { CONNECTION_ERROR_REPROBE_COOLDOWN_MS } from "@/core/constants";
 import { peekRpcMethod, probeDecision } from "./proxy-handshake";
 import { handleVirtualMcpRequest } from "./virtual-mcp";
 export { toServerClient, type MCPProxyClient } from "./mcp-proxy-factory";
@@ -235,9 +236,30 @@ export const createProxyRoutes = () => {
           );
         }
 
-        // Check connection status
+        // Check connection status.
+        // "inactive" = deliberate manual disable: permanent until re-enabled.
+        // "error" = auto-disable after sustained failures: self-heals via a
+        // half-open re-probe once the cooldown (measured from updated_at, the
+        // disable time) elapses. Within the cooldown we fast-fail with a
+        // Retry-After hint so callers stop hammering.
+        let recovering = false;
         if (connection.status !== "active") {
-          throw new Error(`Connection inactive: ${connection.status}`);
+          const sinceDisabledMs =
+            Date.now() - new Date(connection.updated_at).getTime();
+          const canReprobe =
+            connection.status === "error" &&
+            !!connection.connection_url &&
+            sinceDisabledMs >= CONNECTION_ERROR_REPROBE_COOLDOWN_MS;
+          if (canReprobe) {
+            recovering = true;
+          } else {
+            if (connection.status === "error" && connection.connection_url) {
+              const remainingMs =
+                CONNECTION_ERROR_REPROBE_COOLDOWN_MS - sinceDisabledMs;
+              c.header("Retry-After", String(Math.ceil(remainingMs / 1000)));
+            }
+            throw new Error(`Connection inactive: ${connection.status}`);
+          }
         }
 
         // For HTTP connections, eagerly attempt the upstream MCP handshake to
@@ -262,6 +284,7 @@ export const createProxyRoutes = () => {
             ? (await listCache.get(listType, connectionId)) === null
             : true;
         }
+        if (recovering) probe = true; // half-open: a real handshake must test recovery
         if (connection.connection_url && probe) {
           assertCircuitClosed(connectionId);
           await ctx.tracer.startActiveSpan(
@@ -278,6 +301,15 @@ export const createProxyRoutes = () => {
                 await clientFromConnection(connection, ctx, false);
                 recordSuccess(connectionId);
                 void getConnectionCircuitStore().recordSuccess(connectionId);
+                if (recovering) {
+                  await ctx.storage.connections.update(connectionId, {
+                    status: "active",
+                  });
+                  console.info(
+                    "[proxy] auto-recovered connection after successful re-probe",
+                    { connectionId, org: ctx.organization?.slug },
+                  );
+                }
                 span.setStatus({ code: SpanStatusCode.OK });
               } catch (err) {
                 span.setStatus({

--- a/apps/mesh/src/core/constants.ts
+++ b/apps/mesh/src/core/constants.ts
@@ -51,3 +51,11 @@ export const CONNECTION_DISABLE_MIN_WINDOW_MS = 60_000; // 60 seconds
 
 /** TTL for shared failure-counter entries — a connection that stops failing self-resets. */
 export const CONNECTION_CIRCUIT_TTL_MS = 5 * 60_000; // 5 minutes
+
+/**
+ * Cooldown before an auto-disabled (status="error") connection is re-probed.
+ * After this window a single request triggers a half-open handshake; success
+ * re-activates the connection, failure restarts the window. Manual "inactive"
+ * disables never auto-recover.
+ */
+export const CONNECTION_ERROR_REPROBE_COOLDOWN_MS = 60_000; // 60 seconds


### PR DESCRIPTION
## Summary

A connection auto-disabled to `status="error"` (sustained downstream failures via the cross-replica circuit store, or 3 consecutive credential-decrypt failures) **never returned to `"active"`** without a human clicking "Enable" in the UI. So the DB status gate in the MCP proxy fast-failed *every* request forever with an opaque 503 `Connection inactive: error` — and that 503 carried **no `Retry-After`**, so callers (frontend list polls, agent loops, the decopilot reactor) hammered the endpoint indefinitely.

This was observed in prod as a long storm of identical `503 {"error":"Connection inactive: error"}` for a single FarmRio connection.

## Fix — half-open self-healing

Give the durable `"error"` gate the same half-open behavior the in-memory circuit breaker already has:

- **Auto-disable (`"error"`) self-heals.** After a 60s cooldown (measured from `updated_at`, the disable time), the next request to an HTTP connection forces a real upstream handshake. Success flips the connection back to `"active"` (and clears the cross-replica failure store); failure leaves it disabled and restarts the cooldown.
- **Bounded load while broken.** At most one re-probe per replica per cooldown — exactly the existing HALF_OPEN contract.
- **Callers back off.** In-cooldown 503s now carry a `Retry-After` header pointing at the remaining cooldown.
- **Manual disable stays manual.** `"inactive"` (deliberate admin disable) never auto-recovers.

## Changes
- `apps/mesh/src/core/constants.ts` — new `CONNECTION_ERROR_REPROBE_COOLDOWN_MS` (60s).
- `apps/mesh/src/api/routes/proxy.ts` — split the status gate into manual-vs-auto, force a probe when recovering, re-activate on a successful re-probe.

## Testing
- `bun run --cwd=apps/mesh check` — the two changed files are type-clean.
- Formatted with Biome.

## Follow-ups (not in this PR)
- `mcp-proxy-factory.ts:97` has the identical gate for background/programmatic clients with the same "stuck forever" property — worth sharing this recovery logic there.
- An e2e test: disable via sustained failures → advance past cooldown → assert the next request re-activates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-recover MCP connections stuck in `status="error"` by adding a half-open re-probe after a 60s cooldown, so healthy connections return without manual action. 503s during cooldown now include `Retry-After` to reduce hammering; manual `status="inactive"` is unchanged.

- **Bug Fixes**
  - After cooldown, the next request forces a real handshake; success flips status to `active`, failure restarts the cooldown.
  - While in cooldown, return 503 with `Retry-After` for the remaining seconds.
  - Manual disables (`inactive`) never auto-recover.
  - Added `CONNECTION_ERROR_REPROBE_COOLDOWN_MS=60_000` and updated the proxy status gate to drive recovery.

<sup>Written for commit cbe02179e3811dec474783b691061141e579456e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

