### PR TITLE
feat(api): call builtin tools over REST instead of MCP (client↔server)

### DIFF
--- a/apps/mesh/e2e/tests/tools-rest.spec.ts
+++ b/apps/mesh/e2e/tests/tools-rest.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * E2E: REST tool-dispatch endpoint (`POST /api/:org/tools/:name`).
+ *
+ * The web client now calls builtin tools over plain REST instead of MCP. This
+ * verifies the REST front-door enforces the SAME authorization as the legacy
+ * `/mcp/self` path (see basic-usage-grant.spec.ts) — but surfaces it as proper
+ * HTTP status codes instead of MCP `isError` envelopes:
+ *   - a member on a restrictive custom role still gets a basic-usage tool
+ *     (AUTOMATION_LIST → 200, runtime grant), and
+ *   - is denied a gated tool (MONITORING_STATS → 403).
+ *   - unknown tool names → 404 (the manual identifier check).
+ *   - non-members are rejected before the tool runs (resolveOrgFromPath).
+ */
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+test.describe("REST tool dispatch", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("enforces the same authz as /mcp/self, with HTTP status codes", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+
+    // Owner (full access): a builtin tool over REST returns 200 + the raw result.
+    const ok = await ownerCtx.post(
+      `/api/${owner.orgSlug}/tools/AUTOMATION_LIST`,
+      {
+        data: {},
+      },
+    );
+    expect(
+      ok.ok(),
+      `AUTOMATION_LIST: HTTP ${ok.status()} — ${await ok.text().catch(() => "")}`,
+    ).toBe(true);
+    const okBody = (await ok.json()) as { automations?: unknown[] };
+    expect(Array.isArray(okBody.automations)).toBe(true);
+
+    // Unknown tool → 404 (manual identifier check).
+    const notFound = await ownerCtx.post(
+      `/api/${owner.orgSlug}/tools/NOPE_NOT_A_REAL_TOOL`,
+      { data: {} },
+    );
+    expect(notFound.status()).toBe(404);
+
+    // --- restrictive custom-role member ---
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("org not found after signup");
+
+    const roleSlug = `restricted-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const createRole = await ownerCtx.post(
+      "/api/auth/organization/create-role",
+      { data: { organizationId: orgId, role: roleSlug, permission: {} } },
+    );
+    expect(createRole.ok()).toBe(true);
+
+    const memberCtx = await newApiContext(playwright);
+    const member = await signUpViaApi(memberCtx);
+    const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+      data: { organizationId: orgId, email: member.email, role: "user" },
+    });
+    expect(invite.ok()).toBe(true);
+    const inviteJson = (await invite.json()) as {
+      id?: string;
+      invitation?: { id?: string };
+    };
+    const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+    const accept = await memberCtx.post(
+      "/api/auth/organization/accept-invitation",
+      { data: { invitationId } },
+    );
+    expect(accept.ok()).toBe(true);
+
+    const memberRow = await db.query<{ id: string }>(
+      `SELECT id FROM "member" WHERE "userId" = $1 AND "organizationId" = $2`,
+      [member.userId, orgId],
+    );
+    const memberId = memberRow.rows[0]?.id;
+    if (!memberId) throw new Error("member row not found after accept");
+    const assign = await ownerCtx.post(
+      "/api/auth/organization/update-member-role",
+      { data: { organizationId: orgId, memberId, role: [roleSlug] } },
+    );
+    expect(assign.ok()).toBe(true);
+
+    // Basic-usage tool the role does NOT list → granted at runtime → 200.
+    const memberOk = await memberCtx.post(
+      `/api/${owner.orgSlug}/tools/AUTOMATION_LIST`,
+      { data: {} },
+    );
+    expect(
+      memberOk.ok(),
+      `member AUTOMATION_LIST: HTTP ${memberOk.status()}`,
+    ).toBe(true);
+
+    // Gated tool (monitoring:view) NOT granted → 403 with a permission message.
+    const denied = await memberCtx.post(
+      `/api/${owner.orgSlug}/tools/MONITORING_STATS`,
+      { data: {} },
+    );
+    expect(denied.status()).toBe(403);
+    const deniedBody = (await denied.json()) as { error?: string };
+    expect(deniedBody.error ?? "").toMatch(
+      /access denied|permission|forbidden/i,
+    );
+
+    // Non-member is rejected by resolveOrgFromPath before the tool runs.
+    const strangerCtx = await newApiContext(playwright);
+    await signUpViaApi(strangerCtx);
+    const stranger = await strangerCtx.post(
+      `/api/${owner.orgSlug}/tools/AUTOMATION_LIST`,
+      { data: {} },
+    );
+    expect([403, 404]).toContain(stranger.status());
+
+    await ownerCtx.dispose();
+    await memberCtx.dispose();
+    await strangerCtx.dispose();
+  });
+});

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -25,6 +25,7 @@ import { createSelfRoutes } from "./self";
 import { createHomeNextActionsRoutes } from "./home-next-actions";
 import { createObjectStorageRoutes } from "./object-storage";
 import { createThreadOutputsRoutes } from "./thread-outputs";
+import { createToolsRestRoutes } from "./tools-rest";
 import { createTriggerCallbackRoutes } from "./trigger-callback";
 import { createVirtualMcpRoutes } from "./virtual-mcp";
 import { createSandboxRoutes } from "./sandbox-proxy";
@@ -89,6 +90,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   // --- Routes that don't need extra middleware ---
   app.route("/", createDownstreamTokenRoutes()); // /api/:org/connections/:connectionId/oauth-token
   app.route("/", createThreadOutputsRoutes()); // /api/:org/threads/:threadId/outputs
+  app.route("/tools", createToolsRestRoutes()); // /api/:org/tools[/:toolName] — REST builtin-tool dispatch
   app.route("/", createObjectStorageRoutes()); // /api/:org/object-storage/*
   app.route("/", createKVRoutes({ kvStorage: deps.kvStorage }));
   app.route("/", createFileUploadRoutes()); // /api/:org/file-configs/:id/upload

--- a/apps/mesh/src/api/routes/tools-rest.ts
+++ b/apps/mesh/src/api/routes/tools-rest.ts
@@ -1,0 +1,100 @@
+/**
+ * REST tool-dispatch endpoints.
+ *
+ * The web client invokes builtin/management tools over plain REST here instead
+ * of MCP. The tool name in the path is the permission identifier — the same one
+ * the MCP `/mcp/self` path used — enforced by the tool handler's own
+ * `ctx.access.check()`. Auth + org membership are already established by the
+ * global context factory and `resolveOrgFromPath`, so no MCP-specific auth is
+ * needed.
+ *
+ *   POST /api/:org/tools/:toolName   call a tool (body = arguments)
+ *   GET  /api/:org/tools             list the tools visible to this org
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import { ForbiddenError, UnauthorizedError } from "../../core/access-control";
+import { getFilteredTools } from "../../tools";
+import { getToolRegistration } from "../../tools/management-registration";
+import type { Env } from "../hono-env";
+
+const toJsonSchema = (schema: unknown): unknown => {
+  if (!schema || typeof schema !== "object") return undefined;
+  try {
+    return z.toJSONSchema(schema as z.ZodType);
+  } catch {
+    return undefined;
+  }
+};
+
+export const createToolsRestRoutes = () => {
+  const app = new Hono<Env>();
+
+  // GET /api/:org/tools — MCP `listTools` parity (tool metadata, not a call).
+  app.get("/", async (c) => {
+    const ctx = c.get("meshContext");
+    const tools = await getFilteredTools(ctx);
+    const list = [...tools.values()].map((tool) => {
+      const { config } = getToolRegistration(tool);
+      return {
+        name: tool.name,
+        description: config.description,
+        inputSchema: toJsonSchema(config.inputSchema),
+        outputSchema: toJsonSchema(config.outputSchema),
+        annotations: config.annotations,
+        _meta: config._meta,
+      };
+    });
+    return c.json({ tools: list });
+  });
+
+  // POST /api/:org/tools/:toolName — call a builtin tool.
+  app.post("/:toolName", async (c) => {
+    const ctx = c.get("meshContext");
+    const toolName = c.req.param("toolName");
+
+    // Manual tool-identifier check: 404 if the name isn't part of this org's
+    // visible tool surface (unknown name, or a disabled plugin tool).
+    const tools = await getFilteredTools(ctx);
+    const tool = tools.get(toolName);
+    if (!tool) {
+      return c.json({ error: `Unknown tool: ${toolName}` }, 404);
+    }
+
+    // Body is the tool arguments (may be empty for no-arg tools).
+    let rawInput: unknown;
+    try {
+      const text = await c.req.text();
+      rawInput = text ? JSON.parse(text) : {};
+    } catch {
+      return c.json({ error: "Request body must be valid JSON" }, 400);
+    }
+
+    // No MCP layer to validate input — validate against the tool's schema here.
+    const parsed = (tool.inputSchema as z.ZodType).safeParse(rawInput);
+    if (!parsed.success) {
+      return c.json(
+        { error: "Invalid input", issues: parsed.error.issues },
+        400,
+      );
+    }
+
+    try {
+      // `execute` sets the tool name on ctx.access and runs the handler, whose
+      // own `ctx.access.check()` enforces the permission for this tool name.
+      const result = await tool.execute(parsed.data, ctx);
+      return c.json((result ?? {}) as Record<string, unknown>);
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        return c.json({ error: error.message }, 401);
+      }
+      if (error instanceof ForbiddenError) {
+        return c.json({ error: error.message }, 403);
+      }
+      const message = error instanceof Error ? error.message : "Tool failed";
+      return c.json({ error: message }, 500);
+    }
+  });
+
+  return app;
+};

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -246,7 +246,7 @@ const TOOL_BY_NAME: Map<string, CombinedTool> = new Map(
  * when none). Skips the storage reads when no plugin tools exist — transitional,
  * since the plugin system is being retired.
  */
-export async function computeEnabledPlugins(
+async function computeEnabledPlugins(
   ctx: StudioContext,
 ): Promise<string[] | null> {
   if (PLUGIN_TOOLS.length === 0 || !ctx.organization) return null;

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -45,7 +45,7 @@ import * as LinkTools from "./links";
 import * as SearchTools from "./search";
 import { ToolName } from "./registry-metadata";
 // Core tools - always available
-const CORE_TOOLS = [
+export const CORE_TOOLS = [
   OrganizationTools.ORGANIZATION_CREATE,
   OrganizationTools.ORGANIZATION_LIST,
   OrganizationTools.ORGANIZATION_GET,
@@ -203,7 +203,7 @@ const CORE_TOOLS = [
 const PLUGIN_TOOLS = collectPluginTools();
 
 // Tool type for combined core + plugin tools
-interface CombinedTool {
+export interface CombinedTool {
   name: string;
   description: string;
   inputSchema: unknown;
@@ -227,27 +227,63 @@ export type MCPMeshTools = typeof ALL_TOOLS;
 // Derive tool name type from ALL_TOOLS
 export type ToolNameFromTools = (typeof ALL_TOOLS)[number]["name"];
 
-export const managementMCP = async (ctx: StudioContext) => {
-  // Get enabled plugins for this organization to filter plugin tools
-  // Check both org settings (legacy) and all virtual MCPs
-  let enabledPlugins: string[] | null = null;
-  if (ctx.organization) {
-    const settings = await ctx.storage.organizationSettings.get(
-      ctx.organization.id,
-    );
-    const virtualMcpPlugins = await ctx.storage.virtualMcps.listEnabledPlugins(
-      ctx.organization.id,
-    );
-    // Merge enabled plugins from org settings + all virtual MCPs
-    const merged = new Set<string>(settings?.enabled_plugins ?? []);
-    for (const pluginId of virtualMcpPlugins) {
-      merged.add(pluginId);
-    }
-    enabledPlugins = merged.size > 0 ? [...merged] : null;
-  }
+/**
+ * Tuple type of the core tools, preserving each tool's concrete Zod
+ * input/output schema types (unlike the widened `ALL_TOOLS: CombinedTool[]`).
+ * Type-only consumers derive per-tool input/output types from this — see
+ * `./io-types`. Import as `import type` only; importing as a value would pull
+ * the entire server tool graph into a bundle.
+ */
+export type CoreTools = typeof CORE_TOOLS;
 
-  // Filter tools based on enabled plugins
-  // Core tools are always included, plugin tools only if their plugin is enabled
+/** Static name→tool map over ALL_TOOLS, built once at module load. */
+const TOOL_BY_NAME: Map<string, CombinedTool> = new Map(
+  ALL_TOOLS.map((tool) => [tool.name, tool]),
+);
+
+/**
+ * Plugins enabled for an org, merged from org settings + virtual MCPs (null
+ * when none). Skips the storage reads when no plugin tools exist — transitional,
+ * since the plugin system is being retired.
+ */
+export async function computeEnabledPlugins(
+  ctx: StudioContext,
+): Promise<string[] | null> {
+  if (PLUGIN_TOOLS.length === 0 || !ctx.organization) return null;
+  const settings = await ctx.storage.organizationSettings.get(
+    ctx.organization.id,
+  );
+  const virtualMcpPlugins = await ctx.storage.virtualMcps.listEnabledPlugins(
+    ctx.organization.id,
+  );
+  const merged = new Set<string>(settings?.enabled_plugins ?? []);
+  for (const pluginId of virtualMcpPlugins) {
+    merged.add(pluginId);
+  }
+  return merged.size > 0 ? [...merged] : null;
+}
+
+/**
+ * Tools visible to an org as a name→tool map — core always, plugin tools only
+ * when enabled. Mirrors the MCP server's surface for the REST dispatch + list
+ * endpoints, so REST and MCP stay in lockstep on plugin gating.
+ */
+export async function getFilteredTools(
+  ctx: StudioContext,
+): Promise<Map<string, CombinedTool>> {
+  if (PLUGIN_TOOLS.length === 0) return TOOL_BY_NAME;
+  const enabledPlugins = await computeEnabledPlugins(ctx);
+  return new Map(
+    filterToolsByEnabledPlugins(ALL_TOOLS, enabledPlugins).map((tool) => [
+      tool.name,
+      tool,
+    ]),
+  );
+}
+
+export const managementMCP = async (ctx: StudioContext) => {
+  // Filter tools based on enabled plugins: core always, plugin tools when on.
+  const enabledPlugins = await computeEnabledPlugins(ctx);
   const filteredTools = filterToolsByEnabledPlugins(ALL_TOOLS, enabledPlugins);
 
   // Create MCP server directly

--- a/apps/mesh/src/tools/io-types.ts
+++ b/apps/mesh/src/tools/io-types.ts
@@ -1,0 +1,26 @@
+/**
+ * Type-only tool input/output map.
+ *
+ * Derives `{ [toolName]: { input, output } }` from the concrete `CORE_TOOLS`
+ * Zod schemas, giving the web client end-to-end types for REST tool calls
+ * without codegen and without bundling any server code (consumers import this
+ * with `import type` only).
+ */
+import type { z } from "zod";
+import type { CoreTools } from "./index";
+
+type CoreTool = CoreTools[number];
+
+/** Union of all builtin (core) tool names. */
+export type ToolName = CoreTool["name"];
+
+/** Per-tool request (input) and response (output) types, keyed by tool name. */
+export type ToolIO = {
+  [T in CoreTool as T["name"]]: {
+    input: z.input<T["inputSchema"]>;
+    output: z.infer<T["outputSchema"]>;
+  };
+};
+
+export type ToolInput<N extends ToolName> = ToolIO[N]["input"];
+export type ToolOutput<N extends ToolName> = ToolIO[N]["output"];

--- a/apps/mesh/src/web/hooks/use-tags.ts
+++ b/apps/mesh/src/web/hooks/use-tags.ts
@@ -2,17 +2,14 @@
  * Tags Hooks
  *
  * Provides React hooks for managing organization tags and member tag assignments.
- * Uses MCP tools for all operations.
+ * Calls builtin tools over REST via the typed studio-tools client.
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  useMCPClient,
-  useProjectContext,
-  SELF_MCP_ALIAS_ID,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { toast } from "sonner";
 import { KEYS } from "../lib/query-keys";
+import { useStudioTools } from "../lib/studio-tools";
 
 /**
  * Tag data structure
@@ -24,29 +21,18 @@ export interface Tag {
   createdAt: string;
 }
 
-type TagsListOutput = { tags: Tag[] };
-type TagCreateOutput = { tag: Tag };
-
 /**
  * Hook to fetch all organization tags
  */
 export function useTags() {
-  const { org, locator } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const { locator } = useProjectContext();
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.tags(locator),
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "TAGS_LIST",
-        arguments: {},
-      })) as { structuredContent?: unknown };
-      const payload = (result.structuredContent ?? result) as TagsListOutput;
-      return payload.tags;
+      const { tags } = await studio.call("TAGS_LIST", {});
+      return tags;
     },
     staleTime: 30000, // 30 seconds
   });
@@ -57,21 +43,13 @@ export function useTags() {
  */
 export function useCreateTag() {
   const queryClient = useQueryClient();
-  const { org, locator } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const { locator } = useProjectContext();
+  const studio = useStudioTools();
 
   return useMutation({
     mutationFn: async (name: string) => {
-      const result = (await client.callTool({
-        name: "TAGS_CREATE",
-        arguments: { name },
-      })) as { structuredContent?: unknown };
-      const payload = (result.structuredContent ?? result) as TagCreateOutput;
-      return payload.tag;
+      const { tag } = await studio.call("TAGS_CREATE", { name });
+      return tag;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: KEYS.tags(locator) });
@@ -88,30 +66,18 @@ export function useCreateTag() {
 // Member Tags Hooks
 // ============================================================================
 
-type MemberTagsGetOutput = { tags: Tag[] };
-type MemberTagsSetOutput = { success: boolean; tags: Tag[] };
-
 /**
  * Hook to fetch tags for a specific member
  */
 export function useMemberTags(memberId: string) {
-  const { org, locator } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const { locator } = useProjectContext();
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.memberTags(locator, memberId),
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "MEMBER_TAGS_GET",
-        arguments: { memberId },
-      })) as { structuredContent?: unknown };
-      const payload = (result.structuredContent ??
-        result) as MemberTagsGetOutput;
-      return payload.tags;
+      const { tags } = await studio.call("MEMBER_TAGS_GET", { memberId });
+      return tags;
     },
     staleTime: 30000, // 30 seconds
     enabled: !!memberId,
@@ -123,12 +89,8 @@ export function useMemberTags(memberId: string) {
  */
 export function useSetMemberTags() {
   const queryClient = useQueryClient();
-  const { org, locator } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const { locator } = useProjectContext();
+  const studio = useStudioTools();
 
   return useMutation({
     mutationFn: async ({
@@ -138,13 +100,7 @@ export function useSetMemberTags() {
       memberId: string;
       tagIds: string[];
     }) => {
-      const result = (await client.callTool({
-        name: "MEMBER_TAGS_SET",
-        arguments: { memberId, tagIds },
-      })) as { structuredContent?: unknown };
-      const payload = (result.structuredContent ??
-        result) as MemberTagsSetOutput;
-      return payload;
+      return await studio.call("MEMBER_TAGS_SET", { memberId, tagIds });
     },
     onSuccess: (_data, variables) => {
       // Invalidate the specific member's tags

--- a/apps/mesh/src/web/lib/studio-tools.ts
+++ b/apps/mesh/src/web/lib/studio-tools.ts
@@ -13,7 +13,7 @@ import { useProjectContext } from "@decocms/mesh-sdk";
 import type { ToolIO, ToolName } from "@/tools/io-types";
 
 /** Thrown when a tool REST call returns a non-2xx status. `status` is the HTTP code. */
-export class StudioToolError extends Error {
+class StudioToolError extends Error {
   constructor(
     message: string,
     readonly status: number,
@@ -27,7 +27,7 @@ export class StudioToolError extends Error {
  * Call a builtin tool over REST. `orgSlug` scopes the org; `name` is the tool
  * identifier (also the permission identifier checked server-side).
  */
-export async function callStudioTool<N extends ToolName>(
+async function callStudioTool<N extends ToolName>(
   orgSlug: string,
   name: N,
   input: ToolIO[N]["input"],

--- a/apps/mesh/src/web/lib/studio-tools.ts
+++ b/apps/mesh/src/web/lib/studio-tools.ts
@@ -1,0 +1,73 @@
+/**
+ * Typed REST client for builtin/management tools.
+ *
+ * Replaces the in-browser MCP client (`useMCPClient({ connectionId: "self" })`
+ * → `client.callTool(...)`) for the web admin. Calls
+ * `POST /api/:org/tools/:toolName` with the arguments as the JSON body and
+ * returns the tool's typed output. Auth rides the session cookie (same-origin).
+ *
+ * Types come from `@/tools/io-types` (`import type` only — no server code is
+ * bundled).
+ */
+import { useProjectContext } from "@decocms/mesh-sdk";
+import type { ToolIO, ToolName } from "@/tools/io-types";
+
+/** Thrown when a tool REST call returns a non-2xx status. `status` is the HTTP code. */
+export class StudioToolError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "StudioToolError";
+  }
+}
+
+/**
+ * Call a builtin tool over REST. `orgSlug` scopes the org; `name` is the tool
+ * identifier (also the permission identifier checked server-side).
+ */
+export async function callStudioTool<N extends ToolName>(
+  orgSlug: string,
+  name: N,
+  input: ToolIO[N]["input"],
+): Promise<ToolIO[N]["output"]> {
+  const res = await fetch(
+    `/api/${encodeURIComponent(orgSlug)}/tools/${encodeURIComponent(name)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input ?? {}),
+    },
+  );
+
+  if (!res.ok) {
+    let message = `${name} failed (${res.status})`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      // non-JSON error body — keep the default message
+    }
+    throw new StudioToolError(message, res.status);
+  }
+
+  return (await res.json()) as ToolIO[N]["output"];
+}
+
+/**
+ * Hook returning a typed tool caller bound to the current org. Use inside
+ * React Query `queryFn`/`mutationFn` in place of `client.callTool(...)`:
+ *
+ *   const studio = useStudioTools();
+ *   const settings = await studio.call("ORGANIZATION_SETTINGS_GET", {});
+ */
+export function useStudioTools() {
+  const { org } = useProjectContext();
+  const orgSlug = org.slug;
+  return {
+    orgSlug,
+    call: <N extends ToolName>(name: N, input: ToolIO[N]["input"]) =>
+      callStudioTool(orgSlug, name, input),
+  };
+}

--- a/packages/mesh-sdk/src/hooks/use-mcp-client.ts
+++ b/packages/mesh-sdk/src/hooks/use-mcp-client.ts
@@ -1,6 +1,8 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { SELF_MCP_ALIAS_ID } from "../lib/constants";
 import { KEYS } from "../lib/query-keys";
+import { createRestSelfClient } from "../lib/rest-self-client";
 import { StreamableHTTPClientTransport } from "../lib/streamable-http-client-transport";
 
 const DEFAULT_CLIENT_INFO = {
@@ -68,6 +70,25 @@ export async function createMCPClient({
   token,
   meshUrl,
 }: CreateMcpClientOptions): Promise<Client> {
+  const queryKey = KEYS.mcpClient(
+    orgId,
+    connectionId ?? "self",
+    token ?? "",
+    meshUrl ?? "",
+  );
+
+  // Self/management connection → REST-backed client. The browser no longer
+  // speaks MCP to the mesh server for builtin tools; they're called over plain
+  // REST (`/api/:org/tools/:name`). The MCP SDK stays for outbound connections.
+  if (!connectionId || connectionId === SELF_MCP_ALIAS_ID) {
+    return createRestSelfClient({
+      orgSlug,
+      token,
+      meshUrl,
+      toJSONString: `mcp-client:${queryKey.join(":")}`,
+    });
+  }
+
   const url = buildMcpUrl(connectionId, orgSlug, meshUrl);
 
   const client = new Client(DEFAULT_CLIENT_INFO, {
@@ -98,13 +119,6 @@ export async function createMCPClient({
 
   // Add toJSON method for query key serialization
   // This allows the client to be used directly in query keys
-  const queryKey = KEYS.mcpClient(
-    orgId,
-    connectionId ?? "self",
-    token ?? "",
-    meshUrl ?? "",
-  );
-
   (client as Client & { toJSON: () => string }).toJSON = () =>
     `mcp-client:${queryKey.join(":")}`;
 

--- a/packages/mesh-sdk/src/lib/rest-self-client.ts
+++ b/packages/mesh-sdk/src/lib/rest-self-client.ts
@@ -1,0 +1,123 @@
+/**
+ * REST-backed client for the self/management connection.
+ *
+ * The web client no longer speaks MCP to the mesh server for builtin tools —
+ * it calls them over plain REST at `POST /api/:org/tools/:name`. This object
+ * implements the subset of the MCP `Client` interface the app actually uses
+ * against the self connection (`callTool`, `listTools`), returning the same
+ * `CallToolResult`/`ListToolsResult` shapes so existing generic hooks
+ * (`use-collections`, `use-mcp-tools`, …) and call sites work unchanged.
+ *
+ * The MCP SDK is reserved for outbound connections; nothing here imports it at
+ * runtime. Prompts/resources are not used against self in the web, so those
+ * methods throw a clear error if ever called.
+ */
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+export interface RestSelfClientOptions {
+  /** Organization slug, used to build `/api/:org/tools/...`. */
+  orgSlug: string;
+  /** Bearer token for non-cookie auth (external apps). Browser uses the session cookie. */
+  token?: string | null;
+  /** Mesh server origin; defaults to `window.location.origin` in the browser. */
+  meshUrl?: string;
+  /** Stable string used for React Query key serialization (via `toJSON`). */
+  toJSONString: string;
+}
+
+interface CallToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+}
+
+const text = (value: string) => [{ type: "text" as const, text: value }];
+
+export function createRestSelfClient(opts: RestSelfClientOptions): Client {
+  const origin =
+    opts.meshUrl ??
+    (typeof window !== "undefined" ? window.location.origin : undefined);
+  if (!origin) {
+    throw new Error(
+      "RestSelfClient requires either meshUrl or a browser environment.",
+    );
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    ...(opts.token ? { Authorization: `Bearer ${opts.token}` } : {}),
+  };
+
+  const toUrl = (path: string) =>
+    new URL(`/api/${encodeURIComponent(opts.orgSlug)}${path}`, origin).href;
+
+  const callTool = async (params: {
+    name: string;
+    arguments?: Record<string, unknown>;
+  }): Promise<CallToolResult> => {
+    let res: Response;
+    try {
+      res = await fetch(toUrl(`/tools/${encodeURIComponent(params.name)}`), {
+        method: "POST",
+        headers,
+        credentials: "include",
+        body: JSON.stringify(params.arguments ?? {}),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Network error";
+      return { content: text(message), isError: true };
+    }
+
+    if (!res.ok) {
+      let message = `${params.name} failed (${res.status})`;
+      try {
+        const body = (await res.json()) as { error?: string };
+        if (body?.error) message = body.error;
+      } catch {
+        // non-JSON error body — keep the default message
+      }
+      return { content: text(message), isError: true };
+    }
+
+    const result = await res.json().catch(() => ({}));
+    return {
+      content: text(
+        typeof result === "string" ? result : JSON.stringify(result),
+      ),
+      structuredContent: result,
+    };
+  };
+
+  const listTools = async () => {
+    const res = await fetch(toUrl(`/tools`), {
+      method: "GET",
+      headers,
+      credentials: "include",
+    });
+    if (!res.ok) return { tools: [] };
+    return (await res.json()) as { tools: unknown[] };
+  };
+
+  const unsupported = (method: string) => () => {
+    return Promise.reject(
+      new Error(
+        `RestSelfClient: ${method} is not supported over REST for the self connection`,
+      ),
+    );
+  };
+
+  const client = {
+    callTool,
+    listTools,
+    listPrompts: unsupported("listPrompts"),
+    getPrompt: unsupported("getPrompt"),
+    listResources: unsupported("listResources"),
+    readResource: unsupported("readResource"),
+    listResourceTemplates: unsupported("listResourceTemplates"),
+    close: () => Promise.resolve(),
+    toJSON: () => opts.toJSONString,
+  };
+
+  return client as unknown as Client;
+}


### PR DESCRIPTION
## Summary

Moves **client↔server** communication for builtin/management tools off MCP and onto plain REST, so the MCP SDK is reserved for **outbound** (server↔MCP-server) traffic. Additive and behavior-preserving — every existing call site keeps working, now over REST.

- **`POST /api/:org/tools/:toolName`** + **`GET /api/:org/tools`** (`api/routes/tools-rest.ts`) dispatch builtin tools, reusing the existing tool registry, plugin filtering (`getFilteredTools`), and the per-tool `ctx.access` check. The **tool name stays the permission identifier** — a 404 is the manual identifier check; the tool handler's own `ctx.access.check()` enforces authz (mapped to 401/403/400/404/500).
- **`createMCPClient()` returns a REST-backed `RestSelfClient`** for the `self` connection (`mesh-sdk`), so generic collection hooks, chat stores, and direct calls all go over REST with **no call-site churn**. The MCP SDK `Client`/transport is now only used for real connections.
- **Typed `studio-tools` client** (`web/lib/studio-tools.ts`) with a `ToolIO` type map derived from `CORE_TOOLS` Zod schemas (type-only import → zero bundle cost) for direct calls. `use-tags.ts` migrated as a proof.

## Why a `RestSelfClient` (and not pure typed-`meshTool` everywhere)

A chunk of self traffic flows through **generic mesh-sdk collection hooks** (`use-collections.ts` → connections/virtual-mcps/threads) that build tool names dynamically and can't import the app's `ToolIO` types (package boundary). `RestSelfClient` is the only way to move that layer off MCP without redesigning the SDK collection API. It's 100% REST under the hood. Direct app calls use the typed `studio-tools` client.

## Scope / follow-ups

- `/mcp/self` **stays mounted** — still used by virtual-MCP self-aggregation and the runtime workflows engine. Its removal is sequenced with the workflows-plugin deletion (separate PR).
- The typed migration of the remaining ~30 direct-call hooks to `studio-tools` is DX polish on top of this backbone — separate, incremental PRs.

## Testing

- `bun run check` (all workspaces), `bun run lint` (0 errors), and Biome format all pass.
- `e2e/tests/tools-rest.spec.ts` asserts REST authz parity with `/mcp/self` (member→200, gated→403, unknown→404, non-member rejected). Not run locally — this code-only worktree isn't provisioned to boot the full rig (the live dev server belongs to another worktree); **needs a CI / provisioned e2e run**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves builtin tool calls between the web client and server from MCP to REST, keeping MCP only for outbound connections. Behavior is unchanged; calls now use HTTP with proper status codes and no call-site churn. Direct calls can use `useStudioTools()`.

- **New Features**
  - Added POST /api/:org/tools/:toolName and GET /api/:org/tools using the existing registry, plugin filtering (`getFilteredTools`), and per-tool ctx.access.check(). Tool name stays the permission id; returns 401/403/404 as appropriate.
  - `createMCPClient()` now returns a REST-backed `RestSelfClient` for the `self` connection, so generic `@decocms/mesh-sdk` hooks and stores keep working over REST.
  - Typed client for direct calls: `useStudioTools()` built on `ToolIO` from `CORE_TOOLS` (type-only). `use-tags` migrated as a proof.
  - E2E `tools-rest.spec.ts` asserts auth parity with `/mcp/self` (member 200, gated 403, unknown 404, non-member rejected).

- **Refactors**
  - Made `computeEnabledPlugins`, `callStudioTool`, and `StudioToolError` internal (non-exported) to satisfy knip and avoid unused-export warnings.

<sup>Written for commit a6640d1be83c36d6d96564911d39186c3f1bbc55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

