### PR TITLE
fix(mcp-clients): scope read cache per principal, not per org

### DIFF
--- a/apps/mesh/src/mcp-clients/lazy-client.test.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.test.ts
@@ -14,7 +14,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createBridgeTransportPair } from "@decocms/mesh-sdk";
 import { CircuitOpenError, resetAll } from "./circuit-breaker";
-import { createLazyClient } from "./lazy-client";
+import { createLazyClient, resolveReadCacheScope } from "./lazy-client";
 import type { ConnectionEntity } from "../tools/connection/schema";
 import type { StudioContext } from "../core/studio-context";
 
@@ -209,5 +209,25 @@ describe("lazy-client with circuit breaker", () => {
     // NOW it's open (3rd failure)
     const lazy4 = createLazyClient(fakeConnection, fakeCtx, false);
     expect(lazy4.listTools()).rejects.toThrow(CircuitOpenError);
+  });
+});
+
+describe("resolveReadCacheScope", () => {
+  // The read cache must key by principal so a per-user result (anything that
+  // reads the forwarded x-mesh-token) is never served to a different user. Org
+  // scope is only safe when there is no principal to leak.
+  it("keys by principal so distinct users get distinct cache keys", () => {
+    expect(resolveReadCacheScope("user_a")).toEqual({
+      kind: "user",
+      userId: "user_a",
+    });
+    expect(resolveReadCacheScope("user_b")).toEqual({
+      kind: "user",
+      userId: "user_b",
+    });
+  });
+
+  it("falls back to org only when there is no principal", () => {
+    expect(resolveReadCacheScope(undefined)).toEqual({ kind: "org" });
   });
 });

--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -66,12 +66,25 @@ async function isReadOnlyTool(
 }
 
 /**
- * Cache scope for a connection's read-only results. Defaults to "org" (shared
- * across all members). The per-connection "user" opt-out (key by principal) is
- * a follow-up; the cache already keys by scope, so it's a resolver change only.
+ * Cache scope for a connection's read-only results.
+ *
+ * Keyed by the calling principal whenever there is one, so a result that
+ * depends on the caller's identity — anything that reads the forwarded
+ * `x-mesh-token`, e.g. a per-user auth/access check — is never served to a
+ * different user. Studio can't tell which upstream reads vary by caller, so
+ * per-user is the only safe default: org-shared caching would leak the first
+ * caller's result to the whole org for up to `maxStaleMs`. A single user's
+ * repeated reads still hit the cache (the dominant dashboard-polling case);
+ * only cross-user sharing of identity-independent reads is given up.
+ *
+ * Falls back to "org" only when there is no principal at all (e.g. a
+ * super-user background worker with no app user), where there is no per-user
+ * identity to leak.
  */
-function resolveReadCacheScope(): ReadCacheScope {
-  return { kind: "org" };
+export function resolveReadCacheScope(
+  principalId: string | undefined,
+): ReadCacheScope {
+  return principalId ? { kind: "user", userId: principalId } : { kind: "org" };
 }
 
 /**
@@ -195,13 +208,18 @@ export function createLazyClient(
 
   // Read-only results (tools/call for read-only tools, resources/read,
   // prompts/get) are served stale-while-revalidate from the per-pod read cache,
-  // org-scoped by default and shared across org members. Writes, tools we can't
-  // confirm read-only, VIRTUAL connections (they compose other conns), and calls
-  // with a custom result schema bypass entirely. `options` (e.g. the timeout) is
-  // forwarded to the live fetch but excluded from the cache key.
+  // scoped per calling principal by default (see resolveReadCacheScope). Writes,
+  // tools we can't confirm read-only, VIRTUAL connections (they compose other
+  // conns), and calls with a custom result schema bypass entirely. `options`
+  // (e.g. the timeout) is forwarded to the live fetch but excluded from the key.
   // null when MCP caching is disabled (settings-gated).
   const readCache = getMcpReadCache();
   const cacheReads = connection.connection_type !== "VIRTUAL";
+  // Resolved once from the per-request ctx: the lazy client is created per
+  // request, so this is the actual caller, not a stale connection-time identity.
+  const readCacheScope = resolveReadCacheScope(
+    ctx.auth?.user?.id ?? ctx.auth?.apiKey?.userId,
+  );
 
   placeholder.callTool = async (params, resultSchema, options) => {
     const toolName = (params as { name?: unknown })?.name;
@@ -217,7 +235,7 @@ export function createLazyClient(
       const result = await readCache.fetch({
         type: "tools/call",
         connectionId: connection.id,
-        scope: resolveReadCacheScope(),
+        scope: readCacheScope,
         params: {
           name: toolName,
           arguments: (params as { arguments?: unknown })?.arguments,
@@ -261,7 +279,7 @@ export function createLazyClient(
     const result = await readCache.fetch({
       type: "prompts/get",
       connectionId: connection.id,
-      scope: resolveReadCacheScope(),
+      scope: readCacheScope,
       params,
       fetchLive: async () => {
         const real = await getRealClient();
@@ -287,7 +305,7 @@ export function createLazyClient(
     const result = await readCache.fetch({
       type: "resources/read",
       connectionId: connection.id,
-      scope: resolveReadCacheScope(),
+      scope: readCacheScope,
       params,
       fetchLive: async () => {
         const real = await getRealClient();


### PR DESCRIPTION
## Summary

The per-pod MCP **read cache** (`tools/call` for read-only tools, `resources/read`, `prompts/get`) keyed results under an **org-shared** scope that omitted the caller. `resolveReadCacheScope()` was hardcoded to `{ kind: "org" }`, with the per-user opt-out left as a "follow-up".

That is only safe for upstreams whose results **ignore** the forwarded `x-mesh-token`. For any read-only tool whose output **depends on the caller's identity**, the first caller's result was served to every other org member for up to `maxStaleMs` (5 min for `tools/call`), since the cache key was just `connectionId:org:tools/call:{args}`.

### Real-world impact (how this surfaced)

A dashboard MCP (`decommand-center`) exposes a `dashboard_my_access` tool — `readOnlyHint: true`, empty args — that resolves the caller's email from the Mesh SSO context (`ctx.ensureAuthenticated()`) and returns `{ email, authorized, db_connected }`:

- User A (admin) calls it → `{ email: "a@…", authorized: true }` is cached under the org key.
- User B calls it within the stale window → gets **A's** cached payload. B's UI shows **A's email** and inherits A's authorization.
- Conversely, an authorized user could be served an unauthorized caller's cached `{ authorized: false }` → their protected sections **disappear**.

Intermittent, because the served value depends on who populated/revalidated the org key last (revalidate after 30s, hard miss after 5 min).

## Fix

Studio can't introspect whether an upstream's read varies by caller, so **org-shared is an unsafe default**. Key by the calling **principal** whenever there is one; fall back to `org` only when there is **no** principal at all (super-user background workers with no app user — nothing per-user to leak).

- A single user's repeated reads still hit the cache (the dominant dashboard-polling case).
- Only cross-user sharing of *identity-independent* reads is given up.
- The lazy client is created **per request** (`ctx = c.get("meshContext")`), so the principal is read from the per-request ctx — never a stale connection-time identity. Each per-user key is therefore only ever populated/revalidated by that same user's requests, so SWR stays self-consistent.

## Trade-off / alternative

This trades some cross-user cache hit-rate for correctness. Memory stays bounded by the existing entry/byte caps + LRU. If we'd rather **keep** org-shared caching where it's provably safe, the alternative is an explicit per-connection "org-shareable reads" opt-in (a flag on the connection) with this per-user behavior as the default — happy to switch to that shape if preferred. Correctness-by-default seemed the right starting point given this is an identity/authorization leak.

## Testing

- `bun test apps/mesh/src/mcp-clients/lazy-client.test.ts apps/mesh/src/mcp-clients/mcp-read-cache.test.ts` → 21 pass. Added unit coverage for `resolveReadCacheScope` (per-principal keying; org fallback only when no principal).
- `bun run check` (mesh) and `bun run fmt` clean.

## Companion

Immediate app-side mitigation (so a dashboard isn't blocked on a Studio release): drop `readOnlyHint` from the per-user `*_my_access` tools so they're never cached. After this lands, that's no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope the MCP read cache per calling principal instead of per org to prevent one user’s read-only results from being served to other org members for `tools/call`, `resources/read`, and `prompts/get`. Falls back to org scope only when no principal is present.

- **Bug Fixes**
  - Implemented `resolveReadCacheScope(principalId)` to use `{ kind: "user", userId }` when available, else `{ kind: "org" }`.
  - `createLazyClient` now derives the principal from the per-request context (`ctx.auth?.user?.id` or `ctx.auth?.apiKey?.userId`) and passes the scope to cache fetches.
  - Stops identity/authorization leaks from org-shared cache entries (e.g., per-user access checks using `x-mesh-token`).
  - Added unit tests for `resolveReadCacheScope` and updated lazy-client tests.

<sup>Written for commit d3f60ad24aa31e914efd1f58fdee217d4e5802cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

