### PR TITLE
fix(decopilot): retry on free model when OpenRouter hits a credit (402) error

### DIFF
--- a/packages/harness/src/decopilot/mesh-provider.ts
+++ b/packages/harness/src/decopilot/mesh-provider.ts
@@ -9,8 +9,11 @@
  * tsc stack overflow that cluster types induce.
  */
 
+import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { ProviderV3 } from "@ai-sdk/provider";
+import { wrapLanguageModel, type LanguageModelMiddleware } from "ai";
 import type { ModelCapability, ProviderId } from "@decocms/mesh-sdk";
+import { isCreditError } from "./stream-error";
 
 export interface ProviderInfo {
   id: ProviderId;
@@ -98,19 +101,53 @@ interface LanguageModelSelection {
 }
 
 const FREE_FALLBACK_MODEL = "openrouter/free";
-const OPENROUTER_FAMILY = new Set(["openrouter", "deco"]);
+
+/**
+ * Re-issues the SAME call against `free` on an account-level credit rejection
+ * (402) from `primary`, before any chunk is produced. This is the gap the
+ * in-request `models` array can't cover: a 402 terminates the whole request
+ * before model routing, so the array never reaches the free model. If the free
+ * retry also fails, the original error propagates. Only fires for the
+ * 402-at-request-start path (rejected `doStream`/`doGenerate`); mid-stream
+ * errors aren't credit errors.
+ */
+function withCreditFallback(
+  primary: LanguageModelV3,
+  free: LanguageModelV3,
+): LanguageModelV3 {
+  const middleware: LanguageModelMiddleware = {
+    specificationVersion: "v3",
+    wrapStream: async ({ doStream, params }) => {
+      try {
+        return await doStream();
+      } catch (err) {
+        if (!isCreditError(err)) throw err;
+        return free.doStream(params);
+      }
+    },
+    wrapGenerate: async ({ doGenerate, params }) => {
+      try {
+        return await doGenerate();
+      } catch (err) {
+        if (!isCreditError(err)) throw err;
+        return free.doGenerate(params);
+      }
+    },
+  };
+  return wrapLanguageModel({ model: primary, middleware });
+}
 
 /**
  * Creates a language model from the provider.
  *
  * - Enables reasoning when the model advertises the "reasoning" capability
  *   (e.g. OpenRouter thinking models).
- * - For OpenRouter-family providers, attaches a native model-fallback list
- *   (`models: [primary, openrouter/free]`). When the primary fails for ANY
- *   reason — rate-limit, downtime, context-length, or a budget/credit
- *   rejection — OpenRouter retries on the free model instead of surfacing a
- *   hard error to the user. The response's `model` field reports whichever
- *   model actually served the request.
+ * - For the raw OpenRouter provider, attaches a native model-fallback list
+ *   (`models: [primary, openrouter/free]`) for transient model failures
+ *   (provider down / rate-limit / moderation) handled at OpenRouter's edge,
+ *   AND wraps the model with `withCreditFallback` for account-level 402s the
+ *   array can't reach. Excluded for the deco AI gateway, which gates even free
+ *   models on the org credit balance, so a free fallback can't succeed there.
  */
 export function createLanguageModel(
   provider: LanguageModelProvider,
@@ -121,21 +158,24 @@ export function createLanguageModel(
   if (model.capabilities?.reasoning !== false) {
     settings.reasoning = { enabled: true, effort: "medium" };
   }
-  if (
-    provider.info &&
-    OPENROUTER_FAMILY.has(provider.info.id) &&
-    model.id !== FREE_FALLBACK_MODEL
-  ) {
+  const useFreeFallback =
+    provider.info?.id === "openrouter" && model.id !== FREE_FALLBACK_MODEL;
+  if (useFreeFallback) {
     settings.models = [model.id, FREE_FALLBACK_MODEL];
-  }
-
-  if (Object.keys(settings).length === 0) {
-    return provider.aiSdk.languageModel(model.id);
   }
 
   // Provider-specific settings (reasoning / models fallback) are not part of
   // the generic ProviderV3 interface, so we cast to pass them through.
-  // biome-ignore lint/complexity/noBannedTypes: pass-through provider settings
-  const lm = (provider.aiSdk.languageModel as Function)(model.id, settings);
-  return lm as ReturnType<typeof provider.aiSdk.languageModel>;
+  const make = (id: string, s?: Record<string, unknown>): LanguageModelV3 =>
+    (s && Object.keys(s).length > 0
+      ? // biome-ignore lint/complexity/noBannedTypes: pass-through provider settings
+        (provider.aiSdk.languageModel as Function)(id, s)
+      : provider.aiSdk.languageModel(id)) as LanguageModelV3;
+
+  const primary = make(model.id, settings);
+  if (!useFreeFallback) return primary;
+
+  // Free model is plain (no reasoning, no nested models array) so the retry is
+  // a clean single-model call.
+  return withCreditFallback(primary, make(FREE_FALLBACK_MODEL));
 }

--- a/packages/harness/src/decopilot/stream-error.test.ts
+++ b/packages/harness/src/decopilot/stream-error.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { classifyStreamError, sanitizeStreamError } from "./stream-error";
+import {
+  classifyStreamError,
+  isCreditError,
+  sanitizeStreamError,
+} from "./stream-error";
 
 describe("sanitizeStreamError", () => {
   it("strips provider URLs and branding from Error messages", () => {
@@ -33,6 +37,31 @@ describe("sanitizeStreamError", () => {
 
   it("falls back to JSON for opaque objects without a message", () => {
     expect(sanitizeStreamError({ foo: "bar" })).toContain("foo");
+  });
+});
+
+describe("isCreditError", () => {
+  it("matches a 402 statusCode on an Error instance", () => {
+    const err = Object.assign(new Error("Payment Required"), {
+      statusCode: 402,
+    });
+    expect(isCreditError(err)).toBe(true);
+  });
+
+  it("matches a numeric 402 code on a plain gateway object", () => {
+    expect(isCreditError({ code: 402, message: "boom" })).toBe(true);
+  });
+
+  it("matches credit/billing phrasing in the message", () => {
+    expect(isCreditError(new Error("insufficient funds"))).toBe(true);
+    expect(isCreditError({ message: "quota exceeded" })).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isCreditError(new Error("model is overloaded"))).toBe(false);
+    expect(isCreditError({ code: 503, message: "service unavailable" })).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/harness/src/decopilot/stream-error.ts
+++ b/packages/harness/src/decopilot/stream-error.ts
@@ -108,15 +108,14 @@ function extractErrorParts(error: unknown): {
 }
 
 /**
- * Returns a sanitized, user-facing error message.
- * Provider-specific URLs and branding are stripped so they are never
- * surfaced to the client.
+ * Whether an error is an account-level credit/billing rejection (402 and
+ * friends). Shared by `sanitizeStreamError` (UI `[CREDITS]` tagging) and the
+ * free-model fallback middleware (`mesh-provider.ts`) so the two never drift.
  */
-// TODO @pedrofrxncx: remove this code in favor of a better solution
-export function sanitizeStreamError(error: unknown): string {
+export function isCreditError(error: unknown): boolean {
   const { message, statusCode } = extractErrorParts(error);
   const lower = message.toLowerCase();
-  if (
+  return (
     statusCode === 402 ||
     lower.includes("credit") ||
     lower.includes("insufficient funds") ||
@@ -125,7 +124,18 @@ export function sanitizeStreamError(error: unknown): string {
     lower.includes("quota exceeded") ||
     lower.includes("key limit") ||
     lower.includes("payment required")
-  ) {
+  );
+}
+
+/**
+ * Returns a sanitized, user-facing error message.
+ * Provider-specific URLs and branding are stripped so they are never
+ * surfaced to the client.
+ */
+// TODO @pedrofrxncx: remove this code in favor of a better solution
+export function sanitizeStreamError(error: unknown): string {
+  const { message } = extractErrorParts(error);
+  if (isCreditError(error)) {
     // Prefix with [CREDITS] so the frontend can detect credit errors
     // without fragile string matching on provider-specific messages.
     return `[CREDITS] ${stripProviderSpecificDetails(message)}`;


### PR DESCRIPTION
## Summary

Users hitting **"insufficient funds" / 402** errors on the **OpenRouter** provider weren't falling back to the free model, despite the `models: [primary, "openrouter/free"]` array we already attach in `createLanguageModel`.

The reason is semantic: OpenRouter's in-request `models` array is a **model-level** fallback — it advances to the next model only when the *primary model* fails (provider down, rate-limit, moderation). An account-level **402** terminates the whole request *before* model routing, so the array is never consulted.

This PR closes that gap with an AI-SDK language-model middleware.

## What changed

- **`mesh-provider.ts`** — for the raw **OpenRouter** provider, `createLanguageModel` now wraps the model with a `wrapLanguageModel` middleware (`withCreditFallback`). On a credit error from the primary's `doStream`/`doGenerate`, it transparently re-issues the **same call** against `openrouter/free`, *before any UI chunk is produced* — so the streaming pipeline (`run-stream.ts`, `toUIMessageStream`, title gen) is untouched and there's no double-`start`. If the free retry also fails, the original error propagates unchanged.
- **`stream-error.ts`** — extracted a shared `isCreditError(error)` predicate; `sanitizeStreamError` now calls it, so the middleware and the UI `[CREDITS]` tagging can't drift.
- **`stream-error.test.ts`** — added pure-unit cases for `isCreditError` (402 statusCode, numeric `code`, message phrasing, non-matches).

## Scope: OpenRouter only — deco AI gateway excluded

Both free-fallback mechanisms (the existing `models` array **and** the new credit middleware) are now gated on `provider.info.id === "openrouter"`. The **deco AI gateway** gates even free models on the org credit balance, so a free fallback can't succeed there — and a silent downgrade to free would be misleading. Previously the `models` array applied to deco too; this PR removes that.

For raw OpenRouter credentials, free models cost \$0 and work at a zero balance, so this genuinely rescues 402s there.

## Caveats

- Covers **credit (402)** errors only. Model *unavailability* is already handled by the `models` array at OpenRouter's edge. The three direct-provider call sites that bypass `createLanguageModel` (`cluster-research-job.ts`, `suggest-commit-message.ts`, `openai-compat.ts`) still get no fallback — out of scope here.
- Fires only when the credit error surfaces as a rejected `doStream`/`doGenerate` (the 402-at-request-start path). Mid-stream errors aren't credit errors.

## Testing

- `bun test packages/harness/src/decopilot/stream-error.test.ts` — 10 pass
- `tsc --noEmit` (harness) — clean
- `biome format` — clean