### PR TITLE
fix(web-nginx): don't cache asset 404s as immutable for a year

### DIFF
--- a/deploy/helm/studio/files/web-nginx.conf.template
+++ b/deploy/helm/studio/files/web-nginx.conf.template
@@ -70,8 +70,12 @@ server {
   }
 
   # Hashed assets are content-addressed → cache forever.
+  # No `always`: the immutable header must apply only to 2xx/3xx, never to the
+  # =404 below. With `always`, a chunk that's briefly missing during a rollout
+  # returns `404 + immutable, max-age=1y`, which Cloudflare/browsers then cache
+  # for a year — poisoning that asset URL permanently (stale-chunk loop).
   location /assets/ {
-    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri =404;
   }
 


### PR DESCRIPTION
## Problem
Staging got stuck on the SPA's "New version available" screen for **all users**, in a refresh loop. Network tab showed lazy chunks like `/assets/connection-form-helpers-*.js` returning:

```
Status: 404 Not Found (from disk cache)
Cf-Cache-Status: HIT
Content-Type: text/html
Cache-Control: public, max-age=31536000, immutable
```

A **404 cached as `immutable, max-age=1y`**. Cloudflare (and the browser disk cache) served it for a year, so even after the pods had the chunks, the asset URL kept 404ing → `Failed to fetch dynamically imported module` → `ChunkErrorBoundary` → permanent loop.

## Cause
`deploy/helm/studio/files/web-nginx.conf.template`:

```nginx
location /assets/ {
  add_header Cache-Control "public, max-age=31536000, immutable" always;  # <-- always
  try_files $uri =404;
}
```

`add_header ... always` attaches the header to **every** response status — including the `=404`. During a rollout, a request for a chunk that a pod doesn't have yet returns `404 + immutable, max-age=1y`, which gets cached for a year.

## Fix
Drop `always`. Without it, `add_header` applies only to 2xx/3xx (nginx default), so the immutable header lands on real `200` assets but never on the `=404`. Transient rollout 404s are no longer cached long-term.

## Note / immediate remediation
This prevents recurrence. To clear the **already-poisoned** entries, the Cloudflare cache for `studio-stg.decocms.com` (prefix `/assets/`) must be purged once — the year-long cached 404s won't expire on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop caching `/assets` 404s as immutable by removing `always` from `add_header` in `web-nginx.conf.template`. This prevents year-long cached 404s that caused the SPA’s “New version available” loop during rollouts.

- **Migration**
  - Purge the Cloudflare cache for `studio-stg.decocms.com` (prefix `/assets/`) to clear previously cached 404s.

<sup>Written for commit 44a55d006d5a79cd89209fca11aee8991e792bdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

