### PR TITLE
fix(sandbox): toggle drawer on script tab re-click

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/drawer/toolbar.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/drawer/toolbar.tsx
@@ -85,7 +85,10 @@ export function DrawerToolbar(props: DrawerToolbarProps) {
           <TabButton
             key={t}
             active={props.active === t}
-            onClick={() => props.onSelectTab(t)}
+            onClick={() => {
+              if (props.active === t) props.onToggle();
+              else props.onSelectTab(t);
+            }}
             onClose={() => props.onCloseScript(t)}
           >
             {t}


### PR DESCRIPTION
## Summary
- Clicking an already-active script tab (e.g. "dev") now toggles the drawer closed, matching the existing behavior of the "sandbox" (setup) tab
- Previously, only the "sandbox" tab had toggle-to-close behavior; script tabs would do nothing when re-clicked

## Test plan
- [ ] Open a sandbox with a "dev" script tab
- [ ] Click the "dev" tab while it's active — drawer should close
- [ ] Click it again — drawer should reopen
- [ ] Verify "sandbox" tab toggle behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking an active script tab now toggles the drawer closed/open, matching the "sandbox" tab behavior. This makes the drawer controls consistent and quicker to use from script tabs.

<sup>Written for commit 9a04277a8a577372d90cef5ef42574f1729bdc68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

