### PR TITLE
feat(runtime): add configuration.onInstall hook with createAgent

### DIFF
--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -309,11 +309,21 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
         // Create client - pool manages lifecycle, best-effort call
         const client = await clientFromConnection(connection, ctx, false);
 
+        // firstRun fires the MCP's onInstall hook exactly once: true when the
+        // connection had no prior configuration_state (its first config save).
+        const priorState = existing.configuration_state as Record<
+          string,
+          unknown
+        > | null;
+        const firstRun =
+          priorState == null || Object.keys(priorState).length === 0;
+
         await client.callTool({
           name: "ON_MCP_CONFIGURATION",
           arguments: {
             state: finalState,
             scopes: finalScopes,
+            firstRun,
           },
         });
       } catch (error) {

--- a/packages/runtime/src/agents.ts
+++ b/packages/runtime/src/agents.ts
@@ -1,0 +1,305 @@
+import { proxyConnectionForId } from "./bindings.ts";
+import { MCPClient } from "./mcp.ts";
+
+/**
+ * Declarative agent creation for MCP servers.
+ *
+ * An "agent" in Studio is a Virtual MCP (a curated bundle of connections +
+ * tools, optionally with instructions). `createAgent` is typed sugar over the
+ * mesh self-endpoint tools COLLECTION_VIRTUAL_MCP_CREATE + AUTOMATION_CREATE +
+ * AUTOMATION_TRIGGER_ADD — the same self-client pattern `Workflow.sync` uses.
+ *
+ * Exposed to MCP authors through `configuration.onInstall`, which fires once on
+ * the first ON_MCP_CONFIGURATION call (first config save) for a connection.
+ */
+
+/** Model tier presets resolved per-org. Mirrors the server `ChatTierSchema`. */
+export type AgentModelTier = "fast" | "smart" | "thinking";
+
+export interface AgentModels {
+  tier: AgentModelTier;
+  /** Pin a concrete model instead of resolving the org tier preset. */
+  modelId?: string;
+  credentialId?: string;
+}
+
+/** A chat message for an automation's seed thread. */
+export interface AutomationMessage {
+  id?: string;
+  role: "user" | "assistant" | "system";
+  parts: Array<Record<string, unknown>>;
+  metadata?: unknown;
+}
+
+/** Friendly trigger shape, mapped onto AUTOMATION_TRIGGER_ADD's fields. */
+export type AutomationTrigger =
+  | { type: "cron"; cron: string }
+  | {
+      type: "event";
+      connectionId: string;
+      eventType: string;
+      params?: Record<string, string>;
+    }
+  | { type: "webhook" };
+
+export interface CreateAgentAutomation {
+  name: string;
+  messages: string | AutomationMessage[];
+  models?: AgentModels;
+  /** Allowlist of model-facing tool names. null/omitted = all bound tools. */
+  tools?: string[] | null;
+  triggers?: AutomationTrigger[];
+  active?: boolean;
+}
+
+export interface CreateAgentInput {
+  name: string;
+  description?: string;
+  instructions?: string;
+  /**
+   * Connections (and their tool subsets) the agent exposes. Omit to bind the
+   * installing connection itself with all of its tools.
+   */
+  tools?: Array<{ connectionId: string; tools?: string[] | null }>;
+  automations?: CreateAgentAutomation[];
+}
+
+/** Outcome of a single AUTOMATION_TRIGGER_ADD call (never throws the caller out). */
+export interface TriggerResult {
+  type: AutomationTrigger["type"];
+  ok: boolean;
+  id?: string;
+  /** Set when `ok` is false — e.g. an event trigger the target connection rejected. */
+  error?: string;
+  /** Present only for a successful webhook trigger; the token is shown only here. */
+  webhook?: { url: string; token: string };
+}
+
+export interface CreatedAutomation {
+  id: string;
+  name: string;
+  triggers: TriggerResult[];
+}
+
+export interface CreateAgentResult {
+  id: string;
+  automations: CreatedAutomation[];
+  /** Convenience: ids of created automations (empty on a no-op re-install). */
+  automationIds: string[];
+  /** True when an agent with this title already existed (no-op re-install). */
+  alreadyExisted: boolean;
+}
+
+export interface InstallContext {
+  createAgent: (input: CreateAgentInput) => Promise<CreateAgentResult>;
+}
+
+interface VirtualMcpItem {
+  id: string;
+  title: string;
+}
+
+/**
+ * Hand-rolled client for the mesh self-endpoint tools used by createAgent.
+ *
+ * TODO: Replace with a generated client once these collection/automation tools
+ * are covered by a binding. Until then, a rename of a tool or field on the
+ * server requires a matching change here.
+ */
+interface MeshAgentClient {
+  COLLECTION_VIRTUAL_MCP_LIST: (input: {
+    where?: {
+      operator: "and";
+      conditions: Array<{ field: string[]; operator: string; value: unknown }>;
+    };
+    limit?: number;
+    offset?: number;
+  }) => Promise<{
+    items: VirtualMcpItem[];
+    totalCount: number;
+    hasMore: boolean;
+  }>;
+  COLLECTION_VIRTUAL_MCP_CREATE: (input: {
+    data: {
+      title: string;
+      description?: string;
+      metadata?: { instructions?: string };
+      connections: Array<{
+        connection_id: string;
+        selected_tools: string[] | null;
+        selected_resources: string[] | null;
+        selected_prompts: string[] | null;
+      }>;
+    };
+  }) => Promise<{ item: VirtualMcpItem }>;
+  AUTOMATION_CREATE: (input: {
+    name: string;
+    virtual_mcp_id: string;
+    messages: string | AutomationMessage[];
+    models?: AgentModels;
+    tools?: string[] | null;
+    active?: boolean;
+  }) => Promise<{ id: string }>;
+  AUTOMATION_TRIGGER_ADD: (input: {
+    automation_id: string;
+    type: "cron" | "event" | "webhook";
+    cron_expression?: string;
+    connection_id?: string;
+    event_type?: string;
+    params?: Record<string, string>;
+  }) => Promise<{
+    id: string;
+    webhook?: { url: string; token: string } | null;
+  }>;
+}
+
+function createMeshSelfClient(
+  meshUrl: string,
+  token?: string,
+): MeshAgentClient {
+  const connection = proxyConnectionForId("self", { meshUrl, token });
+  return MCPClient.forConnection(connection) as unknown as MeshAgentClient;
+}
+
+/**
+ * Scopes a connection must declare in `configuration.scopes` to use
+ * `createAgent` from `onInstall`. Co-located so a server-side tool rename
+ * surfaces as a compile error in the consumer rather than a silent 403.
+ */
+export const AGENT_SCOPES = [
+  "SELF::COLLECTION_VIRTUAL_MCP_LIST",
+  "SELF::COLLECTION_VIRTUAL_MCP_CREATE",
+  "SELF::AUTOMATION_CREATE",
+  "SELF::AUTOMATION_TRIGGER_ADD",
+] as const;
+
+function triggerArgs(automationId: string, trigger: AutomationTrigger) {
+  switch (trigger.type) {
+    case "cron":
+      return {
+        automation_id: automationId,
+        type: "cron" as const,
+        cron_expression: trigger.cron,
+      };
+    case "event":
+      return {
+        automation_id: automationId,
+        type: "event" as const,
+        connection_id: trigger.connectionId,
+        event_type: trigger.eventType,
+        params: trigger.params,
+      };
+    case "webhook":
+      return { automation_id: automationId, type: "webhook" as const };
+  }
+}
+
+/**
+ * Builds the `createAgent` helper bound to a mesh self-endpoint.
+ *
+ * Idempotent by title: if a Virtual MCP with the same title already exists, the
+ * call is a no-op that returns the existing id. This keeps a cleared-then-
+ * resaved config (which re-fires onInstall) from minting duplicates.
+ */
+export function makeCreateAgent(
+  meshUrl: string | undefined,
+  token: string | undefined,
+  connectionId: string | undefined,
+): (input: CreateAgentInput) => Promise<CreateAgentResult> {
+  return async (input) => {
+    if (!meshUrl) {
+      throw new Error("createAgent: missing meshUrl in MESH_REQUEST_CONTEXT");
+    }
+    const self = createMeshSelfClient(meshUrl, token);
+
+    const existing = await self.COLLECTION_VIRTUAL_MCP_LIST({
+      where: {
+        operator: "and",
+        conditions: [{ field: ["title"], operator: "eq", value: input.name }],
+      },
+      limit: 1,
+    });
+    const match = existing.items.find((i) => i.title === input.name);
+    if (match) {
+      return {
+        id: match.id,
+        automations: [],
+        automationIds: [],
+        alreadyExisted: true,
+      };
+    }
+
+    const connections =
+      input.tools && input.tools.length > 0
+        ? input.tools.map((t) => ({
+            connection_id: t.connectionId,
+            selected_tools: t.tools ?? null,
+            selected_resources: null,
+            selected_prompts: null,
+          }))
+        : connectionId
+          ? [
+              {
+                connection_id: connectionId,
+                selected_tools: null,
+                selected_resources: null,
+                selected_prompts: null,
+              },
+            ]
+          : [];
+
+    const { item } = await self.COLLECTION_VIRTUAL_MCP_CREATE({
+      data: {
+        title: input.name,
+        description: input.description,
+        metadata: input.instructions
+          ? { instructions: input.instructions }
+          : undefined,
+        connections,
+      },
+    });
+
+    const automations: CreatedAutomation[] = [];
+    for (const automation of input.automations ?? []) {
+      const created = await self.AUTOMATION_CREATE({
+        name: automation.name,
+        virtual_mcp_id: item.id,
+        messages: automation.messages,
+        models: automation.models,
+        tools: automation.tools,
+        active: automation.active ?? true,
+      });
+      // Per-trigger isolation: a rejected trigger (e.g. an event trigger the
+      // target connection can't configure) is recorded, not thrown — the agent
+      // and its other triggers still land.
+      const triggers: TriggerResult[] = [];
+      for (const trigger of automation.triggers ?? []) {
+        try {
+          const res = await self.AUTOMATION_TRIGGER_ADD(
+            triggerArgs(created.id, trigger),
+          );
+          triggers.push({
+            type: trigger.type,
+            ok: true,
+            id: res.id,
+            webhook: res.webhook ?? undefined,
+          });
+        } catch (err) {
+          triggers.push({
+            type: trigger.type,
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      automations.push({ id: created.id, name: automation.name, triggers });
+    }
+
+    return {
+      id: item.id,
+      automations,
+      automationIds: automations.map((a) => a.id),
+      alreadyExisted: false,
+    };
+  };
+}

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -27,10 +27,20 @@ import {
   WORKFLOW_SCOPES,
   workflowToolId,
 } from "./workflows.ts";
+import { type InstallContext, makeCreateAgent } from "./agents.ts";
 
 // Re-export EventHandlers type and SELF constant for external use
 export { SELF } from "./events.ts";
 export type { EventHandlers } from "./events.ts";
+export { AGENT_SCOPES } from "./agents.ts";
+export type {
+  InstallContext,
+  CreateAgentInput,
+  CreateAgentResult,
+  CreatedAutomation,
+  TriggerResult,
+  AutomationTrigger,
+} from "./agents.ts";
 export type { WorkflowDefinition } from "./workflows.ts";
 
 export const createRuntimeContext = (prev?: AppContext) => {
@@ -489,6 +499,12 @@ export interface CreateMCPServerOptions<
   };
   configuration?: {
     onChange?: (env: TEnv, cb: OnChangeCallback<State>) => Promise<void>;
+    /**
+     * Fired once per connection, on the first ON_MCP_CONFIGURATION call (the
+     * user's first config save). Use it to provision agents/automations via
+     * the injected `createAgent` helper. Requires AGENT_SCOPES in `scopes`.
+     */
+    onInstall?: (env: TEnv, ctx: InstallContext) => Promise<void>;
     state?: TSchema;
     scopes?: string[];
   };
@@ -575,14 +591,14 @@ const getMeshCtx = (input: { runtimeContext: AppContext }) => {
 const toolsFor = <TSchema extends ZodTypeAny = never>({
   events,
   workflows,
-  configuration: { state: schema, scopes, onChange } = {},
+  configuration: { state: schema, scopes, onChange, onInstall } = {},
 }: ResolvedMCPServerOptions<TSchema> = {}): CreatedTool[] => {
   const jsonSchema = schema
     ? injectBindingSchemas(z.toJSONSchema(schema) as Record<string, unknown>)
     : { type: "object", properties: {} };
   const busProp = String(events?.bus ?? "EVENT_BUS");
   return [
-    ...(onChange || events || workflows?.length
+    ...(onChange || onInstall || events || workflows?.length
       ? [
           createTool({
             id: "ON_MCP_CONFIGURATION",
@@ -594,6 +610,12 @@ const toolsFor = <TSchema extends ZodTypeAny = never>({
                 .describe(
                   "Array of scopes in format 'KEY::SCOPE' (e.g., 'GMAIL::GetCurrentUser')",
                 ),
+              firstRun: z
+                .boolean()
+                .optional()
+                .describe(
+                  "True on the first configuration save for this connection — fires onInstall.",
+                ),
             }),
             outputSchema: z.object({}),
             execute: async (input) => {
@@ -603,6 +625,16 @@ const toolsFor = <TSchema extends ZodTypeAny = never>({
                 state,
                 scopes: (input.context as { scopes: string[] }).scopes,
               });
+
+              if (
+                onInstall &&
+                (input.context as { firstRun?: boolean }).firstRun
+              ) {
+                const { meshUrl, token, connectionId } = getMeshCtx(input);
+                await onInstall(input.runtimeContext.env, {
+                  createAgent: makeCreateAgent(meshUrl, token, connectionId),
+                });
+              }
               const bus = getEventBus(busProp, input.runtimeContext.env);
               if (events && state && bus) {
                 const { connectionId } = getMeshCtx(input);


### PR DESCRIPTION
## Summary

Adds a `configuration.onInstall` lifecycle hook to `@decocms/runtime` so an MCP can provision agents/automations the first time it's configured, via an injected typed `createAgent` helper.

```ts
export default withRuntime({
  configuration: {
    state: stateSchema,
    scopes: [...AGENT_SCOPES],
    onInstall: async (env, { createAgent }) => {
      await createAgent({
        name: "Support Triage",
        instructions: "Triage incoming tickets…",
        automations: [{
          name: "Daily digest",
          messages: "Summarize yesterday's tickets",
          models: { tier: "thinking" },
          triggers: [
            { type: "cron", cron: "0 9 * * *" },
            { type: "event", connectionId: "conn_abc", eventType: "order.created" },
            { type: "webhook" },
          ],
        }],
      });
    },
  },
});
```

## How it works

- **Trigger:** rides the existing `ON_MCP_CONFIGURATION` tool. The mesh (`connection/update.ts`) derives a `firstRun` flag — true when the connection had no prior `configuration_state` — and passes it through. The runtime fires `onInstall` only on `firstRun`.
- **`createAgent`:** typed sugar over the existing self-endpoint tools `COLLECTION_VIRTUAL_MCP_CREATE` + `AUTOMATION_CREATE` + `AUTOMATION_TRIGGER_ADD`, using the same self-client pattern as `Workflow.sync`. An "agent" is a Virtual MCP.
- **Idempotent by title:** a cleared-then-resaved config that re-fires `onInstall` returns the existing agent (`alreadyExisted: true`) instead of duplicating.
- **Per-trigger resilience:** each trigger reports `{ type, ok, id?, error?, webhook? }`; a rejected event trigger (target connection can't be configured) is recorded, not thrown, so the agent and other triggers still land. Webhook URL+token are surfaced back.
- **Scopes:** new `AGENT_SCOPES` const for authors to spread into `configuration.scopes`.

## Files
- `packages/runtime/src/agents.ts` (new) — `makeCreateAgent`, types, `AGENT_SCOPES`
- `packages/runtime/src/tools.ts` — `onInstall` option, `firstRun` in `ON_MCP_CONFIGURATION`, re-exports
- `apps/mesh/src/tools/connection/update.ts` — derive + pass `firstRun`

## Caveats
- "Install" = first config **save**, not connection creation. An MCP with no config state never fires `onInstall` under this approach (tradeoff of riding the existing callback vs. a dedicated `ON_MCP_INSTALL`).
- `AUTOMATION_CREATE` itself is still awaited un-guarded — a failed automation create throws out of `createAgent` (no rollback of the already-created agent).

## Testing
- `bun run check` passes for `packages/runtime` and `apps/mesh` (modulo pre-existing Playwright CT errors unrelated to this change).
- Formatted with Biome.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `configuration.onInstall` hook to `@decocms/runtime` that runs on the first config save and injects a typed `createAgent` helper to provision Virtual MCP agents and automations. Includes `AGENT_SCOPES`, idempotent creation by title, and per-trigger results with webhook details.

- **New Features**
  - `configuration.onInstall(env, { createAgent })` fires once per connection on first config save.
  - `createAgent` wraps `SELF::COLLECTION_VIRTUAL_MCP_CREATE`, `SELF::AUTOMATION_CREATE`, and `SELF::AUTOMATION_TRIGGER_ADD`.
  - Idempotent by agent title; returns `alreadyExisted: true` on re-installs.
  - Per-trigger resilience: each cron/event/webhook reports `{ type, ok, id?, error?, webhook? }`; webhook returns URL + token.
  - Default tool binding: if none provided, binds the installing connection’s tools.
  - Mesh sets `firstRun` from prior empty `configuration_state` and passes it to `ON_MCP_CONFIGURATION`.
  - Exposes `AGENT_SCOPES` and related types for authors to import.

- **Migration**
  - To use `onInstall`/`createAgent`, add `AGENT_SCOPES` to `configuration.scopes`.

<sup>Written for commit 42cdeefb87cad2dc323edfde72708a5fd944ee2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

