### PR TITLE
fix(preview): derive sandbox from active thread's provider kind

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -70,8 +70,8 @@ describe("shouldAutoStart", () => {
     expect(shouldAutoStart({ ...base, userId: null })).toBe(false);
   });
 
-  test("no branch → false", () => {
-    expect(shouldAutoStart({ ...base, branch: null })).toBe(false);
+  test("no branch → true (server generates branch on SANDBOX_START)", () => {
+    expect(shouldAutoStart({ ...base, branch: null })).toBe(true);
   });
 
   test("vmEntry already present → false", () => {

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -13,6 +13,7 @@
 
 import type { PreviewState } from "@/web/components/sandbox/preview/preview-state";
 import type { DrawerStatus } from "@/web/components/sandbox/preview/drawer/status-pill";
+import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 
 // ---------------------------------------------------------------------------
 // Pure helpers (unit-testable)
@@ -47,7 +48,6 @@ export function shouldAutoStart(args: ShouldAutoStartArgs): boolean {
   return (
     args.hasActiveGithubRepo &&
     !!args.userId &&
-    !!args.branch &&
     !args.vmEntry &&
     !args.userStopped &&
     !args.isPending &&
@@ -148,6 +148,7 @@ export function SandboxLifecycleProvider({
   userId,
   hasActiveGithubRepo,
   sandboxMap,
+  sandboxProviderKind,
   children,
 }: {
   virtualMcpId: string | null;
@@ -155,6 +156,10 @@ export function SandboxLifecycleProvider({
   userId: string | null;
   hasActiveGithubRepo: boolean;
   sandboxMap: SandboxMap | undefined;
+  /** Resolved provider kind from the active thread (locked) or live mode pick
+   *  (unlocked). When non-null, entry selection and SANDBOX_START are scoped to
+   *  this kind so the preview never silently shows a different-provider sibling. */
+  sandboxProviderKind: SandboxProviderKind | null;
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
@@ -188,7 +193,13 @@ export function SandboxLifecycleProvider({
           BranchMapEntryLike
         >)
       : {};
-  const vmEntry = selectVmEntry(branchMap);
+  // When a provider kind is known (locked thread or live mode pick), select the
+  // matching entry directly. Fall back to the heuristic only for legacy threads
+  // with no recorded kind (sandboxProviderKind == null).
+  const vmEntry = sandboxProviderKind
+    ? ((branchMap[sandboxProviderKind] as BranchMapEntryLike | undefined) ??
+      null)
+    : selectVmEntry(branchMap);
   const previewUrl = vmEntry?.previewUrl ?? null;
   const userStopped =
     !!virtualMcpId &&
@@ -206,10 +217,12 @@ export function SandboxLifecycleProvider({
   // not already started → fire SANDBOX_START once for this branch."
   // Branch-keyed, not taskId-keyed: that matches useSandboxStart's own
   // dedup and avoids resurrecting a user-killed VM across task switches.
+  // Dedup key: use branch string, or "" for the no-branch (pre-lock) case so a
+  // single auto-start fires even before the server assigns a branch.
+  const autoStartDedupKey = branch ?? "";
   const attempted =
-    branch !== null &&
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; mutation happens inside effect after add()
-    autoStartAttemptedForBranchRef.current.has(branch);
+    autoStartAttemptedForBranchRef.current.has(autoStartDedupKey);
   const autoStartEligible = shouldAutoStart({
     hasActiveGithubRepo,
     userId,
@@ -221,18 +234,28 @@ export function SandboxLifecycleProvider({
   });
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- bridges external state into a one-shot mutation; no render-time equivalent
   useEffect(() => {
-    if (!autoStartEligible || !branch || !virtualMcpId) return;
-    autoStartAttemptedForBranchRef.current.add(branch);
-    // Auto-start is gated on `!!branch` via shouldAutoStart, so the
-    // server-picks-a-branch flow (the onSuccess in self-heal + user start)
-    // is structurally unreachable here. No onSuccess needed.
-    const args: SandboxStartArgs = { virtualMcpId, branch };
+    if (!autoStartEligible || !virtualMcpId) return;
+    autoStartAttemptedForBranchRef.current.add(autoStartDedupKey);
+    const args: SandboxStartArgs = { virtualMcpId };
+    if (branch) args.branch = branch;
+    if (sandboxProviderKind) args.sandboxProviderKind = sandboxProviderKind;
     startVmMutate(args, {
+      onSuccess: (data) => {
+        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
+      },
       onError: (err) => {
         console.error("[sandbox-lifecycle] auto-start failed:", err);
       },
     });
-  }, [autoStartEligible, branch, virtualMcpId, startVmMutate]);
+  }, [
+    autoStartEligible,
+    autoStartDedupKey,
+    branch,
+    virtualMcpId,
+    sandboxProviderKind,
+    startVmMutate,
+    setCurrentTaskBranch,
+  ]);
 
   // Self-heal: SSE emits `gone` → reprovision via SANDBOX_START. Dedup by
   // dead handle so we don't loop on repeat 404s; a new dead handle is fine.
@@ -252,6 +275,7 @@ export function SandboxLifecycleProvider({
     reprovisionedForVmIdRef.current = deadVmId;
     const args: SandboxStartArgs = { virtualMcpId };
     if (branch) args.branch = branch;
+    if (sandboxProviderKind) args.sandboxProviderKind = sandboxProviderKind;
     startVmMutate(args, {
       onSuccess: (data) => {
         if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
@@ -265,6 +289,7 @@ export function SandboxLifecycleProvider({
     deadVmId,
     virtualMcpId,
     branch,
+    sandboxProviderKind,
     startVmMutate,
     setCurrentTaskBranch,
   ]);

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -37,6 +37,7 @@ import {
   type ReactNode,
 } from "react";
 import { Chat, useChatTask } from "@/web/components/chat/index";
+import { useChatPrefs } from "@/web/components/chat/context";
 import { ChatPanel } from "@/web/components/chat/side-panel-chat";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
@@ -216,6 +217,7 @@ function VmEventsBridge({
   children: ReactNode;
 }) {
   const { currentBranch } = useChatTask();
+  const { pendingSandboxProviderKind } = useChatPrefs();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
@@ -236,7 +238,14 @@ function VmEventsBridge({
           BranchMapEntryLike
         >)
       : {};
-  const vmEntry = selectVmEntry(branchMap);
+  // Use the resolved provider kind to pick the matching entry — same logic as
+  // SandboxLifecycleProvider so the SSE previewUrl and the lifecycle vmEntry
+  // always agree on which sandbox is active.
+  const vmEntry = pendingSandboxProviderKind
+    ? ((branchMap[pendingSandboxProviderKind] as
+        | BranchMapEntryLike
+        | undefined) ?? null)
+    : selectVmEntry(branchMap);
   const previewUrl = vmEntry?.previewUrl ?? null;
   const shouldConnect = Object.keys(branchMap).length > 0 || isStartPending;
 
@@ -253,6 +262,7 @@ function VmEventsBridge({
         userId={userId ?? null}
         hasActiveGithubRepo={hasActiveGithubRepo}
         sandboxMap={sandboxMap}
+        sandboxProviderKind={pendingSandboxProviderKind}
       >
         {children}
       </SandboxLifecycleProvider>


### PR DESCRIPTION
## Summary

- **Root bug fixed:** `selectVmEntry` hard-preferred non-desktop siblings, so a codex-local thread always showed the cluster sandbox URL in the preview iframe regardless of mode selection.
- **Kind-keyed selection:** Preview now uses `branchMap[pendingSandboxProviderKind]` (the lock-aware, kind-only value from `useChatPrefs()`) instead of the heuristic, so the mode pill and the preview iframe can never disagree.
- **Auto-start/self-heal pinned:** Both SANDBOX_START calls now include `sandboxProviderKind`, routing to `resolve-provider` precedence-1 (`explicitKind`) so no mismatched sibling can be minted.
- **Always autostart:** Removed `!!branch` gate from `shouldAutoStart` — preview autostarts on brand-new pre-lock threads, adopting the server-generated branch via `onSuccess`.
- **Switch/reuse pre-lock:** Switching kind before lock autostarts a new sibling; switching back reuses the warm existing entry — no teardown code needed, the sibling-preserving branch map handles it.
- **Offline-pinned threads:** A thread locked to `user-desktop` with the link offline shows the offline/starting state — no silent swap to cluster.

## Test plan

- [ ] Select codex-local → preview shows desktop sandbox URL, not cluster
- [ ] Switch to cloud mode before sending → preview switches to cluster sibling
- [ ] Switch back to codex-local → preview reuses warm desktop sibling (no re-provision)
- [ ] Send first message (lock thread) → preview stays pinned to locked kind
- [ ] Revisit old codex-local thread → preview shows desktop sandbox
- [ ] Revisit old cloud thread → preview shows cluster sandbox
- [ ] All unit tests pass (`bun test apps/mesh/src/web/components/sandbox`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes preview sandbox mismatch by selecting the VM entry based on the active thread’s provider kind, keeping the mode pill and iframe in sync. Auto-start and self-heal now pin provisioning to that provider and support brand-new threads.

- **Bug Fixes**
  - Preview picks `branchMap[pendingSandboxProviderKind]`, removing the heuristic that preferred non-desktop siblings.
  - `SANDBOX_START` now includes `sandboxProviderKind` for auto-start and self-heal to prevent cross-provider siblings.
  - Auto-start works with no branch; dedup uses branch or "" and adopts the server branch via `onSuccess`.
  - Desktop-locked/offline threads stay on desktop and show offline/starting states (no silent cluster swap). Updated unit test for branchless auto-start.

<sup>Written for commit bc54bf60a1d6773330017dc16f25cc3aa9b2e9bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

