### PR TITLE
fix(sandbox): default ghs_ token expiry to 55 min when MINT_REPO_TOKEN omits expiresAt

### DIFF
--- a/apps/mesh/migrations/110-backfill-ghs-token-expiry.ts
+++ b/apps/mesh/migrations/110-backfill-ghs-token-expiry.ts
@@ -12,8 +12,8 @@ import { sql, type Kysely } from "kysely";
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
     UPDATE downstream_tokens
-    SET expires_at = created_at + INTERVAL '55 minutes'
-    WHERE expires_at IS NULL
+    SET "expiresAt" = "createdAt" + INTERVAL '55 minutes'
+    WHERE "expiresAt" IS NULL
   `.execute(db);
 }
 

--- a/apps/mesh/migrations/110-backfill-ghs-token-expiry.ts
+++ b/apps/mesh/migrations/110-backfill-ghs-token-expiry.ts
@@ -12,7 +12,7 @@ import { sql, type Kysely } from "kysely";
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
     UPDATE downstream_tokens
-    SET "expiresAt" = "createdAt" + INTERVAL '55 minutes'
+    SET "expiresAt" = "createdAt"::timestamptz + INTERVAL '55 minutes'
     WHERE "expiresAt" IS NULL
   `.execute(db);
 }

--- a/apps/mesh/migrations/110-backfill-ghs-token-expiry.ts
+++ b/apps/mesh/migrations/110-backfill-ghs-token-expiry.ts
@@ -1,0 +1,23 @@
+import { sql, type Kysely } from "kysely";
+
+// GitHub App installation tokens (ghs_) have a ~1h lifetime. Rows written
+// before this fix stored NULL for expires_at, causing isExpired() to treat
+// them as "never expires" and serve stale tokens indefinitely. Backfill those
+// rows with created_at + 55 minutes so they are detected as expired on the
+// next ensureRepoScopedToken call and a fresh token is minted.
+//
+// Using created_at as the anchor is conservative: any token older than 55 min
+// at deploy time is already past GitHub's 60-min window and will be treated
+// as expired immediately, which is the correct outcome.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE downstream_tokens
+    SET expires_at = created_at + INTERVAL '55 minutes'
+    WHERE expires_at IS NULL
+  `.execute(db);
+}
+
+export async function down(_db: Kysely<unknown>): Promise<void> {
+  // Intentionally a no-op: we cannot know which rows originally had NULL
+  // expires_at vs rows that had a legitimate future expiry before this migration.
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -108,6 +108,7 @@ import * as migration106automationtools from "./106-automation-tools.ts";
 import * as migration107orgfspublicorg from "./107-org-fs-public-org.ts";
 import * as migration108automationmaxagentsteps from "./108-automation-max-agent-steps.ts";
 import * as migration109threadmessagepartspermessageseq from "./109-thread-message-parts-per-message-seq.ts";
+import * as migration110backfillghstokenexpiry from "./110-backfill-ghs-token-expiry.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -239,6 +240,7 @@ const migrations: Record<string, Migration> = {
   "108-automation-max-agent-steps": migration108automationmaxagentsteps,
   "109-thread-message-parts-per-message-seq":
     migration109threadmessagepartspermessageseq,
+  "110-backfill-ghs-token-expiry": migration110backfillghstokenexpiry,
 };
 
 export default migrations;

--- a/apps/mesh/src/oauth/github-mint.test.ts
+++ b/apps/mesh/src/oauth/github-mint.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { resolveGhsExpiry } from "./github-mint";
+import { GHS_TOKEN_LIFETIME_MS } from "./token-refresh";
+
+describe("resolveGhsExpiry", () => {
+  const now = Date.now();
+
+  it("uses server-provided expiry when it is strictly in the future", () => {
+    const futureExpiry = new Date(now + 30 * 60 * 1000); // 30 min from now
+    const result = resolveGhsExpiry(futureExpiry, now);
+    expect(result).toBe(futureExpiry);
+  });
+
+  it("falls back to mintStartedAt + GHS_TOKEN_LIFETIME_MS when expiresAt is null", () => {
+    const result = resolveGhsExpiry(null, now);
+    expect(result.getTime()).toBe(now + GHS_TOKEN_LIFETIME_MS);
+  });
+
+  it("falls back when server-provided expiry is in the past (clock skew)", () => {
+    const pastExpiry = new Date(now - 1000);
+    const result = resolveGhsExpiry(pastExpiry, now);
+    expect(result.getTime()).toBe(now + GHS_TOKEN_LIFETIME_MS);
+  });
+
+  it("falls back when server-provided expiry equals mintStartedAt (not strictly future)", () => {
+    const exactNow = new Date(now);
+    const result = resolveGhsExpiry(exactNow, now);
+    expect(result.getTime()).toBe(now + GHS_TOKEN_LIFETIME_MS);
+  });
+
+  it("fallback expiry is ~55 minutes from mint start", () => {
+    const result = resolveGhsExpiry(null, now);
+    const diffMs = result.getTime() - now;
+    expect(diffMs).toBe(55 * 60 * 1000);
+  });
+});

--- a/apps/mesh/src/oauth/github-mint.ts
+++ b/apps/mesh/src/oauth/github-mint.ts
@@ -13,6 +13,7 @@
 
 import type { StudioContext } from "@/core/studio-context";
 import {
+  GHS_TOKEN_LIFETIME_MS,
   PROACTIVE_REFRESH_BUFFER_MS,
   RECONNECT_ERROR,
 } from "@/oauth/token-refresh";
@@ -94,10 +95,26 @@ async function mintRepoToken(
 // rate-limit-expensive on the caller's GitHub budget).
 const inflight = new Map<string, Promise<string>>();
 
-// GitHub App installation tokens always expire in ~1 hour. If MINT_REPO_TOKEN
-// doesn't return expiresAt, use a 55-minute fallback so isExpired() correctly
-// detects the token as stale on re-open instead of treating it as "never expires".
-const GHS_TOKEN_LIFETIME_MS = 55 * 60 * 1000;
+/**
+ * Resolve the expiry date to persist for a freshly minted ghs_ token.
+ *
+ * Rules:
+ * - Use the server-provided expiry only when it is strictly after `mintStartedAt`
+ *   (guards against clock-skewed or already-past values from the upstream).
+ * - Otherwise fall back to `mintStartedAt + GHS_TOKEN_LIFETIME_MS` so the token
+ *   is never stored with a null or past expiry (which would loop or "never expire").
+ *
+ * Exported for unit testing; not part of the module's public API.
+ */
+export function resolveGhsExpiry(
+  mintedExpiresAt: Date | null,
+  mintStartedAt: number,
+): Date {
+  const providedExpiry = mintedExpiresAt?.getTime() ?? 0;
+  return providedExpiry > mintStartedAt
+    ? mintedExpiresAt!
+    : new Date(mintStartedAt + GHS_TOKEN_LIFETIME_MS);
+}
 
 async function mintAndStore(
   ctx: StudioContext,
@@ -105,9 +122,10 @@ async function mintAndStore(
   recipe: RepoScopeRecipe,
   tokenStorage: DownstreamTokenStorage,
 ): Promise<string> {
+  // Anchor the clock before the async RPC so latency doesn't inflate the stored expiry.
+  const mintStartedAt = Date.now();
   const minted = await mintRepoToken(ctx, recipe);
-  const expiresAt =
-    minted.expiresAt ?? new Date(Date.now() + GHS_TOKEN_LIFETIME_MS);
+  const expiresAt = resolveGhsExpiry(minted.expiresAt, mintStartedAt);
   await tokenStorage.upsert({
     connectionId,
     accessToken: minted.accessToken,

--- a/apps/mesh/src/oauth/github-mint.ts
+++ b/apps/mesh/src/oauth/github-mint.ts
@@ -94,6 +94,11 @@ async function mintRepoToken(
 // rate-limit-expensive on the caller's GitHub budget).
 const inflight = new Map<string, Promise<string>>();
 
+// GitHub App installation tokens always expire in ~1 hour. If MINT_REPO_TOKEN
+// doesn't return expiresAt, use a 55-minute fallback so isExpired() correctly
+// detects the token as stale on re-open instead of treating it as "never expires".
+const GHS_TOKEN_LIFETIME_MS = 55 * 60 * 1000;
+
 async function mintAndStore(
   ctx: StudioContext,
   connectionId: string,
@@ -101,12 +106,14 @@ async function mintAndStore(
   tokenStorage: DownstreamTokenStorage,
 ): Promise<string> {
   const minted = await mintRepoToken(ctx, recipe);
+  const expiresAt =
+    minted.expiresAt ?? new Date(Date.now() + GHS_TOKEN_LIFETIME_MS);
   await tokenStorage.upsert({
     connectionId,
     accessToken: minted.accessToken,
     refreshToken: null,
     scope: null,
-    expiresAt: minted.expiresAt,
+    expiresAt,
     clientId: null,
     clientSecret: null,
     tokenEndpoint: null,

--- a/apps/mesh/src/oauth/token-refresh.ts
+++ b/apps/mesh/src/oauth/token-refresh.ts
@@ -21,6 +21,11 @@ export type { TokenRefreshResult } from "./refresh-access-token";
 
 export const PROACTIVE_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
+// GitHub App installation tokens (ghs_) always expire in ~1 hour and have no
+// refresh_token. This constant is the fallback lifetime used when MINT_REPO_TOKEN
+// omits expiresAt, giving a 10-minute safety margin before GitHub's 60-min limit.
+export const GHS_TOKEN_LIFETIME_MS = 55 * 60 * 1000;
+
 export const RECONNECT_ERROR =
   "GitHub token refresh failed — reconnect the mcp-github integration.";
 


### PR DESCRIPTION
## Summary

- GitHub App installation tokens (`ghs_`) always expire in ~1 hour but `MINT_REPO_TOKEN` sometimes omits `expiresAt` in its response
- When `expiresAt` is `null`, `isExpired()` returns `false` ("no expiry = never expires"), so `ensureRepoScopedToken` never re-mints the cached stale token
- On sandbox re-open (hours later), the expired token is passed to `git clone` → GitHub rejects it with "Invalid username or token"
- New branches worked fine because the freshly minted token was still valid at creation time

**Fix:** in `mintAndStore` (`github-mint.ts`), default `expiresAt` to `now + 55 minutes` when the mint response does not include one. This matches the real GitHub App token lifetime, so `isExpired` correctly triggers a re-mint on the next sandbox open.

## Test plan

- Open a sandbox on a branch, wait >1h (or manually expire the token in the DB), then reopen the same branch — clone should succeed
- New branch sandboxes continue to work as before
- Confirm `bun run fmt` and `bun run lint` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default and harden `ghs_` token expiry to 55 minutes when `MINT_REPO_TOKEN` returns a missing or non-future `expiresAt`, and backfill old rows so stale tokens are re-minted. Prevents sandbox reopen clones from failing with “Invalid username or token” after ~1 hour.

- **Bug Fixes**
  - Use `resolveGhsExpiry` to anchor mint start, ignore past/NULL/not-future expiries, and fall back to `now + GHS_TOKEN_LIFETIME_MS` (55m); moved `GHS_TOKEN_LIFETIME_MS` to `token-refresh.ts`.
  - Added unit tests for `resolveGhsExpiry`; behavior for new branches unchanged.

- **Migration**
  - Backfill `downstream_tokens.expiresAt` NULL values to `createdAt + 55m` (`110-backfill-ghs-token-expiry`), casting `createdAt` to `timestamptz` to ensure correct interval math, so stale tokens are evicted on deploy.

<sup>Written for commit be31335462ae85f3fbd361a581540ae1c0711924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

