### PR TITLE
fix(deploy): scope nginx clickjacking guards to the SPA, not /api

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.7
+version: 0.10.8
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/files/web-nginx.conf.template
+++ b/deploy/helm/studio/files/web-nginx.conf.template
@@ -33,11 +33,12 @@ server {
   # nginx defaults to 1m and would 413 large uploads before they reach the API.
   client_max_body_size 100m;
 
-  # Default policy: revalidate HTML + clickjacking guards (mirrors the app's
-  # withSecurityHeaders). Per-location add_header blocks below override this.
-  add_header Cache-Control "no-cache" always;
-  add_header X-Frame-Options "DENY" always;
-  add_header Content-Security-Policy "frame-ancestors 'none'" always;
+  # Clickjacking + cache guards live on the SPA `location /` below, NOT at server
+  # level. nginx's add_header inheritance would otherwise push them onto the
+  # proxied /api location, re-stamping frame-ancestors 'none' over the API's own
+  # per-path CSP — which breaks the file/fs previews the app deliberately iframes
+  # (it exempts /files and /fs/.../read). Scoping to the SPA protects the app
+  # shell while proxied API responses keep the headers the app set.
 
   location = /healthz {
     access_log off;
@@ -74,8 +75,13 @@ server {
     try_files $uri =404;
   }
 
-  # SPA fallback.
+  # SPA fallback. Clickjacking + no-cache guards live here (not server-level) so
+  # they apply to the app shell only — never inherited onto the proxied /api
+  # location, whose responses carry the API's own per-path CSP.
   location / {
+    add_header Cache-Control "no-cache" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Content-Security-Policy "frame-ancestors 'none'" always;
     try_files $uri /index.html;
   }
 }


### PR DESCRIPTION
## Symptom

Previewing a file served via the org-fs read endpoint fails in prod:

```
Framing 'https://studio.decocms.com/' violates the following Content Security
Policy directive: "frame-ancestors 'none'". The request has been blocked.
```

Repro: open the Library → preview `architecture.html` → the pane iframes `https://studio.decocms.com/api/deco/fs/home/read?path=home/architecture.html` and is blocked. Only happens **behind the nginx web-split** (prod), not direct-to-app.

## Root cause

The app already does the right thing — `app.ts` exempts `/files/*` and `/fs/:volume/read` from the `frame-ancestors 'none'` it stamps on everything else, precisely so it can iframe those previews.

But the web **nginx** set the guards at **server level** with `always`:

```nginx
add_header Content-Security-Policy "frame-ancestors 'none'" always;
```

nginx's `add_header` inheritance pushes server-level headers down into any location that defines no `add_header` of its own — including the `/api` proxy location. So nginx re-stamped the deny onto the proxied `/api/.../read` response, clobbering the app's exemption.

Confirmed against live prod — the exempted path carries exactly one CSP (from nginx), while a normal `/api` path carries it **twice** (app + nginx).

## Fix

Move the clickjacking + `no-cache` guards out of the `server` block into the SPA `location /` only. The app shell stays protected; the `/api` proxy location inherits nothing and passes through the API's own per-path CSP. `/assets/` and `/healthz` already had their own `add_header` (unaffected).

Validated with `nginx -t` (passes). Chart bumped `0.10.7 → 0.10.8`.

## Rollout

After merge, the chart needs to reach prod/stg via deco-apps-cd (bump to 0.10.8) — separate PR once this merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope nginx clickjacking and cache headers to the SPA `location /` so `/api` proxy responses keep the app’s CSP. Fixes blocked iframe previews for `/files/*` and `/fs/:volume/read` in prod; bumps Helm chart to 0.10.8.

- **Bug Fixes**
  - Moved `X-Frame-Options: DENY`, `Content-Security-Policy: frame-ancestors 'none'`, and `Cache-Control: no-cache` from server block to SPA fallback to avoid inheritance onto `/api`.
  - `/api` now forwards the API’s per-path CSP unchanged, restoring org-fs file preview iframes (validated with `nginx -t`).

<sup>Written for commit dc7d1bc68ccfcd24bc8188126fb866afe4d244e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

