### PR TITLE
fix(security): re-check org membership in SSO callback (TOCTOU)

### DIFF
--- a/apps/mesh/src/api/routes/org-sso.ts
+++ b/apps/mesh/src/api/routes/org-sso.ts
@@ -269,17 +269,21 @@ function registerSsoRoutes(app: SsoApp) {
       return c.redirect("/?sso_error=token_verification_failed");
     }
 
-    // Create SSO session
-    await ctx.storage.orgSsoSessions.upsert(ctx.auth.user.id, stateData.orgId);
-
-    // Look up org slug via membership to redirect to the org
+    // Re-verify membership before creating the session. The user may have been
+    // removed from the org between /authorize and this callback (TOCTOU).
     const membership = await getOrgMembership(
       ctx,
       ctx.auth.user.id,
       stateData.orgId,
     );
+    if (!membership) {
+      return c.redirect("/?sso_error=not_a_member");
+    }
 
-    const redirectPath = membership?.orgSlug ? `/${membership.orgSlug}` : "/";
+    // Create SSO session
+    await ctx.storage.orgSsoSessions.upsert(ctx.auth.user.id, stateData.orgId);
+
+    const redirectPath = membership.orgSlug ? `/${membership.orgSlug}` : "/";
     return c.redirect(redirectPath);
   });
 


### PR DESCRIPTION
## Summary

- **Re-check org membership in `/callback` before creating SSO session** — the `/authorize` endpoint verified org membership, but `/callback` did not re-check before creating the 24-hour SSO session. A user removed from an org during the OIDC round-trip (TOCTOU gap) could still receive a valid SSO session. If later re-added to the org, they would bypass the SSO re-authentication requirement. Now rejects with `sso_error=not_a_member` when membership is gone.

## Test plan

- [x] `bun run check` — passes
- [x] `bun run fmt` — passes
- [x] `bun run lint` — passes (0 errors)
- [ ] Verify SSO callback rejects removed users with redirect to `/?sso_error=not_a_member`
- [ ] Verify normal SSO flow (user still a member) continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-check org membership in the SSO `/callback` before creating the session to close a TOCTOU gap. If the user is no longer a member, redirect to `/?sso_error=not_a_member`; otherwise create the session and redirect to their org.

<sup>Written for commit 1cdbcf5cc0e7d8ada534bcc64e7cb07d60c648fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

