### PR TITLE
fix(monitoring): let embedded DuckDB spill to disk so GCS dashboard stops OOMing

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
@@ -191,6 +191,7 @@ gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.j
 - **`403 storage.buckets.get denied` on startup:** the collector's service account needs bucket-level `storage.admin` (or at least `storage.buckets.get` plus object write) — see step 2.
 - **Dashboard empty / "Monitoring stats unavailable":** confirm objects exist with `gcloud storage ls "gs://${BUCKET}/logs/"`, and confirm `MONITORING_S3_PREFIX` **exactly matches** the collector's `partition.prefix`.
 - **Studio fails to start with a config error:** when `MONITORING_S3_BUCKET` is set, the HMAC access key and secret are required (the DuckDB extension directory is baked into the official image).
+- **`Out of Memory Error` from `queryMetricTimeseries` / `queryLlmUsageStats`:** the embedded DuckDB engine reads the whole bucket prefix per query and OOMs on a small container. The engine already spills to a temp dir, but on a tight memory limit you can cap it explicitly with `DUCKDB_MEMORY_LIMIT` (e.g. `2GB`) and reduce parallelism with `DUCKDB_THREADS` (e.g. `2`); fewer threads lowers peak memory. Also bound growth with a bucket retention/lifecycle rule so the prefix doesn't accumulate unboundedly.
 
 ## Environment Variables
 
@@ -205,3 +206,5 @@ gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.j
 | `MONITORING_S3_REGION` | falls back to `S3_REGION` | Region for SigV4 signing (`auto` for GCS) |
 | `MONITORING_S3_ACCESS_KEY_ID` | falls back to `S3_ACCESS_KEY_ID` | GCS HMAC key |
 | `MONITORING_S3_SECRET_ACCESS_KEY` | falls back to `S3_SECRET_ACCESS_KEY` | GCS HMAC secret |
+| `DUCKDB_MEMORY_LIMIT` | *(80% of RAM)* | Memory cap for the embedded DuckDB monitoring engine, e.g. `2GB`. Lower it on a memory-constrained container |
+| `DUCKDB_THREADS` | *(all CPUs)* | Thread count for the embedded DuckDB engine. Fewer threads lowers peak memory |

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
@@ -191,6 +191,7 @@ gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.j
 - **`403 storage.buckets.get denied` no startup:** a service account do collector precisa de `storage.admin` no escopo do bucket (ou ao menos `storage.buckets.get` + escrita de objetos) — veja o passo 2.
 - **Dashboard vazio / "Monitoring stats unavailable":** confirme que os objetos existem com `gcloud storage ls "gs://${BUCKET}/logs/"`; e confirme que `MONITORING_S3_PREFIX` **bate exatamente** com o `partition.prefix` do collector.
 - **Studio falha ao iniciar com erro de config:** quando `MONITORING_S3_BUCKET` está definida, a access key e o secret HMAC são obrigatórios (o diretório de extensão do DuckDB já vem embutido na imagem oficial).
+- **`Out of Memory Error` em `queryMetricTimeseries` / `queryLlmUsageStats`:** o engine DuckDB embutido lê todo o prefixo do bucket a cada query e estoura memória em containers pequenos. O engine já faz spill para um diretório temporário, mas com pouca memória você pode limitá-lo explicitamente com `DUCKDB_MEMORY_LIMIT` (ex. `2GB`) e reduzir o paralelismo com `DUCKDB_THREADS` (ex. `2`); menos threads reduz o pico de memória. Defina também uma regra de retenção/lifecycle no bucket para o prefixo não crescer indefinidamente.
 
 ## Variáveis de ambiente
 
@@ -205,3 +206,5 @@ gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.j
 | `MONITORING_S3_REGION` | usa `S3_REGION` como fallback | Região para assinatura SigV4 (`auto` para GCS) |
 | `MONITORING_S3_ACCESS_KEY_ID` | usa `S3_ACCESS_KEY_ID` como fallback | Chave HMAC do GCS |
 | `MONITORING_S3_SECRET_ACCESS_KEY` | usa `S3_SECRET_ACCESS_KEY` como fallback | Segredo HMAC do GCS |
+| `DUCKDB_MEMORY_LIMIT` | *(80% da RAM)* | Limite de memória do engine DuckDB embutido, ex. `2GB`. Reduza em containers com pouca memória |
+| `DUCKDB_THREADS` | *(todas as CPUs)* | Número de threads do engine DuckDB embutido. Menos threads reduz o pico de memória |

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -1195,8 +1195,12 @@ export async function createStudioContextFactory(
       extensionDirectory,
     };
     // One shared engine: same files for logs and log-derived metrics, so the
-    // httpfs + SECRET setup runs once.
-    const gcsEngine = new DuckDBEngine(gcs);
+    // httpfs + SECRET setup runs once. Memory tuning lets constrained
+    // containers cap DuckDB so the OTLP-flatten query spills instead of OOMing.
+    const gcsEngine = new DuckDBEngine(gcs, {
+      memoryLimit: settings.duckdbMemoryLimit,
+      threads: settings.duckdbThreads,
+    });
     monitoringEngine = gcsEngine;
     metricEngine = gcsEngine;
     const otlpSource = buildOtlpFlatSource({

--- a/apps/mesh/src/monitoring/query-engine.test.ts
+++ b/apps/mesh/src/monitoring/query-engine.test.ts
@@ -88,6 +88,29 @@ describe.skipIf(!duckdbAvailable)("DuckDBEngine", () => {
     expect(r2[0]!.tool_name).toBe("TOOL_B");
     expect(Number(r3[0]!.avg_ms)).toBe(150);
   });
+
+  it("enables disk spill and applies memory tuning so large queries don't hard-OOM", async () => {
+    const tuned = new DuckDBEngine(undefined, {
+      memoryLimit: "512MiB",
+      threads: 2,
+    });
+    try {
+      const [order, mem, threads, temp] = await Promise.all([
+        tuned.query("SELECT current_setting('preserve_insertion_order') AS v"),
+        tuned.query("SELECT current_setting('memory_limit') AS v"),
+        tuned.query("SELECT current_setting('threads') AS v"),
+        tuned.query("SELECT current_setting('temp_directory') AS v"),
+      ]);
+      expect(String(order[0]!.v)).toBe("false");
+      // DuckDB normalizes the byte unit (512MiB → "512.0 MiB").
+      expect(String(mem[0]!.v)).toContain("512");
+      expect(Number(threads[0]!.v)).toBe(2);
+      // A non-empty temp_directory is what lets in-memory DuckDB spill.
+      expect(String(temp[0]!.v).length).toBeGreaterThan(0);
+    } finally {
+      await tuned.destroy();
+    }
+  });
 });
 
 describe("createMonitoringEngine", () => {

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -6,6 +6,7 @@
  * - ClickHouseClientEngine: production, uses @clickhouse/client over HTTP
  */
 
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { getLogsDir } from "./schema";
 
@@ -41,6 +42,24 @@ export interface DuckDBGcsConfig {
   extensionDirectory: string;
 }
 
+/**
+ * Memory tuning for the embedded DuckDB engine. The OTLP-flatten query reads
+ * the whole bucket prefix (no time pruning) and `unnest`s nested arrays into a
+ * `map_from_entries` per row, which is memory-heavy. On a small container the
+ * default 80%-of-RAM limit is easily blown, so we (a) enable an on-disk
+ * `temp_directory` — an in-memory DuckDB has none and therefore CANNOT spill,
+ * turning any over-limit operator into a hard OOM instead of a slow query — and
+ * (b) disable `preserve_insertion_order` so large results aren't buffered whole.
+ */
+export interface DuckDBTuning {
+  /** DuckDB `memory_limit` (e.g. "2GB"). Unset → DuckDB's default (80% RAM). */
+  memoryLimit?: string;
+  /** DuckDB `threads`. Unset → all CPUs. Fewer threads → lower peak memory. */
+  threads?: number;
+  /** Spill directory. Unset → a subdir of the OS temp dir. */
+  tempDirectory?: string;
+}
+
 /** Escape a value for a single-quoted DuckDB SQL literal. */
 function escSqlLiteral(value: string): string {
   return value.replace(/'/g, "''");
@@ -74,12 +93,22 @@ export class DuckDBEngine implements QueryEngine {
     import("@duckdb/node-api").DuckDBConnection
   >;
 
-  constructor(gcs?: DuckDBGcsConfig) {
+  constructor(gcs?: DuckDBGcsConfig, tuning?: DuckDBTuning) {
     this.connectionPromise = import("@duckdb/node-api").then(
       async ({ DuckDBInstance }) => {
         const { cpus } = await import("node:os");
-        const threads = String(Math.max(1, cpus().length));
-        const instance = await DuckDBInstance.create("", { threads });
+        const threads = String(Math.max(1, tuning?.threads ?? cpus().length));
+        // An in-memory DuckDB ("") has no temp_directory and so cannot spill —
+        // any operator that exceeds memory_limit throws OutOfMemory instead of
+        // going out-of-core. Point it at a real dir and disable insertion-order
+        // preservation so the OTLP-flatten query streams instead of buffering.
+        const config: Record<string, string> = {
+          threads,
+          temp_directory: tuning?.tempDirectory ?? `${tmpdir()}/duckdb-spill`,
+          preserve_insertion_order: "false",
+        };
+        if (tuning?.memoryLimit) config.memory_limit = tuning.memoryLimit;
+        const instance = await DuckDBInstance.create("", config);
         const connection = await instance.connect();
         if (gcs) {
           await DuckDBEngine.setupGcs(connection, gcs);

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -150,6 +150,10 @@ export function resolveConfig(
     monitoringS3Prefix: envVars.MONITORING_S3_PREFIX,
     duckdbExtensionDirectory:
       envVars.DUCKDB_EXTENSION_DIRECTORY || "/opt/duckdb/extensions",
+    duckdbMemoryLimit: envVars.DUCKDB_MEMORY_LIMIT || undefined,
+    duckdbThreads: envVars.DUCKDB_THREADS
+      ? Number(envVars.DUCKDB_THREADS)
+      : undefined,
 
     // Runtime flags
     isCli: true,

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -84,6 +84,12 @@ export interface Settings {
   // Absolute path to the DuckDB extension directory baked into the image
   // (contains httpfs). Required for the GCS OTLP monitoring path.
   duckdbExtensionDirectory: string | undefined;
+  // Optional memory tuning for the embedded DuckDB monitoring engine on
+  // memory-constrained containers. memory_limit (e.g. "2GB") and thread count;
+  // unset → DuckDB defaults (80% RAM / all CPUs). The engine always spills to a
+  // temp dir and disables insertion-order preservation regardless.
+  duckdbMemoryLimit: string | undefined;
+  duckdbThreads: number | undefined;
 
   // Runtime flags (set by CLI)
   isCli: boolean;


### PR DESCRIPTION
## What is this contribution about?
The self-hosted GCS monitoring path runs an **in-memory** DuckDB, which has no `temp_directory` and therefore cannot spill — so the OTLP-flatten query (it reads the whole bucket prefix, `unnest`s nested arrays into a per-row `map_from_entries`) throws `Out of Memory Error` from `queryMetricTimeseries` / `queryLlmUsageStats` on small containers instead of going out-of-core. This enables an on-disk `temp_directory` and disables `preserve_insertion_order` so those queries spill/stream instead of hard-OOMing, and exposes `DUCKDB_MEMORY_LIMIT` / `DUCKDB_THREADS` so memory-constrained deployments can cap the engine explicitly. Docs (en + pt-br) gain a troubleshooting entry and the two new env vars.

## Screenshots/Demonstration
N/A — backend/config only.

## How to Test
1. Configure the GCS monitoring path (`MONITORING_S3_BUCKET` set, `CLICKHOUSE_URL` unset) on a memory-constrained container.
2. Open the monitoring dashboard against a bucket prefix large enough to previously OOM.
3. Expected: queries complete (spilling to the temp dir) instead of returning `Out of Memory Error`. Optionally set `DUCKDB_MEMORY_LIMIT=2GB` / `DUCKDB_THREADS=2` to bound usage further. `bun test apps/mesh/src/monitoring/query-engine.test.ts` passes (new test asserts the tuning is applied).

## Migration Notes
No DB migration. The engine spills to `<os-tmpdir>/duckdb-spill` by default — ensure `/tmp` is writable (add an `emptyDir` mount if running with a read-only root filesystem). New optional env vars: `DUCKDB_MEMORY_LIMIT`, `DUCKDB_THREADS`.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops GCS monitoring from OOMing by letting the embedded DuckDB spill to disk and adding optional memory/thread limits. Dashboard queries now complete on small containers and can be explicitly bounded.

- **Bug Fixes**
  - Enabled `temp_directory` and set `preserve_insertion_order=false` so OTLP-flatten queries spill/stream instead of OOMing in `queryMetricTimeseries` and `queryLlmUsageStats`.
  - Exposed `DUCKDB_MEMORY_LIMIT` and `DUCKDB_THREADS` (plumbed through settings and used by `@duckdb/node-api`); default spill dir is `<os tmp>/duckdb-spill`.
  - Updated docs (en, pt-br) with troubleshooting and new env vars; added a test to verify tuning is applied.

- **Migration**
  - Ensure `/tmp` (or your configured temp dir) is writable; add an `emptyDir` on read-only roots.
  - Env vars are optional. Set `DUCKDB_MEMORY_LIMIT` (e.g. `2GB`) and `DUCKDB_THREADS` (e.g. `2`) for tight memory budgets.

<sup>Written for commit e13a974dd71f25d91985fe0a2a889429bc3cd477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

