### PR TITLE
refactor(web): migrate direct self tool calls from MCP client to typed REST

### DIFF
--- a/apps/mesh/src/web/hooks/collections/use-ai-providers.ts
+++ b/apps/mesh/src/web/hooks/collections/use-ai-providers.ts
@@ -7,8 +7,6 @@
 
 import type { ModelCollectionEntitySchema } from "@decocms/bindings/llm";
 import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
   useProjectContext,
   type AiProviderModel,
   type AiProviderKey,
@@ -18,27 +16,22 @@ import {
 
 export type { AiProviderKey, AiProviderModel, AiProviderInfo };
 import { z } from "zod";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { KEYS } from "../../lib/query-keys";
+import { callStudioTool, useStudioTools } from "../../lib/studio-tools";
 
 /**
  * Query options for the org's AI provider keys. Shared with parallel-prefetch
  * batches so they warm the exact cache entry useAiProviderKeys reads.
  */
-export function aiProviderKeysQueryOptions(client: Client, orgId: string) {
+export function aiProviderKeysQueryOptions(orgSlug: string, orgId: string) {
   return {
     queryKey: KEYS.aiProviderKeys(orgId),
     staleTime: 60_000,
-    queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_KEY_LIST",
-        arguments: {},
-      })) as {
-        structuredContent?: { keys: AiProviderKey[] };
-      };
-      return result.structuredContent ?? null;
-    },
+    queryFn: async () =>
+      (await callStudioTool(orgSlug, "AI_PROVIDER_KEY_LIST", {})) as {
+        keys: AiProviderKey[];
+      },
   };
 }
 
@@ -52,85 +45,54 @@ export type UseLLMsOptions = UseCollectionListOptions<LLM>;
 
 export function useAiProviders() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data } = useSuspenseQuery({
     queryKey: KEYS.aiProviders(org.id),
     staleTime: Infinity,
-    queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDERS_LIST",
-        arguments: {},
-      })) as {
-        structuredContent?: { providers: AiProviderInfo[] };
-      };
-      return result.structuredContent;
-    },
+    queryFn: async () =>
+      (await studio.call("AI_PROVIDERS_LIST", {})) as {
+        providers: AiProviderInfo[];
+      },
   });
   return data;
 }
 
 export function useAiProviderKeys() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
-
-  const { data } = useSuspenseQuery(aiProviderKeysQueryOptions(client, org.id));
+  const { data } = useSuspenseQuery(
+    aiProviderKeysQueryOptions(org.slug, org.id),
+  );
   return data?.keys ?? [];
 }
 
 export function useAiProviderModels(keyId: string | undefined) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data, isLoading } = useQuery({
     queryKey: KEYS.aiProviderModels(org.id, keyId ?? ""),
     enabled: !!keyId,
     staleTime: 60_000,
-    queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDERS_LIST_MODELS",
-        arguments: { keyId },
-      })) as {
-        structuredContent?: { models: AiProviderModel[] };
-      };
-      return result.structuredContent ?? null;
-    },
+    queryFn: async () =>
+      (await studio.call("AI_PROVIDERS_LIST_MODELS", {
+        keyId: keyId ?? "",
+      })) as { models: AiProviderModel[] },
   });
   return { models: data?.models ?? [], isLoading: !!keyId && isLoading };
 }
 
 export function useSuspenseAiProviderModels(keyId: string) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data } = useSuspenseQuery({
     queryKey: KEYS.aiProviderModels(org.id, keyId),
     staleTime: 60_000,
-    queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDERS_LIST_MODELS",
-        arguments: { keyId },
-      })) as {
-        structuredContent?: { models: AiProviderModel[] };
-      };
-      return result.structuredContent ?? null;
-    },
+    queryFn: async () =>
+      (await studio.call("AI_PROVIDERS_LIST_MODELS", { keyId })) as {
+        models: AiProviderModel[];
+      },
   });
   return data?.models ?? [];
 }

--- a/apps/mesh/src/web/hooks/use-automations.ts
+++ b/apps/mesh/src/web/hooks/use-automations.ts
@@ -12,6 +12,8 @@ import {
 } from "@decocms/mesh-sdk";
 import { toast } from "sonner";
 import { KEYS } from "../lib/query-keys";
+import { useStudioTools } from "../lib/studio-tools";
+import type { ToolInput } from "@/tools/io-types";
 
 // ============================================================================
 // Trigger List Hook
@@ -165,25 +167,17 @@ type AutomationListOutput = { automations: AutomationListItem[] };
 
 export function useAutomations(virtualMcpId?: string | null) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.automations(org.id, virtualMcpId),
     queryFn: async () => {
-      const args: Record<string, unknown> =
+      const payload = (await studio.call(
+        "AUTOMATION_LIST",
         virtualMcpId !== undefined && virtualMcpId !== null
           ? { virtual_mcp_id: virtualMcpId }
-          : {};
-      const result = (await client.callTool({
-        name: "AUTOMATION_LIST",
-        arguments: args,
-      })) as { structuredContent?: unknown };
-      const payload = (result.structuredContent ??
-        result) as AutomationListOutput;
+          : {},
+      )) as AutomationListOutput;
       return payload.automations;
     },
     staleTime: 10_000,
@@ -194,21 +188,14 @@ type AutomationGetOutput = { automation: AutomationDetail | null };
 
 export function useAutomation(id: string) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.automation(org.id, id),
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AUTOMATION_GET",
-        arguments: { id },
-      })) as { structuredContent?: unknown };
-      const payload = (result.structuredContent ??
-        result) as AutomationGetOutput;
+      const payload = (await studio.call("AUTOMATION_GET", {
+        id,
+      })) as AutomationGetOutput;
       return payload.automation;
     },
     enabled: !!id,
@@ -243,11 +230,7 @@ export function useAutomationRunStats(
   range?: { startDate?: string; endDate?: string },
 ) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   return useQuery({
     queryKey: KEYS.automationRunStats(
@@ -256,15 +239,11 @@ export function useAutomationRunStats(
       JSON.stringify(range ?? {}),
     ),
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "AUTOMATION_RUN_STATS",
-        arguments: {
-          automation_id: automationId,
-          ...(range?.startDate ? { startDate: range.startDate } : {}),
-          ...(range?.endDate ? { endDate: range.endDate } : {}),
-        },
-      })) as { structuredContent?: unknown };
-      return (result.structuredContent ?? result) as AutomationRunStats;
+      return (await studio.call("AUTOMATION_RUN_STATS", {
+        automation_id: automationId,
+        ...(range?.startDate ? { startDate: range.startDate } : {}),
+        ...(range?.endDate ? { endDate: range.endDate } : {}),
+      })) as AutomationRunStats;
     },
     enabled: !!automationId,
     staleTime: 30_000,
@@ -292,11 +271,7 @@ export function buildDefaultAutomationInput(virtualMcpId: string) {
 
 export function useAutomationActions() {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
 
   const invalidateAll = () =>
@@ -307,14 +282,10 @@ export function useAutomationActions() {
 
   const create = useMutation({
     mutationFn: async (input: Record<string, unknown>) => {
-      const result = (await client.callTool({
-        name: "AUTOMATION_CREATE",
-        arguments: input,
-      })) as { structuredContent?: unknown };
-      return (result.structuredContent ?? result) as {
-        id: string;
-        name: string;
-      };
+      return (await studio.call(
+        "AUTOMATION_CREATE",
+        input as ToolInput<"AUTOMATION_CREATE">,
+      )) as { id: string; name: string };
     },
     onSuccess: () => {
       invalidateAll();
@@ -328,11 +299,10 @@ export function useAutomationActions() {
 
   const update = useMutation({
     mutationFn: async (input: Record<string, unknown>) => {
-      const result = (await client.callTool({
-        name: "AUTOMATION_UPDATE",
-        arguments: input,
-      })) as { structuredContent?: unknown };
-      return (result.structuredContent ?? result) as { id: string };
+      return (await studio.call(
+        "AUTOMATION_UPDATE",
+        input as ToolInput<"AUTOMATION_UPDATE">,
+      )) as { id: string };
     },
     onSuccess: (_data, variables) => {
       invalidateAll();
@@ -349,11 +319,9 @@ export function useAutomationActions() {
 
   const remove = useMutation({
     mutationFn: async (id: string) => {
-      const result = (await client.callTool({
-        name: "AUTOMATION_DELETE",
-        arguments: { id },
-      })) as { structuredContent?: unknown };
-      return (result.structuredContent ?? result) as { success: boolean };
+      return (await studio.call("AUTOMATION_DELETE", { id })) as {
+        success: boolean;
+      };
     },
     onSuccess: (_data, id) => {
       queryClient.removeQueries({ queryKey: KEYS.automation(org.id, id) });
@@ -368,19 +336,10 @@ export function useAutomationActions() {
 
   const triggerAdd = useMutation({
     mutationFn: async (input: Record<string, unknown>) => {
-      const result = (await client.callTool({
-        name: "AUTOMATION_TRIGGER_ADD",
-        arguments: input,
-      })) as {
-        structuredContent?: unknown;
-        isError?: boolean;
-        content?: Array<{ text?: string }>;
-      };
-      if (result.isError) {
-        const message = result.content?.[0]?.text ?? "Failed to add trigger";
-        throw new Error(message);
-      }
-      return (result.structuredContent ?? result) as {
+      return (await studio.call(
+        "AUTOMATION_TRIGGER_ADD",
+        input as ToolInput<"AUTOMATION_TRIGGER_ADD">,
+      )) as {
         id: string;
         automation_id: string;
         // Only set for webhook triggers. Plaintext token is shown only once.
@@ -398,19 +357,9 @@ export function useAutomationActions() {
       trigger_id: string;
       automation_id: string;
     }) => {
-      const result = (await client.callTool({
-        name: "AUTOMATION_TRIGGER_ROTATE_TOKEN",
-        arguments: { trigger_id: input.trigger_id },
+      return (await studio.call("AUTOMATION_TRIGGER_ROTATE_TOKEN", {
+        trigger_id: input.trigger_id,
       })) as {
-        structuredContent?: unknown;
-        isError?: boolean;
-        content?: Array<{ text?: string }>;
-      };
-      if (result.isError) {
-        const message = result.content?.[0]?.text ?? "Failed to rotate token";
-        throw new Error(message);
-      }
-      return (result.structuredContent ?? result) as {
         trigger_id: string;
         url: string;
         token: string;
@@ -427,11 +376,9 @@ export function useAutomationActions() {
       trigger_id: string;
       automation_id: string;
     }) => {
-      const result = (await client.callTool({
-        name: "AUTOMATION_TRIGGER_REMOVE",
-        arguments: { trigger_id: input.trigger_id },
-      })) as { structuredContent?: unknown };
-      return (result.structuredContent ?? result) as { success: boolean };
+      return (await studio.call("AUTOMATION_TRIGGER_REMOVE", {
+        trigger_id: input.trigger_id,
+      })) as { success: boolean };
     },
     onSuccess: (_data, variables) => {
       invalidateAll();
@@ -441,19 +388,7 @@ export function useAutomationActions() {
 
   const run = useMutation({
     mutationFn: async (id: string) => {
-      const result = (await client.callTool({
-        name: "AUTOMATION_RUN",
-        arguments: { id },
-      })) as {
-        structuredContent?: unknown;
-        isError?: boolean;
-        content?: Array<{ text?: string }>;
-      };
-      if (result.isError) {
-        const message = result.content?.[0]?.text ?? "Failed to run automation";
-        throw new Error(message);
-      }
-      return (result.structuredContent ?? result) as {
+      return (await studio.call("AUTOMATION_RUN", { id })) as {
         threadId?: string;
         error?: string;
         skipped?: string;

--- a/apps/mesh/src/web/hooks/use-current-link.ts
+++ b/apps/mesh/src/web/hooks/use-current-link.ts
@@ -1,10 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { Capability } from "@/links/protocol";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "@/web/lib/query-keys";
 
 export interface CurrentLink {
@@ -25,20 +22,15 @@ const OFFLINE: CurrentLink = { online: false, capabilities: [], ready: false };
 
 export function useCurrentLink(): CurrentLink {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
 
   const { data } = useQuery<CurrentLink>({
     queryKey: KEYS.currentLink(org.id),
     queryFn: async () => {
-      const result = (await client.callTool({
-        name: "LINK_CURRENT_GET",
-        arguments: {},
-      })) as { structuredContent?: Omit<CurrentLink, "ready"> };
-      const link = result.structuredContent;
+      const link = (await studio.call("LINK_CURRENT_GET", {})) as Omit<
+        CurrentLink,
+        "ready"
+      > | null;
       return link ? { ...link, ready: true } : { ...OFFLINE, ready: true };
     },
     staleTime: 4_000,

--- a/apps/mesh/src/web/hooks/use-organization-settings.ts
+++ b/apps/mesh/src/web/hooks/use-organization-settings.ts
@@ -1,10 +1,4 @@
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-  WellKnownOrgMCPId,
-} from "@decocms/mesh-sdk";
-import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { useProjectContext, WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import {
   useMutation,
   useQuery,
@@ -15,6 +9,8 @@ import {
 } from "@tanstack/react-query";
 import { useRef } from "react";
 import { KEYS } from "@/web/lib/query-keys";
+import { callStudioTool, useStudioTools } from "@/web/lib/studio-tools";
+import type { ToolInput } from "@/tools/io-types";
 
 export type { SimpleModeTier } from "@/tools/organization/schema";
 import type { SimpleModeTier } from "@/tools/organization/schema";
@@ -74,22 +70,23 @@ const EMPTY_SIMPLE_MODE: SimpleModeConfig = {
  * build the same query key + queryFn and read one cache entry.
  */
 export function organizationSettingsQueryOptions(
-  client: Client,
+  orgSlug: string,
   orgId: string,
 ) {
   return {
     queryKey: KEYS.organizationSettings(orgId),
     queryFn: async (): Promise<OrganizationSettings> => {
-      const result = (await client.callTool({
-        name: "ORGANIZATION_SETTINGS_GET",
-        arguments: {},
-      })) as { structuredContent?: OrganizationSettings; isError?: boolean };
-      if (result?.isError) {
+      // GET is best-effort: a failed read falls back to empty settings rather
+      // than erroring the shell/home (the REST client throws on non-2xx).
+      try {
+        return (await callStudioTool(
+          orgSlug,
+          "ORGANIZATION_SETTINGS_GET",
+          {},
+        )) as OrganizationSettings;
+      } catch {
         return { ...EMPTY_SETTINGS, organizationId: orgId };
       }
-      return (
-        result.structuredContent ?? { ...EMPTY_SETTINGS, organizationId: orgId }
-      );
     },
     staleTime: 60_000,
   };
@@ -104,14 +101,9 @@ function useOrganizationSettings<T = OrganizationSettings>(
   select?: (settings: OrganizationSettings) => T,
 ): UseQueryResult<T> {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
 
   return useQuery({
-    ...organizationSettingsQueryOptions(client, org.id),
+    ...organizationSettingsQueryOptions(org.slug, org.id),
     select: select as (data: OrganizationSettings) => T,
   });
 }
@@ -131,13 +123,7 @@ export function useOrganizationSettingsNonBlocking(
   orgId: string,
   orgSlug: string,
 ): OrganizationSettings | null {
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId,
-    orgSlug,
-  });
-
-  const { data } = useQuery(organizationSettingsQueryOptions(client, orgId));
+  const { data } = useQuery(organizationSettingsQueryOptions(orgSlug, orgId));
 
   return data ?? null;
 }
@@ -153,11 +139,6 @@ type OrgSettingsUpdateInput = Partial<
   >
 >;
 
-type ToolErrorEnvelope = {
-  isError?: boolean;
-  content?: Array<{ type?: string; text?: string }>;
-};
-
 /**
  * Core mutation hook. Accepts any subset of updatable org-settings fields.
  * On success, writes the full returned row into the shared cache entry so
@@ -169,30 +150,16 @@ export function useUpdateOrganizationSettings(): UseMutationResult<
   OrgSettingsUpdateInput
 > {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (input: OrgSettingsUpdateInput) => {
-      const result = (await client.callTool({
-        name: "ORGANIZATION_SETTINGS_UPDATE",
-        arguments: {
-          organizationId: org.id,
-          ...input,
-        },
-      })) as {
-        structuredContent?: OrganizationSettings;
-      } & ToolErrorEnvelope;
-      if (result?.isError) {
-        throw new Error(
-          result.content?.[0]?.text ?? "Failed to update organization settings",
-        );
-      }
-      const payload = result.structuredContent;
+      // Throws on non-2xx (validation/auth/etc.) — no silent false success.
+      const payload = (await studio.call("ORGANIZATION_SETTINGS_UPDATE", {
+        organizationId: org.id,
+        ...input,
+      } as ToolInput<"ORGANIZATION_SETTINGS_UPDATE">)) as OrganizationSettings;
       if (!payload) {
         throw new Error("ORGANIZATION_SETTINGS_UPDATE returned no payload");
       }

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -62,8 +62,8 @@ export function HomePage() {
   });
   useSuspenseQueries({
     queries: [
-      aiProviderKeysQueryOptions(selfClient, org.id),
-      organizationSettingsQueryOptions(selfClient, org.id),
+      aiProviderKeysQueryOptions(org.slug, org.id),
+      organizationSettingsQueryOptions(org.slug, org.id),
       virtualMcpItemQueryOptions(org.id, displayAgent.id, selfClient),
     ],
   });

--- a/apps/mesh/src/web/lib/studio-tools.ts
+++ b/apps/mesh/src/web/lib/studio-tools.ts
@@ -26,8 +26,13 @@ class StudioToolError extends Error {
 /**
  * Call a builtin tool over REST. `orgSlug` scopes the org; `name` is the tool
  * identifier (also the permission identifier checked server-side).
+ *
+ * Exported for non-hook callers (e.g. shared React Query `queryOptions` used by
+ * parallel-prefetch batches and by the shell, which runs before
+ * `useProjectContext` is available and so can't call `useStudioTools`). In a
+ * component/hook prefer `useStudioTools().call`.
  */
-async function callStudioTool<N extends ToolName>(
+export async function callStudioTool<N extends ToolName>(
   orgSlug: string,
   name: N,
   input: ToolIO[N]["input"],

--- a/apps/mesh/src/web/views/settings/ai-providers/connect-forms.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/connect-forms.tsx
@@ -8,11 +8,9 @@ import { Eye, EyeOff } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { DialogFooter } from "@deco/ui/components/dialog.tsx";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
+import type { ToolInput } from "@/tools/io-types";
 import { KEYS } from "@/web/lib/query-keys";
 import type { OpenAICompatiblePreset } from "@/web/utils/openai-compatible-presets";
 
@@ -33,11 +31,7 @@ export function ConnectApiKeyForm({
   onSuccess: () => void;
 }) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
   const [showKey, setShowKey] = useState(false);
 
@@ -56,13 +50,11 @@ export function ConnectApiKeyForm({
     error,
   } = useMutation({
     mutationFn: async (data: ApiKeyFormData) => {
-      await client.callTool({
-        name: "AI_PROVIDER_KEY_CREATE",
-        arguments: {
-          providerId,
-          label: data.label || "Personal key",
-          apiKey: data.apiKey,
-        },
+      await studio.call("AI_PROVIDER_KEY_CREATE", {
+        providerId:
+          providerId as ToolInput<"AI_PROVIDER_KEY_CREATE">["providerId"],
+        label: data.label || "Personal key",
+        apiKey: data.apiKey,
       });
     },
     onSuccess: () => {
@@ -153,11 +145,7 @@ export function ConnectOpenAICompatibleForm({
   onSuccess: () => void;
 }) {
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
   const [showKey, setShowKey] = useState(false);
 
@@ -184,14 +172,11 @@ export function ConnectOpenAICompatibleForm({
         baseUrl: data.baseUrl,
         apiKey: data.apiKey || "",
       });
-      await client.callTool({
-        name: "AI_PROVIDER_KEY_CREATE",
-        arguments: {
-          providerId: "openai-compatible",
-          label: data.label || preset?.name || data.baseUrl,
-          apiKey: encodedKey,
-          ...(preset ? { presetId: preset.id } : {}),
-        },
+      await studio.call("AI_PROVIDER_KEY_CREATE", {
+        providerId: "openai-compatible",
+        label: data.label || preset?.name || data.baseUrl,
+        apiKey: encodedKey,
+        ...(preset ? { presetId: preset.id } : {}),
       });
     },
     onSuccess: () => {

--- a/apps/mesh/src/web/views/settings/ai-providers/connect-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/connect-provider-dialog.tsx
@@ -11,11 +11,9 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
-import {
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useStudioTools } from "@/web/lib/studio-tools";
+import type { ToolInput } from "@/tools/io-types";
 import { useAiProviders } from "@/web/hooks/collections/use-ai-providers";
 import { KEYS } from "@/web/lib/query-keys";
 import { track } from "@/web/lib/posthog-client";
@@ -58,11 +56,7 @@ export function ConnectProviderDialog({
   const aiProviders = useAiProviders();
   const providers = aiProviders?.providers ?? [];
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
+  const studio = useStudioTools();
   const queryClient = useQueryClient();
   const [state, dispatch] = useReducer(reducer, initialState);
   const triggeredRef = useRef(false);
@@ -100,13 +94,13 @@ export function ConnectProviderDialog({
       stateToken: string;
       label: string;
     }) => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_OAUTH_EXCHANGE",
-        arguments: { providerId, code, stateToken, label },
-      })) as { isError?: boolean; content?: { text?: string }[] };
-      if (result?.isError) {
-        throw new Error(result.content?.[0]?.text ?? "OAuth exchange failed");
-      }
+      await studio.call("AI_PROVIDER_OAUTH_EXCHANGE", {
+        providerId:
+          providerId as ToolInput<"AI_PROVIDER_OAUTH_EXCHANGE">["providerId"],
+        code,
+        stateToken,
+        label,
+      });
       return providerId;
     },
     onSuccess: (providerId) => {
@@ -128,13 +122,10 @@ export function ConnectProviderDialog({
 
   const { mutate: provisionKey } = useMutation({
     mutationFn: async (providerId: string) => {
-      const result = (await client.callTool({
-        name: "AI_PROVIDER_PROVISION_KEY",
-        arguments: { providerId },
-      })) as { isError?: boolean; content?: { text?: string }[] };
-      if (result?.isError) {
-        throw new Error(result.content?.[0]?.text ?? "Key provisioning failed");
-      }
+      await studio.call("AI_PROVIDER_PROVISION_KEY", {
+        providerId:
+          providerId as ToolInput<"AI_PROVIDER_PROVISION_KEY">["providerId"],
+      });
       return providerId;
     },
     onSuccess: (providerId) => {
@@ -179,26 +170,19 @@ export function ConnectProviderDialog({
         method: "oauth-pkce",
       });
       try {
-        const result = (await client.callTool({
-          name: "AI_PROVIDER_OAUTH_URL",
-          arguments: {
-            providerId: provider.id,
-            callbackUrl: `${window.location.origin}/oauth/callback/ai-provider`,
-          },
-        })) as { structuredContent?: { url: string; stateToken: string } };
-        if (!result.structuredContent) {
+        const result = await studio.call("AI_PROVIDER_OAUTH_URL", {
+          providerId: provider.id,
+          callbackUrl: `${window.location.origin}/oauth/callback/ai-provider`,
+        });
+        if (!result?.url) {
           throw new Error("Invalid response from AI_PROVIDER_OAUTH_URL");
         }
         dispatch({
           type: "select-oauth",
           providerId: provider.id,
-          stateToken: result.structuredContent.stateToken,
+          stateToken: result.stateToken,
         });
-        window.open(
-          result.structuredContent.url,
-          "AiProviderOAuth",
-          "width=600,height=700",
-        );
+        window.open(result.url, "AiProviderOAuth", "width=600,height=700");
       } catch (err) {
         toast.error(
           `Failed to start OAuth: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## What is this contribution about?

Continues the MCP-self → REST migration (PR #3932 backbone) by converting the **direct self/builtin tool call sites** in the web admin from the in-browser MCP self client (`useMCPClient({ connectionId: "self" }).callTool({ name, arguments })`) to the typed REST client (`useStudioTools().call(name, input)` / `callStudioTool(orgSlug, name, input)` → `POST /api/:org/tools/:toolName`).

Because the REST client **throws `StudioToolError` on any non-2xx** (unlike `callTool`, which resolves with `isError`), this also fixes a **class of silent-failure bugs**: mutation sites that awaited `callTool` and ignored the result reported server rejections to the user as success — the same bug just fixed for brand context in #4046. Affected here: AI-provider key create, org-settings update, and automation create/update/delete/trigger-remove.

## Migrated (direct self calls)

- `hooks/collections/use-ai-providers.ts` — `AI_PROVIDERS_LIST`, `AI_PROVIDER_KEY_LIST`, `AI_PROVIDERS_LIST_MODELS`. The shared `aiProviderKeysQueryOptions` now takes `orgSlug` + `callStudioTool` (it's also used by the home-page prefetch batch).
- `hooks/use-organization-settings.ts` — `ORGANIZATION_SETTINGS_GET`/`UPDATE`. UPDATE no longer needs a manual `isError` check; GET keeps its best-effort "empty on failure" fallback via try/catch.
- `hooks/use-current-link.ts` — `LINK_CURRENT_GET`.
- `hooks/use-automations.ts` — all the self `AUTOMATION_*` hooks. `useTriggerList` **stays** on `useMCPClient` because it's `connectionId`-parameterized (external-capable).
- `views/settings/ai-providers/connect-forms.tsx` — `AI_PROVIDER_KEY_CREATE` (**silent-failure fix**).
- `views/settings/ai-providers/connect-provider-dialog.tsx` — `AI_PROVIDER_OAUTH_*`, `AI_PROVIDER_PROVISION_KEY`.
- `layouts/home-page/index.tsx` — prefetch batch passes `orgSlug` to the migrated queryOptions (keeps `selfClient` only for the still-generic `virtualMcpItemQueryOptions`).
- `lib/studio-tools.ts` — **export `callStudioTool`** for non-hook callers (shared queryOptions + the shell, which run before `useProjectContext` is available, so they can't use the `useStudioTools` hook).

Narrow provider-id unions and hand-written response types are bridged with the same casts the old code already used, now at the typed-call boundary.

## Intentionally NOT migrated (not "old callTool to kill")

- **Generic collection layer keyed by the client** — `KEYS.collection*(client, …)` in `tool-set-selector.tsx`, `add-connection-dialog.tsx`, and the collection-keyed parts of the github/deco-import dialogs. The client is part of the shared cache key and these can't import `ToolIO` cleanly; they stay on the `RestSelfClient` (already REST) per the migration's hybrid design.
- **`github-repo-picker.tsx` / `import-from-deco-dialog.tsx`** — thread `selfClient.callTool` as a function into helpers (`selfCallTool`) and use the client-keyed collection cache; not a leaf swap. Follow-up.
- **`hooks/registry/use-monitor.ts`** — already throws via its own `callTool` helper (not buggy); 12 sites with hand-written response types → DX-only, deferred.
- **Monitoring views (`audit.tsx`/`threads.tsx`)** — client threaded as a prop; mix of direct `MONITORING_*` and collection-keyed calls.
- **`sandbox-lifecycle-context.tsx`** — shares its client with `useSandboxStart`.
- **Chat stores (`thread-connection.ts`, `thread-manager-store.ts`)** — non-React classes whose tests inject an MCP-client mock; their own PR.

All **external-connection** `callTool` (GitHub MCP, sandbox daemon, registries, object-storage, arbitrary user connections) correctly stays MCP — the migration only swaps the `self` transport.

## How to Test

1. Settings → AI providers: connect via API key / OpenAI-compatible / OAuth / provision — all succeed; a rejected key now surfaces an error toast instead of a false success.
2. Settings (simple mode / registry config) save and reload correctly.
3. Automations: list, create, edit, delete, add/remove/rotate triggers, run.
4. Home loads (prefetch batch) without waterfalls.
5. `bun run --cwd apps/mesh check` (tsc), `bun run fmt`, `bun run lint`, `bun run knip` — all clean.

## Migration Notes

None — client-only; no schema/route changes (the REST route + typed client already exist on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates direct `self` tool calls in the web admin from the MCP client to the typed REST client to standardize calls and improve error handling. This removes silent successes and surfaces real errors via `useStudioTools().call` and `callStudioTool`.

- **Refactors**
  - Replaced `useMCPClient().callTool` with `useStudioTools().call` or `callStudioTool`.
  - Migrated: AI providers (list/keys/models, connect forms/dialog), organization settings (get/update), current link, automations (list/get/run-stats/create/update/delete/trigger add/rotate/remove/run), and home prefetch.
  - `aiProviderKeysQueryOptions`/`organizationSettingsQueryOptions` now take `orgSlug`; `lib/studio-tools` exports `callStudioTool` for non-hook use.
  - Kept MCP where required (e.g. `useTriggerList`, client-keyed collections, monitoring/sandbox/chat) to support external-capable flows.

- **Bug Fixes**
  - REST client throws on non-2xx, fixing past silent failures for AI provider key create, org settings update, and automation mutations; errors now surface to users.
  - `ORGANIZATION_SETTINGS_GET` keeps a best-effort fallback; `LINK_CURRENT_GET` returns offline+ready when no link is found.

<sup>Written for commit 587a57890f148f5f091200145972e1acadac9ab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

