### PR TITLE
feat(org-fs): DISABLE_ORGFS_MOUNTS debug opt-out flag

### DIFF
--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -126,6 +126,7 @@ export function resolveConfig(
       nodeEnv !== "development",
     ),
     orgFsPublicSetsJson: envVars.ORGFS_PUBLIC_SETS,
+    orgFsMountsDisabled: toBool(envVars.DISABLE_ORGFS_MOUNTS),
 
     // Object Storage (S3-compatible)
     s3Endpoint: envVars.S3_ENDPOINT,

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -59,6 +59,10 @@ export interface Settings {
   /** JSON array of public skill-set sources overlaid on the built-in
    *  defaults (see file-storage/public-sets.ts). */
   orgFsPublicSetsJson: string | undefined;
+  /** Debug escape hatch: skip provisioning org-fs mounts into sandboxes
+   *  (DISABLE_ORGFS_MOUNTS). org-fs is otherwise always mounted; this is
+   *  for low-level mount debugging, not a supported org-fs-off mode. */
+  orgFsMountsDisabled: boolean;
 
   // Object Storage (S3-compatible)
   s3Endpoint: string | undefined;

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -417,8 +417,15 @@ async function provisionSandbox(
   // pods always mount (hosted relies on the privileged org-fs sidecar
   // shipping in the default deploy). Guarded inside the helper: a mint
   // failure → undefined → no mounting, never breaks provisioning.
+  //
+  // DISABLE_ORGFS_MOUNTS is a debug escape hatch (opt-out, default off): it
+  // skips provisioning the mount so a sandbox boots without org-fs, for
+  // low-level mount debugging. NOT a supported "org-fs-off" product mode —
+  // the prompt/tools still assume org-fs, so the agent's `org/` paths just
+  // won't exist while it's set.
   const wantsOrgFs =
-    runner.kind === "user-desktop" || runner.kind === "agent-sandbox";
+    (runner.kind === "user-desktop" || runner.kind === "agent-sandbox") &&
+    !getSettings().orgFsMountsDisabled;
   // ctx.organization is unset on the decopilot vm-tools dispatch path (the
   // org travels as the `orgId` param there) — resolve the slug from the row
   // so chat-ephemeral sandboxes get mounts too.


### PR DESCRIPTION
## What is this contribution about?

org-fs is mounted into every sandbox unconditionally (PR #3930). This adds a single **opt-out** env flag, `DISABLE_ORGFS_MOUNTS` (default off), that skips provisioning the mount — a debug escape hatch for low-level mount troubleshooting, not used in prod.

- `settings`: new `orgFsMountsDisabled` resolved from `DISABLE_ORGFS_MOUNTS` (`toBool`, default false).
- `tools/sandbox/start.ts`: `wantsOrgFs` now also requires `!orgFsMountsDisabled`.

**Deliberately minimal:** it gates ONLY mount provisioning. The system prompt + tool descriptions stay unconditional (no re-introduced `if (orgFs)` — that was the context-bloat win of #3930). So with the flag set, the agent is still taught `org/` paths that won't exist — this is a kill-switch for debugging the mount, not a supported "org-fs-off" product mode.

## How to Test
1. Default (unset): sandboxes mount org-fs as today.
2. `DISABLE_ORGFS_MOUNTS=1`: a freshly provisioned sandbox boots with no `org/` mount; `mintOrgFsConfigJson` is skipped.
3. `bun run check` green.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes (default off = current behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `DISABLE_ORGFS_MOUNTS` to let us skip org-fs mount provisioning in sandboxes for low-level debugging. Default is off; prompts/tools still assume org-fs.

- **New Features**
  - New setting `orgFsMountsDisabled` resolved from `DISABLE_ORGFS_MOUNTS` (bool, default false).
  - `wantsOrgFs` in `tools/sandbox/start.ts` now also checks `!orgFsMountsDisabled` before mounting.

<sup>Written for commit 1ac2d2974f75c607e3f0139e71a79e50b32cf4a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

