### PR TITLE
fix(decopilot): log close reason + open duration on /stream tail-closed

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -837,6 +837,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       }
 
       let deliveredChunks = 0;
+      const openedAt = Date.now();
       const tailStream = createUIMessageStream({
         execute: async ({ writer }) => {
           const reader = tailChunkStream.getReader();
@@ -859,6 +860,12 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
                   deliverPolicy,
                   runStartedAgoMs,
                   deliveredChunks,
+                  // openMs = how long the tail stayed open; aborted = the client
+                  // (or proxy) closed the request vs. the JetStream subscription
+                  // ending server-side. Short openMs + aborted:true = client
+                  // reconnect churn; aborted:false = server-side close.
+                  openMs: Date.now() - openedAt,
+                  aborted: c.req.raw.signal.aborted,
                 }),
               );
             }


### PR DESCRIPTION
The `tail-closed` diag logs `deliveredChunks` but not **who closed the stream** — so a run that keeps reconnecting and re-delivering the same 1 buffered chunk (logs below) is ambiguous between client churn and a server-side subscription end.

Add two fields to `tail-closed` (behind the existing `DECOPILOT_STREAM_TRACE` gate, no behavior change):
- **`openMs`** — how long the tail stayed open.
- **`aborted`** — `c.req.raw.signal.aborted`: the client/proxy closed the request (true) vs the JetStream subscription ending server-side (false).

Read: short `openMs` + `aborted:true` = client reconnect churn; `aborted:false` = server-side close. This disambiguates the current symptom (tails delivering 1 chunk then closing while the run sits `in_progress` for 2+ min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add diagnostic fields to the /stream tail-closed log to identify who closed the stream and how long it was open. Logs now include openMs and aborted (client/proxy aborted vs server-side close), gated behind `DECOPILOT_STREAM_TRACE`; no behavior change.

<sup>Written for commit b78c27eeda0dbd8ae10843dcadb58cbb0a4e2397. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

