### PR TITLE
perf(connections): throttle + bound binding-filter tool probes to stop event-loop-lag replica scaling

### DIFF
--- a/apps/mesh/src/tools/connection/list.ts
+++ b/apps/mesh/src/tools/connection/list.ts
@@ -34,6 +34,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import {
   getMcpListCache,
   fetchWithCache,
+  REVALIDATE_MIN_INTERVAL_MS,
 } from "../../mcp-clients/mcp-list-cache";
 import { listToolsWithTimeout } from "../../mcp-clients";
 import { MCP_LIST_TOOLS_TIMEOUT_MS } from "../../core/constants";
@@ -44,6 +45,17 @@ import {
 import { type ConnectionEntity, ConnectionEntitySchema } from "./schema";
 import { getConnectionSlug } from "@/shared/utils/connection-slug";
 import { connectionMatchesWhere } from "./where-match";
+import { mapWithConcurrency } from "./map-with-concurrency";
+
+/**
+ * Max concurrent live tool probes during binding filtering. Each probe eagerly
+ * connects to a downstream MCP server (transport handshake + a `downstream_tokens`
+ * read), so an unbounded `Promise.all` over a large org fires dozens at once —
+ * saturating the DB pool and blocking the single-threaded event loop while it
+ * parses every tool list. Bounding the fan-out keeps a cold cache from spiking
+ * CPU and tripping the HPA into a needless replica.
+ */
+const BINDING_PROBE_CONCURRENCY = 8;
 
 /**
  * Registry binding: matches connections that expose COLLECTION_REGISTRY_APP_LIST
@@ -167,8 +179,10 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
     if (bindingChecker) {
       const cache = getMcpListCache();
       const selfId = WellKnownOrgMCPId.SELF(organization.id);
-      await Promise.all(
-        connections.map(async (connection) => {
+      await mapWithConcurrency(
+        connections,
+        BINDING_PROBE_CONCURRENCY,
+        async (connection) => {
           if (connection.tools !== null) return;
           // The self MCP requires session auth, so an HTTP round-trip would
           // fail without forwarding cookies. Use in-process transport instead.
@@ -189,11 +203,17 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
             connection.id,
             fetchLive,
             cache,
+            // Track background revalidations so the request lifecycle awaits
+            // (and bounds) them instead of leaking a detached MCP handshake per
+            // connection, and throttle them so a polling UI doesn't reconnect to
+            // every downstream on every request. Matches connection/get.ts.
+            (p) => ctx.pendingRevalidations.push(p),
+            REVALIDATE_MIN_INTERVAL_MS,
           );
           if (tools !== null) {
             connection.tools = tools as Tool[];
           }
-        }),
+        },
       );
     }
 

--- a/apps/mesh/src/tools/connection/map-with-concurrency.test.ts
+++ b/apps/mesh/src/tools/connection/map-with-concurrency.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { mapWithConcurrency } from "./map-with-concurrency";
+
+describe("mapWithConcurrency", () => {
+  test("processes every item exactly once", async () => {
+    const items = Array.from({ length: 50 }, (_, i) => i);
+    const seen: number[] = [];
+    await mapWithConcurrency(items, 8, async (i) => {
+      seen.push(i);
+    });
+    expect(seen.sort((a, b) => a - b)).toEqual(items);
+  });
+
+  test("never exceeds the concurrency limit", async () => {
+    const items = Array.from({ length: 40 }, (_, i) => i);
+    let inFlight = 0;
+    let peak = 0;
+    await mapWithConcurrency(items, 5, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      // Yield so multiple workers overlap before any resolves.
+      await Promise.resolve();
+      await Promise.resolve();
+      inFlight--;
+    });
+    expect(peak).toBeLessThanOrEqual(5);
+  });
+
+  test("caps workers at item count when fewer items than concurrency", async () => {
+    let peak = 0;
+    let inFlight = 0;
+    await mapWithConcurrency([1, 2], 16, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await Promise.resolve();
+      inFlight--;
+    });
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  test("is a no-op for an empty list", async () => {
+    let calls = 0;
+    await mapWithConcurrency([], 8, async () => {
+      calls++;
+    });
+    expect(calls).toBe(0);
+  });
+});

--- a/apps/mesh/src/tools/connection/map-with-concurrency.ts
+++ b/apps/mesh/src/tools/connection/map-with-concurrency.ts
@@ -1,0 +1,24 @@
+/**
+ * Run `fn` over `items` with at most `concurrency` tasks in flight at once.
+ *
+ * Used to bound the live tool-probe fan-out during binding filtering: each probe
+ * eagerly connects to a downstream MCP server, so an unbounded `Promise.all` over
+ * a large org saturates the DB pool and blocks the single-threaded event loop.
+ */
+export async function mapWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return;
+  let nextIndex = 0;
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      await fn(items[index]!);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker()),
+  );
+}


### PR DESCRIPTION
> Stacked on #3920 (base branch = `fix/trigger-connection-list-slow-mcp`). The
> diff here is only the perf commit; review #3920 first.

## The performance issue

`COLLECTION_CONNECTIONS_LIST` is the backend behind every binding-filtered
connection list — including the Automations **event-trigger picker**
(`useConnections({ binding: "TRIGGER" })`). To filter by binding it must know each
connection's tool list, so it fans out over every connection and (on a cache
miss/stale) eagerly connects to the downstream MCP server: a transport handshake
plus a `downstream_tokens` DB read, then `listTools()`.

That fan-out had **three** compounding defects — and it was the **only** caller
of `fetchWithCache` that had them (`get.ts`, the lazy client, and the outbound
auth transport all already pass the throttle + tracker):

1. **Background-revalidation throttle disabled.** `list.ts` called
   `fetchWithCache(...)` without `minRevalidateIntervalMs`, which defaults to `0`
   → throttle off. So on every cache *hit*, it scheduled a background
   revalidation for that connection. A UI polling the list reconnected to *every*
   downstream MCP server on *every* request — a perpetual handshake storm.
2. **Detached revalidations.** It also omitted the `onRevalidation` callback, so
   those background promises were never pushed to `ctx.pendingRevalidations` —
   each was a fire-and-forget MCP handshake the request lifecycle never awaited or
   bounded (the app drains `pendingRevalidations` with a 30s cap).
3. **Unbounded concurrency.** The fan-out was a plain `Promise.all`, so a cold
   cache fired one eager connect + one `downstream_tokens` read per connection
   *simultaneously*.

### Production evidence (ns `deco-studio`)

- HPA `deco-studio`: min 2 / max 10, **target CPU 80% of request**, and the CPU
  **request is only 150m** — so ~0.12 cores trips the threshold.
- A `SuccessfulRescale` 2→3 fired on *"cpu resource utilization above target"*,
  then scaled back down minutes later — short CPU-driven scale-ups.
- App logs over 3h: **88** event-loop-lag warnings, worst **1334ms**; *"Slow
  query measurement — likely event-loop lag"* with `eventLoopLagMs: 351` on
  `select * from downstream_tokens` while the DB pool was **25/25 with waiters**.
  `downstream_tokens` is exactly the per-connection client-load path this fan-out
  drives.

Single-threaded Bun + a 150m request means a brief synchronous burst (N
handshakes + N tool-list parses) pegs the core long enough for the HPA to add a
replica — even though the work is largely redundant.

## Fix

- Pass `REVALIDATE_MIN_INTERVAL_MS` (30s) and
  `(p) => ctx.pendingRevalidations.push(p)` to `fetchWithCache`, matching
  `connection/get.ts` and the lazy client. Background revalidation is now
  throttled per-connection and tracked/bounded by the request lifecycle.
- Cap the fan-out at `BINDING_PROBE_CONCURRENCY` (8) via a small
  `mapWithConcurrency` helper, so a cold cache can't open dozens of eager
  connects at once.

## Testing

- New unit test `map-with-concurrency.test.ts` (4 tests, pure logic — no mocks):
  verifies all items run once, peak in-flight never exceeds the limit, workers
  cap at item count, and empty-list is a no-op.
- `tsc --noEmit` passes; `bun run fmt` / `bun run lint` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle and bound binding-filter tool probes in `COLLECTION_CONNECTIONS_LIST` to stop handshake storms that caused event-loop lag and CPU-driven replica scaling. Stabilizes the Automations event-trigger picker and other binding-filtered lists in large orgs.

- **Performance**
  - Throttle per-connection background revalidation with `REVALIDATE_MIN_INTERVAL_MS` (30s) and track via `ctx.pendingRevalidations`.
  - Cap fan-out to `BINDING_PROBE_CONCURRENCY` (8) using `mapWithConcurrency` instead of unbounded `Promise.all`.
  - Align cache behavior with `connection/get.ts` and the lazy client; added unit tests for `mapWithConcurrency`.

<sup>Written for commit f80eefff495f3118f555df6b749f6bc0bb0e2a3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

