### PR TITLE
fix(decopilot): persist finish reason so the incomplete-response banner survives reload

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/consume-harness-stream.ts
+++ b/apps/mesh/src/api/routes/decopilot/consume-harness-stream.ts
@@ -142,6 +142,16 @@ export function consumeHarnessStream(options: ConsumeHarnessStreamOptions): {
       streamFinished = true;
       await Promise.allSettled(pending);
       if (!errored) {
+        // Persist the finish reason on the message metadata so a returning
+        // user sees the same banner the live stream showed (e.g. the
+        // step-limit "tool-calls" "Response incomplete" card) after reload.
+        if (finishReason) {
+          (responseMessage as { metadata?: Record<string, unknown> }).metadata =
+            {
+              ...((responseMessage.metadata as Record<string, unknown>) ?? {}),
+              finishReason,
+            };
+        }
         await options.persistence
           .emitFinal(responseMessage)
           .catch((e) =>

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -438,6 +438,19 @@ export class ThreadConnection {
       };
       const items = payload.items ?? [];
       this.messages.update((curr) => mergeAndSort(curr, items));
+      // Re-surface a settled turn's finish reason (e.g. the step-limit
+      // "tool-calls" pause) so the "Response incomplete" banner persists
+      // across reloads. Live runs set this from the stream's finish chunk;
+      // here we seed it from the persisted finish anchor when none is set.
+      if (this.finishReason.get() === null) {
+        const last = this.messages.get().at(-1);
+        const fr =
+          last?.role === "assistant"
+            ? (last.metadata as { finishReason?: string } | undefined)
+                ?.finishReason
+            : undefined;
+        if (fr) this.finishReason.set(fr);
+      }
       this.serverFetchedCount = items.length;
       this.hasMoreOlder.set(payload.hasMore ?? false);
       if (this.status.get().kind === "loading") {


### PR DESCRIPTION
## Summary

The "Response incomplete" banner — most notably the step-limit `tool-calls` pause (*"Response paused after tool execution to prevent infinite loops and save costs"*) — was driven **only** by the live stream's `finishReason` store. That store is initialized to `null`, set from the stream's `finish` chunk, and never hydrated on load. So on reload (or revisiting the thread later) the banner vanished and a returning user had no way to tell the thread had stopped on the step cap rather than finishing normally.

## Changes

- **Persist the signal** (`consume-harness-stream.ts`, `onFinish`): stamp `finishReason` onto the assistant message `metadata` before `emitFinal`. It rides the existing finish-anchor row (the same path `usage` already uses) and folds back onto `FoldedMessage.metadata` on read — no schema or migration change.
- **Re-surface it** (`thread-connection.ts`, `loadInitialPage`): after the initial page loads, if the live `finishReason` store is still `null`, seed it from the last assistant message's `metadata.finishReason`.

## Why this shape

- **Seeding the store** (not a derive-time fallback) preserves existing semantics for free: `clearFinishReason` (dismiss) and submit both null the store, so the banner clears permanently for the session instead of re-appearing from metadata.
- **No status remap**: `resolveThreadStatus` is untouched, so step-limit turns still persist as `completed` — nothing keying off thread status is affected. The banner is driven purely by the now-persisted finish reason, matching live behavior exactly.
- Existing `showWarning` guards already do the right thing on reload: gated on `!isStreaming`, suppressed when a user_ask/approval/plan card is pending, and ignores `"stop"`.

## Caveats

- Persists `finishReason` for **all** completed turns going forward, not just `tool-calls` (harmless — the client only banners on non-`stop` reasons).
- **Old threads** stopped before this ships have no persisted `finishReason`, so they won't retroactively show the banner — only new runs will.

## Testing

- `bun run fmt` + `bun run check` pass.
- Verified the metadata round-trip by reading the persistence path (`emitFinal` → finish-anchor row → `foldParts` surfaces `metadata` wholesale). Not yet observed live in a reloaded thread.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the assistant turn’s finish reason so the “Response incomplete” banner (e.g., step-limit `tool-calls`) survives reloads and revisits.

- **Bug Fixes**
  - Write `finishReason` to the assistant message `metadata` before `emitFinal` (uses existing finish-anchor path; no schema change).
  - On initial thread load, seed the live `finishReason` store from the last assistant message’s `metadata.finishReason` when unset.

<sup>Written for commit b3a0a6f06b9801b08e58ffcb9fb0a30e6c0ab21f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

