### PR TITLE
fix(security): prevent admin-to-owner privilege escalation in member tools

### DIFF
--- a/apps/mesh/src/auth/roles.test.ts
+++ b/apps/mesh/src/auth/roles.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { canAssignRole } from "./roles";
+
+describe("canAssignRole", () => {
+  it("owner can assign any role", () => {
+    expect(canAssignRole("owner", "owner")).toBe(true);
+    expect(canAssignRole("owner", "admin")).toBe(true);
+    expect(canAssignRole("owner", "user")).toBe(true);
+    expect(canAssignRole("owner", "custom-role")).toBe(true);
+  });
+
+  it("admin can assign non-owner roles", () => {
+    expect(canAssignRole("admin", "admin")).toBe(true);
+    expect(canAssignRole("admin", "user")).toBe(true);
+    expect(canAssignRole("admin", "custom-role")).toBe(true);
+  });
+
+  it("admin cannot assign owner role", () => {
+    expect(canAssignRole("admin", "owner")).toBe(false);
+  });
+
+  it("user role cannot assign any role", () => {
+    expect(canAssignRole("user", "user")).toBe(false);
+    expect(canAssignRole("user", "admin")).toBe(false);
+    expect(canAssignRole("user", "owner")).toBe(false);
+  });
+
+  it("undefined caller role cannot assign any role", () => {
+    expect(canAssignRole(undefined, "user")).toBe(false);
+    expect(canAssignRole(undefined, "owner")).toBe(false);
+  });
+});

--- a/apps/mesh/src/auth/roles.ts
+++ b/apps/mesh/src/auth/roles.ts
@@ -20,3 +20,17 @@ export type BuiltinRole = (typeof BUILTIN_ROLES)[number];
  * Roles with full org access — they bypass all permission checks at runtime.
  */
 export const ADMIN_ROLES: BuiltinRole[] = ["owner", "admin"];
+
+/**
+ * Validate that the caller's role is allowed to assign the target role.
+ * Owners can assign any role. Admins can assign "user" or "admin" but NOT
+ * "owner" — preventing vertical privilege escalation.
+ */
+export function canAssignRole(
+  callerRole: string | undefined,
+  targetRole: string,
+): boolean {
+  if (callerRole === "owner") return true;
+  if (callerRole === "admin") return targetRole !== "owner";
+  return false;
+}

--- a/apps/mesh/src/tools/organization/member-add.ts
+++ b/apps/mesh/src/tools/organization/member-add.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
 import { getUserId, requireAuth } from "../../core/studio-context";
+import { canAssignRole } from "../../auth/roles";
 
 export const ORGANIZATION_MEMBER_ADD = defineTool({
   name: "ORGANIZATION_MEMBER_ADD",
@@ -54,6 +55,13 @@ export const ORGANIZATION_MEMBER_ADD = defineTool({
       throw new Error(
         "Organization ID does not match authenticated organization",
       );
+    }
+
+    // Validate the caller is allowed to assign the target role.
+    // Admins cannot assign "owner" — only owners can.
+    const targetRole = Array.isArray(input.role) ? input.role[0] : input.role;
+    if (targetRole && !canAssignRole(ctx.auth.user?.role, targetRole)) {
+      throw new Error(`Insufficient privileges to assign role "${targetRole}"`);
     }
 
     // Add member via Better Auth

--- a/apps/mesh/src/tools/organization/member-update-role.ts
+++ b/apps/mesh/src/tools/organization/member-update-role.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
 import { getUserId, requireAuth } from "../../core/studio-context";
+import { canAssignRole } from "../../auth/roles";
 
 export const ORGANIZATION_MEMBER_UPDATE_ROLE = defineTool({
   name: "ORGANIZATION_MEMBER_UPDATE_ROLE",
@@ -56,6 +57,13 @@ export const ORGANIZATION_MEMBER_UPDATE_ROLE = defineTool({
       throw new Error(
         "Organization ID required (no active organization in context)",
       );
+    }
+
+    // Validate the caller is allowed to assign the target role.
+    // Admins cannot assign "owner" — only owners can.
+    const targetRole = Array.isArray(input.role) ? input.role[0] : input.role;
+    if (targetRole && !canAssignRole(ctx.auth.user?.role, targetRole)) {
+      throw new Error(`Insufficient privileges to assign role "${targetRole}"`);
     }
 
     // Update member role via bound auth client


### PR DESCRIPTION
## Summary

- **Add role hierarchy enforcement to `ORGANIZATION_MEMBER_ADD` and `ORGANIZATION_MEMBER_UPDATE_ROLE`** — both tools accepted arbitrary role strings (including `"owner"`) with no validation. Better Auth's `addMember` / `updateMemberRole` also performs no role hierarchy check (`parseRoles` just joins the array into a string). An admin could assign `"owner"` to any user — including themselves — gaining full org control (SSO config, member management, org deletion).
- **New `canAssignRole()` guard** in `auth/roles.ts`: owners can assign any role; admins can assign anything except `"owner"`. Applied to both tool handlers before the Better Auth call.

### Files changed

| File | Change |
|------|--------|
| `apps/mesh/src/auth/roles.ts` | Add `canAssignRole(callerRole, targetRole)` |
| `apps/mesh/src/auth/roles.test.ts` | Unit tests for role hierarchy validation |
| `apps/mesh/src/tools/organization/member-add.ts` | Validate role before `addMember()` |
| `apps/mesh/src/tools/organization/member-update-role.ts` | Validate role before `updateMemberRole()` |

## Test plan

- [x] `bun run check` — passes
- [x] `bun run fmt` — passes
- [x] `bun run lint` — passes (0 errors)
- [x] `bun test apps/mesh/src/auth/roles.test.ts` — 5 pass, 0 fail
- [ ] Verify admin calling ORGANIZATION_MEMBER_ADD with `role: ["owner"]` gets error
- [ ] Verify owner calling ORGANIZATION_MEMBER_ADD with `role: ["owner"]` succeeds
- [ ] Verify admin calling ORGANIZATION_MEMBER_UPDATE_ROLE with `role: ["owner"]` gets error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks admin-to-owner privilege escalation by enforcing role assignment rules in organization member tools. Owners can assign any role; admins can assign non-owner roles only.

- **Bug Fixes**
  - Added `canAssignRole(callerRole, targetRole)` in `auth/roles.ts` with unit tests.
  - Validated target role in `ORGANIZATION_MEMBER_ADD` and `ORGANIZATION_MEMBER_UPDATE_ROLE` before calling Better Auth.
  - Admin attempts to assign `owner` now fail; owner assignments by owners still succeed.

<sup>Written for commit 67526d6b9a83719313c1c7bbcfb8c2665425b183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

