### PR TITLE
fix(security): block STDIO command injection — RCE at connection creation

### DIFF
--- a/apps/mesh/src/tools/connection/create.ts
+++ b/apps/mesh/src/tools/connection/create.ts
@@ -14,6 +14,7 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
+import { getSettings } from "../../settings";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
 import { fetchToolsFromMCP } from "./fetch-tools";
 import {
@@ -95,6 +96,18 @@ export const COLLECTION_CONNECTIONS_CREATE = defineTool({
 
       // Ensure the URL is properly formatted
       connectionData.connection_url = buildVirtualUrl(virtualMcpId);
+    }
+
+    // STDIO connections spawn arbitrary local commands — only allow in local mode.
+    // Without this check, the fetchToolsFromMCP call below would spawn
+    // user-supplied commands as child processes on the server.
+    if (
+      connectionData.connection_type === "STDIO" &&
+      !getSettings().localMode
+    ) {
+      throw new Error(
+        "STDIO connections are only available in local mode (--local-mode).",
+      );
     }
 
     // Fetch tools and configuration scopes from the MCP server before creating the connection

--- a/apps/mesh/src/tools/connection/fetch-tools.ts
+++ b/apps/mesh/src/tools/connection/fetch-tools.ts
@@ -10,6 +10,7 @@ import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { getSettings } from "../../settings";
 import type {
   ConnectionParameters,
   HttpConnectionParameters,
@@ -258,11 +259,22 @@ async function fetchToolsFromSSEMCP(
 }
 
 /**
- * Fetch tools from a STDIO-based MCP connection
+ * Fetch tools from a STDIO-based MCP connection.
+ * Guarded by localMode — STDIO spawns arbitrary commands as child processes.
  */
 async function fetchToolsFromStdioMCP(
   connection: ConnectionForToolFetch,
 ): Promise<FetchedMCPData | null> {
+  // Defense-in-depth: callers should check localMode before reaching here,
+  // but reject anyway to prevent any code path from spawning commands in
+  // production deployments.
+  if (!getSettings().localMode) {
+    console.error(
+      `[fetch-tools] Blocked STDIO spawn for ${connection.id}: not in local mode`,
+    );
+    return null;
+  }
+
   const stdioParams = isStdioParameters(connection.connection_headers)
     ? connection.connection_headers
     : null;

--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -19,6 +19,7 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
+import { getSettings } from "../../settings";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
 import { invalidateConnectionCaches } from "../../mcp-clients/mcp-cache-invalidation";
 import { fetchToolsFromMCP } from "./fetch-tools";
@@ -227,6 +228,13 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
           ctx,
         );
       }
+    }
+
+    // STDIO connections spawn arbitrary local commands — only allow in local mode.
+    if (finalConnectionType === "STDIO" && !getSettings().localMode) {
+      throw new Error(
+        "STDIO connections are only available in local mode (--local-mode).",
+      );
     }
 
     // Fetch tools from the MCP server.


### PR DESCRIPTION
## Summary

**Critical: OS command injection via STDIO MCP connections.** Any authenticated user could execute arbitrary commands on the server by creating a STDIO connection with a malicious `command`/`args` in `connection_headers`.

The proxy-time path (`outbound/index.ts:54-60`) correctly blocks STDIO spawns outside local mode. But the **creation-time path** (`create.ts` → `fetchToolsFromMCP()` → `fetchToolsFromStdioMCP()` → `new StdioClientTransport({command, args})`) had **no `localMode` guard** — user-supplied commands were spawned immediately as child processes, with errors silenced by `.catch(() => null)`.

### Attack vector
```bash
POST /api/:org/tools/COLLECTION_CONNECTIONS_CREATE
{
  "data": {
    "connection_type": "STDIO",
    "connection_headers": {
      "command": "bash",
      "args": ["-c", "id > /tmp/rce_proof.txt"]
    }
  }
}
# → 200 OK, command already executed on server
```

### Fix — three guards added

| File | Guard |
|------|-------|
| `apps/mesh/src/tools/connection/create.ts` | Reject STDIO `connection_type` when not in local mode (primary) |
| `apps/mesh/src/tools/connection/update.ts` | Same guard on the update path |
| `apps/mesh/src/tools/connection/fetch-tools.ts` | Defense-in-depth `localMode` check inside `fetchToolsFromStdioMCP` before any `StdioClientTransport` spawn |

## Test plan

- [x] `bun run check` — passes
- [x] `bun run fmt` — passes
- [x] `bun run lint` — passes (0 errors)
- [ ] Verify STDIO connection creation returns error when `localMode=false`
- [ ] Verify STDIO connection creation still works in local mode (`--local-mode`)
- [ ] Verify STDIO connection update returns error when `localMode=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical RCE by blocking STDIO MCP connection create/update outside local mode and adding a defense-in-depth check in the fetch path. Prevents arbitrary command execution on the server; STDIO now works only in local mode.

- **Bug Fixes**
  - Reject `STDIO` connection create/update when `localMode` is false.
  - Add `localMode` guard in `fetchToolsFromStdioMCP` to prevent any spawn in non-local environments.

- **Migration**
  - Production: STDIO connections are disabled. To use STDIO, run the server with --local-mode.
  - No changes for `SSE` or `HTTP` connections.

<sup>Written for commit d92122007be8ac70d55a2d1fe4f4ba6fd50c6dbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

