### PR TITLE
fix(deploy): cp -r + chmod a+rX for web bundle copy

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/web-deployment.yaml
+++ b/deploy/helm/studio/templates/web-deployment.yaml
@@ -74,8 +74,12 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           command: ["sh", "-c"]
+          # cp -r, not -a: -a preserves times/ownership and fails on the
+          # fsGroup-owned emptyDir mount root ("preserving times ... Operation
+          # not permitted"). chmod a+rX guarantees the nginx container (uid 101,
+          # not in the fsGroup) can read the assets regardless of the copy umask.
           args:
-            - cp -a {{ .Values.web.bundlePath }}/. /bundle/
+            - cp -r {{ .Values.web.bundlePath }}/. /bundle/ && chmod -R a+rX /bundle
           volumeMounts:
             - name: bundle
               mountPath: /bundle


### PR DESCRIPTION
Second real-cluster bug from staging. After the runAsUser fix (#3987 / 0.10.1) the web bundle initContainer started but the copy failed:

```
cp: preserving times for '/bundle/.': Operation not permitted
```

`cp -a` preserves times/ownership and can't set them on the fsGroup-owned emptyDir mount root (running as uid 1001, not the dir owner). Static assets don't need attrs preserved.

Fix: `cp -r` (no attr preserve) + `chmod -R a+rX /bundle` so the nginx container (uid 101, outside the fsGroup) can always read the assets regardless of the copy umask.

chart `0.10.1 → 0.10.2`. Deploy-only → e2e skips (per #3986).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the web bundle initContainer copy by switching to a recursive copy and setting read/execute perms, preventing “preserving times … Operation not permitted” errors and ensuring nginx can read assets.

- **Bug Fixes**
  - Replace `cp -a` with `cp -r` to avoid preserving times/ownership on the fsGroup-owned `/bundle`.
  - Add `chmod -R a+rX /bundle` so nginx (uid 101, not in the fsGroup) can always read assets.
  - Bump Helm chart `chart-deco-studio` to `0.10.2`.

<sup>Written for commit b63c067b8c28e2a17711c5221caa274912facf5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

