### PR TITLE
fix(cms): list and edit Tanstack installed apps in Content tab

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/app-catalog.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/app-catalog.test.ts
@@ -138,4 +138,33 @@ describe("app-catalog", () => {
       app: "vtex",
     });
   });
+
+  it("lists installed custom/local apps without manifest or store entries", () => {
+    const emptyMeta: LiveMeta = {
+      manifest: { blocks: { apps: { anyOf: [] } } },
+      schema: {},
+    };
+    const decofile = {
+      "app-tags": {
+        __resolveType: "site/apps/local/app-tags.ts",
+        account: "lojabagaggio",
+      },
+    };
+
+    const catalog = buildAppCatalog([], emptyMeta, decofile);
+
+    expect(catalog).toEqual([
+      {
+        id: "local-app-tags",
+        app: "app-tags",
+        vendor: "local",
+        title: "App Tags",
+        description: "",
+        category: "Custom",
+        resolveType: "site/apps/local/app-tags.ts",
+        blockKey: "app-tags",
+        installed: true,
+      },
+    ]);
+  });
 });

--- a/apps/mesh/src/web/components/sandbox/content/app-catalog.ts
+++ b/apps/mesh/src/web/components/sandbox/content/app-catalog.ts
@@ -1,9 +1,10 @@
 import {
   isSiteAppBlock,
   SITE_APP_RESOLVE_TYPE,
-  type AppEntry,
+  appLabel,
 } from "@/web/components/sections-editor/page-list";
 import {
+  isDecoAppResolveType,
   resolveBlockSchemaMetadata,
   type LiveMeta,
 } from "@/web/components/sections-editor/resolve-schema";
@@ -53,6 +54,18 @@ export function parseAppResolveType(
     return { vendor: legacyMatch[1]!, app: legacyMatch[2]! };
   }
   return null;
+}
+
+function parseAppIdentityFromBlockKey(
+  blockKey: string,
+): { vendor: string; app: string } | null {
+  const blockIdMatch = blockKey.match(/^([^-]+)-(.+)$/);
+  if (!blockIdMatch) return null;
+  return { vendor: blockIdMatch[1]!, app: blockIdMatch[2]! };
+}
+
+function installedAppCategory(vendor: string): string {
+  return vendor === "local" ? "Custom" : "Installed";
 }
 
 function findInstalledBlockKey(
@@ -126,6 +139,37 @@ function catalogEntryFromManifestApp(
   };
 }
 
+function catalogEntryFromInstalledBlock(
+  blockKey: string,
+  block: Record<string, unknown>,
+  meta: LiveMeta,
+): AppCatalogEntry | null {
+  const resolveType = block.__resolveType;
+  if (typeof resolveType !== "string") return null;
+  if (isSiteAppBlock(blockKey, block)) return null;
+  if (!isDecoAppResolveType(resolveType)) return null;
+
+  const parsed =
+    parseAppResolveType(resolveType) ?? parseAppIdentityFromBlockKey(blockKey);
+  if (!parsed) return null;
+
+  const metadata = resolveBlockSchemaMetadata(resolveType, meta);
+  const { vendor, app } = parsed;
+
+  return {
+    id: appBlockId(vendor, app),
+    app,
+    vendor,
+    title: metadata.title ?? appLabel(blockKey, block, meta),
+    description: metadata.description ?? "",
+    category: installedAppCategory(vendor),
+    logo: metadata.logo ?? metadata.icon,
+    resolveType,
+    blockKey,
+    installed: true,
+  };
+}
+
 /**
  * Merges the deco app store, manifest schema apps, and installed decofile
  * blocks — mirrors admin's Apps view data sources.
@@ -149,23 +193,18 @@ export function buildAppCatalog(
     byId.set(entry.id, entry);
   }
 
-  // Installed apps missing from store/schema (legacy block ids, local apps).
-  for (const installed of listInstalledAppEntries(decofile, meta)) {
-    const parsed = parseAppResolveType(installed.resolveType);
-    if (!parsed) continue;
-    const id = appBlockId(parsed.vendor, parsed.app);
-    if (byId.has(id)) continue;
-    byId.set(id, {
-      id,
-      app: parsed.app,
-      vendor: parsed.vendor,
-      title: installed.name,
-      description: "",
-      category: "Installed",
-      resolveType: installed.resolveType,
-      blockKey: installed.key,
-      installed: true,
-    });
+  // Installed custom/local apps and legacy block ids missing from store + manifest.
+  for (const [blockKey, val] of Object.entries(decofile)) {
+    if (blockKey.includes("/")) continue;
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+
+    const entry = catalogEntryFromInstalledBlock(
+      blockKey,
+      val as Record<string, unknown>,
+      meta,
+    );
+    if (!entry || byId.has(entry.id)) continue;
+    byId.set(entry.id, entry);
   }
 
   return [...byId.values()].sort(compareAppCatalogEntries);
@@ -179,53 +218,4 @@ function compareAppCatalogEntries(
     return a.installed ? -1 : 1;
   }
   return a.title.localeCompare(b.title);
-}
-
-function manifestHasApp(meta: LiveMeta, vendor: string, app: string): boolean {
-  const apps = meta.manifest?.blocks?.apps ?? {};
-  for (const alias of [
-    appResolveType(vendor, app),
-    `site/apps/${vendor}/${app}.tsx`,
-    `${vendor}/apps/${app}.ts`,
-    `${vendor}/apps/${app}.tsx`,
-  ]) {
-    if (alias in apps) return true;
-  }
-  return false;
-}
-
-function listInstalledAppEntries(
-  decofile: Record<string, unknown>,
-  meta: LiveMeta,
-): AppEntry[] {
-  const entries: AppEntry[] = [];
-
-  for (const [key, val] of Object.entries(decofile)) {
-    if (key.includes("/")) continue;
-    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
-
-    const obj = val as Record<string, unknown>;
-    const resolveType = obj.__resolveType;
-    if (typeof resolveType !== "string") continue;
-    if (isSiteAppBlock(key, obj)) continue;
-
-    const parsed =
-      parseAppResolveType(resolveType) ??
-      (() => {
-        const blockIdMatch = key.match(/^([^-]+)-(.+)$/);
-        return blockIdMatch
-          ? { vendor: blockIdMatch[1]!, app: blockIdMatch[2]! }
-          : null;
-      })();
-
-    if (!parsed || !manifestHasApp(meta, parsed.vendor, parsed.app)) continue;
-
-    entries.push({
-      key,
-      name: key.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
-      resolveType,
-    });
-  }
-
-  return entries;
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -1,3 +1,21 @@
+import { useState } from "react";
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { DotsGrid, DotsHorizontal, Plus, Trash01 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
@@ -6,11 +24,103 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
 import { getArrayItemImageSrc, getArrayItemLabel } from "../array-item-display";
 import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import { resolveArrayItemSelection } from "../schema-form-breadcrumb";
 import type { FieldProps } from "./field-props";
 import { SchemaForm, renderField } from "../schema-form";
+
+function sortableIdFor(path: string, index: number): string {
+  return `${path}::${index}`;
+}
+
+function SortableArrayRow({
+  sortableId,
+  labelText,
+  imageSrc,
+  onOpen,
+  onRemove,
+}: {
+  sortableId: string;
+  labelText: string;
+  imageSrc?: string;
+  onOpen: () => void;
+  onRemove: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useSortable({
+      id: sortableId,
+      animateLayoutChanges: () => false,
+    });
+
+  const style = {
+    transform: CSS.Transform.toString(
+      transform ? { ...transform, x: 0 } : null,
+    ),
+    opacity: isDragging ? 0.4 : undefined,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground",
+        isDragging && "bg-accent/50",
+      )}
+    >
+      <button
+        type="button"
+        className="shrink-0 cursor-grab touch-none text-muted-foreground/40 active:cursor-grabbing"
+        aria-label={`Reorder ${labelText}`}
+        {...attributes}
+        {...listeners}
+      >
+        <DotsGrid className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="flex min-w-0 flex-1 items-center gap-2.5 text-left text-sm"
+        title={labelText}
+      >
+        {imageSrc && (
+          <img
+            src={imageSrc}
+            alt=""
+            referrerPolicy="no-referrer"
+            className="h-12 max-w-[100px] shrink-0 rounded object-cover"
+          />
+        )}
+        <span className="min-w-0 truncate">{labelText}</span>
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Open actions for ${labelText}`}
+            className="size-6 opacity-0 transition-opacity group-hover:opacity-100"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DotsHorizontal size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={onRemove}
+          >
+            <Trash01 size={14} />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
 
 export function ArrayField({
   schema,
@@ -33,11 +143,13 @@ export function ArrayField({
     itemSchema,
   );
   const selectedIndex = selection?.index ?? null;
+  const [isDragging, setIsDragging] = useState(false);
 
   const itemLabel = (item: unknown, index: number) =>
     getArrayItemLabel(item, index, itemSchema);
 
   const openItem = (index: number) => {
+    if (isDragging) return;
     const labelText = itemLabel(items[index], index);
     onBreadcrumbChange?.([...breadcrumbPath, labelText]);
   };
@@ -98,6 +210,25 @@ export function ArrayField({
       }
       onBreadcrumbChange?.([...breadcrumbPath, labelText]);
     }
+  };
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const sortableIds = items.map((_, i) => sortableIdFor(path, i));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setIsDragging(false);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = sortableIds.indexOf(String(active.id));
+    const newIndex = sortableIds.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+    onChange(arrayMove([...items], oldIndex, newIndex));
   };
 
   if (selectedIndex !== null && selectedIndex < items.length) {
@@ -166,59 +297,35 @@ export function ArrayField({
       </div>
 
       {items.length > 0 && (
-        <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
-          {items.map((item, i) => {
-            const labelText = itemLabel(item, i);
-            const imageSrc = getArrayItemImageSrc(item, itemSchema);
-            return (
-              <div
-                key={`${path}.${i}`}
-                className="group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground"
-              >
-                <DotsGrid className="size-3.5 shrink-0 cursor-grab text-muted-foreground/40" />
-                <button
-                  type="button"
-                  onClick={() => openItem(i)}
-                  className="flex min-w-0 flex-1 items-center gap-2.5 text-left text-sm"
-                  title={labelText}
-                >
-                  {imageSrc && (
-                    <img
-                      src={imageSrc}
-                      alt=""
-                      referrerPolicy="no-referrer"
-                      className="h-12 max-w-[100px] shrink-0 rounded object-cover"
-                    />
-                  )}
-                  <span className="min-w-0 truncate">{labelText}</span>
-                </button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Open actions for ${labelText}`}
-                      className="size-6 opacity-0 transition-opacity group-hover:opacity-100"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <DotsHorizontal size={14} />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onClick={() => removeItem(i)}
-                    >
-                      <Trash01 size={14} />
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            );
-          })}
-        </div>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={() => setIsDragging(true)}
+          onDragEnd={handleDragEnd}
+          onDragCancel={() => setIsDragging(false)}
+        >
+          <SortableContext
+            items={sortableIds}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
+              {items.map((item, i) => {
+                const labelText = itemLabel(item, i);
+                const imageSrc = getArrayItemImageSrc(item, itemSchema);
+                return (
+                  <SortableArrayRow
+                    key={sortableIdFor(path, i)}
+                    sortableId={sortableIdFor(path, i)}
+                    labelText={labelText}
+                    imageSrc={imageSrc}
+                    onOpen={() => openItem(i)}
+                    onRemove={() => removeItem(i)}
+                  />
+                );
+              })}
+            </div>
+          </SortableContext>
+        </DndContext>
       )}
 
       <button

--- a/apps/mesh/src/web/components/sections-editor/fields/secret-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/secret-field.tsx
@@ -1,0 +1,81 @@
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import type { FieldProps } from "./field-props";
+
+const DEFAULT_SECRET_RESOLVE_TYPE = "website/loaders/secret.ts";
+
+export function isSecretBlock(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const resolveType = (value as Record<string, unknown>).__resolveType;
+  return (
+    typeof resolveType === "string" &&
+    (resolveType.endsWith("/secret.ts") ||
+      resolveType.includes("loaders/secret"))
+  );
+}
+
+function emptySecretBlock(): Record<string, unknown> {
+  return {
+    __resolveType: DEFAULT_SECRET_RESOLVE_TYPE,
+    name: "",
+    encrypted: "",
+  };
+}
+
+/**
+ * Deco stores API secrets as `website/loaders/secret.ts` blocks (`name` + `encrypted`).
+ * JSON Schema often marks these as `format: password` or `format: string` without `type`.
+ */
+export function SecretField({
+  schema,
+  value,
+  onChange,
+  label,
+  path,
+}: FieldProps) {
+  const block = isSecretBlock(value)
+    ? (value as Record<string, unknown>)
+    : emptySecretBlock();
+  const name = typeof block.name === "string" ? block.name : "";
+  const hasStoredSecret =
+    typeof block.encrypted === "string" && block.encrypted;
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={`${path}-name`} className="text-sm font-medium">
+        {label}
+      </Label>
+      {schema.description && (
+        <p className="text-xs text-muted-foreground">{schema.description}</p>
+      )}
+      <Input
+        id={`${path}-name`}
+        value={name}
+        placeholder="Secret name"
+        onChange={(e) => onChange({ ...block, name: e.target.value })}
+        className="h-10"
+      />
+      <Input
+        id={`${path}-value`}
+        type="password"
+        placeholder={
+          hasStoredSecret ? "Leave blank to keep current value" : "Secret value"
+        }
+        onChange={(e) => {
+          const next = e.target.value;
+          if (!next) {
+            onChange(block);
+            return;
+          }
+          onChange({ ...block, value: next });
+        }}
+        className="h-10"
+      />
+      {hasStoredSecret && (
+        <p className="text-xs text-muted-foreground">
+          A secret value is stored.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/page-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-list.tsx
@@ -1,4 +1,5 @@
 import {
+  isDecoAppResolveType,
   isResolvableManifestApp,
   resolveBlockSchemaMetadata,
   type LiveMeta,
@@ -159,7 +160,8 @@ export function findSiteAppEntry(
     const resolveType = obj.__resolveType;
     if (
       typeof resolveType === "string" &&
-      isResolvableManifestApp(meta, resolveType)
+      (isSiteAppBlock(SITE_APP_BLOCK_KEY, obj) ||
+        isResolvableManifestApp(meta, resolveType))
     ) {
       return {
         key: SITE_APP_BLOCK_KEY,
@@ -174,13 +176,17 @@ export function findSiteAppEntry(
     if (!val || typeof val !== "object" || Array.isArray(val)) continue;
 
     const obj = val as Record<string, unknown>;
-    if (obj.__resolveType !== SITE_APP_RESOLVE_TYPE) continue;
-    if (!isResolvableManifestApp(meta, SITE_APP_RESOLVE_TYPE)) continue;
+    if (!isSiteAppBlock(key, obj)) continue;
+
+    const resolveType =
+      typeof obj.__resolveType === "string"
+        ? obj.__resolveType
+        : SITE_APP_RESOLVE_TYPE;
 
     return {
       key,
       name: appLabel(key, obj, meta),
-      resolveType: SITE_APP_RESOLVE_TYPE,
+      resolveType,
     };
   }
 
@@ -204,7 +210,12 @@ export function extractApps(
     if (PAGE_RESOLVE_TYPES.has(resolveType)) continue;
     if (typeof obj.path === "string") continue;
     if (isSiteAppBlock(key, obj)) continue;
-    if (!isResolvableManifestApp(meta, resolveType)) continue;
+    if (
+      !isResolvableManifestApp(meta, resolveType) &&
+      !isDecoAppResolveType(resolveType)
+    ) {
+      continue;
+    }
 
     apps.push({
       key,

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -163,6 +163,42 @@ describe("resolveSchema – app resolveType aliases", () => {
     expect(resolved?.properties?.seo?.title).toBe("SEO");
   });
 
+  test("resolves tanstack app schemas from base64 definition keys", () => {
+    const resolveType = "site/apps/local/app-tags.ts";
+    const encoded = Buffer.from(resolveType).toString("base64");
+    const meta: LiveMeta = {
+      manifest: { blocks: {} },
+      schema: {
+        definitions: {
+          [encoded]: {
+            title: resolveType,
+            type: "object",
+            allOf: [
+              {
+                $ref: "#/definitions/AppTagsProps",
+              },
+            ],
+            properties: {
+              __resolveType: {
+                type: "string",
+                enum: [resolveType],
+              },
+            },
+          },
+          AppTagsProps: {
+            type: "object",
+            properties: {
+              account: { type: "string", title: "Account Name" },
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = resolveSchema(resolveType, meta);
+    expect(resolved?.properties?.account?.title).toBe("Account Name");
+  });
+
   test("prefers section array over page multivariate flag for site global", () => {
     const meta: LiveMeta = {
       manifest: {

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -71,6 +71,12 @@ function isArraySchemaBranch(schema: RawSchema): boolean {
 // `format` field natively this guard becomes a no-op.
 const VIDEO_WIDGET_REF_KEY = "VideoWidget";
 
+/** Base64 encode resolveType keys — browser-safe (btoa), Node fallback in tests. */
+function toBase64(str: string): string {
+  if (typeof btoa === "function") return btoa(str);
+  return Buffer.from(str).toString("base64");
+}
+
 function parseSiteAppResolveType(
   resolveType: string,
 ): { vendor: string; app: string } | null {
@@ -112,17 +118,35 @@ function lookupManifestBlockSchema(
   const parsed =
     parseSiteAppResolveType(resolveType) ??
     parseLegacyAppResolveType(resolveType);
-  if (!parsed) return {};
-
-  for (const alias of appManifestResolveTypeAliases(
-    parsed.vendor,
-    parsed.app,
-  )) {
-    for (const blockTypeMap of Object.values(allBlockTypes)) {
-      if (blockTypeMap[alias]) {
-        return blockTypeMap[alias] as RawSchema;
+  if (parsed) {
+    for (const alias of appManifestResolveTypeAliases(
+      parsed.vendor,
+      parsed.app,
+    )) {
+      for (const blockTypeMap of Object.values(allBlockTypes)) {
+        if (blockTypeMap[alias]) {
+          return blockTypeMap[alias] as RawSchema;
+        }
       }
     }
+  }
+
+  // Tanstack sites generate app schemas with base64-encoded resolveType keys
+  // (same convention as sections). Fall back when manifest.blocks.apps is empty.
+  const encodedResolveType = toBase64(resolveType);
+  for (const blockTypeMap of Object.values(allBlockTypes)) {
+    if (blockTypeMap[encodedResolveType]) {
+      return blockTypeMap[encodedResolveType] as RawSchema;
+    }
+  }
+
+  const globalSchema = meta.schema ?? {};
+  const defs = (globalSchema.$defs ?? globalSchema.definitions ?? {}) as Record<
+    string,
+    unknown
+  >;
+  if (defs[encodedResolveType]) {
+    return { $ref: `#/definitions/${encodedResolveType}` };
   }
 
   return {};
@@ -139,8 +163,31 @@ export function isResolvableManifestApp(
     parseLegacyAppResolveType(resolveType);
   if (!parsed) return false;
   const apps = meta.manifest?.blocks?.apps ?? {};
-  return appManifestResolveTypeAliases(parsed.vendor, parsed.app).some(
-    (alias) => alias in apps,
+  if (
+    appManifestResolveTypeAliases(parsed.vendor, parsed.app).some(
+      (alias) => alias in apps,
+    )
+  ) {
+    return true;
+  }
+  const encodedResolveType = toBase64(resolveType);
+  const defs = (meta.schema?.$defs ?? meta.schema?.definitions ?? {}) as Record<
+    string,
+    unknown
+  >;
+  return encodedResolveType in defs;
+}
+
+/**
+ * Whether resolveType is a deco app module path (site/apps or legacy vendor/apps),
+ * excluding the site app itself. Used to detect installed custom/local apps even
+ * when they are missing from manifest.blocks.apps.
+ */
+export function isDecoAppResolveType(resolveType: string): boolean {
+  if (resolveType === "site/apps/site.ts") return false;
+  return (
+    parseSiteAppResolveType(resolveType) !== null ||
+    parseLegacyAppResolveType(resolveType) !== null
   );
 }
 

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -614,6 +614,12 @@ export function resolveSchema(
           rawItems = resolveRef(rawItems.$ref);
         }
         itemsSchema = buildProperty(rawItems, depth + 1);
+        if (
+          typeof rawItems.title === "string" &&
+          rawItems.title.includes("{{")
+        ) {
+          itemsSchema.titleBy = rawItems.title;
+        }
       }
     }
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -9,6 +9,7 @@ import { ObjectField } from "./fields/object-field";
 import { AnyOfField } from "./fields/any-of-field";
 import { FileField } from "./fields/file-field";
 import { ImageField } from "./fields/image-field";
+import { isSecretBlock, SecretField } from "./fields/secret-field";
 import {
   isMultivariateArrayWrapper,
   isPageMultivariateSectionArrayField,
@@ -166,13 +167,31 @@ export function renderField(props: FieldProps) {
     return <AnyOfField key={props.path} {...props} />;
   }
 
+  // Deco API secrets are stored as loader blocks, not plain strings.
+  if (
+    isSecretBlock(value) ||
+    schema.format === "password" ||
+    (value == null && schema.format === "password")
+  ) {
+    return <SecretField key={props.path} {...props} />;
+  }
+
   // If value is null/undefined, try to produce a typed default from schema
   const effectiveValue =
     value === null || value === undefined
       ? defaultForType(schema.type, schema.default)
       : value;
 
-  if (effectiveValue === null || effectiveValue === undefined) return null;
+  if (effectiveValue === null || effectiveValue === undefined) {
+    if (isSecretBlock(value)) {
+      return <SecretField key={props.path} {...props} />;
+    }
+    return null;
+  }
+
+  if (isSecretBlock(effectiveValue)) {
+    return <SecretField key={props.path} {...props} value={effectiveValue} />;
+  }
 
   const effectiveProps = { ...props, value: effectiveValue };
 


### PR DESCRIPTION
## Summary

- **App catalog**: merge installed apps from store, `manifest.blocks.apps`, and decofile scan (custom/local apps) without a `manifestHasApp` gate.
- **Schema resolution**: use `btoa` instead of `Buffer` for base64 defs lookup (fixes `Buffer is not defined` in the browser); support legacy `resolveType` aliases via `isDecoAppResolveType`.
- **Page list**: find site app entries with `isSiteAppBlock` and allow app extraction when resolve type matches without requiring manifest presence.

Part of the Tanstack CMS apps stack alongside:
- deco-start https://github.com/decocms/deco-start/pull/257
- apps-start https://github.com/decocms/apps-start/pull/79
- baggagio-tanstack https://github.com/deco-sites/bagaggio-tanstack/pull/141

## Test plan

- [x] `bun test apps/mesh/src/web/components/sandbox/content/app-catalog.test.ts apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts`
- [ ] Open baggagio sandbox → Content → Apps tab lists VTEX, site, blog, etc.
- [ ] Edit app props in Studio without browser crash on schema lookup


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CMS Content → Apps now lists and lets you edit installed Tanstack apps, including custom/local ones, even when missing from `manifest.blocks.apps`. Adds secret field support and drag‑to‑reorder for array fields in app forms, with safer, browser‑friendly schema resolution.

- **New Features**
  - Merge app catalog from store, `manifest.blocks.apps`, and `decofile` (no gate).
  - Detect and include custom/local apps via block key or resolveType; label as “Custom” or “Installed”.
  - Render `website/loaders/secret.ts` blocks as password fields and keep existing secrets unless a new value is set.
  - Enable drag‑to‑reorder on schema array fields; prevent item open while dragging.
  - Improve app and array item labels using `appLabel` and support `{{...}}` titles via `titleBy`.

- **Bug Fixes**
  - Use `btoa` base64 lookup for schema definitions to avoid `Buffer is not defined` in the browser.
  - Resolve app schemas via base64 keys and legacy resolveType aliases for Tanstack sites, including when only in global schema definitions.

<sup>Written for commit 14703892997e2c57e36c68e1f07f8825a4abafab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

