### PR TITLE
fix(decopilot): drop intermediate draft images from thinking image models

### DIFF
--- a/packages/harness/src/decopilot/built-in-tools/portable-media-tools.ts
+++ b/packages/harness/src/decopilot/built-in-tools/portable-media-tools.ts
@@ -230,8 +230,17 @@ export function createPortableGenerateImageTool(
           );
         }
 
+        // Thinking image models (e.g. Gemini 3 Pro Image) emit intermediate
+        // draft images alongside the final one in a single response. Keep only
+        // the last N — the final renders — so we don't surface duplicate drafts.
+        const requested = input.n ?? 1;
+        const finalImages =
+          result.images.length > requested
+            ? result.images.slice(-requested)
+            : result.images;
+
         const images = await Promise.all(
-          result.images.map(async (img) => {
+          finalImages.map(async (img) => {
             const mediaType = img.mediaType ?? "image/png";
             const ext = mediaType.split("/")[1] ?? "png";
             const key = `generated-images/${crypto.randomUUID()}.${ext}`;


### PR DESCRIPTION
## Summary

A single `generate_image` call (`n:1`) rendered **two** near-identical images in the chat UI. The model called the tool once — the duplication was on our side.

**Root cause:** Thinking image models like `gemini-3-pro-image-preview` emit an intermediate *draft* image part alongside the final render within a single generation. The AI SDK Google image model (`doGenerateGemini`) walks the response and pushes **every** image part into `result.images`, so the array comes back with length 2 even though Gemini forbids `n > 1`. `portable-media-tools.ts` then persisted and returned all of them, and the UI mapped over both.

**Fix:** Keep only the last `n` images (the final renders) before persisting. Imagen — where `n > 1` legitimately returns N distinct images and `length === requested` — is untouched (no slice).

## Testing

- `bun run fmt` clean.
- Behavior is provider-driven; verified by reasoning against the `@ai-sdk/google` `doGenerateGemini` image-collection loop. Worth a manual smoke test against Gemini 3 Pro Image to confirm the *final* (last) image is the one kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix duplicate images in the chat UI for single-image generations. We now ignore draft images from thinking models and only persist the final N renders.

- **Bug Fixes**
  - Keep only the last `n` images from Gemini-style responses, filtering out intermediate drafts collected by `@ai-sdk/google`’s `doGenerateGemini`.
  - Imagen behavior is unchanged; when `n > 1`, all N images are returned.

<sup>Written for commit 3dba76c0b79562aa240f418d5910917aacc31721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

