### PR TITLE
fix(link-daemon): mark TUI connected after tunnel starts

### DIFF
--- a/apps/mesh/src/link-daemon/cluster-connection-tunnel.test.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-tunnel.test.ts
@@ -442,6 +442,39 @@ describe("connectToClusterTunnel", () => {
     await handle.close();
   });
 
+  it("notifies when the first tunnel connection is serving", async () => {
+    const natsClosed = deferred<void | Error>();
+    const serverClosed = deferred<void>();
+    let connected = 0;
+
+    const handle = await connectToClusterTunnel(
+      makeBaseTunnelInput({
+        onConnected: () => {
+          connected++;
+        },
+      }),
+      {
+        fetchSession: async () => sessionWithoutAuth,
+        connectNats: async () =>
+          ({
+            publish: () => {},
+            flush: async () => {},
+            close: async () => natsClosed.resolve(undefined),
+            closed: async () => natsClosed.promise,
+          }) as never,
+        serveTunnel: async (options) => ({
+          hostname: options.hostname,
+          closed: serverClosed.promise,
+          close: async () => serverClosed.resolve(),
+        }),
+        sleep: waitForAbortSleep,
+      },
+    );
+
+    expect(connected).toBe(1);
+    await handle.close();
+  });
+
   it("serves the tunnel without publishing presence frames", async () => {
     const natsClosed = deferred<void | Error>();
     const serverClosed = deferred<void>();

--- a/apps/mesh/src/link-daemon/cluster-connection-tunnel.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-tunnel.ts
@@ -459,8 +459,11 @@ export async function connectToClusterTunnel(
     try {
       while (!stopRequested) {
         active = await startActive();
-        firstReady?.resolve();
-        firstReady = undefined;
+        if (firstReady) {
+          firstReady.resolve();
+          firstReady = undefined;
+          input.onConnected?.();
+        }
         if (stopRequested) {
           await active.close();
           break;


### PR DESCRIPTION
## What is this contribution about?
Fixes `deco link` staying in the TUI connecting state after the tunnel is already serving by firing the existing `onConnected` monitor callback once the first tunnel connection is ready.

## Screenshots/Demonstration
The regression test covers the callback that drives the TUI from `connecting` to `linked`.

## How to Test
- `bun test apps/mesh/src/link-daemon/cluster-connection-tunnel.test.ts`
- `bun run --cwd=apps/mesh check`
- `bun run fmt`

## Migration Notes
No migration required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `deco link` TUI getting stuck in “connecting” by calling the existing onConnected callback when the first tunnel connection starts serving. Adds a regression test to verify the TUI transitions to “linked” as soon as the tunnel is ready.

<sup>Written for commit 594ad92ecb112fd6f3626192b44da20e30386b1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

