### PR TITLE
fix(decopilot): run projector queue on worker pods

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
@@ -7,6 +7,8 @@ import { PartEmitter } from "./part-emitter";
 import { projectRun } from "./project-run";
 import { recordPoison } from "./projector-metrics";
 import { readProjectorRunLog } from "./projector-run-log";
+export { PROJECTOR_QUEUE } from "@/dispatch-queue/queue-names";
+import { PROJECTOR_QUEUE } from "@/dispatch-queue/queue-names";
 
 /**
  * Single partitioned queue for projector runs, partitioned by orgId — mirrors
@@ -17,7 +19,6 @@ import { readProjectorRunLog } from "./projector-run-log";
  * partitions with ENQUEUED work, so idle poll cost is flat regardless of org
  * count. Registered once at boot in `initDbos`; do NOT register per-org queues.
  */
-export const PROJECTOR_QUEUE = "decopilot-projector";
 export const PROJECTOR_PARTITION_CONCURRENCY = 10;
 
 export function projectorWorkflowId(runId: string, fenceToken: string): string {

--- a/apps/mesh/src/dispatch-queue/queue-names.test.ts
+++ b/apps/mesh/src/dispatch-queue/queue-names.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import * as queueNames from "./queue-names";
+
+describe("DBOS queue names", () => {
+  test("exports the projector queue from the side-effect-free queue module", () => {
+    expect(queueNames).toMatchObject({
+      AUTOMATIONS_QUEUE: "automations",
+      THREAD_GATE_QUEUE: "thread-gate",
+      PROJECTOR_QUEUE: "decopilot-projector",
+    });
+  });
+});

--- a/apps/mesh/src/dispatch-queue/queue-names.ts
+++ b/apps/mesh/src/dispatch-queue/queue-names.ts
@@ -8,3 +8,4 @@
  */
 export const THREAD_GATE_QUEUE = "thread-gate";
 export const AUTOMATIONS_QUEUE = "automations";
+export const PROJECTOR_QUEUE = "decopilot-projector";

--- a/apps/mesh/src/index.test.ts
+++ b/apps/mesh/src/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+
+describe("DBOS worker queue selection", () => {
+  test("worker role listens to all run queues, including the durable projector", async () => {
+    const source = await Bun.file(
+      new URL("./index.ts", import.meta.url),
+    ).text();
+
+    expect(source).toContain("PROJECTOR_QUEUE");
+    expect(source).toContain(
+      "const RUN_QUEUES = [AUTOMATIONS_QUEUE, THREAD_GATE_QUEUE, PROJECTOR_QUEUE]",
+    );
+  });
+});

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -11,6 +11,7 @@ import { sleep } from "@decocms/std";
 // the workflow modules, which register workflows at import time).
 import {
   AUTOMATIONS_QUEUE,
+  PROJECTOR_QUEUE,
   THREAD_GATE_QUEUE,
 } from "./dispatch-queue/queue-names";
 import { getSettings } from "./settings";
@@ -65,7 +66,7 @@ function withSslmode(url: string, ssl: boolean): string {
 // pod and stay exactly-once via DBOS's row-locked schedule, so an "api" pod can
 // still fire a cron that a "worker" pod then executes. REQUIREMENT: at least
 // one "worker" (or "all") pod must exist or runs never dispatch.
-const RUN_QUEUES = [AUTOMATIONS_QUEUE, THREAD_GATE_QUEUE];
+const RUN_QUEUES = [AUTOMATIONS_QUEUE, THREAD_GATE_QUEUE, PROJECTOR_QUEUE];
 const listenQueues: string[] | undefined =
   settings.dispatchRole === "worker"
     ? RUN_QUEUES


### PR DESCRIPTION
## Summary
- Include the durable decopilot projector queue in worker pod DBOS listenQueues.
- Move PROJECTOR_QUEUE into the side-effect-free queue names module so index.ts can import it before DBOS workflow registration.
- Add guards for worker queue selection and side-effect-free projector queue export.

## Root cause
Claude Code desktop runs were completing locally and publishing raw chunks plus valid done markers to DECOPILOT_STREAMS, but the DBOS projector workflows stayed ENQUEUED because worker pods only listened to automations and thread-gate queues. Assistant parts were never projected, leaving threads stuck in_progress after the first/second turn.

## Testing
- bun test apps/mesh/src/dispatch-queue/queue-names.test.ts apps/mesh/src/index.test.ts
- bun test apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts apps/mesh/src/api/routes/decopilot/projector-consumer.test.ts apps/mesh/src/dispatch-queue/thread-gate-workflow.test.ts
- bun run fmt
- bun run lint
- bun run check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Workers now listen to the decopilot projector queue so projector workflows run and assistant parts get projected. This fixes threads getting stuck after early turns.

- **Bug Fixes**
  - Added `PROJECTOR_QUEUE` to worker `RUN_QUEUES` in `index.ts`.
  - Moved `PROJECTOR_QUEUE` to side-effect-free `dispatch-queue/queue-names` and re-exported from the workflow to avoid registration-order issues.
  - Added tests for queue exports and worker queue selection.

<sup>Written for commit bd571958d150363ad273e0956c076fe60d3b3e16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

