### PR TITLE
fix(decopilot): instrument silent failure points in /stream publish path

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -500,7 +500,21 @@ export async function dispatchRunAndWait(
         // Fallback: no JetStream tail available — drain uiStream directly.
         // Preserves the previous behavior for test environments and any
         // deployment without NATS. No chunks are observable to tailers in
-        // this mode.
+        // this mode. In a NATS deployment this branch means the buffer is
+        // degraded on the producer pod: the run completes and persists, but
+        // NOTHING is published to the subject, so every `/stream` tailer sees
+        // total silence with no error. High-signal — always logged.
+        if (buffer) {
+          console.warn(
+            JSON.stringify({
+              msg: "decopilot-stream-diag",
+              event: "producer-fallback-no-pump",
+              taskId,
+              hasTail: !!tail,
+              note: "createTailStream returned null — chunks NOT published to NATS; message still persisted upstream",
+            }),
+          );
+        }
         const reader = uiStream.getReader();
         try {
           while (true) {

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -61,6 +61,12 @@ const FRAG_TOTAL_HEADER = "Dp-Frag-Total";
 // (prod publish path stays byte-for-byte unchanged).
 const STREAM_ENCODE_TRACE = process.env.STREAM_ENCODE_TRACE === "1";
 
+// Per-run publish tracing (off by default). When "1", logs how many chunks a
+// pump actually published to the subject — the producer-side counterpart to
+// the /stream `deliveredChunks` log, so a "published N but tail delivered 0"
+// divergence is visible.
+const STREAM_TAIL_TRACE = process.env.DECOPILOT_STREAM_TRACE === "1";
+
 class StreamEncodeProfiler {
   private chunks = 0;
   private encodeMs = 0;
@@ -164,7 +170,15 @@ export class NatsStreamBuffer implements StreamBuffer {
 
   async init(): Promise<void> {
     const nc = this.options.getConnection();
-    if (!nc) return; // NATS not ready — stream buffer disabled
+    if (!nc) {
+      // Expected once at startup (eager init before NATS connects); the
+      // onReady callback re-runs init after connect. If this is the LAST
+      // init log with no following "ready", live /stream stays disabled.
+      console.log(
+        "[Decopilot] StreamBuffer.init skipped: NATS not connected yet",
+      );
+      return;
+    }
     const jsm = await nc.jetstreamManager();
 
     const config = {
@@ -194,6 +208,11 @@ export class NatsStreamBuffer implements StreamBuffer {
 
     this.js = this.options.getJetStream();
     this.jsm = jsm;
+    // `getJetStream()` returns null while the connection is mid-(re)connect; a
+    // null `js` here means pump/tail will no-op until the next init.
+    console.log(
+      `[Decopilot] StreamBuffer.init ${this.js ? "ready" : "degraded (js=null)"}`,
+    );
   }
 
   pump(
@@ -203,7 +222,15 @@ export class NatsStreamBuffer implements StreamBuffer {
     orgId?: string,
   ): void {
     const js = this.js;
-    if (!js) return;
+    if (!js) {
+      // No JetStream client — every chunk for this run is silently dropped
+      // (message still persists upstream). This is the producer side of a
+      // "total stream silence, no error" report.
+      console.warn(
+        `[Decopilot] pump: JetStream client unavailable for thread ${taskId}; chunks NOT published to NATS`,
+      );
+      return;
+    }
 
     const subj = streamSubject(taskId);
     const tracker = createPublishTracker(taskId, orgId);
@@ -267,11 +294,13 @@ export class NatsStreamBuffer implements StreamBuffer {
     void (async () => {
       const reader = stream.getReader();
       let sinceYield = 0;
+      let publishedChunks = 0;
       try {
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
           publishChunk(value);
+          publishedChunks++;
           // `reader.read()` normally yields to the event loop between chunks,
           // but a producer with many buffered chunks can resolve reads
           // synchronously in a burst — starving I/O (health checks, other
@@ -290,6 +319,17 @@ export class NatsStreamBuffer implements StreamBuffer {
       } finally {
         reader.releaseLock();
         publishDone();
+        if (STREAM_TAIL_TRACE) {
+          console.warn(
+            JSON.stringify({
+              msg: "decopilot-stream-diag",
+              event: "pump-done",
+              taskId,
+              publishedChunks,
+              publishErrors: tracker.errorCount,
+            }),
+          );
+        }
       }
     })();
   }
@@ -345,7 +385,15 @@ export class NatsStreamBuffer implements StreamBuffer {
     },
   ): Promise<ReadableStream | null> {
     const js = this.js;
-    if (!js) return null;
+    if (!js) {
+      // No JetStream client — the caller (/stream → 204, or dispatchRunAndWait
+      // → silent direct-drain fallback) gets no tail. Logged here so the
+      // consumer-side blind spot isn't silent.
+      console.warn(
+        `[Decopilot] createTailStream: JetStream client unavailable for thread ${taskId}; no live tail`,
+      );
+      return null;
+    }
 
     const deliverPolicy =
       opts?.deliverPolicy === "new" ? DeliverPolicy.New : DeliverPolicy.All;

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -57,6 +57,14 @@ import { shouldPinV2FromEnv } from "./v2-canary";
 import type { HarnessId } from "@/harnesses";
 import type { Thread } from "@/storage/types";
 
+// Per-connection /stream tail diagnostics. Flip to "1" in an environment where
+// the live stream intermittently delivers no chunks — logs the resolved
+// deliverPolicy, run age, and the delivered chunk count per connection so a
+// "policy=new + 0 chunks delivered, message still persisted" case (the
+// deliverPolicy / cross-run replay race) is visible. The null-tail (204) case
+// is logged unconditionally below since it always means a degraded buffer.
+const STREAM_TAIL_TRACE = process.env.DECOPILOT_STREAM_TRACE === "1";
+
 // ============================================================================
 // Canonical serialization helper
 // ============================================================================
@@ -791,15 +799,44 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       // The buffer is purged on terminal events (run-reactor), so `"all"`
       // only ever replays the current in-flight run.
       const deliverPolicy = thread.status === "in_progress" ? "all" : "new";
+      const runStartedAgoMs = thread.run_started_at
+        ? Date.now() - new Date(thread.run_started_at).getTime()
+        : null;
       const tailChunkStream = await streamBuffer.createTailStream(
         taskId,
         c.req.raw.signal,
         { deliverPolicy },
       );
       if (!tailChunkStream) {
+        // A null tail means the JetStream buffer is degraded on this pod
+        // (client gets 204 → no live chunks). High-signal, always logged.
+        console.warn(
+          JSON.stringify({
+            msg: "decopilot-stream-diag",
+            event: "tail-unavailable-204",
+            taskId,
+            threadStatus: thread.status,
+            deliverPolicy,
+            runStartedAgoMs,
+          }),
+        );
         return c.body(null, 204);
       }
 
+      if (STREAM_TAIL_TRACE) {
+        console.warn(
+          JSON.stringify({
+            msg: "decopilot-stream-diag",
+            event: "tail-open",
+            taskId,
+            threadStatus: thread.status,
+            deliverPolicy,
+            runStartedAgoMs,
+          }),
+        );
+      }
+
+      let deliveredChunks = 0;
       const tailStream = createUIMessageStream({
         execute: async ({ writer }) => {
           const reader = tailChunkStream.getReader();
@@ -807,10 +844,24 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
             while (true) {
               const { done, value } = await reader.read();
               if (done) break;
+              deliveredChunks++;
               writer.write(value);
             }
           } finally {
             reader.releaseLock();
+            if (STREAM_TAIL_TRACE) {
+              console.warn(
+                JSON.stringify({
+                  msg: "decopilot-stream-diag",
+                  event: "tail-closed",
+                  taskId,
+                  threadStatus: thread.status,
+                  deliverPolicy,
+                  runStartedAgoMs,
+                  deliveredChunks,
+                }),
+              );
+            }
           }
         },
       });


### PR DESCRIPTION
## Why

Reports of: a decopilot run where the live `/stream` is **stuck — zero chunks arrive** — yet the assistant message **is saved**, and there are **no error logs** on client or server. On reload, the order breaks (run 1's response renders under run 2's user message, run 1 shows "No response was generated"); a second reload fixes it.

Root cause family: persistence and live streaming are **decoupled**. `consumeHarnessStream` persists the message **upstream** of the NATS `pump()`. So when the JetStream client is degraded on a pod, the run completes + persists while **nothing is published to the subject** — and every fork that handles this is **silent**:

- `NatsStreamBuffer.pump()` returns early when `this.js` is null (no log) → chunks never published.
- `NatsStreamBuffer.createTailStream()` returns `null` when `this.js` is null (no log).
- `dispatchRunAndWait` falls back to draining `uiStream` directly when `createTailStream` returns null — **never pumps to the subject** (silent).
- `/stream` returns a bare `204` on null tail (silent).

`this.js` is cached at `init()` and only refreshed via the `onReady`/reconnect path; a NATS blip (`[NatsProvider] Disconnected`, `console.log` — not `error`, easy to miss) can leave an in-flight run publishing into a void.

## What

Logging only — **no behavior change**.

- **nats-stream-buffer**: `init` logs `ready`/`degraded (js=null)`/`skipped`; `pump` and `createTailStream` `warn` when they no-op on a null JetStream client; per-run published-chunk count behind `DECOPILOT_STREAM_TRACE=1`.
- **dispatch-run**: `warn` (`producer-fallback-no-pump`) when `dispatchRunAndWait` takes the direct-drain fallback and never pumps.
- **routes `/stream`**: always log the null-tail `204` (`tail-unavailable-204`); behind `DECOPILOT_STREAM_TRACE=1` log `deliverPolicy` + run age + delivered chunk count (`tail-open`/`tail-closed`) to confirm the deliverPolicy / cross-run replay race.

All structured logs share `msg: "decopilot-stream-diag"` for grepping.

## How to use in the affected env

1. First check existing logs: `grep "NatsProvider"` for `Disconnected`/`Reconnected` near the incident.
2. `grep "decopilot-stream-diag"` — `producer-fallback-no-pump` or `pump: JetStream client unavailable` ⇒ producer published nothing; `tail-unavailable-204` ⇒ consumer pod's buffer degraded.
3. Set `DECOPILOT_STREAM_TRACE=1` to correlate `pump-done publishedChunks=N` (producer) against `tail-closed deliveredChunks=0` (consumer).

## Testing

`bun test nats-stream-buffer.test.ts` — 23 pass. `bun run check` clean on changed files (pre-existing `ct/` playwright-dep errors unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add diagnostic logging to Decopilot `/stream` to surface silent JetStream degradation where runs persist but no chunks are delivered. No behavior changes; this makes “stream stuck, message saved, no logs” debuggable.

- **New Features**
  - `nats-stream-buffer`: init logs `ready`/`degraded (js=null)`/`skipped`; warn when `pump()` or `createTailStream()` no-op due to missing JetStream; per-run publish counts behind `DECOPILOT_STREAM_TRACE=1`.
  - `dispatch-run`: warn when the direct-drain fallback is used (`producer-fallback-no-pump`).
  - `/stream` route: always log null-tail `204` (`tail-unavailable-204`); with `DECOPILOT_STREAM_TRACE=1` log `deliverPolicy`, run age, and delivered chunk counts (`tail-open`/`tail-closed`).
  - All logs share `msg: "decopilot-stream-diag"` for easy grepping.

<sup>Written for commit 1af9fe5810084f09667fead6d257afe1455b29b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

