### PR TITLE
feat(deploy): web.accessLog toggle for nginx access logs

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.5
+version: 0.10.6
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/files/web-nginx.conf.template
+++ b/deploy/helm/studio/files/web-nginx.conf.template
@@ -24,6 +24,11 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  # ${WEB_ACCESS_LOG} is "/dev/stdout" (default) or "off" (web.accessLog: false,
+  # e.g. when an edge/CDN + app OTel already capture requests). /healthz stays
+  # off regardless (below).
+  access_log ${WEB_ACCESS_LOG};
+
   # Match the app's MAX_UPLOAD_BYTES (file-storage/upload-policy.ts = 100MB).
   # nginx defaults to 1m and would 413 large uploads before they reach the API.
   client_max_body_size 100m;

--- a/deploy/helm/studio/templates/web-deployment.yaml
+++ b/deploy/helm/studio/templates/web-deployment.yaml
@@ -100,6 +100,9 @@ spec:
             # host:port of the API (main) Service; same origin via nginx proxy.
             - name: API_UPSTREAM
               value: {{ .Values.web.apiUpstream | default (printf "%s:%v" (include "chart-deco-studio.fullname" .) .Values.service.port) | quote }}
+            # access_log target: /dev/stdout, or "off" when web.accessLog: false.
+            - name: WEB_ACCESS_LOG
+              value: {{ if .Values.web.accessLog }}"/dev/stdout"{{ else }}"off"{{ end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -124,6 +124,9 @@ web:
   # variant listens on 8080 and runs as uid 101 (non-root) out of the box.
   nginxImage: nginxinc/nginx-unprivileged:1.27-alpine
   nginxImagePullPolicy: IfNotPresent
+  # nginx access log → stdout. Set false to disable (e.g. when an edge/CDN +
+  # app OTel already capture requests). /healthz is never logged either way.
+  accessLog: true
   # host:port of the API (main) Service. Empty → in-namespace main Service.
   # Set to an FQDN (<svc>.<ns>.svc.cluster.local:80) for cross-namespace.
   apiUpstream: ""


### PR DESCRIPTION
Make the web nginx access log toggleable. `access_log ${WEB_ACCESS_LOG};` driven by `web.accessLog` (default **true** → `/dev/stdout`, sensible for self-hosters who lack edge/OTel). Set **false** → `off` for deployments where an edge/CDN + app OTel already capture requests (avoids redundant logs). `/healthz` is never logged either way.

chart `0.10.5 → 0.10.6`. Validated: `helm template` renders `/dev/stdout` (default) and `off` (when false); `nginx -t` passes for both. Deploy-only → e2e skips (#3986).

Private `deco-apps-cd` will set `studio.web.accessLog: false` (CF + OTel cover it there).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `web.accessLog` toggle for web `nginx` access logs. Defaults to `/dev/stdout`; set it to false to disable when edge/CDN + app OTel already capture requests, and `/healthz` is never logged.

- **New Features**
  - `access_log` now reads `${WEB_ACCESS_LOG}` from the pod env, mapped from `web.accessLog` (`/dev/stdout` or `off`).
  - Helm chart bumped to `0.10.6`.

- **Migration**
  - Optional: set `web.accessLog: false` in `values.yaml` to disable logs.

<sup>Written for commit 674ecacd0dc176a774a75f7113d7a17efb0350a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

