### PR TITLE
fix(sidebar): make task row button span full sidebar width

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
@@ -158,6 +158,7 @@ export function TaskGroup({
                 onClick={() => onSelectTask(task)}
                 onArchive={() => onArchiveTask(task)}
                 showAutomationBadge={Boolean(task.trigger_id)}
+                indented
               />
             ))
           ) : (
@@ -278,6 +279,7 @@ function AgentExpandedBody({
               onClick={() => onSelectTask(task)}
               onArchive={() => onArchiveTask(task)}
               showAutomationBadge={Boolean(task.trigger_id)}
+              indented
             />
           ))}
           {(hasMore || isFetching) && (
@@ -336,6 +338,7 @@ function StatusExpandedBody({
           showAutomationBadge={Boolean(task.trigger_id)}
           showAgentIcon
           hideStatusIdle
+          indented
         />
       ))}
       {(hasMore || isFetching) && (

--- a/apps/mesh/src/web/layouts/tasks-panel/task-row.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/task-row.tsx
@@ -22,6 +22,7 @@ export function TaskRow({
   showAutomationBadge,
   showAgentIcon,
   hideStatusIdle,
+  indented,
 }: {
   task: Task;
   isActive: boolean;
@@ -34,6 +35,10 @@ export function TaskRow({
    *  status); the archive button still appears on hover. When false/omitted,
    *  the status icon shows at rest and swaps to archive on hover. */
   hideStatusIdle?: boolean;
+  /** When true (inside a sidebar group), the button area stretches out to the
+   *  group's left edge while the content keeps its indented position, so the
+   *  clickable/hover surface spans the full sidebar width. */
+  indented?: boolean;
 }) {
   const config = getStatusConfig(task.status);
   const StatusIcon = config.icon;
@@ -62,7 +67,11 @@ export function TaskRow({
         }
       }}
       className={cn(
-        "group/row flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer transition-colors",
+        "group/row flex items-center gap-2 py-1.5 pr-2 rounded-md cursor-pointer transition-colors",
+        // Indented rows stretch their background out to the group's left edge
+        // (-ml-4 cancels the wrapper's pl-4) while pl-6 keeps the content where
+        // it sat before, so the button surface spans the full sidebar width.
+        indented ? "-ml-4 pl-6" : "pl-2",
         "focus-visible:outline-none focus-visible:inset-ring-2 focus-visible:inset-ring-ring/50",
         isActive ? "bg-accent text-accent-foreground" : "hover:bg-accent/60",
       )}


### PR DESCRIPTION
## Summary
Sidebar task rows were indented by their group wrapper's `pl-4`, so the clickable/hover/active surface started 16px in rather than at the sidebar edge — unlike the group header buttons, which span the full width.

This makes a task's button area span the full sidebar width while keeping its visible content (icon + title) exactly where it was.

## Changes
- **`task-row.tsx`** — add an optional `indented` prop. When set, the row uses `-ml-4 pl-6` (instead of `px-2`) so the background stretches out to the group's left edge while the content keeps its 24px offset. The right edge is unchanged; default (popover) behavior is preserved via `pl-2`.
- **`task-group.tsx`** — pass `indented` to the three in-group `TaskRow` usages (tool-call-run group, agent group body, status group body). Group wrappers keep `pl-4`, so the "New thread" / "Show more" helpers are untouched.

## Testing
- `bun run fmt` ✓
- `bun run --cwd=apps/mesh check` (tsc) ✓
- Verify visually: `bun run dev` → expand any agent or status group in the sidebar; the task hover/active highlight now reaches the full sidebar width without the icon/title moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix task row buttons in the sidebar to span the full width so hover/click matches group headers. The icon and title stay in the same position.

- **Bug Fixes**
  - Added optional `indented` prop to `TaskRow` to stretch the button background to the left edge (`-ml-4 pl-6`) while keeping content offset.
  - Passed `indented` to in-group `TaskRow` instances in `TaskGroup` (tool-call-run, agent body, status body); group wrappers remain `pl-4`.

<sup>Written for commit 2f2c3490b94f52a1e3dbcc62f99c1a1e67957c74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

