### PR TITLE
fix(deploy): roll web nginx pods when its ConfigMap changes (checksum annotation)

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.8
+version: 0.10.9
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/web-deployment.yaml
+++ b/deploy/helm/studio/templates/web-deployment.yaml
@@ -34,10 +34,14 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Roll the nginx pods whenever the mounted config changes. Without this
+        # a ConfigMap-only edit (e.g. a CSP/header fix) updates the ConfigMap but
+        # never restarts nginx, so it keeps serving the old config indefinitely.
+        checksum/web-nginx-config: {{ include (print $.Template.BasePath "/web-configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-web
         app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
## Why

#3998 (scope nginx clickjacking guards to the SPA) merged, the chart bumped to 0.10.8, and Argo synced — the web Deployment even carries `helm.sh/chart=studio-0.10.8`. **But prod still serves the old config:** `/api/.../read` still returns `frame-ancestors 'none'`, and the web pods are from 06:40 (before the fix existed).

Root cause: the web Deployment has **no config-checksum annotation**. A ConfigMap-only change updates the ConfigMap object, but the pod template is unchanged, so no rollout happens — and nginx only reads its config at startup. Result: every nginx-config change silently fails to take effect until something else happens to restart the pods.

## Fix

Add the standard Helm idiom to the web pod template:

```yaml
annotations:
  checksum/web-nginx-config: {{ include (print $.Template.BasePath "/web-configmap.yaml") . | sha256sum }}
```

Now any change to the nginx ConfigMap changes the pod-template hash → triggers a rollout → new pods load the new config.

Verified with `helm template`:
- annotation renders with a stable sha;
- editing `web-nginx.conf.template` produces a **different** hash (→ rollout);
- an env-only change (`web.accessLog`) does **not** change it (correct — that's a Deployment env var, not ConfigMap content).

`helm lint` passes. Chart bumped `0.10.8 → 0.10.9`.

## Rollout

After merge + chart bump to 0.10.9 in deco-apps-cd, the web pods finally roll and pick up the #3998 CSP fix. (This is also what was blocking validation of that fix.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a checksum annotation to the web Deployment so nginx pods roll when the ConfigMap changes. This fixes stale nginx config in prod and ensures future config updates (like CSP changes) apply automatically.

- **Bug Fixes**
  - Add `checksum/web-nginx-config` (sha256 of `web-configmap.yaml`) to the pod template to trigger rollouts on config updates; keeps `.Values.podAnnotations`.
  - Bump chart `chart-deco-studio` to `0.10.9`.

<sup>Written for commit 4cfecb7ec20b6251298be7d4fdc9273a150347d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

