### PR TITLE
fix(decopilot): hosted assistant message persisted twice (duplicate/empty parts)

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1168,6 +1168,28 @@ async function prepareRun(
       }
     }
 
+    // The assistant message is persisted by a SEPARATE emitter from the user
+    // message's. Its part seqs MUST start at 0 — identical to the durable
+    // projector's fresh emitter — so the live rows (`run:msg:0,1,2`) and the
+    // projector's have the SAME ids and `ON CONFLICT` dedupes them. Reusing the
+    // user-message emitter made the assistant seqs continue after the user's
+    // (`run:msg:2,3,4`), which diverged from the projector's (`run:msg:0,1,2`)
+    // → the same message persisted twice (duplicate/"weird" render). base =
+    // max-existing-created_at + 1 keeps the assistant ordered after the user
+    // message and matches the projector's base, so live wins via first-write.
+    let assistantEmitter: PartEmitter | null = null;
+    if (isV2) {
+      const parts = ctx.storage.threads.messageParts();
+      const maxMs = await parts.maxCreatedAtMsForRun(mem.thread.id);
+      assistantEmitter = new PartEmitter({
+        storage: parts,
+        orgId: input.organizationId,
+        threadId: mem.thread.id,
+        runId: mem.thread.id,
+        baseTimeMs: (maxMs ?? Date.now()) + 1,
+      });
+    }
+
     const pendingOps: Promise<void>[] = [];
 
     // Pre-load conversation (no system messages — those are built separately)
@@ -1419,12 +1441,11 @@ async function prepareRun(
             publishDone: async () => false,
           },
           chunks: dispatchHarnessChunks(),
-          // v2: persist assistant parts live through the SAME PartEmitter that
-          // wrote the user message, so seq stays monotonic (user 0..k, then
-          // assistant) — ordering is exact and the message is in the DB before
-          // the stream closes. The projector re-projects as an idempotent
-          // backstop. v1 threads: null → no-op (legacy read-only).
-          persistence: partEmitter ?? undefined,
+          // v2: persist assistant parts live through a FRESH emitter (seqs from
+          // 0) so the row ids match the projector's and dedupe via ON CONFLICT.
+          // The message is in the DB before the stream closes; the projector is
+          // an idempotent backstop. v1 threads: null → no-op (legacy).
+          persistence: assistantEmitter ?? undefined,
           // Deterministic per run so a synthesized error message dedupes across
           // the live write and the projector backstop (same id).
           errorMessageId: `error-${mem.thread.id}`,

--- a/apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/part-row-builder.test.ts
@@ -263,4 +263,47 @@ describe("PartRowBuilder", () => {
     const finish = rows.find((r) => r.kind === "finish");
     expect(finish?.metadata).toMatchObject({ codingAgentSessionId: "sess-1" });
   });
+
+  it("a FRESH assistant emitter yields the SAME row ids as the projector (dedupes); a SHARED one diverges (the duplicate bug)", () => {
+    // The live path and the durable projector both persist the SAME assistant
+    // message. Dedup depends on identical row ids (`runId:messageId:seq`). The
+    // projector always uses a fresh emitter (assistant-only → seq 0,1,2). If the
+    // live path reuses the emitter that already wrote the user message (seq
+    // 0,1), the assistant seqs shift to 2,3,4 → ids diverge → ON CONFLICT can't
+    // dedupe → the message persists twice. The live path MUST use a fresh
+    // emitter too.
+    const shared = { orgId: "org_1", threadId: "thread_1", runId: "thread_1" };
+    const assistant = {
+      id: "assistant_1",
+      role: "assistant" as const,
+      parts: [
+        { type: "reasoning", state: "done", text: "think" },
+        { type: "text", state: "done", text: "answer" },
+      ],
+    };
+
+    // Projector: fresh emitter, assistant only.
+    const projector = new PartRowBuilder({ ...shared, baseTimeMs: 1000 });
+    const projectorIds = projector.emitFinal(assistant).map((r) => r.id);
+
+    // Live FRESH (the fix): identical row ids → dedupe.
+    const liveFresh = new PartRowBuilder({ ...shared, baseTimeMs: 5000 });
+    expect(liveFresh.emitFinal(assistant).map((r) => r.id)).toEqual(
+      projectorIds,
+    );
+
+    // Live SHARED with the user message (the bug): assistant seqs shift → ids
+    // diverge from the projector → both copies survive ON CONFLICT.
+    const liveShared = new PartRowBuilder({ ...shared, baseTimeMs: 5000 });
+    liveShared.acknowledge(
+      liveShared.emitUserMessage({
+        id: "user_1",
+        role: "user",
+        parts: [{ type: "text", text: "q" }],
+      }),
+    );
+    expect(liveShared.emitFinal(assistant).map((r) => r.id)).not.toEqual(
+      projectorIds,
+    );
+  });
 });


### PR DESCRIPTION
## The bug

Send a message, wait for the response, send a second one in the same thread: the prior assistant message renders empty/duplicated and (on refresh) the first message shows up twice. Root cause, confirmed against a real two-turn OpenRouter run:

The **same** assistant message was persisted with two disjoint sets of part rows:

```
msg_X assistant reasoning seq 2, text seq 3, finish seq 4   ← live path
msg_X assistant reasoning seq 0, text seq 1                 ← projector
```

`thread_message_parts` row id is `run_id:message_id:seq`. The **hosted live path** persisted the assistant through the *same* `PartEmitter` that had just written the **user** message (seqs 0,1), so the assistant's seqs continued at **2,3,4**. The **durable projector** uses a *fresh* emitter (assistant-only → **0,1,2**). Different seqs → different row ids → `ON CONFLICT DO NOTHING` can't dedupe → the message lands twice, folding to reasoning→text→reasoning→text (duplicated/"weird"), and the projector's `finish` (seq 2) collided with the live `reasoning` (seq 2) and was dropped.

This is a regression from the live-persistence change (#4042). The **relay/desktop path was never affected** because it already persists the assistant through a separate fresh emitter (matching the projector) — which is why the canned-chunk relay conformance test stayed green and only the hosted path broke.

## The fix

Persist the hosted assistant through its **own fresh `PartEmitter`** (seqs from 0, `baseTimeMs = maxCreatedAt + 1`) — byte-identical row-id scheme to the projector — so the live write and the projector backstop dedupe perfectly via `ON CONFLICT`. The user message keeps its own emitter.

## Verification

- Real two-turn hosted run (OpenRouter `gpt-4o-mini`): the completed turn now persists a single clean `reasoning(0) / text(1) / finish(2)` sequence (previously `0,1` + `2,3,4`).
- Unit test in `part-row-builder.test.ts`: a fresh assistant emitter yields the **same** row ids as the projector (dedupes); a shared one diverges (reproduces the bug).

## Follow-up (not in this PR)

A `requires_action` → resume turn can still re-emit the assistant's cumulative parts (a separate re-emission path, distinct from this live/projector divergence). Tracking separately; normal completed turns are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicated or empty assistant messages in hosted Decopilot by persisting the assistant with its own fresh emitter that matches the projector’s row IDs. Threads now show a single, ordered reasoning → text → finish sequence.

- **Bug Fixes**
  - Persist assistant via a fresh `PartEmitter` in hosted v2 (seqs start at 0).
  - Set `baseTimeMs = (maxCreatedAtMsForRun(thread) ?? now) + 1` to keep ordering after the user message.
  - Live and projector now emit identical row IDs (`run:message:seq`), so `ON CONFLICT` dedupes.
  - Added a unit test confirming fresh emitter dedupes; shared emitter reproduces the bug.

<sup>Written for commit 950f525e9562e4d9da87636a7ae567c7d0cab8f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

