### PR TITLE
fix(deploy): upstream keepalive for web nginx reverse-proxy

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.3
+version: 0.10.4
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/files/web-nginx.conf.template
+++ b/deploy/helm/studio/files/web-nginx.conf.template
@@ -3,9 +3,19 @@
 # ${API_UPSTREAM} is the only env var substituted; nginx's own $vars are left
 # intact because the stock entrypoint only envsubst's defined env names.
 
+# For WS upgrades, Connection: upgrade. For normal requests, EMPTY (not "close")
+# so the upstream keepalive pool below is reused instead of a new TCP per request.
 map $http_upgrade $connection_upgrade {
   default upgrade;
-  ''      close;
+  ''      "";
+}
+
+# Keepalive pool to the API so /api requests reuse connections (no TCP + handshake
+# per request). server holds ${API_UPSTREAM}; resolved at config-load (pins the
+# ClusterIP — see the location comment).
+upstream studio_api {
+  server ${API_UPSTREAM};
+  keepalive 32;
 }
 
 server {
@@ -33,12 +43,10 @@ server {
   # API + system paths → Bun server. Same origin keeps auth cookies first-party.
   # Path set mirrors apps/mesh vite.config.ts proxy + isServerPath.
   location ~ ^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics)(/|$) {
-    # ponytail: literal proxy_pass → nginx resolves the upstream at config-load
-    # and pins the ClusterIP. Fine here (the API Service exists in the same Helm
-    # release; a not-ready-at-boot DNS just crashloops until it converges). If the
-    # Service is ever recreated with a new ClusterIP, `kubectl rollout restart` the
-    # web Deployment — or switch to a `resolver` + variable proxy_pass if that churns.
-    proxy_pass http://${API_UPSTREAM};
+    # ponytail: upstream resolves at config-load and pins the ClusterIP. Fine
+    # here (the API Service exists in the same Helm release). If the Service is
+    # recreated with a new ClusterIP, `kubectl rollout restart` the web Deployment.
+    proxy_pass http://studio_api;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Before the web pod takes traffic, give the nginx → API reverse-proxy a **keepalive pool** so it doesn't open a new TCP + handshake per `/api` request (a real latency regression otherwise).

- `upstream studio_api { server ${API_UPSTREAM}; keepalive 32; }` + `proxy_pass http://studio_api;`
- Connection map: non-WS → `""` (was `close`) so the pool is reused; WS still → `upgrade`.
- `proxy_http_version 1.1` (already present) completes the keepalive requirement.

chart `0.10.3 → 0.10.4`.

**Validated in kind** (real cluster): pod boots clean with the new upstream block — nginx logs show normal startup, NO `emerg`/`host not found in upstream`; `/healthz` + `/` + hashed asset all 200. (keepalive *reuse* needs a real API to exercise — confirmed at stg, not kind.) Deploy-only → e2e skips (#3986).

Context: this is prep for the stg NLB cutover; the web path isn't live yet (NLB still → API), so no current traffic is affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an upstream keepalive pool to the web nginx reverse-proxy and switches API traffic to a named upstream, so `/api` requests reuse connections and avoid per-request TCP handshakes. Preps for the NLB cutover; chart bumped to `0.10.4`.

- **Refactors**
  - Added `upstream studio_api` with `keepalive 32`; updated API paths to `proxy_pass http://studio_api`.
  - Set non-WS `Connection` to empty string for pool reuse; WS stays `upgrade`; kept `proxy_http_version 1.1`.
  - Validated in a real cluster; no current traffic impact.

<sup>Written for commit c6ef092b5eeb99c1c2c706cf1f37cd550c4b8b58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

