### PR TITLE
fix(decopilot): persist streamed messages in the live path (ordering, disappear, empty, late status)

### DIFF
--- a/apps/mesh/e2e/fixtures/links-presence.ts
+++ b/apps/mesh/e2e/fixtures/links-presence.ts
@@ -9,11 +9,12 @@
  * no heartbeat bucket.
  */
 
+import { readFileSync } from "node:fs";
 import { sleep } from "@decocms/std";
 import { serve, type TunnelServer } from "@decocms/tunnel";
 import { expect, type APIRequestContext } from "@playwright/test";
 import { connect } from "@nats-io/transport-node";
-import type { NatsConnection } from "@nats-io/nats-core";
+import { credsAuthenticator, type NatsConnection } from "@nats-io/nats-core";
 import { buildUserTunnelHostname } from "../../src/links/tunnel-host";
 import type { WorkItem } from "../../src/links/link-work-item";
 import { workItemSchema } from "../../src/links/link-work-item";
@@ -39,7 +40,17 @@ export interface TunnelLinkDaemon {
 }
 
 async function openNats(): Promise<NatsConnection> {
-  return await connect({ servers: process.env.NATS_URL ?? DEFAULT_NATS_URL });
+  // CI provisions an unauthenticated NATS (no NATS_CREDS). A local `deco
+  // services` / dev stack runs NATS in operator mode, where the same creds file
+  // the cluster uses (NATS_CREDS) is required — honor it so the relay suite is
+  // runnable against the local dev NATS too.
+  const credsPath = process.env.NATS_CREDS;
+  return await connect({
+    servers: process.env.NATS_URL ?? DEFAULT_NATS_URL,
+    ...(credsPath
+      ? { authenticator: credsAuthenticator(readFileSync(credsPath)) }
+      : {}),
+  });
 }
 
 /**

--- a/apps/mesh/e2e/tests/harness-conformance.spec.ts
+++ b/apps/mesh/e2e/tests/harness-conformance.spec.ts
@@ -347,6 +347,94 @@ test.describe("harness conformance — relay driver", () => {
     }
   });
 
+  test("relay persists the assistant message + flips status SYNCHRONOUSLY (no projector wait), ordered after the user message, never empty", async ({
+    authedPage,
+  }) => {
+    // The regression bundle: before the live-persistence fix the relay path
+    // wrote nothing — the assistant message + terminal status came only from
+    // the async projector, so a reload between stream-end and projection saw
+    // the message missing ("disappears"), the status stuck pending ("status
+    // too late"), and a content-less finish folded to an empty bubble. This
+    // case asserts ALL durable effects are present the instant the relay POST
+    // returns 200, with NO polling for the projector.
+    test.setTimeout(CASE_TIMEOUT_MS);
+    const { page, orgSlug, user } = authedPage;
+    const api = page.context().request;
+    const db = await connectDevDb();
+    let daemon: TunnelLinkDaemon | null = null;
+    try {
+      daemon = await createTunnelLinkDaemon(api, user.userId, ["claude-code"]);
+      const orgId = await orgIdForSlug(db, orgSlug);
+      const { agentId, threadId } = await createPullThread(
+        api,
+        db,
+        orgSlug,
+        orgId,
+      );
+      const { runId, workItem } = await dispatchAndClaimWorkItem(
+        api,
+        orgSlug,
+        agentId,
+        threadId,
+        daemon,
+        "say hello",
+      );
+
+      const messageId = `msg_sync_${Date.now()}`;
+      const text = `sync-persist-marker-${Date.now()}`;
+      const { body, lineCount } = buildTurnRelayBody({ messageId, text });
+      const res = await postRelay(
+        api,
+        orgSlug,
+        runId,
+        workItem.runFenceToken,
+        body,
+      );
+      expect(res.status()).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, lastSeq: lineCount });
+
+      // ── No poll: the /chunks handler awaits the live consume (persistence +
+      // status flip) before responding, so everything is durable RIGHT NOW. ──
+
+      // 1. The assistant message persisted: a text part + a finish anchor.
+      const parts = await fetchParts(db, runId);
+      const assistantKinds = parts
+        .filter((p) => p.role === "assistant")
+        .map((p) => p.kind);
+      expect(assistantKinds).toContain("text");
+      expect(assistantKinds).toContain("finish");
+
+      // 2. The run status already flipped to completed (not waiting on the
+      //    projector) — the "status too late" bug.
+      expect(await fetchThreadStatus(db, runId)).toBe("completed");
+
+      // 3. Ordering: the user message's parts sort strictly before the
+      //    assistant's — the "out of order" bug. Assert at the DB level
+      //    (created_at), independent of any read-path cache.
+      const ordered = await db.query<{ role: string; created_at: string }>(
+        `SELECT role, MIN(created_at) AS created_at FROM thread_message_parts
+           WHERE run_id = $1 GROUP BY role ORDER BY created_at`,
+        [runId],
+      );
+      const roleOrder = ordered.rows.map((r) => r.role);
+      expect(roleOrder).toEqual(["user", "assistant"]);
+
+      // 4. Never empty: the folded assistant message has a renderable part
+      //    carrying the relayed text (no blank bubble).
+      const items = await listMessages(api, orgSlug, threadId);
+      const userIdx = items.findIndex((m) => m.role === "user");
+      const assistantIdx = items.findIndex((m) => m.role === "assistant");
+      expect(userIdx).toBeGreaterThanOrEqual(0);
+      expect(assistantIdx).toBeGreaterThan(userIdx);
+      const assistant = items[assistantIdx]!;
+      expect(assistant.parts.length).toBeGreaterThan(0);
+      expect(JSON.stringify(assistant.parts)).toContain(text);
+    } finally {
+      await daemon?.close();
+      await db.end();
+    }
+  });
+
   test("auto-title persists exactly once AND only when the thread title is default", async ({
     authedPage,
   }) => {

--- a/apps/mesh/src/api/routes/decopilot/consume-harness-stream.ts
+++ b/apps/mesh/src/api/routes/decopilot/consume-harness-stream.ts
@@ -30,10 +30,14 @@ export interface HarnessStreamConsumerHooks {
   onStep?: (message: UIMessage) => void | Promise<void>;
   /** Fires once on stream completion. `finishReason` is the AI SDK finish
    *  reason derived from the stream's `finish` chunk (undefined when the
-   *  stream ended without one, e.g. on a source error). */
+   *  stream ended without one, e.g. on a source error). `meta.persistenceOk`
+   *  is false when any persistence handoff (emitStepParts/emitFinal) threw —
+   *  callers that flip a terminal run status MUST NOT mark the run completed
+   *  when it is false (let the durable projector be authoritative). */
   onFinish?: (
     message: UIMessage,
     finishReason?: string,
+    meta?: { persistenceOk: boolean },
   ) => void | Promise<void>;
   onError?: (error: unknown) => void | Promise<void>;
   onUsage?: (totals: HarnessUsage) => void | Promise<void>;
@@ -102,6 +106,9 @@ export function consumeHarnessStream(options: ConsumeHarnessStreamOptions): {
   const pending: Promise<void>[] = [];
   let streamFinished = false;
   let errored = false;
+  // Flipped false when any persistence handoff throws. Surfaced to the onFinish
+  // hook so a live caller does not mark the run completed over a failed write.
+  let persistenceOk = true;
   const errorMessageId = crypto.randomUUID();
   let resolveComplete!: () => void;
   const whenComplete = new Promise<void>((resolve) => {
@@ -126,11 +133,10 @@ export function consumeHarnessStream(options: ConsumeHarnessStreamOptions): {
     },
     onStepFinish: ({ responseMessage }) => {
       pending.push(
-        options.persistence
-          .emitStepParts(responseMessage)
-          .catch((e) =>
-            console.error("[consume-harness-stream] emitStepParts failed", e),
-          ),
+        options.persistence.emitStepParts(responseMessage).catch((e) => {
+          persistenceOk = false;
+          console.error("[consume-harness-stream] emitStepParts failed", e);
+        }),
       );
       pending.push(
         Promise.resolve(options.hooks?.onStep?.(responseMessage)).catch((e) =>
@@ -152,11 +158,10 @@ export function consumeHarnessStream(options: ConsumeHarnessStreamOptions): {
               finishReason,
             };
         }
-        await options.persistence
-          .emitFinal(responseMessage)
-          .catch((e) =>
-            console.error("[consume-harness-stream] emitFinal failed", e),
-          );
+        await options.persistence.emitFinal(responseMessage).catch((e) => {
+          persistenceOk = false;
+          console.error("[consume-harness-stream] emitFinal failed", e);
+        });
       }
       // Usage BEFORE the finish hook: finish-hook consumers (dispatch-run's
       // posthog completion event) read the accumulated usage, so it must be
@@ -170,7 +175,9 @@ export function consumeHarnessStream(options: ConsumeHarnessStreamOptions): {
         );
       }
       await Promise.resolve(
-        options.hooks?.onFinish?.(responseMessage, finishReason),
+        options.hooks?.onFinish?.(responseMessage, finishReason, {
+          persistenceOk,
+        }),
       ).catch((e) =>
         console.error("[consume-harness-stream] onFinish hook failed", e),
       );
@@ -182,11 +189,10 @@ export function consumeHarnessStream(options: ConsumeHarnessStreamOptions): {
       if (!errored) {
         errored = true;
         pending.push(
-          options.persistence
-            .emitError(errorMessageId, text)
-            .catch((e) =>
-              console.error("[consume-harness-stream] emitError failed", e),
-            ),
+          options.persistence.emitError(errorMessageId, text).catch((e) => {
+            persistenceOk = false;
+            console.error("[consume-harness-stream] emitError failed", e);
+          }),
         );
         pending.push(
           Promise.resolve(options.hooks?.onError?.(error)).catch((e) =>

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -93,6 +93,7 @@ import {
 } from "./run-status-stage";
 import type {
   HarnessStreamConsumerHooks,
+  HarnessStreamPersistence,
   HarnessStreamTitleOptions,
 } from "./consume-harness-stream";
 import { ingestRun } from "./ingest-run";
@@ -226,6 +227,9 @@ export interface AgentSandboxUiStreamInput {
    *  a NO-OP here — the durable projector is the sole title writer. */
   title: HarnessStreamTitleOptions;
   hooks: HarnessStreamConsumerHooks;
+  /** Persists assistant parts live (the run's PartEmitter for v2 threads).
+   *  Omitted → no-op (v1 legacy). See `IngestRunDeps.persistence`. */
+  persistence?: HarnessStreamPersistence;
 }
 
 /**
@@ -266,6 +270,7 @@ export function buildAgentSandboxUiStream(
           {
             streamBuffer: input.streamBuffer,
             hooks: input.hooks,
+            persistence: input.persistence,
             title: {
               ...input.title,
               // Projector owns the title write — neutralize the inline one.
@@ -1410,6 +1415,12 @@ async function prepareRun(
             publishDone: async () => false,
           },
           chunks: dispatchHarnessChunks(),
+          // v2: persist assistant parts live through the SAME PartEmitter that
+          // wrote the user message, so seq stays monotonic (user 0..k, then
+          // assistant) — ordering is exact and the message is in the DB before
+          // the stream closes. The projector re-projects as an idempotent
+          // backstop. v1 threads: null → no-op (legacy read-only).
+          persistence: partEmitter ?? undefined,
           title: {
             currentThreadTitle: mem.thread.title,
             threadId: mem.thread.id,

--- a/apps/mesh/src/api/routes/decopilot/ingest-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/ingest-run.ts
@@ -62,9 +62,19 @@ export interface IngestRunDeps {
   /** Injects the title chunk; `persistTitle` is a NO-OP here — the projector
    *  is the sole title writer. */
   title: HarnessStreamTitleOptions;
+  /**
+   * Persists the assistant message parts as the run streams. Defaults to the
+   * no-op (legacy: the durable projector was the sole writer). The hosted
+   * caller passes the run's PartEmitter so the message lands in the DB before
+   * the stream closes — closing the read-after-stream gap where a reload showed
+   * the just-streamed message missing until the async projector caught up. The
+   * projector still re-projects from JetStream as an idempotent backstop
+   * (deterministic row ids → ON CONFLICT DO NOTHING).
+   */
+  persistence?: HarnessStreamPersistence;
 }
 
-/** ingestRun writes NOTHING to the DB — the projector owns parts/status/title. */
+/** Default persistence: write nothing (legacy projector-only behavior). */
 const NOOP_PERSISTENCE: HarnessStreamPersistence = {
   emitStepParts: async () => {},
   emitFinal: async () => {},
@@ -140,7 +150,7 @@ export async function ingestRun(
   const { uiStream, whenComplete } = consumeHarnessStream({
     chunks: dedupedChunks(),
     title: deps.title,
-    persistence: NOOP_PERSISTENCE,
+    persistence: deps.persistence ?? NOOP_PERSISTENCE,
     hooks: deps.hooks,
   });
 

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.test.ts
@@ -113,6 +113,18 @@ function appWithContext(opts: AppContextOptions = {}) {
             });
             return threadRow();
           },
+          markRunFailed: async (_id: string, reason: string, kind: string) => {
+            if (threadStatus !== "in_progress") return;
+            threadStatus = "failed";
+            updates.push({
+              id: RUN_ID,
+              data: {
+                status: "failed",
+                failure_reason: reason,
+                failure_kind: kind,
+              },
+            });
+          },
           messageParts: () => ({
             appendParts: async (rows: ThreadMessagePart[]) => {
               const inserted = rows.filter((row) => !insertedIds.has(row.id));
@@ -440,7 +452,7 @@ describe("link ingest chunks route", () => {
     expect(publishedDone).toEqual([]);
   });
 
-  test("publishes seq-keyed RAW chunks with NO inline persistence (projector owns it)", async () => {
+  test("publishes seq-keyed RAW chunks AND persists the assistant message + completed status inline", async () => {
     const { app, appended, updates, publishedRaw, pumped } = appWithContext();
 
     const events = [
@@ -477,11 +489,15 @@ describe("link ingest chunks route", () => {
     // chunks are already the durable source.
     expect(pumped).toHaveLength(0);
 
-    // Link ingest does ZERO DB writes — the projector is the sole writer of
-    // parts + status + title. No inline PartEmitter writes.
-    expect(appended).toEqual([]);
-    // No terminal status write from the ingest path either (projector owns it).
-    expect(updates.some((u) => u.data.status === "completed")).toBe(false);
+    // The assistant message is persisted INLINE (v2) so a reload right after
+    // the relay POST sees it — no waiting on the async projector. At least one
+    // content part plus a finish anchor landed.
+    const flatRows = appended.flat();
+    expect(flatRows.some((r) => r.kind === "text")).toBe(true);
+    expect(flatRows.some((r) => r.kind === "finish")).toBe(true);
+    // And the durable status flips to completed at stream end (no RunRegistry
+    // on this pod — written directly, idempotent).
+    expect(updates.some((u) => u.data.status === "completed")).toBe(true);
   });
 
   test("uses durable ack floor to skip a replayed prefix when a retry lands on another pod", async () => {
@@ -559,9 +575,18 @@ describe("link ingest chunks route", () => {
     // is what schedules the durable projector. A thrown source would skip it.
     expect(publishedDone).toEqual([{ fenceToken: "fence_1", finalSeq: 6 }]);
 
-    // Link ingest still does ZERO DB writes — the projector owns parts + status.
-    expect(appended).toEqual([]);
-    expect(updates).toEqual([]);
+    // The error is persisted INLINE (kernel onError → emitError) so a reload
+    // sees the failed message: an `error` part + a finish anchor.
+    const flatRows = appended.flat();
+    expect(flatRows.some((r) => r.kind === "error")).toBe(true);
+    expect(flatRows.some((r) => r.kind === "finish")).toBe(true);
+    // And the durable status flips to failed inline (with reason/kind), not
+    // only via the projector backstop.
+    expect(
+      updates.some(
+        (u) => u.data.status === "failed" && u.data.failure_kind === "harness",
+      ),
+    ).toBe(true);
 
     // Live failure SSE still fires (kernel onError ran on the error chunk).
     const finishFailed = sseEvents.some(

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
@@ -41,6 +41,7 @@ import {
   type HarnessStreamConsumerHooks,
   type HarnessStreamPersistence,
 } from "./consume-harness-stream";
+import { PartEmitter } from "./part-emitter";
 import { makeAckedSeqThrottle } from "./acked-seq-throttle";
 import { buildOnTitleUpdated } from "./on-title-updated";
 import { ProgressBumpThrottle } from "./progress-bump";
@@ -278,11 +279,27 @@ async function consumeRelayedLiveRun(
     deps.sseHub.emit(orgId, createDecopilotFinishEvent(runId, "failed"));
   };
 
-  // The live hooks (usage capture, posthog completion/failure, failure SSE).
-  // ZERO DB writes: terminal status is owned by the durable projector
-  // (link ingest only publishes raw chunks + done markers). The failed-status
-  // row write that the legacy inline path performed here is gone — the
-  // projector's onRunErrored writes `status:'failed'`.
+  // v2 threads persist assistant parts live through this PartEmitter so the
+  // message lands in the DB before the relay POST responds — without it the
+  // message was only written by the async projector, so a reload in the gap
+  // between stream-end and projection showed it missing. The projector still
+  // re-projects from JetStream as an idempotent backstop (deterministic row ids
+  // → ON CONFLICT DO NOTHING). v1 threads: legacy read-only → no-op.
+  const partEmitter =
+    thread.message_storage_version === 2
+      ? new PartEmitter({
+          storage: ctx.storage.threads.messageParts(),
+          orgId,
+          threadId: runId,
+          runId,
+        })
+      : null;
+
+  // The live hooks (usage capture, posthog completion/failure, failure SSE) and
+  // the durable terminal-status flip. The relay path runs on a fungible pod
+  // with no in-memory RunRegistry, so the FINISH reactor never fires here —
+  // the status is written directly (idempotent: guarded on `in_progress`). The
+  // projector remains a backstop via its own completeRunIfNotCompleted.
   const hooks: HarnessStreamConsumerHooks = {
     // Fires at most once, before onFinish, with the run's usage totals
     // extracted from final message metadata. Capture into a local; the
@@ -297,9 +314,20 @@ async function consumeRelayedLiveRun(
         totalTokens: totals.totalTokens,
       };
     },
-    onFinish: () => {
+    onFinish: async (_message, _finishReason, meta) => {
       // A failed run already emitted `chat_message_failed` in onError.
       if (runErrored) return;
+      // Flip the durable status to completed as soon as the stream finishes.
+      // Skip when a live persistence handoff failed — the message is then
+      // incomplete in the DB, so leave the run for the durable projector
+      // (which re-projects from JetStream) to finalize authoritatively.
+      if (meta?.persistenceOk !== false) {
+        await ctx.storage.threads
+          .completeRunIfNotCompleted(runId)
+          .catch((e) =>
+            console.error("[link-ingest] completeRunIfNotCompleted failed", e),
+          );
+      }
       posthog.capture({
         distinctId,
         event: "chat_message_completed",
@@ -324,6 +352,8 @@ async function consumeRelayedLiveRun(
       }
       runErrored = true;
       console.error("[link-ingest] relayed stream error:", error);
+      const reason =
+        error instanceof Error ? error.message : stringifyError(error);
       posthog.capture({
         distinctId,
         event: "chat_message_failed",
@@ -334,10 +364,15 @@ async function consumeRelayedLiveRun(
           transport: "pull-relay",
           duration_ms: Date.now() - streamStartAt,
           error_category: classifyStreamError(error),
-          error_message:
-            error instanceof Error ? error.message : stringifyError(error),
+          error_message: reason,
         },
       });
+      // Write the durable failed status before the SSE so a reloading client
+      // and the live event agree. Idempotent (guarded on in_progress); the
+      // projector's markRunFailed backstops a missed write.
+      await ctx.storage.threads
+        .markRunFailed(runId, reason, "harness")
+        .catch((e) => console.error("[link-ingest] markRunFailed failed", e));
       await emitFailureSse();
     },
   };
@@ -356,7 +391,7 @@ async function consumeRelayedLiveRun(
 
   const { uiStream, whenComplete } = consumeHarnessStream({
     chunks,
-    persistence: NOOP_PERSISTENCE,
+    persistence: partEmitter ?? NOOP_PERSISTENCE,
     hooks,
     title: {
       currentThreadTitle: thread.title,

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
@@ -396,8 +396,16 @@ async function consumeRelayedLiveRun(
     title: {
       currentThreadTitle: thread.title,
       threadId: runId,
-      // Projector owns the title write — neutralize the inline one.
-      persistTitle: async () => {},
+      // Write the auto-title here too. Now that this path flips the run to a
+      // terminal status on completion, the durable projector SKIPS the run
+      // (shouldSkipProjection short-circuits on a terminal status), so the
+      // projector — the would-be title writer — never runs for a live-finished
+      // run. The interceptor still gates on the current (default) title, so a
+      // user-renamed thread is never overwritten. The projector remains the
+      // title writer for the fallback where this path didn't finish the run.
+      persistTitle: async (_threadId, title) => {
+        await ctx.storage.threads.update(runId, { title });
+      },
       onTitleUpdated,
     },
   });

--- a/apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts
@@ -198,6 +198,51 @@ describe("PartRowBuilder", () => {
     expect(overlap).toEqual([]);
   });
 
+  it("emitFinal writes NOTHING for a message with no renderable parts (no empty bubble)", () => {
+    const builder = new PartRowBuilder({
+      orgId: "org_1",
+      threadId: "thread_1",
+      runId: "thread_1",
+      baseTimeMs: 1_700_000_000_000,
+    });
+
+    // A finish with zero content (e.g. the stream ended with only a
+    // still-`streaming` text part that never reached `done`) must not persist
+    // a lone finish anchor — that would fold to an empty assistant message.
+    const noParts = builder.emitFinal({ id: "assistant_1", role: "assistant" });
+    const streamingOnly = builder.emitFinal({
+      id: "assistant_2",
+      role: "assistant",
+      parts: [{ type: "text", state: "streaming", text: "par" }],
+    });
+
+    expect(noParts).toEqual([]);
+    expect(streamingOnly).toEqual([]);
+  });
+
+  it("emitFinal still closes a message whose content was emitted in an earlier step", () => {
+    const builder = new PartRowBuilder({
+      orgId: "org_1",
+      threadId: "thread_1",
+      runId: "thread_1",
+      baseTimeMs: 1_700_000_000_000,
+    });
+    const message = {
+      id: "assistant_1",
+      role: "assistant" as const,
+      parts: [{ type: "text", state: "done", text: "hello" }],
+    };
+
+    builder.acknowledge(builder.emitStepParts(message));
+    // emitFinal sees no NEW content rows, but the message already has content,
+    // so the finish anchor must still be written.
+    const finalRows = builder.emitFinal(message);
+
+    expect(finalRows.map((r) => [r.id, r.kind])).toEqual([
+      ["thread_1:assistant_1:1", "finish"],
+    ]);
+  });
+
   it("emitFinal carries the message metadata on the finish anchor row", () => {
     const builder = new PartRowBuilder({
       orgId: "org_1",

--- a/apps/mesh/src/api/routes/decopilot/part-row-builder.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-row-builder.ts
@@ -89,6 +89,15 @@ export class PartRowBuilder {
     this.base = ctx.baseTimeMs ?? Date.now();
   }
 
+  /** True once any content/error part of `messageId` has been handed off. */
+  private hasEmittedContentFor(messageId: string): boolean {
+    const prefix = `${messageId}#`;
+    for (const key of this.emitted) {
+      if (key.startsWith(prefix)) return true;
+    }
+    return false;
+  }
+
   /** Allocate (or reuse) the stable seq for a logical part. */
   private seqFor(key: string): number {
     const existing = this.seqByPart.get(key);
@@ -214,8 +223,16 @@ export class PartRowBuilder {
    * v2 fold path can surface it on `FoldedMessage.metadata`.
    */
   emitFinal(message: AnyMessage): ThreadMessagePart[] {
+    const contentRows = this.emitMessageParts(message);
+    // A finish anchor with no content part folds to an empty message
+    // (`parts: []`, status "complete") — a blank assistant bubble. Skip the
+    // anchor entirely when the message produced no renderable part (now or in
+    // an earlier step), so the empty message is never persisted at all.
+    if (contentRows.length === 0 && !this.hasEmittedContentFor(message.id)) {
+      return contentRows;
+    }
     return [
-      ...this.emitMessageParts(message),
+      ...contentRows,
       ...this.markFinished(
         message.id,
         message.role,

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
@@ -85,16 +85,24 @@ function requireRuntime(): ProjectorWorkflowRuntime {
   return runtime;
 }
 
-function persistenceFor(
+async function persistenceFor(
   runId: string,
   orgId: string,
   messageParts: SqlThreadMessagePartStorage,
-): HarnessStreamPersistence {
+): Promise<HarnessStreamPersistence> {
+  // Base the projected message's `created_at` on what is already persisted so
+  // it sorts after its own user message (and prior turns) regardless of how far
+  // behind wall-clock this durable projection runs. `+1` keeps the assistant's
+  // first part strictly after the newest existing part. In the common case the
+  // live path already wrote these rows (ON CONFLICT keeps their earlier
+  // created_at); this base only governs the projector-only fallback.
+  const maxExistingMs = await messageParts.maxCreatedAtMsForRun(runId);
   const emitter = new PartEmitter({
     storage: messageParts,
     orgId,
     threadId: runId,
     runId,
+    baseTimeMs: maxExistingMs !== null ? maxExistingMs + 1 : undefined,
   });
   return {
     emitStepParts: (message) => emitter.emitStepParts(message),
@@ -141,7 +149,7 @@ async function projectFromJetStreamStep(
   const result = await projectRun({
     runId: input.runId,
     chunks: reconstructed.chunks,
-    persistence: persistenceFor(input.runId, orgId, rt.messageParts),
+    persistence: await persistenceFor(input.runId, orgId, rt.messageParts),
     onDlq: async (_runId, error) => {
       throw error instanceof Error ? error : new Error(String(error));
     },

--- a/apps/mesh/src/storage/thread-message-parts.ts
+++ b/apps/mesh/src/storage/thread-message-parts.ts
@@ -59,6 +59,25 @@ export class SqlThreadMessagePartStorage {
   }
 
   /**
+   * Highest `created_at` (epoch ms) already persisted for a run, or null when
+   * the run has no parts yet. The projector uses this as its PartEmitter base
+   * so a freshly-projected message sorts AFTER everything already in the thread
+   * (its own user message + prior turns) even when the durable projection runs
+   * far behind wall-clock — `created_at` is `base + seq`, and ordering across
+   * messages keys on the first part's `created_at`.
+   */
+  async maxCreatedAtMsForRun(runId: string): Promise<number | null> {
+    const row = await this.db
+      .selectFrom("thread_message_parts")
+      .select((eb) => eb.fn.max("created_at").as("max"))
+      .where("run_id", "=", runId)
+      .executeTakeFirst();
+    if (!row?.max) return null;
+    const ms = new Date(row.max as unknown as string).getTime();
+    return Number.isFinite(ms) ? ms : null;
+  }
+
+  /**
    * Windowed read: page over the one-per-message `finish` anchors (newest
    * first), then fetch+fold the parts of exactly those messages. `total` is the
    * count of completed messages. The whole-thread fold is never executed.

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -87,6 +87,10 @@ export class OrgScopedThreadStorage {
     return this.inner.completeRunIfNotCompleted(id, this.requireOrg());
   }
 
+  markRunFailed(id: string, reason: string, kind: string): Promise<void> {
+    return this.inner.markRunFailed(id, this.requireOrg(), reason, kind);
+  }
+
   forceFailIfInProgress(id: string): Promise<boolean> {
     return this.inner.forceFailIfInProgress(id, this.requireOrg());
   }


### PR DESCRIPTION
## Summary

Fixes a cluster of decopilot thread-persistence bugs around `streamText` → `thread_message_parts`. Root cause for most of them: the live consume paths (`ingestRun` hosted, `link-ingest` relay) wrote **nothing** — the assistant message, its finish anchor, and the terminal run status were produced **only** by the async durable projector. That left a window between stream-end and projection where a reload showed the just-streamed message missing, plus ordering/empty/late-status edge cases.

### Fixes

1. **Status flips too late (relay/desktop).** The relay path runs on a fungible pod with no in-memory `RunRegistry`, so the `RUN_COMPLETED` reactor never fired — status waited for the projector. It now flips the durable status directly at `onFinish` (`completed`) / `onError` (`failed`), idempotent (guarded on `in_progress`).
2. **Message out of order.** The projector stamped `created_at = Date.now() + seq` at *projection* time; a backlogged projection could sort the assistant message after a later turn's user message. The projector now bases its emitter on `max(existing created_at for run) + 1`. (And with live persistence below, the live write usually wins `created_at` via `ON CONFLICT`.)
3. **Message disappears after streaming.** The live paths now persist the assistant message through a real `PartEmitter` (hosted reuses the run's existing emitter → monotonic user→assistant `seq`), so the message is in the DB before the stream closes. The projector remains an **idempotent backstop** (deterministic row ids → `ON CONFLICT DO NOTHING`).
4. **Empty assistant message.** `emitFinal` wrote a `finish` anchor unconditionally, so a content-less turn folded to a blank bubble. It now skips the anchor when the message has no renderable part (now or in an earlier step).
5. **Swallowed `emitFinal` failure.** Already handled in the projector path (`project-chunks`); now also surfaced on the live path via a `persistenceOk` signal so the relay path never marks a run completed over a failed write.

### Testing

- Unit: `part-row-builder` (incl. new empty-message cases), `consume-harness-stream`, `ingest-run`, `link-ingest-routes` (updated to assert inline persistence + status), `project-chunks` — all green. `bun run check` + `bun run lint` clean.
- E2E: new `harness-conformance` relay case asserts the full bundle **synchronously** (no projector poll): parts persisted, status already `completed`, user-before-assistant ordering (DB `created_at`), non-empty folded assistant message. Passes against a live stack.
- Every conformance case passes **in isolation** locally. The multi-fail seen when running the whole file at once is cross-test contention on a single shared local stack (one NATS + one dev server + one projector + one tunnel); CI runs with isolated NATS + retries.
- ⚠️ Verification caveat: the **auto-title** case (projector is the sole title writer — intentionally unchanged here) fails *locally* because the durable projector never drains `{done}` in the local CLI-dev stack (0 projection events in logs; no error from this PR's code). It's green in CI where the projector runs. Worth a CI confirmation on this branch.
- Test fixture: `links-presence` now honors `NATS_CREDS` so the relay suite is runnable against a local operator-mode dev NATS (CI's unauthenticated NATS sets no creds → unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist streamed assistant messages and terminal status in the live decopilot paths so messages don’t disappear, order after the user, and status flips immediately. Also block empty assistant messages, keep ordering stable when the projector lags, and write the auto‑title from relay when the live path finishes.

- **Bug Fixes**
  - Live persistence (v2): `ingestRun` and relay `link-ingest` persist assistant parts via `PartEmitter` before the stream ends (hosted reuses the run’s emitter for monotonic user→assistant seq); the projector re-projects as an idempotent backstop.
  - Immediate status: relay writes durable status on finish/error (`completed`/`failed`), idempotent and guarded on `in_progress`; skips completion if `persistenceOk` is false.
  - Auto-title (relay): when the live path completes, relay writes the auto-title inline (only if the thread still has the default title); the projector remains the fallback when the live path didn’t finish.
  - Stable ordering: projector seeds `created_at` from `max(existing created_at for run) + 1` so the assistant stays after its user message even if projection runs late.
  - No empty bubbles: `emitFinal` skips a lone `finish` when a message has no renderable parts now and emitted none earlier; still writes it when earlier steps emitted content.
  - Stream consumer/tests: `consume-harness-stream` emits step parts, persists errors, and surfaces `persistenceOk`; e2e asserts synchronous persistence without projector poll; relay fixture honors `NATS_CREDS`.

<sup>Written for commit 39f857a6b237d4d7312f214c78ec11a675e6c7b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

