### PR TITLE
fix(shutdown): derive shutdown timers from chart grace period

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -300,10 +300,16 @@ async function gracefulShutdown(signal: string) {
   shuttingDown = true;
   console.log(`\n[shutdown] Received ${signal}, shutting down gracefully...`);
 
+  // Single source of truth: the chart's terminationGracePeriodSeconds is
+  // injected as SHUTDOWN_GRACE_SECONDS. Force-exit a few seconds before SIGKILL
+  // so the process always wins the race; drain fills most of the budget.
+  const graceMs = Number(process.env.SHUTDOWN_GRACE_SECONDS ?? 60) * 1_000;
+  const forceExitMs = Math.max(graceMs - 5_000, 10_000);
+
   const forceExitTimer = setTimeout(() => {
-    console.error("[shutdown] Timed out after 55s, forcing exit.");
+    console.error(`[shutdown] Timed out after ${forceExitMs}ms, forcing exit.`);
     process.exit(1);
-  }, 55_000);
+  }, forceExitMs);
   forceExitTimer.unref?.();
 
   let exitCode = 0;
@@ -318,9 +324,12 @@ async function gracefulShutdown(signal: string) {
     //    LB controller observing the pod enter Terminating (this SIGTERM), not
     //    by the K8s Endpoints path — and it takes far longer than the old 2s to
     //    propagate. Closing the listener early leaves the NLB forwarding new
-    //    connections to a dead socket -> CF 520 during rollout. Stay well under
-    //    terminationGracePeriodSeconds (60s) so the force-exit timer never trips.
-    const drainMs = Number(process.env.SHUTDOWN_DRAIN_MS ?? 25_000);
+    //    connections to a dead socket -> CF 520 during rollout. Stay under the
+    //    force-exit timer (derived from terminationGracePeriodSeconds above) so
+    //    it never trips before drain completes.
+    const drainMs = Number(
+      process.env.SHUTDOWN_DRAIN_MS ?? Math.floor(forceExitMs * 0.6),
+    );
     await sleep(drainMs);
 
     // 3. Force-close connections (SSE streams are long-lived and would block

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
             - secretRef:
                 name: {{ include "chart-deco-studio.secretName" . }}
           env:
+            {{- if .Values.terminationGracePeriodSeconds }}
+            - name: SHUTDOWN_GRACE_SECONDS
+              value: {{ .Values.terminationGracePeriodSeconds | quote }}
+            {{- end }}
             {{- if .Values.otel.enabled }}
             {{- if .Values.otel.protocol }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL


### PR DESCRIPTION
## Summary
Makes `terminationGracePeriodSeconds` the single source of truth for graceful-shutdown timing, so the chart value and the app's internal timers can no longer drift apart (the root cause behind #3975, where the chart was bumped 60→120 while `index.ts` still hardcoded 55s/25s and its comment still said `60s`).

- **`deployment.yaml`**: injects the templated `terminationGracePeriodSeconds` into the container as `SHUTDOWN_GRACE_SECONDS`.
- **`index.ts`**: derives `forceExit = grace - 5s` and `drain = 60% of forceExit` from that env var, instead of hardcoding `55_000` / `25_000`. `SHUTDOWN_DRAIN_MS` still overrides drain.

Now bumping the Helm value is the only edit required; the app tracks it automatically.

## Behavior
Invariant `drain < forceExit < grace` holds across values; at the default grace=60 it reproduces the previous 55s force-exit:

| grace | drain | force-exit |
|-------|-------|-----------|
| 30s   | 15s   | 25s |
| 60s   | 33s   | 55s |
| 120s  | 69s   | 115s |

## Testing
- `helm template --set terminationGracePeriodSeconds=120` renders `SHUTDOWN_GRACE_SECONDS="120"`.
- `bun run fmt` clean.
- Ordering invariant verified across grace values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives shutdown timers from the chart’s `terminationGracePeriodSeconds` so app and Helm stay in sync, preventing drift during rollouts. Only the Helm value needs to change; the app adjusts automatically.

- **Bug Fixes**
  - `deployment.yaml`: injects `SHUTDOWN_GRACE_SECONDS` from `terminationGracePeriodSeconds`.
  - `index.ts`: sets `forceExitMs = graceMs - 5000` and default `drainMs = 0.6 * forceExitMs`; `SHUTDOWN_DRAIN_MS` still overrides.

<sup>Written for commit 4871314496805175cf6ac231db7cd4c8f65dc557. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

