### PR TITLE
refactor(watch): unify decopilot + workflow SSE into one cross-tab connection

### DIFF
--- a/apps/mesh/src/web/components/details/workflow/hooks/use-workflow-sse.ts
+++ b/apps/mesh/src/web/components/details/workflow/hooks/use-workflow-sse.ts
@@ -15,24 +15,10 @@
 import { useSyncExternalStore } from "react";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { useProjectContext } from "@decocms/mesh-sdk";
-import { createSSESubscription } from "../../../../hooks/create-sse-subscription";
+import { workflowWatchView } from "../../../../hooks/watch-sse-pool";
 
-// ============================================================================
-// Shared connection pool
-// ============================================================================
-
-const WORKFLOW_EVENT_TYPES = [
-  "workflow.execution.created",
-  "workflow.execution.resumed",
-  "workflow.step.execute",
-  "workflow.step.completed",
-];
-
-const workflowSSE = createSSESubscription({
-  buildUrl: (orgSlug) =>
-    `/api/${encodeURIComponent(orgSlug)}/watch?types=workflow.*`,
-  eventTypes: WORKFLOW_EVENT_TYPES,
-});
+// Workflow view of the unified `/watch` pool (watch-sse-pool.ts).
+const workflowSSE = workflowWatchView;
 
 /** Tool names whose query caches should be invalidated on workflow events */
 const INVALIDATION_TARGETS = [

--- a/apps/mesh/src/web/hooks/create-sse-subscription.ts
+++ b/apps/mesh/src/web/hooks/create-sse-subscription.ts
@@ -1,62 +1,62 @@
 /**
- * Shared SSE subscription factory
- *
- * Manages ref-counted EventSource connections so multiple React components
- * can subscribe to the same SSE endpoint without opening duplicate connections.
- *
- * Each call to `createSSESubscription` creates an independent connection pool
- * keyed by a caller-provided key (typically an orgId).
- *
- * Reconnection: When EventSource enters CLOSED state (server restart, network
- * change), the connection is automatically re-established with exponential
- * backoff (1s → 2s → 4s, capped at 30s). Existing event listeners are
- * re-attached to the new EventSource transparently, and any subscriber that
- * registered an `onReconnect` callback is invoked once the re-established
- * connection opens (initial connect does NOT fire `onReconnect`).
+ * Shared SSE subscription factory. Within a tab, subscribers for the same key
+ * share one ref-counted EventSource. With `crossTab`, exactly one tab per key
+ * holds the real EventSource (leader, elected via a Web Lock) and rebroadcasts
+ * events over a BroadcastChannel — so the whole browser stays under the ~6
+ * connections-per-origin HTTP/1.1 cap. Same-origin tabs share cookies (same
+ * user), so keying by org slug is safe.
  */
 
 import { exponentialBackoffWithJitter } from "@decocms/std";
 
-/** Max reconnect delay in ms */
 const MAX_RECONNECT_DELAY_MS = 30_000;
-/** Base reconnect delay in ms */
 const BASE_RECONNECT_DELAY_MS = 1_000;
 
+type Handler = (e: MessageEvent) => void;
+
+type ChannelMessage =
+  | { kind: "event"; type: string; data: string }
+  | { kind: "reconnect" };
+
 interface SharedConnection {
-  es: EventSource;
+  key: string;
   refCount: number;
-  /** Active handlers to re-attach after reconnect */
-  handlers: Set<(e: MessageEvent) => void>;
+  handlers: Set<Handler>;
   /** Per-subscriber callbacks fired after a re-establishment (not initial open). */
   reconnectHandlers: Set<() => void>;
-  /** Current reconnect attempt (reset on successful open) */
+  /** First open is initial connect; a later open is a re-establishment. */
+  bootDone: boolean;
+
+  es: EventSource | null;
+  isLeader: boolean;
   reconnectAttempt: number;
-  /** Pending reconnect timer */
   reconnectTimer: ReturnType<typeof setTimeout> | null;
+
+  channel: BroadcastChannel | null;
+  /** Aborts a pending Web Lock request on teardown. */
+  lockAbort: AbortController | null;
+  /** Resolving this frees the held Web Lock (relinquishes leadership). */
+  releaseLeadership: (() => void) | null;
 }
 
 export interface SSESubscriptionOptions {
-  /** URL builder given a connection key */
   buildUrl: (key: string) => string;
-  /** SSE event types to listen for */
   eventTypes: string[];
+  /** Web Lock + BroadcastChannel namespace; required when `crossTab` is on. */
+  name?: string;
+  /** Share one EventSource across same-origin tabs; falls back to per-tab when unsupported. */
+  crossTab?: boolean;
 }
 
 export interface SSESubscription {
   /**
-   * Subscribe to SSE events for the given key.
-   * Returns an unsubscribe function.
-   *
-   * Multiple subscribers share one EventSource per key; the connection
-   * is closed when the last subscriber unsubscribes.
-   *
-   * @param onReconnect Optional. Fired once each time the underlying
-   * EventSource is re-established after a drop. NOT fired on the first
-   * successful connect — subscribers do their own initial load.
+   * Subscribe to SSE events for the given key; returns an unsubscribe function.
+   * `onReconnect` fires after each re-establishment (drop or leadership
+   * hand-off), never on the first connect — subscribers do their own initial load.
    */
   subscribe: (
     key: string,
-    handler: (e: MessageEvent) => void,
+    handler: Handler,
     onReconnect?: () => void,
   ) => () => void;
 }
@@ -64,51 +64,77 @@ export interface SSESubscription {
 export function createSSESubscription(
   options: SSESubscriptionOptions,
 ): SSESubscription {
-  const { buildUrl, eventTypes } = options;
+  const { buildUrl, eventTypes, name, crossTab = false } = options;
   const connections = new Map<string, SharedConnection>();
 
-  function attachListeners(
-    es: EventSource,
-    handlers: Set<(e: MessageEvent) => void>,
-  ): void {
-    for (const type of eventTypes) {
-      for (const handler of handlers) {
-        es.addEventListener(type, handler);
+  const supportsCrossTab =
+    crossTab &&
+    typeof BroadcastChannel !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.locks !== "undefined";
+
+  if (supportsCrossTab && !name) {
+    throw new Error("createSSESubscription: `name` is required when crossTab");
+  }
+
+  function deliver(conn: SharedConnection, ev: MessageEvent): void {
+    conn.bootDone = true;
+    for (const handler of conn.handlers) {
+      try {
+        handler(ev);
+      } catch {
+        // a misbehaving subscriber must not break fan-out
       }
     }
   }
 
-  function createEventSource(
-    key: string,
-    conn: SharedConnection,
-    fireReconnect: boolean,
-  ): void {
-    const es = new EventSource(buildUrl(key));
+  /** Fire local onReconnect callbacks (after a drop / leadership hand-off). */
+  function fireReconnect(conn: SharedConnection): void {
+    for (const cb of conn.reconnectHandlers) {
+      try {
+        cb();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  function createEventSource(conn: SharedConnection): void {
+    const es = new EventSource(buildUrl(conn.key));
+    conn.es = es;
 
     es.onopen = () => {
       conn.reconnectAttempt = 0;
-      if (fireReconnect) {
-        for (const cb of conn.reconnectHandlers) cb();
+      // Re-establishment (network blip / leadership promotion); skip initial connect.
+      if (conn.bootDone) {
+        fireReconnect(conn);
+        conn.channel?.postMessage({
+          kind: "reconnect",
+        } satisfies ChannelMessage);
       }
+      conn.bootDone = true;
     };
 
     es.onerror = () => {
-      if (es.readyState === EventSource.CLOSED) {
-        scheduleReconnect(key, conn);
+      if (conn.es === es && es.readyState === EventSource.CLOSED) {
+        scheduleReconnect(conn);
       }
     };
 
-    conn.es = es;
-    attachListeners(es, conn.handlers);
+    const relay: Handler = (e) => {
+      conn.channel?.postMessage({
+        kind: "event",
+        type: e.type,
+        data: e.data,
+      } satisfies ChannelMessage);
+      deliver(conn, e);
+    };
+
+    for (const type of eventTypes) es.addEventListener(type, relay);
   }
 
-  function scheduleReconnect(key: string, conn: SharedConnection): void {
-    if (conn.refCount <= 0) {
-      connections.delete(key);
-      return;
-    }
-
-    if (conn.reconnectTimer) return;
+  function scheduleReconnect(conn: SharedConnection): void {
+    if (conn.refCount <= 0 || conn.reconnectTimer) return;
 
     const delay = exponentialBackoffWithJitter(
       MAX_RECONNECT_DELAY_MS,
@@ -121,32 +147,109 @@ export function createSSESubscription(
 
     conn.reconnectTimer = setTimeout(() => {
       conn.reconnectTimer = null;
-
-      if (conn.refCount <= 0) {
-        connections.delete(key);
-        return;
-      }
-
-      conn.es.close();
-      createEventSource(key, conn, /* fireReconnect */ true);
+      if (conn.refCount <= 0 || !conn.isLeader) return;
+      conn.es?.close();
+      createEventSource(conn);
     }, delay);
   }
 
-  function getOrCreate(key: string): SharedConnection {
-    let conn = connections.get(key);
-    if (!conn) {
-      conn = {
-        es: null!,
-        refCount: 0,
-        handlers: new Set(),
-        reconnectHandlers: new Set(),
-        reconnectAttempt: 0,
-        reconnectTimer: null,
-      };
-      createEventSource(key, conn, /* fireReconnect */ false);
-      connections.set(key, conn);
+  function becomeLeader(conn: SharedConnection): void {
+    if (conn.refCount <= 0) {
+      conn.releaseLeadership?.();
+      conn.releaseLeadership = null;
+      return;
     }
+    conn.isLeader = true;
+    createEventSource(conn);
+  }
+
+  function requestLeadership(conn: SharedConnection): void {
+    if (!supportsCrossTab) {
+      becomeLeader(conn);
+      return;
+    }
+    conn.lockAbort = new AbortController();
+    navigator.locks
+      .request(
+        `sse-leader:${name}:${conn.key}`,
+        { signal: conn.lockAbort.signal },
+        () =>
+          new Promise<void>((resolve) => {
+            conn.releaseLeadership = resolve;
+            becomeLeader(conn);
+          }),
+      )
+      .catch(() => {
+        // AbortError on teardown, or transient lock errors — nothing to do.
+      });
+  }
+
+  function handleChannelMessage(
+    conn: SharedConnection,
+    msg: ChannelMessage,
+  ): void {
+    if (msg.kind === "event") {
+      deliver(conn, new MessageEvent(msg.type, { data: msg.data }));
+    } else if (msg.kind === "reconnect") {
+      fireReconnect(conn);
+    }
+  }
+
+  function getOrCreate(key: string): SharedConnection {
+    const existing = connections.get(key);
+    if (existing) return existing;
+
+    const conn: SharedConnection = {
+      key,
+      refCount: 0,
+      handlers: new Set(),
+      reconnectHandlers: new Set(),
+      bootDone: false,
+      es: null,
+      isLeader: false,
+      reconnectAttempt: 0,
+      reconnectTimer: null,
+      channel: null,
+      lockAbort: null,
+      releaseLeadership: null,
+    };
+    connections.set(key, conn);
+
+    if (supportsCrossTab) {
+      const channel = new BroadcastChannel(`sse:${name}:${key}`);
+      channel.onmessage = (e) =>
+        handleChannelMessage(conn, e.data as ChannelMessage);
+      conn.channel = channel;
+    }
+
+    requestLeadership(conn);
     return conn;
+  }
+
+  function teardown(conn: SharedConnection): void {
+    if (conn.reconnectTimer) {
+      clearTimeout(conn.reconnectTimer);
+      conn.reconnectTimer = null;
+    }
+    conn.es?.close();
+    conn.es = null;
+    conn.releaseLeadership?.(); // free the lock if we hold leadership
+    conn.releaseLeadership = null;
+    conn.lockAbort?.abort(); // cancel a pending lock request if following
+    conn.lockAbort = null;
+    conn.channel?.close();
+    conn.channel = null;
+    connections.delete(conn.key);
+  }
+
+  // HMR: release locks / channels so a dev reload doesn't orphan the Web Lock.
+  const hot = (
+    import.meta as unknown as { hot?: { dispose: (cb: () => void) => void } }
+  ).hot;
+  if (hot) {
+    hot.dispose(() => {
+      for (const conn of [...connections.values()]) teardown(conn);
+    });
   }
 
   return {
@@ -156,29 +259,32 @@ export function createSSESubscription(
       conn.handlers.add(handler);
       if (onReconnect) conn.reconnectHandlers.add(onReconnect);
 
-      for (const type of eventTypes) {
-        conn.es.addEventListener(type, handler);
-      }
-
       let unsubscribed = false;
       return () => {
         if (unsubscribed) return;
         unsubscribed = true;
 
-        for (const type of eventTypes) {
-          conn.es.removeEventListener(type, handler);
-        }
         conn.handlers.delete(handler);
         if (onReconnect) conn.reconnectHandlers.delete(onReconnect);
         conn.refCount--;
-        if (conn.refCount <= 0) {
-          if (conn.reconnectTimer) {
-            clearTimeout(conn.reconnectTimer);
-          }
-          conn.es.close();
-          connections.delete(key);
-        }
+        if (conn.refCount <= 0) teardown(conn);
       };
+    },
+  };
+}
+
+/** View over a shared subscription that delivers only the given event types. */
+export function filterEventTypes(
+  base: SSESubscription,
+  types: string[],
+): SSESubscription {
+  const allow = new Set(types);
+  return {
+    subscribe(key, handler, onReconnect) {
+      const wrapped: Handler = (e) => {
+        if (allow.has(e.type)) handler(e);
+      };
+      return base.subscribe(key, wrapped, onReconnect);
     },
   };
 }

--- a/apps/mesh/src/web/hooks/decopilot-sse-pool.ts
+++ b/apps/mesh/src/web/hooks/decopilot-sse-pool.ts
@@ -1,22 +1,5 @@
-/**
- * Shared decopilot SSE pool.
- *
- * One ref-counted EventSource per `orgSlug` for `/api/:org/watch` filtered
- * to ALL_DECOPILOT_EVENT_TYPES. Both `useDecopilotEvents` and
- * `ThreadManagerStore` subscribe here so an org only ever holds a single
- * `/watch` connection.
- */
+// `decopilot.*` view of the unified `/watch` pool (watch-sse-pool.ts).
+import type { SSESubscription } from "./create-sse-subscription";
+import { decopilotWatchView } from "./watch-sse-pool";
 
-import { ALL_DECOPILOT_EVENT_TYPES } from "@decocms/mesh-sdk";
-import {
-  createSSESubscription,
-  type SSESubscription,
-} from "./create-sse-subscription";
-
-export const decopilotSSE: SSESubscription = createSSESubscription({
-  buildUrl: (orgSlug) => {
-    const typesParam = ALL_DECOPILOT_EVENT_TYPES.join(",");
-    return `/api/${encodeURIComponent(orgSlug)}/watch?types=${typesParam}`;
-  },
-  eventTypes: [...ALL_DECOPILOT_EVENT_TYPES],
-});
+export const decopilotSSE: SSESubscription = decopilotWatchView;

--- a/apps/mesh/src/web/hooks/watch-sse-pool.ts
+++ b/apps/mesh/src/web/hooks/watch-sse-pool.ts
@@ -1,0 +1,50 @@
+/**
+ * Unified `/api/:org/watch` SSE pool. Every consumer (decopilot thread events,
+ * workflow execution events) shares ONE cross-tab connection per org that
+ * streams the union of their event types; each takes a `filterEventTypes` view
+ * of its own.
+ */
+
+import { ALL_DECOPILOT_EVENT_TYPES } from "@decocms/mesh-sdk";
+import {
+  createSSESubscription,
+  filterEventTypes,
+  type SSESubscription,
+} from "./create-sse-subscription";
+
+/** Concrete workflow event names emitted on `/watch`. */
+const WORKFLOW_EVENT_TYPES = [
+  "workflow.execution.created",
+  "workflow.execution.resumed",
+  "workflow.step.execute",
+  "workflow.step.completed",
+];
+
+/** `?types=` patterns sent to the server; `workflow.*` is a wildcard it expands. */
+const WATCH_URL_TYPES = [...ALL_DECOPILOT_EVENT_TYPES, "workflow.*"];
+
+/** Concrete event names the client attaches listeners for. */
+const WATCH_EVENT_TYPES = [
+  ...ALL_DECOPILOT_EVENT_TYPES,
+  ...WORKFLOW_EVENT_TYPES,
+];
+
+/** The single shared, cross-tab `/watch` connection (streams the full union). */
+const watchSSE: SSESubscription = createSSESubscription({
+  name: "watch",
+  buildUrl: (orgSlug) =>
+    `/api/${encodeURIComponent(orgSlug)}/watch?types=${WATCH_URL_TYPES.join(",")}`,
+  eventTypes: WATCH_EVENT_TYPES,
+  crossTab: true,
+});
+
+/** Decopilot thread events (step / finish / thread.status). */
+export const decopilotWatchView: SSESubscription = filterEventTypes(watchSSE, [
+  ...ALL_DECOPILOT_EVENT_TYPES,
+]);
+
+/** Workflow execution events. */
+export const workflowWatchView: SSESubscription = filterEventTypes(
+  watchSSE,
+  WORKFLOW_EVENT_TYPES,
+);


### PR DESCRIPTION
## Summary
Collapses the per-tab, per-consumer `/api/:org/watch` EventSources into a **single connection per org**, shared across all same-origin tabs via Web Lock leader election + BroadcastChannel relay. This keeps the whole browser under the ~6-connections-per-origin HTTP/1.1 cap (multiple tabs × multiple SSE consumers previously exhausted it and stalled ordinary requests).

No feature changes — pure infrastructure refactor of the existing decopilot + workflow watch consumers.

## Changes
- **`create-sse-subscription.ts`** — adds cross-tab leader election (one tab holds the real `EventSource`, rebroadcasts to followers; lock auto-releases → follower promoted on close), reconnect with exponential backoff, `onReconnect` hand-off, HMR lock cleanup, and a `filterEventTypes` view helper. Backward compatible (new options are optional).
- **`watch-sse-pool.ts`** (new) — one shared `crossTab` connection streaming the union of decopilot + workflow event types.
- **`decopilot-sse-pool.ts` / `use-workflow-sse.ts`** — now thin `filterEventTypes` views over the unified pool instead of opening their own connections.

## Testing
- `tsc --noEmit` clean on changed files
- `knip` clean
- `biome format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies all `/api/:org/watch` SSE consumers into a single cross‑tab connection per org to avoid hitting the ~6 HTTP/1.1 connections-per-origin cap. No feature changes; prevents stalled requests across multiple tabs.

- **Refactors**
  - `create-sse-subscription`: adds cross‑tab leader election (Web Locks) with BroadcastChannel relay, jittered backoff reconnects, `onReconnect` hand‑off, HMR lock cleanup, and a `filterEventTypes` helper.
  - New `watch-sse-pool`: one shared connection streaming the union of decopilot and workflow events; exposes `decopilotWatchView` and `workflowWatchView`.
  - `decopilot-sse-pool` and `use-workflow-sse`: now thin views over the unified pool instead of opening separate connections.

<sup>Written for commit 25e9c8ff9a0bafaecafea06459e90e653aaf8cff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

