### PR TITLE
fix(web-nginx): send no-store on asset 404 so Cloudflare won't cache it

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.11
+version: 0.10.12
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/files/web-nginx.conf.template
+++ b/deploy/helm/studio/files/web-nginx.conf.template
@@ -69,14 +69,22 @@ server {
     proxy_send_timeout 3600s;
   }
 
-  # Hashed assets are content-addressed → cache forever.
-  # No `always`: the immutable header must apply only to 2xx/3xx, never to the
-  # =404 below. With `always`, a chunk that's briefly missing during a rollout
-  # returns `404 + immutable, max-age=1y`, which Cloudflare/browsers then cache
-  # for a year — poisoning that asset URL permanently (stale-chunk loop).
+  # Hashed assets are content-addressed → cache forever WHEN PRESENT (no
+  # `always`: the immutable header applies to the 2xx only). A chunk that's
+  # briefly missing during a rollout (old/new pods both behind the LB, each
+  # holding only its own bundle) must return a NON-cacheable 404. Cloudflare
+  # negative-caches bare 404s for 3 minutes by default, so a single skewed
+  # request poisons that chunk URL for everyone behind the colo for minutes —
+  # trapping the SPA on the stale-chunk screen. The explicit `no-store` on the
+  # miss (below) makes Cloudflare BYPASS instead, so it self-heals immediately
+  # once the rollout settles.
   location /assets/ {
+    try_files $uri @asset_missing;
     add_header Cache-Control "public, max-age=31536000, immutable";
-    try_files $uri =404;
+  }
+  location @asset_missing {
+    add_header Cache-Control "no-store" always;
+    return 404;
   }
 
   # SPA fallback. Clickjacking + no-cache guards live here (not server-level) so


### PR DESCRIPTION
## Problem

Releases caused minutes of broken UI: during a web rollout, old and new nginx pods sit behind the NLB at the same time, each holding **only its own bundle** in its emptyDir. A browser that loaded the new `index.html` requests `/assets/index-<newhash>.js`; if the NLB routes that to an old pod, the chunk is missing → **404**. Cloudflare then **negative-caches that 404 for 3 minutes by default** (its behavior for bare 404/410 with no cache directive), poisoning the chunk URL edge-wide and trapping the SPA on the stale-chunk "New version available" screen well past the rollout.

## Why #4009 wasn't enough

#4009 dropped `always` from the `/assets/` `Cache-Control`, which stopped the *year-long* `immutable` caching — but it left the 404 with **no cache header at all**, which falls straight into Cloudflare's 3-minute default negative cache. Removing the header isn't enough; the 404 has to **actively** tell Cloudflare not to cache it.

## Fix

Split the assets location:
- **present** files keep `Cache-Control: public, max-age=31536000, immutable` (2xx only — no `always`)
- **missing** chunk falls to a named `@asset_missing` location that returns `404` + `Cache-Control: no-store`, so Cloudflare marks it **BYPASS**

Net effect: a skewed request during a rollout still 404s transiently, but nothing is cached, so it **self-heals the instant the rollout settles** instead of staying broken for minutes.

Bumps chart `0.10.11 → 0.10.12` (publish-chart triggers on `Chart.yaml`).

## Testing

- `nginx -t` on the rendered template (chart's `nginxinc/nginx-unprivileged:1.27-alpine`) — passes
- Live request test in that image: present asset → `200 + immutable`; missing asset → `404 + no-store`

## Not included (follow-up)

This stops the *caching*; the transient ~rollout-window 404 still occurs. Eliminating it entirely means serving `/assets/` from a shared origin holding all versions (S3/R2) — separate PR, pending a bucket/access decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Cloudflare from caching asset 404s during rollouts by returning `Cache-Control: no-store` for missing assets. This prevents stale-chunk lockups and lets the app recover as soon as the rollout settles.

- **Bug Fixes**
  - Split `/assets/` handling: `try_files $uri` then fall through to `@asset_missing`.
  - Present files: `Cache-Control: public, max-age=31536000, immutable` (2xx only; no `always`).
  - Missing files: `@asset_missing` returns `404` with `Cache-Control: no-store` (`always`) so Cloudflare BYPASSes. Verified with `nginx -t` and live checks.

- **Dependencies**
  - Bump chart version to `0.10.12`.

<sup>Written for commit a2e64d0998bab219678d015e9eaa96c20c8966cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

