### PR TITLE
fix(monitoring): install ca-certificates in mesh image so DuckDB httpfs can read GCS

### DIFF
--- a/apps/mesh/Dockerfile
+++ b/apps/mesh/Dockerfile
@@ -7,13 +7,20 @@ FROM oven/bun:1-slim
 # byte-identical to `bunx @decocms/mesh@<version>` and avoids any npm-registry
 # round-trip (and propagation race) at image-build time.
 
-# Install runtime dependencies (unzip needed by embedded-postgres) plus the
-# toolchain needed to compile node-pty from source. node-pty ships prebuilt
-# binaries only for darwin/win32, so on Linux `bun add` always falls back to
-# `node-gyp rebuild` — which needs python3 + build-essential. We purge the
-# build toolchain after install to keep the layer lean.
+# Install runtime dependencies plus the toolchain needed to compile node-pty.
+# - ca-certificates: the oven/bun:1-slim base ships NO system CA bundle, but
+#   DuckDB's native httpfs (OpenSSL) needs the OS trust store to verify TLS to
+#   storage.googleapis.com. Without it the GCS monitoring read fails with
+#   "Problem with the SSL CA cert (path? access rights?)". Bun/Node bundle their
+#   own roots so they're unaffected; only the native extension needs this.
+#   Named explicitly so it's marked manually-installed and survives the
+#   --auto-remove purge below.
+# - unzip: needed by embedded-postgres.
+# - python3 + build-essential: node-pty ships prebuilt binaries only for
+#   darwin/win32, so on Linux `bun add` falls back to `node-gyp rebuild`. We
+#   purge this toolchain after install to keep the layer lean.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      unzip python3 build-essential && \
+      ca-certificates unzip python3 build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and app directories


### PR DESCRIPTION
## Summary

The GCS-backed monitoring path (`MONITORING_S3_BUCKET` set, `CLICKHOUSE_URL` unset) reads OTLP-JSON logs from `storage.googleapis.com` through DuckDB's native `httpfs` extension. That extension uses **OpenSSL + the OS trust store** to verify TLS — unlike Bun/Node, which bundle their own roots.

The mesh image had **no system CA bundle**: the `oven/bun:1-slim` base ships none (`/etc/ssl/certs` doesn't even exist) and the Dockerfile installed `unzip python3 build-essential` but never `ca-certificates`. So every GCS monitoring read failed at the very first `ListObjectsV2` request with:

```
queryLlmUsageStats failed: IO Error: Problem with the SSL CA cert (path? access rights?)
  error for HTTP GET to
  'https://storage.googleapis.com/<bucket>/?encoding-type=url&list-type=2&prefix=logs%2F'
```

This is a **transport-level trust failure**, which is why:
- it's independent of the bucket/HMAC key (a bad key would be `403 SignatureDoesNotMatch`, a bad bucket `404`), and
- `NODE_EXTRA_CA_CERTS` (used by the helm Postgres-CA feature) doesn't fix it — that only augments Node's TLS, not the native extension's.

## Fix

Add `ca-certificates` to the apt install in `apps/mesh/Dockerfile`. Naming it explicitly marks it *manually-installed*, so the later `apt-get purge -y --auto-remove python3 build-essential` leaves it in place.

## Testing

Verified against the base image:

```
# before
$ docker run --rm oven/bun:1-slim ls /etc/ssl/certs/ca-certificates.crt
ls: cannot access '/etc/ssl/certs/ca-certificates.crt': No such file or directory

# after installing ca-certificates
bundle: -rw-r--r-- 224449 /etc/ssl/certs/ca-certificates.crt   (150 roots)
subject=C=US, O=Google Trust Services LLC, CN=GTS Root R1
subject=C=US, O=Google Trust Services LLC, CN=GTS Root R2
subject=C=US, O=Google Trust Services LLC, CN=GTS Root R3
subject=C=US, O=Google Trust Services LLC, CN=GTS Root R4
```

`storage.googleapis.com` chains to GTS Root R1–R4, which are now present.

## Affected areas

Only `apps/mesh/Dockerfile` (the self-hosted/official image). No code or runtime config change. Local NDJSON and ClickHouse monitoring paths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `ca-certificates` in the mesh Docker image so DuckDB `httpfs` can verify TLS and read logs from GCS. Fixes the "Problem with the SSL CA cert" error on the GCS-backed monitoring path.

- **Bug Fixes**
  - Added `ca-certificates` to `apt-get install` in `apps/mesh/Dockerfile` (base `oven/bun:1-slim` had no system CAs), enabling OpenSSL in `httpfs` to trust `storage.googleapis.com`.
  - Build tools still get purged; `ca-certificates` remains installed. No app code or config changes.

<sup>Written for commit c1105b259f4bd5c4b57e37abdef00e603101d2d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

