### PR TITLE
fix(helm): increase terminationGracePeriodSeconds to 120s

### DIFF
--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -136,7 +136,7 @@ readinessProbe:
   timeoutSeconds: 3
   failureThreshold: 4
 
-terminationGracePeriodSeconds: 60
+terminationGracePeriodSeconds: 120
 
 # Optional lifecycle hooks (preStop, postStart)
 # lifecycle: {}


### PR DESCRIPTION
## Summary
Increase Kubernetes pod termination grace period from 60s to 120s to accommodate Studio's graceful shutdown sequence:
- 25s drain period (load balancer traffic draining)
- 55s graceful shutdown timeout (workers, NATS, telemetry, database cleanup)
- 40s buffer for safety

## Problem
RDS logs show ~60 "Connection reset by peer" errors across staging deployments, concentrated during rolling updates (06:22, 06:27, 06:36). Analysis reveals that the 60s termination timeout was too tight, causing Kubernetes to send SIGKILL before graceful shutdown completed, abruptly closing DB connections without proper cleanup.

## Solution
Align `terminationGracePeriodSeconds` with the actual graceful shutdown duration. This ensures:
- Readiness probes drain (health → 503) within the grace period
- Database pool closes cleanly (`pool.end()` + `db.destroy()`)
- No "Connection reset by peer" errors in RDS logs
- Smooth rolling updates without connection leaks

## Testing
- Local: verified graceful shutdown completes within 80s
- RDS logs: should show no more reset errors during rolling deploys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the pod `terminationGracePeriodSeconds` from 60s to 120s in the Studio Helm chart. This matches the app’s ~80s graceful shutdown so pods aren’t SIGKILLed during rollouts, avoiding RDS “connection reset by peer” errors.

<sup>Written for commit 2815d1ed6099af24bfe93d9cce795d45d8c2fb9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

