### PR TITLE
fix(harness): reliably install codex native binary via decocms

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -40,7 +40,14 @@
   },
   "optionalDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.181",
-    "@duckdb/node-api": "^1.5.0-r.1"
+    "@duckdb/node-api": "^1.5.0-r.1",
+    "@openai/codex": "0.141.0",
+    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
+    "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
+    "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
+    "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
+    "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
+    "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.85",

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "3.35.5",
+      "version": "3.36.5",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -179,6 +179,13 @@
       "optionalDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.181",
         "@duckdb/node-api": "^1.5.0-r.1",
+        "@openai/codex": "0.141.0",
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64",
       },
     },
     "packages/bindings": {
@@ -206,7 +213,7 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "1.6.4",
+      "version": "1.6.6",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/google": "^3.0.83",
@@ -330,7 +337,7 @@
     },
     "packages/tunnel": {
       "name": "@decocms/tunnel",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@nats-io/nats-core": "3.4.0",
         "zod": "^4.0.0",


### PR DESCRIPTION
## Summary

The codex CLI harness was crashing on `bunx decocms link` with an opaque `{"type":"error","errorText":"An error occurred."}`. Root cause: the codex native binary (`@openai/codex-<platform>`) was not reliably installed, so `findCodexExecutable()` threw and the codex app-server exited with code 1.

`@openai/codex` was never declared in the published `decocms` package (`apps/mesh`). It only leaked in as a **doubly-nested transitive-optional** (`ai-sdk-provider-codex-cli` → optional `@openai/codex` → optional `@openai/codex-<platform>`), which bun installs unreliably. Claude Code works because `@anthropic-ai/claude-agent-sdk` *is* declared directly in `apps/mesh`.

## Change

Declare `@openai/codex` directly in `apps/mesh` `optionalDependencies` and **hoist all 6 platform binary packages top-level** so bun installs the os/cpu-matched one deterministically (the standard esbuild/swc workaround). Mirrors the existing `claude-agent-sdk` precedent. Kept optional so a binary-less platform doesn't fail the whole `decocms` install.

This lands in the published `decocms` package, so `bunx decocms link` on a fresh machine installs codex + its native binary alongside `dist/`. It also fixes local monorepo dev via workspace install.

## Verification

- `bun install` → `bun.lock` now records all 7 codex entries directly under the `decocms` manifest.
- `codex --version` → `codex-cli 0.141.0` (native binary resolves and runs).
- `knip` exits 0 — no config change needed (codex is `optionalDependency`, which knip ignores).
- `bun run fmt` clean.

## Scope / caveats

- **Install-time fix only.** It does not retroactively heal a machine whose bun cache is already missing the binary (one-time `bun install -g @openai/codex@latest` for those).
- This does **not** touch the claude-code `resolve-executable.ts` fix — that solves a different (Linux musl/glibc binary *selection*) problem and remains necessary.
- If bun ever still skips the optional dep, a runtime self-heal + better error surfacing (Option A) can be layered on top later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the codex native binary installs reliably by declaring `@openai/codex` and hoisting all six platform packages as `optionalDependencies` in `decocms` (`apps/mesh`). This fixes the harness crash on `bunx decocms link` by making `codex` resolve deterministically across OS/CPU.

- **Dependencies**
  - Add `@openai/codex` and hoist: `@openai/codex-darwin-arm64`, `@openai/codex-darwin-x64`, `@openai/codex-linux-arm64`, `@openai/codex-linux-x64`, `@openai/codex-win32-arm64`, `@openai/codex-win32-x64` as optional deps.

- **Migration**
  - If your machine is already missing the binary, run `bun install -g @openai/codex@latest` once.

<sup>Written for commit 38c3087105dffd79155ca04c6dedc505b539893d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

