### PR TITLE
fix(harness): steer slides/decks to the slides skill, not pptx

### DIFF
--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -195,7 +195,11 @@ export function buildBashDescription(orgFs: boolean): string {
     "Pre-installed file-handling skills also live at " +
     "`/mnt/skills/public/<name>/SKILL.md` (pptx, docx, xlsx, pdf, " +
     "file-reading, slides, templating). Run `ls /mnt/skills/public/` for " +
-    "that index. To make a presentation deck, read the `slides` skill first." +
+    "that index. To make a presentation/slides/deck, ALWAYS use the " +
+    "`slides` skill (HTML decks with a live editable preview) — read its " +
+    "SKILL.md first. `pptx` is NOT for this: it only reads/inspects " +
+    "existing `.pptx` files, and is the right tool only when the user " +
+    "explicitly needs a PowerPoint `.pptx` file as input or output." +
     // Without org-fs there is no org/upload or org/output — the legacy
     // transfer tools (also only registered then) are the one way to move
     // files in and out.

--- a/packages/sandbox/image/skills/pptx/SKILL.md
+++ b/packages/sandbox/image/skills/pptx/SKILL.md
@@ -3,6 +3,13 @@
 Reading and inspection of `.pptx` files. Editing and creation are not yet
 supported.
 
+> **Making a presentation, slide deck, or "slides"?** This is NOT the
+> skill — use the **`slides`** skill (`/mnt/skills/public/slides/SKILL.md`),
+> which authors HTML decks with a live, editable preview. Reach for `pptx`
+> ONLY when the user explicitly works with a PowerPoint `.pptx` file —
+> reading one they uploaded, or when they specifically ask for `.pptx`
+> output (not yet supported here).
+
 ## Quick reference
 
 | Task                          | Command                                       |


### PR DESCRIPTION
## What is this contribution about?

Asking an agent to "create slides / a deck / a presentation" steered it to the **`pptx`** skill instead of the new **`slides`** skill. `pptx` is read-only (it only extracts/inspects existing `.pptx` files — no creation, no live preview), so the result was a dead end. The skill's name and "slides" framing simply out-pulled the slides pointer.

Two high-leverage doc fixes (no behavior code):

1. **Bash skill index** (`buildBashDescription`, always in context): now states the rule explicitly — any presentation/slides/deck ALWAYS uses the `slides` skill (HTML decks with a live editable preview); `pptx` is for reading/inspecting an existing `.pptx`, or only when the user *explicitly* needs PowerPoint `.pptx` as input/output.
2. **`pptx/SKILL.md`** gains a redirect callout at the top, as a safety net if the model opens it anyway: "Making a deck/slides? Use the `slides` skill."

This matches the steering principle the user asked for: PowerPoint `.pptx` format only when explicitly mentioned; everything else "slides/deck" → the HTML slides skill.

## How to Test

1. `ORGFS_CLUSTER_MOUNTS=true bun run dev` with a sandbox image carrying the skills.
2. Ask "make me a slide deck about X" → agent reads `slides/SKILL.md` and runs `slides-create` into `org/<slug>/decks/`; it does NOT reach for `pptx-*`.
3. Ask "read this .pptx and summarize it" (with a `.pptx` attached) → still uses `pptx-extract`. (`bun run fmt && bun run check` green.)

## Migration Notes

The `pptx/SKILL.md` edit ships in the sandbox image (rebuild/release needed); the bash-description change ships with mesh.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Steers presentation requests to the `slides` skill instead of `pptx`, enabling live HTML deck creation and avoiding the read‑only `.pptx` path. Clarifies that `pptx` is only for reading existing `.pptx` files or when `.pptx` is explicitly required.

- **Bug Fixes**
  - Updated bash tool index (`buildBashDescription`) to say: always use `slides` for creating decks; `pptx` is only for reading/inspecting `.pptx` or explicit `.pptx` I/O.
  - Added a top-of-file redirect note in `packages/sandbox/image/skills/pptx/SKILL.md` pointing creation tasks to `slides`.

- **Migration**
  - Rebuild the sandbox image to ship the `pptx/SKILL.md` change.

<sup>Written for commit fc3b0ece3a3dbf2a3ca243c5a600e8408d02b8cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

