### PR TITLE
fix(web): use bg-card on connection and file items in agent settings

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/files-section.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/files-section.tsx
@@ -351,7 +351,7 @@ export function FilesSection({ form }: { form: VirtualMcpFormReturn }) {
           : files.map((file) => (
               <div
                 key={file.id}
-                className="flex items-center gap-3 px-4 py-3 rounded-xl border bg-background"
+                className="flex items-center gap-3 px-4 py-3 rounded-xl border bg-card"
               >
                 {file.kind === "skill" ? (
                   <div className="flex items-center justify-center h-8 w-6.5 shrink-0 rounded-md bg-muted text-muted-foreground">

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -462,7 +462,7 @@ function ConnectionItemWithAuth({
         "rounded-xl border overflow-hidden transition-colors",
         needsAuth || isDisabled
           ? "border-destructive/50 bg-destructive/5"
-          : "border-border",
+          : "border-border bg-card",
       )}
     >
       {/* Body — clickable, navigates to connection detail */}


### PR DESCRIPTION
## What is this contribution about?

Connection cards and file/skill items in the agent settings panel were using `bg-background` (or no background at all), while the Instructions textarea wrapper already uses `bg-card`. This makes the three sections visually inconsistent. The fix applies `bg-card` to both the connection item and the file item cards so all three sections match.

## Screenshots/Demonstration

> See the attached screenshot in the PR request — connections and file cards now have the same card background as the instructions section.

## How to Test

1. Open an agent's settings panel.
2. Add at least one connection and one file/skill.
3. Verify the connection card and file card backgrounds match the instructions textarea background (`bg-card`).

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use bg-card for connection items and file/skill cards in agent settings to match the Instructions section and keep the UI consistent.
Updated backgrounds from bg-background (or none) to bg-card on both components for a unified look.

<sup>Written for commit 79368d4a97faf6da7886670993b6262ae0589d61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

