### PR TITLE
feat(observability): HTTP request-duration histogram scraped by Prometheus

### DIFF
--- a/apps/docs/client/src/components/ArchitectureDiagram.astro
+++ b/apps/docs/client/src/components/ArchitectureDiagram.astro
@@ -3,63 +3,298 @@
 // Layout math runs at build/SSR time and emits plain SVG.
 
 const TIER: Record<string, string> = {
-  edge: "#94a3b8", web: "#22d3ee", api: "#38bdf8", worker: "#a78bfa",
-  mcp: "#2dd4bf", file: "#a3e635", db: "#34d399", nats: "#fbbf24",
-  sbx: "#fb7185", pub: "#fb923c", llm: "#f0abfc", desk: "#c4b5fd",
+  edge: "#94a3b8",
+  web: "#22d3ee",
+  api: "#38bdf8",
+  worker: "#a78bfa",
+  mcp: "#2dd4bf",
+  file: "#a3e635",
+  db: "#34d399",
+  nats: "#fbbf24",
+  sbx: "#fb7185",
+  pub: "#fb923c",
+  llm: "#f0abfc",
+  desk: "#c4b5fd",
 };
 
 const ZONES = [
-  { x: 24, y: 150, w: 140, h: 790, label: "Edge", sub: "public internet", stroke: "rgba(148,163,184,.30)", fill: "rgba(148,163,184,.03)" },
-  { x: 182, y: 150, w: 992, h: 790, label: "Cloud Cluster", sub: "kubernetes", stroke: "rgba(56,189,248,.24)", fill: "rgba(56,189,248,.03)" },
-  { x: 1192, y: 150, w: 384, h: 790, label: "Desktop", sub: "deco link · laptop", stroke: "rgba(168,130,255,.28)", fill: "rgba(168,130,255,.045)" },
+  {
+    x: 24,
+    y: 150,
+    w: 140,
+    h: 790,
+    label: "Edge",
+    sub: "public internet",
+    stroke: "rgba(148,163,184,.30)",
+    fill: "rgba(148,163,184,.03)",
+  },
+  {
+    x: 182,
+    y: 150,
+    w: 992,
+    h: 790,
+    label: "Cloud Cluster",
+    sub: "kubernetes",
+    stroke: "rgba(56,189,248,.24)",
+    fill: "rgba(56,189,248,.03)",
+  },
+  {
+    x: 1192,
+    y: 150,
+    w: 384,
+    h: 790,
+    label: "Desktop",
+    sub: "deco link · laptop",
+    stroke: "rgba(168,130,255,.28)",
+    fill: "rgba(168,130,255,.045)",
+  },
 ];
-const SUBZONES = [{ x: 620, y: 782, w: 556, h: 150, label: "Cloud Sandbox · pod" }];
+const SUBZONES = [
+  { x: 620, y: 782, w: 556, h: 150, label: "Cloud Sandbox · pod" },
+];
 
 type Node = {
-  x: number; y: number; w: number; h: number; tier: string;
-  label: string; tag?: string; shape?: "cyl" | "hex"; replicas?: boolean; ext?: boolean;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  tier: string;
+  label: string;
+  tag?: string;
+  shape?: "cyl" | "hex";
+  replicas?: boolean;
+  ext?: boolean;
 };
 const N: Record<string, Node> = {
-  s3: { x: 470, y: 96, w: 128, h: 54, tier: "file", ext: true, label: "Object Store", tag: "s3 · external" },
-  llm: { x: 760, y: 96, w: 128, h: 54, tier: "llm", ext: true, label: "LLM", tag: "anthropic · external" },
-  dmcp: { x: 1004, y: 96, w: 140, h: 54, tier: "mcp", ext: true, label: "Downstream MCP", tag: "tool servers" },
+  s3: {
+    x: 470,
+    y: 96,
+    w: 128,
+    h: 54,
+    tier: "file",
+    ext: true,
+    label: "Object Store",
+    tag: "s3 · external",
+  },
+  llm: {
+    x: 760,
+    y: 96,
+    w: 128,
+    h: 54,
+    tier: "llm",
+    ext: true,
+    label: "LLM",
+    tag: "anthropic · external",
+  },
+  dmcp: {
+    x: 1004,
+    y: 96,
+    w: 140,
+    h: 54,
+    tier: "mcp",
+    ext: true,
+    label: "Downstream MCP",
+    tag: "tool servers",
+  },
 
-  client: { x: 94, y: 330, w: 118, h: 58, tier: "edge", label: "Client", tag: "browser / mcp" },
-  cf: { x: 94, y: 510, w: 118, h: 58, tier: "edge", label: "CF", tag: "edge / cdn" },
-  nlb: { x: 94, y: 690, w: 118, h: 58, tier: "edge", label: "NLB", tag: "l4 lb" },
+  client: {
+    x: 94,
+    y: 330,
+    w: 118,
+    h: 58,
+    tier: "edge",
+    label: "Client",
+    tag: "browser / mcp",
+  },
+  cf: {
+    x: 94,
+    y: 510,
+    w: 118,
+    h: 58,
+    tier: "edge",
+    label: "CF",
+    tag: "edge / cdn",
+  },
+  nlb: {
+    x: 94,
+    y: 690,
+    w: 118,
+    h: 58,
+    tier: "edge",
+    label: "NLB",
+    tag: "l4 lb",
+  },
 
-  web: { x: 305, y: 545, w: 146, h: 64, tier: "web", label: "Web", tag: "nginx · spa", replicas: true },
-  api: { x: 485, y: 360, w: 148, h: 64, tier: "api", label: "API", tag: "hono · role=api", replicas: true },
-  worker: { x: 485, y: 645, w: 148, h: 64, tier: "worker", label: "Worker", tag: "role=worker · dbos", replicas: true },
-  mcpproxy: { x: 705, y: 300, w: 150, h: 60, tier: "mcp", label: "MCP Proxy", tag: "api routes" },
-  files: { x: 705, y: 470, w: 150, h: 60, tier: "file", label: "Files / Storage", tag: "api · /files /fs" },
-  nats: { x: 930, y: 300, w: 124, h: 82, tier: "nats", shape: "hex", label: "NATS", tag: "messaging" },
-  db: { x: 930, y: 505, w: 122, h: 88, tier: "db", shape: "cyl", label: "DB", tag: "postgres" },
-  daemonctl: { x: 710, y: 852, w: 158, h: 60, tier: "sbx", label: "Daemon API", tag: "protected /_sandbox/*" },
-  orgfsc: { x: 900, y: 852, w: 132, h: 56, tier: "file", label: "Org FS", tag: "mount · sidecar" },
-  daemonprev: { x: 1085, y: 852, w: 152, h: 60, tier: "pub", label: "Preview", tag: "public" },
+  web: {
+    x: 305,
+    y: 545,
+    w: 146,
+    h: 64,
+    tier: "web",
+    label: "Web",
+    tag: "nginx · spa",
+    replicas: true,
+  },
+  api: {
+    x: 485,
+    y: 360,
+    w: 148,
+    h: 64,
+    tier: "api",
+    label: "API",
+    tag: "hono · role=api",
+    replicas: true,
+  },
+  worker: {
+    x: 485,
+    y: 645,
+    w: 148,
+    h: 64,
+    tier: "worker",
+    label: "Worker",
+    tag: "role=worker · dbos",
+    replicas: true,
+  },
+  mcpproxy: {
+    x: 705,
+    y: 300,
+    w: 150,
+    h: 60,
+    tier: "mcp",
+    label: "MCP Proxy",
+    tag: "api routes",
+  },
+  files: {
+    x: 705,
+    y: 470,
+    w: 150,
+    h: 60,
+    tier: "file",
+    label: "Files / Storage",
+    tag: "api · /files /fs",
+  },
+  nats: {
+    x: 930,
+    y: 300,
+    w: 124,
+    h: 82,
+    tier: "nats",
+    shape: "hex",
+    label: "NATS",
+    tag: "messaging",
+  },
+  db: {
+    x: 930,
+    y: 505,
+    w: 122,
+    h: 88,
+    tier: "db",
+    shape: "cyl",
+    label: "DB",
+    tag: "postgres",
+  },
+  daemonctl: {
+    x: 710,
+    y: 852,
+    w: 158,
+    h: 60,
+    tier: "sbx",
+    label: "Daemon API",
+    tag: "protected /_sandbox/*",
+  },
+  orgfsc: {
+    x: 900,
+    y: 852,
+    w: 132,
+    h: 56,
+    tier: "file",
+    label: "Org FS",
+    tag: "mount · sidecar",
+  },
+  daemonprev: {
+    x: 1085,
+    y: 852,
+    w: 152,
+    h: 60,
+    tier: "pub",
+    label: "Preview",
+    tag: "public",
+  },
 
-  linkd: { x: 1300, y: 340, w: 158, h: 62, tier: "desk", label: "Link Daemon", tag: "deco link" },
-  dloop: { x: 1300, y: 560, w: 158, h: 62, tier: "desk", label: "Desktop Loop", tag: "native loop" },
-  dsbx: { x: 1290, y: 800, w: 152, h: 62, tier: "sbx", label: "Desktop Sandbox", tag: "local daemon" },
-  orgfsd: { x: 1460, y: 800, w: 140, h: 56, tier: "file", label: "Org FS", tag: "mount · daemon" },
+  linkd: {
+    x: 1300,
+    y: 340,
+    w: 158,
+    h: 62,
+    tier: "desk",
+    label: "Link Daemon",
+    tag: "deco link",
+  },
+  dloop: {
+    x: 1300,
+    y: 560,
+    w: 158,
+    h: 62,
+    tier: "desk",
+    label: "Desktop Loop",
+    tag: "native loop",
+  },
+  dsbx: {
+    x: 1290,
+    y: 800,
+    w: 152,
+    h: 62,
+    tier: "sbx",
+    label: "Desktop Sandbox",
+    tag: "local daemon",
+  },
+  orgfsd: {
+    x: 1460,
+    y: 800,
+    w: 140,
+    h: 56,
+    tier: "file",
+    label: "Org FS",
+    tag: "mount · daemon",
+  },
 };
 
 // from, to, kind
 const E: [string, string, string][] = [
-  ["client", "cf", "req"], ["cf", "nlb", "req"], ["nlb", "web", "req"], ["web", "api", "req"],
-  ["api", "mcpproxy", "ctrl"], ["mcpproxy", "dmcp", "ctrl"], ["worker", "dmcp", "inproc"],
-  ["api", "files", "ctrl"], ["worker", "files", "ctrl"], ["files", "s3", "ctrl"],
-  ["api", "worker", "ctrl"], ["api", "db", "ctrl"], ["worker", "db", "ctrl"],
-  ["api", "nats", "ctrl"], ["worker", "nats", "ctrl"], ["nats", "linkd", "bridge"],
-  ["worker", "llm", "model"], ["worker", "daemonctl", "ctrl"], ["api", "daemonctl", "ctrl"],
+  ["client", "cf", "req"],
+  ["cf", "nlb", "req"],
+  ["nlb", "web", "req"],
+  ["web", "api", "req"],
+  ["api", "mcpproxy", "ctrl"],
+  ["mcpproxy", "dmcp", "ctrl"],
+  ["worker", "dmcp", "inproc"],
+  ["api", "files", "ctrl"],
+  ["worker", "files", "ctrl"],
+  ["files", "s3", "ctrl"],
+  ["api", "worker", "ctrl"],
+  ["api", "db", "ctrl"],
+  ["worker", "db", "ctrl"],
+  ["api", "nats", "ctrl"],
+  ["worker", "nats", "ctrl"],
+  ["nats", "linkd", "bridge"],
+  ["worker", "llm", "model"],
+  ["worker", "daemonctl", "ctrl"],
+  ["api", "daemonctl", "ctrl"],
   ["client", "daemonprev", "public"],
-  ["daemonctl", "orgfsc", "ctrl"], ["orgfsc", "files", "ctrl"],
-  ["dsbx", "orgfsd", "ctrl"], ["orgfsd", "files", "ctrl"],
-  ["linkd", "dloop", "ctrl"], ["dloop", "llm", "model"], ["dloop", "api", "mcp"], ["dloop", "dsbx", "ctrl"],
+  ["daemonctl", "orgfsc", "ctrl"],
+  ["orgfsc", "files", "ctrl"],
+  ["dsbx", "orgfsd", "ctrl"],
+  ["orgfsd", "files", "ctrl"],
+  ["linkd", "dloop", "ctrl"],
+  ["dloop", "llm", "model"],
+  ["dloop", "api", "mcp"],
+  ["dloop", "dsbx", "ctrl"],
 ];
 
-const EDGE_STYLE: Record<string, { stroke: string; dash?: string; w: number; op: number }> = {
+const EDGE_STYLE: Record<
+  string,
+  { stroke: string; dash?: string; w: number; op: number }
+> = {
   req: { stroke: "#465268", w: 1.5, op: 0.55 },
   ctrl: { stroke: "#465268", w: 1.5, op: 0.5 },
   model: { stroke: TIER.llm, dash: "2 5", w: 1.4, op: 0.45 },
@@ -71,16 +306,37 @@ const EDGE_STYLE: Record<string, { stroke: string; dash?: string; w: number; op:
 
 // manual margin routes for long cross-diagram edges
 const ROUTES: Record<string, { x: number; y: number }[]> = {
-  "client>daemonprev": [{ x: 35, y: 330 }, { x: 12, y: 330 }, { x: 12, y: 986 }, { x: 1085, y: 986 }, { x: 1085, y: 882 }],
-  "dloop>api": [{ x: 1300, y: 529 }, { x: 1300, y: 128 }, { x: 485, y: 128 }, { x: 485, y: 328 }],
-  "orgfsd>files": [{ x: 1460, y: 828 }, { x: 1460, y: 1002 }, { x: 600, y: 1002 }, { x: 600, y: 470 }, { x: 630, y: 470 }],
+  "client>daemonprev": [
+    { x: 35, y: 330 },
+    { x: 12, y: 330 },
+    { x: 12, y: 986 },
+    { x: 1085, y: 986 },
+    { x: 1085, y: 882 },
+  ],
+  "dloop>api": [
+    { x: 1300, y: 529 },
+    { x: 1300, y: 128 },
+    { x: 485, y: 128 },
+    { x: 485, y: 328 },
+  ],
+  "orgfsd>files": [
+    { x: 1460, y: 828 },
+    { x: 1460, y: 1002 },
+    { x: 600, y: 1002 },
+    { x: 600, y: 470 },
+    { x: 630, y: 470 },
+  ],
 };
 function roundedPath(pts: { x: number; y: number }[], r = 16) {
   let d = `M${pts[0].x},${pts[0].y}`;
   for (let i = 1; i < pts.length - 1; i++) {
-    const p = pts[i], a = pts[i - 1], b = pts[i + 1];
-    const v1 = { x: p.x - a.x, y: p.y - a.y }, v2 = { x: b.x - p.x, y: b.y - p.y };
-    const l1 = Math.hypot(v1.x, v1.y) || 1, l2 = Math.hypot(v2.x, v2.y) || 1;
+    const p = pts[i],
+      a = pts[i - 1],
+      b = pts[i + 1];
+    const v1 = { x: p.x - a.x, y: p.y - a.y },
+      v2 = { x: b.x - p.x, y: b.y - p.y };
+    const l1 = Math.hypot(v1.x, v1.y) || 1,
+      l2 = Math.hypot(v2.x, v2.y) || 1;
     const rr = Math.min(r, l1 / 2, l2 / 2);
     const s = { x: p.x - (v1.x / l1) * rr, y: p.y - (v1.y / l1) * rr };
     const e = { x: p.x + (v2.x / l2) * rr, y: p.y + (v2.y / l2) * rr };
@@ -91,21 +347,37 @@ function roundedPath(pts: { x: number; y: number }[], r = 16) {
   return d;
 }
 
-const NORMAL: Record<string, [number, number]> = { r: [1, 0], l: [-1, 0], t: [0, -1], b: [0, 1] };
+const NORMAL: Record<string, [number, number]> = {
+  r: [1, 0],
+  l: [-1, 0],
+  t: [0, -1],
+  b: [0, 1],
+};
 function sides(a: Node, b: Node): [string, string] {
-  const dx = b.x - a.x, dy = b.y - a.y;
+  const dx = b.x - a.x,
+    dy = b.y - a.y;
   if (Math.abs(dx) >= Math.abs(dy)) return dx > 0 ? ["r", "l"] : ["l", "r"];
   return dy > 0 ? ["b", "t"] : ["t", "b"];
 }
 function anchor(n: Node, side: string, f: number) {
-  const hw = n.w / 2, hh = n.h / 2;
+  const hw = n.w / 2,
+    hh = n.h / 2;
   if (side === "r") return { x: n.x + hw, y: n.y - hh + f * n.h, n: NORMAL.r };
   if (side === "l") return { x: n.x - hw, y: n.y - hh + f * n.h, n: NORMAL.l };
   if (side === "t") return { x: n.x - hw + f * n.w, y: n.y - hh, n: NORMAL.t };
   return { x: n.x - hw + f * n.w, y: n.y + hh, n: NORMAL.b };
 }
 
-type EM = { from: string; to: string; kind: string; sa: string; sb: string; fa?: number; fb?: number; routed?: { x: number; y: number }[] };
+type EM = {
+  from: string;
+  to: string;
+  kind: string;
+  sa: string;
+  sb: string;
+  fa?: number;
+  fb?: number;
+  routed?: { x: number; y: number }[];
+};
 const edgeMeta: EM[] = [];
 const buckets: Record<string, { i: number; end: "a" | "b" }[]> = {};
 E.forEach((e, i) => {
@@ -126,13 +398,16 @@ Object.entries(buckets).forEach(([key, list]) => {
   const n = list.length;
   list.forEach((it, k) => {
     const f = (k + 1) / (n + 1);
-    if (it.end === "a") edgeMeta[it.i].fa = f; else edgeMeta[it.i].fb = f;
+    if (it.end === "a") edgeMeta[it.i].fa = f;
+    else edgeMeta[it.i].fb = f;
   });
 });
 function pathFor(m: EM) {
   if (m.routed) return roundedPath(m.routed);
-  const A = N[m.from], B = N[m.to];
-  const p1 = anchor(A, m.sa, m.fa ?? 0.5), p2 = anchor(B, m.sb, m.fb ?? 0.5);
+  const A = N[m.from],
+    B = N[m.to];
+  const p1 = anchor(A, m.sa, m.fa ?? 0.5),
+    p2 = anchor(B, m.sb, m.fb ?? 0.5);
   const dist = Math.hypot(p2.x - p1.x, p2.y - p1.y);
   const k = Math.min(160, Math.max(48, dist * 0.4));
   const c1 = { x: p1.x + p1.n[0] * k, y: p1.y + p1.n[1] * k };
@@ -145,18 +420,33 @@ const nodes = Object.values(N).map((n) => {
   const col = TIER[n.tier];
   let shape = "";
   if (n.shape === "cyl") {
-    const w = n.w, h = n.h, rx = w / 2, ry = 10;
+    const w = n.w,
+      h = n.h,
+      rx = w / 2,
+      ry = 10;
     shape = `M${-rx},${-h / 2 + ry} a${rx},${ry} 0 0 1 ${w},0 v${h - 2 * ry} a${rx},${ry} 0 0 1 ${-w},0 Z`;
   } else if (n.shape === "hex") {
-    const w = n.w / 2, h = n.h / 2, c = 18;
+    const w = n.w / 2,
+      h = n.h / 2,
+      c = 18;
     shape = `M${-w + c},${-h} H${w - c} L${w},0 L${w - c},${h} H${-w + c} L${-w},0 Z`;
   }
   return { ...n, col, shape };
 });
 
 const legend = [
-  ["edge", "Edge"], ["web", "Web"], ["api", "API"], ["worker", "Worker"], ["mcp", "MCP"], ["file", "Files"],
-  ["db", "Postgres"], ["nats", "NATS"], ["sbx", "Sandbox"], ["pub", "Preview"], ["llm", "LLM"], ["desk", "Desktop"],
+  ["edge", "Edge"],
+  ["web", "Web"],
+  ["api", "API"],
+  ["worker", "Worker"],
+  ["mcp", "MCP"],
+  ["file", "Files"],
+  ["db", "Postgres"],
+  ["nats", "NATS"],
+  ["sbx", "Sandbox"],
+  ["pub", "Preview"],
+  ["llm", "LLM"],
+  ["desk", "Desktop"],
 ];
 ---
 

--- a/apps/docs/client/src/components/ui/Sidebar.astro
+++ b/apps/docs/client/src/components/ui/Sidebar.astro
@@ -172,7 +172,11 @@ function buildTree(docs: any[]): TreeNode[] {
 
         // Custom order for self-hosting section
         if (parentPath === "self-hosting") {
-          const selfHostingOrder = ["quickstart", "architecture", "authentication"];
+          const selfHostingOrder = [
+            "quickstart",
+            "architecture",
+            "authentication",
+          ];
           const aIndex = selfHostingOrder.indexOf(a.name);
           const bIndex = selfHostingOrder.indexOf(b.name);
           if (aIndex !== -1 && bIndex !== -1) {

--- a/apps/mesh/src/observability/middleware.ts
+++ b/apps/mesh/src/observability/middleware.ts
@@ -6,8 +6,14 @@
  */
 
 import type { MiddlewareHandler } from "hono";
-import { SpanStatusCode, type Exception, type Span } from "@opentelemetry/api";
 import {
+  SpanStatusCode,
+  type Exception,
+  type Histogram,
+  type Span,
+} from "@opentelemetry/api";
+import {
+  meter,
   tracer,
   withRequest,
   reqCorrelationId,
@@ -15,6 +21,20 @@ import {
 } from "./index";
 import type { Env } from "../api/hono-env";
 import { isHealthPath } from "../api/utils/paths";
+
+// Lazily created on first request: `meter` is a no-op until initObservability()
+// runs sdk.start(), so creating the instrument at module load would bind it to
+// the NoopMeter. The ESM live binding means reading `meter` here picks up the
+// real meter once it's reassigned.
+let _durationHistogram: Histogram | undefined;
+const durationHistogram = (): Histogram =>
+  (_durationHistogram ??= meter.createHistogram(
+    "http.server.request.duration",
+    {
+      description: "Duration of inbound HTTP requests handled by the API.",
+      unit: "s",
+    },
+  ));
 
 /**
  * Tracing middleware that creates a span for each request
@@ -27,6 +47,7 @@ export const tracingMiddleware: MiddlewareHandler<Env> = async (c, next) => {
 
   const req = c.req.raw;
   const url = new URL(req.url);
+  const start = performance.now();
 
   // Create context with request for sampling decisions
   const parentContext = withRequest(req);
@@ -97,6 +118,15 @@ export const tracingMiddleware: MiddlewareHandler<Env> = async (c, next) => {
         if (correlationId) {
           setCorrelationIdHeader(c.res.headers, correlationId);
         }
+
+        // Latency histogram for Prometheus (the span carries the trace; this is
+        // the only HTTP-duration signal scraped at /metrics). Labelled by the
+        // matched route pattern — not the raw path — to keep cardinality bounded.
+        durationHistogram().record((performance.now() - start) / 1000, {
+          "http.request.method": req.method,
+          "http.route": c.req.routePath,
+          "http.response.status_code": status,
+        });
 
         span.end();
       }

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.6
+version: 0.10.7
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -25,9 +25,19 @@ spec:
       {{- include "chart-deco-studio.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.metrics.scrape .Values.podAnnotations }}
       annotations:
+        {{- if .Values.metrics.scrape }}
+        # Annotation-based discovery: vmagent's kubernetes-pods job scrapes the
+        # app's Prometheus endpoint (/metrics is auth-exempt). Port mirrors the
+        # http containerPort so it tracks service.targetPort overrides.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.service.targetPort | default 3000 | quote }}
+        prometheus.io/path: {{ .Values.metrics.path | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "chart-deco-studio.podLabels" . | nindent 8 }}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -29,6 +29,14 @@ service:
   # to take effect; falls back to all endpoints otherwise.
   trafficDistribution: ""
 
+# Prometheus scraping of the app's /metrics endpoint (HTTP request-duration
+# histogram, event-loop delay, runtime metrics). Adds prometheus.io/* pod
+# annotations for vmagent's kubernetes-pods job. Disable if your cluster uses
+# ServiceMonitor CRDs or doesn't scrape pods by annotation.
+metrics:
+  scrape: true
+  path: /metrics
+
 resources:
   requests:
     memory: "2Gi"


### PR DESCRIPTION
## Why

We have no real web/api latency signal in Prometheus. The existing p95 panel only works for the sandbox preview because that path goes through Envoy. For `deco-studio` web/api, only cAdvisor / kube-state / opencost are scraped — **latency was dropped, not faked**.

Two gaps, both addressed here:

1. The tracing middleware (`apps/mesh/src/observability/middleware.ts`) emits a **span** per request but records **no metric**. The only histogram in the meter was `eventloop.delay`.
2. The chart shipped **no scrape hint**. `/metrics` exists (and is auth-exempt) but vmagent never scraped it.

## What

- **App**: record `http.server.request.duration` (seconds) on the existing OTel `meter`, labelled by `http.request.method` + `http.route` (the *matched route pattern*, not the raw path — keeps cardinality bounded) + `http.response.status_code`. The `PrometheusExporter` already serializes it at `/metrics`; no new wiring. Instrument is created lazily on first request because `meter` is a no-op until `initObservability()` runs `sdk.start()`.
- **Chart**: `prometheus.io/scrape` pod annotations on the API deployment, gated by `metrics.scrape` (default `true`). Port mirrors `service.targetPort` so it tracks overrides. Disable for clusters using ServiceMonitor CRDs. Chart bumped `0.10.6 → 0.10.7`.

This covers every proxied path (`/api`, `/mcp`, `/oauth-proxy`, …) since nginx forwards those to the API and the API records them.

## Deliberately skipped

- **nginx VTS / stub_status** for the web tier — static SPA + asset serving latency is negligible and would need a custom nginx build. The API histogram covers the request paths that matter. Add when static-serve latency becomes a real concern.

## Testing

- `helm template` renders the three `prometheus.io/*` annotations; `helm lint` passes.
- `tsc --noEmit` clean; `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `http.server.request.duration` and enable `/metrics` scraping on API pods to expose real web/API latency in Prometheus. Also formats docs components (`ArchitectureDiagram.astro`, `Sidebar.astro`); no logic changes.

- **New Features**
  - Record `http.server.request.duration` (seconds) with labels: method, route pattern, status; instrument created lazily.
  - Exported at `/metrics` (auth-exempt) via the existing Prometheus exporter; covers all API-handled paths.
  - Helm chart adds `prometheus.io/*` pod annotations controlled by `metrics.scrape` (default `true`) and `metrics.path`; port follows `service.targetPort`. Chart `0.10.7`.

- **Migration**
  - If your cluster uses ServiceMonitor CRDs, set `metrics.scrape: false`. No other changes required.

<sup>Written for commit 0b17c2a1f5dd731ea4cbb3473b3f42568ee289df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

