### PR TITLE
docs(buckets): document user-configured S3 bucket setup and IAM permissions

### DIFF
--- a/apps/docs/client/src/components/ui/Sidebar.astro
+++ b/apps/docs/client/src/components/ui/Sidebar.astro
@@ -86,6 +86,7 @@ function buildTree(docs: any[]): TreeNode[] {
                   "automations",
                   "monitoring",
                   "ai-providers",
+                  "buckets",
                   "projects",
                   "store",
                   "api-keys",

--- a/apps/docs/client/src/content/deco-studio/en/studio/buckets.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/buckets.mdx
@@ -1,0 +1,118 @@
+---
+title: Buckets
+description: Connect your own S3-compatible bucket for CMS assets — and the IAM permissions it needs
+icon: HardDrive
+---
+
+import Callout from "../../../../components/ui/Callout.astro";
+
+## What are buckets?
+
+A **bucket** is an S3-compatible object store you connect to Studio to hold **CMS assets** — the files you upload and reference from the content you build (images, slides, decks). You configure buckets at the organization level under **Settings → Buckets**, and credentials are encrypted at rest and never returned over the API.
+
+<Callout type="note">
+This is the bucket **you** bring and configure in the UI, used only for CMS assets. It is **not** the object store that backs a self-hosted deployment's org filesystem (org-fs) — that one is configured via environment variables on the deployment, not here. This page is about the user-configured bucket.
+</Callout>
+
+Studio works with any S3-compatible provider:
+
+| Provider | Endpoint | Force path-style |
+|---|---|---|
+| **AWS S3** | leave blank (default) | off |
+| **Cloudflare R2** | `https://<account>.r2.cloudflarestorage.com` | off |
+| **Google Cloud Storage** | `https://storage.googleapis.com` | **on** |
+| **MinIO** | your MinIO URL | usually **on** |
+
+## Adding a bucket
+
+Click **Add bucket** and fill in:
+
+| Field | Required | Notes |
+|---|---|---|
+| **Name** | ✅ | Letters, digits, underscore, dot, hyphen. Unique within the org. |
+| **Bucket** | ✅ | The bucket name. |
+| **Region** | ✅ | e.g. `us-east-1`. |
+| **Endpoint** | — | Required for non-AWS providers (R2, GCS, MinIO). Leave blank for AWS. |
+| **Force path-style URLs** | — | Required for GCS and most MinIO setups. |
+| **Key prefix** | — | All object keys are written under this prefix — useful for multi-tenant buckets or credentials scoped to a sub-path. A trailing slash is added automatically. |
+| **Public URL base** | — | Host used to build the public URLs returned for each asset (R2 dev domain, CDN, custom host). Leave blank to use the bucket's S3 host. |
+| **Credentials** | ✅ | A static key pair, or a temporary STS session (see below). |
+
+### Credential types
+
+- **Static key pair (long-lived)** — an `Access key ID` and `Secret access key`, used as-is. The most common choice.
+- **Temporary session (STS, auto-refreshed)** — stores only a refresh endpoint URL and an API key. Short-lived credentials are fetched on demand and refreshed automatically; no S3 secret is stored.
+
+## AWS IAM permissions
+
+Studio touches the bucket in only two ways: it **uploads** assets to it, and it **lists** objects to power the asset picker. It never reads objects back through the server, never deletes them, and never touches bucket configuration. So for an AWS S3 bucket connected via a **static key pair**, the IAM user (or role) behind the access key needs very little:
+
+| What Studio does | S3 operation | IAM action |
+|---|---|---|
+| Upload an asset (streamed via multipart for large files) | `Upload` (multipart `PutObject`) | `s3:PutObject` |
+| Clean up a failed multipart upload | `AbortMultipartUpload` | `s3:AbortMultipartUpload` |
+| List objects for the asset picker | `ListObjectsV2` | `s3:ListBucket` |
+
+<Callout type="note">
+Studio **does not** read uploaded assets back. The picker and your CMS link to each object's **public URL** (the `Public URL base` you set, or the bucket's canonical S3 URL), which the browser fetches directly. So the Studio credential does **not** need `s3:GetObject` — instead the objects must be publicly readable (or fronted by a CDN) for those URLs to resolve. That's a separate concern from this IAM policy: a bucket policy / object ACL / Block-Public-Access setting, or a CDN in front.
+</Callout>
+
+### Minimal policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "StudioUploads",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:AbortMultipartUpload"
+      ],
+      "Resource": "arn:aws:s3:::YOUR_BUCKET/*"
+    },
+    {
+      "Sid": "StudioListBucket",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::YOUR_BUCKET"
+    }
+  ]
+}
+```
+
+<Callout type="warning">
+**`s3:ListBucket` is a bucket-level action** — its `Resource` is the bucket ARN (`arn:aws:s3:::YOUR_BUCKET`), **without** the `/*` suffix. The object action (`s3:PutObject`, `s3:AbortMultipartUpload`) operates on objects, so its `Resource` **does** end in `/*`. Pointing `ListBucket` at the `/*` ARN is the most common cause of `AccessDenied` when listing.
+</Callout>
+
+### Scoping to a prefix (optional)
+
+If you set a **Key prefix** on the bucket, you can lock the credential to just that path:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "StudioUploads",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:AbortMultipartUpload"],
+      "Resource": "arn:aws:s3:::YOUR_BUCKET/YOUR_PREFIX/*"
+    },
+    {
+      "Sid": "StudioListBucket",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::YOUR_BUCKET",
+      "Condition": { "StringLike": { "s3:prefix": ["YOUR_PREFIX/*"] } }
+    }
+  ]
+}
+```
+
+---
+
+<Callout type="info">
+Credentials are stored encrypted in Studio's credential vault and are never returned over the API. Removing a bucket configuration deletes the stored credentials — the bucket itself and its contents are untouched.
+</Callout>

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/buckets.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/buckets.mdx
@@ -1,0 +1,118 @@
+---
+title: Buckets
+description: Conecte seu proprio bucket compativel com S3 para assets do CMS — e as permissoes IAM que ele precisa
+icon: HardDrive
+---
+
+import Callout from "../../../../components/ui/Callout.astro";
+
+## O que sao buckets?
+
+Um **bucket** e um armazenamento de objetos compativel com S3 que voce conecta ao Studio para guardar **assets do CMS** — os arquivos que voce envia e referencia no conteudo que constroi (imagens, slides, decks). Voce configura buckets no nivel da organizacao em **Configuracoes → Buckets**, e as credenciais sao criptografadas em repouso e nunca retornadas pela API.
+
+<Callout type="note">
+Este e o bucket que **voce** traz e configura na UI, usado apenas para assets do CMS. Ele **nao** e o armazenamento de objetos que lastreia o sistema de arquivos da organizacao (org-fs) em um deployment self-hosted — esse e configurado via variaveis de ambiente no deployment, nao aqui. Esta pagina e sobre o bucket configurado pelo usuario.
+</Callout>
+
+O Studio funciona com qualquer provedor compativel com S3:
+
+| Provedor | Endpoint | Force path-style |
+|---|---|---|
+| **AWS S3** | deixe em branco (padrao) | desligado |
+| **Cloudflare R2** | `https://<account>.r2.cloudflarestorage.com` | desligado |
+| **Google Cloud Storage** | `https://storage.googleapis.com` | **ligado** |
+| **MinIO** | a URL do seu MinIO | normalmente **ligado** |
+
+## Adicionando um bucket
+
+Clique em **Add bucket** e preencha:
+
+| Campo | Obrigatorio | Observacoes |
+|---|---|---|
+| **Name** | ✅ | Letras, digitos, underscore, ponto, hifen. Unico dentro da organizacao. |
+| **Bucket** | ✅ | O nome do bucket. |
+| **Region** | ✅ | ex: `us-east-1`. |
+| **Endpoint** | — | Obrigatorio para provedores nao-AWS (R2, GCS, MinIO). Deixe em branco para AWS. |
+| **Force path-style URLs** | — | Obrigatorio para GCS e a maioria dos setups MinIO. |
+| **Key prefix** | — | Todas as chaves de objeto sao gravadas sob esse prefixo — util para buckets multi-tenant ou credenciais escopadas a um sub-caminho. A barra final e adicionada automaticamente. |
+| **Public URL base** | — | Host usado para montar as URLs publicas retornadas para cada asset (dominio dev do R2, CDN, host customizado). Deixe em branco para usar o host S3 do bucket. |
+| **Credentials** | ✅ | Um par de chaves estatico, ou uma sessao temporaria STS (veja abaixo). |
+
+### Tipos de credencial
+
+- **Static key pair (long-lived)** — um `Access key ID` e um `Secret access key`, usados como estao. A escolha mais comum.
+- **Temporary session (STS, auto-refreshed)** — armazena apenas uma URL de refresh e uma API key. Credenciais de curta duracao sao buscadas sob demanda e renovadas automaticamente; nenhum segredo S3 e armazenado.
+
+## Permissoes IAM da AWS
+
+O Studio toca o bucket de apenas duas formas: ele **envia** assets para ele e **lista** objetos para alimentar o seletor de assets. Ele nunca le objetos de volta pelo servidor, nunca os deleta e nunca mexe na configuracao do bucket. Entao, para um bucket S3 da AWS conectado via **par de chaves estatico**, o usuario (ou role) IAM por tras da access key precisa de muito pouco:
+
+| O que o Studio faz | Operacao S3 | Acao IAM |
+|---|---|---|
+| Enviar um asset (streaming via multipart para arquivos grandes) | `Upload` (multipart `PutObject`) | `s3:PutObject` |
+| Limpar um upload multipart que falhou | `AbortMultipartUpload` | `s3:AbortMultipartUpload` |
+| Listar objetos para o seletor de assets | `ListObjectsV2` | `s3:ListBucket` |
+
+<Callout type="note">
+O Studio **nao** le os assets enviados de volta. O seletor e o seu CMS apontam para a **URL publica** de cada objeto (o `Public URL base` que voce define, ou a URL S3 canonica do bucket), que o navegador busca diretamente. Por isso a credencial do Studio **nao** precisa de `s3:GetObject` — em vez disso, os objetos precisam ser publicamente legiveis (ou estar atras de uma CDN) para que essas URLs resolvam. Isso e uma preocupacao separada desta policy IAM: uma bucket policy / ACL de objeto / configuracao de Block Public Access, ou uma CDN na frente.
+</Callout>
+
+### Politica minima
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "StudioUploads",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:AbortMultipartUpload"
+      ],
+      "Resource": "arn:aws:s3:::SEU_BUCKET/*"
+    },
+    {
+      "Sid": "StudioListBucket",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::SEU_BUCKET"
+    }
+  ]
+}
+```
+
+<Callout type="warning">
+**`s3:ListBucket` e uma acao em nivel de bucket** — o `Resource` dela e o ARN do bucket (`arn:aws:s3:::SEU_BUCKET`), **sem** o sufixo `/*`. A acao de objeto (`s3:PutObject`, `s3:AbortMultipartUpload`) opera sobre objetos, entao o `Resource` dela **termina** em `/*`. Apontar o `ListBucket` para o ARN com `/*` e a causa mais comum de `AccessDenied` ao listar.
+</Callout>
+
+### Escopando por prefixo (opcional)
+
+Se voce definir um **Key prefix** no bucket, pode travar a credencial somente nesse caminho:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "StudioUploads",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:AbortMultipartUpload"],
+      "Resource": "arn:aws:s3:::SEU_BUCKET/SEU_PREFIXO/*"
+    },
+    {
+      "Sid": "StudioListBucket",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::SEU_BUCKET",
+      "Condition": { "StringLike": { "s3:prefix": ["SEU_PREFIXO/*"] } }
+    }
+  ]
+}
+```
+
+---
+
+<Callout type="info">
+As credenciais sao armazenadas criptografadas no cofre de credenciais do Studio e nunca sao retornadas pela API. Remover a configuracao de um bucket apaga as credenciais armazenadas — o bucket em si e seu conteudo permanecem intactos.
+</Callout>

--- a/apps/docs/client/src/utils/navigation.ts
+++ b/apps/docs/client/src/utils/navigation.ts
@@ -45,6 +45,7 @@ export async function getNavigationLinks(
     "studio/automations",
     "studio/monitoring",
     "studio/ai-providers",
+    "studio/buckets",
 
     // 4. Decopilot
     "studio/decopilot/overview",


### PR DESCRIPTION
## What is this contribution about?
Adds a **Buckets** docs page (EN + PT-BR) — the feature had no documentation. It covers how to connect an S3-compatible bucket (AWS S3, R2, GCS, MinIO) for CMS assets and, crucially, the minimal AWS IAM permissions a static credential needs: `s3:PutObject` + `s3:AbortMultipartUpload` on `bucket/*` and `s3:ListBucket` on the bucket (no `s3:GetObject`, since Studio never reads objects back — the browser fetches each asset's public URL). The page is scoped to the user-configured BYOB bucket (`file-config-s3.ts` path) and explicitly distinguishes it from the env-var-backed org-fs object store so the two aren't conflated.

## Screenshots/Demonstration
N/A — docs-only; the new page is registered in the sidebar and prev/next nav after "AI Providers".

## How to Test
1. `bun run docs:dev` and open the docs site.
2. Navigate to **Studio → Buckets** (EN) / **Studio → Buckets** (PT-BR) — it appears right after AI Providers.
3. Expected: page renders with the provider table, field reference, IAM permission table, and the minimal + prefix-scoped policy JSON; the `ListBucket` bucket-level vs object-level callout shows correctly.

## Migration Notes
Not applicable.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Buckets docs page (EN + PT-BR) explaining how to connect a user-configured S3-compatible bucket for CMS assets and the minimal AWS IAM policy required. The page is added to the Studio docs navigation and clarifies it’s separate from the env-var-backed org-fs store (no `s3:GetObject`; only `s3:PutObject` and `s3:AbortMultipartUpload` on `bucket/*`, plus `s3:ListBucket` on the bucket).

<sup>Written for commit 5779a055b5ba2a02026bc74f7caeeee0c15d2d6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

