### PR TITLE
feat(deploy): zone-aware routing scaffolding (safe)

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/service.yaml
+++ b/deploy/helm/studio/templates/service.yaml
@@ -13,6 +13,12 @@ spec:
       name: http
   selector:
     {{- include "chart-deco-studio.selectorLabels" . | nindent 4 }}
+  {{- with .Values.service.trafficDistribution }}
+  # Prefer same-zone endpoints (kube-proxy topology hints) → less cross-zone
+  # traffic. Best-effort: falls back to all endpoints when a zone has none.
+  # Requires k8s >= 1.31; leave empty on older clusters.
+  trafficDistribution: {{ . }}
+  {{- end }}
   {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- end }}

--- a/deploy/helm/studio/templates/web-deployment.yaml
+++ b/deploy/helm/studio/templates/web-deployment.yaml
@@ -150,4 +150,19 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.web.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.web.topologySpreadConstraints | nindent 8 }}
+      {{- else }}
+      # Spread web pods across zones (soft) so same-zone routing has an endpoint
+      # in each zone. ScheduleAnyway → never blocks scheduling.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-web
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -23,6 +23,11 @@ service:
   type: ClusterIP
   port: 80
   targetPort: 3000
+  # Same-zone endpoint preference (kube-proxy topology hints) to cut cross-zone
+  # traffic. Empty → field omitted (REQUIRED on k8s < 1.31, where it's rejected).
+  # Set "PreferClose" on k8s >= 1.31. Best-effort: needs pods spread across zones
+  # to take effect; falls back to all endpoints otherwise.
+  trafficDistribution: ""
 
 resources:
   requests:
@@ -154,6 +159,10 @@ web:
   # initContainer is cache-warm. Set to override (or to {} via --set to keep the
   # default; set a non-empty affinity to replace it entirely).
   affinity: {}
+  # Empty → the template defaults to a SOFT zone spread (maxSkew 1,
+  # ScheduleAnyway) so same-zone routing has a web endpoint per zone. Override
+  # with your own constraints.
+  topologySpreadConstraints: []
 
 configMap:
   meshConfig:


### PR DESCRIPTION
Scaffolding for zone-aware (same-zone) routing — the **safe, additive** half. No pod-balance enforcement and no NLB change (those carry real trade-offs; tracked separately).

## What this does

- **`service.trafficDistribution` knob** on the API Service. Default `""` → field omitted (portable: k8s < 1.31 rejects the field). Set `"PreferClose"` (k8s ≥ 1.31) to make kube-proxy prefer same-zone endpoints → less cross-zone egress on `nginx → API` and any internal caller.
- **Web pods get a default SOFT zone `topologySpreadConstraint`** (`maxSkew 1`, `ScheduleAnyway`) so same-zone routing has a web endpoint per zone. Never blocks scheduling.
- chart `0.9.0 → 0.10.0`.

## Why "safe"

`PreferClose` is best-effort: when a caller's zone has no local endpoint, kube-proxy falls back to **all** endpoints — no blackhole, even with today's unbalanced API (both replicas in `us-west-2c`). `ScheduleAnyway` spread never blocks pods. So this is a no-op-or-better everywhere.

## NOT in this PR (needs a decision)

Confirmed live: API HPA `minReplicas: 2`, both pods in `us-west-2c`, services have no topology config, NLB cross-zone enabled.

1. **Pod balance** (the actual prerequisite): API `minReplicas` 2 → ≥3 (one per zone) + spread `ScheduleAnyway` → `DoNotSchedule` to *enforce* it. Hard spread can block scheduling if a zone lacks capacity — that's the trade-off.
2. **NLB cross-zone**: disabling keeps traffic in the entry zone, but only safe once targets are balanced per zone.

Until (1), `trafficDistribution` is dormant (nothing to prefer). This PR just lands the capability with zero risk.

## Follow-up (prod enable, separate PR in deco-apps-cd, blocked on chart 0.10.0)

`studio.service.trafficDistribution: PreferClose` + `studio.nats.service.merge.spec.trafficDistribution: PreferClose` (the NATS chart exposes a `service.merge` patch hook).

## Validated

`helm template`: default omits the field; `PreferClose` renders; web pods get the spread; full render OK with web on + PreferClose.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add safe scaffolding for zone-aware routing: optional same-zone endpoint preference and a soft zone spread for web pods. No scheduling enforcement or NLB changes; defaults keep current behavior.

- **New Features**
  - `service.trafficDistribution` on the API Service. Default omitted; set `"PreferClose"` on k8s ≥ 1.31 to prefer same-zone endpoints and reduce cross-zone egress.
  - Default SOFT `topologySpreadConstraints` for web (zone, maxSkew 1, `ScheduleAnyway`) so each zone has a web endpoint without blocking.
  - Helm chart version bumped to 0.10.0.

- **Migration**
  - Upgrade to chart 0.10.0; no behavior change by default.
  - To enable zone preference, set `service.trafficDistribution: PreferClose` on k8s ≥ 1.31. Override `web.topologySpreadConstraints` if you need custom spread rules.

<sup>Written for commit d3d99a7c77baca3686cc7565cbf12ed6d5b547ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

