### PR TITLE
fix(chat): keep archive fallback on the caller's own threads

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -179,8 +179,14 @@ export function TaskGroupsList() {
     const wasActive = task.id === activeTaskId;
     hide(task.id);
     if (!wasActive) return;
+    // Land only on the caller's own threads. The panel lists org-wide threads
+    // under the "All members" filter, so an unscoped fallback would teleport
+    // the user into another member's chat.
     const next = sortedThreads.find(
-      (t) => t.id !== task.id && t.virtual_mcp_id === task.virtual_mcp_id,
+      (t) =>
+        t.id !== task.id &&
+        t.virtual_mcp_id === task.virtual_mcp_id &&
+        t.created_by === currentUserId,
     );
     if (next) {
       setTaskId(next.id, next.virtual_mcp_id);


### PR DESCRIPTION
## What is this contribution about?
Archiving the active chat picked the "next" thread from the panel's org-wide thread list while ignoring ownership, so the user was silently teleported into another member's chat (the panel lists everyone's threads under the "All members" filter). This scopes the archive fallback to the caller's own threads, falling back to the empty state when none remain. The org-wide read/observability behavior (the "All members" toggle, opening others' threads explicitly) is intentional and untouched — only the implicit jump on archive is fixed.

## Screenshots/Demonstration
N/A — no visual change; behavior only.

## How to Test
1. As user A, create 2+ chats under the same agent; have user B also have an active chat in that agent within the same org.
2. As user A, open one of your chats and archive it.
3. Expected: you land on your own next chat for that agent (or the empty state if you have none) — never on user B's chat.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat archive fallback. After archiving an active chat, we now navigate only to your own next thread for that agent (or show the empty state) instead of jumping into another member’s chat when “All members” is on.

<sup>Written for commit d75a894fbce41dd23687eee3126a5a1c19a648f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

