### PR TITLE
fix(sandbox): refresh ghs_ token on every clone and sync origin on resume

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1597,6 +1597,7 @@ async function resolvePullSandboxConfig(
               ctx,
               connectionId,
               organizationId: input.organizationId,
+              forceRefresh: true,
               onLegacyMintError: (error) => {
                 console.warn(
                   "[pullDispatch] repo-scoped legacy token mint failed",

--- a/apps/mesh/src/oauth/github-mint.ts
+++ b/apps/mesh/src/oauth/github-mint.ts
@@ -148,6 +148,7 @@ async function mintAndStore(
 export async function ensureRepoScopedToken(
   ctx: StudioContext,
   connection: ConnectionEntity,
+  opts?: { forceRefresh?: boolean },
 ): Promise<string> {
   const recipe = getRepoScope(connection);
   if (!recipe) {
@@ -159,7 +160,11 @@ export async function ensureRepoScopedToken(
 
   const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
   const cached = await tokenStorage.get(connection.id);
-  if (cached && !tokenStorage.isExpired(cached, PROACTIVE_REFRESH_BUFFER_MS)) {
+  if (
+    !opts?.forceRefresh &&
+    cached &&
+    !tokenStorage.isExpired(cached, PROACTIVE_REFRESH_BUFFER_MS)
+  ) {
     return cached.accessToken;
   }
 

--- a/apps/mesh/src/shared/github-clone-info.ts
+++ b/apps/mesh/src/shared/github-clone-info.ts
@@ -4,10 +4,11 @@
  * remote so subsequent fetch/pull/push from inside the sandbox keep
  * working with no further plumbing.
  *
- * The token is set once per sandbox. If it expires or is revoked, the
- * sandbox must be destroyed and recreated — studio does not push token
- * updates to running daemons. Falls back to generic identity defaults on
- * /user failure so callers never block on a flaky upstream.
+ * The token is baked into the clone URL on each SANDBOX_START (always
+ * re-minted for legacy repo-scoped connections). The daemon syncs `origin`
+ * when credentials rotate on a resumed sandbox. Falls back to generic
+ * identity defaults on /user failure so callers never block on a flaky
+ * upstream.
  */
 
 import type { Kysely } from "kysely";
@@ -48,6 +49,8 @@ export async function ensureGithubCloneToken(params: {
   ctx: StudioContext;
   connectionId: string;
   organizationId: string;
+  /** Always re-mint legacy repo-scoped ghs_ tokens (e.g. before git clone). */
+  forceRefresh?: boolean;
   onLegacyMintError?: (error: unknown) => void;
 }): Promise<void> {
   const connection = await params.ctx.storage.connections.findById(
@@ -58,7 +61,9 @@ export async function ensureGithubCloneToken(params: {
   if (!connection || !repoScope?.sourceConnectionId) return;
 
   try {
-    await ensureRepoScopedToken(params.ctx, connection);
+    await ensureRepoScopedToken(params.ctx, connection, {
+      forceRefresh: params.forceRefresh,
+    });
   } catch (error) {
     params.onLegacyMintError?.(error);
   }

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -309,6 +309,7 @@ async function provisionSandbox(
         ctx,
         connectionId: githubRepo.connectionId,
         organizationId: orgId,
+        forceRefresh: true,
         onLegacyMintError: (error) => {
           // Swallow + log: a failed mint intentionally falls through to
           // buildCloneInfo's own "No GitHub token found" throw below (sandbox

--- a/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/mesh/src/tools/sandbox/sync-git-credentials.ts
@@ -52,6 +52,7 @@ export async function refreshSandboxGitCredentials(
     ctx,
     connectionId: githubRepo.connectionId,
     organizationId,
+    forceRefresh: true,
     onLegacyMintError: (error) => {
       const message = error instanceof Error ? error.message : RECONNECT_ERROR;
       throw new GitPushAuthError(message);

--- a/packages/sandbox/daemon/config-store/classify.test.ts
+++ b/packages/sandbox/daemon/config-store/classify.test.ts
@@ -52,6 +52,28 @@ describe("classify", () => {
     expect(classify(before, after).kind).not.toBe("identity-conflict");
   });
 
+  it("cloneUrl credential-only change = git-credential-refresh", () => {
+    const before: TenantConfig = {
+      git: {
+        repository: {
+          cloneUrl: "https://x-access-token:OLD_TOKEN@github.com/org/repo.git",
+        },
+      },
+    };
+    const after: TenantConfig = {
+      git: {
+        repository: {
+          cloneUrl: "https://x-access-token:NEW_TOKEN@github.com/org/repo.git",
+        },
+      },
+    };
+    const result = classify(before, after);
+    expect(result.kind).toBe("git-credential-refresh");
+    if (result.kind === "git-credential-refresh") {
+      expect(result.cloneUrl).toBe(after.git?.repository?.cloneUrl);
+    }
+  });
+
   it("branch change = branch-change", () => {
     const before: TenantConfig = {
       git: { repository: { cloneUrl: "x", branch: "main" } },

--- a/packages/sandbox/daemon/config-store/classify.ts
+++ b/packages/sandbox/daemon/config-store/classify.ts
@@ -8,7 +8,8 @@ import type { Transition } from "./types";
  *
  * Precedence (highest first):
  *   identity-conflict > bootstrap > branch-change >
- *   runtime-change > pm-change > port-change > no-op
+ *   runtime-change > pm-change > port-change > env-change >
+ *   git-credential-refresh > no-op
  */
 export function classify(
   before: TenantConfig | null,
@@ -81,6 +82,16 @@ export function classify(
   const envDiff = diffEnv(before.env, after.env);
   if (envDiff) {
     return { kind: "env-change", changed: envDiff };
+  }
+
+  // 7. Git credential refresh (same repo path, rotated embedded token).
+  if (
+    beforeUrl !== undefined &&
+    afterUrl !== undefined &&
+    beforeUrl !== afterUrl &&
+    stripCredentials(beforeUrl) === stripCredentials(afterUrl)
+  ) {
+    return { kind: "git-credential-refresh", cloneUrl: afterUrl };
   }
 
   return { kind: "no-op" };

--- a/packages/sandbox/daemon/config-store/store.test.ts
+++ b/packages/sandbox/daemon/config-store/store.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { TenantConfigStore } from "./store";
+
+describe("TenantConfigStore", () => {
+  it("persists git credential refresh and notifies subscribers", async () => {
+    const store = new TenantConfigStore();
+    await store.apply({
+      git: {
+        repository: {
+          cloneUrl: "https://x-access-token:OLD@github.com/org/repo.git",
+        },
+      },
+      application: { packageManager: { name: "npm" }, runtime: "node" },
+    });
+
+    const transitions: string[] = [];
+    store.subscribe((e) => transitions.push(e.transition.kind));
+
+    const result = await store.apply({
+      git: {
+        repository: {
+          cloneUrl: "https://x-access-token:NEW@github.com/org/repo.git",
+        },
+      },
+    });
+
+    expect(result.kind).toBe("applied");
+    if (result.kind === "applied") {
+      expect(result.transition.kind).toBe("git-credential-refresh");
+    }
+    expect(store.read()?.git?.repository?.cloneUrl).toBe(
+      "https://x-access-token:NEW@github.com/org/repo.git",
+    );
+    expect(transitions).toContain("git-credential-refresh");
+  });
+});

--- a/packages/sandbox/daemon/config-store/types.ts
+++ b/packages/sandbox/daemon/config-store/types.ts
@@ -26,6 +26,7 @@ export type Transition =
       kind: "env-change";
       changed: { set: string[]; deleted: string[] };
     }
+  | { kind: "git-credential-refresh"; cloneUrl: string }
   | { kind: "identity-conflict"; field: "cloneUrl" }
   | { kind: "no-op" };
 

--- a/packages/sandbox/daemon/git/sync-origin-remote.test.ts
+++ b/packages/sandbox/daemon/git/sync-origin-remote.test.ts
@@ -1,0 +1,53 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { cloneUrlHasCredentials, syncOriginRemote } from "./sync-origin-remote";
+
+describe("cloneUrlHasCredentials", () => {
+  it("detects embedded token userinfo", () => {
+    expect(
+      cloneUrlHasCredentials(
+        "https://x-access-token:ghs_abc@github.com/org/repo.git",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for anonymous HTTPS clone URLs", () => {
+    expect(cloneUrlHasCredentials("https://github.com/org/repo.git")).toBe(
+      false,
+    );
+  });
+});
+
+describe("syncOriginRemote", () => {
+  it("updates origin remote URL", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sync-origin-"));
+    const gitcfg =
+      "-c user.email=test@example.com -c user.name=test -c commit.gpgsign=false";
+    try {
+      execSync(`git ${gitcfg} init --bare repo.git`, {
+        cwd: dir,
+        stdio: "ignore",
+      });
+      execSync(`git ${gitcfg} clone repo.git work`, {
+        cwd: dir,
+        stdio: "ignore",
+      });
+      const repoDir = join(dir, "work");
+      const credentialed =
+        "https://x-access-token:NEW_TOKEN@github.com/org/repo.git";
+      syncOriginRemote(repoDir, credentialed);
+      const origin = execSync(
+        `git ${gitcfg} -C ${repoDir} remote get-url origin`,
+        {
+          encoding: "utf-8",
+        },
+      ).trim();
+      expect(origin).toBe(credentialed);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/sandbox/daemon/git/sync-origin-remote.ts
+++ b/packages/sandbox/daemon/git/sync-origin-remote.ts
@@ -1,0 +1,16 @@
+import { gitSync } from "./git-sync";
+
+export function cloneUrlHasCredentials(url: string): boolean {
+  try {
+    const u = new URL(url);
+    return u.username.length > 0 || u.password.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Point `origin` at the credentialed clone URL from daemon config. */
+export function syncOriginRemote(repoDir: string, cloneUrl: string): void {
+  if (!cloneUrlHasCredentials(cloneUrl)) return;
+  gitSync(["remote", "set-url", "origin", cloneUrl], { cwd: repoDir });
+}

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -6,6 +6,10 @@ import { computeBranchDivergence } from "../git/branch-divergence";
 import { parsePorcelainFiles } from "../git/porcelain";
 import { rebaseOntoBase } from "../git/rebase-onto-base";
 import {
+  cloneUrlHasCredentials,
+  syncOriginRemote,
+} from "../git/sync-origin-remote";
+import {
   assertValidRemoteBranchName,
   InvalidRemoteBranchNameError,
 } from "../git/ref-name";
@@ -336,20 +340,6 @@ function resolveRepoRelativePath(deps: GitDeps, userPath: string): string {
     throw new Error(`Invalid path: ${userPath}`);
   }
   return rel;
-}
-
-function cloneUrlHasCredentials(url: string): boolean {
-  try {
-    const u = new URL(url);
-    return u.username.length > 0 || u.password.length > 0;
-  } catch {
-    return false;
-  }
-}
-
-function syncOriginRemote(repoDir: string, cloneUrl: string): void {
-  if (!cloneUrlHasCredentials(cloneUrl)) return;
-  runGit(repoDir, ["remote", "set-url", "origin", cloneUrl]);
 }
 
 function pushBranch(repoDir: string, branch: string): void {

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -16,6 +16,7 @@ import type { DaemonStatus } from "../events/types";
 import type { BranchStatusMonitor } from "../git/branch-status";
 import { gitSync } from "../git/git-sync";
 import { spawnCheckoutBranch } from "../git/checkout-branch";
+import { syncOriginRemote } from "../git/sync-origin-remote";
 import type { InstallState } from "../install/install-state";
 import { InstallState as InstallStateClass } from "../install/install-state";
 import type { LifecycleManager } from "../lifecycle/manager";
@@ -96,15 +97,19 @@ export class SetupOrchestrator {
     });
   }
 
-  /** Config-store transition → step. Fire-and-forget. */
-  handle(transition: Transition): void {
-    const step = transitionToStep(transition);
-    if (!step) return;
+  /** Studio retry endpoint → resume from a named step. Fire-and-forget. */
+  resumeFrom(step: Step): void {
     this.enqueueStep(step);
   }
 
-  /** Studio retry endpoint → resume from a named step. Fire-and-forget. */
-  resumeFrom(step: Step): void {
+  /** Token rotation on an already-cloned repo — sync origin, no full clone. */
+  handle(transition: Transition): void {
+    if (transition.kind === "git-credential-refresh") {
+      this.syncGitRemoteCredentials(transition.cloneUrl);
+      return;
+    }
+    const step = transitionToStep(transition);
+    if (!step) return;
     this.enqueueStep(step);
   }
 
@@ -215,6 +220,10 @@ export class SetupOrchestrator {
     const config = this.currentConfig();
     if (!config) return false;
     const cloneUrl = config.git?.repository?.cloneUrl;
+
+    if (cloneUrl && hasGitRepo(config.repoDir)) {
+      this.syncGitRemoteCredentials(cloneUrl);
+    }
 
     if (cloneUrl && !hasGitRepo(config.repoDir)) {
       this.deps.lifecycle.transition({ phase: "cloning" });
@@ -563,6 +572,20 @@ export class SetupOrchestrator {
       log: (message) => this.chunk(message),
     });
   }
+
+  private syncGitRemoteCredentials(cloneUrl: string): void {
+    const repoDir = this.deps.bootConfig.repoDir;
+    if (!repoDir || !hasGitRepo(repoDir)) return;
+    try {
+      syncOriginRemote(repoDir, cloneUrl);
+      this.chunk("[orchestrator] synced origin credentials\r\n");
+    } catch (e) {
+      const msg = (e as Error).message;
+      this.chunk(
+        `\r\n[orchestrator] failed to sync origin credentials: ${msg}\r\n`,
+      );
+    }
+  }
 }
 
 function transitionToStep(t: Transition): Step | null {
@@ -576,6 +599,7 @@ function transitionToStep(t: Transition): Step | null {
     case "port-change":
       return "start";
     case "env-change":
+    case "git-credential-refresh":
     case "identity-conflict":
     case "no-op":
       return null;


### PR DESCRIPTION
## Summary

- Force re-mint legacy repo-scoped `ghs_` tokens on every `SANDBOX_START`, git publish credential refresh, and desktop pull dispatch (`forceRefresh: true`) so the clone URL always carries a fresh token instead of reusing cache
- Add daemon `git-credential-refresh` transition when only the embedded token in `cloneUrl` changes — config is now persisted (previously classified as `no-op` and discarded) and the orchestrator runs `git remote set-url origin`
- Sync `origin` credentials at the start of `stepClone` when the repo is already present, so branch checkout/fetch on resume uses the new token

Follow-up to #3949: that PR fixed stale `expiresAt` in the DB, but resumed sandboxes still failed because the daemon kept the old token on `origin` and credential-only config updates were dropped.

## Test plan

- [x] `bun test packages/sandbox/daemon/config-store/classify.test.ts packages/sandbox/daemon/config-store/store.test.ts packages/sandbox/daemon/git/sync-origin-remote.test.ts apps/mesh/src/oauth/github-mint.test.ts`
- [ ] Open sandbox on a branch, wait >1h (or expire token in DB), reopen same branch — clone/checkout should succeed
- [ ] Git publish on a long-running sandbox still works after token rotation
- [ ] New branch sandbox (first clone) continues to work as before


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always refresh legacy GitHub repo-scoped `ghs_` tokens on clone and keep resumed sandboxes in sync by updating the `origin` remote when credentials rotate. Fixes checkout/fetch failures on resume caused by expired embedded tokens.

- **Bug Fixes**
  - Always re-mint legacy repo-scoped tokens before building clone URLs on `SANDBOX_START`, git publish refresh, and desktop pull dispatch (`ensureRepoScopedToken({ forceRefresh: true })`).
  - Treat credential-only `cloneUrl` changes as `git-credential-refresh`, persist them, and have the orchestrator sync `origin` via `git remote set-url origin` instead of discarding as no-op.
  - On resume, if the repo already exists, sync `origin` at the start of `stepClone` so subsequent fetch/checkout uses the fresh token.
  - Added `sync-origin-remote` helper and tests; moved credential detection to a shared module.

<sup>Written for commit b9226e9cca4634e4bc5fe3f7f6f5dd8ed7957914. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

