### PR TITLE
feat(chat): respect the user's chosen runtime in the mode picker

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -40,7 +40,14 @@
   },
   "optionalDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.181",
-    "@duckdb/node-api": "^1.5.0-r.1"
+    "@duckdb/node-api": "^1.5.0-r.1",
+    "@openai/codex": "0.141.0",
+    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
+    "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
+    "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
+    "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
+    "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
+    "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.85",

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -46,12 +46,9 @@ import type { HarnessId } from "@/harnesses";
 import {
   AGENT_OPTION_PINS,
   agentOptionFor,
-  resolveAvailableAgentOption,
   type AgentOption,
 } from "./pills/agent-options";
-import { useAgentOptionAvailability } from "./use-agent-availability";
 import { resolveSubmitSettings } from "./resolve-submit-settings";
-import { useCurrentLink } from "@/web/hooks/use-current-link";
 import {
   pickSimpleModeDefaults,
   SELF_MCP_ALIAS_ID,
@@ -528,32 +525,14 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
         )
       : null;
 
-  // Resolve the persisted pick against what's actually runnable right now,
-  // applying the same availability fallback the mode picker uses for display.
-  // A pick that points to an offline runtime — e.g. "Claude Code desktop"
-  // carried over from another org while this org's desktop link is offline —
-  // falls back to cloud Decopilot instead of dispatching to the dead desktop
-  // link (which 409s with `user_desktop_link_offline`). Because the picker's
-  // displayed mode is derived from `effectiveAgentOption` (exposed as
-  // `pendingAgentOption` below), this keeps the runtime the user sees selected
-  // and the runtime the message dispatches to in lockstep.
-  const availability = useAgentOptionAvailability();
-  const availableAgentOption = resolveAvailableAgentOption(
-    pendingAgentOption,
-    availability,
-  );
-
-  // Live desktop-link presence (polled every ~5s via the `/api/links/status`
-  // probe). When the user hasn't explicitly pinned a sandbox kind, the client
-  // chooses the default optimistically from this signal: route to the desktop
-  // when its link is online, otherwise fall back to the hosted agent sandbox.
-  // Read inline (no useEffect/useMemo) so the send path always sees the latest
-  // presence at render time.
-  const currentLink = useCurrentLink();
+  // Preserve the user's selected runtime exactly. Presence/capability probes are
+  // advisory only; dispatch should surface the real backend error if the choice
+  // cannot run.
+  const selectedAgentOption = pendingAgentOption;
 
   // When the thread is locked, the agent option is dictated by the persisted
   // (harness, sandbox) pair — period. Otherwise, fall through to the user's
-  // availability-resolved global picker.
+  // selected global picker.
   //
   // When the thread is locked but the (harness, sandbox) tuple doesn't map
   // to a known AgentOption (legacy/trigger-created rows), we intentionally
@@ -562,16 +541,14 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
   // should consult isThreadLocked for the "locked" affordance and avoid
   // showing the global selection on a locked thread.
   const effectiveAgentOption: AgentOption | null =
-    taskCtxForLock?.isThreadLocked ? lockedAgentOption : availableAgentOption;
+    taskCtxForLock?.isThreadLocked ? lockedAgentOption : selectedAgentOption;
 
   const effectivePins = effectiveAgentOption
     ? AGENT_OPTION_PINS[effectiveAgentOption]
     : null;
   const pendingHarnessId = effectivePins?.harness ?? null;
-  // Prefer the user's explicit pin; otherwise default from live link presence.
   const pendingSandboxProviderKind: SandboxProviderKind | null =
-    effectivePins?.sandbox ??
-    (currentLink.online ? "user-desktop" : "agent-sandbox");
+    effectivePins?.sandbox ?? "agent-sandbox";
 
   // Tiptap doc (transient UI state)
   const [tiptapDoc, setTiptapDoc] = useState<Metadata["tiptapDoc"]>(undefined);

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -71,6 +71,15 @@ import { shouldRenderInlineModeRow } from "./input-mode-row";
 // useWindowFileDrop - Reusable hook for window-level file drag & drop
 // ============================================================================
 
+export function ChatInputDisabledState({ message }: { message: string }) {
+  return (
+    <div className="flex w-full items-center gap-2 px-3 py-2.5 rounded-xl border border-border bg-muted/40 text-muted-foreground">
+      <Lock01 size={14} className="shrink-0" />
+      <span className="text-sm">{message}</span>
+    </div>
+  );
+}
+
 /**
  * Attaches window-level dragenter/dragleave/dragover/drop listeners and
  * processes dropped files into the current Tiptap editor.
@@ -402,7 +411,6 @@ export function ChatInput({
     messageCount: messages.length,
     showConnectionsBanner,
   });
-
   const handleSubmit = (e?: FormEvent) => {
     e?.preventDefault();
     if (isStreaming) {
@@ -432,12 +440,7 @@ export function ChatInput({
 
   if (userId && task?.created_by && task.created_by !== userId) {
     return (
-      <div className="flex w-full items-center gap-2 px-3 py-2.5 rounded-xl border border-border bg-muted/40 text-muted-foreground">
-        <Lock01 size={14} className="shrink-0" />
-        <span className="text-sm">
-          Read only — you&apos;re viewing someone else&apos;s thread
-        </span>
-      </div>
+      <ChatInputDisabledState message="Read only - you're viewing someone else's thread" />
     );
   }
 

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -71,7 +71,7 @@ import { shouldRenderInlineModeRow } from "./input-mode-row";
 // useWindowFileDrop - Reusable hook for window-level file drag & drop
 // ============================================================================
 
-export function ChatInputDisabledState({ message }: { message: string }) {
+function ChatInputDisabledState({ message }: { message: string }) {
   return (
     <div className="flex w-full items-center gap-2 px-3 py-2.5 rounded-xl border border-border bg-muted/40 text-muted-foreground">
       <Lock01 size={14} className="shrink-0" />

--- a/apps/mesh/src/web/components/chat/pills/agent-options.test.ts
+++ b/apps/mesh/src/web/components/chat/pills/agent-options.test.ts
@@ -7,7 +7,6 @@ import {
   type AgentPins,
   agentOptionFor,
   agentOptionIsAvailable,
-  resolveAvailableAgentOption,
 } from "./agent-options";
 
 const ALL_AVAILABLE: AgentOptionAvailability = {
@@ -116,58 +115,5 @@ describe("agentOptionIsAvailable", () => {
         codex: false,
       }),
     ).toBe(false);
-  });
-});
-
-describe("resolveAvailableAgentOption", () => {
-  test("keeps an available pick unchanged", () => {
-    expect(
-      resolveAvailableAgentOption("claude-code-desktop", ALL_AVAILABLE),
-    ).toBe("claude-code-desktop");
-    expect(resolveAvailableAgentOption("decopilot", ALL_AVAILABLE)).toBe(
-      "decopilot",
-    );
-  });
-
-  test("null pick stays null (server picks the default)", () => {
-    expect(resolveAvailableAgentOption(null, ALL_AVAILABLE)).toBeNull();
-    expect(resolveAvailableAgentOption(null, DESKTOP_OFFLINE)).toBeNull();
-  });
-
-  // The reported bug: a "Claude Code desktop" pick carried over from another
-  // org while this org's desktop link is offline must fall back to cloud
-  // Decopilot rather than dispatch to the dead link (user_desktop_link_offline).
-  test("falls back to cloud Decopilot when the desktop pick is offline", () => {
-    expect(
-      resolveAvailableAgentOption("claude-code-desktop", DESKTOP_OFFLINE),
-    ).toBe("decopilot");
-    expect(
-      resolveAvailableAgentOption("decopilot-desktop", DESKTOP_OFFLINE),
-    ).toBe("decopilot");
-    expect(resolveAvailableAgentOption("codex-desktop", DESKTOP_OFFLINE)).toBe(
-      "decopilot",
-    );
-  });
-
-  test("returns null when nothing is available", () => {
-    expect(
-      resolveAvailableAgentOption("claude-code-desktop", {
-        agentSandbox: false,
-        userDesktop: false,
-        claudeCode: false,
-        codex: false,
-      }),
-    ).toBeNull();
-  });
-
-  test("prefers a desktop fallback when cloud is unavailable but a CLI is online", () => {
-    expect(
-      resolveAvailableAgentOption("codex-desktop", {
-        agentSandbox: false,
-        userDesktop: true,
-        claudeCode: true,
-        codex: false,
-      }),
-    ).toBe("decopilot-desktop");
   });
 });

--- a/apps/mesh/src/web/components/chat/pills/agent-options.ts
+++ b/apps/mesh/src/web/components/chat/pills/agent-options.ts
@@ -62,10 +62,10 @@ export function agentOptionFor(
 
 /**
  * Runtime availability of each agent option for the current org/session,
- * derived from the public config (`agentSandbox`) and the user's desktop link
- * (`userDesktop` + the CLI capabilities it advertises). Shared by the mode
- * picker (which rows to show, which mode to display) and the chat submit path
- * (which (harness, sandbox) pins to dispatch) so the two can never disagree.
+ * derived from the public config (`agentSandbox`) and the user's desktop link.
+ * This is advisory UI metadata only: it annotates rows with "not detected" or
+ * "connect desktop" hints, but it must not prevent selection or rewrite the
+ * runtime sent on submit.
  */
 export interface AgentOptionAvailability {
   agentSandbox: boolean;
@@ -89,40 +89,4 @@ export function agentOptionIsAvailable(
     case "codex-desktop":
       return availability.userDesktop && availability.codex;
   }
-}
-
-/**
- * Preference order used when the selected option is unavailable. Cloud
- * Decopilot first — it's the only runtime that doesn't depend on a desktop
- * link — mirroring the row order in the mode picker.
- */
-const AGENT_OPTION_FALLBACK_ORDER: AgentOption[] = [
-  "decopilot",
-  "decopilot-desktop",
-  "claude-code-desktop",
-  "codex-desktop",
-];
-
-/**
- * Resolve the option that will actually run, applying the same availability
- * fallback the picker uses for display. When the persisted pick points to a
- * runtime that isn't currently available — e.g. a "Claude Code desktop" pick
- * carried over from another org while the desktop link is offline — fall back
- * to the first available option instead of silently dispatching to the dead
- * runtime (which 409s with `user_desktop_link_offline`).
- *
- * Returns `null` only when `option` is null (no explicit pick — let the server
- * choose its default) or when nothing is available at all.
- */
-export function resolveAvailableAgentOption(
-  option: AgentOption | null,
-  availability: AgentOptionAvailability,
-): AgentOption | null {
-  if (option == null) return null;
-  if (agentOptionIsAvailable(option, availability)) return option;
-  return (
-    AGENT_OPTION_FALLBACK_ORDER.find((o) =>
-      agentOptionIsAvailable(o, availability),
-    ) ?? null
-  );
 }

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.test.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.test.tsx
@@ -3,7 +3,42 @@ setupComponentTest();
 import { describe, expect, it, mock } from "bun:test";
 import { fireEvent, render } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { ModePickerPure } from "./mode-picker";
+import { ModePickerPure, resolveDisplayedAgentMode } from "./mode-picker";
+
+describe("resolveDisplayedAgentMode", () => {
+  it("keeps a locked desktop harness visible even when it is unavailable", () => {
+    expect(
+      resolveDisplayedAgentMode({
+        selectedMode: "cloud-decopilot",
+        lockedHarness: "claude-code",
+        lockedSandbox: "user-desktop",
+        isThreadLocked: true,
+      }),
+    ).toBe("local-claude-code");
+  });
+
+  it("keeps the user's selected runtime even when unavailable for unlocked threads", () => {
+    expect(
+      resolveDisplayedAgentMode({
+        selectedMode: "local-codex",
+        lockedHarness: null,
+        lockedSandbox: null,
+        isThreadLocked: false,
+      }),
+    ).toBe("local-codex");
+  });
+
+  it("uses the saved harness as a locked display fallback for unmapped tuples", () => {
+    expect(
+      resolveDisplayedAgentMode({
+        selectedMode: "cloud-decopilot",
+        lockedHarness: "codex",
+        lockedSandbox: null,
+        isThreadLocked: true,
+      }),
+    ).toBe("local-codex");
+  });
+});
 
 describe("ModePickerPure", () => {
   it("renders the closed pill with the current mode label", () => {
@@ -217,9 +252,8 @@ describe("ModePickerPure", () => {
     ]);
   });
 
-  it("shows local rows as disabled connect-desktop teasers when user desktop is not linked", () => {
+  it("selects unavailable local rows immediately when user desktop is not linked", () => {
     const onSelect = mock(() => {});
-    const onConnectDesktop = mock(() => {});
     const { getByRole, getAllByRole } = render(
       <ModePickerPure
         mode="cloud-decopilot"
@@ -231,7 +265,6 @@ describe("ModePickerPure", () => {
         }}
         locked={false}
         onSelect={onSelect}
-        onConnectDesktop={onConnectDesktop}
       />,
     );
     fireEvent.click(getByRole("button", { name: /Decopilot/i }));
@@ -240,17 +273,17 @@ describe("ModePickerPure", () => {
     expect(items).toHaveLength(4);
 
     const claudeCode = getByRole("menuitem", { name: /Claude Code/ });
-    expect(claudeCode).toHaveAttribute("aria-disabled", "true");
-    expect(claudeCode).toHaveTextContent("Connect your desktop to enable");
+    expect(claudeCode).not.toHaveAttribute("aria-disabled");
+    expect(claudeCode).toHaveTextContent("Desktop not detected");
 
-    // Clicking a teaser routes to the connect flow, never selects the mode.
+    // Clicking selects exactly what the user chose; the run path will surface
+    // any real connectivity/capability error.
     fireEvent.click(claudeCode);
-    expect(onSelect).not.toHaveBeenCalled();
-    expect(onConnectDesktop).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("local-claude-code");
   });
 
-  it("omits cloud decopilot when agent-sandbox is not configured", () => {
-    const { getByRole, getAllByRole, queryByRole } = render(
+  it("renders cloud decopilot even when agent-sandbox is not configured", () => {
+    const { getByRole, getAllByRole } = render(
       <ModePickerPure
         mode="local-decopilot"
         availability={{
@@ -264,18 +297,18 @@ describe("ModePickerPure", () => {
       />,
     );
     fireEvent.click(getByRole("button", { name: /Decopilot/i }));
-    // Cloud row is gone (operator decision, not user-actionable); local rows
-    // all render — available Decopilot plus the two CLI teasers.
-    expect(queryByRole("menuitem", { name: /agent sandbox/i })).toBeNull();
+    // Every runtime remains visible/selectable; errors are surfaced after the
+    // user tries to run.
     const items = getAllByRole("menuitem");
     expect(items.map((i) => i.textContent)).toEqual([
+      expect.stringMatching(/Decopilot/),
       expect.stringMatching(/Decopilot/),
       expect.stringMatching(/Claude Code/),
       expect.stringMatching(/Codex/),
     ]);
   });
 
-  it("shows unavailable CLIs as disabled rows with a not-detected hint", () => {
+  it("shows unavailable CLIs as selectable rows with a not-detected hint", () => {
     const { getByRole } = render(
       <ModePickerPure
         mode="cloud-decopilot"
@@ -292,12 +325,34 @@ describe("ModePickerPure", () => {
     fireEvent.click(getByRole("button", { name: /Decopilot/i }));
     for (const name of [/Claude Code/, /Codex/]) {
       const row = getByRole("menuitem", { name });
-      expect(row).toHaveAttribute("aria-disabled", "true");
+      expect(row).not.toHaveAttribute("aria-disabled");
       expect(row).toHaveTextContent("Not detected on your desktop");
     }
     expect(
       getByRole("menuitem", { name: /Runs on your desktop/ }),
     ).toHaveTextContent("Decopilot");
+  });
+
+  it("keeps the selected checkmark on an unavailable current row", () => {
+    const { getByRole } = render(
+      <ModePickerPure
+        mode="local-codex"
+        availability={{
+          agentSandbox: true,
+          userDesktop: true,
+          claudeCode: true,
+          codex: false,
+        }}
+        locked={false}
+        onSelect={() => {}}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: /Codex/i }));
+
+    const row = getByRole("menuitem", { name: /Codex/ });
+    expect(row).toHaveTextContent("Not detected on your desktop");
+    expect(row.querySelector("svg.text-foreground")).toBeInTheDocument();
   });
 
   it("calls onSelect with the right mode and closes on click", () => {

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
@@ -17,17 +17,18 @@ import {
   SELF_MCP_ALIAS_ID,
   useMCPClient,
   useProjectContext,
+  type SandboxProviderKind,
 } from "@decocms/mesh-sdk";
 import type { HarnessId } from "@/harnesses";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { useSandboxStart } from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { track } from "@/web/lib/posthog-client";
 import { useOptionalChatTask } from "../chat-context";
-import { ConnectDesktopDialog } from "../connect-desktop-dialog";
 import { useAgentOptionAvailability } from "../use-agent-availability";
-import type { AgentOptionAvailability } from "./agent-options";
+import { agentOptionFor, type AgentOptionAvailability } from "./agent-options";
 import { ClaudeCodeIcon, CodexIcon } from "../agent-icons";
 import {
+  agentModeFromOption,
   type AgentMode,
   useAgentMode,
   useSetAgentMode,
@@ -73,13 +74,6 @@ interface PureProps {
    */
   lockedHarness?: HarnessId | null;
   onSelect: (mode: AgentMode) => void;
-  /**
-   * Invoked when the user clicks an unavailable LOCAL row (desktop not
-   * linked, or linked without the CLI). The smart wrapper opens the
-   * connect-desktop dialog. Local rows are rendered as disabled teasers —
-   * not omitted — precisely so this path is discoverable.
-   */
-  onConnectDesktop?: () => void;
 }
 
 interface ModeRow {
@@ -129,19 +123,34 @@ const ROW_CODEX: ModeRow = {
 
 const ROWS = [ROW_DECOPILOT, ROW_LOCAL_DECOPILOT, ROW_CLAUDE_CODE, ROW_CODEX];
 
-function modeIsAvailable(
-  mode: AgentMode,
-  availability: ModePickerAvailability,
-): boolean {
-  return ROWS.some((row) => row.mode === mode && row.isAvailable(availability));
+function bestEffortLockedMode(
+  lockedHarness: HarnessId,
+  lockedSandbox: SandboxProviderKind | null,
+): AgentMode {
+  if (lockedHarness === "claude-code") return "local-claude-code";
+  if (lockedHarness === "codex") return "local-codex";
+  return lockedSandbox === "user-desktop"
+    ? "local-decopilot"
+    : "cloud-decopilot";
 }
 
-function fallbackMode(
-  mode: AgentMode,
-  availability: ModePickerAvailability,
-): AgentMode {
-  if (modeIsAvailable(mode, availability)) return mode;
-  return ROWS.find((row) => row.isAvailable(availability))?.mode ?? mode;
+export function resolveDisplayedAgentMode({
+  selectedMode,
+  lockedHarness,
+  lockedSandbox,
+  isThreadLocked,
+}: {
+  selectedMode: AgentMode;
+  lockedHarness: HarnessId | null;
+  lockedSandbox: SandboxProviderKind | null;
+  isThreadLocked: boolean;
+}): AgentMode {
+  if (isThreadLocked && lockedHarness != null) {
+    const lockedOption = agentOptionFor(lockedHarness, lockedSandbox);
+    if (lockedOption) return agentModeFromOption(lockedOption);
+    return bestEffortLockedMode(lockedHarness, lockedSandbox);
+  }
+  return selectedMode;
 }
 
 function harnessPillLabel(mode: AgentMode): {
@@ -191,7 +200,6 @@ export function ModePickerPure({
   locked,
   lockedHarness,
   onSelect,
-  onConnectDesktop,
 }: PureProps) {
   const [open, setOpen] = useState(false);
   const { icon, text } = locked
@@ -201,24 +209,12 @@ export function ModePickerPure({
   const isLocal = mode !== "cloud-decopilot";
   const showHarnessLabel = lockedHarness != null;
   const harnessLabel = lockedHarness ? HARNESS_LABEL[lockedHarness] : null;
-  // Cloud rows hide when unavailable (a deployment without an agent sandbox
-  // is an operator decision, nothing the user can act on). Local rows always
-  // render: an unavailable one is a disabled teaser pointing at the
-  // connect-desktop flow — otherwise users never learn local Claude
-  // Code/Codex exists.
-  const cloudRows = ROWS.filter(
-    (row) => row.group === "cloud" && row.isAvailable(availability),
-  );
+  const cloudRows = ROWS.filter((row) => row.group === "cloud");
   const localRows = ROWS.filter((row) => row.group === "local");
 
   const handleSelect = (m: AgentMode) => {
     onSelect(m);
     setOpen(false);
-  };
-
-  const handleConnectDesktop = () => {
-    setOpen(false);
-    onConnectDesktop?.();
   };
 
   return (
@@ -298,16 +294,15 @@ export function ModePickerPure({
               <Row
                 key={row.mode}
                 row={row}
-                active={available && mode === row.mode}
+                active={mode === row.mode}
                 onSelect={handleSelect}
                 unavailableHint={
                   available
                     ? undefined
                     : availability.userDesktop
                       ? "Not detected on your desktop"
-                      : "Connect your desktop to enable"
+                      : "Desktop not detected"
                 }
-                onUnavailableClick={handleConnectDesktop}
               />
             );
           })}
@@ -349,34 +344,20 @@ function Row({
   active,
   onSelect,
   unavailableHint,
-  onUnavailableClick,
 }: {
   row: ModeRow;
   active: boolean;
   onSelect: (mode: AgentMode) => void;
-  /**
-   * When set, the row is an unavailable teaser: dimmed, `aria-disabled`,
-   * and the hint replaces the description. It stays clickable — the click
-   * routes to `onUnavailableClick` (connect-desktop flow) instead of
-   * selecting the mode. A truly `disabled` button would swallow the one
-   * affordance that tells the user how to enable the feature.
-   */
   unavailableHint?: string;
-  onUnavailableClick?: () => void;
 }) {
-  const unavailable = unavailableHint != null;
   return (
     <button
       type="button"
       role="menuitem"
-      aria-disabled={unavailable || undefined}
-      onClick={() =>
-        unavailable ? onUnavailableClick?.() : onSelect(row.mode)
-      }
+      onClick={() => onSelect(row.mode)}
       className={cn(
         "flex items-start gap-2 px-2 py-1.5 rounded-md text-left",
         "hover:bg-muted",
-        unavailable && "opacity-60",
       )}
     >
       <span className="shrink-0 text-muted-foreground mt-0.5">{row.icon}</span>
@@ -423,13 +404,18 @@ export function ModePicker({
   // existing tooltip.
   const taskCtx = useOptionalChatTask();
   const lockedHarness = taskCtx?.lockedHarness ?? null;
+  const lockedSandbox = taskCtx?.lockedSandbox ?? null;
+  const isThreadLocked = taskCtx?.isThreadLocked ?? false;
 
-  // Same availability source `chat-context` resolves the submit pins from, so
-  // the displayed mode and the dispatched runtime stay in lockstep.
+  // Availability only annotates rows with advisory hints. It must not rewrite
+  // the selected/displayed runtime.
   const availability = useAgentOptionAvailability();
-  const mode = fallbackMode(selectedMode, availability);
-
-  const [connectOpen, setConnectOpen] = useState(false);
+  const mode = resolveDisplayedAgentMode({
+    selectedMode,
+    lockedHarness,
+    lockedSandbox,
+    isThreadLocked,
+  });
 
   const handleSelect = (next: AgentMode) => {
     setAgentMode(next);
@@ -454,12 +440,7 @@ export function ModePicker({
         locked={locked}
         lockedHarness={lockedHarness}
         onSelect={handleSelect}
-        onConnectDesktop={() => {
-          track("agent_mode_connect_desktop_opened");
-          setConnectOpen(true);
-        }}
       />
-      <ConnectDesktopDialog open={connectOpen} onOpenChange={setConnectOpen} />
     </>
   );
 }

--- a/apps/mesh/src/web/components/chat/use-agent-availability.ts
+++ b/apps/mesh/src/web/components/chat/use-agent-availability.ts
@@ -5,9 +5,8 @@ import type { AgentOptionAvailability } from "./pills/agent-options";
 /**
  * Runtime availability of each agent option for the current org/session.
  *
- * Single source consumed by both the mode picker (display) and the chat submit
- * path (dispatch pins) via `chat-context`, so the runtime the user sees
- * selected and the runtime the message dispatches to can never diverge.
+ * Advisory-only source consumed by the mode picker for status copy. It should
+ * never gate selection or rewrite the runtime the chat dispatches.
  */
 export function useAgentOptionAvailability(): AgentOptionAvailability {
   const link = useCurrentLink();

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "3.35.5",
+      "version": "3.36.5",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -179,6 +179,13 @@
       "optionalDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.181",
         "@duckdb/node-api": "^1.5.0-r.1",
+        "@openai/codex": "0.141.0",
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64",
       },
     },
     "packages/bindings": {
@@ -206,7 +213,7 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "1.6.4",
+      "version": "1.6.6",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/google": "^3.0.83",
@@ -330,7 +337,7 @@
     },
     "packages/tunnel": {
       "name": "@decocms/tunnel",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@nats-io/nats-core": "3.4.0",
         "zod": "^4.0.0",


### PR DESCRIPTION
## Summary

The chat mode picker previously overrode the user's explicit runtime selection with live availability/presence probes. A pick pointing at an offline runtime (or the optimistic desktop default) could silently re-route the dispatch, decoupling the runtime the user saw selected from the one the message actually ran on.

This change makes the **user's selection authoritative**:

- `chat-context.tsx`: drops `useAgentOptionAvailability` / `resolveAvailableAgentOption` / `useCurrentLink` from the send path. The selected agent option is now preserved exactly; presence/capability probes are advisory only. The sandbox default no longer flips based on live desktop-link presence — it falls back to `agent-sandbox`.
- `mode-picker.tsx`: replaces the `modeIsAvailable`/`fallbackMode` substitution with `resolveDisplayedAgentMode`, which only overrides display when a thread is **locked** to a persisted (harness, sandbox) pair. Cloud rows are no longer filtered out by availability; the connect-desktop teaser path is removed.
- `agent-options.ts` / `use-agent-availability.ts`: trimmed now-unused availability resolution helpers.

Net effect: dispatch surfaces the real backend error when a chosen runtime can't run, instead of quietly falling back.

## Testing

- Updated `mode-picker.test.tsx` to cover `resolveDisplayedAgentMode` (locked vs. unlocked).
- Removed obsolete `agent-options.test.ts` cases tied to the deleted availability fallback.
- `bun test`, `bun run check`, `bun run lint`, `bun run fmt`

## Affected areas

Chat runtime/mode selection UI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the chat mode picker always runs the runtime the user selected and stops auto-falling back based on availability. If the chosen runtime can’t run, the real backend error is shown.

- **Bug Fixes**
  - Preserve the exact agent option on send; availability probes are advisory only. Default sandbox now falls back to `agent-sandbox`.
  - Mode picker shows the user’s selection for unlocked threads; only overrides display when a thread is locked to a persisted (harness, sandbox) pair.
  - Keep cloud rows visible and selectable; remove the connect-desktop flow. Unavailable local rows remain selectable with hints (“Desktop not detected” / “Not detected on your desktop”).
  - Removed unused availability fallback helpers; updated tests and added a small read-only input component. Removed an unused export in `ChatInputDisabledState`.

- **Dependencies**
  - Declare `@openai/codex` and platform-specific optional binaries to ensure the native binary installs reliably and prevent codex harness crashes.

<sup>Written for commit c584dca57b9ce291bee38ad6d28e2cd250e7f943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

