### PR TITLE
fix(oauth): re-resolve stale token endpoints on host mismatch

### DIFF
--- a/apps/mesh/src/oauth/token-refresh.integration.test.ts
+++ b/apps/mesh/src/oauth/token-refresh.integration.test.ts
@@ -19,6 +19,7 @@ import { CredentialVault } from "../encryption/credential-vault";
 import { DownstreamTokenStorage } from "../storage/downstream-token";
 import { ConnectionStorage } from "../storage/connection";
 import type { TokenRefreshResult } from "./refresh-access-token";
+import type { DownstreamToken } from "../storage/types";
 
 // Narrow justified mock per TESTING.md: refreshAccessToken makes a real
 // HTTP call to a third-party OAuth token endpoint we can't wire up in
@@ -27,6 +28,14 @@ const mockRefreshAccessToken =
   vi.fn<(...args: unknown[]) => Promise<TokenRefreshResult>>();
 mock.module("./refresh-access-token", () => ({
   refreshAccessToken: mockRefreshAccessToken,
+}));
+
+// resolveOriginTokenEndpoint makes real metadata HTTP calls to the origin we
+// can't wire up in tests; mock it to assert the re-resolution wiring.
+const mockResolveOriginTokenEndpoint =
+  vi.fn<(url: string) => Promise<string | null>>();
+mock.module("./resolve-token-endpoint", () => ({
+  resolveOriginTokenEndpoint: mockResolveOriginTokenEndpoint,
 }));
 
 const { refreshAndStore, clearRefreshBackoff } = await import(
@@ -64,6 +73,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   mockRefreshAccessToken.mockReset();
+  mockResolveOriginTokenEndpoint.mockReset();
   clearRefreshBackoff();
   await tokenStorage.delete(connectionId);
   await tokenStorage.upsert({
@@ -309,5 +319,80 @@ describe("getValidDownstreamAccessToken", () => {
       accessToken: null,
     });
     expect(await tokenStorage.get(connectionId)).toBeNull();
+  });
+
+  it("re-resolves a stale-host token endpoint and self-heals the stored row", async () => {
+    // Captured at authorize time against the canonical `*.decocache.com` host,
+    // which now 525s; the connection lives on the working `*.deco.site` alias.
+    await tokenStorage.delete(connectionId);
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "stale",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() - 1000),
+      clientId: "cid",
+      clientSecret: null,
+      tokenEndpoint: "https://sites-google-calendar.decocache.com/token",
+    });
+    mockResolveOriginTokenEndpoint.mockResolvedValueOnce(
+      "https://sites-google-calendar.deco.site/token",
+    );
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh",
+      refreshToken: "rt",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+
+    const result = await getValidDownstreamAccessToken({
+      connectionId,
+      connectionUrl: "https://sites-google-calendar.deco.site/mcp",
+      tokenStorage,
+    });
+
+    expect(result).toEqual({ state: "refreshed", accessToken: "fresh" });
+    expect(mockResolveOriginTokenEndpoint).toHaveBeenCalledWith(
+      "https://sites-google-calendar.deco.site/mcp",
+    );
+    // Refreshed against the re-resolved endpoint, not the stale one.
+    expect(
+      (mockRefreshAccessToken.mock.calls[0]![0] as DownstreamToken)
+        .tokenEndpoint,
+    ).toBe("https://sites-google-calendar.deco.site/token");
+    // Self-heal: the persisted endpoint is the good one.
+    expect((await tokenStorage.get(connectionId))?.tokenEndpoint).toBe(
+      "https://sites-google-calendar.deco.site/token",
+    );
+  });
+
+  it("does not re-resolve when the stored endpoint host matches the connection", async () => {
+    await tokenStorage.delete(connectionId);
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "stale",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() - 1000),
+      clientId: "cid",
+      clientSecret: null,
+      tokenEndpoint: "https://sites-google-calendar.deco.site/token",
+    });
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh",
+      refreshToken: "rt",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+
+    await getValidDownstreamAccessToken({
+      connectionId,
+      connectionUrl: "https://sites-google-calendar.deco.site/mcp",
+      tokenStorage,
+    });
+
+    expect(mockResolveOriginTokenEndpoint).not.toHaveBeenCalled();
   });
 });

--- a/apps/mesh/src/oauth/token-refresh.test.ts
+++ b/apps/mesh/src/oauth/token-refresh.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "bun:test";
+import { needsTokenEndpointReresolution } from "./token-refresh";
+
+describe("needsTokenEndpointReresolution", () => {
+  it("re-resolves oauth-proxy URLs", () => {
+    expect(
+      needsTokenEndpointReresolution(
+        "https://studio.example.com/oauth-proxy/conn_x/token",
+        "https://sites-x.deco.site/mcp",
+      ),
+    ).toBe(true);
+  });
+
+  it("re-resolves when the stored host is stale (host mismatch)", () => {
+    // Captured against the `*.decocache.com` canonical host at authorize time;
+    // the connection lives on the working `*.deco.site` alias.
+    expect(
+      needsTokenEndpointReresolution(
+        "https://sites-x.decocache.com/token",
+        "https://sites-x.deco.site/mcp",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not re-resolve when the host matches", () => {
+    expect(
+      needsTokenEndpointReresolution(
+        "https://sites-x.deco.site/token",
+        "https://sites-x.deco.site/mcp",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not re-resolve on unparseable input", () => {
+    expect(
+      needsTokenEndpointReresolution("not a url", "https://x.deco.site/mcp"),
+    ).toBe(false);
+  });
+});

--- a/apps/mesh/src/oauth/token-refresh.ts
+++ b/apps/mesh/src/oauth/token-refresh.ts
@@ -28,6 +28,34 @@ export function canRefresh(token: DownstreamToken): boolean {
   return !!token.refreshToken && !!token.tokenEndpoint && !!token.clientId;
 }
 
+/**
+ * Should we re-discover the origin token endpoint from the connection's
+ * *current* metadata instead of trusting the stored one? Yes when the stored
+ * value is unusable for a direct server-side refresh:
+ *   - it routes back through our own oauth-proxy (`/oauth-proxy/:id/token`), or
+ *   - its host no longer matches the connection's host — a stale endpoint
+ *     captured at authorize time. Deco-serverless integrations were authorized
+ *     against the `*.decocache.com` canonical host, which now fails the
+ *     Cloudflare→origin TLS handshake (HTTP 525), while the connection itself
+ *     lives on the working `*.deco.site` alias.
+ *
+ * Re-resolution is best-effort and fail-safe: a legitimate external IdP (host
+ * intentionally differs from the connection) re-discovers the same correct
+ * endpoint via metadata, and a failed discovery keeps the stored value. A
+ * successful refresh persists the re-resolved endpoint, so the row self-heals.
+ */
+export function needsTokenEndpointReresolution(
+  tokenEndpoint: string,
+  connectionUrl: string,
+): boolean {
+  if (tokenEndpoint.includes("/oauth-proxy/")) return true;
+  try {
+    return new URL(tokenEndpoint).host !== new URL(connectionUrl).host;
+  } catch {
+    return false;
+  }
+}
+
 const inflightRefreshes = new Map<string, Promise<string | null>>();
 
 /**
@@ -158,7 +186,11 @@ export async function getValidDownstreamAccessToken(params: {
   }
 
   let tokenEndpoint = token.tokenEndpoint;
-  if (connectionUrl && tokenEndpoint?.includes("/oauth-proxy/")) {
+  if (
+    connectionUrl &&
+    tokenEndpoint &&
+    needsTokenEndpointReresolution(tokenEndpoint, connectionUrl)
+  ) {
     const originEndpoint = await resolveOriginTokenEndpoint(connectionUrl);
     if (originEndpoint) tokenEndpoint = originEndpoint;
   }


### PR DESCRIPTION
## Summary

OAuth token refresh was fetching the stored `downstream_tokens.tokenEndpoint` **verbatim**. Deco-serverless integrations were authorized against the `*.decocache.com` canonical host, so that host got persisted as the token endpoint. `*.decocache.com` now fails the Cloudflare→origin TLS handshake (**HTTP 525**), while the connection itself lives on the working `*.deco.site` alias — so every refresh of those connections breaks with `[TokenRefresh] refresh failed`, and the downstream MCP call 401s.

Observed in prod (decopilot trace): `POST https://sites-google-calendar.decocache.com/token` → 525 → refresh failed. **62 of 326** rows in `downstream_tokens` hold a `*.decocache.com` token endpoint (gmail, drive, sheets, docs, meet, slides, big-query, search-console, calendar, …).

## Root cause

`refresh-access-token.ts` does `fetch(token.tokenEndpoint)`. The re-resolver in `getValidDownstreamAccessToken` (`resolve-token-endpoint.ts`) only fired when the stored endpoint was an `/oauth-proxy/` URL — so an absolute, stale `*.decocache.com` endpoint was used as-is. Nothing rewrites the host at request time; the stale host was simply persisted at authorize time.

## Fix

Re-resolve the origin token endpoint from the connection's **current** metadata not only for oauth-proxy URLs, but also when the stored endpoint's **host no longer matches the connection host**:

- **Fail-safe**: a legitimate external IdP (host intentionally differs) re-discovers the same correct endpoint via metadata; a failed discovery keeps the stored value (current behavior).
- **Self-healing**: a successful refresh persists the re-resolved endpoint, so the 62 affected rows fix themselves on their next refresh — no data migration required.
- **Scoped**: gated on `connectionUrl`, which only the MCP proxy `build_headers` path passes. The GitHub callers omit it, so they're unaffected.

## Testing

- `token-refresh.test.ts` (new, pure unit): `needsTokenEndpointReresolution` — oauth-proxy, host-mismatch, host-match, unparseable.
- `token-refresh.integration.test.ts`: re-resolves a stale-host endpoint, refreshes against the resolved one, and self-heals the stored row; does **not** re-resolve when the host already matches.
- `bun run fmt`, `bun run check` (typecheck), `bun run lint` all clean (the 2 lint warnings are pre-existing, in `packages/sandbox`).

> Note: the integration test needs Postgres (runs in CI); unit + typecheck verified locally.

## Out of scope / follow-up

This is the resilient mesh-side fix. The **root cause is infra**: the `*.decocache.com` edge→origin TLS (525) on the deco-serverless / Cloudflare side — still reproduces (`deco.site` → 200, `decocache.com` → 525). That fix lives in the deco-serverless deployment, not this repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth refresh failures by re-resolving token endpoints when the stored host differs from the connection host or points to `/oauth-proxy/`. This unblocks connections stuck on `*.decocache.com` (TLS 525) and self-heals stored endpoints on refresh.

- **Bug Fixes**
  - Added `needsTokenEndpointReresolution` to detect oauth-proxy URLs and host mismatches, then re-discover the origin endpoint from current connection metadata (only when `connectionUrl` is provided).
  - Persist the resolved endpoint after a successful refresh so affected rows self-heal; no migration needed.
  - Fail-safe: if discovery fails, use the stored endpoint. GitHub callers are unaffected since they omit `connectionUrl`.
  - Added unit and integration tests for host mismatch, oauth-proxy, and no-op cases.

<sup>Written for commit d273958ab08677546794ba89a1778d0e87c8c921. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

