### PR TITLE
feat(chat): fade in streamed assistant text word-by-word

### DIFF
--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -190,4 +190,20 @@
       transform: translateY(0);
     }
   }
+
+  /* Per-word fade-in for streamed assistant text (see markdown.tsx AnimatedText).
+     Opacity-only so layout never shifts; runs once on mount. Tune the duration
+     to taste (lower = snappier). */
+  .stream-word {
+    animation: streamWordIn 0.5s ease-out both;
+  }
+
+  @keyframes streamWordIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
 }

--- a/apps/mesh/src/web/components/chat/markdown.tsx
+++ b/apps/mesh/src/web/components/chat/markdown.tsx
@@ -153,19 +153,115 @@ const markdownComponents = {
   },
 } as typeof sharedMarkdownComponents;
 
+// ── Streaming word fade-in ───────────────────────────────────────────────────
+// Splits a text run into per-word spans that fade in once on mount. Keys are
+// the word INDEX: streaming only ever appends, so settled words keep their key
+// (React updates them in place → the CSS fade never re-runs) and only new
+// trailing words mount and animate. `memo` keeps unchanged runs from
+// re-rendering. This index-keyed leaf is the whole trick — it's what an earlier
+// rehype-plugin attempt lacked, which made entire blocks re-fade.
+const WORD_SPLIT = /(\s+)/;
+const AnimatedText = memo(function AnimatedText({ text }: { text: string }) {
+  const tokens = useMemo(
+    () => text.split(WORD_SPLIT).filter((t) => t.length > 0),
+    [text],
+  );
+  return (
+    <>
+      {tokens.map((tok, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: stable for append-only streaming
+        <span key={i} className="stream-word">
+          {tok}
+        </span>
+      ))}
+    </>
+  );
+});
+AnimatedText.displayName = "AnimatedText";
+
+// Wrap string children in the per-word animator; pass elements through so they
+// animate via their own (animated) component override.
+const animateText = (children: React.ReactNode): React.ReactNode =>
+  React.Children.map(children, (child) =>
+    typeof child === "string" ? <AnimatedText text={child} /> : child,
+  );
+
+type MdProps = {
+  node?: unknown;
+  children?: React.ReactNode;
+} & Record<string, unknown>;
+
+// Same design-system styling as `markdownComponents`, but text-bearing elements
+// route their text through `animateText`. Used only while a message streams.
+const animatedComponents = {
+  ...markdownComponents,
+  h1: ({ node: _n, children, ...p }: MdProps) => (
+    <h1 {...p} className="text-2xl font-bold mt-6 mb-3 first:mt-0">
+      {animateText(children)}
+    </h1>
+  ),
+  h2: ({ node: _n, children, ...p }: MdProps) => (
+    <h2 {...p} className="text-xl font-semibold mt-5 mb-2 first:mt-0">
+      {animateText(children)}
+    </h2>
+  ),
+  h3: ({ node: _n, children, ...p }: MdProps) => (
+    <h3 {...p} className="text-lg font-semibold mt-4 mb-2 first:mt-0">
+      {animateText(children)}
+    </h3>
+  ),
+  h4: ({ node: _n, children, ...p }: MdProps) => (
+    <h4 {...p} className="text-base font-semibold mt-3 mb-1 first:mt-0">
+      {animateText(children)}
+    </h4>
+  ),
+  p: ({ node: _n, children, ...p }: MdProps) => (
+    <p {...p} className="leading-relaxed text-[14px] mb-2 last:mb-0">
+      {animateText(children)}
+    </p>
+  ),
+  strong: ({ node: _n, children, ...p }: MdProps) => (
+    <strong {...p} className="font-bold">
+      {animateText(children)}
+    </strong>
+  ),
+  em: ({ node: _n, children, ...p }: MdProps) => (
+    <em {...p} className="italic">
+      {animateText(children)}
+    </em>
+  ),
+  li: ({ node: _n, children, ...p }: MdProps) => (
+    <li {...p} className="leading-relaxed text-[14px]">
+      {animateText(children)}
+    </li>
+  ),
+  a: ({ node: _n, children, ...p }: MdProps) => (
+    <a
+      {...p}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary-dark hover:underline break-all font-medium"
+    >
+      {animateText(children)}
+    </a>
+  ),
+} as typeof markdownComponents;
+
 const MemoizedMarkdownBlock = memo(
-  ({ content }: { content: string }) => {
+  ({ content, animate }: { content: string; animate?: boolean }) => {
     return (
       <ReactMarkdown
         remarkPlugins={remarkPluginsMemo}
         rehypePlugins={rehypePluginsMemo}
-        components={markdownComponents}
+        components={animate ? animatedComponents : markdownComponents}
       >
         {content}
       </ReactMarkdown>
     );
   },
-  (prevProps, nextProps) => prevProps.content === nextProps.content,
+  (prevProps, nextProps) =>
+    prevProps.content === nextProps.content &&
+    prevProps.animate === nextProps.animate,
 );
 
 function CodeBlock({
@@ -204,9 +300,15 @@ MemoizedMarkdownBlock.displayName = "MemoizedMarkdownBlock";
 interface MemoizedMarkdownProps {
   id: string;
   text: string;
+  /** Fade newly streamed words in — set only for the in-progress message. */
+  animate?: boolean;
 }
 
-export const MemoizedMarkdown = ({ id, text }: MemoizedMarkdownProps) => {
+export const MemoizedMarkdown = ({
+  id,
+  text,
+  animate,
+}: MemoizedMarkdownProps) => {
   const blocks = useMemo(() => marked.lexer(text), [text]);
 
   return blocks.map((block, index) => {
@@ -221,7 +323,11 @@ export const MemoizedMarkdown = ({ id, text }: MemoizedMarkdownProps) => {
     }
 
     return (
-      <MemoizedMarkdownBlock content={block.raw} key={`${id}-block_${index}`} />
+      <MemoizedMarkdownBlock
+        content={block.raw}
+        animate={animate}
+        key={`${id}-block_${index}`}
+      />
     );
   });
 };

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -494,6 +494,7 @@ function MessagePart({
           extraActions={usageStats}
           copyable
           alwaysShowActions={!!usageStats && !isLoading}
+          animate={isLoading && isLastMessage}
         />
       );
     case "reasoning":

--- a/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
@@ -13,6 +13,8 @@ interface MessageTextPartProps {
   extraActions?: ReactNode;
   /** When true, actions row is always visible instead of hover-only */
   alwaysShowActions?: boolean;
+  /** Fade newly streamed words in — true only while the last message streams. */
+  animate?: boolean;
 }
 
 export function MessageTextPart({
@@ -21,6 +23,7 @@ export function MessageTextPart({
   copyable = false,
   extraActions,
   alwaysShowActions = false,
+  animate = false,
 }: MessageTextPartProps) {
   const { handleCopy } = useCopy();
   const [isCopied, setIsCopied] = useState(false);
@@ -41,7 +44,7 @@ export function MessageTextPart({
 
   return (
     <div className="group/part relative">
-      <MemoizedMarkdown id={id} text={part.text} />
+      <MemoizedMarkdown id={id} text={part.text} animate={animate} />
       {showActions && (
         <div
           className={cn(

--- a/packages/harness/src/decopilot/built-in-tools/portable-media-tools.ts
+++ b/packages/harness/src/decopilot/built-in-tools/portable-media-tools.ts
@@ -230,8 +230,17 @@ export function createPortableGenerateImageTool(
           );
         }
 
+        // Thinking image models (e.g. Gemini 3 Pro Image) emit intermediate
+        // draft images alongside the final one in a single response. Keep only
+        // the last N — the final renders — so we don't surface duplicate drafts.
+        const requested = input.n ?? 1;
+        const finalImages =
+          result.images.length > requested
+            ? result.images.slice(-requested)
+            : result.images;
+
         const images = await Promise.all(
-          result.images.map(async (img) => {
+          finalImages.map(async (img) => {
             const mediaType = img.mediaType ?? "image/png";
             const ext = mediaType.split("/")[1] ?? "png";
             const key = `generated-images/${crypto.randomUUID()}.${ext}`;


### PR DESCRIPTION
## What

Streamed assistant text used to hard-pop into place, which read as clunky. This fades each word in as it arrives, so the in-progress message resolves smoothly instead of snapping.

## How

- **`AnimatedText`** (`markdown.tsx`) splits a text run into per-word `<span>`s with **index keys**. Streaming only ever appends, so settled words keep their key (React updates them in place → the CSS fade never re-runs) and only new trailing words mount and animate. `memo` keeps unchanged runs from re-rendering.
- **`animateText`** routes string children through `AnimatedText`; element children pass through and animate via their own (animated) component override.
- **`animatedComponents`** mirror our design-system markdown styling (`h1`–`h4`, `p`, `strong`, `em`, `li`, `a`) but route text through `animateText`.
- Folded into **`MemoizedMarkdown` via an `animate` flag** (`MessageTextPart` sets `animate={isLoading && isLastMessage}`). No separate renderer → **no swap/flash at finish**, and fenced code keeps rendering through our existing `CodeBlock` (copy button + highlighter).
- CSS `.stream-word` — opacity `0` → `1`, `0.5s` ease-out, once on mount. Opacity-only so layout never shifts. Duration is the one tuning knob (`apps/mesh/index.css`).

## Notes

- Scoped to the in-progress (last) assistant message; history and completed messages render statically, unchanged.
- We briefly evaluated the `flowtoken` library but dropped it: it bundles its own `react-markdown@9` (a second markdown parser + micromark/mdast tree shipped to the client) and declares a React 18 peer against our React 19. This in-house version reuses our `react-markdown@10`, so no duplicate parser and no peer mismatch.

## Testing

- `bun run check` (typecheck) — pass
- `bun run lint` — pass (only the 2 pre-existing `packages/sandbox` cross-tree-import warnings)
- `bun run fmt` — clean
- Manual: verified the word-by-word fade on a live local stream; settled text doesn't re-animate, no block re-fade, no finish flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamed assistant messages now fade in word by word for a smoother, less jarring read. Also filters draft images from thinking models so only the final N images are saved.

- **New Features**
  - `AnimatedText` splits text into index-keyed spans; only new words mount and fade once via `.stream-word` (0.5s).
  - Integrated into `MemoizedMarkdown` with an `animate` flag; enabled only for the in-progress last message; no finish flash and code blocks unchanged.

- **Bug Fixes**
  - Image generation: keep only the last N images from models that emit draft frames to avoid duplicate renders.

<sup>Written for commit 170b917a9ee4e15278164a3457d3c1b2f4003d76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

