### PR TITLE
refactor(automations): run dispatch inline, drop the thread-gate hop

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1503,7 +1503,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Stash deps for the DBOS workflow body. Safe to call before DBOS.launch():
   // it only writes a module-level pointer, no DBOS API calls.
   // The actual dispatch (and its dispatch-run deps) lives on the thread-gate
-  // runtime now — automations hand off via `awaitThreadRun`.
+  // runtime now — automations invoke its shared `runDispatchSteps` body.
   setAutomationRuntime({
     storage: automationsStorage,
     meshContextFactory: automationContextFactory,

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -38,7 +38,7 @@
 import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
 import type { Pool } from "pg";
 import {
-  awaitThreadRun,
+  runDispatchSteps,
   type SerializableDispatchRunInput,
 } from "@/dispatch-queue";
 import {
@@ -306,13 +306,11 @@ type BuildDispatchRequestOutcome =
  *
  * Runs as a step so the request payload — including `crypto.randomUUID()`
  * message ids — is recorded in the workflow journal and replay returns the
- * same payload. `awaitThreadRun` is invoked from the workflow body (not
- * here) because DBOS forbids workflow-to-workflow calls from inside a
- * step.
+ * same payload. `runDispatchSteps` is invoked from the workflow body (not
+ * here) because its inner steps can't be nested inside another step.
  *
- * The membership check is intentionally repeated by the thread-gate
- * workflow on dispatch; doing it here as well lets us early-exit before
- * the thread-gate queue takes a slot.
+ * The membership check is intentionally repeated by the dispatch body; doing
+ * it here as well lets us early-exit before running the dispatch.
  */
 async function buildDispatchRequestStep(
   automation: Automation,
@@ -404,9 +402,10 @@ async function fireAutomationWorkflowFn(
   //   1. `buildDispatchRequest` step — membership pre-check + assemble the
   //      serializable request. Recorded in the journal so replays reuse the
   //      same message ids.
-  //   2. `awaitThreadRun` from the workflow body — calls
-  //      `DBOS.startWorkflow(threadGateWorkflow, ...)`, which is illegal
-  //      from inside a step. Errors are caught here to preserve the
+  //   2. `runDispatchSteps` from the workflow body — runs the dispatch (and
+  //      its analytics steps) directly. We already hold this org's queue slot,
+  //      and each fire is a fresh thread, so there's no per-thread gate to
+  //      cross — no second queue hop. Errors are caught here to preserve the
   //      `FireAutomationOutcome` API (callers expect a resolved
   //      `{taskId, error}` outcome, not a thrown promise).
   const built = await DBOS.runStep(
@@ -428,7 +427,7 @@ async function fireAutomationWorkflowFn(
 
   const rt = requireRuntime();
   try {
-    await awaitThreadRun({
+    await runDispatchSteps({
       threadId: taskId,
       request: built.request,
       timeoutMs: rt.runTimeoutMs ?? AUTOMATIONS_RUN_TIMEOUT_MS,

--- a/apps/mesh/src/dispatch-queue/index.ts
+++ b/apps/mesh/src/dispatch-queue/index.ts
@@ -1,6 +1,6 @@
 export {
-  awaitThreadRun,
   enqueueThreadRun,
+  runDispatchSteps,
   setThreadGateRuntime,
   THREAD_GATE_PARTITION_CONCURRENCY,
   THREAD_GATE_QUEUE,

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -10,9 +10,9 @@
  * is what gives us "queue behavior" — DBOS won't dequeue the next message
  * on the same thread until this run is finished.
  *
- * Used by user-message POSTs (later: automation fires too). Automations
- * layer their existing per-automation and global gates above this
- * per-thread one; user messages enter here directly.
+ * Used by user-message POSTs. Automation fires do NOT pass through this
+ * queue — each fire is a fresh thread (no per-thread contention), so it runs
+ * the shared `runDispatchSteps` body directly on its own per-org queue slot.
  *
  * Runtime dependencies (dispatch fn, studio-context factory, dispatch deps)
  * are looked up via a module-level registry. App boot wires them via
@@ -424,7 +424,22 @@ async function trackMessageFailedStep(
   });
 }
 
-async function threadGateWorkflowFn(
+/**
+ * The dispatch execution body: track-started → dispatch → track-failed,
+ * as recorded DBOS steps. Shared by two callers so the executor lives in one
+ * place:
+ *
+ *  - `threadGateWorkflow` (user messages) runs it behind the per-thread queue
+ *    slot, which is what serializes messages on the same thread.
+ *  - `fireAutomationWorkflow` calls it directly on its own per-org queue slot.
+ *    Automation fires each create a fresh thread, so they need no per-thread
+ *    gate — routing them through the thread-gate queue was only ever a way to
+ *    reuse this body, at the cost of a second queue hop.
+ *
+ * MUST be called from within a DBOS workflow context (it issues `runStep`s).
+ * The analytics steps no-op for non-`user-message` sources.
+ */
+export async function runDispatchSteps(
   ctx: ThreadGateContext,
 ): Promise<ThreadGateOutcome> {
   await DBOS.runStep(() => trackMessageStartedStep(ctx), {
@@ -462,6 +477,12 @@ async function threadGateWorkflowFn(
   return { taskId: ctx.request.taskId ?? ctx.threadId };
 }
 
+async function threadGateWorkflowFn(
+  ctx: ThreadGateContext,
+): Promise<ThreadGateOutcome> {
+  return runDispatchSteps(ctx);
+}
+
 const threadGateWorkflow = DBOS.registerWorkflow(threadGateWorkflowFn, {
   name: "threadGateWorkflow",
 });
@@ -476,8 +497,6 @@ const threadGateWorkflow = DBOS.registerWorkflow(threadGateWorkflowFn, {
  * existing workflow handle instead of duplicating the run.
  *
  * Fire-and-forget: returns the workflowID without awaiting completion.
- * Use `awaitThreadRun` when the caller needs to block on the dispatch
- * outcome (e.g. parent workflows that hold their own queue slot).
  */
 export async function enqueueThreadRun(
   ctx: ThreadGateContext,
@@ -489,23 +508,4 @@ export async function enqueueThreadRun(
     workflowID: opts?.workflowID,
   })(ctx);
   return { workflowID: handle.workflowID };
-}
-
-/**
- * Enqueue and await completion. Used by callers that hold an outer
- * workflow slot and need the dispatch outcome to advance — chiefly the
- * automation fire path, which layers its own per-automation and global
- * gates above this per-thread one. Failures from the inner workflow
- * propagate so the caller's step is recorded as failed by DBOS.
- */
-export async function awaitThreadRun(
-  ctx: ThreadGateContext,
-  opts?: { workflowID?: string },
-): Promise<ThreadGateOutcome> {
-  const handle = await DBOS.startWorkflow(threadGateWorkflow, {
-    queueName: THREAD_GATE_QUEUE,
-    enqueueOptions: { queuePartitionKey: ctx.threadId },
-    workflowID: opts?.workflowID,
-  })(ctx);
-  return await handle.getResult();
 }


### PR DESCRIPTION
## Summary

Follow-up to #3918 (now merged). Addresses the "why two dispatch queues, they feel like the same thing" smell.

Before, an automation fire passed through **both** partitioned queues:

```
cron/event → fireAutomationWorkflow      [automations queue: ≤10 per org]
               └─ awaitThreadRun → threadGateWorkflow   [thread-gate queue: 1 per thread]  ← extra hop + child workflow
```

But each fire creates a **fresh thread** (`taskId` from `createRunThreadStep`), so the thread-gate's per-thread serialization is a no-op for automations — they routed through it only to reuse the dispatch body.

This extracts that body as `runDispatchSteps` (track-started → dispatch → track-failed) and calls it **directly** from `fireAutomationWorkflow`, which already holds the org's queue slot.

## Result

The two queues now have crisp, non-overlapping roles:
- **`thread-gate`** — user-message executor, serialized per thread (where ordering actually matters).
- **`automations`** — org-capped automation executor.

No shared hop, **one fewer workflow per fire**, both guarantees preserved (per-org fairness + per-thread ordering for users).

## Why not fully merge to one queue?

Considered it: you'd either lose per-org fairness, or merge interactive user traffic with background cron fan-out into one pool — letting a cron storm delay user chats. Two queues give that isolation; the only real redundancy was the hop, which this removes. (DBOS gives one partition key + one cap per queue, and these are two genuine axes: orgId fan-out vs threadId order.)

## Safety

- Dispatch step keeps its **exact** config (`retriesAllowed: false`); recovery semantics are unchanged — it just lives in the fire workflow's journal now instead of a separate child. ⚠️ **Reviewers:** the one thing to confirm on staging is automation dispatch recovery on pod-death-mid-stream, since the non-retriable step changed host workflow. Config is identical, but this path is sensitive (recent decopilot-recovery work touches it).
- `awaitThreadRun` had no remaining callers and is removed; `enqueueThreadRun` (user POST) unchanged.
- Both analytics steps already no-op for `source: "automation"`, so the shared body is correct for both callers.

## Testing

- `bun run --cwd apps/mesh check` — clean.
- `bun test apps/mesh/src/dispatch-queue apps/mesh/src/automations` — 31 pass.
- `bun run fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs automation dispatch inline in `fireAutomationWorkflow` and removes the extra `thread-gate` queue hop. This drops one child workflow per fire while keeping per-org fairness and per-thread ordering for user messages.

- **Refactors**
  - Extracted dispatch executor to `runDispatchSteps` (track-started → dispatch → track-failed).
  - `fireAutomationWorkflow` now calls `runDispatchSteps` directly; automations skip `thread-gate`.
  - `threadGateWorkflow` wraps the same body for user messages only.
  - Removed `awaitThreadRun`; `enqueueThreadRun` remains.
  - Preserved dispatch step config (`retriesAllowed: false`) and recovery semantics.

<sup>Written for commit c32ab0ba257916734e4f51c126deeff9c3dfa0e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

