### PR TITLE
fix(deploy): pin runAsUser on web bundle initContainer

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/web-deployment.yaml
+++ b/deploy/helm/studio/templates/web-deployment.yaml
@@ -65,10 +65,14 @@ spec:
         - name: bundle
           image: "{{ .Values.web.bundleImage.repository | default .Values.image.repository }}:{{ .Values.web.bundleImage.tag | default .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.web.bundleImage.pullPolicy | default "IfNotPresent" }}
-          {{- with .Values.web.securityContext }}
           securityContext:
+            # Explicit numeric uid: the mesh image declares USER as a NAME
+            # (bunuser), which kubelet can't verify against runAsNonRoot. Pin the
+            # mesh image's uid so the init container is admitted.
+            runAsUser: {{ .Values.web.bundleRunAsUser | default 1001 }}
+            {{- with .Values.web.securityContext }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           command: ["sh", "-c"]
           args:
             - cp -a {{ .Values.web.bundlePath }}/. /bundle/

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -117,6 +117,9 @@ web:
   # Path of the built bundle inside the mesh image (where `bun add decocms`
   # installs it).
   bundlePath: /app/apps/mesh/node_modules/decocms/dist/client
+  # Numeric uid of the mesh image (its USER is the non-numeric "bunuser", which
+  # kubelet can't verify against runAsNonRoot). Pins the bundle initContainer.
+  bundleRunAsUser: 1001
   # Stock nginx that serves the bundle + reverse-proxies. The unprivileged
   # variant listens on 8080 and runs as uid 101 (non-root) out of the box.
   nginxImage: nginxinc/nginx-unprivileged:1.27-alpine


### PR DESCRIPTION
Fix surfaced in **staging** (deco-apps-cd#69): the web bundle initContainer uses the mesh image, whose `USER` is the non-numeric `bunuser`. With `runAsNonRoot: true` and no numeric `runAsUser`, kubelet can't verify non-root and refuses the container:

```
Error: container has runAsNonRoot and image has non-numeric user (bunuser), cannot verify user is non-root
```

Pins the mesh image's numeric uid (`web.bundleRunAsUser`, default `1001`) on the init container. The nginx container is unaffected — its image `USER` is numeric `101`. The main deco-studio deployment already sets `runAsUser: 1001`, which is why it never hit this.

chart `0.10.0 → 0.10.1`. Validated: `helm template` renders `runAsUser: 1001` + hardening on the init container, nginx unchanged.

This is the kind of real-cluster bug stg-first is meant to catch before prod.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins a numeric `runAsUser` on the web bundle initContainer so `runAsNonRoot` works with the mesh image’s named user (`bunuser`). Fixes initContainer admission failures; nginx is unchanged.

- **Bug Fixes**
  - Set `runAsUser` on the bundle initContainer from `web.bundleRunAsUser` (default `1001`).
  - Bump chart version to `0.10.1`.

- **Migration**
  - No action needed. If your mesh image UID isn’t `1001`, set `web.bundleRunAsUser` to the correct UID.

<sup>Written for commit aeb37093f6913d038da8ebd78970356aea14baa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

