### PR TITLE
fix(chat): surface image-generation errors and make failed runs expandable

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
@@ -10,6 +10,7 @@ import type { ToolUIPart } from "ai";
 import { useOrg } from "@decocms/mesh-sdk";
 import { ToolCallShell } from "./common.tsx";
 import { getEffectiveState } from "./utils.tsx";
+import { getToolPartErrorText, safeStringifyFormatted } from "../utils.ts";
 import { ImageLightbox } from "../../../image-lightbox.tsx";
 import type { UsageStats } from "@/web/lib/usage-utils.ts";
 import { formatDuration } from "@/web/lib/format-time.ts";
@@ -120,6 +121,19 @@ export function GenerateImagePart({ part, latency }: GenerateImagePartProps) {
   }
 
   if (state === "error" || !images || images.length === 0) {
+    const errorText =
+      state === "error" ? getToolPartErrorText(part) : undefined;
+    let detail = "";
+    if (input !== undefined) {
+      detail += "# Input\n" + safeStringifyFormatted(input);
+    }
+    if (errorText) {
+      if (detail) detail += "\n\n";
+      detail += "# Error\n" + errorText;
+    } else if (result !== undefined) {
+      if (detail) detail += "\n\n";
+      detail += "# Output\n" + safeStringifyFormatted(result);
+    }
     return (
       <ToolCallShell
         icon={<Image01 size={14} />}
@@ -128,6 +142,7 @@ export function GenerateImagePart({ part, latency }: GenerateImagePartProps) {
         state={state === "error" ? "error" : "idle"}
         usage={usage}
         trailing={latencyLabel}
+        detail={detail || null}
       />
     );
   }

--- a/apps/mesh/src/web/components/chat/message/parts/utils.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/utils.ts
@@ -29,6 +29,17 @@ export function safeStringify(value: unknown): string {
   }
 }
 
+/** Like {@link safeStringify} but pretty-printed (2-space indent) for expandable detail panels. */
+export function safeStringifyFormatted(value: unknown): string {
+  const str = safeStringify(value);
+  if (str === "" || str === "[Non-serializable value]") return str;
+  try {
+    return JSON.stringify(JSON.parse(str), null, 2);
+  } catch {
+    return str;
+  }
+}
+
 const isToolLike = (
   p: UIMessagePart<UIDataTypes, UITools>,
 ): p is DynamicToolUIPart | ToolUIPart => {


### PR DESCRIPTION
## Problem

Two issues with how image-generation tool calls render in the decopilot chat:

1. **Errors aren't surfaced.** When `generate_image` fails, the renderer showed only a `Failed` badge — the actual `errorText` (which the server already sanitizes and forwards via `sanitizeStreamError`) was never displayed.
2. **No way to inspect a non-image result.** The success path makes generated images clickable (lightbox), but the failed / "no images generated" branch passed neither `detail` nor `children` to `ToolCallShell`, so `isExpandable` was `false`. There was no way to click to expand and see the input/output.

<img width="400" alt="Image generation Failed with no detail" src="https://github.com/user-attachments/assets/placeholder" />

## Fix

In `GenerateImagePart`'s error / no-images branch, build an expandable `detail` string (`# Input`, then `# Error` or `# Output`) — the same shape the generic tool-call renderer uses — and pass it to `ToolCallShell`. The failed row now expands to show the prompt/input and the real error message.

Extracts the existing `safeStringifyFormatted` JSON pretty-printer into the shared `parts/utils.ts` so both renderers can use it.

## Testing notes

- `bun run check` — no errors in the changed files.
- `bun run fmt` — clean.
- Affected area: decopilot chat → assistant message → image-generation tool calls (failed / empty results). Success path (rendered images + lightbox) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface real error messages for image-generation tool calls and make failed/no-image runs expandable in the decopilot chat. Improves debuggability without changing the success path.

- **Bug Fixes**
  - In `GenerateImagePart`, compose a `detail` panel with “# Input” and “# Error” or “# Output”, then pass it to `ToolCallShell` so failed rows expand and show the sanitized `errorText`.
  - Successful image renders (with lightbox) are unchanged.

- **Refactors**
  - Extracted `safeStringifyFormatted` to `parts/utils.ts` for shared, pretty-printed JSON in expandable detail panels.

<sup>Written for commit 6b0a8dd4455e7d33ef5b616f4774f3e7eb28af21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

