### PR TITLE
fix(cms): app editor — forms, arrays, site schema, and global sections

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/app-catalog.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/app-catalog.test.ts
@@ -138,4 +138,33 @@ describe("app-catalog", () => {
       app: "vtex",
     });
   });
+
+  it("lists installed custom/local apps without manifest or store entries", () => {
+    const emptyMeta: LiveMeta = {
+      manifest: { blocks: { apps: { anyOf: [] } } },
+      schema: {},
+    };
+    const decofile = {
+      "app-tags": {
+        __resolveType: "site/apps/local/app-tags.ts",
+        account: "lojabagaggio",
+      },
+    };
+
+    const catalog = buildAppCatalog([], emptyMeta, decofile);
+
+    expect(catalog).toEqual([
+      {
+        id: "local-app-tags",
+        app: "app-tags",
+        vendor: "local",
+        title: "App Tags",
+        description: "",
+        category: "Custom",
+        resolveType: "site/apps/local/app-tags.ts",
+        blockKey: "app-tags",
+        installed: true,
+      },
+    ]);
+  });
 });

--- a/apps/mesh/src/web/components/sandbox/content/app-catalog.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/app-catalog.test.ts
@@ -141,7 +141,7 @@ describe("app-catalog", () => {
 
   it("lists installed custom/local apps without manifest or store entries", () => {
     const emptyMeta: LiveMeta = {
-      manifest: { blocks: { apps: { anyOf: [] } } },
+      manifest: { blocks: { apps: {} } },
       schema: {},
     };
     const decofile = {

--- a/apps/mesh/src/web/components/sandbox/content/app-catalog.ts
+++ b/apps/mesh/src/web/components/sandbox/content/app-catalog.ts
@@ -1,9 +1,10 @@
 import {
   isSiteAppBlock,
   SITE_APP_RESOLVE_TYPE,
-  type AppEntry,
+  appLabel,
 } from "@/web/components/sections-editor/page-list";
 import {
+  isDecoAppResolveType,
   resolveBlockSchemaMetadata,
   type LiveMeta,
 } from "@/web/components/sections-editor/resolve-schema";
@@ -53,6 +54,18 @@ export function parseAppResolveType(
     return { vendor: legacyMatch[1]!, app: legacyMatch[2]! };
   }
   return null;
+}
+
+function parseAppIdentityFromBlockKey(
+  blockKey: string,
+): { vendor: string; app: string } | null {
+  const blockIdMatch = blockKey.match(/^([^-]+)-(.+)$/);
+  if (!blockIdMatch) return null;
+  return { vendor: blockIdMatch[1]!, app: blockIdMatch[2]! };
+}
+
+function installedAppCategory(vendor: string): string {
+  return vendor === "local" ? "Custom" : "Installed";
 }
 
 function findInstalledBlockKey(
@@ -126,6 +139,37 @@ function catalogEntryFromManifestApp(
   };
 }
 
+function catalogEntryFromInstalledBlock(
+  blockKey: string,
+  block: Record<string, unknown>,
+  meta: LiveMeta,
+): AppCatalogEntry | null {
+  const resolveType = block.__resolveType;
+  if (typeof resolveType !== "string") return null;
+  if (isSiteAppBlock(blockKey, block)) return null;
+  if (!isDecoAppResolveType(resolveType)) return null;
+
+  const parsed =
+    parseAppResolveType(resolveType) ?? parseAppIdentityFromBlockKey(blockKey);
+  if (!parsed) return null;
+
+  const metadata = resolveBlockSchemaMetadata(resolveType, meta);
+  const { vendor, app } = parsed;
+
+  return {
+    id: appBlockId(vendor, app),
+    app,
+    vendor,
+    title: metadata.title ?? appLabel(blockKey, block, meta),
+    description: metadata.description ?? "",
+    category: installedAppCategory(vendor),
+    logo: metadata.logo ?? metadata.icon,
+    resolveType,
+    blockKey,
+    installed: true,
+  };
+}
+
 /**
  * Merges the deco app store, manifest schema apps, and installed decofile
  * blocks — mirrors admin's Apps view data sources.
@@ -149,23 +193,18 @@ export function buildAppCatalog(
     byId.set(entry.id, entry);
   }
 
-  // Installed apps missing from store/schema (legacy block ids, local apps).
-  for (const installed of listInstalledAppEntries(decofile, meta)) {
-    const parsed = parseAppResolveType(installed.resolveType);
-    if (!parsed) continue;
-    const id = appBlockId(parsed.vendor, parsed.app);
-    if (byId.has(id)) continue;
-    byId.set(id, {
-      id,
-      app: parsed.app,
-      vendor: parsed.vendor,
-      title: installed.name,
-      description: "",
-      category: "Installed",
-      resolveType: installed.resolveType,
-      blockKey: installed.key,
-      installed: true,
-    });
+  // Installed custom/local apps and legacy block ids missing from store + manifest.
+  for (const [blockKey, val] of Object.entries(decofile)) {
+    if (blockKey.includes("/")) continue;
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+
+    const entry = catalogEntryFromInstalledBlock(
+      blockKey,
+      val as Record<string, unknown>,
+      meta,
+    );
+    if (!entry || byId.has(entry.id)) continue;
+    byId.set(entry.id, entry);
   }
 
   return [...byId.values()].sort(compareAppCatalogEntries);
@@ -179,53 +218,4 @@ function compareAppCatalogEntries(
     return a.installed ? -1 : 1;
   }
   return a.title.localeCompare(b.title);
-}
-
-function manifestHasApp(meta: LiveMeta, vendor: string, app: string): boolean {
-  const apps = meta.manifest?.blocks?.apps ?? {};
-  for (const alias of [
-    appResolveType(vendor, app),
-    `site/apps/${vendor}/${app}.tsx`,
-    `${vendor}/apps/${app}.ts`,
-    `${vendor}/apps/${app}.tsx`,
-  ]) {
-    if (alias in apps) return true;
-  }
-  return false;
-}
-
-function listInstalledAppEntries(
-  decofile: Record<string, unknown>,
-  meta: LiveMeta,
-): AppEntry[] {
-  const entries: AppEntry[] = [];
-
-  for (const [key, val] of Object.entries(decofile)) {
-    if (key.includes("/")) continue;
-    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
-
-    const obj = val as Record<string, unknown>;
-    const resolveType = obj.__resolveType;
-    if (typeof resolveType !== "string") continue;
-    if (isSiteAppBlock(key, obj)) continue;
-
-    const parsed =
-      parseAppResolveType(resolveType) ??
-      (() => {
-        const blockIdMatch = key.match(/^([^-]+)-(.+)$/);
-        return blockIdMatch
-          ? { vendor: blockIdMatch[1]!, app: blockIdMatch[2]! }
-          : null;
-      })();
-
-    if (!parsed || !manifestHasApp(meta, parsed.vendor, parsed.app)) continue;
-
-    entries.push({
-      key,
-      name: key.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
-      resolveType,
-    });
-  }
-
-  return entries;
 }

--- a/apps/mesh/src/web/components/sandbox/content/app-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/app-editor.tsx
@@ -1,8 +1,9 @@
 import { ChevronRight, Loading01 } from "@untitledui/icons";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { cn } from "@deco/ui/lib/utils.js";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { AddSectionModal } from "@/web/components/sections-editor/add-section-modal";
 import { appLabel } from "@/web/components/sections-editor/page-list";
 import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 import type { SectionCatalogEntry } from "@/web/components/sections-editor/section-catalog";
@@ -12,8 +13,9 @@ import {
   useSaveBlock,
 } from "@/web/components/sections-editor/use-save-block";
 import { resolveAppEditorSchema } from "./app-editor-schema";
-import { nextUniqueBlockKey } from "./content-mutations";
+import { buildSectionBlockFromCatalogEntry } from "./section-create";
 import { SchemaForm } from "@/web/components/sections-editor/schema-form";
+import { breadcrumbsForHeaderClick } from "@/web/components/sections-editor/schema-form-breadcrumb";
 import { SaveStatus } from "./blog/save-status";
 
 export function AppEditor({
@@ -50,7 +52,7 @@ export function AppEditor({
   const title =
     titleOverride ?? (block ? appLabel(blockKey, block, meta) : blockKey);
 
-  const { save, isPending } = useDebouncedSaveBlock({
+  const { save, flush, isPending } = useDebouncedSaveBlock({
     orgSlug,
     virtualMcpId,
     branch,
@@ -66,6 +68,8 @@ export function AppEditor({
   );
   const [formResetKey, setFormResetKey] = useState(0);
   const [breadcrumbs, setBreadcrumbs] = useState<string[]>([]);
+  const [addSectionOpen, setAddSectionOpen] = useState(false);
+  const pendingAppendRef = useRef<((item: unknown) => void) | null>(null);
 
   if (prevBlockKey !== blockKey) {
     setPrevBlockKey(blockKey);
@@ -97,24 +101,43 @@ export function AppEditor({
     entry: SectionCatalogEntry,
     append: (item: unknown) => void,
   ) => {
-    const baseLabel = (entry.title || entry.resolveType.split("/").pop() || "")
-      .replace(/\.(tsx?|jsx?)$/, "")
-      .replace(/[^A-Za-z0-9_-]/g, "");
-    const safeBase =
-      /^[A-Za-z]/.test(baseLabel) && baseLabel.length > 0
-        ? baseLabel
-        : "Section";
-    const newKey = nextUniqueBlockKey(decofile, safeBase);
-    const data: Record<string, unknown> = {
-      __resolveType: entry.resolveType,
-      name: newKey,
-    };
-    await saveBlock.mutateAsync({ blockKey: newKey, data });
-    toast.success(`Created section "${newKey}"`);
-    append({ __resolveType: newKey });
+    try {
+      const { blockKey: newKey, data } = buildSectionBlockFromCatalogEntry(
+        entry,
+        decofile,
+      );
+      await saveBlock.mutateAsync({ blockKey: newKey, data });
+      toast.success(`Created section "${newKey}"`);
+      append({ __resolveType: newKey });
+      flush();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Could not add section";
+      toast.error(message);
+      throw err;
+    }
   };
 
-  const breadcrumbKey = breadcrumbs.join("\0");
+  const handleRequestAddSection = (context: {
+    append: (item: unknown) => void;
+  }) => {
+    pendingAppendRef.current = context.append;
+    setAddSectionOpen(true);
+  };
+
+  const handleSelectSection = async (entry: SectionCatalogEntry) => {
+    const append = pendingAppendRef.current;
+    if (!append) return;
+    try {
+      await handleAddSectionItem(entry, (item) => {
+        append(item);
+        setAddSectionOpen(false);
+        pendingAppendRef.current = null;
+      });
+    } catch {
+      // Toast shown in handleAddSectionItem.
+    }
+  };
 
   const headerCrumbs = breadcrumbs.length > 0 ? [title, ...breadcrumbs] : [];
 
@@ -142,7 +165,9 @@ export function AppEditor({
                       if (index === 0) {
                         handleBreadcrumbChange([]);
                       } else {
-                        handleBreadcrumbChange(breadcrumbs.slice(0, index - 1));
+                        handleBreadcrumbChange(
+                          breadcrumbsForHeaderClick(breadcrumbs, index),
+                        );
                       }
                       setFormResetKey((key) => key + 1);
                     }}
@@ -170,7 +195,7 @@ export function AppEditor({
           <div className="mx-auto max-w-xl">
             {hasEditableFields ? (
               <SchemaForm
-                key={`${blockKey}:${formResetKey}:${breadcrumbKey}`}
+                key={`${blockKey}:${formResetKey}`}
                 schema={schema!}
                 value={effectiveValue}
                 onChange={handleChange}
@@ -182,6 +207,7 @@ export function AppEditor({
                 onSaveReferencedBlock={saveReferencedBlock}
                 previewBaseUrl={previewBaseUrl}
                 onAddSectionItem={handleAddSectionItem}
+                onRequestAddSection={handleRequestAddSection}
               />
             ) : schemaPending ? (
               <div className="flex flex-col items-center gap-2 py-6 text-center text-xs text-muted-foreground">
@@ -196,6 +222,22 @@ export function AppEditor({
           </div>
         </div>
       </ScrollArea>
+
+      {previewBaseUrl && (
+        <AddSectionModal
+          open={addSectionOpen}
+          onOpenChange={(open) => {
+            setAddSectionOpen(open);
+            if (!open) pendingAppendRef.current = null;
+          }}
+          meta={meta}
+          decofile={decofile}
+          previewBaseUrl={previewBaseUrl}
+          onSelect={(entry) => {
+            void handleSelectSection(entry);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sandbox/content/app-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/app-editor.tsx
@@ -1,13 +1,19 @@
 import { ChevronRight, Loading01 } from "@untitledui/icons";
 import { useState } from "react";
+import { toast } from "sonner";
 import { cn } from "@deco/ui/lib/utils.js";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import { appLabel } from "@/web/components/sections-editor/page-list";
 import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import type { SectionCatalogEntry } from "@/web/components/sections-editor/section-catalog";
 import { createReferencedBlockSaver } from "@/web/components/sections-editor/save-referenced-block";
+import {
+  useDebouncedSaveBlock,
+  useSaveBlock,
+} from "@/web/components/sections-editor/use-save-block";
 import { resolveAppEditorSchema } from "./app-editor-schema";
+import { nextUniqueBlockKey } from "./content-mutations";
 import { SchemaForm } from "@/web/components/sections-editor/schema-form";
-import { useDebouncedSaveBlock } from "@/web/components/sections-editor/use-save-block";
 import { SaveStatus } from "./blog/save-status";
 
 export function AppEditor({
@@ -21,6 +27,7 @@ export function AppEditor({
   title: titleOverride,
   excludeFields,
   schemaPending = false,
+  previewBaseUrl = null,
 }: {
   orgSlug: string;
   virtualMcpId: string;
@@ -33,6 +40,7 @@ export function AppEditor({
   /** Top-level schema fields to omit (e.g. site `seo` is edited in the SEO tab). */
   excludeFields?: readonly string[];
   schemaPending?: boolean;
+  previewBaseUrl?: string | null;
 }) {
   const resolveType =
     typeof block?.__resolveType === "string" ? block.__resolveType : "";
@@ -47,6 +55,7 @@ export function AppEditor({
     virtualMcpId,
     branch,
   });
+  const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
   const saveReferencedBlock = createReferencedBlockSaver((refKey, data) =>
     save(refKey, data),
   );
@@ -65,8 +74,11 @@ export function AppEditor({
     setBreadcrumbs([]);
   }
 
-  const savedValue = block ?? {};
-  const effectiveValue = (formValue ?? savedValue) as Record<string, unknown>;
+  const savedValue = (block ?? {}) as Record<string, unknown>;
+  const effectiveValue = {
+    ...savedValue,
+    ...(formValue ?? {}),
+  } as Record<string, unknown>;
 
   const handleChange = (next: unknown) => {
     const nextRecord = next as Record<string, unknown>;
@@ -76,6 +88,33 @@ export function AppEditor({
       __resolveType: resolveType,
     });
   };
+
+  const handleBreadcrumbChange = (next: string[]) => {
+    setBreadcrumbs(next);
+  };
+
+  const handleAddSectionItem = async (
+    entry: SectionCatalogEntry,
+    append: (item: unknown) => void,
+  ) => {
+    const baseLabel = (entry.title || entry.resolveType.split("/").pop() || "")
+      .replace(/\.(tsx?|jsx?)$/, "")
+      .replace(/[^A-Za-z0-9_-]/g, "");
+    const safeBase =
+      /^[A-Za-z]/.test(baseLabel) && baseLabel.length > 0
+        ? baseLabel
+        : "Section";
+    const newKey = nextUniqueBlockKey(decofile, safeBase);
+    const data: Record<string, unknown> = {
+      __resolveType: entry.resolveType,
+      name: newKey,
+    };
+    await saveBlock.mutateAsync({ blockKey: newKey, data });
+    toast.success(`Created section "${newKey}"`);
+    append({ __resolveType: newKey });
+  };
+
+  const breadcrumbKey = breadcrumbs.join("\0");
 
   const headerCrumbs = breadcrumbs.length > 0 ? [title, ...breadcrumbs] : [];
 
@@ -99,11 +138,14 @@ export function AppEditor({
                   )}
                   <button
                     type="button"
-                    onClick={() =>
-                      setBreadcrumbs(
-                        index === 0 ? [] : breadcrumbs.slice(0, index),
-                      )
-                    }
+                    onClick={() => {
+                      if (index === 0) {
+                        handleBreadcrumbChange([]);
+                      } else {
+                        handleBreadcrumbChange(breadcrumbs.slice(0, index - 1));
+                      }
+                      setFormResetKey((key) => key + 1);
+                    }}
                     title={crumb}
                     className={cn(
                       "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors",
@@ -128,16 +170,18 @@ export function AppEditor({
           <div className="mx-auto max-w-xl">
             {hasEditableFields ? (
               <SchemaForm
-                key={`${blockKey}:${formResetKey}`}
+                key={`${blockKey}:${formResetKey}:${breadcrumbKey}`}
                 schema={schema!}
                 value={effectiveValue}
                 onChange={handleChange}
                 basePath=""
                 breadcrumbPath={breadcrumbs}
-                onBreadcrumbChange={setBreadcrumbs}
+                onBreadcrumbChange={handleBreadcrumbChange}
                 decofile={decofile}
                 meta={meta}
                 onSaveReferencedBlock={saveReferencedBlock}
+                previewBaseUrl={previewBaseUrl}
+                onAddSectionItem={handleAddSectionItem}
               />
             ) : schemaPending ? (
               <div className="flex flex-col items-center gap-2 py-6 text-center text-xs text-muted-foreground">

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -756,6 +756,7 @@ function ContentBrowserReady({
                 title="Site"
                 excludeFields={["seo"]}
                 schemaPending={isAppSchemaLoading(siteApp.resolveType, ["seo"])}
+                previewBaseUrl={previewUrl}
               />
             ) : (
               <EmptyMessage
@@ -784,6 +785,7 @@ function ContentBrowserReady({
                 block={decofile[selection.key] as Record<string, unknown>}
                 decofile={decofile}
                 meta={meta}
+                previewBaseUrl={previewUrl}
                 schemaPending={isAppSchemaLoading(
                   typeof (decofile[selection.key] as Record<string, unknown>)
                     ?.__resolveType === "string"
@@ -1445,16 +1447,18 @@ function ItemRow({
 }) {
   const rowIcon =
     variantCount && variantCount > 1 ? (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Icon
-            size={16}
-            className="shrink-0"
-            style={{ color: VARIANT_GREEN }}
-          />
-        </TooltipTrigger>
-        <TooltipContent side="right">{variantCount} variants</TooltipContent>
-      </Tooltip>
+      <span className="flex size-8 shrink-0 items-center justify-center">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Icon
+              size={16}
+              className="shrink-0"
+              style={{ color: VARIANT_GREEN }}
+            />
+          </TooltipTrigger>
+          <TooltipContent side="right">{variantCount} variants</TooltipContent>
+        </Tooltip>
+      </span>
     ) : logoUrl ? (
       <img
         src={logoUrl}
@@ -1462,13 +1466,15 @@ function ItemRow({
         className="size-8 shrink-0 rounded-lg object-cover bg-muted"
       />
     ) : (
-      <Icon
-        size={16}
-        className={cn(
-          "shrink-0",
-          active ? "text-accent-foreground" : "text-muted-foreground",
-        )}
-      />
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+        <Icon
+          size={16}
+          className={cn(
+            "shrink-0",
+            active ? "text-accent-foreground" : "text-muted-foreground",
+          )}
+        />
+      </span>
     );
 
   return (

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -96,6 +96,7 @@ import {
   nextUniqueName,
   nextUniquePagePath,
 } from "./content-mutations";
+import { buildSectionBlockFromCatalogEntry } from "./section-create";
 import { PageFormDialog, type PageFormMode } from "./page-form-dialog";
 import { SectionRenameDialog } from "./section-rename-dialog";
 import {
@@ -534,18 +535,10 @@ function ContentBrowserReady({
 
   // ------------------ Section CRUD ------------------
   const handleCreateSection = async (entry: SectionCatalogEntry) => {
-    const baseLabel = (entry.title || entry.resolveType.split("/").pop() || "")
-      .replace(/\.(tsx?|jsx?)$/, "")
-      .replace(/[^A-Za-z0-9_-]/g, "");
-    const safeBase =
-      /^[A-Za-z]/.test(baseLabel) && baseLabel.length > 0
-        ? baseLabel
-        : "Section";
-    const newKey = nextUniqueBlockKey(decofile, safeBase);
-    const data: Record<string, unknown> = {
-      __resolveType: entry.resolveType,
-      name: newKey,
-    };
+    const { blockKey: newKey, data } = buildSectionBlockFromCatalogEntry(
+      entry,
+      decofile,
+    );
     try {
       await saveBlock.mutateAsync({ blockKey: newKey, data });
       toast.success(`Created section "${newKey}"`);

--- a/apps/mesh/src/web/components/sandbox/content/section-create.ts
+++ b/apps/mesh/src/web/components/sandbox/content/section-create.ts
@@ -1,0 +1,22 @@
+import type { SectionCatalogEntry } from "@/web/components/sections-editor/section-catalog";
+import { nextUniqueBlockKey } from "./content-mutations";
+
+/** Build a new saved global section block from a catalog entry. */
+export function buildSectionBlockFromCatalogEntry(
+  entry: SectionCatalogEntry,
+  decofile: Record<string, unknown>,
+): { blockKey: string; data: Record<string, unknown> } {
+  const baseLabel = (entry.title || entry.resolveType.split("/").pop() || "")
+    .replace(/\.(tsx?|jsx?)$/, "")
+    .replace(/[^A-Za-z0-9_-]/g, "");
+  const safeBase =
+    /^[A-Za-z]/.test(baseLabel) && baseLabel.length > 0 ? baseLabel : "Section";
+  const blockKey = nextUniqueBlockKey(decofile, safeBase);
+  return {
+    blockKey,
+    data: {
+      __resolveType: entry.resolveType,
+      name: blockKey,
+    },
+  };
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -19,6 +19,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { DotsGrid, DotsHorizontal, Plus, Trash01 } from "@untitledui/icons";
+import { toast } from "sonner";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   DropdownMenu,
@@ -27,11 +28,23 @@ import {
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { AddSectionModal } from "../add-section-modal";
 import { getArrayItemImageSrc, getArrayItemLabel } from "../array-item-display";
 import { isEmbeddedUnionResolveType } from "../block-type-utils";
-import { resolveArrayItemSelection } from "../schema-form-breadcrumb";
+import {
+  buildArrayDrillDownBreadcrumb,
+  normalizeBreadcrumbLabel,
+  resolveArrayItemSelection,
+} from "../schema-form-breadcrumb";
+import { isSectionArrayField } from "../section-array-field";
+import type { SectionCatalogEntry } from "../section-catalog";
 import type { FieldProps } from "./field-props";
 import { SchemaForm, renderField } from "../schema-form";
+import {
+  resolveSchema,
+  type LiveMeta,
+  type SchemaProperty,
+} from "../resolve-schema";
 
 /** Stable DnD id per row; item data always comes from the `items` prop. */
 interface ArrayEntry {
@@ -44,6 +57,48 @@ function createArrayEntries(count: number): ArrayEntry[] {
     id: crypto.randomUUID(),
     index,
   }));
+}
+
+function itemEditorSchema(
+  item: unknown,
+  itemSchema: SchemaProperty | undefined,
+  meta?: LiveMeta,
+  containerResolveType?: string,
+  arrayFieldKey?: string,
+): SchemaProperty | undefined {
+  if (
+    itemSchema?.type === "object" &&
+    itemSchema.properties &&
+    Object.keys(itemSchema.properties).length > 0
+  ) {
+    return itemSchema;
+  }
+  if (itemSchema?.type === "block-ref" && itemSchema.anyOfRefs?.length) {
+    return itemSchema;
+  }
+  if (item != null && typeof item === "object" && !Array.isArray(item)) {
+    const resolveType = (item as Record<string, unknown>).__resolveType;
+    if (typeof resolveType === "string" && meta) {
+      const resolved = resolveSchema(resolveType, meta);
+      if (resolved?.properties && Object.keys(resolved.properties).length > 0) {
+        return resolved;
+      }
+    }
+  }
+  if (meta && containerResolveType && arrayFieldKey) {
+    const container = resolveSchema(containerResolveType, meta);
+    const itemsSchema = container?.properties?.[arrayFieldKey]?.items;
+    if (
+      itemsSchema?.properties &&
+      Object.keys(itemsSchema.properties).length > 0
+    ) {
+      return {
+        ...itemsSchema,
+        titleBy: itemsSchema.titleBy ?? itemSchema?.titleBy,
+      };
+    }
+  }
+  return itemSchema;
 }
 
 function remapEntryIndices(entries: ArrayEntry[]): ArrayEntry[] {
@@ -66,6 +121,13 @@ function resizeArrayEntries(
     }),
   );
   return [...current, ...extra];
+}
+
+function findBreadcrumbLabelIndex(path: string[], targetLabel: string): number {
+  const normalized = normalizeBreadcrumbLabel(targetLabel);
+  return path.findIndex(
+    (crumb) => normalizeBreadcrumbLabel(crumb) === normalized,
+  );
 }
 
 function ArrayRowContent({
@@ -189,9 +251,16 @@ export function ArrayField({
   meta,
   decofile,
   onSaveReferencedBlock,
+  containerResolveType,
+  previewBaseUrl,
+  onAddSectionItem,
 }: FieldProps) {
   const items = Array.isArray(value) ? value : [];
   const itemSchema = schema.items;
+  const usesSectionPicker = isSectionArrayField(schema);
+  const arrayFieldKey = path.includes(".")
+    ? path.slice(0, path.indexOf("."))
+    : path;
   const selection = resolveArrayItemSelection(
     label,
     breadcrumbPath,
@@ -204,6 +273,7 @@ export function ArrayField({
     createArrayEntries(items.length),
   );
   const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
+  const [addSectionOpen, setAddSectionOpen] = useState(false);
   const [prevListKey, setPrevListKey] = useState(path);
   const [prevItemCount, setPrevItemCount] = useState(items.length);
   const suppressClickRef = useRef(false);
@@ -223,7 +293,19 @@ export function ArrayField({
   const openItem = (index: number) => {
     if (suppressClickRef.current) return;
     const labelText = itemLabel(items[index], index);
-    onBreadcrumbChange?.([...breadcrumbPath, labelText]);
+    onBreadcrumbChange?.(
+      buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
+    );
+  };
+
+  const appendItem = (item: unknown) => {
+    const next = [...items, item];
+    onChange(next);
+    const nextIndex = next.length - 1;
+    const labelText = getArrayItemLabel(item, nextIndex, itemSchema);
+    onBreadcrumbChange?.(
+      buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
+    );
   };
 
   const addItem = () => {
@@ -252,14 +334,45 @@ export function ArrayField({
     onChange(next);
     const nextIndex = next.length - 1;
     const labelText = getArrayItemLabel(defaultVal, nextIndex, itemSchema);
-    onBreadcrumbChange?.([...breadcrumbPath, labelText]);
+    onBreadcrumbChange?.(
+      buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
+    );
+  };
+
+  const handleAddClick = () => {
+    if (usesSectionPicker) {
+      if (!previewBaseUrl) {
+        toast.error("Start the preview dev server to add sections.");
+        return;
+      }
+      setAddSectionOpen(true);
+      return;
+    }
+    addItem();
+  };
+
+  const handleSelectSection = async (entry: SectionCatalogEntry) => {
+    const append = (item: unknown) => {
+      appendItem(item);
+      setAddSectionOpen(false);
+    };
+
+    try {
+      if (onAddSectionItem) {
+        await onAddSectionItem(entry, append);
+        return;
+      }
+      append({ __resolveType: entry.resolveType });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not add section");
+    }
   };
 
   const removeItem = (index: number) => {
     onChange(items.filter((_, i) => i !== index));
     if (selectedIndex === index) {
       const itemName = itemLabel(items[index], index);
-      const itemIndex = breadcrumbPath.indexOf(itemName);
+      const itemIndex = findBreadcrumbLabelIndex(breadcrumbPath, itemName);
       onBreadcrumbChange?.(
         itemIndex >= 0 ? breadcrumbPath.slice(0, itemIndex) : [],
       );
@@ -273,14 +386,16 @@ export function ArrayField({
     if (selectedIndex === index) {
       const previousName = itemLabel(items[index], index);
       const labelText = itemLabel(val, index);
-      const itemIndex = breadcrumbPath.indexOf(previousName);
+      const itemIndex = findBreadcrumbLabelIndex(breadcrumbPath, previousName);
       if (itemIndex >= 0) {
         const nextPath = [...breadcrumbPath];
         nextPath[itemIndex] = labelText;
         onBreadcrumbChange?.(nextPath);
         return;
       }
-      onBreadcrumbChange?.([...breadcrumbPath, labelText]);
+      onBreadcrumbChange?.(
+        buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
+      );
     }
   };
 
@@ -335,20 +450,32 @@ export function ArrayField({
 
   if (selectedIndex !== null && selectedIndex < items.length) {
     const item = items[selectedIndex];
+    const editorSchema = itemEditorSchema(
+      item,
+      itemSchema,
+      meta,
+      containerResolveType,
+      arrayFieldKey,
+    );
     const arrayItemPrefix = () => {
       const itemName = itemLabel(item, selectedIndex);
-      const itemIndex = breadcrumbPath.indexOf(itemName);
+      const trail = buildArrayDrillDownBreadcrumb(
+        breadcrumbPath,
+        label,
+        itemName,
+      );
+      const itemIndex = findBreadcrumbLabelIndex(trail, itemName);
       if (itemIndex >= 0) {
-        return breadcrumbPath.slice(0, itemIndex + 1);
+        return trail.slice(0, itemIndex + 1);
       }
-      return [...breadcrumbPath, itemName];
+      return trail;
     };
 
     return (
       <div className="min-w-0">
-        {itemSchema?.type === "object" && itemSchema.properties ? (
+        {editorSchema?.type === "object" && editorSchema.properties ? (
           <SchemaForm
-            schema={itemSchema}
+            schema={editorSchema}
             value={item}
             onChange={(val) => updateItem(selectedIndex, val)}
             basePath={`${path}.${selectedIndex}`}
@@ -359,14 +486,16 @@ export function ArrayField({
             meta={meta}
             decofile={decofile}
             onSaveReferencedBlock={onSaveReferencedBlock}
+            previewBaseUrl={previewBaseUrl}
+            onAddSectionItem={onAddSectionItem}
           />
-        ) : itemSchema ? (
+        ) : editorSchema ? (
           renderField({
-            schema: itemSchema,
+            schema: editorSchema,
             value: item,
             onChange: (val) => updateItem(selectedIndex, val),
             path: `${path}.${selectedIndex}`,
-            label: itemSchema.title ?? `Item ${selectedIndex + 1}`,
+            label: editorSchema.title ?? `Item ${selectedIndex + 1}`,
             breadcrumbPath: selection?.innerPath ?? [],
             onBreadcrumbChange: (nextPath) => {
               onBreadcrumbChange?.([...arrayItemPrefix(), ...nextPath]);
@@ -374,6 +503,8 @@ export function ArrayField({
             meta,
             decofile,
             onSaveReferencedBlock,
+            previewBaseUrl,
+            onAddSectionItem,
           })
         ) : null}
       </div>
@@ -447,12 +578,25 @@ export function ArrayField({
 
       <button
         type="button"
-        onClick={addItem}
+        onClick={handleAddClick}
         className="flex w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-border/60 py-2.5 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-muted/30"
       >
         <Plus size={14} />
-        Add item
+        {usesSectionPicker ? "Add section" : "Add item"}
       </button>
+
+      {usesSectionPicker && previewBaseUrl && (
+        <AddSectionModal
+          open={addSectionOpen}
+          onOpenChange={setAddSectionOpen}
+          meta={meta}
+          decofile={decofile}
+          previewBaseUrl={previewBaseUrl}
+          onSelect={(entry) => {
+            void handleSelectSection(entry);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -136,7 +136,7 @@ function SortableArrayRow({
       }}
       className={cn(
         "group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground touch-none",
-        isDragging ? "cursor-grabbing" : "cursor-grab",
+        isDragging ? "cursor-grabbing" : "cursor-pointer",
       )}
       title={labelText}
     >

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   DndContext,
+  DragOverlay,
   type DragEndEvent,
+  type DragStartEvent,
   KeyboardSensor,
   PointerSensor,
   closestCenter,
@@ -31,8 +33,64 @@ import { resolveArrayItemSelection } from "../schema-form-breadcrumb";
 import type { FieldProps } from "./field-props";
 import { SchemaForm, renderField } from "../schema-form";
 
-function sortableIdFor(path: string, index: number): string {
-  return `${path}::${index}`;
+/** Stable DnD id per row; item data always comes from the `items` prop. */
+interface ArrayEntry {
+  id: string;
+  index: number;
+}
+
+function createArrayEntries(count: number): ArrayEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: crypto.randomUUID(),
+    index,
+  }));
+}
+
+function remapEntryIndices(entries: ArrayEntry[]): ArrayEntry[] {
+  return entries.map((entry, index) => ({ ...entry, index }));
+}
+
+function resizeArrayEntries(
+  current: ArrayEntry[],
+  nextCount: number,
+): ArrayEntry[] {
+  if (nextCount === current.length) return current;
+  if (nextCount < current.length) {
+    return remapEntryIndices(current.slice(0, nextCount));
+  }
+  const extra = Array.from(
+    { length: nextCount - current.length },
+    (_, offset) => ({
+      id: crypto.randomUUID(),
+      index: current.length + offset,
+    }),
+  );
+  return [...current, ...extra];
+}
+
+function ArrayRowContent({
+  labelText,
+  imageSrc,
+}: {
+  labelText: string;
+  imageSrc?: string;
+}) {
+  return (
+    <>
+      <DotsGrid className="size-3.5 shrink-0 text-muted-foreground/40" />
+      <div className="flex min-w-0 flex-1 items-center gap-2.5 text-sm">
+        {imageSrc && (
+          <img
+            src={imageSrc}
+            alt=""
+            referrerPolicy="no-referrer"
+            className="h-12 max-w-[100px] shrink-0 rounded object-cover"
+          />
+        )}
+        <span className="min-w-0 truncate">{labelText}</span>
+      </div>
+    </>
+  );
 }
 
 function SortableArrayRow({
@@ -58,17 +116,14 @@ function SortableArrayRow({
     transform: CSS.Transform.toString(
       transform ? { ...transform, x: 0 } : null,
     ),
-    opacity: isDragging ? 0.4 : undefined,
+    opacity: isDragging ? 0 : undefined,
   };
 
   return (
     <div
       ref={setNodeRef}
       style={style}
-      className={cn(
-        "group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground",
-        isDragging && "bg-accent/50",
-      )}
+      className="group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground"
     >
       <button
         type="button"
@@ -143,13 +198,29 @@ export function ArrayField({
     itemSchema,
   );
   const selectedIndex = selection?.index ?? null;
-  const [isDragging, setIsDragging] = useState(false);
+
+  const [entries, setEntries] = useState<ArrayEntry[]>(() =>
+    createArrayEntries(items.length),
+  );
+  const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
+  const [prevListKey, setPrevListKey] = useState(path);
+  const [prevItemCount, setPrevItemCount] = useState(items.length);
+  const suppressClickRef = useRef(false);
+
+  if (prevListKey !== path) {
+    setPrevListKey(path);
+    setPrevItemCount(items.length);
+    setEntries(createArrayEntries(items.length));
+  } else if (prevItemCount !== items.length) {
+    setPrevItemCount(items.length);
+    setEntries((current) => resizeArrayEntries(current, items.length));
+  }
 
   const itemLabel = (item: unknown, index: number) =>
     getArrayItemLabel(item, index, itemSchema);
 
   const openItem = (index: number) => {
-    if (isDragging) return;
+    if (suppressClickRef.current) return;
     const labelText = itemLabel(items[index], index);
     onBreadcrumbChange?.([...breadcrumbPath, labelText]);
   };
@@ -213,23 +284,54 @@ export function ArrayField({
   };
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),
   );
 
-  const sortableIds = items.map((_, i) => sortableIdFor(path, i));
+  const entryIds = entries.map((entry) => entry.id);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveEntryId(String(event.active.id));
+  };
 
   const handleDragEnd = (event: DragEndEvent) => {
-    setIsDragging(false);
+    setActiveEntryId(null);
     const { active, over } = event;
     if (!over || active.id === over.id) return;
-    const oldIndex = sortableIds.indexOf(String(active.id));
-    const newIndex = sortableIds.indexOf(String(over.id));
+
+    const oldIndex = entryIds.indexOf(String(active.id));
+    const newIndex = entryIds.indexOf(String(over.id));
     if (oldIndex === -1 || newIndex === -1) return;
+
+    setEntries((current) =>
+      remapEntryIndices(arrayMove([...current], oldIndex, newIndex)),
+    );
     onChange(arrayMove([...items], oldIndex, newIndex));
+    suppressClickRef.current = true;
+    requestAnimationFrame(() => {
+      suppressClickRef.current = false;
+    });
   };
+
+  const handleDragCancel = () => {
+    setActiveEntryId(null);
+  };
+
+  const activeEntry = activeEntryId
+    ? entries.find((entry) => entry.id === activeEntryId)
+    : null;
+  const activeItem =
+    activeEntry != null ? items[activeEntry.index] : undefined;
+  const activeLabel =
+    activeEntry != null && activeItem !== undefined
+      ? itemLabel(activeItem, activeEntry.index)
+      : null;
+  const activeImage =
+    activeEntry != null && activeItem !== undefined
+      ? getArrayItemImageSrc(activeItem, itemSchema)
+      : undefined;
 
   if (selectedIndex !== null && selectedIndex < items.length) {
     const item = items[selectedIndex];
@@ -297,35 +399,52 @@ export function ArrayField({
       </div>
 
       {items.length > 0 && (
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragStart={() => setIsDragging(true)}
-          onDragEnd={handleDragEnd}
-          onDragCancel={() => setIsDragging(false)}
-        >
-          <SortableContext
-            items={sortableIds}
-            strategy={verticalListSortingStrategy}
+        <div className={cn(activeEntryId && "cursor-grabbing")}>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
           >
-            <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
-              {items.map((item, i) => {
-                const labelText = itemLabel(item, i);
-                const imageSrc = getArrayItemImageSrc(item, itemSchema);
-                return (
-                  <SortableArrayRow
-                    key={sortableIdFor(path, i)}
-                    sortableId={sortableIdFor(path, i)}
-                    labelText={labelText}
-                    imageSrc={imageSrc}
-                    onOpen={() => openItem(i)}
-                    onRemove={() => removeItem(i)}
+            <SortableContext
+              items={entryIds}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
+                {entries.map((entry) => {
+                  const item = items[entry.index];
+                  if (item === undefined) return null;
+                  const labelText = itemLabel(item, entry.index);
+                  const imageSrc = getArrayItemImageSrc(item, itemSchema);
+                  return (
+                    <SortableArrayRow
+                      key={entry.id}
+                      sortableId={entry.id}
+                      labelText={labelText}
+                      imageSrc={imageSrc}
+                      onOpen={() => openItem(entry.index)}
+                      onRemove={() => removeItem(entry.index)}
+                    />
+                  );
+                })}
+              </div>
+            </SortableContext>
+
+            <DragOverlay dropAnimation={null}>
+              {activeLabel ? (
+                <div
+                  className="flex min-w-0 items-center gap-2.5 rounded-lg border border-border/60 bg-background px-2 py-2.5 shadow-lg ring-1 ring-border/60"
+                >
+                  <ArrayRowContent
+                    labelText={activeLabel}
+                    imageSrc={activeImage}
                   />
-                );
-              })}
-            </div>
-          </SortableContext>
-        </DndContext>
+                </div>
+              ) : null}
+            </DragOverlay>
+          </DndContext>
+        </div>
       )}
 
       <button

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -28,16 +28,14 @@ import {
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { AddSectionModal } from "../add-section-modal";
 import { getArrayItemImageSrc, getArrayItemLabel } from "../array-item-display";
 import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import {
   buildArrayDrillDownBreadcrumb,
-  normalizeBreadcrumbLabel,
+  findBreadcrumbLabelIndex,
   resolveArrayItemSelection,
 } from "../schema-form-breadcrumb";
 import { isSectionArrayField } from "../section-array-field";
-import type { SectionCatalogEntry } from "../section-catalog";
 import type { FieldProps } from "./field-props";
 import { SchemaForm, renderField } from "../schema-form";
 import {
@@ -101,6 +99,11 @@ function itemEditorSchema(
   return itemSchema;
 }
 
+function arrayFieldKeyFromPath(path: string): string {
+  const segments = path.split(".").filter((segment) => !/^\d+$/.test(segment));
+  return segments[segments.length - 1] ?? path;
+}
+
 function remapEntryIndices(entries: ArrayEntry[]): ArrayEntry[] {
   return entries.map((entry, index) => ({ ...entry, index }));
 }
@@ -121,13 +124,6 @@ function resizeArrayEntries(
     }),
   );
   return [...current, ...extra];
-}
-
-function findBreadcrumbLabelIndex(path: string[], targetLabel: string): number {
-  const normalized = normalizeBreadcrumbLabel(targetLabel);
-  return path.findIndex(
-    (crumb) => normalizeBreadcrumbLabel(crumb) === normalized,
-  );
 }
 
 function ArrayRowContent({
@@ -254,13 +250,12 @@ export function ArrayField({
   containerResolveType,
   previewBaseUrl,
   onAddSectionItem,
+  onRequestAddSection,
 }: FieldProps) {
   const items = Array.isArray(value) ? value : [];
   const itemSchema = schema.items;
-  const usesSectionPicker = isSectionArrayField(schema);
-  const arrayFieldKey = path.includes(".")
-    ? path.slice(0, path.indexOf("."))
-    : path;
+  const arrayFieldKey = arrayFieldKeyFromPath(path);
+  const usesSectionPicker = isSectionArrayField(schema, arrayFieldKey);
   const selection = resolveArrayItemSelection(
     label,
     breadcrumbPath,
@@ -273,7 +268,6 @@ export function ArrayField({
     createArrayEntries(items.length),
   );
   const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
-  const [addSectionOpen, setAddSectionOpen] = useState(false);
   const [prevListKey, setPrevListKey] = useState(path);
   const [prevItemCount, setPrevItemCount] = useState(items.length);
   const suppressClickRef = useRef(false);
@@ -345,27 +339,14 @@ export function ArrayField({
         toast.error("Start the preview dev server to add sections.");
         return;
       }
-      setAddSectionOpen(true);
+      if (onRequestAddSection) {
+        onRequestAddSection({ append: appendItem });
+        return;
+      }
+      toast.error("Section picker is not available in this editor.");
       return;
     }
     addItem();
-  };
-
-  const handleSelectSection = async (entry: SectionCatalogEntry) => {
-    const append = (item: unknown) => {
-      appendItem(item);
-      setAddSectionOpen(false);
-    };
-
-    try {
-      if (onAddSectionItem) {
-        await onAddSectionItem(entry, append);
-        return;
-      }
-      append({ __resolveType: entry.resolveType });
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Could not add section");
-    }
   };
 
   const removeItem = (index: number) => {
@@ -383,20 +364,6 @@ export function ArrayField({
     const next = [...items];
     next[index] = val;
     onChange(next);
-    if (selectedIndex === index) {
-      const previousName = itemLabel(items[index], index);
-      const labelText = itemLabel(val, index);
-      const itemIndex = findBreadcrumbLabelIndex(breadcrumbPath, previousName);
-      if (itemIndex >= 0) {
-        const nextPath = [...breadcrumbPath];
-        nextPath[itemIndex] = labelText;
-        onBreadcrumbChange?.(nextPath);
-        return;
-      }
-      onBreadcrumbChange?.(
-        buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
-      );
-    }
   };
 
   const sensors = useSensors(
@@ -488,6 +455,7 @@ export function ArrayField({
             onSaveReferencedBlock={onSaveReferencedBlock}
             previewBaseUrl={previewBaseUrl}
             onAddSectionItem={onAddSectionItem}
+            onRequestAddSection={onRequestAddSection}
           />
         ) : editorSchema ? (
           renderField({
@@ -505,6 +473,7 @@ export function ArrayField({
             onSaveReferencedBlock,
             previewBaseUrl,
             onAddSectionItem,
+            onRequestAddSection,
           })
         ) : null}
       </div>
@@ -584,19 +553,6 @@ export function ArrayField({
         <Plus size={14} />
         {usesSectionPicker ? "Add section" : "Add item"}
       </button>
-
-      {usesSectionPicker && previewBaseUrl && (
-        <AddSectionModal
-          open={addSectionOpen}
-          onOpenChange={setAddSectionOpen}
-          meta={meta}
-          decofile={decofile}
-          previewBaseUrl={previewBaseUrl}
-          onSelect={(entry) => {
-            void handleSelectSection(entry);
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -123,33 +123,33 @@ function SortableArrayRow({
     <div
       ref={setNodeRef}
       style={style}
-      className="group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground"
+      {...attributes}
+      {...listeners}
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className={cn(
+        "group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground touch-none",
+        isDragging ? "cursor-grabbing" : "cursor-grab",
+      )}
+      title={labelText}
     >
-      <button
-        type="button"
-        className="shrink-0 cursor-grab touch-none text-muted-foreground/40 active:cursor-grabbing"
-        aria-label={`Reorder ${labelText}`}
-        {...attributes}
-        {...listeners}
-      >
-        <DotsGrid className="size-3.5" />
-      </button>
-      <button
-        type="button"
-        onClick={onOpen}
-        className="flex min-w-0 flex-1 items-center gap-2.5 text-left text-sm"
-        title={labelText}
-      >
-        {imageSrc && (
-          <img
-            src={imageSrc}
-            alt=""
-            referrerPolicy="no-referrer"
-            className="h-12 max-w-[100px] shrink-0 rounded object-cover"
-          />
-        )}
-        <span className="min-w-0 truncate">{labelText}</span>
-      </button>
+      <DotsGrid className="size-3.5 shrink-0 text-muted-foreground/40" />
+      {imageSrc && (
+        <img
+          src={imageSrc}
+          alt=""
+          referrerPolicy="no-referrer"
+          className="h-12 max-w-[100px] shrink-0 rounded object-cover"
+        />
+      )}
+      <span className="min-w-0 flex-1 truncate text-sm">{labelText}</span>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
@@ -157,8 +157,9 @@ function SortableArrayRow({
             variant="ghost"
             size="icon"
             aria-label={`Open actions for ${labelText}`}
-            className="size-6 opacity-0 transition-opacity group-hover:opacity-100"
+            className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
             onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
           >
             <DotsHorizontal size={14} />
           </Button>
@@ -322,8 +323,7 @@ export function ArrayField({
   const activeEntry = activeEntryId
     ? entries.find((entry) => entry.id === activeEntryId)
     : null;
-  const activeItem =
-    activeEntry != null ? items[activeEntry.index] : undefined;
+  const activeItem = activeEntry != null ? items[activeEntry.index] : undefined;
   const activeLabel =
     activeEntry != null && activeItem !== undefined
       ? itemLabel(activeItem, activeEntry.index)
@@ -433,9 +433,7 @@ export function ArrayField({
 
             <DragOverlay dropAnimation={null}>
               {activeLabel ? (
-                <div
-                  className="flex min-w-0 items-center gap-2.5 rounded-lg border border-border/60 bg-background px-2 py-2.5 shadow-lg ring-1 ring-border/60"
-                >
+                <div className="flex min-w-0 items-center gap-2.5 rounded-lg border border-border/60 bg-background px-2 py-2.5 shadow-lg ring-1 ring-border/60">
                   <ArrayRowContent
                     labelText={activeLabel}
                     imageSrc={activeImage}

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -1,3 +1,21 @@
+import { useState } from "react";
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { DotsGrid, DotsHorizontal, Plus, Trash01 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
@@ -6,11 +24,103 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
 import { getArrayItemImageSrc, getArrayItemLabel } from "../array-item-display";
 import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import { resolveArrayItemSelection } from "../schema-form-breadcrumb";
 import type { FieldProps } from "./field-props";
 import { SchemaForm, renderField } from "../schema-form";
+
+function sortableIdFor(path: string, index: number): string {
+  return `${path}::${index}`;
+}
+
+function SortableArrayRow({
+  sortableId,
+  labelText,
+  imageSrc,
+  onOpen,
+  onRemove,
+}: {
+  sortableId: string;
+  labelText: string;
+  imageSrc?: string;
+  onOpen: () => void;
+  onRemove: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useSortable({
+      id: sortableId,
+      animateLayoutChanges: () => false,
+    });
+
+  const style = {
+    transform: CSS.Transform.toString(
+      transform ? { ...transform, x: 0 } : null,
+    ),
+    opacity: isDragging ? 0.4 : undefined,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground",
+        isDragging && "bg-accent/50",
+      )}
+    >
+      <button
+        type="button"
+        className="shrink-0 cursor-grab touch-none text-muted-foreground/40 active:cursor-grabbing"
+        aria-label={`Reorder ${labelText}`}
+        {...attributes}
+        {...listeners}
+      >
+        <DotsGrid className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="flex min-w-0 flex-1 items-center gap-2.5 text-left text-sm"
+        title={labelText}
+      >
+        {imageSrc && (
+          <img
+            src={imageSrc}
+            alt=""
+            referrerPolicy="no-referrer"
+            className="h-12 max-w-[100px] shrink-0 rounded object-cover"
+          />
+        )}
+        <span className="min-w-0 truncate">{labelText}</span>
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Open actions for ${labelText}`}
+            className="size-6 opacity-0 transition-opacity group-hover:opacity-100"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DotsHorizontal size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={onRemove}
+          >
+            <Trash01 size={14} />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
 
 export function ArrayField({
   schema,
@@ -33,11 +143,13 @@ export function ArrayField({
     itemSchema,
   );
   const selectedIndex = selection?.index ?? null;
+  const [isDragging, setIsDragging] = useState(false);
 
   const itemLabel = (item: unknown, index: number) =>
     getArrayItemLabel(item, index, itemSchema);
 
   const openItem = (index: number) => {
+    if (isDragging) return;
     const labelText = itemLabel(items[index], index);
     onBreadcrumbChange?.([...breadcrumbPath, labelText]);
   };
@@ -98,6 +210,25 @@ export function ArrayField({
       }
       onBreadcrumbChange?.([...breadcrumbPath, labelText]);
     }
+  };
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const sortableIds = items.map((_, i) => sortableIdFor(path, i));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setIsDragging(false);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = sortableIds.indexOf(String(active.id));
+    const newIndex = sortableIds.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+    onChange(arrayMove([...items], oldIndex, newIndex));
   };
 
   if (selectedIndex !== null && selectedIndex < items.length) {
@@ -166,59 +297,35 @@ export function ArrayField({
       </div>
 
       {items.length > 0 && (
-        <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
-          {items.map((item, i) => {
-            const labelText = itemLabel(item, i);
-            const imageSrc = getArrayItemImageSrc(item, itemSchema);
-            return (
-              <div
-                key={`${path}.${i}`}
-                className="group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground"
-              >
-                <DotsGrid className="size-3.5 shrink-0 cursor-grab text-muted-foreground/40" />
-                <button
-                  type="button"
-                  onClick={() => openItem(i)}
-                  className="flex min-w-0 flex-1 items-center gap-2.5 text-left text-sm"
-                  title={labelText}
-                >
-                  {imageSrc && (
-                    <img
-                      src={imageSrc}
-                      alt=""
-                      referrerPolicy="no-referrer"
-                      className="h-12 max-w-[100px] shrink-0 rounded object-cover"
-                    />
-                  )}
-                  <span className="min-w-0 truncate">{labelText}</span>
-                </button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Open actions for ${labelText}`}
-                      className="size-6 opacity-0 transition-opacity group-hover:opacity-100"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <DotsHorizontal size={14} />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onClick={() => removeItem(i)}
-                    >
-                      <Trash01 size={14} />
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            );
-          })}
-        </div>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={() => setIsDragging(true)}
+          onDragEnd={handleDragEnd}
+          onDragCancel={() => setIsDragging(false)}
+        >
+          <SortableContext
+            items={sortableIds}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
+              {items.map((item, i) => {
+                const labelText = itemLabel(item, i);
+                const imageSrc = getArrayItemImageSrc(item, itemSchema);
+                return (
+                  <SortableArrayRow
+                    key={sortableIdFor(path, i)}
+                    sortableId={sortableIdFor(path, i)}
+                    labelText={labelText}
+                    imageSrc={imageSrc}
+                    onOpen={() => openItem(i)}
+                    onRemove={() => removeItem(i)}
+                  />
+                );
+              })}
+            </div>
+          </SortableContext>
+        </DndContext>
       )}
 
       <button

--- a/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
@@ -17,6 +17,7 @@ export interface FieldProps {
     entry: SectionCatalogEntry,
     append: (item: unknown) => void,
   ) => void | Promise<void>;
+  onRequestAddSection?: (context: { append: (item: unknown) => void }) => void;
   onSaveReferencedBlock?: (
     blockKey: string,
     data: Record<string, unknown>,

--- a/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
@@ -1,4 +1,5 @@
 import type { LiveMeta, SchemaProperty } from "../resolve-schema";
+import type { SectionCatalogEntry } from "../section-catalog";
 
 export interface FieldProps {
   schema: SchemaProperty;
@@ -10,6 +11,12 @@ export interface FieldProps {
   onBreadcrumbChange?: (path: string[]) => void;
   meta?: LiveMeta;
   decofile?: Record<string, unknown>;
+  containerResolveType?: string;
+  previewBaseUrl?: string | null;
+  onAddSectionItem?: (
+    entry: SectionCatalogEntry,
+    append: (item: unknown) => void,
+  ) => void | Promise<void>;
   onSaveReferencedBlock?: (
     blockKey: string,
     data: Record<string, unknown>,

--- a/apps/mesh/src/web/components/sections-editor/fields/object-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/object-field.tsx
@@ -15,6 +15,9 @@ export function ObjectField({
   meta,
   decofile,
   onSaveReferencedBlock,
+  previewBaseUrl,
+  onAddSectionItem,
+  onRequestAddSection,
 }: FieldProps) {
   const [open, setOpen] = useState(false);
   const objValue =
@@ -71,6 +74,9 @@ export function ObjectField({
             meta={meta}
             decofile={decofile}
             onSaveReferencedBlock={onSaveReferencedBlock}
+            previewBaseUrl={previewBaseUrl}
+            onAddSectionItem={onAddSectionItem}
+            onRequestAddSection={onRequestAddSection}
           />
         </div>
       )}

--- a/apps/mesh/src/web/components/sections-editor/fields/secret-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/secret-field.tsx
@@ -22,9 +22,17 @@ function emptySecretBlock(): Record<string, unknown> {
   };
 }
 
+function omitPendingSecretValue(
+  block: Record<string, unknown>,
+): Record<string, unknown> {
+  const { value: _omit, ...rest } = block;
+  return rest;
+}
+
 /**
  * Deco stores API secrets as `website/loaders/secret.ts` blocks (`name` + `encrypted`).
- * JSON Schema often marks these as `format: password` or `format: string` without `type`.
+ * The editor may emit a transient `value` when the user enters a new secret; the deco
+ * runtime encrypts it on save. JSON Schema often marks these as `format: password`.
  */
 export function SecretField({
   schema,
@@ -33,6 +41,31 @@ export function SecretField({
   label,
   path,
 }: FieldProps) {
+  if (typeof value === "string" || (value == null && !isSecretBlock(value))) {
+    const stringValue = typeof value === "string" ? value : "";
+    return (
+      <div className="space-y-2">
+        <Label htmlFor={path} className="text-sm font-medium">
+          {label}
+        </Label>
+        {schema.description && (
+          <p className="text-xs text-muted-foreground">{schema.description}</p>
+        )}
+        <Input
+          id={path}
+          type="password"
+          value={stringValue}
+          autoComplete="new-password"
+          autoCorrect="off"
+          spellCheck={false}
+          placeholder="Secret value"
+          onChange={(e) => onChange(e.target.value)}
+          className="h-10"
+        />
+      </div>
+    );
+  }
+
   const block = isSecretBlock(value)
     ? (value as Record<string, unknown>)
     : emptySecretBlock();
@@ -58,13 +91,16 @@ export function SecretField({
       <Input
         id={`${path}-value`}
         type="password"
+        autoComplete="new-password"
+        autoCorrect="off"
+        spellCheck={false}
         placeholder={
           hasStoredSecret ? "Leave blank to keep current value" : "Secret value"
         }
         onChange={(e) => {
           const next = e.target.value;
           if (!next) {
-            onChange(block);
+            onChange(hasStoredSecret ? omitPendingSecretValue(block) : block);
             return;
           }
           onChange({ ...block, value: next });

--- a/apps/mesh/src/web/components/sections-editor/fields/secret-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/secret-field.tsx
@@ -1,0 +1,81 @@
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import type { FieldProps } from "./field-props";
+
+const DEFAULT_SECRET_RESOLVE_TYPE = "website/loaders/secret.ts";
+
+export function isSecretBlock(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const resolveType = (value as Record<string, unknown>).__resolveType;
+  return (
+    typeof resolveType === "string" &&
+    (resolveType.endsWith("/secret.ts") ||
+      resolveType.includes("loaders/secret"))
+  );
+}
+
+function emptySecretBlock(): Record<string, unknown> {
+  return {
+    __resolveType: DEFAULT_SECRET_RESOLVE_TYPE,
+    name: "",
+    encrypted: "",
+  };
+}
+
+/**
+ * Deco stores API secrets as `website/loaders/secret.ts` blocks (`name` + `encrypted`).
+ * JSON Schema often marks these as `format: password` or `format: string` without `type`.
+ */
+export function SecretField({
+  schema,
+  value,
+  onChange,
+  label,
+  path,
+}: FieldProps) {
+  const block = isSecretBlock(value)
+    ? (value as Record<string, unknown>)
+    : emptySecretBlock();
+  const name = typeof block.name === "string" ? block.name : "";
+  const hasStoredSecret =
+    typeof block.encrypted === "string" && block.encrypted;
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={`${path}-name`} className="text-sm font-medium">
+        {label}
+      </Label>
+      {schema.description && (
+        <p className="text-xs text-muted-foreground">{schema.description}</p>
+      )}
+      <Input
+        id={`${path}-name`}
+        value={name}
+        placeholder="Secret name"
+        onChange={(e) => onChange({ ...block, name: e.target.value })}
+        className="h-10"
+      />
+      <Input
+        id={`${path}-value`}
+        type="password"
+        placeholder={
+          hasStoredSecret ? "Leave blank to keep current value" : "Secret value"
+        }
+        onChange={(e) => {
+          const next = e.target.value;
+          if (!next) {
+            onChange(block);
+            return;
+          }
+          onChange({ ...block, value: next });
+        }}
+        className="h-10"
+      />
+      {hasStoredSecret && (
+        <p className="text-xs text-muted-foreground">
+          A secret value is stored.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/page-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-list.tsx
@@ -1,4 +1,5 @@
 import {
+  isDecoAppResolveType,
   isResolvableManifestApp,
   resolveBlockSchemaMetadata,
   type LiveMeta,
@@ -159,7 +160,8 @@ export function findSiteAppEntry(
     const resolveType = obj.__resolveType;
     if (
       typeof resolveType === "string" &&
-      isResolvableManifestApp(meta, resolveType)
+      (isSiteAppBlock(SITE_APP_BLOCK_KEY, obj) ||
+        isResolvableManifestApp(meta, resolveType))
     ) {
       return {
         key: SITE_APP_BLOCK_KEY,
@@ -174,13 +176,17 @@ export function findSiteAppEntry(
     if (!val || typeof val !== "object" || Array.isArray(val)) continue;
 
     const obj = val as Record<string, unknown>;
-    if (obj.__resolveType !== SITE_APP_RESOLVE_TYPE) continue;
-    if (!isResolvableManifestApp(meta, SITE_APP_RESOLVE_TYPE)) continue;
+    if (!isSiteAppBlock(key, obj)) continue;
+
+    const resolveType =
+      typeof obj.__resolveType === "string"
+        ? obj.__resolveType
+        : SITE_APP_RESOLVE_TYPE;
 
     return {
       key,
       name: appLabel(key, obj, meta),
-      resolveType: SITE_APP_RESOLVE_TYPE,
+      resolveType,
     };
   }
 
@@ -204,7 +210,12 @@ export function extractApps(
     if (PAGE_RESOLVE_TYPES.has(resolveType)) continue;
     if (typeof obj.path === "string") continue;
     if (isSiteAppBlock(key, obj)) continue;
-    if (!isResolvableManifestApp(meta, resolveType)) continue;
+    if (
+      !isResolvableManifestApp(meta, resolveType) &&
+      !isDecoAppResolveType(resolveType)
+    ) {
+      continue;
+    }
 
     apps.push({
       key,

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -163,6 +163,42 @@ describe("resolveSchema – app resolveType aliases", () => {
     expect(resolved?.properties?.seo?.title).toBe("SEO");
   });
 
+  test("resolves tanstack app schemas from base64 definition keys", () => {
+    const resolveType = "site/apps/local/app-tags.ts";
+    const encoded = Buffer.from(resolveType).toString("base64");
+    const meta: LiveMeta = {
+      manifest: { blocks: {} },
+      schema: {
+        definitions: {
+          [encoded]: {
+            title: resolveType,
+            type: "object",
+            allOf: [
+              {
+                $ref: "#/definitions/AppTagsProps",
+              },
+            ],
+            properties: {
+              __resolveType: {
+                type: "string",
+                enum: [resolveType],
+              },
+            },
+          },
+          AppTagsProps: {
+            type: "object",
+            properties: {
+              account: { type: "string", title: "Account Name" },
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = resolveSchema(resolveType, meta);
+    expect(resolved?.properties?.account?.title).toBe("Account Name");
+  });
+
   test("prefers section array over page multivariate flag for site global", () => {
     const meta: LiveMeta = {
       manifest: {

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -199,6 +199,66 @@ describe("resolveSchema – app resolveType aliases", () => {
     expect(resolved?.properties?.account?.title).toBe("Account Name");
   });
 
+  test("merges properties from deeply nested allOf chains", () => {
+    const resolveType = "site/apps/site.ts";
+    const encoded = Buffer.from(resolveType).toString("base64");
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          apps: {
+            [resolveType]: { $ref: `#/definitions/${encoded}` },
+          },
+        },
+      },
+      schema: {
+        definitions: {
+          BaseSite: {
+            type: "object",
+            properties: {
+              global: {
+                title: "Global Sections",
+                type: "array",
+                items: { type: "object" },
+              },
+              caching: { type: "object", title: "Caching configuration" },
+            },
+          },
+          ExtensionSite: {
+            type: "object",
+            properties: {
+              badIPS: {
+                type: "array",
+                title: "Bad IPS",
+                items: { type: "string" },
+              },
+            },
+          },
+          Layer4: { $ref: "#/definitions/Layer3" },
+          Layer3: { $ref: "#/definitions/Layer2" },
+          Layer2: { $ref: "#/definitions/Layer1" },
+          Layer1: { $ref: "#/definitions/Layer0" },
+          Layer0: {
+            allOf: [
+              { $ref: "#/definitions/ExtensionSite" },
+              { $ref: "#/definitions/BaseSite" },
+            ],
+          },
+          [encoded]: {
+            allOf: [{ $ref: "#/definitions/Layer4" }],
+            properties: {
+              __resolveType: { type: "string", enum: [resolveType] },
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = resolveSchema(resolveType, meta);
+    expect(resolved?.properties?.global?.title).toBe("Global Sections");
+    expect(resolved?.properties?.caching?.title).toBe("Caching configuration");
+    expect(resolved?.properties?.badIPS?.title).toBe("Bad IPS");
+  });
+
   test("prefers section array over page multivariate flag for site global", () => {
     const meta: LiveMeta = {
       manifest: {
@@ -265,6 +325,59 @@ describe("resolveSchema – app resolveType aliases", () => {
     expect(global?.title).toBe("Global");
     expect(global?.anyOfRefs).toBeUndefined();
     expect(global?.items).toBeDefined();
+  });
+
+  test("prefers config array over product-list loaders in app flag anyOf", () => {
+    const loaderRef = "#/definitions/ProductList";
+    const meta: LiveMeta = {
+      manifest: { blocks: {} },
+      schema: {
+        definitions: {
+          ProductList: {
+            type: "object",
+            properties: {
+              __resolveType: {
+                enum: ["vtex/loaders/ProductList.ts"],
+              },
+              query: { type: "string", title: "Query" },
+            },
+          },
+          AppProps: {
+            type: "object",
+            properties: {
+              flags: {
+                title: "Flags Personalizada",
+                anyOf: [
+                  { $ref: "#/definitions/Resolvable" },
+                  {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      title: "{{{name}}}",
+                      properties: {
+                        name: { type: "string", title: "Name" },
+                        text: { type: "string", title: "Text" },
+                      },
+                    },
+                  },
+                  { $ref: loaderRef },
+                ],
+              },
+            },
+          },
+          [Buffer.from("site/apps/local/app-tags.ts").toString("base64")]: {
+            allOf: [{ $ref: "#/definitions/AppProps" }],
+          },
+        },
+      },
+    };
+
+    const flags = resolveSchema("site/apps/local/app-tags.ts", meta)?.properties
+      ?.flags;
+    expect(flags?.type).toBe("array");
+    expect(flags?.items?.properties?.name?.title).toBe("Name");
+    expect(flags?.items?.titleBy).toBe("{{{name}}}");
+    expect(flags?.anyOfRefs).toBeUndefined();
   });
 });
 

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -71,6 +71,12 @@ function isArraySchemaBranch(schema: RawSchema): boolean {
 // `format` field natively this guard becomes a no-op.
 const VIDEO_WIDGET_REF_KEY = "VideoWidget";
 
+/** Base64 encode resolveType keys — browser-safe (btoa), Node fallback in tests. */
+function toBase64(str: string): string {
+  if (typeof btoa === "function") return btoa(str);
+  return Buffer.from(str).toString("base64");
+}
+
 function parseSiteAppResolveType(
   resolveType: string,
 ): { vendor: string; app: string } | null {
@@ -112,17 +118,35 @@ function lookupManifestBlockSchema(
   const parsed =
     parseSiteAppResolveType(resolveType) ??
     parseLegacyAppResolveType(resolveType);
-  if (!parsed) return {};
-
-  for (const alias of appManifestResolveTypeAliases(
-    parsed.vendor,
-    parsed.app,
-  )) {
-    for (const blockTypeMap of Object.values(allBlockTypes)) {
-      if (blockTypeMap[alias]) {
-        return blockTypeMap[alias] as RawSchema;
+  if (parsed) {
+    for (const alias of appManifestResolveTypeAliases(
+      parsed.vendor,
+      parsed.app,
+    )) {
+      for (const blockTypeMap of Object.values(allBlockTypes)) {
+        if (blockTypeMap[alias]) {
+          return blockTypeMap[alias] as RawSchema;
+        }
       }
     }
+  }
+
+  // Tanstack sites generate app schemas with base64-encoded resolveType keys
+  // (same convention as sections). Fall back when manifest.blocks.apps is empty.
+  const encodedResolveType = toBase64(resolveType);
+  for (const blockTypeMap of Object.values(allBlockTypes)) {
+    if (blockTypeMap[encodedResolveType]) {
+      return blockTypeMap[encodedResolveType] as RawSchema;
+    }
+  }
+
+  const globalSchema = meta.schema ?? {};
+  const defs = (globalSchema.$defs ?? globalSchema.definitions ?? {}) as Record<
+    string,
+    unknown
+  >;
+  if (defs[encodedResolveType]) {
+    return { $ref: `#/definitions/${encodedResolveType}` };
   }
 
   return {};
@@ -139,8 +163,31 @@ export function isResolvableManifestApp(
     parseLegacyAppResolveType(resolveType);
   if (!parsed) return false;
   const apps = meta.manifest?.blocks?.apps ?? {};
-  return appManifestResolveTypeAliases(parsed.vendor, parsed.app).some(
-    (alias) => alias in apps,
+  if (
+    appManifestResolveTypeAliases(parsed.vendor, parsed.app).some(
+      (alias) => alias in apps,
+    )
+  ) {
+    return true;
+  }
+  const encodedResolveType = toBase64(resolveType);
+  const defs = (meta.schema?.$defs ?? meta.schema?.definitions ?? {}) as Record<
+    string,
+    unknown
+  >;
+  return encodedResolveType in defs;
+}
+
+/**
+ * Whether resolveType is a deco app module path (site/apps or legacy vendor/apps),
+ * excluding the site app itself. Used to detect installed custom/local apps even
+ * when they are missing from manifest.blocks.apps.
+ */
+export function isDecoAppResolveType(resolveType: string): boolean {
+  if (resolveType === "site/apps/site.ts") return false;
+  return (
+    parseSiteAppResolveType(resolveType) !== null ||
+    parseLegacyAppResolveType(resolveType) !== null
   );
 }
 

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -60,9 +60,34 @@ export interface LiveMeta {
 
 type RawSchema = Record<string, unknown>;
 
+/** Max `$ref` / `allOf` hops while flattening top-level properties. */
+const MAX_COLLECT_PROPS_DEPTH = 12;
+
+/** Max recursion while building nested field schemas. */
+const MAX_BUILD_PROPERTY_DEPTH = 8;
+
 function isArraySchemaBranch(schema: RawSchema): boolean {
   const t = schema.type;
   return t === "array" || (Array.isArray(t) && t.includes("array"));
+}
+
+/**
+ * Section/loader arrays (items carry `__resolveType` or `anyOf`) vs config
+ * arrays (plain object items, e.g. app flag lists).
+ */
+function isSectionLoaderArrayBranch(
+  branch: RawSchema,
+  resolveRef: (ref: string) => RawSchema,
+): boolean {
+  let items = branch.items as RawSchema | undefined;
+  if (!items) return false;
+  if (typeof items.$ref === "string") {
+    items = resolveRef(items.$ref);
+  }
+  if (Array.isArray(items.anyOf) || Array.isArray(items.oneOf)) return true;
+  const props = items.properties as RawSchema | undefined;
+  const rtEnum = (props?.__resolveType as RawSchema | undefined)?.enum;
+  return Array.isArray(rtEnum) && typeof rtEnum[0] === "string";
 }
 
 // deco.cx convention: VideoWidget schemas don't carry `format` in their
@@ -281,7 +306,7 @@ export function resolveSchema(
     seenRefs: Set<string> = new Set(),
     depth = 0,
   ): RawSchema => {
-    if (depth > 5) return {};
+    if (depth > MAX_COLLECT_PROPS_DEPTH) return {};
 
     if (typeof s.$ref === "string") {
       const key = s.$ref.split("/").pop() ?? "";
@@ -421,6 +446,8 @@ export function resolveSchema(
 
         // Site `global` / page `sections`: plain section arrays with an optional
         // page multivariate flag branch. Prefer the array (admin hides the flag UI).
+        // App config arrays (e.g. flag lists) share anyOf with product-list loaders;
+        // prefer the array branch when items are plain objects, not section refs.
         const arrayBranch = nonNull.find(isArraySchemaBranch);
         const hasPageMultivariateLoader = loaderBranches.some((branch) => {
           const rtEnum = (
@@ -433,18 +460,41 @@ export function resolveSchema(
             rtEnum[0] === PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE
           );
         });
-        if (arrayBranch && hasPageMultivariateLoader) {
-          const built = buildProperty(arrayBranch, depth + 1);
-          return {
-            ...built,
-            type: "array",
-            title:
-              typeof resolved.title === "string" ? resolved.title : built.title,
-            description:
-              typeof resolved.description === "string"
-                ? resolved.description
-                : built.description,
-          };
+        if (arrayBranch) {
+          const isConfigArray = !isSectionLoaderArrayBranch(
+            arrayBranch,
+            resolveRef,
+          );
+          if (isConfigArray && nonNull.length > 1) {
+            const built = buildProperty(arrayBranch, depth + 1);
+            return {
+              ...built,
+              type: "array",
+              title:
+                typeof resolved.title === "string"
+                  ? resolved.title
+                  : built.title,
+              description:
+                typeof resolved.description === "string"
+                  ? resolved.description
+                  : built.description,
+            };
+          }
+          if (hasPageMultivariateLoader) {
+            const built = buildProperty(arrayBranch, depth + 1);
+            return {
+              ...built,
+              type: "array",
+              title:
+                typeof resolved.title === "string"
+                  ? resolved.title
+                  : built.title,
+              description:
+                typeof resolved.description === "string"
+                  ? resolved.description
+                  : built.description,
+            };
+          }
         }
 
         if (loaderBranches.length > 0) {
@@ -464,7 +514,9 @@ export function resolveSchema(
                   ? branch.description
                   : undefined,
               schema:
-                depth + 1 < 6 ? buildProperty(branch, depth + 1) : undefined,
+                depth + 1 < MAX_BUILD_PROPERTY_DEPTH
+                  ? buildProperty(branch, depth + 1)
+                  : undefined,
             };
           });
           return {
@@ -499,7 +551,10 @@ export function resolveSchema(
                   ? def.description
                   : undefined,
               discriminatorValue,
-              schema: depth + 1 < 6 ? buildProperty(def, depth + 1) : undefined,
+              schema:
+                depth + 1 < MAX_BUILD_PROPERTY_DEPTH
+                  ? buildProperty(def, depth + 1)
+                  : undefined,
             };
           });
           return {
@@ -565,7 +620,10 @@ export function resolveSchema(
                   ? def.description
                   : undefined,
               discriminatorValue,
-              schema: depth + 1 < 6 ? buildProperty(def, depth + 1) : undefined,
+              schema:
+                depth + 1 < MAX_BUILD_PROPERTY_DEPTH
+                  ? buildProperty(def, depth + 1)
+                  : undefined,
             });
           }
           return {
@@ -592,7 +650,7 @@ export function resolveSchema(
     // deco sections nest images at depth 4+ (`images[].desktop.src`); the
     // old cap left those leaves un-resolved and stripped their `format`.
     let nestedProperties: Record<string, SchemaProperty> | undefined;
-    if (depth < 6) {
+    if (depth < MAX_BUILD_PROPERTY_DEPTH) {
       const nestedRaw = collectProps(resolved);
       const nestedEntries = Object.entries(nestedRaw).filter(
         ([k]) => !k.startsWith("__") && k !== "@type",
@@ -607,7 +665,10 @@ export function resolveSchema(
 
     // Array items
     let itemsSchema: SchemaProperty | undefined;
-    if ((type === "array" || resolved.type === "array") && depth < 6) {
+    if (
+      (type === "array" || resolved.type === "array") &&
+      depth < MAX_BUILD_PROPERTY_DEPTH
+    ) {
       let rawItems = resolved.items as RawSchema | undefined;
       if (rawItems) {
         if (typeof rawItems.$ref === "string") {

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -614,6 +614,12 @@ export function resolveSchema(
           rawItems = resolveRef(rawItems.$ref);
         }
         itemsSchema = buildProperty(rawItems, depth + 1);
+        if (
+          typeof rawItems.title === "string" &&
+          rawItems.title.includes("{{")
+        ) {
+          itemsSchema.titleBy = rawItems.title;
+        }
       }
     }
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { SchemaProperty } from "./resolve-schema";
 import {
+  breadcrumbPathForActiveField,
+  buildArrayDrillDownBreadcrumb,
   fieldDisplayLabel,
   isArrayDrillDownField,
   resolveActiveFieldKey,
@@ -60,6 +62,16 @@ describe("resolveActiveFieldKey", () => {
     expect(resolveActiveFieldKey(["layout"], properties, {}, [])).toBeNull();
   });
 
+  test("matches array field label anywhere in breadcrumb trail", () => {
+    expect(
+      resolveActiveFieldKey(["layout", "cards"], properties, {}, [
+        "Options",
+        "Cards",
+        "Men's",
+      ]),
+    ).toBe("cards");
+  });
+
   test("finds nested array field inside object ancestor", () => {
     const globalHeader = {
       logos: { title: "Logos", type: "object", properties: {} },
@@ -95,6 +107,27 @@ describe("resolveActiveFieldKey", () => {
         ["A Utah Proud Brand Since 1921"],
       ),
     ).toBe("alert");
+  });
+
+  test("matches array field when runtime value is an array", () => {
+    const properties = {
+      appKey: { type: "string", title: "App Key" } as SchemaProperty,
+      flags: {
+        title: "Flags Personalizada",
+        type: "object",
+      } as SchemaProperty,
+    };
+
+    expect(
+      resolveActiveFieldKey(
+        ["appKey", "flags"],
+        properties,
+        {
+          flags: [{ name: "Sale" }, { name: "Holiday" }],
+        },
+        ["Flags Personalizada", "Sale"],
+      ),
+    ).toBe("flags");
   });
 });
 
@@ -134,6 +167,47 @@ describe("isArrayDrillDownField", () => {
         ],
       } as SchemaProperty),
     ).toBe(true);
+  });
+});
+
+describe("buildArrayDrillDownBreadcrumb", () => {
+  test("includes array label before item label", () => {
+    expect(
+      buildArrayDrillDownBreadcrumb([], "Flag Desconto", "Partiu ferias"),
+    ).toEqual(["Flag Desconto", "Partiu ferias"]);
+  });
+
+  test("does not duplicate crumbs already in trail", () => {
+    expect(
+      buildArrayDrillDownBreadcrumb(
+        ["Flag Desconto", "Partiu ferias"],
+        "Flag Desconto",
+        "Partiu ferias",
+      ),
+    ).toEqual(["Flag Desconto", "Partiu ferias"]);
+  });
+});
+
+describe("breadcrumbPathForActiveField", () => {
+  const schema = {
+    title: "Flag Desconto",
+    type: "array",
+    items: { type: "object" },
+  } as SchemaProperty;
+
+  test("strips array field label from head", () => {
+    expect(
+      breadcrumbPathForActiveField("flags", schema, [
+        "Flag Desconto",
+        "Partiu ferias",
+      ]),
+    ).toEqual(["Partiu ferias"]);
+  });
+
+  test("keeps trail when head is item label", () => {
+    expect(
+      breadcrumbPathForActiveField("flags", schema, ["Partiu ferias"]),
+    ).toEqual(["Partiu ferias"]);
   });
 });
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -2,14 +2,47 @@ import { describe, expect, test } from "bun:test";
 import type { SchemaProperty } from "./resolve-schema";
 import {
   breadcrumbPathForActiveField,
+  breadcrumbsForHeaderClick,
   buildArrayDrillDownBreadcrumb,
   fieldDisplayLabel,
+  findBreadcrumbLabelIndex,
   isArrayDrillDownField,
+  normalizeBreadcrumbLabel,
   resolveActiveFieldKey,
   resolveArrayItemSelection,
   isBreadcrumbInsideObject,
 } from "./schema-form-breadcrumb";
 import { PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE } from "./section-types";
+
+describe("normalizeBreadcrumbLabel", () => {
+  test("normalizes composed characters to NFC", () => {
+    const nfd = "cafe\u0301";
+    const nfc = "caf\u00e9";
+    expect(normalizeBreadcrumbLabel(nfd)).toBe(normalizeBreadcrumbLabel(nfc));
+  });
+});
+
+describe("breadcrumbsForHeaderClick", () => {
+  test("maps header index to breadcrumb trail", () => {
+    const breadcrumbs = ["Global Sections", "Analytics"];
+    expect(breadcrumbsForHeaderClick(breadcrumbs, 0)).toEqual([]);
+    expect(breadcrumbsForHeaderClick(breadcrumbs, 1)).toEqual([
+      "Global Sections",
+    ]);
+    expect(breadcrumbsForHeaderClick(breadcrumbs, 2)).toEqual([
+      "Global Sections",
+      "Analytics",
+    ]);
+  });
+});
+
+describe("findBreadcrumbLabelIndex", () => {
+  test("matches labels with NFC normalization", () => {
+    const nfd = "cafe\u0301";
+    const nfc = "caf\u00e9";
+    expect(findBreadcrumbLabelIndex(["Flag", nfd], nfc)).toBe(1);
+  });
+});
 
 describe("fieldDisplayLabel", () => {
   test("prefers schema title", () => {

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
@@ -9,14 +9,64 @@ function humanize(key: string): string {
     .replace(/^\w/, (c) => c.toUpperCase());
 }
 
+/** Normalize labels so breadcrumb matching survives NFC/NFD differences (e.g. `ª`). */
+export function normalizeBreadcrumbLabel(label: string): string {
+  return label.normalize("NFC").trim();
+}
+
+function labelsMatch(a: string, b: string): boolean {
+  return normalizeBreadcrumbLabel(a) === normalizeBreadcrumbLabel(b);
+}
+
+/** Breadcrumb trail when opening an array item (includes the array field label). */
+export function buildArrayDrillDownBreadcrumb(
+  breadcrumbPath: string[],
+  arrayLabel: string,
+  itemLabel: string,
+): string[] {
+  const normalizedItem = normalizeBreadcrumbLabel(itemLabel);
+  if (
+    breadcrumbPath.some(
+      (crumb) =>
+        labelsMatch(crumb, normalizedItem) || labelsMatch(crumb, itemLabel),
+    )
+  ) {
+    return breadcrumbPath;
+  }
+  const trail = [...breadcrumbPath];
+  const hasArrayLabel = trail.some((crumb) => labelsMatch(crumb, arrayLabel));
+  if (!hasArrayLabel) trail.push(arrayLabel);
+  trail.push(itemLabel);
+  return trail;
+}
+
+/** Drop crumbs consumed by the active field so children see a relative trail. */
+export function breadcrumbPathForActiveField(
+  activeKey: string,
+  schema: SchemaProperty,
+  breadcrumbPath: string[],
+): string[] {
+  if (breadcrumbPath.length === 0) return breadcrumbPath;
+  const label = fieldDisplayLabel(activeKey, schema);
+  const head = breadcrumbPath[0]!;
+  if (labelsMatch(head, label) || labelsMatch(head, activeKey)) {
+    return breadcrumbPath.slice(1);
+  }
+  return breadcrumbPath;
+}
+
 export function fieldDisplayLabel(key: string, schema: SchemaProperty): string {
   return schema.title ?? humanize(key);
 }
 
 /** Breadcrumb drill-down applies to array fields only (not nested objects). */
-export function isArrayDrillDownField(schema: SchemaProperty): boolean {
+export function isArrayDrillDownField(
+  schema: SchemaProperty,
+  value?: unknown,
+): boolean {
   if (schema.type === "array" && schema.items) return true;
-  return isPageMultivariateSectionArrayField(schema);
+  if (isPageMultivariateSectionArrayField(schema)) return true;
+  return Array.isArray(value);
 }
 
 function asObjectRecord(value: unknown): Record<string, unknown> {
@@ -37,19 +87,27 @@ function resolveActiveFieldKeyInScope(
 
   for (const key of keys) {
     const schema = properties[key];
-    if (!schema || !isArrayDrillDownField(schema)) continue;
+    if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
     const label = fieldDisplayLabel(key, schema);
-    if (head === label || head === key) return key;
+    if (labelsMatch(head, label) || labelsMatch(head, key)) return key;
+    if (
+      breadcrumbPath.some(
+        (crumb) => labelsMatch(crumb, label) || labelsMatch(crumb, key),
+      )
+    ) {
+      return key;
+    }
   }
 
   for (const key of keys) {
     const schema = properties[key];
-    if (!schema || !isArrayDrillDownField(schema)) continue;
+    if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
     const val = objValue[key];
     if (!Array.isArray(val)) continue;
     const itemSchema = schema.items;
     for (let i = 0; i < val.length; i++) {
-      if (getArrayItemLabel(val[i], i, itemSchema) === head) return key;
+      const itemLabel = getArrayItemLabel(val[i], i, itemSchema);
+      if (labelsMatch(itemLabel, head)) return key;
     }
   }
 
@@ -68,7 +126,7 @@ function resolveActiveFieldKeyInScope(
     );
     if (direct) return key;
 
-    if (head === label || head === key) {
+    if (labelsMatch(head, label) || labelsMatch(head, key)) {
       const viaLabel = resolveActiveFieldKeyInScope(
         childKeys,
         schema.properties,
@@ -120,7 +178,7 @@ export function isBreadcrumbInsideObject(
   }
 
   const head = breadcrumbPath[0]!;
-  if (head !== label && head !== fieldKey) return false;
+  if (!labelsMatch(head, label) && !labelsMatch(head, fieldKey)) return false;
 
   return (
     breadcrumbPath.length > 1 ||
@@ -143,19 +201,21 @@ export function resolveArrayItemSelection(
 
   for (let pi = 0; pi < breadcrumbPath.length; pi++) {
     const crumb = breadcrumbPath[pi]!;
-    const index = items.findIndex(
-      (item, i) => getArrayItemLabel(item, i, itemSchema) === crumb,
+    const index = items.findIndex((item, i) =>
+      labelsMatch(getArrayItemLabel(item, i, itemSchema), crumb),
     );
     if (index >= 0) {
       return { index, innerPath: breadcrumbPath.slice(pi + 1) };
     }
   }
 
-  const labelIndex = breadcrumbPath.indexOf(label);
+  const labelIndex = breadcrumbPath.findIndex((crumb) =>
+    labelsMatch(crumb, label),
+  );
   if (labelIndex >= 0 && breadcrumbPath.length > labelIndex + 1) {
     const itemCrumb = breadcrumbPath[labelIndex + 1]!;
-    const index = items.findIndex(
-      (item, i) => getArrayItemLabel(item, i, itemSchema) === itemCrumb,
+    const index = items.findIndex((item, i) =>
+      labelsMatch(getArrayItemLabel(item, i, itemSchema), itemCrumb),
     );
     if (index >= 0) {
       return { index, innerPath: breadcrumbPath.slice(labelIndex + 2) };

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
@@ -59,6 +59,25 @@ export function fieldDisplayLabel(key: string, schema: SchemaProperty): string {
   return schema.title ?? humanize(key);
 }
 
+/** Map a header crumb index to the breadcrumb trail (`headerCrumbs = [title, ...breadcrumbs]`). */
+export function breadcrumbsForHeaderClick(
+  breadcrumbs: string[],
+  headerIndex: number,
+): string[] {
+  if (headerIndex <= 0) return [];
+  return breadcrumbs.slice(0, headerIndex);
+}
+
+export function findBreadcrumbLabelIndex(
+  path: string[],
+  targetLabel: string,
+): number {
+  const normalized = normalizeBreadcrumbLabel(targetLabel);
+  return path.findIndex(
+    (crumb) => normalizeBreadcrumbLabel(crumb) === normalized,
+  );
+}
+
 /** Breadcrumb drill-down applies to array fields only (not nested objects). */
 export function isArrayDrillDownField(
   schema: SchemaProperty,

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -17,6 +17,7 @@ import {
   wrapMultivariateArrayValue,
 } from "./page-variants";
 import {
+  breadcrumbPathForActiveField,
   fieldDisplayLabel,
   resolveActiveFieldKey,
 } from "./schema-form-breadcrumb";
@@ -248,6 +249,8 @@ export function SchemaForm({
   meta,
   decofile,
   onSaveReferencedBlock,
+  previewBaseUrl,
+  onAddSectionItem,
 }: {
   schema: SchemaProperty;
   value: unknown;
@@ -261,6 +264,8 @@ export function SchemaForm({
     blockKey: string,
     data: Record<string, unknown>,
   ) => void;
+  previewBaseUrl?: string | null;
+  onAddSectionItem?: FieldProps["onAddSectionItem"];
 }) {
   const properties = schema.properties;
   if (!properties) return null;
@@ -286,12 +291,21 @@ export function SchemaForm({
     onChange({ ...objValue, [key]: fieldValue });
   };
 
+  const containerResolveType =
+    typeof objValue.__resolveType === "string"
+      ? objValue.__resolveType
+      : undefined;
+
   const activeKey =
     breadcrumbPath.length > 0
       ? resolveActiveFieldKey(keys, properties, objValue, breadcrumbPath)
       : null;
   const activeSchema = activeKey ? properties[activeKey] : null;
   const visibleKeys = activeKey && activeSchema ? [activeKey] : keys;
+  const fieldBreadcrumbPath =
+    activeKey && activeSchema
+      ? breadcrumbPathForActiveField(activeKey, activeSchema, breadcrumbPath)
+      : breadcrumbPath;
   return (
     <div className="min-w-0 space-y-6">
       {visibleKeys.map((key) => {
@@ -306,11 +320,14 @@ export function SchemaForm({
           onChange: (val) => updateField(key, val),
           path: fieldPath,
           label,
-          breadcrumbPath,
+          breadcrumbPath: fieldBreadcrumbPath,
           onBreadcrumbChange,
           meta,
           decofile,
           onSaveReferencedBlock,
+          containerResolveType,
+          previewBaseUrl,
+          onAddSectionItem,
         });
       })}
     </div>

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -9,6 +9,7 @@ import { ObjectField } from "./fields/object-field";
 import { AnyOfField } from "./fields/any-of-field";
 import { FileField } from "./fields/file-field";
 import { ImageField } from "./fields/image-field";
+import { isSecretBlock, SecretField } from "./fields/secret-field";
 import {
   isMultivariateArrayWrapper,
   isPageMultivariateSectionArrayField,
@@ -166,13 +167,31 @@ export function renderField(props: FieldProps) {
     return <AnyOfField key={props.path} {...props} />;
   }
 
+  // Deco API secrets are stored as loader blocks, not plain strings.
+  if (
+    isSecretBlock(value) ||
+    schema.format === "password" ||
+    (value == null && schema.format === "password")
+  ) {
+    return <SecretField key={props.path} {...props} />;
+  }
+
   // If value is null/undefined, try to produce a typed default from schema
   const effectiveValue =
     value === null || value === undefined
       ? defaultForType(schema.type, schema.default)
       : value;
 
-  if (effectiveValue === null || effectiveValue === undefined) return null;
+  if (effectiveValue === null || effectiveValue === undefined) {
+    if (isSecretBlock(value)) {
+      return <SecretField key={props.path} {...props} />;
+    }
+    return null;
+  }
+
+  if (isSecretBlock(effectiveValue)) {
+    return <SecretField key={props.path} {...props} value={effectiveValue} />;
+  }
 
   const effectiveProps = { ...props, value: effectiveValue };
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -251,6 +251,7 @@ export function SchemaForm({
   onSaveReferencedBlock,
   previewBaseUrl,
   onAddSectionItem,
+  onRequestAddSection,
 }: {
   schema: SchemaProperty;
   value: unknown;
@@ -266,6 +267,7 @@ export function SchemaForm({
   ) => void;
   previewBaseUrl?: string | null;
   onAddSectionItem?: FieldProps["onAddSectionItem"];
+  onRequestAddSection?: FieldProps["onRequestAddSection"];
 }) {
   const properties = schema.properties;
   if (!properties) return null;
@@ -328,6 +330,7 @@ export function SchemaForm({
           containerResolveType,
           previewBaseUrl,
           onAddSectionItem,
+          onRequestAddSection,
         });
       })}
     </div>

--- a/apps/mesh/src/web/components/sections-editor/secret-field.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/secret-field.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { isSecretBlock } from "./fields/secret-field";
+
+describe("isSecretBlock", () => {
+  test("detects website secret loader blocks", () => {
+    expect(
+      isSecretBlock({
+        __resolveType: "website/loaders/secret.ts",
+        name: "apiKey",
+        encrypted: "abc",
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects plain strings and unrelated objects", () => {
+    expect(isSecretBlock("secret")).toBe(false);
+    expect(isSecretBlock({ __resolveType: "site/sections/Hero.tsx" })).toBe(
+      false,
+    );
+    expect(isSecretBlock(null)).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/section-array-field.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-array-field.test.ts
@@ -60,4 +60,28 @@ describe("isSectionArrayField", () => {
       } as SchemaProperty),
     ).toBe(false);
   });
+
+  test("detects global field by key even when items are plain objects", () => {
+    expect(
+      isSectionArrayField(
+        {
+          type: "array",
+          items: { type: "object", properties: {} },
+        } as SchemaProperty,
+        "global",
+      ),
+    ).toBe(true);
+  });
+
+  test("detects sections field by key", () => {
+    expect(
+      isSectionArrayField(
+        {
+          type: "array",
+          items: { type: "object" },
+        } as SchemaProperty,
+        "sections",
+      ),
+    ).toBe(true);
+  });
 });

--- a/apps/mesh/src/web/components/sections-editor/section-array-field.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-array-field.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import type { SchemaProperty } from "./resolve-schema";
+import { isSectionArrayField } from "./section-array-field";
+import { PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE } from "./section-types";
+
+describe("isSectionArrayField", () => {
+  test("detects global/page section arrays", () => {
+    expect(
+      isSectionArrayField({
+        type: "array",
+        items: {
+          type: "block-ref",
+          anyOfRefs: [
+            { resolveType: "site/sections/Analytics.tsx", title: "Analytics" },
+          ],
+        },
+      } as SchemaProperty),
+    ).toBe(true);
+  });
+
+  test("detects page multivariate section array fields", () => {
+    expect(
+      isSectionArrayField({
+        type: "block-ref",
+        anyOfRefs: [
+          {
+            resolveType: PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
+            title: "Page Variants",
+            schema: {
+              type: "object",
+              properties: {
+                variants: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      value: { type: "array", items: { type: "object" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      } as SchemaProperty),
+    ).toBe(true);
+  });
+
+  test("ignores config flag arrays", () => {
+    expect(
+      isSectionArrayField({
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string", title: "Name" },
+            text: { type: "string", title: "Text" },
+          },
+        },
+      } as SchemaProperty),
+    ).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/section-array-field.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-array-field.ts
@@ -1,0 +1,22 @@
+import type { SchemaProperty } from "./resolve-schema";
+import { isPageMultivariateSectionArrayField } from "./page-variants";
+import { SECTION_MULTIVARIATE_RESOLVE_TYPE } from "./section-types";
+
+/** True when an array field holds page/global section entries (block-ref items). */
+export function isSectionArrayField(schema: SchemaProperty): boolean {
+  if (isPageMultivariateSectionArrayField(schema)) return true;
+
+  const items = schema.type === "array" ? schema.items : undefined;
+  if (!items || items.type !== "block-ref" || !items.anyOfRefs?.length) {
+    return false;
+  }
+
+  return items.anyOfRefs.some((ref) => {
+    const rt = ref.resolveType;
+    return (
+      rt.includes("/sections/") ||
+      rt.includes("multivariate/section") ||
+      rt === SECTION_MULTIVARIATE_RESOLVE_TYPE
+    );
+  });
+}

--- a/apps/mesh/src/web/components/sections-editor/section-array-field.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-array-field.ts
@@ -2,21 +2,47 @@ import type { SchemaProperty } from "./resolve-schema";
 import { isPageMultivariateSectionArrayField } from "./page-variants";
 import { SECTION_MULTIVARIATE_RESOLVE_TYPE } from "./section-types";
 
-/** True when an array field holds page/global section entries (block-ref items). */
-export function isSectionArrayField(schema: SchemaProperty): boolean {
+function sectionRefResolveType(resolveType: string): boolean {
+  return (
+    resolveType.includes("/sections/") ||
+    resolveType.includes("multivariate/section") ||
+    resolveType === SECTION_MULTIVARIATE_RESOLVE_TYPE
+  );
+}
+
+function itemsLookLikeSections(items: SchemaProperty): boolean {
+  if (items.type === "block-ref" && items.anyOfRefs?.length) {
+    return items.anyOfRefs.some((ref) =>
+      sectionRefResolveType(ref.resolveType),
+    );
+  }
+
+  if (items.anyOfRefs?.length) {
+    return items.anyOfRefs.some((ref) =>
+      sectionRefResolveType(ref.resolveType),
+    );
+  }
+
+  const rtProp = items.properties?.__resolveType;
+  if (rtProp?.type === "block-ref" && rtProp.anyOfRefs?.length) {
+    return rtProp.anyOfRefs.some((ref) =>
+      sectionRefResolveType(ref.resolveType),
+    );
+  }
+
+  return false;
+}
+
+/** True when an array field holds page/global section entries. */
+export function isSectionArrayField(
+  schema: SchemaProperty,
+  fieldKey?: string,
+): boolean {
+  if (fieldKey === "global" || fieldKey === "sections") return true;
   if (isPageMultivariateSectionArrayField(schema)) return true;
 
   const items = schema.type === "array" ? schema.items : undefined;
-  if (!items || items.type !== "block-ref" || !items.anyOfRefs?.length) {
-    return false;
-  }
+  if (!items) return false;
 
-  return items.anyOfRefs.some((ref) => {
-    const rt = ref.resolveType;
-    return (
-      rt.includes("/sections/") ||
-      rt.includes("multivariate/section") ||
-      rt === SECTION_MULTIVARIATE_RESOLVE_TYPE
-    );
-  });
+  return itemsLookLikeSections(items);
 }


### PR DESCRIPTION
## Summary

Improves the CMS Content tab app editor and Site settings form:

- **App catalog**: lists installed apps from store + manifest + decofile (including custom/local apps); aligns fallback icons with logo rows.
- **Array fields**: drag-to-reorder, breadcrumb drill-down into items, NFC-safe label matching, and secret/password fields for app credentials.
- **Schema resolution**: prefers config-array branches in `anyOf` (e.g. app flag lists), increases `allOf` traversal depth so Site app exposes Global Sections, Caching, etc., and resolves Tanstack app schemas from base64 keys.
- **Global Sections**: "Add section" opens the same section gallery modal as the Sections tab; creates a saved block and appends it to the `global` array.

## Test plan

- [x] `bun test` for `app-catalog`, `resolve-schema`, `schema-form-breadcrumb`, `section-array-field`
- [ ] Content → Apps → app-tags: click flag array item → only item props visible; top-level fields hidden
- [ ] Content → Site: Global Sections, Caching configuration, and other base fields visible
- [ ] Content → Site → Global Sections → Add section: gallery opens (preview dev server required)
- [ ] Content → Apps: custom app icons align with installed apps that have logos