### PR TITLE
fix(sections-editor): fetch desktop preview metadata locally

### DIFF
--- a/apps/mesh/src/link-daemon/local-ingress.ts
+++ b/apps/mesh/src/link-daemon/local-ingress.ts
@@ -29,6 +29,14 @@ const MAX_PENDING_FRAMES = 256;
  */
 const CONNECTING_HTML = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Connecting…</title><style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#fafafa;color:#555}div{text-align:center;max-width:420px;padding:24px}h3{margin:0 0 8px}p{margin:0;font-size:14px;color:#999;line-height:1.5}</style></head><body><div><h3>Connecting to sandbox…</h3><p>Waiting for the local sandbox to come online. This page refreshes automatically.</p></div><script>setTimeout(function(){window.location.reload()},1500)</script></body></html>`;
 
+function applyCors(headers: Headers): Headers {
+  headers.set("access-control-allow-origin", "*");
+  headers.set("access-control-allow-methods", "GET, HEAD, POST, OPTIONS");
+  headers.set("access-control-allow-headers", "*");
+  headers.set("access-control-allow-private-network", "true");
+  return headers;
+}
+
 export interface StartLocalIngressInput {
   port: number;
   lookupSandboxPort: (handle: string) => number | null;
@@ -74,11 +82,20 @@ export async function startLocalIngress(
         }
         return new Response(CONNECTING_HTML, {
           status: 503,
-          headers: {
-            "Content-Type": "text/html; charset=utf-8",
-            "Cache-Control": "no-store",
-            "Retry-After": "1",
-          },
+          headers: applyCors(
+            new Headers({
+              "Content-Type": "text/html; charset=utf-8",
+              "Cache-Control": "no-store",
+              "Retry-After": "1",
+            }),
+          ),
+        });
+      }
+
+      if (req.method === "OPTIONS") {
+        return new Response(null, {
+          status: 204,
+          headers: applyCors(new Headers()),
         });
       }
 
@@ -99,11 +116,17 @@ export async function startLocalIngress(
       const target = `http://127.0.0.1:${sandboxPort}${url.pathname}${url.search}`;
       const headers = new Headers(req.headers);
       headers.set("host", `127.0.0.1:${sandboxPort}`);
-      return fetch(target, {
+      const upstream = await fetch(target, {
         method: req.method,
         headers,
         body: req.body,
         redirect: "manual",
+      });
+      const responseHeaders = new Headers(upstream.headers);
+      return new Response(upstream.body, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers: applyCors(responseHeaders),
       });
     },
     websocket: {

--- a/apps/mesh/src/web/components/sections-editor/preview-fetch-url.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/preview-fetch-url.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { buildPreviewFetchUrl } from "./preview-fetch-url";
+
+const sandbox = {
+  orgSlug: "acme",
+  virtualMcpId: "vm/one",
+  branch: "feature/local-preview",
+};
+
+describe("buildPreviewFetchUrl", () => {
+  test("uses the browser-reachable preview URL for localhost desktop previews", () => {
+    expect(
+      buildPreviewFetchUrl({
+        ...sandbox,
+        previewUrl: "http://abc.localhost:7070/some-page",
+        path: "/.decofile",
+      }),
+    ).toBe("http://abc.localhost:7070/.decofile");
+  });
+
+  test("uses a browser fallback preview URL when params do not include one", () => {
+    expect(
+      buildPreviewFetchUrl({
+        ...sandbox,
+        getFallbackPreviewUrl: () => "http://abc.localhost:7070/page",
+        path: "/live/_meta",
+      }),
+    ).toBe("http://abc.localhost:7070/live/_meta");
+  });
+
+  test("keeps using the API proxy for non-local preview URLs", () => {
+    expect(
+      buildPreviewFetchUrl({
+        ...sandbox,
+        previewUrl: "https://abc.preview.example.com/",
+        path: "/live/_meta",
+      }),
+    ).toBe(
+      "/api/acme/sandbox/vm%2Fone/feature%2Flocal-preview/preview-fetch?path=%2Flive%2F_meta",
+    );
+  });
+
+  test("falls back to the API proxy when no preview URL is available", () => {
+    expect(
+      buildPreviewFetchUrl({
+        ...sandbox,
+        previewUrl: undefined,
+        path: "/.decofile",
+      }),
+    ).toBe(
+      "/api/acme/sandbox/vm%2Fone/feature%2Flocal-preview/preview-fetch?path=%2F.decofile",
+    );
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/preview-fetch-url.ts
+++ b/apps/mesh/src/web/components/sections-editor/preview-fetch-url.ts
@@ -1,0 +1,45 @@
+interface PreviewFetchInput {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  previewUrl?: string | null;
+  getFallbackPreviewUrl?: () => string | null;
+  path: "/.decofile" | "/live/_meta";
+}
+
+function isBrowserReachableLocalPreview(previewUrl: string): boolean {
+  try {
+    const { hostname } = new URL(previewUrl);
+    return (
+      hostname === "localhost" ||
+      hostname.endsWith(".localhost") ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readPreviewUrlFromDocument(): string | null {
+  if (typeof document === "undefined") return null;
+  const iframes = Array.from(document.querySelectorAll("iframe"));
+  for (const iframe of iframes) {
+    const src = iframe.getAttribute("src");
+    if (src && isBrowserReachableLocalPreview(src)) return src;
+  }
+  return null;
+}
+
+export function buildPreviewFetchUrl(input: PreviewFetchInput): string {
+  const browserPreviewUrl =
+    input.previewUrl ??
+    input.getFallbackPreviewUrl?.() ??
+    readPreviewUrlFromDocument();
+  if (browserPreviewUrl && isBrowserReachableLocalPreview(browserPreviewUrl)) {
+    return new URL(input.path, browserPreviewUrl).toString();
+  }
+
+  const search = new URLSearchParams({ path: input.path });
+  return `/api/${input.orgSlug}/sandbox/${encodeURIComponent(input.virtualMcpId)}/${encodeURIComponent(input.branch)}/preview-fetch?${search.toString()}`;
+}

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -1,10 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
+import { buildPreviewFetchUrl } from "./preview-fetch-url";
 
 interface UseDecofileParams {
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
+  previewUrl?: string | null;
 }
 
 export function useDecofile(
@@ -12,15 +14,14 @@ export function useDecofile(
   options?: { fetchEnabled?: boolean },
 ) {
   const key = params
-    ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}`
+    ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}/${params.previewUrl ?? ""}`
     : "";
   const fetchEnabled = options?.fetchEnabled ?? true;
   return useQuery({
     queryKey: KEYS.decofile(key),
     queryFn: async () => {
-      const search = new URLSearchParams({ path: "/.decofile" });
       const res = await fetch(
-        `/api/${params!.orgSlug}/sandbox/${encodeURIComponent(params!.virtualMcpId)}/${encodeURIComponent(params!.branch)}/preview-fetch?${search.toString()}`,
+        buildPreviewFetchUrl({ ...params!, path: "/.decofile" }),
       );
       if (!res.ok) {
         const err = new Error(`Failed to fetch decofile: ${res.status}`);

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -1,11 +1,13 @@
 import { type Query, useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
+import { buildPreviewFetchUrl } from "./preview-fetch-url";
 import type { LiveMeta } from "./resolve-schema";
 
 interface UseLiveMetaParams {
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
+  previewUrl?: string | null;
 }
 
 export function useLiveMeta(
@@ -19,15 +21,14 @@ export function useLiveMeta(
   },
 ) {
   const key = params
-    ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}`
+    ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}/${params.previewUrl ?? ""}`
     : "";
   const fetchEnabled = options?.fetchEnabled ?? true;
   return useQuery({
     queryKey: KEYS.liveMeta(key),
     queryFn: async () => {
-      const search = new URLSearchParams({ path: "/live/_meta" });
       const res = await fetch(
-        `/api/${params!.orgSlug}/sandbox/${encodeURIComponent(params!.virtualMcpId)}/${encodeURIComponent(params!.branch)}/preview-fetch?${search.toString()}`,
+        buildPreviewFetchUrl({ ...params!, path: "/live/_meta" }),
       );
       if (!res.ok) {
         const err = new Error(`Failed to fetch live meta: ${res.status}`);


### PR DESCRIPTION
## Summary
- Fetch sections editor metadata directly from browser-reachable localhost previews when available.
- Keep the existing same-origin preview-fetch proxy for remote/agent preview URLs.
- Add CORS and private-network preflight support to desktop local ingress for readable metadata responses.

## Test Plan
- bun test apps/mesh/src/web/components/sections-editor/preview-fetch-url.test.ts
- bun run check
- bun run lint
- bun run fmt

Notes: lint exits 0 with existing warnings unrelated to this patch; fmt exits 0 while Biome reports permission diagnostics for out-of-root ../org/public files in this sandbox.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch Sections Editor metadata directly from local desktop previews to avoid proxy issues and unblock reads. Keeps the API proxy for remote previews and adds CORS/private-network support to the local ingress.

- **Bug Fixes**
  - Use the preview origin when it’s browser-reachable (`localhost`, `*.localhost`, `127.0.0.1`, `::1`); otherwise fall back to `/api/.../preview-fetch`.
  - Add CORS headers and `OPTIONS` handling to the local ingress, including on 503 and proxied responses.
  - Add `buildPreviewFetchUrl` and move fetching in `use-decofile` and `use-live-meta` to this helper; include unit tests.

<sup>Written for commit 635da6eb513eb1fb76e83552a24eaf142a7d045d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

