### PR TITLE
fix(helm): zero-downtime web rollout behind NLB

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.8
+version: 0.10.9
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/web-deployment.yaml
+++ b/deploy/helm/studio/templates/web-deployment.yaml
@@ -51,6 +51,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      # Front door behind an NLB (target-type: ip). On rollout the LB controller
+      # deregisters the pod IP asynchronously; without a drain delay nginx exits
+      # before the NLB stops sending new flows → RST/5xx. Grace must exceed the
+      # preStop sleep + nginx drain.
+      terminationGracePeriodSeconds: {{ .Values.web.terminationGracePeriodSeconds | default 45 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -115,6 +120,17 @@ spec:
               port: http
             initialDelaySeconds: 3
             periodSeconds: 5
+          # Keep serving while the NLB deregisters this pod IP, then nginx's
+          # SIGQUIT drains in-flight. Override via web.lifecycle to replace.
+          {{- if .Values.web.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.web.lifecycle | nindent 12 }}
+          {{- else }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "{{ .Values.web.preStopSleepSeconds | default 15 }}"]
+          {{- end }}
           volumeMounts:
             - name: bundle
               mountPath: /usr/share/nginx/html

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -148,6 +148,13 @@ web:
   service:
     type: ClusterIP
     port: 80
+  # Graceful-drain knobs for NLB-fronted rollouts (target-type: ip). The preStop
+  # sleep keeps the pod serving while the LB controller deregisters its IP, so
+  # in-flight requests aren't reset. Grace must exceed the sleep + nginx drain.
+  preStopSleepSeconds: 15
+  terminationGracePeriodSeconds: 45
+  # Set to fully replace the default preStop hook (e.g. a custom drain command).
+  lifecycle: {}
   resources:
     requests:
       cpu: "50m"


### PR DESCRIPTION
## Problem
We see brief downtime whenever the `deco-studio-web` pods are replaced (rollouts, node churn). The NLB fronting Studio uses `target-type: ip` and now targets the nginx **web** pods directly. On termination, nginx closes its listener and exits (SIGQUIT, default 30s grace) *before* the AWS Load Balancer Controller finishes deregistering the pod IP from the NLB target group. New connections the NLB keeps routing during that deregistration window hit a gone pod → connection reset / 5xx.

Root cause: the chart's `web-deployment.yaml` never rendered `lifecycle` or `terminationGracePeriodSeconds` (the `deployment.yaml` and `worker-deployment.yaml` templates already do), so web pods ran with **no preStop drain** and only the **default 30s grace**.

## Fix
Web container now gets, by default:
- `preStop: ["sleep","15"]` — keeps the pod serving while the LB controller deregisters its IP, then nginx's SIGQUIT drains in-flight requests.
- `terminationGracePeriodSeconds: 45` — comfortably covers the sleep + drain.

All three are overridable via `web.preStopSleepSeconds`, `web.terminationGracePeriodSeconds`, and `web.lifecycle` (set the latter to fully replace the hook). Default-on so an environment can't silently miss it — which is how this regressed.

Chart bumped `0.10.8` → `0.10.9`.

## Testing
`helm template ... --set web.enabled=true` renders:
```
grace: 45 | lifecycle: {'preStop': {'exec': {'command': ['sleep', '15']}}}
```

## Follow-up
The consuming GitOps repo `decocms/deco-apps-cd` needs to bump the `chart-deco-studio` dependency to `0.10.9` (prod + stg) once this publishes — separate PR. No values change required there (fix is default-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix brief downtime during `deco-studio-web` rollouts behind the NLB by adding a drain hook and longer termination grace to the `web` deployment. This prevents 5xx/RSTs while the AWS LB Controller deregisters pod IPs.

- **Bug Fixes**
  - Added default `lifecycle.preStop` sleep and `terminationGracePeriodSeconds` to `web` pods to keep nginx serving during NLB (`target-type: ip`) deregistration.
  - Exposed overrides: `web.preStopSleepSeconds`, `web.terminationGracePeriodSeconds`, `web.lifecycle`. Bumped chart to `0.10.9`.

- **Migration**
  - Update consuming repos to `chart-deco-studio` `0.10.9`; no values changes required.

<sup>Written for commit 7ce22245392ec80093fa67c04357b969e735a059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

