### PR TITLE
analytics: cross-subdomain identity for the unified onboarding funnel

### DIFF
--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -21,6 +21,13 @@ export function initPostHog(key: string, host: string) {
   if (initialized || typeof window === "undefined") return;
   posthog.init(key, {
     api_host: host,
+    // Persist the PostHog cookie on the `.decocms.com` root domain so a visitor
+    // is the SAME person across www.decocms.com (landing) and
+    // studio.decocms.com (this app). Required for the unified
+    // acquisition → signup funnel — both surfaces must share ONE project key
+    // for the cookie to match. posthog-js defaults this to true; pinned
+    // explicitly so it can't silently regress and break cross-domain identity.
+    cross_subdomain_cookie: true,
     capture_pageview: "history_change",
     capture_pageleave: true,
     autocapture: true,


### PR DESCRIPTION
## What
Pin `cross_subdomain_cookie: true` in the browser PostHog init (`apps/mesh/src/web/lib/posthog-client.ts`).

## Why
We're unifying deco's **acquisition → signup funnel** into one PostHog project (Option A). `www.decocms.com` (landing) and `studio.decocms.com` (this app) share the `.decocms.com` root domain, so **one PostHog project + a root-scoped cookie = the same `person` across both surfaces** — a visitor who lands on www and signs up in Studio becomes a single identity, with first-touch attribution (`$initial_utm_*`, referrer) carried automatically onto `user_signed_up`. No manual cross-project stitching.

Studio already runs on the target project (id `394178`), and posthog-js defaults `cross_subdomain_cookie` to true — this PR just **pins it explicitly** so a future config change can't silently break cross-domain identity. Behavior is unchanged on its own.

## The other half (required for this to do anything)
The landing must be pointed at the **same PostHog project key** as Studio. That PR is on `deco-sites/decocms`, plus an ops step: set the landing's PostHog key Secret to Studio's project (`394178`) key + host `https://us.i.posthog.com` in the deco admin. Until both share the key, the cookie won't match and the funnel stays split.

## Risk
None in isolation (explicit default). The funnel only changes once the landing is re-pointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `cross_subdomain_cookie: true` in the PostHog browser init to scope the cookie to `.decocms.com`, making visitors the same person across `www.decocms.com` and `studio.decocms.com`. This secures cross-subdomain identity for a single acquisition → signup funnel and prevents future config regressions; no behavior change on its own.

- **Migration**
  - Point the landing (`www.decocms.com`) to the same PostHog project as Studio (`394178`) with host `https://us.i.posthog.com`.
  - Once both share the project key, UTMs/referrer will flow into `user_signed_up` automatically.

<sup>Written for commit 3982216c6084aa269493fd59e07949b4a5956ee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

