### PR TITLE
fix(claude-code): restore user/project/local settingSources for skill loading

### DIFF
--- a/packages/harness/src/claude-code/model/index.ts
+++ b/packages/harness/src/claude-code/model/index.ts
@@ -48,6 +48,13 @@ export function createClaudeCodeModel(
   > = {
     mcpServers: options?.mcpServers,
     cwd: options?.cwd ?? process.cwd(),
+    // ai-sdk-provider-claude-code@3.5.0 changed: when settingSources is
+    // undefined, it now passes [] to the binary (no settings loaded at all).
+    // In 3.4.4 it was omitted, letting the binary use its defaults (user
+    // plugins/skills). Restore that by explicitly requesting all three sources
+    // so user skills (e.g. superpower), project .claude/ config, and
+    // machine-local overrides all load in headless mode.
+    settingSources: ["user", "project", "local"],
   };
 
   // Pin the native binary that matches this host's libc. Without this the SDK


### PR DESCRIPTION
## Summary

- `ai-sdk-provider-claude-code@3.5.0` changed its default behavior: when `settingSources` is not explicitly set, it now passes `[]` to the Claude Code binary instead of omitting the option and letting the binary use its own defaults.
- This silently blocked all user-level skills (e.g. superpower), project `.claude/` config, and machine-local overrides from loading in headless mode.
- Fix: explicitly set `settingSources: ["user", "project", "local"]` in `createClaudeCodeModel` to restore the previous behavior.

## Test plan

- [ ] Start a Claude Code session via the harness and verify user skills (superpower, etc.) load correctly
- [ ] Confirm project-level `.claude/` config is applied
- [ ] `bun run fmt` and `bun run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly sets `settingSources: ["user", "project", "local"]` in the Claude Code model to restore loading of user skills, project `.claude/` config, and machine-local overrides in headless sessions. This works around the default change in `ai-sdk-provider-claude-code@3.5.0` that passed an empty list and disabled settings.

<sup>Written for commit f9246ae2936374ec0f434b28289cc0229a5eeae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

