### PR TITLE
fix(harness): pin claude-code native binary to host libc (glibc/musl)

### DIFF
--- a/apps/mesh/src/link-daemon/capabilities.ts
+++ b/apps/mesh/src/link-daemon/capabilities.ts
@@ -94,8 +94,21 @@ export function startCapabilityReprobe(
 
 async function detectClaudeCode(): Promise<boolean> {
   try {
-    const { query } = await import("@anthropic-ai/claude-agent-sdk");
-    const q = query({ prompt: "", options: { maxTurns: 1 } });
+    const [{ query }, { resolveClaudeCodeExecutable }] = await Promise.all([
+      import("@anthropic-ai/claude-agent-sdk"),
+      import("@decocms/harness/claude-code/resolve-executable"),
+    ]);
+    // Pin the host-matching native binary so detection doesn't trip over the
+    // SDK's libc misdetection (which can pick the unrunnable `-musl` binary on
+    // glibc). Omitted when undefined so the SDK resolves as before.
+    const pathToClaudeCodeExecutable = resolveClaudeCodeExecutable();
+    const q = query({
+      prompt: "",
+      options: {
+        maxTurns: 1,
+        ...(pathToClaudeCodeExecutable ? { pathToClaudeCodeExecutable } : {}),
+      },
+    });
     const info = await q.accountInfo();
     q.return(undefined);
     return Boolean(info.email);

--- a/packages/harness/src/claude-code/model/index.ts
+++ b/packages/harness/src/claude-code/model/index.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { createClaudeCode } from "ai-sdk-provider-claude-code";
+import { resolveClaudeCodeExecutable } from "../resolve-executable";
 import type { ToolApprovalLevel } from "../../types";
 
 /**
@@ -48,6 +49,16 @@ export function createClaudeCodeModel(
     mcpServers: options?.mcpServers,
     cwd: options?.cwd ?? process.cwd(),
   };
+
+  // Pin the native binary that matches this host's libc. Without this the SDK
+  // self-resolves it, and on some glibc hosts its detection wrongly picks the
+  // `-musl` binary (which can't launch) — see resolveClaudeCodeExecutable. When
+  // it returns undefined (non-linux, or it can't resolve) we omit the option
+  // and let the SDK resolve as before.
+  const executablePath = resolveClaudeCodeExecutable();
+  if (executablePath) {
+    settings.pathToClaudeCodeExecutable = executablePath;
+  }
 
   const restrictWrites =
     options?.isPlanMode || options?.toolApprovalLevel === "readonly";

--- a/packages/harness/src/claude-code/resolve-executable.test.ts
+++ b/packages/harness/src/claude-code/resolve-executable.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import { decideMusl, nativeVariantOrder } from "./resolve-executable";
+
+describe("decideMusl", () => {
+  it("is never musl off-linux (no gnu/musl split there)", () => {
+    expect(
+      decideMusl({
+        platform: "darwin",
+        glibcVersionRuntime: undefined,
+        hasMuslLoader: true,
+      }),
+    ).toBe(false);
+    expect(
+      decideMusl({
+        platform: "win32",
+        glibcVersionRuntime: undefined,
+        hasMuslLoader: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a positive glibc version as authoritative glibc", () => {
+    expect(
+      decideMusl({
+        platform: "linux",
+        glibcVersionRuntime: "2.35",
+        hasMuslLoader: false,
+      }),
+    ).toBe(false);
+    // A stray musl loader must not override a positive glibc signal.
+    expect(
+      decideMusl({
+        platform: "linux",
+        glibcVersionRuntime: "2.35",
+        hasMuslLoader: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("THE BUG: glibcVersionRuntime undefined on a glibc host (no musl loader) is NOT musl", () => {
+    // This is the customer's case. The SDK's own check (glibcVersionRuntime
+    // only) would wrongly conclude musl here; the loader probe keeps us correct.
+    expect(
+      decideMusl({
+        platform: "linux",
+        glibcVersionRuntime: undefined,
+        hasMuslLoader: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("is musl on a real musl host (no glibc version + musl loader present)", () => {
+    expect(
+      decideMusl({
+        platform: "linux",
+        glibcVersionRuntime: undefined,
+        hasMuslLoader: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats an empty-string glibc version as absent", () => {
+    expect(
+      decideMusl({
+        platform: "linux",
+        glibcVersionRuntime: "",
+        hasMuslLoader: true,
+      }),
+    ).toBe(true);
+    expect(
+      decideMusl({
+        platform: "linux",
+        glibcVersionRuntime: "",
+        hasMuslLoader: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("nativeVariantOrder", () => {
+  it("prefers gnu, falls back to musl, on glibc linux", () => {
+    expect(nativeVariantOrder("linux", "x64", false)).toEqual([
+      "linux-x64",
+      "linux-x64-musl",
+    ]);
+    expect(nativeVariantOrder("linux", "arm64", false)).toEqual([
+      "linux-arm64",
+      "linux-arm64-musl",
+    ]);
+  });
+
+  it("prefers musl, falls back to gnu, on musl linux", () => {
+    expect(nativeVariantOrder("linux", "x64", true)).toEqual([
+      "linux-x64-musl",
+      "linux-x64",
+    ]);
+  });
+
+  it("uses the single platform variant off-linux", () => {
+    expect(nativeVariantOrder("darwin", "arm64", false)).toEqual([
+      "darwin-arm64",
+    ]);
+    expect(nativeVariantOrder("win32", "x64", false)).toEqual(["win32-x64"]);
+  });
+});

--- a/packages/harness/src/claude-code/resolve-executable.ts
+++ b/packages/harness/src/claude-code/resolve-executable.ts
@@ -1,0 +1,139 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+/**
+ * Resolves the Claude Code native binary that matches the current host so we
+ * can hand it to the SDK as `pathToClaudeCodeExecutable`.
+ *
+ * WHY THIS EXISTS — the Claude Agent SDK ships per-platform native binaries
+ * (`@anthropic-ai/claude-agent-sdk-linux-x64`, `-linux-x64-musl`, ...) and
+ * picks one at spawn time. Its libc check trusts a SINGLE signal:
+ * `process.report.getReport().header.glibcVersionRuntime`. On a glibc host that
+ * field is normally a version string ("2.35"), but some runtimes (musl-linked
+ * or older Bun/Node builds) leave it `undefined` even on glibc — and the SDK
+ * then treats the host as musl and selects the `-musl` binary. That binary
+ * cannot launch on glibc (its dynamic loader `/lib/ld-musl-*.so.1` is absent),
+ * so the chat turn dies with "Claude Code native binary not found at
+ * .../claude-agent-sdk-linux-x64-musl/claude" (or a spawn crash).
+ *
+ * We resolve the binary ourselves using a more robust libc check (a filesystem
+ * ground-truth probe in addition to `glibcVersionRuntime`) and pass it
+ * explicitly, which bypasses the SDK's built-in detection entirely.
+ */
+
+/**
+ * Decide whether the host uses the musl C library from the available libc
+ * signals. Pure — no `process`/filesystem access — so it is unit testable.
+ *
+ * `glibcVersionRuntime` is the SDK's only signal; `hasMuslLoader` is the
+ * filesystem tie-breaker that keeps glibc hosts from being misclassified when
+ * the runtime fails to report a glibc version.
+ */
+export function decideMusl(signals: {
+  platform: NodeJS.Platform;
+  glibcVersionRuntime: unknown;
+  hasMuslLoader: boolean;
+}): boolean {
+  if (signals.platform !== "linux") return false;
+  // A positive glibc version is authoritative — it means glibc, full stop
+  // (and never musl, even if a musl loader happens to be installed too).
+  if (
+    typeof signals.glibcVersionRuntime === "string" &&
+    signals.glibcVersionRuntime.length > 0
+  ) {
+    return false;
+  }
+  // No glibc version reported: either a real musl host OR a runtime that just
+  // doesn't expose it. The presence of the musl dynamic loader on disk settles
+  // it — musl hosts ship it, glibc hosts do not.
+  return signals.hasMuslLoader;
+}
+
+/**
+ * Ordered `claude-agent-sdk-<variant>` suffixes to try, most-preferred first.
+ * Pure. Mirrors the SDK's own ordering (preferred libc first, other as
+ * fallback) so a host missing its preferred binary still resolves the other.
+ */
+export function nativeVariantOrder(
+  platform: NodeJS.Platform,
+  arch: string,
+  musl: boolean,
+): string[] {
+  if (platform !== "linux") return [`${platform}-${arch}`];
+  const gnu = `linux-${arch}`;
+  const muslVariant = `linux-${arch}-musl`;
+  return musl ? [muslVariant, gnu] : [gnu, muslVariant];
+}
+
+/** Maps Node's `process.arch` to the musl loader's machine token. */
+function muslLoaderMachine(arch: string): string {
+  if (arch === "arm64") return "aarch64";
+  if (arch === "x64") return "x86_64";
+  return arch;
+}
+
+/** musl ships its dynamic loader at /lib/ld-musl-<machine>.so.1; glibc doesn't. */
+function hasMuslLoader(arch: string): boolean {
+  const machine = muslLoaderMachine(arch);
+  return [
+    `/lib/ld-musl-${machine}.so.1`,
+    `/usr/lib/ld-musl-${machine}.so.1`,
+  ].some((p) => existsSync(p));
+}
+
+function glibcVersionRuntime(): unknown {
+  const report =
+    typeof process.report?.getReport === "function"
+      ? (process.report.getReport() as {
+          header?: { glibcVersionRuntime?: unknown };
+        })
+      : null;
+  return report?.header?.glibcVersionRuntime;
+}
+
+/** True when the current host uses the musl C library (e.g. Alpine). */
+export function isMuslLibc(): boolean {
+  return decideMusl({
+    platform: process.platform,
+    glibcVersionRuntime: glibcVersionRuntime(),
+    hasMuslLoader: hasMuslLoader(process.arch),
+  });
+}
+
+const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
+
+/**
+ * Absolute path to the Claude Code native binary matching THIS host, or
+ * `undefined` when it can't be resolved (callers should then let the SDK
+ * resolve on its own — i.e. preserve today's behavior).
+ *
+ * Only linux is handled: it is the only platform that ships split gnu/musl
+ * native packages, so it is the only one the SDK can get wrong. On
+ * macOS/Windows there is a single native package and the SDK resolves it
+ * correctly, so we defer to it.
+ */
+export function resolveClaudeCodeExecutable(): string | undefined {
+  if (process.platform !== "linux") return undefined;
+
+  let scopeDir: string;
+  try {
+    // The native variant packages are installed as siblings of the main SDK
+    // package (Bun symlinks them next to it; npm/bunx lay them out flat), so
+    // resolve the SDK entry and walk up to the `@anthropic-ai` scope dir.
+    const sdkEntry = createRequire(import.meta.url).resolve(SDK_PACKAGE);
+    scopeDir = dirname(dirname(sdkEntry));
+  } catch {
+    return undefined;
+  }
+
+  for (const variant of nativeVariantOrder(
+    process.platform,
+    process.arch,
+    isMuslLibc(),
+  )) {
+    const bin = join(scopeDir, `claude-agent-sdk-${variant}`, "claude");
+    if (existsSync(bin)) return bin;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What is this contribution about?
On glibc Linux hosts the Claude Agent SDK can pick the wrong native binary and fail with `Claude Code native binary not found at …-linux-x64-musl/claude`, breaking claude-code detection and chat. The SDK chooses its binary from a single signal (`process.report.getReport().header.glibcVersionRuntime`), which some runtimes (musl-linked or older Bun/Node) leave undefined even on glibc, so it selects the `-musl` binary that can't launch there. This PR adds `resolveClaudeCodeExecutable()` — a libc resolver that augments `glibcVersionRuntime` with a filesystem ground-truth probe (`/lib/ld-musl-*.so.1`) — and passes the resolved path as `pathToClaudeCodeExecutable` from both runtime call sites (daemon capability detection and the chat harness), bypassing the SDK's faulty detection. It returns `undefined` off-linux or when it can't resolve, preserving today's behavior.

## How to Test
1. On a glibc Linux host where the runtime doesn't report `glibcVersionRuntime` (reproducible in Docker: Ubuntu 22.04 + strip the field from `process.report`), run claude-code detection/chat.
2. Before: the SDK self-resolves the `-musl` binary and crashes (`native binary not found` / spawn failure), so `claude-code` is never detected.
3. After: `resolveClaudeCodeExecutable()` picks the gnu binary, it spawns cleanly, and `detectCapabilities()` advertises `claude-code`. Verified end-to-end in Docker on glibc (Ubuntu 22.04) and musl (Alpine, picks the musl binary — no regression); unit tests cover the pure decision logic.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Claude Code native binary to the host’s libc (glibc or musl) so the SDK doesn’t pick the wrong Linux variant, fixing crashes and restoring `claude-code` detection/chat on glibc hosts.

- **Bug Fixes**
  - Added `resolveClaudeCodeExecutable()` that combines `process.report.header.glibcVersionRuntime` with a filesystem probe for `/lib/ld-musl-*.so.1` to choose the correct binary.
  - Passes the resolved path as `pathToClaudeCodeExecutable` in link-daemon capability detection and the harness model; falls back to SDK resolution off-Linux or when unresolved.
  - Included unit tests for libc decision logic and native variant ordering; works with `@anthropic-ai/claude-agent-sdk`.

<sup>Written for commit 2dedf95634bbaa9599b0ff1f831cadec37ceb940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

