### PR TITLE
chore(helm): bump chart-deco-studio to 0.8.0

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: "latest"
 
 dependencies:


### PR DESCRIPTION
## What
Bumps `deploy/helm/studio/Chart.yaml` version `0.7.1 → 0.8.0`.

## Why
`publish-chart.yml` only fires on `Chart.yaml` changes — there's no auto-release/auto-bump. This bump is what publishes `oci://ghcr.io/decocms/chart-deco-studio:0.8.0` containing the optional agent-loop **worker Deployment** + `dispatchRole` queue split from #3937.

Minor bump: the worker feature is backward-compatible and default-off (`worker.enabled=false`, `dispatchRole=""` → byte-identical render to 0.7.1).

## ⚠️ Merge ordering
**Merge this AFTER #3937.** `publish-chart.yml` packages `main`'s current chart content with `--dependency-update` at merge time. If this lands before #3937, it would publish 0.8.0 *without* the worker template. Sequence:
1. Merge #3937 (worker template + guard; no Chart.yaml change → no publish).
2. Merge this PR → publish workflow ships 0.8.0 with the worker template.
3. Then bump the `deco-studio-stg` wrapper's `studio` dependency to 0.8.0 + re-vendor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump Helm chart `chart-deco-studio` from 0.7.1 to 0.8.0 to publish the optional agent-loop worker Deployment and `dispatchRole` queue split from #3937. Minor, backward-compatible release; the worker is off by default.

- **Migration**
  - Merge #3937 first.
  - Then merge this PR to trigger `publish-chart.yml` and publish `oci://ghcr.io/decocms/chart-deco-studio:0.8.0`.
  - Update the `deco-studio-stg` wrapper to depend on `chart-deco-studio` 0.8.0 and re-vendor.

<sup>Written for commit 2283daecaaf887bb97037676d854818cc3844525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

