### PR TITLE
fix(cms-studio): fix block-ref schema resolution for @decocms/start >=6.10 loaders

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/array-item-display.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/array-item-display.test.ts
@@ -39,6 +39,30 @@ describe("getArrayItemLabel", () => {
     const schema: SchemaProperty = { type: "object", title: "Routes" };
     expect(getArrayItemLabel(item, 0, schema)).toBe("Audience");
   });
+
+  test("falls through whitespace-only title to the section name", () => {
+    // Real bagaggio data: nested section with title " " (a single space).
+    const item = {
+      __resolveType: "site/sections/Content/BannerCarrouselDepartment.tsx",
+      layout: { numberOfSliders: { mobile: 3, desktop: 6 } },
+      title: " ",
+    };
+    expect(getArrayItemLabel(item, 0, undefined)).toBe(
+      "BannerCarrouselDepartment",
+    );
+  });
+
+  test("labels Lazy-wrapped item by its inner section name", () => {
+    const item = {
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: {
+        __resolveType: "site/sections/Content/BannerCarrouselDepartment.tsx",
+      },
+    };
+    expect(getArrayItemLabel(item, 0, undefined)).toBe(
+      "BannerCarrouselDepartment",
+    );
+  });
 });
 
 describe("getArrayItemImageSrc", () => {

--- a/apps/mesh/src/web/components/sections-editor/array-item-display.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/array-item-display.test.ts
@@ -52,6 +52,36 @@ describe("getArrayItemLabel", () => {
     );
   });
 
+  test("strips HTML from rich-text title fields", () => {
+    const item = {
+      matcher: "/garantia-vitalicia",
+      title:
+        '<h1 style="text-align: start"><span style="font-size: 38pt">Garantia Vitalícia</span></h1>',
+      description: "<p>Obtenha tranquilidade...</p>",
+    };
+    const schema: SchemaProperty = {
+      type: "object",
+      properties: {
+        matcher: { type: "string" },
+        title: { type: "string", format: "rich-text" },
+        description: { type: "string", format: "rich-text" },
+      },
+    };
+    expect(getArrayItemLabel(item, 0, schema)).toBe("Garantia Vitalícia");
+  });
+
+  test("falls through empty rich-text to next key", () => {
+    const item = { title: "<p></p>", name: "Fallback" };
+    const schema: SchemaProperty = {
+      type: "object",
+      properties: {
+        title: { type: "string", format: "rich-text" },
+        name: { type: "string" },
+      },
+    };
+    expect(getArrayItemLabel(item, 0, schema)).toBe("Fallback");
+  });
+
   test("labels Lazy-wrapped item by its inner section name", () => {
     const item = {
       __resolveType: "website/sections/Rendering/Lazy.tsx",

--- a/apps/mesh/src/web/components/sections-editor/array-item-display.ts
+++ b/apps/mesh/src/web/components/sections-editor/array-item-display.ts
@@ -79,6 +79,11 @@ export function renderMustacheTemplate(
   return result.trim() || undefined;
 }
 
+/** Strip HTML tags to extract the text content (e.g. `<h1>Title</h1>` → `Title`). */
+function stripHtmlTags(html: string): string {
+  return html.replace(/<[^>]*>/g, "").trim();
+}
+
 function readTitleByValue(
   obj: Record<string, unknown>,
   titleBy: string,
@@ -138,7 +143,18 @@ export function getArrayItemLabel(
       // Skip whitespace-only strings (e.g. title: " ") so the item still gets a
       // meaningful label (falls through to the section name) and a stable,
       // non-blank breadcrumb crumb you can click into.
-      if (typeof value === "string" && value.trim()) return value;
+      if (typeof value === "string" && value.trim()) {
+        // Rich-text / HTML fields store raw markup.  Use the plain-text
+        // content as the label so array items show readable names and the
+        // breadcrumb crumb stays stable for navigation.
+        const fmt = itemSchema?.properties?.[key]?.format;
+        if (fmt === "rich-text" || fmt === "html") {
+          const text = stripHtmlTags(value);
+          if (text) return text;
+          continue; // empty after stripping → try next key
+        }
+        return value;
+      }
       if (Array.isArray(value)) {
         const joined = value
           .map((entry) => (entry == null ? "" : String(entry)))

--- a/apps/mesh/src/web/components/sections-editor/array-item-display.ts
+++ b/apps/mesh/src/web/components/sections-editor/array-item-display.ts
@@ -103,7 +103,7 @@ export function getArrayItemLabel(
   index: number,
   itemSchema?: SchemaProperty,
 ): string {
-  if (typeof item === "string") return item || `Item ${index + 1}`;
+  if (typeof item === "string") return item.trim() ? item : `Item ${index + 1}`;
   if (typeof item === "number" || typeof item === "boolean") {
     return String(item);
   }
@@ -135,7 +135,10 @@ export function getArrayItemLabel(
       "key",
     ]) {
       const value = obj[key];
-      if (typeof value === "string" && value) return value;
+      // Skip whitespace-only strings (e.g. title: " ") so the item still gets a
+      // meaningful label (falls through to the section name) and a stable,
+      // non-blank breadcrumb crumb you can click into.
+      if (typeof value === "string" && value.trim()) return value;
       if (Array.isArray(value)) {
         const joined = value
           .map((entry) => (entry == null ? "" : String(entry)))

--- a/apps/mesh/src/web/components/sections-editor/array-item-display.ts
+++ b/apps/mesh/src/web/components/sections-editor/array-item-display.ts
@@ -112,7 +112,16 @@ export function getArrayItemLabel(
       const fromTitleBy = readTitleByValue(obj, itemSchema.titleBy);
       if (fromTitleBy) return fromTitleBy;
     }
-    for (const key of ["name", "label", "title", "alt", "text", "href", "id"]) {
+    for (const key of [
+      "name",
+      "label",
+      "title",
+      "alt",
+      "text",
+      "href",
+      "id",
+      "key",
+    ]) {
       const value = obj[key];
       if (typeof value === "string" && value) return value;
       if (Array.isArray(value)) {

--- a/apps/mesh/src/web/components/sections-editor/array-item-display.ts
+++ b/apps/mesh/src/web/components/sections-editor/array-item-display.ts
@@ -1,6 +1,6 @@
+import { lazyWrappedInner } from "./block-ref-field-utils";
 import { extractUrl } from "./fields/extract-url";
 import type { SchemaProperty } from "./resolve-schema";
-import { isLazyResolveType } from "./section-lazy";
 import { labelFromResolveType } from "./section-types";
 import { safeEditorImageUrl } from "./safe-editor-image-url";
 
@@ -116,14 +116,9 @@ export function getArrayItemLabel(
     let obj = item as Record<string, unknown>;
     // Lazy-wrapped section items (`{ __resolveType: ".../Lazy.tsx", section: {...} }`)
     // should be labelled by the inner section, not "Lazy".
-    if (
-      typeof obj.__resolveType === "string" &&
-      isLazyResolveType(obj.__resolveType) &&
-      obj.section &&
-      typeof obj.section === "object" &&
-      !Array.isArray(obj.section)
-    ) {
-      obj = obj.section as Record<string, unknown>;
+    const inner = lazyWrappedInner(obj);
+    if (inner) {
+      obj = inner;
     }
     if (itemSchema?.titleBy) {
       const fromTitleBy = readTitleByValue(obj, itemSchema.titleBy);

--- a/apps/mesh/src/web/components/sections-editor/array-item-display.ts
+++ b/apps/mesh/src/web/components/sections-editor/array-item-display.ts
@@ -1,5 +1,6 @@
 import { extractUrl } from "./fields/extract-url";
 import type { SchemaProperty } from "./resolve-schema";
+import { isLazyResolveType } from "./section-lazy";
 import { labelFromResolveType } from "./section-types";
 import { safeEditorImageUrl } from "./safe-editor-image-url";
 
@@ -107,7 +108,18 @@ export function getArrayItemLabel(
     return String(item);
   }
   if (item && typeof item === "object" && !Array.isArray(item)) {
-    const obj = item as Record<string, unknown>;
+    let obj = item as Record<string, unknown>;
+    // Lazy-wrapped section items (`{ __resolveType: ".../Lazy.tsx", section: {...} }`)
+    // should be labelled by the inner section, not "Lazy".
+    if (
+      typeof obj.__resolveType === "string" &&
+      isLazyResolveType(obj.__resolveType) &&
+      obj.section &&
+      typeof obj.section === "object" &&
+      !Array.isArray(obj.section)
+    ) {
+      obj = obj.section as Record<string, unknown>;
+    }
     if (itemSchema?.titleBy) {
       const fromTitleBy = readTitleByValue(obj, itemSchema.titleBy);
       if (fromTitleBy) return fromTitleBy;

--- a/apps/mesh/src/web/components/sections-editor/block-ref-array-inference.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-ref-array-inference.ts
@@ -1,0 +1,27 @@
+import type { SchemaProperty } from "./resolve-schema";
+
+/**
+ * When a block-ref field holds a resolved plain array (the loader has already
+ * been evaluated), infer a minimal item schema from the first element so the
+ * array can be rendered as an editable ArrayField.
+ * Only primitive types (string, number, boolean) are inferred — nested
+ * objects/arrays are intentionally skipped.
+ */
+export function inferBlockRefArrayItemSchema(
+  value: unknown[],
+): SchemaProperty | undefined {
+  const first = value.length > 0 ? value[0] : undefined;
+  if (first == null || typeof first !== "object" || Array.isArray(first)) {
+    return undefined;
+  }
+  const properties: Record<string, SchemaProperty> = {};
+  for (const [k, v] of Object.entries(first as Record<string, unknown>)) {
+    if (k.startsWith("__")) continue;
+    if (typeof v === "string") properties[k] = { type: "string" };
+    else if (typeof v === "number") properties[k] = { type: "number" };
+    else if (typeof v === "boolean") properties[k] = { type: "boolean" };
+  }
+  return Object.keys(properties).length > 0
+    ? { type: "object", properties }
+    : undefined;
+}

--- a/apps/mesh/src/web/components/sections-editor/block-ref-field-utils.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-ref-field-utils.test.ts
@@ -4,6 +4,7 @@ import {
   blockRefLoaderConfigHasData,
   detectBlockRefType,
   enrichBlockRefOptions,
+  lazyWrappedInner,
   moduleResolveTypeFromBlockData,
   resolveNestedBlockRefSchema,
   schemaWithoutDiscriminator,
@@ -274,5 +275,39 @@ describe("blockRefLoaderConfigHasData", () => {
         variants: [{ value: [] }],
       }),
     ).toBe(true);
+  });
+});
+
+describe("lazyWrappedInner", () => {
+  const LAZY = "website/sections/Rendering/Lazy.tsx";
+
+  test("returns the inner section for a Lazy-wrapped value (so the form binds real props)", () => {
+    const wrapper = {
+      __resolveType: LAZY,
+      section: {
+        __resolveType: "site/sections/Content/BannerCarrouselDepartment.tsx",
+        carrousels: [{ matcher: "/x" }],
+        title: "T",
+      },
+    };
+    const inner = lazyWrappedInner(wrapper);
+    expect(inner?.["title"]).toBe("T");
+    expect(Array.isArray(inner?.["carrousels"])).toBe(true);
+  });
+
+  test("returns null for non-Lazy block-ref values", () => {
+    expect(
+      lazyWrappedInner({
+        __resolveType: "site/sections/Content/BannerCarrouselDepartment.tsx",
+        carrousels: [],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when there is no inner section object", () => {
+    expect(lazyWrappedInner({ __resolveType: LAZY })).toBeNull();
+    expect(lazyWrappedInner({ __resolveType: LAZY, section: "x" })).toBeNull();
+    expect(lazyWrappedInner(null)).toBeNull();
+    expect(lazyWrappedInner([])).toBeNull();
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/block-ref-field-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-ref-field-utils.ts
@@ -191,6 +191,32 @@ export function schemaWithoutDiscriminator(
   return { ...schema, properties };
 }
 
+/**
+ * When a block-ref value is a Lazy section wrapper
+ * (`{ __resolveType: ".../Lazy.tsx", section: { <real section> } }`), return the
+ * inner section so the form can bind against the real props. The schema is
+ * already resolved from the inner (via moduleResolveTypeFromBlockData), so
+ * without unwrapping the value too every field would render empty. Returns null
+ * when `value` is not a Lazy wrapper.
+ */
+export function lazyWrappedInner(
+  value: unknown,
+): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const obj = value as Record<string, unknown>;
+  if (
+    typeof obj.__resolveType !== "string" ||
+    !isLazyResolveType(obj.__resolveType)
+  ) {
+    return null;
+  }
+  const section = obj.section;
+  if (!section || typeof section !== "object" || Array.isArray(section)) {
+    return null;
+  }
+  return section as Record<string, unknown>;
+}
+
 export function blockRefLoaderConfigHasData(
   editorValue: unknown,
   savedBlockKey?: string,

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -27,6 +27,7 @@ import {
 } from "../block-type-utils";
 import type { SchemaProperty } from "../resolve-schema";
 import type { FieldProps } from "./field-props";
+
 import { SchemaForm } from "../schema-form";
 import { unwrapBlockReference } from "../unwrap-section";
 
@@ -148,9 +149,16 @@ export function AnyOfField({
       : (refs[0]?.resolveType ?? "");
   const [selectedRt, setSelectedRt] = useState(inferredRt);
   const [prevInferredRt, setPrevInferredRt] = useState(inferredRt);
+  // Module loaders use an internal breadcrumb so nested array/object navigation
+  // doesn't leak to the outer section-editor breadcrumb. The outer breadcrumb
+  // can't resolve loader-internal keys (e.g. "selectedFacets" from the loader's
+  // schema) at the section level (e.g. SearchResult), causing the whole form
+  // to render instead of just the focused item.
+  const [loaderBreadcrumbs, setLoaderBreadcrumbs] = useState<string[]>([]);
   if (prevInferredRt !== inferredRt) {
     setPrevInferredRt(inferredRt);
     setSelectedRt(inferredRt);
+    setLoaderBreadcrumbs([]);
   }
   const [loaderConfigOpen, setLoaderConfigOpen] = useState(() =>
     blockRefLoaderConfigHasData(editorValue, savedRef?.blockKey),
@@ -170,6 +178,16 @@ export function AnyOfField({
       schema.discriminatorKey,
     );
     const discriminatorKey = schema.discriminatorKey;
+
+    // Module loaders: loader-internal fields include "/" in resolveType.
+    const isBlockRef = schema.type === "block-ref";
+    const isModuleLoaderUnion =
+      isBlockRef &&
+      refs.some(
+        (r) =>
+          r.resolveType.includes("/") &&
+          !isEmbeddedUnionResolveType(r.resolveType),
+      );
 
     const handleRefChange = (rt: string) => {
       setSelectedRt(rt);
@@ -241,23 +259,18 @@ export function AnyOfField({
           persistUnionValue(next);
         }}
         basePath={path}
-        breadcrumbPath={breadcrumbPath}
-        onBreadcrumbChange={onBreadcrumbChange}
+        breadcrumbPath={
+          isModuleLoaderUnion ? loaderBreadcrumbs : breadcrumbPath
+        }
+        onBreadcrumbChange={
+          isModuleLoaderUnion ? setLoaderBreadcrumbs : onBreadcrumbChange
+        }
         meta={meta}
         decofile={decofile}
         onSaveReferencedBlock={onSaveReferencedBlock}
       />
     ) : null;
 
-    // Module loaders (jsonLD, slug, …): nest props in a collapsible card.
-    const isBlockRef = schema.type === "block-ref";
-    const isModuleLoaderUnion =
-      isBlockRef &&
-      refs.some(
-        (r) =>
-          r.resolveType.includes("/") &&
-          !isEmbeddedUnionResolveType(r.resolveType),
-      );
     const isNestedBlockRef = path.includes(".");
 
     return (

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -147,14 +147,40 @@ export function AnyOfField({
     refs.length > 0
       ? detectBlockRefType(editorValue, refs, savedRef?.blockKey)
       : (refs[0]?.resolveType ?? "");
+  const isBlockRef = schema.type === "block-ref";
+  const isModuleLoaderUnion =
+    isBlockRef &&
+    refs.some(
+      (r) =>
+        r.resolveType.includes("/") &&
+        !isEmbeddedUnionResolveType(r.resolveType),
+    );
+
   const [selectedRt, setSelectedRt] = useState(inferredRt);
   const [prevInferredRt, setPrevInferredRt] = useState(inferredRt);
   // Module loaders use an internal breadcrumb so nested array/object navigation
   // doesn't leak to the outer section-editor breadcrumb. The outer breadcrumb
   // can't resolve loader-internal keys (e.g. "selectedFacets" from the loader's
   // schema) at the section level (e.g. SearchResult), causing the whole form
-  // to render instead of just the focused item.
+  // to show all fields instead of the focused item.
   const [loaderBreadcrumbs, setLoaderBreadcrumbs] = useState<string[]>([]);
+  // When the user drills into a loader item (loaderBreadcrumbs becomes non-empty),
+  // collapse the outer section form by focusing it on this loader field's key.
+  // When the user goes back (loaderBreadcrumbs becomes empty), restore the full form.
+  const [prevLoaderBcrLen, setPrevLoaderBcrLen] = useState(0);
+  if (prevLoaderBcrLen !== loaderBreadcrumbs.length) {
+    setPrevLoaderBcrLen(loaderBreadcrumbs.length);
+    if (isModuleLoaderUnion && onBreadcrumbChange) {
+      if (loaderBreadcrumbs.length > 0) {
+        // Focus the outer form on just this field (e.g. "page") so surrounding
+        // section fields (sections, layout, etc.) collapse out of view.
+        const outerKey = path.includes(".") ? path.split(".")[0]! : path;
+        onBreadcrumbChange([outerKey]);
+      } else {
+        onBreadcrumbChange([]);
+      }
+    }
+  }
   if (prevInferredRt !== inferredRt) {
     setPrevInferredRt(inferredRt);
     setSelectedRt(inferredRt);
@@ -178,16 +204,6 @@ export function AnyOfField({
       schema.discriminatorKey,
     );
     const discriminatorKey = schema.discriminatorKey;
-
-    // Module loaders: loader-internal fields include "/" in resolveType.
-    const isBlockRef = schema.type === "block-ref";
-    const isModuleLoaderUnion =
-      isBlockRef &&
-      refs.some(
-        (r) =>
-          r.resolveType.includes("/") &&
-          !isEmbeddedUnionResolveType(r.resolveType),
-      );
 
     const handleRefChange = (rt: string) => {
       setSelectedRt(rt);

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -25,6 +25,7 @@ import {
   embeddedUnionBlockId,
   isEmbeddedUnionResolveType,
 } from "../block-type-utils";
+import { labelFromResolveType } from "../section-types";
 import type { SchemaProperty } from "../resolve-schema";
 import type { FieldProps } from "./field-props";
 
@@ -292,13 +293,20 @@ export function AnyOfField({
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              {refs.map((ref) => (
-                <SelectItem key={ref.resolveType} value={ref.resolveType}>
-                  {ref.title ??
-                    embeddedUnionBlockId(ref.resolveType) ??
-                    ref.resolveType}
-                </SelectItem>
-              ))}
+              {refs.map((ref) => {
+                // If title is a file path (contains "/"), derive a human label
+                // from the resolveType instead (e.g. "DeliveryPromiseProductListingPage").
+                const displayTitle =
+                  ref.title && !ref.title.includes("/")
+                    ? ref.title
+                    : (embeddedUnionBlockId(ref.resolveType) ??
+                      labelFromResolveType(ref.resolveType));
+                return (
+                  <SelectItem key={ref.resolveType} value={ref.resolveType}>
+                    {displayTitle}
+                  </SelectItem>
+                );
+              })}
             </SelectContent>
           </Select>
           {schema.description && (

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -158,16 +158,19 @@ export function AnyOfField({
     );
 
   // In module-loader mode the breadcrumb path passes through this component.
-  // We strip our own key from the front before passing to the nested SchemaForm
-  // so the loader's internal schema can resolve the path correctly (e.g.
-  // breadcrumbPath ["page", "productClusterIds"] → nested receives
-  // ["productClusterIds"] → loader SchemaForm finds "selectedFacets" array
-  // because an item label matches). nestedOnBreadcrumbChange prepends the key
-  // back so the outer section editor sees the full path.
-  const outerKey = path.includes(".") ? path.split(".")[0]! : path;
+  // We strip our own crumb from the front before passing to the nested
+  // SchemaForm so the loader's internal schema can resolve the path correctly
+  // (e.g. ["Página de Listagem", "productClusterIds"] → nested receives
+  // ["productClusterIds"] → loader SchemaForm finds "selectedFacets" because an
+  // item label matches). nestedOnBreadcrumbChange prepends the crumb back so the
+  // outer section editor sees the full path.
+  // The crumb uses this field's display LABEL (not the raw key) so the breadcrumb
+  // reads "Página de Listagem" instead of "page". resolveActiveFieldKey matches
+  // both label and key, so resolution still works.
+  const outerCrumb = label ?? (path.includes(".") ? path.split(".")[0]! : path);
   const safeBreadcrumbPath = breadcrumbPath ?? [];
   const nestedBreadcrumbPath =
-    isModuleLoaderUnion && safeBreadcrumbPath[0] === outerKey
+    isModuleLoaderUnion && safeBreadcrumbPath[0] === outerCrumb
       ? safeBreadcrumbPath.slice(1)
       : isModuleLoaderUnion
         ? []
@@ -175,7 +178,7 @@ export function AnyOfField({
   const nestedOnBreadcrumbChange: ((p: string[]) => void) | undefined =
     isModuleLoaderUnion
       ? (newPath) => {
-          onBreadcrumbChange?.([outerKey, ...newPath]);
+          onBreadcrumbChange?.([outerCrumb, ...newPath]);
         }
       : onBreadcrumbChange;
 

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -156,35 +156,33 @@ export function AnyOfField({
         !isEmbeddedUnionResolveType(r.resolveType),
     );
 
+  // In module-loader mode the breadcrumb path passes through this component.
+  // We strip our own key from the front before passing to the nested SchemaForm
+  // so the loader's internal schema can resolve the path correctly (e.g.
+  // breadcrumbPath ["page", "productClusterIds"] → nested receives
+  // ["productClusterIds"] → loader SchemaForm finds "selectedFacets" array
+  // because an item label matches). nestedOnBreadcrumbChange prepends the key
+  // back so the outer section editor sees the full path.
+  const outerKey = path.includes(".") ? path.split(".")[0]! : path;
+  const safeBreadcrumbPath = breadcrumbPath ?? [];
+  const nestedBreadcrumbPath =
+    isModuleLoaderUnion && safeBreadcrumbPath[0] === outerKey
+      ? safeBreadcrumbPath.slice(1)
+      : isModuleLoaderUnion
+        ? []
+        : safeBreadcrumbPath;
+  const nestedOnBreadcrumbChange: ((p: string[]) => void) | undefined =
+    isModuleLoaderUnion
+      ? (newPath) => {
+          onBreadcrumbChange?.([outerKey, ...newPath]);
+        }
+      : onBreadcrumbChange;
+
   const [selectedRt, setSelectedRt] = useState(inferredRt);
   const [prevInferredRt, setPrevInferredRt] = useState(inferredRt);
-  // Module loaders use an internal breadcrumb so nested array/object navigation
-  // doesn't leak to the outer section-editor breadcrumb. The outer breadcrumb
-  // can't resolve loader-internal keys (e.g. "selectedFacets" from the loader's
-  // schema) at the section level (e.g. SearchResult), causing the whole form
-  // to show all fields instead of the focused item.
-  const [loaderBreadcrumbs, setLoaderBreadcrumbs] = useState<string[]>([]);
-  // When the user drills into a loader item (loaderBreadcrumbs becomes non-empty),
-  // collapse the outer section form by focusing it on this loader field's key.
-  // When the user goes back (loaderBreadcrumbs becomes empty), restore the full form.
-  const [prevLoaderBcrLen, setPrevLoaderBcrLen] = useState(0);
-  if (prevLoaderBcrLen !== loaderBreadcrumbs.length) {
-    setPrevLoaderBcrLen(loaderBreadcrumbs.length);
-    if (isModuleLoaderUnion && onBreadcrumbChange) {
-      if (loaderBreadcrumbs.length > 0) {
-        // Focus the outer form on just this field (e.g. "page") so surrounding
-        // section fields (sections, layout, etc.) collapse out of view.
-        const outerKey = path.includes(".") ? path.split(".")[0]! : path;
-        onBreadcrumbChange([outerKey]);
-      } else {
-        onBreadcrumbChange([]);
-      }
-    }
-  }
   if (prevInferredRt !== inferredRt) {
     setPrevInferredRt(inferredRt);
     setSelectedRt(inferredRt);
-    setLoaderBreadcrumbs([]);
   }
   const [loaderConfigOpen, setLoaderConfigOpen] = useState(() =>
     blockRefLoaderConfigHasData(editorValue, savedRef?.blockKey),
@@ -275,12 +273,8 @@ export function AnyOfField({
           persistUnionValue(next);
         }}
         basePath={path}
-        breadcrumbPath={
-          isModuleLoaderUnion ? loaderBreadcrumbs : breadcrumbPath
-        }
-        onBreadcrumbChange={
-          isModuleLoaderUnion ? setLoaderBreadcrumbs : onBreadcrumbChange
-        }
+        breadcrumbPath={nestedBreadcrumbPath}
+        onBreadcrumbChange={nestedOnBreadcrumbChange}
         meta={meta}
         decofile={decofile}
         onSaveReferencedBlock={onSaveReferencedBlock}

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -18,6 +18,7 @@ import {
   blockRefLoaderConfigHasData,
   detectBlockRefType,
   enrichBlockRefOptions,
+  lazyWrappedInner,
   resolveNestedBlockRefSchema,
   schemaWithoutDiscriminator,
 } from "../block-ref-field-utils";
@@ -140,6 +141,13 @@ export function AnyOfField({
   const savedRef =
     decofile && value ? unwrapBlockReference(value, decofile) : null;
   const editorValue = savedRef?.data ?? value;
+  // Nested section array items are Lazy-wrapped (`{ __resolveType: ".../Lazy.tsx",
+  // section: { <real section> } }`). The schema resolves to the inner section
+  // (via moduleResolveTypeFromBlockData) but the value must be unwrapped too,
+  // otherwise the form binds against the wrapper and every field renders empty.
+  // We bind the inner `section` and re-wrap on change.
+  const lazyInner = savedRef ? null : lazyWrappedInner(editorValue);
+  const boundValue = lazyInner ?? editorValue;
   const refs = enrichBlockRefOptions(baseRefs, {
     savedBlockKey: savedRef?.blockKey,
     editorValue,
@@ -265,13 +273,21 @@ export function AnyOfField({
     const nestedProps = nestedSchema?.properties ? (
       <SchemaForm
         schema={nestedSchema}
-        value={editorValue}
+        value={boundValue}
         onChange={(next) => {
           if (savedRef && onSaveReferencedBlock) {
             onSaveReferencedBlock(
               savedRef.blockKey,
               next as Record<string, unknown>,
             );
+            return;
+          }
+          // Re-wrap into the Lazy section wrapper so the decofile shape is preserved.
+          if (lazyInner) {
+            onChange({
+              ...(editorValue as Record<string, unknown>),
+              section: next,
+            });
             return;
           }
           persistUnionValue(next);

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -180,9 +180,7 @@ export function AnyOfField({
   const nestedBreadcrumbPath =
     isModuleLoaderUnion && safeBreadcrumbPath[0] === outerCrumb
       ? safeBreadcrumbPath.slice(1)
-      : isModuleLoaderUnion
-        ? []
-        : safeBreadcrumbPath;
+      : safeBreadcrumbPath;
   const nestedOnBreadcrumbChange: ((p: string[]) => void) | undefined =
     isModuleLoaderUnion
       ? (newPath) => {

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -37,7 +37,7 @@ import {
 } from "../schema-form-breadcrumb";
 import { isSectionArrayField } from "../section-array-field";
 import type { FieldProps } from "./field-props";
-import { SchemaForm, renderField } from "../schema-form";
+import { SchemaForm, renderField, inferSchemaFromValue } from "../schema-form";
 import {
   resolveSchema,
   type LiveMeta,
@@ -96,6 +96,18 @@ function itemEditorSchema(
       };
     }
   }
+  // Last resort: infer schema from the item's runtime value so that
+  // data-inferred arrays (e.g. menuItems [{target,href,label}]) can be edited.
+  if (item != null && typeof item === "object" && !Array.isArray(item)) {
+    const obj = item as Record<string, unknown>;
+    if (typeof obj.__resolveType !== "string") {
+      const inferred = inferSchemaFromValue(item);
+      if (inferred?.properties && Object.keys(inferred.properties).length > 0) {
+        return inferred;
+      }
+    }
+  }
+
   return itemSchema;
 }
 

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -37,7 +37,7 @@ import {
 } from "../schema-form-breadcrumb";
 import { isSectionArrayField } from "../section-array-field";
 import type { FieldProps } from "./field-props";
-import { SchemaForm, renderField, inferSchemaFromValue } from "../schema-form";
+import { SchemaForm, renderField } from "../schema-form";
 import {
   resolveSchema,
   type LiveMeta,
@@ -96,18 +96,6 @@ function itemEditorSchema(
       };
     }
   }
-  // Last resort: infer schema from the item's runtime value so that
-  // data-inferred arrays (e.g. menuItems [{target,href,label}]) can be edited.
-  if (item != null && typeof item === "object" && !Array.isArray(item)) {
-    const obj = item as Record<string, unknown>;
-    if (typeof obj.__resolveType !== "string") {
-      const inferred = inferSchemaFromValue(item);
-      if (inferred?.properties && Object.keys(inferred.properties).length > 0) {
-        return inferred;
-      }
-    }
-  }
-
   return itemSchema;
 }
 

--- a/apps/mesh/src/web/components/sections-editor/fields/rich-text-field.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/rich-text-field.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { isSafeLinkUrl } from "../rich-text-link-validation";
+
+describe("isSafeLinkUrl", () => {
+  test("allows https URLs", () => {
+    expect(isSafeLinkUrl("https://example.com")).toBe(true);
+    expect(isSafeLinkUrl("https://example.com/path?q=1#frag")).toBe(true);
+  });
+
+  test("allows http URLs", () => {
+    expect(isSafeLinkUrl("http://example.com")).toBe(true);
+  });
+
+  test("allows mailto links", () => {
+    expect(isSafeLinkUrl("mailto:user@example.com")).toBe(true);
+  });
+
+  test("allows tel links", () => {
+    expect(isSafeLinkUrl("tel:+5511999999999")).toBe(true);
+  });
+
+  test("allows ftp links", () => {
+    expect(isSafeLinkUrl("ftp://files.example.com")).toBe(true);
+  });
+
+  test("allows relative paths", () => {
+    expect(isSafeLinkUrl("/about")).toBe(true);
+    expect(isSafeLinkUrl("/sale?utm=1")).toBe(true);
+  });
+
+  test("allows dot-relative paths", () => {
+    expect(isSafeLinkUrl("./page")).toBe(true);
+    expect(isSafeLinkUrl("../other")).toBe(true);
+  });
+
+  test("allows fragment-only links", () => {
+    expect(isSafeLinkUrl("#section")).toBe(true);
+  });
+
+  test("rejects javascript: URLs", () => {
+    expect(isSafeLinkUrl("javascript:alert('xss')")).toBe(false);
+    expect(isSafeLinkUrl("javascript:void(0)")).toBe(false);
+  });
+
+  test("rejects data: URLs", () => {
+    expect(isSafeLinkUrl("data:text/html,<script>alert(1)</script>")).toBe(
+      false,
+    );
+  });
+
+  test("rejects vbscript: URLs", () => {
+    expect(isSafeLinkUrl("vbscript:MsgBox('xss')")).toBe(false);
+  });
+
+  test("rejects blob: URLs", () => {
+    expect(isSafeLinkUrl("blob:https://example.com/uuid")).toBe(false);
+  });
+
+  test("treats protocol-less strings as relative paths (safe)", () => {
+    // ":::invalid" is parsed as a relative path against the base URL,
+    // resulting in https: protocol — this is safe (not javascript:/data:).
+    expect(isSafeLinkUrl(":::invalid")).toBe(true);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/fields/rich-text-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/rich-text-field.tsx
@@ -1,0 +1,188 @@
+import { useRef } from "react";
+import {
+  Bold01,
+  Heading01,
+  Heading02,
+  Italic01,
+  Link01,
+  List,
+  Strikethrough01,
+  Underline01,
+} from "@untitledui/icons";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { Label } from "@deco/ui/components/label.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import type { FieldProps } from "./field-props";
+
+function ToolbarButton({
+  active,
+  label,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className={cn(
+        "flex h-7 w-7 items-center justify-center rounded transition-colors cursor-pointer",
+        active
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function RichTextField({
+  schema,
+  value,
+  onChange,
+  path,
+  label,
+}: FieldProps) {
+  const strValue = typeof value === "string" ? value : "";
+
+  const onChangeRef = useRef(onChange);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read only inside the onUpdate callback, never during render
+  onChangeRef.current = onChange;
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [1, 2, 3] },
+      }),
+    ],
+    content: strValue || "",
+    editorProps: {
+      attributes: {
+        class: cn(
+          "prose prose-sm dark:prose-invert max-w-none focus:outline-none",
+          "min-h-[80px] px-3 py-2",
+        ),
+      },
+    },
+    onUpdate: ({ editor }) => {
+      const next = editor.getHTML();
+      onChangeRef.current(next === "<p></p>" ? "" : next);
+    },
+  });
+
+  if (!editor) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="space-y-0.5">
+        <Label htmlFor={path}>{label}</Label>
+        {schema.description && (
+          <p className="text-xs leading-normal text-muted-foreground">
+            {schema.description}
+          </p>
+        )}
+      </div>
+      <div className="overflow-hidden rounded-md border border-input">
+        <div className="flex flex-wrap items-center gap-0.5 border-b border-border/60 bg-muted/30 px-1.5 py-1">
+          <ToolbarButton
+            active={editor.isActive("bold")}
+            label="Bold"
+            onClick={() => editor.chain().focus().toggleBold().run()}
+          >
+            <Bold01 size={14} />
+          </ToolbarButton>
+          <ToolbarButton
+            active={editor.isActive("italic")}
+            label="Italic"
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+          >
+            <Italic01 size={14} />
+          </ToolbarButton>
+          <ToolbarButton
+            active={editor.isActive("underline")}
+            label="Underline"
+            onClick={() => editor.chain().focus().toggleUnderline().run()}
+          >
+            <Underline01 size={14} />
+          </ToolbarButton>
+          <ToolbarButton
+            active={editor.isActive("strike")}
+            label="Strikethrough"
+            onClick={() => editor.chain().focus().toggleStrike().run()}
+          >
+            <Strikethrough01 size={14} />
+          </ToolbarButton>
+
+          <div className="mx-0.5 h-4 w-px bg-border" />
+
+          <ToolbarButton
+            active={editor.isActive("heading", { level: 1 })}
+            label="Heading 1"
+            onClick={() =>
+              editor.chain().focus().toggleHeading({ level: 1 }).run()
+            }
+          >
+            <Heading01 size={14} />
+          </ToolbarButton>
+          <ToolbarButton
+            active={editor.isActive("heading", { level: 2 })}
+            label="Heading 2"
+            onClick={() =>
+              editor.chain().focus().toggleHeading({ level: 2 }).run()
+            }
+          >
+            <Heading02 size={14} />
+          </ToolbarButton>
+
+          <div className="mx-0.5 h-4 w-px bg-border" />
+
+          <ToolbarButton
+            active={editor.isActive("bulletList")}
+            label="Bullet list"
+            onClick={() => editor.chain().focus().toggleBulletList().run()}
+          >
+            <List size={14} />
+          </ToolbarButton>
+          <ToolbarButton
+            active={editor.isActive("orderedList")}
+            label="Ordered list"
+            onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          >
+            <span className="text-[11px] font-semibold leading-none">1.</span>
+          </ToolbarButton>
+
+          <div className="mx-0.5 h-4 w-px bg-border" />
+
+          <ToolbarButton
+            active={editor.isActive("link")}
+            label="Link"
+            onClick={() => {
+              const prev = editor.getAttributes("link").href as
+                | string
+                | undefined;
+              const url = window.prompt("Link URL", prev ?? "https://");
+              if (url === null) return;
+              if (url === "") {
+                editor.chain().focus().unsetLink().run();
+              } else {
+                editor.chain().focus().setLink({ href: url }).run();
+              }
+            }}
+          >
+            <Link01 size={14} />
+          </ToolbarButton>
+        </div>
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/rich-text-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/rich-text-field.tsx
@@ -14,6 +14,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { Label } from "@deco/ui/components/label.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
 import type { FieldProps } from "./field-props";
+import { isSafeLinkUrl } from "../rich-text-link-validation";
 
 function ToolbarButton({
   active,
@@ -173,7 +174,7 @@ export function RichTextField({
               if (url === null) return;
               if (url === "") {
                 editor.chain().focus().unsetLink().run();
-              } else {
+              } else if (isSafeLinkUrl(url)) {
                 editor.chain().focus().setLink({ href: url }).run();
               }
             }}

--- a/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
@@ -11,6 +11,7 @@ import {
 } from "@deco/ui/components/popover.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import type { FieldProps } from "./field-props";
+import { RichTextField } from "./rich-text-field";
 
 const pad = (n: number) => String(n).padStart(2, "0");
 
@@ -169,11 +170,22 @@ export function StringField({
   const format = schema.format;
 
   if (
-    format === "textarea" ||
     format === "rich-text" ||
     format === "rich-text-inline" ||
-    format === "markdown"
+    format === "html"
   ) {
+    return (
+      <RichTextField
+        schema={schema}
+        value={value}
+        onChange={onChange}
+        path={path}
+        label={label}
+      />
+    );
+  }
+
+  if (format === "textarea" || format === "markdown") {
     return (
       <div className="space-y-2">
         <FieldLabel

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -585,3 +585,50 @@ describe("resolveSchema – type-discriminated unions", () => {
     expect(options?.anyOfRefs).toHaveLength(2);
   });
 });
+
+describe("resolveSchema – @hide on block-ref fields", () => {
+  // Mirrors @decocms/start ≥6.10: a hidden loader/block-ref prop is emitted as
+  // `{ anyOf: [Resolvable, loaderRef], hide: "true" }`. The block-ref return in
+  // buildProperty must propagate `hidden: true` so the form filters it out
+  // (e.g. SearchResult's `tags` / `locationUser` / `stores`).
+  test("hidden block-ref prop carries hidden:true", () => {
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        tags: {
+          title: "Tags",
+          hide: "true",
+          anyOf: [
+            { $ref: "#/definitions/Resolvable" },
+            { $ref: "#/definitions/SomeLoader" },
+          ],
+        },
+        visibleField: { type: "string", title: "Visible" },
+      },
+    });
+    (meta.schema as { definitions: Record<string, unknown> }).definitions = {
+      Resolvable: {
+        type: "object",
+        properties: { __resolveType: { type: "string" } },
+      },
+      SomeLoader: {
+        title: "site/loaders/some.ts",
+        type: "object",
+        properties: {
+          __resolveType: {
+            type: "string",
+            enum: ["site/loaders/some.ts"],
+            default: "site/loaders/some.ts",
+          },
+          q: { type: "string", title: "Q" },
+        },
+      },
+    };
+
+    const props = resolveSchema("site/sections/Test.tsx", meta)?.properties;
+    expect(props?.tags?.type).toBe("block-ref");
+    expect(props?.tags?.hidden).toBe(true);
+    // sanity: non-hidden field stays visible
+    expect(props?.visibleField?.hidden).toBeUndefined();
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -604,6 +604,16 @@ export function resolveSchema(
                 }
               }
             }
+            // @decocms/start ≥6.10 emits flat loader defs (no allOf) with
+            // __resolveType.enum directly in properties — check that too.
+            if (!rt) {
+              const rtProp = (def.properties as RawSchema | undefined)
+                ?.__resolveType as RawSchema | undefined;
+              const e = rtProp?.enum;
+              if (Array.isArray(e) && typeof e[0] === "string") {
+                rt = e[0];
+              }
+            }
             if (!rt) {
               rt = (branch.$ref as string).split("/").pop() ?? "";
             }

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -528,6 +528,8 @@ export function resolveSchema(
                 ? resolved.description
                 : undefined,
             anyOfRefs,
+            hidden:
+              isSchemaHidden(resolved) || isSchemaHidden(v) ? true : undefined,
           };
         }
 
@@ -573,6 +575,8 @@ export function resolveSchema(
                   : undefined,
             discriminatorKey: "type",
             anyOfRefs,
+            hidden:
+              isSchemaHidden(resolved) || isSchemaHidden(v) ? true : undefined,
           };
         }
 
@@ -645,6 +649,8 @@ export function resolveSchema(
                 ? resolved.description
                 : undefined,
             anyOfRefs,
+            hidden:
+              isSchemaHidden(resolved) || isSchemaHidden(v) ? true : undefined,
           };
         }
 

--- a/apps/mesh/src/web/components/sections-editor/rich-text-link-validation.ts
+++ b/apps/mesh/src/web/components/sections-editor/rich-text-link-validation.ts
@@ -1,0 +1,21 @@
+const SAFE_LINK_PROTOCOLS = new Set([
+  "http:",
+  "https:",
+  "mailto:",
+  "tel:",
+  "ftp:",
+]);
+
+/** Only allow safe URL protocols — blocks `javascript:`, `data:`, `vbscript:`, etc. */
+export function isSafeLinkUrl(url: string): boolean {
+  // Relative paths and fragment links are always safe.
+  if (url.startsWith("/") || url.startsWith(".") || url.startsWith("#")) {
+    return true;
+  }
+  try {
+    const parsed = new URL(url, "https://placeholder.invalid");
+    return SAFE_LINK_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return false;
+  }
+}

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -142,6 +142,73 @@ describe("resolveActiveFieldKey", () => {
     ).toBe("alert");
   });
 
+  test("disambiguates block-refs with same label by inner value keys", () => {
+    const properties = {
+      asideMenu: {
+        title: "Section",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "AsideMenu.tsx", title: "Aside" }],
+      } as SchemaProperty,
+      content: {
+        title: "Section",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "CategoryTextHero.tsx", title: "Hero" }],
+      } as SchemaProperty,
+    };
+    const objValue = {
+      asideMenu: {
+        __resolveType: "AsideMenu.tsx",
+        menuItems: [{ label: "Garantia Vitalícia" }],
+      },
+      content: {
+        __resolveType: "CategoryTextHero.tsx",
+        textSeo: [{ matcher: "/garantia-vitalicia" }],
+      },
+    };
+    // "Text Seo" matches humanize("textSeo") in content, not asideMenu
+    expect(
+      resolveActiveFieldKey(["asideMenu", "content"], properties, objValue, [
+        "Section",
+        "Text Seo",
+        "Garantia Vitalícia",
+      ]),
+    ).toBe("content");
+  });
+
+  test("disambiguates block-refs when breadcrumb uses schema title casing", () => {
+    // Schema title "TextSeo" vs humanize("textSeo") = "Text Seo"
+    const properties = {
+      asideMenu: {
+        title: "Section",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "AsideMenu.tsx", title: "Aside" }],
+      } as SchemaProperty,
+      content: {
+        title: "Section",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "CategoryTextHero.tsx", title: "Hero" }],
+      } as SchemaProperty,
+    };
+    const objValue = {
+      asideMenu: {
+        __resolveType: "AsideMenu.tsx",
+        menuItems: [{ label: "Garantia Vitalícia" }],
+      },
+      content: {
+        __resolveType: "CategoryTextHero.tsx",
+        textSeo: [{ matcher: "/garantia-vitalicia" }],
+      },
+    };
+    // "TextSeo" (schema title) should match value key "textSeo" via loose comparison
+    expect(
+      resolveActiveFieldKey(["asideMenu", "content"], properties, objValue, [
+        "Section",
+        "TextSeo",
+        "/garantia-vitalicia",
+      ]),
+    ).toBe("content");
+  });
+
   test("matches array field when runtime value is an array", () => {
     const properties = {
       appKey: { type: "string", title: "App Key" } as SchemaProperty,

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
@@ -156,6 +156,18 @@ function resolveActiveFieldKeyInScope(
     }
   }
 
+  // Block-ref fields (loader/section selectors) can also be "drilled into"
+  // via the breadcrumb path when the head matches the field's key or label.
+  // This lets loader props like `page: ProductListingPage` participate in
+  // breadcrumb navigation (e.g. path ["page", "selectedFacets", "productClusterIds"]
+  // resolves to "page" at the SearchResult level).
+  for (const key of keys) {
+    const schema = properties[key];
+    if (schema?.type !== "block-ref") continue;
+    const label = fieldDisplayLabel(key, schema);
+    if (head === label || head === key) return key;
+  }
+
   return null;
 }
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
@@ -18,6 +18,14 @@ function labelsMatch(a: string, b: string): boolean {
   return normalizeBreadcrumbLabel(a) === normalizeBreadcrumbLabel(b);
 }
 
+/** Looser comparison that ignores spaces and casing — handles humanize("textSeo") = "Text Seo" vs schema title "TextSeo". */
+function labelsMatchLoose(a: string, b: string): boolean {
+  return (
+    normalizeBreadcrumbLabel(a).replace(/\s+/g, "").toLowerCase() ===
+    normalizeBreadcrumbLabel(b).replace(/\s+/g, "").toLowerCase()
+  );
+}
+
 /** Breadcrumb trail when opening an array item (includes the array field label). */
 export function buildArrayDrillDownBreadcrumb(
   breadcrumbPath: string[],
@@ -161,12 +169,36 @@ function resolveActiveFieldKeyInScope(
   // This lets loader props like `page: ProductListingPage` participate in
   // breadcrumb navigation (e.g. path ["page", "selectedFacets", "productClusterIds"]
   // resolves to "page" at the SearchResult level).
+  //
+  // When multiple block-refs share the same label (e.g. both "asideMenu"
+  // and "content" have schema title "Section"), disambiguate by checking
+  // whether the block-ref's VALUE contains a key that matches the next
+  // breadcrumb crumb.  The one whose data actually owns the nested field
+  // wins; the rest are kept as a fallback.
+  let blockRefFallback: string | null = null;
   for (const key of keys) {
     const schema = properties[key];
     if (schema?.type !== "block-ref") continue;
-    const label = fieldDisplayLabel(key, schema);
-    if (head === label || head === key) return key;
+    const fieldLabel = fieldDisplayLabel(key, schema);
+    if (head !== fieldLabel && head !== key) continue;
+
+    if (breadcrumbPath.length > 1) {
+      const val = objValue[key];
+      if (val && typeof val === "object" && !Array.isArray(val)) {
+        const nextCrumb = breadcrumbPath[1]!;
+        const hasInnerMatch = Object.keys(val as Record<string, unknown>).some(
+          (k) =>
+            !k.startsWith("__") &&
+            (labelsMatchLoose(humanize(k), nextCrumb) ||
+              labelsMatchLoose(k, nextCrumb)),
+        );
+        if (hasInnerMatch) return key;
+      }
+    }
+
+    if (!blockRefFallback) blockRefFallback = key;
   }
+  if (blockRefFallback) return blockRefFallback;
 
   return null;
 }

--- a/apps/mesh/src/web/components/sections-editor/schema-form.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { inferBlockRefArrayItemSchema } from "./block-ref-array-inference";
+
+describe("inferBlockRefArrayItemSchema", () => {
+  test("infers string, number, boolean from first item", () => {
+    const items = [{ label: "Sale", count: 3, active: true }];
+    const schema = inferBlockRefArrayItemSchema(items);
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        label: { type: "string" },
+        count: { type: "number" },
+        active: { type: "boolean" },
+      },
+    });
+  });
+
+  test("skips keys starting with __", () => {
+    const items = [{ __resolveType: "loader.ts", name: "Product" }];
+    const schema = inferBlockRefArrayItemSchema(items);
+    expect(schema).toEqual({
+      type: "object",
+      properties: { name: { type: "string" } },
+    });
+  });
+
+  test("returns undefined for empty array", () => {
+    expect(inferBlockRefArrayItemSchema([])).toBeUndefined();
+  });
+
+  test("returns undefined when first item is null", () => {
+    expect(inferBlockRefArrayItemSchema([null])).toBeUndefined();
+  });
+
+  test("returns undefined when first item is a primitive", () => {
+    expect(inferBlockRefArrayItemSchema(["hello"])).toBeUndefined();
+    expect(inferBlockRefArrayItemSchema([42])).toBeUndefined();
+  });
+
+  test("returns undefined when first item is a nested array", () => {
+    expect(inferBlockRefArrayItemSchema([[1, 2]])).toBeUndefined();
+  });
+
+  test("skips nested objects and arrays in properties", () => {
+    const items = [{ name: "A", nested: { x: 1 }, tags: ["a", "b"] }];
+    const schema = inferBlockRefArrayItemSchema(items);
+    expect(schema).toEqual({
+      type: "object",
+      properties: { name: { type: "string" } },
+    });
+  });
+
+  test("returns undefined when all keys are internal (__prefixed)", () => {
+    const items = [{ __resolveType: "X", __id: "123" }];
+    expect(inferBlockRefArrayItemSchema(items)).toBeUndefined();
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -21,6 +21,7 @@ import {
   fieldDisplayLabel,
   resolveActiveFieldKey,
 } from "./schema-form-breadcrumb";
+import { inferBlockRefArrayItemSchema } from "./block-ref-array-inference";
 
 /** Skip internal deco properties that shouldn't be user-editable. */
 const HIDDEN_PROPS = new Set(["__resolveType", "@type"]);
@@ -132,20 +133,7 @@ export function renderField(props: FieldProps) {
     !isMultivariateArrayWrapper(value) &&
     schema.type === "block-ref"
   ) {
-    const first = value.length > 0 ? value[0] : undefined;
-    let items: SchemaProperty | undefined;
-    if (first != null && typeof first === "object" && !Array.isArray(first)) {
-      const properties: Record<string, SchemaProperty> = {};
-      for (const [k, v] of Object.entries(first as Record<string, unknown>)) {
-        if (k.startsWith("__")) continue;
-        if (typeof v === "string") properties[k] = { type: "string" };
-        else if (typeof v === "number") properties[k] = { type: "number" };
-        else if (typeof v === "boolean") properties[k] = { type: "boolean" };
-      }
-      if (Object.keys(properties).length > 0) {
-        items = { type: "object", properties };
-      }
-    }
+    const items = inferBlockRefArrayItemSchema(value);
     if (items) {
       const arraySchema: SchemaProperty = { ...schema, type: "array", items };
       return (

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -25,49 +25,6 @@ import {
 /** Skip internal deco properties that shouldn't be user-editable. */
 const HIDDEN_PROPS = new Set(["__resolveType", "@type"]);
 
-/**
- * Build a SchemaProperty from a runtime value so data-only fields
- * (present in page data but absent from the _meta schema) can be edited.
- *
- * When `hints` is provided (a map of known property schemas), matching keys
- * in an inferred object will use the hint's full definition (preserving
- * format, title, description, etc.) instead of a bare type-only schema.
- * This lets data-only arrays like `textSeo` inherit the parent schema's
- * rich-text format, descriptions, and labels for their items.
- */
-export function inferSchemaFromValue(
-  val: unknown,
-  hints?: Record<string, SchemaProperty>,
-): SchemaProperty | undefined {
-  if (val === null || val === undefined) return undefined;
-  if (typeof val === "string") return { type: "string" };
-  if (typeof val === "number") return { type: "number" };
-  if (typeof val === "boolean") return { type: "boolean" };
-  if (Array.isArray(val)) {
-    const items =
-      val.length > 0 ? inferSchemaFromValue(val[0], hints) : undefined;
-    return { type: "array", items };
-  }
-  if (typeof val === "object") {
-    const properties: Record<string, SchemaProperty> = {};
-    for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
-      if (k.startsWith("__")) continue;
-      // Use the hint schema when available — it carries format, title,
-      // description, and other metadata that inference alone can't produce.
-      const hint = hints?.[k];
-      if (hint) {
-        properties[k] = hint;
-      } else {
-        const prop = inferSchemaFromValue(v);
-        if (prop) properties[k] = prop;
-      }
-    }
-    if (Object.keys(properties).length === 0) return undefined;
-    return { type: "object", properties };
-  }
-  return undefined;
-}
-
 function multivariateMediaKind(
   schema: SchemaProperty,
 ): "image" | "file" | null {
@@ -166,16 +123,29 @@ export function renderField(props: FieldProps) {
     }
   }
 
-  // Block-ref schema but the actual value is a plain array (not a
-  // multivariate wrapper). Infer item schema from the first element and
-  // render as ArrayField so items like menuItems [{target,href,label}]
-  // become an editable draggable list.
+  // Block-ref schema but the actual value is already a resolved plain array
+  // (not a multivariate wrapper).  The loader has been evaluated and the page
+  // data holds the concrete items — render as ArrayField so users can edit
+  // them directly (e.g. menuItems [{target,href,label}]).
   if (
     Array.isArray(value) &&
     !isMultivariateArrayWrapper(value) &&
     schema.type === "block-ref"
   ) {
-    const items = value.length > 0 ? inferSchemaFromValue(value[0]) : undefined;
+    const first = value.length > 0 ? value[0] : undefined;
+    let items: SchemaProperty | undefined;
+    if (first != null && typeof first === "object" && !Array.isArray(first)) {
+      const properties: Record<string, SchemaProperty> = {};
+      for (const [k, v] of Object.entries(first as Record<string, unknown>)) {
+        if (k.startsWith("__")) continue;
+        if (typeof v === "string") properties[k] = { type: "string" };
+        else if (typeof v === "number") properties[k] = { type: "number" };
+        else if (typeof v === "boolean") properties[k] = { type: "boolean" };
+      }
+      if (Object.keys(properties).length > 0) {
+        items = { type: "object", properties };
+      }
+    }
     if (items) {
       const arraySchema: SchemaProperty = { ...schema, type: "array", items };
       return (
@@ -348,50 +318,7 @@ export function SchemaForm({
     (k) => !HIDDEN_PROPS.has(k) && properties[k]?.hidden !== true,
   );
 
-  // Gather data-only keys: present in the value but not declared in
-  // the schema. This makes fields like `textSeo` (present in page data
-  // but absent from the _meta schema) visible and editable.
-  const dataOnlyKeys = Object.keys(objValue).filter(
-    (k) =>
-      !HIDDEN_PROPS.has(k) &&
-      !k.startsWith("__") &&
-      !properties[k] &&
-      objValue[k] !== undefined,
-  );
-  const dataOnlySchemas: Record<string, SchemaProperty> = {};
-  for (const k of dataOnlyKeys) {
-    // Pass the schema's own properties as hints so that data-only arrays
-    // whose items share property names with the schema (e.g. `textSeo`
-    // items have `matcher`, `title`, `description` matching the schema's
-    // flat properties) inherit format, title, description, and other
-    // metadata — e.g. `format: "rich-text"` on the `title` field.
-    const inferred = inferSchemaFromValue(objValue[k], properties);
-    if (!inferred) continue;
-    // When the inferred field is an array whose items matched schema hints,
-    // also propagate `titleBy` from the parent schema so that the array
-    // item label uses the right key (e.g. `matcher` instead of `title`
-    // which may contain raw HTML).
-    if (inferred.type === "array" && inferred.items && schema.titleBy) {
-      inferred.items = { ...inferred.items, titleBy: schema.titleBy };
-    }
-    dataOnlySchemas[k] = inferred;
-  }
-  const allDataOnlyKeys = dataOnlyKeys.filter((k) => dataOnlySchemas[k]);
-
-  // When ALL schema-defined field values are empty but data-only keys
-  // contain the actual data (e.g. CategoryTextHero defines flat
-  // `matcher, title, description, max` but the data wraps them in
-  // `textSeo: [{matcher, title, description}]`), hide the empty schema
-  // fields so the user only sees the populated data-only fields.
-  const schemaFieldsAllEmpty =
-    allDataOnlyKeys.length > 0 &&
-    keys.every((k) => {
-      const v = objValue[k];
-      return v === undefined || v === null || v === "";
-    });
-  const effectiveSchemaKeys = schemaFieldsAllEmpty ? [] : keys;
-
-  if (effectiveSchemaKeys.length === 0 && allDataOnlyKeys.length === 0) {
+  if (keys.length === 0) {
     return (
       <div className="px-3 py-6 text-center text-xs text-muted-foreground">
         No editable fields on this section.
@@ -408,18 +335,12 @@ export function SchemaForm({
       ? objValue.__resolveType
       : undefined;
 
-  const allKeys = [...effectiveSchemaKeys, ...allDataOnlyKeys];
-  const allProperties: Record<string, SchemaProperty> = {
-    ...properties,
-    ...dataOnlySchemas,
-  };
-
   const activeKey =
     breadcrumbPath.length > 0
-      ? resolveActiveFieldKey(allKeys, allProperties, objValue, breadcrumbPath)
+      ? resolveActiveFieldKey(keys, properties, objValue, breadcrumbPath)
       : null;
-  const activeSchema = activeKey ? allProperties[activeKey] : null;
-  const visibleKeys = activeKey && activeSchema ? [activeKey] : allKeys;
+  const activeSchema = activeKey ? properties[activeKey] : null;
+  const visibleKeys = activeKey && activeSchema ? [activeKey] : keys;
   const fieldBreadcrumbPath =
     activeKey && activeSchema
       ? breadcrumbPathForActiveField(activeKey, activeSchema, breadcrumbPath)
@@ -427,7 +348,7 @@ export function SchemaForm({
   return (
     <div className="min-w-0 space-y-6">
       {visibleKeys.map((key) => {
-        const propSchema = allProperties[key];
+        const propSchema = properties[key];
         if (!propSchema) return null;
         const fieldPath = basePath ? `${basePath}.${key}` : key;
         const label = fieldDisplayLabel(key, propSchema);

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -25,6 +25,49 @@ import {
 /** Skip internal deco properties that shouldn't be user-editable. */
 const HIDDEN_PROPS = new Set(["__resolveType", "@type"]);
 
+/**
+ * Build a SchemaProperty from a runtime value so data-only fields
+ * (present in page data but absent from the _meta schema) can be edited.
+ *
+ * When `hints` is provided (a map of known property schemas), matching keys
+ * in an inferred object will use the hint's full definition (preserving
+ * format, title, description, etc.) instead of a bare type-only schema.
+ * This lets data-only arrays like `textSeo` inherit the parent schema's
+ * rich-text format, descriptions, and labels for their items.
+ */
+export function inferSchemaFromValue(
+  val: unknown,
+  hints?: Record<string, SchemaProperty>,
+): SchemaProperty | undefined {
+  if (val === null || val === undefined) return undefined;
+  if (typeof val === "string") return { type: "string" };
+  if (typeof val === "number") return { type: "number" };
+  if (typeof val === "boolean") return { type: "boolean" };
+  if (Array.isArray(val)) {
+    const items =
+      val.length > 0 ? inferSchemaFromValue(val[0], hints) : undefined;
+    return { type: "array", items };
+  }
+  if (typeof val === "object") {
+    const properties: Record<string, SchemaProperty> = {};
+    for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
+      if (k.startsWith("__")) continue;
+      // Use the hint schema when available — it carries format, title,
+      // description, and other metadata that inference alone can't produce.
+      const hint = hints?.[k];
+      if (hint) {
+        properties[k] = hint;
+      } else {
+        const prop = inferSchemaFromValue(v);
+        if (prop) properties[k] = prop;
+      }
+    }
+    if (Object.keys(properties).length === 0) return undefined;
+    return { type: "object", properties };
+  }
+  return undefined;
+}
+
 function multivariateMediaKind(
   schema: SchemaProperty,
 ): "image" | "file" | null {
@@ -111,6 +154,30 @@ export function renderField(props: FieldProps) {
   ) {
     const arraySchema = arraySchemaForValue(schema);
     if (arraySchema) {
+      return (
+        <ArrayField
+          key={props.path}
+          {...props}
+          schema={arraySchema}
+          value={value}
+          onChange={props.onChange}
+        />
+      );
+    }
+  }
+
+  // Block-ref schema but the actual value is a plain array (not a
+  // multivariate wrapper). Infer item schema from the first element and
+  // render as ArrayField so items like menuItems [{target,href,label}]
+  // become an editable draggable list.
+  if (
+    Array.isArray(value) &&
+    !isMultivariateArrayWrapper(value) &&
+    schema.type === "block-ref"
+  ) {
+    const items = value.length > 0 ? inferSchemaFromValue(value[0]) : undefined;
+    if (items) {
+      const arraySchema: SchemaProperty = { ...schema, type: "array", items };
       return (
         <ArrayField
           key={props.path}
@@ -281,7 +348,50 @@ export function SchemaForm({
     (k) => !HIDDEN_PROPS.has(k) && properties[k]?.hidden !== true,
   );
 
-  if (keys.length === 0) {
+  // Gather data-only keys: present in the value but not declared in
+  // the schema. This makes fields like `textSeo` (present in page data
+  // but absent from the _meta schema) visible and editable.
+  const dataOnlyKeys = Object.keys(objValue).filter(
+    (k) =>
+      !HIDDEN_PROPS.has(k) &&
+      !k.startsWith("__") &&
+      !properties[k] &&
+      objValue[k] !== undefined,
+  );
+  const dataOnlySchemas: Record<string, SchemaProperty> = {};
+  for (const k of dataOnlyKeys) {
+    // Pass the schema's own properties as hints so that data-only arrays
+    // whose items share property names with the schema (e.g. `textSeo`
+    // items have `matcher`, `title`, `description` matching the schema's
+    // flat properties) inherit format, title, description, and other
+    // metadata — e.g. `format: "rich-text"` on the `title` field.
+    const inferred = inferSchemaFromValue(objValue[k], properties);
+    if (!inferred) continue;
+    // When the inferred field is an array whose items matched schema hints,
+    // also propagate `titleBy` from the parent schema so that the array
+    // item label uses the right key (e.g. `matcher` instead of `title`
+    // which may contain raw HTML).
+    if (inferred.type === "array" && inferred.items && schema.titleBy) {
+      inferred.items = { ...inferred.items, titleBy: schema.titleBy };
+    }
+    dataOnlySchemas[k] = inferred;
+  }
+  const allDataOnlyKeys = dataOnlyKeys.filter((k) => dataOnlySchemas[k]);
+
+  // When ALL schema-defined field values are empty but data-only keys
+  // contain the actual data (e.g. CategoryTextHero defines flat
+  // `matcher, title, description, max` but the data wraps them in
+  // `textSeo: [{matcher, title, description}]`), hide the empty schema
+  // fields so the user only sees the populated data-only fields.
+  const schemaFieldsAllEmpty =
+    allDataOnlyKeys.length > 0 &&
+    keys.every((k) => {
+      const v = objValue[k];
+      return v === undefined || v === null || v === "";
+    });
+  const effectiveSchemaKeys = schemaFieldsAllEmpty ? [] : keys;
+
+  if (effectiveSchemaKeys.length === 0 && allDataOnlyKeys.length === 0) {
     return (
       <div className="px-3 py-6 text-center text-xs text-muted-foreground">
         No editable fields on this section.
@@ -298,12 +408,18 @@ export function SchemaForm({
       ? objValue.__resolveType
       : undefined;
 
+  const allKeys = [...effectiveSchemaKeys, ...allDataOnlyKeys];
+  const allProperties: Record<string, SchemaProperty> = {
+    ...properties,
+    ...dataOnlySchemas,
+  };
+
   const activeKey =
     breadcrumbPath.length > 0
-      ? resolveActiveFieldKey(keys, properties, objValue, breadcrumbPath)
+      ? resolveActiveFieldKey(allKeys, allProperties, objValue, breadcrumbPath)
       : null;
-  const activeSchema = activeKey ? properties[activeKey] : null;
-  const visibleKeys = activeKey && activeSchema ? [activeKey] : keys;
+  const activeSchema = activeKey ? allProperties[activeKey] : null;
+  const visibleKeys = activeKey && activeSchema ? [activeKey] : allKeys;
   const fieldBreadcrumbPath =
     activeKey && activeSchema
       ? breadcrumbPathForActiveField(activeKey, activeSchema, breadcrumbPath)
@@ -311,7 +427,7 @@ export function SchemaForm({
   return (
     <div className="min-w-0 space-y-6">
       {visibleKeys.map((key) => {
-        const propSchema = properties[key];
+        const propSchema = allProperties[key];
         if (!propSchema) return null;
         const fieldPath = basePath ? `${basePath}.${key}` : key;
         const label = fieldDisplayLabel(key, propSchema);


### PR DESCRIPTION
## Summary

Two fixes for CMS Studio editing of sections that use loader props (e.g. `SearchResult.page: ProductListingPage`) in `@decocms/start` sites (bagaggio-tanstack, granadobr-tanstack).

### `resolve-schema.ts` — extract resolveType from flat loader definitions

`@decocms/start >=6.10` generates loader definitions with `__resolveType.enum` directly in `properties` (not nested under `allOf`). The `allRefs` block in `buildProperty` was falling back to the base64 definition key instead of the real resolveType (e.g. `site/loaders/deliveryPromiseProductListingPage.ts`), causing duplicate entries in the AnyOf dropdown.

Now also checks `def.properties.__resolveType.enum` directly, so the correct resolveType is extracted from flat definitions.

### `any-of-field.tsx` — isolate loader breadcrumb from section breadcrumb

When a user drilled into an array item inside a loader config (e.g. `selectedFacets` → Item 1), `onBreadcrumbChange` propagated the loader-internal path (e.g. `['selectedFacets', '0']`) to the outer section-editor breadcrumb. Since that path has no match in the section's top-level schema (SearchResult has `page`, `sections`, `layout`… not `selectedFacets`), the form showed ALL fields instead of just the focused item.

Module loaders now manage their breadcrumb state locally (`loaderBreadcrumbs`) so navigation inside a loader config stays self-contained and doesn't pollute the outer form.

## Related

- [DECO-5295](https://linear.app/decocms/issue/DECO-5295) — CMS Studio form vazio para seções inline (bagaggio-tanstack)
- [DECO-5296](https://linear.app/decocms/issue/DECO-5296) — @decocms/start: gerar schemas de loaders para o admin CMS

## Test plan

- [ ] Open CMS Studio against bagaggio/granado (with @decocms/start 6.10.2)
- [ ] SearchResult → Página de Listagem → loader dropdown shows correct name (not base64)
- [ ] Click into selectedFacets → Item 1 → form shows only Key + Value, no surrounding section fields
- [ ] CategoryBanner, Header, Footer (saved blocks) still work without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CMS Studio editing for loader props in `@decocms/start` 6.10+: correct resolve types, hidden fields honored, predictable breadcrumbs, and clearer labels (including Lazy and rich‑text); adds a rich‑text editor, safe link handling, and editing for resolved plain arrays from block‑refs. Addresses DECO-5295, DECO-5296, and DECO-5297.

- **Bug Fixes**
  - Schema resolution: read `properties.__resolveType.enum` in flat loader defs to avoid base64 `$ref` fallback and duplicate AnyOf options.
  - Hidden block-ref fields: propagate `hidden` on all block-ref returns so `hide: "true"` props don’t show.
  - Breadcrumbs: module-loader unions use the field label; strip/add the outer crumb when drilling; match by label or key; disambiguate same‑label block‑refs by checking inner value keys; collapse/restore outer form correctly.
  - Labels and Lazy: use filename for loader dropdowns; label Section[] items by the inner section; ignore whitespace-only titles; strip HTML from rich‑text titles; use `key` as fallback; bind the unwrapped inner `section` and re-wrap on change.
  - Block-ref arrays: when a value is a resolved plain array, render it as an editable `ArrayField`.
  - Rich‑text links: validate URLs and block `javascript:`, `data:`, and `vbscript:`.

- **New Features**
  - Rich‑text editor for `rich-text`, `rich-text-inline`, and `html`.

<sup>Written for commit c9649d332b20b1d7d2365a6d8a74c7af5e7e2a37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

