### PR TITLE
fix(web): coerce numeric tool-inspector inputs before tools/call

### DIFF
--- a/apps/mesh/src/web/components/details/tool.tsx
+++ b/apps/mesh/src/web/components/details/tool.tsx
@@ -293,6 +293,18 @@ function ToolDetailsAuthenticated({
               } catch {
                 // Parsing failed, send as string (will likely fail validation but let server handle it)
               }
+            } else if (
+              (prop.type === "number" || prop.type === "integer") &&
+              typeof args[key] === "string" &&
+              args[key] !== ""
+            ) {
+              // Text inputs yield strings; coerce numeric fields so the tool's
+              // schema (e.g. z.number()) doesn't reject "7776000". Leave
+              // non-numeric strings untouched for the server to reject.
+              const n = Number(args[key]);
+              if (!Number.isNaN(n)) {
+                args[key] = n;
+              }
             }
           },
         );


### PR DESCRIPTION
## Summary

The tool details **inspector** (`apps/mesh/src/web/components/details/tool.tsx`) renders every primitive input field as a text `<Input>`, so `e.target.value` is always a **string**. `handleExecute` already parsed `object`/`array` fields from strings, but left `number`/`integer` fields as strings when building the `tools/call` arguments.

As a result, calling any tool with a numeric argument through the inspector failed server-side Zod validation:

```
MCP error -32602: Input validation error: expected number, received string
```

Repro: `API_KEY_CREATE` with `expiresIn: 7776000` — the UI sent `"7776000"` (string) and the call was rejected.

## Fix

During argument assembly, coerce fields whose JSON Schema `type` is `number`/`integer` via `Number()`, mirroring the existing `object`/`array` `JSON.parse` handling. Empty and non-numeric strings are left untouched so the server still reports a meaningful validation error.

## Testing

- Manually reproduced against prod: `API_KEY_CREATE` with a numeric `expiresIn` was rejected before, succeeds with the number coercion.
- `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coerces numeric inputs in the tool inspector to numbers before calling `tools/call`, so tools receive the right types. Fixes Zod validation errors for numeric args (e.g., `API_KEY_CREATE` `expiresIn`).

- **Bug Fixes**
  - Convert `number`/`integer` schema fields from non-empty strings via `Number()` during argument assembly.
  - Leave empty or non-numeric strings unchanged to preserve server-side validation messages.

<sup>Written for commit 17b0b313edb884f263ecde23288a89190d009ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

