### PR TITLE
fix(decopilot): sanitize non-Error stream errors instead of leaking raw JSON

### DIFF
--- a/packages/harness/src/decopilot/native-agent-loop-core.ts
+++ b/packages/harness/src/decopilot/native-agent-loop-core.ts
@@ -30,11 +30,21 @@ export interface NativeAgentLoopCoreHandle {
 }
 
 function stringifyProviderError(error: unknown): string {
-  return error instanceof Error
-    ? error.message
-    : typeof error === "string"
-      ? error
-      : `${error}`;
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  // Provider/gateway errors often arrive as plain objects (e.g. the
+  // `{ code, message, metadata }` shape a 504 idle timeout carries). Prefer a
+  // string `message` field; `${error}` would otherwise log `[object Object]`.
+  if (typeof error === "object" && error !== null) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
 }
 
 export function runNativeAgentLoopCore(

--- a/packages/harness/src/decopilot/stream-error.test.ts
+++ b/packages/harness/src/decopilot/stream-error.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { classifyStreamError, sanitizeStreamError } from "./stream-error";
+
+describe("sanitizeStreamError", () => {
+  it("strips provider URLs and branding from Error messages", () => {
+    const err = new Error(
+      "Model failed. See https://openrouter.ai/docs for details. Try again.",
+    );
+    const out = sanitizeStreamError(err);
+    expect(out).not.toContain("openrouter");
+    expect(out).not.toContain("https://");
+  });
+
+  it("extracts the message from non-Error gateway objects (no raw JSON)", () => {
+    // The shape a 504 idle timeout arrives as — a plain object, not an Error.
+    const err = {
+      code: 504,
+      message: "Upstream idle timeout exceeded",
+      metadata: { error_type: "timeout" },
+    };
+    expect(sanitizeStreamError(err)).toBe("Upstream idle timeout exceeded.");
+  });
+
+  it("tags 402 plain objects as credit errors via numeric code", () => {
+    const err = { code: 402, message: "Insufficient funds" };
+    expect(sanitizeStreamError(err)).toContain("[CREDITS]");
+  });
+
+  it("detects credit errors from message text on plain objects", () => {
+    const err = { message: "Your account has insufficient balance" };
+    expect(sanitizeStreamError(err)).toContain("[CREDITS]");
+  });
+
+  it("falls back to JSON for opaque objects without a message", () => {
+    expect(sanitizeStreamError({ foo: "bar" })).toContain("foo");
+  });
+});
+
+describe("classifyStreamError", () => {
+  it("classifies a plain 504 idle-timeout object as timeout", () => {
+    const err = {
+      code: 504,
+      message: "Upstream idle timeout exceeded",
+      metadata: { error_type: "timeout" },
+    };
+    expect(classifyStreamError(err)).toBe("timeout");
+  });
+});

--- a/packages/harness/src/decopilot/stream-error.ts
+++ b/packages/harness/src/decopilot/stream-error.ts
@@ -71,30 +71,64 @@ export function classifyStreamError(
 }
 
 /**
+ * Pull a human-readable message + HTTP status out of an unknown error.
+ * Gateway/provider errors frequently arrive as plain objects rather than
+ * `Error` instances (e.g. the `{ code, message, metadata }` shape a 504 idle
+ * timeout carries), so we look past `instanceof Error` and read a string
+ * `message` field. `statusCode` falls back to a numeric `code` so the credits
+ * (402) detection below works on both shapes.
+ */
+function extractErrorParts(error: unknown): {
+  message: string;
+  statusCode?: number;
+} {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      statusCode: (error as { statusCode?: number }).statusCode,
+    };
+  }
+  if (typeof error === "object" && error !== null) {
+    const obj = error as {
+      message?: unknown;
+      statusCode?: unknown;
+      code?: unknown;
+    };
+    const message =
+      typeof obj.message === "string" ? obj.message : stringifyError(error);
+    const statusCode =
+      typeof obj.statusCode === "number"
+        ? obj.statusCode
+        : typeof obj.code === "number"
+          ? obj.code
+          : undefined;
+    return { message, statusCode };
+  }
+  return { message: String(error) };
+}
+
+/**
  * Returns a sanitized, user-facing error message.
  * Provider-specific URLs and branding are stripped so they are never
  * surfaced to the client.
  */
 // TODO @pedrofrxncx: remove this code in favor of a better solution
 export function sanitizeStreamError(error: unknown): string {
-  if (error instanceof Error) {
-    const statusCode = (error as { statusCode?: number }).statusCode;
-    const msg = error.message.toLowerCase();
-    if (
-      statusCode === 402 ||
-      msg.includes("credit") ||
-      msg.includes("insufficient funds") ||
-      msg.includes("insufficient balance") ||
-      msg.includes("billing") ||
-      msg.includes("quota exceeded") ||
-      msg.includes("key limit") ||
-      msg.includes("payment required")
-    ) {
-      // Prefix with [CREDITS] so the frontend can detect credit errors
-      // without fragile string matching on provider-specific messages.
-      return `[CREDITS] ${stripProviderSpecificDetails(error.message)}`;
-    }
-    return stripProviderSpecificDetails(error.message);
+  const { message, statusCode } = extractErrorParts(error);
+  const lower = message.toLowerCase();
+  if (
+    statusCode === 402 ||
+    lower.includes("credit") ||
+    lower.includes("insufficient funds") ||
+    lower.includes("insufficient balance") ||
+    lower.includes("billing") ||
+    lower.includes("quota exceeded") ||
+    lower.includes("key limit") ||
+    lower.includes("payment required")
+  ) {
+    // Prefix with [CREDITS] so the frontend can detect credit errors
+    // without fragile string matching on provider-specific messages.
+    return `[CREDITS] ${stripProviderSpecificDetails(message)}`;
   }
-  return stringifyError(error);
+  return stripProviderSpecificDetails(message);
 }


### PR DESCRIPTION
## Summary

Production logs surfaced a decopilot run failing on an upstream `504 Upstream idle timeout exceeded`. Tracing the handling turned up two defects in how **non-`Error`** stream errors are processed. Gateway/provider errors frequently arrive as plain objects (`{ code, message, metadata }`), not `Error` instances, and both code paths assumed `instanceof Error`:

1. **Raw JSON leaked to the client.** `sanitizeStreamError` only sanitized `Error` instances; everything else fell through to `JSON.stringify`. So the message persisted to the thread and shown to the user became the literal `{"code":504,"message":"Upstream idle timeout exceeded","metadata":{"error_type":"timeout"}}` blob, and the provider-URL/branding stripping was skipped entirely.
2. **Useless log line.** `stringifyProviderError` did `` `${error}` `` for object errors, so the `[runAgentLoop:...] Error` line logged `[object Object]` and hid the real cause.

## Changes

- `stream-error.ts`: add `extractErrorParts(error)` that pulls a string `message` and a numeric `statusCode` (falling back to a numeric `code`) out of object errors. `sanitizeStreamError` now runs both `Error` and object errors through the same credits-detection + URL/branding-strip logic.
- `native-agent-loop-core.ts`: `stringifyProviderError` now prefers a string `message` field on object errors, falling back to JSON.
- Add `stream-error.test.ts` covering the 504-object path for both `sanitizeStreamError` and `classifyStreamError`, plus the credits/opaque-object branches.

## Scope / not included

This does **not** change retry/recovery behavior. The underlying resilience gap — a mid-stream idle timeout has no auto-retry or resume, since the SDK's `maxRetries` only covers the initial request — is intentionally left out as a separate design discussion.

## Testing

- `bun test packages/harness/src/decopilot/stream-error.test.ts native-agent-loop-core.test.ts` — pass
- `tsc --noEmit` on `packages/harness` — clean
- `bun run fmt` — applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes non-Error stream errors so users see clean messages instead of raw JSON. Also fixes provider error logging to show real messages from object errors.

- **Bug Fixes**
  - Unified error handling for `Error` and object errors: extract `message` + `statusCode`/`code`, strip provider URLs/branding, and tag credit issues with `[CREDITS]`.
  - Improved logs: prefer object `message` in `stringifyProviderError`; fall back to JSON to avoid `[object Object]`.
  - Tests added for 504 idle-timeout objects, credit detection, opaque objects, and error classification.

<sup>Written for commit 4669007eb12a3e7e38e868355beb75a92845dbb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

