### PR TITLE
Migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,6 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+archive = "rm -rf node_modules"
+run = "bun run dev:conductor"
+setup = "bun install"

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,0 @@
-{
-  "scripts": {
-    "setup": "bun install",
-    "run": "bun run dev:conductor",
-    "archive": "rm -rf node_modules"
-  }
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated repo config from `conductor.json` to `.conductor/settings.toml` using the Conductor Settings v2 schema. Added `$schema` reference and kept scripts unchanged: `setup` (`bun install`), `run` (`bun run dev:conductor`), `archive` (`rm -rf node_modules`).

<sup>Written for commit b9d508a6bdc959231b76dcb9f57abdd17d51f495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

