### PR TITLE
fix(sandbox): reconcile stale VIRTUAL_MCP cache so preview unsticks w…

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -3,6 +3,7 @@ import {
   selectVmEntry,
   shouldAutoStart,
   shouldSelfHeal,
+  shouldReconcileStaleCache,
   computeDrawerStatus,
   type BranchMapEntryLike,
 } from "./sandbox-lifecycle-context";
@@ -127,6 +128,47 @@ describe("shouldSelfHeal", () => {
 
   test("user stopped → false", () => {
     expect(shouldSelfHeal({ ...base, userStopped: true })).toBe(false);
+  });
+});
+
+describe("shouldReconcileStaleCache", () => {
+  const base = {
+    phase: "running" as string | null,
+    previewUrl: null as string | null,
+    userStopped: false,
+    alreadyReconciled: false,
+  };
+
+  test("running with no previewUrl in cache → true", () => {
+    expect(shouldReconcileStaleCache(base)).toBe(true);
+  });
+
+  test("previewUrl already present → false", () => {
+    expect(
+      shouldReconcileStaleCache({ ...base, previewUrl: "https://x" }),
+    ).toBe(false);
+  });
+
+  test("still booting (not running) → false", () => {
+    expect(shouldReconcileStaleCache({ ...base, phase: "starting" })).toBe(
+      false,
+    );
+  });
+
+  test("no phase yet → false", () => {
+    expect(shouldReconcileStaleCache({ ...base, phase: null })).toBe(false);
+  });
+
+  test("user stopped → false", () => {
+    expect(shouldReconcileStaleCache({ ...base, userStopped: true })).toBe(
+      false,
+    );
+  });
+
+  test("already reconciled for this arrival → false", () => {
+    expect(
+      shouldReconcileStaleCache({ ...base, alreadyReconciled: true }),
+    ).toBe(false);
   });
 });
 

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -73,6 +73,35 @@ export function shouldSelfHeal(args: ShouldSelfHealArgs): boolean {
   );
 }
 
+export interface ShouldReconcileStaleCacheArgs {
+  /** Latest LifecycleState phase from the SSE stream. */
+  phase: string | null;
+  /** previewUrl resolved from the cached sandboxMap (null when the cache is stale). */
+  previewUrl: string | null;
+  userStopped: boolean;
+  /** Whether we already invalidated for this sandbox arrival (dedup). */
+  alreadyReconciled: boolean;
+}
+
+/**
+ * The dev server reached `running` (SSE) but the cached VIRTUAL_MCP entity still
+ * has no previewUrl for this user/branch/kind — the sandboxMap row was written by
+ * a path that didn't invalidate React Query (agent-triggered start, another
+ * tab/device, an SSE reconnect onto an already-running pod, or the kind-keyed
+ * entry not yet fetched). Re-fetch once so previewUrl resolves and the preview
+ * unsticks without a manual page refresh.
+ */
+export function shouldReconcileStaleCache(
+  args: ShouldReconcileStaleCacheArgs,
+): boolean {
+  return (
+    args.phase === "running" &&
+    !args.previewUrl &&
+    !args.userStopped &&
+    !args.alreadyReconciled
+  );
+}
+
 export function computeDrawerStatus(state: PreviewState): DrawerStatus {
   switch (state.kind) {
     case "suspended":
@@ -180,6 +209,10 @@ export function SandboxLifecycleProvider({
   // branch-keyed (VmEventsBridge) dedup refs).
   const autoStartAttemptedForBranchRef = useRef<Set<string>>(new Set());
   const reprovisionedForVmIdRef = useRef<string | null>(null);
+  // Dedup for the stale-cache reconcile effect: records the
+  // `${vmId}:${branch}:${kind}` we last invalidated for, so a single `running`
+  // arrival re-fetches once (and a kind switch can reconcile again).
+  const staleReconciledRef = useRef<string | null>(null);
 
   // Derived values, recomputed each render.
   // Cast: parseBranchMap returns SandboxRecord where sandboxProviderKind is
@@ -294,6 +327,36 @@ export function SandboxLifecycleProvider({
     setCurrentTaskBranch,
   ]);
 
+  // Stale-cache reconcile: the dev server is up (SSE `running`) but the cached
+  // VIRTUAL_MCP entity has no previewUrl for this user/branch/kind — the
+  // sandboxMap row landed without a client-side invalidation. Re-fetch once so
+  // previewUrl resolves and the preview (and Sections editor) mount without a
+  // hard refresh. Keyed on provider kind too, since selection is kind-scoped.
+  const reconcileKey =
+    virtualMcpId && branch
+      ? `${virtualMcpId}:${branch}:${sandboxProviderKind ?? ""}`
+      : null;
+  const reconcileStaleCache = shouldReconcileStaleCache({
+    phase: events.lifecycle.phase,
+    previewUrl,
+    userStopped,
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; recorded inside effect after invalidating
+    alreadyReconciled: staleReconciledRef.current === reconcileKey,
+  });
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- bridges SSE lifecycle into a one-shot query invalidation; no render-time equivalent
+  useEffect(() => {
+    if (previewUrl) {
+      // Cache caught up — clear dedup so a later cold restart can reconcile again.
+      // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- reset dedup once the entry is present
+      staleReconciledRef.current = null;
+      return;
+    }
+    if (!reconcileStaleCache || !reconcileKey) return;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- record arrival to invalidate at most once
+    staleReconciledRef.current = reconcileKey;
+    invalidateVirtualMcpQueries(queryClient);
+  }, [reconcileStaleCache, reconcileKey, previewUrl, queryClient]);
+
   // User-driven actions.
   const start = () => {
     if (!virtualMcpId) return;
@@ -342,6 +405,8 @@ export function SandboxLifecycleProvider({
     autoStartAttemptedForBranchRef.current = new Set();
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- reset dedup so self-heal can fire on next gone
     reprovisionedForVmIdRef.current = null;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- reset dedup so a fresh cold start can reconcile again
+    staleReconciledRef.current = null;
     startVmReset();
     start();
   };


### PR DESCRIPTION
## Problem
When the `sandboxMap` entry is written by a path that doesn't resolve a client-side `useSandboxStart` mutation — agent-triggered start, another tab, or an SSE reconnect onto an already-running pod — the cached VIRTUAL_MCP entity stays stale. `previewUrl` resolves to null even though the dev server reports `running`, so the preview sticks on "Server is starting…" and the Sections Editor stays inaccessible until a hard refresh re-fetches the entity. This matches the issue's "requires refresh on first open."

## Root cause
`previewUrl` is derived only from the React-Query-cached entity (`COLLECTION_VIRTUAL_MCP_GET`, `staleTime 60s`, no polling). The SSE stream carries `phase` but never `previewUrl`, and no cache invalidation is tied to the SSE lifecycle. So any write path that doesn't go through the mutation's `onSuccess` leaves the cache stale for up to 60s — exactly the window where a hard refresh "fixes" it.

(Slightly narrower than the trigger described in the issue: the stuck state is reproducible whenever the cache is stale with `phase === 'running'`, not only on first CMS-tab open.)

## Fix
Adds a stale-cache reconcile in `SandboxLifecycleProvider`: when the pod reports `running` but the cache still has no `previewUrl`, invalidate the VIRTUAL_MCP query once so `previewUrl` re-resolves. Gated on:
- `phase === 'running'` — write is guaranteed landed, avoids re-fetching before the row exists (no early-write race)
- `!previewUrl` — warm path untouched, zero regression
- deduped per sandbox arrival via a kind-aware key, mirroring the existing `shouldAutoStart` / `shouldSelfHeal` effects in the same file

Reuses `invalidateVirtualMcpQueries`. Touches only `VIRTUAL_MCP` keys, so no redundant refetch of `decofile` / `liveMeta`.

## Interaction with #4034
Consistent. `decofile` / `meta` are gated on `devServerReady` and resolve via the mesh proxy, independent of `previewUrl`, so they're unaffected. This fix restores the `previewUrl` that gives the iframe its local `src` — enabling (not conflicting with) #4034's browser-reachable fetch path.

## Verification
- Unit tests for `shouldReconcileStaleCache` (27 pass): running+null → invalidate; previewUrl present → no-op (warm path); non-running → no-op (no early race); userStopped → no-op; deduped → no loop.
- Code trace confirming the stale-cache path persists on current `main` (post-#4025 / #4034).
- Live A/B (stuck → unstuck) not captured: blocked by a separate desktop-sandbox boot issue on Windows (git-status flood preventing `running`), unrelated to this change.

Fixes #3482

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unsticks the sandbox preview by reconciling a stale `VIRTUAL_MCP` cache when the dev server is already running, removing the need to refresh. Fixes #3482.

- **Bug Fixes**
  - In `SandboxLifecycleProvider`, when SSE reports `phase === 'running'` but cached `previewUrl` is null, invalidate `VIRTUAL_MCP` queries once (keyed by `vmId:branch:kind`) to re-fetch and populate the preview URL.
  - Deduped per arrival and skipped when `previewUrl` exists, not running, or user stopped; dedup resets once the preview is available or on restart. Only `VIRTUAL_MCP` queries are touched (no `decofile`/`liveMeta` refetch).
  - Added unit tests for `shouldReconcileStaleCache`.

<sup>Written for commit 81cd1a3f7fab62a07cd9ab35dbee2b861fad11ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

