### PR TITLE
fix(sandbox): auto-restart preview on git-auth clone failure

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
@@ -12,10 +12,20 @@ import { useRef, useState } from "react";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
 import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
-import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events";
+import {
+  useSandboxChunkHandler,
+  useSandboxEvents,
+} from "@/web/components/sandbox/hooks/use-sandbox-events";
 import { PreviewDrawer } from "@/web/components/sandbox/preview/drawer/drawer";
 
 const STORAGE_KEY = (id: string) => `preview-drawer:${id}`;
+
+// Clone aborts (exit 128) when the GitHub token mesh handed the orchestrator is
+// stale/invalid. A restart re-mints a fresh installation token, so auto
+// stop+start once per VM to recover. Match the auth-specific lines, not the
+// bare exit code (which covers unrelated git failures).
+const GIT_AUTH_FAILURE_RE =
+  /Authentication failed for|Invalid username or token|Password authentication is not supported/i;
 
 function readPersisted(virtualMcpId: string): boolean {
   try {
@@ -41,6 +51,20 @@ export function PreviewDrawerHost() {
   const virtualMcpId = inset?.virtualMcpId ?? null;
   const lifecycle = useSandboxLifecycle();
   const events = useSandboxEvents();
+
+  // Detect the git-auth clone failure in the live "setup" log stream and
+  // auto-recover with one stop+start. Test the accumulated buffer (not the raw
+  // chunk) so a message split across SSE frames still matches. Guard by
+  // virtualMcpId so we recover at most once per VM — never loop on a token
+  // that's permanently revoked.
+  const autoRestartedVmcpRef = useRef<string | null>(null);
+  useSandboxChunkHandler((source) => {
+    if (source !== "setup" || !virtualMcpId) return;
+    if (autoRestartedVmcpRef.current === virtualMcpId) return;
+    if (!GIT_AUTH_FAILURE_RE.test(events.getBuffer("setup"))) return;
+    autoRestartedVmcpRef.current = virtualMcpId;
+    void lifecycle.restart();
+  });
 
   // `null` = not yet hydrated for this VM. Render-time setState gated by a ref
   // re-hydrates when virtualMcpId changes (idiomatic in this codebase;


### PR DESCRIPTION
## Summary

When the sandbox preview clone fails with a GitHub auth error (stale/invalid token → `Authentication failed for ...`, `clone failed (exit 128)`), the preview is dead and the user has to manually Stop + Start.

This wires `PreviewDrawerHost` to watch the live `setup` log stream, match the git-auth failure pattern, and auto stop+start the sandbox **once per VM** (`lifecycle.restart()`). A restart re-mints a fresh installation token, which clears the transient case.

- Tests the accumulated buffer (not the raw chunk) so a message split across SSE frames still matches.
- Matches the auth-specific lines only — not the bare `exit 128`, which covers unrelated git failures.
- Guarded by `virtualMcpId` so it never loops on a permanently revoked token; manual Stop/Retry remain for that case.

## ⚠️ Temporary — intended to be reverted

**This is a client-side stopgap.** We intend to revert it soon and fix the root cause server-side: mesh should hand the orchestrator a valid token (or re-mint/retry the clone itself) rather than relying on the UI to notice the failure and restart. Tracking the real fix separately.

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/mesh check` (tsc) ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically restarts the sandbox preview when a Git clone fails with a GitHub auth error, reducing dead previews and avoiding manual Stop/Start. Temporary client-side stopgap until server-side token handling retries are in place.

- **Bug Fixes**
  - Watches the `setup` log stream and matches auth-specific lines; ignores generic `exit 128`.
  - Tests the accumulated buffer to catch messages split across SSE frames.
  - Restarts only once per VM using `virtualMcpId` and `lifecycle.restart()`.

<sup>Written for commit 9bfa276bb3f2898dd80661a4ef2fa36399349a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

