### PR TITLE
ci: skip app test suites for deploy-only changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,7 +53,7 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              .github/*|apps/docs/*|*.md) ;;
+              .github/*|apps/docs/*|deploy/*|*.md) ;;
               *) relevant=true; break ;;
             esac
           done <<< "$FILES"

--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -61,7 +61,7 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              .github/*|apps/docs/*|*.md) ;;
+              .github/*|apps/docs/*|deploy/*|*.md) ;;
               *) relevant=true; break ;;
             esac
           done <<< "$FILES"

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -65,7 +65,7 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              .github/*|apps/docs/*|*.md) ;;
+              .github/*|apps/docs/*|deploy/*|*.md) ;;
               *) relevant=true; break ;;
             esac
           done <<< "$FILES"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              .github/*|apps/docs/*|*.md) ;;
+              .github/*|apps/docs/*|deploy/*|*.md) ;;
               *) relevant=true; break ;;
             esac
           done <<< "$FILES"


### PR DESCRIPTION
Stop running the heavy app test suites on **deploy/chart-only** PRs.

Adds `deploy/*` to the changes-filter ignore list (next to `.github/*`, `apps/docs/*`, `*.md`) in: `e2e`, `test`, `storage-integration`, `sandbox-daemon`. A PR that only touches `deploy/**` (Helm chart, nginx config, s3-sync) no longer triggers the full Playwright/unit/storage/daemon suites — those exercise **runtime behavior**, not Helm templates, so they prove nothing about a chart change (and E2E alone is ~4-5 min).

Safe: the app Dockerfile lives under `apps/mesh/`, not `deploy/`, so any actual runtime change still triggers everything. The `studio chart` lint (helm-test / publish-chart) is unaffected and keeps validating chart changes.

Context: #3985 (a chart-only PR) sat blocked on E2E for no reason.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip heavy app test suites when a PR only changes `deploy/**`, speeding up CI for chart/config-only changes. Added `deploy/*` to the changes-filter ignore list in `.github/workflows/e2e.yml`, `.github/workflows/test.yml`, `.github/workflows/storage-integration.yml`, and `.github/workflows/sandbox-daemon.yml`; runtime changes (e.g., `apps/mesh/**`) still trigger all suites, and chart lint/publish jobs continue to validate `deploy/**`.

<sup>Written for commit 491769e6f9565cbdad5f80365b653d01234ea413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

