### PR TITLE
fix(observability): seconds bucket boundaries for http.server.request.duration

### DIFF
--- a/apps/mesh/src/observability/middleware.ts
+++ b/apps/mesh/src/observability/middleware.ts
@@ -33,6 +33,16 @@ const durationHistogram = (): Histogram =>
     {
       description: "Duration of inbound HTTP requests handled by the API.",
       unit: "s",
+      // We record seconds, so the boundaries must be seconds too. Without this
+      // advice the SDK applies its default millisecond boundaries (5, 10, …,
+      // 10000), into which every sub-5s request collapses — making the quantiles
+      // meaningless. These are the OTel HTTP semconv buckets for the metric.
+      advice: {
+        explicitBucketBoundaries: [
+          0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5,
+          10,
+        ],
+      },
     },
   ));
 


### PR DESCRIPTION
## Bug

The `http.server.request.duration` histogram (#3993) records **seconds** but supplied no explicit bucket boundaries, so the OTel SDK fell back to its **default millisecond** buckets:

```
[0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000, +Inf]
```

Every request under 5 seconds (i.e. essentially all of them) collapses into the first bucket `le=5`. `histogram_quantile` then just interpolates *inside* that one bucket, so in stg every percentile is a fixed artifact of the bucket width:

| | observed (broken) |
|---|---|
| p50 | 2.5 s (midpoint of [0,5]) |
| p95 | 4.75 s |
| p99 | 4.95 s |

— independent of real latency.

## Fix

Add `advice.explicitBucketBoundaries` with the OTel HTTP semconv **seconds** buckets:

```
0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10
```

Now sub-second latencies resolve properly. Unit stays `s`; the Grafana panels (unit `s`, marker lines at 0.3s / 1s) need no change.

## Notes

- Only affects **new** samples after deploy; the coarse historical series stay as-is.
- Verified: `tsc --noEmit` clean, `bun run fmt` no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly set seconds-based histogram buckets for `http.server.request.duration` to fix broken percentiles from default millisecond buckets. Sub-second latencies now resolve correctly.

- **Bug Fixes**
  - Added OTel HTTP semconv seconds buckets: 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10.
  - Unit stays `s`; existing Grafana panels require no changes.
  - Applies to new samples only; historical data is unchanged.

<sup>Written for commit e87135e07e580c07df0096ba5a0ad5cbb3f7f8a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

