### PR TITLE
fix(chat): preserve created_at so stream replay can't reorder messages on reconnect

### DIFF
--- a/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
@@ -6,6 +6,7 @@ import {
   mergeAndSort,
   type RequestOptions,
   type ThreadObserver,
+  upsertById,
 } from "./thread-connection";
 import type { UIMessage } from "ai";
 
@@ -647,6 +648,20 @@ describe("mergeAndSort", () => {
     expect(mergeAndSort(prev, incoming).map((m) => m.id)).toEqual(["a", "opt"]);
   });
 
+  test("timestamp-less incoming does NOT strip an existing created_at (replay)", () => {
+    // deliverPolicy:"all" reconnect replays turn-1's assistant as a streamed
+    // (timestamp-less) UIMessage over the DB-seeded row. Without preservation
+    // it loses created_at → sorts to the end → renders under turn-2's user.
+    const prev = [
+      msg("u1", "2026-01-01T00:00:00Z", "user"),
+      msg("a1", "2026-01-01T00:00:01Z", "assistant"),
+      msg("u2", "2026-01-01T00:00:02Z", "user"),
+    ];
+    const replayedA1 = msg("a1", undefined, "assistant");
+    const out = mergeAndSort(prev, [replayedA1]);
+    expect(out.map((m) => m.id)).toEqual(["u1", "a1", "u2"]);
+  });
+
   test("stable id tiebreaker when two rows share a timestamp", () => {
     const incoming = [
       msg("z", "2026-01-01T00:00:00Z"),
@@ -780,6 +795,47 @@ describe("mergeAndSort", () => {
 });
 
 // ─── async-research stub dedup ───────────────────────────────────────────────
+
+describe("upsertById", () => {
+  function msg(
+    id: string,
+    createdAt: string | undefined,
+    role: "user" | "assistant" = "assistant",
+  ): UIMessage {
+    return {
+      id,
+      role,
+      parts: [{ type: "text", text: id }],
+      ...(createdAt !== undefined ? { created_at: createdAt } : {}),
+      // biome-ignore lint/suspicious/noExplicitAny: test helper
+    } as any;
+  }
+
+  test("appends when id is absent", () => {
+    const out = upsertById([msg("a", "t0")], msg("b", "t1"));
+    expect(out.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+
+  test("replaces in place and keeps the prior created_at when incoming lacks one", () => {
+    const prev = [msg("a", "2026-01-01T00:00:01Z")];
+    const streamed = msg("a", undefined);
+    const out = upsertById(prev, streamed);
+    expect(out).toHaveLength(1);
+    expect((out[0] as { created_at?: unknown }).created_at).toBe(
+      "2026-01-01T00:00:01Z",
+    );
+    // fresher parts from the streamed copy are still applied
+    expect(out[0]?.parts).toEqual(streamed.parts);
+  });
+
+  test("incoming created_at overwrites when present (persisted update)", () => {
+    const prev = [msg("a", "2026-01-01T00:00:01Z")];
+    const out = upsertById(prev, msg("a", "2026-01-01T00:00:09Z"));
+    expect((out[0] as { created_at?: unknown }).created_at).toBe(
+      "2026-01-01T00:00:09Z",
+    );
+  });
+});
 
 describe("dropRedundantStubs", () => {
   // biome-ignore lint/suspicious/noExplicitAny: test helper

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -941,11 +941,34 @@ export class ThreadConnection {
   }
 }
 
-function upsertById(list: UIMessage[], msg: UIMessage): UIMessage[] {
+/**
+ * Keep the prior row's authoritative `created_at` when its replacement lacks
+ * one. A `deliverPolicy: "all"` replay on reconnect re-delivers an
+ * already-persisted run as timestamp-less streamed UIMessages; upserting one
+ * over its DB-seeded row would otherwise strip the `created_at`, so
+ * `readTimestamp` returns +Infinity and the message jumps to the end of the
+ * sort — it renders under the NEXT turn's user message and leaves its own slot
+ * empty ("No response was generated"). Only fills a missing timestamp; a
+ * genuine persisted update (incoming has `created_at`) overwrites as before.
+ */
+function preserveCreatedAt(
+  prev: UIMessage | undefined,
+  next: UIMessage,
+): UIMessage {
+  if (!prev) return next;
+  const prevTs = (prev as { created_at?: unknown }).created_at;
+  const nextTs = (next as { created_at?: unknown }).created_at;
+  if (nextTs == null && prevTs != null) {
+    return { ...next, created_at: prevTs } as UIMessage;
+  }
+  return next;
+}
+
+export function upsertById(list: UIMessage[], msg: UIMessage): UIMessage[] {
   const idx = list.findIndex((m) => m.id === msg.id);
   if (idx === -1) return [...list, msg];
   const next = [...list];
-  next[idx] = msg;
+  next[idx] = preserveCreatedAt(next[idx], msg);
   return next;
 }
 
@@ -1030,7 +1053,8 @@ export function mergeAndSort(
   incoming: UIMessage[],
 ): UIMessage[] {
   const byId = new Map(prev.map((m) => [m.id, m] as const));
-  for (const m of incoming) byId.set(m.id, m);
+  for (const m of incoming)
+    byId.set(m.id, preserveCreatedAt(byId.get(m.id), m));
   const merged = [...byId.values()];
   merged.sort((a, b) => {
     const ta = readTimestamp(a);


### PR DESCRIPTION
Follow-up fix to #3951 (the diagnostics, now merged). The `decopilot-stream-diag` logs from #3951 confirmed the publish path is **healthy** (35/35 chunks delivered, 0 errors) — the bug is client-side ordering.

## Symptom

Reload mid-run → turn-1's assistant response renders **under turn-2's user message**; turn-1's own slot shows "No response was generated". A second reload fixes it.

## Cause

On reload mid-run the client reconnects, the thread is `in_progress`, so `/stream` uses `deliverPolicy: "all"` and **replays the whole per-thread subject** (an already-persisted run + the next one) as timestamp-less streamed `UIMessage`s. `upsertById` then lets a replayed (timestamp-less) message overwrite its DB-seeded row, which carried the authoritative top-level `created_at`. The timestamp is **stripped** → `readTimestamp` returns `+Infinity` → the message sorts to the **end** → renders under the next turn's user message, original slot empty. A refresh fixes it only because, with no active run, the reconnect uses `deliverPolicy: "new"` and replays nothing.

## Fix

`thread-connection.ts` — `preserveCreatedAt`: when an upsert/merge replacement lacks `created_at` but the prior row has one, keep it. A genuine persisted update (incoming has `created_at`) still overwrites. Applied in `upsertById` (stream commit path) and `mergeAndSort` (defensive). Exported `upsertById`; added 3 unit tests.

## Testing

`bun test thread-connection.test.ts` — 45 pass (+3). `bun run check` clean on changed files; `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves created_at on upsert/merge so replayed stream chunks don’t reorder messages after a reconnect. Fix prevents assistant replies from appearing under the next user turn and avoids the “No response was generated” placeholder.

- **Bug Fixes**
  - Keep the prior row’s created_at when the incoming message has none (replay on reconnect); applied in upsertById and mergeAndSort, while persisted updates still overwrite.
  - Export upsertById and add 3 unit tests (append, preserve, overwrite).

<sup>Written for commit 0b0ee521487930ef2f7b5f73ace1de3762a38720. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

