### PR TITLE
feat(chat): live countdown while a bash `sleep` runs

### DIFF
--- a/apps/mesh/src/storage/fold-parts.test.ts
+++ b/apps/mesh/src/storage/fold-parts.test.ts
@@ -43,8 +43,33 @@ describe("foldParts", () => {
     expect(out).toHaveLength(1);
     expect(out[0]!.id).toBe("m1");
     expect(out[0]!.parts).toEqual([
-      { type: "text", text: "A" },
-      { type: "text", text: "B" },
+      { type: "text", text: "A", created_at: "2026-01-01T00:00:00.000Z" },
+      { type: "text", text: "B", created_at: "2026-01-01T00:00:00.000Z" },
+    ]);
+  });
+
+  it("preserves each part's own created_at on the part", () => {
+    const out = foldParts([
+      part({
+        id: "r1:0",
+        seq: 0,
+        payload: { type: "tool-bash", state: "input-available" },
+        created_at: "2026-01-01T00:00:01.000Z",
+      }),
+      part({
+        id: "r1:1",
+        seq: 1,
+        payload: { type: "text", text: "B" },
+        created_at: "2026-01-01T00:00:09.000Z",
+      }),
+    ]);
+    expect(out[0]!.parts).toEqual([
+      {
+        type: "tool-bash",
+        state: "input-available",
+        created_at: "2026-01-01T00:00:01.000Z",
+      },
+      { type: "text", text: "B", created_at: "2026-01-01T00:00:09.000Z" },
     ]);
   });
 
@@ -55,9 +80,9 @@ describe("foldParts", () => {
       part({ id: "r1:1", seq: 1, payload: { type: "text", text: "B" } }),
     ]);
     expect(out[0]!.parts).toEqual([
-      { type: "text", text: "A" },
-      { type: "text", text: "B" },
-      { type: "text", text: "C" },
+      { type: "text", text: "A", created_at: "2026-01-01T00:00:00.000Z" },
+      { type: "text", text: "B", created_at: "2026-01-01T00:00:00.000Z" },
+      { type: "text", text: "C", created_at: "2026-01-01T00:00:00.000Z" },
     ]);
   });
 
@@ -157,8 +182,12 @@ describe("foldParts", () => {
     // Both messages survive (neither set was dropped by an id collision) and
     // order user-before-assistant by created_at.
     expect(out.map((m) => m.id)).toEqual(["user_1", "assistant_1"]);
-    expect(out[0]!.parts).toEqual([{ type: "text", text: "question" }]);
-    expect(out[1]!.parts).toEqual([{ type: "text", text: "answer" }]);
+    expect(out[0]!.parts).toEqual([
+      { type: "text", text: "question", created_at: `${userBase}Z` },
+    ]);
+    expect(out[1]!.parts).toEqual([
+      { type: "text", text: "answer", created_at: `${assistantBase}Z` },
+    ]);
     expect(out[0]!.status).toBe("complete");
     expect(out[1]!.status).toBe("complete");
   });

--- a/apps/mesh/src/storage/fold-parts.ts
+++ b/apps/mesh/src/storage/fold-parts.ts
@@ -47,7 +47,23 @@ export function foldParts(parts: ThreadMessagePart[]): FoldedMessage[] {
     messages.push({
       id: messageId,
       role: first.role,
-      parts: sorted.filter((p) => p.kind !== "finish").map((p) => p.payload),
+      // Preserve each part's own `created_at` on the part itself — it's the
+      // only per-part timestamp the client gets (the AI-SDK part type has
+      // none), and the UI uses it to anchor e.g. the bash `sleep` countdown to
+      // when that specific call actually fired. Non-object payloads (none in
+      // practice) pass through untouched.
+      parts: sorted
+        .filter((p) => p.kind !== "finish")
+        .map((p) =>
+          p.payload &&
+          typeof p.payload === "object" &&
+          !Array.isArray(p.payload)
+            ? {
+                ...(p.payload as Record<string, unknown>),
+                created_at: p.created_at,
+              }
+            : p.payload,
+        ),
       created_at: first.created_at,
       status: sorted.some((p) => p.kind === "finish")
         ? "complete"

--- a/apps/mesh/src/storage/thread-message-parts.integration.test.ts
+++ b/apps/mesh/src/storage/thread-message-parts.integration.test.ts
@@ -108,7 +108,13 @@ describe("SqlThreadMessagePartStorage", () => {
     const { messages } = await parts.loadWindow(threadId, { limit: 50 });
     const m = messages.find((x) => x.id === "m_c1")!;
     expect(m.status).toBe("complete");
-    expect(m.parts).toEqual([{ type: "text", text: "answer" }]);
+    expect(m.parts).toEqual([
+      {
+        type: "text",
+        text: "answer",
+        created_at: new Date(1700000000000).toISOString(),
+      },
+    ]);
   });
 
   it("C5: order follows seq-derived created_at, not insertion order", async () => {

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/bash-sleep.test.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/bash-sleep.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { parseSleepMs } from "./bash-sleep.ts";
+
+describe("parseSleepMs", () => {
+  test("returns null when there is no sleep", () => {
+    expect(parseSleepMs("ls -la")).toBeNull();
+    expect(parseSleepMs("echo sleeping")).toBeNull();
+    expect(parseSleepMs("./sleepyhead.sh")).toBeNull();
+    expect(parseSleepMs("sleep")).toBeNull();
+  });
+
+  test("parses a bare sleep in seconds", () => {
+    expect(parseSleepMs("sleep 30")).toBe(30_000);
+    expect(parseSleepMs("sleep 0.5")).toBe(500);
+  });
+
+  test("honors coreutils unit suffixes", () => {
+    expect(parseSleepMs("sleep 5m")).toBe(300_000);
+    expect(parseSleepMs("sleep 2h")).toBe(7_200_000);
+    expect(parseSleepMs("sleep 1d")).toBe(86_400_000);
+    expect(parseSleepMs("sleep 10s")).toBe(10_000);
+  });
+
+  test("sums multiple args and multiple sleeps", () => {
+    expect(parseSleepMs("sleep 1m 30")).toBe(90_000);
+    expect(parseSleepMs("sleep 10 && sleep 5")).toBe(15_000);
+    expect(parseSleepMs("foo; sleep 3 | bar")).toBe(3_000);
+  });
+
+  test("matches only on a word boundary before sleep", () => {
+    expect(parseSleepMs("(sleep 2)")).toBe(2_000);
+    expect(parseSleepMs("nosleep 2")).toBeNull();
+  });
+});

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/bash-sleep.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/bash-sleep.ts
@@ -1,0 +1,28 @@
+const SLEEP_UNIT_MS: Record<string, number> = {
+  s: 1000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+};
+
+/**
+ * Sum the durations of any `sleep` invocations in a shell command, in ms, or
+ * null when there is none. Mirrors coreutils `sleep`: a default `s` suffix plus
+ * `m`/`h`/`d`, and multiple args summed together (`sleep 1m 30` = 90s).
+ */
+export function parseSleepMs(command: string): number | null {
+  const re = /(?:^|[\s;&|(])sleep((?:\s+[\d.]+[smhd]?)+)/g;
+  let total = 0;
+  let found = false;
+  for (const match of command.matchAll(re)) {
+    for (const arg of match[1]!.trim().split(/\s+/)) {
+      const parsed = /^([\d.]+)([smhd]?)$/.exec(arg);
+      if (!parsed) continue;
+      const value = Number.parseFloat(parsed[1]!);
+      if (!Number.isFinite(value)) continue;
+      total += value * (SLEEP_UNIT_MS[parsed[2] || "s"] ?? 1000);
+      found = true;
+    }
+  }
+  return found ? total : null;
+}

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/bash-wait.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/bash-wait.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { useClockTick } from "@/web/lib/use-clock-tick.ts";
+
+const STORAGE_PREFIX = "bash-sleep-start:";
+
+/**
+ * First-observed fire time (epoch ms) for a bash `sleep`, keyed by toolCallId
+ * and persisted to `sessionStorage`. This is the fallback when the part has no
+ * server-stamped `created_at` (v1 threads, or an in-flight turn whose parts
+ * aren't folded from storage yet) — without persistence the anchor would reset
+ * to "now" on every page refresh and restart the countdown. The toolCallId is
+ * stable across refresh, so the original observation is recovered. Returns
+ * `Date.now()` (and records it) the first time a given call is seen.
+ */
+function firstSeenStart(toolCallId: string): number {
+  const key = STORAGE_PREFIX + toolCallId;
+  try {
+    const stored = sessionStorage.getItem(key);
+    if (stored !== null) {
+      const parsed = Number.parseInt(stored, 10);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    const now = Date.now();
+    sessionStorage.setItem(key, String(now));
+    return now;
+  } catch {
+    // sessionStorage unavailable (SSR / privacy mode): best-effort, non-sticky.
+    return Date.now();
+  }
+}
+
+/**
+ * Resolve the countdown anchor. Prefer `anchorMs` — the part's own server-
+ * stamped `created_at` (v2), accurate across any client. Otherwise fall back to
+ * the first time this browser observed the call running, persisted in
+ * sessionStorage so it survives a page refresh instead of resetting.
+ */
+function useSleepStartedAt(
+  toolCallId: string,
+  anchorMs: number | null,
+): number {
+  const fallback = useState(() => firstSeenStart(toolCallId))[0];
+  return anchorMs ?? fallback;
+}
+
+function formatCountdown(ms: number): string {
+  const secs = Math.ceil(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return rem ? `${mins}m ${rem}s` : `${mins}m`;
+}
+
+/**
+ * Live "waiting on `sleep`" hint for a still-running `bash` tool call.
+ *
+ * Anchored on the call's fire time (`anchorMs`, else the sessionStorage-backed
+ * first-observed time) so a reloaded / late-attaching client counts down from
+ * real elapsed time rather than restarting. Once the window elapses we show
+ * "wrapping up" instead of a negative number; the row flips to its result the
+ * moment the tool returns. Ticks once per second via the shared clock store.
+ */
+export function BashWaitSummary({
+  toolCallId,
+  durationMs,
+  anchorMs,
+}: {
+  toolCallId: string;
+  durationMs: number;
+  anchorMs: number | null;
+}) {
+  useClockTick(1000);
+  const startedAt = useSleepStartedAt(toolCallId, anchorMs);
+  const remaining = startedAt + durationMs - Date.now();
+  return (
+    <span className="tabular-nums">
+      {remaining > 0 ? `Waiting ${formatCountdown(remaining)}` : "Wrapping up…"}
+    </span>
+  );
+}

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
@@ -24,8 +24,8 @@ export interface ToolCallShellProps {
   usage?: UsageStatsType | null;
   /** Latency in seconds for the operation (optional) */
   latency?: number;
-  /** Short status text shown inline after the label */
-  summary?: string;
+  /** Short status text (or node, e.g. a live countdown) shown inline after the label */
+  summary?: ReactNode;
   /** Derived UI state computed by caller based on their loading semantics */
   state: "loading" | "error" | "idle";
   /** Detail shown in expanded view */

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -44,13 +44,16 @@ import {
   XClose,
 } from "@untitledui/icons";
 import { TOOL_DISPLAY_MAP } from "./tool-display-map.ts";
+import { BashWaitSummary } from "./bash-wait.tsx";
+import { parseSleepMs } from "./bash-sleep.ts";
+import { toEpochMs } from "@/web/lib/format-time.ts";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import type React from "react";
 import { Suspense } from "react";
 import { ErrorBoundary } from "@/web/components/error-boundary.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 
-import { getToolPartErrorText, safeStringify } from "../utils.ts";
+import { getToolPartErrorText, safeStringifyFormatted } from "../utils.ts";
 import { ToolCallShell } from "./common.tsx";
 import { getEffectiveState } from "./utils.tsx";
 
@@ -70,14 +73,28 @@ interface GenericToolCallPartProps {
   toolMeta?: ToolDefinition["_meta"];
 }
 
-function safeStringifyFormatted(value: unknown): string {
-  const str = safeStringify(value);
-  if (str === "" || str === "[Non-serializable value]") return str;
-  try {
-    return JSON.stringify(JSON.parse(str), null, 2);
-  } catch {
-    return str;
-  }
+/**
+ * Read the part's own persisted `created_at` (epoch ms). `foldParts` stamps it
+ * onto each part on the v2 read path — it's the only per-part timestamp the
+ * client gets, and it anchors the `bash` `sleep` countdown to when that
+ * specific call fired (correct across reload / late attach). Null while the
+ * turn is still in-flight (parts not yet folded from storage).
+ */
+function partCreatedAtMs(part: unknown): number | null {
+  const raw =
+    part && typeof part === "object" && "created_at" in part
+      ? (part as { created_at?: unknown }).created_at
+      : undefined;
+  return typeof raw === "string" || raw instanceof Date ? toEpochMs(raw) : null;
+}
+
+/** Effective bash timeout (ms) the daemon enforces — mirrors BashInputSchema. */
+function bashTimeoutMs(input: unknown): number {
+  const t =
+    input && typeof input === "object" && "timeout" in input
+      ? (input as { timeout?: unknown }).timeout
+      : undefined;
+  return Math.min(typeof t === "number" ? t : 30_000, 120_000);
 }
 
 function AnnotationBadge({
@@ -337,11 +354,38 @@ export function GenericToolCallPart({
   const errorText =
     part.state === "output-error" ? getToolPartErrorText(part) : undefined;
 
-  const summary = isStaleApproval
-    ? "Cancelled"
-    : isOutputError
-      ? "Failed"
-      : getSummary(part.state, part.output, errorText);
+  // While a `bash` `sleep` is still running, replace the generic "Preparing…"
+  // with a live countdown. Duration is parsed from the command (capped at the
+  // daemon timeout, since a longer sleep is killed there); the countdown anchors
+  // on this part's own persisted `created_at` (when the call fired) so the
+  // remaining time stays correct across reload / late attach.
+  const sleepCommand =
+    toolName === "bash" &&
+    effectiveState === "loading" &&
+    part.input &&
+    typeof part.input === "object" &&
+    typeof (part.input as { command?: unknown }).command === "string"
+      ? (part.input as { command: string }).command
+      : null;
+  const sleepMs = sleepCommand !== null ? parseSleepMs(sleepCommand) : null;
+  const sleepDurationMs =
+    sleepMs !== null ? Math.min(sleepMs, bashTimeoutMs(part.input)) : null;
+  const toolCallId = "toolCallId" in part ? part.toolCallId : "";
+
+  const summary =
+    sleepDurationMs !== null ? (
+      <BashWaitSummary
+        toolCallId={toolCallId}
+        durationMs={sleepDurationMs}
+        anchorMs={partCreatedAtMs(part)}
+      />
+    ) : isStaleApproval ? (
+      "Cancelled"
+    ) : isOutputError ? (
+      "Failed"
+    ) : (
+      getSummary(part.state, part.output, errorText)
+    );
 
   // Build expanded content
   let detail = "";

--- a/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
@@ -835,6 +835,38 @@ describe("upsertById", () => {
       "2026-01-01T00:00:09Z",
     );
   });
+
+  test("carries a tool part's created_at forward when the streamed copy lacks it", () => {
+    // Durable (DB-loaded) copy has the per-part fire time; the streamed replay
+    // that upserts over it does not — without preservation a late-attaching /
+    // reconnecting client loses the bash-sleep countdown anchor.
+    const durable = {
+      id: "m1",
+      role: "assistant",
+      created_at: "2026-01-01T00:00:00Z",
+      parts: [
+        {
+          type: "tool-bash",
+          toolCallId: "tc1",
+          state: "input-available",
+          created_at: "2026-01-01T00:00:05Z",
+        },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: test helper
+    } as any;
+    const streamed = {
+      id: "m1",
+      role: "assistant",
+      parts: [
+        { type: "tool-bash", toolCallId: "tc1", state: "input-available" },
+      ],
+      // biome-ignore lint/suspicious/noExplicitAny: test helper
+    } as any;
+    const out = upsertById([durable], streamed);
+    expect((out[0]!.parts[0] as { created_at?: unknown }).created_at).toBe(
+      "2026-01-01T00:00:05Z",
+    );
+  });
 });
 
 describe("dropRedundantStubs", () => {

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -951,6 +951,52 @@ export class ThreadConnection {
  * empty ("No response was generated"). Only fills a missing timestamp; a
  * genuine persisted update (incoming has `created_at`) overwrites as before.
  */
+/**
+ * Carry each tool call part's persisted `created_at` forward across a merge.
+ * The durable (DB-loaded) copy of an in-flight message has a per-part
+ * `created_at` (stamped by `foldParts`); the streamed/replayed copy that
+ * upserts over it does not. Without this, a late-attaching or reconnecting
+ * client loses the fire time of a still-running call (e.g. the `bash` `sleep`
+ * countdown anchor) and restarts the timer. Matched by `toolCallId`; only fills
+ * a missing timestamp, so a genuine durable update still wins.
+ */
+function preservePartCreatedAt(
+  prev: UIMessage,
+  next: UIMessage,
+): UIMessage["parts"] {
+  const prevByToolCall = new Map<string, unknown>();
+  for (const p of prev.parts) {
+    if (
+      p &&
+      typeof p === "object" &&
+      "toolCallId" in p &&
+      "created_at" in p &&
+      typeof (p as { toolCallId?: unknown }).toolCallId === "string"
+    ) {
+      prevByToolCall.set(
+        (p as { toolCallId: string }).toolCallId,
+        (p as { created_at: unknown }).created_at,
+      );
+    }
+  }
+  if (prevByToolCall.size === 0) return next.parts;
+  return next.parts.map((p) => {
+    if (
+      p &&
+      typeof p === "object" &&
+      "toolCallId" in p &&
+      !("created_at" in p) &&
+      typeof (p as { toolCallId?: unknown }).toolCallId === "string"
+    ) {
+      const carried = prevByToolCall.get(
+        (p as { toolCallId: string }).toolCallId,
+      );
+      if (carried != null) return { ...p, created_at: carried };
+    }
+    return p;
+  });
+}
+
 function preserveCreatedAt(
   prev: UIMessage | undefined,
   next: UIMessage,
@@ -958,10 +1004,12 @@ function preserveCreatedAt(
   if (!prev) return next;
   const prevTs = (prev as { created_at?: unknown }).created_at;
   const nextTs = (next as { created_at?: unknown }).created_at;
+  const parts = preservePartCreatedAt(prev, next);
+  let result = parts === next.parts ? next : ({ ...next, parts } as UIMessage);
   if (nextTs == null && prevTs != null) {
-    return { ...next, created_at: prevTs } as UIMessage;
+    result = { ...result, created_at: prevTs } as UIMessage;
   }
-  return next;
+  return result;
 }
 
 export function upsertById(list: UIMessage[], msg: UIMessage): UIMessage[] {


### PR DESCRIPTION
## Summary

When the model calls the `bash` tool with a `sleep`, the tool row just showed a silent **"Preparing…"** — no hint the thread is parked. This surfaces a live **"Waiting Ns"** countdown while the call runs, flipping to "Wrapping up…" as the window elapses and to the normal result the moment the tool returns.

The countdown is anchored on **when the call actually fired**, so it shows true remaining time across reload / late attach rather than restarting.

## How it works

- **Parse client-side** — `bash-sleep.ts` extracts the sleep duration from the tool input (coreutils `s`/`m`/`h`/`d` suffixes, multiple args, `&&`/`;`/`|` chains), capped at the daemon bash timeout. No server-side parsing.
- **Per-part timestamp** — `foldParts` now preserves each part's own `created_at` (v2 read path). It's the only per-part timestamp the client gets (the AI-SDK part type has none), and it's the shared source a *different* client needs for late attach.
- **Survive the live stream** — during an in-flight run the rendered part is the streamed copy, which has no timestamp and was overwriting the durable copy on upsert. `preserveCreatedAt` now carries the per-part `created_at` forward (matched by `toolCallId`), so a reconnecting / late-attaching client keeps the anchor.
- **Fallbacks** — `sessionStorage` (keyed by `toolCallId`) survives same-tab refresh on v1 threads; first-observed time is the last resort.
- `ToolCallShell.summary` widened to `ReactNode` to host the live element.

## Coverage / caveat

- **v2 threads**: correct across reload *and* late attach from any client.
- **v1 threads** (current default): correct across same-tab refresh; a *fresh* client attaching mid-sleep shows an approximate countdown that self-corrects when the call returns — v1 storage has no per-part timestamp to transmit.

## Testing

- `bash-sleep.test.ts` — sleep parser (suffixes, multi-arg, chains, word boundaries).
- `fold-parts.test.ts` — per-part `created_at` preservation + updated existing assertions.
- `thread-connection.test.ts` — `created_at` carried forward across streamed-over-durable upsert.
- `thread-message-parts.integration.test.ts` — updated v2 fold assertion.
- `bun run check` clean; `bun run fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live countdown for `bash` tool calls that include `sleep`, showing “Waiting Ns” and then “Wrapping up…” until the tool returns. The timer is anchored to when the call actually started and stays accurate across reloads and late attach.

- **New Features**
  - Parse `sleep` duration from the tool input client-side (coreutils `s`/`m`/`h`/`d`, multiple args, `&&`/`;`/`|`), capped at the daemon timeout.
  - Anchor on per-part `created_at`: `foldParts` preserves it (v2), and `preserveCreatedAt` carries it across streamed-over-durable merges.
  - Fallbacks for v1/in-flight: `sessionStorage` keyed by `toolCallId`, then first-seen time.
  - `ToolCallShell.summary` now accepts a `ReactNode` to render the live countdown.

<sup>Written for commit c7e7589f14cb3ef32844c93f558a1f9444cd809b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

