### PR TITLE
fix(oauth): keep MCP callbacks on browser origin

### DIFF
--- a/apps/mesh/src/web/providers/theme-provider.test.ts
+++ b/apps/mesh/src/web/providers/theme-provider.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, test } from "bun:test";
+
+describe("ThemeProvider OAuth redirect origin", () => {
+  test("does not point MCP OAuth callbacks at the internal API URL", () => {
+    const source = readFileSync(join(import.meta.dir, "theme-provider.tsx"), {
+      encoding: "utf8",
+    });
+
+    expect(source).not.toContain("setOAuthRedirectOrigin");
+  });
+});

--- a/apps/mesh/src/web/providers/theme-provider.tsx
+++ b/apps/mesh/src/web/providers/theme-provider.tsx
@@ -9,7 +9,6 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { useLayoutEffect, type ReactNode } from "react";
 import type { PublicConfig } from "@/api/routes/public-config";
 import { KEYS } from "@/web/lib/query-keys";
-import { setOAuthRedirectOrigin } from "@decocms/mesh-sdk";
 import { usePreferences } from "@/web/hooks/use-preferences";
 
 async function fetchPublicConfig(): Promise<PublicConfig> {
@@ -82,11 +81,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   });
 
   const [preferences] = usePreferences();
-
-  // Set OAuth redirect origin for proxy environments (e.g. tokyo.localhost → localhost:3000)
-  if (publicConfig.internalUrl) {
-    setOAuthRedirectOrigin(publicConfig.internalUrl);
-  }
 
   // Inject theme variables synchronously before paint to avoid FOUC
   // useLayoutEffect is correct here (not useEffect) for DOM mutations that affect visual appearance


### PR DESCRIPTION
## What is this contribution about?
Stops Studio from overriding MCP OAuth callback generation with the local API `internalUrl`, so browser OAuth callbacks stay on the Vite/SPA origin such as `http://kelowna.localhost/oauth/callback`.
This fixes GitHub OAuth popups that were generating `localhost:<api-port>/oauth/callback` and landing on a server-side JSON 404.
Adds a regression test to keep the theme provider from wiring OAuth redirects to the internal API URL.

## Screenshots/Demonstration
Verified in DevTools that the GitHub OAuth popup's decoded state now contains `redirectUri: "http://kelowna.localhost/oauth/callback"` instead of `http://localhost:3001/oauth/callback`.

## How to Test
1. Open `http://kelowna.localhost/gimenes-local/settings/connections/mcp-github`.
2. Click `Authorize` on the GitHub connection.
3. Expected outcome: the OAuth popup uses the browser-facing Studio callback origin, so completing the provider flow returns to the SPA callback route instead of the API server.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes
