### PR TITLE
perf(decopilot): drop duplicate per-run listTools over the tool surface

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/tools.ts
@@ -241,19 +241,22 @@ export async function assembleDecopilotTools(
   // try/finally only covers post-construction errors, so the cleanup
   // belongs inside the helper.
   try {
-    const { tools: rawPassthroughTools, nameMap: passthroughNameMap } =
-      await toolsFromMCP(
-        passthroughClient,
-        extras.toolOutputMap,
-        extras.writer,
-        input.toolApprovalLevel,
-        {
-          isPlanMode,
-          timeoutMs: MCP_TOOL_CALL_TIMEOUT_MS,
-          resolveArgs: extras.resolveArgs,
-          onToolCalled: extras.onToolCalled,
-        },
-      );
+    const {
+      tools: rawPassthroughTools,
+      nameMap: passthroughNameMap,
+      rawTools: passthroughToolList,
+    } = await toolsFromMCP(
+      passthroughClient,
+      extras.toolOutputMap,
+      extras.writer,
+      input.toolApprovalLevel,
+      {
+        isPlanMode,
+        timeoutMs: MCP_TOOL_CALL_TIMEOUT_MS,
+        resolveArgs: extras.resolveArgs,
+        onToolCalled: extras.onToolCalled,
+      },
+    );
     // Restrict to the allowlist (if any) so enable_tool enumeration, the
     // connections block, and the model-facing toolset all agree.
     const passthroughTools = filterPassthroughByAllowlist(
@@ -323,8 +326,8 @@ export async function assembleDecopilotTools(
 
     // Collect (rawName, safeName, connectionId) triples for the
     // connections block and the per-tool annotations used for plan-mode
-    // gating — both from a single listTools() round-trip.
-    const passthroughToolList = (await passthroughClient.listTools()).tools;
+    // gating — both from the single listTools() round-trip toolsFromMCP
+    // already issued (reused via its `rawTools`), as the docstring intends.
     const connectionsBlockTools: ConnectionsBlockTool[] = [];
     const toolAnnotations = new Map<string, { readOnlyHint?: boolean }>();
     for (const t of passthroughToolList) {

--- a/packages/harness/src/decopilot/desktop-runtime.ts
+++ b/packages/harness/src/decopilot/desktop-runtime.ts
@@ -291,7 +291,11 @@ function createDesktopToolRuntime(args: {
 
       try {
         // 2. Passthrough tools from the MCP endpoint.
-        const { tools: passthroughTools, nameMap } = await toolsFromMCP(
+        const {
+          tools: passthroughTools,
+          nameMap,
+          rawTools: passthroughToolList,
+        } = await toolsFromMCP(
           mcpClient,
           toolOutputMap,
           undefined,
@@ -304,8 +308,9 @@ function createDesktopToolRuntime(args: {
 
         // 3. Connections-block list + read-only annotations from the raw
         //    listing (drives enable_tool + the connections prompt block +
-        //    plan-mode gating).
-        const passthroughToolList = (await mcpClient.listTools()).tools;
+        //    plan-mode gating). Reuses the listing toolsFromMCP already
+        //    fetched — avoids a second full listTools round-trip per run,
+        //    which is costly at high tool counts (100s of tools).
         const connectionsBlockTools: ConnectionsBlockTool[] = [];
         const toolAnnotations = new Map<string, { readOnlyHint?: boolean }>();
         for (const t of passthroughToolList) {

--- a/packages/harness/src/decopilot/mcp-tools.ts
+++ b/packages/harness/src/decopilot/mcp-tools.ts
@@ -164,7 +164,11 @@ export async function toolsFromMCP(
   writer?: UIMessageStreamWriter,
   toolApprovalLevel: ToolApprovalLevel = "auto",
   options: ToolsFromMcpOptions = {},
-): Promise<{ tools: ToolSet; nameMap: Map<string, string> }> {
+): Promise<{
+  tools: ToolSet;
+  nameMap: Map<string, string>;
+  rawTools: Awaited<ReturnType<Client["listTools"]>>["tools"];
+}> {
   const truncate = !options.disableOutputTruncation;
   const list = await client.listTools();
   const visibleTools = list.tools.filter((t) =>
@@ -289,5 +293,12 @@ export async function toolsFromMCP(
     ];
   });
 
-  return { tools: Object.fromEntries(toolEntries), nameMap };
+  // Return the raw listing too: callers (desktop-runtime's connections-block)
+  // otherwise re-call client.listTools(), doubling the list+parse pass over the
+  // full tool surface every run — costly at high tool counts (100s of tools).
+  return {
+    tools: Object.fromEntries(toolEntries),
+    nameMap,
+    rawTools: list.tools,
+  };
 }


### PR DESCRIPTION
## What
Both decopilot harness paths fetched the virtual-MCP tool surface **twice per run**:
- `toolsFromMCP()` lists the tools internally to build the model ToolSet, then
- the caller immediately calls `client.listTools()` **again** to build the connections-block + plan-mode annotations.

`apps/mesh/.../tools.ts` even documents *"a single `listTools()` round-trip"* — the code contradicted its own intent.

## Why it matters
Each `listTools()` is a full list + parse + per-tool build pass over the **entire aggregated tool surface**. The cost scales with tool count, so an org with many connections (hundreds of tools) pays it twice on every run. In a load profile of a 100-connection org (~800 aggregated tools, 10 concurrent runs), the under-load CPU is dominated by serialization/buffer churn over exactly these large tool-list payloads — halving the list passes is a direct, proportional cut.

## Change
`toolsFromMCP` now returns the raw listing it already fetched (`rawTools`); both callers (`desktop-runtime.ts`, `apps/mesh/.../tools.ts`) reuse it instead of re-listing. One list pass per run instead of two. Behavior is identical (same unfiltered list, same connections-block derivation).

## Validation
- `bun run check` (tsc, harness + mesh) — clean
- `bun run fmt` — clean
- `bun test packages/harness/src/decopilot` — 149 pass / 0 fail
- `bun test apps/mesh/src/harnesses/decopilot` — 83 pass; the 1 failure (`web-search.integration.test.ts`) is a pre-existing integration test in an untouched module (needs external infra), not related to this change.

## Note / follow-up
This removes the *redundant* pass. The residual cost — assembling + serializing the full tool surface and sending it to the model each step — is inherent to large tool surfaces; the real lever there is narrowing the toolset (the `enable_tool` / connections-block mechanism already exists). Tracked separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates the duplicate per-run `listTools()` call over the virtual MCP tool surface. Reuses the listing from `toolsFromMCP` in both decopilot harness paths to avoid a second full list+parse pass.

- **Refactors**
  - `toolsFromMCP` now returns `rawTools`; callers use it for the connections block and plan-mode annotations.
  - Updated `apps/mesh/src/harnesses/decopilot/tools.ts` and `packages/harness/src/decopilot/desktop-runtime.ts` to stop re-calling `client.listTools()`.
  - No behavior changes. One list pass per run instead of two, reducing CPU at high tool counts.

<sup>Written for commit 73fc254273e1eccad23c05ad7314ab328728c2a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

