### PR TITLE
fix(deploy): drop chmod from web bundle copy (cp -r is enough)

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.2
+version: 0.10.3
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/web-deployment.yaml
+++ b/deploy/helm/studio/templates/web-deployment.yaml
@@ -76,10 +76,12 @@ spec:
           command: ["sh", "-c"]
           # cp -r, not -a: -a preserves times/ownership and fails on the
           # fsGroup-owned emptyDir mount root ("preserving times ... Operation
-          # not permitted"). chmod a+rX guarantees the nginx container (uid 101,
-          # not in the fsGroup) can read the assets regardless of the copy umask.
+          # not permitted"). No chmod: the mesh image's umask is 022 → copies are
+          # 0644, which the nginx container (uid 101) reads fine. (A chmod on
+          # /bundle itself fails — the mount root is owned by root, not uid 1001.)
+          # Validated end-to-end in a kind cluster (real fsGroup/uid enforcement).
           args:
-            - cp -r {{ .Values.web.bundlePath }}/. /bundle/ && chmod -R a+rX /bundle
+            - cp -r {{ .Values.web.bundlePath }}/. /bundle/
           volumeMounts:
             - name: bundle
               mountPath: /bundle


### PR DESCRIPTION
Third staging-found issue, now **validated in a kind cluster** before shipping (real Linux uid/fsGroup enforcement — the macOS Docker that hid the first two bugs can't reproduce it).

The `chmod -R a+rX /bundle` I added in 0.10.2 fails:
```
chmod: changing permissions of '/bundle': Operation not permitted
```
The emptyDir mount root is owned by **root**, not the init container's uid 1001. And it was unnecessary: the mesh image's umask is **022**, so `cp -r` already produces **0644** files — readable by the nginx container (uid 101) via the 'other' bits.

Fix: `cp -r` only, no chmod. chart `0.10.2 → 0.10.3`.

**kind validation (PASS):** initContainer exit 0, pod 1/1 Ready, `/healthz` 200, `/` 200 text/html, hashed asset 200, `index.html` mode `-rw-r--r--`. Deploy-only → e2e skips (#3986).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix init container failures by removing chmod from the web bundle copy. `cp -r` is enough and keeps files readable via umask 022.

- **Bug Fixes**
  - Drop `chmod` from init container; `cp -r` only to avoid permission errors on root-owned emptyDir.
  - Copies are `0644` due to umask `022`, so nginx can read assets.
  - Validated on a kind cluster; pod Ready and health checks pass. Bump chart to `0.10.3`.

<sup>Written for commit 7a20f957b3c37140013e8e4b7b13750215259e80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

