### PR TITLE
feat(virtual-mcp): "Call from your app" chat-bridge API key + docs

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/api-reference/external-agent-integration.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/api-reference/external-agent-integration.mdx
@@ -1,0 +1,157 @@
+---
+title: Call an Agent from Your App
+description: Drive a Studio agent from an external system with a scoped API key — create a thread, run the agent, stream the response, and read the thread back
+icon: MessageCircle
+---
+
+import Callout from "../../../../../components/ui/Callout.astro";
+
+## Overview
+
+You can drive any Studio agent from an external system — a chatbot backend, a
+webhook handler, a CRON job — using a scoped **API key** over plain HTTP. The
+flow is the same one the Studio web client uses:
+
+1. **Create a thread** for the agent.
+2. **Post a message** to enqueue a run.
+3. **Stream** the agent's response in real time.
+4. **Read the full thread** back later from durable storage.
+
+No SDK is required — every step is a normal HTTP request authenticated with
+`Authorization: Bearer <api-key>`.
+
+## Create the API key
+
+The fastest way is from the agent's **Connect** dialog → **Call from your app** →
+**Create API key**. It mints a key scoped to exactly the tools this flow needs
+and shows it once.
+
+To create it programmatically, call the `API_KEY_CREATE` tool with these
+permissions:
+
+```json
+{
+  "name": "chat-bridge-my-agent",
+  "permissions": {
+    "self": [
+      "COLLECTION_THREADS_CREATE",
+      "COLLECTION_THREADS_GET",
+      "COLLECTION_THREAD_MESSAGES_LIST",
+      "COLLECTION_THREADS_LIST"
+    ]
+  },
+  "expiresIn": 7776000
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | `string` | Human-readable label |
+| `permissions` | `{ [resource]: string[] }` | `self` holds the management tools above |
+| `expiresIn` | `number` | Lifetime in **seconds** (here, 90 days). Omit for no expiry |
+
+<Callout type="warning">
+  `expiresIn` is a **number** of seconds, not a string. The key value is
+  returned only once, at creation — store it immediately.
+</Callout>
+
+The run and stream endpoints below only require that the key belongs to a
+member of the org, so no connection-scoped grant is needed. The `self`
+permissions are only what the thread read/write **tools** require.
+
+## Endpoints
+
+All paths are org-scoped, where `:org` is your organization **slug**.
+
+| Step | Method & path |
+|------|---------------|
+| Create thread | `POST /api/:org/tools/COLLECTION_THREADS_CREATE` |
+| Run agent | `POST /api/:org/decopilot/threads/:threadId/messages` |
+| Stream | `GET /api/:org/decopilot/threads/:threadId/stream` |
+| Read thread | `POST /api/:org/tools/COLLECTION_THREAD_MESSAGES_LIST` |
+| Thread status | `POST /api/:org/tools/COLLECTION_THREADS_GET` |
+
+### 1. Create a thread
+
+The `virtual_mcp_id` is the agent (Virtual MCP) id — find it in the agent's URL
+or via `COLLECTION_CONNECTIONS_LIST`.
+
+```bash
+curl -X POST "$MESH_BASE_URL/api/$MESH_ORG/tools/COLLECTION_THREADS_CREATE" \
+  -H "Authorization: Bearer $MESH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "data": { "title": "Support chat", "virtual_mcp_id": "'"$MESH_AGENT_ID"'" } }'
+# → { "item": { "id": "thrd_...", "status": "...", ... } }
+```
+
+Use the returned `item.id` as `:threadId` for the next steps. (You may also
+supply your own `data.id`.)
+
+### 2. Run the agent
+
+This enqueues a run and returns `202` immediately — the body carries no output.
+
+```bash
+curl -X POST "$MESH_BASE_URL/api/$MESH_ORG/decopilot/threads/$THREAD_ID/messages" \
+  -H "Authorization: Bearer $MESH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{ "role": "user", "parts": [{ "type": "text", "text": "Hello!" }] }],
+    "agent": { "id": "'"$MESH_AGENT_ID"'" },
+    "tier": "smart"
+  }'
+# → 202 { "taskId": "thrd_..." }
+```
+
+<Callout type="info">
+  The request body is validated strictly — send only `messages`, `agent`, and
+  optional `tier` / `temperature`. Exactly one non-system message is allowed per
+  call. The thread id lives in the URL; don't also put a mismatched `thread_id`
+  in the body.
+</Callout>
+
+### 3. Stream the response
+
+The agent output is a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+stream (AI SDK UI-message chunks), backed by NATS JetStream server-side.
+
+```bash
+curl -N "$MESH_BASE_URL/api/$MESH_ORG/decopilot/threads/$THREAD_ID/stream" \
+  -H "Authorization: Bearer $MESH_API_KEY" \
+  -H "Accept: text/event-stream"
+```
+
+<Callout type="tip">
+  Open the stream **before** posting the message so you don't miss early chunks.
+  The browser's native `EventSource` cannot send an `Authorization` header — use
+  `fetch()` and read the response body as a stream instead.
+</Callout>
+
+<Callout type="warning">
+  The stream is an ephemeral live buffer (~5 minutes retention), not the system
+  of record. For the durable transcript, read the thread (step 4).
+</Callout>
+
+### 4. Read the thread back
+
+The authoritative, durable transcript is available any time:
+
+```bash
+curl -X POST "$MESH_BASE_URL/api/$MESH_ORG/tools/COLLECTION_THREAD_MESSAGES_LIST" \
+  -H "Authorization: Bearer $MESH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "thread_id": "'"$THREAD_ID"'", "limit": 200 }'
+```
+
+Poll run progress with `COLLECTION_THREADS_GET` (`{ "id": "<threadId>" }`) and
+watch `status` move from `in_progress` to `completed` or `failed`.
+
+## Scoping & security
+
+- A key is bound to a single organization (embedded at creation). The `:org` in
+  the path must match that org's slug.
+- The `self` thread permissions gate the read/write **tools**, but the run and
+  stream endpoints authorize on org membership alone — so any valid org key can
+  drive agents. Treat these keys like any production credential: name them per
+  integration, set an expiry, and rotate by deleting (`API_KEY_DELETE`) and
+  re-creating.

--- a/apps/docs/client/src/utils/navigation.ts
+++ b/apps/docs/client/src/utils/navigation.ts
@@ -65,6 +65,7 @@ export async function getNavigationLinks(
 
     // 9. API Reference
     "studio/api-reference/connection-proxy",
+    "studio/api-reference/external-agent-integration",
     "studio/api-reference/built-in-tools",
     "studio/api-reference/built-in-tools/tool-search",
     "studio/api-reference/built-in-tools/tool-enable",

--- a/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
@@ -359,6 +359,153 @@ function TypegenSection({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
 }
 
 /**
+ * Permissions for an "agent chat bridge" API key: enough to create a thread,
+ * run this agent, and read the thread back from an external app. The run and
+ * stream endpoints only require org membership, so no connection-scoped grant
+ * is needed — just the thread tools on `self`.
+ */
+const CHAT_BRIDGE_PERMISSIONS: Record<string, string[]> = {
+  self: [
+    "COLLECTION_THREADS_CREATE",
+    "COLLECTION_THREADS_GET",
+    "COLLECTION_THREAD_MESSAGES_LIST",
+    "COLLECTION_THREADS_LIST",
+  ],
+};
+const CHAT_BRIDGE_EXPIRES_IN = 60 * 60 * 24 * 90; // 90 days
+
+/**
+ * Chat bridge section — mints a scoped API key for driving this agent from an
+ * external system (create thread → POST messages → stream → read thread back).
+ */
+function ChatBridgeSectionInner({
+  virtualMcp,
+}: {
+  virtualMcp: VirtualMCPEntity;
+}) {
+  const studio = useStudioTools();
+  const { org } = useProjectContext();
+  const [apiKey, setApiKey] = useState<string | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const mcpId = virtualMcp.id;
+  const agentName = virtualMcp.title || `agent-${mcpId.slice(0, 8)}`;
+  const baseUrl = window.location.origin;
+
+  const envBlock = [
+    `MESH_BASE_URL=${baseUrl}`,
+    `MESH_ORG=${org.slug}`,
+    `MESH_AGENT_ID=${mcpId}`,
+    `MESH_API_KEY=${apiKey ?? "<api-key>"}`,
+  ].join("\n");
+
+  const handleGenerateKey = async () => {
+    setGenerating(true);
+    try {
+      const { key } = await studio.call("API_KEY_CREATE", {
+        name: `chat-bridge-${agentName}`,
+        permissions: CHAT_BRIDGE_PERMISSIONS,
+        expiresIn: CHAT_BRIDGE_EXPIRES_IN,
+      });
+      if (!key) throw new Error("No key in response");
+      setApiKey(key);
+      track("agent_chat_bridge_key_generated", { agent_id: mcpId });
+    } catch {
+      track("agent_chat_bridge_key_failed", { agent_id: mcpId });
+      toast.error("Failed to create API key");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    track("agent_connect_action", {
+      agent_id: mcpId,
+      action: "chat_bridge_copy_env",
+      has_api_key: Boolean(apiKey),
+    });
+    await navigator.clipboard.writeText(envBlock);
+    setCopied(true);
+    toast.success("Connection details copied to clipboard");
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-0.5">
+          <h4 className="text-sm font-medium text-foreground">
+            Call from your app
+          </h4>
+          <p className="text-xs text-muted-foreground">
+            Create a scoped API key to start a thread, run this agent, and
+            stream results from an external system (e.g. a chatbot webhook).
+          </p>
+        </div>
+        {!apiKey && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0 gap-1.5"
+            onClick={handleGenerateKey}
+            disabled={generating}
+          >
+            {generating ? (
+              <Loading01 size={14} className="animate-spin" />
+            ) : (
+              <Key01 size={14} />
+            )}
+            <span>{generating ? "Creating…" : "Create API key"}</span>
+          </Button>
+        )}
+      </div>
+
+      {apiKey && (
+        <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+          Store this key securely — it won't be shown again.
+        </p>
+      )}
+
+      <p className="text-xs font-medium text-muted-foreground">
+        Connection details
+      </p>
+      <div className="rounded-md border border-input bg-muted/50 px-3 py-2.5">
+        <div className="flex items-start gap-2">
+          <code className="min-w-0 flex-1 whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">
+            {envBlock}
+          </code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-6 shrink-0"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <Check size={12} className="text-green-600" />
+            ) : (
+              <Copy01 size={12} />
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChatBridgeSection({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
+  return (
+    <Suspense
+      fallback={<div className="h-20 animate-pulse rounded-md bg-muted" />}
+    >
+      <ChatBridgeSectionInner virtualMcp={virtualMcp} />
+    </Suspense>
+  );
+}
+
+/**
  * Share Modal - Virtual MCP sharing and IDE integration
  */
 export function VirtualMCPShareModal({
@@ -406,6 +553,11 @@ export function VirtualMCPShareModal({
 
       {/* Typegen */}
       <TypegenSection virtualMcp={virtualMcp} />
+
+      <div className="border-t border-border" />
+
+      {/* Chat bridge — scoped key for external integrations */}
+      <ChatBridgeSection virtualMcp={virtualMcp} />
     </div>
   );
 


### PR DESCRIPTION
Follow-up to #3952 (the numeric tool-inspector fix, already merged). This adds the external-integration feature + docs.

## feat: "Call from your app" in the agent Connect modal
`apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx`

Adds a section to the agent **Connect** dialog that mints a **scoped API key** for driving the agent from an external system (chatbot backend, webhook, CRON), reusing the existing `useStudioTools().call("API_KEY_CREATE", …)` + reveal/copy pattern. The key is scoped to the thread tools on `self`:

- `COLLECTION_THREADS_CREATE`, `COLLECTION_THREADS_GET`, `COLLECTION_THREAD_MESSAGES_LIST`, `COLLECTION_THREADS_LIST`
- 90-day expiry; shown once with a copyable `MESH_BASE_URL` / `MESH_ORG` / `MESH_AGENT_ID` / `MESH_API_KEY` block.

The run + stream endpoints authorize on org membership, so no connection-scoped grant is needed — only the thread tools require `self` permissions.

## docs: external agent integration API
New page `studio/api-reference/external-agent-integration` documenting the end-to-end flow (create thread → post message → stream → read thread back): key permissions, endpoints, the SSE / `EventSource`-can't-send-Bearer caveat, the ~5-min stream-buffer-vs-durable-store distinction, and scoping/security notes. Wired into the docs nav after `connection-proxy`.

## Testing
- `bun run fmt`, `bun run check` (all workspaces, incl. docs content sync), `bun run lint` (0 errors) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “Call from your app” to the agent Connect modal to mint a scoped API key for external control of an agent. Also adds an API reference page that documents the full HTTP flow (create thread → run → stream → read).

- **New Features**
  - New Connect modal section that creates a 90‑day scoped key via `API_KEY_CREATE`, shown once with a copyable block: `MESH_BASE_URL`, `MESH_ORG`, `MESH_AGENT_ID`, `MESH_API_KEY`.
  - Key is limited to `self` thread tools: `COLLECTION_THREADS_CREATE`, `COLLECTION_THREADS_GET`, `COLLECTION_THREAD_MESSAGES_LIST`, `COLLECTION_THREADS_LIST`. Run/stream endpoints authorize by org membership only.
  - New API reference page “Call an Agent from Your App” with examples for create thread, post message, SSE streaming, and reading the durable thread; includes EventSource header caveat and security/scoping notes. Linked in docs nav.

<sup>Written for commit 08a672c69c9a99b576c4a0f71805698e88fb7211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

