### PR TITLE
docs(self-hosting): add architecture overview

### DIFF
--- a/apps/docs/client/src/components/ArchitectureDiagram.astro
+++ b/apps/docs/client/src/components/ArchitectureDiagram.astro
@@ -1,0 +1,237 @@
+---
+// Static, server-rendered architecture diagram. No client JS.
+// Layout math runs at build/SSR time and emits plain SVG.
+
+const TIER: Record<string, string> = {
+  edge: "#94a3b8", web: "#22d3ee", api: "#38bdf8", worker: "#a78bfa",
+  mcp: "#2dd4bf", file: "#a3e635", db: "#34d399", nats: "#fbbf24",
+  sbx: "#fb7185", pub: "#fb923c", llm: "#f0abfc", desk: "#c4b5fd",
+};
+
+const ZONES = [
+  { x: 24, y: 150, w: 140, h: 790, label: "Edge", sub: "public internet", stroke: "rgba(148,163,184,.30)", fill: "rgba(148,163,184,.03)" },
+  { x: 182, y: 150, w: 992, h: 790, label: "Cloud Cluster", sub: "kubernetes", stroke: "rgba(56,189,248,.24)", fill: "rgba(56,189,248,.03)" },
+  { x: 1192, y: 150, w: 384, h: 790, label: "Desktop", sub: "deco link · laptop", stroke: "rgba(168,130,255,.28)", fill: "rgba(168,130,255,.045)" },
+];
+const SUBZONES = [{ x: 772, y: 782, w: 404, h: 150, label: "Cloud Sandbox · pod" }];
+
+type Node = {
+  x: number; y: number; w: number; h: number; tier: string;
+  label: string; tag?: string; shape?: "cyl" | "hex"; replicas?: boolean; ext?: boolean;
+};
+const N: Record<string, Node> = {
+  s3: { x: 470, y: 96, w: 128, h: 54, tier: "file", ext: true, label: "Object Store", tag: "s3 · external" },
+  llm: { x: 760, y: 96, w: 128, h: 54, tier: "llm", ext: true, label: "LLM", tag: "anthropic · external" },
+  dmcp: { x: 1004, y: 96, w: 140, h: 54, tier: "mcp", ext: true, label: "Downstream MCP", tag: "tool servers" },
+
+  client: { x: 94, y: 330, w: 118, h: 58, tier: "edge", label: "Client", tag: "browser / mcp" },
+  cf: { x: 94, y: 510, w: 118, h: 58, tier: "edge", label: "CF", tag: "edge / cdn" },
+  nlb: { x: 94, y: 690, w: 118, h: 58, tier: "edge", label: "NLB", tag: "l4 lb" },
+
+  web: { x: 305, y: 545, w: 146, h: 64, tier: "web", label: "Web", tag: "nginx · spa", replicas: true },
+  api: { x: 485, y: 360, w: 148, h: 64, tier: "api", label: "API", tag: "hono · role=api", replicas: true },
+  worker: { x: 485, y: 645, w: 148, h: 64, tier: "worker", label: "Worker", tag: "role=worker · dbos", replicas: true },
+  mcpproxy: { x: 705, y: 300, w: 150, h: 60, tier: "mcp", label: "MCP Proxy", tag: "api routes" },
+  files: { x: 705, y: 470, w: 150, h: 60, tier: "file", label: "Files / Storage", tag: "api routes" },
+  nats: { x: 930, y: 300, w: 124, h: 82, tier: "nats", shape: "hex", label: "NATS", tag: "messaging" },
+  db: { x: 930, y: 505, w: 122, h: 88, tier: "db", shape: "cyl", label: "DB", tag: "postgres" },
+  daemonctl: { x: 862, y: 852, w: 158, h: 60, tier: "sbx", label: "Daemon API", tag: "protected /_sandbox/*" },
+  daemonprev: { x: 1068, y: 852, w: 152, h: 60, tier: "pub", label: "Preview", tag: "public" },
+
+  linkd: { x: 1300, y: 340, w: 158, h: 62, tier: "desk", label: "Link Daemon", tag: "deco link" },
+  dloop: { x: 1300, y: 560, w: 158, h: 62, tier: "desk", label: "Desktop Loop", tag: "native loop" },
+  dsbx: { x: 1430, y: 800, w: 152, h: 62, tier: "sbx", label: "Desktop Sandbox", tag: "local daemon" },
+};
+
+// from, to, kind
+const E: [string, string, string][] = [
+  ["client", "cf", "req"], ["cf", "nlb", "req"], ["nlb", "web", "req"], ["web", "api", "req"],
+  ["api", "mcpproxy", "ctrl"], ["mcpproxy", "dmcp", "ctrl"], ["worker", "dmcp", "inproc"],
+  ["api", "files", "ctrl"], ["worker", "files", "ctrl"], ["files", "s3", "ctrl"],
+  ["api", "worker", "ctrl"], ["api", "db", "ctrl"], ["worker", "db", "ctrl"],
+  ["api", "nats", "ctrl"], ["worker", "nats", "ctrl"], ["nats", "linkd", "bridge"],
+  ["worker", "llm", "model"], ["worker", "daemonctl", "ctrl"], ["api", "daemonctl", "ctrl"],
+  ["client", "daemonprev", "public"],
+  ["linkd", "dloop", "ctrl"], ["dloop", "llm", "model"], ["dloop", "api", "mcp"], ["dloop", "dsbx", "ctrl"],
+];
+
+const EDGE_STYLE: Record<string, { stroke: string; dash?: string; w: number; op: number }> = {
+  req: { stroke: "#465268", w: 1.5, op: 0.55 },
+  ctrl: { stroke: "#465268", w: 1.5, op: 0.5 },
+  model: { stroke: TIER.llm, dash: "2 5", w: 1.4, op: 0.45 },
+  bridge: { stroke: TIER.desk, dash: "7 5", w: 1.8, op: 0.7 },
+  mcp: { stroke: "#52607a", dash: "3 6", w: 1.4, op: 0.4 },
+  inproc: { stroke: TIER.mcp, dash: "2 4", w: 1.4, op: 0.5 },
+  public: { stroke: TIER.pub, dash: "6 5", w: 1.5, op: 0.6 },
+};
+
+// manual margin routes for long cross-diagram edges
+const ROUTES: Record<string, { x: number; y: number }[]> = {
+  "client>daemonprev": [{ x: 35, y: 330 }, { x: 12, y: 330 }, { x: 12, y: 986 }, { x: 1068, y: 986 }, { x: 1068, y: 882 }],
+  "dloop>api": [{ x: 1300, y: 529 }, { x: 1300, y: 128 }, { x: 485, y: 128 }, { x: 485, y: 328 }],
+};
+function roundedPath(pts: { x: number; y: number }[], r = 16) {
+  let d = `M${pts[0].x},${pts[0].y}`;
+  for (let i = 1; i < pts.length - 1; i++) {
+    const p = pts[i], a = pts[i - 1], b = pts[i + 1];
+    const v1 = { x: p.x - a.x, y: p.y - a.y }, v2 = { x: b.x - p.x, y: b.y - p.y };
+    const l1 = Math.hypot(v1.x, v1.y) || 1, l2 = Math.hypot(v2.x, v2.y) || 1;
+    const rr = Math.min(r, l1 / 2, l2 / 2);
+    const s = { x: p.x - (v1.x / l1) * rr, y: p.y - (v1.y / l1) * rr };
+    const e = { x: p.x + (v2.x / l2) * rr, y: p.y + (v2.y / l2) * rr };
+    d += ` L${s.x.toFixed(1)},${s.y.toFixed(1)} Q${p.x},${p.y} ${e.x.toFixed(1)},${e.y.toFixed(1)}`;
+  }
+  const last = pts[pts.length - 1];
+  d += ` L${last.x},${last.y}`;
+  return d;
+}
+
+const NORMAL: Record<string, [number, number]> = { r: [1, 0], l: [-1, 0], t: [0, -1], b: [0, 1] };
+function sides(a: Node, b: Node): [string, string] {
+  const dx = b.x - a.x, dy = b.y - a.y;
+  if (Math.abs(dx) >= Math.abs(dy)) return dx > 0 ? ["r", "l"] : ["l", "r"];
+  return dy > 0 ? ["b", "t"] : ["t", "b"];
+}
+function anchor(n: Node, side: string, f: number) {
+  const hw = n.w / 2, hh = n.h / 2;
+  if (side === "r") return { x: n.x + hw, y: n.y - hh + f * n.h, n: NORMAL.r };
+  if (side === "l") return { x: n.x - hw, y: n.y - hh + f * n.h, n: NORMAL.l };
+  if (side === "t") return { x: n.x - hw + f * n.w, y: n.y - hh, n: NORMAL.t };
+  return { x: n.x - hw + f * n.w, y: n.y + hh, n: NORMAL.b };
+}
+
+type EM = { from: string; to: string; kind: string; sa: string; sb: string; fa?: number; fb?: number; routed?: { x: number; y: number }[] };
+const edgeMeta: EM[] = [];
+const buckets: Record<string, { i: number; end: "a" | "b" }[]> = {};
+E.forEach((e, i) => {
+  const routed = ROUTES[e[0] + ">" + e[1]];
+  const [af, bf] = sides(N[e[0]], N[e[1]]);
+  edgeMeta.push({ from: e[0], to: e[1], kind: e[2], sa: af, sb: bf, routed });
+  if (routed) return;
+  (buckets[e[0] + "|" + af] ||= []).push({ i, end: "a" });
+  (buckets[e[1] + "|" + bf] ||= []).push({ i, end: "b" });
+});
+Object.entries(buckets).forEach(([key, list]) => {
+  const side = key.split("|")[1];
+  list.sort((p, q) => {
+    const op = p.end === "a" ? N[edgeMeta[p.i].to] : N[edgeMeta[p.i].from];
+    const oq = q.end === "a" ? N[edgeMeta[q.i].to] : N[edgeMeta[q.i].from];
+    return side === "t" || side === "b" ? op.x - oq.x : op.y - oq.y;
+  });
+  const n = list.length;
+  list.forEach((it, k) => {
+    const f = (k + 1) / (n + 1);
+    if (it.end === "a") edgeMeta[it.i].fa = f; else edgeMeta[it.i].fb = f;
+  });
+});
+function pathFor(m: EM) {
+  if (m.routed) return roundedPath(m.routed);
+  const A = N[m.from], B = N[m.to];
+  const p1 = anchor(A, m.sa, m.fa ?? 0.5), p2 = anchor(B, m.sb, m.fb ?? 0.5);
+  const dist = Math.hypot(p2.x - p1.x, p2.y - p1.y);
+  const k = Math.min(160, Math.max(48, dist * 0.4));
+  const c1 = { x: p1.x + p1.n[0] * k, y: p1.y + p1.n[1] * k };
+  const c2 = { x: p2.x + p2.n[0] * k, y: p2.y + p2.n[1] * k };
+  return `M${p1.x.toFixed(1)},${p1.y.toFixed(1)} C${c1.x.toFixed(1)},${c1.y.toFixed(1)} ${c2.x.toFixed(1)},${c2.y.toFixed(1)} ${p2.x.toFixed(1)},${p2.y.toFixed(1)}`;
+}
+
+const edges = edgeMeta.map((m) => ({ d: pathFor(m), ...EDGE_STYLE[m.kind] }));
+const nodes = Object.values(N).map((n) => {
+  const col = TIER[n.tier];
+  let shape = "";
+  if (n.shape === "cyl") {
+    const w = n.w, h = n.h, rx = w / 2, ry = 10;
+    shape = `M${-rx},${-h / 2 + ry} a${rx},${ry} 0 0 1 ${w},0 v${h - 2 * ry} a${rx},${ry} 0 0 1 ${-w},0 Z`;
+  } else if (n.shape === "hex") {
+    const w = n.w / 2, h = n.h / 2, c = 18;
+    shape = `M${-w + c},${-h} H${w - c} L${w},0 L${w - c},${h} H${-w + c} L${-w},0 Z`;
+  }
+  return { ...n, col, shape };
+});
+
+const legend = [
+  ["edge", "Edge"], ["web", "Web"], ["api", "API"], ["worker", "Worker"], ["mcp", "MCP"], ["file", "Files"],
+  ["db", "Postgres"], ["nats", "NATS"], ["sbx", "Sandbox"], ["pub", "Preview"], ["llm", "LLM"], ["desk", "Desktop"],
+];
+---
+
+<figure class="arch">
+  <div class="arch-scroll">
+    <svg viewBox="0 0 1600 1020" role="img" aria-label="Studio system architecture: edge, cloud cluster and desktop tiers">
+      <defs>
+        <marker id="arch-ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="#5b6a82"></path>
+        </marker>
+      </defs>
+
+      {ZONES.map((z) => (
+        <g>
+          <rect x={z.x} y={z.y} width={z.w} height={z.h} rx="16" fill={z.fill} stroke={z.stroke} stroke-width="1.2"></rect>
+          <text x={z.x + 16} y={z.y + 24} class="zlabel">{z.label}</text>
+          <text x={z.x + 16} y={z.y + 38} class="zsub">{z.sub}</text>
+        </g>
+      ))}
+      {SUBZONES.map((z) => (
+        <g>
+          <rect x={z.x} y={z.y} width={z.w} height={z.h} rx="12" fill="rgba(251,113,133,.05)" stroke="rgba(251,113,133,.32)" stroke-width="1" stroke-dasharray="5 4"></rect>
+          <text x={z.x + 14} y={z.y + 20} class="szlabel">{z.label}</text>
+        </g>
+      ))}
+
+      {edges.map((e) => (
+        <path d={e.d} fill="none" stroke={e.stroke} stroke-width={e.w} stroke-dasharray={e.dash} opacity={e.op} marker-end="url(#arch-ah)"></path>
+      ))}
+
+      {nodes.map((n) => (
+        <g transform={`translate(${n.x},${n.y})`}>
+          {n.replicas && [2, 1].map((s) => (
+            <rect x={-n.w / 2 + s * 6} y={-n.h / 2 - s * 6} width={n.w} height={n.h} rx="11" fill="#0a0f17" stroke={n.col} stroke-width="1.3" opacity="0.55"></rect>
+          ))}
+          {n.shape ? (
+            <path d={n.shape} fill="#0d131c" stroke={n.col} stroke-width="1.5" stroke-dasharray={n.ext ? "5 4" : undefined}></path>
+          ) : (
+            <rect x={-n.w / 2} y={-n.h / 2} width={n.w} height={n.h} rx="12" fill="#0d131c" stroke={n.col} stroke-width="1.5" stroke-dasharray={n.ext ? "5 4" : undefined}></rect>
+          )}
+          <text text-anchor="middle" y={n.tag ? -3 : 5} class="nlabel">{n.label}</text>
+          {n.tag && <text text-anchor="middle" y="11" class="ntag" fill={n.col}>{n.tag}</text>}
+          {n.replicas && <text text-anchor="middle" y={n.h / 2 + 12} class="nflag">×N · scales independently</text>}
+        </g>
+      ))}
+    </svg>
+  </div>
+  <div class="arch-legend">
+    {legend.map(([t, name]) => (
+      <span><i style={`background:${TIER[t]}`}></i>{name}</span>
+    ))}
+  </div>
+  <figcaption>Request path, agent runs and sandboxes across the edge, cloud cluster and desktop tiers.</figcaption>
+</figure>
+
+<style>
+  .arch {
+    margin: 1.5rem 0;
+    border: 1px solid #1a2230;
+    border-radius: 16px;
+    background:
+      radial-gradient(1200px 700px at 80% -20%, #10202c 0%, transparent 55%),
+      #070910;
+    padding: 14px 14px 16px;
+    color: #e8eef6;
+    font-family: ui-monospace, "IBM Plex Mono", Menlo, monospace;
+  }
+  .arch-scroll { overflow-x: auto; }
+  .arch svg { display: block; width: 100%; min-width: 1180px; height: auto; }
+  .arch .zlabel { font-size: 10px; letter-spacing: .34em; text-transform: uppercase; fill: #7c8aa3; font-weight: 600; }
+  .arch .zsub { font-size: 8.5px; letter-spacing: .18em; text-transform: uppercase; fill: #465268; }
+  .arch .szlabel { font-size: 9px; letter-spacing: .22em; text-transform: uppercase; fill: rgba(251,113,133,.65); font-weight: 600; }
+  .arch .nlabel { fill: #e8eef6; font-size: 13.5px; font-weight: 600; letter-spacing: .02em; }
+  .arch .ntag { font-size: 8px; letter-spacing: .13em; text-transform: uppercase; opacity: .9; }
+  .arch .nflag { fill: #7c8aa3; font-size: 7.5px; letter-spacing: .1em; }
+  .arch-legend {
+    display: flex; flex-wrap: wrap; gap: 6px 14px;
+    font-size: 10.5px; color: #7c8aa3; margin: 10px 4px 0;
+  }
+  .arch-legend span { display: inline-flex; align-items: center; gap: 6px; }
+  .arch-legend i { width: 11px; height: 11px; border-radius: 3px; }
+  .arch figcaption { font-size: 11px; color: #56607a; margin: 12px 4px 2px; font-family: inherit; }
+</style>

--- a/apps/docs/client/src/components/ArchitectureDiagram.astro
+++ b/apps/docs/client/src/components/ArchitectureDiagram.astro
@@ -13,7 +13,7 @@ const ZONES = [
   { x: 182, y: 150, w: 992, h: 790, label: "Cloud Cluster", sub: "kubernetes", stroke: "rgba(56,189,248,.24)", fill: "rgba(56,189,248,.03)" },
   { x: 1192, y: 150, w: 384, h: 790, label: "Desktop", sub: "deco link · laptop", stroke: "rgba(168,130,255,.28)", fill: "rgba(168,130,255,.045)" },
 ];
-const SUBZONES = [{ x: 772, y: 782, w: 404, h: 150, label: "Cloud Sandbox · pod" }];
+const SUBZONES = [{ x: 620, y: 782, w: 556, h: 150, label: "Cloud Sandbox · pod" }];
 
 type Node = {
   x: number; y: number; w: number; h: number; tier: string;
@@ -32,15 +32,17 @@ const N: Record<string, Node> = {
   api: { x: 485, y: 360, w: 148, h: 64, tier: "api", label: "API", tag: "hono · role=api", replicas: true },
   worker: { x: 485, y: 645, w: 148, h: 64, tier: "worker", label: "Worker", tag: "role=worker · dbos", replicas: true },
   mcpproxy: { x: 705, y: 300, w: 150, h: 60, tier: "mcp", label: "MCP Proxy", tag: "api routes" },
-  files: { x: 705, y: 470, w: 150, h: 60, tier: "file", label: "Files / Storage", tag: "api routes" },
+  files: { x: 705, y: 470, w: 150, h: 60, tier: "file", label: "Files / Storage", tag: "api · /files /fs" },
   nats: { x: 930, y: 300, w: 124, h: 82, tier: "nats", shape: "hex", label: "NATS", tag: "messaging" },
   db: { x: 930, y: 505, w: 122, h: 88, tier: "db", shape: "cyl", label: "DB", tag: "postgres" },
-  daemonctl: { x: 862, y: 852, w: 158, h: 60, tier: "sbx", label: "Daemon API", tag: "protected /_sandbox/*" },
-  daemonprev: { x: 1068, y: 852, w: 152, h: 60, tier: "pub", label: "Preview", tag: "public" },
+  daemonctl: { x: 710, y: 852, w: 158, h: 60, tier: "sbx", label: "Daemon API", tag: "protected /_sandbox/*" },
+  orgfsc: { x: 900, y: 852, w: 132, h: 56, tier: "file", label: "Org FS", tag: "mount · sidecar" },
+  daemonprev: { x: 1085, y: 852, w: 152, h: 60, tier: "pub", label: "Preview", tag: "public" },
 
   linkd: { x: 1300, y: 340, w: 158, h: 62, tier: "desk", label: "Link Daemon", tag: "deco link" },
   dloop: { x: 1300, y: 560, w: 158, h: 62, tier: "desk", label: "Desktop Loop", tag: "native loop" },
-  dsbx: { x: 1430, y: 800, w: 152, h: 62, tier: "sbx", label: "Desktop Sandbox", tag: "local daemon" },
+  dsbx: { x: 1290, y: 800, w: 152, h: 62, tier: "sbx", label: "Desktop Sandbox", tag: "local daemon" },
+  orgfsd: { x: 1460, y: 800, w: 140, h: 56, tier: "file", label: "Org FS", tag: "mount · daemon" },
 };
 
 // from, to, kind
@@ -52,6 +54,8 @@ const E: [string, string, string][] = [
   ["api", "nats", "ctrl"], ["worker", "nats", "ctrl"], ["nats", "linkd", "bridge"],
   ["worker", "llm", "model"], ["worker", "daemonctl", "ctrl"], ["api", "daemonctl", "ctrl"],
   ["client", "daemonprev", "public"],
+  ["daemonctl", "orgfsc", "ctrl"], ["orgfsc", "files", "ctrl"],
+  ["dsbx", "orgfsd", "ctrl"], ["orgfsd", "files", "ctrl"],
   ["linkd", "dloop", "ctrl"], ["dloop", "llm", "model"], ["dloop", "api", "mcp"], ["dloop", "dsbx", "ctrl"],
 ];
 
@@ -67,8 +71,9 @@ const EDGE_STYLE: Record<string, { stroke: string; dash?: string; w: number; op:
 
 // manual margin routes for long cross-diagram edges
 const ROUTES: Record<string, { x: number; y: number }[]> = {
-  "client>daemonprev": [{ x: 35, y: 330 }, { x: 12, y: 330 }, { x: 12, y: 986 }, { x: 1068, y: 986 }, { x: 1068, y: 882 }],
+  "client>daemonprev": [{ x: 35, y: 330 }, { x: 12, y: 330 }, { x: 12, y: 986 }, { x: 1085, y: 986 }, { x: 1085, y: 882 }],
   "dloop>api": [{ x: 1300, y: 529 }, { x: 1300, y: 128 }, { x: 485, y: 128 }, { x: 485, y: 328 }],
+  "orgfsd>files": [{ x: 1460, y: 828 }, { x: 1460, y: 1002 }, { x: 600, y: 1002 }, { x: 600, y: 470 }, { x: 630, y: 470 }],
 };
 function roundedPath(pts: { x: number; y: number }[], r = 16) {
   let d = `M${pts[0].x},${pts[0].y}`;

--- a/apps/docs/client/src/components/ui/Sidebar.astro
+++ b/apps/docs/client/src/components/ui/Sidebar.astro
@@ -172,7 +172,7 @@ function buildTree(docs: any[]): TreeNode[] {
 
         // Custom order for self-hosting section
         if (parentPath === "self-hosting") {
-          const selfHostingOrder = ["quickstart", "authentication"];
+          const selfHostingOrder = ["quickstart", "architecture", "authentication"];
           const aIndex = selfHostingOrder.indexOf(a.name);
           const bIndex = selfHostingOrder.indexOf(b.name);
           if (aIndex !== -1 && bIndex !== -1) {

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/architecture.mdx
@@ -1,0 +1,131 @@
+---
+title: "Architecture"
+description: How Studio is wired end to end — edge, cloud cluster, and desktop — and how requests, runs, and sandboxes flow between the tiers.
+icon: Network
+---
+
+import Callout from "../../../../../components/ui/Callout.astro";
+
+This page describes how a running Studio deployment is wired together: the tiers, what each one does, and how a request becomes an agent run, a tool call, or a sandbox preview. It is the conceptual companion to the [Kubernetes](/studio/self-hosting/deploy/kubernetes) and [Docker Compose](/studio/self-hosting/deploy/docker-compose) deploy guides.
+
+## The three tiers
+
+Studio spans three trust/locality boundaries:
+
+- **Edge** — the public internet path: a CDN and an L4 load balancer.
+- **Cloud cluster** — the Kubernetes deployment: web, API, workers, Postgres, NATS, and cloud sandboxes.
+- **Desktop** — the user's laptop, connected by `deco link`, where the desktop loop and desktop sandbox can run.
+
+```
+EDGE                CLOUD CLUSTER                                     DESKTOP
+────                ─────────────                                     ───────
+
+Client ─▶ CF ─▶ NLB ─▶ Web(nginx) ─▶ API ──┬─▶ MCP Proxy ─▶ Downstream MCP (ext)
+                                            ├─▶ Files/Storage ─▶ Object Store (ext)
+                                            ├─▶ DB (Postgres)
+                                            ├─▶ NATS ───────────────▶ Link Daemon
+                                            └─▶ Worker                    │
+                                                  │  model               ▼
+                                                  ├──────────▶ LLM   Desktop Loop ─▶ Desktop Sandbox
+                                                  ├─▶ DB                  │
+                                                  ├─▶ Files/Storage       └─(MCP via presigned URL)─▶ API
+                                                  ├─▶ Downstream MCP (in-process bridge)
+                                                  └─▶ Cloud Sandbox ─┬─ Daemon API (protected /_sandbox/*)
+                                                                     └─ Preview (public)
+```
+
+## Edge
+
+| Component | Role |
+| --- | --- |
+| **CF** (Cloudflare) | TLS termination, static SPA caching, DDoS/bot mitigation. First hop for all traffic. |
+| **NLB** | L4 load balancer fronting the cluster. Routes to the web (front-door) pods; the `frontDoorLabels` selector decides which pods receive ingress. |
+
+## Cloud cluster
+
+### Web, API, and Worker scale independently
+
+These three deployments are separate and scale on their own. The web tier was split out from the API (the "front-door split") so the static front door can deploy and scale on a different cadence than the application server.
+
+| Tier | Deployment | Responsibility |
+| --- | --- | --- |
+| **Web** | nginx | Serves the React SPA and reverse-proxies `/api`, `/mcp`, `/oauth-proxy`, `/.well-known` to the API Service. Port 8080. |
+| **API** | Hono, `MESH_DISPATCH_ROLE=api` | HTTP routes, Better Auth, the MCP proxy, access control. **Enqueues** decopilot runs onto DBOS queues and tails NATS to stream output back to the UI. Stateless. **Does not run the agent loop.** |
+| **Worker** | Hono, `MESH_DISPATCH_ROLE=worker` | **Dequeues** DBOS queues and **runs the agent loop** (`streamText`: model → tool → repeat). CPU-bound. These are the run executors. |
+
+<Callout type="note">
+  The split is by role, not by image — both run the same build. `MESH_DISPATCH_ROLE` decides whether a pod listens on the DBOS queues (`worker`) or only serves HTTP and enqueues (`api`). A single-deployment setup can use `all`.
+</Callout>
+
+### Datastores
+
+| Component | Role |
+| --- | --- |
+| **DB** (PostgreSQL, via Kysely) | System of record: orgs, connections, credential vault, audit, threads + messages, and `sandbox_runner_state`. It also holds the **DBOS queues and `workflow_status` journal** that make runs durable and recoverable. |
+| **NATS** | Live messaging infrastructure with three jobs: (1) JetStream `/stream` fan-out (`decopilot.stream.<thread>`) → UI live tail; (2) the pull work-queue (`link.work.<user>`) → desktop; (3) the link-claim KV (`studio_links`) tracking which pod owns each user's link. |
+
+<Callout type="warning">
+  **The event bus is dormant.** The CloudEvents pub/sub *feature* (`EVENT_PUBLISH`/`EVENT_SUBSCRIBE`, the durable event queue, `ON_EVENTS` subscribers) is only consumed by the workflow plugin, which is not in use. NATS itself is **not** dormant — it serves the live jobs listed above. Don't conflate the two.
+</Callout>
+
+## The decopilot run lifecycle
+
+1. A message (`POST /messages`) or an automation fire creates a **run** on a thread.
+2. The **API** enqueues it onto a DBOS queue in Postgres:
+   - `THREAD_GATE_QUEUE` — serialized per thread (concurrency 1 per `threadId`).
+   - `AUTOMATIONS_QUEUE` — per-org parallelism.
+3. A **Worker** dequeues it and runs the agent loop: call the model, execute any tool calls, repeat (up to a step limit).
+4. Output chunks are published to NATS and tailed back to the UI over `/stream`.
+5. If the pod crashes, **DBOS journal replay** resumes retriable steps on another pod — recovery is the framework's job, not hand-rolled.
+
+There are two transports for step 3:
+
+- **Hosted** (default) — the run executes in-process on the worker and uses a **cloud sandbox**.
+- **Pull** — the run is published to NATS `link.work.<user>`; the user's **desktop** picks it up and runs the loop locally against a **desktop sandbox**.
+
+## MCP: in-process vs. the proxy routes
+
+This distinction matters for reasoning about the system:
+
+- **The worker calls MCP tools in-process.** The agent loop builds a `PassthroughClient` over an in-memory bridge and calls tools directly — **no HTTP hop inside the cluster**. It still connects outward to downstream MCP servers.
+- **The MCP proxy routes are for external clients.** `/mcp/virtual-mcp/:id`, `/mcp/:connectionId`, `/oauth-proxy/*`, and `/.well-known` are served by the **API** to external IDEs (Cursor, Claude, VS Code). The worker does not use these.
+
+### Which routes are called by whom
+
+| Routes | API / external | Worker |
+| --- | --- | --- |
+| MCP proxy (`/mcp/*`, `/oauth-proxy/*`, `.well-known`) | ✅ external clients via the API | ❌ (in-process instead) |
+| File & object-storage (`/api/:org/files/*`, presigned GET/PUT, uploads) | ✅ serving clients | ✅ agent tools read/write files & mint presigned URLs |
+| Worker-only over HTTP | — | none — tool calls are in-process |
+
+File and object-storage routes are the genuine "called by both" surface, and they are backed by an S3-compatible **Object Store**.
+
+## Sandboxes
+
+A sandbox clones the repo, runs the dev server, and exposes an in-pod **daemon**. Its HTTP surface splits in two:
+
+| Surface | Auth | Purpose | Caller |
+| --- | --- | --- | --- |
+| **Preview** (catch-all `*`) | None — the handle (subdomain) is the secret | Reverse-proxies the running dev server (the live app preview); injects HMR. `/_sandbox/*` is actively rejected here. | The end user's browser, at `<handle>.preview.<domain>` |
+| **Daemon API** (`/_sandbox/*`) | Bearer `DAEMON_TOKEN` | Control surface: fs ops (read/write/edit/bash/grep), git (status/diff/publish), exec scripts, setup (clone → install → start), tasks, SSE events, harness dispatch. | The cluster (worker for agent fs/git/bash tools; API for UI setup + events) |
+
+### Cloud vs. desktop sandboxes
+
+| | Cloud sandbox | Desktop sandbox |
+| --- | --- | --- |
+| Where | agent-sandbox operator + a `SandboxClaim` pod per (user, projectRef) | Same daemon, spawned locally on the laptop |
+| Reached over | k8s port-forward / in-cluster Service (control); ingress or port-forward (preview) | loopback (control); `<handle>.localhost:<port>` (preview) |
+| Selected when | the default for hosted runs | a `deco link` is live — `user-desktop` is the default provider then |
+
+## Desktop
+
+When a user runs `deco link`, a **Link Daemon** on their laptop long-polls the cluster (`/api/links/work` for chat, `/api/links/proxy` for sandbox control) and heartbeats presence into the NATS link-claim KV. Pulled runs execute in the **Desktop Loop** (`runNativeAgentLoopCore`) — a portable copy of the agent loop. The thinking model is injected by the cluster, and MCP is reached over HTTP via a presigned URL back to the cluster.
+
+## At a glance
+
+- **Web / API / Worker** are independent deployments; workers are DBOS run executors.
+- **Runs are durable** via DBOS queues + journal in Postgres; recovery is automatic.
+- **MCP tool calls are in-process** on the worker; the `/mcp/*` proxy routes are for external clients only.
+- **File/object-storage routes** are the shared API+worker surface.
+- **NATS is live**; the CloudEvents event-bus feature is dormant.
+- **Sandboxes** expose a public preview and a token-protected control API, in the cloud (k8s) or on the desktop (`deco link`).

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/architecture.mdx
@@ -5,6 +5,7 @@ icon: Network
 ---
 
 import Callout from "../../../../../components/ui/Callout.astro";
+import ArchitectureDiagram from "../../../../../components/ArchitectureDiagram.astro";
 
 This page describes how a running Studio deployment is wired together: the tiers, what each one does, and how a request becomes an agent run, a tool call, or a sandbox preview. It is the conceptual companion to the [Kubernetes](/studio/self-hosting/deploy/kubernetes) and [Docker Compose](/studio/self-hosting/deploy/docker-compose) deploy guides.
 
@@ -15,6 +16,10 @@ Studio spans three trust/locality boundaries:
 - **Edge** — the public internet path: a CDN and an L4 load balancer.
 - **Cloud cluster** — the Kubernetes deployment: web, API, workers, Postgres, NATS, and cloud sandboxes.
 - **Desktop** — the user's laptop, connected by `deco link`, where the desktop loop and desktop sandbox can run.
+
+<ArchitectureDiagram />
+
+The same flow as text:
 
 ```
 EDGE                CLOUD CLUSTER                                     DESKTOP

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/architecture.mdx
@@ -100,10 +100,10 @@ This distinction matters for reasoning about the system:
 | Routes | API / external | Worker |
 | --- | --- | --- |
 | MCP proxy (`/mcp/*`, `/oauth-proxy/*`, `.well-known`) | ✅ external clients via the API | ❌ (in-process instead) |
-| File & object-storage (`/api/:org/files/*`, presigned GET/PUT, uploads) | ✅ serving clients | ✅ agent tools read/write files & mint presigned URLs |
+| File & object-storage (`/api/:org/files/*`, presigned GET/PUT, uploads, `/api/:org/fs/*`) | ✅ serving clients | ✅ agent tools read/write files & mint presigned URLs |
 | Worker-only over HTTP | — | none — tool calls are in-process |
 
-File and object-storage routes are the genuine "called by both" surface, and they are backed by an S3-compatible **Object Store**.
+File and object-storage routes are the genuine "called by both" surface, and they are backed by an S3-compatible **Object Store**. The `/api/:org/fs/*` routes also back the [org-filesystem mount](#org-filesystem-org-fs) inside sandboxes.
 
 ## Sandboxes
 
@@ -121,6 +121,18 @@ A sandbox clones the repo, runs the dev server, and exposes an in-pod **daemon**
 | Where | agent-sandbox operator + a `SandboxClaim` pod per (user, projectRef) | Same daemon, spawned locally on the laptop |
 | Reached over | k8s port-forward / in-cluster Service (control); ingress or port-forward (preview) | loopback (control); `<handle>.localhost:<port>` (preview) |
 | Selected when | the default for hosted runs | a `deco link` is live — `user-desktop` is the default provider then |
+
+### Org filesystem (org-fs)
+
+Each sandbox can mount the **org filesystem** at `<appRoot>/org/<volume>`, so the agent and dev server read and write org files as ordinary paths. The mount stack is `rclone (NFS/FUSE) → the daemon's loopback WebDAV → /api/:org/fs/* → S3` — the same object store as the file routes, surfaced as a mounted volume.
+
+It is wired on **both** providers, with different mount mechanics:
+
+| | Cloud sandbox | Desktop sandbox |
+| --- | --- | --- |
+| Who mounts | a **privileged sidecar** container (the unprivileged daemon can't mount) | the **daemon directly** (it has full permissions) |
+| Config delivery | post-bind: mesh `POST /_sandbox/orgfs-config`; the daemon relays it to a shared control volume the sidecar watches (warm-pool claims reject `spec.env`) | boot env: `ORGFS_CONFIG`, mounted at daemon startup |
+| Propagation | `rclone` with `allowOther` so the mount propagates to the main container | single client — no propagation needed |
 
 ## Desktop
 

--- a/apps/docs/client/src/utils/navigation.ts
+++ b/apps/docs/client/src/utils/navigation.ts
@@ -77,6 +77,7 @@ export async function getNavigationLinks(
 
     // 10. Self-Hosting
     "studio/self-hosting/quickstart",
+    "studio/self-hosting/architecture",
     "studio/self-hosting/authentication",
     "studio/self-hosting/monitoring",
     "studio/self-hosting/deploy/docker-compose",


### PR DESCRIPTION
## Summary
Adds a **Self-Hosting → Architecture** page to the docs site describing how a running Studio deployment is wired together.

Covers:
- The three tiers — **edge / cloud cluster / desktop** — with a text topology diagram.
- The **web / API / worker** role split (`MESH_DISPATCH_ROLE`), each scaling independently; workers are the DBOS run executors.
- The **decopilot run lifecycle**: DBOS queues (`THREAD_GATE`, `AUTOMATIONS`) in Postgres, journal-replay recovery, and the **hosted vs. pull** transports.
- **MCP in-process vs. the proxy routes** — the worker calls tools in-process; `/mcp/*` and `/oauth-proxy/*` are API/external-only. Caller buckets in a table.
- **File & object-storage** routes as the genuine both-callers surface.
- **NATS live roles** vs. the **dormant event-bus feature** (Callout).
- The sandbox daemon's **public preview** vs **protected `/_sandbox/*`** control API, cloud (agent-sandbox) vs desktop.

Registered in the sidebar order (`Sidebar.astro`) and prev/next nav (`navigation.ts`), under Self-Hosting after Quickstart.

## Testing
- `astro sync` passes (content schema valid).
- `astro build` exits 0.
- Verified end-to-end on the dev server: `/latest/en/studio/self-hosting/architecture` returns **200** with the rendered title and body.

## Notes
- English only — the parallel `pt-br` tree is not translated in this PR.
- The `No entry type found` build warning is the pre-existing benign glob-loader warning shared by other nested docs (e.g. `deploy/kubernetes.mdx`); those are live pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Self-Hosting → Architecture page explaining how Studio runs across edge, cloud, and desktop, with a server-rendered SVG diagram (no client JS). Registers the page in the sidebar order and prev/next navigation.

- **New Features**
  - Covers the web/API/worker split and independent scaling (`MESH_DISPATCH_ROLE`).
  - Details the decopilot run lifecycle: DBOS queues + journal replay; hosted vs pull transports.
  - Clarifies MCP in-process calls on workers vs `/mcp/*` proxy routes; notes file/object-storage as the shared surface.
  - Describes NATS live roles and states the CloudEvents event-bus feature is dormant.
  - Explains sandbox preview (public) vs control API (`/_sandbox/*`, protected), and cloud vs desktop sandboxes.
  - Adds the org filesystem mount in both sandboxes, backed by S3 via `/api/:org/fs/*`; mounted by a privileged sidecar in cloud and daemon-direct on desktop; diagram updated with Org FS nodes.

<sup>Written for commit 4826d3c479b11aedb119e30ea9c62bc353c76df2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

