### PR TITLE
fix(connections): bound per-connection listTools probe so one slow MCP can't hang the trigger picker

### DIFF
--- a/apps/mesh/src/core/constants.ts
+++ b/apps/mesh/src/core/constants.ts
@@ -14,6 +14,15 @@ export const MCP_MESH_KEY = "mcp.mesh";
  */
 export const MCP_TOOL_CALL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Timeout for the live `listTools()` probe used when filtering a connection
+ * collection by binding (e.g. the Automations event-trigger picker, which lists
+ * every TRIGGER-capable connection). The probe eagerly connects to the
+ * downstream MCP server, so without a bound a single slow/hung connection
+ * stalls the whole fan-out and the UI hangs until the SDK's 60s default fires.
+ */
+export const MCP_LIST_TOOLS_TIMEOUT_MS = 5_000; // 5 seconds
+
 /** Number of consecutive failures before opening the circuit breaker for a connection */
 export const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 3;
 

--- a/apps/mesh/src/mcp-clients/index.ts
+++ b/apps/mesh/src/mcp-clients/index.ts
@@ -7,8 +7,5 @@
  */
 
 export { clientFromConnection } from "./client";
-export {
-  listToolsWithTimeout,
-  ListToolsTimeoutError,
-} from "./list-tools-with-timeout";
+export { listToolsWithTimeout } from "./list-tools-with-timeout";
 export { serverFromConnection } from "./server";

--- a/apps/mesh/src/mcp-clients/index.ts
+++ b/apps/mesh/src/mcp-clients/index.ts
@@ -7,4 +7,8 @@
  */
 
 export { clientFromConnection } from "./client";
+export {
+  listToolsWithTimeout,
+  ListToolsTimeoutError,
+} from "./list-tools-with-timeout";
 export { serverFromConnection } from "./server";

--- a/apps/mesh/src/mcp-clients/list-tools-with-timeout.ts
+++ b/apps/mesh/src/mcp-clients/list-tools-with-timeout.ts
@@ -1,0 +1,66 @@
+/**
+ * Bounded `listTools()` probe.
+ *
+ * `clientFromConnection` connects eagerly (the transport handshake and the
+ * downstream-token DB read both happen before `listTools()` is even sent), so a
+ * timeout on the request alone wouldn't cover a connection that hangs during
+ * connect. We race the whole connect+list against a deadline and abort the
+ * in-flight request on timeout so a slow downstream can't pin a socket open.
+ */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { StudioContext } from "../core/studio-context";
+import type { ConnectionEntity } from "../tools/connection/schema";
+import { clientFromConnection } from "./client";
+
+export class ListToolsTimeoutError extends Error {
+  constructor(connectionId: string, timeoutMs: number) {
+    super(
+      `listTools timed out after ${timeoutMs}ms for connection ${connectionId}`,
+    );
+    this.name = "ListToolsTimeoutError";
+  }
+}
+
+/**
+ * Connect to a connection's MCP server and list its tools, bounded by
+ * `timeoutMs`. Rejects with {@link ListToolsTimeoutError} on timeout; the
+ * underlying request is aborted and the client closed in the background.
+ */
+export async function listToolsWithTimeout(
+  connection: ConnectionEntity,
+  ctx: StudioContext,
+  timeoutMs: number,
+): Promise<Tool[]> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new ListToolsTimeoutError(connection.id, timeoutMs));
+    }, timeoutMs);
+  });
+
+  const work = (async () => {
+    const client = await clientFromConnection(connection, ctx, true);
+    try {
+      const result = await client.listTools(undefined, {
+        timeout: timeoutMs,
+        signal: controller.signal,
+      });
+      return result.tools;
+    } finally {
+      await client.close().catch(() => {});
+    }
+  })();
+
+  // Don't leave the losing `work` promise unhandled when the timeout wins.
+  work.catch(() => {});
+
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/apps/mesh/src/mcp-clients/list-tools-with-timeout.ts
+++ b/apps/mesh/src/mcp-clients/list-tools-with-timeout.ts
@@ -13,7 +13,7 @@ import type { StudioContext } from "../core/studio-context";
 import type { ConnectionEntity } from "../tools/connection/schema";
 import { clientFromConnection } from "./client";
 
-export class ListToolsTimeoutError extends Error {
+class ListToolsTimeoutError extends Error {
   constructor(connectionId: string, timeoutMs: number) {
     super(
       `listTools timed out after ${timeoutMs}ms for connection ${connectionId}`,

--- a/apps/mesh/src/tools/connection/list.ts
+++ b/apps/mesh/src/tools/connection/list.ts
@@ -35,7 +35,8 @@ import {
   getMcpListCache,
   fetchWithCache,
 } from "../../mcp-clients/mcp-list-cache";
-import { clientFromConnection } from "../../mcp-clients";
+import { listToolsWithTimeout } from "../../mcp-clients";
+import { MCP_LIST_TOOLS_TIMEOUT_MS } from "../../core/constants";
 import {
   createDevAssetsConnectionEntity,
   usesLocalObjectStorage,
@@ -177,19 +178,12 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
                   const { listManagementTools } = await import("../../tools");
                   return listManagementTools(ctx) as Promise<unknown[]>;
                 }
-              : async () => {
-                  const client = await clientFromConnection(
+              : () =>
+                  listToolsWithTimeout(
                     connection,
                     ctx,
-                    true,
+                    MCP_LIST_TOOLS_TIMEOUT_MS,
                   );
-                  try {
-                    const result = await client.listTools();
-                    return result.tools;
-                  } finally {
-                    await client.close().catch(() => {});
-                  }
-                };
           const tools = await fetchWithCache(
             "tools",
             connection.id,

--- a/apps/mesh/src/tools/connection/list.ts
+++ b/apps/mesh/src/tools/connection/list.ts
@@ -34,6 +34,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import {
   getMcpListCache,
   fetchWithCache,
+  REVALIDATE_MIN_INTERVAL_MS,
 } from "../../mcp-clients/mcp-list-cache";
 import { listToolsWithTimeout } from "../../mcp-clients";
 import { MCP_LIST_TOOLS_TIMEOUT_MS } from "../../core/constants";
@@ -44,6 +45,17 @@ import {
 import { type ConnectionEntity, ConnectionEntitySchema } from "./schema";
 import { getConnectionSlug } from "@/shared/utils/connection-slug";
 import { connectionMatchesWhere } from "./where-match";
+import { mapWithConcurrency } from "./map-with-concurrency";
+
+/**
+ * Max concurrent live tool probes during binding filtering. Each probe eagerly
+ * connects to a downstream MCP server (transport handshake + a `downstream_tokens`
+ * read), so an unbounded `Promise.all` over a large org fires dozens at once —
+ * saturating the DB pool and blocking the single-threaded event loop while it
+ * parses every tool list. Bounding the fan-out keeps a cold cache from spiking
+ * CPU and tripping the HPA into a needless replica.
+ */
+const BINDING_PROBE_CONCURRENCY = 8;
 
 /**
  * Registry binding: matches connections that expose COLLECTION_REGISTRY_APP_LIST
@@ -167,8 +179,10 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
     if (bindingChecker) {
       const cache = getMcpListCache();
       const selfId = WellKnownOrgMCPId.SELF(organization.id);
-      await Promise.all(
-        connections.map(async (connection) => {
+      await mapWithConcurrency(
+        connections,
+        BINDING_PROBE_CONCURRENCY,
+        async (connection) => {
           if (connection.tools !== null) return;
           // The self MCP requires session auth, so an HTTP round-trip would
           // fail without forwarding cookies. Use in-process transport instead.
@@ -189,11 +203,17 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
             connection.id,
             fetchLive,
             cache,
+            // Track background revalidations so the request lifecycle awaits
+            // (and bounds) them instead of leaking a detached MCP handshake per
+            // connection, and throttle them so a polling UI doesn't reconnect to
+            // every downstream on every request. Matches connection/get.ts.
+            (p) => ctx.pendingRevalidations.push(p),
+            REVALIDATE_MIN_INTERVAL_MS,
           );
           if (tools !== null) {
             connection.tools = tools as Tool[];
           }
-        }),
+        },
       );
     }
 

--- a/apps/mesh/src/tools/connection/map-with-concurrency.test.ts
+++ b/apps/mesh/src/tools/connection/map-with-concurrency.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { mapWithConcurrency } from "./map-with-concurrency";
+
+describe("mapWithConcurrency", () => {
+  test("processes every item exactly once", async () => {
+    const items = Array.from({ length: 50 }, (_, i) => i);
+    const seen: number[] = [];
+    await mapWithConcurrency(items, 8, async (i) => {
+      seen.push(i);
+    });
+    expect(seen.sort((a, b) => a - b)).toEqual(items);
+  });
+
+  test("never exceeds the concurrency limit", async () => {
+    const items = Array.from({ length: 40 }, (_, i) => i);
+    let inFlight = 0;
+    let peak = 0;
+    await mapWithConcurrency(items, 5, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      // Yield so multiple workers overlap before any resolves.
+      await Promise.resolve();
+      await Promise.resolve();
+      inFlight--;
+    });
+    expect(peak).toBeLessThanOrEqual(5);
+  });
+
+  test("caps workers at item count when fewer items than concurrency", async () => {
+    let peak = 0;
+    let inFlight = 0;
+    await mapWithConcurrency([1, 2], 16, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await Promise.resolve();
+      inFlight--;
+    });
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  test("is a no-op for an empty list", async () => {
+    let calls = 0;
+    await mapWithConcurrency([], 8, async () => {
+      calls++;
+    });
+    expect(calls).toBe(0);
+  });
+});

--- a/apps/mesh/src/tools/connection/map-with-concurrency.ts
+++ b/apps/mesh/src/tools/connection/map-with-concurrency.ts
@@ -1,0 +1,24 @@
+/**
+ * Run `fn` over `items` with at most `concurrency` tasks in flight at once.
+ *
+ * Used to bound the live tool-probe fan-out during binding filtering: each probe
+ * eagerly connects to a downstream MCP server, so an unbounded `Promise.all` over
+ * a large org saturates the DB pool and blocks the single-threaded event loop.
+ */
+export async function mapWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return;
+  let nextIndex = 0;
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      await fn(items[index]!);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker()),
+  );
+}


### PR DESCRIPTION
## Problem

In **Automations → add trigger → Event**, the picker calls
`useConnections({ binding: "TRIGGER" })`, which hits `COLLECTION_CONNECTIONS_LIST`
with a binding filter. To filter by binding the backend must know each
connection's tool list, so it fans out over **every** connection in the org and
eagerly connects to its MCP server to call `listTools()`.

That probe had **no timeout** (`apps/mesh/src/tools/connection/list.ts`). The
fan-out is a `Promise.all`, so a single slow or hung downstream stalled the
whole call. The `EventTriggerForm` is rendered behind a `<Suspense>` boundary
that suspends on this query, so the user saw **"Loading connections…" hang for
up to 60s** (the MCP SDK's default request timeout) before anything appeared —
in an org with many connections, all it takes is one slow MCP.

## Fix

Add `listToolsWithTimeout()` — it bounds the **entire** connect + `listTools()`
(the transport handshake and downstream-token read happen eagerly, *before* the
request is sent, so a request-only timeout wouldn't cover a connection that
hangs during connect). On timeout it aborts the in-flight request and closes the
client in the background so a slow downstream can't pin a socket open.

The binding filter now uses a **5s** bound per connection
(`MCP_LIST_TOOLS_TIMEOUT_MS`). A slow connection is dropped from the filtered
list instead of blocking the rest, so the picker renders promptly with whatever
responded in time. Already-cached connections (the common case) are unaffected —
they never hit the live probe.

## Testing

- `tsc --noEmit` passes; `bun run fmt` / `bun run lint` clean (2 pre-existing
  unrelated warnings).
- Manual: open Automations → add Event trigger in an org with a deliberately
  slow MCP connection; the connection dropdown now populates within ~5s with the
  responsive connections instead of hanging.

## Notes

This is the **UX half**. A follow-up PR addresses the *performance* half — the
same fan-out fires N eager connects + N `downstream_tokens` reads at once with
the background-revalidation throttle disabled, which spikes CPU / event-loop lag
and triggers HPA replica scale-ups.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the per-connection `listTools()` probe and throttled the binding-filter fan-out so one slow MCP can’t hang or overload the Automations → Add Trigger → Event picker. The dropdown now renders within ~5s with responsive connections; slow ones are skipped, and background revalidations no longer storm downstream servers.

- **Bug Fixes**
  - Added `listToolsWithTimeout` to bound connect + `listTools()` with `MCP_LIST_TOOLS_TIMEOUT_MS` (5s); aborts and closes on timeout.
  - Updated `COLLECTION_CONNECTIONS_LIST` binding filter to use the bounded probe so a single slow connection won’t stall the whole fan-out.
  - Exported the helper from `mcp-clients` and kept the timeout error internal; cached connections are unaffected.

- **Performance**
  - Throttled cache revalidations with `REVALIDATE_MIN_INTERVAL_MS` and tracked them via `ctx.pendingRevalidations` to avoid detached handshakes.
  - Replaced unbounded `Promise.all` with `mapWithConcurrency`; capped live tool probes at 8 (`BINDING_PROBE_CONCURRENCY`) to reduce DB and event-loop pressure.

<sup>Written for commit 117b6064b005d33866b780289ae7c8270ff4e346. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

