### PR TITLE
feat(sections-editor): add section variant creation

### DIFF
--- a/apps/mesh/ct/harness/variant-harnesses.tsx
+++ b/apps/mesh/ct/harness/variant-harnesses.tsx
@@ -41,6 +41,7 @@ export function SectionVariantListHarness({
         onDuplicate={(index) => push({ type: "duplicate", index })}
         onDelete={(index) => push({ type: "delete", index })}
         onRemoveAll={() => push({ type: "removeAll" })}
+        onAdd={() => push({ type: "add" })}
       />
       <EventLog events={events} />
     </div>

--- a/apps/mesh/ct/tests/section-variant-list.ct.tsx
+++ b/apps/mesh/ct/tests/section-variant-list.ct.tsx
@@ -88,3 +88,11 @@ test("remove-all fires onRemoveAll", async ({ mount }) => {
     .poll(() => readEvents(component))
     .toEqual([{ type: "removeAll" }]);
 });
+
+test("add-variant button fires onAdd", async ({ mount }) => {
+  const component = await mount(
+    <SectionVariantListHarness variants={TWO} selectedIndex={0} />,
+  );
+  await component.getByRole("button", { name: "Add variant" }).click();
+  await expect.poll(() => readEvents(component)).toEqual([{ type: "add" }]);
+});

--- a/apps/mesh/src/web/components/sections-editor/page-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.ts
@@ -63,7 +63,7 @@ export function wrapMultivariateArrayValue(
     ...((obj.variants as Array<Record<string, unknown>>) ?? []),
   ];
   if (variants.length === 0) {
-    variants.push({ rule: defaultPageVariantRule(), value: nextArray });
+    variants.push({ rule: defaultVariantRule(), value: nextArray });
   } else {
     variants[0] = { ...variants[0], value: nextArray };
   }

--- a/apps/mesh/src/web/components/sections-editor/page-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.ts
@@ -6,7 +6,7 @@ import {
 import { isDefaultVariantRule } from "./section-variants";
 import type { RawSection } from "./section-types";
 import {
-  ALWAYS_MATCHER_RESOLVE_TYPE,
+  defaultVariantRule,
   PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
 } from "./section-types";
 
@@ -156,13 +156,9 @@ export function parsePageVariants(
   return [];
 }
 
-function defaultPageVariantRule(): Record<string, unknown> {
-  return { __resolveType: ALWAYS_MATCHER_RESOLVE_TYPE };
-}
-
 function createPageVariantEntry(value: RawSection[]): Record<string, unknown> {
   return {
-    rule: defaultPageVariantRule(),
+    rule: defaultVariantRule(),
     value,
   };
 }

--- a/apps/mesh/src/web/components/sections-editor/section-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-list.tsx
@@ -39,6 +39,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { canMakeSectionReusable } from "./page-sections";
+import { VARIANT_MENU_ITEM_CLASS } from "./section-variant-list";
 import { canAddSectionVariant } from "./section-variants";
 import { isLazyResolveType } from "./section-lazy";
 import { getSectionPreviewImageSrc } from "./section-preview-image";
@@ -298,7 +299,7 @@ function SortableSectionItem({
           </DropdownMenuItem>
           {enableAddVariant && (
             <DropdownMenuItem
-              className="text-[oklch(0.45_0.15_160)] focus:bg-[oklch(0.65_0.15_160/0.12)] focus:text-[oklch(0.45_0.15_160)] dark:text-[oklch(0.78_0.15_160)] dark:focus:bg-[oklch(0.65_0.15_160/0.15)] dark:focus:text-[oklch(0.78_0.15_160)]"
+              className={VARIANT_MENU_ITEM_CLASS}
               onClick={(e) => {
                 e.stopPropagation();
                 onAddVariant();

--- a/apps/mesh/src/web/components/sections-editor/section-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-list.tsx
@@ -7,6 +7,7 @@ import {
   DotsHorizontal,
   Eye,
   EyeOff,
+  Flag01,
   LayoutAlt01,
   Plus,
   Trash01,
@@ -38,6 +39,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { canMakeSectionReusable } from "./page-sections";
+import { canAddSectionVariant } from "./section-variants";
 import { isLazyResolveType } from "./section-lazy";
 import { getSectionPreviewImageSrc } from "./section-preview-image";
 import type { LiveMeta } from "./resolve-schema";
@@ -163,6 +165,7 @@ function SortableSectionItem({
   onMakeReusable,
   onToggleHidden,
   onToggleLazy,
+  onAddVariant,
 }: {
   section: ParsedSection;
   raw: RawSection | undefined;
@@ -175,10 +178,12 @@ function SortableSectionItem({
   onMakeReusable: () => void;
   onToggleHidden: () => void;
   onToggleLazy: () => void;
+  onAddVariant: () => void;
 }) {
   const isAsyncRender = raw
     ? isLazyResolveType(raw.__resolveType ?? "")
     : false;
+  const enableAddVariant = canAddSectionVariant(section);
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useSortable({
       id: sortableId,
@@ -291,6 +296,18 @@ function SortableSectionItem({
             <Copy01 className="h-4 w-4" />
             Duplicate
           </DropdownMenuItem>
+          {enableAddVariant && (
+            <DropdownMenuItem
+              className="text-[oklch(0.45_0.15_160)] focus:bg-[oklch(0.65_0.15_160/0.12)] focus:text-[oklch(0.45_0.15_160)] dark:text-[oklch(0.78_0.15_160)] dark:focus:bg-[oklch(0.65_0.15_160/0.15)] dark:focus:text-[oklch(0.78_0.15_160)]"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddVariant();
+              }}
+            >
+              <Flag01 className="h-4 w-4" />
+              Add variant
+            </DropdownMenuItem>
+          )}
           {enableMakeReusable && (
             <DropdownMenuItem
               className={GLOBAL_SECTION_MENU_ITEM_CLASS}
@@ -334,6 +351,7 @@ export function SectionList({
   onMakeReusable,
   onToggleHidden,
   onToggleLazy,
+  onAddVariant,
   onAddSection,
   canAddSection = true,
 }: {
@@ -349,6 +367,7 @@ export function SectionList({
   onMakeReusable: (index: number) => void;
   onToggleHidden: (index: number) => void;
   onToggleLazy: (index: number) => void;
+  onAddVariant: (index: number) => void;
   onAddSection: () => void;
   canAddSection?: boolean;
 }) {
@@ -472,6 +491,7 @@ export function SectionList({
                   onMakeReusable={() => onMakeReusable(entry.index)}
                   onToggleHidden={() => onToggleHidden(entry.index)}
                   onToggleLazy={() => onToggleLazy(entry.index)}
+                  onAddVariant={() => onAddVariant(entry.index)}
                 />
               );
             })}

--- a/apps/mesh/src/web/components/sections-editor/section-types.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-types.ts
@@ -22,6 +22,11 @@ export const PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE =
 export const SECTION_MULTIVARIATE_RESOLVE_TYPE =
   "website/flags/multivariate/section.ts";
 
+/** Default variant rule — always matches, used as the seed for new variants. */
+export function defaultVariantRule(): Record<string, unknown> {
+  return { __resolveType: ALWAYS_MATCHER_RESOLVE_TYPE };
+}
+
 /** Human label from a deco resolve type path or block id. */
 export function labelFromResolveType(rt: string): string {
   const segments = rt.split("/");

--- a/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
@@ -8,6 +8,7 @@ import {
   Copy01,
   DotsHorizontal,
   LayoutAlt01,
+  Plus,
   Trash01,
 } from "@untitledui/icons";
 import {
@@ -117,6 +118,7 @@ export function SectionVariantList({
   onDuplicate,
   onDelete,
   onRemoveAll,
+  onAdd,
 }: {
   variants: SectionVariantEntry[];
   selectedIndex: number;
@@ -124,6 +126,7 @@ export function SectionVariantList({
   onDuplicate: (index: number) => void;
   onDelete: (index: number) => void;
   onRemoveAll: () => void;
+  onAdd: () => void;
 }) {
   const canDelete = variants.length > 1;
 
@@ -133,21 +136,38 @@ export function SectionVariantList({
         <span className="text-xs font-medium text-muted-foreground">
           Variants
         </span>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label="Remove all variants"
-              className="size-6 text-muted-foreground hover:text-destructive"
-              onClick={onRemoveAll}
-            >
-              <Trash01 size={14} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Remove all variants</TooltipContent>
-        </Tooltip>
+        <div className="flex items-center gap-0.5">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Add variant"
+                className="size-6"
+                onClick={onAdd}
+              >
+                <Plus size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Add variant</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Remove all variants"
+                className="size-6 text-muted-foreground hover:text-destructive"
+                onClick={onRemoveAll}
+              >
+                <Trash01 size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Remove all variants</TooltipContent>
+          </Tooltip>
+        </div>
       </div>
       <div className="space-y-0.5">
         {variants.map((variant) => (

--- a/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
@@ -24,6 +24,8 @@ const VARIANT_ROW_CLASS =
   "text-[oklch(0.45_0.15_160)] hover:bg-[oklch(0.65_0.15_160/0.12)] dark:text-[oklch(0.78_0.15_160)] dark:hover:bg-[oklch(0.65_0.15_160/0.15)]";
 const VARIANT_SELECTED_ROW_CLASS =
   "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.2)]";
+export const VARIANT_MENU_ITEM_CLASS =
+  "text-[oklch(0.45_0.15_160)] focus:bg-[oklch(0.65_0.15_160/0.12)] focus:text-[oklch(0.45_0.15_160)] dark:text-[oklch(0.78_0.15_160)] dark:focus:bg-[oklch(0.65_0.15_160/0.15)] dark:focus:text-[oklch(0.78_0.15_160)]";
 
 export interface SectionVariantEntry {
   index: number;

--- a/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  appendSectionVariant,
   deleteMultivariateSectionVariant,
   duplicateMultivariateSectionVariant,
   flattenMultivariateSection,
@@ -396,12 +397,100 @@ describe("section-variants", () => {
     ).toBeNull();
   });
 
-  it("showSection returns null when there are no variants", () => {
+  it("appendSectionVariant wraps a plain section with two variants", () => {
+    const hero = {
+      __resolveType: "site/sections/Hero.tsx",
+      title: "Hello",
+    } as never;
+
+    const result = appendSectionVariant(hero, {
+      index: 0,
+      resolveType: "site/sections/Hero.tsx",
+      label: "Hero",
+    });
+
+    expect(result?.newVariantIndex).toBe(1);
+    expect(result?.section).toEqual({
+      __resolveType: "website/flags/multivariate/section.ts",
+      variants: [
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: hero,
+        },
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: hero,
+        },
+      ],
+    });
+    expect(parseSections([result!.section], {})[0]?.isMultivariate).toBe(true);
+  });
+
+  it("appendSectionVariant keeps lazy wrapper outside multivariate", () => {
+    const lazy = {
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: { __resolveType: "site/sections/Hero.tsx", title: "Lazy" },
+    } as never;
+
+    const result = appendSectionVariant(lazy, {
+      index: 0,
+      resolveType: "website/sections/Rendering/Lazy.tsx",
+      label: "Hero",
+      isLazy: true,
+    });
+
+    expect(result?.section.__resolveType).toBe(
+      "website/sections/Rendering/Lazy.tsx",
+    );
     expect(
-      showSection({
-        __resolveType: "website/flags/multivariate/section.ts",
-        variants: [],
-      } as never),
+      (result?.section.section as Record<string, unknown> | undefined)
+        ?.__resolveType,
+    ).toBe("website/flags/multivariate/section.ts");
+  });
+
+  it("appendSectionVariant extends an existing multivariate section", () => {
+    const mvSection = {
+      __resolveType: "website/flags/multivariate/section.ts",
+      variants: [
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: { __resolveType: "site/sections/Hero.tsx", title: "A" },
+        },
+        {
+          rule: {
+            __resolveType: "website/matchers/device.ts",
+            mobile: true,
+          },
+          value: { __resolveType: "site/sections/Hero.tsx", title: "B" },
+        },
+      ],
+    } as never;
+
+    const result = appendSectionVariant(mvSection, {
+      index: 0,
+      resolveType: "website/flags/multivariate/section.ts",
+      label: "Variants of Hero",
+      isMultivariate: true,
+    });
+
+    expect(result?.newVariantIndex).toBe(2);
+    expect((result?.section as { variants: unknown[] }).variants).toHaveLength(
+      3,
+    );
+  });
+
+  it("appendSectionVariant rejects hidden sections", () => {
+    const hidden = hideSection({
+      __resolveType: "site/sections/Hero.tsx",
+    } as never);
+
+    expect(
+      appendSectionVariant(hidden as never, {
+        index: 0,
+        resolveType: hidden.__resolveType as string,
+        label: "Hero",
+        isHidden: true,
+      }),
     ).toBeNull();
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
@@ -513,6 +513,6 @@ describe("section-variants", () => {
       true,
     );
     expect(canAddSectionVariant({})).toBe(true);
-    expect(canAddSectionVariant({ isMultivariate: true })).toBe(true);
+    expect(canAddSectionVariant({ isHidden: false })).toBe(true);
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   appendSectionVariant,
+  canAddSectionVariant,
   deleteMultivariateSectionVariant,
   duplicateMultivariateSectionVariant,
   flattenMultivariateSection,
@@ -492,5 +493,26 @@ describe("section-variants", () => {
         isHidden: true,
       }),
     ).toBeNull();
+  });
+
+  it("appendSectionVariant rejects saved-block sections", () => {
+    expect(
+      appendSectionVariant({ __resolveType: "Header" } as never, {
+        index: 0,
+        resolveType: "Header",
+        label: "Header",
+        isSavedBlock: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("canAddSectionVariant blocks hidden and saved-block sections, allows others", () => {
+    expect(canAddSectionVariant({ isHidden: true })).toBe(false);
+    expect(canAddSectionVariant({ isSavedBlock: true })).toBe(false);
+    expect(canAddSectionVariant({ isHidden: false, isSavedBlock: false })).toBe(
+      true,
+    );
+    expect(canAddSectionVariant({})).toBe(true);
+    expect(canAddSectionVariant({ isMultivariate: true })).toBe(true);
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/section-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.ts
@@ -1,7 +1,7 @@
 import type { ParsedSection } from "./parse-sections";
 import { isLazyResolveType, LAZY_RENDER_RESOLVE_TYPE } from "./section-lazy";
 import {
-  ALWAYS_MATCHER_RESOLVE_TYPE,
+  defaultVariantRule,
   NEVER_MATCHER_RESOLVE_TYPE,
   SECTION_MULTIVARIATE_RESOLVE_TYPE,
   type RawSection,
@@ -354,15 +354,11 @@ export function deleteMultivariateSectionVariant(
   return { ...mvObj, variants };
 }
 
-function defaultSectionVariantRule(): Record<string, unknown> {
-  return { __resolveType: ALWAYS_MATCHER_RESOLVE_TYPE };
-}
-
 function createSectionVariantEntry(
   value: Record<string, unknown>,
 ): Record<string, unknown> {
   return {
-    rule: defaultSectionVariantRule(),
+    rule: defaultVariantRule(),
     value: structuredClone(value),
   };
 }
@@ -379,12 +375,15 @@ function createMultivariateSectionObject(
 }
 
 /** Whether a section can be converted to (or extended with) variants. */
-export function canAddSectionVariant(section: { isHidden?: boolean }): boolean {
-  return section.isHidden !== true;
+export function canAddSectionVariant(section: {
+  isHidden?: boolean;
+  isSavedBlock?: boolean;
+}): boolean {
+  return section.isHidden !== true && section.isSavedBlock !== true;
 }
 
 /** Extract the variant payload from a raw section for wrapping or seeding. */
-export function extractSectionVariantSeed(
+function extractSectionVariantSeed(
   raw: RawSection,
   parsed: ParsedSection,
 ): Record<string, unknown> | null {
@@ -411,7 +410,7 @@ export function extractSectionVariantSeed(
  * Wrap a plain or lazy section in a multivariate block with two variants
  * (original + clone). Returns null for hidden or unsupported shapes.
  */
-export function wrapSectionAsMultivariate(
+function wrapSectionAsMultivariate(
   raw: RawSection,
   parsed: ParsedSection,
   seedValue?: Record<string, unknown>,
@@ -445,7 +444,7 @@ export function appendSectionVariant(
   parsed: ParsedSection,
   seedValue?: Record<string, unknown>,
 ): { section: RawSection; newVariantIndex: number } | null {
-  if (parsed.isHidden) return null;
+  if (parsed.isHidden || parsed.isSavedBlock) return null;
 
   if (parsed.isMultivariate) {
     const mvObj = getMultivariateSectionObject(raw, parsed);

--- a/apps/mesh/src/web/components/sections-editor/section-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.ts
@@ -1,5 +1,7 @@
+import type { ParsedSection } from "./parse-sections";
 import { isLazyResolveType, LAZY_RENDER_RESOLVE_TYPE } from "./section-lazy";
 import {
+  ALWAYS_MATCHER_RESOLVE_TYPE,
   NEVER_MATCHER_RESOLVE_TYPE,
   SECTION_MULTIVARIATE_RESOLVE_TYPE,
   type RawSection,
@@ -350,4 +352,124 @@ export function deleteMultivariateSectionVariant(
 
   variants.splice(variantIndex, 1);
   return { ...mvObj, variants };
+}
+
+function defaultSectionVariantRule(): Record<string, unknown> {
+  return { __resolveType: ALWAYS_MATCHER_RESOLVE_TYPE };
+}
+
+function createSectionVariantEntry(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    rule: defaultSectionVariantRule(),
+    value: structuredClone(value),
+  };
+}
+
+function createMultivariateSectionObject(
+  variants: Array<Record<string, unknown>>,
+  existing?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...existing,
+    __resolveType: SECTION_MULTIVARIATE_RESOLVE_TYPE,
+    variants,
+  };
+}
+
+/** Whether a section can be converted to (or extended with) variants. */
+export function canAddSectionVariant(section: { isHidden?: boolean }): boolean {
+  return section.isHidden !== true;
+}
+
+/** Extract the variant payload from a raw section for wrapping or seeding. */
+export function extractSectionVariantSeed(
+  raw: RawSection,
+  parsed: ParsedSection,
+): Record<string, unknown> | null {
+  if (parsed.isHidden) return null;
+
+  if (parsed.isMultivariate) {
+    const mvObj = getMultivariateSectionObject(raw, parsed);
+    const variants = (mvObj?.variants as Array<Record<string, unknown>>) ?? [];
+    const last = variants[variants.length - 1]?.value as
+      | Record<string, unknown>
+      | undefined;
+    return last ? structuredClone(last) : null;
+  }
+
+  if (parsed.isLazy) {
+    const inner = raw.section as Record<string, unknown> | undefined;
+    return inner ? structuredClone(inner) : null;
+  }
+
+  return structuredClone(raw) as Record<string, unknown>;
+}
+
+/**
+ * Wrap a plain or lazy section in a multivariate block with two variants
+ * (original + clone). Returns null for hidden or unsupported shapes.
+ */
+export function wrapSectionAsMultivariate(
+  raw: RawSection,
+  parsed: ParsedSection,
+  seedValue?: Record<string, unknown>,
+): RawSection | null {
+  if (parsed.isMultivariate || parsed.isHidden) return null;
+
+  const seed = seedValue ?? extractSectionVariantSeed(raw, parsed);
+  if (!seed) return null;
+
+  const mvObj = createMultivariateSectionObject([
+    createSectionVariantEntry(seed),
+    createSectionVariantEntry(seed),
+  ]);
+
+  if (parsed.isLazy) {
+    return {
+      ...raw,
+      section: mvObj,
+    } as RawSection;
+  }
+
+  return mvObj as RawSection;
+}
+
+/**
+ * Append a section variant. Wraps plain/lazy sections on first use; extends
+ * existing multivariate sections. Returns null when the shape cannot be extended.
+ */
+export function appendSectionVariant(
+  raw: RawSection,
+  parsed: ParsedSection,
+  seedValue?: Record<string, unknown>,
+): { section: RawSection; newVariantIndex: number } | null {
+  if (parsed.isHidden) return null;
+
+  if (parsed.isMultivariate) {
+    const mvObj = getMultivariateSectionObject(raw, parsed);
+    if (!mvObj) return null;
+
+    const variants = (mvObj.variants as Array<Record<string, unknown>>) ?? [];
+    const seed =
+      seedValue ??
+      (variants[variants.length - 1]?.value as
+        | Record<string, unknown>
+        | undefined);
+    if (!seed) return null;
+
+    const updatedMvObj = createMultivariateSectionObject(
+      [...variants, createSectionVariantEntry(seed)],
+      mvObj,
+    );
+    return {
+      section: rebuildSectionWithMultivariate(raw, parsed, updatedMvObj),
+      newVariantIndex: variants.length,
+    };
+  }
+
+  const wrapped = wrapSectionAsMultivariate(raw, parsed, seedValue);
+  if (!wrapped) return null;
+  return { section: wrapped, newVariantIndex: 1 };
 }

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -395,6 +395,26 @@ function PageHeaderInputs({
   );
 }
 
+function AddVariantButton({ onClick }: { onClick: () => void }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Add variant"
+          className="size-7 shrink-0 text-[oklch(0.65_0.15_160)]"
+          onClick={onClick}
+        >
+          <Flag01 size={14} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Add variant</TooltipContent>
+    </Tooltip>
+  );
+}
+
 /**
  * Side panel for editing deco.cx page sections.
  * Renders sections for the currently active page and a schema-driven form.
@@ -2111,22 +2131,7 @@ export function SectionsEditor({
                 !isEditingMultivariateSection &&
                 !selectedParsed?.isHidden &&
                 activePageKey && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        aria-label="Add variant"
-                        className="size-7 shrink-0"
-                        style={{ color: "oklch(0.65 0.15 160)" }}
-                        onClick={() => handleAddSectionVariant()}
-                      >
-                        <Flag01 size={14} />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">Add variant</TooltipContent>
-                  </Tooltip>
+                  <AddVariantButton onClick={() => handleAddSectionVariant()} />
                 )}
             </div>
             {showGlobalBanner && (
@@ -2180,22 +2185,7 @@ export function SectionsEditor({
               </TooltipTrigger>
               <TooltipContent side="bottom">View JSON</TooltipContent>
             </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Add variant"
-                  className="size-7 shrink-0"
-                  style={{ color: "oklch(0.65 0.15 160)" }}
-                  onClick={handleAddPageVariant}
-                >
-                  <Flag01 size={14} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Add variant</TooltipContent>
-            </Tooltip>
+            <AddVariantButton onClick={handleAddPageVariant} />
           </div>
         )}
       </div>

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -84,6 +84,7 @@ import {
   validateBlockId,
 } from "./page-sections";
 import {
+  appendSectionVariant,
   deleteMultivariateSectionVariant,
   duplicateMultivariateSectionVariant,
   flattenMultivariateSection,
@@ -1252,6 +1253,36 @@ export function SectionsEditor({
     savePageSections(updatedSections);
   };
 
+  const handleAddSectionVariant = (index?: number) => {
+    const sectionIndex = index ?? selectedSectionIndex;
+    if (sectionIndex === null || !activePageKey) return;
+
+    const rawSection = rawSections[sectionIndex];
+    const parsed = parsedSections[sectionIndex];
+    if (!rawSection || !parsed) return;
+
+    const result = appendSectionVariant(rawSection, parsed);
+    if (!result) {
+      toast.error("This section cannot have variants.");
+      return;
+    }
+
+    const updatedSections = [...rawSections];
+    updatedSections[sectionIndex] = result.section;
+    const nextParsed = parseSections(updatedSections, decofile)[sectionIndex];
+    if (!nextParsed?.isMultivariate) {
+      toast.error("Could not add variant.");
+      return;
+    }
+
+    setSelectedSectionIndex(sectionIndex);
+    setActiveSectionVariantIndex(result.newVariantIndex);
+    setFieldBreadcrumbs([]);
+    setFormResetKey((key) => key + 1);
+    applySectionVariant(result.section, nextParsed, result.newVariantIndex);
+    savePageSections(updatedSections);
+  };
+
   const handleRemoveAllSectionVariants = () => {
     if (selectedSectionIndex === null || !activePageKey) return;
     const rawSection = rawSections[selectedSectionIndex];
@@ -2076,6 +2107,27 @@ export function SectionsEditor({
                   </TooltipContent>
                 </Tooltip>
               )}
+              {isEditingSection &&
+                !isEditingMultivariateSection &&
+                !selectedParsed?.isHidden &&
+                activePageKey && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Add variant"
+                        className="size-7 shrink-0"
+                        style={{ color: "oklch(0.65 0.15 160)" }}
+                        onClick={() => handleAddSectionVariant()}
+                      >
+                        <Flag01 size={14} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Add variant</TooltipContent>
+                  </Tooltip>
+                )}
             </div>
             {showGlobalBanner && (
               <p className="mt-1.5 py-1.5 pl-1 text-sm leading-snug text-foreground">
@@ -2208,6 +2260,7 @@ export function SectionsEditor({
                 onDuplicate={handleDuplicateSectionVariant}
                 onDelete={handleDeleteSectionVariant}
                 onRemoveAll={handleRemoveAllSectionVariants}
+                onAdd={() => handleAddSectionVariant()}
               />
               {isEditingMultivariateSection && (
                 <div className="px-3 py-3 border-b space-y-2">
@@ -2333,6 +2386,7 @@ export function SectionsEditor({
               onMakeReusable={setMakeReusableIndex}
               onToggleHidden={handleToggleHidden}
               onToggleLazy={handleToggleLazy}
+              onAddVariant={handleAddSectionVariant}
               onAddSection={() => setAddSectionOpen(true)}
               canAddSection={canAddSection}
             />


### PR DESCRIPTION
## Summary

- Sections can now be converted into multivariate A/B variants, mirroring the existing page-variant flow
- New `appendSectionVariant()` utility wraps a plain/lazy section into a `website/flags/multivariate/section.ts` block (seeded with 2 copies) or appends a new variant to an existing one
- Entry points: section row context menu (⋯ → Add variant), flag button in the edit header breadcrumb bar, and a `+` button in the variant list header when already editing a multivariate section

## Changes

- `section-variants.ts` — `appendSectionVariant`, `wrapSectionAsMultivariate`, `extractSectionVariantSeed`, `canAddSectionVariant` helpers
- `section-list.tsx` — "Add variant" item in the section row dropdown menu
- `section-variant-list.tsx` — `+` button in the variants list header to add more variants; `onAdd` prop
- `sections-editor.tsx` — `handleAddSectionVariant` handler wired to all three entry points
- `section-variants.test.ts` — 4 new unit tests (wrap plain, wrap lazy, extend existing, reject hidden)

## Test plan

- [ ] Select a plain section → breadcrumb header shows flag icon → click → section becomes multivariate with 2 variants
- [ ] Right-click (⋯) on a section → "Add variant" → same result
- [ ] While editing a multivariate section, click `+` in the variants panel → third variant appended
- [ ] Hidden sections do not show "Add variant" in the menu
- [ ] Lazy sections produce `Lazy.tsx → multivariate/section.ts` shape (lazy wrapper preserved)
- [ ] `bun test apps/mesh/src/web/components/sections-editor/section-variants.test.ts` — all 24 pass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add section variant creation in the Sections Editor. Convert a section to a multivariate block or append variants from the row menu, the header flag button, or the variants list.

- **New Features**
  - Added `appendSectionVariant` to wrap plain/lazy sections with two seeded variants or append to an existing multivariate section (lazy shell preserved).
  - Entry points: row menu, header flag, and variants list “+” (`onAdd` wired in the list and CT harness).
  - Introduced `defaultVariantRule()` shared by page and section variants.

- **Bug Fixes**
  - Block variant creation for hidden and saved-block sections via `canAddSectionVariant` and `appendSectionVariant`.
  - Replaced duplicate page-level rule with `defaultVariantRule()` in `page-variants.ts` and fixed related TS errors.

<sup>Written for commit b6dc18abeafe06ebdf1920b866de469aa3f23cf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

