### PR TITLE
feat(web): restore last org + agent + thread on reopen

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/input.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.tsx
@@ -132,10 +132,10 @@ export function TiptapProvider({
   // Sync editor content when tiptapDoc changes externally
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {
-    if (editor?.isDestroyed) return;
+    if (!editor || editor.isDestroyed) return;
 
     // Only update if the content is different to avoid unnecessary updates
-    const currentJson = JSON.stringify(editor?.getJSON());
+    const currentJson = JSON.stringify(editor.getJSON());
     const newJson = JSON.stringify(tiptapDoc || { type: "doc", content: [] });
 
     if (currentJson !== newJson) {

--- a/apps/mesh/src/web/components/org-access-gate.tsx
+++ b/apps/mesh/src/web/components/org-access-gate.tsx
@@ -13,22 +13,22 @@ import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 export function OrgAccessGate({ orgSlug }: { orgSlug: string }) {
   const { data } = useOrgAccessStatus(orgSlug);
 
-  // Self-heal the home route's optimistic redirect: if we sent the user here
-  // from a cached slug (or restored last-location) that turned out to be stale
-  // (org deleted or membership lost), clear it and bounce back to "/" so the
-  // home loader can pick a valid destination — instead of dead-ending on the
-  // not-found / no-access screen, or looping straight back to the same org.
-  const staleSlug =
-    localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === orgSlug;
-  const staleLocation = readLastLocation()?.org === orgSlug;
-  if (
-    (data.status === "not-found" || data.status === "no-access") &&
-    (staleSlug || staleLocation)
-  ) {
-    if (staleSlug) localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
-    if (staleLocation) clearLastLocation();
-    window.location.href = "/";
-    return null;
+  if (data.status === "not-found" || data.status === "no-access") {
+    // A bad org must never be restored on the next cold entry. orgLayout's
+    // beforeLoad records the current org optimistically (before membership is
+    // known), so clear it here whether the user arrived deliberately or via a
+    // stale restore — otherwise homeRoute would keep bouncing them back here.
+    if (readLastLocation()?.org === orgSlug) clearLastLocation();
+
+    // Self-heal the home route's optimistic cached-slug redirect: bounce back
+    // to "/" so the loader can pick a valid destination instead of dead-ending.
+    // Only for the cached slug — a deliberate visit to a bad org (e.g. a shared
+    // link) should show the not-found / no-access screen, not silently bounce.
+    if (localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === orgSlug) {
+      localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+      window.location.href = "/";
+      return null;
+    }
   }
 
   if (data.status === "not-found") {

--- a/apps/mesh/src/web/components/org-access-gate.tsx
+++ b/apps/mesh/src/web/components/org-access-gate.tsx
@@ -2,6 +2,7 @@ import { AutoDomainJoinScreen } from "@/web/components/auto-domain-join-screen";
 import { NoAccessScreen } from "@/web/components/no-access-screen";
 import { PendingInviteScreen } from "@/web/components/pending-invite-screen";
 import { useOrgAccessStatus } from "@/web/hooks/use-org-access-status";
+import { clearLastLocation, readLastLocation } from "@/web/lib/last-location";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 
 /**
@@ -13,14 +14,19 @@ export function OrgAccessGate({ orgSlug }: { orgSlug: string }) {
   const { data } = useOrgAccessStatus(orgSlug);
 
   // Self-heal the home route's optimistic redirect: if we sent the user here
-  // from a cached slug that turned out to be stale (org deleted or membership
-  // lost), clear it and bounce back to "/" so the home loader can pick a valid
-  // destination — instead of dead-ending on the not-found / no-access screen.
+  // from a cached slug (or restored last-location) that turned out to be stale
+  // (org deleted or membership lost), clear it and bounce back to "/" so the
+  // home loader can pick a valid destination — instead of dead-ending on the
+  // not-found / no-access screen, or looping straight back to the same org.
+  const staleSlug =
+    localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === orgSlug;
+  const staleLocation = readLastLocation()?.org === orgSlug;
   if (
     (data.status === "not-found" || data.status === "no-access") &&
-    localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === orgSlug
+    (staleSlug || staleLocation)
   ) {
-    localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+    if (staleSlug) localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+    if (staleLocation) clearLastLocation();
     window.location.href = "/";
     return null;
   }

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -20,6 +20,7 @@ import "../../index.css";
 
 import { listOrganizationsCached } from "@/web/lib/auth-client";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+import { readLastLocation, saveLastLocation } from "@/web/lib/last-location";
 import { initPwaInstallCapture } from "@/web/lib/pwa-install";
 
 import { sourcePlugins } from "./plugins.ts";
@@ -120,6 +121,21 @@ const homeRoute = createRoute({
   getParentRoute: () => shellLayout,
   path: "/",
   beforeLoad: async () => {
+    // Restore the user where they left off: same org + agent + thread. Read
+    // synchronously so cold entry stays instant (no network round-trip). A
+    // stale org/thread self-heals — OrgAccessGate clears it and bounces back
+    // to "/", and an unknown taskId is re-fetched/created by useEnsureTask.
+    const lastLocation = readLastLocation();
+    if (lastLocation) {
+      throw redirect({
+        to: "/$org/$taskId",
+        params: { org: lastLocation.org, taskId: lastLocation.taskId },
+        search: lastLocation.virtualmcpid
+          ? { virtualmcpid: lastLocation.virtualmcpid }
+          : {},
+      });
+    }
+
     // Fast path: redirect returning users immediately from the cached slug,
     // WITHOUT awaiting the org-list network call. This is what keeps a cold
     // load from blocking on a round-trip (the previous blank/white screen).
@@ -226,6 +242,15 @@ const unifiedChatRoute = createRoute({
   getParentRoute: () => agentShellLayout,
   path: "/$taskId",
   validateSearch: unifiedChatSearchSchema,
+  // Remember the open thread so cold entry ("/") can restore it. Preloading is
+  // off (defaultPreload unset), so this only fires on real navigation.
+  beforeLoad: ({ params, search }) => {
+    saveLastLocation({
+      org: params.org,
+      taskId: params.taskId,
+      virtualmcpid: search.virtualmcpid,
+    });
+  },
   component: () => null,
 });
 

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -121,19 +121,15 @@ const homeRoute = createRoute({
   getParentRoute: () => shellLayout,
   path: "/",
   beforeLoad: async () => {
-    // lastOrgSlug is the authoritative "last org": it updates on every org view
-    // (including switching to an org's home). lastLocation only updates when a
-    // *thread* is opened, so after an org switch the two disagree — and the
-    // slug wins. Reads are synchronous so cold entry stays instant.
-    const lastOrgSlug = localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug());
-
-    // Restore the exact thread (same org + agent + thread) only when it belongs
-    // to the org the user was last in. Without this guard, switching orgs would
-    // be undone on reopen by restoring a stale thread from the previous org. A
-    // stale org/thread self-heals — OrgAccessGate clears it and bounces back to
+    // Restore where the user last was. lastLocation is recorded on every
+    // org-scoped navigation (orgLayout writes the org; the thread route adds
+    // the taskId), so it's always current — including after an in-app org
+    // switch, which the queryFn-driven lastOrgSlug can miss when the new org
+    // is already cached. Reads are synchronous so cold entry stays instant. A
+    // stale org/thread self-heals: OrgAccessGate clears it and bounces back to
     // "/", and an unknown taskId is re-fetched/created by useEnsureTask.
     const lastLocation = readLastLocation();
-    if (lastLocation && (!lastOrgSlug || lastLocation.org === lastOrgSlug)) {
+    if (lastLocation?.taskId) {
       throw redirect({
         to: "/$org/$taskId",
         params: { org: lastLocation.org, taskId: lastLocation.taskId },
@@ -142,12 +138,16 @@ const homeRoute = createRoute({
           : {},
       });
     }
+    if (lastLocation) {
+      throw redirect({ to: "/$org", params: { org: lastLocation.org } });
+    }
 
     // Fast path: redirect returning users immediately from the cached slug,
     // WITHOUT awaiting the org-list network call. This is what keeps a cold
     // load from blocking on a round-trip (the previous blank/white screen).
     // The org layout validates membership via getFullOrganization, and a stale
     // slug self-heals in OrgAccessGate (clears the slug + bounces back to "/").
+    const lastOrgSlug = localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug());
     if (lastOrgSlug) {
       throw redirect({
         to: "/$org",
@@ -197,6 +197,12 @@ const onboardingRoute = createRoute({
 const orgLayout = createRoute({
   getParentRoute: () => shellLayout,
   path: "/$org",
+  // Record the org on every entry/switch (this re-runs whenever the $org param
+  // changes). Clears any prior taskId; the thread route re-adds it right after
+  // for /$org/$taskId, since this parent beforeLoad runs before the child's.
+  beforeLoad: ({ params }) => {
+    saveLastLocation({ org: params.org });
+  },
   component: lazyRouteComponent(() => import("./layouts/org-layout.tsx")),
 });
 

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -121,12 +121,19 @@ const homeRoute = createRoute({
   getParentRoute: () => shellLayout,
   path: "/",
   beforeLoad: async () => {
-    // Restore the user where they left off: same org + agent + thread. Read
-    // synchronously so cold entry stays instant (no network round-trip). A
-    // stale org/thread self-heals — OrgAccessGate clears it and bounces back
-    // to "/", and an unknown taskId is re-fetched/created by useEnsureTask.
+    // lastOrgSlug is the authoritative "last org": it updates on every org view
+    // (including switching to an org's home). lastLocation only updates when a
+    // *thread* is opened, so after an org switch the two disagree — and the
+    // slug wins. Reads are synchronous so cold entry stays instant.
+    const lastOrgSlug = localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+
+    // Restore the exact thread (same org + agent + thread) only when it belongs
+    // to the org the user was last in. Without this guard, switching orgs would
+    // be undone on reopen by restoring a stale thread from the previous org. A
+    // stale org/thread self-heals — OrgAccessGate clears it and bounces back to
+    // "/", and an unknown taskId is re-fetched/created by useEnsureTask.
     const lastLocation = readLastLocation();
-    if (lastLocation) {
+    if (lastLocation && (!lastOrgSlug || lastLocation.org === lastOrgSlug)) {
       throw redirect({
         to: "/$org/$taskId",
         params: { org: lastLocation.org, taskId: lastLocation.taskId },
@@ -141,7 +148,6 @@ const homeRoute = createRoute({
     // load from blocking on a round-trip (the previous blank/white screen).
     // The org layout validates membership via getFullOrganization, and a stale
     // slug self-heals in OrgAccessGate (clears the slug + bounces back to "/").
-    const lastOrgSlug = localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug());
     if (lastOrgSlug) {
       throw redirect({
         to: "/$org",

--- a/apps/mesh/src/web/lib/last-location.ts
+++ b/apps/mesh/src/web/lib/last-location.ts
@@ -1,0 +1,45 @@
+import { LOCALSTORAGE_KEYS } from "./localstorage-keys";
+
+/** The thread the user last had open, restored on cold app entry ("/"). */
+export interface LastLocation {
+  org: string;
+  taskId: string;
+  virtualmcpid?: string;
+}
+
+export function saveLastLocation(loc: LastLocation): void {
+  try {
+    localStorage.setItem(LOCALSTORAGE_KEYS.lastLocation(), JSON.stringify(loc));
+  } catch {
+    // ignore quota / privacy-mode failures — restore is best-effort
+  }
+}
+
+export function readLastLocation(): LastLocation | null {
+  try {
+    const raw = localStorage.getItem(LOCALSTORAGE_KEYS.lastLocation());
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<LastLocation>;
+    if (typeof parsed?.org === "string" && typeof parsed?.taskId === "string") {
+      return {
+        org: parsed.org,
+        taskId: parsed.taskId,
+        virtualmcpid:
+          typeof parsed.virtualmcpid === "string"
+            ? parsed.virtualmcpid
+            : undefined,
+      };
+    }
+  } catch {
+    // corrupt value — treat as absent
+  }
+  return null;
+}
+
+export function clearLastLocation(): void {
+  try {
+    localStorage.removeItem(LOCALSTORAGE_KEYS.lastLocation());
+  } catch {
+    // ignore
+  }
+}

--- a/apps/mesh/src/web/lib/last-location.ts
+++ b/apps/mesh/src/web/lib/last-location.ts
@@ -1,9 +1,14 @@
 import { LOCALSTORAGE_KEYS } from "./localstorage-keys";
 
-/** The thread the user last had open, restored on cold app entry ("/"). */
+/**
+ * Where the user last was, restored on cold app entry ("/"). Recorded on every
+ * org-scoped navigation: `org` alone for an org home / non-thread route, plus
+ * `taskId` + `virtualmcpid` once a thread is open. Single source of truth, so
+ * it can never disagree with itself the way two separate keys could.
+ */
 export interface LastLocation {
   org: string;
-  taskId: string;
+  taskId?: string;
   virtualmcpid?: string;
 }
 
@@ -20,10 +25,10 @@ export function readLastLocation(): LastLocation | null {
     const raw = localStorage.getItem(LOCALSTORAGE_KEYS.lastLocation());
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<LastLocation>;
-    if (typeof parsed?.org === "string" && typeof parsed?.taskId === "string") {
+    if (typeof parsed?.org === "string") {
       return {
         org: parsed.org,
-        taskId: parsed.taskId,
+        taskId: typeof parsed.taskId === "string" ? parsed.taskId : undefined,
         virtualmcpid:
           typeof parsed.virtualmcpid === "string"
             ? parsed.virtualmcpid

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -35,6 +35,7 @@ export const LOCALSTORAGE_KEYS = {
   pluginConnection: (org: string, pluginId: string) =>
     `mesh:plugin:connection:${org}:${pluginId}`,
   lastOrgSlug: () => `mesh:last-org-slug`,
+  lastLocation: () => `mesh:last-location`,
   connectionsTab: (org: string) => `mesh:connections:tab:${org}`,
   taskLastViewed: (locator: ProjectLocator) =>
     `mesh:chat:task-last-viewed:${locator}`,


### PR DESCRIPTION
## Summary

When you reopen Studio, it now opens **where you left off** — same org, same agent, same thread — instead of dropping you on the org home.

Org restore already existed (`lastOrgSlug`). This adds the missing pieces: the **agent** (`virtualmcpid`) and the **thread** (`taskId`).

## How it works

- **`lib/last-location.ts`** (new) — a tiny localStorage-backed `{ org, taskId, virtualmcpid }` record with `save` / `read` / `clear`.
- **Persist** — `unifiedChatRoute.beforeLoad` saves the location on every navigation to a thread. `defaultPreload` is off, so this only fires on real navigation (not hover-preload).
- **Restore** — `homeRoute.beforeLoad` (path `/`) redirects to the saved `/$org/$taskId?virtualmcpid=…` *before* the existing `lastOrgSlug` fast path. The read is synchronous, so cold entry stays instant (no added network round-trip). `autosend` and other transient search params are intentionally **not** restored, so reopening never re-sends a message.
- **Self-heal** — `OrgAccessGate` now also clears `last-location` (not just `lastOrgSlug`) when the restored org turns out to be stale, so a revoked-access org can't loop back to itself. A stale `taskId` self-heals via `useEnsureTask` (re-fetch from server; idempotent create only if it genuinely doesn't exist).

## Affected areas
- `apps/mesh/src/web/index.tsx` — restore + persist hooks
- `apps/mesh/src/web/lib/last-location.ts` — new helper
- `apps/mesh/src/web/lib/localstorage-keys.ts` — new `lastLocation` key
- `apps/mesh/src/web/components/org-access-gate.tsx` — loop-safe self-heal

## Testing
- `bun run --cwd=apps/mesh check` — no type errors in the touched files.
- `bun run lint` / `bun run fmt` — clean (the 2 lint warnings are pre-existing in `packages/sandbox`).
- **Not yet run live** — needs a manual pass:
  1. Open a thread under an agent, send a message.
  2. Close the tab / quit the PWA, reopen at `/`.
  3. Expect to land back in that same thread (org + agent + thread), with no auto-resend.
  4. Lose access to that org (or delete it) → reopening should bounce cleanly to a valid org, not loop or dead-end.

> Note: this changes the default landing for returning users from the org home to their last thread — which is the intent of the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On reopen, Studio now restores where you left off: same org, agent (`virtualmcpid`), and thread (`taskId`). Uses a single `last-location` source of truth, won’t undo a recent org switch, and avoids auto-resend and extra network on cold entry.

- **New Features**
  - Added a `last-location` localStorage helper (save/read/clear).
  - Record org via `orgLayout.beforeLoad`; add `taskId`/`virtualmcpid` via `unifiedChatRoute.beforeLoad`.
  - Restore on “/” via `homeRoute.beforeLoad` from `last-location` (thread first, else org); fall back to `lastOrgSlug` only if absent.
  - Self-heal: stale `taskId` is recovered by `useEnsureTask`.

- **Bug Fixes**
  - Guarded null `editor` in the Tiptap content-sync effect to prevent a startup crash when restoring into a thread.
  - `OrgAccessGate`: show not-found/no-access for deliberately bad orgs; only bounce to “/” when the visit came from the cached `lastOrgSlug`. Clear a matching `last-location` so it won’t be restored.

<sup>Written for commit fc56bf75928625ed725d1533ab4d7b9bf8ffaf09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

