### PR TITLE
feat(chat): waiting UX for slow/silent turns + tighter SSE keepalive

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/sse-keepalive.ts
+++ b/apps/mesh/src/api/routes/decopilot/sse-keepalive.ts
@@ -36,7 +36,14 @@
 
 const KEEPALIVE_BYTES = new TextEncoder().encode(": keepalive\n\n");
 const LF = 0x0a;
-const DEFAULT_INTERVAL_MS = 15_000;
+// 10s, not 15s. The tightest proxy idle timeout in the path is Istio's 15s
+// (see below); a 15s heartbeat lands ON that boundary, so a silent model gap
+// (slow time-to-first-token, between-step pauses — worse with proxied/liteLLM
+// providers but provider-agnostic) can race-lose and get the socket cut
+// mid-run. The client reconnects and the JetStream tail replays the whole
+// in-flight run as one burst — the "frozen then everything at once" symptom.
+// 10s keeps a ~5s margin so a silent turn survives without a reconnect.
+const DEFAULT_INTERVAL_MS = 10_000;
 
 /**
  * Wrap an SSE response body with periodic keepalive comments.

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -42,6 +42,7 @@ import { useOptionalChatStream, useOptionalChatTask } from "../context.tsx";
 import { LiveTimer } from "../../live-timer.tsx";
 import { GridLoader } from "../../grid-loader.tsx";
 import { formatDuration, toEpochMs } from "../../../lib/format-time.ts";
+import { useClockTick } from "../../../lib/use-clock-tick.ts";
 
 type ThinkingStage = "planning" | "thinking";
 
@@ -106,6 +107,51 @@ function GeneratingFooter({ startedAt }: { startedAt: number }) {
     <div className="flex items-center gap-2.5 mt-1 pb-1 text-muted-foreground/40 select-none">
       <GridLoader />
       <LiveTimer since={startedAt} />
+    </div>
+  );
+}
+
+// After this long with no streamed content, the turn looks frozen even though
+// the model may just be slow to first token (common with proxied/liteLLM
+// providers). Surface the elapsed time + a cancel escape hatch rather than a
+// silent "Thinking…".
+const SLOW_AFTER_MS = 20_000;
+
+/**
+ * Waiting state for a turn that has produced no parts yet. Pairs the
+ * `TypingIndicator` with a live elapsed clock and, once the wait crosses
+ * `SLOW_AFTER_MS`, a "taking longer than usual" hint + Cancel. `useClockTick`
+ * (singleton interval via useSyncExternalStore — no useEffect) re-renders this
+ * once per second so the threshold flips without a per-component timer.
+ */
+function ThinkingState({ startedAt }: { startedAt: number | null }) {
+  useClockTick(1000);
+  const stream = useOptionalChatStream();
+  const elapsedMs = startedAt !== null ? Date.now() - startedAt : 0;
+  const isSlow = elapsedMs >= SLOW_AFTER_MS;
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="flex items-center gap-2">
+        <TypingIndicator />
+        {startedAt !== null && (
+          <span className="opacity-60">
+            <LiveTimer since={startedAt} />
+          </span>
+        )}
+      </div>
+      {isSlow && stream?.stop && (
+        <div className="flex items-center gap-2 pb-1 text-[13px] text-muted-foreground/60">
+          <span>This is taking longer than usual.</span>
+          <button
+            type="button"
+            onClick={() => stream.stop()}
+            className="text-muted-foreground hover:text-foreground underline underline-offset-2"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -790,7 +836,7 @@ export function MessageAssistant({
           )}
         </div>
       ) : isLoading ? (
-        <TypingIndicator />
+        <ThinkingState startedAt={startedAt} />
       ) : (
         <EmptyAssistantState isRunInProgress={isLast && isRunInProgress} />
       )}


### PR DESCRIPTION
UX follow-ups to the decopilot stream investigation (#3951 diagnostics, #3956 reorder fix). Targets the "thinking forever, then everything at once" report — which, per testing, happens with **any** model (just more often with proxied/liteLLM providers), so the cause is not model-specific buffering.

## #1 — Waiting state for slow/silent turns

The pre-first-chunk window rendered only a silent `Thinking…`. New `ThinkingState`:
- live **elapsed clock** next to the typing indicator,
- after **20s**, a "taking longer than usual" hint + **Cancel** (wired to the existing `stop()` → `/cancel/:taskId`).

Uses `useClockTick` (singleton `useSyncExternalStore` interval) so the slow-threshold flips **without** `useEffect` (per the repo's banned-hooks rules).

## #4 — SSE keepalive 15s → 10s

The tightest proxy idle timeout in the path is **Istio's 15s**. A 15s heartbeat lands *on* that boundary, so a silent model gap (slow time-to-first-token / between-step pauses — provider-agnostic, worse with liteLLM) can race-lose and get the socket **cut mid-run**. The client reconnects and the JetStream tail replays the whole in-flight run as **one burst** — exactly the "frozen then everything at once" symptom, and it explains why it's model-agnostic. 10s keeps a ~5s margin so a silent turn survives without a reconnect.

## #2 — Reasoning + tool steps: already surfaced (no code)

Verified during the investigation: reasoning renders via `ThoughtSummary` ("Thinking…" while streaming) and tool calls via the per-tool part components, as soon as parts stream. The only blank window is pre-first-part — which #1 now fills. No redundant rendering added.

## Testing

`tsc` + `oxlint` clean on changed files; `sse-keepalive.test.ts` passes (6). UI change is render-only in the empty-loading branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves chat streaming by adding a clear waiting state for slow/silent turns and tightens SSE keepalive to avoid disconnects that cause “frozen then all at once” responses.

- **New Features**
  - Added a pre-first-chunk waiting UI with a live elapsed timer and a Cancel option after 20s.
  - Uses a shared clock tick to update the timer without per-component intervals.

- **Bug Fixes**
  - Reduced SSE keepalive from 15s to 10s to stay under Istio’s 15s idle timeout, preventing mid-run disconnects and burst replays.

<sup>Written for commit c8c7e8d744e9ad77919e0d837690a097d6cacb5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

