### PR TITLE
feat(home): visual grid size picker for tiles

### DIFF
--- a/apps/mesh/src/web/components/home/tile-board/constants.ts
+++ b/apps/mesh/src/web/components/home/tile-board/constants.ts
@@ -9,16 +9,4 @@ export const GRID_GAP_PX = 12;
 /** Tallest a tile may grow in the resize menu. */
 export const MAX_TILE_ROWS = 5;
 
-// Every width (1..GRID_COLS) × height (1..MAX_TILE_ROWS) combination,
-// ordered by width then shortest → tallest, so the resize menu reads
-// naturally from compact to dramatic.
-export const ALL_SIZES: TileSize[] = Array.from(
-  { length: GRID_COLS },
-  (_, wi) =>
-    Array.from({ length: MAX_TILE_ROWS }, (_, hi) => ({
-      w: wi + 1,
-      h: hi + 1,
-    })),
-).flat();
-
 export const DEFAULT_SIZE: TileSize = { w: 2, h: 2 };

--- a/apps/mesh/src/web/components/home/tile-board/constants.ts
+++ b/apps/mesh/src/web/components/home/tile-board/constants.ts
@@ -1,50 +1,24 @@
 /** 4-column home-board grid; tiles snap to a discrete preset list. */
 
-import type { TileSize, TileSizeKey } from "./types";
+import type { TileSize } from "./types";
 
 export const GRID_COLS = 4;
 export const ROW_HEIGHT_PX = 100;
 export const GRID_GAP_PX = 12;
 
-export const SIZE_PRESETS: Record<TileSizeKey, TileSize> = {
-  S: { w: 1, h: 1 },
-  M: { w: 1, h: 2 },
-  T: { w: 1, h: 3 },
-  L: { w: 2, h: 1 },
-  XL: { w: 2, h: 2 },
-  LT: { w: 2, h: 3 },
-  XLT: { w: 2, h: 4 },
-  XXLT: { w: 2, h: 5 },
-  W: { w: 4, h: 1 },
-  WT: { w: 4, h: 3 },
-};
+/** Tallest a tile may grow in the resize menu. */
+export const MAX_TILE_ROWS = 5;
 
-export const SIZE_LABELS: Record<TileSizeKey, string> = {
-  S: "Small",
-  M: "Tall",
-  T: "Column",
-  L: "Wide",
-  XL: "Large",
-  LT: "Showcase",
-  XLT: "Display",
-  XXLT: "Tower",
-  W: "Full width",
-  WT: "Hero",
-};
-
-// Ordered shortest → tallest within each width so the resize menu reads
+// Every width (1..GRID_COLS) × height (1..MAX_TILE_ROWS) combination,
+// ordered by width then shortest → tallest, so the resize menu reads
 // naturally from compact to dramatic.
-export const ALL_SIZES: TileSizeKey[] = [
-  "S",
-  "M",
-  "T",
-  "L",
-  "XL",
-  "LT",
-  "XLT",
-  "XXLT",
-  "W",
-  "WT",
-];
+export const ALL_SIZES: TileSize[] = Array.from(
+  { length: GRID_COLS },
+  (_, wi) =>
+    Array.from({ length: MAX_TILE_ROWS }, (_, hi) => ({
+      w: wi + 1,
+      h: hi + 1,
+    })),
+).flat();
 
-export const DEFAULT_SIZE: TileSize = SIZE_PRESETS.XL;
+export const DEFAULT_SIZE: TileSize = { w: 2, h: 2 };

--- a/apps/mesh/src/web/components/home/tile-board/tile-board.tsx
+++ b/apps/mesh/src/web/components/home/tile-board/tile-board.tsx
@@ -20,7 +20,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
@@ -29,15 +28,13 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { DotsGrid, DotsHorizontal, Trash01 } from "@untitledui/icons";
 import { type ReactNode, useRef, useState } from "react";
 import {
-  ALL_SIZES,
   GRID_COLS,
   GRID_GAP_PX,
+  MAX_TILE_ROWS,
   ROW_HEIGHT_PX,
-  SIZE_LABELS,
-  SIZE_PRESETS,
 } from "./constants";
 import { TileErrorBoundary } from "./tile-error-boundary";
-import type { TileInstance, TileSizeKey } from "./types";
+import type { TileInstance } from "./types";
 
 interface TileBoardProps {
   tiles: TileInstance[];
@@ -294,27 +291,10 @@ function TileMenu({
   onResize: (id: string, size: { w: number; h: number }) => void;
   onRemove: (id: string) => void;
 }) {
-  const minW = tile.minW ?? 1;
-  const minH = tile.minH ?? 1;
-  // Drop presets that would shrink the tile below its declared minimum —
-  // e.g. an embedded UI tile needs at least 2 rows to leave room for the
-  // iframe under the header.
-  const allowed = ALL_SIZES.filter((key) => {
-    const size = SIZE_PRESETS[key];
-    return size.w >= minW && size.h >= minH;
-  });
-
-  const matchSizeKey = (): TileSizeKey | null => {
-    for (const key of ALL_SIZES) {
-      const size = SIZE_PRESETS[key];
-      if (size.w === tile.w && size.h === tile.h) return key;
-    }
-    return null;
-  };
-  const currentKey = matchSizeKey();
+  const [open, setOpen] = useState(false);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
@@ -324,23 +304,14 @@ function TileMenu({
           <DotsHorizontal size={16} />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-44">
-        <DropdownMenuLabel>Size</DropdownMenuLabel>
-        {allowed.map((key) => {
-          const size = SIZE_PRESETS[key];
-          return (
-            <DropdownMenuItem
-              key={key}
-              onSelect={() => onResize(tile.id, size)}
-              className="flex items-center justify-between"
-            >
-              <span>{SIZE_LABELS[key]}</span>
-              <span className="text-xs text-muted-foreground">
-                {currentKey === key ? "✓" : `${size.w}×${size.h}`}
-              </span>
-            </DropdownMenuItem>
-          );
-        })}
+      <DropdownMenuContent align="end" className="w-auto">
+        <TileSizeGrid
+          tile={tile}
+          onPick={(size) => {
+            onResize(tile.id, size);
+            setOpen(false);
+          }}
+        />
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={() => onRemove(tile.id)}
@@ -351,5 +322,64 @@ function TileMenu({
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+/** Word-processor-style size picker: hover the grid to choose width×height,
+ *  click to apply. Cells below the tile's min size are disabled. */
+function TileSizeGrid({
+  tile,
+  onPick,
+}: {
+  tile: TileInstance;
+  onPick: (size: { w: number; h: number }) => void;
+}) {
+  const minW = tile.minW ?? 1;
+  const minH = tile.minH ?? 1;
+  const [hover, setHover] = useState<{ w: number; h: number } | null>(null);
+  const active = hover ?? { w: tile.w, h: tile.h };
+
+  return (
+    <div className="px-2 py-1.5">
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <span className="text-xs text-muted-foreground">Size</span>
+        <span className="text-xs font-medium tabular-nums">
+          {active.w} × {active.h}
+        </span>
+      </div>
+      <div
+        className="grid w-max gap-1"
+        style={{ gridTemplateColumns: `repeat(${GRID_COLS}, 1.25rem)` }}
+        onPointerLeave={() => setHover(null)}
+      >
+        {Array.from({ length: MAX_TILE_ROWS }, (_, ri) =>
+          Array.from({ length: GRID_COLS }, (_, ci) => {
+            const w = ci + 1;
+            const h = ri + 1;
+            const disabled = w < minW || h < minH;
+            const selected = w <= active.w && h <= active.h;
+            return (
+              <button
+                key={`${w}x${h}`}
+                type="button"
+                disabled={disabled}
+                aria-label={`${w} by ${h}`}
+                onPointerEnter={() => setHover({ w, h })}
+                onClick={() => onPick({ w, h })}
+                className={cn(
+                  "size-5 rounded-sm border transition-colors",
+                  selected
+                    ? "border-primary bg-primary/30"
+                    : "border-border bg-muted",
+                  disabled
+                    ? "cursor-not-allowed opacity-40"
+                    : "cursor-pointer hover:border-primary/60",
+                )}
+              />
+            );
+          }),
+        )}
+      </div>
+    </div>
   );
 }

--- a/apps/mesh/src/web/components/home/tile-board/types.ts
+++ b/apps/mesh/src/web/components/home/tile-board/types.ts
@@ -4,18 +4,6 @@
  * the board stays generic.
  */
 
-export type TileSizeKey =
-  | "S"
-  | "M"
-  | "L"
-  | "XL"
-  | "W"
-  | "T"
-  | "LT"
-  | "WT"
-  | "XLT"
-  | "XXLT";
-
 export interface TileSize {
   w: number;
   h: number;


### PR DESCRIPTION
## Summary

Editing a Home tile previously listed sizes as a long vertical menu of dimension strings (1×3, 1×4, 2×2, …) — a wall of numbers that was painful to scan.

This replaces it with a **word-processor-style grid picker**: hover the grid to choose width×height, click to apply. The live `w × h` readout updates as you hover.

It also broadens the available sizes: tiles can now be **any column (1–4) × row (1–5)** combination, instead of a hand-curated subset (the old `S/M/L/XL/...` named presets). Cells below a tile's declared `minW`/`minH` are disabled.

## Changes
- `constants.ts` — drop the arbitrary named presets; generate `ALL_SIZES` as the full 4×5 grid; add `MAX_TILE_ROWS`.
- `types.ts` — remove the now-unused `TileSizeKey` union.
- `tile-board.tsx` — replace the resize dropdown list with a `TileSizeGrid` hover/click picker.

## Testing
- `bun run --cwd=apps/mesh check` — no new type errors in the touched files.

## Screenshots
_Before:_ a long list of `1×3 / 1×4 / 2×2 / …` items.
_After:_ a 4×5 grid you hover to pick a size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the long numeric size list with a visual grid picker for Home tiles, making resizing faster and clearer. Tiles now support any 1–4 columns by 1–5 rows, with a live size readout.

- New Features
  - Visual grid picker in the tile menu; hover to preview, click to set.
  - Full size range: 1–4 cols × 1–5 rows; cells below `minW`/`minH` are disabled.
  - Live “w × h” readout updates on hover.

- Refactors
  - Removed named presets, labels, and `ALL_SIZES`; added `MAX_TILE_ROWS`.
  - Dropped `TileSizeKey`; use `{ w, h }` directly across components.
  - Replaced the dropdown list with `TileSizeGrid` in `tile-board.tsx`.

<sup>Written for commit 1b3114ebb0d0db1620460c4e9a79511106ace7f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

