### PR TITLE
fix(decopilot): ignore stale progress on new runs

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/liveness.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/liveness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { isRunStuck } from "./liveness";
+import { effectiveLastProgressAt, isRunStuck } from "./liveness";
 
 const MIN = 60_000;
 
@@ -35,5 +35,34 @@ describe("isRunStuck (progress-based liveness)", () => {
         idleTimeoutMs: 5 * MIN,
       }),
     ).toBe(true);
+  });
+});
+
+describe("effectiveLastProgressAt", () => {
+  it("uses the current run start when persisted progress belongs to an older run", () => {
+    expect(
+      effectiveLastProgressAt({
+        persistedLastProgressAt: 10 * MIN,
+        currentRunStartedAt: 20 * MIN,
+      }),
+    ).toBe(20 * MIN);
+  });
+
+  it("uses persisted progress when it is newer than the current run start", () => {
+    expect(
+      effectiveLastProgressAt({
+        persistedLastProgressAt: 25 * MIN,
+        currentRunStartedAt: 20 * MIN,
+      }),
+    ).toBe(25 * MIN);
+  });
+
+  it("falls back to the current run start when no progress has been recorded", () => {
+    expect(
+      effectiveLastProgressAt({
+        persistedLastProgressAt: null,
+        currentRunStartedAt: 20 * MIN,
+      }),
+    ).toBe(20 * MIN);
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/liveness.ts
+++ b/apps/mesh/src/api/routes/decopilot/liveness.ts
@@ -12,3 +12,13 @@ export function isRunStuck(input: {
 }): boolean {
   return input.now - input.lastProgressAt > input.idleTimeoutMs;
 }
+
+export function effectiveLastProgressAt(input: {
+  persistedLastProgressAt: number | null;
+  currentRunStartedAt: number;
+}): number {
+  return Math.max(
+    input.persistedLastProgressAt ?? Number.NEGATIVE_INFINITY,
+    input.currentRunStartedAt,
+  );
+}

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -125,6 +125,12 @@ describe("reactAll (real Postgres)", () => {
     it("flips the row to in_progress and emits 1 status event", async () => {
       const { deps, sseEvents, purged } = makeReactor();
       const thread = await createThread(); // default status "completed"
+      await database.db
+        .updateTable("threads")
+        .set({ last_progress_at: new Date(0).toISOString() })
+        .where("id", "=", thread.id)
+        .where("organization_id", "=", ORG)
+        .execute();
 
       await react(
         {
@@ -138,8 +144,15 @@ describe("reactAll (real Postgres)", () => {
       );
 
       const row = await storage.get(thread.id, ORG);
+      const rawRow = await database.db
+        .selectFrom("threads")
+        .select("last_progress_at")
+        .where("id", "=", thread.id)
+        .where("organization_id", "=", ORG)
+        .executeTakeFirstOrThrow();
       expect(row?.status).toBe("in_progress");
       expect(row?.run_started_at).not.toBeNull();
+      expect(rawRow.last_progress_at).toBeNull();
       expect(sseEvents).toHaveLength(1);
       expect(purged).toHaveLength(0);
     });

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -89,6 +89,7 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
         status: "in_progress",
         run_config: event.runConfig ?? null,
         run_started_at: new Date().toISOString(),
+        last_progress_at: null,
       });
       const startedThread = await storage.get(event.taskId, event.orgId);
       sseHub.emit(

--- a/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
@@ -203,5 +203,32 @@ describe("RunRegistry storage orchestration (real Postgres)", () => {
       expect(row?.run_started_at).toBeNull();
       expect(purged).toContain(thread.id);
     });
+
+    it("does not reap a fresh run when last_progress_at belongs to a previous turn", async () => {
+      let now = new Date("2024-01-01T00:00:00Z");
+      const { registry } = makeRegistry({ clock: () => now });
+      const thread = await seedRunningThread();
+
+      await database.db
+        .updateTable("threads")
+        .set({
+          last_progress_at: new Date(
+            now.getTime() - RUN_IDLE_TIMEOUT_MS - 1,
+          ).toISOString(),
+        })
+        .where("id", "=", thread.id)
+        .execute();
+
+      startThread(registry, thread.id); // fresh run starts after stale progress
+      now = new Date(now.getTime() + RUN_IDLE_TIMEOUT_MS - 1);
+
+      await (
+        registry as unknown as { reapStaleRuns(): Promise<void> }
+      ).reapStaleRuns();
+
+      expect(registry.isRunning(thread.id)).toBe(true);
+      const row = await storage.get(thread.id, ORG);
+      expect(row?.status).toBe("in_progress");
+    });
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/run-registry.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.ts
@@ -18,7 +18,7 @@ import { decide } from "./run-decider";
 import { project } from "./run-projector";
 import type { RunReactorDeps } from "./run-reactor";
 import { reactAll } from "./run-reactor";
-import { isRunStuck } from "./liveness";
+import { effectiveLastProgressAt, isRunStuck } from "./liveness";
 import { meter } from "@/observability";
 
 export type { RunReactorDeps };
@@ -213,8 +213,10 @@ export class RunRegistry {
         // `run_started_at` (a wall-clock string written by whichever pod
         // claimed the run) so the idle window is measured consistently and a
         // brand-new run is never instakilled.
-        lastProgressAt =
-          progress?.lastProgressAt ?? state.status.startedAt.getTime();
+        lastProgressAt = effectiveLastProgressAt({
+          persistedLastProgressAt: progress?.lastProgressAt ?? null,
+          currentRunStartedAt: state.status.startedAt.getTime(),
+        });
       } catch (err) {
         // Storage blip — assume progress, skip this sweep for this run.
         console.warn(

--- a/apps/mesh/src/dispatch-queue/thread-gate-reaper.integration.test.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-reaper.integration.test.ts
@@ -57,7 +57,7 @@ async function seedRun(opts: {
 }
 
 describe("SqlThreadStorage.listStuckRuns (real Postgres)", () => {
-  it("returns only in_progress runs stale past the cutoff (COALESCE last_progress_at, run_started_at)", async () => {
+  it("returns only in_progress runs stale past the cutoff (newest of last_progress_at, run_started_at)", async () => {
     const now = Date.now();
     const iso = (ms: number) => new Date(now - ms).toISOString();
     const cutoff = new Date(now - 45 * 60 * 1000).toISOString();
@@ -76,7 +76,11 @@ describe("SqlThreadStorage.listStuckRuns (real Postgres)", () => {
     });
     const freshColdStart = await seedRun({
       lastProgressAt: null,
-      runStartedAt: iso(1 * 60 * 1000), // started 1 min ago → fresh via COALESCE
+      runStartedAt: iso(1 * 60 * 1000), // started 1 min ago → fresh
+    });
+    const freshNewTurnWithStaleProgress = await seedRun({
+      lastProgressAt: iso(60 * 60 * 1000),
+      runStartedAt: iso(1 * 60 * 1000),
     });
 
     const stuck = await storage.listStuckRuns(cutoff);
@@ -86,6 +90,7 @@ describe("SqlThreadStorage.listStuckRuns (real Postgres)", () => {
     expect(stuck.every((r) => r.organizationId === ORG)).toBe(true);
     expect(ids).not.toContain(healthy);
     expect(ids).not.toContain(freshColdStart);
+    expect(ids).not.toContain(freshNewTurnWithStaleProgress);
   });
 
   it("ignores non-in_progress threads", async () => {

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -27,13 +27,22 @@ import type {
   ThreadMessage,
 } from "./types";
 
+export type ThreadUpdateData = Partial<Thread> & {
+  /**
+   * Internal liveness heartbeat. Exposed only on updates so RUN_STARTED can
+   * clear progress from an older turn in the same write that marks the new run
+   * active.
+   */
+  last_progress_at?: string | null;
+};
+
 export interface ThreadStoragePort {
   create(data: Partial<Thread>): Promise<Thread>;
   get(id: string, organizationId: string): Promise<Thread | null>;
   update(
     id: string,
     organizationId: string,
-    data: Partial<Thread>,
+    data: ThreadUpdateData,
   ): Promise<Thread>;
   /**
    * Atomically transition an in-progress thread to completed.

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -8,7 +8,7 @@
 import { sql, type Kysely } from "kysely";
 import { generatePrefixedId } from "@/shared/utils/generate-id";
 import { DEFAULT_THREAD_TITLE } from "@/api/routes/decopilot/constants";
-import type { ThreadStoragePort } from "./ports";
+import type { ThreadStoragePort, ThreadUpdateData } from "./ports";
 import { SqlThreadMessagePartStorage } from "./thread-message-parts";
 import type {
   Database,
@@ -79,7 +79,7 @@ export class OrgScopedThreadStorage {
     return this.inner.get(id, this.requireOrg());
   }
 
-  update(id: string, data: Partial<Thread>): Promise<Thread> {
+  update(id: string, data: ThreadUpdateData): Promise<Thread> {
     return this.inner.update(id, this.requireOrg(), data);
   }
 
@@ -323,7 +323,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
   async update(
     id: string,
     organizationId: string,
-    data: Partial<Thread>,
+    data: ThreadUpdateData,
   ): Promise<Thread> {
     const now = new Date().toISOString();
 
@@ -359,6 +359,9 @@ export class SqlThreadStorage implements ThreadStoragePort {
     }
     if (data.run_started_at !== undefined) {
       updateData.run_started_at = data.run_started_at;
+    }
+    if (data.last_progress_at !== undefined) {
+      updateData.last_progress_at = data.last_progress_at;
     }
     if (data.metadata !== undefined) {
       updateData.metadata = JSON.stringify(data.metadata);
@@ -454,9 +457,11 @@ export class SqlThreadStorage implements ThreadStoragePort {
 
   /**
    * Cross-org scan for runs stuck `in_progress` past `cutoffIso`. Liveness is
-   * `COALESCE(last_progress_at, run_started_at)`: last_progress_at is NULL until
-   * the first streamed chunk, so run_started_at is the floor that keeps a
-   * brand-new cold-starting run from being reaped before it produces output.
+   * `GREATEST(last_progress_at, run_started_at)`: last_progress_at is NULL until
+   * the first streamed chunk, and can also belong to a previous turn if a row was
+   * written before the RUN_STARTED reset. The newest timestamp is the liveness
+   * floor that keeps a brand-new cold-starting run from being reaped before it
+   * produces output.
    * Used ONLY by the cross-pod thread-gate reaper (see thread-gate-reaper.ts),
    * which is why it is not org-scoped — it must sweep every org.
    */
@@ -468,7 +473,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .select(["id", "organization_id"])
       .where("status", "=", "in_progress")
       .where(
-        sql<boolean>`coalesce(last_progress_at, run_started_at) < ${cutoffIso}::timestamptz`,
+        sql<boolean>`greatest(coalesce(last_progress_at, '-infinity'::timestamptz), coalesce(run_started_at, '-infinity'::timestamptz)) < ${cutoffIso}::timestamptz`,
       )
       .execute();
     return rows.map((r) => ({ id: r.id, organizationId: r.organization_id }));


### PR DESCRIPTION
## Summary
- Clear stale `last_progress_at` when `RUN_STARTED` marks a new run active
- Make the in-pod reaper and cross-pod stuck-run scan use the newest of current run start and persisted progress
- Add regressions for stale progress from a previous turn across pure liveness, RunRegistry, RunReactor, and thread-gate reaper paths

## Verification
- `bun run fmt`
- `bun run check`
- `bun run lint` (passes with existing warnings)
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres bun test --serial apps/mesh/src/api/routes/decopilot/liveness.test.ts apps/mesh/src/api/routes/decopilot/run-registry.test.ts apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts apps/mesh/src/dispatch-queue/thread-gate-reaper.integration.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents newly started runs from being reaped by stale progress from a previous turn by clearing `last_progress_at` on RUN_STARTED and using the newest of `last_progress_at` and `run_started_at` for liveness.

- **Bug Fixes**
  - Clear `last_progress_at` on RUN_STARTED in `run-reactor` (atomic via `ThreadUpdateData`).
  - Use `effectiveLastProgressAt` in `RunRegistry` to compare against idle timeout.
  - Update `SqlThreadStorage.listStuckRuns` to use `GREATEST(last_progress_at, run_started_at)` (with `-infinity` fallbacks).
  - Add regressions for stale progress across liveness, run-reactor, run-registry, and thread-gate reaper.

<sup>Written for commit 2dd3b7b1e62803fe6bf1f9c2d8d95d953fd817b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

