### PR TITLE
refactor(web): migrate self builtin-tool calls to the typed studio-tools client

### DIFF
--- a/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
@@ -11,14 +11,11 @@ import { Check, Copy01 } from "@untitledui/icons";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import type { Capability } from "@/links/protocol";
 import { useCurrentLink } from "@/web/hooks/use-current-link";
 import { KEYS } from "@/web/lib/query-keys";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 const INSTALL_SNIPPET = "bunx decocms link";
 
@@ -64,26 +61,14 @@ export function ConnectDesktopDialog({
   const [copied, setCopied] = useState(false);
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   // Tells the linked daemon to shut down (a `shutdown` control frame rides
   // its held control long-poll) and removes the presence claim, so the link
   // flips offline immediately. The dialog then shows the reconnect snippet.
   const disconnect = useMutation({
     mutationFn: async () => {
-      const result = (await client.callTool({
-        name: "LINK_DISCONNECT",
-        arguments: {},
-      })) as { isError?: boolean; content?: { text?: string }[] };
-      if (result?.isError) {
-        throw new Error(
-          result.content?.[0]?.text ?? "Failed to disconnect desktop",
-        );
-      }
+      await studio.call("LINK_DISCONNECT", {});
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({

--- a/apps/mesh/src/web/components/chat/credits-empty-state.tsx
+++ b/apps/mesh/src/web/components/chat/credits-empty-state.tsx
@@ -26,13 +26,10 @@ import {
 import { cn } from "@deco/ui/lib/utils.ts";
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 const QUICK_AMOUNTS = {
   usd: [
@@ -64,11 +61,7 @@ export function CreditsEmptyState() {
   const { org } = useProjectContext();
   const navigate = useNavigate();
   const { decoKeyId } = useDecoCredits();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const [open, setOpen] = useState(true);
   const [customAmount, setCustomAmount] = useState("");
@@ -95,24 +88,12 @@ export function CreditsEmptyState() {
 
   const { mutate: topUp, isPending } = useMutation({
     mutationFn: async (amountCents: number) => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_TOPUP_URL",
-        arguments: {
-          providerId: "deco",
-          amountCents,
-          currency,
-        },
-      })) as {
-        structuredContent?: { url: string };
-        isError?: boolean;
-        content?: { text?: string }[];
-      };
-      if (result?.isError) {
-        throw new Error(
-          result.content?.[0]?.text ?? "Failed to get top-up URL",
-        );
-      }
-      return result.structuredContent?.url;
+      const { url } = await studio.call("AI_PROVIDER_TOPUP_URL", {
+        providerId: "deco",
+        amountCents,
+        currency,
+      });
+      return url;
     },
     onSuccess: (url) => {
       if (url) window.open(url, "_blank", "noopener,noreferrer");

--- a/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
+++ b/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
@@ -25,13 +25,10 @@ import { Input } from "@deco/ui/components/input.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 const QUICK_AMOUNTS = {
   usd: [
@@ -60,11 +57,7 @@ export function CreditsExhaustedBanner({
   const { org } = useProjectContext();
   const navigate = useNavigate();
   const { decoKeyId } = useDecoCredits();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const [customAmount, setCustomAmount] = useState("");
   const [showCustom, setShowCustom] = useState(false);
@@ -78,24 +71,12 @@ export function CreditsExhaustedBanner({
 
   const { mutate: topUp, isPending } = useMutation({
     mutationFn: async (amountCents: number) => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_TOPUP_URL",
-        arguments: {
-          providerId: "deco",
-          amountCents,
-          currency,
-        },
-      })) as {
-        structuredContent?: { url: string };
-        isError?: boolean;
-        content?: { text?: string }[];
-      };
-      if (result?.isError) {
-        throw new Error(
-          result.content?.[0]?.text ?? "Failed to get top-up URL",
-        );
-      }
-      return result.structuredContent?.url;
+      const { url } = await studio.call("AI_PROVIDER_TOPUP_URL", {
+        providerId: "deco",
+        amountCents,
+        currency,
+      });
+      return url;
     },
     onSuccess: (url) => {
       if (url) window.open(url, "_blank", "noopener,noreferrer");

--- a/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
+++ b/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
@@ -6,16 +6,12 @@ import {
   ProviderGrid,
   type ProviderSelection,
 } from "@/web/views/settings/ai-providers/provider-grid";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { useAiProviders } from "@/web/hooks/collections/use-ai-providers";
 import { useAuthConfig } from "@/web/providers/auth-config-provider";
 import { useCurrentLink } from "@/web/hooks/use-current-link";
 import { KEYS } from "@/web/lib/query-keys";
-import { unwrapToolResult } from "@/web/lib/unwrap-tool-result";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { useQuery } from "@tanstack/react-query";
 import type { BrandContext } from "@/storage/types";
 import { ConnectDesktopDialog } from "./connect-desktop-dialog";
@@ -27,21 +23,13 @@ interface NoAiProviderEmptyStateProps {
 
 function useDefaultBrand(): BrandContext | null {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data } = useQuery<BrandContext | null>({
     queryKey: KEYS.defaultBrand(org.id),
     queryFn: async () => {
-      const result = await client.callTool({
-        name: "BRAND_CONTEXT_LIST",
-        arguments: {},
-      });
-      const data = unwrapToolResult<{ items?: BrandContext[] }>(result);
-      const brands = Array.isArray(data?.items) ? data.items : [];
+      const { items } = await studio.call("BRAND_CONTEXT_LIST", {});
+      const brands = (Array.isArray(items) ? items : []) as BrandContext[];
       return brands.find((b) => b.isDefault && !b.archivedAt) ?? null;
     },
   });

--- a/apps/mesh/src/web/components/details/connection/connection-activity.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-activity.tsx
@@ -9,12 +9,9 @@ import {
   ChartTooltipContent,
 } from "@deco/ui/components/chart.tsx";
 import { KEYS } from "@/web/lib/query-keys.ts";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { cn } from "@deco/ui/lib/utils.ts";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useState } from "react";
 import { Bar, BarChart, Cell } from "recharts";
@@ -47,37 +44,23 @@ const CHART_CONFIG = {
 interface ActivityChartProps {
   connectionId: string;
   orgId: string;
-  orgSlug: string;
   timeframe: Timeframe;
 }
 
-function ActivityChart({
-  connectionId,
-  orgId,
-  orgSlug,
-  timeframe,
-}: ActivityChartProps) {
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId,
-    orgSlug,
-  });
+function ActivityChart({ connectionId, orgId, timeframe }: ActivityChartProps) {
+  const studio = useStudioTools();
   const dateRange = getDateRange(timeframe);
 
   const { data } = useSuspenseQuery({
     queryKey: KEYS.connectionActivity(connectionId, timeframe, orgId),
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "MONITORING_LOGS_LIST",
-        arguments: {
-          startDate: dateRange.startDate.toISOString(),
-          endDate: dateRange.endDate.toISOString(),
-          connectionId,
-          limit: 2000,
-          offset: 0,
-        },
-      })) as { structuredContent?: unknown };
-      return (result.structuredContent ?? result) as BaseMonitoringLogsResponse;
+      return (await studio.call("MONITORING_LOGS_LIST", {
+        startDate: dateRange.startDate.toISOString(),
+        endDate: dateRange.endDate.toISOString(),
+        connectionId,
+        limit: 2000,
+        offset: 0,
+      })) as BaseMonitoringLogsResponse;
     },
     staleTime: 5 * 60 * 1000,
   });
@@ -227,7 +210,6 @@ export function ConnectionActivity({ connectionId }: ConnectionActivityProps) {
         <ActivityChart
           connectionId={connectionId}
           orgId={org.id}
-          orgSlug={org.slug}
           timeframe={timeframe}
         />
       </Suspense>

--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -32,7 +32,6 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   getHomeTiles,
   isDecopilot,
-  SELF_MCP_ALIAS_ID,
   useMCPClient,
   useProjectContext,
   useVirtualMCPActions,
@@ -69,7 +68,7 @@ import { getUIResourceUri } from "@/mcp-apps/types.ts";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { KEYS } from "@/web/lib/query-keys";
-import { unwrapToolResult } from "@/web/lib/unwrap-tool-result";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
 
 /** How many agents the home view can actually display — adding past this is
@@ -596,12 +595,7 @@ function AgentToolList({
   connectionIds: string[];
   pinnedResourceUris: Set<string>;
 }) {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data, isLoading } = useQuery({
     queryKey: KEYS.projectConnectionDetails(agent.id, connectionIds),
@@ -610,21 +604,9 @@ function AgentToolList({
       const results = await Promise.all(
         connectionIds.map(async (connId) => {
           try {
-            const result = await client.callTool({
-              name: "COLLECTION_CONNECTIONS_GET",
-              arguments: { id: connId },
+            const { item } = await studio.call("COLLECTION_CONNECTIONS_GET", {
+              id: connId,
             });
-            const { item } = unwrapToolResult<{
-              item: {
-                title?: string;
-                icon?: string | null;
-                tools?: Array<{
-                  name: string;
-                  description?: string;
-                  _meta?: Record<string, unknown>;
-                }> | null;
-              } | null;
-            }>(result);
             const uiTools: UITool[] = (item?.tools ?? []).flatMap((t) => {
               const resourceUri = getUIResourceUri(t._meta);
               if (!resourceUri) return [];

--- a/apps/mesh/src/web/components/monitoring/hooks.ts
+++ b/apps/mesh/src/web/components/monitoring/hooks.ts
@@ -1,11 +1,7 @@
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 /** Connection ID used for all LLM calls emitted by Decopilot. Must match server-side DECOPILOT_CONNECTION_ID. */
 const DECOPILOT_CONNECTION_ID = "decopilot";
@@ -28,28 +24,11 @@ interface MonitoringStatsParams extends MonitoringMetricFilters {
   endDate: string;
 }
 
-/**
- * MCP tools can return a successful HTTP response with `isError: true` in the
- * body. React Query treats that as success, so we promote it to a thrown error
- * here — that way `isError`/`error` on the hook reflect tool failures.
- */
 async function callMonitoringTool<TData>(
-  client: Client,
+  studio: ReturnType<typeof useStudioTools>,
   toolArguments: Record<string, unknown>,
 ): Promise<TData> {
-  const result = (await client.callTool({
-    name: "MONITORING_STATS",
-    arguments: toolArguments,
-  })) as {
-    isError?: boolean;
-    structuredContent?: unknown;
-  };
-
-  if (result.isError) {
-    throw new Error("MONITORING_STATS tool returned an error");
-  }
-
-  return (result.structuredContent ?? result) as TData;
+  return (await studio.call("MONITORING_STATS", toolArguments)) as TData;
 }
 
 interface MonitoringStatsResult {
@@ -81,11 +60,7 @@ export function useMonitoringStats(
   queryOptions?: MonitoringQueryOptions,
 ) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const toolArguments = {
     ...params,
@@ -101,7 +76,7 @@ export function useMonitoringStats(
       JSON.stringify(toolArguments),
     ),
     queryFn: () =>
-      callMonitoringTool<MonitoringStatsResult>(client, toolArguments),
+      callMonitoringTool<MonitoringStatsResult>(studio, toolArguments),
     staleTime: 30_000,
     retry: false,
     ...queryOptions,
@@ -151,11 +126,7 @@ export function useMonitoringLlmStats(
   queryOptions?: MonitoringQueryOptions,
 ) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const toolArguments = {
     ...params,
@@ -168,7 +139,7 @@ export function useMonitoringLlmStats(
   return useQuery<MonitoringLlmStatsResult, Error>({
     queryKey: KEYS.monitoringStatsLlm(org.id, JSON.stringify(toolArguments)),
     queryFn: () =>
-      callMonitoringTool<MonitoringLlmStatsResult>(client, toolArguments),
+      callMonitoringTool<MonitoringLlmStatsResult>(studio, toolArguments),
     staleTime: 30_000,
     retry: false,
     ...queryOptions,

--- a/apps/mesh/src/web/components/settings/delete-organization-section.tsx
+++ b/apps/mesh/src/web/components/settings/delete-organization-section.tsx
@@ -1,11 +1,8 @@
 import { invalidateOrganizationListCache } from "@/web/lib/auth-client";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { track } from "@/web/lib/posthog-client";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -32,28 +29,11 @@ export function DeleteOrganizationSection() {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmName, setConfirmName] = useState("");
 
-  const selfClient = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgSlug: org.slug,
-    orgId: org.id,
-  });
+  const studio = useStudioTools();
 
   const deleteMutation = useMutation({
     mutationFn: async () => {
-      const result = await selfClient.callTool({
-        name: "ORGANIZATION_DELETE",
-        arguments: { id: org.id },
-      });
-      if (result.isError) {
-        const content = result.content;
-        const text =
-          Array.isArray(content) &&
-          content[0]?.type === "text" &&
-          typeof content[0].text === "string"
-            ? content[0].text
-            : "Failed to delete organization";
-        throw new Error(text);
-      }
+      await studio.call("ORGANIZATION_DELETE", { id: org.id });
     },
     onSuccess: () => {
       track("organization_deleted", { organization_id: org.id });

--- a/apps/mesh/src/web/components/settings/domain-settings.tsx
+++ b/apps/mesh/src/web/components/settings/domain-settings.tsx
@@ -1,11 +1,7 @@
 import { authClient } from "@/web/lib/auth-client";
 import { KEYS } from "@/web/lib/query-keys";
-import { unwrapToolResult } from "@/web/lib/unwrap-tool-result";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Switch } from "@deco/ui/components/switch.tsx";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -26,21 +22,11 @@ export function DomainSettings() {
   const { org } = useProjectContext();
   const { data: session } = authClient.useSession();
   const queryClient = useQueryClient();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data, isPending } = useQuery<DomainData>({
     queryKey: KEYS.organizationDomain(org.id),
-    queryFn: async () => {
-      const result = await client.callTool({
-        name: "ORGANIZATION_DOMAIN_GET",
-        arguments: {},
-      });
-      return unwrapToolResult<DomainData>(result);
-    },
+    queryFn: () => studio.call("ORGANIZATION_DOMAIN_GET", {}),
   });
 
   const userEmail = session?.user?.email ?? "";
@@ -55,13 +41,11 @@ export function DomainSettings() {
     });
 
   const setDomainMutation = useMutation({
-    mutationFn: async () => {
-      const result = await client.callTool({
-        name: "ORGANIZATION_DOMAIN_SET",
-        arguments: { domain: userDomain, autoJoinEnabled: false },
-      });
-      return unwrapToolResult(result);
-    },
+    mutationFn: () =>
+      studio.call("ORGANIZATION_DOMAIN_SET", {
+        domain: userDomain,
+        autoJoinEnabled: false,
+      }),
     onSuccess: () => {
       track("organization_domain_claimed", {
         organization_id: org.id,
@@ -83,13 +67,7 @@ export function DomainSettings() {
   });
 
   const clearDomainMutation = useMutation({
-    mutationFn: async () => {
-      const result = await client.callTool({
-        name: "ORGANIZATION_DOMAIN_CLEAR",
-        arguments: {},
-      });
-      return unwrapToolResult(result);
-    },
+    mutationFn: () => studio.call("ORGANIZATION_DOMAIN_CLEAR", {}),
     onSuccess: () => {
       track("organization_domain_cleared", {
         organization_id: org.id,
@@ -117,11 +95,9 @@ export function DomainSettings() {
         organization_id: org.id,
         enabled,
       });
-      const result = await client.callTool({
-        name: "ORGANIZATION_DOMAIN_UPDATE",
-        arguments: { autoJoinEnabled: enabled },
+      return studio.call("ORGANIZATION_DOMAIN_UPDATE", {
+        autoJoinEnabled: enabled,
       });
-      return unwrapToolResult(result);
     },
     onSuccess: () => {
       invalidate();

--- a/apps/mesh/src/web/components/sidebar/task-groups/use-group-show-more.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/use-group-show-more.ts
@@ -1,16 +1,13 @@
 import { useState } from "react";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { toast } from "sonner";
 import {
   useThreadManager,
   useThreads,
 } from "@/web/components/chat/store/hooks";
 import type { Task } from "@/web/components/chat/task/types";
-import { extractToolErrorMessage } from "@/web/components/chat/store/mcp-utils";
+import { useStudioTools } from "@/web/lib/studio-tools";
+import type { ToolInput } from "@/tools/io-types";
 import {
   groupShowMoreIdentity,
   shouldDeferGroupProbe,
@@ -49,8 +46,7 @@ function parseListResult(result: unknown): {
   hasMore: boolean;
   totalCount?: number;
 } {
-  const payload = ((result as { structuredContent?: unknown })
-    .structuredContent ?? result) as {
+  const payload = result as {
     items?: Task[];
     hasMore?: boolean;
     totalCount?: number;
@@ -125,11 +121,7 @@ export function useGroupShowMore(
     globalHasMore,
   );
 
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   if (state.identity === identity && state.serverHasMore === null) {
     const resolvedWithoutProbe =
@@ -162,15 +154,10 @@ export function useGroupShowMore(
       identity,
       async () => {
         const args = buildShowMoreArgs(kind, key, 0, filters, 1);
-        const result = await client.callTool({
-          name: "COLLECTION_THREADS_LIST",
-          arguments: args as unknown as Record<string, unknown>,
-        });
-        if ((result as { isError?: boolean }).isError) {
-          throw new Error(
-            extractToolErrorMessage(result, "COLLECTION_THREADS_LIST failed"),
-          );
-        }
+        const result = await studio.call(
+          "COLLECTION_THREADS_LIST",
+          args as unknown as ToolInput<"COLLECTION_THREADS_LIST">,
+        );
         const { totalCount } = parseListResult(result);
         const visible = nextPageOffset(
           manager.threads.get(),
@@ -211,17 +198,11 @@ export function useGroupShowMore(
       );
 
       const result = await enqueueGroupThreadsFetch(() =>
-        client.callTool({
-          name: "COLLECTION_THREADS_LIST",
-          arguments: args as unknown as Record<string, unknown>,
-        }),
+        studio.call(
+          "COLLECTION_THREADS_LIST",
+          args as unknown as ToolInput<"COLLECTION_THREADS_LIST">,
+        ),
       );
-
-      if ((result as { isError?: boolean }).isError) {
-        throw new Error(
-          extractToolErrorMessage(result, "COLLECTION_THREADS_LIST failed"),
-        );
-      }
 
       const {
         items,

--- a/apps/mesh/src/web/hooks/registry/use-discover-tools.ts
+++ b/apps/mesh/src/web/hooks/registry/use-discover-tools.ts
@@ -1,21 +1,6 @@
 import { useState } from "react";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import type { RegistryToolMeta } from "@/web/lib/registry/types";
-
-interface DiscoverToolsResponse {
-  tools: RegistryToolMeta[];
-  error?: string | null;
-}
-
-interface ToolResult<T> {
-  structuredContent?: T;
-  isError?: boolean;
-  content?: Array<{ type?: string; text?: string }>;
-}
 
 export type DiscoverStatus =
   | "idle"
@@ -28,12 +13,7 @@ export function useDiscoverTools() {
   const [discoverStatus, setDiscoverStatus] = useState<DiscoverStatus>("idle");
   const [discoverError, setDiscoverError] = useState<string | null>(null);
 
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const discover = async (
     remoteUrl: string,
@@ -44,25 +24,10 @@ export function useDiscoverTools() {
     setDiscoverError(null);
 
     try {
-      const result = (await client.callTool({
-        name: "REGISTRY_DISCOVER_TOOLS",
-        arguments: {
-          url: remoteUrl,
-          type: remoteType === "sse" ? "sse" : "http",
-        },
-      })) as ToolResult<DiscoverToolsResponse>;
-
-      const data = (result.structuredContent ??
-        result) as DiscoverToolsResponse;
-
-      if (result.isError) {
-        const message =
-          result.content?.find((item) => item.type === "text")?.text ??
-          "Tool returned an error";
-        setDiscoverError(message);
-        setDiscoverStatus("error");
-        return null;
-      }
+      const data = await studio.call("REGISTRY_DISCOVER_TOOLS", {
+        url: remoteUrl,
+        type: remoteType === "sse" ? "sse" : "http",
+      });
 
       if (data.error) {
         // Detect auth-required errors — server IS reachable but needs credentials

--- a/apps/mesh/src/web/hooks/registry/use-registry.ts
+++ b/apps/mesh/src/web/hooks/registry/use-registry.ts
@@ -4,13 +4,9 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-  WellKnownOrgMCPId,
-} from "@decocms/mesh-sdk";
+import { useProjectContext, WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import { toast } from "sonner";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "@/web/lib/registry/query-keys";
 import type {
   PublishApiKeyGenerateResult,
@@ -28,39 +24,21 @@ import type {
 
 const DEFAULT_LIMIT = 24;
 
-type ToolResult<T> = { structuredContent?: T } & T;
-
 function normalizeSearch(search: string): string {
   return search.trim();
 }
 
+type StudioTools = ReturnType<typeof useStudioTools>;
+
 async function callTool<T>(
-  client: ReturnType<typeof useMCPClient>,
+  studio: StudioTools,
   name: string,
   args: Record<string, unknown>,
 ): Promise<T> {
-  const result = (await client.callTool({
-    name,
-    arguments: args,
-  })) as
-    | (ToolResult<T> & {
-        isError?: boolean;
-        content?: Array<{ type?: string; text?: string }>;
-      })
-    | undefined;
-
-  if (!result || typeof result !== "object") {
-    throw new Error(`Invalid tool response for ${name}`);
-  }
-
-  if (result.isError) {
-    const message =
-      result.content?.find((item) => item.type === "text")?.text ??
-      `Tool ${name} returned an error`;
-    throw new Error(message);
-  }
-
-  return (result.structuredContent ?? result) as T;
+  return studio.call(
+    name as Parameters<StudioTools["call"]>[0],
+    args as Parameters<StudioTools["call"]>[1],
+  ) as Promise<T>;
 }
 
 export function useRegistryItems(params: {
@@ -69,12 +47,7 @@ export function useRegistryItems(params: {
   categories: string[];
   limit?: number;
 }) {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const search = normalizeSearch(params.search);
   const limit = params.limit ?? DEFAULT_LIMIT;
 
@@ -110,7 +83,7 @@ export function useRegistryItems(params: {
             }
           : undefined;
 
-      return callTool<RegistryListResponse>(client, "REGISTRY_ITEM_LIST", {
+      return callTool<RegistryListResponse>(studio, "REGISTRY_ITEM_LIST", {
         cursor: pageParam as string | undefined,
         limit,
         tags: params.tags.length ? params.tags : undefined,
@@ -125,17 +98,12 @@ export function useRegistryItems(params: {
 }
 
 export function useRegistryFilters() {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.filters(),
     queryFn: async () =>
-      callTool<RegistryFilters>(client, "REGISTRY_ITEM_FILTERS", {}),
+      callTool<RegistryFilters>(studio, "REGISTRY_ITEM_FILTERS", {}),
     placeholderData: { tags: [], categories: [] },
     staleTime: 60_000,
   });
@@ -143,12 +111,7 @@ export function useRegistryFilters() {
 
 export function useRegistryMutations() {
   const queryClient = useQueryClient();
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const invalidateAll = async () => {
     await Promise.all([
@@ -160,7 +123,7 @@ export function useRegistryMutations() {
   const createMutation = useMutation({
     mutationFn: async (data: RegistryCreateInput) => {
       const response = await callTool<{ item: RegistryItem }>(
-        client,
+        studio,
         "REGISTRY_ITEM_CREATE",
         { data },
       );
@@ -178,7 +141,7 @@ export function useRegistryMutations() {
       data: RegistryUpdateInput;
     }) => {
       const response = await callTool<{ item: RegistryItem }>(
-        client,
+        studio,
         "REGISTRY_ITEM_UPDATE",
         { id, data },
       );
@@ -190,7 +153,7 @@ export function useRegistryMutations() {
   const deleteMutation = useMutation({
     mutationFn: async (id: string) => {
       const response = await callTool<{ item: RegistryItem | null }>(
-        client,
+        studio,
         "REGISTRY_ITEM_DELETE",
         { id },
       );
@@ -201,7 +164,7 @@ export function useRegistryMutations() {
 
   const bulkCreateMutation = useMutation({
     mutationFn: async (items: RegistryCreateInput[]) =>
-      callTool<RegistryBulkCreateResult>(client, "REGISTRY_ITEM_BULK_CREATE", {
+      callTool<RegistryBulkCreateResult>(studio, "REGISTRY_ITEM_BULK_CREATE", {
         items,
       }),
     onSuccess: invalidateAll,
@@ -234,11 +197,7 @@ interface RegistryConfigSettings {
 
 export function useRegistryConfig(pluginId: string) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
 
   const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
@@ -246,7 +205,7 @@ export function useRegistryConfig(pluginId: string) {
   const configQuery = useQuery({
     queryKey: KEYS.registryConfigByPlugin(selfConnectionId, pluginId),
     queryFn: async () =>
-      callTool<PluginConfigResponse>(client, "VIRTUAL_MCP_PLUGIN_CONFIG_GET", {
+      callTool<PluginConfigResponse>(studio, "VIRTUAL_MCP_PLUGIN_CONFIG_GET", {
         virtualMcpId: selfConnectionId,
         pluginId,
       }),
@@ -258,7 +217,7 @@ export function useRegistryConfig(pluginId: string) {
   const configMutation = useMutation({
     mutationFn: async (settingsPatch: RegistryConfigSettings) => {
       const latestData = await callTool<PluginConfigResponse>(
-        client,
+        studio,
         "VIRTUAL_MCP_PLUGIN_CONFIG_GET",
         {
           virtualMcpId: selfConnectionId,
@@ -269,7 +228,7 @@ export function useRegistryConfig(pluginId: string) {
         (latestData?.config?.settings as RegistryConfigSettings | null) ?? {};
 
       return callTool<PluginConfigResponse>(
-        client,
+        studio,
         "VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE",
         {
           virtualMcpId: selfConnectionId,
@@ -355,11 +314,7 @@ export function usePublishRequests(params: {
   sortDirection: "asc" | "desc";
 }) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const limit = DEFAULT_LIMIT;
 
   return useInfiniteQuery({
@@ -371,7 +326,7 @@ export function usePublishRequests(params: {
     ),
     queryFn: async ({ pageParam }) =>
       callTool<PublishRequestListResponse>(
-        client,
+        studio,
         "REGISTRY_PUBLISH_REQUEST_LIST",
         {
           status: params.status,
@@ -396,17 +351,13 @@ export function usePublishRequests(params: {
 
 export function usePublishRequestCount() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.publishRequestsCountByOrg(org.id),
     queryFn: async () =>
       callTool<{ pending: number }>(
-        client,
+        studio,
         "REGISTRY_PUBLISH_REQUEST_COUNT",
         {},
       ),
@@ -416,12 +367,7 @@ export function usePublishRequestCount() {
 
 export function usePublishRequestMutations() {
   const queryClient = useQueryClient();
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const invalidateAll = async () => {
     await Promise.all([
@@ -436,7 +382,7 @@ export function usePublishRequestMutations() {
       reviewerNotes?: string;
     }) => {
       return callTool<{ item: PublishRequest }>(
-        client,
+        studio,
         "REGISTRY_PUBLISH_REQUEST_REVIEW",
         data,
       );
@@ -447,7 +393,7 @@ export function usePublishRequestMutations() {
   const deleteMutation = useMutation({
     mutationFn: async (id: string) => {
       return callTool<{ item: PublishRequest | null }>(
-        client,
+        studio,
         "REGISTRY_PUBLISH_REQUEST_DELETE",
         { id },
       );
@@ -461,18 +407,13 @@ export function usePublishRequestMutations() {
 // ─── Publish API Keys ───
 
 export function usePublishApiKeys() {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.publishApiKeys(),
     queryFn: async () =>
       callTool<PublishApiKeyListResponse>(
-        client,
+        studio,
         "REGISTRY_PUBLISH_API_KEY_LIST",
         {},
       ),
@@ -482,17 +423,12 @@ export function usePublishApiKeys() {
 
 export function usePublishApiKeyMutations() {
   const queryClient = useQueryClient();
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const generateMutation = useMutation({
     mutationFn: async (name: string) =>
       callTool<PublishApiKeyGenerateResult>(
-        client,
+        studio,
         "REGISTRY_PUBLISH_API_KEY_GENERATE",
         { name },
       ),
@@ -506,7 +442,7 @@ export function usePublishApiKeyMutations() {
   const revokeMutation = useMutation({
     mutationFn: async (keyId: string) =>
       callTool<{ success: boolean; keyId: string }>(
-        client,
+        studio,
         "REGISTRY_PUBLISH_API_KEY_REVOKE",
         { keyId },
       ),

--- a/apps/mesh/src/web/hooks/use-current-link.ts
+++ b/apps/mesh/src/web/hooks/use-current-link.ts
@@ -1,12 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import type { Capability } from "@/links/protocol";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
-import { unwrapToolResult } from "@/web/lib/unwrap-tool-result";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 export interface CurrentLink {
   online: boolean;
@@ -26,20 +22,12 @@ const OFFLINE: CurrentLink = { online: false, capabilities: [], ready: false };
 
 export function useCurrentLink(): CurrentLink {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data } = useQuery<CurrentLink>({
     queryKey: KEYS.currentLink(org.id),
     queryFn: async () => {
-      const result = await client.callTool({
-        name: "LINK_CURRENT_GET",
-        arguments: {},
-      });
-      const link = unwrapToolResult<Omit<CurrentLink, "ready">>(result);
+      const link = await studio.call("LINK_CURRENT_GET", {});
       return link ? { ...link, ready: true } : { ...OFFLINE, ready: true };
     },
     staleTime: 10_000,

--- a/apps/mesh/src/web/hooks/use-deco-credits.ts
+++ b/apps/mesh/src/web/hooks/use-deco-credits.ts
@@ -5,13 +5,10 @@
  * chat error banners, and settings page into a single source of truth.
  */
 
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "../lib/query-keys";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { useAiProviderKeys } from "./collections/use-ai-providers";
 import { track } from "../lib/posthog-client";
 import { useRef } from "react";
@@ -24,11 +21,7 @@ const lastSeenBalance = new Map<string, number>();
 
 export function useDecoCredits() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const keys = useAiProviderKeys();
 
   const decoKey = keys.find((k) => k.providerId === "deco");
@@ -38,15 +31,11 @@ export function useDecoCredits() {
     enabled: !!decoKey,
     staleTime: 60_000,
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_CREDITS",
-        arguments: { providerId: "deco" },
-      })) as {
-        structuredContent?: { balanceCents: number };
-        isError?: boolean;
-      };
-      if (result?.isError) return null;
-      return result.structuredContent ?? null;
+      try {
+        return await studio.call("AI_PROVIDER_CREDITS", { providerId: "deco" });
+      } catch {
+        return null;
+      }
     },
   });
 

--- a/apps/mesh/src/web/hooks/use-delete-connection.ts
+++ b/apps/mesh/src/web/hooks/use-delete-connection.ts
@@ -1,7 +1,5 @@
 import {
-  SELF_MCP_ALIAS_ID,
   UI_RESOURCE_HTML_KEY,
-  useMCPClient,
   useProjectContext,
   type ConnectionEntity,
 } from "@decocms/mesh-sdk";
@@ -9,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import { clearHtmlResourceCacheForConnection } from "@/web/lib/html-resource-persist";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 export type DeleteConnectionState =
   | { mode: "idle" }
@@ -19,18 +18,6 @@ export type DeleteConnectionState =
       agentNames: string;
     };
 
-function getMcpErrorText(result: Record<string, unknown>): string {
-  const content = result.content;
-  if (
-    Array.isArray(content) &&
-    content[0]?.type === "text" &&
-    typeof content[0].text === "string"
-  ) {
-    return content[0].text;
-  }
-  return "Unknown error";
-}
-
 export function useDeleteConnection({
   onSuccess,
 }: {
@@ -38,11 +25,7 @@ export function useDeleteConnection({
 } = {}) {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
-  const selfClient = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const [deleteState, setDeleteState] = useState<DeleteConnectionState>({
     mode: "idle",
@@ -93,39 +76,32 @@ export function useDeleteConnection({
     setDeleteState({ mode: "idle" });
 
     try {
-      const result = await selfClient.callTool({
-        name: "COLLECTION_CONNECTIONS_DELETE",
-        arguments: { id: connection.id },
+      await studio.call("COLLECTION_CONNECTIONS_DELETE", {
+        id: connection.id,
       });
-
-      if (result.isError) {
-        const errorText = getMcpErrorText(result);
-
-        const jsonText = errorText.replace(/^Error:\s*/, "");
-        try {
-          const parsed = JSON.parse(jsonText) as {
-            code?: string;
-            agentNames?: string[];
-          };
-          if (parsed.code === "CONNECTION_IN_USE" && parsed.agentNames) {
-            setDeleteState({
-              mode: "force-deleting",
-              connection,
-              agentNames: parsed.agentNames.map((n) => `"${n}"`).join(", "),
-            });
-            return;
-          }
-        } catch {
-          // Not JSON — fall through to generic error toast
-        }
-
-        toast.error(`Failed to delete connection: ${errorText}`);
-        return;
-      }
 
       handleSuccess(connection.id);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+
+      const jsonText = message.replace(/^Error:\s*/, "");
+      try {
+        const parsed = JSON.parse(jsonText) as {
+          code?: string;
+          agentNames?: string[];
+        };
+        if (parsed.code === "CONNECTION_IN_USE" && parsed.agentNames) {
+          setDeleteState({
+            mode: "force-deleting",
+            connection,
+            agentNames: parsed.agentNames.map((n) => `"${n}"`).join(", "),
+          });
+          return;
+        }
+      } catch {
+        // Not JSON — fall through to generic error toast
+      }
+
       toast.error(`Failed to delete connection: ${message}`);
     }
   };
@@ -137,15 +113,7 @@ export function useDeleteConnection({
     setDeleteState({ mode: "idle" });
 
     try {
-      const result = await selfClient.callTool({
-        name: "COLLECTION_CONNECTIONS_DELETE",
-        arguments: { id, force: true },
-      });
-
-      if (result.isError) {
-        toast.error(`Failed to delete connection: ${getMcpErrorText(result)}`);
-        return;
-      }
+      await studio.call("COLLECTION_CONNECTIONS_DELETE", { id, force: true });
 
       handleSuccess(id);
     } catch (error) {

--- a/apps/mesh/src/web/hooks/use-enable-plugin.ts
+++ b/apps/mesh/src/web/hooks/use-enable-plugin.ts
@@ -6,34 +6,15 @@
  */
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  useProjectContext,
-  useMCPClient,
-  SELF_MCP_ALIAS_ID,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "@/web/lib/query-keys";
 import { toast } from "sonner";
-
-type ProjectUpdateOutput = {
-  project: {
-    id: string;
-    organizationId: string;
-    slug: string;
-    name: string;
-    description: string | null;
-    enabledPlugins: string[] | null;
-  } | null;
-};
 
 export function useEnablePlugin() {
   const { org, project } = useProjectContext();
   const queryClient = useQueryClient();
-
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const mutation = useMutation({
     mutationFn: async (pluginId: string) => {
@@ -46,21 +27,14 @@ export function useEnablePlugin() {
 
       const enabledPlugins = [...currentPlugins, pluginId];
 
-      const result = await client.callTool({
-        name: "COLLECTION_VIRTUAL_MCP_UPDATE",
-        arguments: {
-          id: project.id,
-          data: {
-            metadata: {
-              enabled_plugins: enabledPlugins,
-            },
+      return await studio.call("COLLECTION_VIRTUAL_MCP_UPDATE", {
+        id: project.id,
+        data: {
+          metadata: {
+            enabled_plugins: enabledPlugins,
           },
         },
       });
-
-      const payload =
-        (result as { structuredContent?: unknown }).structuredContent ?? result;
-      return payload as ProjectUpdateOutput;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/apps/mesh/src/web/hooks/use-file-configs.ts
+++ b/apps/mesh/src/web/hooks/use-file-configs.ts
@@ -1,16 +1,12 @@
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import {
   useMutation,
   useQuery,
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "../lib/query-keys";
-import { unwrapToolResult } from "../lib/unwrap-tool-result";
 
 export interface FileConfigInfo {
   id: string;
@@ -30,22 +26,12 @@ export interface FileConfigInfo {
 
 export function useFileConfigs() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data } = useSuspenseQuery({
     queryKey: KEYS.fileConfigs(org.id),
     staleTime: 60_000,
-    queryFn: async () => {
-      const result = await client.callTool({
-        name: "FILE_CONFIG_LIST",
-        arguments: {},
-      });
-      return unwrapToolResult<{ configs: FileConfigInfo[] }>(result);
-    },
+    queryFn: () => studio.call("FILE_CONFIG_LIST", {}),
   });
 
   return data.configs;
@@ -60,22 +46,12 @@ export function useFileConfigs() {
  */
 export function useFileConfigsQuery() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.fileConfigs(org.id),
     staleTime: 60_000,
-    queryFn: async () => {
-      const result = await client.callTool({
-        name: "FILE_CONFIG_LIST",
-        arguments: {},
-      });
-      return unwrapToolResult<{ configs: FileConfigInfo[] }>(result);
-    },
+    queryFn: () => studio.call("FILE_CONFIG_LIST", {}),
   });
 }
 
@@ -94,21 +70,12 @@ export interface CreateFileConfigInput {
 
 export function useCreateFileConfig() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: CreateFileConfigInput) => {
-      const result = await client.callTool({
-        name: "FILE_CONFIG_CREATE",
-        arguments: { ...input },
-      });
-      return unwrapToolResult<FileConfigInfo>(result);
-    },
+    mutationFn: (input: CreateFileConfigInput) =>
+      studio.call("FILE_CONFIG_CREATE", { ...input }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: KEYS.fileConfigs(org.id) });
     },
@@ -117,21 +84,11 @@ export function useCreateFileConfig() {
 
 export function useDeleteFileConfig() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (id: string) => {
-      const result = await client.callTool({
-        name: "FILE_CONFIG_DELETE",
-        arguments: { id },
-      });
-      return unwrapToolResult<{ success: true }>(result);
-    },
+    mutationFn: (id: string) => studio.call("FILE_CONFIG_DELETE", { id }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: KEYS.fileConfigs(org.id) });
     },

--- a/apps/mesh/src/web/hooks/use-file-picker.ts
+++ b/apps/mesh/src/web/hooks/use-file-picker.ts
@@ -8,14 +8,10 @@
  * `@aws-sdk/lib-storage`.
  */
 
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { useInfiniteQuery, useMutation } from "@tanstack/react-query";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "../lib/query-keys";
-import { unwrapToolResult } from "../lib/unwrap-tool-result";
 
 export interface PickerObject {
   key: string;
@@ -41,11 +37,7 @@ export function useFilePickerObjects(params: {
   enabled?: boolean;
 }) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   return useInfiniteQuery({
     queryKey: KEYS.filePickerObjects(org.id, params.configId),
@@ -53,14 +45,11 @@ export function useFilePickerObjects(params: {
     staleTime: 30_000,
     initialPageParam: null as string | null,
     queryFn: async ({ pageParam }) => {
-      const result = await client.callTool({
-        name: "FILE_OBJECTS_LIST",
-        arguments: {
-          configId: params.configId,
-          cursor: pageParam ?? undefined,
-        },
+      // configId is non-null here: the query is gated by `enabled: !!configId`.
+      return await studio.call("FILE_OBJECTS_LIST", {
+        configId: params.configId as string,
+        cursor: pageParam ?? undefined,
       });
-      return unwrapToolResult<ListObjectsResponse>(result);
     },
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });

--- a/apps/mesh/src/web/hooks/use-invitations.ts
+++ b/apps/mesh/src/web/hooks/use-invitations.ts
@@ -6,11 +6,8 @@
  */
 
 import { KEYS } from "@/web/lib/query-keys";
-import {
-  useMCPClient,
-  useProjectContext,
-  SELF_MCP_ALIAS_ID,
-} from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import {
   useMutation,
   useQueryClient,
@@ -42,22 +39,16 @@ interface OrganizationData {
  * @returns Query result with invitations data (uses Suspense for loading, ErrorBoundary for errors)
  */
 export function useInvitations() {
-  const { org, locator } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const { locator } = useProjectContext();
+  const studio = useStudioTools();
 
   return useSuspenseQuery({
     queryKey: KEYS.invitations(locator),
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "ORGANIZATION_GET",
-        arguments: {},
-      })) as { structuredContent?: unknown };
-      const orgData = (result.structuredContent ??
-        result) as OrganizationData | null;
+      const orgData = (await studio.call(
+        "ORGANIZATION_GET",
+        {},
+      )) as OrganizationData | null;
 
       return orgData?.invitations ?? [];
     },

--- a/apps/mesh/src/web/hooks/use-secrets.ts
+++ b/apps/mesh/src/web/hooks/use-secrets.ts
@@ -1,15 +1,11 @@
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import {
   useMutation,
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "../lib/query-keys";
-import { unwrapToolResult } from "../lib/unwrap-tool-result";
 
 export type SecretScopeKind = "user" | "organization";
 
@@ -27,21 +23,13 @@ export interface SecretInfo {
 
 export function useSecrets() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data } = useSuspenseQuery({
     queryKey: KEYS.secrets(org.id),
     staleTime: 60_000,
     queryFn: async () => {
-      const result = await client.callTool({
-        name: "SECRET_LIST",
-        arguments: {},
-      });
-      return unwrapToolResult<{ secrets: SecretInfo[] }>(result);
+      return await studio.call("SECRET_LIST", {});
     },
   });
 
@@ -57,20 +45,12 @@ export interface CreateSecretInput {
 
 export function useCreateSecret() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (input: CreateSecretInput) => {
-      const result = await client.callTool({
-        name: "SECRET_CREATE",
-        arguments: { ...input },
-      });
-      return unwrapToolResult<SecretInfo>(result);
+      return await studio.call("SECRET_CREATE", { ...input });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: KEYS.secrets(org.id) });

--- a/apps/mesh/src/web/hooks/use-task-expanded-tools.ts
+++ b/apps/mesh/src/web/hooks/use-task-expanded-tools.ts
@@ -5,45 +5,29 @@
  * the most recent expansion for a given tool name wins.
  */
 
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { ThreadExpandedTool, ThreadMetadata } from "../../storage/types";
 import type { Task } from "../components/chat/task/types";
 import { useOptionalThreadManager } from "../components/chat/store/hooks";
 import { KEYS } from "../lib/query-keys";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 export type { ThreadExpandedTool };
-
-type ThreadGetItem = {
-  metadata?: ThreadMetadata;
-} | null;
-
-type ThreadGetOutput = { item: ThreadGetItem };
 
 export function useTaskExpandedTools(taskId: string | null) {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
   const manager = useOptionalThreadManager();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const mutation = useMutation({
     mutationFn: async (tool: Omit<ThreadExpandedTool, "expandedAt">) => {
       if (!taskId) throw new Error("useTaskExpandedTools: no task in context");
-      const getResult = (await client.callTool({
-        name: "COLLECTION_THREADS_GET",
-        arguments: { id: taskId },
-      })) as { structuredContent?: unknown };
-      const getPayload = (getResult.structuredContent ??
-        getResult) as ThreadGetOutput;
+      const getPayload = await studio.call("COLLECTION_THREADS_GET", {
+        id: taskId,
+      });
       const currentMetadata: ThreadMetadata = getPayload.item?.metadata ?? {};
       const currentTools: ThreadExpandedTool[] =
         currentMetadata.expanded_tools ?? [];
@@ -56,12 +40,9 @@ export function useTaskExpandedTools(taskId: string | null) {
         expanded_tools: next,
       };
 
-      await client.callTool({
-        name: "COLLECTION_THREADS_UPDATE",
-        arguments: {
-          id: taskId,
-          data: { metadata: nextMetadata },
-        },
+      await studio.call("COLLECTION_THREADS_UPDATE", {
+        id: taskId,
+        data: { metadata: nextMetadata },
       });
 
       return next;

--- a/apps/mesh/src/web/hooks/use-user-by-id.ts
+++ b/apps/mesh/src/web/hooks/use-user-by-id.ts
@@ -7,11 +7,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "../lib/query-keys";
-import {
-  useMCPClient,
-  useProjectContext,
-  SELF_MCP_ALIAS_ID,
-} from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 /**
  * User data returned by the API
@@ -23,8 +19,6 @@ export interface UserData {
   image: string | null;
 }
 
-type UserGetOutput = { user: UserData | null };
-
 /**
  * Hook for fetching user data
  *
@@ -32,22 +26,13 @@ type UserGetOutput = { user: UserData | null };
  * @returns React Query result with user data
  */
 export function useUserById(userId: string) {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.user(userId),
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "USER_GET",
-        arguments: { id: userId },
-      })) as { structuredContent?: unknown };
-      const payload = (result.structuredContent ?? result) as UserGetOutput;
-      return payload.user;
+      const { user } = await studio.call("USER_GET", { id: userId });
+      return user;
     },
     staleTime: 5 * 60 * 1000, // 5 minutes - users don't change frequently
     retry: 1,

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -15,13 +15,12 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Globe01, Monitor01 } from "@untitledui/icons";
 import { createElement, useSyncExternalStore } from "react";
 import {
-  SELF_MCP_ALIAS_ID,
   useConnections,
-  useMCPClient,
   useProjectContext,
   useVirtualMCP,
 } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import {
   agentHasClonableSource,
   agentHasConnectedGithub,
@@ -83,11 +82,7 @@ export interface MainPanelTabs {
 
 function useTaskMetadata(taskId: string): ThreadMetadata | null {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const manager = useThreadManager();
   // Subscribe to the store so a row that lands AFTER first render (snapshot
   // arrives late, manager.create prepends, etc.) re-renders this hook with
@@ -111,16 +106,12 @@ function useTaskMetadata(taskId: string): ThreadMetadata | null {
   >({
     queryKey: KEYS.ensureTask(org.id, taskId),
     queryFn: async () => {
-      if (!taskId || !client) return null;
+      if (!taskId) return null;
       try {
-        const result = (await client.callTool({
-          name: "COLLECTION_THREADS_GET",
-          arguments: { id: taskId },
-        })) as { structuredContent?: unknown };
-        const payload = (result.structuredContent ?? result) as {
-          item?: Task | null;
-        };
-        return payload.item ?? null;
+        const { item } = await studio.call("COLLECTION_THREADS_GET", {
+          id: taskId,
+        });
+        return (item as Task | null) ?? null;
       } catch {
         return null;
       }

--- a/apps/mesh/src/web/layouts/plugin-layout.tsx
+++ b/apps/mesh/src/web/layouts/plugin-layout.tsx
@@ -19,14 +19,13 @@ import {
 import type { PluginRenderHeaderProps } from "@decocms/bindings/plugins";
 import { PluginContextProvider } from "@decocms/mesh-sdk/plugins";
 import {
-  SELF_MCP_ALIAS_ID,
   useConnections,
-  useMCPClient,
   useMCPClientOptional,
   useProjectContext,
   type ConnectionEntity,
 } from "@decocms/mesh-sdk";
 import { authClient } from "@/web/lib/auth-client";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import {
   Outlet,
   useParams,
@@ -84,16 +83,6 @@ function toPluginConnectionEntity(
  * valid connections are available. Connection-related fields are
  * null in that case.
  */
-type PluginConfigOutput = {
-  config: {
-    id: string;
-    projectId: string;
-    pluginId: string;
-    connectionId: string | null;
-    settings: Record<string, unknown> | null;
-  } | null;
-};
-
 export function PluginLayout({
   bindingName,
   renderEmptyState,
@@ -114,23 +103,15 @@ export function PluginLayout({
   const { data: authSession } = authClient.useSession();
 
   // Fetch project's plugin config to get configured connection
-  const selfClient = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data: pluginConfig, isLoading: isLoadingConfig } = useQuery({
     queryKey: KEYS.projectPluginConfig(project.id ?? "", pluginId),
     queryFn: async () => {
-      const result = (await selfClient.callTool({
-        name: "VIRTUAL_MCP_PLUGIN_CONFIG_GET",
-        arguments: {
-          virtualMcpId: project.id,
-          pluginId,
-        },
-      })) as { structuredContent?: unknown };
-      return (result.structuredContent ?? result) as PluginConfigOutput;
+      return await studio.call("VIRTUAL_MCP_PLUGIN_CONFIG_GET", {
+        virtualMcpId: project.id,
+        pluginId,
+      });
     },
     enabled: !!project.id && !!pluginId,
   });

--- a/apps/mesh/src/web/layouts/tasks-panel/global-search-dialog.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/global-search-dialog.tsx
@@ -14,11 +14,8 @@ import {
   CommandItem,
   CommandList,
 } from "@deco/ui/components/command.tsx";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "@/web/lib/query-keys";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { McpAvatar } from "./mcp-avatar";
@@ -51,11 +48,7 @@ export function GlobalSearchDialog({
   const [query, setQuery] = useState("");
   const { org } = useProjectContext();
   const { setTaskId } = usePanelActions();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const trimmed = query.trim();
 
@@ -63,12 +56,10 @@ export function GlobalSearchDialog({
     queryKey: KEYS.globalSearch(org.id, trimmed),
     enabled: open && trimmed.length > 0,
     queryFn: async (): Promise<SearchResponse> => {
-      if (!client) throw new Error("MCP client unavailable");
-      const result = (await client.callTool({
-        name: "GLOBAL_SEARCH",
-        arguments: { query: trimmed, limit: 20 },
-      })) as { structuredContent?: unknown };
-      return (result.structuredContent ?? result) as SearchResponse;
+      return await studio.call("GLOBAL_SEARCH", {
+        query: trimmed,
+        limit: 20,
+      });
     },
     staleTime: 10_000,
   });

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -76,15 +76,14 @@ import {
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
-  SELF_MCP_ALIAS_ID,
   useConnectionActions,
   useConnections,
-  useMCPClient,
   useProjectContext,
   type ConnectionEntity,
   useVirtualMCPs,
   type VirtualMCPEntity,
 } from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { toast } from "sonner";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
@@ -912,11 +911,7 @@ function ConnectionResults({
     }
   };
 
-  const selfClient = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const invalidateConnections = () => {
     queryClient.invalidateQueries({
@@ -940,11 +935,8 @@ function ConnectionResults({
 
     for (const id of ids) {
       try {
-        const result = await selfClient!.callTool({
-          name: "COLLECTION_CONNECTIONS_DELETE",
-          arguments: { id, force: true },
-        });
-        if (!result.isError) deleted++;
+        await studio.call("COLLECTION_CONNECTIONS_DELETE", { id, force: true });
+        deleted++;
       } catch {
         // continue with next
       }
@@ -996,7 +988,7 @@ function ConnectionResults({
 
   const handleAddToAgent = async (agentId: string) => {
     const agent = agents.find((a) => a.id === agentId);
-    if (!agent || !selfClient) return;
+    if (!agent) return;
     track("connections_bulk_add_to_agent", {
       agent_id: agentId,
       count: selectedIds.size,
@@ -1020,13 +1012,10 @@ function ConnectionResults({
     }
 
     try {
-      await selfClient.callTool({
-        name: "COLLECTION_VIRTUAL_MCP_UPDATE",
-        arguments: {
-          id: agentId,
-          data: {
-            connections: [...agent.connections, ...newConns],
-          },
+      await studio.call("COLLECTION_VIRTUAL_MCP_UPDATE", {
+        id: agentId,
+        data: {
+          connections: [...agent.connections, ...newConns],
         },
       });
 

--- a/apps/mesh/src/web/views/automations/automation-runs.tsx
+++ b/apps/mesh/src/web/views/automations/automation-runs.tsx
@@ -38,6 +38,7 @@ import { useMembers } from "@/web/hooks/use-members";
 import { KEYS } from "@/web/lib/query-keys";
 import { STATUS_CONFIG } from "@/web/lib/task-status";
 import { useAutomationRunStats } from "@/web/hooks/use-automations";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import {
   ThreadSheetBody,
   type ThreadEntity,
@@ -204,6 +205,7 @@ export function AutomationRunsView({
     orgId: org.id,
     orgSlug: org.slug,
   });
+  const studio = useStudioTools();
   const allConnections = useConnections();
   const allVirtualMcps = useVirtualMCPs();
   const { data: membersData } = useMembers();
@@ -216,15 +218,11 @@ export function AutomationRunsView({
     useInfiniteQuery({
       queryKey: KEYS.automationRuns(org.id, automationId, triggerIds),
       queryFn: async ({ pageParam = 0 }) => {
-        const result = (await client.callTool({
-          name: "COLLECTION_THREADS_LIST",
-          arguments: {
-            limit: RUNS_PAGE_SIZE,
-            offset: pageParam,
-            where: { trigger_ids: triggerIds },
-          },
-        })) as { structuredContent?: unknown };
-        return (result.structuredContent ?? result) as {
+        return (await studio.call("COLLECTION_THREADS_LIST", {
+          limit: RUNS_PAGE_SIZE,
+          offset: pageParam,
+          where: { trigger_ids: triggerIds },
+        })) as {
           items: ThreadEntity[];
           totalCount: number;
           hasMore: boolean;
@@ -252,15 +250,11 @@ export function AutomationRunsView({
       JSON.stringify({ ids: threadIds, ...range }),
     ),
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "MONITORING_THREAD_USAGE",
-        arguments: {
-          threadIds,
-          ...(range.startDate ? { startDate: range.startDate } : {}),
-          ...(range.endDate ? { endDate: range.endDate } : {}),
-        },
-      })) as { structuredContent?: unknown };
-      return (result.structuredContent ?? result) as {
+      return (await studio.call("MONITORING_THREAD_USAGE", {
+        threadIds,
+        ...(range.startDate ? { startDate: range.startDate } : {}),
+        ...(range.endDate ? { endDate: range.endDate } : {}),
+      })) as {
         items: Array<ThreadUsage & { threadId: string }>;
       };
     },

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -7,6 +7,7 @@ import {
 } from "@decocms/mesh-sdk";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { clearHtmlResourceCacheForConnection } from "@/web/lib/html-resource-persist";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { Badge } from "@deco/ui/components/badge.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Card } from "@deco/ui/components/card.tsx";
@@ -76,6 +77,7 @@ function ConnectionRow({
   const updateAuth = useUpdateMonitorConnectionAuth();
   const { updateMutation } = useRegistryMutations();
   const { org } = useProjectContext();
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
   const connectionId = entry.mapping.connection_id;
   const authStatus = entry.mapping.auth_status;
@@ -211,26 +213,10 @@ function ConnectionRow({
   };
 
   const saveTokenInternal = async (token: string) => {
-    const res = await fetch(`/api/${org.slug}/mcp/self`, {
-      method: "POST",
-      credentials: "include",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "tools/call",
-        params: {
-          name: "COLLECTION_CONNECTIONS_UPDATE",
-          arguments: {
-            id: connectionId,
-            data: { connection_token: token },
-          },
-        },
-      }),
+    await studio.call("COLLECTION_CONNECTIONS_UPDATE", {
+      id: connectionId,
+      data: { connection_token: token },
     });
-    if (!res.ok) {
-      throw new Error("Failed to save token");
-    }
   };
 
   const handleSaveToken = async () => {

--- a/apps/mesh/src/web/views/settings/ai-providers/deco-credits-hero.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/deco-credits-hero.tsx
@@ -24,11 +24,8 @@ import {
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
 import { useAiProviderKeys } from "@/web/hooks/collections/use-ai-providers";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "@/web/lib/query-keys";
 import { cn } from "@deco/ui/lib/utils.ts";
 
@@ -40,34 +37,17 @@ const TOP_UP_PRESETS = {
 } as const;
 
 function QuickTopUp() {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const [customOpen, setCustomOpen] = useState(false);
 
   const { mutate: topUp, isPending } = useMutation({
     mutationFn: async (amountCents: number) => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_TOPUP_URL",
-        arguments: {
-          providerId: "deco",
-          amountCents,
-          currency,
-        },
-      })) as {
-        structuredContent?: { url: string };
-        isError?: boolean;
-        content?: { text?: string }[];
-      };
-      if (result?.isError) {
-        throw new Error(
-          result.content?.[0]?.text ?? "Failed to get top-up URL",
-        );
-      }
-      return result.structuredContent?.url;
+      const { url } = await studio.call("AI_PROVIDER_TOPUP_URL", {
+        providerId: "deco",
+        amountCents,
+        currency,
+      });
+      return url;
     },
     onSuccess: (url) => {
       if (url) window.open(url, "_blank", "noopener,noreferrer");
@@ -177,11 +157,7 @@ function creditColorClass(dollars: number): string {
 
 export function DecoCreditsHero() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
   const allKeys = useAiProviderKeys();
   const decoKey = allKeys.find((k) => k.providerId === "deco");
@@ -190,10 +166,7 @@ export function DecoCreditsHero() {
   const { mutate: disconnect, isPending: isDisconnecting } = useMutation({
     mutationFn: async () => {
       if (!decoKey) return;
-      await client.callTool({
-        name: "AI_PROVIDER_KEY_DELETE",
-        arguments: { keyId: decoKey.id },
-      });
+      await studio.call("AI_PROVIDER_KEY_DELETE", { keyId: decoKey.id });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: KEYS.aiProviderKeys(org.id) });
@@ -211,15 +184,11 @@ export function DecoCreditsHero() {
     enabled: !!decoKey,
     staleTime: 60_000,
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_CREDITS",
-        arguments: { providerId: "deco" },
-      })) as {
-        structuredContent?: { balanceCents: number };
-        isError?: boolean;
-      };
-      if (result?.isError) return null;
-      return result.structuredContent ?? null;
+      try {
+        return await studio.call("AI_PROVIDER_CREDITS", { providerId: "deco" });
+      } catch {
+        return null;
+      }
     },
   });
 

--- a/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
@@ -16,13 +16,12 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
   useProjectContext,
   type AiProviderInfo,
   type AiProviderKey,
 } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import {
   OPENAI_COMPATIBLE_PRESETS,
   type OpenAICompatiblePreset,
@@ -65,11 +64,7 @@ function EditForm({
   onSuccess,
 }: EditFormProps) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
   const [showKey, setShowKey] = useState(false);
 
@@ -118,13 +113,10 @@ function EditForm({
         });
       }
 
-      await client.callTool({
-        name: "AI_PROVIDER_KEY_UPDATE",
-        arguments: {
-          keyId: providerKey.id,
-          label: data.label,
-          ...(apiKeyValue !== undefined ? { apiKey: apiKeyValue } : {}),
-        },
+      await studio.call("AI_PROVIDER_KEY_UPDATE", {
+        keyId: providerKey.id,
+        label: data.label,
+        ...(apiKeyValue !== undefined ? { apiKey: apiKeyValue } : {}),
       });
     },
     onSuccess: () => {
@@ -224,12 +216,7 @@ export function EditProviderKeyDialog({
   open,
   onOpenChange,
 }: EditProviderKeyDialogProps) {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const preset: OpenAICompatiblePreset | undefined =
     provider.id === "openai-compatible" && providerKey.presetId
@@ -240,19 +227,8 @@ export function EditProviderKeyDialog({
 
   const { data: preview, isLoading } = useQuery({
     queryKey: KEYS.aiProviderKeyPreview(providerKey.id),
-    queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_KEY_PREVIEW",
-        arguments: { keyId: providerKey.id },
-      })) as {
-        structuredContent?: {
-          label: string;
-          maskedKey: string;
-          baseUrl?: string;
-        };
-      };
-      return result.structuredContent!;
-    },
+    queryFn: () =>
+      studio.call("AI_PROVIDER_KEY_PREVIEW", { keyId: providerKey.id }),
     enabled: open,
     staleTime: 0,
   });

--- a/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
@@ -17,12 +17,11 @@ import {
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
 import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
   useProjectContext,
   type AiProviderInfo,
   type AiProviderKey,
 } from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "@/web/lib/query-keys";
 import {
   OPENAI_COMPATIBLE_PRESETS,
@@ -37,11 +36,7 @@ interface ProviderKeyRowProps {
 
 export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
@@ -69,10 +64,7 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
 
   const { mutate: deleteKey, isPending: isDeleting } = useMutation({
     mutationFn: async () => {
-      await client.callTool({
-        name: "AI_PROVIDER_KEY_DELETE",
-        arguments: { keyId: providerKey.id },
-      });
+      await studio.call("AI_PROVIDER_KEY_DELETE", { keyId: providerKey.id });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: KEYS.aiProviderKeys(org.id) });

--- a/apps/mesh/src/web/views/settings/ai-providers/use-deco-connect.ts
+++ b/apps/mesh/src/web/views/settings/ai-providers/use-deco-connect.ts
@@ -1,31 +1,18 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
 import { track } from "@/web/lib/posthog-client";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 export function useDecoConnect() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async () => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_PROVISION_KEY",
-        arguments: { providerId: "deco" },
-      })) as { isError?: boolean; content?: { text?: string }[] };
-      if (result?.isError) {
-        throw new Error(result.content?.[0]?.text ?? "Key provisioning failed");
-      }
+      await studio.call("AI_PROVIDER_PROVISION_KEY", { providerId: "deco" });
     },
     onSuccess: () => {
       track("ai_provider_provision_succeeded", { provider_id: "deco" });

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -16,7 +16,7 @@ import {
   isConnectionAuthenticated,
 } from "@/web/lib/mcp-oauth";
 import { KEYS } from "@/web/lib/query-keys";
-import { unwrapToolResult } from "@/web/lib/unwrap-tool-result";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { getConnectionSlug } from "@/shared/utils/connection-slug";
 import {
   AlertDialog,
@@ -56,12 +56,10 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import {
   type ConnectionEntity,
   ENV_VAR_KEY_RE,
-  SELF_MCP_ALIAS_ID,
   StudioPackAgentId,
   useConnection,
   useConnectionActions,
   useConnections,
-  useMCPClient,
   useProjectContext,
   useVirtualMCP,
   useVirtualMCPActions,
@@ -687,12 +685,7 @@ function LayoutTabContent({
   form: VirtualMcpFormReturn;
   flushAndSave: () => Promise<unknown>;
 }) {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const virtualMcp = useVirtualMCP(virtualMcpId);
 
@@ -707,22 +700,9 @@ function LayoutTabContent({
       const results = await Promise.all(
         connectionIds.map(async (connId) => {
           try {
-            const result = await client.callTool({
-              name: "COLLECTION_CONNECTIONS_GET",
-              arguments: { id: connId },
+            const { item } = await studio.call("COLLECTION_CONNECTIONS_GET", {
+              id: connId,
             });
-            const { item } = unwrapToolResult<{
-              item: {
-                title?: string;
-                icon?: string | null;
-                tools?: Array<{
-                  name: string;
-                  title?: string;
-                  description?: string;
-                  _meta?: Record<string, unknown>;
-                }> | null;
-              } | null;
-            }>(result);
             const uiTools: UITool[] = (item?.tools ?? []).flatMap((t) => {
               const resourceUri = getUIResourceUri(t._meta);
               if (!resourceUri) return [];
@@ -1157,11 +1137,7 @@ function VirtualMcpDetailViewWithData({
   const lastUsedAt = lastUsedMap?.get(virtualMcp.id)?.last_used_at;
   const connectionActions = useConnectionActions();
   const queryClient = useQueryClient();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   // Form setup
   const form = useForm<VirtualMcpFormData>({
@@ -1399,13 +1375,9 @@ function VirtualMcpDetailViewWithData({
 
     // We need the full connection entity to clone from
     try {
-      const result = await client.callTool({
-        name: "COLLECTION_CONNECTIONS_GET",
-        arguments: { id: connectionId },
+      const { item: base } = await studio.call("COLLECTION_CONNECTIONS_GET", {
+        id: connectionId,
       });
-      const { item: base } = (result.structuredContent ?? {}) as {
-        item: ConnectionEntity | null;
-      };
       if (!base) return;
 
       const baseName = base.title.replace(/\s*\(.*?\)\s*$/, "");

--- a/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
@@ -12,17 +12,14 @@ import {
   DrawerTitle,
 } from "@deco/ui/components/drawer.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk";
 import { Check, Copy01, Key01, Loading01 } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";
 import { track } from "@/web/lib/posthog-client";
+import { useStudioTools } from "@/web/lib/studio-tools";
 
 /**
  * Unicode-safe base64 encoding for browser environments
@@ -187,15 +184,10 @@ function InstallClaudeButton({ url, serverName, agentId }: ShareWithNameProps) {
 }
 
 /**
- * Typegen section inner — uses Suspense-based useMCPClient
+ * Typegen section inner — calls builtin tools via useStudioTools
  */
 function TypegenSectionInner({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const [apiKey, setApiKey] = useState<string | null>(null);
   const [generating, setGenerating] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -209,14 +201,10 @@ function TypegenSectionInner({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
   const handleGenerateKey = async () => {
     setGenerating(true);
     try {
-      const result = (await client.callTool({
-        name: "API_KEY_CREATE",
-        arguments: {
-          name: `typegen-${agentName}`,
-          permissions: { [mcpId]: ["*"] },
-        },
-      })) as { structuredContent?: { key?: string } };
-      const key = result.structuredContent?.key;
+      const { key } = await studio.call("API_KEY_CREATE", {
+        name: `typegen-${agentName}`,
+        permissions: { [mcpId]: ["*"] },
+      });
       if (!key) throw new Error("No key in response");
       setApiKey(key);
       track("agent_typegen_key_generated", { agent_id: mcpId });


### PR DESCRIPTION
## Summary

Follow-up to #3932 (the `RestSelfClient` backbone). Migrates **34 web hooks/components** from the in-browser MCP self-client to the typed `studio-tools` client:

```diff
- const client = useMCPClient({ connectionId: SELF_MCP_ALIAS_ID, orgId, orgSlug });
- const r = (await client.callTool({ name: "TAGS_LIST", arguments: {} })) as { structuredContent?: ... };
- return (r.structuredContent ?? r).tags;
+ const studio = useStudioTools();
+ const { tags } = await studio.call("TAGS_LIST", {});
+ return tags;
```

**Behavior-preserving** — same tool names, arguments, React Query keys, optimistic updates and error handling; only the transport-call shape + the now-redundant `structuredContent`/`isError` envelope unwrap change. Net **−674 lines**. Self traffic already ran over REST via the backbone; this adds compile-time type-safety (tool name + input/output inferred from `CORE_TOOLS` via `ToolIO`).

## How it was done

A per-file migration (one agent per candidate, each only touching confirmed *self* calls) + a 4-dimension adversarial review of the diff. Then centrally verified.

## Intentionally left for a follow-up (still on `RestSelfClient`, working over REST)

- **Generic collection consumers** whose React Query key is the *client instance* (`KEYS.collectionList(client, …)`) — can't key on a typed call: `github-repo-picker`, `import-from-deco-dialog`, `tool-set-selector`, `add-connection-dialog`, `use-ai-providers`.
- **Looser-than-UI output schemas** — files where the tool's output schema is less precise than the UI's local types (so a clean typed migration needs the *schemas* tightened first, not suppression casts): `use-automations` (+ `automation-detail`), `use-monitor`, ai-providers connect dialogs, `org-brand-context`, `sandbox-lifecycle`.

## Testing

- `bun run check` (all workspaces), `knip`, `lint`, Biome format — all green.
- Adversarial review (connection-call leakage, React Query semantics, leftover envelope unwrap, plugin-tool/import misuse) — clean after fixing one leftover unwrap (`use-group-show-more`).
- Runtime parity is already covered by the merged `tools-rest.spec.ts` e2e; these call sites are behavior-preserving swaps over the same endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates self builtin-tool calls in the web app to the typed `studio-tools` client over REST, replacing `useMCPClient` calls with `useStudioTools().call(...)`. Behavior is unchanged; adds compile-time typing and removes ~674 LOC.

- **Refactors**
  - Updated 34 components/hooks (chat, settings, registry, monitoring, virtual MCP) to use `useStudioTools().call(name, input)`.
  - Removed `structuredContent`/`isError` envelopes; standardized thrown-error handling while preserving tool names, args, React Query keys, and optimistic updates.
  - Builds on the `RestSelfClient` backbone with I/O types inferred from `CORE_TOOLS` via `ToolIO`. Follow-ups remain on `RestSelfClient` for client-keyed collection consumers and files with looser tool output schemas (e.g., `use-automations`, `use-monitor`, ai-provider connect dialogs, `org-brand-context`, `sandbox-lifecycle`).

<sup>Written for commit f1644bb308d1334d9e1d4cf75d3038a85416a964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

