### PR TITLE
feat(file-configs): add generic sts-session credential type

### DIFF
--- a/apps/mesh/migrations/112-org-file-configs-credential-type.ts
+++ b/apps/mesh/migrations/112-org-file-configs-credential-type.ts
@@ -1,0 +1,30 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Adds a credential discriminator to `org_file_configs` so a config can hold
+ * either a static long-lived key pair (the existing behaviour, default
+ * `static`) or a `sts-session` reference whose temporary credentials are
+ * fetched on demand from `refresh_url` and auto-refreshed by the S3 client.
+ *
+ * For `sts-session` rows, `encrypted_credentials` holds only the API key used
+ * to authenticate the refresh call — never any S3 secret. Existing rows keep
+ * `credential_type = 'static'` and their `{accessKeyId, secretAccessKey}` blob
+ * untouched.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("org_file_configs")
+    .addColumn("credential_type", "text", (col) =>
+      col.notNull().defaultTo("static"),
+    )
+    .addColumn("refresh_url", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("org_file_configs")
+    .dropColumn("credential_type")
+    .dropColumn("refresh_url")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -110,6 +110,7 @@ import * as migration108automationmaxagentsteps from "./108-automation-max-agent
 import * as migration109threadmessagepartspermessageseq from "./109-thread-message-parts-per-message-seq.ts";
 import * as migration110backfillghstokenexpiry from "./110-backfill-ghs-token-expiry.ts";
 import * as migration111orgfsthreadid from "./111-org-fs-thread-id.ts";
+import * as migration112orgfileconfigscredentialtype from "./112-org-file-configs-credential-type.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -243,6 +244,8 @@ const migrations: Record<string, Migration> = {
     migration109threadmessagepartspermessageseq,
   "110-backfill-ghs-token-expiry": migration110backfillghstokenexpiry,
   "111-org-fs-thread-id": migration111orgfsthreadid,
+  "112-org-file-configs-credential-type":
+    migration112orgfileconfigscredentialtype,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/routes/deco-sites.ts
+++ b/apps/mesh/src/api/routes/deco-sites.ts
@@ -321,45 +321,42 @@ const requireAuth = async (
 const ADMIN_MCP = "https://sites-admin-mcp.deco.site/api/mcp";
 const ADMIN_API = "https://admin.deco.cx";
 
-/**
- * Bucket layout that deco-sites/admin's provisionTenantS3Credentials
- * sets up: a single `deco-assets` bucket on GCS (path-style S3 interop),
- * one managed folder per site under `<siteName>/`, served through the
- * `decoims.com` image CDN. Mirrors what the legacy admin's media widget
- * already reads from — see `clients/gcsTenantCredentials.ts` in admin.
- */
-const DECO_ASSETS_BUCKET = "deco-assets";
-const DECO_ASSETS_ENDPOINT = "https://storage.googleapis.com";
-const DECOIMS_CDN = "https://decoims.com";
 const FILE_CONFIG_NAME_PREFIX = "deco-assets-";
 
-interface TenantS3Credentials {
-  accessKeyId: string;
-  secretAccessKey: string;
+/** Full storage descriptor returned by admin's s3-credentials endpoint. */
+interface AdminS3Descriptor {
+  bucket: string;
+  region: string;
+  endpoint: string;
+  prefix: string;
+  forcePathStyle: boolean;
+  publicUrlBase: string;
+}
+
+/** Builds the per-site refresh endpoint URL on admin. */
+function refreshUrlFor(siteName: string): string {
+  return `${ADMIN_API}/api/${encodeURIComponent(siteName)}/s3-credentials`;
 }
 
 /**
- * Calls `POST admin.deco.cx/api/<site>/s3-credentials` as the team's
- * service account. The endpoint provisions (idempotently) a GCP service
- * account, IAM-binds it to the site's managed folder, and mints a fresh
- * HMAC key — see deco-sites/admin#3223 / #3235 for the auth contract.
- * Returns null on any failure so callers can fall back to best-effort
- * behaviour (the deco-sites import itself shouldn't fail just because
- * storage couldn't be provisioned).
+ * Calls `POST admin.deco.cx/api/<site>/s3-credentials` as the team's service
+ * account once, to (a) validate the service-account key can mint credentials
+ * and (b) read the storage descriptor (bucket/region/endpoint/prefix/CDN).
+ * The temporary credentials in the response are intentionally discarded — the
+ * file config stores only a refresh reference, and the S3 client fetches fresh
+ * creds on demand. Returns null on any failure so the deco-sites import stays
+ * best-effort (it shouldn't fail just because storage couldn't be set up).
  */
-async function provisionDecoAssetsCredentials(
+async function fetchDecoAssetsDescriptor(
   siteName: string,
   serviceAccountApiKey: string,
-): Promise<TenantS3Credentials | null> {
+): Promise<AdminS3Descriptor | null> {
   try {
-    const res = await fetch(
-      `${ADMIN_API}/api/${encodeURIComponent(siteName)}/s3-credentials`,
-      {
-        method: "POST",
-        headers: { "x-api-key": serviceAccountApiKey },
-        signal: AbortSignal.timeout(20_000),
-      },
-    );
+    const res = await fetch(refreshUrlFor(siteName), {
+      method: "POST",
+      headers: { "x-api-key": serviceAccountApiKey },
+      signal: AbortSignal.timeout(20_000),
+    });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
       console.error(
@@ -367,19 +364,20 @@ async function provisionDecoAssetsCredentials(
       );
       return null;
     }
-    const data = (await res.json()) as {
-      accessKeyId?: string;
-      secretAccessKey?: string;
-    };
-    if (!data.accessKeyId || !data.secretAccessKey) {
+    const data = (await res.json()) as Partial<AdminS3Descriptor>;
+    if (!data.bucket || !data.region || !data.endpoint || !data.publicUrlBase) {
       console.error(
-        `[deco-sites] s3-credentials returned malformed response for site=${siteName}`,
+        `[deco-sites] s3-credentials returned malformed descriptor for site=${siteName}`,
       );
       return null;
     }
     return {
-      accessKeyId: data.accessKeyId,
-      secretAccessKey: data.secretAccessKey,
+      bucket: data.bucket,
+      region: data.region,
+      endpoint: data.endpoint,
+      prefix: data.prefix ?? `${siteName}/`,
+      forcePathStyle: data.forcePathStyle ?? false,
+      publicUrlBase: data.publicUrlBase,
     };
   } catch (err) {
     console.error(
@@ -391,11 +389,12 @@ async function provisionDecoAssetsCredentials(
 }
 
 /**
- * Create a FILE_CONFIG row pointing at the per-site managed folder
- * inside `gs://deco-assets`, served through `https://decoims.com`. If a
- * config with the same name already exists in this org (re-import of
- * the same site), no-op — credentials there may have been rotated by
- * the user. Caller treats this as best-effort.
+ * Create an `sts-session` FILE_CONFIG row for the site's prefix on the
+ * deco-managed assets bucket, served through the CDN reported by admin. The
+ * config stores only a refresh reference (the admin endpoint URL + the team's
+ * service-account API key); the S3 client fetches short-lived credentials on
+ * demand and refreshes them automatically. If a config with the same name
+ * already exists in this org (re-import of the same site), no-op. Best-effort.
  */
 async function provisionDecoAssetsFileConfig(params: {
   ctx: StudioContext;
@@ -415,23 +414,24 @@ async function provisionDecoAssetsFileConfig(params: {
     return;
   }
 
-  const creds = await provisionDecoAssetsCredentials(
+  const descriptor = await fetchDecoAssetsDescriptor(
     siteName,
     serviceAccountApiKey,
   );
-  if (!creds) return;
+  if (!descriptor) return;
 
   await ctx.storage.orgFileConfigs.create({
     organizationId: orgId,
     name: configName,
     description: `deco-assets storage for site "${siteName}". Provisioned during deco.cx import.`,
-    bucket: DECO_ASSETS_BUCKET,
-    region: "auto",
-    endpoint: DECO_ASSETS_ENDPOINT,
-    forcePathStyle: true,
-    prefix: `${siteName}/`,
-    publicUrlBase: DECOIMS_CDN,
-    credentials: creds,
+    bucket: descriptor.bucket,
+    region: descriptor.region,
+    endpoint: descriptor.endpoint,
+    forcePathStyle: descriptor.forcePathStyle,
+    prefix: descriptor.prefix,
+    publicUrlBase: descriptor.publicUrlBase,
+    refreshUrl: refreshUrlFor(siteName),
+    credentials: { type: "sts-session", apiKey: serviceAccountApiKey },
     createdBy: userId,
   });
   console.log(

--- a/apps/mesh/src/api/routes/file-uploads.ts
+++ b/apps/mesh/src/api/routes/file-uploads.ts
@@ -17,12 +17,11 @@
  * single-shot PutObject offers when the SDK can't replay a stream.
  */
 
-import { S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { StudioContext } from "@/core/studio-context";
-import { buildPublicUrl } from "@/file-storage/file-config-s3";
+import { buildPublicUrl, buildS3Client } from "@/file-storage/file-config-s3";
 import {
   MAX_UPLOAD_BYTES,
   UploadRejected,
@@ -129,17 +128,7 @@ export const createFileUploadRoutes = () => {
       filename,
     });
 
-    const client = new S3Client({
-      region: fileCfg.info.region,
-      endpoint: fileCfg.info.endpoint ?? undefined,
-      forcePathStyle: fileCfg.info.forcePathStyle,
-      credentials: {
-        accessKeyId: fileCfg.credentials.accessKeyId,
-        secretAccessKey: fileCfg.credentials.secretAccessKey,
-      },
-      requestChecksumCalculation: "WHEN_REQUIRED",
-      responseChecksumValidation: "WHEN_REQUIRED",
-    });
+    const client = buildS3Client(fileCfg);
 
     try {
       const upload = new Upload({

--- a/apps/mesh/src/file-storage/file-config-s3.test.ts
+++ b/apps/mesh/src/file-storage/file-config-s3.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
-import { buildPublicUrl } from "./file-config-s3";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { buildPublicUrl, stsCredentialProvider } from "./file-config-s3";
 import type { FileConfigInfo } from "../storage/types";
 
 function info(overrides: Partial<FileConfigInfo>): FileConfigInfo {
@@ -14,6 +14,8 @@ function info(overrides: Partial<FileConfigInfo>): FileConfigInfo {
     forcePathStyle: false,
     prefix: null,
     publicUrlBase: null,
+    credentialType: "static",
+    refreshUrl: null,
     createdBy: "u",
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedBy: "u",
@@ -73,6 +75,71 @@ describe("buildPublicUrl", () => {
   test("percent-encodes path segments but keeps slashes", () => {
     expect(buildPublicUrl(info({}), "folder/with spaces/é.png")).toBe(
       "https://my-bucket.s3.us-east-1.amazonaws.com/folder/with%20spaces/%C3%A9.png",
+    );
+  });
+});
+
+describe("stsCredentialProvider", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const stsInfo = info({
+    credentialType: "sts-session",
+    refreshUrl: "https://admin.example.com/api/acme/s3-credentials",
+  });
+
+  test("posts to refreshUrl with the api key and maps the response", async () => {
+    const seen: { url?: string; headers?: Headers } = {};
+    globalThis.fetch = mock(async (url: string, init: RequestInit) => {
+      seen.url = url;
+      seen.headers = new Headers(init.headers);
+      return new Response(
+        JSON.stringify({
+          accessKeyId: "AKIA",
+          secretAccessKey: "secret",
+          sessionToken: "token",
+          expiration: "2026-06-19T00:00:00.000Z",
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const creds = await stsCredentialProvider(stsInfo, "api-key-123")();
+
+    expect(seen.url).toBe("https://admin.example.com/api/acme/s3-credentials");
+    expect(seen.headers?.get("x-api-key")).toBe("api-key-123");
+    expect(creds.accessKeyId).toBe("AKIA");
+    expect(creds.sessionToken).toBe("token");
+    expect(creds.expiration).toEqual(new Date("2026-06-19T00:00:00.000Z"));
+  });
+
+  test("throws when the refresh call fails", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("nope", { status: 403 }),
+    ) as unknown as typeof fetch;
+    expect(stsCredentialProvider(stsInfo, "k")()).rejects.toThrow(
+      /sts refresh failed \(403\)/,
+    );
+  });
+
+  test("throws when the response is missing the session token", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({ accessKeyId: "AKIA", secretAccessKey: "s" }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+    expect(stsCredentialProvider(stsInfo, "k")()).rejects.toThrow(
+      /incomplete credentials/,
+    );
+  });
+
+  test("throws when refreshUrl is missing", () => {
+    expect(() => stsCredentialProvider(info({}), "k")).toThrow(
+      /missing a refreshUrl/,
     );
   });
 });

--- a/apps/mesh/src/file-storage/file-config-s3.ts
+++ b/apps/mesh/src/file-storage/file-config-s3.ts
@@ -2,8 +2,9 @@
  * S3 client built from a resolved org file config. Unlike the shared
  * `object-storage/S3Service`, this client does NOT inject any per-org key
  * prefix — the prefix configured on the file config itself is the only
- * namespace. Each call site owns its own client because credentials are
- * different per config and the SDK client caches the signer.
+ * namespace. Clients are cached per config (see `buildS3Client`) so the SDK's
+ * signer and — for `sts-session` configs — its credential memoization persist
+ * across requests.
  */
 
 import { ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
@@ -18,21 +19,103 @@ export interface FileConfigContext {
   credentials: FileConfigCredentials;
 }
 
-function buildS3Client(ctx: FileConfigContext): S3Client {
-  return new S3Client({
+/** Shape the AWS SDK accepts as a resolved credential identity. */
+interface ResolvedCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  expiration?: Date;
+}
+
+/**
+ * For an `sts-session` config, returns an async credential provider instead of
+ * a static key pair. The AWS SDK memoizes the provider's result and re-invokes
+ * it once the returned `expiration` is near, so temporary credentials refresh
+ * automatically — as long as the owning `S3Client` instance is reused (see the
+ * client cache below). Each call fetches fresh creds from the config's
+ * `refreshUrl`, authenticating with the stored API key.
+ */
+export function stsCredentialProvider(
+  info: FileConfigInfo,
+  apiKey: string,
+): () => Promise<ResolvedCredentials> {
+  const url = info.refreshUrl;
+  if (!url) {
+    throw new Error(
+      `sts-session file config ${info.id} is missing a refreshUrl`,
+    );
+  }
+  return async () => {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "x-api-key": apiKey },
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `sts refresh failed (${res.status}) for file config ${info.id}: ${body.slice(0, 200)}`,
+      );
+    }
+    const data = (await res.json()) as {
+      accessKeyId?: string;
+      secretAccessKey?: string;
+      sessionToken?: string;
+      expiration?: string;
+    };
+    if (!data.accessKeyId || !data.secretAccessKey || !data.sessionToken) {
+      throw new Error(
+        `sts refresh returned incomplete credentials for file config ${info.id}`,
+      );
+    }
+    return {
+      accessKeyId: data.accessKeyId,
+      secretAccessKey: data.secretAccessKey,
+      sessionToken: data.sessionToken,
+      expiration: data.expiration ? new Date(data.expiration) : undefined,
+    };
+  };
+}
+
+// S3Client instances are cached so the SDK's credential memoization survives
+// across requests — critical for `sts-session` configs, where a fresh client
+// per request would re-fetch temporary creds every single time instead of
+// refreshing only near expiry. Keyed by config id + updatedAt so any change
+// to the config (incl. credential rotation) transparently busts the entry.
+const CLIENT_CACHE_MAX = 256;
+const clientCache = new Map<string, S3Client>();
+
+export function buildS3Client(ctx: FileConfigContext): S3Client {
+  const cacheKey = `${ctx.info.id}:${ctx.info.updatedAt}`;
+  const cached = clientCache.get(cacheKey);
+  if (cached) return cached;
+
+  const credentials =
+    ctx.credentials.type === "sts-session"
+      ? stsCredentialProvider(ctx.info, ctx.credentials.apiKey)
+      : {
+          accessKeyId: ctx.credentials.accessKeyId,
+          secretAccessKey: ctx.credentials.secretAccessKey,
+        };
+
+  const client = new S3Client({
     region: ctx.info.region,
     endpoint: ctx.info.endpoint ?? undefined,
     forcePathStyle: ctx.info.forcePathStyle,
-    credentials: {
-      accessKeyId: ctx.credentials.accessKeyId,
-      secretAccessKey: ctx.credentials.secretAccessKey,
-    },
+    credentials,
     // GCS, R2, and MinIO don't all honor the `x-amz-checksum-*` headers
     // AWS SDK v3 auto-injects. Disable unless an operation explicitly
     // requires them.
     requestChecksumCalculation: "WHEN_REQUIRED",
     responseChecksumValidation: "WHEN_REQUIRED",
   });
+
+  if (clientCache.size >= CLIENT_CACHE_MAX) {
+    const oldest = clientCache.keys().next().value;
+    if (oldest !== undefined) clientCache.delete(oldest);
+  }
+  clientCache.set(cacheKey, client);
+  return client;
 }
 
 /**

--- a/apps/mesh/src/storage/org-file-configs.ts
+++ b/apps/mesh/src/storage/org-file-configs.ts
@@ -15,6 +15,8 @@ type FileConfigRow = {
   force_path_style: boolean;
   prefix: string | null;
   public_url_base: string | null;
+  credential_type: "static" | "sts-session";
+  refresh_url: string | null;
   created_by: string;
   created_at: Date | string;
   updated_by: string;
@@ -32,16 +34,25 @@ const PUBLIC_COLUMNS = [
   "force_path_style",
   "prefix",
   "public_url_base",
+  "credential_type",
+  "refresh_url",
   "created_by",
   "created_at",
   "updated_by",
   "updated_at",
 ] as const satisfies readonly (keyof OrgFileConfigTable)[];
 
-export interface FileConfigCredentials {
-  accessKeyId: string;
-  secretAccessKey: string;
-}
+/**
+ * Credentials persisted (encrypted) for a file config.
+ *
+ * - `static`: a long-lived S3 key pair, used verbatim.
+ * - `sts-session`: only the API key needed to authenticate the refresh call —
+ *   no S3 secret is stored. The actual temporary credentials are fetched on
+ *   demand from the config's `refreshUrl` and refreshed automatically.
+ */
+export type FileConfigCredentials =
+  | { type: "static"; accessKeyId: string; secretAccessKey: string }
+  | { type: "sts-session"; apiKey: string };
 
 function toIsoString(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : String(value);
@@ -72,6 +83,8 @@ export class OrgFileConfigStorage {
       forcePathStyle: row.force_path_style,
       prefix: row.prefix,
       publicUrlBase: row.public_url_base,
+      credentialType: row.credential_type ?? "static",
+      refreshUrl: row.refresh_url,
       createdBy: row.created_by,
       createdAt: toIsoString(row.created_at),
       updatedBy: row.updated_by,
@@ -89,6 +102,7 @@ export class OrgFileConfigStorage {
     forcePathStyle?: boolean;
     prefix?: string | null;
     publicUrlBase?: string | null;
+    refreshUrl?: string | null;
     credentials: FileConfigCredentials;
     createdBy: string;
   }): Promise<FileConfigInfo> {
@@ -111,6 +125,8 @@ export class OrgFileConfigStorage {
         force_path_style: params.forcePathStyle ?? false,
         prefix: params.prefix ?? null,
         public_url_base: params.publicUrlBase ?? null,
+        credential_type: params.credentials.type,
+        refresh_url: params.refreshUrl ?? null,
         encrypted_credentials: encryptedCredentials,
         created_by: params.createdBy,
         created_at: now,
@@ -134,6 +150,7 @@ export class OrgFileConfigStorage {
     forcePathStyle?: boolean;
     prefix?: string | null;
     publicUrlBase?: string | null;
+    refreshUrl?: string | null;
     credentials?: FileConfigCredentials;
     updatedBy: string;
   }): Promise<FileConfigInfo> {
@@ -155,6 +172,8 @@ export class OrgFileConfigStorage {
       force_path_style: boolean;
       prefix: string | null;
       public_url_base: string | null;
+      credential_type: "static" | "sts-session";
+      refresh_url: string | null;
       encrypted_credentials: string;
       updated_by: string;
       updated_at: Date;
@@ -174,7 +193,9 @@ export class OrgFileConfigStorage {
     if (params.prefix !== undefined) patch.prefix = params.prefix;
     if (params.publicUrlBase !== undefined)
       patch.public_url_base = params.publicUrlBase;
+    if (params.refreshUrl !== undefined) patch.refresh_url = params.refreshUrl;
     if (params.credentials !== undefined) {
+      patch.credential_type = params.credentials.type;
       patch.encrypted_credentials = await this.vault.encrypt(
         JSON.stringify(params.credentials),
       );
@@ -244,9 +265,10 @@ export class OrgFileConfigStorage {
 
     if (!row) throw new OrgFileConfigNotFoundError(id);
 
-    const decrypted = await this.vault.decrypt(row.encrypted_credentials);
-    const credentials = JSON.parse(decrypted) as FileConfigCredentials;
-    return { info: this.rowToInfo(row), credentials };
+    return {
+      info: this.rowToInfo(row),
+      credentials: await this.decodeCredentials(row),
+    };
   }
 
   async resolveByName(params: {
@@ -262,8 +284,31 @@ export class OrgFileConfigStorage {
 
     if (!row) throw new OrgFileConfigNotFoundError(params.name);
 
+    return {
+      info: this.rowToInfo(row),
+      credentials: await this.decodeCredentials(row),
+    };
+  }
+
+  /**
+   * Decrypt and shape the stored credentials according to the row's
+   * `credential_type` column (the source of truth). Legacy rows predate the
+   * column — they default to `static` and their blob holds the key pair
+   * directly, with no `type` field — so we never rely on the blob's shape.
+   */
+  private async decodeCredentials(row: {
+    credential_type: "static" | "sts-session";
+    encrypted_credentials: string;
+  }): Promise<FileConfigCredentials> {
     const decrypted = await this.vault.decrypt(row.encrypted_credentials);
-    const credentials = JSON.parse(decrypted) as FileConfigCredentials;
-    return { info: this.rowToInfo(row), credentials };
+    const parsed = JSON.parse(decrypted) as Record<string, unknown>;
+    if ((row.credential_type ?? "static") === "sts-session") {
+      return { type: "sts-session", apiKey: String(parsed.apiKey) };
+    }
+    return {
+      type: "static",
+      accessKeyId: String(parsed.accessKeyId),
+      secretAccessKey: String(parsed.secretAccessKey),
+    };
   }
 }

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -323,6 +323,17 @@ export interface OrgFileConfigTable {
   prefix: string | null;
   // Public URL host (e.g. R2 dev domain, CDN). Null = compute from bucket+region.
   public_url_base: string | null;
+  // "static" (long-lived key pair in encrypted_credentials) or "sts-session"
+  // (temporary creds fetched on demand from refresh_url; the encrypted blob
+  // holds only the API key for the refresh call). Has a DB default of 'static'.
+  credential_type: ColumnType<
+    "static" | "sts-session",
+    "static" | "sts-session" | undefined,
+    "static" | "sts-session"
+  >;
+  // Endpoint that vends temporary credentials for `sts-session` configs. Null
+  // for `static`.
+  refresh_url: string | null;
   encrypted_credentials: string;
   created_by: string;
   created_at: ColumnType<Date, Date | string, never>;
@@ -376,6 +387,8 @@ export interface FileConfigInfo {
   forcePathStyle: boolean;
   prefix: string | null;
   publicUrlBase: string | null;
+  credentialType: "static" | "sts-session";
+  refreshUrl: string | null;
   createdBy: string;
   createdAt: string;
   updatedBy: string;

--- a/apps/mesh/src/tools/file-configs/create.ts
+++ b/apps/mesh/src/tools/file-configs/create.ts
@@ -11,24 +11,56 @@ import {
 export const FILE_CONFIG_CREATE = defineTool({
   name: "FILE_CONFIG_CREATE",
   description:
-    "Create an S3-compatible bucket configuration scoped to the organization. The access key and secret key are encrypted at rest in the credential vault and never returned by any tool.",
-  inputSchema: z.object({
-    name: fileConfigNameSchema,
-    description: z.string().max(500).optional(),
-    bucket: z.string().min(1).max(255),
-    region: z.string().min(1).max(64),
-    endpoint: z.string().url().optional(),
-    forcePathStyle: z.boolean().optional(),
-    prefix: z.string().max(512).optional(),
-    publicUrlBase: z.string().url().optional(),
-    accessKeyId: z.string().min(1),
-    secretAccessKey: z.string().min(1),
-  }),
+    "Create an S3-compatible bucket configuration scoped to the organization. Defaults to a `static` long-lived key pair (accessKeyId + secretAccessKey). Pass credentialType `sts-session` to instead store a refreshUrl + apiKey reference whose temporary credentials are fetched on demand and auto-refreshed. Secrets are encrypted at rest and never returned by any tool.",
+  inputSchema: z
+    .object({
+      name: fileConfigNameSchema,
+      description: z.string().max(500).optional(),
+      bucket: z.string().min(1).max(255),
+      region: z.string().min(1).max(64),
+      endpoint: z.string().url().optional(),
+      forcePathStyle: z.boolean().optional(),
+      prefix: z.string().max(512).optional(),
+      publicUrlBase: z.string().url().optional(),
+      credentialType: z.enum(["static", "sts-session"]).default("static"),
+      // static
+      accessKeyId: z.string().min(1).optional(),
+      secretAccessKey: z.string().min(1).optional(),
+      // sts-session
+      refreshUrl: z.string().url().optional(),
+      apiKey: z.string().min(1).optional(),
+    })
+    .superRefine((v, c) => {
+      if (v.credentialType === "sts-session") {
+        if (!v.refreshUrl || !v.apiKey) {
+          c.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              "sts-session requires refreshUrl and apiKey (and no accessKeyId/secretAccessKey).",
+          });
+        }
+      } else if (!v.accessKeyId || !v.secretAccessKey) {
+        c.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "static credentials require accessKeyId and secretAccessKey.",
+        });
+      }
+    }),
   outputSchema: fileConfigInfoSchema,
   handler: async (input, ctx) => {
     requireAuth(ctx);
     const org = requireOrganization(ctx);
     await ctx.access.check();
+
+    const credentials =
+      input.credentialType === "sts-session"
+        ? { type: "sts-session" as const, apiKey: input.apiKey! }
+        : {
+            type: "static" as const,
+            accessKeyId: input.accessKeyId!,
+            secretAccessKey: input.secretAccessKey!,
+          };
 
     return ctx.storage.orgFileConfigs.create({
       organizationId: org.id,
@@ -40,10 +72,8 @@ export const FILE_CONFIG_CREATE = defineTool({
       forcePathStyle: input.forcePathStyle ?? false,
       prefix: normalizePrefix(input.prefix),
       publicUrlBase: normalizePublicUrlBase(input.publicUrlBase),
-      credentials: {
-        accessKeyId: input.accessKeyId,
-        secretAccessKey: input.secretAccessKey,
-      },
+      refreshUrl: input.refreshUrl ?? null,
+      credentials,
       createdBy: ctx.auth.user!.id,
     });
   },

--- a/apps/mesh/src/tools/file-configs/schema.ts
+++ b/apps/mesh/src/tools/file-configs/schema.ts
@@ -16,6 +16,8 @@ export const fileConfigInfoSchema = z.object({
   forcePathStyle: z.boolean(),
   prefix: z.string().nullable(),
   publicUrlBase: z.string().nullable(),
+  credentialType: z.enum(["static", "sts-session"]),
+  refreshUrl: z.string().nullable(),
   createdBy: z.string(),
   createdAt: z.string(),
   updatedBy: z.string(),

--- a/apps/mesh/src/tools/file-configs/update.ts
+++ b/apps/mesh/src/tools/file-configs/update.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/studio-context";
+import type { FileConfigCredentials } from "../../storage/org-file-configs";
 import {
   fileConfigInfoSchema,
   fileConfigNameSchema,
@@ -23,30 +24,59 @@ export const FILE_CONFIG_UPDATE = defineTool({
       forcePathStyle: z.boolean().optional(),
       prefix: z.string().max(512).nullable().optional(),
       publicUrlBase: z.string().url().nullable().optional(),
+      // Rotate credentials by providing one complete set. Omit all to leave
+      // credentials untouched. `static`: accessKeyId + secretAccessKey.
+      // `sts-session`: refreshUrl + apiKey.
       accessKeyId: z.string().min(1).optional(),
       secretAccessKey: z.string().min(1).optional(),
+      refreshUrl: z.string().url().optional(),
+      apiKey: z.string().min(1).optional(),
     })
-    .refine(
-      (v) =>
-        (v.accessKeyId === undefined) === (v.secretAccessKey === undefined),
-      {
-        message:
-          "accessKeyId and secretAccessKey must be provided together when rotating credentials.",
-      },
-    ),
+    .superRefine((v, c) => {
+      const hasStatic =
+        v.accessKeyId !== undefined || v.secretAccessKey !== undefined;
+      const hasSts = v.refreshUrl !== undefined || v.apiKey !== undefined;
+      if (hasStatic && hasSts) {
+        c.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "Provide either static (accessKeyId + secretAccessKey) or sts-session (refreshUrl + apiKey) credentials, not both.",
+        });
+      }
+      if (hasStatic && !(v.accessKeyId && v.secretAccessKey)) {
+        c.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "accessKeyId and secretAccessKey must be provided together when rotating static credentials.",
+        });
+      }
+      if (hasSts && !(v.refreshUrl && v.apiKey)) {
+        c.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "refreshUrl and apiKey must be provided together when rotating sts-session credentials.",
+        });
+      }
+    }),
   outputSchema: fileConfigInfoSchema,
   handler: async (input, ctx) => {
     requireAuth(ctx);
     const org = requireOrganization(ctx);
     await ctx.access.check();
 
-    const credentials =
-      input.accessKeyId && input.secretAccessKey
-        ? {
-            accessKeyId: input.accessKeyId,
-            secretAccessKey: input.secretAccessKey,
-          }
-        : undefined;
+    let credentials: FileConfigCredentials | undefined;
+    let refreshUrl: string | null | undefined;
+    if (input.accessKeyId && input.secretAccessKey) {
+      credentials = {
+        type: "static",
+        accessKeyId: input.accessKeyId,
+        secretAccessKey: input.secretAccessKey,
+      };
+      refreshUrl = null;
+    } else if (input.refreshUrl && input.apiKey) {
+      credentials = { type: "sts-session", apiKey: input.apiKey };
+      refreshUrl = input.refreshUrl;
+    }
 
     return ctx.storage.orgFileConfigs.update({
       id: input.id,
@@ -63,6 +93,7 @@ export const FILE_CONFIG_UPDATE = defineTool({
         input.publicUrlBase === undefined
           ? undefined
           : normalizePublicUrlBase(input.publicUrlBase),
+      refreshUrl,
       credentials,
       updatedBy: ctx.auth.user!.id,
     });

--- a/apps/mesh/src/web/hooks/use-file-configs.ts
+++ b/apps/mesh/src/web/hooks/use-file-configs.ts
@@ -18,6 +18,8 @@ export interface FileConfigInfo {
   forcePathStyle: boolean;
   prefix: string | null;
   publicUrlBase: string | null;
+  credentialType: "static" | "sts-session";
+  refreshUrl: string | null;
   createdBy: string;
   createdAt: string;
   updatedBy: string;

--- a/apps/mesh/src/web/hooks/use-file-configs.ts
+++ b/apps/mesh/src/web/hooks/use-file-configs.ts
@@ -66,8 +66,16 @@ export interface CreateFileConfigInput {
   forcePathStyle?: boolean;
   prefix?: string;
   publicUrlBase?: string;
-  accessKeyId: string;
-  secretAccessKey: string;
+  // Defaults to "static" (long-lived key pair). "sts-session" instead stores a
+  // refreshUrl + apiKey reference whose temporary credentials are fetched on
+  // demand and auto-refreshed.
+  credentialType?: "static" | "sts-session";
+  // static
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  // sts-session
+  refreshUrl?: string;
+  apiKey?: string;
 }
 
 export function useCreateFileConfig() {

--- a/apps/mesh/src/web/views/settings/buckets.tsx
+++ b/apps/mesh/src/web/views/settings/buckets.tsx
@@ -22,6 +22,13 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
 import { Switch } from "@deco/ui/components/switch.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
@@ -90,6 +97,11 @@ function FileConfigRow({
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <span className="font-medium text-sm truncate">{config.name}</span>
+            {config.credentialType === "sts-session" ? (
+              <span className="text-[10px] uppercase tracking-wide font-medium px-1.5 py-0.5 rounded bg-muted text-muted-foreground shrink-0">
+                STS
+              </span>
+            ) : null}
             <span className="text-xs text-muted-foreground truncate">
               {config.bucket} · {config.region}
             </span>
@@ -173,8 +185,13 @@ function CreateFileConfigDialog({
   const [forcePathStyle, setForcePathStyle] = useState(false);
   const [prefix, setPrefix] = useState("");
   const [publicUrlBase, setPublicUrlBase] = useState("");
+  const [credentialType, setCredentialType] = useState<
+    "static" | "sts-session"
+  >("static");
   const [accessKeyId, setAccessKeyId] = useState("");
   const [secretAccessKey, setSecretAccessKey] = useState("");
+  const [refreshUrl, setRefreshUrl] = useState("");
+  const [apiKey, setApiKey] = useState("");
   const createConfig = useCreateFileConfig();
 
   function reset() {
@@ -186,14 +203,35 @@ function CreateFileConfigDialog({
     setForcePathStyle(false);
     setPrefix("");
     setPublicUrlBase("");
+    setCredentialType("static");
     setAccessKeyId("");
     setSecretAccessKey("");
+    setRefreshUrl("");
+    setApiKey("");
   }
+
+  const credentialsValid =
+    credentialType === "sts-session"
+      ? Boolean(refreshUrl.trim() && apiKey.trim())
+      : Boolean(accessKeyId && secretAccessKey);
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
     if (!name.trim() || !bucket.trim() || !region.trim()) return;
-    if (!accessKeyId || !secretAccessKey) return;
+    if (!credentialsValid) return;
+
+    const credentialFields =
+      credentialType === "sts-session"
+        ? {
+            credentialType: "sts-session" as const,
+            refreshUrl: refreshUrl.trim(),
+            apiKey: apiKey.trim(),
+          }
+        : {
+            credentialType: "static" as const,
+            accessKeyId,
+            secretAccessKey,
+          };
 
     try {
       await createConfig.mutateAsync({
@@ -205,8 +243,7 @@ function CreateFileConfigDialog({
         forcePathStyle,
         prefix: prefix.trim() || undefined,
         publicUrlBase: publicUrlBase.trim() || undefined,
-        accessKeyId,
-        secretAccessKey,
+        ...credentialFields,
       });
       toast.success(`Bucket "${name.trim()}" added`);
       reset();
@@ -221,8 +258,7 @@ function CreateFileConfigDialog({
     !name.trim() ||
     !bucket.trim() ||
     !region.trim() ||
-    !accessKeyId ||
-    !secretAccessKey;
+    !credentialsValid;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -344,27 +380,99 @@ function CreateFileConfigDialog({
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="file-config-access-key">Access key ID</Label>
-            <Input
-              id="file-config-access-key"
-              value={accessKeyId}
-              onChange={(e) => setAccessKeyId(e.target.value)}
-              autoComplete="off"
-              required
-            />
+            <Label htmlFor="file-config-credential-type">Credentials</Label>
+            <Select
+              value={credentialType}
+              onValueChange={(v) =>
+                setCredentialType(v as "static" | "sts-session")
+              }
+            >
+              <SelectTrigger
+                id="file-config-credential-type"
+                className="w-full"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="static">
+                  Static key pair (long-lived)
+                </SelectItem>
+                <SelectItem value="sts-session">
+                  Temporary session (STS, auto-refreshed)
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {credentialType === "sts-session"
+                ? "Stores only a refresh endpoint + API key; short-lived credentials are fetched on demand and refreshed automatically."
+                : "A long-lived access key ID and secret, used as-is."}
+            </p>
           </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="file-config-secret-key">Secret access key</Label>
-            <Input
-              id="file-config-secret-key"
-              type="password"
-              value={secretAccessKey}
-              onChange={(e) => setSecretAccessKey(e.target.value)}
-              autoComplete="new-password"
-              required
-            />
-          </div>
+          {credentialType === "static" ? (
+            <>
+              <div className="space-y-1.5">
+                <Label htmlFor="file-config-access-key">Access key ID</Label>
+                <Input
+                  id="file-config-access-key"
+                  value={accessKeyId}
+                  onChange={(e) => setAccessKeyId(e.target.value)}
+                  autoComplete="off"
+                  required
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="file-config-secret-key">
+                  Secret access key
+                </Label>
+                <Input
+                  id="file-config-secret-key"
+                  type="password"
+                  value={secretAccessKey}
+                  onChange={(e) => setSecretAccessKey(e.target.value)}
+                  autoComplete="new-password"
+                  required
+                />
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="space-y-1.5">
+                <Label htmlFor="file-config-refresh-url">Refresh URL</Label>
+                <Input
+                  id="file-config-refresh-url"
+                  type="url"
+                  value={refreshUrl}
+                  onChange={(e) => setRefreshUrl(e.target.value)}
+                  placeholder="https://admin.example.com/api/acme/s3-credentials"
+                  autoComplete="off"
+                  required
+                />
+                <p className="text-xs text-muted-foreground">
+                  Endpoint POSTed (with the API key below) to vend temporary
+                  credentials. Must return accessKeyId, secretAccessKey,
+                  sessionToken, and expiration.
+                </p>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="file-config-api-key">API key</Label>
+                <Input
+                  id="file-config-api-key"
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  autoComplete="new-password"
+                  required
+                />
+                <p className="text-xs text-muted-foreground">
+                  Sent as the <code>x-api-key</code> header on each refresh
+                  call.
+                </p>
+              </div>
+            </>
+          )}
 
           <div className="space-y-1.5">
             <Label htmlFor="file-config-description">


### PR DESCRIPTION
## What

Adds a second, provider-agnostic credential **type** to org file configs alongside the existing `static` key pair: **`sts-session`**, whose temporary credentials are fetched on demand from a refresh URL and refreshed automatically by the AWS SDK. The only secret stored for an sts-session config is the API key used to authenticate the refresh call — never an S3 secret.

## Why

The deco-assets storage is moving from per-tenant GCS HMAC keys to AWS STS (`AssumeRole`) on `deco-sites/admin`, so the credentials it vends now expire (12h) and carry a `sessionToken`. Studio previously assumed long-lived 2-field credentials. Rather than special-casing deco, this adds a generic refreshing-credential type any config can use.

## How

- **Migration 112**: `credential_type` (default `static`) + `refresh_url` columns. Existing rows stay `static` with their key-pair blob untouched — no re-encryption.
- `FileConfigCredentials` is now a discriminated union; the column is the source of truth when decoding (legacy blobs have no `type` field).
- `buildS3Client` hands the SDK an **async credential provider** for sts-session configs; the SDK memoizes and refreshes near `expiration`. S3 clients are **cached per `id:updatedAt`** so that memoization survives across requests (and rotation busts the entry). The upload route reuses the shared factory.
- `FILE_CONFIG_CREATE`/`UPDATE` accept either credential set generically.
- The deco-sites import now creates an `sts-session` config: one call to admin reads the storage descriptor, and it stores the refresh reference (admin URL + the team's service-account API key) instead of long-lived keys.

## Rollout order

Ship this **before** `deco-sites/admin` switches its `s3-credentials` endpoint to STS, so studio understands the temp-credential response before admin starts emitting it. Already-imported sites keep their existing `static` GCS configs (the import no-ops when a config already exists) — only new imports use sts-session.

## Test plan

- `bun test apps/mesh/src/file-storage/file-config-s3.test.ts` — 10 pass (incl. new provider tests: maps response, throws on failure / incomplete creds / missing refreshUrl).
- `tsc --noEmit` clean; `oxlint` clean; `biome format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `sts-session` credential type for org file configs that fetches temporary creds on demand via a refresh URL and auto-refreshes; updates S3 client to use an async provider with per-config caching. Existing `static` configs keep working unchanged, deco-sites imports store only a refresh reference, and the bucket create UI now supports STS.

- **New Features**
  - Add `credential_type: "sts-session"` with `refresh_url`; store only an API key for the refresh call.
  - S3 clients use an async credential provider and are cached per `id:updatedAt` to preserve memoized sessions.
  - `FILE_CONFIG_CREATE` and `FILE_CONFIG_UPDATE` accept `static` or `sts-session` with input validation.
  - deco-sites import creates `sts-session` configs by reading admin’s storage descriptor and saving the refresh reference.
  - Web: Add credentials selector (Static vs STS with Refresh URL + API key) and show an “STS” badge in the bucket list.

- **Migration**
  - Migration 112 adds `credential_type` (default `static`) and `refresh_url` to `org_file_configs`; no re-encryption of existing rows.
  - Credential decoding uses the column as source of truth and supports legacy blobs without a `type`.

<sup>Written for commit 7c243ad0bf4b44d18987f4ce76d127d95f8c54d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

