### PR TITLE
perf(automations): consolidate per-org queues into one partitioned queue

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -155,7 +155,10 @@ import "../auth/install-studio-pack-workflow";
 import { cleanupOldMonitoringFiles } from "../monitoring/ndjson-retention";
 import { getLogsDir, getTracesDir, getMetricsDir } from "../monitoring/schema";
 import {
+  AUTOMATIONS_PARTITION_CONCURRENCY,
+  AUTOMATIONS_QUEUE,
   AutomationEventDispatcher,
+  cleanupOrphanedOrgQueues,
   enqueueAutomationFire,
   fireAutomationNow,
   reconcileAutomationSchedules,
@@ -2174,12 +2177,16 @@ export async function createApp(options: CreateAppOptions = {}) {
    * — they don't need any setup here.
    */
   const initDbos = async () => {
-    // Automation fires run directly on the per-org queue
-    // `automations-org-<orgId>` — the queue's concurrency IS the per-org
-    // tenant-fairness cap. Those queues are NOT registered here: they are
-    // created on demand by `ensureOrgQueue` and auto-discovered by every
-    // replica's dispatcher via `wfQueueRunner.discoverAndLaunchDbQueues`.
-    //
+    // Automation fires run on ONE partitioned queue, partitioned by orgId.
+    // Per-partition concurrency gives each org its own fairness cap (a
+    // saturated org blocks only its own partition), while a single queue
+    // means one dequeue-polling loop per replica instead of one per org —
+    // and DBOS only polls partitions with ENQUEUED work, so idle poll cost
+    // is flat regardless of org count.
+    await DBOS.registerQueue(AUTOMATIONS_QUEUE, {
+      partitionQueue: true,
+      concurrency: AUTOMATIONS_PARTITION_CONCURRENCY,
+    });
     // Per-thread agent-run gate. Partition key = threadId, concurrency=1,
     // so messages on the same thread serialize behind the active run while
     // different threads progress in parallel. Used by user-message POSTs
@@ -2191,7 +2198,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     await reconcileAutomationSchedules(automationsStorage);
 
     // One-time cleanup of the retired per-automation/global gate queues.
-    // Fires now run directly on the per-org queue, so these rows are orphaned;
+    // Fires now run on the partitioned queue, so these rows are orphaned;
     // deleteQueue is a no-op once they're gone. Stale gate workflows still
     // ENQUEUED from a previous version are cancelled by the reconciler.
     await Promise.allSettled(
@@ -2199,6 +2206,10 @@ export async function createApp(options: CreateAppOptions = {}) {
         DBOS.deleteQueue(q),
       ),
     );
+    // MIGRATION: drop the retired per-org `automations-org-<orgId>` queue rows
+    // (empty ones only) so DBOS stops launching a dequeue loop for each. Runs
+    // every boot; idempotent. Remove once prod shows zero such rows.
+    await cleanupOrphanedOrgQueues(database.pool);
 
     // Fire-and-forget backfill of studio pack agents for every org. Safe
     // to skip awaiting — the workflow IDs are deterministic per-org, so

--- a/apps/mesh/src/automations/dbos-sync.ts
+++ b/apps/mesh/src/automations/dbos-sync.ts
@@ -12,10 +12,9 @@
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import type { Automation, AutomationTrigger } from "@/storage/types";
 import {
+  AUTOMATIONS_QUEUE,
   cronEntryWorkflow,
-  ensureOrgQueue,
   fireAutomationWorkflow,
-  orgQueueName,
   type FireAutomationContext,
   type FireAutomationOutcome,
 } from "./dbos-workflow";
@@ -122,11 +121,11 @@ export async function fireAutomationNow(
   ctx: FireAutomationContext,
   opts?: { idempotencyKey?: string },
 ): Promise<FireAutomationOutcome> {
-  await ensureOrgQueue(ctx.organizationId);
   const workflowID = workflowIdFromIdempotencyKey(ctx, opts?.idempotencyKey);
   const handle = await DBOS.startWorkflow(fireAutomationWorkflow, {
     workflowID,
-    queueName: orgQueueName(ctx.organizationId),
+    queueName: AUTOMATIONS_QUEUE,
+    enqueueOptions: { queuePartitionKey: ctx.organizationId },
   })(ctx);
   return await handle.getResult();
 }
@@ -136,10 +135,10 @@ export async function enqueueAutomationFire(
   ctx: FireAutomationContext,
   opts?: { idempotencyKey?: string },
 ): Promise<void> {
-  await ensureOrgQueue(ctx.organizationId);
   const workflowID = workflowIdFromIdempotencyKey(ctx, opts?.idempotencyKey);
   await DBOS.startWorkflow(fireAutomationWorkflow, {
     workflowID,
-    queueName: orgQueueName(ctx.organizationId),
+    queueName: AUTOMATIONS_QUEUE,
+    enqueueOptions: { queuePartitionKey: ctx.organizationId },
   })(ctx);
 }

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -2,25 +2,24 @@
  * DBOS workflow definitions for automation fires.
  *
  * Single cap — per-org tenant fairness:
- * - `automations-org-<orgId>` — one queue per organization, lazily created
- *   on first fire via `ensureOrgQueue`. Per-org `concurrency` is mutable at
- *   runtime through `WorkflowQueue.setConcurrency`, so users/admins can
- *   self-tune the cap from a settings UI without redeploying. The
- *   `dbos.queues` row is the source of truth for the limit — mesh keeps
- *   no copy.
+ * - One partitioned queue (`AUTOMATIONS_QUEUE`), partitioned by orgId. DBOS
+ *   enforces `concurrency` per partition, so the per-org cap is preserved —
+ *   one org saturating its slots only blocks its own partition, never
+ *   another org's — without paying for one queue (and one dequeue loop) per
+ *   org. See `AUTOMATIONS_QUEUE` below for the idle-polling rationale.
  *
- * `fireAutomationWorkflow` runs *directly* on the per-org queue, so the
- * queue's concurrency IS the cap — no dedicated gate workflow holds a slot
- * just to enforce it. A queue caps whatever runs on it; one org saturating
- * its slots only blocks its own fires, never another org's.
+ * `fireAutomationWorkflow` runs *directly* on the partitioned queue, so the
+ * queue's per-partition concurrency IS the cap — no dedicated gate workflow
+ * holds a slot just to enforce it.
  *
  * Two workflows:
- * - `fireAutomationWorkflow` — runs on the per-org queue, split into recorded
- *   steps (prepare → createRunThread → updateTriggerTiming → dispatchRunAndWait).
+ * - `fireAutomationWorkflow` — runs on the partitioned queue, split into
+ *   recorded steps (prepare → createRunThread → updateTriggerTiming →
+ *   dispatchRunAndWait).
  * - `cronEntryWorkflow` — bound to `DBOS.createSchedule`. The Schedule API
- *   can't target a dynamic per-org queue name, so this fire-and-forget shim
- *   re-enqueues `fireAutomationWorkflow` on the org queue and returns without
- *   awaiting so the scheduler tick is never blocked.
+ *   can't target a partition key directly, so this fire-and-forget shim
+ *   re-enqueues `fireAutomationWorkflow` on the org's partition and returns
+ *   without awaiting so the scheduler tick is never blocked.
  *
  * Exactly-once semantics:
  * Cron is intrinsically exactly-once: `DBOS.createSchedule` assigns each tick
@@ -37,6 +36,7 @@
  */
 
 import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
+import type { Pool } from "pg";
 import {
   awaitThreadRun,
   type SerializableDispatchRunInput,
@@ -57,34 +57,58 @@ import {
 import { computeNextRunAt, type StudioContextFactory } from "./fire";
 
 /**
- * Per-org queueing uses one DB-backed queue per organization, named
- * `automations-org-<orgId>`. The `dbos.queues` row IS the per-org config:
- * `concurrency` is mutable at runtime via the `WorkflowQueue` setters,
- * and `discoverAndLaunchDbQueues` makes every replica honor changes
- * within one poll cycle. Mesh stores no copy of these limits — DBOS owns
- * them end-to-end.
+ * Automation fires run on ONE partitioned queue, partitioned by orgId.
  *
- * Lazy-created on the first enqueue (`ensureOrgQueue`) with default
- * concurrency.
+ * DBOS enforces `concurrency` PER PARTITION (its dequeue counts running
+ * workflows scoped to the partition key), so each org still gets its own
+ * fairness cap — a saturated org blocks only its own partition, never
+ * another's — exactly like the retired per-org-queue model. The win: one
+ * queue means one dequeue-polling loop per replica instead of one loop per
+ * org, and DBOS only polls partitions that currently have ENQUEUED work
+ * (`getQueuePartitions`), so idle queue-poll cost is flat regardless of how
+ * many orgs exist. The per-org model paid one dequeue/sec/org forever — even
+ * for orgs that fired once and never again — which scaled linearly with org
+ * count.
+ *
+ * Registered once at boot in `app.initDbos` (like the thread-gate queue),
+ * not lazily per fire.
  */
+export const AUTOMATIONS_QUEUE = "automations";
+/** Per-org (per-partition) concurrency cap. */
+export const AUTOMATIONS_PARTITION_CONCURRENCY = 10;
+/** Prefix of the retired per-org queues — kept only for migration cleanup. */
 const AUTOMATIONS_ORG_QUEUE_PREFIX = "automations-org-";
-/** Concurrency a new org's queue starts at. Updatable per-org afterwards. */
-const DEFAULT_ORG_CONCURRENCY = 10;
 const AUTOMATIONS_RUN_TIMEOUT_MS = 5 * 60 * 1000;
-export function orgQueueName(orgId: string): string {
-  return `${AUTOMATIONS_ORG_QUEUE_PREFIX}${orgId}`;
-}
 
 /**
- * Idempotently create the org's queue with default concurrency. Safe to
- * call on every fire — `onConflict: "never_update"` means an existing
- * user-tuned `concurrency` value is never clobbered by this call.
+ * MIGRATION (remove once no `automations-org-*` rows remain): delete the
+ * retired per-org queue rows so DBOS stops launching a dequeue loop for each.
+ * Only deletes queues with NO non-terminal (ENQUEUED/PENDING) workflows, so
+ * fires enqueued before the cutover drain on their original queue first — a
+ * later boot removes the now-empty row. Same Postgres as the app DB
+ * (`systemDatabaseUrl` = app `databaseUrl`, schema `dbos`), so the app pool
+ * can reach `dbos.queues`. Idempotent and best-effort.
  */
-export async function ensureOrgQueue(orgId: string): Promise<void> {
-  await DBOS.registerQueue(orgQueueName(orgId), {
-    concurrency: DEFAULT_ORG_CONCURRENCY,
-    onConflict: "never_update",
-  });
+export async function cleanupOrphanedOrgQueues(pool: Pool): Promise<void> {
+  try {
+    const { rows } = await pool.query<{ name: string }>(
+      `SELECT q.name FROM dbos.queues q
+        WHERE q.name LIKE $1
+          AND NOT EXISTS (
+            SELECT 1 FROM dbos.workflow_status w
+             WHERE w.queue_name = q.name
+               AND w.status IN ('ENQUEUED', 'PENDING')
+          )`,
+      [`${AUTOMATIONS_ORG_QUEUE_PREFIX}%`],
+    );
+    if (rows.length === 0) return;
+    await Promise.allSettled(rows.map((r) => DBOS.deleteQueue(r.name)));
+    console.log(
+      `[automations] migration: removed ${rows.length} orphaned per-org queue(s)`,
+    );
+  } catch (err) {
+    console.error("[automations] per-org queue cleanup failed:", err);
+  }
 }
 
 export interface AutomationRuntime {
@@ -444,16 +468,16 @@ export const fireAutomationWorkflow = DBOS.registerWorkflow(
 
 /**
  * Scheduled-fire entry. Bound to DBOS schedules created per cron trigger.
- * Ensures the org queue exists, then re-enqueues `fireAutomationWorkflow` on
- * it. Returns without awaiting so the scheduler tick stays fast.
+ * Re-enqueues `fireAutomationWorkflow` on the org's partition of the shared
+ * automations queue. Returns without awaiting so the scheduler tick stays fast.
  */
 async function cronEntryWorkflowFn(
   _scheduledTime: Date,
   ctx: FireAutomationContext,
 ): Promise<void> {
-  await ensureOrgQueue(ctx.organizationId);
   await DBOS.startWorkflow(fireAutomationWorkflow, {
-    queueName: orgQueueName(ctx.organizationId),
+    queueName: AUTOMATIONS_QUEUE,
+    enqueueOptions: { queuePartitionKey: ctx.organizationId },
   })(ctx);
 }
 

--- a/apps/mesh/src/automations/index.ts
+++ b/apps/mesh/src/automations/index.ts
@@ -1,5 +1,10 @@
 export { AutomationEventDispatcher } from "./automation-event-dispatcher";
-export { setAutomationRuntime } from "./dbos-workflow";
+export {
+  AUTOMATIONS_PARTITION_CONCURRENCY,
+  AUTOMATIONS_QUEUE,
+  cleanupOrphanedOrgQueues,
+  setAutomationRuntime,
+} from "./dbos-workflow";
 export type { ContextMessage, ContextMessagePart } from "./dbos-workflow";
 export { enqueueAutomationFire, fireAutomationNow } from "./dbos-sync";
 export { reconcileAutomationSchedules } from "./dbos-reconciler";


### PR DESCRIPTION
## Summary

**Prototype** for cutting idle CPU/DB load (paired with the event-loop-lag investigation on `deco-studio`).

Today each org gets its own DBOS queue `automations-org-<orgId>`, created lazily on first fire. DBOS launches **one dequeue-polling loop per database-backed queue** (`wfQueueRunner` runs `runQueue` per queue, default `pollingIntervalSec: 1`). So N orgs = **N polling loops per replica, forever** — even orgs that fired once months ago keep a loop running. In `deco-studio` that's currently ~20 queues = ~20 dequeue queries/s/replica at idle, scaling linearly with org growth.

This moves automation fires to a **single partitioned queue** (`automations`), partitioned by `orgId` — the same `partitionQueue: true` pattern the `thread-gate` queue already uses.

## Why it's safe

- **Per-org fairness preserved.** DBOS enforces `concurrency` *per partition* (`countRunningWorkflowsForQueue(name, partitionKey)`), so a saturated org blocks only its own partition — identical to the old per-org-queue behavior.
- **Idle cost collapses.** The partitioned dequeue loop calls `getQueuePartitions`, which is `SELECT DISTINCT queue_partition_key ... WHERE status = 'ENQUEUED'` — it only polls partitions with pending work. At idle that's ~1 query/s/replica total, **flat regardless of org count**.
- **No feature lost.** Per-org concurrency was nominally runtime-tunable via `WorkflowQueue.setConcurrency`, but there are **zero callers** in the codebase — every org used the default (10), preserved here as the per-partition cap.

## Changes

- `dbos-workflow.ts` — replace per-org `ensureOrgQueue`/`orgQueueName` with `AUTOMATIONS_QUEUE` + `AUTOMATIONS_PARTITION_CONCURRENCY`; `cronEntryWorkflow` enqueues with `enqueueOptions.queuePartitionKey = orgId`.
- `dbos-sync.ts` — `fireAutomationNow` / `enqueueAutomationFire` enqueue on the partitioned queue.
- `app.ts initDbos` — register the partitioned `automations` queue; run migration cleanup.

## Migration

`cleanupOrphanedOrgQueues(pool)` deletes retired `automations-org-*` rows so DBOS stops launching their loops. It deletes **only queues with no ENQUEUED/PENDING workflows**, so fires enqueued before the cutover drain on their original queue first; a later boot removes the now-empty row. Runs every boot, idempotent. The app pool reaches `dbos.queues` because `systemDatabaseUrl` = the app `databaseUrl` (schema `dbos`). Remove the cleanup once prod shows zero such rows.

## Testing

- `bun run --cwd apps/mesh check` — clean.
- `bun test apps/mesh/src/automations` — 18 pass.
- `bun run fmt` applied.

## Notes / open questions for review

- This is a **prototype** — the migration drains across reboots rather than in one shot. Fine for a rolling deploy; flagging it explicitly.
- Worth confirming on staging that `getQueuePartitions` + per-partition `findAndMarkStartableWorkflows` doesn't regress dequeue latency for an org with a large backlog (one loop now serves all partitions vs. one loop each before). For expected fire volumes this should be a non-issue, but it's the one behavioral difference to watch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidate per‑org automation queues into a single partitioned `automations` queue to cut idle DB/CPU load while keeping per‑org fairness. Idle dequeue polling drops to ~1 query/replica, regardless of org count.

- **Refactors**
  - Route all fires to `automations` with `queuePartitionKey = orgId`; per‑partition concurrency stays 10.
  - Register the queue at boot; `fireAutomationWorkflow` and cron re-enqueues target the shared queue.
  - Remove lazy per‑org queue creation and related helpers.

- **Migration**
  - Add `cleanupOrphanedOrgQueues` to delete empty `automations-org-*` rows on boot; in-flight items drain first. Remove once no such rows remain.

<sup>Written for commit 7468fc92fd57dc929525aa453253051afd73b950. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

