### PR TITLE
fix(sidebar): make New thread and Show more buttons span full sidebar width

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/show-more-button.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/show-more-button.tsx
@@ -4,6 +4,11 @@ import { cn } from "@deco/ui/lib/utils.ts";
 interface ShowMoreButtonProps {
   onClick: () => void;
   isFetching: boolean;
+  /** When true (inside a sidebar group with `pl-4`), the button stretches its
+   *  hover surface out to the group's left edge (-ml-4 cancels the wrapper's
+   *  pl-4) while pl-6 keeps the content indented — matching the indented
+   *  TaskRow treatment so the clickable surface spans the full sidebar width. */
+  indented?: boolean;
 }
 
 /**
@@ -11,7 +16,11 @@ interface ShowMoreButtonProps {
  * determines there are more pages to fetch (`hasMore || isFetching`).
  * Wire it to a paginator via `useGroupShowMore`.
  */
-export function ShowMoreButton({ onClick, isFetching }: ShowMoreButtonProps) {
+export function ShowMoreButton({
+  onClick,
+  isFetching,
+  indented,
+}: ShowMoreButtonProps) {
   return (
     <button
       type="button"
@@ -19,7 +28,8 @@ export function ShowMoreButton({ onClick, isFetching }: ShowMoreButtonProps) {
       onClick={onClick}
       disabled={isFetching}
       className={cn(
-        "flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-muted-foreground",
+        "flex items-center gap-2 py-1.5 rounded-md text-sm text-muted-foreground",
+        indented ? "-ml-4 pl-6 pr-2" : "px-2",
         "hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         "transition-colors disabled:cursor-progress disabled:opacity-60",
       )}

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
@@ -264,7 +264,10 @@ function AgentExpandedBody({
         <button
           type="button"
           onClick={() => onNewTaskInGroup(virtualMcpId)}
-          className="flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer text-sm text-muted-foreground hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 transition-colors"
+          // -ml-4 cancels the group wrapper's pl-4 so the hover surface spans
+          // the full sidebar width, while pl-6 keeps the content indented —
+          // matching the indented TaskRow treatment.
+          className="flex items-center gap-2 -ml-4 pl-6 pr-2 py-1.5 rounded-md cursor-pointer text-sm text-muted-foreground hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 transition-colors"
         >
           <Plus size={14} />
           <span>New thread</span>
@@ -286,6 +289,7 @@ function AgentExpandedBody({
             <ShowMoreButton
               onClick={() => void loadMore()}
               isFetching={isFetching}
+              indented
             />
           )}
         </>
@@ -345,6 +349,7 @@ function StatusExpandedBody({
         <ShowMoreButton
           onClick={() => void loadMore()}
           isFetching={isFetching}
+          indented
         />
       )}
     </>


### PR DESCRIPTION
## Summary

Follow-up to #4024 (which made task rows span the full sidebar width). Two interactive elements inside the `pl-4` agent-group wrapper were missed and kept `px-2`, leaving their hover/click surfaces inset and narrower than the surrounding task rows:

- **"+ New thread"** button — shown when an agent group has zero threads (`task-group.tsx`)
- **"Show more"** pagination button (`show-more-button.tsx`)

Both now get the same treatment as the `indented` `TaskRow`: `-ml-4 pl-6 pr-2` cancels the wrapper's `pl-4` so the surface spans the full sidebar width while the content stays visually indented.

`ShowMoreButton` gained an `indented?` prop (mirroring how #4024 did `TaskRow`) rather than hardcoding the offset, because it's *also* used in `collapsed-group-popover.tsx`, which has **no** `pl-4` and whose `TaskRow` is deliberately not indented — that call site is left unchanged.

## Changes
- `show-more-button.tsx`: add `indented?` prop → `indented ? "-ml-4 pl-6 pr-2" : "px-2"`
- `task-group.tsx`: swap the "+ New thread" button to `-ml-4 pl-6 pr-2`; pass `indented` at the two in-group `ShowMoreButton` call sites
- `collapsed-group-popover.tsx`: untouched (correct non-indented context)

## Testing
Pure Tailwind class changes, no logic. `bun run fmt` clean. Visual: hover surface of both buttons now bleeds to the sidebar's left edge, matching the task rows above/below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar “+ New thread” and “Show more” buttons so their hover/click surface spans the full sidebar width, matching the indented task rows. Adds an optional `indented` prop to `ShowMoreButton` for use inside padded groups; the popover usage remains unchanged.

<sup>Written for commit c553411be30120c3bf40cd3d752c4aabb44480f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

