### PR TITLE
fix(link): use bunx decocms@latest link in all user-facing references

### DIFF
--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -318,7 +318,7 @@ export async function startLinkDaemon(
   process.on("SIGTERM", () => void shutdown());
   onRemoteShutdown = () => {
     console.log(
-      "Disconnect requested from the Studio web UI — shutting down. Run `bunx decocms link` to reconnect.",
+      "Disconnect requested from the Studio web UI — shutting down. Run `bunx decocms@latest link` to reconnect.",
     );
     void shutdown();
   };

--- a/apps/mesh/src/link-daemon/outbox-imports.test.ts
+++ b/apps/mesh/src/link-daemon/outbox-imports.test.ts
@@ -1,6 +1,6 @@
 /**
  * Guard: the durable-outbox core must stay cluster-free so the link daemon
- * bundle (`bunx decocms link`, distributed to users) never drags in cluster
+ * bundle (`bunx decocms@latest link`, distributed to users) never drags in cluster
  * code (StudioContext, storage, API routes, @decocms/sandbox). The mesh
  * cross-tree guard (src/harnesses/cross-tree-guard.test.ts) covers only the
  * @decocms/harness package tree — NOT src/link-daemon — so this is the

--- a/apps/mesh/src/link-daemon/outbox-runtime.ts
+++ b/apps/mesh/src/link-daemon/outbox-runtime.ts
@@ -1,7 +1,7 @@
 /**
  * Runtime guard for the durable outbox (spec §5.1, N5).
  *
- * The link daemon ships via `bunx decocms link` and runs under the *user's*
+ * The link daemon ships via `bunx decocms@latest link` and runs under the *user's*
  * runtime — unlike the spawned sandbox daemon (`bun build --target=bun`). The
  * outbox uses `bun:sqlite`, which is built-in ONLY under Bun. We require Bun
  * and fail loudly otherwise rather than crashing later with an opaque import

--- a/apps/mesh/src/tools/links/disconnect.ts
+++ b/apps/mesh/src/tools/links/disconnect.ts
@@ -5,7 +5,7 @@ import { requireAuth } from "../../core/studio-context";
 export const LINK_DISCONNECT = defineTool({
   name: "LINK_DISCONNECT",
   description:
-    "Disconnect the calling user's desktop link from the Studio side: tells the linked daemon to shut down (via a `shutdown` control frame) and removes the presence claim. The user re-links by running `bunx decocms link` on the desktop.",
+    "Disconnect the calling user's desktop link from the Studio side: tells the linked daemon to shut down (via a `shutdown` control frame) and removes the presence claim. The user re-links by running `bunx decocms@latest link` on the desktop.",
   inputSchema: z.object({}),
   outputSchema: z.object({
     /**

--- a/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
@@ -17,7 +17,7 @@ import { useCurrentLink } from "@/web/hooks/use-current-link";
 import { KEYS } from "@/web/lib/query-keys";
 import { useStudioTools } from "@/web/lib/studio-tools";
 
-const INSTALL_SNIPPET = "bunx decocms link";
+const INSTALL_SNIPPET = "bunx decocms@latest link";
 
 const CAPABILITY_LABELS: Partial<Record<Capability, string>> = {
   "claude-code": "Claude Code",

--- a/apps/mesh/src/web/components/chat/desktop-offline-banner.tsx
+++ b/apps/mesh/src/web/components/chat/desktop-offline-banner.tsx
@@ -52,9 +52,9 @@ export function DesktopOfflineBanner() {
         }
       >
         <p className="mx-4 text-xs text-muted-foreground">
-          Run <code className="font-mono">bunx decocms@latest link</code> in a terminal
-          on that machine to bring it back. Messages you send while it's offline
-          will fail.
+          Run <code className="font-mono">bunx decocms@latest link</code> in a
+          terminal on that machine to bring it back. Messages you send while
+          it's offline will fail.
         </p>
       </CollapsibleHighlight>
       <ConnectDesktopDialog open={connectOpen} onOpenChange={setConnectOpen} />

--- a/apps/mesh/src/web/components/chat/desktop-offline-banner.tsx
+++ b/apps/mesh/src/web/components/chat/desktop-offline-banner.tsx
@@ -52,7 +52,7 @@ export function DesktopOfflineBanner() {
         }
       >
         <p className="mx-4 text-xs text-muted-foreground">
-          Run <code className="font-mono">bunx decocms link</code> in a terminal
+          Run <code className="font-mono">bunx decocms@latest link</code> in a terminal
           on that machine to bring it back. Messages you send while it's offline
           will fail.
         </p>

--- a/apps/mesh/src/web/components/chat/highlight/parse-error-message.test.ts
+++ b/apps/mesh/src/web/components/chat/highlight/parse-error-message.test.ts
@@ -37,7 +37,7 @@ describe("parseErrorMessage", () => {
       '{"error":"link_unavailable","code":"user_desktop_link_offline"}';
     const result = parseErrorMessage(raw);
     expect(result.summary).toContain("desktop is offline");
-    expect(result.summary).toContain("bunx decocms link");
+    expect(result.summary).toContain("bunx decocms@latest link");
     expect(result.rawDetails).toBe(raw);
   });
 

--- a/apps/mesh/src/web/components/chat/highlight/parse-error-message.ts
+++ b/apps/mesh/src/web/components/chat/highlight/parse-error-message.ts
@@ -48,7 +48,7 @@ export function parseErrorMessage(message: string): {
     }
     return {
       summary:
-        "Your desktop is offline. Run `bunx decocms link` in a terminal on it, then try again.",
+        "Your desktop is offline. Run `bunx decocms@latest link` in a terminal on it, then try again.",
       rawDetails: message,
     };
   }

--- a/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
+++ b/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
@@ -91,8 +91,8 @@ export function NoAiProviderEmptyState({
   const subtitle =
     description ??
     (localMode
-      ? "Connect a provider, or run `bunx decocms link` on your desktop for Claude Code, Codex, and local files."
-      : "Connect a provider — or run `bunx decocms link` on your desktop to use Claude Code, Codex, or your local files.");
+      ? "Connect a provider, or run `bunx decocms@latest link` on your desktop for Claude Code, Codex, and local files."
+      : "Connect a provider — or run `bunx decocms@latest link` on your desktop to use Claude Code, Codex, or your local files.");
 
   // Badge styles: use brand color if available, otherwise a neutral muted background
   const hasBrandStyle = !!(brandIcon || primaryColor);

--- a/tests/multi-pod/scenarios/link-uplink-toxiproxy.test.ts
+++ b/tests/multi-pod/scenarios/link-uplink-toxiproxy.test.ts
@@ -8,7 +8,7 @@
  *
  * ── PREREQUISITES (the bodies stay `test.skip` until these land) ─────────────
  * 1. tests/multi-pod/docker-compose.yml services:
- *      - `link-daemon`: runs the `bunx decocms link` daemon against a mesh pod,
+ *      - `link-daemon`: runs the `bunx decocms@latest link` daemon against a mesh pod,
  *        env LINK_WS_UPLINK=true (dial GET /api/links/uplink). restart:"no" so
  *        pod.ts kill/start drives the outbox-replay-across-restart scenario.
  *      - `toxiproxy`: TCP proxy interposed on the uplink WS path (admin :8474)


### PR DESCRIPTION
## Summary
- Replace all occurrences of `bunx decocms link` with `bunx decocms@latest link` across UI text, log messages, tool descriptions, comments, and tests

## Why
Using `@latest` ensures users always invoke the most recent CLI version rather than a potentially stale locally-cached copy, avoiding subtle version mismatch issues when connecting the desktop link.

## Test plan
- [ ] Existing `parse-error-message` test updated to assert the new string — runs with `bun test`
- [ ] No logic changes; purely a string/text update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all user-facing references of `bunx decocms link` with `bunx decocms@latest link` so users run the latest CLI when linking their desktop. Updated UI copy, logs, tool descriptions, and tests, and applied Biome formatting; no behavior changes.

<sup>Written for commit 3c90db69a7e70bc52def92dad7581aafe5def196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

