### PR TITLE
feat(web): conversational personal home (/me) + cockpit proposal

### DIFF
--- a/apps/mesh/src/web/views/deco-redesign/PROPOSAL.md
+++ b/apps/mesh/src/web/views/deco-redesign/PROPOSAL.md
@@ -1,0 +1,109 @@
+# Proposal: the personal home (`/me`) — a user-centric layer above orgs
+
+## Problem
+
+Studio is **always** org-scoped. On `main`, the root route `/` immediately
+redirects you into your first org (`listOrganizationsCached() → firstOrg →
+/$org`). There is no place that is simply **you**. You can't see all your
+projects at a glance, and you can't talk to deco without first picking an org.
+
+But the person is the root entity. An org is a *context you enter*. When I open
+deco I'm talking to my teammate that helps me across many projects — decocms,
+anjo.chat, tama, mangabeira — each its own org, with its own members. I should
+land in **my** space, see everything I have access to, and drop into a project
+when I want to work on it.
+
+## Model
+
+```
+YOU ─┬─ decocms     (org) ─ agents, members, loops
+     ├─ anjo.chat   (org) ─ agents, members, loops
+     ├─ tama        (org) ─ ...
+     └─ mangabeira  (org) ─ ...
+```
+
+The person is root. Each project is an org you're a member of. `/me` is the
+layer where *you* live; entering a project drops into `/$org`. Primary unit in
+the cockpit = **projects (orgs)**, expandable to the agents inside each.
+
+## Where it lives
+
+Two layers — one mostly exists, one is the real work.
+
+**1. Route / UX (exists on this branch).** `/me` is mounted under `rootRoute`,
+above any org, and `/` redirects to it. Rendered in the same shell chrome as an
+agent. This is the `rafavalls/product-redesign` scaffold — **this PR is stacked
+on it** because it's the fastest base (the `/me` view already exists).
+
+**2. Cross-org data layer (does NOT exist — the work).** The backend is
+deliberately hard org-scoped: `createOrgScopedApi`, the `resolveOrgFromPath`
+middleware, cross-org isolation enforced and tested (404 on any cross-org read).
+The only above-org primitive is Better Auth's `listOrganizations(user)`.
+
+The right shape is a **fan-out aggregator, not a god-scope** — it never bypasses
+isolation, it just iterates the user's own memberships and merges:
+
+```
+/api/me/*  (personal scope)
+  └─ for each org in listOrganizations(user):
+       call that org's existing scoped endpoints
+       (agents, last-used, pending tasks/inbox, automation runs, findings)
+  └─ aggregate + rank
+```
+
+For the MVP this can even run **client-side** (most users have a handful of
+orgs), then move server-side for caching once it matters.
+
+## The home is a chat (this PR)
+
+The home today is a passive dashboard whose "New task" button just fires a
+toast. This PR makes the home **conversational**: the hero is a composer — the
+org-less "talk to deco" surface — so you can ask about anything across your
+projects before entering one. Quick-prompt chips replace the old static
+"Suggestions" grid.
+
+What's wired here: the composer UI (`HomeChat` in `personal-home.tsx`), with
+`⌘/Ctrl+Enter` to send. What's stubbed: submit toasts instead of opening a
+thread — because the backend below is the next step.
+
+## The four elements of `/me` (priority order)
+
+1. **Teammates rail** — your projects/agents across all orgs, each with a
+   liveness dot. Click → enter `/$org`. `⌘K` to jump to any project. *(sidebar
+   exists; wire to `listOrganizations` fan-out instead of `mock-user`.)*
+2. **Talk to deco** — the org-less composer (this PR). Backed by a personal
+   Decopilot thread that can answer "how's everything doing," route you into a
+   project, or spin up a new one (create org).
+3. **Needs-you queue** — the single cross-project list: pending approvals,
+   failures, regressions. **This is where the per-loop morning email lands
+   in-app.**
+4. **Project updates** — per-org 24h digest (loop summaries, deploys, metric
+   deltas). Reuse the tile board from `new-home` / `restore-home-dnd-ux`.
+
+## Why this matters beyond the home
+
+`/me` is the cockpit for **all your loops across all projects**; the org-level
+Studio is the cockpit for one project's loops. Same product, two zoom levels.
+The "Needs-you" queue *is* every loop's morning email, aggregated. Build `/me`
+and the loops vision gets its natural home.
+
+## Build sequence (low-hanging first)
+
+1. **Land `/me`** — route + `PersonalHome` shell + chat composer. *(this PR)*
+2. **Teammates rail → real data** — replace `mock-user` with a client-side
+   fan-out over `listOrganizations` + `agent-last-used-info`. *Fixes the core
+   complaint on its own; ~days.*
+3. **Org-less "talk to deco" thread** — a personal Decopilot thread; submit in
+   `HomeChat` opens/streams it. Later: cross-org routing + "create project."
+4. **Needs-you queue** — aggregate pending tasks/inbox + failed automation runs
+   + findings across orgs (reuse `home-next-actions.ts` per org).
+5. **Project updates tiles** — per-org 24h digest.
+
+## Notes
+
+- Stacked on `rafavalls/product-redesign` (fastest base; `/me` lives there).
+  Can be rebased onto `main` with the `/me` route cherry-picked if we want it to
+  land independently.
+- `personal-home.tsx` is still backed by `mock-user.ts`. Steps 2–4 swap mock for
+  the fan-out aggregator. No backend isolation is weakened — `/api/me/*` only
+  ever reads the user's own org memberships.

--- a/apps/mesh/src/web/views/deco-redesign/personal-home.tsx
+++ b/apps/mesh/src/web/views/deco-redesign/personal-home.tsx
@@ -1,9 +1,12 @@
 // Personal home — the USER's space, above any org (the "chatgpt.com" layer),
-// inside the same shell chrome as an Agent (sidebar + toolbar). Mirrors the org
-// home (Figma 8243-11524): a brief + New task, important highlights, then
-// "Agent updates" (per-Agent groups — the Figma's "Projects updates", renamed),
-// and suggestions. Entering an Agent drops into the org experience (/$org).
-// Standalone mock at /me (no org / ProjectContext needed).
+// inside the same shell chrome as an Agent (sidebar + toolbar). The home is
+// CONVERSATIONAL: you talk to deco here, before entering any project. The hero
+// is a chat composer (the org-less "talk to deco" surface), followed by a brief,
+// important highlights, then "Agent updates" (per-Agent groups). Entering an
+// Agent drops into the org experience (/$org).
+// Standalone mock at /me (no org / ProjectContext needed). The composer's
+// backend (a personal, org-less Decopilot thread that can route across your
+// orgs) is the work tracked in the proposal; submit is stubbed for now.
 import { useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import {
@@ -18,6 +21,7 @@ import {
 } from "@deco/ui/components/sidebar.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { Button } from "@deco/ui/components/button.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   Activity,
@@ -278,6 +282,8 @@ function PersonalHomeContent({
     <div className="mx-auto flex w-full max-w-[900px] flex-col gap-10 px-10 py-10">
       <Greeting reviewTotal={reviewTotal} />
 
+      <HomeChat />
+
       <Highlights reviewTotal={reviewTotal} />
 
       <section>
@@ -298,23 +304,6 @@ function PersonalHomeContent({
         <div className="grid gap-3 sm:grid-cols-2">
           {USER_CONNECTIONS.map((c) => (
             <ConnectionRow key={c.id} connection={c} />
-          ))}
-        </div>
-      </section>
-
-      <section>
-        <SectionLabel>Suggestions</SectionLabel>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          {SUGGESTIONS.map((s) => (
-            <button
-              key={s.label}
-              type="button"
-              onClick={() => toast.message(s.label)}
-              className="flex h-40 flex-col justify-between rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-ring/40 hover:bg-accent/30"
-            >
-              <s.icon size={18} className="text-muted-foreground" />
-              <span className="text-sm text-foreground">{s.label}</span>
-            </button>
           ))}
         </div>
       </section>
@@ -341,15 +330,66 @@ function Greeting({ reviewTotal }: { reviewTotal: number }) {
           ? `You have ${reviewTotal} updates in need of review across your teammates. Farm Rio needs the most attention.`
           : "Your teammates are all caught up. Nothing needs your review right now."}
       </p>
-      <Button
-        size="sm"
-        className="mt-5"
-        onClick={() => toast.message("New task")}
-      >
-        <Plus size={16} />
-        New task
-      </Button>
     </div>
+  );
+}
+
+// The home is conversational — you talk to deco *before* entering any project.
+// This composer is the org-less "talk to deco" surface. The backend (a personal
+// Decopilot thread that can route across your orgs and spin up new projects) is
+// the work tracked in the proposal; submit is stubbed to a toast for now.
+function HomeChat() {
+  const [value, setValue] = useState("");
+
+  const submit = () => {
+    const text = value.trim();
+    if (!text) return;
+    // TODO(personal-thread): open an org-less Decopilot thread and stream here.
+    toast.message("Talk to deco", { description: text });
+    setValue("");
+  };
+
+  return (
+    <section>
+      <div className="card-shadow rounded-2xl border border-border bg-card p-2">
+        <Textarea
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          placeholder="Ask deco anything across your projects…"
+          className="min-h-[88px] resize-none border-0 bg-transparent text-base shadow-none focus-visible:ring-0"
+        />
+        <div className="flex items-center gap-2 px-1.5 pb-1.5">
+          <div className="flex min-w-0 flex-1 flex-wrap gap-1.5">
+            {SUGGESTIONS.map((s) => (
+              <button
+                key={s.label}
+                type="button"
+                onClick={() => setValue(s.label)}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:border-ring/40 hover:text-foreground"
+              >
+                <s.icon size={12} />
+                {s.label}
+              </button>
+            ))}
+          </div>
+          <Button
+            size="sm"
+            className="shrink-0"
+            onClick={submit}
+            disabled={!value.trim()}
+          >
+            <Stars02 size={16} />
+            Ask deco
+          </Button>
+        </div>
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Why

Studio is **always** org-scoped — `/` redirects you straight into your first org, so there's no place that is simply *you*. You can't see your projects at a glance or talk to deco without first picking an org. The person should be root; an org is a context you enter.

This PR takes the first, lowest-risk step on the `/me` personal-home idea and **makes the home conversational**, plus lands a written proposal for the full cockpit.

## What's in here

- **`HomeChat`** — the `/me` hero is now a chat composer (the org-less "talk to deco" surface). `⌘/Ctrl+Enter` to send. Quick-prompt chips replace the old static "Suggestions" grid.
- **`PROPOSAL.md`** (co-located) — the personal `/me` layer above orgs, the **cross-org fan-out aggregator** (`/api/me/*` iterating `listOrganizations` — never a god-scope), the four cockpit elements (Teammates rail · Talk to deco · Needs-you queue · Project updates), and a low-hanging build sequence.

## What's stubbed (next steps, in the proposal)

- Submit currently toasts. Wiring it to a **personal, org-less Decopilot thread** that can route across your orgs and spin up new projects is step 3.
- `personal-home.tsx` is still backed by `mock-user.ts`. Step 2 swaps the Teammates rail to a `listOrganizations` fan-out — that alone fixes the core complaint.

## Notes

- **Stacked on `rafavalls/product-redesign`** (fastest base — the `/me` route + `PersonalHome` view already live there). Base this PR there to keep the diff focused; can be rebased onto `main` with `/me` cherry-picked if we want it to land independently.
- No backend isolation is weakened — the proposed `/api/me/*` only ever reads the user's own org memberships.
- `bun run fmt` (Biome) applied to the edited file.

## Testing notes

- UI-only change to the `/me` mock view; no API/backend changes in this PR.
- Screenshots TODO (run `bun run --cwd=apps/mesh dev:client`, visit `/me`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `/me` personal home conversational by adding a chat composer as the hero surface, letting users talk to deco before entering an org. Also adds a proposal for the full cockpit and a cross‑org fan‑out plan.

- **New Features**
  - Added `HomeChat` to `/me`: quick‑prompt chips, `⌘/Ctrl+Enter` to send, submit stubbed to a toast for now.
  - Replaced the static Suggestions grid with prompt chips in the composer.
  - Added `PROPOSAL.md` outlining the personal `/me` layer, `/api/me/*` fan‑out (never a god‑scope), cockpit elements, and build steps.
  - UI‑only change; no backend updates.

<sup>Written for commit efb0753168395de2e01a97910c2a23a9df6b6cb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

