### PR TITLE
perf(decopilot): checkpoint thread on every step instead of every 5th

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1343,13 +1343,9 @@ async function prepareRun(
                 }),
               );
               if (!partEmitter) {
-                // v1 (unchanged): coarse whole-message checkpoints — every step
-                // on resume, every 5th step otherwise.
+                // v1: whole-message checkpoints on every step.
                 const stepEvent = transitions[0]?.event;
-                const shouldSave = input.isResume
-                  ? stepEvent?.type === "STEP_COMPLETED"
-                  : stepEvent?.type === "STEP_COMPLETED" &&
-                    stepEvent.stepCount % 5 === 0;
+                const shouldSave = stepEvent?.type === "STEP_COMPLETED";
                 if (shouldSave) {
                   pendingOps.push(
                     saveMessagesToThread(responseMessage as ChatMessage).catch(


### PR DESCRIPTION
## Summary
The v1 whole-message checkpoint path in `dispatch-run.ts` only persisted the thread every 5th step for normal (non-resume) runs. This increases flush frequency to **every step**, matching the resume path.

A mid-run pod death now loses at most one step of progress instead of up to five.

## Change
`onStep` save condition collapses from `STEP_COMPLETED && stepCount % 5 === 0` (non-resume) to just `STEP_COMPLETED` — the resume branch already saved on every step, so both paths are now identical.

## Testing
Type-level only; logic is a one-line condition simplification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checkpoint the Decopilot thread on every step for all runs, not just resumes. This reduces worst-case progress loss to one step and simplifies the save condition to `STEP_COMPLETED`.

<sup>Written for commit ae4c62b7431ceb5c20d5af6940d11f963e87a538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

