### PR TITLE
refactor(org-fs): make org-fs unconditional; delete legacy transfer tools

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -10,9 +10,9 @@ export { generateMessageId } from "@decocms/harness/decopilot/harness-constants"
  * skill sets so the agent surfaces them when asked about its capabilities.
  * Settings-stable per deployment, so it lives in the cached prompt prefix.
  *
- * Portable pure function but kept mesh-side (consumed by the cluster
- * `build-agent-system-prompt`, which gates it on `getSettings().orgFsClusterMounts`
- * + `getPublicSets()` — both cluster-only).
+ * Portable pure function kept mesh-side (consumed by the cluster
+ * `build-agent-system-prompt` with `getPublicSets()`). org-fs is mounted
+ * into every sandbox now, so it is emitted unconditionally.
  */
 export function buildOrgFilesystemPrompt(publicSets: string[]): string {
   const sets =

--- a/apps/mesh/src/api/routes/decopilot/file-materializer.ts
+++ b/apps/mesh/src/api/routes/decopilot/file-materializer.ts
@@ -26,7 +26,6 @@ import { isLocalMode } from "@/auth/local-mode";
 import type { StudioContext } from "@/core/studio-context";
 import { fsObjectKey } from "@/file-storage/org-fs-path";
 import { detectContentType, toFilesUrl } from "@/object-storage/key-utils";
-import { getSettings } from "@/settings";
 import type { ChatMessage } from "./types";
 import {
   toMeshStorageUri,
@@ -246,11 +245,9 @@ async function storeAttachment(
     });
     return {
       key: fsObjectKey("uploads", path),
-      // The in-sandbox path only exists on deployments that mount org-fs
-      // into sandboxes — don't promise it to the model elsewhere.
-      sandboxPath: getSettings().orgFsClusterMounts
-        ? `org/upload/${filename}`
-        : null,
+      // org-fs is mounted into every sandbox, so the upload is always
+      // reachable at this in-sandbox path.
+      sandboxPath: `org/upload/${filename}`,
     };
   } catch (err) {
     console.error("[file-materializer] uploads-volume write failed:", err);

--- a/apps/mesh/src/api/routes/decopilot/file-materializer.ts
+++ b/apps/mesh/src/api/routes/decopilot/file-materializer.ts
@@ -39,9 +39,8 @@ import {
  * "Failed to parse [file://...]", others silently ignore the file), and
  * the sandbox skills (pptx-extract, docx, xlsx) consistently produce
  * better results than any provider's native parser. The model picks
- * these up from the annotation text emitted by uploadFileParts: with
- * org-fs mounts they're already at `org/upload/<name>`; otherwise it
- * pulls them in via copy_to_sandbox.
+ * these up from the annotation text emitted by uploadFileParts — they
+ * are already at `org/upload/<name>` in the mounted org filesystem.
  *
  * PDFs stay on the native path — every provider with a `file` capability
  * handles them fine and going through the sandbox would be a regression.
@@ -454,8 +453,9 @@ export async function resolveStorageRefs(
   if (!ctx.organization) return messages;
 
   // First pass: drop sandbox-only file parts (Office formats). The model
-  // reads these via copy_to_sandbox using the mesh-storage URI in the
-  // annotation text emitted by uploadFileParts.
+  // reads these directly from `org/upload/<name>` (the uploads volume is
+  // mounted in the sandbox); the annotation text from uploadFileParts
+  // points at the path.
   const filtered = messages.map((msg) => {
     const filteredParts = msg.parts.filter(
       (part) => !isSandboxOnlyFilePart(part),

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -22,7 +22,6 @@ import {
 } from "@decocms/harness/decopilot/prompt-constants";
 import { buildOrgFilesystemPrompt } from "@/api/routes/decopilot/constants";
 import { getPublicSets } from "@/file-storage/public-sets";
-import { getSettings } from "@/settings";
 import type { GithubRepo } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
@@ -134,14 +133,10 @@ export async function buildAgentSystemPrompt(
     add("repoEnv", buildRepoEnvironmentPrompt(opts.virtualMcp.repo));
   }
 
-  // Org filesystem layout + the deployment's public skill sets. Gated on the
-  // deployment actually mounting org-fs into hosted sandboxes
-  // (ORGFS_CLUSTER_MOUNTS) — otherwise agents get taught `org/...` paths
-  // that don't exist and burn turns on `ls org/` failures. Settings-stable
-  // either way, so still cache-safe.
-  if (getSettings().orgFsClusterMounts) {
-    add("orgFs", buildOrgFilesystemPrompt(getPublicSets().map((s) => s.set)));
-  }
+  // Org filesystem layout + the deployment's public skill sets. org-fs is
+  // mounted into every sandbox now (desktop + cluster), so this is
+  // unconditional. Settings-stable, so still cache-safe.
+  add("orgFs", buildOrgFilesystemPrompt(getPublicSets().map((s) => s.set)));
 
   if (opts.kind === "agent") {
     if (opts.isDecopilot) {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -227,7 +227,6 @@ async function buildAllTools(
       ctx,
       threadId: vmContext.threadId,
       virtualMcpId: vmContext.virtualMcpId,
-      orgFs: getSettings().orgFsClusterMounts,
     }) as ToolSet;
     Object.assign(tools, vmTools);
   }

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-buffer.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-buffer.ts
@@ -15,7 +15,6 @@
 
 import type { StudioContext } from "@/core/studio-context";
 import { homeMountPath } from "@/file-storage/home-mount";
-import { getSettings } from "@/settings";
 import { matchDeckToolPath } from "@decocms/harness/decopilot/built-in-tools/vm-tools/deck-paths";
 import type { DeckBuffer } from "@decocms/harness/decopilot/built-in-tools/vm-tools/types";
 
@@ -24,7 +23,7 @@ const HOME_VOLUME = "home";
 const NOOP: DeckBuffer = { enqueue: () => {}, flush: async () => {} };
 
 export function createDeckBuffer(ctx: StudioContext): DeckBuffer {
-  const orgFs = getSettings().orgFsClusterMounts ? ctx.orgFs : null;
+  const orgFs = ctx.orgFs;
   const orgSlug = ctx.organization?.slug ?? null;
   const actor = ctx.auth?.user?.id ?? null;
   if (!orgFs || !orgSlug || !actor) return NOOP;

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-watcher.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/deck-watcher.ts
@@ -18,7 +18,6 @@
 
 import type { StudioContext } from "@/core/studio-context";
 import { homeMountPath } from "@/file-storage/home-mount";
-import { getSettings } from "@/settings";
 import { matchDeckEntryPath } from "@decocms/harness/decopilot/built-in-tools/vm-tools/deck-paths";
 import type { UIMessageStreamWriter } from "ai";
 
@@ -44,7 +43,7 @@ export function createDeckWatcher(
   ctx: StudioContext,
   writer: UIMessageStreamWriter,
 ): DeckWatcher {
-  const orgFs = getSettings().orgFsClusterMounts ? ctx.orgFs : null;
+  const orgFs = ctx.orgFs;
   const orgSlug = ctx.organization?.slug ?? null;
   if (!orgFs || !orgSlug) {
     return { sweep: async () => {} };

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -125,7 +125,6 @@ export function resolveConfig(
       envVars.MCP_CACHE_ENABLED,
       nodeEnv !== "development",
     ),
-    orgFsClusterMounts: toBool(envVars.ORGFS_CLUSTER_MOUNTS),
     orgFsPublicSetsJson: envVars.ORGFS_PUBLIC_SETS,
 
     // Object Storage (S3-compatible)

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -58,7 +58,6 @@ export interface Settings {
   mcpCacheEnabled: boolean;
   /** Mint org-fs tokens for hosted (agent-sandbox) pods too — only useful
    *  when the sandbox-env chart runs the org-fs sidecar (orgFs.enabled). */
-  orgFsClusterMounts: boolean;
   /** JSON array of public skill-set sources (see file-storage/public-sets.ts);
    *  unset = no public sets. */
   orgFsPublicSetsJson: string | undefined;

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -56,10 +56,8 @@ export interface Settings {
   /** MCP read/list caching. On by default in production, off in development;
    *  MCP_CACHE_ENABLED explicitly overrides either default. */
   mcpCacheEnabled: boolean;
-  /** Mint org-fs tokens for hosted (agent-sandbox) pods too — only useful
-   *  when the sandbox-env chart runs the org-fs sidecar (orgFs.enabled). */
-  /** JSON array of public skill-set sources (see file-storage/public-sets.ts);
-   *  unset = no public sets. */
+  /** JSON array of public skill-set sources overlaid on the built-in
+   *  defaults (see file-storage/public-sets.ts). */
   orgFsPublicSetsJson: string | undefined;
 
   // Object Storage (S3-compatible)

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -413,14 +413,12 @@ async function provisionSandbox(
       : null;
 
   // Org-fs mounts: mint an fs-scoped token + build the daemon's ORGFS_CONFIG.
-  // Desktop links always mount; hosted pods only when the cluster runs the
-  // privileged org-fs sidecar (settings.orgFsClusterMounts ↔ the sandbox-env
-  // chart's orgFs.enabled — without the sidecar the minted key would just go
-  // unused). Guarded inside the helper: a mint failure → undefined → no
-  // mounting, never breaks provisioning.
+  // org-fs is the universal substrate now — both desktop links and hosted
+  // pods always mount (hosted relies on the privileged org-fs sidecar
+  // shipping in the default deploy). Guarded inside the helper: a mint
+  // failure → undefined → no mounting, never breaks provisioning.
   const wantsOrgFs =
-    runner.kind === "user-desktop" ||
-    (runner.kind === "agent-sandbox" && getSettings().orgFsClusterMounts);
+    runner.kind === "user-desktop" || runner.kind === "agent-sandbox";
   // ctx.organization is unset on the decopilot vm-tools dispatch path (the
   // org travels as the `orgId` param there) — resolve the slug from the row
   // so chat-ephemeral sandboxes get mounts too.

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -21,7 +21,7 @@ installed (it ships the CRDs + controller).
 ## Prerequisites
 
 - `sandbox-operator` chart installed in `agent-sandbox-system`.
-- Kubernetes 1.30+ (for `spec.hostUsers: false` user namespace remap).
+- Kubernetes with `spec.hostUsers: true` privileged-sidecar support (org-fs FUSE mount).
 - The studio release for THIS environment must point its mesh runner at
   the env-suffixed SandboxTemplate by setting
   `STUDIO_SANDBOX_TEMPLATE_NAME=studio-sandbox-<envName>` in the studio
@@ -179,7 +179,6 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `resources.*` | 0.5/2 CPU, 1/4Gi RAM | per sandbox pod |
 | `nodeSelector` / `tolerations` / `affinity` | `{}` | for sandbox isolation NodePool |
 | `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |
-| `hostUsers` | `false` | userns remap; flip to `true` if kernel/containerd doesn't support userns |
 | `readOnlyRootFilesystem` | `true` | RO rootfs + emptyDirs on /app, /tmp, /home |
 | `networkPolicy.enabled` | `true` | locks down ingress/egress |
 | `warmPool.enabled` / `warmPool.size` | `false` / `0` | only after measuring cold-start pain |

--- a/deploy/helm/sandbox-env/examples/values-kind.yaml
+++ b/deploy/helm/sandbox-env/examples/values-kind.yaml
@@ -23,9 +23,8 @@ resources:
     memory: "3Gi"
 
 # ── pod hardening (relaxed for kind) ───────────────────────────────────
-# Plain host-users mode. userns remap requires K8s 1.30+ on a kernel that
-# supports it; kind nodes can vary. Keep simple for local dev.
-hostUsers: true
+# hostUsers is fixed true by the template now (org-fs's privileged sidecar
+# is incompatible with userns remap), so nothing to set here.
 readOnlyRootFilesystem: false
 
 # ── no preview Gateway in kind ─────────────────────────────────────────

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -6,9 +6,6 @@
 # default. The template *name* is suffixed with envName so multiple
 # environments' SandboxTemplates coexist; mesh in this env must reference
 # the suffixed name via STUDIO_SANDBOX_TEMPLATE_NAME.
-{{- if and .Values.orgFs.enabled (not .Values.hostUsers) }}
-{{- fail "orgFs.enabled requires hostUsers=true: privileged sidecar + Bidirectional mount propagation are incompatible with user-namespaced pods" }}
-{{- end }}
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
 metadata:
@@ -81,13 +78,13 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if not .Values.hostUsers }}
-      # User namespace remap: UID 1000 inside the pod maps to a high
-      # subordinate UID on the node, so a container escape lands as a
-      # nobody-user, not as a real node UID. Requires K8s 1.30+ and a
-      # containerd/kernel that support userns (EKS default AMIs are fine).
-      hostUsers: false
-      {{- end }}
+      # org-fs is a hard requirement, and its privileged FUSE sidecar +
+      # Bidirectional mount propagation are incompatible with user-namespace
+      # remapping — so `hostUsers: true` is fixed (no userns-remap). The
+      # untrusted agent container is still locked down independently
+      # (drop ALL caps, no privilege escalation, runAsNonRoot, seccomp
+      # RuntimeDefault below); only the org-fs sidecar is privileged.
+      hostUsers: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -201,14 +198,12 @@ spec:
             - name: GIT_CONFIG_VALUE_0
               value: "*"
             {{- end }}
-            {{- if .Values.orgFs.enabled }}
             # org-fs relay: the daemon writes the mount config here for the
             # sidecar, and gates the per-run output link on its status file.
             - name: ORGFS_SIDECAR_CONFIG_PATH
               value: "/run/orgfs/config.json"
             - name: ORGFS_SIDECAR_STATUS_PATH
               value: "/run/orgfs/status.json"
-            {{- end }}
           ports:
             - name: daemon
               containerPort: 9000
@@ -232,15 +227,12 @@ spec:
             {{- end }}
             - name: home
               mountPath: /home/sandbox
-            {{- if .Values.orgFs.enabled }}
             # The sidecar's FUSE mounts under /app/org surface here.
             - name: orgfs-org
               mountPath: /app/org
               mountPropagation: HostToContainer
             - name: orgfs-ctl
               mountPath: /run/orgfs
-            {{- end }}
-        {{- if .Values.orgFs.enabled }}
         # Privileged org-fs mounter: waits for the daemon to relay the mount
         # config onto /run/orgfs (post-bind push), FUSE-mounts the org volumes
         # under the shared /app/org, and Bidirectional propagation surfaces
@@ -266,7 +258,6 @@ spec:
               mountPropagation: Bidirectional
             - name: orgfs-ctl
               mountPath: /run/orgfs
-        {{- end }}
       volumes:
         {{- if .Values.readOnlyRootFilesystem }}
         # Sized to match the per-container ephemeral-storage limit shape;
@@ -281,7 +272,6 @@ spec:
         - name: home
           emptyDir:
             sizeLimit: 5Gi
-        {{- if .Values.orgFs.enabled }}
         # Mount surface (volumes attach under it) + relay control files.
         - name: orgfs-org
           emptyDir:
@@ -289,4 +279,3 @@ spec:
         - name: orgfs-ctl
           emptyDir:
             sizeLimit: 1Mi
-        {{- end }}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -193,8 +193,8 @@ dnsConfig:
 # user-namespaced pods, and Bidirectional propagation requires privileged.
 # Enabling this trades the userns-remap hardening for org-fs mounts; the
 # template fails to render otherwise so the trade-off stays explicit.
-# Mesh side: set ORGFS_CLUSTER_MOUNTS=1 on the studio install so it mints
-# org-fs tokens for hosted sandboxes.
+# Mesh side mints org-fs tokens for hosted sandboxes unconditionally now —
+# this sidecar must be enabled wherever those mounts are expected.
 orgFs:
   enabled: false
   image:

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -181,22 +181,22 @@ dnsConfig:
       value: "1"
 
 # ── org-fs sidecar (organization filesystem mounts) ───────────────────
-# Opt-in: a privileged sidecar that FUSE-mounts the org filesystem volumes
-# (skills + outputs) at /app/org/* via WebDAV→rclone, propagated into the
-# unprivileged sandbox container (Bidirectional → HostToContainer). The
-# mount config arrives post-bind: mesh POSTs it to the daemon's
-# /_sandbox/orgfs-config, which relays it onto the shared /run/orgfs
-# control volume the sidecar watches (warm-pool claims reject spec.env,
-# so boot env can't carry it).
+# Mandatory, always deployed: a privileged sidecar that FUSE-mounts the org
+# filesystem volumes (skills + outputs + home) at /app/org/* via
+# WebDAV→rclone, propagated into the unprivileged sandbox container
+# (Bidirectional → HostToContainer). The mount config arrives post-bind:
+# mesh POSTs it to the daemon's /_sandbox/orgfs-config, which relays it onto
+# the shared /run/orgfs control volume the sidecar watches (warm-pool claims
+# reject spec.env, so boot env can't carry it).
 #
-# REQUIRES hostUsers: true — Kubernetes forbids privileged containers in
-# user-namespaced pods, and Bidirectional propagation requires privileged.
-# Enabling this trades the userns-remap hardening for org-fs mounts; the
-# template fails to render otherwise so the trade-off stays explicit.
-# Mesh side mints org-fs tokens for hosted sandboxes unconditionally now —
-# this sidecar must be enabled wherever those mounts are expected.
+# org-fs is a hard product requirement (skills, uploads, outputs, home all
+# live here), so there is no toggle. It forces `hostUsers: true` (no
+# user-namespace remap) — Kubernetes forbids privileged containers +
+# Bidirectional propagation in user-namespaced pods. Security note: only
+# THIS sidecar is privileged; the untrusted agent container keeps drop-ALL
+# caps, no privilege escalation, runAsNonRoot, and seccomp RuntimeDefault
+# (see the sandbox container in templates/sandbox-template.yaml).
 orgFs:
-  enabled: false
   image:
     repository: ghcr.io/decocms/studio/orgfs-sidecar
     # Bump to ship a new sidecar image — release-orgfs-sidecar.yaml reads
@@ -210,20 +210,6 @@ orgFs:
     limits:
       cpu: 500m
       memory: 512Mi
-
-# ── sandbox-pod hardening ──────────────────────────────────────────────
-# User namespace remap (`spec.hostUsers: false`): UID 1000 inside the pod
-# maps to a high, unprivileged subordinate UID on the node, so a
-# container escape doesn't land as a real node UID. Requires K8s 1.30+
-# with a containerd/kernel that support userns (EKS default AMIs from
-# late 2024 onward are fine; kind nodes vary).
-#
-# Defaults to the secure path because this chart runs untrusted user
-# code. Override to true (back to host users) ONLY on clusters whose
-# kernel/containerd doesn't support userns — symptoms of unsupported
-# runtime are pod scheduling failures with messages like "user
-# namespaces are not enabled".
-hostUsers: false
 
 # Read-only root filesystem. When true, /app + /tmp + /home/sandbox are
 # remounted as emptyDirs and `safe.directory '*'` is set so git works

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
@@ -1,21 +1,18 @@
 /**
  * VM File Tools — runner-agnostic.
  *
- * Registers the eight LLM-visible tools (read/write/edit/grep/glob/bash +
- * copy_to_sandbox/share_with_user) on top of the injected `SandboxFsHooks`.
+ * Registers the six LLM-visible file tools (read/write/edit/grep/glob/bash)
+ * on top of the injected `SandboxFsHooks`.
  * The hooks speak the unified `/_sandbox/*` surface with plain JSON bodies and
  * own the handle resolution + auto-restart retry layer, so this module never
  * imports the sandbox-provider package directly (cycle-break, spec §4.3).
  */
 
 import { tool, zodSchema } from "ai";
-import path from "node:path";
 import { maybeTruncate } from "./common";
 import {
-  buildBashDescription,
+  BASH_DESCRIPTION,
   BashInputSchema,
-  COPY_TO_SANDBOX_DESCRIPTION,
-  CopyToSandboxInputSchema,
   EDIT_DESCRIPTION,
   EditInputSchema,
   GLOB_DESCRIPTION,
@@ -24,82 +21,11 @@ import {
   GrepInputSchema,
   READ_DESCRIPTION,
   ReadInputSchema,
-  SHARE_WITH_USER_DESCRIPTION,
-  ShareWithUserInputSchema,
   TOOL_APPROVAL,
-  buildWriteDescription,
+  WRITE_DESCRIPTION,
   WriteInputSchema,
 } from "./schemas";
 import type { VmToolsParams } from "./types";
-
-const MESH_STORAGE_SCHEME = "mesh-storage://";
-
-/**
- * Resolve a `copy_to_sandbox` input to a fetchable URL the daemon can GET.
- * Accepts only org-scoped storage references — `mesh-storage://KEY` (the
- * shape that lands in chat annotations) or a bare KEY. Both are minted
- * to a presigned GET via `ctx.objectStorage`, so the daemon only ever
- * fetches from S3/R2 endpoints mesh controls.
- *
- * Arbitrary `http(s)://` URLs are intentionally rejected: for public
- * URLs the model can use `bash` + `curl` (which is approval-gated, like
- * any shell command), and excluding them keeps the daemon's fetch path
- * free of SSRF concerns.
- *
- * The tool-arg interceptor (`resolveArgsStorageRefs` in file-materializer)
- * substitutes mesh-storage:// → presigned-URL before this handler runs in
- * the happy path. This function is the safety net when interception didn't
- * happen, plus the path for bare keys.
- */
-async function resolveSourceUrl(
-  raw: string,
-  ctx: VmToolsParams["ctx"],
-): Promise<string> {
-  if (raw.startsWith("https://") || raw.startsWith("http://")) {
-    throw new Error(
-      "copy_to_sandbox does not accept arbitrary URLs — pass a " +
-        "mesh-storage:// URI or a bare org storage key. For public URLs, " +
-        "use the bash tool (curl).",
-    );
-  }
-  const key = raw.startsWith(MESH_STORAGE_SCHEME)
-    ? raw.slice(MESH_STORAGE_SCHEME.length)
-    : raw;
-  if (!key || key.startsWith("/") || key.includes("..")) {
-    throw new Error(`Invalid source: ${raw}`);
-  }
-  const storage = ctx.objectStorage;
-  if (!storage) {
-    throw new Error("Object storage is not configured for this org");
-  }
-  return storage.presignedGetUrl(key);
-}
-
-function sanitizeFilename(name: string): string | null {
-  const trimmed = name.trim();
-  if (!trimmed) return null;
-  if (trimmed.includes("/") || trimmed.includes("\\")) return null;
-  if (trimmed === "." || trimmed === ".." || trimmed.includes("..")) {
-    return null;
-  }
-  if (trimmed.length > 255) return null;
-  return trimmed;
-}
-
-/**
- * Build a stable file-redirect URL. Must encode each path segment so
- * keys carrying URL-special chars (`?`, `#`, `&`, space, ...) survive
- * round-trip — the `/api/:org/files/*` route reads `c.req.path` which
- * truncates at the first unescaped `?`.
- */
-function toFileDownloadUrl(
-  baseUrl: string,
-  orgSlug: string,
-  key: string,
-): string {
-  const encodedKey = key.split("/").map(encodeURIComponent).join("/");
-  return `${baseUrl}/api/${encodeURIComponent(orgSlug)}/files/${encodedKey}`;
-}
 
 export type { VmToolsParams } from "./types";
 
@@ -111,9 +37,6 @@ export function createVmTools(params: VmToolsParams) {
     toolOutputMap,
     needsApproval,
     pendingImages,
-    ctx,
-    threadId,
-    orgFs = false,
   } = params;
   const approvalFor = (mutating: boolean) => (mutating ? needsApproval : false);
 
@@ -162,7 +85,7 @@ export function createVmTools(params: VmToolsParams) {
 
   const write = tool({
     needsApproval: approvalFor(TOOL_APPROVAL.write),
-    description: buildWriteDescription(orgFs),
+    description: WRITE_DESCRIPTION,
     inputSchema: zodSchema(WriteInputSchema),
     execute: async (input) => {
       const daemonResult = await call("/_sandbox/write", input);
@@ -222,7 +145,7 @@ export function createVmTools(params: VmToolsParams) {
 
   const bash = tool({
     needsApproval: approvalFor(TOOL_APPROVAL.bash),
-    description: buildBashDescription(orgFs),
+    description: BASH_DESCRIPTION,
     inputSchema: zodSchema(BashInputSchema),
     execute: async (input) => {
       const result = await call("/_sandbox/bash", input);
@@ -230,63 +153,8 @@ export function createVmTools(params: VmToolsParams) {
     },
   });
 
-  const copy_to_sandbox = tool({
-    needsApproval: approvalFor(TOOL_APPROVAL.copy_to_sandbox),
-    description: COPY_TO_SANDBOX_DESCRIPTION,
-    inputSchema: zodSchema(CopyToSandboxInputSchema),
-    execute: async (input) => {
-      const sourceUrl = await resolveSourceUrl(input.url, ctx);
-      const result = await call("/_sandbox/write_from_url", {
-        url: sourceUrl,
-        path: input.target,
-      });
-      return result as { ok: boolean; path: string; size: number };
-    },
-  });
-
-  const share_with_user = tool({
-    needsApproval: approvalFor(TOOL_APPROVAL.share_with_user),
-    description: SHARE_WITH_USER_DESCRIPTION,
-    inputSchema: zodSchema(ShareWithUserInputSchema),
-    execute: async (input) => {
-      const orgSlug = ctx.organization?.slug;
-      const storage = ctx.objectStorage;
-      if (!orgSlug || !storage) {
-        throw new Error("Object storage is not configured for this org");
-      }
-      const filename = sanitizeFilename(
-        input.name ?? path.basename(input.source),
-      );
-      if (!filename) {
-        throw new Error(`Invalid filename: ${input.name ?? input.source}`);
-      }
-      const key = `model-outputs/${threadId}/${filename}`;
-      const presignedPutUrl = await storage.presignedPutUrl(key);
-      await call("/_sandbox/upload_to_url", {
-        path: input.source,
-        url: presignedPutUrl,
-      });
-      return {
-        key,
-        filename,
-        downloadUrl: toFileDownloadUrl(ctx.baseUrl, orgSlug, key),
-      };
-    },
-  });
-
-  return {
-    read,
-    write,
-    edit,
-    grep,
-    glob,
-    bash,
-    // With org-fs mounts live, both legacy transfer tools disappear:
-    // `org/output/` + the thread-outputs chips replace share_with_user
-    // (model-outputs), and chat attachments land in `org/upload/` via the
-    // uploads volume, replacing copy_to_sandbox. Only register them when
-    // the deployment hasn't flipped the flag. (`orgFs` is the harness-package
-    // DI'd equivalent of the cluster's `getSettings().orgFsClusterMounts`.)
-    ...(orgFs ? {} : { share_with_user, copy_to_sandbox }),
-  };
+  // org-fs is now the universal substrate: chat attachments arrive in
+  // `org/upload/` (no copy_to_sandbox) and deliverables go to `org/output/`
+  // surfaced via the thread-outputs chips (no share_with_user).
+  return { read, write, edit, grep, glob, bash };
 }

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
@@ -42,7 +42,7 @@ export function createVmTools(params: VmToolsParams) {
 
   // Proxy an arbitrary `/_sandbox/*` route through the fs hooks' retry layer.
   // Used by the tools whose daemon surface the typed flat ops don't model
-  // (image-read, html-buffer write/edit, write_from_url, upload_to_url).
+  // (image-read, html-buffer write/edit).
   const call = (
     daemonPath: string,
     input: Record<string, unknown>,

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -79,47 +79,12 @@ export const BashInputSchema = z.object({
     .describe("Timeout in milliseconds (default 30000, max 120000)"),
 });
 
-export const CopyToSandboxInputSchema = z.object({
-  url: z
-    .string()
-    .describe(
-      "Org-scoped storage reference. Accepts a mesh-storage:// URI from " +
-        "chat (e.g. mesh-storage://chat-uploads/abc.pdf) or a bare key " +
-        "(e.g. chat-uploads/abc.pdf). Arbitrary http(s):// URLs are NOT " +
-        "accepted — for public URLs use the bash tool with curl.",
-    ),
-  target: z
-    .string()
-    .describe(
-      "Destination path on the sandbox FS (relative to project root). " +
-        "Parent directories are created as needed.",
-    ),
-});
-
-export const ShareWithUserInputSchema = z.object({
-  source: z
-    .string()
-    .describe(
-      "Path to a file on the sandbox FS to share back to the user. " +
-        "Must be a single file (not a directory).",
-    ),
-  name: z
-    .string()
-    .optional()
-    .describe(
-      "Filename to surface in the chat UI (default: basename of source). " +
-        "Cannot contain slashes.",
-    ),
-});
-
 export type ReadInput = z.infer<typeof ReadInputSchema>;
 export type WriteInput = z.infer<typeof WriteInputSchema>;
 export type EditInput = z.infer<typeof EditInputSchema>;
 export type GrepInput = z.infer<typeof GrepInputSchema>;
 export type GlobInput = z.infer<typeof GlobInputSchema>;
 export type BashInput = z.infer<typeof BashInputSchema>;
-export type CopyToSandboxInput = z.infer<typeof CopyToSandboxInputSchema>;
-export type ShareWithUserInput = z.infer<typeof ShareWithUserInputSchema>;
 
 export const READ_DESCRIPTION =
   "Read a file. For text files, returns content with line numbers (use offset " +
@@ -129,36 +94,21 @@ export const READ_DESCRIPTION =
   "binary formats are not supported; use a format-specific skill " +
   "(e.g. pptx-extract for .pptx).";
 
-/** `orgFs`: mirrors buildBashDescription — when the org filesystem is
- *  mounted, decks/durable files belong under `org/`, and `pages/` must
- *  not swallow slide requests. */
-export function buildWriteDescription(orgFs: boolean): string {
-  return (
-    "Write content to a file in the VM's project directory. " +
-    "Creates parent directories if needed. Overwrites existing files entirely.\n\n" +
-    (orgFs
-      ? // Org-fs deployments: every live-preview HTML artifact lives in the
-        // org home volume (durable, Library-visible, deck editing). The
-        // legacy root `pages/` pipeline is intentionally not advertised.
-        "Viewable HTML artifacts get a LIVE PREVIEW in the chat side panel " +
-        "and persist in the org's shared folder when written under " +
-        "`org/<your-org-slug>/` (lowercase-kebab names):\n" +
-        "- Presentation decks / slides → `org/<your-org-slug>/decks/<name>.html` " +
-        "— read the slides skill (`org/public/core/slides/SKILL.md`) FIRST " +
-        "and create the deck with its CLI.\n" +
-        "- Standalone pages (landing pages, brand kits, one-pagers) → " +
-        "`org/<your-org-slug>/pages/<name>.html` — single self-contained " +
-        "HTML file.\n" +
-        "HTML written anywhere else will not render a preview."
-      : "Reserved path — `pages/<slug>.html`: writes to this prefix are " +
-        "automatically published to the org's object storage and rendered " +
-        "as a live preview in the chat side panel. Use this whenever the " +
-        "user wants a viewable HTML page (landing pages, brand kits, " +
-        "one-pagers). Slug must be lowercase kebab (e.g. " +
-        "`pages/landing.html`). HTML written elsewhere stays sandbox-only " +
-        "and will not render a preview.")
-  );
-}
+export const WRITE_DESCRIPTION =
+  "Write content to a file in the VM's project directory. " +
+  "Creates parent directories if needed. Overwrites existing files entirely.\n\n" +
+  // Every live-preview HTML artifact lives in the org home volume
+  // (durable, Library-visible, deck editing).
+  "Viewable HTML artifacts get a LIVE PREVIEW in the chat side panel " +
+  "and persist in the org's shared folder when written under " +
+  "`org/<your-org-slug>/` (lowercase-kebab names):\n" +
+  "- Presentation decks / slides → `org/<your-org-slug>/decks/<name>.html` " +
+  "— read the slides skill (`org/public/core/slides/SKILL.md`) FIRST " +
+  "and create the deck with its CLI.\n" +
+  "- Standalone pages (landing pages, brand kits, one-pagers) → " +
+  "`org/<your-org-slug>/pages/<name>.html` — single self-contained " +
+  "HTML file.\n" +
+  "HTML written anywhere else will not render a preview.";
 
 export const EDIT_DESCRIPTION =
   "Perform exact string replacement in a file in the VM. " +
@@ -172,78 +122,29 @@ export const GLOB_DESCRIPTION =
   "Find files by name pattern in the VM's project directory. " +
   "Uses ripgrep for gitignore-aware matching. Returns relative file paths.";
 
-/** `orgFs`: deployment mounts org-fs into hosted sandboxes — the caller
- *  passes the settings flag (this module stays dependency-free). */
-export function buildBashDescription(orgFs: boolean): string {
-  // Shared tail: skill-selection steering, independent of WHERE skills
-  // live (org/public on org-fs, /mnt on legacy).
-  const skillSteering =
-    "To make a presentation/slides/deck, ALWAYS use the `slides` skill " +
-    "(HTML decks with a live editable preview) — read its SKILL.md first. " +
-    "`pptx` is NOT for this: it only reads/inspects existing `.pptx` files, " +
-    "and is the right tool only when the user explicitly needs a PowerPoint " +
-    "`.pptx` file as input or output.";
-
-  return (
-    "Execute a shell command in the VM's project directory. " +
-    "Working directory is the project root. Timeout default 30s, max 2min.\n\n" +
-    (orgFs
-      ? // Org-fs deployments: ONE skill mechanism — the synced public sets
-        // mounted at `org/public/<set>/`. The image-baked `/mnt/skills/public`
-        // is not advertised here (it is the legacy non-org-fs fallback below).
-        "The organization filesystem is mounted at `org/`:\n" +
-        "- `org/<your-org-slug>/` — the org's shared home folder (editable, " +
-        "shared across runs; `ls org/` shows the actual name). Organize it " +
-        "freely; check it before non-trivial work and record durable facts, " +
-        "decisions, and learnings as small markdown files.\n" +
-        "- `org/public/<set>/` — curated read-only skill sets (file-handling: " +
-        "pptx, docx, xlsx, pdf, file-reading; plus slides + templating). Run " +
-        "`ls org/public/` for the sets and read " +
-        "`org/public/<set>/<name>/SKILL.md` before using a skill.\n" +
-        "- `org/upload/` — files the user attached to this conversation are " +
-        "already here; read them directly.\n" +
-        "- `org/output/` — write deliverables here; they are shared back to the " +
-        "organization under this run's folder.\n\n" +
-        skillSteering
-      : // Legacy non-org-fs deployments: skills are image-baked and the
-        // transfer tools are the only way to move files in/out.
-        "Pre-installed file-handling skills live at " +
-        "`/mnt/skills/public/<name>/SKILL.md` (pptx, docx, xlsx, pdf, " +
-        "file-reading, slides, templating). Run `ls /mnt/skills/public/` for " +
-        "that index. " +
-        skillSteering +
-        "\n\nTo bring chat attachments / presigned URLs into the sandbox FS " +
-        "use `copy_to_sandbox` (NOT bash + curl). To deliver a file you " +
-        "produced back to the user as a download chip, use `share_with_user`.")
-  );
-}
-
-export const COPY_TO_SANDBOX_DESCRIPTION =
-  "Copy a chat-attached or org-storage file into the sandbox filesystem " +
-  "at `target`. Use this BEFORE running format-specific skills " +
-  "(pptx-extract, pdf, docx, ...) on user-uploaded files. Accepts " +
-  "mesh-storage:// URIs and bare org-storage keys only — for arbitrary " +
-  "public URLs use bash + curl. Bytes stream directly from S3 to the " +
-  "sandbox; they do not pass through the model.";
-
-export const SHARE_WITH_USER_DESCRIPTION =
-  "Upload a file from the sandbox FS back to the user's chat as a download " +
-  "chip on this turn. Use this for artifacts the user should be able to " +
-  "save (CSV reports, generated decks, zipped builds, etc). The file " +
-  "lands under the current thread's outputs prefix; the UI surfaces it " +
-  "automatically when the turn finishes.";
+export const BASH_DESCRIPTION =
+  "Execute a shell command in the VM's project directory. " +
+  "Working directory is the project root. Timeout default 30s, max 2min.\n\n" +
+  "The organization filesystem is mounted at `org/`:\n" +
+  "- `org/<your-org-slug>/` — the org's shared home folder (editable, " +
+  "shared across runs; `ls org/` shows the actual name). Organize it " +
+  "freely; check it before non-trivial work and record durable facts, " +
+  "decisions, and learnings as small markdown files.\n" +
+  "- `org/public/<set>/` — curated read-only skill sets (file-handling: " +
+  "pptx, docx, xlsx, pdf, file-reading; plus slides + templating). Run " +
+  "`ls org/public/` for the sets and read " +
+  "`org/public/<set>/<name>/SKILL.md` before using a skill.\n" +
+  "- `org/upload/` — files the user attached to this conversation are " +
+  "already here; read them directly.\n" +
+  "- `org/output/` — write deliverables here; they are shared back to the " +
+  "organization under this run's folder.\n\n" +
+  "To make a presentation/slides/deck, ALWAYS use the `slides` skill " +
+  "(HTML decks with a live editable preview) — read its SKILL.md first. " +
+  "`pptx` is NOT for this: it only reads/inspects existing `.pptx` files, " +
+  "and is the right tool only when the user explicitly needs a PowerPoint " +
+  "`.pptx` file as input or output.";
 
 // read/grep/glob are non-mutating; write/edit/bash mutate.
-//
-// copy_to_sandbox + share_with_user are intentionally NOT approval-gated.
-// Both write side effects technically mutate state — copy_to_sandbox
-// drops bytes on the sandbox FS (already gated by `safePath`, no escape
-// outside `/app`), and share_with_user uploads to a thread-scoped S3
-// prefix the user already owns. Gating either would surface an approval
-// prompt on the most natural path the model takes for chat artifacts
-// (download → process → share), which is high-friction for a flow the
-// user just initiated by attaching a file. Reserve approvals for shell
-// + project-FS mutation where the blast radius is broader.
 export const TOOL_APPROVAL = {
   read: false,
   write: true,
@@ -251,6 +152,4 @@ export const TOOL_APPROVAL = {
   grep: false,
   glob: false,
   bash: true,
-  copy_to_sandbox: false,
-  share_with_user: false,
 } as const;

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/types.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/types.ts
@@ -67,27 +67,14 @@ export interface VmToolsParams {
    */
   readonly pendingImages: PendingImage[];
   /**
-   * Mesh context for tools that need to mint presigned URLs against the
-   * org's object storage (`copy_to_sandbox`, `share_with_user`) or
-   * resolve the org id for stable file URLs.
+   * Mesh context for tools that resolve the org id / object storage for
+   * stable file URLs (and the deck fast-path mirror).
    */
   readonly ctx: VmToolContext;
-  /**
-   * Current chat thread id. `share_with_user` writes artifacts under
-   * `model-outputs/<threadId>/<filename>` so the chat UI can list them.
-   */
+  /** Current chat thread id (accepted for parity across callers). */
   readonly threadId: string;
   /**
-   * Virtual MCP ID. `set_vm_config` mirrors packageManager / previewPort
-   * back to the Virtual MCP metadata so new branch sandboxes are
-   * provisioned with the updated workload rather than stale defaults.
+   * Virtual MCP ID (accepted for parity across callers).
    */
   readonly virtualMcpId: string;
-  /**
-   * Whether the org filesystem (`org/`) is mounted in the sandbox (the cluster's
-   * `getSettings().orgFsClusterMounts`). Injected (the portable tool can't read
-   * cluster settings): drives the `bash` description's org-fs guidance and
-   * replaces the legacy `share_with_user` tool with `org/output/` when on.
-   */
-  readonly orgFs?: boolean;
 }

--- a/packages/harness/src/decopilot/desktop-parity.test.ts
+++ b/packages/harness/src/decopilot/desktop-parity.test.ts
@@ -50,14 +50,12 @@ const input = {
 // path.
 const DESKTOP_TOOL_KEYS_BASELINE = [
   "bash",
-  "copy_to_sandbox",
   "edit",
   "glob",
   "grep",
   "propose_plan",
   "read",
   "read_tool_output",
-  "share_with_user",
   "subtask",
   "todo_write",
   "update_interests",


### PR DESCRIPTION
## What is this contribution about?

org-fs is the universal sandbox substrate now (confirmed in staging + prod): desktop links mount it kext-free (rclone nfsmount), hosted pods via the privileged sidecar in the default deploy. So the "optional org-fs" fallbacks — the conditional prompt branches and the legacy transfer tools — are removed.

### Removed
- **`ORGFS_CLUSTER_MOUNTS` setting** + the `orgFs` boolean threaded through `createVmTools` and the tool-description builders. `buildBashDescription(orgFs)` / `buildWriteDescription(orgFs)` → unconditional `BASH_DESCRIPTION` / `WRITE_DESCRIPTION` consts (one org-fs text, no branch).
- The setting gate on: the org-fs **system-prompt block** (`build-agent-system-prompt`), the **deck watcher/buffer**, the **upload materializer** sandbox path, and **sandbox provisioning** (`wantsOrgFs` always true).
- **`copy_to_sandbox` / `share_with_user` tools** — defs, schemas, descriptions, `TOOL_APPROVAL` entries, and now-dead helpers (`resolveSourceUrl`, the local `sanitizeFilename`, `toFileDownloadUrl`). `org/upload/` (attachments) + `org/output/` (deliverables, surfaced via the thread-output chips) are the universal in/out path.

### Kept deliberately
- Historical rendering: the web `tool-display-map` entries + `thread-outputs` route + `use-thread-outputs` scan — so **old threads still render** their `share_with_user`/`copy_to_sandbox` parts and `model-outputs/` files.
- `upload-policy`'s exported `sanitizeFilename` (separate, still used).
- Desktop tool-set **parity baseline** updated (drops the two transfer tools) — a deliberate, locked drift.

### Net: −330/+67 lines.

## Follow-up (separate PR)
Retiring the image-baked `/mnt/skills/public` skills + adding the bare-command `skill` launcher that resolves across the synced `org/public/<set>/` — that needs a docker build + kind validation cycle, so it ships on its own.

## How to Test
1. `bun run fmt && bun run lint && bun run check && bun run knip` — all green.
2. `bun test packages/harness/src/decopilot/desktop-parity.test.ts apps/mesh/src/harnesses/decopilot/built-in-tools/tool-vocabulary.test.ts` — pass.
3. Run an agent (desktop or cluster): bash/write tool descriptions describe `org/` unconditionally; `copy_to_sandbox`/`share_with_user` are gone; attachments arrive in `org/upload/`, deliverables in `org/output/`. Old threads still render their historical shared files.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes for historical thread rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make org-fs the default filesystem for all sandboxes (desktop + hosted) and remove the legacy transfer tools. This unifies file I/O, simplifies prompts and provisioning, and removes config flags and chart toggles.

- **Refactors**
  - Removed `ORGFS_CLUSTER_MOUNTS` and the `orgFs` flag across VM tools and prompt builders; `bash`/`write` descriptions are now unconditional.
  - Deleted `copy_to_sandbox` and `share_with_user`. Chat attachments arrive at `org/upload/`; deliverables go to `org/output/` and surface via thread-output chips.
  - Always include the org-fs block in the system prompt; deck watcher/buffer use `ctx.orgFs`; upload materializer always returns an in-sandbox path; hosted pods and desktop links always mount org-fs.
  - Helm `sandbox-env`: org-fs sidecar is mandatory; removed `orgFs.enabled`; fixed `hostUsers: true` (no userns-remap). README and kind example updated.
  - Scrubbed stale comments referencing the removed transfer tools and daemon routes.

- **Migration**
  - Remove `ORGFS_CLUSTER_MOUNTS` from config.
  - Drop `orgFs.enabled` and `hostUsers` from `sandbox-env` values; ensure the cluster supports a privileged sidecar with Bidirectional mount propagation.
  - Stop calling `copy_to_sandbox` and `share_with_user`. Use `org/upload/` and `org/output/` instead. Old threads still render historical tool outputs and `model-outputs/` files.

<sup>Written for commit 9549150a6a658d91fdc05dadd1ab4c1e7667ee2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

