### PR TITLE
feat(sandbox-env): chart 0.9.0 — publish mandatory org-fs + disableFsSidecar debug opt-out

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,13 +9,17 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.9.0: org-fs is mandatory — removed the `orgFs.enabled` + `hostUsers`
+# toggles (sidecar always deployed, hostUsers fixed true). Minor bump:
+# behavior change for consumers that ran with org-fs disabled / userns
+# remap — those settings are now ignored.
 # 0.8.1: housekeeper no longer force-deletes claims on a transient
 # ReconcilerError (grace window + adopted-claim guard) — fixes the "did not
 # record an adopted Sandbox within 60s" auto-start freeze.
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.8.1
+version: 0.9.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.5.7"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -78,13 +78,14 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      # org-fs is a hard requirement, and its privileged FUSE sidecar +
-      # Bidirectional mount propagation are incompatible with user-namespace
-      # remapping — so `hostUsers: true` is fixed (no userns-remap). The
-      # untrusted agent container is still locked down independently
+      # org-fs's privileged FUSE sidecar + Bidirectional mount propagation
+      # are incompatible with user-namespace remapping, so hostUsers tracks
+      # the sidecar: true (no userns-remap) when org-fs is on (the default),
+      # false (userns-remap restored) when disableFsSidecar opts out. The
+      # untrusted agent container is locked down independently either way
       # (drop ALL caps, no privilege escalation, runAsNonRoot, seccomp
       # RuntimeDefault below); only the org-fs sidecar is privileged.
-      hostUsers: true
+      hostUsers: {{ not .Values.disableFsSidecar }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -198,12 +199,14 @@ spec:
             - name: GIT_CONFIG_VALUE_0
               value: "*"
             {{- end }}
+            {{- if not .Values.disableFsSidecar }}
             # org-fs relay: the daemon writes the mount config here for the
             # sidecar, and gates the per-run output link on its status file.
             - name: ORGFS_SIDECAR_CONFIG_PATH
               value: "/run/orgfs/config.json"
             - name: ORGFS_SIDECAR_STATUS_PATH
               value: "/run/orgfs/status.json"
+            {{- end }}
           ports:
             - name: daemon
               containerPort: 9000
@@ -227,12 +230,15 @@ spec:
             {{- end }}
             - name: home
               mountPath: /home/sandbox
+            {{- if not .Values.disableFsSidecar }}
             # The sidecar's FUSE mounts under /app/org surface here.
             - name: orgfs-org
               mountPath: /app/org
               mountPropagation: HostToContainer
             - name: orgfs-ctl
               mountPath: /run/orgfs
+            {{- end }}
+        {{- if not .Values.disableFsSidecar }}
         # Privileged org-fs mounter: waits for the daemon to relay the mount
         # config onto /run/orgfs (post-bind push), FUSE-mounts the org volumes
         # under the shared /app/org, and Bidirectional propagation surfaces
@@ -258,6 +264,7 @@ spec:
               mountPropagation: Bidirectional
             - name: orgfs-ctl
               mountPath: /run/orgfs
+        {{- end }}
       volumes:
         {{- if .Values.readOnlyRootFilesystem }}
         # Sized to match the per-container ephemeral-storage limit shape;
@@ -272,6 +279,7 @@ spec:
         - name: home
           emptyDir:
             sizeLimit: 5Gi
+        {{- if not .Values.disableFsSidecar }}
         # Mount surface (volumes attach under it) + relay control files.
         - name: orgfs-org
           emptyDir:
@@ -279,3 +287,4 @@ spec:
         - name: orgfs-ctl
           emptyDir:
             sizeLimit: 1Mi
+        {{- end }}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -190,12 +190,21 @@ dnsConfig:
 # reject spec.env, so boot env can't carry it).
 #
 # org-fs is a hard product requirement (skills, uploads, outputs, home all
-# live here), so there is no toggle. It forces `hostUsers: true` (no
-# user-namespace remap) — Kubernetes forbids privileged containers +
+# live here), so it is ON by default. When on it forces `hostUsers: true`
+# (no user-namespace remap) — Kubernetes forbids privileged containers +
 # Bidirectional propagation in user-namespaced pods. Security note: only
 # THIS sidecar is privileged; the untrusted agent container keeps drop-ALL
 # caps, no privilege escalation, runAsNonRoot, and seccomp RuntimeDefault
 # (see the sandbox container in templates/sandbox-template.yaml).
+#
+# disableFsSidecar (opt-out, default false): a DEBUG escape hatch — drops
+# the sidecar + its mounts entirely and restores userns remap
+# (hostUsers: false). The mesh side still teaches `org/` paths, so this is
+# for low-level pod/mount debugging, not a supported org-fs-off mode. NOT
+# used in prod. (Mirror the mesh-side DISABLE_ORGFS_MOUNTS flag, which
+# skips minting the mount config without removing the sidecar.)
+disableFsSidecar: false
+
 orgFs:
   image:
     repository: ghcr.io/decocms/studio/orgfs-sidecar


### PR DESCRIPTION
## What / why

Two things, so the mandatory-org-fs chart change actually ships **and** stays debuggable:

1. **Publish the toggle removal.** #3930 removed the old `orgFs.enabled` / `hostUsers` opt-IN toggles from the template but didn't bump `Chart.yaml`, and the publish workflow skips existing versions — so the change sat on main unpublished (latest OCI chart is still 0.8.1). Bumped `0.8.1 → 0.9.0` so it ships.

2. **`disableFsSidecar` debug opt-out (default false).** One chart knob, the chart-side mirror of mesh's `DISABLE_ORGFS_MOUNTS`:
   - default (false): sidecar + mounts + `hostUsers: true` — org-fs on, prod behavior.
   - true: drops the privileged sidecar + its volumes and restores userns-remap (hostUsers tracks `not disableFsSidecar`) → a clean non-org-fs pod for low-level debugging. Not used in prod.

   Opt-OUT (default on), unlike the old opt-IN toggle — same spirit as the mesh debug flag; no fail guard, no separate hostUsers knob.

helm template verified both modes: default → 1 sidecar / 1 privileged / hostUsers:true; disableFsSidecar=true → 0 sidecar / 0 privileged / hostUsers:false / no orgfs volumes.

## After merge + publish
deco-apps-cd bumps studio-sandbox-{prod,stg} targetRevision 0.8.0/0.8.1 → 0.9.0 (prod/stg leave disableFsSidecar at default false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)