### PR TITLE
fix(decopilot): stop eager `ls org/` exploration on greetings

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -8,20 +8,29 @@ export { generateMessageId } from "@decocms/harness/decopilot/harness-constants"
 /**
  * Teaches the org filesystem layout, including the deployment's actual public
  * skill sets so the agent surfaces them when asked about its capabilities.
- * Settings-stable per deployment, so it lives in the cached prompt prefix.
+ * Stable per org (slug + deployment settings), so it stays in the cached
+ * prompt prefix across that org's runs.
  *
  * Portable pure function kept mesh-side (consumed by the cluster
- * `build-agent-system-prompt` with `getPublicSets()`). org-fs is mounted
- * into every sandbox now, so it is emitted unconditionally.
+ * `build-agent-system-prompt` with `getPublicSets()` and the org slug). org-fs
+ * is mounted into every sandbox now, so it is emitted unconditionally.
  */
-export function buildOrgFilesystemPrompt(publicSets: string[]): string {
+export function buildOrgFilesystemPrompt(
+  publicSets: string[],
+  orgSlug?: string,
+): string {
   const sets =
     publicSets.length > 0
       ? `Available sets: ${publicSets.join(", ")}.`
       : "No sets are configured on this deployment.";
+  // Name the home folder directly so the agent never runs `ls org/` just to
+  // learn its own slug — that discovery step was firing even on bare greetings.
+  const home = orgSlug
+    ? `\`org/${orgSlug}/\``
+    : "the folder named after your organization (its slug is the single entry under `org/`)";
   return `<organization-filesystem>
 The organization filesystem is mounted at \`org/\` in your sandbox (when available):
-- the folder named after your organization (its slug — run \`ls org/\` to see it) — the org's shared home folder, editable and shared across every agent, member, and run. Organize it freely with subfolders. Check it for relevant context before starting non-trivial work, and record durable knowledge as you learn it: decisions, preferences, project facts, gotchas. Prefer small focused markdown files over one big log, and update stale notes instead of appending duplicates.
+- ${home} — the org's shared home folder, editable and shared across every agent, member, and run. Organize it freely with subfolders. Consult it only when a task needs background you don't already have (past decisions, preferences, project facts, gotchas) — then read it first. Do NOT browse it in response to greetings, small talk, or questions you can answer directly. Record durable knowledge here as you learn it; prefer small focused markdown files over one big log, and update stale notes instead of appending duplicates.
 - \`org/public/<set>/\` — curated read-only skill sets. ${sets} Each skill is a folder with a SKILL.md — read it before applying the skill.
 - \`org/upload/\` — files the user attached to this conversation are already here; read them directly (no copy step needed).
 - \`org/output/\` — write final deliverables here; they are shared back to the organization under this run's folder.

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -135,8 +135,16 @@ export async function buildAgentSystemPrompt(
 
   // Org filesystem layout + the deployment's public skill sets. org-fs is
   // mounted into every sandbox now (desktop + cluster), so this is
-  // unconditional. Settings-stable, so still cache-safe.
-  add("orgFs", buildOrgFilesystemPrompt(getPublicSets().map((s) => s.set)));
+  // unconditional. Passing the slug lets the prompt name `org/<slug>/`
+  // directly instead of telling the agent to `ls org/` to discover it.
+  // Stable per org, so still cache-safe.
+  add(
+    "orgFs",
+    buildOrgFilesystemPrompt(
+      getPublicSets().map((s) => s.set),
+      opts.organization.slug,
+    ),
+  );
 
   if (opts.kind === "agent") {
     if (opts.isDecopilot) {


### PR DESCRIPTION
## What is this contribution about?
The org-filesystem system prompt told the agent to `run ls org/` to discover its org slug and to "check it for relevant context before starting non-trivial work", so the agent explored the org filesystem even when the user just said "oi". This injects the org slug into the prompt so it names `org/<slug>/` directly (no discovery `ls` needed), reframes consultation as need-triggered instead of a start-of-conversation ritual, and adds an explicit carve-out against browsing on greetings, small talk, or questions answerable directly. The block stays in the cached prompt prefix since it's stable per org.

## Screenshots/Demonstration
N/A — prompt-only change, no UI.

## How to Test
1. Start a fresh agent thread and send a bare greeting (e.g. "oi").
2. Confirm the agent replies conversationally and does **not** run `ls org/` or otherwise browse the filesystem.
3. Then ask something that needs org context and confirm it reads `org/<slug>/` as expected.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Decopilot from eagerly running `ls org/` on greetings by naming `org/<slug>/` directly in the system prompt and making org filesystem consultation on-demand.

- **Bug Fixes**
  - Injects the org slug into the prompt so it references `org/<slug>/` without discovery.
  - Removes the “run `ls org/`” instruction and reframes guidance to consult org files only when needed.
  - Adds an explicit carve-out to not browse on greetings, small talk, or directly answerable questions.
  - Keeps the prompt block cached per org for stability.

<sup>Written for commit deb45ed0427102fd4084de61c48a85bb8b5ebb13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

