### PR TITLE
feat(sections-editor): detach saved block into local section

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.test.ts
@@ -47,6 +47,7 @@ describe("block-type-utils", () => {
 
   it("isSavedBlockResolveType detects block id references", () => {
     expect(isSavedBlockResolveType("Header")).toBe(true);
+    expect(isSavedBlockResolveType("MelhoresMalas/MaisVendidos")).toBe(true);
     expect(isSavedBlockResolveType("site/sections/Header/Header.tsx")).toBe(
       false,
     );

--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
@@ -80,7 +80,8 @@ export function isManifestMatcherResolveType(
 
 /** Block id reference (no module path) — e.g. `Header`, not `site/sections/Header.tsx`. */
 export function isSavedBlockResolveType(resolveType: string): boolean {
-  if (resolveType.includes("/")) return false;
+  // Module paths end with a file extension (e.g. site/sections/Header.tsx)
+  if (/\.\w+$/.test(resolveType)) return false;
   if (resolveType === "__proto__" || resolveType === "constructor") {
     return false;
   }

--- a/apps/mesh/src/web/components/sections-editor/deco-block-key.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/deco-block-key.test.ts
@@ -33,8 +33,12 @@ describe("deco-block-key", () => {
     expect(() => assertSafeDecoBlockKey("../package.json")).toThrow(
       /Invalid block key/,
     );
-    expect(() => assertSafeDecoBlockKey("foo/bar")).toThrow(
-      /Invalid block key/,
-    );
+  });
+
+  it("allows slashes in block keys", () => {
+    expect(() => assertSafeDecoBlockKey("foo/bar")).not.toThrow();
+    expect(() =>
+      assertSafeDecoBlockKey("MelhoresMalas/MaisVendidos"),
+    ).not.toThrow();
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/deco-block-key.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/deco-block-key.test.ts
@@ -41,4 +41,13 @@ describe("deco-block-key", () => {
       assertSafeDecoBlockKey("MelhoresMalas/MaisVendidos"),
     ).not.toThrow();
   });
+
+  it("rejects percent-encoded slashes in block keys", () => {
+    expect(() => assertSafeDecoBlockKey("foo%2fbar")).toThrow(
+      /Invalid block key/,
+    );
+    expect(() => assertSafeDecoBlockKey("foo%2Fbar")).toThrow(
+      /Invalid block key/,
+    );
+  });
 });

--- a/apps/mesh/src/web/components/sections-editor/deco-block-key.ts
+++ b/apps/mesh/src/web/components/sections-editor/deco-block-key.ts
@@ -5,7 +5,6 @@
 function containsPathTraversal(segment: string): boolean {
   if (
     !segment ||
-    segment.includes("/") ||
     segment.includes("\\") ||
     segment.includes("..") ||
     segment.includes("\0")
@@ -15,10 +14,7 @@ function containsPathTraversal(segment: string): boolean {
   try {
     const decoded = decodeURIComponent(segment);
     return (
-      decoded.includes("/") ||
-      decoded.includes("\\") ||
-      decoded.includes("..") ||
-      decoded.includes("\0")
+      decoded.includes("\\") || decoded.includes("..") || decoded.includes("\0")
     );
   } catch {
     return true;

--- a/apps/mesh/src/web/components/sections-editor/deco-block-key.ts
+++ b/apps/mesh/src/web/components/sections-editor/deco-block-key.ts
@@ -13,9 +13,23 @@ function containsPathTraversal(segment: string): boolean {
   }
   try {
     const decoded = decodeURIComponent(segment);
-    return (
-      decoded.includes("\\") || decoded.includes("..") || decoded.includes("\0")
-    );
+    if (
+      decoded.includes("\\") ||
+      decoded.includes("..") ||
+      decoded.includes("\0")
+    ) {
+      return true;
+    }
+    // A percent-encoded slash (%2f/%2F) decodes to "/" — reject it.
+    // Literal slashes in the original key are safe (encodeURIComponent
+    // escapes them in the filename), but encoded ones indicate smuggling.
+    if (decoded !== segment && decoded.includes("/")) {
+      // Only flag if decoding actually introduced new slashes
+      const originalSlashes = (segment.match(/\//g) ?? []).length;
+      const decodedSlashes = (decoded.match(/\//g) ?? []).length;
+      if (decodedSlashes > originalSlashes) return true;
+    }
+    return false;
   } catch {
     return true;
   }

--- a/apps/mesh/src/web/components/sections-editor/page-sections.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-sections.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildPageDataWithSections,
+  canMakeSectionReusable,
   suggestBlockId,
   validateBlockId,
 } from "./page-sections";
@@ -78,6 +79,13 @@ describe("page-sections", () => {
       "Must start with a letter",
     );
     expect(validateBlockId("MyNewBlock", decofile)).toBeNull();
+  });
+
+  it("canMakeSectionReusable rejects saved, multivariate, and hidden sections", () => {
+    expect(canMakeSectionReusable({})).toBe(true);
+    expect(canMakeSectionReusable({ isSavedBlock: true })).toBe(false);
+    expect(canMakeSectionReusable({ isMultivariate: true })).toBe(false);
+    expect(canMakeSectionReusable({ isHidden: true })).toBe(false);
   });
 
   it("suggestBlockId sanitizes labels", () => {

--- a/apps/mesh/src/web/components/sections-editor/page-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-sections.ts
@@ -40,8 +40,9 @@ export function cloneSection(section: RawSection): RawSection {
 export function canMakeSectionReusable(section: {
   isSavedBlock?: boolean;
   isMultivariate?: boolean;
+  isHidden?: boolean;
 }): boolean {
-  return !section.isSavedBlock && !section.isMultivariate;
+  return !section.isSavedBlock && !section.isMultivariate && !section.isHidden;
 }
 
 export function suggestBlockId(label: string): string {

--- a/apps/mesh/src/web/components/sections-editor/parse-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/parse-sections.ts
@@ -30,7 +30,7 @@ export function parseSections(
     const rt = s.__resolveType ?? "";
     const isLazy = isLazyResolveType(rt);
 
-    if (!isLazy && rt !== "" && !rt.includes("/") && rt in decofile) {
+    if (!isLazy && rt !== "" && !/\.\w+$/.test(rt) && rt in decofile) {
       const resolvedBlock = decofile[rt] as Record<string, unknown> | undefined;
       const label =
         (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
@@ -102,7 +102,7 @@ export function parseSections(
     if (
       isLazy &&
       effectiveRt !== "" &&
-      !effectiveRt.includes("/") &&
+      !/\.\w+$/.test(effectiveRt) &&
       effectiveRt in decofile
     ) {
       const resolvedBlock = decofile[effectiveRt] as

--- a/apps/mesh/src/web/components/sections-editor/parse-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/parse-sections.ts
@@ -1,3 +1,4 @@
+import { isSavedBlockResolveType } from "./block-type-utils";
 import { isLazyResolveType } from "./section-lazy";
 import {
   labelFromResolveType,
@@ -30,7 +31,7 @@ export function parseSections(
     const rt = s.__resolveType ?? "";
     const isLazy = isLazyResolveType(rt);
 
-    if (!isLazy && rt !== "" && !/\.\w+$/.test(rt) && rt in decofile) {
+    if (!isLazy && rt !== "" && isSavedBlockResolveType(rt) && rt in decofile) {
       const resolvedBlock = decofile[rt] as Record<string, unknown> | undefined;
       const label =
         (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
@@ -102,7 +103,7 @@ export function parseSections(
     if (
       isLazy &&
       effectiveRt !== "" &&
-      !/\.\w+$/.test(effectiveRt) &&
+      isSavedBlockResolveType(effectiveRt) &&
       effectiveRt in decofile
     ) {
       const resolvedBlock = decofile[effectiveRt] as

--- a/apps/mesh/src/web/components/sections-editor/section-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-list.tsx
@@ -20,6 +20,11 @@ import {
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import {
   DndContext,
   DragOverlay,
   closestCenter,
@@ -167,6 +172,7 @@ function SortableSectionItem({
   onToggleHidden,
   onToggleLazy,
   onAddVariant,
+  onDetach,
 }: {
   section: ParsedSection;
   raw: RawSection | undefined;
@@ -180,6 +186,7 @@ function SortableSectionItem({
   onToggleHidden: () => void;
   onToggleLazy: () => void;
   onAddVariant: () => void;
+  onDetach: () => void;
 }) {
   const isAsyncRender = raw
     ? isLazyResolveType(raw.__resolveType ?? "")
@@ -224,53 +231,70 @@ function SortableSectionItem({
       <SectionRowContent section={section} raw={raw} meta={meta} />
 
       {!section.isMultivariate && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label={
-            isAsyncRender ? "Disable async render" : "Enable async render"
-          }
-          className={cn(
-            "h-7 w-7 shrink-0",
-            isAsyncRender ? "" : "opacity-0 group-hover:opacity-100",
-          )}
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleLazy();
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-        >
-          <Zap
-            className={cn("h-3.5 w-3.5", isAsyncRender && "text-yellow-500")}
-          />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={
+                isAsyncRender ? "Disable async render" : "Enable async render"
+              }
+              className={cn(
+                "h-7 w-7 shrink-0",
+                isAsyncRender ? "" : "opacity-0 group-hover:opacity-100",
+              )}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleLazy();
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              <Zap
+                className={cn(
+                  "h-3.5 w-3.5",
+                  isAsyncRender && "text-yellow-500",
+                )}
+              />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {isAsyncRender ? "Disable async render" : "Enable async render"}
+          </TooltipContent>
+        </Tooltip>
       )}
 
       {!section.isMultivariate && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label={section.isHidden ? "Show section" : "Hide section"}
-          className={cn(
-            "h-7 w-7 shrink-0",
-            section.isHidden
-              ? "opacity-100"
-              : "opacity-0 group-hover:opacity-100",
-          )}
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleHidden();
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-        >
-          {section.isHidden ? (
-            <EyeOff className="h-3.5 w-3.5" />
-          ) : (
-            <Eye className="h-3.5 w-3.5" />
-          )}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={section.isHidden ? "Show section" : "Hide section"}
+              className={cn(
+                "h-7 w-7 shrink-0",
+                section.isHidden
+                  ? "opacity-100"
+                  : "opacity-0 group-hover:opacity-100",
+              )}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleHidden();
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              {section.isHidden ? (
+                <EyeOff className="h-3.5 w-3.5" />
+              ) : (
+                <Eye className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {section.isHidden ? "Show section" : "Hide section"}
+          </TooltipContent>
+        </Tooltip>
       )}
 
       <DropdownMenu>
@@ -321,6 +345,17 @@ function SortableSectionItem({
               Make reusable
             </DropdownMenuItem>
           )}
+          {section.isSavedBlock === true && !section.isMultivariate && (
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onDetach();
+              }}
+            >
+              <LayoutAlt01 className="h-4 w-4" />
+              Detach
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
             onClick={(e) => {
@@ -353,6 +388,7 @@ export function SectionList({
   onToggleHidden,
   onToggleLazy,
   onAddVariant,
+  onDetach,
   onAddSection,
   canAddSection = true,
 }: {
@@ -369,6 +405,7 @@ export function SectionList({
   onToggleHidden: (index: number) => void;
   onToggleLazy: (index: number) => void;
   onAddVariant: (index: number) => void;
+  onDetach: (index: number) => void;
   onAddSection: () => void;
   canAddSection?: boolean;
 }) {
@@ -493,6 +530,7 @@ export function SectionList({
                   onToggleHidden={() => onToggleHidden(entry.index)}
                   onToggleLazy={() => onToggleLazy(entry.index)}
                   onAddVariant={() => onAddVariant(entry.index)}
+                  onDetach={() => onDetach(entry.index)}
                 />
               );
             })}

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1152,7 +1152,7 @@ export function SectionsEditor({
     if (!rawSection || !parsed?.isSavedBlock) return;
 
     const unwrapped = unwrapSection(rawSection, parsed, decofile);
-    if (!unwrapped) return;
+    if (!unwrapped?.data) return;
 
     // Remove the `name` field — it belongs to the saved block, not the inline copy
     const { name: _name, ...inlineData } = unwrapped.data;

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1145,6 +1145,33 @@ export function SectionsEditor({
     savePageSections(updatedSections);
   };
 
+  const handleDetachSection = (index: number) => {
+    if (!activePageKey) return;
+    const rawSection = rawSections[index];
+    const parsed = parsedSections[index];
+    if (!rawSection || !parsed?.isSavedBlock) return;
+
+    const unwrapped = unwrapSection(rawSection, parsed, decofile);
+    if (!unwrapped) return;
+
+    // Remove the `name` field — it belongs to the saved block, not the inline copy
+    const { name: _name, ...inlineData } = unwrapped.data;
+
+    const updatedSections = [...rawSections];
+    if (parsed.isLazy) {
+      // Preserve the lazy wrapper, replace the inner saved-block reference
+      updatedSections[index] = {
+        ...rawSection,
+        section: inlineData,
+      } as RawSection;
+    } else {
+      updatedSections[index] = inlineData as RawSection;
+    }
+
+    if (selectedSectionIndex === index) clearSectionEditing();
+    savePageSections(updatedSections);
+  };
+
   const handleAddSection = (entry: SectionCatalogEntry) => {
     if (!activePageKey) return;
 
@@ -2377,6 +2404,7 @@ export function SectionsEditor({
               onToggleHidden={handleToggleHidden}
               onToggleLazy={handleToggleLazy}
               onAddVariant={handleAddSectionVariant}
+              onDetach={handleDetachSection}
               onAddSection={() => setAddSectionOpen(true)}
               canAddSection={canAddSection}
             />


### PR DESCRIPTION
## Summary
- Add **Detach** option in the section three-dot menu for saved/global blocks, converting a global reference into a local inline copy so users can customize it per-page without affecting other usages
- Hide **Make reusable** for hidden sections (they use a multivariate+never wrapper internally)
- Add **tooltips** to the async render (Zap) and hide/show (Eye) icon buttons
- Fix saved block resolve type detection for block IDs containing slashes (e.g. `MelhoresMalas/MaisVendidos`)

## Test plan
- [ ] Open a page with a global/saved section → three-dot menu shows "Detach"
- [ ] Click Detach → section becomes a local inline copy, global block unchanged
- [ ] Detach a lazy+saved section → lazy wrapper preserved, inner block inlined
- [ ] Hidden section menu no longer shows "Make reusable"
- [ ] Hover async render icon → tooltip "Enable/Disable async render"
- [ ] Hover hide/show icon → tooltip "Hide/Show section"
- [ ] `bun run fmt`, `bun run lint`, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Detach option to convert a saved/global block into a local inline section while preserving lazy wrappers, so pages can customize safely. Also adds tooltips, hides “Make reusable” for hidden sections, and hardens resolve/key handling.

- **New Features**
  - Add “Detach” for saved/global blocks; creates a local copy and keeps the lazy wrapper.
  - Add tooltips to async render (Zap) and hide/show (Eye) buttons.
  - Hide “Make reusable” for hidden sections.

- **Bug Fixes**
  - Use `isSavedBlockResolveType` in parsing and detection (file-extension check), allowing IDs with slashes.
  - Allow literal slashes in block keys; reject percent-encoded slashes that decode to new “/” to prevent path traversal.
  - Add a defensive guard in Detach when unwrapped data is missing.

<sup>Written for commit cc5ac77ed0b2a199c9ba553b947e2ccae3591ac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

