### PR TITLE
fix(github-repo-picker): guard getOrgGithubConnections against undefined input

### DIFF
--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -104,6 +104,6 @@ export function getRepoScope(connection: {
  */
 export function getOrgGithubConnections<
   T extends { metadata: Record<string, unknown> | null },
->(connections: T[]): T[] {
-  return connections.filter((c) => getRepoScope(c) === null);
+>(connections: T[] | undefined | null): T[] {
+  return (connections ?? []).filter((c) => getRepoScope(c) === null);
 }


### PR DESCRIPTION
## Summary

- `getOrgGithubConnections` was calling `.filter()` directly on the `connections` argument without a null/undefined guard
- `useConnections` (backed by `useSuspenseQuery`) can return `undefined` during React 19 concurrent rendering transitions or query error states
- This caused a `TypeError: Cannot read properties of undefined (reading 'filter')` crash reported in production (PostHog)

## Fix

Accept `T[] | undefined | null` in `getOrgGithubConnections` and short-circuit with `?? []` before calling `.filter()`.

## Testing

No unit test needed — this is a pure defensive null-guard on an already-tested helper. The crash was confirmed via PostHog exception trace pointing to `github-repo-picker`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `getOrgGithubConnections` against undefined/null inputs to stop a crash in the GitHub repo picker during React 19 transitions. Defaults to an empty list so `.filter()` never runs on `undefined`.

- **Bug Fixes**
  - Updated `getOrgGithubConnections` to accept `T[] | undefined | null` and use `(connections ?? [])`.
  - Prevents `TypeError` when `useConnections` can be `undefined` in concurrent or error states.

<sup>Written for commit a33825ef3faf257476c32dd2e4d14d6fdfe413f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

