### PR TITLE
test(sections-editor): Playwright component tests for form widgets

### DIFF
--- a/apps/mesh/.gitignore
+++ b/apps/mesh/.gitignore
@@ -39,6 +39,12 @@ logs/
 # Test coverage
 coverage/
 
+# Playwright component-testing artifacts
+test-results/
+playwright-report/
+.cache/
+playwright/.cache/
+
 # Temporary files
 /tmp/
 

--- a/apps/mesh/ct/harness/ct-utils.ts
+++ b/apps/mesh/ct/harness/ct-utils.ts
@@ -11,3 +11,12 @@ export async function readBreadcrumb(component: Locator): Promise<string[]> {
   const txt = await component.getByTestId("breadcrumb").textContent();
   return JSON.parse(txt ?? "[]");
 }
+
+/**
+ * Parse the harness's `events` <pre> — the list of callback invocations
+ * recorded by the variant harnesses (each entry is e.g. `{type, index}`).
+ */
+export async function readEvents(component: Locator): Promise<unknown[]> {
+  const txt = await component.getByTestId("events").textContent();
+  return JSON.parse(txt ?? "[]");
+}

--- a/apps/mesh/ct/harness/ct-utils.ts
+++ b/apps/mesh/ct/harness/ct-utils.ts
@@ -1,0 +1,13 @@
+import type { Locator } from "@playwright/test";
+
+/** Parse the harness's `form-value` <pre> back into a JS value. */
+export async function readFormValue(component: Locator): Promise<unknown> {
+  const txt = await component.getByTestId("form-value").textContent();
+  return JSON.parse(txt ?? "null");
+}
+
+/** Parse the harness's `breadcrumb` <pre> back into a string[]. */
+export async function readBreadcrumb(component: Locator): Promise<string[]> {
+  const txt = await component.getByTestId("breadcrumb").textContent();
+  return JSON.parse(txt ?? "[]");
+}

--- a/apps/mesh/ct/harness/field-harness.tsx
+++ b/apps/mesh/ct/harness/field-harness.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { renderField } from "@/web/components/sections-editor/schema-form";
+import type {
+  LiveMeta,
+  SchemaProperty,
+} from "@/web/components/sections-editor/resolve-schema";
+
+/**
+ * Single-field CT surface: render one already-resolved SchemaProperty via
+ * `renderField` with internal value + breadcrumb state. Use this when a
+ * hand-crafted SchemaProperty (e.g. a `block-ref` with `anyOfRefs`, or a
+ * specific `format`) is more direct to express than a full JSON Schema fed
+ * through resolveSchema.
+ */
+export function FieldHarness({
+  schema,
+  initialValue = null,
+  path = "field",
+  label = "Field",
+  meta,
+  decofile = {},
+}: {
+  schema: SchemaProperty;
+  initialValue?: unknown;
+  path?: string;
+  label?: string;
+  meta?: LiveMeta;
+  decofile?: Record<string, unknown>;
+}) {
+  const [value, setValue] = useState<unknown>(initialValue);
+  const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
+
+  return (
+    <div data-testid="harness">
+      {renderField({
+        schema,
+        value,
+        onChange: setValue,
+        path,
+        label,
+        breadcrumbPath: breadcrumb,
+        onBreadcrumbChange: setBreadcrumb,
+        meta,
+        decofile,
+      })}
+      <pre data-testid="form-value">{JSON.stringify(value)}</pre>
+      <pre data-testid="breadcrumb">{JSON.stringify(breadcrumb)}</pre>
+    </div>
+  );
+}

--- a/apps/mesh/ct/harness/fixtures.ts
+++ b/apps/mesh/ct/harness/fixtures.ts
@@ -1,0 +1,29 @@
+import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+
+/** The single section resolveType all SchemaFormHarness fixtures live under. */
+export const TEST_RESOLVE_TYPE = "site/sections/Test.tsx";
+
+/**
+ * Build a LiveMeta whose only block is the section schema under test, mirroring
+ * the `metaWithSchema` helper used by the co-located resolve-schema unit tests.
+ * `defs` populates the global `schema.$defs` for $ref resolution.
+ */
+export function metaWithSchema(
+  blockSchema: Record<string, unknown>,
+  defs?: Record<string, unknown>,
+): LiveMeta {
+  return {
+    manifest: {
+      blocks: { sections: { [TEST_RESOLVE_TYPE]: blockSchema } },
+    },
+    schema: defs ? { $defs: defs } : {},
+  };
+}
+
+/** Shorthand: a section schema with the given object `properties`. */
+export function sectionWithProps(
+  properties: Record<string, unknown>,
+  defs?: Record<string, unknown>,
+): LiveMeta {
+  return metaWithSchema({ type: "object", properties }, defs);
+}

--- a/apps/mesh/ct/harness/fixtures.ts
+++ b/apps/mesh/ct/harness/fixtures.ts
@@ -8,7 +8,7 @@ export const TEST_RESOLVE_TYPE = "site/sections/Test.tsx";
  * the `metaWithSchema` helper used by the co-located resolve-schema unit tests.
  * `defs` populates the global `schema.$defs` for $ref resolution.
  */
-export function metaWithSchema(
+function metaWithSchema(
   blockSchema: Record<string, unknown>,
   defs?: Record<string, unknown>,
 ): LiveMeta {

--- a/apps/mesh/ct/harness/schema-form-harness.tsx
+++ b/apps/mesh/ct/harness/schema-form-harness.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import {
+  resolveSchema,
+  type LiveMeta,
+} from "@/web/components/sections-editor/resolve-schema";
+import { SchemaForm } from "@/web/components/sections-editor/schema-form";
+
+/**
+ * Canonical CT surface: raw CMS JSON Schema (LiveMeta) in → resolveSchema →
+ * SchemaForm → edit → serialized value out. Exercises BOTH the schema
+ * resolution mapping and the widget rendering/edit wiring in one shot — the
+ * true "a field in the CMS schema renders the right widget and round-trips its
+ * value" guarantee.
+ *
+ * The current value and breadcrumb trail are dumped into testid'd <pre>s so
+ * specs can assert the serialized form state after interactions.
+ */
+export function SchemaFormHarness({
+  meta,
+  resolveType,
+  initialValue = {},
+  decofile = {},
+}: {
+  meta: LiveMeta;
+  resolveType: string;
+  initialValue?: Record<string, unknown>;
+  decofile?: Record<string, unknown>;
+}) {
+  const resolved = resolveSchema(resolveType, meta);
+  const [value, setValue] = useState<unknown>(initialValue);
+  const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
+
+  return (
+    <div data-testid="harness">
+      {resolved ? (
+        <SchemaForm
+          schema={resolved}
+          value={value}
+          onChange={setValue}
+          basePath=""
+          breadcrumbPath={breadcrumb}
+          onBreadcrumbChange={setBreadcrumb}
+          meta={meta}
+          decofile={decofile}
+        />
+      ) : (
+        <div data-testid="resolve-null">resolveSchema returned null</div>
+      )}
+      <pre data-testid="form-value">{JSON.stringify(value)}</pre>
+      <pre data-testid="breadcrumb">{JSON.stringify(breadcrumb)}</pre>
+    </div>
+  );
+}

--- a/apps/mesh/ct/harness/stubs/file-picker-dialog.tsx
+++ b/apps/mesh/ct/harness/stubs/file-picker-dialog.tsx
@@ -1,0 +1,48 @@
+/**
+ * CT stub for `@/web/components/file-picker/file-picker-dialog`.
+ *
+ * The real dialog pulls in @tanstack/react-router (<Link>), Suspense queries,
+ * and the MCP client. For component tests we render a tiny deterministic stand
+ * in that mirrors the real contract (open/onOpenChange/mode/onSelect) so we can
+ * assert "Browse opens the picker" and "selecting a file calls onChange".
+ */
+import type { ReactNode } from "react";
+
+export const LAST_CONFIG_KEY = "deco:file-picker:last-config";
+
+const PICKED_URL = "https://cdn.example.com/ct-picked.png";
+
+export function FilePickerDialog({
+  open,
+  onOpenChange,
+  mode,
+  onSelect,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "image" | "any" | string;
+  onSelect: (url: string) => void;
+}): ReactNode {
+  if (!open) return null;
+  return (
+    <div data-testid="file-picker-stub" data-mode={mode}>
+      <button
+        type="button"
+        data-testid="file-picker-pick"
+        onClick={() => {
+          onSelect(PICKED_URL);
+          onOpenChange(false);
+        }}
+      >
+        ct-pick
+      </button>
+      <button
+        type="button"
+        data-testid="file-picker-close"
+        onClick={() => onOpenChange(false)}
+      >
+        ct-close
+      </button>
+    </div>
+  );
+}

--- a/apps/mesh/ct/harness/stubs/use-file-configs.ts
+++ b/apps/mesh/ct/harness/stubs/use-file-configs.ts
@@ -1,0 +1,19 @@
+/**
+ * CT stub for `@/web/hooks/use-file-configs`.
+ *
+ * The real hook calls the FILE_CONFIG_LIST MCP tool via @decocms/mesh-sdk,
+ * which needs the full app provider tree (ProjectContext + MCP client) and a
+ * live backend. In component tests we only exercise the field's own
+ * render/paste/remove logic, so we return a fixed shape. Zero configs means
+ * "drop-on-field" defers to the picker dialog (also stubbed), which is exactly
+ * the deterministic path we want under test.
+ *
+ * Only the exports actually imported by image-field/file-field are provided.
+ */
+export function useFileConfigsQuery() {
+  return {
+    data: { configs: [] as Array<{ id: string }> },
+    isPending: false,
+    isError: false,
+  };
+}

--- a/apps/mesh/ct/harness/stubs/use-file-picker.ts
+++ b/apps/mesh/ct/harness/stubs/use-file-picker.ts
@@ -1,0 +1,17 @@
+/**
+ * CT stub for `@/web/hooks/use-file-picker`.
+ *
+ * The real hook uploads a File through the org-scoped proxy to S3. In
+ * component tests there is no backend; we return a resolved mutation so the
+ * upload code path is inert. The real upload is covered (or deferred to) e2e.
+ *
+ * Only `useFilePickerUpload` is consumed by image-field/file-field.
+ */
+export function useFilePickerUpload() {
+  return {
+    isPending: false,
+    mutateAsync: async (_input: { configId: string; file: File }) => ({
+      publicUrl: "https://cdn.example.com/ct-uploaded.png",
+    }),
+  };
+}

--- a/apps/mesh/ct/harness/variant-harnesses.tsx
+++ b/apps/mesh/ct/harness/variant-harnesses.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import {
+  SectionVariantList,
+  type SectionVariantEntry,
+} from "@/web/components/sections-editor/section-variant-list";
+import { PageVariantTabs } from "@/web/components/sections-editor/page-variant-tabs";
+import type { PageVariant } from "@/web/components/sections-editor/page-variants";
+import { VariantRenameDialog } from "@/web/components/sections-editor/variant-rename-dialog";
+import {
+  MatcherPicker,
+  type MatcherEntry,
+} from "@/web/components/sections-editor/matcher-picker";
+
+/**
+ * Harnesses for the variant/matcher UI components. These components are
+ * callback-driven (they don't own the variant data), so each harness records
+ * every callback invocation into a `data-testid="events"` <pre> that specs read
+ * via readEvents(). That lets us assert exactly which action fired with which
+ * argument when the user clicks a tab / menu item / dialog button.
+ */
+
+function EventLog({ events }: { events: unknown[] }) {
+  return <pre data-testid="events">{JSON.stringify(events)}</pre>;
+}
+
+export function SectionVariantListHarness({
+  variants,
+  selectedIndex,
+}: {
+  variants: SectionVariantEntry[];
+  selectedIndex: number;
+}) {
+  const [events, setEvents] = useState<unknown[]>([]);
+  const push = (e: unknown) => setEvents((prev) => [...prev, e]);
+  return (
+    <div data-testid="harness">
+      <SectionVariantList
+        variants={variants}
+        selectedIndex={selectedIndex}
+        onSelect={(index) => push({ type: "select", index })}
+        onDuplicate={(index) => push({ type: "duplicate", index })}
+        onDelete={(index) => push({ type: "delete", index })}
+        onRemoveAll={() => push({ type: "removeAll" })}
+      />
+      <EventLog events={events} />
+    </div>
+  );
+}
+
+export function PageVariantTabsHarness({
+  variants,
+  activeIndex,
+  matchers = [],
+}: {
+  variants: PageVariant[];
+  activeIndex: number;
+  matchers?: Array<{ resolveType: string; iconName: string }>;
+}) {
+  const [events, setEvents] = useState<unknown[]>([]);
+  const push = (e: unknown) => setEvents((prev) => [...prev, e]);
+  return (
+    <div data-testid="harness">
+      <PageVariantTabs
+        listKey="ct"
+        variants={variants}
+        activeIndex={activeIndex}
+        decofile={{}}
+        meta={null}
+        matchers={matchers}
+        onSelect={(index) => push({ type: "select", index })}
+        onReorder={(from, to) => push({ type: "reorder", from, to })}
+        onRename={(index) => push({ type: "rename", index })}
+        onDelete={(index) => push({ type: "delete", index })}
+        onAdd={() => push({ type: "add" })}
+      />
+      <EventLog events={events} />
+    </div>
+  );
+}
+
+export function VariantRenameDialogHarness({
+  initialName,
+  autoLabel,
+}: {
+  initialName: string;
+  autoLabel: string;
+}) {
+  const [open, setOpen] = useState(true);
+  const [events, setEvents] = useState<unknown[]>([]);
+  const push = (e: unknown) => setEvents((prev) => [...prev, e]);
+  return (
+    <div data-testid="harness">
+      <VariantRenameDialog
+        open={open}
+        initialName={initialName}
+        autoLabel={autoLabel}
+        onSubmit={(name) => push({ type: "submit", name })}
+        onOpenChange={(next) => {
+          push({ type: "openChange", open: next });
+          setOpen(next);
+        }}
+      />
+      <EventLog events={events} />
+    </div>
+  );
+}
+
+export function MatcherPickerHarness({
+  currentRt,
+  currentLabel,
+  matchers,
+}: {
+  currentRt: string;
+  currentLabel: string;
+  matchers: MatcherEntry[];
+}) {
+  const [events, setEvents] = useState<unknown[]>([]);
+  const push = (e: unknown) => setEvents((prev) => [...prev, e]);
+  return (
+    <div data-testid="harness">
+      <MatcherPicker
+        currentRt={currentRt}
+        currentLabel={currentLabel}
+        matchers={matchers}
+        onSelect={(resolveType) => push({ type: "select", resolveType })}
+      />
+      <EventLog events={events} />
+    </div>
+  );
+}

--- a/apps/mesh/ct/playwright/index.css
+++ b/apps/mesh/ct/playwright/index.css
@@ -1,0 +1,22 @@
+@import "tailwindcss";
+
+/*
+ * Tailwind v4 auto-scans the project root but EXCLUDES node_modules — and
+ * @deco/ui (where Switch, Button, Select, etc. live) is a workspace package
+ * resolved through node_modules. Without scanning it, sizing utilities like the
+ * Switch's `h-[1.15rem] w-8` are never generated, so icon-only buttons collapse
+ * to 0x0 and Playwright treats them as hidden. Point @source at the real UI
+ * package src (and the app web src) so every utility class actually used by the
+ * components under test gets generated and elements have real layout.
+ *
+ * We still do NOT import the design-system @theme tokens: unresolved token
+ * utilities (e.g. `bg-primary`) only affect color, not visibility, so behavior
+ * tests don't need them.
+ */
+@source "../../src/web";
+@source "../../../../packages/ui/src";
+
+/* Ensure the mount root never collapses, so click targets have layout. */
+#root {
+  padding: 16px;
+}

--- a/apps/mesh/ct/playwright/index.html
+++ b/apps/mesh/ct/playwright/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>sections-editor component tests</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/apps/mesh/ct/playwright/index.tsx
+++ b/apps/mesh/ct/playwright/index.tsx
@@ -1,0 +1,19 @@
+import { beforeMount } from "@playwright/experimental-ct-react/hooks";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@deco/ui/components/tooltip.tsx";
+import "./index.css";
+
+// One client per page load; retries off so failed (stubbed) queries settle fast.
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+beforeMount(async ({ App }) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider delayDuration={0}>
+        <App />
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+});

--- a/apps/mesh/ct/tests/array-field.ct.tsx
+++ b/apps/mesh/ct/tests/array-field.ct.tsx
@@ -1,0 +1,163 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import { readBreadcrumb, readFormValue } from "../harness/ct-utils";
+
+test("empty array shows an Add item button and no count badge", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    tags: { type: "array", title: "Tags", items: { type: "string" } },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{}}
+    />,
+  );
+
+  await expect(component.getByText("Tags")).toBeVisible();
+  await expect(
+    component.getByRole("button", { name: "Add item" }),
+  ).toBeVisible();
+  // No item rows yet, so no count badge: the form value has no tags key.
+  await expect.poll(() => readFormValue(component)).toEqual({});
+  await expect.poll(() => readBreadcrumb(component)).toEqual([]);
+});
+
+test("add a string item appends an empty string and drills into it", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    tags: { type: "array", title: "Tags", items: { type: "string" } },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{}}
+    />,
+  );
+
+  await component.getByRole("button", { name: "Add item" }).click();
+
+  // The new item is appended as an empty string.
+  await expect.poll(() => readFormValue(component)).toEqual({ tags: [""] });
+  // Adding drills the breadcrumb into the new item.
+  await expect
+    .poll(async () => (await readBreadcrumb(component)).length)
+    .toBeGreaterThan(0);
+});
+
+test("editing the drilled-in string item round-trips its value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    tags: { type: "array", title: "Tags", items: { type: "string" } },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{}}
+    />,
+  );
+
+  await component.getByRole("button", { name: "Add item" }).click();
+  await expect.poll(() => readFormValue(component)).toEqual({ tags: [""] });
+
+  // After drilling in, the item editor shows a string input labelled "Item 1".
+  const itemInput = component.getByLabel("Item 1");
+  await expect(itemInput).toBeVisible();
+  await itemInput.fill("hello");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ tags: ["hello"] });
+});
+
+test("populated array shows item rows and a count badge", async ({ mount }) => {
+  const meta = sectionWithProps({
+    tags: { type: "array", title: "Tags", items: { type: "string" } },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ tags: ["a", "b", "c"] }}
+    />,
+  );
+
+  // Empty breadcrumb keeps the list view (not drilled into an item).
+  await expect.poll(() => readBreadcrumb(component)).toEqual([]);
+
+  // Count badge reflects the number of items.
+  await expect(component.getByText("3", { exact: true })).toBeVisible();
+
+  // Each row label shows the string value.
+  await expect(component.getByText("a", { exact: true })).toBeVisible();
+  await expect(component.getByText("b", { exact: true })).toBeVisible();
+  await expect(component.getByText("c", { exact: true })).toBeVisible();
+});
+
+test("delete removes the targeted item from the list", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    tags: { type: "array", title: "Tags", items: { type: "string" } },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ tags: ["a", "b"] }}
+    />,
+  );
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ tags: ["a", "b"] });
+
+  // The per-row actions trigger is in the DOM (opacity-0 until hover) and clickable.
+  await component.getByRole("button", { name: "Open actions for a" }).click();
+  // The DropdownMenu content is portaled onto document.body — query via page.
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ tags: ["b"] });
+});
+
+test("add a number item appends the default 0", async ({ mount }) => {
+  const meta = sectionWithProps({
+    nums: { type: "array", title: "Nums", items: { type: "number" } },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{}}
+    />,
+  );
+
+  await component.getByRole("button", { name: "Add item" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ nums: [0] });
+});
+
+test("add a boolean item appends the default false", async ({ mount }) => {
+  const meta = sectionWithProps({
+    flags: { type: "array", title: "Flags", items: { type: "boolean" } },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{}}
+    />,
+  );
+
+  await component.getByRole("button", { name: "Add item" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ flags: [false] });
+});

--- a/apps/mesh/ct/tests/array-object-drilldown.ct.tsx
+++ b/apps/mesh/ct/tests/array-object-drilldown.ct.tsx
@@ -1,0 +1,217 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import { readBreadcrumb, readFormValue } from "../harness/ct-utils";
+
+/**
+ * ArrayField with OBJECT items + breadcrumb drill-down, exercised through the
+ * full SchemaFormHarness (raw JSON Schema -> resolveSchema -> SchemaForm).
+ *
+ * The card item schema carries titleBy="name", so item rows are labelled by
+ * their `name` value; drilling into a row swaps the list for that item's
+ * nested object form (Name + Count) and pushes the row label onto the
+ * breadcrumb trail.
+ */
+const cardArrayProps = {
+  cards: {
+    type: "array",
+    title: "Cards",
+    items: {
+      type: "object",
+      title: "Card",
+      titleBy: "name",
+      properties: {
+        name: { type: "string", title: "Name" },
+        count: { type: "number", title: "Count" },
+      },
+    },
+  },
+};
+
+test("add object item: appends empty {} and drills into the nested fields", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps(cardArrayProps);
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("button", { name: "Add item" }).click();
+
+  // Empty object default pushed onto the array.
+  await expect.poll(() => readFormValue(component)).toEqual({ cards: [{}] });
+
+  // Breadcrumb drilled into the new row (label falls back to the item title).
+  await expect.poll(() => readBreadcrumb(component)).toEqual(["Card"]);
+
+  // Nested fields are now visible inline at paths cards.0.name / cards.0.count.
+  const nameInput = component.getByLabel("Name");
+  const countInput = component.getByLabel("Count");
+  await expect(nameInput).toBeVisible();
+  await expect(countInput).toBeVisible();
+  await expect(nameInput).toHaveAttribute("id", "cards.0.name");
+  await expect(countInput).toHaveAttribute("id", "cards.0.count");
+});
+
+test("add object item then edit Name updates cards[0].name", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps(cardArrayProps);
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("button", { name: "Add item" }).click();
+  await expect.poll(() => readFormValue(component)).toEqual({ cards: [{}] });
+
+  await component.getByLabel("Name").fill("Hero");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ cards: [{ name: "Hero" }] });
+});
+
+test("editing a drilled-in object item sets both fields", async ({ mount }) => {
+  const meta = sectionWithProps(cardArrayProps);
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("button", { name: "Add item" }).click();
+  await component.getByLabel("Name").fill("Hero");
+  await component.getByLabel("Count").fill("3");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ cards: [{ name: "Hero", count: 3 }] });
+});
+
+test("item rows are labelled by titleBy with a count badge", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps(cardArrayProps);
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ cards: [{ name: "Alpha" }, { name: "Beta" }] }}
+    />,
+  );
+
+  // Empty breadcrumb -> list view with both rows.
+  await expect.poll(() => readBreadcrumb(component)).toEqual([]);
+  await expect(
+    component.getByRole("button", { name: "Alpha", exact: true }),
+  ).toBeVisible();
+  await expect(
+    component.getByRole("button", { name: "Beta", exact: true }),
+  ).toBeVisible();
+
+  // Count badge reflects the number of items.
+  await expect(component.getByText("2", { exact: true })).toBeVisible();
+});
+
+test("clicking a row drills into that item and shows its Name value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps(cardArrayProps);
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ cards: [{ name: "Alpha" }, { name: "Beta" }] }}
+    />,
+  );
+
+  await component.getByRole("button", { name: "Alpha", exact: true }).click();
+
+  // Breadcrumb drilled into the Alpha row.
+  await expect.poll(() => readBreadcrumb(component)).toContain("Alpha");
+
+  // The drilled-in Name field renders with the row's value.
+  const nameInput = component.getByLabel("Name");
+  await expect(nameInput).toBeVisible();
+  await expect(nameInput).toHaveAttribute("id", "cards.0.name");
+  await expect(nameInput).toHaveValue("Alpha");
+});
+
+test("editing a drilled-in item updates the correct index", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps(cardArrayProps);
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ cards: [{ name: "Alpha" }, { name: "Beta" }] }}
+    />,
+  );
+
+  // Drill into the second row (index 1).
+  await component.getByRole("button", { name: "Beta", exact: true }).click();
+  await expect.poll(() => readBreadcrumb(component)).toContain("Beta");
+
+  const nameInput = component.getByLabel("Name");
+  await expect(nameInput).toHaveAttribute("id", "cards.1.name");
+  await nameInput.fill("Beta2");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ cards: [{ name: "Alpha" }, { name: "Beta2" }] });
+});
+
+test("deleting a row removes the right item from the array", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps(cardArrayProps);
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ cards: [{ name: "Alpha" }, { name: "Beta" }] }}
+    />,
+  );
+
+  // Open the actions menu for the Alpha row (button is in the DOM though hidden).
+  await component
+    .getByRole("button", { name: "Open actions for Alpha" })
+    .click();
+  // DropdownMenu content is portaled onto document.body -> query via page.
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ cards: [{ name: "Beta" }] });
+});
+
+test("fallback label 'Item 1' when itemSchema has no titleBy/title and item has no name", async ({
+  mount,
+}) => {
+  // No titleBy and no title on the item schema, and the item carries no
+  // name/label/title key -> getArrayItemLabel falls back to "Item <n>".
+  const meta = sectionWithProps({
+    cards: {
+      type: "array",
+      title: "Cards",
+      items: {
+        type: "object",
+        properties: {
+          count: { type: "number", title: "Count" },
+        },
+      },
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ cards: [{ count: 7 }] }}
+    />,
+  );
+
+  await expect.poll(() => readBreadcrumb(component)).toEqual([]);
+  await expect(
+    component.getByRole("button", { name: "Item 1", exact: true }),
+  ).toBeVisible();
+});

--- a/apps/mesh/ct/tests/boolean-field.ct.tsx
+++ b/apps/mesh/ct/tests/boolean-field.ct.tsx
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import { readFormValue } from "../harness/ct-utils";
+
+test("renders an unchecked switch by default", async ({ mount }) => {
+  const meta = sectionWithProps({
+    enabled: { type: "boolean", title: "Enabled" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const sw = component.getByLabel("Enabled");
+  await expect(sw).toBeVisible();
+  await expect(sw).not.toBeChecked();
+});
+
+test("getByLabel returns the role=switch element", async ({ mount }) => {
+  const meta = sectionWithProps({
+    enabled: { type: "boolean", title: "Enabled" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const sw = component.getByLabel("Enabled");
+  await expect(sw).toHaveRole("switch");
+});
+
+test("clicking an unchecked switch sets the value to true", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    enabled: { type: "boolean", title: "Enabled" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const sw = component.getByLabel("Enabled");
+  await sw.click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ enabled: true });
+  await expect(sw).toBeChecked();
+});
+
+test("an initial true value renders a checked switch", async ({ mount }) => {
+  const meta = sectionWithProps({
+    enabled: { type: "boolean", title: "Enabled" },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ enabled: true }}
+    />,
+  );
+
+  const sw = component.getByLabel("Enabled");
+  await expect(sw).toBeChecked();
+});
+
+test("clicking a checked switch sets the value to false", async ({ mount }) => {
+  const meta = sectionWithProps({
+    enabled: { type: "boolean", title: "Enabled" },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ enabled: true }}
+    />,
+  );
+
+  const sw = component.getByLabel("Enabled");
+  await expect(sw).toBeChecked();
+  await sw.click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ enabled: false });
+  await expect(sw).not.toBeChecked();
+});
+
+test("renders the schema description", async ({ mount }) => {
+  const meta = sectionWithProps({
+    enabled: {
+      type: "boolean",
+      title: "Enabled",
+      description: "Toggle this feature on or off",
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(
+    component.getByText("Toggle this feature on or off"),
+  ).toBeVisible();
+});
+
+test("toggling on then off round-trips back to false", async ({ mount }) => {
+  const meta = sectionWithProps({
+    enabled: { type: "boolean", title: "Enabled" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const sw = component.getByLabel("Enabled");
+  await sw.click();
+  await expect.poll(() => readFormValue(component)).toEqual({ enabled: true });
+
+  await sw.click();
+  await expect.poll(() => readFormValue(component)).toEqual({ enabled: false });
+  await expect(sw).not.toBeChecked();
+});
+
+test("humanizes the field key when no title is provided", async ({ mount }) => {
+  const meta = sectionWithProps({
+    isFeatured: { type: "boolean" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const sw = component.getByLabel("Is Featured");
+  await expect(sw).toBeVisible();
+  await expect(sw).not.toBeChecked();
+
+  await sw.click();
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ isFeatured: true });
+});

--- a/apps/mesh/ct/tests/enum-field.ct.tsx
+++ b/apps/mesh/ct/tests/enum-field.ct.tsx
@@ -1,0 +1,209 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import { readFormValue } from "../harness/ct-utils";
+
+test("string enum renders a combobox trigger", async ({ mount }) => {
+  const meta = sectionWithProps({
+    size: { type: "string", enum: ["sm", "md", "lg"], title: "Size" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const trigger = component.getByRole("combobox");
+  await expect(trigger).toBeVisible();
+  await expect(component.getByText("Size")).toBeVisible();
+});
+
+test("string enum: open and pick an option round-trips its value", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    size: { type: "string", enum: ["sm", "md", "lg"], title: "Size" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "md" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ size: "md" });
+});
+
+test("string enum: each option is selectable", async ({ mount, page }) => {
+  const meta = sectionWithProps({
+    size: { type: "string", enum: ["sm", "md", "lg"], title: "Size" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "sm" }).click();
+  await expect.poll(() => readFormValue(component)).toEqual({ size: "sm" });
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "lg" }).click();
+  await expect.poll(() => readFormValue(component)).toEqual({ size: "lg" });
+});
+
+test("string enum: initial value is shown on the trigger", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    size: { type: "string", enum: ["sm", "md", "lg"], title: "Size" },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ size: "lg" }}
+    />,
+  );
+
+  await expect(component.getByRole("combobox")).toHaveText("lg");
+});
+
+test("string enum: initial value can be changed via the picker", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    size: { type: "string", enum: ["sm", "md", "lg"], title: "Size" },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ size: "lg" }}
+    />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "sm" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ size: "sm" });
+  await expect(component.getByRole("combobox")).toHaveText("sm");
+});
+
+test("numeric enum: picking an option yields a NUMBER, not a string", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    size: { type: "number", enum: [1, 2, 3] },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "2" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ size: 2 });
+});
+
+test("numeric enum: initial numeric value is shown on the trigger", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    size: { type: "number", enum: [1, 2, 3] },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ size: 3 }}
+    />,
+  );
+
+  await expect(component.getByRole("combobox")).toHaveText("3");
+});
+
+test("empty-string enum: picking a non-empty option works", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    size: { type: "string", enum: ["", "a"] },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "a" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ size: "a" });
+});
+
+test("empty-string enum: both options are present in the menu", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    size: { type: "string", enum: ["", "a"] },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("combobox").click();
+  await expect(page.getByRole("option")).toHaveCount(2);
+});
+
+test("empty-string enum: selecting the empty option yields an empty string", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    size: { type: "string", enum: ["", "a"] },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ size: "a" }}
+    />,
+  );
+
+  // The first option corresponds to the empty-string enum entry.
+  await component.getByRole("combobox").click();
+  await page.getByRole("option").first().click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({ size: "" });
+});
+
+test("enum: description renders next to the label", async ({ mount }) => {
+  const meta = sectionWithProps({
+    size: {
+      type: "string",
+      enum: ["sm", "md", "lg"],
+      title: "Size",
+      description: "Pick a size for the section",
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(
+    component.getByText("Pick a size for the section"),
+  ).toBeVisible();
+});
+
+test("enum: label falls back to the humanized key when no title", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    textAlign: { type: "string", enum: ["left", "center", "right"] },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.getByText("Text Align")).toBeVisible();
+});

--- a/apps/mesh/ct/tests/file-field.ct.tsx
+++ b/apps/mesh/ct/tests/file-field.ct.tsx
@@ -1,0 +1,176 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { FieldHarness } from "../harness/field-harness";
+import { readFormValue } from "../harness/ct-utils";
+import type { SchemaProperty } from "@/web/components/sections-editor/resolve-schema";
+
+const FILE_SCHEMA: SchemaProperty = {
+  type: "string",
+  format: "file-uri",
+  title: "Doc",
+};
+
+const VIDEO_SCHEMA: SchemaProperty = {
+  type: "string",
+  format: "video-uri",
+  title: "Clip",
+};
+
+// ── file format ─────────────────────────────────────────────────────────────
+
+test("file: empty state shows the drop/browse prompt", async ({ mount }) => {
+  const component = await mount(
+    <FieldHarness schema={FILE_SCHEMA} label="Doc" path="doc" />,
+  );
+
+  await expect(
+    component.getByText("Drop a file or click to browse"),
+  ).toBeVisible();
+});
+
+test("file: pasting a url into the text input round-trips the value", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={FILE_SCHEMA} label="Doc" path="doc" />,
+  );
+
+  const input = component.getByLabel("Doc");
+  await expect(input).toBeVisible();
+  await input.fill("https://x.test/report.pdf");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual("https://x.test/report.pdf");
+});
+
+test("file: with a value the filename and uppercase ext chip are shown", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={FILE_SCHEMA}
+      label="Doc"
+      path="doc"
+      initialValue="https://x.test/report.pdf"
+    />,
+  );
+
+  await expect(
+    component.getByText("report.pdf", { exact: true }),
+  ).toBeVisible();
+  // Lowercase text node; uppercase is CSS text-transform only.
+  await expect(component.getByText("pdf", { exact: true })).toBeVisible();
+});
+
+test("file: with a value Replace and Remove file controls appear", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={FILE_SCHEMA}
+      label="Doc"
+      path="doc"
+      initialValue="https://x.test/report.pdf"
+    />,
+  );
+
+  await expect(
+    component.getByRole("button", { name: "Replace" }),
+  ).toBeVisible();
+  await expect(
+    component.getByRole("button", { name: "Remove file" }),
+  ).toBeVisible();
+});
+
+test("file: clicking Remove file clears the value to an empty string", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={FILE_SCHEMA}
+      label="Doc"
+      path="doc"
+      initialValue="https://x.test/report.pdf"
+    />,
+  );
+
+  await component.getByRole("button", { name: "Remove file" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual("");
+});
+
+test("file: empty state has no Replace/Remove controls and shows Browse", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={FILE_SCHEMA} label="Doc" path="doc" />,
+  );
+
+  await expect(
+    component.getByRole("button", { name: "Browse", exact: true }),
+  ).toBeVisible();
+  await expect(component.getByRole("button", { name: "Replace" })).toHaveCount(
+    0,
+  );
+  await expect(
+    component.getByRole("button", { name: "Remove file" }),
+  ).toHaveCount(0);
+});
+
+// ── browse + pick ─────────────────────────────────────────────────────────────
+
+test("file: clicking Browse opens the file picker", async ({ mount }) => {
+  const component = await mount(
+    <FieldHarness schema={FILE_SCHEMA} label="Doc" path="doc" />,
+  );
+
+  await expect(component.getByTestId("file-picker-stub")).toHaveCount(0);
+  await component.getByRole("button", { name: "Browse", exact: true }).click();
+
+  await expect(component.getByTestId("file-picker-stub")).toBeVisible();
+});
+
+test("file: picking a file from the picker sets the value", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={FILE_SCHEMA} label="Doc" path="doc" />,
+  );
+
+  await component.getByRole("button", { name: "Browse", exact: true }).click();
+  await component.getByTestId("file-picker-pick").click();
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual("https://cdn.example.com/ct-picked.png");
+});
+
+// ── video format ─────────────────────────────────────────────────────────────
+
+test("video: empty state shows the video drop/browse prompt", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={VIDEO_SCHEMA} label="Clip" path="clip" />,
+  );
+
+  await expect(
+    component.getByText("Drop a video here or click to browse"),
+  ).toBeVisible();
+});
+
+test("video: with a value a <video> element and the filename render", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={VIDEO_SCHEMA}
+      label="Clip"
+      path="clip"
+      initialValue="https://x.test/clip.mp4"
+    />,
+  );
+
+  await expect(component.locator("video")).toBeVisible();
+  await expect(component.getByText("clip.mp4", { exact: true })).toBeVisible();
+});

--- a/apps/mesh/ct/tests/image-field.ct.tsx
+++ b/apps/mesh/ct/tests/image-field.ct.tsx
@@ -1,0 +1,210 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { FieldHarness } from "../harness/field-harness";
+import { readFormValue } from "../harness/ct-utils";
+import type { SchemaProperty } from "@/web/components/sections-editor/resolve-schema";
+
+/**
+ * ImageField (format "image-uri"). FieldHarness renders ONE field via
+ * renderField; the form VALUE is the field's own string. The FilePickerDialog
+ * is stubbed inline (data-testid="file-picker-stub") and its pick button
+ * selects "https://cdn.example.com/ct-picked.png".
+ */
+const IMAGE_SCHEMA: SchemaProperty = {
+  type: "string",
+  format: "image-uri",
+  title: "Hero",
+};
+
+test("empty state: drop-zone prompt, empty url input, Browse button", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={IMAGE_SCHEMA} label="Hero" />,
+  );
+
+  // Empty drop zone prompt visible.
+  await expect(
+    component.getByText("Drop an image or click to browse"),
+  ).toBeVisible();
+
+  // url input present and empty (getByLabel("Hero") -> Input id=path).
+  const urlInput = component.getByLabel("Hero");
+  await expect(urlInput).toBeVisible();
+  await expect(urlInput).toHaveAttribute("type", "url");
+  await expect(urlInput).toHaveValue("");
+
+  // Browse button present; Replace / Remove image absent.
+  await expect(
+    component.getByRole("button", { name: "Browse", exact: true }),
+  ).toBeVisible();
+  await expect(component.getByRole("button", { name: "Replace" })).toHaveCount(
+    0,
+  );
+  await expect(
+    component.getByRole("button", { name: "Remove image" }),
+  ).toHaveCount(0);
+});
+
+test("empty state: initial form value is null", async ({ mount }) => {
+  const component = await mount(
+    <FieldHarness schema={IMAGE_SCHEMA} label="Hero" />,
+  );
+  await expect.poll(() => readFormValue(component)).toEqual(null);
+});
+
+test("paste URL: round-trips value into form state", async ({ mount }) => {
+  const component = await mount(
+    <FieldHarness schema={IMAGE_SCHEMA} label="Hero" />,
+  );
+
+  await component.getByLabel("Hero").fill("https://x.test/a.png");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual("https://x.test/a.png");
+});
+
+test("paste URL: shows filename and extension chip", async ({ mount }) => {
+  const component = await mount(
+    <FieldHarness schema={IMAGE_SCHEMA} label="Hero" />,
+  );
+
+  await component.getByLabel("Hero").fill("https://x.test/a.png");
+
+  // Filename derived from the URL pathname.
+  await expect(component.getByText("a.png", { exact: true })).toBeVisible();
+  // Extension chip. The text node is lowercase ("png"); the uppercase look is
+  // CSS text-transform, which does not change textContent — so match lowercase.
+  await expect(component.getByText("png", { exact: true })).toBeVisible();
+});
+
+test("paste URL: Browse becomes Replace and Remove image appears", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={IMAGE_SCHEMA} label="Hero" />,
+  );
+
+  await component.getByLabel("Hero").fill("https://x.test/a.png");
+
+  await expect(
+    component.getByRole("button", { name: "Replace" }),
+  ).toBeVisible();
+  await expect(
+    component.getByRole("button", { name: "Browse", exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    component.getByRole("button", { name: "Remove image" }),
+  ).toBeVisible();
+});
+
+test("populated: renders Replace + Remove image from initialValue", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={IMAGE_SCHEMA}
+      label="Hero"
+      initialValue="https://x.test/a.png"
+    />,
+  );
+
+  await expect(component.getByLabel("Hero")).toHaveValue(
+    "https://x.test/a.png",
+  );
+  await expect(
+    component.getByRole("button", { name: "Replace" }),
+  ).toBeVisible();
+  await expect(
+    component.getByRole("button", { name: "Remove image" }),
+  ).toBeVisible();
+  // Empty prompt should not be shown when populated.
+  await expect(
+    component.getByText("Drop an image or click to browse"),
+  ).toHaveCount(0);
+});
+
+test("remove: clicking Remove image clears the value to empty string", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={IMAGE_SCHEMA}
+      label="Hero"
+      initialValue="https://x.test/a.png"
+    />,
+  );
+
+  await component.getByRole("button", { name: "Remove image" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual("");
+});
+
+test("remove: empty drop-zone returns and url input is empty after remove", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={IMAGE_SCHEMA}
+      label="Hero"
+      initialValue="https://x.test/a.png"
+    />,
+  );
+
+  await component.getByRole("button", { name: "Remove image" }).click();
+
+  await expect(
+    component.getByText("Drop an image or click to browse"),
+  ).toBeVisible();
+  await expect(component.getByLabel("Hero")).toHaveValue("");
+  await expect(
+    component.getByRole("button", { name: "Browse", exact: true }),
+  ).toBeVisible();
+});
+
+test("browse: clicking Browse opens the stubbed file picker", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={IMAGE_SCHEMA} label="Hero" />,
+  );
+
+  await expect(component.getByTestId("file-picker-stub")).toHaveCount(0);
+
+  await component.getByRole("button", { name: "Browse", exact: true }).click();
+
+  const stub = component.getByTestId("file-picker-stub");
+  await expect(stub).toBeVisible();
+  // ImageField opens the picker in "image" mode.
+  await expect(stub).toHaveAttribute("data-mode", "image");
+});
+
+test("browse + pick: selecting a file sets the picked URL as value", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={IMAGE_SCHEMA} label="Hero" />,
+  );
+
+  await component.getByRole("button", { name: "Browse", exact: true }).click();
+  await component.getByTestId("file-picker-pick").click();
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual("https://cdn.example.com/ct-picked.png");
+});
+
+test("browse + pick: picker closes after selecting a file", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={IMAGE_SCHEMA} label="Hero" />,
+  );
+
+  await component.getByRole("button", { name: "Browse", exact: true }).click();
+  await expect(component.getByTestId("file-picker-stub")).toBeVisible();
+
+  await component.getByTestId("file-picker-pick").click();
+
+  await expect(component.getByTestId("file-picker-stub")).toHaveCount(0);
+});

--- a/apps/mesh/ct/tests/matcher-picker.ct.tsx
+++ b/apps/mesh/ct/tests/matcher-picker.ct.tsx
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { MatcherPickerHarness } from "../harness/variant-harnesses";
+import { readEvents } from "../harness/ct-utils";
+import type { MatcherEntry } from "@/web/components/sections-editor/matcher-picker";
+
+/**
+ * MatcherPicker — a trigger button + cmdk CommandDialog (portaled → queried via
+ * `page`). The list always offers "Always" (selecting it emits "") plus one
+ * entry per matcher (emitting its resolveType). Selecting closes the dialog.
+ */
+const MATCHERS: MatcherEntry[] = [
+  {
+    resolveType: "site/matchers/Device.ts",
+    title: "Device",
+    description: "Match by device type",
+    iconName: "Phone01",
+  },
+  {
+    resolveType: "site/matchers/Geo.ts",
+    title: "Geolocation",
+    description: "Match by country",
+    iconName: "Globe01",
+  },
+];
+
+test("the trigger shows the current label", async ({ mount }) => {
+  const component = await mount(
+    <MatcherPickerHarness
+      currentRt=""
+      currentLabel="Always"
+      matchers={MATCHERS}
+    />,
+  );
+  await expect(component.getByRole("button", { name: "Always" })).toBeVisible();
+});
+
+test("clicking the trigger opens the rule dialog", async ({ mount, page }) => {
+  const component = await mount(
+    <MatcherPickerHarness
+      currentRt=""
+      currentLabel="Always"
+      matchers={MATCHERS}
+    />,
+  );
+  await component.getByRole("button", { name: "Always" }).click();
+  await expect(page.getByPlaceholder("Search rules...")).toBeVisible();
+  await expect(page.getByRole("option", { name: /Device/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /Geolocation/ })).toBeVisible();
+});
+
+test("selecting Always emits an empty resolveType", async ({ mount, page }) => {
+  const component = await mount(
+    <MatcherPickerHarness
+      currentRt="site/matchers/Device.ts"
+      currentLabel="Device"
+      matchers={MATCHERS}
+    />,
+  );
+  await component.getByRole("button", { name: "Device" }).click();
+  await page.getByRole("option", { name: /Target all users/ }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "select", resolveType: "" }]);
+});
+
+test("selecting a matcher emits its resolveType", async ({ mount, page }) => {
+  const component = await mount(
+    <MatcherPickerHarness
+      currentRt=""
+      currentLabel="Always"
+      matchers={MATCHERS}
+    />,
+  );
+  await component.getByRole("button", { name: "Always" }).click();
+  await page.getByRole("option", { name: /Geolocation/ }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "select", resolveType: "site/matchers/Geo.ts" }]);
+});
+
+test("selecting a rule closes the dialog", async ({ mount, page }) => {
+  const component = await mount(
+    <MatcherPickerHarness
+      currentRt=""
+      currentLabel="Always"
+      matchers={MATCHERS}
+    />,
+  );
+  await component.getByRole("button", { name: "Always" }).click();
+  await page.getByRole("option", { name: /Device/ }).click();
+  await expect(page.getByPlaceholder("Search rules...")).toHaveCount(0);
+});
+
+test("typing in the search filters the rule list", async ({ mount, page }) => {
+  const component = await mount(
+    <MatcherPickerHarness
+      currentRt=""
+      currentLabel="Always"
+      matchers={MATCHERS}
+    />,
+  );
+  await component.getByRole("button", { name: "Always" }).click();
+  await page.getByPlaceholder("Search rules...").fill("Geoloc");
+  await expect(page.getByRole("option", { name: /Geolocation/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /Device/ })).toHaveCount(0);
+});

--- a/apps/mesh/ct/tests/number-field.ct.tsx
+++ b/apps/mesh/ct/tests/number-field.ct.tsx
@@ -1,0 +1,122 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import { readFormValue } from "../harness/ct-utils";
+
+test("renders an input[type=number] and round-trips an integer value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    count: { type: "number", title: "Count" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Count");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "number");
+  await input.fill("42");
+
+  await expect.poll(() => readFormValue(component)).toEqual({ count: 42 });
+});
+
+test("stores number values as numbers, not strings", async ({ mount }) => {
+  const meta = sectionWithProps({
+    count: { type: "number", title: "Count" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByLabel("Count").fill("42");
+
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as { count: unknown };
+      return typeof value.count;
+    })
+    .toBe("number");
+});
+
+test("integer type behaves the same as number", async ({ mount }) => {
+  const meta = sectionWithProps({
+    count: { type: "integer", title: "Count" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Count");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "number");
+  await input.fill("7");
+
+  await expect.poll(() => readFormValue(component)).toEqual({ count: 7 });
+});
+
+test("accepts decimal values", async ({ mount }) => {
+  const meta = sectionWithProps({
+    count: { type: "number", title: "Count" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByLabel("Count").fill("3.14");
+
+  await expect.poll(() => readFormValue(component)).toEqual({ count: 3.14 });
+});
+
+test("clearing the input drops the key (onChange undefined)", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    count: { type: "number", title: "Count" },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ count: 5 }}
+    />,
+  );
+
+  const input = component.getByLabel("Count");
+  await expect(input).toHaveValue("5");
+  await input.fill("");
+
+  await expect.poll(() => readFormValue(component)).toEqual({});
+});
+
+test("reflects an initial value in the input", async ({ mount }) => {
+  const meta = sectionWithProps({
+    count: { type: "number", title: "Count" },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ count: 99 }}
+    />,
+  );
+
+  await expect(component.getByLabel("Count")).toHaveValue("99");
+});
+
+test("renders the schema description", async ({ mount }) => {
+  const meta = sectionWithProps({
+    count: {
+      type: "number",
+      title: "Count",
+      description: "How many widgets to display",
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(
+    component.getByText("How many widgets to display"),
+  ).toBeVisible();
+});

--- a/apps/mesh/ct/tests/object-field.ct.tsx
+++ b/apps/mesh/ct/tests/object-field.ct.tsx
@@ -1,0 +1,191 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import { readFormValue } from "../harness/ct-utils";
+
+const ctaSchema = {
+  type: "object",
+  title: "CTA",
+  properties: {
+    text: { type: "string", title: "Text" },
+    href: { type: "string", title: "Href" },
+  },
+} as const;
+
+test("nested object is collapsed by default — nested field not visible", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({ cta: ctaSchema });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  // The CTA toggle button is present...
+  const toggle = component.getByRole("button", { name: "CTA" });
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+  // ...but the nested "Text" field is not rendered while collapsed.
+  await expect(component.getByLabel("Text")).toHaveCount(0);
+});
+
+test("clicking the CTA toggle expands nested fields (aria-expanded true)", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({ cta: ctaSchema });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const toggle = component.getByRole("button", { name: "CTA" });
+  await toggle.click();
+
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expect(component.getByLabel("Text")).toBeVisible();
+  await expect(component.getByLabel("Href")).toBeVisible();
+});
+
+test("editing a nested field writes a nested value", async ({ mount }) => {
+  const meta = sectionWithProps({ cta: ctaSchema });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("button", { name: "CTA" }).click();
+
+  const textInput = component.getByLabel("Text");
+  await expect(textInput).toBeVisible();
+  // Nested input id == path == "cta.text".
+  await expect(textInput).toHaveAttribute("id", "cta.text");
+
+  await textInput.fill("Click");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ cta: { text: "Click" } });
+});
+
+test("editing two nested fields accumulates into one object", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({ cta: ctaSchema });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("button", { name: "CTA" }).click();
+
+  await component.getByLabel("Text").fill("Click");
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ cta: { text: "Click" } });
+
+  await component.getByLabel("Href").fill("/go");
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ cta: { text: "Click", href: "/go" } });
+});
+
+test("object description is visible", async ({ mount }) => {
+  const meta = sectionWithProps({
+    cta: {
+      type: "object",
+      title: "CTA",
+      description: "Call to action button",
+      properties: {
+        text: { type: "string", title: "Text" },
+      },
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.getByText("Call to action button")).toBeVisible();
+});
+
+test("pre-populated nested object renders existing value once expanded", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({ cta: ctaSchema });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ cta: { text: "Buy now", href: "/cart" } }}
+    />,
+  );
+
+  await component.getByRole("button", { name: "CTA" }).click();
+
+  await expect(component.getByLabel("Text")).toHaveValue("Buy now");
+  await expect(component.getByLabel("Href")).toHaveValue("/cart");
+});
+
+test("deep nesting: object inside object, edit leaf writes a deep value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    a: {
+      type: "object",
+      title: "A",
+      properties: {
+        b: {
+          type: "object",
+          title: "B",
+          properties: {
+            c: { type: "string", title: "C" },
+          },
+        },
+      },
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  // Inner field hidden until both levels are expanded.
+  await expect(component.getByLabel("C")).toHaveCount(0);
+
+  // Expand outer object.
+  const outer = component.getByRole("button", { name: "A" });
+  await outer.click();
+  await expect(outer).toHaveAttribute("aria-expanded", "true");
+
+  // Inner object toggle now visible; still no leaf.
+  const inner = component.getByRole("button", { name: "B" });
+  await expect(inner).toBeVisible();
+  await expect(component.getByLabel("C")).toHaveCount(0);
+
+  // Expand inner object.
+  await inner.click();
+  await expect(inner).toHaveAttribute("aria-expanded", "true");
+
+  const leaf = component.getByLabel("C");
+  await expect(leaf).toBeVisible();
+  // Deep path id == "a.b.c".
+  await expect(leaf).toHaveAttribute("id", "a.b.c");
+
+  await leaf.fill("x");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ a: { b: { c: "x" } } });
+});
+
+test("collapsing an expanded object hides its nested fields again", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({ cta: ctaSchema });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const toggle = component.getByRole("button", { name: "CTA" });
+  await toggle.click();
+  await expect(component.getByLabel("Text")).toBeVisible();
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  await expect(component.getByLabel("Text")).toHaveCount(0);
+});

--- a/apps/mesh/ct/tests/page-variant-tabs.ct.tsx
+++ b/apps/mesh/ct/tests/page-variant-tabs.ct.tsx
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { PageVariantTabsHarness } from "../harness/variant-harnesses";
+import { readEvents } from "../harness/ct-utils";
+import type { PageVariant } from "@/web/components/sections-editor/page-variants";
+
+/**
+ * PageVariantTabs — the horizontal page-variant tab strip. Add a variant,
+ * select a tab, or open a tab's actions menu to rename / delete. Delete is
+ * disabled when only one variant remains. The DropdownMenu is portaled →
+ * queried via `page`.
+ */
+const TWO: PageVariant[] = [
+  { label: "Default", sections: [] },
+  { label: "Mobile", sections: [], rule: { __resolveType: "x/matchers/A.ts" } },
+];
+
+test("renders a tab per variant plus an add button", async ({ mount }) => {
+  const component = await mount(
+    <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
+  );
+  await expect(
+    component.getByRole("button", { name: "Default", exact: true }),
+  ).toBeVisible();
+  await expect(
+    component.getByRole("button", { name: "Mobile", exact: true }),
+  ).toBeVisible();
+  await expect(
+    component.getByRole("button", { name: "Add variant" }),
+  ).toBeVisible();
+});
+
+test("clicking the add button fires onAdd", async ({ mount }) => {
+  const component = await mount(
+    <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
+  );
+  await component.getByRole("button", { name: "Add variant" }).click();
+  await expect.poll(() => readEvents(component)).toEqual([{ type: "add" }]);
+});
+
+test("clicking a tab fires onSelect with its index", async ({ mount }) => {
+  const component = await mount(
+    <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
+  );
+  await component.getByRole("button", { name: "Mobile", exact: true }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "select", index: 1 }]);
+});
+
+test("rename from the tab menu fires onRename", async ({ mount, page }) => {
+  const component = await mount(
+    <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
+  );
+  await component.getByRole("button", { name: "Actions for Mobile" }).click();
+  await page.getByRole("menuitem", { name: "Rename" }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "rename", index: 1 }]);
+});
+
+test("delete from the tab menu fires onDelete (multiple variants)", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
+  );
+  await component.getByRole("button", { name: "Actions for Default" }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "delete", index: 0 }]);
+});
+
+test("delete is disabled when only one variant remains", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <PageVariantTabsHarness
+      variants={[{ label: "Solo", sections: [] }]}
+      activeIndex={0}
+    />,
+  );
+  await component.getByRole("button", { name: "Actions for Solo" }).click();
+  await expect(page.getByRole("menuitem", { name: "Delete" })).toBeDisabled();
+});

--- a/apps/mesh/ct/tests/schema-resolution-render.ct.tsx
+++ b/apps/mesh/ct/tests/schema-resolution-render.ct.tsx
@@ -1,0 +1,274 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+
+/**
+ * Schema-resolution edge cases that change WHAT renders: nullable unions that
+ * must preserve their leaf `format`, enum-from-const unions, hidden/internal
+ * property filtering, and the "no editable fields" empty state. Each test feeds
+ * a raw JSON Schema through resolveSchema → SchemaForm (via SchemaFormHarness)
+ * and asserts the resulting widget, NOT a generic text box.
+ */
+
+test("nullable image union resolves to an ImageField (not a text box)", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    hero: {
+      anyOf: [
+        { type: "string", format: "image-uri", title: "Hero image" },
+        { type: "null" },
+      ],
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  // ImageField empty-state: the image drop/browse button.
+  await expect(
+    component.getByRole("button", {
+      name: "Drop an image or click to browse",
+    }),
+  ).toBeVisible();
+  // The label comes from the union leaf's title.
+  await expect(component.getByText("Hero image")).toBeVisible();
+  // ImageField exposes a url <Input id={path}>, so getByLabel finds it.
+  const urlInput = component.getByLabel("Hero image");
+  await expect(urlInput).toBeVisible();
+  await expect(urlInput).toHaveAttribute("type", "url");
+});
+
+test("nullable image union round-trips a typed url", async ({ mount }) => {
+  const meta = sectionWithProps({
+    hero: {
+      anyOf: [
+        { type: "string", format: "image-uri", title: "Hero image" },
+        { type: "null" },
+      ],
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component
+    .getByLabel("Hero image")
+    .fill("https://example.com/banner.png");
+
+  await expect
+    .poll(() => component.getByTestId("form-value").textContent())
+    .toContain("https://example.com/banner.png");
+});
+
+test("nullable file union resolves to a FileField", async ({ mount }) => {
+  const meta = sectionWithProps({
+    asset: {
+      anyOf: [
+        { type: "string", format: "file-uri", title: "Asset" },
+        { type: "null" },
+      ],
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  // FileField empty-state: the file drop/browse button.
+  await expect(
+    component.getByRole("button", { name: "Drop a file or click to browse" }),
+  ).toBeVisible();
+  const urlInput = component.getByLabel("Asset");
+  await expect(urlInput).toBeVisible();
+  await expect(urlInput).toHaveAttribute("type", "url");
+});
+
+test("enum-from-const union resolves to an EnumField with all options", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    variant: {
+      title: "Variant",
+      anyOf: [{ const: "a" }, { const: "b" }, { const: "c" }],
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  // EnumField renders a <Select> trigger (role=combobox), not a text box.
+  const trigger = component.getByRole("combobox");
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+
+  // Options are portaled to document.body → query via page.
+  await expect(page.getByRole("option", { name: "a" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "b" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "c" })).toBeVisible();
+});
+
+test("enum-from-const union round-trips the picked const value", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    variant: {
+      title: "Variant",
+      anyOf: [{ const: "a" }, { const: "b" }, { const: "c" }],
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "b" }).click();
+
+  await expect
+    .poll(() => component.getByTestId("form-value").textContent())
+    .toContain('"variant":"b"');
+});
+
+test("hidden property (hide:true) is not rendered", async ({ mount }) => {
+  const meta = sectionWithProps({
+    visible: { type: "string", title: "Visible" },
+    secret: { type: "string", hide: true, title: "Secret" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.getByLabel("Visible")).toBeVisible();
+  await expect(component.getByText("Secret")).toHaveCount(0);
+  await expect(component.getByLabel("Secret")).toHaveCount(0);
+});
+
+test("__resolveType and @type are never rendered as fields", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    __resolveType: { type: "string", title: "Resolve Type" },
+    "@type": { type: "string", title: "At Type" },
+    title: { type: "string", title: "Title" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  // The real field renders.
+  await expect(component.getByLabel("Title", { exact: true })).toBeVisible();
+  // The internal deco props produce no input.
+  await expect(component.getByLabel("Resolve Type")).toHaveCount(0);
+  await expect(component.getByLabel("At Type")).toHaveCount(0);
+  await expect(component.getByText("Resolve Type")).toHaveCount(0);
+  await expect(component.getByText("At Type")).toHaveCount(0);
+});
+
+test("a section whose only field is hidden shows the empty-state message", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    secret: { type: "string", hide: true, title: "Secret" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  // resolveSchema keeps the hidden prop (so it does NOT return null), and
+  // SchemaForm filters it out → the "No editable fields" empty state.
+  await expect(component.getByTestId("resolve-null")).toHaveCount(0);
+  await expect(
+    component.getByText("No editable fields on this section."),
+  ).toBeVisible();
+});
+
+test("all internal props hidden/filtered shows the empty-state message", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    __resolveType: { type: "string", title: "Resolve Type" },
+    "@type": { type: "string", title: "At Type" },
+    secret: { type: "string", hide: true, title: "Secret" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(
+    component.getByText("No editable fields on this section."),
+  ).toBeVisible();
+});
+
+test("multiple string fields render all their labels", async ({ mount }) => {
+  const meta = sectionWithProps({
+    title: { type: "string", title: "Title" },
+    subtitle: { type: "string", title: "Subtitle" },
+    cta: { type: "string", title: "Call To Action" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.getByLabel("Title", { exact: true })).toBeVisible();
+  await expect(component.getByLabel("Subtitle")).toBeVisible();
+  await expect(component.getByLabel("Call To Action")).toBeVisible();
+});
+
+test("field with no title is humanized into a label", async ({ mount }) => {
+  const meta = sectionWithProps({
+    heroSubtitle: { type: "string" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  // fieldDisplayLabel humanizes camelCase keys when no title is present.
+  await expect(component.getByLabel("Hero Subtitle")).toBeVisible();
+});
+
+test("field description renders alongside the field", async ({ mount }) => {
+  const meta = sectionWithProps({
+    title: {
+      type: "string",
+      title: "Title",
+      description: "Shown in the page hero header.",
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.getByLabel("Title", { exact: true })).toBeVisible();
+  await expect(
+    component.getByText("Shown in the page hero header."),
+  ).toBeVisible();
+});
+
+test("nullable image union inherits the leaf description", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    hero: {
+      anyOf: [
+        {
+          type: "string",
+          format: "image-uri",
+          title: "Hero image",
+          description: "Recommended 1600x900.",
+        },
+        { type: "null" },
+      ],
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.getByText("Recommended 1600x900.")).toBeVisible();
+  await expect(
+    component.getByRole("button", {
+      name: "Drop an image or click to browse",
+    }),
+  ).toBeVisible();
+});

--- a/apps/mesh/ct/tests/section-variant-list.ct.tsx
+++ b/apps/mesh/ct/tests/section-variant-list.ct.tsx
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SectionVariantListHarness } from "../harness/variant-harnesses";
+import { readEvents } from "../harness/ct-utils";
+
+/**
+ * SectionVariantList — the A/B section variants sidebar. Callback-driven:
+ * select a row, or open a row's actions menu to duplicate / delete; plus a
+ * "remove all" affordance. Delete is disabled when only one variant remains.
+ * DropdownMenu content is portaled → queried via `page`.
+ */
+const TWO = [
+  { index: 0, label: "Default" },
+  { index: 1, label: "Variant B" },
+];
+
+test("renders a row per variant", async ({ mount }) => {
+  const component = await mount(
+    <SectionVariantListHarness variants={TWO} selectedIndex={0} />,
+  );
+  await expect(component.getByText("Default", { exact: true })).toBeVisible();
+  await expect(component.getByText("Variant B", { exact: true })).toBeVisible();
+});
+
+test("clicking a row fires onSelect with its index", async ({ mount }) => {
+  const component = await mount(
+    <SectionVariantListHarness variants={TWO} selectedIndex={0} />,
+  );
+  await component.getByText("Variant B", { exact: true }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "select", index: 1 }]);
+});
+
+test("duplicate from the row menu fires onDuplicate", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <SectionVariantListHarness variants={TWO} selectedIndex={0} />,
+  );
+  await component
+    .getByRole("button", { name: "Open actions for Variant B", exact: true })
+    .click();
+  await page.getByRole("menuitem", { name: "Duplicate" }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "duplicate", index: 1 }]);
+});
+
+test("delete from the row menu fires onDelete (multiple variants)", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <SectionVariantListHarness variants={TWO} selectedIndex={0} />,
+  );
+  await component
+    .getByRole("button", { name: "Open actions for Default", exact: true })
+    .click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "delete", index: 0 }]);
+});
+
+test("delete is disabled when only one variant remains", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <SectionVariantListHarness
+      variants={[{ index: 0, label: "Only" }]}
+      selectedIndex={0}
+    />,
+  );
+  await component
+    .getByRole("button", { name: "Open actions for Only", exact: true })
+    .click();
+  await expect(page.getByRole("menuitem", { name: "Delete" })).toBeDisabled();
+});
+
+test("remove-all fires onRemoveAll", async ({ mount }) => {
+  const component = await mount(
+    <SectionVariantListHarness variants={TWO} selectedIndex={0} />,
+  );
+  await component.getByRole("button", { name: "Remove all variants" }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "removeAll" }]);
+});

--- a/apps/mesh/ct/tests/smoke.ct.tsx
+++ b/apps/mesh/ct/tests/smoke.ct.tsx
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import { readFormValue } from "../harness/ct-utils";
+
+test("renders a string field and round-trips typed value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    title: { type: "string", title: "Title" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Title");
+  await expect(input).toBeVisible();
+  await input.fill("Hello world");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ title: "Hello world" });
+});
+
+test("returns null render for a schema with no properties", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({});
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+  await expect(component.getByTestId("resolve-null")).toBeVisible();
+});

--- a/apps/mesh/ct/tests/string-field.ct.tsx
+++ b/apps/mesh/ct/tests/string-field.ct.tsx
@@ -1,0 +1,236 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import { readFormValue } from "../harness/ct-utils";
+
+test("plain string renders a textbox and round-trips typed value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    title: { type: "string", title: "Title" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Title");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "text");
+  await input.fill("Hello");
+
+  await expect.poll(() => readFormValue(component)).toEqual({ title: "Hello" });
+});
+
+test("default value is used as the input placeholder", async ({ mount }) => {
+  const meta = sectionWithProps({
+    title: { type: "string", title: "Title", default: "placeholder text" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Title");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("placeholder", "placeholder text");
+});
+
+test("url format renders input[type=url] and round-trips typed value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    link: { type: "string", title: "Link", format: "url" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Link");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "url");
+  await input.fill("https://deco.cx");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ link: "https://deco.cx" });
+});
+
+test("textarea format renders a <textarea> and round-trips typed value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    body: { type: "string", title: "Body", format: "textarea" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const field = component.getByLabel("Body");
+  await expect(field).toBeVisible();
+  await expect(component.locator("textarea#body")).toBeVisible();
+  await field.fill("multi\nline\ntext");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ body: "multi\nline\ntext" });
+});
+
+test("rich-text format renders a <textarea> and round-trips typed value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    body: { type: "string", title: "Body", format: "rich-text" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const field = component.getByLabel("Body");
+  await expect(field).toBeVisible();
+  await expect(component.locator("textarea#body")).toBeVisible();
+  await field.fill("rich content");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ body: "rich content" });
+});
+
+test("rich-text-inline format renders a <textarea> and round-trips typed value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    body: { type: "string", title: "Body", format: "rich-text-inline" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const field = component.getByLabel("Body");
+  await expect(field).toBeVisible();
+  await expect(component.locator("textarea#body")).toBeVisible();
+  await field.fill("inline content");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ body: "inline content" });
+});
+
+test("markdown format renders a <textarea> and round-trips typed value", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    body: { type: "string", title: "Body", format: "markdown" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const field = component.getByLabel("Body");
+  await expect(field).toBeVisible();
+  await expect(component.locator("textarea#body")).toBeVisible();
+  await field.fill("# heading");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ body: "# heading" });
+});
+
+test("color-input format renders a color input plus a text input", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    color: { type: "string", title: "Color", format: "color-input" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.locator('input[type="color"]')).toBeVisible();
+  const textInput = component.getByLabel("Color");
+  await expect(textInput).toBeVisible();
+});
+
+test("color-input text input round-trips the hex value", async ({ mount }) => {
+  const meta = sectionWithProps({
+    color: { type: "string", title: "Color", format: "color-input" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByLabel("Color").fill("#ff0000");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ color: "#ff0000" });
+});
+
+test("date format renders input[type=date] and converts to an ISO string", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    when: { type: "string", title: "When", format: "date" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("When");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "date");
+  await input.fill("2024-01-15");
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ when: "2024-01-15T00:00:00.000Z" });
+});
+
+test("date format exposes an Open calendar button", async ({ mount }) => {
+  const meta = sectionWithProps({
+    when: { type: "string", title: "When", format: "date" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(
+    component.getByRole("button", { name: "Open calendar" }),
+  ).toBeVisible();
+});
+
+test("date-time format renders input[type=datetime-local] and converts to an ISO string", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    when: { type: "string", title: "When", format: "date-time" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("When");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "datetime-local");
+  await input.fill("2024-06-15T10:30");
+
+  // Resulting ISO string is timezone-dependent; assert shape, not exact value.
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as { when?: unknown };
+      return (
+        typeof value.when === "string" &&
+        /^\d{4}-\d{2}-\d{2}T.*Z$/.test(value.when)
+      );
+    })
+    .toBe(true);
+});
+
+test("description text is rendered alongside the field", async ({ mount }) => {
+  const meta = sectionWithProps({
+    title: { type: "string", title: "Title", description: "Help text" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.getByText("Help text")).toBeVisible();
+});

--- a/apps/mesh/ct/tests/union-anyof-field.ct.tsx
+++ b/apps/mesh/ct/tests/union-anyof-field.ct.tsx
@@ -1,0 +1,369 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { FieldHarness } from "../harness/field-harness";
+import { readFormValue } from "../harness/ct-utils";
+import type { SchemaProperty } from "@/web/components/sections-editor/resolve-schema";
+
+// ── (A) module-loader union ────────────────────────────────────────────────
+// resolveTypes contain "/" → AnyOfField treats this as a module-loader union:
+// no discriminator, value carries __resolveType, and the nested config is
+// tucked inside a "Loader configuration" collapsible card.
+const moduleLoaderUnion: SchemaProperty = {
+  type: "block-ref",
+  anyOfRefs: [
+    {
+      resolveType: "site/loaders/A.ts",
+      title: "Loader A",
+      schema: {
+        type: "object",
+        properties: { foo: { type: "string", title: "Foo" } },
+      },
+    },
+    {
+      resolveType: "site/loaders/B.ts",
+      title: "Loader B",
+      schema: {
+        type: "object",
+        properties: { bar: { type: "number", title: "Bar" } },
+      },
+    },
+  ],
+};
+
+// ── (B) type-discriminated union ────────────────────────────────────────────
+// Short resolveTypes (no "/") + discriminatorKey "type" → NOT a module loader,
+// so nested props render INLINE (no collapsible), and the value carries the
+// discriminator field instead of __resolveType.
+const typeDiscriminatedUnion: SchemaProperty = {
+  type: "block-ref",
+  discriminatorKey: "type",
+  anyOfRefs: [
+    {
+      resolveType: "image-card",
+      discriminatorValue: "image-card",
+      title: "Image Card",
+      schema: {
+        type: "object",
+        properties: { src: { type: "string", title: "Src" } },
+      },
+    },
+    {
+      resolveType: "text-card",
+      discriminatorValue: "text-card",
+      title: "Text Card",
+      schema: {
+        type: "object",
+        properties: { body: { type: "string", title: "Body" } },
+      },
+    },
+  ],
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// (A) module-loader union
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("module union: combobox renders with both loader options", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={moduleLoaderUnion} label="Source" />,
+  );
+
+  const trigger = component.getByRole("combobox");
+  await expect(trigger).toBeVisible();
+
+  await trigger.click();
+  await expect(page.getByRole("option", { name: "Loader A" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "Loader B" })).toBeVisible();
+  await expect(page.getByRole("option")).toHaveCount(2);
+});
+
+test("module union: default selection is the first ref (Loader A)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={moduleLoaderUnion} label="Source" />,
+  );
+
+  await expect(component.getByRole("combobox")).toHaveText("Loader A");
+});
+
+test("module union: label renders next to the combobox", async ({ mount }) => {
+  const component = await mount(
+    <FieldHarness schema={moduleLoaderUnion} label="Source" />,
+  );
+
+  await expect(component.getByText("Source")).toBeVisible();
+});
+
+test("module union: selecting Loader B sets __resolveType on the value", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={moduleLoaderUnion} label="Source" />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Loader B" }).click();
+
+  // The combobox now reflects the new branch...
+  await expect(component.getByRole("combobox")).toHaveText("Loader B");
+
+  // ...and the value object carries the loader's __resolveType. Nested
+  // defaults (e.g. bar: 0) may also be present, so assert the key only.
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as Record<string, unknown>;
+      return value?.__resolveType;
+    })
+    .toBe("site/loaders/B.ts");
+});
+
+test("module union: nested config is collapsed by default", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={moduleLoaderUnion} label="Source" />,
+  );
+
+  const configToggle = component.getByRole("button", {
+    name: /loader configuration/i,
+  });
+  await expect(configToggle).toBeVisible();
+  await expect(configToggle).toHaveAttribute("aria-expanded", "false");
+
+  // The nested leaf is not rendered while the collapsible is closed.
+  await expect(component.getByLabel("Foo")).toHaveCount(0);
+});
+
+test("module union: expanding the config reveals the nested field", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={moduleLoaderUnion} label="Source" />,
+  );
+
+  const configToggle = component.getByRole("button", {
+    name: /loader configuration/i,
+  });
+  await configToggle.click();
+
+  await expect(configToggle).toHaveAttribute("aria-expanded", "true");
+  await expect(component.getByLabel("Foo")).toBeVisible();
+});
+
+test("module union: editing the nested leaf updates the value object", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={moduleLoaderUnion} label="Source" />,
+  );
+
+  // Switch to Loader B (number leaf "Bar").
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Loader B" }).click();
+
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as Record<string, unknown>;
+      return value?.__resolveType;
+    })
+    .toBe("site/loaders/B.ts");
+
+  // Open the collapsible config card, then edit the nested "Bar" field.
+  await component
+    .getByRole("button", { name: /loader configuration/i })
+    .click();
+
+  const barInput = component.getByLabel("Bar");
+  await expect(barInput).toBeVisible();
+  // Nested field path == `${path}.bar`; default FieldHarness path is "field".
+  await expect(barInput).toHaveAttribute("id", "field.bar");
+
+  await barInput.fill("42");
+
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as Record<string, unknown>;
+      return { bar: value?.bar, rt: value?.__resolveType };
+    })
+    .toEqual({ bar: 42, rt: "site/loaders/B.ts" });
+});
+
+test("module union: pre-populated value selects the matching branch and edits in place", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={moduleLoaderUnion}
+      label="Source"
+      initialValue={{ __resolveType: "site/loaders/A.ts", foo: "hello" }}
+    />,
+  );
+
+  // The inferred branch matches the value's __resolveType (Loader A).
+  await expect(component.getByRole("combobox")).toHaveText("Loader A");
+
+  // With existing data the collapsible config is open from the start.
+  const fooInput = component.getByLabel("Foo");
+  await expect(fooInput).toBeVisible();
+  await expect(fooInput).toHaveValue("hello");
+
+  await fooInput.fill("world");
+
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as Record<string, unknown>;
+      return { foo: value?.foo, rt: value?.__resolveType };
+    })
+    .toEqual({ foo: "world", rt: "site/loaders/A.ts" });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// (B) type-discriminated union
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("type union: combobox renders with both discriminated options", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={typeDiscriminatedUnion} label="Card" />,
+  );
+
+  await component.getByRole("combobox").click();
+  await expect(page.getByRole("option", { name: "Image Card" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "Text Card" })).toBeVisible();
+  await expect(page.getByRole("option")).toHaveCount(2);
+});
+
+test("type union: default selection is the first branch (Image Card)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={typeDiscriminatedUnion} label="Card" />,
+  );
+
+  await expect(component.getByRole("combobox")).toHaveText("Image Card");
+});
+
+test("type union: nested props render INLINE (no collapsible card)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={typeDiscriminatedUnion} label="Card" />,
+  );
+
+  // No "Configuration"/"Loader configuration" collapsible for type unions.
+  await expect(
+    component.getByRole("button", { name: /configuration/i }),
+  ).toHaveCount(0);
+
+  // The first branch's leaf ("Src") is visible inline immediately.
+  await expect(component.getByLabel("Src")).toBeVisible();
+});
+
+test("type union: selecting Text Card writes the discriminator into the value", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={typeDiscriminatedUnion} label="Card" />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Text Card" }).click();
+
+  await expect(component.getByRole("combobox")).toHaveText("Text Card");
+
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as Record<string, unknown>;
+      return value?.type;
+    })
+    .toBe("text-card");
+});
+
+test("type union: Text Card's nested Body field renders inline and is editable", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={typeDiscriminatedUnion} label="Card" />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Text Card" }).click();
+
+  // The discriminator must land before we touch the nested field.
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as Record<string, unknown>;
+      return value?.type;
+    })
+    .toBe("text-card");
+
+  const bodyInput = component.getByLabel("Body");
+  await expect(bodyInput).toBeVisible();
+  await expect(bodyInput).toHaveAttribute("id", "field.body");
+
+  await bodyInput.fill("Hello there");
+
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as Record<string, unknown>;
+      return { type: value?.type, body: value?.body };
+    })
+    .toEqual({ type: "text-card", body: "Hello there" });
+});
+
+test("type union: the active branch's discriminator field is hidden from nested form", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={typeDiscriminatedUnion} label="Card" />,
+  );
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Text Card" }).click();
+
+  // "Body" is editable, but the "type" discriminator leaf is stripped — there
+  // is no "Type" labelled field for the user to edit directly.
+  await expect(component.getByLabel("Body")).toBeVisible();
+  await expect(component.getByLabel("Type")).toHaveCount(0);
+});
+
+test("type union: switching back to Image Card swaps the active discriminator", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness schema={typeDiscriminatedUnion} label="Card" />,
+  );
+
+  // Image Card -> Text Card -> Image Card, verifying the discriminator each time.
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Text Card" }).click();
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as Record<string, unknown>;
+      return value?.type;
+    })
+    .toBe("text-card");
+
+  await component.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Image Card" }).click();
+  await expect(component.getByRole("combobox")).toHaveText("Image Card");
+  await expect
+    .poll(async () => {
+      const value = (await readFormValue(component)) as Record<string, unknown>;
+      return value?.type;
+    })
+    .toBe("image-card");
+
+  await expect(component.getByLabel("Src")).toBeVisible();
+});

--- a/apps/mesh/ct/tests/variant-rename-dialog.ct.tsx
+++ b/apps/mesh/ct/tests/variant-rename-dialog.ct.tsx
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { VariantRenameDialogHarness } from "../harness/variant-harnesses";
+import { readEvents } from "../harness/ct-utils";
+
+/**
+ * VariantRenameDialog — a controlled Radix dialog (portaled → queried via
+ * `page`). Submitting fires onSubmit with the trimmed name; Cancel / dismiss
+ * fires onOpenChange(false). The name input is prefilled with initialName and
+ * uses autoLabel as its placeholder.
+ */
+
+test("renders prefilled with initialName and autoLabel placeholder", async ({
+  mount,
+  page,
+}) => {
+  await mount(
+    <VariantRenameDialogHarness initialName="Holiday" autoLabel="Mobile" />,
+  );
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await expect(page.getByText("Rename variant")).toBeVisible();
+  const input = page.getByLabel("Name", { exact: true });
+  await expect(input).toHaveValue("Holiday");
+});
+
+test("empty initialName falls back to autoLabel as placeholder", async ({
+  mount,
+  page,
+}) => {
+  await mount(
+    <VariantRenameDialogHarness initialName="" autoLabel="Mobile users" />,
+  );
+  const input = page.getByLabel("Name", { exact: true });
+  await expect(input).toHaveValue("");
+  await expect(input).toHaveAttribute("placeholder", "Mobile users");
+});
+
+test("typing a name and Save fires onSubmit", async ({ mount, page }) => {
+  const component = await mount(
+    <VariantRenameDialogHarness initialName="" autoLabel="Mobile" />,
+  );
+  await page.getByLabel("Name", { exact: true }).fill("Spring sale");
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "submit", name: "Spring sale" }]);
+});
+
+test("Save trims surrounding whitespace from the name", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <VariantRenameDialogHarness initialName="" autoLabel="Mobile" />,
+  );
+  await page.getByLabel("Name", { exact: true }).fill("   Padded   ");
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "submit", name: "Padded" }]);
+});
+
+test("Cancel fires onOpenChange(false)", async ({ mount, page }) => {
+  const component = await mount(
+    <VariantRenameDialogHarness initialName="Holiday" autoLabel="Mobile" />,
+  );
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toContainEqual({ type: "openChange", open: false });
+});

--- a/apps/mesh/ct/tests/widget-dispatch.ct.tsx
+++ b/apps/mesh/ct/tests/widget-dispatch.ct.tsx
@@ -1,0 +1,201 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+
+/**
+ * Widget dispatch matrix — the regression net guarding that "the right widget
+ * renders for each schema shape". One section property per case, fed through
+ * resolveSchema → SchemaForm → renderField, asserting only the DISTINGUISHING
+ * element of the expected widget is visible.
+ */
+
+test("string schema → text input", async ({ mount }) => {
+  const meta = sectionWithProps({
+    title: { type: "string", title: "Title" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Title");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "text");
+});
+
+test("number schema → number input", async ({ mount }) => {
+  const meta = sectionWithProps({
+    count: { type: "number", title: "Count" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Count");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "number");
+});
+
+test("integer schema → number input", async ({ mount }) => {
+  const meta = sectionWithProps({
+    quantity: { type: "integer", title: "Quantity" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Quantity");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "number");
+});
+
+test("boolean schema → switch", async ({ mount }) => {
+  const meta = sectionWithProps({
+    active: { type: "boolean", title: "Active" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const sw = component.getByLabel("Active");
+  await expect(sw).toBeVisible();
+  // BooleanField renders a Radix Switch (role="switch"); getByLabel resolves
+  // to that button via <Label htmlFor={path}>.
+  await expect(sw).toBeChecked({ checked: false });
+  await expect(component.getByRole("switch", { name: "Active" })).toBeVisible();
+});
+
+test("enum schema → combobox select", async ({ mount }) => {
+  const meta = sectionWithProps({
+    variant: { type: "string", title: "Variant", enum: ["a", "b"] },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const combobox = component.getByRole("combobox");
+  await expect(combobox).toBeVisible();
+});
+
+test("image-uri format → ImageField picker", async ({ mount }) => {
+  const meta = sectionWithProps({
+    hero: { type: "string", title: "Hero", format: "image-uri" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(
+    component.getByText("Drop an image or click to browse"),
+  ).toBeVisible();
+});
+
+test("file-uri format → FileField picker", async ({ mount }) => {
+  const meta = sectionWithProps({
+    attachment: { type: "string", title: "Attachment", format: "file-uri" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(
+    component.getByText("Drop a file or click to browse"),
+  ).toBeVisible();
+});
+
+test("video-uri format → FileField video picker", async ({ mount }) => {
+  const meta = sectionWithProps({
+    clip: { type: "string", title: "Clip", format: "video-uri" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(
+    component.getByText("Drop a video here or click to browse"),
+  ).toBeVisible();
+});
+
+test("array schema → Add item button", async ({ mount }) => {
+  const meta = sectionWithProps({
+    tags: {
+      type: "array",
+      title: "Tags",
+      items: { type: "string" },
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(
+    component.getByRole("button", { name: "Add item" }),
+  ).toBeVisible();
+});
+
+test("object schema → collapsible toggle button with label", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    seo: {
+      type: "object",
+      title: "Seo",
+      properties: {
+        description: { type: "string", title: "Description" },
+      },
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.getByRole("button", { name: "Seo" })).toBeVisible();
+});
+
+test("color-input format → native color input", async ({ mount }) => {
+  const meta = sectionWithProps({
+    accent: { type: "string", title: "Accent", format: "color-input" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.locator('input[type="color"]')).toBeVisible();
+});
+
+test("date format → native date input", async ({ mount }) => {
+  const meta = sectionWithProps({
+    publishedAt: { type: "string", title: "Published At", format: "date" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Published At");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "date");
+});
+
+test("date-time format → native datetime-local input", async ({ mount }) => {
+  const meta = sectionWithProps({
+    startsAt: { type: "string", title: "Starts At", format: "date-time" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Starts At");
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("type", "datetime-local");
+});
+
+test("textarea format → textarea element", async ({ mount }) => {
+  const meta = sectionWithProps({
+    body: { type: "string", title: "Body", format: "textarea" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const textarea = component.locator("textarea#body");
+  await expect(textarea).toBeVisible();
+});

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -32,6 +32,8 @@
     "test": "bun test",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "test:ct": "playwright test -c playwright-ct.config.ts",
+    "test:ct:ui": "playwright test -c playwright-ct.config.ts --ui",
     "better-auth:migrate": "bunx --bun @better-auth/cli migrate -y --config src/auth/index.ts",
     "smoke:link": "bun run scripts/smoke-link.ts",
     "prepublishOnly": "bun run build:client && bun run build:server"
@@ -101,6 +103,7 @@
     "@opentelemetry/sdk-metrics": "^2.2.0",
     "@opentelemetry/sdk-node": "^0.207.0",
     "@opentelemetry/sdk-trace-base": "^2.5.0",
+    "@playwright/experimental-ct-react": "1.59.1",
     "@playwright/test": "^1.58.2",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/apps/mesh/playwright-ct.config.ts
+++ b/apps/mesh/playwright-ct.config.ts
@@ -1,0 +1,77 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { defineConfig, devices } from "@playwright/experimental-ct-react";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const stub = (rel: string) => path.join(here, "ct", "harness", "stubs", rel);
+
+/**
+ * Playwright Component Testing config for the sections-editor form widgets.
+ *
+ * These tests mount the real SchemaForm / field components in a browser with
+ * synthetic JSON-Schema fixtures — no app server, no sandbox dev server. The
+ * goal is a regression guard on widget rendering + edit behavior: given a CMS
+ * JSON Schema, the right widget renders and editing it produces the right
+ * serialized value.
+ *
+ * Test files are `*.ct.tsx` under ./ct/tests so they never collide with:
+ *   - `bun test` (unit) — globs `*.test.ts` / `*.spec.ts` under src/ + packages/
+ *   - `playwright test` (e2e) — testDir ./e2e, matches `*.spec.ts`
+ */
+export default defineConfig({
+  testDir: "./ct/tests",
+  testMatch: "**/*.ct.tsx",
+  snapshotDir: "./ct/__snapshots__",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 4 : undefined,
+  reporter: process.env.CI ? "line" : [["list"], ["html", { open: "never" }]],
+  use: {
+    trace: "on-first-retry",
+    ctPort: 3120,
+    ctTemplateDir: "./ct/playwright",
+    ctViteConfig: {
+      plugins: [
+        // No babel-plugin-react-compiler here: it's a build-time optimization,
+        // not a correctness requirement. The components are valid React 19
+        // without it, and dropping it keeps the CT bundle fast and avoids
+        // pulling compiler edge cases into the test harness.
+        react(),
+        tailwindcss(),
+        tsconfigPaths({ root: "." }),
+      ],
+      resolve: {
+        // Sever the I/O boundary of ImageField/FileField. Both statically
+        // import these modules (transitively pulling in @decocms/mesh-sdk's
+        // MCP client + @tanstack/react-router), and call useProjectContext()
+        // at mount — which throws without the full app provider tree. The
+        // stubs let us test the fields' own render/paste/remove logic
+        // deterministically. The real S3 upload path stays an e2e concern.
+        alias: [
+          {
+            find: /^@\/web\/hooks\/use-file-configs$/,
+            replacement: stub("use-file-configs.ts"),
+          },
+          {
+            find: /^@\/web\/hooks\/use-file-picker$/,
+            replacement: stub("use-file-picker.ts"),
+          },
+          {
+            find: /^@\/web\/components\/file-picker\/file-picker-dialog$/,
+            replacement: stub("file-picker-dialog.tsx"),
+          },
+          // General `@/* -> src/*` alias. MUST come after the stub aliases
+          // above so Vite (first-match-wins) resolves those first. Matches
+          // only `@/`-prefixed ids, so `@deco/ui`, `@tanstack/*` etc. are
+          // untouched.
+          { find: "@/", replacement: `${path.join(here, "src")}/` },
+        ],
+      },
+    },
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/apps/mesh/tsconfig.json
+++ b/apps/mesh/tsconfig.json
@@ -47,6 +47,7 @@
     "src/**/*",
     "**/*.test.ts",
     "**/*.spec.ts",
+    "ct/**/*",
     "scripts/generate-migrations.ts"
   ],
   "exclude": ["node_modules", "dist", "data"]

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "3.18.5",
+      "version": "3.21.0",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -103,6 +103,7 @@
         "@opentelemetry/sdk-metrics": "^2.2.0",
         "@opentelemetry/sdk-node": "^0.207.0",
         "@opentelemetry/sdk-trace-base": "^2.5.0",
+        "@playwright/experimental-ct-react": "1.59.1",
         "@playwright/test": "^1.58.2",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -177,7 +178,7 @@
     },
     "packages/bindings": {
       "name": "@decocms/bindings",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "dependencies": {
         "@decocms/mcp-utils": "^1.0.5",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -200,7 +201,7 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "1.4.1",
+      "version": "1.5.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.80",
         "@ai-sdk/google": "^3.0.80",
@@ -221,7 +222,7 @@
     },
     "packages/mcp-utils": {
       "name": "@decocms/mcp-utils",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@decocms/std": "workspace:*",
         "ajv": "^8.20.0",
@@ -264,7 +265,7 @@
     },
     "packages/mesh-sdk": {
       "name": "@decocms/mesh-sdk",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.1",
         "@decocms/mcp-utils": "workspace:*",
@@ -283,7 +284,7 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.10",
         "@cloudflare/workers-types": "^4.20250617.0",
@@ -305,7 +306,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/std": "workspace:*",
@@ -1106,6 +1107,10 @@
     "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ=="],
 
     "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
+
+    "@playwright/experimental-ct-core": ["@playwright/experimental-ct-core@1.59.1", "", { "dependencies": { "playwright": "1.59.1", "playwright-core": "1.59.1", "vite": "^6.4.1" } }, "sha512-U7+jNROBJxfwjM/G7011+UNEyLiI5zIT1HWAn1k89WZIWl5RUWaCGWlYkYdAZwBSVfGstjF9AgkzmS0RsF8Ulw=="],
+
+    "@playwright/experimental-ct-react": ["@playwright/experimental-ct-react@1.59.1", "", { "dependencies": { "@playwright/experimental-ct-core": "1.59.1", "@vitejs/plugin-react": "^4.2.1" }, "bin": { "playwright": "cli.js" } }, "sha512-72v9XzatgFRBXLz42uth1tMVNAmGXOk+BCHPh5Rtxrc7SMKIRid0LiqUyuaZKD5udK/3yiy4wog8iAMDu7Razw=="],
 
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
@@ -3535,6 +3540,10 @@
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
 
+    "@playwright/experimental-ct-core/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
+
+    "@playwright/experimental-ct-react/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
     "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "@radix-ui/react-accordion/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
@@ -3919,6 +3928,12 @@
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
+    "@playwright/experimental-ct-core/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "@playwright/experimental-ct-react/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@playwright/experimental-ct-react/@vitejs/plugin-react/react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
     "@triplit/client/superjson/copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
 
     "ai-sdk-provider-claude-code/@anthropic-ai/claude-agent-sdk/@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw=="],
@@ -4212,6 +4227,58 @@
     "@better-auth/sso/better-auth/better-call/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@playwright/experimental-ct-core/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@triplit/client/superjson/copy-anything/is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -20,7 +20,14 @@
         "src/api/routes/dev-only.ts",
         // Browser asset served verbatim from the Vite public dir; deck HTML
         // files reference it via <script src="/deck-runtime/v1/...">.
-        "public/deck-runtime/**/*.js"
+        "public/deck-runtime/**/*.js",
+        // Playwright Component Testing harness. The mount template is loaded
+        // via ct/playwright/index.html + ctTemplateDir (index.css is imported
+        // from it), and the I/O stubs are wired only through resolve.alias in
+        // playwright-ct.config.ts — both are reachable by tooling knip can't
+        // trace. The *.ct.tsx specs are already entries via the playwright config.
+        "ct/playwright/index.tsx",
+        "ct/harness/stubs/**"
       ],
       "ignore": ["src/api/index.ts"],
       "ignoreDependencies": [


### PR DESCRIPTION
## What is this contribution about?
Adds a Playwright **Component Testing** tier (`apps/mesh/ct/`) that mounts the real `SchemaForm` + field components with synthetic JSON-Schema fixtures — no app server and no sandbox dev server — to lock in the basic rendering and edit behavior of every sections-editor widget so future changes can't silently break them. 128 tests cover string (text/url/textarea/color/date), number, boolean, enum, object (nested), array (+ object drill-down), union/anyOf, image, file/video, the widget-dispatch matrix, and `resolveSchema` edge cases (nullable unions, enum-from-const, hidden-field filtering, empty state). Test files are `*.ct.tsx` under `ct/tests/` with a separate `playwright-ct.config.ts` so they never collide with `bun test` (unit) or the e2e `playwright test`; the image/file fields' MCP/router I/O is stubbed at the boundary via Vite aliases, so real S3 upload remains an e2e concern.

> **Note on test doctrine:** `TESTING.md` currently describes two tiers (pure-unit + full-stack e2e). Component testing is arguably a third tier — these components are near-pure (`schema → DOM → onChange`) so it leans unit-like, but it does render DOM. Flagging for a deliberate call before merge.

## Screenshots/Demonstration
N/A — this is test infrastructure (no UI/behavior changes to the app).

## How to Test
1. `bun install` (adds `@playwright/experimental-ct-react`).
2. `bun run --cwd=apps/mesh test:ct`
3. Expected: `128 passed`. `bun run check` and `bun run lint` also pass.

## Migration Notes
No DB/config migrations. One new dev dependency (`@playwright/experimental-ct-react`), so reviewers must `bun install`.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright Component Testing for the sections-editor `SchemaForm`, field widgets, and variant/matcher UI, mounting real components with JSON Schema fixtures to lock in rendering and edit behavior. The suite now has 151 tests across string/number/boolean/enum/object/array/union, image/file/video, widget dispatch, schema-resolution edge cases, and `SectionVariantList`/`PageVariantTabs`/`VariantRenameDialog`/`MatcherPicker`.

- **New Features**
  - New CT suite under `apps/mesh/ct/` with `SchemaFormHarness`/`FieldHarness` and variant/matcher harnesses; tests in `ct/tests/*.ct.tsx` isolated via `playwright-ct.config.ts`.
  - Added coverage for variant/matcher UI with an event-log harness (select/add/rename/delete/duplicate/remove-all, matcher pick/search).
  - Stubs for file picker and upload keep I/O out of CT; Tailwind v4 CT setup scans `apps/mesh/src/web` and `packages/ui/src`; Knip marks CT harness/template and stubs as entries; `tsconfig` includes `ct/**`.

- **Migration**
  - Install deps: `bun install` (adds `@playwright/experimental-ct-react`).
  - Run: `bun run --cwd=apps/mesh test:ct` or `bun run --cwd=apps/mesh test:ct:ui`.

<sup>Written for commit a96e93ef0c8e200775e436d6eae14e0566cbbb89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

