### PR TITLE
fix(credits): stop sidebar chip hammering AI_PROVIDER_CREDITS on every focus

### DIFF
--- a/apps/mesh/src/web/components/sidebar/top-actions.tsx
+++ b/apps/mesh/src/web/components/sidebar/top-actions.tsx
@@ -8,13 +8,8 @@ import {
 } from "@deco/ui/components/sidebar.tsx";
 import { Coins04 } from "@untitledui/icons";
 import { useNavigate } from "@tanstack/react-router";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useMCPToolCallQuery,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
-import { useAiProviderKeys } from "@/web/hooks/collections/use-ai-providers";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useDecoCredits } from "@/web/hooks/use-deco-credits";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   Tooltip,
@@ -50,33 +45,17 @@ function creditColor(balanceDollars: number): string {
 function CreditChip() {
   const navigate = useNavigate();
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
-  const { data, isPending, isError } = useMCPToolCallQuery<
-    { balanceCents: number } | undefined
-  >({
-    client,
-    toolName: "AI_PROVIDER_CREDITS",
-    toolArguments: { providerId: "deco" },
-    staleTime: 60_000,
-    select: (result) =>
-      (result as { structuredContent?: { balanceCents: number } })
-        .structuredContent,
-  });
-  const balanceDollars =
-    data?.balanceCents != null ? data.balanceCents / 100 : null;
-  const tooltipLabel =
-    isPending || isError || balanceDollars == null
-      ? "Credits"
-      : `Credits: $${balanceDollars.toFixed(2)}`;
+  const { hasDecoKey, balanceDollars } = useDecoCredits();
+  if (!hasDecoKey) return null;
   return (
     <SidebarMenu>
       <SidebarMenuItem>
         <SidebarMenuButton
-          tooltip={tooltipLabel}
+          tooltip={
+            balanceDollars != null
+              ? `Credits: $${balanceDollars.toFixed(2)}`
+              : "Credits"
+          }
           className={cn(balanceDollars != null && creditColor(balanceDollars))}
           onClick={() =>
             navigate({
@@ -97,18 +76,11 @@ function CreditChip() {
   );
 }
 
-function CreditChipConditional() {
-  const keys = useAiProviderKeys();
-  const hasDecoKey = keys.some((k) => k.providerId === "deco");
-  if (!hasDecoKey) return null;
-  return <CreditChip />;
-}
-
 export function SidebarTopActions() {
   return (
     <SilentErrorBoundary>
       <Suspense fallback={null}>
-        <CreditChipConditional />
+        <CreditChip />
       </Suspense>
     </SilentErrorBoundary>
   );
@@ -117,28 +89,12 @@ export function SidebarTopActions() {
 function CreditChipInline() {
   const navigate = useNavigate();
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
-  const { data, isPending, isError } = useMCPToolCallQuery<
-    { balanceCents: number } | undefined
-  >({
-    client,
-    toolName: "AI_PROVIDER_CREDITS",
-    toolArguments: { providerId: "deco" },
-    staleTime: 60_000,
-    select: (result) =>
-      (result as { structuredContent?: { balanceCents: number } })
-        .structuredContent,
-  });
-  const balanceDollars =
-    data?.balanceCents != null ? data.balanceCents / 100 : null;
+  const { hasDecoKey, balanceDollars } = useDecoCredits();
+  if (!hasDecoKey) return null;
   const tooltipLabel =
-    isPending || isError || balanceDollars == null
-      ? "Credits"
-      : `Credits: $${balanceDollars.toFixed(2)}`;
+    balanceDollars != null
+      ? `Credits: $${balanceDollars.toFixed(2)}`
+      : "Credits";
   return (
     <Tooltip delayDuration={300}>
       <TooltipTrigger asChild>
@@ -160,18 +116,11 @@ function CreditChipInline() {
   );
 }
 
-function CreditChipInlineConditional() {
-  const keys = useAiProviderKeys();
-  const hasDecoKey = keys.some((k) => k.providerId === "deco");
-  if (!hasDecoKey) return null;
-  return <CreditChipInline />;
-}
-
 export function SidebarTopActionsInline() {
   return (
     <SilentErrorBoundary>
       <Suspense fallback={null}>
-        <CreditChipInlineConditional />
+        <CreditChipInline />
       </Suspense>
     </SilentErrorBoundary>
   );


### PR DESCRIPTION
## Problem

The logs show `POST /api/:org/tools/AI_PROVIDER_CREDITS → 500: "Failed to fetch credits balance: 401"` firing repeatedly.

It's **not a retry loop**. The sidebar credit chip (`top-actions.tsx`) called the tool via `useMCPToolCallQuery`, which **throws** on the upstream 401. An errored react-query is *always* stale (staleTime ignored), and the global default is `refetchOnWindowFocus: true`. The sidebar is always mounted, so **every tab/window focus re-fired the failing call** — indefinitely.

The other three callers (home, chat, settings) go through `useDecoCredits`, which swallows the error and caches `null` → quiet for 60s. That's why only the chip spammed.

(The 401 root cause — the minted gateway JWT being rejected by `ai-site.deco.site` — is a separate config/infra issue, not addressed here.)

## Fix

Point the chip at the shared `useDecoCredits()` hook it was already documented to use ("sidebar chip ... single source of truth"). The hook swallows + caches the failure, so:

- no more focus-driven 500 storm
- one shared query key instead of two redundant backend calls
- ~60 lines of duplicated query code deleted

## Testing

`bun run fmt`, `bun run lint`, and `bun run --cwd=apps/mesh check` pass. Exported `SidebarTopActions` / `SidebarTopActionsInline` signatures unchanged (still consumed by `sidebar/footer/inbox.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the sidebar credits chip from re-calling `AI_PROVIDER_CREDITS` on every window focus by switching to the shared `useDecoCredits()` hook. Prevents focus-driven 5xx spam and removes duplicate query code.

- **Bug Fixes**
  - Replaced `useMCPToolCallQuery` with `useDecoCredits()` in both chips; errors are cached as `null` and don’t refetch on focus.
  - Inlined the `hasDecoKey` check and removed conditional wrappers; UI and exports unchanged while using a single query key.

<sup>Written for commit bdf646504f7ad85fa1c93754265c0e0d17bcbe35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

