### PR TITLE
fix(std): publish @decocms/std and stop shipping workspace:* in deps

### DIFF
--- a/.github/workflows/publish-std-npm.yaml
+++ b/.github/workflows/publish-std-npm.yaml
@@ -1,0 +1,84 @@
+name: Publish @decocms/std
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/std/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node.js for npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check if version changed
+        id: version-check
+        run: |
+          # Get the current version from package.json
+          CURRENT_VERSION=$(bun -e "console.log(require('./package.json').version)")
+
+          # Check if this specific version already exists in npm
+          if npm view @decocms/std@$CURRENT_VERSION version >/dev/null 2>&1; then
+            echo "version-changed=false" >> $GITHUB_OUTPUT
+            echo "⏭️ Version $CURRENT_VERSION already published, skipping publish"
+          else
+            echo "version-changed=true" >> $GITHUB_OUTPUT
+            echo "✅ Version $CURRENT_VERSION not found in npm, will publish"
+          fi
+
+          echo "current-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+          # Check if this is a prerelease version (contains a hyphen)
+          if [[ "$CURRENT_VERSION" == *-* ]]; then
+            echo "npm-tag=next" >> $GITHUB_OUTPUT
+            echo "📦 Prerelease version detected, will publish with tag 'next'"
+          else
+            echo "npm-tag=latest" >> $GITHUB_OUTPUT
+            echo "📦 Stable version detected, will publish with tag 'latest'"
+          fi
+        working-directory: packages/std
+
+      - name: Publish to npm
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: npm publish --access public --tag ${{ steps.version-check.outputs.npm-tag }} --provenance
+        working-directory: packages/std
+
+      - name: Create Release
+        if: steps.version-check.outputs.version-changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "std-v${{ steps.version-check.outputs.current-version }}" \
+            --title "@decocms/std v${{ steps.version-check.outputs.current-version }}" \
+            --notes "## Changes
+
+          Automated release of @decocms/std package.
+
+          ### Installation
+          \`\`\`bash
+          npm install @decocms/std
+          \`\`\`
+
+          ### Features
+          - Isomorphic async primitives ported from Deno std: sleep/delay, retry, exponentialBackoffWithJitter"

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "3.21.0",
+      "version": "3.31.3",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -178,7 +178,7 @@
     },
     "packages/bindings": {
       "name": "@decocms/bindings",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "dependencies": {
         "@decocms/mcp-utils": "^1.0.5",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -201,7 +201,7 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "1.5.1",
+      "version": "1.6.3",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.80",
         "@ai-sdk/google": "^3.0.80",
@@ -222,9 +222,9 @@
     },
     "packages/mcp-utils": {
       "name": "@decocms/mcp-utils",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "dependencies": {
-        "@decocms/std": "workspace:*",
+        "@decocms/std": "^0.1.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
       },
@@ -239,7 +239,7 @@
     },
     "packages/mesh-plugin-workflows": {
       "name": "mesh-plugin-workflows",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@decocms/bindings": "workspace:*",
         "@decocms/mesh-sdk": "workspace:*",
@@ -265,7 +265,7 @@
     },
     "packages/mesh-sdk": {
       "name": "@decocms/mesh-sdk",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.1",
         "@decocms/mcp-utils": "workspace:*",
@@ -284,9 +284,8 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "2.0.2",
+      "version": "2.1.1",
       "dependencies": {
-        "@ai-sdk/provider": "^3.0.10",
         "@cloudflare/workers-types": "^4.20250617.0",
         "@decocms/bindings": "^1.0.7",
         "@decocms/mcp-utils": "^1.0.5",
@@ -306,7 +305,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.2.5",
+      "version": "1.2.8",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/std": "workspace:*",

--- a/packages/mcp-utils/package.json
+++ b/packages/mcp-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/mcp-utils",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Primitives for building MCP proxies, gateways, and sandboxes",
   "type": "module",
   "main": "./src/index.ts",
@@ -15,7 +15,7 @@
     "./aggregate": "./src/aggregate/index.ts"
   },
   "dependencies": {
-    "@decocms/std": "workspace:*",
+    "@decocms/std": "^0.1.0",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1"
   },

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -7,7 +7,9 @@
   "sideEffects": false,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
-  "files": ["src"],
+  "files": [
+    "src"
+  ],
   "scripts": {
     "check": "tsc --noEmit",
     "test": "bun test"

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@decocms/std",
   "version": "0.1.0",
+  "description": "Isomorphic, zero-dependency async primitives (sleep, retry, backoff) ported from Deno std",
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "files": ["src"],
   "scripts": {
     "check": "tsc --noEmit",
     "test": "bun test"


### PR DESCRIPTION
## Problem

```
$ bun i @decocms/runtime@latest
error: Workspace dependency "@decocms/std" not found
error: @decocms/std@workspace:* failed to resolve
```

Installing `@decocms/runtime` anywhere outside this monorepo fails. The chain is `runtime → @decocms/mcp-utils → @decocms/std`, and two things are broken:

1. **`npm publish` does not rewrite the `workspace:` protocol** (only bun/pnpm/yarn do). The published `@decocms/mcp-utils@1.0.7` literally contains `"@decocms/std": "workspace:*"`, which no external installer can resolve.
2. **`@decocms/std` was never published** — `npm view @decocms/std` is a 404. There was no publish workflow for it.

Every other cross-package dependency in the repo already uses a real semver range (e.g. `runtime → "@decocms/bindings": "^1.0.7"`), which `npm publish` leaves intact. `mcp-utils → std` was the only one in a published package using `workspace:*`, so it was the only one that broke.

## Fix

- **Publish `@decocms/std`**: new `publish-std-npm.yaml` workflow (mirrors the mcp-utils one) + publish-ready metadata (`description`, `license`, `files`).
- **`mcp-utils` std dep `workspace:*` → `^0.1.0`** (the convention the rest of the repo uses). Bun still resolves it to the local workspace copy in-monorepo (`bun.lock`: `@decocms/std@workspace:packages/std`); external consumers get a resolvable range.
- **Bump `mcp-utils` 1.0.7 → 1.0.8** so the corrected metadata republishes.

## Merge ordering

On merge, both publish workflows fire (both paths changed). `@decocms/std@0.1.0` must exist on npm before `mcp-utils@1.0.8`'s `^0.1.0` resolves for external installers. The jobs run in parallel (~seconds apart); if you want zero risk of a brief gap, run **Publish @decocms/std** via `workflow_dispatch` first, confirm it's live, then merge.

## Notes

- `bun.lock` churn beyond the std lines is pre-existing drift — main's lockfile was behind the already-released package.json versions; a plain `bun install` reconverges it.
- Typecheck passes for `std` and `mcp-utils`; no code changed, only package metadata + a workflow.
