### PR TITLE
ci(deploy): scope releases so web-only changes roll only web pods

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -405,6 +405,19 @@ jobs:
       - name: Skip notice (dispatch token not configured)
         if: env.DISPATCH_TOKEN == ''
         run: echo "::notice::DEPLOY_REPO_TOKEN not set — skipping the deco-apps-cd bump."
+      - uses: actions/checkout@v4
+        if: env.DISPATCH_TOKEN != ''
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Read deploy scope from release commit
+        id: scope
+        if: env.DISPATCH_TOKEN != ''
+        # release-tagging stamps a `Deploy-Scope:` trailer on the [release]
+        # commit (web / server / both). deco-apps-cd's bump-studio-image rolls
+        # only the matching tier. Absent/old commits default to both.
+        run: |
+          S=$(git log -1 --format=%B | sed -n 's/^Deploy-Scope:[[:space:]]*//p' | head -1)
+          echo "scope=${S:-both}" >> "$GITHUB_OUTPUT"
       - name: Dispatch studio-image-bump to deco-apps-cd
         if: env.DISPATCH_TOKEN != ''
         uses: peter-evans/repository-dispatch@v3
@@ -412,7 +425,7 @@ jobs:
           token: ${{ secrets.DEPLOY_REPO_TOKEN }}
           repository: decocms/deco-apps-cd
           event-type: studio-image-bump
-          client-payload: '{"version": "${{ needs.prepare.outputs.version }}"}'
+          client-payload: '{"version": "${{ needs.prepare.outputs.version }}", "scope": "${{ steps.scope.outputs.scope }}"}'
       - name: Summary
         if: env.DISPATCH_TOKEN != ''
-        run: echo "Dispatched \`studio-image-bump\` (version ${{ needs.prepare.outputs.version }}) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "Dispatched \`studio-image-bump\` (version ${{ needs.prepare.outputs.version }}, scope ${{ steps.scope.outputs.scope }}) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -134,6 +134,22 @@ jobs:
           echo "Workspace manifests to bump: $PACKAGE_MANIFESTS"
           echo "package_manifests=$PACKAGE_MANIFESTS" >> "$GITHUB_OUTPUT"
 
+          # Deploy scope drives which CD tier rolls (see deco-apps-cd
+          # bump-studio-image): web-only changes (apps/mesh/src/web/** and
+          # nothing else under apps/mesh/) roll only the web pods; server-only
+          # roll api+worker; mixed or no-mesh-files roll both (safe default).
+          MESH=$(echo "$FILES" | grep '^apps/mesh/' || true)
+          SCOPE=both
+          if [ -n "$MESH" ]; then
+            if echo "$MESH" | grep -qv '^apps/mesh/src/web/'; then
+              if echo "$MESH" | grep -q '^apps/mesh/src/web/'; then SCOPE=both; else SCOPE=server; fi
+            else
+              SCOPE=web
+            fi
+          fi
+          echo "Deploy scope: $SCOPE"
+          echo "deploy_scope=$SCOPE" >> "$GITHUB_OUTPUT"
+
       - name: Update package.json versions
         id: update_versions
         if: >-
@@ -145,6 +161,7 @@ jobs:
           PACKAGE_MANIFESTS: ${{ steps.changed_workspaces.outputs.package_manifests }}
           PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
           PR_TITLE: ${{ steps.find_pr.outputs.pr_title }}
+          DEPLOY_SCOPE: ${{ steps.changed_workspaces.outputs.deploy_scope }}
         run: |
           set -euo pipefail
 
@@ -203,6 +220,10 @@ jobs:
             `Bump type: ${bumpType}`,
             "",
             summary,
+            "",
+            // Read by release-mesh's deco-apps-cd dispatch to roll only the
+            // affected CD tier (web / server / both).
+            `Deploy-Scope: ${process.env.DEPLOY_SCOPE || "both"}`,
           ].join("\n");
 
           fs.writeFileSync(".release-commit-message", `${commitMessage}\n`);


### PR DESCRIPTION
## Problem

Every Argo sync rolls **all three tiers** (api, worker, web) even when a PR only touched the web UI. Root cause: there is one mesh image and one shared tag. The web UI lives at \`apps/mesh/src/web\`, so a web-only PR still bumps \`apps/mesh/package.json\` → builds \`mesh:X\` → deco-apps-cd sets a single \`studio.image.tag=X\` that all three Deployments reference → all three roll.

## Fix

Thread a **deploy scope** through the release chain so only the affected tier rolls:

- **\`release-tagging.yml\`** — classifies each release from the merged PR's changed files: all under \`apps/mesh/src/web/**\` → \`web\`; none under it → \`server\`; mixed (or no mesh files) → \`both\`. Stamps a \`Deploy-Scope:\` trailer on the \`[release]\` commit.
- **\`release-mesh.yml\`** — reads that trailer off the release commit and forwards \`scope\` in the \`studio-image-bump\` repository_dispatch payload.

The CD side (deco-apps-cd PR) reads \`scope\` and bumps \`web.bundleImage.tag\` and/or \`image.tag\` independently.

## Safety / rollout ordering

- **Safe to merge in any order** vs the deco-apps-cd PR. The added \`scope\` payload field is ignored by the current bump workflow, so this PR alone changes nothing observable.
- The behavior only activates once **both** this and decocms/deco-apps-cd#<TBD> are merged.
- Unknown/old commits with no trailer default to \`both\` — today's behavior.

A new image is still built on a web change (the SPA bytes live in the mesh image) — this only stops the **api/worker rollout**, no second image needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes deploys so web-only PRs roll only web pods. We propagate a `Deploy-Scope` (web/server/both) from `release-tagging` to `release-mesh` and include it in the `deco-apps-cd` bump.

- **New Features**
  - `release-tagging.yaml`: Classifies changed files under `apps/mesh/` → sets `deploy_scope` (web if only `apps/mesh/src/web/**`; server if non-web only; both for mixed/none) and stamps `Deploy-Scope:` on the `[release]` commit.
  - `release-mesh.yaml`: Checks out the release ref, reads the trailer, defaults to `both`, and sends `scope` in the repository dispatch to `decocms/deco-apps-cd` (`studio-image-bump`).

- **Migration**
  - Safe to merge alone; current CD ignores the new `scope` field.
  - Behavior activates once the matching change in `deco-apps-cd` is merged.
  - Old/unknown commits default to `both`. A new image still builds; only API/worker rollouts are skipped for web-only changes.

<sup>Written for commit 9de08248bc238e1e5522a8cd835fa70b2001ddec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

