### PR TITLE
fix(sandbox): stop SandboxClaim watch loop on permanent 401/403

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
@@ -757,6 +757,20 @@ async function runWatch<T>(opts: RunWatchOpts<T>): Promise<void> {
         } catch {
           /* ignore */
         }
+        // 401/403 mean the loaded kubeconfig can't watch this resource and
+        // never will without new credentials — retrying every few seconds is
+        // pure log spam. The common trigger is local dev where
+        // `loadDefaultKubeConfig` picks up a personal `~/.kube/config` pointed
+        // at a real cluster the dev has no RBAC for. Log once and stop instead
+        // of looping forever.
+        if (resp.status === 401 || resp.status === 403) {
+          console.warn(
+            `[lifecycle-watcher] ${label} stopped: watch denied (${resp.status} ${resp.statusText}). ` +
+              "The kubeconfig in use cannot watch SandboxClaims — if you are running locally, " +
+              "this provider should not be active (check STUDIO_SANDBOX_PROVIDER / your sandbox preference).",
+          );
+          return;
+        }
         throw new Error(
           `watch handshake failed: ${resp.status} ${resp.statusText}`,
         );


### PR DESCRIPTION
## Problem

In local dev (no kubernetes), the logs spam this every few seconds:

```
[lifecycle-watcher] sandboxclaim-reaper watch ended: watch handshake failed: 403 Forbidden
```

The agent-sandbox lifecycle watch loop (`runWatch` in `lifecycle-watcher.ts`) treats **every** handshake failure as transient and reconnects forever with a 5s-capped exponential backoff. A `401`/`403` never self-heals with the same kubeconfig, so the loop just logs the same failure indefinitely.

### Why it fires locally

The env default in dev is `user-desktop`, but the `AgentSandboxProvider` still gets instantiated by a non-env path — the preview reverse-proxy, or a run whose project's sandbox preference is `agent-sandbox`. Its constructor unconditionally calls `startClaimReaper()`, and `loadDefaultKubeConfig()` picks up the developer's personal `~/.kube/config` (pointed at a real cluster they have no RBAC for). The cluster-wide reaper watch then loops on `403` forever.

## Fix

Treat `401`/`403` on the watch handshake as **terminal**: log a single clear line (pointing at `STUDIO_SANDBOX_PROVIDER` / sandbox preference) and stop, instead of retrying. Transient failures (stream timeout, control-plane upgrade, 5xx) keep reconnecting with backoff exactly as before.

This is environment-agnostic — a `403` is permanent in-cluster too (misconfigured RBAC), where retrying every 5s is equally pointless. The fix lives in the shared `runWatch`, so all four watchers (pod, sandbox CR, events, reaper) benefit.

## Testing

- `bun run --cwd=packages/sandbox check` passes.
- `bun run fmt` clean.
- No unit test added: per `TESTING.md`, exercising `runWatch` requires a mocked `kubeFetch`, which is explicitly e2e territory, not a unit test. The existing `lifecycle-watcher.test.ts` only covers the pure `derivePhase` reducer; the watch transport is covered by `client.test.ts` + integration runs against a real cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the SandboxClaim reaper (and other lifecycle watchers) from endlessly retrying on Kubernetes watch handshakes that return 401/403. We now log once with a clear hint and stop, removing noisy log spam in local dev and misconfigured RBAC cases.

- **Bug Fixes**
  - Treat 401/403 as terminal in `runWatch`; keep backoff/retries for transient errors.
  - Emit a single warning with a hint to check `STUDIO_SANDBOX_PROVIDER` or sandbox preference; applies to pod, sandbox CR, events, and reaper watchers.

<sup>Written for commit 4ac0418a7f5c69d6fe559ff410c49fe727e55b49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

