### PR TITLE
fix(deploy): keep helm.sh/chart off pod templates (independent rollouts)

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.4
+version: 0.10.5
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -38,6 +38,21 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Pod-template labels — same as .labels but WITHOUT helm.sh/chart. The chart label
+carries the chart version, so putting it on a pod template makes every chart
+version bump change the template hash and roll ALL deployments. Keep it on
+Deployment metadata (.labels), not the pod template, so a version bump only
+rolls a Deployment whose actual pod spec changed.
+*/}}
+{{- define "chart-deco-studio.podLabels" -}}
+{{ include "chart-deco-studio.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "chart-deco-studio.selectorLabels" -}}

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "chart-deco-studio.labels" . | nindent 8 }}
+        {{- include "chart-deco-studio.podLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/studio/templates/web-deployment.yaml
+++ b/deploy/helm/studio/templates/web-deployment.yaml
@@ -43,7 +43,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: web
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        helm.sh/chart: {{ include "chart-deco-studio.chart" . }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/studio/templates/worker-deployment.yaml
+++ b/deploy/helm/studio/templates/worker-deployment.yaml
@@ -42,7 +42,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: worker
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        helm.sh/chart: {{ include "chart-deco-studio.chart" . }}
         {{- if .Chart.AppVersion }}
         app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
         {{- end }}


### PR DESCRIPTION
**Why `argo sync` replaces ALL pods on a chart bump:** the `helm.sh/chart: chart-deco-studio-<version>` label was in every Deployment's **pod template** (`spec.template.metadata.labels`). A chart-version bump changes that label → the pod-template hash changes for api + worker + web → all three roll, regardless of what actually changed. That defeats independent rollout for chart-version bumps.

**Fix:** new `chart-deco-studio.podLabels` helper = `.labels` minus `helm.sh/chart`, used by all three pod templates. The chart label stays on Deployment **metadata** (unchanged there — doesn't trigger rollouts). The selector uses `name`+`instance` (untouched), so this is safe.

**After this lands:** one final roll-all (the pod templates change to drop the label), then a chart bump only rolls a Deployment whose actual pod spec changed.

Note: image-tag deploys (bump `image.tag` / `web.bundleImage.tag` in values, no chart bump) were **already** independent — this extends that to chart-version bumps too.

chart `0.10.4 → 0.10.5`. Validated: `helm template` shows `helm.sh/chart` only in Deployment metadata (not pod templates) for api/worker/web; full render OK. Deploy-only → e2e skips (#3986).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents chart-version bumps from rolling all pods by removing the `helm.sh/chart` label from pod templates. Adds `chart-deco-studio.podLabels` and keeps the chart label only on Deployment metadata for independent rollouts of api, worker, and web.

- **Bug Fixes**
  - Use `chart-deco-studio.podLabels` in all pod templates (drops `helm.sh/chart`).
  - Selectors stay `name` + `instance`; rollout behavior is safe and unchanged.
  - Expect one full rollout on first deploy; future chart bumps only roll pods when the pod spec changes.

- **Dependencies**
  - Chart version bumped to 0.10.5.

<sup>Written for commit 34bd4d987f3c90d21b0add87f8e54f8713742008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

