### PR TITLE
fix(security): prevent cross-org KV data leak for multi-org users

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -86,7 +86,6 @@ import {
 } from "./routes/oauth-proxy";
 import openaiCompatRoutes from "./routes/openai-compat";
 import { createProxyRoutes } from "./routes/proxy";
-import { createKVRoutes } from "./routes/kv";
 import { createTriggerCallbackRoutes } from "./routes/trigger-callback";
 import publicConfigRoutes from "./routes/public-config";
 import filesRoutes from "./routes/files";
@@ -1979,16 +1978,12 @@ export async function createApp(options: CreateAppOptions = {}) {
   );
   app.route("/api", legacyTriggerCallback);
 
-  // KV store (org-scoped, for external MCPs to persist state)
-  // Legacy mount at /api/* with deprecation log; the new /api/:org/* mount
-  // is wired in a later task.
+  // KV store — org-scoped only. The legacy unscoped mount at /api/kv/:key was
+  // removed because it lacked resolveOrgFromPath middleware, allowing multi-org
+  // users to read/write KV data from an unintended org (non-deterministic org
+  // resolution via .executeTakeFirst() without ORDER BY). All callers must use
+  // the org-scoped route: /api/:org/kv/:key.
   const kvStorage = new KyselyKVStorage(database.db);
-  const legacyKVRoutes = new Hono<{
-    Variables: { meshContext: StudioContext };
-  }>();
-  legacyKVRoutes.use("*", createLogDeprecatedRoute({ mountPath: "/api" }));
-  legacyKVRoutes.route("/", createKVRoutes({ kvStorage }));
-  app.route("/api", legacyKVRoutes);
 
   // Public Events endpoint — legacy mount with deprecation log. New mount
   // lives at `POST /api/:org/events/:type` (registered via createOrgScopedApi).

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -659,7 +659,16 @@ async function authenticateRequest(
             .where("organization.slug", "=", orgSlugHint)
             .executeTakeFirst();
         }
-        return base.executeTakeFirst();
+        // No org hint — only resolve when the user has exactly one membership.
+        // For multi-org users without a hint, return undefined so callers get
+        // no org context instead of a non-deterministic pick (the previous
+        // .executeTakeFirst() without ORDER BY could return any membership row
+        // depending on PostgreSQL's physical row ordering).
+        return base
+          .orderBy("member.createdAt", "asc")
+          .limit(2)
+          .execute()
+          .then((rows) => (rows.length === 1 ? rows[0] : undefined));
       });
 
       if (isOrgArchived({ metadata: membership?.orgMetadata })) {


### PR DESCRIPTION
## Summary

- **Remove legacy unscoped `/api/kv/:key` routes** — these lacked `resolveOrgFromPath` middleware, so org context was resolved via the MCP OAuth fallback path which uses `.executeTakeFirst()` without `ORDER BY`. For multi-org users without an `x-org-id` header, PostgreSQL could return any membership row, causing reads/writes to land in the wrong org's KV namespace. The org-scoped version at `/api/:org/kv/:key` (mounted in `org-scoped.ts` with proper middleware) already exists and is unaffected.
- **Fix MCP OAuth org resolution fallback** — when no `x-org-id`/`x-org-slug` header is provided, the fallback now only resolves an org when the user has exactly one membership. Multi-org users without a hint get `organization: undefined` (resulting in a 400 "Organization required" from any org-scoped endpoint) instead of a non-deterministic pick.

### Files changed

| File | Change |
|------|--------|
| `apps/mesh/src/api/app.ts` | Remove legacy `/api/kv/:key` mount and unused import |
| `apps/mesh/src/core/context-factory.ts` | Replace bare `.executeTakeFirst()` with `limit(2).execute()` — return the row only when exactly 1 membership exists |

## Test plan

- [x] `bun run check` — passes (no type errors)
- [x] `bun run fmt` — passes
- [x] `bun run lint` — passes (0 errors)
- [x] `bun test apps/mesh/src/core/` — 57 pass, 4 fail (pre-existing integration test failures on main due to no local PostgreSQL)
- [ ] Verify `GET /api/kv/:key` returns 404 (route removed)
- [ ] Verify `GET /api/:org/kv/:key` works correctly with `resolveOrgFromPath`
- [ ] Verify multi-org MCP OAuth user without `x-org-id` header gets `organization: undefined` → 400 on org-scoped endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross‑org KV access for multi‑org users by removing the unscoped `/api/kv/:key` and hardening MCP OAuth org resolution. KV is now org‑scoped only; multi‑org requests without an org hint return 400, and removed users no longer get SSO sessions.

- **Bug Fixes**
  - In MCP OAuth fallback, only resolve an org when the user has exactly one membership; otherwise leave org undefined.
  - Re‑verify org membership in SSO `/callback` before creating a session; redirect with `sso_error=not_a_member` if not a member.

- **Migration**
  - Replace `/api/kv/:key` with `/api/:org/kv/:key`.
  - For multi‑org users, include `x-org-id` or `x-org-slug`; otherwise org‑scoped endpoints return 400.

<sup>Written for commit be14453bd82aa4503d35753c6858817a1fc55732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

