### PR TITLE
feat(web): scripted full-screen product demo mode

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -323,6 +323,13 @@ interface TaskProviderInternals {
 // ============================================================================
 
 const ChatStreamCtx = createContext<ChatStreamContextValue | null>(null);
+/**
+ * Exposed so Demo Mode (`web/demo/`) can supply a scripted `ChatStreamContextValue`
+ * directly — feeding the real chat renderers a recorded stream without the live
+ * `ActiveTaskProvider` (MCP transport, SSE, etc.). Not for app use; prefer the
+ * hooks. See `web/demo/demo-chat-stream.tsx`.
+ */
+export { ChatStreamCtx as DemoChatStreamContext };
 const ChatTaskCtx = createContext<ChatTaskContextValue | null>(null);
 const ChatPrefsCtx = createContext<ChatPrefsContextValue | null>(null);
 

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -9,6 +9,7 @@ import {
 import type { ToolUIPart } from "ai";
 import { type ReactNode, Suspense, useEffect, useState } from "react";
 import { ToolCallShell } from "./parts/tool-call-part/common.tsx";
+import { getPartRenderer as getExtraPartRenderer } from "./parts/extra-part-renderers.ts";
 import type { ChatMessage } from "../types.ts";
 import { MessageStatsBar } from "../usage-stats.tsx";
 import { MessageTextPart } from "./parts/text-part.tsx";
@@ -424,6 +425,11 @@ function MessagePart({
     dataParts.toolMetadata.get(toolCallId);
   const getSubtaskMeta = (toolCallId: string) =>
     dataParts.toolSubtaskMetadata.get(toolCallId);
+
+  // Custom part renderers (e.g. Demo Mode) take precedence over the built-in
+  // switch. Empty registry in normal use — see extra-part-renderers.ts.
+  const extraRenderer = getExtraPartRenderer(part.type);
+  if (extraRenderer) return <>{extraRenderer(part as { type: string })}</>;
 
   switch (part.type) {
     case "dynamic-tool":

--- a/apps/mesh/src/web/components/chat/message/parts/extra-part-renderers.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/extra-part-renderers.ts
@@ -1,0 +1,21 @@
+/**
+ * Tiny extension point for rendering custom message parts inline in the chat.
+ *
+ * The core renderer (`message/assistant.tsx`) consults this registry before its
+ * built-in switch, so non-core surfaces (e.g. Demo Mode) can render their own
+ * part types in the real chat flow WITHOUT the core importing them. The registry
+ * is empty in normal use; a consumer registers a renderer at module load.
+ */
+import type { ReactNode } from "react";
+
+type PartRenderer = (part: { type: string; output?: unknown }) => ReactNode;
+
+const registry = new Map<string, PartRenderer>();
+
+export function registerPartRenderer(type: string, render: PartRenderer): void {
+  registry.set(type, render);
+}
+
+export function getPartRenderer(type: string): PartRenderer | undefined {
+  return registry.get(type);
+}

--- a/apps/mesh/src/web/demo/chrome.tsx
+++ b/apps/mesh/src/web/demo/chrome.tsx
@@ -1,0 +1,65 @@
+/**
+ * Demo Mode — shared chrome for scenario stages.
+ *
+ * Lightweight product-like framing (top bar, preview pane) around the REAL
+ * chat. Pure presentational; all live content comes from the Director's stores.
+ */
+
+export function DemoTopBar({
+  org,
+  agent,
+  left,
+  right,
+}: {
+  org: string;
+  agent: string;
+  left?: React.ReactNode;
+  right?: React.ReactNode;
+}) {
+  return (
+    <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-4">
+      <div className="flex size-6 items-center justify-center rounded-md bg-foreground text-[11px] font-bold text-background">
+        {org.slice(0, 1)}
+      </div>
+      <div className="flex items-baseline gap-2">
+        <span className="text-sm font-medium text-foreground">{org}</span>
+        <span className="text-muted-foreground/40">/</span>
+        <span className="text-sm text-muted-foreground">{agent}</span>
+      </div>
+      {left}
+      <div className="ml-auto flex items-center gap-2">{right}</div>
+    </header>
+  );
+}
+
+/** A browser-like preview pane that renders demo HTML in an isolated iframe. */
+export function PreviewFrame({ url, html }: { url: string; html: string }) {
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border bg-card">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border bg-muted/40 px-3">
+        <span className="flex gap-1.5">
+          <span className="size-2.5 rounded-full bg-muted-foreground/25" />
+          <span className="size-2.5 rounded-full bg-muted-foreground/25" />
+          <span className="size-2.5 rounded-full bg-muted-foreground/25" />
+        </span>
+        <div className="ml-2 flex h-5 flex-1 items-center rounded-md bg-background px-2 text-[11px] text-muted-foreground">
+          {url}
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 bg-white">
+        {html ? (
+          <iframe
+            title={url}
+            srcDoc={html}
+            className="size-full border-0"
+            sandbox=""
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Loading preview…
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/demo/chrome.tsx
+++ b/apps/mesh/src/web/demo/chrome.tsx
@@ -48,10 +48,12 @@ export function PreviewFrame({ url, html }: { url: string; html: string }) {
       </div>
       <div className="min-h-0 flex-1 bg-white">
         {html ? (
+          // key on html → each preview change fades in (masks the srcDoc swap)
           <iframe
+            key={html}
             title={url}
             srcDoc={html}
-            className="size-full border-0"
+            className="size-full border-0 animate-in fade-in duration-700"
             sandbox=""
           />
         ) : (

--- a/apps/mesh/src/web/demo/demo-chat-stream.tsx
+++ b/apps/mesh/src/web/demo/demo-chat-stream.tsx
@@ -1,0 +1,55 @@
+/**
+ * Demo Mode — the chat seam.
+ *
+ * Supplies a scripted `ChatStreamContextValue` to the REAL chat renderers
+ * (`Chat.Messages` → `MessagePair` → `MessageAssistant` → tool-call parts) by
+ * providing the same context the live `ActiveTaskProvider` provides. The value
+ * is backed by a single track's `Store<DemoChatState>`, so as the Director
+ * mutates messages the real components re-render identically to a live stream —
+ * no live MCP transport, SSE, or backend involved.
+ *
+ * One provider per track ⇒ several can be mounted side-by-side for a parallel
+ * multi-agent layout.
+ */
+import { useSyncExternalStore, type PropsWithChildren } from "react";
+import {
+  DemoChatStreamContext,
+  type ChatStreamContextValue,
+} from "@/web/components/chat/chat-context";
+import type { Store } from "@/web/components/chat/store/store-primitive";
+import type { DemoChatState } from "./director-stores";
+
+const noop = () => {};
+const asyncNoop = async () => {};
+
+export function DemoChatStreamProvider({
+  store,
+  children,
+}: PropsWithChildren<{ store: Store<DemoChatState> }>) {
+  const state = useSyncExternalStore(store.subscribe, store.get, store.get);
+
+  const value: ChatStreamContextValue = {
+    messages: state.messages,
+    status: state.status,
+    sendMessage: asyncNoop,
+    stop: noop,
+    submit: asyncNoop,
+    error: null,
+    clearError: noop,
+    finishReason: null,
+    clearFinishReason: noop,
+    isStreaming: state.status === "streaming" || state.status === "submitted",
+    isChatEmpty: state.messages.length === 0,
+    isWaitingForApprovals: false,
+    isRunInProgress: false,
+    hasMoreOlder: false,
+    isFetchingOlder: false,
+    fetchOlderMessages: asyncNoop,
+  };
+
+  return (
+    <DemoChatStreamContext.Provider value={value}>
+      {children}
+    </DemoChatStreamContext.Provider>
+  );
+}

--- a/apps/mesh/src/web/demo/demo-providers.tsx
+++ b/apps/mesh/src/web/demo/demo-providers.tsx
@@ -15,6 +15,8 @@
 import { useState, type PropsWithChildren } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ProjectContextProvider } from "@decocms/mesh-sdk";
+// Side effect: register the demo's inline chat-part renderers (work plan / PR).
+import "./register-parts";
 
 export const DEMO_ORG = {
   id: "demo-org",

--- a/apps/mesh/src/web/demo/demo-providers.tsx
+++ b/apps/mesh/src/web/demo/demo-providers.tsx
@@ -1,0 +1,57 @@
+/**
+ * Demo Mode — provider shell.
+ *
+ * Mirrors the real provider stack just enough to mount Studio components in a
+ * fully-mocked, network-free context:
+ *  - `ProjectContextProvider` with a mock org/project (real `useOrg` /
+ *    `useProjectContext` / collection hooks resolve against it).
+ *  - A dedicated `QueryClient` with `staleTime: Infinity`, `retry: false`,
+ *    `refetchOnWindowFocus: false`, so any real hook that reads the cache gets
+ *    seeded fixtures and never hits the network.
+ *
+ * It deliberately omits the auth gate (`RequiredAuthLayout` / `OrgAccessGate`)
+ * — the demo is unauthenticated and public.
+ */
+import { useState, type PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ProjectContextProvider } from "@decocms/mesh-sdk";
+
+export const DEMO_ORG = {
+  id: "demo-org",
+  name: "Acme",
+  slug: "acme",
+  logo: null,
+} as const;
+
+export const DEMO_PROJECT = {
+  id: "demo-project",
+  slug: "default",
+  name: "Default",
+} as const;
+
+function createDemoQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: Infinity,
+        gcTime: Infinity,
+        retry: false,
+        refetchOnWindowFocus: false,
+        refetchOnMount: false,
+        refetchOnReconnect: false,
+      },
+    },
+  });
+}
+
+export function DemoProviders({ children }: PropsWithChildren) {
+  const [queryClient] = useState(createDemoQueryClient);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ProjectContextProvider org={DEMO_ORG} project={DEMO_PROJECT}>
+        {children}
+      </ProjectContextProvider>
+    </QueryClientProvider>
+  );
+}

--- a/apps/mesh/src/web/demo/director-stores.ts
+++ b/apps/mesh/src/web/demo/director-stores.ts
@@ -46,6 +46,10 @@ export interface DemoUiState {
   caption: string | null;
   /** which org/workspace the viewer is currently looking at (multi-org nav) */
   currentOrg: string | null;
+  /** the demo has finished a full play-through — show the end card */
+  ended: boolean;
+  /** bumped by the end card's "Replay" button to restart the scenario */
+  replayToken: number;
 }
 
 const DEFAULT_CHAT: DemoChatState = { messages: [], status: "ready" };
@@ -63,6 +67,8 @@ export class DemoStores {
     inputs: {},
     caption: null,
     currentOrg: null,
+    ended: false,
+    replayToken: 0,
   });
 
   private readonly chats = new Map<string, Store<DemoChatState>>();
@@ -82,12 +88,15 @@ export class DemoStores {
     for (const store of this.chats.values()) {
       store.set({ messages: [], status: "ready" });
     }
-    this.ui.set({
+    // Preserve replayToken (monotonic) so awaitReplay can detect the next bump.
+    this.ui.update((s) => ({
       openDialogs: [],
       inputs: {},
       caption: null,
       currentOrg: null,
-    });
+      ended: false,
+      replayToken: s.replayToken,
+    }));
     this.cursor.set({
       x: 0,
       y: 0,

--- a/apps/mesh/src/web/demo/director-stores.ts
+++ b/apps/mesh/src/web/demo/director-stores.ts
@@ -37,6 +37,32 @@ export interface CursorState {
   moveMs: number;
 }
 
+export type PlanTaskStatus = "queued" | "active" | "done";
+export interface PlanTask {
+  title: string;
+  detail?: string;
+  status: PlanTaskStatus;
+}
+export interface PlanState {
+  title: string;
+  tasks: PlanTask[];
+  /** false until the viewer approves; gates execution */
+  accepted: boolean;
+}
+export interface PRState {
+  number: number;
+  title: string;
+  branch: string;
+  files: number;
+  additions: number;
+  deletions: number;
+  checks: "running" | "passed";
+  merged: boolean;
+}
+export interface DigestState {
+  connected: "slack" | "teams" | null;
+}
+
 export interface DemoUiState {
   /** ids of dialogs the director has opened (real components read this) */
   openDialogs: readonly string[];
@@ -44,8 +70,10 @@ export interface DemoUiState {
   inputs: Readonly<Record<string, string>>;
   /** optional chapter caption shown over the stage */
   caption: string | null;
-  /** which org/workspace the viewer is currently looking at (multi-org nav) */
+  /** which agent/workspace the viewer is currently looking at (sidebar nav) */
   currentOrg: string | null;
+  /** agent ids with an unseen completion — drives the sidebar notification dot */
+  notified: readonly string[];
   /** the demo has finished a full play-through — show the end card */
   ended: boolean;
   /** bumped by the end card's "Replay" button to restart the scenario */
@@ -67,6 +95,7 @@ export class DemoStores {
     inputs: {},
     caption: null,
     currentOrg: null,
+    notified: [],
     ended: false,
     replayToken: 0,
   });
@@ -94,6 +123,7 @@ export class DemoStores {
       inputs: {},
       caption: null,
       currentOrg: null,
+      notified: [],
       ended: false,
       replayToken: s.replayToken,
     }));

--- a/apps/mesh/src/web/demo/director-stores.ts
+++ b/apps/mesh/src/web/demo/director-stores.ts
@@ -1,0 +1,103 @@
+/**
+ * Demo Mode — external stores (Director state lives OUTSIDE React).
+ *
+ * Reuses the same `Store<T>` primitive the chat uses
+ * (`components/chat/store/store-primitive.ts`) so React subscribes via
+ * `useSyncExternalStore` and we never need `useEffect` to drive animation
+ * (banned by `plugins/ban-use-effect.js`). The Director (a plain class) owns
+ * all timers and mutates these stores; components are pure subscribers.
+ *
+ * Multiple chat "tracks" are supported (one `Store<DemoChatState>` per track id)
+ * so a scenario can render several agent sessions running in parallel — each
+ * track feeds its own `<Chat.Messages>` via `DemoChatStreamProvider`.
+ *
+ * Every `set`/`update` MUST produce new top-level references — `Store.set`
+ * bails on `Object.is` equality, so in-place mutation would be silently dropped.
+ */
+import { Store } from "@/web/components/chat/store/store-primitive";
+import type { ChatMessage } from "@/web/components/chat/types";
+
+export type DemoChatStatus = "ready" | "submitted" | "streaming" | "error";
+
+/** The minimal slice the real chat renderers read via `useChatStream()`. */
+export interface DemoChatState {
+  messages: ChatMessage[];
+  status: DemoChatStatus;
+}
+
+export interface CursorState {
+  /** viewport coordinates (px) */
+  x: number;
+  y: number;
+  /** click pulse currently animating */
+  clicking: boolean;
+  /** cursor mounted/visible at all */
+  visible: boolean;
+  /** duration (ms) of the in-flight move — drives the CSS transition */
+  moveMs: number;
+}
+
+export interface DemoUiState {
+  /** ids of dialogs the director has opened (real components read this) */
+  openDialogs: readonly string[];
+  /** controlled text for demo inputs/terminals/previews, keyed by id */
+  inputs: Readonly<Record<string, string>>;
+  /** optional chapter caption shown over the stage */
+  caption: string | null;
+  /** which org/workspace the viewer is currently looking at (multi-org nav) */
+  currentOrg: string | null;
+}
+
+const DEFAULT_CHAT: DemoChatState = { messages: [], status: "ready" };
+
+export class DemoStores {
+  readonly cursor = new Store<CursorState>({
+    x: 0,
+    y: 0,
+    clicking: false,
+    visible: false,
+    moveMs: 600,
+  });
+  readonly ui = new Store<DemoUiState>({
+    openDialogs: [],
+    inputs: {},
+    caption: null,
+    currentOrg: null,
+  });
+
+  private readonly chats = new Map<string, Store<DemoChatState>>();
+
+  /** Lazily create (and cache) the chat store for a track id. */
+  getChat(trackId = "main"): Store<DemoChatState> {
+    let store = this.chats.get(trackId);
+    if (!store) {
+      store = new Store<DemoChatState>({ ...DEFAULT_CHAT });
+      this.chats.set(trackId, store);
+    }
+    return store;
+  }
+
+  /** Clear every track + ui/cursor so the autoplay loop can replay clean. */
+  resetAll(): void {
+    for (const store of this.chats.values()) {
+      store.set({ messages: [], status: "ready" });
+    }
+    this.ui.set({
+      openDialogs: [],
+      inputs: {},
+      caption: null,
+      currentOrg: null,
+    });
+    this.cursor.set({
+      x: 0,
+      y: 0,
+      clicking: false,
+      visible: false,
+      moveMs: 600,
+    });
+  }
+}
+
+export function createDemoStores(): DemoStores {
+  return new DemoStores();
+}

--- a/apps/mesh/src/web/demo/director.ts
+++ b/apps/mesh/src/web/demo/director.ts
@@ -170,9 +170,15 @@ export class Track {
     this.commit();
   }
 
-  /** Run several tool steps concurrently within this turn (fan-out). */
-  async parallel(steps: ToolStep[]): Promise<void> {
-    await Promise.all(steps.map((s) => this.tool(s)));
+  /** Run several tool steps concurrently within this turn (fan-out). `staggerMs`
+   *  delays each successive start so they don't all pop at once. */
+  async parallel(steps: ToolStep[], staggerMs = 0): Promise<void> {
+    await Promise.all(
+      steps.map(async (s, i) => {
+        if (staggerMs && i > 0) await this.wait(staggerMs * i);
+        await this.tool(s);
+      }),
+    );
   }
 
   /** Finalize the current assistant turn (status → ready). */
@@ -215,8 +221,8 @@ export class Director {
   tool(step: ToolStep) {
     return this.track().tool(step);
   }
-  parallel(steps: ToolStep[]) {
-    return this.track().parallel(steps);
+  parallel(steps: ToolStep[], staggerMs = 0) {
+    return this.track().parallel(steps, staggerMs);
   }
   endTurn() {
     this.track().endTurn();
@@ -229,9 +235,39 @@ export class Director {
     return sleep(ms, { signal: this.signal });
   }
 
+  /** Semantic pause between beats (reads better than bare `wait` in scripts). */
+  beat(ms = 900): Promise<void> {
+    return this.wait(ms);
+  }
+
   /** Set the chapter caption shown over the stage (null clears it). */
   caption(text: string | null): void {
     this.stores.ui.update((s) => ({ ...s, caption: text }));
+  }
+
+  // ---- ending / replay ----------------------------------------------------
+
+  /** Mark the demo finished — the stage shows the end card (replay / sign up). */
+  markEnded(): void {
+    this.stores.ui.update((s) => ({ ...s, ended: true, caption: null }));
+    this.stores.cursor.update((c) => ({ ...c, visible: false }));
+  }
+
+  /** Resolve when the viewer clicks "Replay" (bumps `replayToken`) or on abort. */
+  awaitReplay(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.signal.aborted) return resolve();
+      const start = this.stores.ui.get().replayToken;
+      const finish = () => {
+        unsub();
+        this.signal.removeEventListener("abort", finish);
+        resolve();
+      };
+      const unsub = this.stores.ui.subscribe(() => {
+        if (this.stores.ui.get().replayToken !== start) finish();
+      });
+      this.signal.addEventListener("abort", finish, { once: true });
+    });
   }
 
   /** Type text into a demo input/terminal char by char (drives `ui.inputs[id]`). */
@@ -269,15 +305,15 @@ export class Director {
 
   // ---- ghost cursor -------------------------------------------------------
 
-  /** Show the ghost cursor, optionally at a starting viewport point. */
+  /** Show the ghost cursor. Preserves its last position so re-showing glides
+   *  from where it was (not a reset point); falls back to bottom-center. */
   showCursor(x?: number, y?: number): void {
-    const cx =
-      x ?? (typeof window !== "undefined" ? window.innerWidth / 2 : 640);
-    const cy =
-      y ?? (typeof window !== "undefined" ? window.innerHeight - 120 : 600);
+    const cur = this.stores.cursor.get();
+    const fbX = typeof window !== "undefined" ? window.innerWidth / 2 : 640;
+    const fbY = typeof window !== "undefined" ? window.innerHeight - 120 : 600;
     this.stores.cursor.set({
-      x: cx,
-      y: cy,
+      x: x ?? cur.x ?? fbX,
+      y: y ?? cur.y ?? fbY,
       clicking: false,
       visible: true,
       moveMs: 0,

--- a/apps/mesh/src/web/demo/director.ts
+++ b/apps/mesh/src/web/demo/director.ts
@@ -1,0 +1,326 @@
+/**
+ * Demo Mode — the Director.
+ *
+ * A plain (non-React) class that owns ALL timing for a scripted demo. Screenplays
+ * are async functions that `await` the Director's primitives, so a demo reads
+ * top-to-bottom like a storyboard:
+ *
+ *   await d.user("Optimize my storefront");
+ *   await d.stream("On it — let me take a look.");
+ *   await d.tool(takeScreenshot({ url, image }));
+ *   await d.endTurn();
+ *
+ * Multiple agent sessions can run at once via tracks:
+ *
+ *   const a = d.track("acme"); const b = d.track("fin");
+ *   await Promise.all([arc(a), arc(b)]);  // two agents stream in parallel
+ *
+ * Because the Director lives outside React and mutates `Store`s that components
+ * subscribe to via `useSyncExternalStore`, no component needs `useEffect` to
+ * animate (banned by `plugins/ban-use-effect.js`). All waits go through
+ * `sleep(ms, { signal })` from `@decocms/std` (no hand-rolled timers) and honor
+ * an `AbortSignal`, so the autoplay loop can cancel/restart cleanly on unmount.
+ */
+import { sleep } from "@decocms/std";
+import type { Store } from "@/web/components/chat/store/store-primitive";
+import type { ChatMessage } from "@/web/components/chat/types";
+import {
+  emptyAssistant,
+  toolMetadataPart,
+  toolPartPending,
+  userMessage,
+  type ToolStep,
+} from "./message-builders";
+import type { DemoChatState, DemoStores } from "./director-stores";
+
+type Part = ChatMessage["parts"][number];
+/** Mutable typed handle for the part the typewriter is revealing into. */
+type RevealPart = { type: "text" | "reasoning"; text: string };
+
+/** Thrown when a primitive runs after the demo was aborted. The runner swallows it. */
+export class DemoAborted extends Error {}
+
+export interface StreamOptions {
+  /** characters per second for the typewriter reveal (default 55) */
+  cps?: number;
+  /** drop the text in fully at once (for large markdown blocks/tables that
+   *  look broken mid-parse) — still followed by a short settle beat */
+  instant?: boolean;
+}
+
+/**
+ * One agent conversation. Holds its own draft/active-message/status and writes
+ * to its own chat store. The real chat renderers read it via `useChatStream()`.
+ */
+export class Track {
+  private draft: ChatMessage[] = [];
+  private activeId: string | null = null;
+  private status: DemoChatState["status"] = "ready";
+
+  constructor(
+    private readonly store: Store<DemoChatState>,
+    private readonly signal: AbortSignal,
+  ) {}
+
+  wait(ms: number): Promise<void> {
+    return sleep(ms, { signal: this.signal });
+  }
+
+  private throwIfAborted() {
+    if (this.signal.aborted) throw new DemoAborted();
+  }
+
+  /** Snapshot the working draft with fresh references for the active message +
+   *  its parts (so memoized renderers re-render). Other messages keep identity. */
+  private commit() {
+    const messages = this.draft.map((m) =>
+      m.id === this.activeId
+        ? { ...m, parts: m.parts.map((p) => ({ ...p })) }
+        : m,
+    );
+    this.store.set({ messages, status: this.status });
+  }
+
+  private get active(): ChatMessage {
+    const msg = this.draft.find((m) => m.id === this.activeId);
+    if (!msg) throw new Error("Track: no active assistant message");
+    return msg;
+  }
+
+  private startAssistantTurn() {
+    const msg = emptyAssistant();
+    this.draft.push(msg);
+    this.activeId = msg.id;
+    this.status = "streaming";
+  }
+
+  private ensureAssistant() {
+    if (!this.activeId) this.startAssistantTurn();
+  }
+
+  /** Push a user message and a brief "submitted" beat. Closes any open turn. */
+  async user(text: string): Promise<void> {
+    this.activeId = null;
+    this.draft.push(userMessage(text));
+    this.status = "submitted";
+    this.commit();
+    await this.wait(450);
+  }
+
+  /** Append a text part to the current assistant turn and reveal it char by
+   *  char (typewriter). Opens an assistant turn if none is active. */
+  async stream(text: string, opts?: StreamOptions): Promise<void> {
+    this.ensureAssistant();
+    const part: RevealPart = { type: "text", text: "" };
+    this.active.parts.push(part as unknown as Part);
+    if (opts?.instant) {
+      part.text = text;
+      this.commit();
+      await this.wait(500);
+      return;
+    }
+    const cps = opts?.cps ?? 55;
+    const stepMs = Math.max(8, Math.round(1000 / cps));
+    for (let i = 1; i <= text.length; i++) {
+      this.throwIfAborted();
+      part.text = text.slice(0, i);
+      this.commit();
+      await this.wait(stepMs);
+    }
+  }
+
+  /** Append a reasoning ("thinking") block, revealed like `stream`. */
+  async think(text: string, opts?: StreamOptions): Promise<void> {
+    this.ensureAssistant();
+    const meta = this.active.metadata as
+      | { reasoning_start_at?: string }
+      | undefined;
+    if (meta && !meta.reasoning_start_at) {
+      meta.reasoning_start_at = new Date().toISOString();
+    }
+    const part: RevealPart = { type: "reasoning", text: "" };
+    this.active.parts.push(part as unknown as Part);
+    const cps = opts?.cps ?? 90;
+    const stepMs = Math.max(8, Math.round(1000 / cps));
+    for (let i = 1; i <= text.length; i++) {
+      this.throwIfAborted();
+      part.text = text.slice(0, i);
+      this.commit();
+      await this.wait(stepMs);
+    }
+    const m2 = this.active.metadata as
+      | { reasoning_end_at?: string }
+      | undefined;
+    if (m2) m2.reasoning_end_at = new Date().toISOString();
+    this.commit();
+  }
+
+  /** Run a tool call: show it loading, wait its latency, then resolve its
+   *  output and emit the latency metadata part. */
+  async tool(step: ToolStep): Promise<void> {
+    this.ensureAssistant();
+    const toolCallId = crypto.randomUUID();
+    const part = toolPartPending(step.name, toolCallId, step.input);
+    this.active.parts.push(part);
+    this.commit();
+    await this.wait(step.latencyMs);
+    this.throwIfAborted();
+    Object.assign(part, { state: "output-available", output: step.output });
+    this.active.parts.push(toolMetadataPart(toolCallId, step.latencyMs));
+    this.commit();
+  }
+
+  /** Run several tool steps concurrently within this turn (fan-out). */
+  async parallel(steps: ToolStep[]): Promise<void> {
+    await Promise.all(steps.map((s) => this.tool(s)));
+  }
+
+  /** Finalize the current assistant turn (status → ready). */
+  endTurn(): void {
+    this.status = "ready";
+    this.activeId = null;
+    this.commit();
+  }
+}
+
+export class Director {
+  private readonly tracks = new Map<string, Track>();
+
+  constructor(
+    private readonly stores: DemoStores,
+    private readonly signal: AbortSignal,
+  ) {}
+
+  /** Get (or create) the conversation track for `id`. */
+  track(id = "main"): Track {
+    let track = this.tracks.get(id);
+    if (!track) {
+      track = new Track(this.stores.getChat(id), this.signal);
+      this.tracks.set(id, track);
+    }
+    return track;
+  }
+
+  // ---- single-track convenience (proxy to the "main" track) ---------------
+
+  user(text: string) {
+    return this.track().user(text);
+  }
+  stream(text: string, opts?: StreamOptions) {
+    return this.track().stream(text, opts);
+  }
+  think(text: string, opts?: StreamOptions) {
+    return this.track().think(text, opts);
+  }
+  tool(step: ToolStep) {
+    return this.track().tool(step);
+  }
+  parallel(steps: ToolStep[]) {
+    return this.track().parallel(steps);
+  }
+  endTurn() {
+    this.track().endTurn();
+  }
+
+  // ---- timing / staging ---------------------------------------------------
+
+  /** Sleep `ms`, rejecting if the demo is aborted. */
+  wait(ms: number): Promise<void> {
+    return sleep(ms, { signal: this.signal });
+  }
+
+  /** Set the chapter caption shown over the stage (null clears it). */
+  caption(text: string | null): void {
+    this.stores.ui.update((s) => ({ ...s, caption: text }));
+  }
+
+  /** Type text into a demo input/terminal char by char (drives `ui.inputs[id]`). */
+  async type(
+    inputId: string,
+    text: string,
+    opts?: StreamOptions,
+  ): Promise<void> {
+    const cps = opts?.cps ?? 28;
+    const stepMs = Math.max(12, Math.round(1000 / cps));
+    for (let i = 1; i <= text.length; i++) {
+      if (this.signal.aborted) throw new DemoAborted();
+      const value = text.slice(0, i);
+      this.stores.ui.update((s) => ({
+        ...s,
+        inputs: { ...s.inputs, [inputId]: value },
+      }));
+      await this.wait(stepMs);
+    }
+  }
+
+  /** Set an input value instantly (no typing animation). */
+  setInput(inputId: string, value: string): void {
+    this.stores.ui.update((s) => ({
+      ...s,
+      inputs: { ...s.inputs, [inputId]: value },
+    }));
+  }
+
+  /** Switch which org/workspace the viewer is looking at. Background tracks keep
+   *  streaming, so returning to an org shows the work that ran while away. */
+  setOrg(orgId: string): void {
+    this.stores.ui.update((s) => ({ ...s, currentOrg: orgId }));
+  }
+
+  // ---- ghost cursor -------------------------------------------------------
+
+  /** Show the ghost cursor, optionally at a starting viewport point. */
+  showCursor(x?: number, y?: number): void {
+    const cx =
+      x ?? (typeof window !== "undefined" ? window.innerWidth / 2 : 640);
+    const cy =
+      y ?? (typeof window !== "undefined" ? window.innerHeight - 120 : 600);
+    this.stores.cursor.set({
+      x: cx,
+      y: cy,
+      clicking: false,
+      visible: true,
+      moveMs: 0,
+    });
+  }
+
+  hideCursor(): void {
+    this.stores.cursor.update((s) => ({ ...s, visible: false }));
+  }
+
+  /** Move the ghost cursor to a viewport point with an animated glide. */
+  async moveCursor(x: number, y: number, moveMs = 650): Promise<void> {
+    this.stores.cursor.set({ x, y, clicking: false, visible: true, moveMs });
+    await this.wait(moveMs + 60);
+  }
+
+  /** Move to a `[data-demo-target="id"]` element and play a click pulse. The
+   *  caller performs the resulting action (open modal, etc.) explicitly. */
+  async click(targetId: string): Promise<void> {
+    const el =
+      typeof document !== "undefined"
+        ? document.querySelector(`[data-demo-target="${targetId}"]`)
+        : null;
+    if (el) {
+      const r = el.getBoundingClientRect();
+      await this.moveCursor(r.left + r.width / 2, r.top + r.height / 2);
+    }
+    this.stores.cursor.update((s) => ({ ...s, clicking: true }));
+    await this.wait(180);
+    this.stores.cursor.update((s) => ({ ...s, clicking: false }));
+    await this.wait(140);
+  }
+
+  /** Set the preview HTML for an org's preview pane (rendered in an iframe). */
+  setPreview(orgId: string, html: string): void {
+    this.setInput(`preview:${orgId}`, html);
+  }
+
+  // ---- lifecycle ----------------------------------------------------------
+
+  /** Clear all scripted state so the autoplay loop can replay from scratch. */
+  reset(): void {
+    this.tracks.clear();
+    this.stores.resetAll();
+  }
+}

--- a/apps/mesh/src/web/demo/director.ts
+++ b/apps/mesh/src/web/demo/director.ts
@@ -25,13 +25,22 @@ import { sleep } from "@decocms/std";
 import type { Store } from "@/web/components/chat/store/store-primitive";
 import type { ChatMessage } from "@/web/components/chat/types";
 import {
+  dailyDigestPart,
   emptyAssistant,
+  pullRequestPart,
   toolMetadataPart,
   toolPartPending,
   userMessage,
+  workPlanPart,
   type ToolStep,
 } from "./message-builders";
-import type { DemoChatState, DemoStores } from "./director-stores";
+import type {
+  DemoChatState,
+  DemoStores,
+  DigestState,
+  PRState,
+  PlanState,
+} from "./director-stores";
 
 type Part = ChatMessage["parts"][number];
 /** Mutable typed handle for the part the typewriter is revealing into. */
@@ -56,6 +65,15 @@ export class Track {
   private draft: ChatMessage[] = [];
   private activeId: string | null = null;
   private status: DemoChatState["status"] = "ready";
+  /** message ids holding live inline cards (plan/PR) — always re-cloned on
+   *  commit so their updates render even after the turn ends. */
+  private readonly cardMsgIds = new Set<string>();
+  // Live handles to the card parts. We replace `.output` with a NEW object on
+  // every update (never mutate in place) so the card's prop identity changes
+  // and React (compiler-memoized) actually re-renders.
+  private planPart: { output: PlanState } | null = null;
+  private prPart: { output: PRState } | null = null;
+  private digestPart: { output: DigestState } | null = null;
 
   constructor(
     private readonly store: Store<DemoChatState>,
@@ -74,7 +92,7 @@ export class Track {
    *  its parts (so memoized renderers re-render). Other messages keep identity. */
   private commit() {
     const messages = this.draft.map((m) =>
-      m.id === this.activeId
+      m.id === this.activeId || this.cardMsgIds.has(m.id)
         ? { ...m, parts: m.parts.map((p) => ({ ...p })) }
         : m,
     );
@@ -179,6 +197,85 @@ export class Track {
         await this.tool(s);
       }),
     );
+  }
+
+  // ---- inline work-plan (sprint) + PR cards ------------------------------
+
+  /** Append an inline work-plan card to the current turn (tasks queued). */
+  showPlan(title: string, tasks: { title: string; detail?: string }[]): void {
+    this.ensureAssistant();
+    const output: PlanState = {
+      title,
+      accepted: false,
+      tasks: tasks.map((t) => ({ ...t, status: "queued" })),
+    };
+    const part = workPlanPart(output);
+    this.planPart = part as unknown as { output: PlanState };
+    this.active.parts.push(part);
+    this.cardMsgIds.add(this.active.id);
+    this.commit();
+  }
+
+  acceptPlan(): void {
+    if (!this.planPart) return;
+    this.planPart.output = { ...this.planPart.output, accepted: true };
+    this.commit();
+  }
+
+  setTask(index: number, status: "queued" | "active" | "done"): void {
+    if (!this.planPart) return;
+    const o = this.planPart.output;
+    this.planPart.output = {
+      ...o,
+      tasks: o.tasks.map((t, i) => (i === index ? { ...t, status } : t)),
+    };
+    this.commit();
+  }
+
+  /** Append an inline PR card (checks running). */
+  openPR(pr: {
+    number: number;
+    title: string;
+    branch: string;
+    files: number;
+    additions: number;
+    deletions: number;
+  }): void {
+    this.ensureAssistant();
+    const output: PRState = { ...pr, checks: "running", merged: false };
+    const part = pullRequestPart(output);
+    this.prPart = part as unknown as { output: PRState };
+    this.active.parts.push(part);
+    this.cardMsgIds.add(this.active.id);
+    this.commit();
+  }
+
+  passPRChecks(): void {
+    if (!this.prPart) return;
+    this.prPart.output = { ...this.prPart.output, checks: "passed" };
+    this.commit();
+  }
+
+  mergePR(): void {
+    if (!this.prPart) return;
+    this.prPart.output = { ...this.prPart.output, merged: true };
+    this.commit();
+  }
+
+  /** Append an inline "get this every day" digest CTA card. */
+  showDigest(): void {
+    this.ensureAssistant();
+    const part = dailyDigestPart({ connected: null } as DigestState);
+    this.digestPart = part as unknown as { output: DigestState };
+    this.active.parts.push(part);
+    this.cardMsgIds.add(this.active.id);
+    this.commit();
+  }
+
+  connectDigest(channel: "slack" | "teams"): void {
+    if (!this.digestPart) return;
+    this.digestPart.output = { connected: channel };
+    this.commit();
   }
 
   /** Finalize the current assistant turn (status → ready). */
@@ -297,10 +394,24 @@ export class Director {
     }));
   }
 
-  /** Switch which org/workspace the viewer is looking at. Background tracks keep
-   *  streaming, so returning to an org shows the work that ran while away. */
+  /** Switch which agent the viewer is looking at (clears its notification).
+   *  Background tracks keep streaming, so returning shows the work done while away. */
   setOrg(orgId: string): void {
-    this.stores.ui.update((s) => ({ ...s, currentOrg: orgId }));
+    this.stores.ui.update((s) => ({
+      ...s,
+      currentOrg: orgId,
+      notified: s.notified.filter((n) => n !== orgId),
+    }));
+  }
+
+  /** Flag an agent as finished-while-away — shows a sidebar notification dot.
+   *  No-op if the viewer is already looking at that agent. */
+  notify(agentId: string): void {
+    this.stores.ui.update((s) =>
+      s.currentOrg === agentId || s.notified.includes(agentId)
+        ? s
+        : { ...s, notified: [...s.notified, agentId] },
+    );
   }
 
   // ---- ghost cursor -------------------------------------------------------
@@ -350,6 +461,40 @@ export class Director {
   /** Set the preview HTML for an org's preview pane (rendered in an iframe). */
   setPreview(orgId: string, html: string): void {
     this.setInput(`preview:${orgId}`, html);
+  }
+
+  // ---- work plan / sprint + PR (inline cards, proxy to main track) --------
+
+  showPlan(title: string, tasks: { title: string; detail?: string }[]) {
+    return this.track().showPlan(title, tasks);
+  }
+  acceptPlan() {
+    this.track().acceptPlan();
+  }
+  setTask(index: number, status: "queued" | "active" | "done") {
+    this.track().setTask(index, status);
+  }
+  openPR(pr: {
+    number: number;
+    title: string;
+    branch: string;
+    files: number;
+    additions: number;
+    deletions: number;
+  }) {
+    this.track().openPR(pr);
+  }
+  passPRChecks() {
+    this.track().passPRChecks();
+  }
+  mergePR() {
+    this.track().mergePR();
+  }
+  showDigest() {
+    this.track().showDigest();
+  }
+  connectDigest(channel: "slack" | "teams") {
+    this.track().connectDigest(channel);
   }
 
   // ---- lifecycle ----------------------------------------------------------

--- a/apps/mesh/src/web/demo/end-card.tsx
+++ b/apps/mesh/src/web/demo/end-card.tsx
@@ -1,0 +1,65 @@
+/**
+ * Demo Mode — end card.
+ *
+ * Shown after a full play-through (instead of silently looping). Offers a
+ * replay or a sign-up CTA. Driven by `ui.ended`; "Replay" bumps `replayToken`
+ * which the runner's `awaitReplay()` is waiting on.
+ */
+import { useSyncExternalStore } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Button } from "@deco/ui/components/button.tsx";
+import { ArrowRight, RefreshCcw01 } from "@untitledui/icons";
+import type { DemoStores } from "./director-stores";
+
+export function EndCard({
+  stores,
+  title,
+  subtitle,
+}: {
+  stores: DemoStores;
+  title: string;
+  subtitle: string;
+}) {
+  const ended = useSyncExternalStore(
+    stores.ui.subscribe,
+    () => stores.ui.get().ended,
+    () => stores.ui.get().ended,
+  );
+  const navigate = useNavigate();
+  if (!ended) return null;
+
+  const replay = () =>
+    stores.ui.update((s) => ({
+      ...s,
+      ended: false,
+      replayToken: s.replayToken + 1,
+    }));
+
+  return (
+    <div className="absolute inset-0 z-[120] flex items-center justify-center bg-background/70 backdrop-blur-sm animate-in fade-in duration-500">
+      <div className="animate-in fade-in zoom-in-95 duration-500 w-full max-w-md rounded-2xl border border-border bg-card p-8 text-center shadow-2xl">
+        <h2 className="text-xl font-semibold text-foreground">{title}</h2>
+        <p className="mt-2 text-sm text-muted-foreground">{subtitle}</p>
+        <div className="mt-6 flex flex-col gap-2">
+          <Button
+            type="button"
+            onClick={() => navigate({ to: "/login" })}
+            className="w-full gap-2"
+          >
+            Get started free
+            <ArrowRight className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={replay}
+            className="w-full gap-2 text-muted-foreground"
+          >
+            <RefreshCcw01 className="size-4" />
+            Watch again
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/demo/ghost-cursor.tsx
+++ b/apps/mesh/src/web/demo/ghost-cursor.tsx
@@ -1,0 +1,57 @@
+/**
+ * Demo Mode — ghost cursor overlay.
+ *
+ * A simulated pointer that glides to targets and "clicks", giving the scripted
+ * demo a live-session feel. Driven entirely by the Director's `cursor` store
+ * (read via `useSyncExternalStore`); CSS transitions handle the motion, so no
+ * `useEffect`.
+ */
+import { useSyncExternalStore } from "react";
+import type { DemoStores } from "./director-stores";
+
+export function GhostCursor({ stores }: { stores: DemoStores }) {
+  const c = useSyncExternalStore(
+    stores.cursor.subscribe,
+    stores.cursor.get,
+    stores.cursor.get,
+  );
+  if (!c.visible) return null;
+  return (
+    <div
+      className="pointer-events-none fixed left-0 top-0 z-[100]"
+      style={{
+        transform: `translate(${c.x}px, ${c.y}px)`,
+        transition: `transform ${c.moveMs}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+      }}
+    >
+      {/* click ripple */}
+      <div
+        className="absolute -left-3 -top-3 size-6 rounded-full border-2 border-primary"
+        style={{
+          opacity: c.clicking ? 0.9 : 0,
+          transform: c.clicking ? "scale(1.6)" : "scale(0.4)",
+          transition: "transform 200ms ease-out, opacity 200ms ease-out",
+        }}
+      />
+      {/* pointer */}
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        className="drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]"
+        style={{
+          transform: c.clicking ? "scale(0.85)" : "scale(1)",
+          transition: "transform 120ms ease-out",
+        }}
+      >
+        <path
+          d="M5 3l14 7-6 1.6L9.5 18 5 3z"
+          fill="white"
+          stroke="black"
+          strokeWidth="1.4"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/demo/link-flow.tsx
+++ b/apps/mesh/src/web/demo/link-flow.tsx
@@ -1,0 +1,130 @@
+/**
+ * Demo Mode — desktop-link flow visuals (agents scenario).
+ *
+ * Faithful re-creation of `ConnectDesktopDialog` (same Dialog primitives + copy)
+ * plus a mocked iTerm window running `bunx decocms link`, driven by demo ui
+ * state instead of live link queries:
+ *   ui.inputs["link"]   = "" | "waiting" | "connected"
+ *   ui.inputs["iterm"]  = "" | "open" | "min"
+ *   ui.inputs["iterm:text"] = terminal contents (typed by the Director)
+ */
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Spinner } from "@deco/ui/components/spinner.tsx";
+import { Copy01 } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import type { DemoStores } from "./director-stores";
+import { useDemoInput } from "./use-demo-stores";
+
+export function DemoLinkDialog({ stores }: { stores: DemoStores }) {
+  const state = useDemoInput(stores, "link");
+  const online = state === "connected";
+  const open = state !== "";
+
+  return (
+    <Dialog open={open}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {online ? "Desktop connected" : "Connect your desktop"}
+          </DialogTitle>
+          <DialogDescription>
+            {online
+              ? "Your desktop is online. Pick a desktop agent in the chat to use it."
+              : "Run this command in your desktop terminal. The dialog will close once your desktop is online."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!online && (
+          <div className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-sm">
+            <span className="flex-1">bunx decocms link</span>
+            <Copy01 size={14} className="text-muted-foreground" />
+          </div>
+        )}
+
+        {!online ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Spinner size="sm" />
+            Waiting for desktop…
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1 text-sm">
+            <p className="text-foreground">MacBook Pro is linked.</p>
+            <p className="text-muted-foreground">
+              Available: Claude Code, Codex
+            </p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function ITermWindow({ stores }: { stores: DemoStores }) {
+  const state = useDemoInput(stores, "iterm");
+  const text = useDemoInput(stores, "iterm:text");
+  if (state !== "open" && state !== "min") return null;
+  const minimized = state === "min";
+  return (
+    <div
+      className="pointer-events-none fixed left-1/2 top-24 z-[90] w-[560px] max-w-[90vw] overflow-hidden rounded-xl shadow-2xl"
+      style={{
+        transformOrigin: "bottom center",
+        transform: minimized
+          ? "translate(-50%, 70vh) scale(0.35)"
+          : "translate(-50%, 0) scale(1)",
+        opacity: minimized ? 0 : 1,
+        transition:
+          "transform 600ms cubic-bezier(0.5, 0, 0.75, 0), opacity 600ms ease-in",
+      }}
+    >
+      {/* title bar */}
+      <div
+        className="flex items-center gap-2 px-3 py-2"
+        style={{ background: "#2b2b33" }}
+      >
+        <span className="flex gap-1.5">
+          <span
+            className="size-3 rounded-full"
+            style={{ background: "#ff5f57" }}
+          />
+          <span
+            className="size-3 rounded-full"
+            style={{ background: "#febc2e" }}
+          />
+          <span
+            className="size-3 rounded-full"
+            style={{ background: "#28c840" }}
+          />
+        </span>
+        <span
+          className="mx-auto font-mono text-xs"
+          style={{ color: "#b8b8c0" }}
+        >
+          claude-code — bunx decocms link — 80×24
+        </span>
+      </div>
+      {/* terminal body */}
+      <div
+        className="min-h-[220px] px-4 py-3 font-mono text-[13px] leading-relaxed"
+        style={{ background: "#16161e", color: "#d7d7e0" }}
+      >
+        <pre className="whitespace-pre-wrap">{text}</pre>
+        <span
+          className={cn("inline-block", !minimized && "animate-pulse")}
+          style={{
+            width: 8,
+            height: 16,
+            background: "#7dd3fc",
+            verticalAlign: "text-bottom",
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/demo/message-builders.ts
+++ b/apps/mesh/src/web/demo/message-builders.ts
@@ -1,0 +1,127 @@
+/**
+ * Demo Mode — builders for scripted chat content.
+ *
+ * These produce the exact `ChatMessage` / UIMessage part shapes the REAL chat
+ * renderers consume (`message/assistant.tsx`, `parts/tool-call-part/*`), so a
+ * scripted turn is pixel-identical to a live one. The Director owns timing and
+ * state transitions; these are pure data factories.
+ *
+ * Tool parts follow the AI-SDK v5 `ToolUIPart` shape:
+ *   { type: `tool-${name}`, toolCallId, state, input, output }
+ * with the matching `data-tool-metadata` part (keyed by the same id) carrying
+ * latency for the usage/latency chips.
+ */
+import type { ChatMessage } from "@/web/components/chat/types";
+
+type Part = ChatMessage["parts"][number];
+
+/**
+ * A declarative tool step. The Director assigns the `toolCallId`, drives the
+ * `input-available → output-available` transition, and emits the latency
+ * metadata part. Scripts just describe the call and its result.
+ */
+export interface ToolStep {
+  /** built-in tool name without the `tool-` prefix, e.g. "take_screenshot" */
+  name: string;
+  input: unknown;
+  output: unknown;
+  /** time spent in the loading state before the output lands (ms) */
+  latencyMs: number;
+}
+
+export function userMessage(text: string): ChatMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: "user",
+    parts: [{ type: "text", text }],
+    metadata: {
+      created_at: new Date().toISOString(),
+      user: { name: "You" },
+    },
+  } as ChatMessage;
+}
+
+export function emptyAssistant(): ChatMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: "assistant",
+    parts: [],
+    metadata: { created_at: new Date().toISOString() },
+  } as ChatMessage;
+}
+
+/** A tool part in its in-flight (loading) state. */
+export function toolPartPending(
+  name: string,
+  toolCallId: string,
+  input: unknown,
+): Part {
+  return {
+    type: `tool-${name}`,
+    toolCallId,
+    state: "input-available",
+    input,
+  } as unknown as Part;
+}
+
+/** The latency-carrying metadata part (id MUST equal the tool's toolCallId). */
+export function toolMetadataPart(toolCallId: string, latencyMs: number): Part {
+  return {
+    type: "data-tool-metadata",
+    id: toolCallId,
+    data: { latencyMs },
+  } as unknown as Part;
+}
+
+// ============================================================================
+// Tool step factories (one per renderer we drive)
+// ============================================================================
+
+/** `take_screenshot` — `image.uri` is used as-is when not a mesh-storage key,
+ *  so a `data:` URI or absolute/relative asset URL renders directly. */
+export function takeScreenshot(args: {
+  url: string;
+  image: string;
+  latencyMs?: number;
+}): ToolStep {
+  return {
+    name: "take_screenshot",
+    input: { url: args.url, fullPage: true },
+    output: {
+      success: true,
+      url: args.url,
+      image: { uri: args.image, mediaType: "image/png" },
+    },
+    latencyMs: args.latencyMs ?? 1600,
+  };
+}
+
+/** `propose_plan` — renders the "Implementation Plan" card (collapsible
+ *  markdown). `approved: true` shows the green Approved badge. */
+export function proposePlan(args: {
+  plan: string;
+  approved?: boolean;
+  latencyMs?: number;
+}): ToolStep {
+  return {
+    name: "propose_plan",
+    input: { plan: args.plan },
+    output: { approved: args.approved ?? true },
+    latencyMs: args.latencyMs ?? 800,
+  };
+}
+
+/** A generic tool call rendered by `GenericToolCallPart`. */
+export function genericTool(args: {
+  name: string;
+  input?: unknown;
+  output?: unknown;
+  latencyMs?: number;
+}): ToolStep {
+  return {
+    name: args.name,
+    input: args.input ?? {},
+    output: args.output ?? { success: true },
+    latencyMs: args.latencyMs ?? 1000,
+  };
+}

--- a/apps/mesh/src/web/demo/message-builders.ts
+++ b/apps/mesh/src/web/demo/message-builders.ts
@@ -64,6 +64,36 @@ export function toolPartPending(
   } as unknown as Part;
 }
 
+/** Inline work-plan (sprint) card part — rendered by the demo part registry. */
+export function workPlanPart(output: unknown): Part {
+  return {
+    type: "tool-work_plan",
+    toolCallId: crypto.randomUUID(),
+    state: "output-available",
+    output,
+  } as unknown as Part;
+}
+
+/** Inline pull-request card part — rendered by the demo part registry. */
+export function pullRequestPart(output: unknown): Part {
+  return {
+    type: "tool-pull_request",
+    toolCallId: crypto.randomUUID(),
+    state: "output-available",
+    output,
+  } as unknown as Part;
+}
+
+/** Inline "get this daily" digest card part — rendered by the demo registry. */
+export function dailyDigestPart(output: unknown): Part {
+  return {
+    type: "tool-daily_digest",
+    toolCallId: crypto.randomUUID(),
+    state: "output-available",
+    output,
+  } as unknown as Part;
+}
+
 /** The latency-carrying metadata part (id MUST equal the tool's toolCallId). */
 export function toolMetadataPart(toolCallId: string, latencyMs: number): Part {
   return {

--- a/apps/mesh/src/web/demo/register-parts.tsx
+++ b/apps/mesh/src/web/demo/register-parts.tsx
@@ -1,0 +1,20 @@
+/**
+ * Registers Demo Mode's inline chat-part renderers with the core chat renderer.
+ * Imported for its side effect by DemoProviders, so these only activate inside
+ * the demo (the registry is empty in the normal app).
+ */
+import { registerPartRenderer } from "@/web/components/chat/message/parts/extra-part-renderers";
+import { WorkPlanCard, PRCard, DailyDigestCard } from "./work-plan";
+import type { DigestState, PlanState, PRState } from "./director-stores";
+
+registerPartRenderer("tool-work_plan", (part) => (
+  <WorkPlanCard plan={part.output as PlanState} />
+));
+
+registerPartRenderer("tool-pull_request", (part) => (
+  <PRCard pr={part.output as PRState} />
+));
+
+registerPartRenderer("tool-daily_digest", (part) => (
+  <DailyDigestCard digest={part.output as DigestState} />
+));

--- a/apps/mesh/src/web/demo/runner.ts
+++ b/apps/mesh/src/web/demo/runner.ts
@@ -1,17 +1,12 @@
 /**
- * Demo Mode — autoplay loop.
+ * Demo Mode — play-once runner.
  *
- * Plays each scenario in turn, pauses, resets, and advances — forever, until
- * the `AbortSignal` fires (on unmount). `onEnter(index)` is called right before
- * a scenario runs so the stage can swap to that scenario's layout. All
- * primitives reject with the signal's reason when aborted; we swallow those so
- * unmount is silent.
+ * Plays the scenario once, then shows the end card and waits for the viewer to
+ * click "Replay" (no silent auto-loop). All primitives reject with the signal's
+ * reason on abort; we swallow those so a real unmount is silent.
  */
 import type { Director } from "./director";
 import type { Scenario } from "./types";
-
-/** Pause between the end of a scenario and the next one. */
-const HANDOFF_PAUSE_MS = 3500;
 
 export async function runAutoplay(
   director: Director,
@@ -19,21 +14,21 @@ export async function runAutoplay(
   signal: AbortSignal,
   onEnter: (index: number) => void,
 ): Promise<void> {
-  let index = 0;
+  const scenario = scenarios[0];
+  if (!scenario) return;
+
   while (!signal.aborted) {
-    const i = index % scenarios.length;
-    const scenario = scenarios[i]!;
     director.reset();
-    onEnter(i);
+    onEnter(0);
     try {
-      // Let the new layout mount before the first beat writes to its stores.
-      await director.wait(250);
+      // Let the layout mount before the first beat writes to its stores.
+      await director.wait(300);
       await scenario.run(director);
-      await director.wait(HANDOFF_PAUSE_MS);
     } catch {
-      // Aborted (real unmount) or a scripted error — stop cleanly on abort.
       if (signal.aborted) return;
     }
-    index++;
+    if (signal.aborted) return;
+    director.markEnded();
+    await director.awaitReplay();
   }
 }

--- a/apps/mesh/src/web/demo/runner.ts
+++ b/apps/mesh/src/web/demo/runner.ts
@@ -1,0 +1,39 @@
+/**
+ * Demo Mode — autoplay loop.
+ *
+ * Plays each scenario in turn, pauses, resets, and advances — forever, until
+ * the `AbortSignal` fires (on unmount). `onEnter(index)` is called right before
+ * a scenario runs so the stage can swap to that scenario's layout. All
+ * primitives reject with the signal's reason when aborted; we swallow those so
+ * unmount is silent.
+ */
+import type { Director } from "./director";
+import type { Scenario } from "./types";
+
+/** Pause between the end of a scenario and the next one. */
+const HANDOFF_PAUSE_MS = 3500;
+
+export async function runAutoplay(
+  director: Director,
+  scenarios: Scenario[],
+  signal: AbortSignal,
+  onEnter: (index: number) => void,
+): Promise<void> {
+  let index = 0;
+  while (!signal.aborted) {
+    const i = index % scenarios.length;
+    const scenario = scenarios[i]!;
+    director.reset();
+    onEnter(i);
+    try {
+      // Let the new layout mount before the first beat writes to its stores.
+      await director.wait(250);
+      await scenario.run(director);
+      await director.wait(HANDOFF_PAUSE_MS);
+    } catch {
+      // Aborted (real unmount) or a scripted error — stop cleanly on abort.
+      if (signal.aborted) return;
+    }
+    index++;
+  }
+}

--- a/apps/mesh/src/web/demo/scenarios/agents.tsx
+++ b/apps/mesh/src/web/demo/scenarios/agents.tsx
@@ -1,11 +1,12 @@
 /**
- * Scenario 2 — Studio as a web Conductor: drive work across orgs in parallel.
+ * Scenario 2 — Studio as a web Conductor: drive several agents in parallel.
  *
- * One workspace: chat on the left, a live PREVIEW on the right. The viewer
- * kicks off a storefront redesign in one org, switches to a second org to swap
- * an MCP, then returns to the first — where the redesign finished in the
- * background. Demonstrates: parallel requests, org switching, and seeing the
- * other work being done. Uses the REAL chat; the preview is an isolated iframe.
+ * A sidebar lists the workspace's agents (like the real Studio shell). The
+ * viewer kicks one agent off on a long task, switches to another agent via the
+ * sidebar to do more work, and the first agent keeps running in the background
+ * — when it finishes, a notification dot appears on its sidebar icon. Switching
+ * back shows the completed work. Chat (real) on the left, a live preview on the
+ * right (isolated iframe).
  */
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Chat } from "@/web/components/chat";
@@ -13,18 +14,37 @@ import { DemoChatStreamProvider } from "../demo-chat-stream";
 import { DemoTopBar, PreviewFrame } from "../chrome";
 import { DemoLinkDialog, ITermWindow } from "../link-flow";
 import { genericTool } from "../message-builders";
-import { useCurrentOrg, useDemoInput, useTrackBusy } from "../use-demo-stores";
+import {
+  useCurrentOrg,
+  useDemoInput,
+  useNotified,
+  useTrackBusy,
+} from "../use-demo-stores";
 import type { Director, Track } from "../director";
 import type { DemoStores } from "../director-stores";
 import type { Scenario } from "../types";
 
-const ORGS = [
-  { id: "acme", org: "Acme Store", agent: "Storefront Agent", url: "acme.com" },
+const AGENTS = [
+  {
+    id: "acme",
+    name: "Storefront Bot",
+    sub: "Acme Store",
+    url: "acme.com",
+    glyph: "A",
+  },
   {
     id: "north",
-    org: "Northwind",
-    agent: "Payments Agent",
+    name: "Payments Agent",
+    sub: "Northwind",
     url: "app.northwind.com/connections",
+    glyph: "N",
+  },
+  {
+    id: "support",
+    name: "Support Triage",
+    sub: "Helpdesk",
+    url: "helpdesk.app/inbox",
+    glyph: "H",
   },
 ] as const;
 
@@ -94,31 +114,89 @@ function connections(active: "stripe" | "adyen"): string {
 
 // ---- stage -----------------------------------------------------------------
 
-function OrgTab({
+type Agent = (typeof AGENTS)[number];
+
+function SidebarAgent({
   stores,
-  id,
-  label,
+  agent,
   active,
 }: {
   stores: DemoStores;
-  id: string;
-  label: string;
+  agent: Agent;
   active: boolean;
 }) {
-  const busy = useTrackBusy(stores, id);
+  const busy = useTrackBusy(stores, agent.id);
+  const notified = useNotified(stores, agent.id);
   return (
     <span
-      data-demo-target={`org:${id}`}
+      data-demo-target={`agent:${agent.id}`}
       className={cn(
-        "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors duration-300",
-        active ? "bg-muted text-foreground" : "text-muted-foreground",
+        "flex items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors duration-300",
+        active ? "bg-muted" : "hover:bg-muted/50",
       )}
     >
-      {label}
-      {busy && !active && (
-        <span className="size-1.5 animate-pulse rounded-full bg-primary" />
-      )}
+      <span className="relative shrink-0">
+        <span
+          className={cn(
+            "flex size-7 items-center justify-center rounded-md text-[12px] font-semibold",
+            active
+              ? "bg-foreground text-background"
+              : "bg-muted text-muted-foreground",
+          )}
+        >
+          {agent.glyph}
+        </span>
+        {notified && (
+          <span className="absolute -right-1 -top-1 size-2.5 rounded-full bg-primary ring-2 ring-background animate-in zoom-in duration-300" />
+        )}
+        {busy && !active && !notified && (
+          <span className="absolute -right-1 -top-1 size-2 animate-pulse rounded-full bg-primary/70 ring-2 ring-background" />
+        )}
+      </span>
+      <span className="flex min-w-0 flex-col leading-tight">
+        <span
+          className={cn(
+            "truncate text-[13px] font-medium",
+            active ? "text-foreground" : "text-muted-foreground",
+          )}
+        >
+          {agent.name}
+        </span>
+        <span className="truncate text-[11px] text-muted-foreground">
+          {agent.sub}
+        </span>
+      </span>
     </span>
+  );
+}
+
+function DemoSidebar({
+  stores,
+  current,
+}: {
+  stores: DemoStores;
+  current: string;
+}) {
+  return (
+    <nav className="flex w-60 shrink-0 flex-col gap-0.5 border-r border-border bg-card/40 p-2">
+      <div className="flex items-center gap-2 px-2 py-2">
+        <span className="flex size-6 items-center justify-center rounded-md bg-foreground text-[11px] font-bold text-background">
+          d
+        </span>
+        <span className="text-sm font-semibold text-foreground">deco</span>
+      </div>
+      <div className="px-2 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
+        Agents
+      </div>
+      {AGENTS.map((a) => (
+        <SidebarAgent
+          key={a.id}
+          stores={stores}
+          agent={a}
+          active={a.id === current}
+        />
+      ))}
+    </nav>
   );
 }
 
@@ -142,43 +220,33 @@ function LinkButton({ stores }: { stores: DemoStores }) {
 }
 
 function AgentsStage({ stores }: { stores: DemoStores }) {
-  const current = useCurrentOrg(stores) ?? ORGS[0].id;
-  const meta = ORGS.find((o) => o.id === current) ?? ORGS[0];
+  const current = useCurrentOrg(stores) ?? AGENTS[0].id;
+  const meta = AGENTS.find((a) => a.id === current) ?? AGENTS[0];
   const previewHtml = useDemoInput(stores, `preview:${current}`);
 
   return (
-    <div className="flex h-full flex-col">
-      <DemoTopBar
-        org={meta.org}
-        agent={meta.agent}
-        left={
-          <div className="ml-3 flex items-center gap-1 rounded-lg border border-border p-0.5">
-            {ORGS.map((o) => (
-              <OrgTab
-                key={o.id}
-                stores={stores}
-                id={o.id}
-                label={o.org}
-                active={o.id === current}
-              />
-            ))}
+    <div className="flex h-full">
+      <DemoSidebar stores={stores} current={current} />
+      <div className="flex min-h-0 flex-1 flex-col">
+        <DemoTopBar
+          org={meta.sub}
+          agent={meta.name}
+          right={<LinkButton stores={stores} />}
+        />
+        {/* key on agent → the workspace crossfades when switching agents */}
+        <div
+          key={current}
+          className="grid min-h-0 flex-1 grid-cols-2 gap-3 p-3 animate-in fade-in duration-500"
+        >
+          <div className="flex min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-card">
+            <DemoChatStreamProvider store={stores.getChat(current)}>
+              <Chat className="bg-card">
+                <Chat.Messages />
+              </Chat>
+            </DemoChatStreamProvider>
           </div>
-        }
-        right={<LinkButton stores={stores} />}
-      />
-      {/* key on org → the workspace crossfades when switching contexts */}
-      <div
-        key={current}
-        className="grid min-h-0 flex-1 grid-cols-2 gap-3 p-3 animate-in fade-in duration-500"
-      >
-        <div className="flex min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-card">
-          <DemoChatStreamProvider store={stores.getChat(current)}>
-            <Chat className="bg-card">
-              <Chat.Messages />
-            </Chat>
-          </DemoChatStreamProvider>
+          <PreviewFrame url={meta.url} html={previewHtml} />
         </div>
-        <PreviewFrame url={meta.url} html={previewHtml} />
       </div>
       <DemoLinkDialog stores={stores} />
       <ITermWindow stores={stores} />
@@ -241,11 +309,11 @@ async function connectDesktop(d: Director) {
   await d.beat(700);
 }
 
-/** Move the ghost cursor onto an org tab, click it, and switch the view. */
-async function switchOrg(d: Director, id: string) {
+/** Move the ghost cursor onto a sidebar agent, click it, and switch the view. */
+async function switchAgent(d: Director, id: string) {
   d.showCursor();
   await d.beat(450);
-  await d.click(`org:${id}`);
+  await d.click(`agent:${id}`);
   d.setOrg(id);
   await d.beat(550);
   d.hideCursor();
@@ -309,32 +377,37 @@ export const agentsScenario: Scenario = {
 
     await connectDesktop(d);
 
-    // 1) Kick off a storefront redesign in Acme — runs in the background.
-    d.caption("Start in Acme — ask the agent to redesign the storefront");
+    // 1) Kick off a storefront redesign on the first agent — runs in the
+    //    background. When it finishes it notifies (sidebar dot).
+    d.caption("Give Storefront Bot a task");
     await d.beat(900);
     await acme.user("Add a Summer Sale banner and make the product grid 4-up.");
     await d.beat(500);
-    const acmeDone = acmeRedesign(d, acme).catch(() => {});
-    await d.beat(4200); // watch Acme start working + the first preview change
+    const acmeDone = acmeRedesign(d, acme)
+      .then(() => d.notify("acme"))
+      .catch(() => {});
+    await d.beat(4200); // watch it start working + the first preview change
 
-    // 2) Jump to a second org while Acme keeps building (its tab pulses).
-    d.caption("Jump to another org — Acme keeps building in the background");
+    // 2) Switch to another agent via the sidebar — the first keeps running.
+    d.caption("Switch agents in the sidebar — work keeps running");
     await d.beat(800);
-    await switchOrg(d, "north");
+    await switchAgent(d, "north");
     d.setPreview("north", connections("stripe"));
     await d.beat(700);
     await north.user("Swap the payments MCP from Stripe to Adyen.");
     await d.beat(400);
     await northSwap(d, north);
-    await d.beat(1500); // read the Adyen result
+    await d.beat(1200);
 
-    // 3) Back to Acme — the redesign finished while we were away.
-    d.caption("Back to Acme — the redesign finished while you were away");
-    await d.beat(700);
-    await switchOrg(d, "acme");
+    // 3) The first agent finished while we were away — sidebar dot appears.
     await acmeDone;
-    await d.beat(1700);
-    d.caption("Parallel work across orgs — switch context, nothing waits");
+    d.caption("Storefront Bot finished — see the dot on its sidebar icon");
+    await d.beat(2800);
+
+    // 4) Switch back — the dot clears and the finished work is right there.
+    await switchAgent(d, "acme");
+    await d.beat(1900);
+    d.caption("Switch anytime — agents keep working and ping you when done");
     await d.beat(3200);
   },
 };

--- a/apps/mesh/src/web/demo/scenarios/agents.tsx
+++ b/apps/mesh/src/web/demo/scenarios/agents.tsx
@@ -108,8 +108,9 @@ function OrgTab({
   const busy = useTrackBusy(stores, id);
   return (
     <span
+      data-demo-target={`org:${id}`}
       className={cn(
-        "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+        "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors duration-300",
         active ? "bg-muted text-foreground" : "text-muted-foreground",
       )}
     >
@@ -165,9 +166,13 @@ function AgentsStage({ stores }: { stores: DemoStores }) {
         }
         right={<LinkButton stores={stores} />}
       />
-      <div className="grid min-h-0 flex-1 grid-cols-2 gap-3 p-3">
+      {/* key on org → the workspace crossfades when switching contexts */}
+      <div
+        key={current}
+        className="grid min-h-0 flex-1 grid-cols-2 gap-3 p-3 animate-in fade-in duration-500"
+      >
         <div className="flex min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-card">
-          <DemoChatStreamProvider key={current} store={stores.getChat(current)}>
+          <DemoChatStreamProvider store={stores.getChat(current)}>
             <Chat className="bg-card">
               <Chat.Messages />
             </Chat>
@@ -206,60 +211,83 @@ const ITERM_LINKED = `$ bunx decocms link
 /** Opening beat: click the topbar link button → modal → iTerm runs
  *  `bunx decocms link` → minimize → modal shows connected. */
 async function connectDesktop(d: Director) {
+  d.caption("Drive your local Claude Code from the web");
+  await d.beat(1300);
+
   d.showCursor();
-  d.caption("Link your machine — drive local Claude Code from the web");
-  await d.wait(600);
+  await d.beat(500);
   await d.click("link-button");
   d.setInput("link", "waiting"); // modal opens
-  await d.wait(900);
+  await d.beat(1100);
 
-  d.setInput("iterm", "open"); // iTerm window appears
+  // iTerm window appears and the dev runs the link command.
+  d.setInput("iterm", "open");
   d.setInput("iterm:text", "");
-  await d.type("iterm:text", "$ bunx decocms link", { cps: 22 });
-  await d.wait(500);
+  await d.beat(500);
+  await d.type("iterm:text", "$ bunx decocms link", { cps: 18 });
+  await d.beat(750);
   d.setInput("iterm:text", ITERM_AUTH);
-  await d.wait(850);
+  await d.beat(1300);
   d.setInput("iterm:text", ITERM_LINKED);
-  await d.wait(1100);
+  await d.beat(1700); // read the linked output
 
   d.setInput("iterm", "min"); // dev minimizes the terminal
   d.hideCursor();
-  await d.wait(800);
+  await d.beat(950);
   d.setInput("link", "connected"); // modal flips to connected
-  await d.wait(1700);
+  await d.beat(2300); // let "Desktop connected" land
   d.setInput("link", ""); // close modal
   d.setInput("iterm", ""); // unmount terminal
-  await d.wait(400);
+  await d.beat(700);
+}
+
+/** Move the ghost cursor onto an org tab, click it, and switch the view. */
+async function switchOrg(d: Director, id: string) {
+  d.showCursor();
+  await d.beat(450);
+  await d.click(`org:${id}`);
+  d.setOrg(id);
+  await d.beat(550);
+  d.hideCursor();
 }
 
 /** Acme storefront redesign — runs in the background while the viewer is away. */
 async function acmeRedesign(d: Director, t: Track) {
   await t.think(
     "I'll add a Summer Sale hero banner, then widen the product grid to 4-up.",
+    { cps: 80 },
   );
-  await t.stream("Adding the Summer Sale banner and refreshing the hero.");
+  await t.stream("Adding the Summer Sale banner and refreshing the hero.", {
+    cps: 44,
+  });
   await t.tool(codeTool("edit_section", "hero → banner + bold headline", 2400));
   d.setPreview("acme", storefront({ banner: true, cols: 3 }));
-  await t.stream("Now widening the product grid to four columns.");
+  await t.wait(1000); // let the preview change register
+  await t.stream("Now widening the product grid to four columns.", { cps: 44 });
   await t.tool(codeTool("update_layout", "product grid → 4 columns", 2200));
   d.setPreview("acme", storefront({ banner: true, cols: 4 }));
-  await t.tool(codeTool("build", "vite build · 0 errors", 2200));
-  await t.tool(codeTool("deploy", "acme.com · v43 live", 1700));
-  await t.stream("✅ Live on acme.com — new banner + 4-up grid.");
+  await t.wait(1000);
+  await t.tool(codeTool("build", "vite build · 0 errors", 2000));
+  await t.tool(codeTool("deploy", "acme.com · v43 live", 1800));
+  await t.stream("✅ Live on acme.com — new banner + 4-up grid.", { cps: 44 });
   t.endTurn();
 }
 
 /** Northwind MCP swap — done while Acme keeps building. */
 async function northSwap(d: Director, t: Track) {
   await t.think(
-    "Swap the payments MCP: disconnect Stripe, connect Adyen, re-run checkout tests.",
+    "I'll disconnect Stripe, connect Adyen, then re-run the checkout tests.",
+    { cps: 80 },
   );
-  await t.stream("Swapping the payments MCP from Stripe to Adyen.");
-  await t.tool(codeTool("disconnect_mcp", "Stripe · removed", 1600));
-  await t.tool(codeTool("connect_mcp", "Adyen · connected", 1900));
+  await t.stream("Swapping the payments MCP from Stripe to Adyen.", {
+    cps: 44,
+  });
+  await t.tool(codeTool("disconnect_mcp", "Stripe · removed", 1700));
+  await t.tool(codeTool("connect_mcp", "Adyen · connected", 2000));
   d.setPreview("north", connections("adyen"));
+  await t.wait(1000);
   await t.tool(codeTool("run_tests", "checkout smoke · 6 passed", 2200));
-  await t.stream("✅ Adyen is now live for checkout.");
+  await t.stream("✅ Adyen is now live for checkout.", { cps: 44 });
   t.endTurn();
 }
 
@@ -267,39 +295,46 @@ export const agentsScenario: Scenario = {
   id: "agents",
   title: "Drive agents across orgs in parallel",
   Stage: AgentsStage,
+  endCard: {
+    title: "Build & ship agents across your orgs",
+    subtitle: "Link your machine and drive agents anywhere — free to start.",
+  },
   run: async (d: Director) => {
     const acme = d.track("acme");
     const north = d.track("north");
 
     d.setOrg("acme");
     d.setPreview("acme", storefront({ banner: false, cols: 3 }));
+    await d.beat(500);
 
     await connectDesktop(d);
 
+    // 1) Kick off a storefront redesign in Acme — runs in the background.
     d.caption("Start in Acme — ask the agent to redesign the storefront");
-    await d.wait(500);
+    await d.beat(900);
     await acme.user("Add a Summer Sale banner and make the product grid 4-up.");
-
-    // Kick Acme off in the BACKGROUND — we don't await it yet. Swallow the
-    // abort rejection so an unmount mid-flight doesn't surface as unhandled.
+    await d.beat(500);
     const acmeDone = acmeRedesign(d, acme).catch(() => {});
-    await d.wait(3600);
+    await d.beat(4200); // watch Acme start working + the first preview change
 
-    // Switch orgs while Acme keeps working (its tab pulses).
-    d.setOrg("north");
+    // 2) Jump to a second org while Acme keeps building (its tab pulses).
+    d.caption("Jump to another org — Acme keeps building in the background");
+    await d.beat(800);
+    await switchOrg(d, "north");
     d.setPreview("north", connections("stripe"));
-    d.caption("Switch to Northwind — Acme keeps building in the background");
-    await d.wait(700);
+    await d.beat(700);
     await north.user("Swap the payments MCP from Stripe to Adyen.");
+    await d.beat(400);
     await northSwap(d, north);
-    await d.wait(900);
+    await d.beat(1500); // read the Adyen result
 
-    // Back to Acme — the redesign finished while we were away.
-    d.setOrg("acme");
-    d.caption("Back in Acme — the redesign finished while you were away");
+    // 3) Back to Acme — the redesign finished while we were away.
+    d.caption("Back to Acme — the redesign finished while you were away");
+    await d.beat(700);
+    await switchOrg(d, "acme");
     await acmeDone;
-    await d.wait(1200);
+    await d.beat(1700);
     d.caption("Parallel work across orgs — switch context, nothing waits");
-    await d.wait(2200);
+    await d.beat(3200);
   },
 };

--- a/apps/mesh/src/web/demo/scenarios/agents.tsx
+++ b/apps/mesh/src/web/demo/scenarios/agents.tsx
@@ -1,0 +1,305 @@
+/**
+ * Scenario 2 — Studio as a web Conductor: drive work across orgs in parallel.
+ *
+ * One workspace: chat on the left, a live PREVIEW on the right. The viewer
+ * kicks off a storefront redesign in one org, switches to a second org to swap
+ * an MCP, then returns to the first — where the redesign finished in the
+ * background. Demonstrates: parallel requests, org switching, and seeing the
+ * other work being done. Uses the REAL chat; the preview is an isolated iframe.
+ */
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Chat } from "@/web/components/chat";
+import { DemoChatStreamProvider } from "../demo-chat-stream";
+import { DemoTopBar, PreviewFrame } from "../chrome";
+import { DemoLinkDialog, ITermWindow } from "../link-flow";
+import { genericTool } from "../message-builders";
+import { useCurrentOrg, useDemoInput, useTrackBusy } from "../use-demo-stores";
+import type { Director, Track } from "../director";
+import type { DemoStores } from "../director-stores";
+import type { Scenario } from "../types";
+
+const ORGS = [
+  { id: "acme", org: "Acme Store", agent: "Storefront Agent", url: "acme.com" },
+  {
+    id: "north",
+    org: "Northwind",
+    agent: "Payments Agent",
+    url: "app.northwind.com/connections",
+  },
+] as const;
+
+// ---- preview HTML builders -------------------------------------------------
+
+const STYLE = `*{box-sizing:border-box;margin:0;font-family:Inter,system-ui,sans-serif}
+body{background:#fff;color:#0f172a}
+header{display:flex;align-items:center;justify-content:space-between;padding:14px 22px;border-bottom:1px solid #eef2f7}
+.logo{font-weight:800;letter-spacing:-.02em}
+nav a{margin-left:16px;color:#64748b;text-decoration:none;font-size:12px}
+.banner{background:#0f172a;color:#fff;text-align:center;padding:9px;font-size:12px;font-weight:600;letter-spacing:.01em}
+.hero{padding:46px 22px 30px;text-align:center}
+.hero h1{font-size:30px;letter-spacing:-.02em;margin-bottom:10px}
+.hero p{color:#64748b;font-size:14px}
+.cta{display:inline-block;margin-top:16px;background:#16a34a;color:#fff;padding:9px 18px;border-radius:8px;font-size:13px;font-weight:600}
+.grid{display:grid;gap:12px;padding:18px 22px}
+.card{border:1px solid #eef2f7;border-radius:10px;height:96px;background:linear-gradient(135deg,#f8fafc,#eef2f7)}
+.conn{display:flex;align-items:center;gap:12px;border:1px solid #eef2f7;border-radius:10px;padding:13px 14px;margin:10px 22px}
+.dot{width:26px;height:26px;border-radius:7px;background:#eef2f7;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700}
+.cname{font-size:13px;font-weight:600}
+.csub{font-size:11px;color:#94a3b8}
+.badge{margin-left:auto;font-size:11px;padding:3px 9px;border-radius:999px;font-weight:600}
+.on{background:#dcfce7;color:#166534}
+.off{background:#f1f5f9;color:#94a3b8}
+h2{font-size:14px;padding:18px 22px 4px;color:#0f172a}`;
+
+function page(body: string): string {
+  return `<!doctype html><html><head><meta charset="utf8"><style>${STYLE}</style></head><body>${body}</body></html>`;
+}
+
+function storefront({
+  banner,
+  cols,
+}: {
+  banner: boolean;
+  cols: number;
+}): string {
+  const cards = Array.from(
+    { length: cols * 2 },
+    () => `<div class="card"></div>`,
+  ).join("");
+  return page(`
+    ${banner ? `<div class="banner">☀️ Summer Sale — up to 40% off everything</div>` : ""}
+    <header><span class="logo">ACME</span><nav><a>Shop</a><a>New</a><a>Sale</a><a>Cart</a></nav></header>
+    <div class="hero">
+      <h1>Gear that keeps up.</h1>
+      <p>Free shipping over $50 — built for everyday adventures.</p>
+      <span class="cta">Shop the sale</span>
+    </div>
+    <div class="grid" style="grid-template-columns:repeat(${cols},1fr)">${cards}</div>
+  `);
+}
+
+function connections(active: "stripe" | "adyen"): string {
+  const row = (key: string, name: string, sub: string, glyph: string) =>
+    `<div class="conn"><div class="dot">${glyph}</div><div><div class="cname">${name}</div><div class="csub">${sub}</div></div><span class="badge ${active === key ? "on" : "off"}">${active === key ? "Active" : "Available"}</span></div>`;
+  return page(`
+    <header><span class="logo">Northwind · Connections</span></header>
+    <h2>Payments</h2>
+    ${row("stripe", "Stripe", "Cards · wallets", "S")}
+    ${row("adyen", "Adyen", "Cards · wallets · local methods", "A")}
+    <h2>Other</h2>
+    ${row("shopify", "Shopify", "Catalog sync", "🛍")}
+    ${row("slack", "Slack", "Order alerts", "#")}
+  `);
+}
+
+// ---- stage -----------------------------------------------------------------
+
+function OrgTab({
+  stores,
+  id,
+  label,
+  active,
+}: {
+  stores: DemoStores;
+  id: string;
+  label: string;
+  active: boolean;
+}) {
+  const busy = useTrackBusy(stores, id);
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+        active ? "bg-muted text-foreground" : "text-muted-foreground",
+      )}
+    >
+      {label}
+      {busy && !active && (
+        <span className="size-1.5 animate-pulse rounded-full bg-primary" />
+      )}
+    </span>
+  );
+}
+
+function LinkButton({ stores }: { stores: DemoStores }) {
+  const linked = useDemoInput(stores, "link") === "connected";
+  return (
+    <button
+      type="button"
+      data-demo-target="link-button"
+      className="flex items-center gap-1.5 rounded-full border border-border px-2.5 py-1 text-xs text-muted-foreground"
+    >
+      <span
+        className={cn(
+          "size-1.5 rounded-full",
+          linked ? "bg-primary" : "bg-muted-foreground/40",
+        )}
+      />
+      {linked ? "Claude Code · MacBook Pro" : "Connect desktop"}
+    </button>
+  );
+}
+
+function AgentsStage({ stores }: { stores: DemoStores }) {
+  const current = useCurrentOrg(stores) ?? ORGS[0].id;
+  const meta = ORGS.find((o) => o.id === current) ?? ORGS[0];
+  const previewHtml = useDemoInput(stores, `preview:${current}`);
+
+  return (
+    <div className="flex h-full flex-col">
+      <DemoTopBar
+        org={meta.org}
+        agent={meta.agent}
+        left={
+          <div className="ml-3 flex items-center gap-1 rounded-lg border border-border p-0.5">
+            {ORGS.map((o) => (
+              <OrgTab
+                key={o.id}
+                stores={stores}
+                id={o.id}
+                label={o.org}
+                active={o.id === current}
+              />
+            ))}
+          </div>
+        }
+        right={<LinkButton stores={stores} />}
+      />
+      <div className="grid min-h-0 flex-1 grid-cols-2 gap-3 p-3">
+        <div className="flex min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-card">
+          <DemoChatStreamProvider key={current} store={stores.getChat(current)}>
+            <Chat className="bg-card">
+              <Chat.Messages />
+            </Chat>
+          </DemoChatStreamProvider>
+        </div>
+        <PreviewFrame url={meta.url} html={previewHtml} />
+      </div>
+      <DemoLinkDialog stores={stores} />
+      <ITermWindow stores={stores} />
+    </div>
+  );
+}
+
+// ---- screenplay ------------------------------------------------------------
+
+function codeTool(name: string, result: string, latencyMs: number) {
+  return genericTool({ name, output: { result }, latencyMs });
+}
+
+const ITERM_AUTH = `$ bunx decocms link
+
+  ↗ Opening browser to authorize…
+  ✓ Authorized as dev@acme.com
+`;
+
+const ITERM_LINKED = `$ bunx decocms link
+
+  ↗ Opening browser to authorize…
+  ✓ Authorized as dev@acme.com
+  ✓ Linked to "MacBook Pro"
+    • claude-code 2.1    • codex 0.9
+
+  Listening for tasks…  (⌃C to quit)
+`;
+
+/** Opening beat: click the topbar link button → modal → iTerm runs
+ *  `bunx decocms link` → minimize → modal shows connected. */
+async function connectDesktop(d: Director) {
+  d.showCursor();
+  d.caption("Link your machine — drive local Claude Code from the web");
+  await d.wait(600);
+  await d.click("link-button");
+  d.setInput("link", "waiting"); // modal opens
+  await d.wait(900);
+
+  d.setInput("iterm", "open"); // iTerm window appears
+  d.setInput("iterm:text", "");
+  await d.type("iterm:text", "$ bunx decocms link", { cps: 22 });
+  await d.wait(500);
+  d.setInput("iterm:text", ITERM_AUTH);
+  await d.wait(850);
+  d.setInput("iterm:text", ITERM_LINKED);
+  await d.wait(1100);
+
+  d.setInput("iterm", "min"); // dev minimizes the terminal
+  d.hideCursor();
+  await d.wait(800);
+  d.setInput("link", "connected"); // modal flips to connected
+  await d.wait(1700);
+  d.setInput("link", ""); // close modal
+  d.setInput("iterm", ""); // unmount terminal
+  await d.wait(400);
+}
+
+/** Acme storefront redesign — runs in the background while the viewer is away. */
+async function acmeRedesign(d: Director, t: Track) {
+  await t.think(
+    "I'll add a Summer Sale hero banner, then widen the product grid to 4-up.",
+  );
+  await t.stream("Adding the Summer Sale banner and refreshing the hero.");
+  await t.tool(codeTool("edit_section", "hero → banner + bold headline", 2400));
+  d.setPreview("acme", storefront({ banner: true, cols: 3 }));
+  await t.stream("Now widening the product grid to four columns.");
+  await t.tool(codeTool("update_layout", "product grid → 4 columns", 2200));
+  d.setPreview("acme", storefront({ banner: true, cols: 4 }));
+  await t.tool(codeTool("build", "vite build · 0 errors", 2200));
+  await t.tool(codeTool("deploy", "acme.com · v43 live", 1700));
+  await t.stream("✅ Live on acme.com — new banner + 4-up grid.");
+  t.endTurn();
+}
+
+/** Northwind MCP swap — done while Acme keeps building. */
+async function northSwap(d: Director, t: Track) {
+  await t.think(
+    "Swap the payments MCP: disconnect Stripe, connect Adyen, re-run checkout tests.",
+  );
+  await t.stream("Swapping the payments MCP from Stripe to Adyen.");
+  await t.tool(codeTool("disconnect_mcp", "Stripe · removed", 1600));
+  await t.tool(codeTool("connect_mcp", "Adyen · connected", 1900));
+  d.setPreview("north", connections("adyen"));
+  await t.tool(codeTool("run_tests", "checkout smoke · 6 passed", 2200));
+  await t.stream("✅ Adyen is now live for checkout.");
+  t.endTurn();
+}
+
+export const agentsScenario: Scenario = {
+  id: "agents",
+  title: "Drive agents across orgs in parallel",
+  Stage: AgentsStage,
+  run: async (d: Director) => {
+    const acme = d.track("acme");
+    const north = d.track("north");
+
+    d.setOrg("acme");
+    d.setPreview("acme", storefront({ banner: false, cols: 3 }));
+
+    await connectDesktop(d);
+
+    d.caption("Start in Acme — ask the agent to redesign the storefront");
+    await d.wait(500);
+    await acme.user("Add a Summer Sale banner and make the product grid 4-up.");
+
+    // Kick Acme off in the BACKGROUND — we don't await it yet. Swallow the
+    // abort rejection so an unmount mid-flight doesn't surface as unhandled.
+    const acmeDone = acmeRedesign(d, acme).catch(() => {});
+    await d.wait(3600);
+
+    // Switch orgs while Acme keeps working (its tab pulses).
+    d.setOrg("north");
+    d.setPreview("north", connections("stripe"));
+    d.caption("Switch to Northwind — Acme keeps building in the background");
+    await d.wait(700);
+    await north.user("Swap the payments MCP from Stripe to Adyen.");
+    await northSwap(d, north);
+    await d.wait(900);
+
+    // Back to Acme — the redesign finished while we were away.
+    d.setOrg("acme");
+    d.caption("Back in Acme — the redesign finished while you were away");
+    await acmeDone;
+    await d.wait(1200);
+    d.caption("Parallel work across orgs — switch context, nothing waits");
+    await d.wait(2200);
+  },
+};

--- a/apps/mesh/src/web/demo/scenarios/index.ts
+++ b/apps/mesh/src/web/demo/scenarios/index.ts
@@ -1,0 +1,10 @@
+/** Demo scenario registry — each gets its own URL (`/demo/<id>`). */
+import { storefrontScenario } from "./storefront";
+import { agentsScenario } from "./agents";
+import type { Scenario } from "../types";
+
+export const SCENARIOS: Scenario[] = [storefrontScenario, agentsScenario];
+
+export const SCENARIO_BY_ID: Record<string, Scenario> = Object.fromEntries(
+  SCENARIOS.map((s) => [s.id, s]),
+);

--- a/apps/mesh/src/web/demo/scenarios/storefront.tsx
+++ b/apps/mesh/src/web/demo/scenarios/storefront.tsx
@@ -1,0 +1,162 @@
+/**
+ * Scenario 1 — Business user: drop in your site, get an accurate diagnosis.
+ *
+ * A store owner pastes their URL; the agent captures the live page, runs a
+ * performance + SEO audit, presents a real scorecard with the highest-impact
+ * issues, proposes a fix plan, applies the fixes in parallel, and re-audits +
+ * deploys. All rendered with the REAL chat components.
+ */
+import { DemoTopBar } from "../chrome";
+import { Chat } from "@/web/components/chat";
+import { DemoChatStreamProvider } from "../demo-chat-stream";
+import type { DemoStores } from "../director-stores";
+import type { Scenario } from "../types";
+import { genericTool, proposePlan, takeScreenshot } from "../message-builders";
+
+const SHOT =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='640' height='380'>
+       <rect width='640' height='380' fill='#0b0b0f'/>
+       <rect width='640' height='52' fill='#16161d'/>
+       <circle cx='26' cy='26' r='5' fill='#ff5f57'/>
+       <circle cx='44' cy='26' r='5' fill='#febc2e'/>
+       <circle cx='62' cy='26' r='5' fill='#28c840'/>
+       <rect x='120' y='17' width='400' height='18' rx='9' fill='#26262e'/>
+       <rect x='40' y='92' width='240' height='150' rx='10' fill='#1d1d27'/>
+       <rect x='300' y='92' width='300' height='26' rx='6' fill='#23232d'/>
+       <rect x='300' y='132' width='240' height='14' rx='5' fill='#1b1b24'/>
+       <rect x='300' y='156' width='260' height='14' rx='5' fill='#1b1b24'/>
+       <rect x='300' y='196' width='120' height='34' rx='8' fill='#2f7d5b'/>
+       <rect x='40' y='270' width='560' height='70' rx='10' fill='#15151d'/>
+       <text x='320' y='362' fill='#5b6472' font-family='sans-serif' font-size='13' text-anchor='middle'>acme.com — home</text>
+     </svg>`,
+  );
+
+function StorefrontStage({ stores }: { stores: DemoStores }) {
+  return (
+    <div className="flex h-full flex-col">
+      <DemoTopBar org="Acme" agent="Storefront Optimizer" />
+      <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col">
+        <DemoChatStreamProvider store={stores.getChat("main")}>
+          <Chat>
+            <Chat.Messages />
+          </Chat>
+        </DemoChatStreamProvider>
+      </div>
+    </div>
+  );
+}
+
+const DIAGNOSIS = `### Audit results for acme.com
+
+| Metric | Score | Status |
+| --- | --- | --- |
+| Performance | **38 / 100** | 🔴 Poor |
+| Largest Contentful Paint | **4.2 s** | 🔴 Poor |
+| Cumulative Layout Shift | **0.27** | 🔴 Poor |
+| Interaction to Next Paint | **380 ms** | 🟠 Needs work |
+| SEO | **64 / 100** | 🟠 Needs work |
+
+**The four things costing you the most:**
+
+1. **2.4 MB of unoptimized images** — the hero alone is a 1.1 MB PNG served full-size.
+2. **Render-blocking CSS** — 3 stylesheets (180 KB) block first paint.
+3. **No structured data** — missing Product & Organization JSON-LD, so you're invisible to rich results.
+4. **Layout shift** from unsized images and late-loading web fonts.`;
+
+const PLAN = `**Performance**
+- Convert & compress images to WebP, resize the hero to its display size
+- Inline critical CSS, defer the rest
+- Reserve space for media + preload the primary font
+
+**SEO**
+- Add Product, Offer, and Organization JSON-LD
+- Generate descriptive alt text for product imagery
+
+**Safety**
+- Apply on a preview branch, verify Lighthouse ≥ 90, then promote to production`;
+
+const RESULT = `### Re-audit — deployed to production ✅
+
+| Metric | Before | After |
+| --- | --- | --- |
+| Performance | 38 | **96** |
+| Largest Contentful Paint | 4.2 s | **1.3 s** |
+| Cumulative Layout Shift | 0.27 | **0.02** |
+| Interaction to Next Paint | 380 ms | **140 ms** |
+| SEO | 64 | **98** |
+
+Live at **acme.com** — the homepage is **3.2× faster** and now eligible for product rich results. I'll keep watching and re-optimize automatically when new pages ship. 🚀`;
+
+export const storefrontScenario: Scenario = {
+  id: "storefront",
+  title: "Drop in your site, get a diagnosis",
+  Stage: StorefrontStage,
+  run: async (d) => {
+    d.caption("A store owner drops in their URL → an accurate diagnosis");
+    await d.wait(500);
+
+    await d.user(
+      "Here's my store: https://acme.com — can you make it faster and rank better?",
+    );
+    await d.think(
+      "I'll capture the live homepage, run a performance + SEO audit, then rank the issues by impact before touching anything.",
+    );
+    await d.stream("On it. Loading acme.com and running a full audit.");
+    await d.tool(takeScreenshot({ url: "https://acme.com", image: SHOT }));
+    await d.tool(
+      genericTool({
+        name: "lighthouse_audit",
+        input: { url: "https://acme.com", categories: ["performance", "seo"] },
+        output: { result: "Performance 38 · SEO 64 · 11 opportunities found" },
+        latencyMs: 2000,
+      }),
+    );
+
+    d.caption("Accurate diagnosis — measured, not guessed");
+    await d.stream(DIAGNOSIS, { instant: true });
+    await d.wait(1400);
+
+    await d.stream("Here's the plan I'd apply:");
+    await d.tool(proposePlan({ plan: PLAN, approved: true }));
+    await d.stream("Approved — applying every fix on a preview branch.");
+
+    d.caption("Fixing the highest-impact issues in parallel");
+    await d.parallel([
+      genericTool({
+        name: "optimize_images",
+        output: { result: "14 images → WebP · 2.4 MB → 380 KB" },
+        latencyMs: 2600,
+      }),
+      genericTool({
+        name: "inline_critical_css",
+        output: { result: "Critical CSS inlined · 3 stylesheets deferred" },
+        latencyMs: 2100,
+      }),
+      genericTool({
+        name: "add_structured_data",
+        output: { result: "Product + Organization JSON-LD added to 24 pages" },
+        latencyMs: 1700,
+      }),
+      genericTool({
+        name: "fix_layout_shift",
+        output: { result: "Media sized + font preloaded · CLS 0.27 → 0.02" },
+        latencyMs: 1400,
+      }),
+    ]);
+
+    await d.tool(
+      genericTool({
+        name: "deploy_to_production",
+        output: { result: "Promoted preview → production · acme.com" },
+        latencyMs: 1800,
+      }),
+    );
+
+    d.caption("Re-audited and deployed");
+    await d.stream(RESULT, { instant: true });
+    await d.endTurn();
+    await d.wait(1500);
+  },
+};

--- a/apps/mesh/src/web/demo/scenarios/storefront.tsx
+++ b/apps/mesh/src/web/demo/scenarios/storefront.tsx
@@ -93,70 +93,103 @@ export const storefrontScenario: Scenario = {
   id: "storefront",
   title: "Drop in your site, get a diagnosis",
   Stage: StorefrontStage,
+  endCard: {
+    title: "Optimize your storefront, automatically",
+    subtitle:
+      "Connect your site and let agents ship the fixes — free to start.",
+  },
   run: async (d) => {
-    d.caption("A store owner drops in their URL → an accurate diagnosis");
-    await d.wait(500);
+    // 1) Setup — let the layout settle, then frame the story.
+    await d.beat(700);
+    d.caption("A store owner pastes their URL");
+    await d.beat(1400);
 
+    // 2) The ask.
     await d.user(
       "Here's my store: https://acme.com — can you make it faster and rank better?",
     );
+    await d.beat(700);
     await d.think(
-      "I'll capture the live homepage, run a performance + SEO audit, then rank the issues by impact before touching anything.",
+      "I'll capture the live homepage, run a performance + SEO audit, then rank every issue by impact before touching anything.",
+      { cps: 80 },
     );
-    await d.stream("On it. Loading acme.com and running a full audit.");
-    await d.tool(takeScreenshot({ url: "https://acme.com", image: SHOT }));
+    await d.stream("On it — capturing your homepage now.", { cps: 44 });
+
+    // 3) Look at the real page.
+    await d.tool(
+      takeScreenshot({ url: "https://acme.com", image: SHOT, latencyMs: 1900 }),
+    );
+    await d.beat(1200);
+
+    // 4) Audit → diagnosis (hold long enough to read).
+    d.caption("Running a full performance + SEO audit");
+    await d.beat(900);
     await d.tool(
       genericTool({
         name: "lighthouse_audit",
         input: { url: "https://acme.com", categories: ["performance", "seo"] },
         output: { result: "Performance 38 · SEO 64 · 11 opportunities found" },
-        latencyMs: 2000,
+        latencyMs: 2200,
       }),
     );
-
-    d.caption("Accurate diagnosis — measured, not guessed");
+    await d.stream("Here's what I found — measured, not guessed:", { cps: 44 });
+    d.caption("An accurate diagnosis");
     await d.stream(DIAGNOSIS, { instant: true });
-    await d.wait(1400);
+    await d.beat(4800);
 
-    await d.stream("Here's the plan I'd apply:");
+    // 5) The plan.
+    d.caption("A plan, ranked by impact");
+    await d.beat(800);
+    await d.stream("Here's the plan I'd apply:", { cps: 44 });
     await d.tool(proposePlan({ plan: PLAN, approved: true }));
-    await d.stream("Approved — applying every fix on a preview branch.");
+    await d.beat(900);
+    await d.stream("Approved — applying every fix on a preview branch.", {
+      cps: 44,
+    });
 
+    // 6) Fixes cascade in parallel.
     d.caption("Fixing the highest-impact issues in parallel");
-    await d.parallel([
-      genericTool({
-        name: "optimize_images",
-        output: { result: "14 images → WebP · 2.4 MB → 380 KB" },
-        latencyMs: 2600,
-      }),
-      genericTool({
-        name: "inline_critical_css",
-        output: { result: "Critical CSS inlined · 3 stylesheets deferred" },
-        latencyMs: 2100,
-      }),
-      genericTool({
-        name: "add_structured_data",
-        output: { result: "Product + Organization JSON-LD added to 24 pages" },
-        latencyMs: 1700,
-      }),
-      genericTool({
-        name: "fix_layout_shift",
-        output: { result: "Media sized + font preloaded · CLS 0.27 → 0.02" },
-        latencyMs: 1400,
-      }),
-    ]);
+    await d.beat(600);
+    await d.parallel(
+      [
+        genericTool({
+          name: "optimize_images",
+          output: { result: "14 images → WebP · 2.4 MB → 380 KB" },
+          latencyMs: 2600,
+        }),
+        genericTool({
+          name: "inline_critical_css",
+          output: { result: "Critical CSS inlined · 3 stylesheets deferred" },
+          latencyMs: 2400,
+        }),
+        genericTool({
+          name: "add_structured_data",
+          output: { result: "Product + Organization JSON-LD on 24 pages" },
+          latencyMs: 2200,
+        }),
+        genericTool({
+          name: "fix_layout_shift",
+          output: { result: "Media sized + font preloaded · CLS 0.27 → 0.02" },
+          latencyMs: 2000,
+        }),
+      ],
+      650,
+    );
+    await d.beat(900);
 
+    // 7) Ship + re-audit (hold to read).
+    d.caption("Re-auditing and shipping to production");
+    await d.beat(600);
     await d.tool(
       genericTool({
         name: "deploy_to_production",
         output: { result: "Promoted preview → production · acme.com" },
-        latencyMs: 1800,
+        latencyMs: 1900,
       }),
     );
-
-    d.caption("Re-audited and deployed");
     await d.stream(RESULT, { instant: true });
     await d.endTurn();
-    await d.wait(1500);
+    d.caption("From audit to deployed — automatically");
+    await d.beat(4500);
   },
 };

--- a/apps/mesh/src/web/demo/scenarios/storefront.tsx
+++ b/apps/mesh/src/web/demo/scenarios/storefront.tsx
@@ -11,7 +11,7 @@ import { Chat } from "@/web/components/chat";
 import { DemoChatStreamProvider } from "../demo-chat-stream";
 import type { DemoStores } from "../director-stores";
 import type { Scenario } from "../types";
-import { genericTool, proposePlan, takeScreenshot } from "../message-builders";
+import { genericTool, takeScreenshot } from "../message-builders";
 
 const SHOT =
   "data:image/svg+xml;utf8," +
@@ -64,18 +64,6 @@ const DIAGNOSIS = `### Audit results for acme.com
 2. **Render-blocking CSS** — 3 stylesheets (180 KB) block first paint.
 3. **No structured data** — missing Product & Organization JSON-LD, so you're invisible to rich results.
 4. **Layout shift** from unsized images and late-loading web fonts.`;
-
-const PLAN = `**Performance**
-- Convert & compress images to WebP, resize the hero to its display size
-- Inline critical CSS, defer the rest
-- Reserve space for media + preload the primary font
-
-**SEO**
-- Add Product, Offer, and Organization JSON-LD
-- Generate descriptive alt text for product imagery
-
-**Safety**
-- Apply on a preview branch, verify Lighthouse ≥ 90, then promote to production`;
 
 const RESULT = `### Re-audit — deployed to production ✅
 
@@ -135,61 +123,109 @@ export const storefrontScenario: Scenario = {
     await d.stream("Here's what I found — measured, not guessed:", { cps: 44 });
     d.caption("An accurate diagnosis");
     await d.stream(DIAGNOSIS, { instant: true });
+    d.endTurn(); // close the turn so later cards don't collapse into it
     await d.beat(4800);
 
-    // 5) The plan.
-    d.caption("A plan, ranked by impact");
-    await d.beat(800);
-    await d.stream("Here's the plan I'd apply:", { cps: 44 });
-    await d.tool(proposePlan({ plan: PLAN, approved: true }));
-    await d.beat(900);
-    await d.stream("Approved — applying every fix on a preview branch.", {
+    // 5) A real work plan — shown as a sprint, awaiting approval.
+    d.caption("A work plan, laid out as a sprint");
+    await d.beat(700);
+    await d.stream("I've turned this into a sprint — review and approve:", {
       cps: 44,
     });
+    d.showPlan("Sprint · Storefront performance", [
+      { title: "Convert & compress images to WebP", detail: "2.4 MB → 380 KB" },
+      {
+        title: "Inline critical CSS, defer the rest",
+        detail: "−180 KB blocking",
+      },
+      {
+        title: "Add Product + Organization JSON-LD",
+        detail: "across 24 pages",
+      },
+      { title: "Fix layout shift", detail: "sized media + font preload" },
+      {
+        title: "Open a PR & deploy to preview",
+        detail: "reviewable, reversible",
+      },
+    ]);
+    await d.beat(2000); // read the sprint
 
-    // 6) Fixes cascade in parallel.
-    d.caption("Fixing the highest-impact issues in parallel");
-    await d.beat(600);
-    await d.parallel(
-      [
-        genericTool({
-          name: "optimize_images",
-          output: { result: "14 images → WebP · 2.4 MB → 380 KB" },
-          latencyMs: 2600,
-        }),
-        genericTool({
-          name: "inline_critical_css",
-          output: { result: "Critical CSS inlined · 3 stylesheets deferred" },
-          latencyMs: 2400,
-        }),
-        genericTool({
-          name: "add_structured_data",
-          output: { result: "Product + Organization JSON-LD on 24 pages" },
-          latencyMs: 2200,
-        }),
-        genericTool({
-          name: "fix_layout_shift",
-          output: { result: "Media sized + font preloaded · CLS 0.27 → 0.02" },
-          latencyMs: 2000,
-        }),
-      ],
-      650,
-    );
-    await d.beat(900);
+    // 6) Approve — the viewer clicks (ghost cursor).
+    d.caption("Review the plan, then approve");
+    d.showCursor();
+    await d.beat(700);
+    await d.click("approve-plan");
+    d.acceptPlan();
+    d.hideCursor();
+    await d.beat(700);
+    d.endTurn();
 
-    // 7) Ship + re-audit (hold to read).
-    d.caption("Re-auditing and shipping to production");
-    await d.beat(600);
+    // 7) Execute — the sprint board ticks as the agent works.
+    d.caption("Approved — running the sprint");
+    await d.stream("On it — working through the sprint on a preview branch.", {
+      cps: 44,
+    });
+    for (const i of [0, 1, 2, 3]) {
+      d.setTask(i, "active");
+      await d.beat(1700);
+      d.setTask(i, "done");
+      await d.beat(400);
+    }
+
+    // 8) First deliverable: a pull request with the code changes.
+    d.setTask(4, "active");
+    d.caption("Opening a pull request with the changes");
+    await d.stream("Opening a PR with the changes for review…", { cps: 44 });
+    await d.beat(1400);
+    d.openPR({
+      number: 128,
+      title: "perf: optimize storefront",
+      branch: "perf/storefront-optimizations",
+      files: 6,
+      additions: 214,
+      deletions: 88,
+    });
+    await d.beat(2000); // CI running
+    d.passPRChecks();
+    d.setTask(4, "done");
+    await d.beat(1300);
+
+    // 9) Merge (ghost cursor) → deploy → re-audit.
+    d.caption("Checks pass — merge & ship");
+    d.showCursor();
+    await d.beat(700);
+    await d.click("merge-pr");
+    d.mergePR();
+    d.hideCursor();
+    await d.beat(500);
+    await d.stream("Merged. Deploying to production…", { cps: 44 });
     await d.tool(
       genericTool({
         name: "deploy_to_production",
         output: { result: "Promoted preview → production · acme.com" },
-        latencyMs: 1900,
+        latencyMs: 1800,
       }),
     );
     await d.stream(RESULT, { instant: true });
-    await d.endTurn();
-    d.caption("From audit to deployed — automatically");
-    await d.beat(4500);
+    d.endTurn(); // close (pull_request + deploy = 2 tools — no collapse)
+    await d.beat(1600);
+
+    // 10) Offer to run this every day, posted to Slack / Teams.
+    d.caption("Get this every morning — in Slack or Teams");
+    await d.stream(
+      "Want this every morning? I can audit your storefront daily and post the report to your team.",
+      { cps: 44 },
+    );
+    d.showDigest();
+    await d.beat(1800);
+    d.showCursor();
+    await d.beat(600);
+    await d.click("connect-slack");
+    d.connectDigest("slack");
+    d.hideCursor();
+    await d.beat(800);
+    d.endTurn();
+    d.caption("From a one-off audit to a daily, automated report");
+    await d.beat(4200);
   },
 };

--- a/apps/mesh/src/web/demo/stage.tsx
+++ b/apps/mesh/src/web/demo/stage.tsx
@@ -14,15 +14,25 @@ import { Director } from "./director";
 import { runAutoplay } from "./runner";
 import { useCaption } from "./use-demo-stores";
 import { GhostCursor } from "./ghost-cursor";
+import { EndCard } from "./end-card";
 import type { DemoStores } from "./director-stores";
 import type { Scenario } from "./types";
+
+const DEFAULT_END = {
+  title: "Build this on your own data",
+  subtitle: "Spin up your first agent in minutes — free to start.",
+};
 
 function DemoCaption({ stores }: { stores: DemoStores }) {
   const caption = useCaption(stores);
   if (!caption) return null;
   return (
-    <div className="pointer-events-none absolute bottom-6 left-1/2 z-50 -translate-x-1/2">
-      <div className="rounded-full bg-foreground/90 px-4 py-1.5 text-sm font-medium text-background shadow-lg backdrop-blur">
+    <div className="pointer-events-none absolute bottom-7 left-1/2 z-50 -translate-x-1/2">
+      {/* key on text so each new caption fades/slides in fresh */}
+      <div
+        key={caption}
+        className="animate-in fade-in slide-in-from-bottom-2 duration-500 rounded-full bg-foreground/90 px-4 py-1.5 text-sm font-medium text-background shadow-lg backdrop-blur"
+      >
         {caption}
       </div>
     </div>
@@ -100,6 +110,11 @@ export function DemoStage({ scenarios }: { scenarios: Scenario[] }) {
         <ActiveStage stores={stores} />
         <DemoCaption stores={stores} />
         <GhostCursor stores={stores} />
+        <EndCard
+          stores={stores}
+          title={active.endCard?.title ?? DEFAULT_END.title}
+          subtitle={active.endCard?.subtitle ?? DEFAULT_END.subtitle}
+        />
       </div>
     </DemoProviders>
   );

--- a/apps/mesh/src/web/demo/stage.tsx
+++ b/apps/mesh/src/web/demo/stage.tsx
@@ -1,0 +1,106 @@
+/**
+ * Demo Mode — the stage.
+ *
+ * Full-screen surface that runs the autoplay loop and renders the ACTIVE
+ * scenario's own layout (`scenario.Stage`). The Director owns all timing
+ * outside React; the only `useEffect` here is the runner's start/abort
+ * lifecycle boundary (same documented exception pattern as
+ * `components/live-timer.tsx`).
+ */
+import { useEffect, useState } from "react";
+import { DemoProviders } from "./demo-providers";
+import { createDemoStores } from "./director-stores";
+import { Director } from "./director";
+import { runAutoplay } from "./runner";
+import { useCaption } from "./use-demo-stores";
+import { GhostCursor } from "./ghost-cursor";
+import type { DemoStores } from "./director-stores";
+import type { Scenario } from "./types";
+
+function DemoCaption({ stores }: { stores: DemoStores }) {
+  const caption = useCaption(stores);
+  if (!caption) return null;
+  return (
+    <div className="pointer-events-none absolute bottom-6 left-1/2 z-50 -translate-x-1/2">
+      <div className="rounded-full bg-foreground/90 px-4 py-1.5 text-sm font-medium text-background shadow-lg backdrop-blur">
+        {caption}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One autoplay loop per `DemoStores` instance, kept OUTSIDE React's effect
+ * lifecycle. The dev runtime (React Compiler / StrictMode) re-runs passive
+ * effects while preserving state, which would otherwise abort + restart the
+ * scenario mid-play. We key the running loop on the (mount-stable) stores
+ * instance and set it up once; teardown is deferred so a transient
+ * teardown→setup cycle (which re-sets `keep`) never kills it — only a real
+ * unmount, where no setup follows, aborts.
+ */
+const RUNNERS = new WeakMap<
+  DemoStores,
+  { controller: AbortController; keep: boolean }
+>();
+
+export function DemoStage({ scenarios }: { scenarios: Scenario[] }) {
+  const [stores] = useState(createDemoStores);
+  // Pin scenarios on mount so an unstable prop (a fresh array literal each
+  // parent render) can't influence the runner.
+  const [pinnedScenarios] = useState(() => scenarios);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect, eslint-plugin-react-hooks/exhaustive-deps -- runner lifecycle (start/abort) is singleton-guarded per stores; all timing lives in the Director
+  useEffect(() => {
+    // Demo always renders in light mode (overrides the app's theme preference).
+    const root = document.documentElement;
+    const wasDark = root.classList.contains("dark");
+    root.classList.remove("dark");
+
+    let entry = RUNNERS.get(stores);
+    if (!entry) {
+      const controller = new AbortController();
+      entry = { controller, keep: true };
+      RUNNERS.set(stores, entry);
+      const director = new Director(stores, controller.signal);
+      void runAutoplay(
+        director,
+        pinnedScenarios,
+        controller.signal,
+        setActiveIndex,
+      );
+    }
+    entry.keep = true; // setup cancels any pending teardown
+
+    return () => {
+      const e = RUNNERS.get(stores);
+      if (e) {
+        e.keep = false;
+        queueMicrotask(() => {
+          // A synchronous re-setup (StrictMode / spurious re-run) flips `keep`
+          // back to true before this runs → loop survives. Real unmount leaves
+          // it false → abort.
+          if (!e.keep) {
+            e.controller.abort();
+            RUNNERS.delete(stores);
+          }
+        });
+      }
+      if (wasDark) root.classList.add("dark");
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const active = pinnedScenarios[activeIndex] ?? pinnedScenarios[0]!;
+  const ActiveStage = active.Stage;
+
+  return (
+    <DemoProviders>
+      <div className="relative flex h-screen w-screen flex-col overflow-hidden bg-background">
+        <ActiveStage stores={stores} />
+        <DemoCaption stores={stores} />
+        <GhostCursor stores={stores} />
+      </div>
+    </DemoProviders>
+  );
+}

--- a/apps/mesh/src/web/demo/types.ts
+++ b/apps/mesh/src/web/demo/types.ts
@@ -13,4 +13,6 @@ export interface Scenario {
   title: string;
   Stage: ComponentType<{ stores: DemoStores }>;
   run: (d: Director) => Promise<void>;
+  /** Copy for the end card shown after a full play-through. */
+  endCard?: { title: string; subtitle: string };
 }

--- a/apps/mesh/src/web/demo/types.ts
+++ b/apps/mesh/src/web/demo/types.ts
@@ -1,0 +1,16 @@
+import type { ComponentType } from "react";
+import type { Director } from "./director";
+import type { DemoStores } from "./director-stores";
+
+/**
+ * A demo screenplay. `run` drives the Director top-to-bottom; `Stage` is the
+ * React layout that renders this scenario's tracks/chrome (single chat, a
+ * multi-agent grid, a terminal + panes, …). The autoplay loop calls `run`
+ * repeatedly, resetting state between runs — keep it idempotent.
+ */
+export interface Scenario {
+  id: string;
+  title: string;
+  Stage: ComponentType<{ stores: DemoStores }>;
+  run: (d: Director) => Promise<void>;
+}

--- a/apps/mesh/src/web/demo/use-demo-stores.ts
+++ b/apps/mesh/src/web/demo/use-demo-stores.ts
@@ -29,6 +29,15 @@ export function useCurrentOrg(stores: DemoStores): string | null {
   );
 }
 
+/** Whether an agent has an unseen completion (sidebar notification dot). */
+export function useNotified(stores: DemoStores, agentId: string): boolean {
+  return useSyncExternalStore(
+    stores.ui.subscribe,
+    () => stores.ui.get().notified.includes(agentId),
+    () => stores.ui.get().notified.includes(agentId),
+  );
+}
+
 /** True when a given org's agent track is mid-stream — drives the "working in
  *  the background" pulse on inactive org tabs. */
 export function useTrackBusy(stores: DemoStores, orgId: string): boolean {

--- a/apps/mesh/src/web/demo/use-demo-stores.ts
+++ b/apps/mesh/src/web/demo/use-demo-stores.ts
@@ -1,0 +1,43 @@
+/**
+ * Demo Mode — React subscription hooks for the Director's external stores.
+ * All reads go through `useSyncExternalStore` (no `useEffect`).
+ */
+import { useSyncExternalStore } from "react";
+import type { DemoStores } from "./director-stores";
+
+export function useCaption(stores: DemoStores): string | null {
+  return useSyncExternalStore(
+    stores.ui.subscribe,
+    () => stores.ui.get().caption,
+    () => stores.ui.get().caption,
+  );
+}
+
+export function useDemoInput(stores: DemoStores, id: string): string {
+  return useSyncExternalStore(
+    stores.ui.subscribe,
+    () => stores.ui.get().inputs[id] ?? "",
+    () => stores.ui.get().inputs[id] ?? "",
+  );
+}
+
+export function useCurrentOrg(stores: DemoStores): string | null {
+  return useSyncExternalStore(
+    stores.ui.subscribe,
+    () => stores.ui.get().currentOrg,
+    () => stores.ui.get().currentOrg,
+  );
+}
+
+/** True when a given org's agent track is mid-stream — drives the "working in
+ *  the background" pulse on inactive org tabs. */
+export function useTrackBusy(stores: DemoStores, orgId: string): boolean {
+  const store = stores.getChat(orgId);
+  return useSyncExternalStore(
+    store.subscribe,
+    () =>
+      store.get().status === "streaming" || store.get().status === "submitted",
+    () =>
+      store.get().status === "streaming" || store.get().status === "submitted",
+  );
+}

--- a/apps/mesh/src/web/demo/work-plan.tsx
+++ b/apps/mesh/src/web/demo/work-plan.tsx
@@ -1,0 +1,284 @@
+/**
+ * Demo Mode — inline work-plan (sprint) + pull-request cards.
+ *
+ * Rendered INLINE in the chat flow (registered via the part-renderer registry,
+ * see register-parts.tsx) from the message part's `output`. Pure + data-driven:
+ * the Director mutates the part output to tick tasks / approve / merge. Buttons
+ * carry `data-demo-target` so the ghost cursor can aim at them; they're visual
+ * only (the Director performs the action).
+ */
+import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  Bell01,
+  Check,
+  GitBranch01,
+  GitPullRequest,
+  Target04,
+} from "@untitledui/icons";
+import type {
+  DigestState,
+  PlanState,
+  PlanTaskStatus,
+  PRState,
+} from "./director-stores";
+
+function TaskIcon({ status }: { status: PlanTaskStatus }) {
+  if (status === "done") {
+    return (
+      <span className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
+        <Check className="size-3" />
+      </span>
+    );
+  }
+  if (status === "active") {
+    return (
+      <span className="size-5 animate-spin rounded-full border-2 border-muted-foreground/25 border-t-foreground" />
+    );
+  }
+  return (
+    <span className="size-5 rounded-full border-2 border-dashed border-muted-foreground/30" />
+  );
+}
+
+function StatusLabel({ status }: { status: PlanTaskStatus }) {
+  const map = {
+    done: { text: "Done", cls: "text-primary" },
+    active: { text: "In progress", cls: "text-foreground" },
+    queued: { text: "Queued", cls: "text-muted-foreground" },
+  } as const;
+  const { text, cls } = map[status];
+  return <span className={cn("text-[11px] font-medium", cls)}>{text}</span>;
+}
+
+export function WorkPlanCard({ plan }: { plan: PlanState }) {
+  const done = plan.tasks.filter((t) => t.status === "done").length;
+  return (
+    <div className="my-2 w-full animate-in fade-in slide-in-from-bottom-2 overflow-hidden rounded-2xl border border-border bg-card duration-500">
+      <div className="flex items-center gap-2.5 border-b border-border px-4 py-3">
+        <span className="flex size-7 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Target04 className="size-4" />
+        </span>
+        <div className="flex flex-col leading-tight">
+          <span className="text-sm font-semibold text-foreground">
+            {plan.title}
+          </span>
+          <span className="text-[11px] text-muted-foreground">
+            {plan.tasks.length} tasks ·{" "}
+            {plan.accepted
+              ? `${done}/${plan.tasks.length} done`
+              : "needs your approval"}
+          </span>
+        </div>
+        <span
+          className={cn(
+            "ml-auto rounded-full px-2.5 py-1 text-[11px] font-medium",
+            plan.accepted
+              ? "bg-primary/10 text-primary"
+              : "bg-amber-500/10 text-amber-600",
+          )}
+        >
+          {plan.accepted ? "Approved" : "Review"}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2 p-3">
+        {plan.tasks.map((t, i) => (
+          <div
+            key={i}
+            className={cn(
+              "flex items-center gap-3 rounded-xl border p-3 transition-colors duration-300",
+              t.status === "active"
+                ? "border-foreground/20 bg-muted/40"
+                : "border-border bg-background",
+            )}
+          >
+            <TaskIcon status={t.status} />
+            <div className="flex min-w-0 flex-col leading-tight">
+              <span
+                className={cn(
+                  "text-[13px] font-medium",
+                  t.status === "done"
+                    ? "text-muted-foreground"
+                    : "text-foreground",
+                )}
+              >
+                {t.title}
+              </span>
+              {t.detail && (
+                <span className="text-[11px] text-muted-foreground">
+                  {t.detail}
+                </span>
+              )}
+            </div>
+            <span className="ml-auto shrink-0">
+              <StatusLabel status={t.status} />
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {!plan.accepted && (
+        <div className="flex items-center gap-2 border-t border-border px-4 py-3">
+          <Button
+            type="button"
+            size="sm"
+            data-demo-target="approve-plan"
+            className="gap-1.5"
+          >
+            <Check className="size-3.5" />
+            Approve &amp; start
+          </Button>
+          <Button type="button" size="sm" variant="ghost">
+            Edit plan
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChannelButton({
+  target,
+  glyph,
+  color,
+  label,
+}: {
+  target: string;
+  glyph: string;
+  color: string;
+  label: string;
+}) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      data-demo-target={target}
+      className="gap-2"
+    >
+      <span
+        className="flex size-4 items-center justify-center rounded text-[10px] font-bold"
+        style={{ background: color, color: "#fff" }}
+      >
+        {glyph}
+      </span>
+      {label}
+    </Button>
+  );
+}
+
+export function DailyDigestCard({ digest }: { digest: DigestState }) {
+  const connected = digest.connected;
+  return (
+    <div className="my-2 w-full animate-in fade-in slide-in-from-bottom-2 overflow-hidden rounded-2xl border border-border bg-card duration-500">
+      <div className="flex items-center gap-2.5 px-4 py-3">
+        <span className="flex size-7 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Bell01 className="size-4" />
+        </span>
+        <div className="flex flex-col leading-tight">
+          <span className="text-sm font-semibold text-foreground">
+            Get this report every morning
+          </span>
+          <span className="text-[11px] text-muted-foreground">
+            Auto-audit your storefront daily and post it to your team
+          </span>
+        </div>
+      </div>
+      <div className="border-t border-border px-4 py-3">
+        {connected ? (
+          <div className="flex items-center gap-2 text-[13px] font-medium text-primary">
+            <Check className="size-4" />
+            Connected to {connected === "slack" ? "Slack" : "Microsoft Teams"} —
+            daily digest at 9:00 AM
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <ChannelButton
+              target="connect-slack"
+              glyph="S"
+              color="#4A154B"
+              label="Connect Slack"
+            />
+            <ChannelButton
+              target="connect-teams"
+              glyph="T"
+              color="#4B53BC"
+              label="Connect Teams"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function PRCard({ pr }: { pr: PRState }) {
+  return (
+    <div className="my-2 w-full animate-in fade-in slide-in-from-bottom-2 overflow-hidden rounded-2xl border border-border bg-card duration-500">
+      <div className="flex items-center gap-2.5 px-4 py-3">
+        <span
+          className={cn(
+            "flex size-7 items-center justify-center rounded-lg",
+            pr.merged
+              ? "bg-primary/10 text-primary"
+              : "bg-muted text-foreground",
+          )}
+        >
+          <GitPullRequest className="size-4" />
+        </span>
+        <span className="min-w-0 truncate text-sm font-medium text-foreground">
+          #{pr.number} · {pr.title}
+        </span>
+        <span
+          className={cn(
+            "ml-auto rounded-full px-2.5 py-1 text-[11px] font-medium",
+            pr.merged
+              ? "bg-primary/10 text-primary"
+              : "bg-muted text-muted-foreground",
+          )}
+        >
+          {pr.merged ? "Merged" : "Open"}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-t border-border px-4 py-3 text-[12px] text-muted-foreground">
+        <span className="inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 font-mono text-[11px]">
+          <GitBranch01 className="size-3" />
+          {pr.branch}
+        </span>
+        <span>{pr.files} files changed</span>
+        <span className="font-medium text-primary">+{pr.additions}</span>
+        <span className="font-medium text-destructive">−{pr.deletions}</span>
+        <span className="inline-flex items-center gap-1.5">
+          {pr.checks === "running" ? (
+            <>
+              <span className="size-3 animate-spin rounded-full border-2 border-muted-foreground/25 border-t-foreground" />
+              Checks running…
+            </>
+          ) : (
+            <>
+              <Check className="size-3.5 text-primary" />
+              All checks passed
+            </>
+          )}
+        </span>
+      </div>
+
+      {!pr.merged && (
+        <div className="border-t border-border px-4 py-3">
+          <Button
+            type="button"
+            size="sm"
+            data-demo-target="merge-pr"
+            disabled={pr.checks !== "passed"}
+            className="gap-1.5"
+          >
+            <GitPullRequest className="size-3.5" />
+            Merge pull request
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -105,6 +105,20 @@ const oauthCallbackAiProviderRoute = createRoute({
   ),
 });
 
+// Public, full-screen scripted product demos (see web/demo/). Unauthenticated,
+// outside the org shell. `/demo` is a chooser; each demo plays at `/demo/<id>`.
+const demoIndexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/demo",
+  component: lazyRouteComponent(() => import("./routes/demo.tsx")),
+});
+
+const demoScenarioRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/demo/$scenario",
+  component: lazyRouteComponent(() => import("./routes/demo-scenario.tsx")),
+});
+
 // ============================================
 // SHELL LAYOUT (authenticated wrapper)
 // ============================================
@@ -638,6 +652,8 @@ const routeTree = rootRoute.addChildren([
   betterAuthRoutes,
   oauthCallbackRoute,
   oauthCallbackAiProviderRoute,
+  demoIndexRoute,
+  demoScenarioRoute,
 ]);
 
 const router = createRouter({

--- a/apps/mesh/src/web/routes/demo-scenario.tsx
+++ b/apps/mesh/src/web/routes/demo-scenario.tsx
@@ -1,0 +1,16 @@
+/**
+ * Public, full-screen Demo Mode player (`/demo/$scenario`).
+ *
+ * Plays a SINGLE scenario on a loop — no cross-scenario auto-advance. Each demo
+ * has its own URL so they can be shared/linked independently.
+ */
+import { useParams } from "@tanstack/react-router";
+import { DemoStage } from "@/web/demo/stage";
+import { SCENARIO_BY_ID, SCENARIOS } from "@/web/demo/scenarios";
+
+export default function DemoScenarioRoute() {
+  const { scenario } = useParams({ strict: false }) as { scenario?: string };
+  const found = (scenario && SCENARIO_BY_ID[scenario]) || SCENARIOS[0]!;
+  // Single-element array ⇒ the runner replays just this scenario.
+  return <DemoStage key={found.id} scenarios={[found]} />;
+}

--- a/apps/mesh/src/web/routes/demo.tsx
+++ b/apps/mesh/src/web/routes/demo.tsx
@@ -1,0 +1,38 @@
+/**
+ * Public Demo Mode index (`/demo`) — a simple chooser linking to each scripted
+ * demo. Each demo plays on its own URL (`/demo/<id>`).
+ */
+import { Link } from "@tanstack/react-router";
+import { SCENARIOS } from "@/web/demo/scenarios";
+
+export default function DemoIndexRoute() {
+  return (
+    <div className="flex h-screen w-screen items-center justify-center bg-background p-8">
+      <div className="w-full max-w-2xl">
+        <h1 className="mb-1 text-2xl font-semibold text-foreground">
+          Studio — live demos
+        </h1>
+        <p className="mb-6 text-sm text-muted-foreground">
+          Scripted walkthroughs built from the real product.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {SCENARIOS.map((s) => (
+            <Link
+              key={s.id}
+              to="/demo/$scenario"
+              params={{ scenario: s.id }}
+              className="rounded-xl border border-border bg-card p-5 transition-colors hover:border-foreground/20"
+            >
+              <div className="text-base font-medium text-foreground">
+                {s.title}
+              </div>
+              <div className="mt-1 font-mono text-xs text-muted-foreground">
+                /demo/{s.id}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

A public, fully-mocked, **full-screen product demo** (oya.ai-style) that animates the **real Studio chat components** from a scripted stream — no backend, MCP transport, or auth. The whole thing is a reusable framework: a demo reads top-to-bottom like a storyboard.

```ts
await d.user("Here's my store: https://acme.com — make it faster");
await d.tool(takeScreenshot({ url, image }));
await d.stream(DIAGNOSIS, { instant: true });
```

### Two demos, each on its own URL (light mode)
- **`/demo/storefront`** — business user drops in a URL → accurate perf+SEO **diagnosis scorecard** (real GFM table) → fix plan → parallel fixes → re-audit before/after → deploy.
- **`/demo/agents`** — Studio as a web Conductor: the ghost cursor clicks **Connect desktop** → the real link modal opens → a mocked **iTerm window** runs \`bunx decocms link\` then minimizes → modal flips to **Connected** → work runs across **two orgs in parallel** (chat + live preview), switching context while the first org keeps building in the background.
- **`/demo`** — a chooser linking to both. No cross-scenario auto-advance.

## How it works (`apps/mesh/src/web/demo/`)
- **Director** — non-React class owning all timing via \`@decocms/std\` \`sleep\`; mutates external \`Store\`s that components read through \`useSyncExternalStore\`, so **no \`useEffect\`** is needed to animate (the one lifecycle effect is documented, same pattern as \`live-timer.tsx\`).
- **Chat seam** — \`DemoChatStreamProvider\` supplies a scripted \`ChatStreamContextValue\` (via a new exported \`DemoChatStreamContext\`), so the real \`Chat.Messages\` → \`MessageAssistant\` → tool-call renderers paint it identically to a live stream.
- **DemoProviders** — mock \`ProjectContext\` + a network-free \`QueryClient\` (no auth gate).
- Multi-track chats, org switching, iframe previews, ghost cursor, typed terminal — all driven by the same Director primitives.

The autoplay runner is guarded by a per-\`stores\` singleton with **deferred teardown**, so the dev runtime's spurious passive-effect re-runs (React Compiler / StrictMode) can't abort + restart a scenario mid-play.

## Affected areas
- New: \`apps/mesh/src/web/demo/**\`, \`routes/demo.tsx\`, \`routes/demo-scenario.tsx\`
- Touched: \`web/index.tsx\` (register \`/demo\` + \`/demo/$scenario\` as public routes), \`components/chat/chat-context.tsx\` (export the chat-stream context for the demo seam — one line)
- No backend/server changes.

## Testing
- \`bun run check\` ✅ · \`bun run lint\` ✅ · \`bun run fmt:check\` ✅
- Verified end-to-end with Playwright: both demos run to completion in a stable loop with **0 console errors**; zero network requests beyond static assets.
- **Screenshots:** view live at \`/demo/storefront\` and \`/demo/agents\` (dev). UI is fully scripted/animated; static frames don't capture the motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public, full-screen Demo Mode that scripts the real Studio chat UI with no backend or auth. Now includes inline sprint/PR/daily-digest cards and an agent sidebar with background notifications; each demo plays once and then shows a CTA end card.

- **New Features**
  - Inline chat cards: work plan (approve then live task ticks), pull request (checks → merge), and daily digest (connect Slack/Teams) via a tiny part-renderer registry.
  - Storefront demo: capture page → audit → show diagnosis → approve sprint → PR checks+merge → deploy → re‑audit → connect daily digest.
  - Agents demo: Studio-style sidebar to switch agents; work continues in the background with a notification dot; connect-desktop dialog + mocked iTerm and live preview panes.

- **Refactors**
  - Core chat accepts external part renderers before its built-in switch; demo registers its cards, app behavior unchanged.
  - Exported `DemoChatStreamContext`; updates to card outputs are applied immutably so memoized components re-render reliably.

<sup>Written for commit 813d9480728b2742966da697b2ca89fda7a7eff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

