### PR TITLE
fix(mesh): guard against undefined in useRegistryConnections filter

### DIFF
--- a/apps/mesh/src/web/hooks/use-registry-connections.ts
+++ b/apps/mesh/src/web/hooks/use-registry-connections.ts
@@ -35,5 +35,5 @@ export function useRegistryConnections() {
   // Fetch all connections (no binding filter = no tool enumeration)
   const allConnections = useConnections();
 
-  return allConnections.filter((c) => registryIds.has(c.id));
+  return (allConnections ?? []).filter((c) => registryIds.has(c.id));
 }


### PR DESCRIPTION
## Summary
- `useConnections()` can return `undefined` when the MCP client is not yet ready or during query race conditions, causing a crash: `Cannot read properties of undefined (reading 'filter')`
- Added `?? []` fallback to prevent the crash in `useRegistryConnections()`

## Test plan
- [ ] Verify connections page loads without crash
- [ ] Verify registry connections still filter correctly when data is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the registry connections view when `useConnections()` temporarily returns undefined by falling back to an empty array before filtering. Prevents “Cannot read properties of undefined (reading 'filter')” during client init or query races.

<sup>Written for commit 2608b5ef7fc81896933ac11793476b2b9935f39a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

