### PR TITLE
fix(threads): default new threads to v2 message storage

### DIFF
--- a/apps/mesh/migrations/098-thread-message-parts.integration.test.ts
+++ b/apps/mesh/migrations/098-thread-message-parts.integration.test.ts
@@ -3,7 +3,7 @@
  * columns on threads.
  *
  * Verifies the table is created with the expected columns and that the
- * `message_storage_version` column (with default 1) and `last_progress_at`
+ * `message_storage_version` column and `last_progress_at`
  * are added to `threads`.
  */
 
@@ -50,12 +50,12 @@ describe("migration 098 thread_message_parts", () => {
     expect(names).toContain("created_at");
   });
 
-  it("adds message_storage_version defaulting to 1 on threads", async () => {
+  it("keeps new thread rows on the v2 message storage default", async () => {
     const cols = await sql<{ column_default: string | null }>`
       SELECT column_default FROM information_schema.columns
       WHERE table_name = 'threads' AND column_name = 'message_storage_version'
     `.execute(database.db);
-    expect(cols.rows[0]?.column_default).toContain("1");
+    expect(cols.rows[0]?.column_default).toContain("2");
   });
 
   it("adds last_progress_at column to threads", async () => {

--- a/apps/mesh/migrations/115-thread-message-storage-v2-default.integration.test.ts
+++ b/apps/mesh/migrations/115-thread-message-storage-v2-default.integration.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { sql, type Kysely } from "kysely";
+import type { StudioDatabase } from "../src/database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../src/database/test-db-pg";
+import { up as up115 } from "./115-thread-message-storage-v2-default";
+
+describe("migration 115 thread message storage v2 default", () => {
+  let database: StudioDatabase;
+
+  beforeEach(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
+  });
+
+  afterEach(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("promotes empty legacy v1 threads but keeps legacy threads with messages on v1", async () => {
+    const now = new Date().toISOString();
+
+    await sql`
+      INSERT INTO threads
+        (id, organization_id, created_by, title, status, created_at, updated_at, message_storage_version)
+      VALUES
+        ('thrd_empty_v1', 'org_1', 'user_1', 'Empty v1', 'idle', ${now}, ${now}, 1),
+        ('thrd_with_legacy_messages', 'org_1', 'user_1', 'Legacy v1', 'idle', ${now}, ${now}, 1)
+    `.execute(database.db);
+
+    await sql`
+      INSERT INTO thread_messages
+        (id, thread_id, metadata, parts, role, created_at, updated_at)
+      VALUES
+        ('msg_legacy', 'thrd_with_legacy_messages', '{}', '[]', 'assistant', ${now}, ${now})
+    `.execute(database.db);
+
+    await up115(database.db as unknown as Kysely<unknown>);
+
+    const rows = await database.db
+      .selectFrom("threads")
+      .select(["id", "message_storage_version"])
+      .where("id", "in", ["thrd_empty_v1", "thrd_with_legacy_messages"])
+      .orderBy("id")
+      .execute();
+
+    expect(rows).toEqual([
+      { id: "thrd_empty_v1", message_storage_version: 2 },
+      { id: "thrd_with_legacy_messages", message_storage_version: 1 },
+    ]);
+  });
+});

--- a/apps/mesh/migrations/115-thread-message-storage-v2-default.ts
+++ b/apps/mesh/migrations/115-thread-message-storage-v2-default.ts
@@ -1,0 +1,31 @@
+import { sql, type Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE threads
+    ALTER COLUMN message_storage_version SET DEFAULT 2
+  `.execute(db);
+
+  await sql`
+    UPDATE threads
+    SET message_storage_version = 2
+    WHERE message_storage_version = 1
+      AND NOT EXISTS (
+        SELECT 1
+        FROM thread_messages
+        WHERE thread_messages.thread_id = threads.id
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM thread_message_parts
+        WHERE thread_message_parts.thread_id = threads.id
+      )
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE threads
+    ALTER COLUMN message_storage_version SET DEFAULT 1
+  `.execute(db);
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -113,6 +113,7 @@ import * as migration111orgfsthreadid from "./111-org-fs-thread-id.ts";
 import * as migration112orgfileconfigscredentialtype from "./112-org-file-configs-credential-type.ts";
 import * as migration113threadfailurereason from "./113-thread-failure-reason.ts";
 import * as migration114runackedseq from "./114-run-acked-seq.ts";
+import * as migration115threadmessagestoragev2default from "./115-thread-message-storage-v2-default.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -250,6 +251,8 @@ const migrations: Record<string, Migration> = {
     migration112orgfileconfigscredentialtype,
   "113-thread-failure-reason": migration113threadfailurereason,
   "114-run-acked-seq": migration114runackedseq,
+  "115-thread-message-storage-v2-default":
+    migration115threadmessagestoragev2default,
 };
 
 export default migrations;

--- a/apps/mesh/src/storage/automations.integration.test.ts
+++ b/apps/mesh/src/storage/automations.integration.test.ts
@@ -1,0 +1,65 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../database/test-db-pg";
+import { createAutomationsStorage } from "./automations";
+import type { AutomationsStorage } from "./automations";
+
+const ORG = "org_1";
+const USER = "user_1";
+
+describe("AutomationsStorage", () => {
+  let database: StudioDatabase;
+  let automations: AutomationsStorage;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  beforeEach(async () => {
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
+    automations = createAutomationsStorage(database.db);
+  });
+
+  it("creates automation run threads on message storage v2", async () => {
+    const automation = await automations.create({
+      organization_id: ORG,
+      name: "Grafana alerts",
+      created_by: USER,
+      messages: "[]",
+      models: "{}",
+      virtual_mcp_id: "vir_test",
+    });
+
+    const threadId = await automations.createAutomationRunThread(
+      automation,
+      null,
+    );
+
+    const row = await database.db
+      .selectFrom("threads")
+      .select(["message_storage_version", "status", "title"])
+      .where("id", "=", threadId)
+      .executeTakeFirstOrThrow();
+
+    expect(row.message_storage_version).toBe(2);
+    expect(row.status).toBe("in_progress");
+    expect(row.title).toBe("Automation: Grafana alerts");
+  });
+});

--- a/apps/mesh/src/storage/automations.ts
+++ b/apps/mesh/src/storage/automations.ts
@@ -596,6 +596,7 @@ class KyselyAutomationsStorage implements AutomationsStorage {
         status: "in_progress",
         trigger_id: triggerId,
         virtual_mcp_id: automation.virtual_mcp_id,
+        message_storage_version: 2,
         hidden: false,
         created_at: now,
         updated_at: now,

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -276,6 +276,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
       trigger_id: data.trigger_id ?? null,
       virtual_mcp_id: data.virtual_mcp_id ?? "",
       branch: data.branch ?? null,
+      message_storage_version: data.message_storage_version ?? 2,
       sandbox_provider_kind: null,
       harness_id: null,
       created_at: now,

--- a/apps/mesh/src/tools/thread/create.integration.test.ts
+++ b/apps/mesh/src/tools/thread/create.integration.test.ts
@@ -57,6 +57,22 @@ describe("COLLECTION_THREADS_CREATE", () => {
     expect(result.item.branch).toBeNull();
   });
 
+  it("creates new tasks on message storage v2", async () => {
+    const vmcp = await env.ctx.storage.virtualMcps.create(
+      env.orgId,
+      env.userId,
+      { title: "v2-task", connections: [], status: "active", pinned: false },
+    );
+
+    const result = await COLLECTION_THREADS_CREATE.handler(
+      { data: { virtual_mcp_id: vmcp.id, title: "t" } },
+      env.ctx,
+    );
+
+    const row = await env.ctx.storage.threads.get(result.item.id);
+    expect(row?.message_storage_version).toBe(2);
+  });
+
   it("uses the input branch when the vMCP has a github repo", async () => {
     const vmcp = await env.ctx.storage.virtualMcps.create(
       env.orgId,

--- a/apps/mesh/src/tools/thread/list-messages.integration.test.ts
+++ b/apps/mesh/src/tools/thread/list-messages.integration.test.ts
@@ -13,6 +13,7 @@ describe("COLLECTION_THREAD_MESSAGES_LIST orderBy → sort translation", () => {
       id: threadId,
       title: "orderby test",
       created_by: env.userId,
+      message_storage_version: 1,
     });
 
     // Three messages with strictly ordered created_at so asc/desc differ.


### PR DESCRIPTION
## Summary
- set the final `threads.message_storage_version` database default to v2
- backfill only empty legacy v1 threads to v2 while leaving v1 threads with legacy messages untouched
- make generic thread creation and automation run thread creation explicitly write v2
- pin legacy list-messages fixtures to v1 so the old read path stays covered

## Testing
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres bun test --serial apps/mesh/migrations/098-thread-message-parts.integration.test.ts apps/mesh/migrations/115-thread-message-storage-v2-default.integration.test.ts apps/mesh/src/tools/thread/create.integration.test.ts apps/mesh/src/storage/automations.integration.test.ts apps/mesh/src/tools/thread/list-messages.integration.test.ts apps/mesh/src/api/routes/decopilot/memory.integration.test.ts apps/mesh/src/storage/threads.integration.test.ts`
- `bun run check`
- `bun run lint` (0 errors; 3 existing warnings outside this change)

## Notes
- I also attempted full `DATABASE_URL=... bun test`; it did not run to completion because the current baseline hits unrelated `apps/mesh/playwright.config.test.ts` expectation failures around `MCP_CACHE_ENABLED=true`, then enters resilience tests that wait for a running Studio stack.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default new threads to v2 message storage and selectively backfill v1 threads. New and automation-run threads now write to v2; legacy v1 threads with messages stay unchanged.

- **Migration**
  - Set default for `threads.message_storage_version` to 2.
  - Promote only empty v1 threads to v2; keep v1 threads with legacy messages on v1.

- **New Features**
  - Thread creation and automation run thread creation now set `message_storage_version: 2`.
  - Pinned legacy list-messages tests to v1 to keep the old read path covered.

<sup>Written for commit fb6d3abec46dc72444d18955442ec913b0d2e18a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

