### PR TITLE
fix(decopilot): unblock DBOS recovery — drop run-owner claim, make dispatch step retriable

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -162,6 +162,7 @@ import {
   setAutomationRuntime,
 } from "../automations";
 import {
+  requeueInflightThreadGateWorkflows,
   setThreadGateRuntime,
   THREAD_GATE_PARTITION_CONCURRENCY,
   THREAD_GATE_QUEUE,
@@ -172,7 +173,6 @@ import {
   dispatchRunAndWait,
   pullDispatch,
 } from "./routes/decopilot/dispatch-run";
-import { getPodId } from "../core/pod-identity";
 import { createAutomationsStorage } from "../storage/automations";
 import { KyselyKVStorage } from "../storage/kv";
 import { KyselyTriggerCallbackTokenStorage } from "../storage/trigger-callback-tokens";
@@ -1130,8 +1130,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     sseHub,
   };
 
-  const POD_ID = getPodId();
-  const runRegistry = new RunRegistry(cancelReactorDeps, POD_ID);
+  const runRegistry = new RunRegistry(cancelReactorDeps);
 
   // Shared async-research-job storage — used both by the background
   // sweeper and by the automation context factory below, which rebinds it
@@ -2153,6 +2152,17 @@ export async function createApp(options: CreateAppOptions = {}) {
     await flushMonitoringData().catch((err: unknown) =>
       console.error("[shutdown] Telemetry flush error:", err),
     );
+
+    // Phase 4b: Hand in-flight runs back to the queue. Runs AFTER DBOS.shutdown()
+    // (index.ts) left the interrupted thread-gate workflows PENDING and AFTER the
+    // run-registry abort cancelled their daemons, but BEFORE the pool closes, so
+    // another executor re-dequeues and finishes them.
+    console.log("[shutdown] Re-enqueuing in-flight runs...");
+    await requeueInflightThreadGateWorkflows(database.db)
+      .then((n) => console.log(`[shutdown] Re-enqueued ${n} in-flight run(s).`))
+      .catch((err: unknown) =>
+        console.error("[shutdown] Re-enqueue error:", err),
+      );
 
     // Phase 5: Close database (last — other steps may need DB)
     console.log("[shutdown] Closing database...");

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -162,7 +162,6 @@ import {
   setAutomationRuntime,
 } from "../automations";
 import {
-  requeueInflightThreadGateWorkflows,
   setThreadGateRuntime,
   THREAD_GATE_PARTITION_CONCURRENCY,
   THREAD_GATE_QUEUE,
@@ -2152,17 +2151,6 @@ export async function createApp(options: CreateAppOptions = {}) {
     await flushMonitoringData().catch((err: unknown) =>
       console.error("[shutdown] Telemetry flush error:", err),
     );
-
-    // Phase 4b: Hand in-flight runs back to the queue. Runs AFTER DBOS.shutdown()
-    // (index.ts) left the interrupted thread-gate workflows PENDING and AFTER the
-    // run-registry abort cancelled their daemons, but BEFORE the pool closes, so
-    // another executor re-dequeues and finishes them.
-    console.log("[shutdown] Re-enqueuing in-flight runs...");
-    await requeueInflightThreadGateWorkflows(database.db)
-      .then((n) => console.log(`[shutdown] Re-enqueued ${n} in-flight run(s).`))
-      .catch((err: unknown) =>
-        console.error("[shutdown] Re-enqueue error:", err),
-      );
 
     // Phase 5: Close database (last — other steps may need DB)
     console.log("[shutdown] Closing database...");

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -3,12 +3,11 @@
  *
  * The reactor is "the only layer in the pipeline that performs I/O" (see the
  * module header). Its whole contract is the side effects it applies to the
- * threads table — claim-on-start CAS, status transitions, and clearing the
- * run_* columns on terminal events. A previous version of this file mocked
- * the entire ThreadStoragePort and asserted `toHaveBeenCalledWith(...)`, which
- * only proved the reactor calls the function it calls — it would stay green
- * even if `claimRunStart`'s CAS SQL were broken, the exact bug that layer can
- * have. See TESTING.md: don't mock your own code.
+ * threads table — status transitions and clearing the run_* columns on terminal
+ * events. A previous version of this file mocked the entire ThreadStoragePort
+ * and asserted `toHaveBeenCalledWith(...)`, which only proved the reactor calls
+ * the function it calls — it would stay green even if the underlying SQL were
+ * broken. See TESTING.md: don't mock your own code.
  *
  * So here `storage` is a real SqlThreadStorage against real Postgres, and we
  * assert the actual row state after each event. The two remaining deps —
@@ -36,7 +35,7 @@ import {
 import type { SSEEvent } from "@/event-bus";
 import { SqlThreadStorage } from "@/storage/threads";
 import type { Thread } from "@/storage/types";
-import { reactAll, RunClaimError, type RunReactorDeps } from "./run-reactor";
+import { reactAll, type RunReactorDeps } from "./run-reactor";
 import type { RunEvent } from "./run-state";
 import type { StreamBuffer } from "./stream-buffer";
 
@@ -103,20 +102,13 @@ function createThread(overrides: Partial<Thread> = {}) {
   });
 }
 
-/** Drive a thread into in_progress, owned by `pod`, with a non-null run_config. */
-async function setInProgress(id: string, pod = "pod-1") {
-  const claimed = await storage.claimRunStart(
-    id,
-    ORG,
-    {
-      status: "in_progress",
-      run_owner_pod: pod,
-      run_config: { resume: true },
-      run_started_at: new Date().toISOString(),
-    },
-    pod,
-  );
-  expect(claimed).toBe(true);
+/** Drive a thread into in_progress with a non-null run_config. */
+async function setInProgress(id: string) {
+  await storage.update(id, ORG, {
+    status: "in_progress",
+    run_config: { resume: true },
+    run_started_at: new Date().toISOString(),
+  });
 }
 
 /** Status-event payloads carry thread metadata on `data`. */
@@ -130,7 +122,7 @@ function statusData(event: SSEEvent): Record<string, unknown> {
 
 describe("reactAll (real Postgres)", () => {
   describe("RUN_STARTED", () => {
-    it("claims the run via real CAS: row flips to in_progress, 1 status event", async () => {
+    it("flips the row to in_progress and emits 1 status event", async () => {
       const { deps, sseEvents, purged } = makeReactor();
       const thread = await createThread(); // default status "completed"
 
@@ -147,9 +139,7 @@ describe("reactAll (real Postgres)", () => {
 
       const row = await storage.get(thread.id, ORG);
       expect(row?.status).toBe("in_progress");
-      // No podId on the event → owner pod and started_at stay null.
-      expect(row?.run_owner_pod).toBeNull();
-      expect(row?.run_started_at).toBeNull();
+      expect(row?.run_started_at).not.toBeNull();
       expect(sseEvents).toHaveLength(1);
       expect(purged).toHaveLength(0);
     });
@@ -173,8 +163,8 @@ describe("reactAll (real Postgres)", () => {
         deps,
       );
 
-      // claimRunStart bumps updated_at, so compare against the row as it is
-      // *after* the claim — the source the reactor read from.
+      // RUN_STARTED bumps updated_at, so compare against the row as it is
+      // *after* the write — the source the reactor read from.
       const row = await storage.get(thread.id, ORG);
       const data = statusData(sseEvents[0]!.event);
       expect(data.title).toBe("Test thread");
@@ -182,36 +172,10 @@ describe("reactAll (real Postgres)", () => {
       expect(data.created_at).toBe(row?.created_at);
       expect(data.updated_at).toBe(row?.updated_at);
     });
-
-    it("throws RunClaimError on real CAS contention (already running on another pod)", async () => {
-      const { deps, sseEvents } = makeReactor();
-      const thread = await createThread();
-      await setInProgress(thread.id, "pod-other");
-
-      // Event carries no podId → CAS cannot match the foreign pod → 0 rows.
-      await expect(
-        react(
-          {
-            type: "RUN_STARTED",
-            taskId: thread.id,
-            orgId: ORG,
-            userId: USER,
-            abortController: new AbortController(),
-          },
-          deps,
-        ),
-      ).rejects.toBeInstanceOf(RunClaimError);
-
-      expect(sseEvents).toHaveLength(0);
-      // Row is untouched — still owned by the other pod.
-      const row = await storage.get(thread.id, ORG);
-      expect(row?.status).toBe("in_progress");
-      expect(row?.run_owner_pod).toBe("pod-other");
-    });
   });
 
   describe("RUN_RESUMED", () => {
-    it("sets run_owner_pod + run_started_at WITHOUT touching status; emits 1 event", async () => {
+    it("sets run_started_at WITHOUT touching status; emits 1 event", async () => {
       const { deps, sseEvents, purged } = makeReactor();
       const thread = await createThread(); // status "completed"
 
@@ -228,7 +192,6 @@ describe("reactAll (real Postgres)", () => {
       );
 
       const row = await storage.get(thread.id, ORG);
-      expect(row?.run_owner_pod).toBe("pod-1");
       expect(row?.run_started_at).toBeTruthy();
       // Proof the status column was never written: it stays "completed".
       expect(row?.status).toBe("completed");
@@ -375,48 +338,6 @@ describe("reactAll (real Postgres)", () => {
       const after = await storage.get(thread.id, ORG);
       expect(after).toEqual(before); // byte-for-byte unchanged
       expect(purged).toHaveLength(0);
-      expect(sseEvents).toHaveLength(0);
-    });
-  });
-
-  describe("reactAll error propagation", () => {
-    it("stops on the first thrown error; later events are not processed", async () => {
-      const { deps, sseEvents } = makeReactor();
-      const thread = await createThread();
-      await setInProgress(thread.id);
-
-      // First event: RUN_STARTED for a thread that doesn't exist → claimRunStart
-      // updates 0 rows → RunClaimError. Second event would complete `thread`.
-      await expect(
-        reactAll(
-          [
-            {
-              event: {
-                type: "RUN_STARTED",
-                taskId: "thrd_does_not_exist",
-                orgId: ORG,
-                userId: USER,
-                abortController: new AbortController(),
-              },
-              state: undefined,
-            },
-            {
-              event: {
-                type: "RUN_COMPLETED",
-                taskId: thread.id,
-                orgId: ORG,
-                stepCount: 1,
-              },
-              state: undefined,
-            },
-          ],
-          deps,
-        ),
-      ).rejects.toBeInstanceOf(RunClaimError);
-
-      // The RUN_COMPLETED never ran: `thread` is still in_progress.
-      const row = await storage.get(thread.id, ORG);
-      expect(row?.status).toBe("in_progress");
       expect(sseEvents).toHaveLength(0);
     });
   });

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -24,15 +24,6 @@ import type { RunEvent, RunTransition } from "./run-state";
 // Errors
 // ============================================================================
 
-export class RunClaimError extends Error {
-  constructor(taskId: string) {
-    super(
-      `Failed to claim run for thread ${taskId} — already running on another pod`,
-    );
-    this.name = "RunClaimError";
-  }
-}
-
 // ============================================================================
 // Deps
 // ============================================================================
@@ -58,7 +49,6 @@ async function handleTerminalStatus(
 
   await storage.update(taskId, orgId, {
     status,
-    run_owner_pod: null,
     run_config: null,
     run_started_at: null,
   });
@@ -87,20 +77,14 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
 
   switch (event.type) {
     case "RUN_STARTED": {
-      const claimed = await storage.claimRunStart(
-        event.taskId,
-        event.orgId,
-        {
-          status: "in_progress",
-          run_owner_pod: event.podId ?? null,
-          run_config: event.runConfig ?? null,
-          run_started_at: event.podId ? new Date().toISOString() : null,
-        },
-        event.podId ?? null,
-      );
-      if (!claimed) {
-        throw new RunClaimError(event.taskId);
-      }
+      // Single-execution is guaranteed by the DBOS thread-gate queue
+      // (concurrency=1 per threadId partition), so there is no mesh-level
+      // run-owner claim to win/lose here — just record the run as active.
+      await storage.update(event.taskId, event.orgId, {
+        status: "in_progress",
+        run_config: event.runConfig ?? null,
+        run_started_at: new Date().toISOString(),
+      });
       const startedThread = await storage.get(event.taskId, event.orgId);
       sseHub.emit(
         event.orgId,
@@ -119,7 +103,6 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
 
     case "RUN_RESUMED": {
       await storage.update(event.taskId, event.orgId, {
-        run_owner_pod: event.podId,
         run_started_at: new Date().toISOString(),
       });
       const resumedThread = await storage.get(event.taskId, event.orgId);
@@ -168,14 +151,12 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
         if (!transitioned) return;
         // Clear run columns for ghost failures too
         await storage.update(event.taskId, event.orgId, {
-          run_owner_pod: null,
           run_config: null,
           run_started_at: null,
         });
       } else {
         await storage.update(event.taskId, event.orgId, {
           status: "failed",
-          run_owner_pod: null,
           run_config: null,
           run_started_at: null,
         });

--- a/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
@@ -1,8 +1,8 @@
 /**
  * RunRegistry — storage-integration tests (real Postgres).
  *
- * The methods exercised here orchestrate real SQL: stopAll (orphanRunsByPod)
- * and the reaper's terminal DB write. A previous version mocked the entire
+ * The methods exercised here orchestrate real SQL: the reaper's terminal DB
+ * write. A previous version mocked the entire
  * ThreadStoragePort and asserted `toHaveBeenCalled`, which proved nothing about
  * the queries themselves. See TESTING.md: don't mock your own code.
  *
@@ -40,7 +40,6 @@ import type { StreamBuffer } from "./stream-buffer";
 
 const ORG = "org_1";
 const USER = "user_1";
-const POD = "test-pod";
 // Progress-based reaper idle timeout (run-registry.ts RUN_IDLE_TIMEOUT_MS).
 const RUN_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -71,7 +70,7 @@ afterEach(() => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeRegistry(opts: { podId?: string; clock?: () => Date } = {}) {
+function makeRegistry(opts: { clock?: () => Date } = {}) {
   const sseEvents: Array<{ orgId: string; event: SSEEvent }> = [];
   const purged: string[] = [];
   const deps: RunReactorDeps = {
@@ -87,10 +86,9 @@ function makeRegistry(opts: { podId?: string; clock?: () => Date } = {}) {
       },
     } as unknown as StreamBuffer,
   };
-  const podId = opts.podId ?? POD;
   const registry = opts.clock
-    ? new RunRegistry(deps, podId, opts.clock)
-    : new RunRegistry(deps, podId);
+    ? new RunRegistry(deps, opts.clock)
+    : new RunRegistry(deps);
   createdRegistries.push(registry);
   return { registry, sseEvents, purged };
 }
@@ -105,27 +103,17 @@ function startThread(registry: RunRegistry, taskId: string, orgId = ORG) {
   });
 }
 
-/**
- * Create a thread and drive it to in_progress with a non-null run_config,
- * owned by `pod` (or orphaned when null).
- */
-async function seedRunningThread(pod: string | null): Promise<Thread> {
+/** Create a thread and drive it to in_progress with a non-null run_config. */
+async function seedRunningThread(): Promise<Thread> {
   const thread = await storage.create({
     organization_id: ORG,
     created_by: USER,
   });
-  const claimed = await storage.claimRunStart(
-    thread.id,
-    ORG,
-    {
-      status: "in_progress",
-      run_owner_pod: pod,
-      run_config: { resume: true },
-      run_started_at: new Date().toISOString(),
-    },
-    pod,
-  );
-  expect(claimed).toBe(true);
+  await storage.update(thread.id, ORG, {
+    status: "in_progress",
+    run_config: { resume: true },
+    run_started_at: new Date().toISOString(),
+  });
   return thread;
 }
 
@@ -148,10 +136,14 @@ async function waitFor(
 
 describe("RunRegistry storage orchestration (real Postgres)", () => {
   describe("stopAll", () => {
-    it("orphans this pod's in_progress rows in the DB, aborts controllers, clears state", async () => {
+    it("aborts in-flight controllers and clears in-memory state", async () => {
+      // stopAll no longer writes the DB (no run-owner claim to release) — it
+      // aborts the in-flight controllers (which cancels their daemons) and
+      // clears the in-memory map. Re-enqueueing the backing DBOS workflows for
+      // handoff happens separately in app shutdown.
       const { registry } = makeRegistry();
-      const t1 = await seedRunningThread(POD);
-      const t2 = await seedRunningThread(POD);
+      const t1 = await seedRunningThread();
+      const t2 = await seedRunningThread();
       startThread(registry, t1.id);
       startThread(registry, t2.id);
       const s1 = registry.getAbortSignal(t1.id)!;
@@ -159,40 +151,10 @@ describe("RunRegistry storage orchestration (real Postgres)", () => {
 
       await registry.stopAll();
 
-      // DB: run_owner_pod cleared (resumable) but status preserved.
-      for (const t of [t1, t2]) {
-        const row = await storage.get(t.id, ORG);
-        expect(row?.run_owner_pod).toBeNull();
-        expect(row?.status).toBe("in_progress");
-      }
-      // In-memory: controllers aborted and state cleared.
       expect(s1.aborted).toBe(true);
       expect(s2.aborted).toBe(true);
       expect(registry.isRunning(t1.id)).toBe(false);
       expect(registry.isRunning(t2.id)).toBe(false);
-    });
-
-    it("still aborts + clears in-memory state when the DB orphan write fails", async () => {
-      // Real failure, not a mock: a SqlThreadStorage on a destroyed pool. The
-      // contract is that stopAll's try/catch guarantees in-memory cleanup even
-      // when orphanRunsByPod throws.
-      const brokenDb = await connectTestPgDatabase();
-      await closeTestPgDatabase(brokenDb);
-      const deps: RunReactorDeps = {
-        storage: new SqlThreadStorage(brokenDb.db),
-        sseHub: { emit() {} },
-        streamBuffer: { purge() {} } as unknown as StreamBuffer,
-      };
-      const registry = new RunRegistry(deps, POD);
-      createdRegistries.push(registry);
-
-      startThread(registry, "t1"); // in-memory only
-      const signal = registry.getAbortSignal("t1")!;
-
-      await registry.stopAll(); // must not throw
-
-      expect(signal.aborted).toBe(true);
-      expect(registry.isRunning("t1")).toBe(false);
     });
   });
 
@@ -200,7 +162,7 @@ describe("RunRegistry storage orchestration (real Postgres)", () => {
     it("reaps a stuck run: real terminal DB write (failed, run_* cleared) + purge", async () => {
       let now = new Date("2024-01-01T00:00:00Z");
       const { registry, purged } = makeRegistry({ clock: () => now });
-      const thread = await seedRunningThread(POD);
+      const thread = await seedRunningThread();
       startThread(registry, thread.id); // in-memory running, startedAt = now
 
       const signal = registry.getAbortSignal(thread.id)!;

--- a/apps/mesh/src/api/routes/decopilot/run-registry.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.test.ts
@@ -34,8 +34,6 @@ function inertDeps(): RunReactorDeps {
       listMessages: async () => ({ messages: [], total: 0 }),
       listByTriggerIds: async () => ({ threads: [], total: 0 }),
       forceFailIfInProgress: async () => false,
-      claimRunStart: async () => true,
-      orphanRunsByPod: async () => [],
       bumpProgress: noop,
       // null → reaper falls back to the run's in-memory startedAt baseline,
       // which is exactly the timing these pure tests exercise.
@@ -55,10 +53,9 @@ afterEach(() => {
 
 /** Create a registry and register it for reaper-timer cleanup. */
 function createRegistry(clock?: () => Date): RunRegistry {
-  const podId = "test-pod";
   const r = clock
-    ? new RunRegistry(inertDeps(), podId, clock)
-    : new RunRegistry(inertDeps(), podId);
+    ? new RunRegistry(inertDeps(), clock)
+    : new RunRegistry(inertDeps());
   createdRegistries.push(r);
   return r;
 }

--- a/apps/mesh/src/api/routes/decopilot/run-registry.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.ts
@@ -63,7 +63,6 @@ export class RunRegistry {
 
   constructor(
     private readonly deps: RunReactorDeps,
-    private readonly podId: string,
     private readonly clock: () => Date = () => new Date(),
   ) {
     this.reaperTimer = setInterval(() => {
@@ -157,26 +156,17 @@ export class RunRegistry {
   }
 
   /**
-   * Graceful shutdown: orphan all runs in the DB first (so they are resumable
-   * if the process dies), then abort in-memory controllers and clear state.
-   * The DB write MUST happen before states.clear() — if the process dies
-   * between clear() and the DB write, threads would be permanently stuck.
+   * Graceful shutdown: abort in-memory controllers (stops streamText loops and
+   * cancels the daemon via the run's abort path) and clear state. Re-enqueueing
+   * the backing thread-gate DBOS workflows for handoff happens separately in
+   * app shutdown (`requeueInflightThreadGateWorkflows`), after `DBOS.shutdown()`.
    */
   async stopAll(): Promise<void> {
-    // 1. DB: orphan all runs owned by this pod FIRST
-    //    (if process dies after this, runs are resumable)
-    try {
-      await this.deps.storage.orphanRunsByPod(this.podId);
-    } catch (err) {
-      console.error("[RunRegistry] Failed to orphan runs in DB:", err);
-    }
-    // 2. In-memory: abort all controllers (stops streamText loops)
     for (const [, state] of this.states) {
       if (state.status.tag === "running") {
         state.status.abortController.abort();
       }
     }
-    // 3. In-memory: clear map
     this.states.clear();
   }
 

--- a/apps/mesh/src/api/routes/decopilot/run-registry.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.ts
@@ -157,9 +157,9 @@ export class RunRegistry {
 
   /**
    * Graceful shutdown: abort in-memory controllers (stops streamText loops and
-   * cancels the daemon via the run's abort path) and clear state. Re-enqueueing
-   * the backing thread-gate DBOS workflows for handoff happens separately in
-   * app shutdown (`requeueInflightThreadGateWorkflows`), after `DBOS.shutdown()`.
+   * cancels the daemon via the run's abort path) and clear state. Recovery of an
+   * interrupted run is DBOS's job — the thread-gate workflow is durable and its
+   * dispatch step is retriable, so DBOS re-runs it on another executor.
    */
   async stopAll(): Promise<void> {
     for (const [, state] of this.states) {

--- a/apps/mesh/src/dispatch-queue/index.ts
+++ b/apps/mesh/src/dispatch-queue/index.ts
@@ -1,6 +1,7 @@
 export {
   awaitThreadRun,
   enqueueThreadRun,
+  requeueInflightThreadGateWorkflows,
   setThreadGateRuntime,
   THREAD_GATE_PARTITION_CONCURRENCY,
   THREAD_GATE_QUEUE,

--- a/apps/mesh/src/dispatch-queue/index.ts
+++ b/apps/mesh/src/dispatch-queue/index.ts
@@ -1,7 +1,6 @@
 export {
   awaitThreadRun,
   enqueueThreadRun,
-  requeueInflightThreadGateWorkflows,
   setThreadGateRuntime,
   THREAD_GATE_PARTITION_CONCURRENCY,
   THREAD_GATE_QUEUE,

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -21,8 +21,6 @@
  */
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
-import { sql, type Kysely } from "kysely";
-import type { Database as DatabaseSchema } from "@/storage/types";
 import type {
   DispatchRunDeps,
   DispatchRunInput,
@@ -485,42 +483,6 @@ export async function enqueueThreadRun(
     workflowID: opts?.workflowID,
   })(ctx);
   return { workflowID: handle.workflowID };
-}
-
-/**
- * Hand this executor's in-flight thread-gate runs back to the queue on graceful
- * shutdown so another executor finishes them.
- *
- * Flips this executor's PENDING thread-gate workflows to ENQUEUED and clears the
- * owning executor, so another executor re-dequeues and re-runs them. The
- * workflow's `application_version` is preserved, so only a matching-version
- * executor picks it up — same-version peers during a crash, or the overlap
- * window of a rolling deploy. The dispatch step is retriable, so the re-dequeued
- * workflow re-executes the run.
- *
- * Ordering: must run AFTER `DBOS.shutdown()` has left the interrupted workflows
- * PENDING and BEFORE the pg pool closes. Pairs with the run-registry abort that
- * cancels the daemon first, so the re-dispatch can't race a live first dispatch.
- *
- * Returns the number of workflows re-enqueued.
- */
-export async function requeueInflightThreadGateWorkflows(
-  db: Kysely<DatabaseSchema>,
-): Promise<number> {
-  const executorID = DBOS.executorID;
-  if (!executorID || executorID === "local") return 0;
-  const result = await sql`
-    UPDATE ${sql.id("dbos", "workflow_status")}
-    SET status = 'ENQUEUED',
-        executor_id = NULL,
-        started_at_epoch_ms = NULL,
-        recovery_attempts = 0,
-        updated_at = ${Date.now()}
-    WHERE queue_name = ${THREAD_GATE_QUEUE}
-      AND status = 'PENDING'
-      AND executor_id = ${executorID}
-  `.execute(db);
-  return Number(result.numAffectedRows ?? 0n);
 }
 
 /**

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -430,16 +430,20 @@ async function threadGateWorkflowFn(
   await DBOS.runStep(() => trackMessageStartedStep(ctx), {
     name: "trackMessageStarted",
   });
-  try {
-    // The dispatch step is retriable so a re-enqueued run (pod death / rollout)
-    // is re-executed on another executor. Graceful shutdown aborts the in-flight
-    // run and cancels the daemon (down-channel `cancel` frame) before the
-    // workflow is re-enqueued, and the daemon fences stale epochs by fenceToken,
-    // so a replay can't race a still-running first dispatch against the same
-    // workdir. The thread-gate queue (concurrency=1 per threadId) guarantees a
-    // single in-flight dispatch per thread regardless of retries.
+    // Retriable EXCEPT for `user-desktop` runs. A user-desktop run dispatches to
+    // a daemon on the user's laptop that keeps running after the pod dies; a DBOS
+    // replay on another executor would open a SECOND concurrent dispatch against
+    // the same workdir, racing on git state and tool output. We can't reliably
+    // stop that daemon on a hard crash (the graceful abort doesn't run), so these
+    // stay non-retriable: pod death = clean "run failed", not a corruption hazard.
+    // Hosted/in-process runs (agent-sandbox, undefined target) have no external
+    // daemon to race, so they're retriable and DBOS recovers them. The thread-gate
+    // queue (concurrency=1 per threadId) still guarantees a single in-flight
+    // dispatch per thread.
+    const retriable = ctx.request.target?.sandboxProviderKind !== "user-desktop";
     await DBOS.runStep(() => dispatchRunAndWaitStep(ctx), {
       name: "dispatchRunAndWait",
+      retriesAllowed: retriable,
     });
   } catch (err) {
     // Setup errors (prepareRun) propagate out of `dispatchRunAndWait`; in-flight

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -21,6 +21,8 @@
  */
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
+import { sql, type Kysely } from "kysely";
+import type { Database as DatabaseSchema } from "@/storage/types";
 import type {
   DispatchRunDeps,
   DispatchRunInput,
@@ -431,15 +433,15 @@ async function threadGateWorkflowFn(
     name: "trackMessageStarted",
   });
   try {
-    // The dispatch step is non-retriable for v1. If a pod dies mid-stream,
-    // the desktop daemon (if remote-cli) keeps running, and a DBOS replay
-    // would open a second concurrent dispatch against the same workdir —
-    // racing on git state and tool output. Marking the step non-retriable
-    // converts pod death into a clean "run failed" rather than a corruption
-    // hazard. Re-attach semantics (stable runId, daemon-side dedupe) are v2.
+    // The dispatch step is retriable so a re-enqueued run (pod death / rollout)
+    // is re-executed on another executor. Graceful shutdown aborts the in-flight
+    // run and cancels the daemon (down-channel `cancel` frame) before the
+    // workflow is re-enqueued, and the daemon fences stale epochs by fenceToken,
+    // so a replay can't race a still-running first dispatch against the same
+    // workdir. The thread-gate queue (concurrency=1 per threadId) guarantees a
+    // single in-flight dispatch per thread regardless of retries.
     await DBOS.runStep(() => dispatchRunAndWaitStep(ctx), {
       name: "dispatchRunAndWait",
-      retriesAllowed: false,
     });
   } catch (err) {
     // Setup errors (prepareRun) propagate out of `dispatchRunAndWait`; in-flight
@@ -483,6 +485,43 @@ export async function enqueueThreadRun(
     workflowID: opts?.workflowID,
   })(ctx);
   return { workflowID: handle.workflowID };
+}
+
+/**
+ * Hand this executor's in-flight thread-gate runs back to the queue on graceful
+ * shutdown so another executor finishes them.
+ *
+ * Flips this executor's PENDING thread-gate workflows to ENQUEUED and clears the
+ * owning executor + app version, so ANY live executor — including a new rollout
+ * version — re-dequeues and re-runs them (the queue dequeue allows
+ * `application_version IS NULL`; cross-version recovery via the SDK's PENDING
+ * path does not). The dispatch step is retriable, so the re-dequeued workflow
+ * re-executes the run.
+ *
+ * Ordering: must run AFTER `DBOS.shutdown()` has left the interrupted workflows
+ * PENDING and BEFORE the pg pool closes. Pairs with the run-registry abort that
+ * cancels the daemon first, so the re-dispatch can't race a live first dispatch.
+ *
+ * Returns the number of workflows re-enqueued.
+ */
+export async function requeueInflightThreadGateWorkflows(
+  db: Kysely<DatabaseSchema>,
+): Promise<number> {
+  const executorID = DBOS.executorID;
+  if (!executorID || executorID === "local") return 0;
+  const result = await sql`
+    UPDATE ${sql.id("dbos", "workflow_status")}
+    SET status = 'ENQUEUED',
+        application_version = NULL,
+        executor_id = NULL,
+        started_at_epoch_ms = NULL,
+        recovery_attempts = 0,
+        updated_at = ${Date.now()}
+    WHERE queue_name = ${THREAD_GATE_QUEUE}
+      AND status = 'PENDING'
+      AND executor_id = ${executorID}
+  `.execute(db);
+  return Number(result.numAffectedRows ?? 0n);
 }
 
 /**

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -430,6 +430,7 @@ async function threadGateWorkflowFn(
   await DBOS.runStep(() => trackMessageStartedStep(ctx), {
     name: "trackMessageStarted",
   });
+  try {
     // Retriable EXCEPT for `user-desktop` runs. A user-desktop run dispatches to
     // a daemon on the user's laptop that keeps running after the pod dies; a DBOS
     // replay on another executor would open a SECOND concurrent dispatch against

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -441,7 +441,8 @@ async function threadGateWorkflowFn(
     // daemon to race, so they're retriable and DBOS recovers them. The thread-gate
     // queue (concurrency=1 per threadId) still guarantees a single in-flight
     // dispatch per thread.
-    const retriable = ctx.request.target?.sandboxProviderKind !== "user-desktop";
+    const retriable =
+      ctx.request.target?.sandboxProviderKind !== "user-desktop";
     await DBOS.runStep(() => dispatchRunAndWaitStep(ctx), {
       name: "dispatchRunAndWait",
       retriesAllowed: retriable,

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -492,11 +492,11 @@ export async function enqueueThreadRun(
  * shutdown so another executor finishes them.
  *
  * Flips this executor's PENDING thread-gate workflows to ENQUEUED and clears the
- * owning executor + app version, so ANY live executor — including a new rollout
- * version — re-dequeues and re-runs them (the queue dequeue allows
- * `application_version IS NULL`; cross-version recovery via the SDK's PENDING
- * path does not). The dispatch step is retriable, so the re-dequeued workflow
- * re-executes the run.
+ * owning executor, so another executor re-dequeues and re-runs them. The
+ * workflow's `application_version` is preserved, so only a matching-version
+ * executor picks it up — same-version peers during a crash, or the overlap
+ * window of a rolling deploy. The dispatch step is retriable, so the re-dequeued
+ * workflow re-executes the run.
  *
  * Ordering: must run AFTER `DBOS.shutdown()` has left the interrupted workflows
  * PENDING and BEFORE the pg pool closes. Pairs with the run-registry abort that
@@ -512,7 +512,6 @@ export async function requeueInflightThreadGateWorkflows(
   const result = await sql`
     UPDATE ${sql.id("dbos", "workflow_status")}
     SET status = 'ENQUEUED',
-        application_version = NULL,
         executor_id = NULL,
         started_at_epoch_ms = NULL,
         recovery_attempts = 0,

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -76,20 +76,6 @@ export interface ThreadStoragePort {
     options?: { limit?: number; offset?: number },
   ): Promise<{ threads: Thread[]; total: number }>;
   /**
-   * Atomically claim a run start via CAS. Returns true if this pod won.
-   * Allows: new runs (not in_progress), orphans (null pod), or same-pod restarts.
-   */
-  claimRunStart(
-    taskId: string,
-    organizationId: string,
-    data: Partial<Thread>,
-    podId: string | null,
-  ): Promise<boolean>;
-
-  /** Release ownership for all runs owned by this pod (graceful shutdown). */
-  orphanRunsByPod(podId: string): Promise<string[]>;
-
-  /**
    * Stamp `last_progress_at = now()` on a thread. Cheap single-column UPDATE
    * used by the progress-liveness heartbeat (throttled by the caller). No-op
    * if the row doesn't exist.

--- a/apps/mesh/src/storage/threads.integration.test.ts
+++ b/apps/mesh/src/storage/threads.integration.test.ts
@@ -174,45 +174,6 @@ describe("SqlThreadStorage", () => {
   // ==========================================================================
 
   describe("durable run operations", () => {
-    describe("orphanRunsByPod", () => {
-      it("clears ownership for all runs owned by pod", async () => {
-        const thread = await storage.create({
-          organization_id: "org_1",
-          created_by: "user_1",
-          status: "in_progress",
-        });
-        await storage.update(thread.id, "org_1", {
-          run_owner_pod: "pod-orphan-test",
-          run_config: { agent: { id: "a" } },
-        });
-
-        await storage.orphanRunsByPod("pod-orphan-test");
-
-        const loaded = await storage.get(thread.id, "org_1");
-        expect(loaded?.run_owner_pod).toBeNull();
-        // status should remain in_progress
-        expect(loaded?.status).toBe("in_progress");
-        // run_config should be preserved
-        expect(loaded?.run_config).not.toBeNull();
-      });
-
-      it("does not affect runs owned by other pods", async () => {
-        const thread = await storage.create({
-          organization_id: "org_1",
-          created_by: "user_1",
-          status: "in_progress",
-        });
-        await storage.update(thread.id, "org_1", {
-          run_owner_pod: "pod-other",
-        });
-
-        await storage.orphanRunsByPod("pod-orphan-different");
-
-        const loaded = await storage.get(thread.id, "org_1");
-        expect(loaded?.run_owner_pod).toBe("pod-other");
-      });
-    });
-
     describe("update() with new columns", () => {
       it("persists run_owner_pod", async () => {
         const thread = await storage.create({

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -799,58 +799,6 @@ export class SqlThreadStorage implements ThreadStoragePort {
     };
   }
 
-  async claimRunStart(
-    taskId: string,
-    organizationId: string,
-    data: Partial<Thread>,
-    podId: string | null,
-  ): Promise<boolean> {
-    const now = new Date().toISOString();
-
-    const updateData: Record<string, unknown> = { updated_at: now };
-    if (data.status !== undefined) updateData.status = data.status;
-    if (data.run_owner_pod !== undefined)
-      updateData.run_owner_pod = data.run_owner_pod;
-    if (data.run_config !== undefined) {
-      updateData.run_config = data.run_config
-        ? JSON.stringify(data.run_config)
-        : null;
-    }
-    if (data.run_started_at !== undefined)
-      updateData.run_started_at = data.run_started_at;
-
-    // CAS: only claim if not already running on a different pod
-    const result = await this.db
-      .updateTable("threads")
-      .set(updateData)
-      .where("id", "=", taskId)
-      .where("organization_id", "=", organizationId)
-      .where(({ eb, or }) =>
-        or([
-          // Not currently in_progress → fresh start
-          eb("status", "!=", "in_progress"),
-          // Orphan → null pod
-          eb("run_owner_pod", "is", null),
-          // Same pod restart
-          ...(podId ? [eb("run_owner_pod", "=", podId)] : []),
-        ]),
-      )
-      .executeTakeFirst();
-
-    return (result?.numUpdatedRows ?? 0n) > 0n;
-  }
-
-  async orphanRunsByPod(podId: string): Promise<string[]> {
-    const rows = await this.db
-      .updateTable("threads")
-      .set({ run_owner_pod: null, updated_at: new Date().toISOString() })
-      .where("run_owner_pod", "=", podId)
-      .where("status", "=", "in_progress")
-      .returning("id")
-      .execute();
-    return rows.map((r) => r.id);
-  }
-
   async bumpProgress(taskId: string, organizationId: string): Promise<void> {
     // Single-column heartbeat write — intentionally does NOT touch
     // `updated_at` (that's the user-facing "last activity" timestamp; a


### PR DESCRIPTION
## Problem

A pod dying mid-run left decopilot runs stranded and threw `RunClaimError: already running on another pod` on retry. Two things in mesh were **blocking DBOS's own workflow recovery**:

1. **`run_owner_pod` mesh claim** — a second single-execution guard (CAS in `claimRunStart`) layered on top of the DBOS thread-gate queue's `concurrency=1` per `threadId`. Redundant, and the one layer DBOS can't see/reconcile, so a dead pod's stale `run_owner_pod` blocked any re-dispatch.
2. **`retriesAllowed: false`** on the `dispatchRunAndWait` step — so a workflow DBOS *did* recover would refuse to re-run the step and just error.

## Fix — only what's needed to let DBOS recover runs

- **Remove the `run_owner_pod` claim.** `RUN_STARTED` is a plain `status='in_progress'` write; deleted `RunClaimError`, `claimRunStart`, `orphanRunsByPod`. The DBOS thread-gate queue is the sole single-execution guarantee.
- **Make the dispatch step retriable** (drop `retriesAllowed: false`) so DBOS re-runs the run on another executor. Safe because `stopAll()` aborts the in-flight run and cancels the daemon (down-channel `cancel` frame) on shutdown, and the daemon fences stale epochs by `fenceToken`.
- `stopAll()` no longer writes the DB — aborts controllers + clears in-memory state.

**No custom recovery logic.** Recovery is DBOS's job; this PR just stops blocking it.

## Why not a custom re-enqueue on shutdown (removed)

An earlier revision re-enqueued workflows in the shutdown hook. Removed — redundant with DBOS and it didn't work: an empirical probe (real DBOS + Postgres) showed **`DBOS.shutdown()` drains in-flight workflows** (a sleeping step ran to SUCCESS during shutdown), so there are no PENDING workflows for a hook to re-enqueue. The probe also confirmed the underlying primitive is sound: a workflow orphaned by a crashed executor, once visible to a live executor, re-runs its retriable step and completes — which is what DBOS recovery drives.

## Testing

- `bun run check` clean; `run-registry` unit tests 19/19. Obsolete claim/orphan test cases removed.
- **Validate in staging:** kill a pod mid-run and confirm DBOS recovers it on another executor. (DBOS startup recovery is per-executor + version-scoped, and executor IDs are random in Conductor mode, so cross-pod recovery leans on the DBOS Conductor — if unreliable in prod that's a DBOS/Conductor config issue, not something to fix with custom mesh logic.)

## Follow-up
- Drop the now-vestigial `run_owner_pod` column (migration).
