### PR TITLE
fix(security): require authentication on public events endpoint

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -693,6 +693,15 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
  */
 const eventsHandler: MiddlewareHandler<Env> = async (c) => {
   const ctx = c.var.meshContext;
+
+  // Require authentication — without this check, resolveOrgFromPath lets
+  // unauthenticated callers through (by design, for MCP OAuth discovery)
+  // and anyone with a valid org slug could publish arbitrary events.
+  const userId = ctx.auth?.user?.id ?? ctx.auth?.apiKey?.userId;
+  if (!userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
   const orgId = ctx.organization?.id ?? c.req.param("organizationId");
   if (!orgId) {
     return c.json({ error: "organization id missing" }, 400);


### PR DESCRIPTION
## Summary

- **Add auth check to `POST /api/:org/events/:type`** — the events handler had no authentication check. Since `resolveOrgFromPath` intentionally allows unauthenticated callers through (needed for MCP OAuth discovery), anyone with a valid org slug could publish arbitrary events — including scheduled (`deliverAt`) and recurring (`cron`) events — to any org's event bus without credentials. Adds the same auth pattern used by the adjacent `watchHandler`.

## Test plan

- [x] `bun run check` — passes
- [x] `bun run fmt` — passes
- [x] `bun run lint` — passes (0 errors)
- [ ] Verify unauthenticated `POST /api/:org/events/:type` returns 401
- [ ] Verify authenticated calls still publish successfully
- [ ] Verify the legacy route at `POST /org/:organizationId/events/:type` also requires auth (shares the same handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require authentication for event publishing endpoints to prevent unauthorized event injection. Unauthenticated requests to `POST /api/:org/events/:type` (and legacy `POST /org/:organizationId/events/:type`) now return 401; authenticated behavior is unchanged.

- **Bug Fixes**
  - Added user/API key auth check in the events handler, matching the `watchHandler` pattern.
  - Prevents publishing arbitrary, scheduled (`deliverAt`), and recurring (`cron`) events using only an org slug.

<sup>Written for commit 4ef64ca3a026eb07e2df7b8dbef149f0ae62f941. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

