### PR TITLE
feat(dbos): pod dispatch-role split (api/worker) via listenQueues

### DIFF
--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -73,7 +73,8 @@ import { computeNextRunAt, type StudioContextFactory } from "./fire";
  * Registered once at boot in `app.initDbos` (like the thread-gate queue),
  * not lazily per fire.
  */
-export const AUTOMATIONS_QUEUE = "automations";
+export { AUTOMATIONS_QUEUE } from "../dispatch-queue/queue-names";
+import { AUTOMATIONS_QUEUE } from "../dispatch-queue/queue-names";
 /** Per-org (per-partition) concurrency cap. */
 export const AUTOMATIONS_PARTITION_CONCURRENCY = 10;
 /**

--- a/apps/mesh/src/dispatch-queue/queue-names.ts
+++ b/apps/mesh/src/dispatch-queue/queue-names.ts
@@ -1,0 +1,10 @@
+/**
+ * DBOS workflow-queue NAMES, isolated from the workflow modules that register
+ * them. Those modules (`thread-gate-workflow`, `automations/dbos-workflow`)
+ * run `DBOS.registerWorkflow` at import time, and `index.ts` documents that
+ * `DBOS.setConfig` must run *before* any such registration. `setConfig` now
+ * needs the queue names (for the `listenQueues` pod-role split), so they live
+ * here — a side-effect-free module safe to import before `setConfig`.
+ */
+export const THREAD_GATE_QUEUE = "thread-gate";
+export const AUTOMATIONS_QUEUE = "automations";

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -37,7 +37,8 @@ import type {
   WorkItemSandbox,
 } from "@/api/routes/decopilot/link-work-queue";
 
-export const THREAD_GATE_QUEUE = "thread-gate";
+export { THREAD_GATE_QUEUE } from "./queue-names";
+import { THREAD_GATE_QUEUE } from "./queue-names";
 
 /** Thread statuses that indicate a run has reached a terminal state. */
 export const TERMINAL_STATUSES = new Set([

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -7,6 +7,12 @@
  */
 
 import { sleep } from "@decocms/std";
+// Side-effect-free queue names — safe to import before DBOS.setConfig (unlike
+// the workflow modules, which register workflows at import time).
+import {
+  AUTOMATIONS_QUEUE,
+  THREAD_GATE_QUEUE,
+} from "./dispatch-queue/queue-names";
 import { getSettings } from "./settings";
 import { initObservability } from "./observability";
 import { startProfiling } from "./observability/profiling";
@@ -42,6 +48,40 @@ function withSslmode(url: string, ssl: boolean): string {
   }
   return u.toString();
 }
+// ── Pod dispatch role (horizontal split) ────────────────────────────────────
+// `MESH_DISPATCH_ROLE` selects which DBOS queues this pod DEQUEUES (via the
+// SDK's `listenQueues` filter). It lets you run two Deployments off the SAME
+// image/DB/auth and scale them independently:
+//   - "all"    (default) — dequeue every queue. Unchanged single-deployment
+//                          behavior; safe default, no opt-in required.
+//   - "worker" — dequeue only the agent/automation RUN queues, so these pods
+//                execute decopilot streams + automation fires. Scale these on
+//                CPU (the LLM-stream load) without touching API pods.
+//   - "api"    — dequeue NOTHING (only DBOS's internal queue still runs). These
+//                pods serve HTTP, enqueue runs, and tail NATS for /stream, but
+//                never run the heavy agent loop.
+// Scheduled (cron) workflows and enqueueing are unaffected — they run on every
+// pod and stay exactly-once via DBOS's row-locked schedule, so an "api" pod can
+// still fire a cron that a "worker" pod then executes. REQUIREMENT: at least
+// one "worker" (or "all") pod must exist or runs never dispatch.
+const dispatchRole = (process.env.MESH_DISPATCH_ROLE ?? "all").trim();
+const RUN_QUEUES = [AUTOMATIONS_QUEUE, THREAD_GATE_QUEUE];
+const listenQueues: string[] | undefined =
+  dispatchRole === "worker"
+    ? RUN_QUEUES
+    : dispatchRole === "api"
+      ? []
+      : undefined; // "all" → omit → DBOS listens to every queue
+if (
+  dispatchRole !== "all" &&
+  dispatchRole !== "worker" &&
+  dispatchRole !== "api"
+) {
+  console.warn(
+    `[dispatch-role] unknown MESH_DISPATCH_ROLE="${dispatchRole}" — falling back to "all" (dequeue every queue)`,
+  );
+}
+
 DBOS.setConfig({
   name: "decocms",
   systemDatabaseUrl: withSslmode(settings.databaseUrl, settings.databasePgSsl),
@@ -54,6 +94,9 @@ DBOS.setConfig({
   // over port 3001. Re-enable per-process once we need workflow admin HTTP.
   runAdminServer: false,
   executorID: settings.podName,
+  // Pod-role queue filter (see above). Omitted for "all" so behavior is
+  // identical to before unless a role is explicitly set.
+  ...(listenQueues !== undefined ? { listenQueues } : {}),
 });
 
 const { createApp } = await import("./api/app");

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -49,8 +49,9 @@ function withSslmode(url: string, ssl: boolean): string {
   return u.toString();
 }
 // ── Pod dispatch role (horizontal split) ────────────────────────────────────
-// `MESH_DISPATCH_ROLE` selects which DBOS queues this pod DEQUEUES (via the
-// SDK's `listenQueues` filter). It lets you run two Deployments off the SAME
+// `settings.dispatchRole` (from `MESH_DISPATCH_ROLE`, resolved in
+// resolve-config) selects which DBOS queues this pod DEQUEUES (via the SDK's
+// `listenQueues` filter). It lets you run two Deployments off the SAME
 // image/DB/auth and scale them independently:
 //   - "all"    (default) — dequeue every queue. Unchanged single-deployment
 //                          behavior; safe default, no opt-in required.
@@ -64,23 +65,13 @@ function withSslmode(url: string, ssl: boolean): string {
 // pod and stay exactly-once via DBOS's row-locked schedule, so an "api" pod can
 // still fire a cron that a "worker" pod then executes. REQUIREMENT: at least
 // one "worker" (or "all") pod must exist or runs never dispatch.
-const dispatchRole = (process.env.MESH_DISPATCH_ROLE ?? "all").trim();
 const RUN_QUEUES = [AUTOMATIONS_QUEUE, THREAD_GATE_QUEUE];
 const listenQueues: string[] | undefined =
-  dispatchRole === "worker"
+  settings.dispatchRole === "worker"
     ? RUN_QUEUES
-    : dispatchRole === "api"
+    : settings.dispatchRole === "api"
       ? []
       : undefined; // "all" → omit → DBOS listens to every queue
-if (
-  dispatchRole !== "all" &&
-  dispatchRole !== "worker" &&
-  dispatchRole !== "api"
-) {
-  console.warn(
-    `[dispatch-role] unknown MESH_DISPATCH_ROLE="${dispatchRole}" — falling back to "all" (dequeue every queue)`,
-  );
-}
 
 DBOS.setConfig({
   name: "decocms",

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -5,9 +5,19 @@
  */
 
 import { homedir } from "os";
-import type { CliFlags, Settings } from "./types";
+import type { CliFlags, DispatchRole, Settings } from "./types";
 
 type SandboxProviderKind = Settings["sandboxProviderKind"];
+
+const DISPATCH_ROLES = new Set<DispatchRole>(["all", "worker", "api"]);
+
+/** Normalize `MESH_DISPATCH_ROLE`; anything unknown coerces to the safe "all". */
+function resolveDispatchRole(raw: string | undefined): DispatchRole {
+  const role = (raw ?? "").trim();
+  return DISPATCH_ROLES.has(role as DispatchRole)
+    ? (role as DispatchRole)
+    : "all";
+}
 
 function toBool(value: string | undefined): boolean {
   return value === "true" || value === "1";
@@ -158,6 +168,7 @@ export function resolveConfig(
     isCli: true,
     noTui: flags.noTui === true,
     podName: envVars.POD_NAME ?? crypto.randomUUID(),
+    dispatchRole: resolveDispatchRole(envVars.MESH_DISPATCH_ROLE),
     sandboxProviderKind: resolveSandboxProviderKind(
       envVars.STUDIO_SANDBOX_PROVIDER,
     ),

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -5,6 +5,9 @@
  * via getSettings() for the lifetime of the process.
  */
 
+/** Pod dispatch role — selects which DBOS run queues a pod dequeues. */
+export type DispatchRole = "all" | "worker" | "api";
+
 export interface Settings {
   // Core
   nodeEnv: "production" | "development" | "test";
@@ -92,6 +95,8 @@ export interface Settings {
   isCli: boolean;
   noTui: boolean;
   podName: string;
+  /** Which DBOS run queues this pod dequeues (pod dispatch-role split). */
+  dispatchRole: DispatchRole;
   sandboxProviderKind: "agent-sandbox" | "user-desktop";
 
   // External service credentials (optional)

--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -122,6 +122,17 @@ Global validations to ensure scaling requirements are met.
 {{- end }}
 
 {{/*
+Guards the dispatch-role split: if the main deployment stops dequeuing runs
+(dispatchRole=api) there must be a worker deployment to pick them up, or runs
+never dispatch.
+*/}}
+{{- define "chart-deco-studio.validateDispatchRole" -}}
+{{- if and (eq .Values.dispatchRole "api") (not .Values.worker.enabled) }}
+{{- fail "chart-deco-studio: dispatchRole=api requires worker.enabled=true — otherwise no pod dequeues the run queues and runs never dispatch. Set worker.enabled=true first, confirm workers dequeue, then switch dispatchRole to api." -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Returns podSecurityContext with fsGroupChangePolicy adjusted for volumes.
 */}}
 {{- define "chart-deco-studio.podSecurityContext" -}}

--- a/deploy/helm/studio/templates/validations.yaml
+++ b/deploy/helm/studio/templates/validations.yaml
@@ -4,4 +4,5 @@ This file only runs chart-level validations and renders no resources.
 {{- include "chart-deco-studio.validate" . -}}
 {{- include "chart-deco-studio.validateOtel" . -}}
 {{- include "chart-deco-studio.validateExternalSecret" . -}}
+{{- include "chart-deco-studio.validateDispatchRole" . -}}
 

--- a/deploy/helm/studio/templates/worker-deployment.yaml
+++ b/deploy/helm/studio/templates/worker-deployment.yaml
@@ -1,28 +1,36 @@
+{{- if .Values.worker.enabled }}
+{{/*
+Agent-loop worker Deployment. Same image / DB / auth as the main Deployment,
+but MESH_DISPATCH_ROLE=worker so it dequeues ONLY the agent/automation run
+queues. It carries a distinct `app.kubernetes.io/name` ("<name>-worker") so the
+main Deployment selector and the Service selector do NOT match its pods —
+workers never get LB/HTTP traffic; they only pull work from the DBOS queue.
+
+NOTE: this intentionally mirrors deployment.yaml's pod spec (minus the s3-sync
+sidecar / PVC). A future cleanup could share a named pod-spec template; kept
+separate here so the main Deployment's rendered output is unchanged.
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "chart-deco-studio.fullname" . }}
+  name: {{ include "chart-deco-studio.fullname" . }}-worker
   labels:
-    {{- include "chart-deco-studio.labels" . | nindent 4 }}
-spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
-  strategy:
-    type: {{ include "chart-deco-studio.deploymentStrategy" . }}
-    {{- $strategyType := include "chart-deco-studio.deploymentStrategy" . }}
-    {{- if eq $strategyType "RollingUpdate" }}
-    rollingUpdate:
-      {{- if and .Values.strategy .Values.strategy.rollingUpdate }}
-      {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}
-      {{- else }}
-      maxSurge: 1
-      maxUnavailable: 0
-      {{- end }}
+    app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "chart-deco-studio.chart" . }}
+    {{- if .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     {{- end }}
+spec:
+  {{- if not .Values.worker.autoscaling.enabled }}
+  replicas: {{ .Values.worker.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
-      {{- include "chart-deco-studio.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-worker
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -30,7 +38,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "chart-deco-studio.labels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-worker
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: worker
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ include "chart-deco-studio.chart" . }}
+        {{- if .Chart.AppVersion }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -46,7 +61,7 @@ spec:
       securityContext:
         {{- include "chart-deco-studio.podSecurityContext" . | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}-worker
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -67,6 +82,9 @@ spec:
             - secretRef:
                 name: {{ include "chart-deco-studio.secretName" . }}
           env:
+            # Role: dequeue only the agent/automation run queues.
+            - name: MESH_DISPATCH_ROLE
+              value: worker
             {{- if .Values.otel.enabled }}
             {{- if .Values.otel.protocol }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
@@ -74,7 +92,7 @@ spec:
             {{- end }}
             {{- if .Values.otel.service }}
             - name: OTEL_SERVICE_NAME
-              value: {{ .Values.otel.service | quote }}
+              value: {{ printf "%s-worker" .Values.otel.service | quote }}
             {{- end }}
             {{- if .Values.otel.endpoint }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -103,11 +121,7 @@ spec:
               value: {{ . | quote }}
             {{- end }}
             {{- end }}
-            {{- with .Values.dispatchRole }}
-            - name: MESH_DISPATCH_ROLE
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.env }}
+            {{- with .Values.worker.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.livenessProbe }}
@@ -122,7 +136,7 @@ spec:
           lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.resources }}
+          {{- with .Values.worker.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -137,29 +151,6 @@ spec:
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if .Values.s3Sync.enabled }}
-        - name: s3-sync
-          image: "{{ .Values.s3Sync.image.repository }}:{{ .Values.s3Sync.image.tag }}"
-          imagePullPolicy: {{ .Values.s3Sync.image.pullPolicy }}
-          command: ["/bin/sh", "/scripts/sync.sh"]
-          {{- with .Values.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.s3Sync.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: data
-              mountPath: {{ .Values.configMap.meshConfig.DATA_DIR | default "/app/data" }}
-            - name: s3-sync-script
-              mountPath: /scripts
-              readOnly: true
-      {{- end }}
-      {{- with .Values.extraContainers }}
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
       volumes:
         {{- if and (eq (lower (default "sqlite" .Values.database.engine)) "postgresql") .Values.database.caCert }}
         - name: ca-cert
@@ -169,29 +160,10 @@ spec:
               - key: ca-cert.pem
                 path: ca-cert.pem
         {{- end }}
-        {{- if .Values.persistence.enabled }}
-        - name: data
-          {{- if .Values.persistence.claimName }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.persistence.claimName }}
-          {{- else }}
-          persistentVolumeClaim:
-            claimName: {{ include "chart-deco-studio.fullname" . }}-data
-          {{- end }}
-        {{- else }}
+        # Workers are stateless (no PVC / s3-sync): DATA_DIR is scratch.
         - name: data
           emptyDir:
             sizeLimit: {{ .Values.persistence.emptyDirSizeLimit | default "10Gi" }}
-        {{- end }}
-        {{- if .Values.s3Sync.enabled }}
-        - name: s3-sync-script
-          configMap:
-            name: {{ include "chart-deco-studio.fullname" . }}-s3-sync
-            defaultMode: 0755
-            items:
-              - key: sync.sh
-                path: sync.sh
-        {{- end }}
         {{- with .Values.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -207,17 +179,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.topologySpreadConstraints (gt (len .Values.topologySpreadConstraints) 0) }}
-      topologySpreadConstraints:
-        {{- range .Values.topologySpreadConstraints }}
-        - {{- if not .labelSelector }}
-          {{- fail "labelSelector é obrigatório em topologySpreadConstraints. Especifique explicitamente os labels." }}
-          {{- else }}
-          labelSelector:
-            {{- toYaml .labelSelector | nindent 12 }}
-          {{- end }}
-          maxSkew: {{ .maxSkew }}
-          topologyKey: {{ .topologyKey }}
-          whenUnsatisfiable: {{ .whenUnsatisfiable }}
-        {{- end }}
-      {{- end }}
+{{- end }}

--- a/deploy/helm/studio/templates/worker-hpa.yaml
+++ b/deploy/helm/studio/templates/worker-hpa.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.worker.enabled .Values.worker.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}-worker
+  labels:
+    app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "chart-deco-studio.chart" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chart-deco-studio.fullname" . }}-worker
+  minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -52,6 +52,44 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
+# Pod dispatch-role split (see apps/mesh MESH_DISPATCH_ROLE). One release, one
+# Argo app: the main Deployment serves HTTP; an optional `worker` Deployment
+# runs the agent loop. Workers carry a distinct `app.kubernetes.io/name`
+# (`<name>-worker`), so the main Deployment selector AND the Service selector
+# do NOT match them — workers stay OFF the load balancer and receive work only
+# by pulling the DBOS queue. /stream is served by the (api) main pods, which
+# tail NATS for chunks the workers published. Health probes hit pods directly,
+# so workers stay live regardless of Service membership.
+#
+# Rollout: set worker.enabled=true first (workers come up; main is still "all"
+# so nothing breaks), confirm workers dequeue, THEN set dispatchRole=api so the
+# main pods stop running the agent loop. Rollback = unset both.
+#
+# dispatchRole controls the MAIN deployment's MESH_DISPATCH_ROLE.
+#   "" (default) → unset → "all" (unchanged behavior). Set to "api" once
+#   workers exist so HTTP pods stop dequeuing runs. Env-only update (rolling,
+#   no recreate); does NOT touch the immutable selector.
+dispatchRole: ""
+
+worker:
+  # When true, render a second Deployment (`<fullname>-worker`) that dequeues
+  # only the agent/automation run queues (MESH_DISPATCH_ROLE=worker). Default
+  # false → chart output is identical to before.
+  enabled: false
+  replicaCount: 2
+  # Workers are CPU-bound on LLM streams — give headroom and scale on CPU.
+  resources:
+    requests:
+      cpu: "1"
+      memory: 1Gi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 30
+    targetCPUUtilizationPercentage: 65
+  # Extra env for worker pods only (merged after the shared envFrom).
+  env: []
+
 configMap:
   meshConfig:
     NODE_ENV: "production"


### PR DESCRIPTION
## What
Pod **dispatch-role split** so request-serving and agent-loop execution scale as independent pods **off one image, one Helm release, one Argo app**.

**App (`MESH_DISPATCH_ROLE`):** `all` (default, unchanged) · `worker` (dequeue only the `thread-gate`/`automations` run queues) · `api` (dequeue nothing; serve HTTP + enqueue). Wired via `DBOSConfig.listenQueues`; `all` omits it → identical to today.

**Chart (`worker.enabled`):** renders a second `<fullname>-worker` Deployment + CPU HPA, same image/DB/auth. `dispatchRole` sets the main deployment's role.

## How the LB can't hit a busy worker
Worker pods carry a distinct `app.kubernetes.io/name` (`<name>-worker`), so **neither the main Deployment selector nor the Service selector match them**. Workers are never Service endpoints → the LB has no path to them; they receive work only by **pulling the DBOS queue**. `/stream` is served by the api pods (which tail NATS for chunks workers published). Kubelet health probes hit pods directly, so workers stay live despite being off-Service.

## Safety
- `worker.enabled=false` (default) renders **byte-identical** to the current chart (verified with `helm template` diff) — zero impact until you opt in.
- Distinct `-worker` name means **no change to the main Deployment's immutable selector** and **no Service change** → no recreate.
- `dispatchRole` is an env-only change (rolling, no recreate).
- Requires ≥1 worker (or `all`) pod or runs never dispatch.

## Rollout
1. `worker.enabled=true` → workers come up; main still `all`, nothing breaks.
2. Confirm workers dequeue + a real decopilot run executes.
3. `dispatchRole=api` → main pods stop running the agent loop.
Rollback = unset both.

## Validation
tsc clean · `bun test dispatch-queue automations` 31/0 · `helm lint` clean · `helm template` worker-off == baseline (byte-identical) · worker-on renders main=api / worker=worker with disjoint selectors + worker HPA.

## Why
Profiling showed studio's under-load CPU is streaming throughput (NATS/socket I/O + AI-SDK parsing), not GC/idle-polling/Ajv. Scaling studio replicas to absorb it also multiplies the heavy per-pod footprint (DB pool, DBOS executor + queue polling). This lets the agent-loop workers scale on CPU independently of the request tier.
