### PR TITLE
feat(org-fs): default public sets + single skill mechanism in the prompt

### DIFF
--- a/apps/mesh/src/file-storage/public-sets.test.ts
+++ b/apps/mesh/src/file-storage/public-sets.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_PUBLIC_SETS, resolvePublicSets } from "./public-sets";
+
+describe("resolvePublicSets", () => {
+  test("no env → the hardcoded defaults (local studio pulls core OOTB)", () => {
+    expect(resolvePublicSets(undefined)).toEqual(DEFAULT_PUBLIC_SETS);
+    expect(resolvePublicSets("")).toEqual(DEFAULT_PUBLIC_SETS);
+    expect(resolvePublicSets(undefined).some((s) => s.set === "core")).toBe(
+      true,
+    );
+  });
+
+  test("env ADDS a new set without dropping the defaults", () => {
+    const out = resolvePublicSets(
+      JSON.stringify([
+        {
+          set: "acme",
+          repo: "acme/skills",
+          ref: "main",
+          paths: [{ from: "." }],
+        },
+      ]),
+    );
+    const names = out.map((s) => s.set).sort();
+    expect(names).toContain("core");
+    expect(names).toContain("acme");
+  });
+
+  test("env OVERRIDES a default by set name (env wins)", () => {
+    const out = resolvePublicSets(
+      JSON.stringify([
+        { set: "core", repo: "acme/forked", ref: "v2", paths: [{ from: "x" }] },
+      ]),
+    );
+    const core = out.find((s) => s.set === "core");
+    expect(core).toEqual({
+      set: "core",
+      repo: "acme/forked",
+      ref: "v2",
+      paths: [{ from: "x" }],
+    });
+    // Still exactly one `core` (overridden, not duplicated).
+    expect(out.filter((s) => s.set === "core")).toHaveLength(1);
+  });
+
+  test("malformed env → defaults only, never throws", () => {
+    expect(resolvePublicSets("not json")).toEqual(DEFAULT_PUBLIC_SETS);
+    expect(resolvePublicSets("{}")).toEqual(DEFAULT_PUBLIC_SETS);
+    // Duplicate set names are rejected by the schema → defaults kept.
+    expect(
+      resolvePublicSets(
+        JSON.stringify([
+          { set: "dup", repo: "a/b", ref: "m", paths: [{ from: "." }] },
+          { set: "dup", repo: "a/c", ref: "m", paths: [{ from: "." }] },
+        ]),
+      ),
+    ).toEqual(DEFAULT_PUBLIC_SETS);
+  });
+});

--- a/apps/mesh/src/file-storage/public-sets.ts
+++ b/apps/mesh/src/file-storage/public-sets.ts
@@ -50,9 +50,28 @@ const setSchema = z.object({
 export type PublicSkillSetSource = z.infer<typeof setSchema>;
 
 /**
- * Parse the deployment's ORGFS_PUBLIC_SETS (a JSON array of sets). Malformed
- * config returns [] with a warn — public sets must never break boot.
+ * Built-in skill sets, present in EVERY deployment with no configuration —
+ * so a freshly-cloned local studio (and any prod deploy) pulls the core
+ * skills automatically. `core` is the canonical skill source: the
+ * file-handling skills (pptx/docx/xlsx/pdf/file-reading) plus slides +
+ * templating, synced from the studio repo and mounted read-only at
+ * `org/public/core`. This is what replaces the image-baked
+ * `/mnt/skills/public`.
+ *
+ * `ORGFS_PUBLIC_SETS` does NOT replace these — it overrides by set name
+ * and adds new sets (env wins on a name collision). So a deployment can
+ * repoint `core` (e.g. at a pinned ref) or add its own sets without
+ * losing the built-ins.
  */
+export const DEFAULT_PUBLIC_SETS: PublicSkillSetSource[] = [
+  {
+    set: "core",
+    repo: "decocms/studio",
+    ref: "main",
+    paths: [{ from: "packages/sandbox/image/skills" }],
+  },
+];
+
 const setsSchema = z
   .array(setSchema)
   // Duplicate names share one volume — each sync cycle would delete the
@@ -62,18 +81,34 @@ const setsSchema = z
     message: "duplicate set names",
   });
 
-export function getPublicSets(): PublicSkillSetSource[] {
-  const raw = getSettings().orgFsPublicSetsJson;
-  if (!raw) return [];
-  try {
-    return setsSchema.parse(JSON.parse(raw));
-  } catch (err) {
-    console.warn(
-      "[org-fs] invalid ORGFS_PUBLIC_SETS — public sets disabled",
-      err,
-    );
-    return [];
+/**
+ * Resolve the effective public sets from a raw `ORGFS_PUBLIC_SETS` value:
+ * the hardcoded defaults, then the parsed env overlaid by set name (env
+ * wins). Malformed env is ignored with a warn — it must never break boot,
+ * and never drop the defaults. Pure (no settings/IO) so it's unit-testable.
+ */
+export function resolvePublicSets(
+  raw: string | undefined,
+): PublicSkillSetSource[] {
+  const byName = new Map<string, PublicSkillSetSource>(
+    DEFAULT_PUBLIC_SETS.map((s) => [s.set, s]),
+  );
+  if (raw) {
+    try {
+      for (const s of setsSchema.parse(JSON.parse(raw))) byName.set(s.set, s);
+    } catch (err) {
+      console.warn(
+        "[org-fs] invalid ORGFS_PUBLIC_SETS — using built-in defaults only",
+        err,
+      );
+    }
   }
+  return [...byName.values()];
+}
+
+/** The deployment's effective public sets (defaults + env override). */
+export function getPublicSets(): PublicSkillSetSource[] {
+  return resolvePublicSets(getSettings().orgFsPublicSetsJson);
 }
 
 /**

--- a/apps/mesh/src/file-storage/public-sets.ts
+++ b/apps/mesh/src/file-storage/public-sets.ts
@@ -70,6 +70,16 @@ export const DEFAULT_PUBLIC_SETS: PublicSkillSetSource[] = [
     ref: "main",
     paths: [{ from: "packages/sandbox/image/skills" }],
   },
+  {
+    set: "storefront",
+    repo: "decocms/storefront-skills",
+    ref: "main",
+    paths: [
+      { from: ".claude-seo/skills" },
+      { from: ".claude-performance/skills" },
+      { from: ".claude-deco/skills" },
+    ],
+  },
 ];
 
 const setsSchema = z

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -144,8 +144,8 @@ export function buildWriteDescription(orgFs: boolean): string {
         "and persist in the org's shared folder when written under " +
         "`org/<your-org-slug>/` (lowercase-kebab names):\n" +
         "- Presentation decks / slides → `org/<your-org-slug>/decks/<name>.html` " +
-        "— read `/mnt/skills/public/slides/SKILL.md` FIRST and create the " +
-        "deck with its CLI.\n" +
+        "— read the slides skill (`org/public/core/slides/SKILL.md`) FIRST " +
+        "and create the deck with its CLI.\n" +
         "- Standalone pages (landing pages, brand kits, one-pagers) → " +
         "`org/<your-org-slug>/pages/<name>.html` — single self-contained " +
         "HTML file.\n" +
@@ -175,37 +175,44 @@ export const GLOB_DESCRIPTION =
 /** `orgFs`: deployment mounts org-fs into hosted sandboxes — the caller
  *  passes the settings flag (this module stays dependency-free). */
 export function buildBashDescription(orgFs: boolean): string {
+  // Shared tail: skill-selection steering, independent of WHERE skills
+  // live (org/public on org-fs, /mnt on legacy).
+  const skillSteering =
+    "To make a presentation/slides/deck, ALWAYS use the `slides` skill " +
+    "(HTML decks with a live editable preview) — read its SKILL.md first. " +
+    "`pptx` is NOT for this: it only reads/inspects existing `.pptx` files, " +
+    "and is the right tool only when the user explicitly needs a PowerPoint " +
+    "`.pptx` file as input or output.";
+
   return (
     "Execute a shell command in the VM's project directory. " +
     "Working directory is the project root. Timeout default 30s, max 2min.\n\n" +
     (orgFs
-      ? "The organization filesystem is mounted at `org/` (when available):\n" +
+      ? // Org-fs deployments: ONE skill mechanism — the synced public sets
+        // mounted at `org/public/<set>/`. The image-baked `/mnt/skills/public`
+        // is not advertised here (it is the legacy non-org-fs fallback below).
+        "The organization filesystem is mounted at `org/`:\n" +
         "- `org/<your-org-slug>/` — the org's shared home folder (editable, " +
         "shared across runs; `ls org/` shows the actual name). Organize it " +
         "freely; check it before non-trivial work and record durable facts, " +
         "decisions, and learnings as small markdown files.\n" +
-        "- `org/public/<set>/` — curated read-only skill sets. Run " +
-        "`ls org/public/` for the sets and `cat org/public/<set>/<name>/SKILL.md` " +
-        "before using a skill.\n" +
+        "- `org/public/<set>/` — curated read-only skill sets (file-handling: " +
+        "pptx, docx, xlsx, pdf, file-reading; plus slides + templating). Run " +
+        "`ls org/public/` for the sets and read " +
+        "`org/public/<set>/<name>/SKILL.md` before using a skill.\n" +
         "- `org/upload/` — files the user attached to this conversation are " +
         "already here; read them directly.\n" +
         "- `org/output/` — write deliverables here; they are shared back to the " +
-        "organization under this run's folder.\n\n"
-      : "") +
-    "Pre-installed file-handling skills also live at " +
-    "`/mnt/skills/public/<name>/SKILL.md` (pptx, docx, xlsx, pdf, " +
-    "file-reading, slides, templating). Run `ls /mnt/skills/public/` for " +
-    "that index. To make a presentation/slides/deck, ALWAYS use the " +
-    "`slides` skill (HTML decks with a live editable preview) — read its " +
-    "SKILL.md first. `pptx` is NOT for this: it only reads/inspects " +
-    "existing `.pptx` files, and is the right tool only when the user " +
-    "explicitly needs a PowerPoint `.pptx` file as input or output." +
-    // Without org-fs there is no org/upload or org/output — the legacy
-    // transfer tools (also only registered then) are the one way to move
-    // files in and out.
-    (orgFs
-      ? ""
-      : "\n\nTo bring chat attachments / presigned URLs into the sandbox FS " +
+        "organization under this run's folder.\n\n" +
+        skillSteering
+      : // Legacy non-org-fs deployments: skills are image-baked and the
+        // transfer tools are the only way to move files in/out.
+        "Pre-installed file-handling skills live at " +
+        "`/mnt/skills/public/<name>/SKILL.md` (pptx, docx, xlsx, pdf, " +
+        "file-reading, slides, templating). Run `ls /mnt/skills/public/` for " +
+        "that index. " +
+        skillSteering +
+        "\n\nTo bring chat attachments / presigned URLs into the sandbox FS " +
         "use `copy_to_sandbox` (NOT bash + curl). To deliver a file you " +
         "produced back to the user as a download chip, use `share_with_user`.")
   );


### PR DESCRIPTION
## What is this contribution about?

First, safe step toward **org-fs as the default skill substrate**, retiring the dual `/mnt/skills/public` (image-baked) + `org/public/<set>` (synced) mechanism. Two decision-independent changes:

### 1. Hardcoded default public sets (env overrides, not replaces)
`ORGFS_PUBLIC_SETS` had **no default** — an unconfigured deploy got zero public skills. Now a hardcoded `DEFAULT_PUBLIC_SETS` (`core` → `decocms/studio` `packages/sandbox/image/skills`) is always present, and the env var **overrides by set name and adds** rather than being the sole source. So:
- a freshly-cloned local studio (and any prod deploy) pulls the `core` skills out of the box;
- operators can repoint `core` (e.g. a pinned ref) or add their own sets **without losing the built-ins**.

Pure `resolvePublicSets()` extracted and unit-tested (defaults / add / override-by-name / malformed-keeps-defaults).

### 2. One skill mechanism in the tool prompt (context de-bloat)
The bash/write tool descriptions advertised skills at **both** `/mnt/skills/public` and `org/public/<set>`. The org-fs branch now describes only the synced sets at `org/public/<set>/`; `/mnt/skills/public` remains **only** in the legacy non-org-fs branch (which genuinely uses it). Removes the dual-mechanism prompt bloat for org-fs deployments.

## What this deliberately does NOT do (and why)

Full plan: `docs/superpowers/specs/2026-06-15-skills-via-public-sets-design.md`. Deferred, each gated:
- **Desktop org-fs prompt/tool awareness** — desktop already mounts org-fs (kext-free rclone nfsmount) but the tool layer/prompt are unaware (`createVmTools` gets `orgFs:false`, `buildDesktopPrompt` has no org-fs section). Fixing it needs a cross-tree prompt extraction + threading the mounted-set list into the desktop runtime + desktop-path validation → its own focused PR.
- **Cluster default-on** — `ORGFS_CLUSTER_MOUNTS` flip is an ops/infra change (requires the privileged org-fs sidecar in the default deploy), not a blind code default.
- **Physical deletion** of image skills + `copy_to_sandbox`/`share_with_user` + the bare-command `skill` launcher — high blast radius (breaks deploys without the sidecar / before first sync, or if launcher resolution is wrong), needs docker+kind validation. Crucially, it buys **no additional context savings** — the bloat is the prompt text, fixed here.

## Notes / to confirm
- The default `core` set fetches `codeload.github.com/decocms/studio/tar.gz/main`. If `decocms/studio` is private in a given deployment, that default needs a token or a public mirror (the dev rig already syncs this repo, so it works there). Flagging for prod.
- `ref: "main"` tracks latest studio skills; a pinned tag may be preferable for reproducible prod deploys (overridable via env).

## How to Test
1. `bun test apps/mesh/src/file-storage/public-sets.test.ts` (4 pass).
2. Local studio with no `ORGFS_PUBLIC_SETS`: `org/public/core/` populates from the sync; `ls org/public/` shows `core`.
3. `bun run fmt && bun run lint && bun run check` green.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes (defaults are additive; legacy non-org-fs path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds default `core` and `storefront` public skill sets and updates org-fs prompts to use a single skill mechanism, so skills work out of the box and prompts are smaller. Legacy (non-org-fs) keeps `/mnt/skills/public` unchanged.

- New Features
  - Default `core` and `storefront` sets via `DEFAULT_PUBLIC_SETS` (`core` from `decocms/studio` `packages/sandbox/image/skills`; `storefront` from `decocms/storefront-skills` at `.claude-seo/skills`, `.claude-performance/skills`, `.claude-deco/skills`); `ORGFS_PUBLIC_SETS` now adds and overrides by set name; malformed env keeps defaults.
  - New pure `resolvePublicSets()` with unit tests (defaults, add, override, malformed).
  - `bash`/`write` tool descriptions (org-fs): advertise only `org/public/<set>/`; clarify slides vs `pptx`; `/mnt/skills/public` shown only for non-org-fs.

<sup>Written for commit bd5af5ae8e374fa16dd249a891a71ac093f50a2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

