### PR TITLE
fix(daemon): prevent index.lock race between BranchStatusMonitor and git commit

### DIFF
--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -188,7 +188,15 @@ export class BranchStatusMonitor {
         // Pin discovery to repoDir so a parent .git (e.g. the host's
         // workspace tree containing sandboxes/<handle>/repo) can't
         // hijack the lookup and report the wrong branch.
-        env: { ...process.env, GIT_CEILING_DIRECTORIES: this.config.repoDir },
+        // GIT_OPTIONAL_LOCKS=0: status/rev-parse don't need to refresh the
+        // index cache, so skip the optional index.lock acquisition. Without
+        // this the monitor races publish()'s git-add/commit for the lock and
+        // causes "Unable to create index.lock" failures on every commit.
+        env: {
+          ...process.env,
+          GIT_CEILING_DIRECTORIES: this.config.repoDir,
+          GIT_OPTIONAL_LOCKS: "0",
+        },
       });
     } catch {
       return "";

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -28,7 +28,17 @@ export interface GitDeps {
 }
 
 function gitEnv(repoDir: string): Record<string, string> {
-  return { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
+  return {
+    ...process.env,
+    GIT_CEILING_DIRECTORIES: repoDir,
+    // Status/diff/rev-parse calls in this file are read-only probes that don't
+    // need to refresh the index cache. Skipping the optional lock acquisition
+    // prevents racing with publish()'s git-add/commit for index.lock, which
+    // caused "Unable to create index.lock" and the agent falling back to the
+    // GitHub API. git-add and git-commit ignore this env var for their own
+    // non-optional index writes, so the write path is unaffected.
+    GIT_OPTIONAL_LOCKS: "0",
+  };
 }
 
 function runGit(


### PR DESCRIPTION
## Summary

- `BranchStatusMonitor` watches `.git/` and runs `git status` every 250ms (on change) and every 3s (poll fallback). Without `GIT_OPTIONAL_LOCKS=0`, each status call opportunistically refreshes the index cache and takes `index.lock`.
- When `publish()` runs `git add` + `git commit` at the same moment, whichever git process loses the lock race fails with `fatal: Unable to create '.git/index.lock': File exists`.
- The agent misdiagnoses this as a read-only `.git` directory and silently falls back to committing via the GitHub API — leaving the local clone behind its own branch, which causes divergence on subsequent commits.

**Fix:** set `GIT_OPTIONAL_LOCKS=0` in the env for all read-only git invocations in `BranchStatusMonitor.runGit` and `gitEnv()` in the git HTTP routes. This tells git to skip the optional index refresh without affecting `git add`/`git commit`, which always acquire the lock unconditionally.

## Files changed

- `packages/sandbox/daemon/git/branch-status.ts` — add `GIT_OPTIONAL_LOCKS: "0"` to `runGit` env
- `packages/sandbox/daemon/routes/git.ts` — add `GIT_OPTIONAL_LOCKS: "0"` to `gitEnv()` helper

## Test plan

- [ ] Trigger a publish (Save changes) while the dev server is running and `BranchStatusMonitor` is actively polling — confirm no "index.lock" failure in daemon logs
- [ ] Confirm `git status` in the branch-status monitor no longer shows up as holding `index.lock` during a commit
- [ ] Confirm the fallback-to-GitHub-API path is no longer triggered during normal commits
- [ ] `bun run fmt` and `bun run check` pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented index.lock races between the daemon’s read-only git calls and publish commits by setting GIT_OPTIONAL_LOCKS=0 on status/rev-parse probes. This removes spurious commit failures and stops fallback-to-GitHub-API, keeping the local clone in sync.

- **Bug Fixes**
  - Set `GIT_OPTIONAL_LOCKS=0` for read-only git invocations in BranchStatusMonitor and git HTTP routes.
  - Avoids racing `git add`/`git commit`; write path is unchanged.
  - Eliminates "Unable to create .git/index.lock" errors and the GitHub-API fallback.

<sup>Written for commit afe21343d7c978579813111808f673a0161d72f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

