### PR TITLE
fix(decopilot): deterministic synthesized-error message id

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/consume-harness-stream.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/consume-harness-stream.test.ts
@@ -359,4 +359,37 @@ describe("consumeHarnessStream", () => {
     expect(errorChunk?.errorText).toBe("[SANITIZED] raw provider failure");
     expect(emitted).toEqual(["raw provider failure"]);
   });
+
+  test("uses the provided errorMessageId so the error message is stable across retries", async () => {
+    const seenIds: string[] = [];
+    // Two independent consumptions of the same erroring run (e.g. a projector
+    // retry or a daemon resend). With a run-derived id the synthesized error
+    // message lands at the SAME id both times → ON CONFLICT dedupes it.
+    for (let i = 0; i < 2; i++) {
+      const { uiStream, whenComplete } = consumeHarnessStream({
+        chunks: (async function* () {
+          yield { type: "start" } as UIMessageChunk;
+          throw new Error("boom");
+        })(),
+        originalMessages: [],
+        title: {
+          currentThreadTitle: "t",
+          threadId: "run-1",
+          persistTitle: async () => {},
+        },
+        errorMessageId: "error-run-1",
+        persistence: {
+          emitFinal: async () => {},
+          emitStepParts: async () => {},
+          emitError: async (messageId) => {
+            seenIds.push(messageId);
+          },
+        },
+      });
+      await drain(uiStream);
+      await whenComplete;
+    }
+
+    expect(seenIds).toEqual(["error-run-1", "error-run-1"]);
+  });
 });

--- a/apps/mesh/src/api/routes/decopilot/consume-harness-stream.ts
+++ b/apps/mesh/src/api/routes/decopilot/consume-harness-stream.ts
@@ -65,6 +65,15 @@ export interface ConsumeHarnessStreamOptions {
    * chunk the kernel itself synthesizes from a thrown error.
    */
   sanitizeErrorText?: (error: unknown) => string;
+  /**
+   * Message id for the error part the kernel synthesizes on a stream error.
+   * MUST be deterministic per run (`error-${runId}`) so the SAME error message
+   * dedupes across re-projection attempts, DBOS step retries, daemon
+   * full-prefix resends, and the live/projector double-write — the
+   * deterministic-id idempotency `projectRun` relies on. Defaults to a random
+   * UUID only for callers with no run identity (none persist on retry).
+   */
+  errorMessageId?: string;
 }
 
 function asReadableStream<T>(source: AsyncIterable<T>): ReadableStream<T> {
@@ -109,7 +118,7 @@ export function consumeHarnessStream(options: ConsumeHarnessStreamOptions): {
   // Flipped false when any persistence handoff throws. Surfaced to the onFinish
   // hook so a live caller does not mark the run completed over a failed write.
   let persistenceOk = true;
-  const errorMessageId = crypto.randomUUID();
+  const errorMessageId = options.errorMessageId ?? crypto.randomUUID();
   let resolveComplete!: () => void;
   const whenComplete = new Promise<void>((resolve) => {
     resolveComplete = resolve;

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -230,6 +230,9 @@ export interface AgentSandboxUiStreamInput {
   /** Persists assistant parts live (the run's PartEmitter for v2 threads).
    *  Omitted → no-op (v1 legacy). See `IngestRunDeps.persistence`. */
   persistence?: HarnessStreamPersistence;
+  /** Deterministic id for a synthesized error message (`error-${runId}`) so the
+   *  live write and the projector backstop dedupe it. */
+  errorMessageId?: string;
 }
 
 /**
@@ -266,6 +269,7 @@ export function buildAgentSandboxUiStream(
             runId: input.runId,
             fenceToken: input.fenceToken,
             chunks: seqChunks(),
+            errorMessageId: input.errorMessageId,
           },
           {
             streamBuffer: input.streamBuffer,
@@ -1421,6 +1425,9 @@ async function prepareRun(
           // the stream closes. The projector re-projects as an idempotent
           // backstop. v1 threads: null → no-op (legacy read-only).
           persistence: partEmitter ?? undefined,
+          // Deterministic per run so a synthesized error message dedupes across
+          // the live write and the projector backstop (same id).
+          errorMessageId: `error-${mem.thread.id}`,
           title: {
             currentThreadTitle: mem.thread.title,
             threadId: mem.thread.id,

--- a/apps/mesh/src/api/routes/decopilot/ingest-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/ingest-run.ts
@@ -53,6 +53,9 @@ export interface IngestRunInput {
    * Defaults to 0 (fresh run: publish everything from seq 1).
    */
   initialAckSeq?: number;
+  /** Deterministic id for a synthesized error message (`error-${runId}`) so the
+   *  live write and the projector backstop dedupe it. See consumeHarnessStream. */
+  errorMessageId?: string;
 }
 
 export interface IngestRunDeps {
@@ -152,6 +155,7 @@ export async function ingestRun(
     title: deps.title,
     persistence: deps.persistence ?? NOOP_PERSISTENCE,
     hooks: deps.hooks,
+    errorMessageId: input.errorMessageId,
   });
 
   await drain(uiStream);

--- a/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/link-ingest-routes.ts
@@ -392,6 +392,9 @@ async function consumeRelayedLiveRun(
   const { uiStream, whenComplete } = consumeHarnessStream({
     chunks,
     persistence: partEmitter ?? NOOP_PERSISTENCE,
+    // Same deterministic id the projector uses, so a synthesized error message
+    // dedupes across daemon resends + the projector backstop.
+    errorMessageId: `error-${runId}`,
     hooks,
     title: {
       currentThreadTitle: thread.title,

--- a/apps/mesh/src/api/routes/decopilot/project-chunks.ts
+++ b/apps/mesh/src/api/routes/decopilot/project-chunks.ts
@@ -30,6 +30,9 @@ export interface ProjectChunksOptions {
   persistence: HarnessStreamPersistence;
   /** Mirrors consumeHarnessStream: shapes the synthesized error part text. */
   sanitizeErrorText?: (error: unknown) => string;
+  /** Deterministic id for a synthesized error message (`error-${runId}`) so
+   *  re-projection attempts dedupe it. See consumeHarnessStream. */
+  errorMessageId?: string;
   /**
    * When set, the projector persists the harness title chunk via this writer
    * (it is the sole title writer). Omitted → the title is a no-op (legacy).
@@ -158,6 +161,7 @@ export async function projectChunks(
         },
     persistence,
     sanitizeErrorText: options.sanitizeErrorText,
+    errorMessageId: options.errorMessageId,
     hooks: {
       onError: () => {
         // Fires for BOTH in-band {type:"error"} chunks AND thrown source

--- a/apps/mesh/src/api/routes/decopilot/project-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/project-run.ts
@@ -69,6 +69,9 @@ export async function projectRun(
         })(),
         persistence: options.persistence,
         sanitizeErrorText: options.sanitizeErrorText,
+        // Deterministic per run so an error message dedupes across this loop's
+        // attempts, DBOS step retries, and the live-path write (same id).
+        errorMessageId: `error-${options.runId}`,
         title: options.title,
       });
       return { ok: true, attempts: attempt + 1, outcome };


### PR DESCRIPTION
## Summary

Follow-up to #4042 (per the DBOS-idempotency point). The harness kernel minted a **random** `crypto.randomUUID()` as the `message_id` for the error message it synthesizes when a stream errors. That breaks the deterministic-id idempotency the projector relies on (`projectRun` even documents "PartEmitter deterministic ids make re-projection idempotent"):

- `projectRun`'s own 5-attempt retry loop,
- DBOS step retries of the projector workflow,
- the daemon's full-prefix resends (relay reconnect), and
- the live-path write vs. the projector backstop writing the same run

each produced a **new** `message_id` → a new row id (`runId:<uuid>:seq`) that `ON CONFLICT` couldn't dedupe → **duplicate error messages**.

## Fix

Derive the synthesized error message id deterministically from the run (`error-${runId}`) and thread it through every path that consumes the kernel: projector (`project-run` → `project-chunks`), relay (`link-ingest`), and hosted (`dispatch-run` → `ingest-run`). The same error now lands at one stable id, so all the retry/replay/double-write paths dedupe via `ON CONFLICT DO NOTHING`. Default stays a random UUID for callers with no run identity.

## Testing

- `consume-harness-stream.test.ts`: new case asserts two independent consumptions of the same erroring run hand the SAME id to `emitError` (so it dedupes).
- `bun run check` + affected unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make synthesized error message IDs deterministic (`error-${runId}`) so retries, resends, and live vs. projector writes dedupe correctly. This prevents duplicate error messages in the DB.

- **Bug Fixes**
  - Added `errorMessageId` option to `consumeHarnessStream`; defaults to a random UUID only when no run identity exists.
  - Threaded the deterministic ID through `projectRun`, `projectChunks`, `dispatch-run`, `ingest-run`, and `link-ingest` so all paths use the same ID.
  - Added a test to confirm the same error ID is emitted across independent retries, enabling `ON CONFLICT DO NOTHING` to dedupe.

<sup>Written for commit 4762a232d1d0d01f5aeb020058200559ddd74353. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

