### PR TITLE
test(cms): regression test — site app entry detection on TanStack Start sites

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/page-list.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-list.test.ts
@@ -164,6 +164,37 @@ describe("page-list", () => {
     });
   });
 
+  it("findSiteAppEntry resolves site app on TanStack Start sites (no manifest apps block)", () => {
+    // TanStack Start's composeMeta only generates sections/pages/loaders/actions/matchers —
+    // it does not register site/apps/site.ts in manifest.blocks.apps. The function
+    // should still return the entry because the canonical "site" key is trusted directly.
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          sections: {
+            "site/sections/Header.tsx": { $ref: "#/definitions/Header" },
+          },
+          pages: {},
+          loaders: {},
+        },
+      },
+      schema: {},
+    };
+    const decofile = {
+      site: {
+        __resolveType: "site/apps/site.ts",
+        seo: { title: "Home" },
+        platform: "vtex",
+      },
+    };
+
+    expect(findSiteAppEntry(decofile, meta)).toEqual({
+      key: "site",
+      name: "Site",
+      resolveType: "site/apps/site.ts",
+    });
+  });
+
   it("extractGlobalSections uses catalog filters for saved blocks", () => {
     const meta: LiveMeta = {
       manifest: {


### PR DESCRIPTION
## Summary

- Adds a regression test for `findSiteAppEntry` covering TanStack Start sites, where `@decocms/start`'s `composeMeta` does not populate `manifest.blocks.apps`
- The fix itself landed in #4012 (using `isSiteAppBlock` instead of `isResolvableManifestApp` for the canonical `site` key); this PR guards against future regressions

## Root cause documented

TanStack Start's `generate-schema.ts` only emits `manifest.blocks.sections`. `composeMeta` adds pages/loaders/actions/matchers at runtime, but never `apps`. As a result `isResolvableManifestApp(meta, "site/apps/site.ts")` was returning `false` and the Studio's **Site** tab showed _Site settings not found_.

The fix in #4012 (`isSiteAppBlock` short-circuit on the canonical `site` key) is the correct behavior; the schema rendering is addressed on the site side via the companion PR in `baggagio-tanstack`.

## Test plan
- `bun test apps/mesh/src/web/components/sections-editor/page-list.test.ts` — 13 pass

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test for findSiteAppEntry so TanStack Start sites resolve the site app even when manifest.blocks.apps is missing. This locks in the behavior that trusts the canonical "site" key and prevents the Studio Site tab from showing "Site settings not found".

<sup>Written for commit fd6fd98a1cafc99cdda5b255b2db2ec5a3743c79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

