### PR TITLE
feat(skills): progressive discovery — catalog + read-only skill tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ deploy/test*
 
 # Data Test files
 apps/benchmark/data
+# Local DevObjectStorage scratch dir (org-fs / skill-catalog integration tests)
+data/
 
 # AI planning files (root-level only, not docs/plans/)
 /plans

--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -6,23 +6,17 @@ export {
 export { generateMessageId } from "@decocms/harness/decopilot/harness-constants";
 
 /**
- * Teaches the org filesystem layout, including the deployment's actual public
- * skill sets so the agent surfaces them when asked about its capabilities.
- * Stable per org (slug + deployment settings), so it stays in the cached
- * prompt prefix across that org's runs.
+ * Teaches the org filesystem layout. Skill discovery now lives in the
+ * `<available-skills>` catalog + the `skill` tool, so this block no longer
+ * enumerates sets or tells the agent to `ls org/public/` — it just names the
+ * mount points. Stable per org (slug only), so it stays in the cached prompt
+ * prefix across that org's runs.
  *
  * Portable pure function kept mesh-side (consumed by the cluster
- * `build-agent-system-prompt` with `getPublicSets()` and the org slug). org-fs
- * is mounted into every sandbox now, so it is emitted unconditionally.
+ * `build-agent-system-prompt` with the org slug). org-fs is mounted into every
+ * sandbox now, so it is emitted unconditionally.
  */
-export function buildOrgFilesystemPrompt(
-  publicSets: string[],
-  orgSlug?: string,
-): string {
-  const sets =
-    publicSets.length > 0
-      ? `Available sets: ${publicSets.join(", ")}.`
-      : "No sets are configured on this deployment.";
+export function buildOrgFilesystemPrompt(orgSlug?: string): string {
   // Name the home folder directly so the agent never runs `ls org/` just to
   // learn its own slug — that discovery step was firing even on bare greetings.
   const home = orgSlug
@@ -31,10 +25,8 @@ export function buildOrgFilesystemPrompt(
   return `<organization-filesystem>
 The organization filesystem is mounted at \`org/\` in your sandbox (when available):
 - ${home} — the org's shared home folder, editable and shared across every agent, member, and run. Organize it freely with subfolders. Consult it only when a task needs background you don't already have (past decisions, preferences, project facts, gotchas) — then read it first. Do NOT browse it in response to greetings, small talk, or questions you can answer directly. Record durable knowledge here as you learn it; prefer small focused markdown files over one big log, and update stale notes instead of appending duplicates.
-- \`org/public/<set>/\` — curated read-only skill sets. ${sets} Each skill is a folder with a SKILL.md — read it before applying the skill.
+- \`org/public/<set>/\` — curated read-only skill sets, mounted here. Your skills are listed in the <available-skills> catalog; load one with the \`skill\` tool before applying it.
 - \`org/upload/\` — files the user attached to this conversation are already here; read them directly (no copy step needed).
 - \`org/output/\` — write final deliverables here; they are shared back to the organization under this run's folder.
-
-When asked about your skills or capabilities, list the contents of \`org/public/\` too — it is part of your skill surface.
 </organization-filesystem>`;
 }

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -149,6 +149,10 @@ export async function handleVirtualMcpRequest(
             virtualMcp,
             ctx,
             "passthrough",
+            false,
+            // Serves the agent's MCP (incl. the desktop daemon); surface the
+            // skill catalog in the instructions it reads.
+            { includeSkillsCatalog: true },
           );
           span.setStatus({ code: SpanStatusCode.OK });
           return result;

--- a/apps/mesh/src/file-storage/skill-catalog.integration.test.ts
+++ b/apps/mesh/src/file-storage/skill-catalog.integration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Skill catalog detection — storage-integration tier (real Postgres + real
+ * object storage, zero mocks). Exercises `detectSkills` over the OrgFs
+ * manifest end to end. See TESTING.md.
+ *
+ * Local run:
+ *   docker run -d --name pg -p 5432:5432 -e POSTGRES_USER=postgres \
+ *     -e POSTGRES_PASSWORD=postgres postgres:16
+ *   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+ *     bun run --cwd=apps/mesh migrate
+ *   DATABASE_URL=... bun test apps/mesh/src/file-storage/skill-catalog.integration.test.ts
+ */
+
+import { rmSync } from "node:fs";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { DevObjectStorage } from "../object-storage/dev-object-storage";
+import { OrgFsEntryStorage } from "../storage/org-fs";
+import { detectSkills } from "./skill-catalog";
+import { OrgFs } from "./org-fs";
+
+const ORG = "org_skill_catalog";
+const ACTOR = "user_skill_catalog";
+const VOL = "home";
+// DevObjectStorage writes bytes under ./data/assets/<org>/ — clean it up so the
+// test never leaves artifacts in the working tree (data/ is gitignored too).
+const ASSETS_DIR = `./data/assets/${ORG}`;
+
+function buildFs(db: StudioDatabase) {
+  return new OrgFs(
+    new DevObjectStorage(ORG, "http://test"),
+    new OrgFsEntryStorage(db.db),
+    ORG,
+  );
+}
+
+async function seedOrg(db: StudioDatabase) {
+  const now = new Date().toISOString();
+  await sql`
+    INSERT INTO "organization" (id, name, slug, "createdAt")
+    VALUES (${ORG}, ${ORG}, ${ORG}, ${now})
+    ON CONFLICT (id) DO NOTHING
+  `.execute(db.db);
+}
+
+describe("detectSkills (integration)", () => {
+  let db: StudioDatabase;
+  let fs: OrgFs;
+
+  beforeAll(async () => {
+    db = await connectTestPgDatabase();
+    await seedOrg(db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(db);
+    rmSync(ASSETS_DIR, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    await resetTestPgDatabase(db);
+    await seedOrg(db);
+    fs = buildFs(db);
+  });
+
+  const budget = () => ({ remaining: 200 });
+
+  it("detects frontmatter and plain skills, with name fallback", async () => {
+    await fs.write(
+      VOL,
+      "slides/SKILL.md",
+      "---\nname: slides\ndescription: Make decks.\n---\n\n# slides\n",
+      { actor: ACTOR },
+    );
+    await fs.write(VOL, "pdf/SKILL.md", "# pdf — docs\n\nRead PDFs.\n", {
+      actor: ACTOR,
+    });
+
+    const out = await detectSkills(fs, VOL, "", budget());
+    const byDir = new Map(out.map((s) => [s.dirPath, s]));
+    expect(byDir.get("slides")).toEqual({
+      dirPath: "slides",
+      name: "slides",
+      description: "Make decks.",
+    });
+    expect(byDir.get("pdf")).toEqual({
+      dirPath: "pdf",
+      name: "pdf", // frontmatter absent → dir basename
+      description: "Read PDFs.",
+    });
+  });
+
+  it("skips dirs without a SKILL.md and tombstoned SKILL.md", async () => {
+    await fs.write(VOL, "real/SKILL.md", "# real\n\nA skill.\n", {
+      actor: ACTOR,
+    });
+    await fs.mkdir(VOL, "plain", { actor: ACTOR });
+    await fs.write(VOL, "gone/SKILL.md", "# gone\n", { actor: ACTOR });
+    await fs.delete(VOL, "gone/SKILL.md", { actor: ACTOR });
+
+    const out = await detectSkills(fs, VOL, "", budget());
+    expect(out.map((s) => s.dirPath).sort()).toEqual(["real"]);
+  });
+
+  it("scans a nested base (skills/) and returns volume-relative dirPaths", async () => {
+    await fs.write(VOL, "skills/onboarding/SKILL.md", "# onboarding\n\nHi.\n", {
+      actor: ACTOR,
+    });
+    const out = await detectSkills(fs, VOL, "skills", budget());
+    expect(out.map((s) => s.dirPath)).toEqual(["skills/onboarding"]);
+  });
+
+  it("returns [] for an empty / nonexistent base and never throws", async () => {
+    expect(await detectSkills(fs, VOL, "", budget())).toEqual([]);
+    expect(await detectSkills(fs, VOL, "does-not-exist", budget())).toEqual([]);
+  });
+
+  it("respects the read budget cap", async () => {
+    for (const n of ["a", "b", "c"]) {
+      await fs.write(VOL, `${n}/SKILL.md`, `# ${n}\n\ndesc\n`, {
+        actor: ACTOR,
+      });
+    }
+    const out = await detectSkills(fs, VOL, "", { remaining: 2 });
+    expect(out.length).toBe(2);
+  });
+});

--- a/apps/mesh/src/file-storage/skill-catalog.ts
+++ b/apps/mesh/src/file-storage/skill-catalog.ts
@@ -1,0 +1,193 @@
+/**
+ * Skill catalog — enumerates the skills available to an org's agents so they
+ * can be surfaced up front (the `<available-skills>` block) for Claude-Code
+ * style progressive discovery. Reads the same `SKILL.md` folders the sandbox
+ * mounts: the shared read-only public sets (`org/public/<set>/`) plus the
+ * org's own home volume (`org/<slug>/`).
+ *
+ * Each entry carries a collision-free `id` (`<set>/<dir>` for public,
+ * `home/<dir>` for home) that doubles as the `skill` tool's argument and maps
+ * deterministically back to a sandbox path.
+ *
+ * Cheap and defensive: bounded probes (no recursive home scan), best-effort
+ * per-file reads, never throws. The public portion is org-independent and
+ * cached process-wide; the home portion is two batch probes per call.
+ */
+
+import { parseSkillMd } from "@decocms/harness/skills/skill-md";
+import type { StudioContext } from "../core/studio-context";
+import { createBoundObjectStorage } from "../object-storage/bound-object-storage";
+import { DevObjectStorage } from "../object-storage/dev-object-storage";
+import { getObjectStorageS3Service } from "../object-storage/factory";
+import { OrgFs } from "./org-fs";
+import { orgFsSandboxPath } from "./mount/provisioning";
+import {
+  buildPublicOrgFs,
+  getPublicSets,
+  publicVolumeForSet,
+} from "./public-sets";
+
+export interface SkillCatalogEntry {
+  /** Resolvable, collision-free id (`core/slides`, `home/skills/foo`). */
+  id: string;
+  /** Display name (frontmatter `name`, falling back to the dir basename). */
+  name: string;
+  description: string | null;
+  /** Provenance shown to the model (`public:<set>` or `home`). */
+  source: string;
+  /** Sandbox path of the skill folder (e.g. `org/public/core/slides`). */
+  sandboxPath: string;
+}
+
+/** Total SKILL.md reads per build — a backstop against a pathological tree. */
+const MAX_SKILLS = 200;
+/** Public sets are global + change only on the ~10-min sync; cache process-wide. */
+const PUBLIC_TTL_MS = 5 * 60_000;
+const HOME_VOLUME = "home";
+
+let publicCache: { entries: SkillCatalogEntry[]; expires: number } | null =
+  null;
+
+function basename(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? path : path.slice(i + 1);
+}
+
+/** A skill folder detected under a volume, with its parsed metadata. */
+export interface DetectedSkill {
+  /** Volume-relative dir path (e.g. `slides`, `skills/foo`). */
+  dirPath: string;
+  /** Frontmatter `name`, falling back to the dir basename. */
+  name: string;
+  description: string | null;
+}
+
+/**
+ * Detect skill folders directly under `(volume, base)`: list immediate child
+ * dirs, batch-probe `<dir>/SKILL.md`, read + parse the hits. One listDir + one
+ * filesExist + one read per skill. Best-effort — returns [] on any storage
+ * error and skips individual unreadable skills. `budget` caps total reads.
+ */
+export async function detectSkills(
+  fs: OrgFs,
+  volume: string,
+  base: string,
+  budget: { remaining: number },
+): Promise<DetectedSkill[]> {
+  try {
+    const dirs = (await fs.listDir(volume, base)).filter(
+      (e) => e.kind === "dir",
+    );
+    if (dirs.length === 0) return [];
+    const found = await fs.filesExist(
+      volume,
+      dirs.map((d) => `${d.path}/SKILL.md`),
+    );
+    const out: DetectedSkill[] = [];
+    for (const d of dirs) {
+      if (budget.remaining <= 0) break;
+      if (!found.has(`${d.path}/SKILL.md`)) continue;
+      budget.remaining -= 1;
+      try {
+        const bytes = await fs.read(volume, `${d.path}/SKILL.md`);
+        const meta = parseSkillMd(new TextDecoder().decode(bytes));
+        out.push({
+          dirPath: d.path,
+          name: meta.name ?? basename(d.path),
+          description: meta.description,
+        });
+      } catch {
+        // Skill dir without a readable SKILL.md (sync race, vanished file) —
+        // skip it rather than fail the whole catalog.
+      }
+    }
+    return out;
+  } catch (err) {
+    console.warn(`[skill-catalog] scan failed (${volume}:${base || "/"})`, err);
+    return [];
+  }
+}
+
+/** Public sets are org-independent (shared system scope); build once + cache. */
+async function buildPublicEntries(
+  ctx: StudioContext,
+  budget: { remaining: number },
+): Promise<SkillCatalogEntry[]> {
+  if (publicCache && publicCache.expires > Date.now())
+    return publicCache.entries;
+
+  const pub = buildPublicOrgFs(ctx);
+  const entries: SkillCatalogEntry[] = [];
+  for (const { set } of getPublicSets()) {
+    const volume = publicVolumeForSet(set);
+    const detected = await detectSkills(pub, volume, "", budget);
+    for (const s of detected) {
+      entries.push({
+        id: `${set}/${s.dirPath}`,
+        name: s.name,
+        description: s.description,
+        source: `public:${set}`,
+        // org-independent for public volumes (slug arg is ignored).
+        sandboxPath: orgFsSandboxPath(volume, s.dirPath, ""),
+      });
+    }
+  }
+  // Only cache a non-empty result. `detectSkills` swallows transient storage
+  // errors into `[]`; caching that (the cache is global) would suppress public
+  // skills for EVERY org until the TTL expires. An empty result also covers the
+  // pre-first-sync cold-boot window — re-probe until the set is populated.
+  if (entries.length > 0) {
+    publicCache = { entries, expires: Date.now() + PUBLIC_TTL_MS };
+  }
+  return entries;
+}
+
+/** Build a per-org OrgFs bound to the org's keyspace (mirrors rebindOrgScope). */
+function buildOrgFs(ctx: StudioContext, orgId: string): OrgFs {
+  const s3Service = getObjectStorageS3Service();
+  const storage = s3Service
+    ? createBoundObjectStorage(s3Service, orgId)
+    : new DevObjectStorage(orgId, ctx.baseUrl);
+  return new OrgFs(storage, ctx.storage.orgFsEntries, orgId);
+}
+
+/** Home skills: bounded probe of `org/<slug>/*` and `org/<slug>/skills/*`. */
+async function buildHomeEntries(
+  ctx: StudioContext,
+  orgId: string,
+  orgSlug: string,
+  budget: { remaining: number },
+): Promise<SkillCatalogEntry[]> {
+  const home = buildOrgFs(ctx, orgId);
+  const [top, nested] = await Promise.all([
+    detectSkills(home, HOME_VOLUME, "", budget),
+    detectSkills(home, HOME_VOLUME, "skills", budget),
+  ]);
+  return [...top, ...nested].map((s) => ({
+    id: `home/${s.dirPath}`,
+    name: s.name,
+    description: s.description,
+    source: "home",
+    sandboxPath: orgFsSandboxPath(HOME_VOLUME, s.dirPath, orgSlug),
+  }));
+}
+
+/**
+ * The skills available to `orgId`'s agents: public sets + the org's home,
+ * sorted deterministically (so the rendered block stays byte-stable and in the
+ * cached prompt prefix). Never throws.
+ */
+export async function buildSkillCatalog(
+  ctx: StudioContext,
+  orgId: string,
+  orgSlug: string,
+): Promise<SkillCatalogEntry[]> {
+  const budget = { remaining: MAX_SKILLS };
+  const [pub, home] = await Promise.all([
+    buildPublicEntries(ctx, budget),
+    buildHomeEntries(ctx, orgId, orgSlug, budget),
+  ]);
+  return [...pub, ...home].sort(
+    (a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id),
+  );
+}

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -24,7 +24,6 @@ import {
   type CodingWorkspacePromptInput,
 } from "@decocms/harness/coding-workspace-prompt";
 import { buildOrgFilesystemPrompt } from "@/api/routes/decopilot/constants";
-import { getPublicSets } from "@/file-storage/public-sets";
 import type { GithubRepo } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
@@ -135,18 +134,12 @@ export async function buildAgentSystemPrompt(
 
   add("codingWorkspace", buildCodingWorkspacePrompt(opts.codingWorkspace));
 
-  // Org filesystem layout + the deployment's public skill sets. org-fs is
-  // mounted into every sandbox now (desktop + cluster), so this is
-  // unconditional. Passing the slug lets the prompt name `org/<slug>/`
-  // directly instead of telling the agent to `ls org/` to discover it.
-  // Stable per org, so still cache-safe.
-  add(
-    "orgFs",
-    buildOrgFilesystemPrompt(
-      getPublicSets().map((s) => s.set),
-      opts.organization.slug,
-    ),
-  );
+  // Org filesystem layout. org-fs is mounted into every sandbox now (desktop +
+  // cluster), so this is unconditional. Passing the slug lets the prompt name
+  // `org/<slug>/` directly instead of telling the agent to `ls org/` to
+  // discover it. Skills are surfaced separately via the <available-skills>
+  // catalog (served instructions). Stable per org, so still cache-safe.
+  add("orgFs", buildOrgFilesystemPrompt(opts.organization.slug));
 
   if (opts.kind === "agent") {
     if (opts.isDecopilot) {

--- a/apps/mesh/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/mesh/src/harnesses/decopilot/harness-deps.ts
@@ -152,7 +152,7 @@ export function buildClusterEnvironmentTools(args: {
             ctx,
             "passthrough",
             opts?.superUser ?? false,
-            { listTimeoutMs: opts?.listTimeoutMs },
+            { listTimeoutMs: opts?.listTimeoutMs, includeSkillsCatalog: true },
           ),
         provider: modelRuntime.thinking.provider,
         imageProvider:

--- a/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
+++ b/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
@@ -53,6 +53,7 @@ export async function resolveSubagent(
     ctx,
     "passthrough",
     superUser,
+    { includeSkillsCatalog: true },
   );
 
   return {

--- a/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
@@ -13,6 +13,7 @@ import type { StudioContext } from "../../core/studio-context";
 import type { ConnectionEntity } from "../../tools/connection/schema";
 import type { VirtualMCPEntity } from "../../tools/virtual/schema";
 import { PassthroughClient } from "./passthrough-client";
+import { renderSkillsCatalogBlock } from "./skills-instructions";
 import type { VirtualClientOptions } from "./types";
 
 /**
@@ -69,7 +70,7 @@ export async function createVirtualClientFrom(
   ctx: StudioContext,
   _strategy: "passthrough",
   superUser = false,
-  options?: { listTimeoutMs?: number },
+  options?: { listTimeoutMs?: number; includeSkillsCatalog?: boolean },
 ): Promise<PassthroughClient> {
   // Inclusion mode: use only the connections specified in virtual MCP
   const connectionIds = virtualMcp.connections.map((c) => c.connection_id);
@@ -113,6 +114,15 @@ export async function createVirtualClientFrom(
       !isSelfReferencingVirtual(conn, virtualMcp.id),
   );
 
+  // Agent runtimes opt into the skill catalog: enumerate the org's skills now
+  // (async — the sync getInstructions() can't) and stash the rendered block so
+  // it reaches both the cluster engine and the desktop daemon. Cheap: the
+  // public portion is cached process-wide. Skipped for non-agent consumers
+  // (e.g. the home-next-actions prompt poll).
+  const skillsBlock = options?.includeSkillsCatalog
+    ? ((await renderSkillsCatalogBlock(ctx, virtualMcp)) ?? undefined)
+    : undefined;
+
   // Build aggregator options
   const clientOptions: VirtualClientOptions = {
     connections: loadedConnections,
@@ -120,6 +130,7 @@ export async function createVirtualClientFrom(
     superUser,
     mcpListCache: getMcpListCache() ?? undefined,
     listTimeoutMs: options?.listTimeoutMs,
+    skillsBlock,
   };
 
   return new PassthroughClient(clientOptions, ctx);

--- a/apps/mesh/src/mcp-clients/virtual-mcp/knowledge.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/knowledge.ts
@@ -1,5 +1,5 @@
 /**
- * buildKnowledgeBlock — renders an agent's attached files and skills into a
+ * buildKnowledgeBlock — renders an agent's attached reference FILES into a
  * `<knowledge>` block that is appended to the agent's served instructions.
  *
  * It lives in the served instructions (not a cluster-only prompt block) so it
@@ -8,7 +8,12 @@
  * cluster engine runs the richer `buildAgentSystemPrompt`. Keeping it here is
  * the single source that covers both.
  *
- * Awareness-first: the agent is told the complete set of attached items with
+ * Attached SKILLS are deliberately NOT listed here — they live in the single
+ * `<available-skills>` catalog (skills-instructions.ts), where they're flagged
+ * as user-configured. Keeping skill metadata in one place avoids the catalog
+ * and this block drifting out of sync.
+ *
+ * Awareness-first: the agent is told the complete set of attached files with
  * the exact sandbox path to read each one. Files are mounted into the agent's
  * org filesystem, so it can open them directly with its file tools (works for
  * text and binary alike) — no inlining needed.
@@ -24,18 +29,17 @@ function describe(file: KnowledgeFile): string {
 }
 
 /**
- * Build the `<knowledge>` block for an agent's attached files/skills, or
- * `null` when there are none. Pure and synchronous so it can be folded into
+ * Build the `<knowledge>` block for an agent's attached files, or `null` when
+ * there are none. Pure and synchronous so it can be folded into
  * `getInstructions()` on the passthrough client and the virtual-MCP endpoint.
  */
 function buildKnowledgeBlock(
   knowledge: KnowledgeFile[] | null | undefined,
   orgSlug: string,
 ): string | null {
-  if (!knowledge || knowledge.length === 0) return null;
-
-  const docs = knowledge.filter((f) => f.kind !== "skill");
-  const skills = knowledge.filter((f) => f.kind === "skill");
+  // Skills go in the <available-skills> catalog, not here.
+  const docs = (knowledge ?? []).filter((f) => f.kind !== "skill");
+  if (docs.length === 0) return null;
 
   const docInventory = docs
     .map(
@@ -43,21 +47,15 @@ function buildKnowledgeBlock(
         `- ${f.name} (${describe(f)}), read it at \`${orgFsSandboxPath(f.volume, f.path, orgSlug)}\``,
     )
     .join("\n");
-  const skillInventory = skills
-    .map(
-      (s) =>
-        `- ${s.name}: a skill at \`${orgFsSandboxPath(s.volume, s.path, orgSlug)}\`; read its \`SKILL.md\` before applying it`,
-    )
-    .join("\n");
 
-  const lines = [
+  return [
     "<knowledge>",
-    "The following files and skills are attached to you as reference knowledge. They are mounted in your sandbox at the paths below; read them with your file tools when relevant to the task, and treat them as authoritative reference material.",
-  ];
-  if (docInventory) lines.push("", "Attached files:", docInventory);
-  if (skillInventory) lines.push("", "Attached skills:", skillInventory);
-  lines.push("</knowledge>");
-  return lines.join("\n");
+    "The following files are attached to you as reference knowledge. They are mounted in your sandbox at the paths below; read them with your file tools when relevant to the task, and treat them as authoritative reference material.",
+    "",
+    "Attached files:",
+    docInventory,
+    "</knowledge>",
+  ].join("\n");
 }
 
 /** Append the knowledge block to an agent's instructions, if it has any. */

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.test.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.test.ts
@@ -290,6 +290,42 @@ describe("PassthroughClient", () => {
 
       expect(pt.getInstructions()).toBeUndefined();
     });
+
+    it("appends the skills catalog block after the base instructions", () => {
+      const conn = makeConnection("conn_sk", "Sk");
+      mockCreateLazyClient.mockReturnValue(makeMockClient() as any);
+
+      const pt = new PassthroughClient(
+        {
+          connections: [conn],
+          virtualMcp: makeVirtualMcp([makeVmcpConn("conn_sk")], {
+            instructions: "Be helpful",
+          }),
+          skillsBlock: "\n\n<available-skills>\nid\n</available-skills>",
+        },
+        mockCtx,
+      );
+
+      const out = pt.getInstructions();
+      expect(out?.startsWith("Be helpful")).toBe(true);
+      expect(out).toContain("<available-skills>");
+    });
+
+    it("serves the skills block alone (leading newlines trimmed) when there are no base instructions", () => {
+      const conn = makeConnection("conn_sk2", "Sk2");
+      mockCreateLazyClient.mockReturnValue(makeMockClient() as any);
+
+      const pt = new PassthroughClient(
+        {
+          connections: [conn],
+          virtualMcp: makeVirtualMcp([makeVmcpConn("conn_sk2")]),
+          skillsBlock: "\n\n<available-skills>\nid\n</available-skills>",
+        },
+        mockCtx,
+      );
+
+      expect(pt.getInstructions()?.startsWith("<available-skills>")).toBe(true);
+    });
   });
 
   describe("close", () => {

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -136,11 +136,16 @@ export class PassthroughClient extends GatewayClient {
     // they reach the model on every run path (cluster engine AND sandbox
     // daemon both read instructions; only the cluster runs the richer
     // buildAgentSystemPrompt).
-    return withKnowledge(
+    const base = withKnowledge(
       this.options.virtualMcp.metadata?.instructions ?? undefined,
       this.options.virtualMcp.metadata?.knowledge,
       this.ctx.organization?.slug ?? "",
     );
+    // Append the pre-rendered <available-skills> catalog (built async in the
+    // factory). Same seam, same both-paths guarantee as the knowledge block.
+    const skills = this.options.skillsBlock;
+    if (!skills) return base;
+    return base ? `${base}${skills}` : skills.replace(/^\n+/, "");
   }
 
   getConnectionTitleMap(): Map<string, string> {

--- a/apps/mesh/src/mcp-clients/virtual-mcp/skills-instructions.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/skills-instructions.ts
@@ -1,0 +1,54 @@
+/**
+ * Renders the `<available-skills>` catalog block for an agent's served
+ * instructions. Built here (async, server-side) — NOT inside the synchronous
+ * `getInstructions()` — because enumerating skills reads org-fs. The factory
+ * stashes the result on the client so `getInstructions()` can append it
+ * synchronously, and it then reaches every run path (cluster engine + desktop
+ * daemon) the same way the `<knowledge>` block does.
+ */
+
+import { buildSkillsBlock } from "@decocms/harness/decopilot/skills-block";
+import type { StudioContext } from "../../core/studio-context";
+import { buildSkillCatalog } from "../../file-storage/skill-catalog";
+import { orgFsSandboxPath } from "../../file-storage/mount/provisioning";
+import type { VirtualMCPEntity } from "../../tools/virtual/schema";
+
+/**
+ * Build the catalog block, or null when there are no skills / no org context.
+ * Skills already attached to the agent (the `<knowledge>` block lists those)
+ * are excluded to avoid double-listing. Never throws — a storage hiccup
+ * degrades to "no skills block", never a failed client creation.
+ */
+export async function renderSkillsCatalogBlock(
+  ctx: StudioContext,
+  virtualMcp: VirtualMCPEntity,
+): Promise<string | null> {
+  const orgId = ctx.organization?.id;
+  if (!orgId) return null;
+  const orgSlug = ctx.organization?.slug ?? "";
+  try {
+    const entries = await buildSkillCatalog(ctx, orgId, orgSlug);
+    if (entries.length === 0) return null;
+
+    // Exclude skills already surfaced by the <knowledge> block (attached
+    // skills), matched by their resolved sandbox path.
+    const attached = new Set(
+      (virtualMcp.metadata?.knowledge ?? [])
+        .filter((k) => k.kind === "skill")
+        .map((k) => orgFsSandboxPath(k.volume, k.path, orgSlug)),
+    );
+
+    return buildSkillsBlock(
+      entries
+        .filter((e) => !attached.has(e.sandboxPath))
+        .map((e) => ({
+          id: e.id,
+          description: e.description,
+          source: e.source,
+        })),
+    );
+  } catch (err) {
+    console.warn("[skill-catalog] failed to render skills block", err);
+    return null;
+  }
+}

--- a/apps/mesh/src/mcp-clients/virtual-mcp/skills-instructions.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/skills-instructions.ts
@@ -15,8 +15,10 @@ import type { VirtualMCPEntity } from "../../tools/virtual/schema";
 
 /**
  * Build the catalog block, or null when there are no skills / no org context.
- * Skills already attached to the agent (the `<knowledge>` block lists those)
- * are excluded to avoid double-listing. Never throws — a storage hiccup
+ * The skills the user attached to this agent are the SAME entries the catalog
+ * already enumerates (the attach picker draws from the same home + public-set
+ * scopes), so they aren't listed separately — they're flagged inline as
+ * user-configured so the model prefers them. Never throws — a storage hiccup
  * degrades to "no skills block", never a failed client creation.
  */
 export async function renderSkillsCatalogBlock(
@@ -30,22 +32,24 @@ export async function renderSkillsCatalogBlock(
     const entries = await buildSkillCatalog(ctx, orgId, orgSlug);
     if (entries.length === 0) return null;
 
-    // Exclude skills already surfaced by the <knowledge> block (attached
-    // skills), matched by their resolved sandbox path.
+    // Skills the user attached to this agent, matched to catalog entries by
+    // resolved sandbox path → their ids get the user-configured callout.
     const attached = new Set(
       (virtualMcp.metadata?.knowledge ?? [])
         .filter((k) => k.kind === "skill")
         .map((k) => orgFsSandboxPath(k.volume, k.path, orgSlug)),
     );
+    const configuredIds = entries
+      .filter((e) => attached.has(e.sandboxPath))
+      .map((e) => e.id);
 
     return buildSkillsBlock(
-      entries
-        .filter((e) => !attached.has(e.sandboxPath))
-        .map((e) => ({
-          id: e.id,
-          description: e.description,
-          source: e.source,
-        })),
+      entries.map((e) => ({
+        id: e.id,
+        description: e.description,
+        source: e.source,
+      })),
+      configuredIds,
     );
   } catch (err) {
     console.warn("[skill-catalog] failed to render skills block", err);

--- a/apps/mesh/src/mcp-clients/virtual-mcp/types.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/types.ts
@@ -18,4 +18,11 @@ export interface VirtualClientOptions {
   mcpListCache?: McpListCache;
   /** Per-connection timeout (ms) for list operations (listTools/listResources/listPrompts). Connections that exceed this are skipped. */
   listTimeoutMs?: number;
+  /**
+   * Pre-rendered `<available-skills>` catalog block, appended to the served
+   * instructions by `getInstructions()`. Built async in the factory (the sync
+   * `getInstructions()` can't read org-fs) so it reaches both the in-process
+   * cluster engine and the sandbox/desktop daemon. Only set for agent runtimes.
+   */
+  skillsBlock?: string;
 }

--- a/apps/mesh/src/web/components/automations/automation-config.tsx
+++ b/apps/mesh/src/web/components/automations/automation-config.tsx
@@ -397,6 +397,12 @@ const BUILTIN_GROUPS: BuiltinGroup[] = [
         description: "Read an MCP prompt definition",
         icon: BookOpen01,
       },
+      {
+        name: "skill",
+        title: "Load Skill",
+        description: "Load a skill's full instructions (SKILL.md) by id",
+        icon: BookOpen01,
+      },
     ],
   },
   {

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/tool-display-map.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/tool-display-map.ts
@@ -43,6 +43,7 @@ export const TOOL_DISPLAY_MAP: Record<string, ToolDisplay> = {
   read_tool_output: { icon: File06, label: "Read Tool Output" },
   read_resource: { icon: Database01, label: "Read Resource" },
   read_prompt: { icon: BookOpen01, label: "Read Prompt" },
+  skill: { icon: BookOpen01, label: "Load Skill" },
 
   // System tools
   enable_tool: { icon: Tool01, label: "Enable Tool" },

--- a/apps/mesh/src/web/layouts/library/skill.ts
+++ b/apps/mesh/src/web/layouts/library/skill.ts
@@ -1,54 +1,7 @@
 /**
- * SKILL.md parsing — the Claude Code skill format: optional flat YAML
- * frontmatter (`name`, `description`, …) followed by a markdown body.
- * Some first-party skills skip the frontmatter entirely (plain markdown),
- * so everything degrades: name falls back to the dir name (caller's job),
- * description falls back to the first body paragraph.
+ * SKILL.md parsing for the Library — re-exported from the shared harness
+ * module (`@decocms/harness/skills/skill-md`) so the web UI and the mesh
+ * server-side skill catalog parse identically.
  */
 
-export interface SkillMeta {
-  name: string | null;
-  description: string | null;
-  /** Markdown body with the frontmatter fence stripped. */
-  body: string;
-}
-
-/** Flat `key: value` frontmatter subset — skill files don't nest. */
-function parseFrontmatter(block: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const line of block.split("\n")) {
-    const m = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/);
-    if (m?.[1] && m[2] !== undefined) {
-      out[m[1].toLowerCase()] = m[2].trim();
-    }
-  }
-  return out;
-}
-
-/** First non-heading paragraph of a markdown body (description fallback). */
-function firstParagraph(body: string): string | null {
-  for (const block of body.split(/\n\s*\n/)) {
-    const text = block.trim();
-    if (!text || text.startsWith("#")) continue;
-    return text.replace(/\n/g, " ");
-  }
-  return null;
-}
-
-export function parseSkillMd(text: string): SkillMeta {
-  const m = text.match(/^---\n([\s\S]*?)\n---\n?/);
-  if (!m || m[1] === undefined) {
-    return {
-      name: null,
-      description: firstParagraph(text),
-      body: text,
-    };
-  }
-  const fm = parseFrontmatter(m[1]);
-  const body = text.slice(m[0].length);
-  return {
-    name: fm.name || null,
-    description: fm.description || firstParagraph(body),
-    body,
-  };
-}
+export { parseSkillMd, type SkillMeta } from "@decocms/harness/skills/skill-md";

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
@@ -21,10 +21,13 @@ import {
   GrepInputSchema,
   READ_DESCRIPTION,
   ReadInputSchema,
+  SKILL_DESCRIPTION,
+  SkillInputSchema,
   TOOL_APPROVAL,
   WRITE_DESCRIPTION,
   WriteInputSchema,
 } from "./schemas";
+import { resolveSkillPath } from "./skill-resolve";
 import type { VmToolsParams } from "./types";
 
 export type { VmToolsParams } from "./types";
@@ -36,6 +39,7 @@ export function createVmTools(params: VmToolsParams) {
     toolOutputMap,
     needsApproval,
     pendingImages,
+    ctx,
   } = params;
   const approvalFor = (mutating: boolean) => (mutating ? needsApproval : false);
 
@@ -144,8 +148,33 @@ export function createVmTools(params: VmToolsParams) {
     },
   });
 
+  // Progressive skill discovery: <available-skills> lists each skill's id +
+  // description; this loads one skill's full SKILL.md on demand (read-only),
+  // resolving the catalog id to its mounted path.
+  const skill = tool({
+    needsApproval: approvalFor(TOOL_APPROVAL.skill),
+    description: SKILL_DESCRIPTION,
+    inputSchema: zodSchema(SkillInputSchema),
+    execute: async ({ id }) => {
+      const path = resolveSkillPath(id, ctx.organization?.slug);
+      if (!path) {
+        return {
+          error: `Invalid skill id "${id}". Use an id from <available-skills>.`,
+        };
+      }
+      try {
+        const result = await call("/_sandbox/read", { path });
+        return maybeTruncate(result, toolOutputMap);
+      } catch {
+        return {
+          error: `Skill "${id}" not found. Use an id from <available-skills>.`,
+        };
+      }
+    },
+  });
+
   // org-fs is now the universal substrate: chat attachments arrive in
   // `org/upload/` (no copy_to_sandbox) and deliverables go to `org/output/`
   // surfaced via the thread-outputs chips (no share_with_user).
-  return { read, write, edit, grep, glob, bash };
+  return { read, write, edit, grep, glob, bash, skill };
 }

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -79,12 +79,22 @@ export const BashInputSchema = z.object({
     .describe("Timeout in milliseconds (default 30000, max 120000)"),
 });
 
+export const SkillInputSchema = z.object({
+  id: z
+    .string()
+    .describe(
+      "Skill id from the <available-skills> catalog (e.g. 'core/slides' or " +
+        "'home/<name>').",
+    ),
+});
+
 export type ReadInput = z.infer<typeof ReadInputSchema>;
 export type WriteInput = z.infer<typeof WriteInputSchema>;
 export type EditInput = z.infer<typeof EditInputSchema>;
 export type GrepInput = z.infer<typeof GrepInputSchema>;
 export type GlobInput = z.infer<typeof GlobInputSchema>;
 export type BashInput = z.infer<typeof BashInputSchema>;
+export type SkillInput = z.infer<typeof SkillInputSchema>;
 
 export const READ_DESCRIPTION =
   "Read a file. For text files, returns content with line numbers (use offset " +
@@ -103,12 +113,18 @@ export const WRITE_DESCRIPTION =
   "and persist in the org's shared folder when written under " +
   "`org/<your-org-slug>/` (lowercase-kebab names):\n" +
   "- Presentation decks / slides → `org/<your-org-slug>/decks/<name>.html` " +
-  "— read the slides skill (`org/public/core/slides/SKILL.md`) FIRST " +
+  "— load the slides skill (`skill({ id: 'core/slides' })`) FIRST " +
   "and create the deck with its CLI.\n" +
   "- Standalone pages (landing pages, brand kits, one-pagers) → " +
   "`org/<your-org-slug>/pages/<name>.html` — single self-contained " +
   "HTML file.\n" +
   "HTML written anywhere else will not render a preview.";
+
+export const SKILL_DESCRIPTION =
+  "Load a skill's full instructions (its SKILL.md) by id, for the skills " +
+  "listed in <available-skills>. Read-only. Call this BEFORE applying a skill, " +
+  "then follow its SKILL.md (run its scripts via bash). Do NOT call it for a " +
+  "skill whose SKILL.md is already in the conversation.";
 
 export const EDIT_DESCRIPTION =
   "Perform exact string replacement in a file in the VM. " +
@@ -130,21 +146,21 @@ export const BASH_DESCRIPTION =
   "shared across runs; `ls org/` shows the actual name). Organize it " +
   "freely; check it before non-trivial work and record durable facts, " +
   "decisions, and learnings as small markdown files.\n" +
-  "- `org/public/<set>/` — curated read-only skill sets (file-handling: " +
-  "pptx, docx, xlsx, pdf, file-reading; plus slides + templating). Run " +
-  "`ls org/public/` for the sets and read " +
-  "`org/public/<set>/<name>/SKILL.md` before using a skill.\n" +
+  "- `org/public/<set>/` — curated read-only skill sets, mounted here. Your " +
+  "skills are listed in the <available-skills> catalog; load one with the " +
+  "`skill` tool before applying it (don't `ls org/public/` to discover them).\n" +
   "- `org/upload/` — files the user attached to this conversation are " +
   "already here; read them directly.\n" +
   "- `org/output/` — write deliverables here; they are shared back to the " +
   "organization under this run's folder.\n\n" +
   "To make a presentation/slides/deck, ALWAYS use the `slides` skill " +
-  "(HTML decks with a live editable preview) — read its SKILL.md first. " +
+  "(HTML decks with a live editable preview) — load it with " +
+  "`skill({ id: 'core/slides' })` first. " +
   "`pptx` is NOT for this: it only reads/inspects existing `.pptx` files, " +
   "and is the right tool only when the user explicitly needs a PowerPoint " +
   "`.pptx` file as input or output.";
 
-// read/grep/glob are non-mutating; write/edit/bash mutate.
+// read/grep/glob/skill are non-mutating; write/edit/bash mutate.
 export const TOOL_APPROVAL = {
   read: false,
   write: true,
@@ -152,4 +168,5 @@ export const TOOL_APPROVAL = {
   grep: false,
   glob: false,
   bash: true,
+  skill: false,
 } as const;

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/skill-resolve.test.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/skill-resolve.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSkillPath } from "./skill-resolve";
+
+describe("resolveSkillPath", () => {
+  test("resolves a public-set skill", () => {
+    expect(resolveSkillPath("core/slides", "acme")).toBe(
+      "org/public/core/slides/SKILL.md",
+    );
+  });
+
+  test("resolves a nested public id", () => {
+    expect(resolveSkillPath("storefront/seo/audit", "acme")).toBe(
+      "org/public/storefront/seo/audit/SKILL.md",
+    );
+  });
+
+  test("resolves a home skill against the org slug", () => {
+    expect(resolveSkillPath("home/skills/onboarding", "acme")).toBe(
+      "org/acme/skills/onboarding/SKILL.md",
+    );
+    expect(resolveSkillPath("home/foo", "acme")).toBe("org/acme/foo/SKILL.md");
+  });
+
+  test("falls back to literal `home` for reserved/unsafe/empty slugs", () => {
+    expect(resolveSkillPath("home/foo", "public")).toBe(
+      "org/home/foo/SKILL.md",
+    );
+    expect(resolveSkillPath("home/foo", "")).toBe("org/home/foo/SKILL.md");
+    expect(resolveSkillPath("home/foo", null)).toBe("org/home/foo/SKILL.md");
+  });
+
+  test("rejects traversal, absolute, and malformed ids", () => {
+    expect(resolveSkillPath("../etc/passwd", "acme")).toBeNull();
+    expect(resolveSkillPath("core/../../secret", "acme")).toBeNull();
+    expect(resolveSkillPath("/core/slides", "acme")).toBeNull();
+    expect(resolveSkillPath("core/", "acme")).toBeNull();
+    expect(resolveSkillPath("core", "acme")).toBeNull();
+    expect(resolveSkillPath("", "acme")).toBeNull();
+    expect(resolveSkillPath("core/sli des", "acme")).toBeNull();
+  });
+});

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/skill-resolve.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/skill-resolve.ts
@@ -1,0 +1,48 @@
+/**
+ * Resolve a skill catalog id (`<scope>/<rest>`) to the mounted SKILL.md path
+ * the `skill` tool reads. Deterministic + traversal-safe: every path segment
+ * must be a safe token, so an unknown / `../`-laden id resolves to null rather
+ * than escaping a skill scope.
+ *
+ *   core/slides        → org/public/core/slides/SKILL.md
+ *   home/skills/foo    → org/<home-base>/skills/foo/SKILL.md
+ */
+
+/** One safe path segment — no traversal, hidden dirs, or empties. */
+const SAFE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Names that live directly under `org/` and would shadow a home slug. */
+const RESERVED_HOME_PATHS = new Set(["output", "upload", "public", "home"]);
+
+/**
+ * The org's home mount base under `org/` — the slug, falling back to literal
+ * `home` when the slug collides with a reserved name or isn't a safe segment.
+ * Mirrors `homeMountPath` in apps/mesh/src/file-storage/home-mount.ts (kept in
+ * sync by hand — the harness package can't import mesh).
+ */
+function homeMountBase(orgSlug: string): string {
+  if (
+    !orgSlug ||
+    RESERVED_HOME_PATHS.has(orgSlug) ||
+    !SAFE_SEGMENT.test(orgSlug)
+  ) {
+    return "home";
+  }
+  return orgSlug;
+}
+
+export function resolveSkillPath(
+  id: string,
+  orgSlug: string | null | undefined,
+): string | null {
+  const parts = id.split("/");
+  if (parts.length < 2) return null;
+  if (!parts.every((p) => SAFE_SEGMENT.test(p))) return null;
+  const [scope, ...rest] = parts;
+  const restPath = rest.join("/");
+  if (scope === "home") {
+    return `org/${homeMountBase(orgSlug ?? "")}/${restPath}/SKILL.md`;
+  }
+  // Any other scope is a public set name → org/public/<set>/<rest>.
+  return `org/public/${scope}/${restPath}/SKILL.md`;
+}

--- a/packages/harness/src/decopilot/csv.ts
+++ b/packages/harness/src/decopilot/csv.ts
@@ -1,0 +1,17 @@
+/**
+ * Minimal RFC-4180 CSV field escaping, shared by the system-prompt catalog
+ * blocks (`<available-prompts>`, `<available-skills>`). Quotes a field only
+ * when it contains a delimiter, quote, semicolon, or newline.
+ */
+export function csvField(s: string | null | undefined): string {
+  if (s == null || s === "") return "";
+  if (
+    s.includes(",") ||
+    s.includes('"') ||
+    s.includes("\n") ||
+    s.includes(";")
+  ) {
+    return `"${s.replaceAll('"', '""')}"`;
+  }
+  return s;
+}

--- a/packages/harness/src/decopilot/desktop-parity.test.ts
+++ b/packages/harness/src/decopilot/desktop-parity.test.ts
@@ -56,6 +56,7 @@ const DESKTOP_TOOL_KEYS_BASELINE = [
   "propose_plan",
   "read",
   "read_tool_output",
+  "skill",
   "subtask",
   "todo_write",
   "update_interests",

--- a/packages/harness/src/decopilot/prompts-block.ts
+++ b/packages/harness/src/decopilot/prompts-block.ts
@@ -6,6 +6,8 @@
  * entirely.
  */
 
+import { csvField } from "./csv";
+
 export interface PromptsBlockEntry {
   name: string;
   description: string | null;
@@ -20,19 +22,6 @@ history (e.g. applied via /promptName in the UI), you MUST NOT call read_prompt
 for it — the content is already loaded. Follow its instructions directly.
 Only call read_prompt for prompts whose content is NOT yet in the conversation.
 </prompts-usage>`;
-
-function csvField(s: string | null | undefined): string {
-  if (s == null || s === "") return "";
-  if (
-    s.includes(",") ||
-    s.includes('"') ||
-    s.includes("\n") ||
-    s.includes(";")
-  ) {
-    return `"${s.replaceAll('"', '""')}"`;
-  }
-  return s;
-}
 
 export function buildPromptsBlock(prompts: PromptsBlockEntry[]): string | null {
   if (prompts.length === 0) return null;

--- a/packages/harness/src/decopilot/skills-block.test.ts
+++ b/packages/harness/src/decopilot/skills-block.test.ts
@@ -52,4 +52,25 @@ describe("buildSkillsBlock", () => {
     expect(row).toContain("…");
     expect(row?.length).toBeLessThan(220);
   });
+
+  test("calls out user-configured skills by id (also listed as rows)", () => {
+    const result = buildSkillsBlock(
+      [entry("core/slides", "decks"), entry("home/onb", "onboarding", "home")],
+      ["home/onb"],
+    );
+    expect(result).toContain(
+      "The user explicitly configured these skills for this agent",
+    );
+    expect(result).toContain("home/onb");
+    // still a normal catalog row, not a separate listing.
+    expect(result).toContain("home/onb,onboarding,home");
+  });
+
+  test("ignores configured ids not present in the catalog; no callout when none", () => {
+    const result = buildSkillsBlock(
+      [entry("core/slides", "decks")],
+      ["ghost/x"],
+    );
+    expect(result).not.toContain("explicitly configured");
+  });
 });

--- a/packages/harness/src/decopilot/skills-block.test.ts
+++ b/packages/harness/src/decopilot/skills-block.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { buildSkillsBlock, type SkillsBlockEntry } from "./skills-block";
+
+const entry = (
+  id: string,
+  description: string | null,
+  source = "public:core",
+): SkillsBlockEntry => ({ id, description, source });
+
+describe("buildSkillsBlock", () => {
+  test("returns null when there are no skills", () => {
+    expect(buildSkillsBlock([])).toBeNull();
+  });
+
+  test("emits CSV catalog with id,description,source header", () => {
+    const result = buildSkillsBlock([
+      entry("core/slides", "Create decks"),
+      entry("home/onboarding", "Org onboarding", "home"),
+    ]);
+    expect(result).toContain("<available-skills>");
+    expect(result).toContain("id,description,source");
+    expect(result).toContain("core/slides,Create decks,public:core");
+    expect(result).toContain("home/onboarding,Org onboarding,home");
+  });
+
+  test("includes <skills-usage> with skill tool + already-loaded warning", () => {
+    const result = buildSkillsBlock([entry("core/slides", "Create decks")]);
+    expect(result).toContain("<skills-usage>");
+    // lowercase to match the registered tool name (`skill`, not `Skill`).
+    expect(result).toContain("skill({ id })");
+    expect(result).toContain("WARNING");
+    expect(result).toContain("already appears");
+  });
+
+  test("renders empty description as an empty CSV column", () => {
+    const result = buildSkillsBlock([entry("core/bare", null)]);
+    expect(result).toContain("\ncore/bare,,public:core\n");
+  });
+
+  test("escapes CSV-special characters per RFC 4180", () => {
+    const result = buildSkillsBlock([entry("core/x", `desc, with "quote"`)]);
+    expect(result).toContain(`core/x,"desc, with ""quote""",public:core`);
+  });
+
+  test("truncates long descriptions and flattens whitespace", () => {
+    const long = "a".repeat(250);
+    const result = buildSkillsBlock([entry("core/x", `multi\n  line ${long}`)]);
+    // newline collapsed → field not quoted; ellipsis appended; capped at 200.
+    const row = result?.split("\n").find((l) => l.startsWith("core/x,"));
+    expect(row).toBeDefined();
+    expect(row).toContain("multi line");
+    expect(row).toContain("…");
+    expect(row?.length).toBeLessThan(220);
+  });
+});

--- a/packages/harness/src/decopilot/skills-block.ts
+++ b/packages/harness/src/decopilot/skills-block.ts
@@ -40,7 +40,14 @@ loaded. Only call skill for a skill whose SKILL.md is NOT yet in the
 conversation.
 </skills-usage>`;
 
-export function buildSkillsBlock(skills: SkillsBlockEntry[]): string | null {
+/**
+ * @param configuredIds ids the user explicitly attached to this agent — called
+ *   out so the model prefers them. They also appear as normal catalog rows.
+ */
+export function buildSkillsBlock(
+  skills: SkillsBlockEntry[],
+  configuredIds: string[] = [],
+): string | null {
   if (skills.length === 0) return null;
 
   const rows = skills.map(
@@ -48,8 +55,17 @@ export function buildSkillsBlock(skills: SkillsBlockEntry[]): string | null {
       `${csvField(s.id)},${csvField(truncate(s.description))},${csvField(s.source)}`,
   );
 
+  const present = new Set(skills.map((s) => s.id));
+  const configured = configuredIds.filter((id) => present.has(id));
+  const callout =
+    configured.length > 0
+      ? `\n\nThe user explicitly configured these skills for this agent — ` +
+        `prefer them when the task is relevant: ${configured.join(", ")}.`
+      : "";
+
   return (
     `\n\n<available-skills>\nid,description,source\n${rows.join("\n")}\n</available-skills>` +
+    callout +
     `\n\n${USAGE}`
   );
 }

--- a/packages/harness/src/decopilot/skills-block.ts
+++ b/packages/harness/src/decopilot/skills-block.ts
@@ -1,0 +1,55 @@
+/**
+ * Builds the <available-skills> + <skills-usage> system-prompt block — the
+ * skill analogue of <available-prompts> (prompts-block.ts). Gives the agent
+ * Claude-Code-style progressive discovery: every skill's id + description is
+ * listed up front, and the full SKILL.md body is loaded on demand via the
+ * `skill` tool.
+ *
+ * Returns null when the catalog is empty so the block — and the Skill-tool
+ * guidance that depends on it — drops out of the prompt entirely.
+ */
+
+import { csvField } from "./csv";
+
+export interface SkillsBlockEntry {
+  /** Resolvable, collision-free id the `skill` tool takes (e.g. "core/slides"). */
+  id: string;
+  description: string | null;
+  /** Provenance shown to the model (e.g. "public:core" or "home"). */
+  source: string;
+}
+
+/** Keep descriptions compact so the catalog stays in the cached prefix. */
+const MAX_DESCRIPTION = 200;
+function truncate(s: string | null): string {
+  if (!s) return "";
+  const flat = s.replace(/\s+/g, " ").trim();
+  return flat.length <= MAX_DESCRIPTION
+    ? flat
+    : `${flat.slice(0, MAX_DESCRIPTION - 1).trimEnd()}…`;
+}
+
+const USAGE = `<skills-usage>
+Each skill is a reusable capability with full instructions in its SKILL.md.
+Load one with skill({ id }) BEFORE applying it, then follow its instructions
+(run its scripts via bash).
+
+WARNING: If a skill's SKILL.md already appears anywhere in the conversation
+history, you MUST NOT call skill for it again — its instructions are already
+loaded. Only call skill for a skill whose SKILL.md is NOT yet in the
+conversation.
+</skills-usage>`;
+
+export function buildSkillsBlock(skills: SkillsBlockEntry[]): string | null {
+  if (skills.length === 0) return null;
+
+  const rows = skills.map(
+    (s) =>
+      `${csvField(s.id)},${csvField(truncate(s.description))},${csvField(s.source)}`,
+  );
+
+  return (
+    `\n\n<available-skills>\nid,description,source\n${rows.join("\n")}\n</available-skills>` +
+    `\n\n${USAGE}`
+  );
+}

--- a/packages/harness/src/skills/skill-md.test.ts
+++ b/packages/harness/src/skills/skill-md.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { parseSkillMd } from "./skill-md";
+
+const FRONTMATTER_STYLE = `---
+name: slides
+description: Create and edit presentation decks as single self-contained HTML files.
+---
+
+# slides — presentation decks
+
+Create and edit presentation decks.
+`;
+
+const PLAIN_STYLE = `# xlsx — Excel spreadsheets
+
+Use this skill to read or summarize \`.xlsx\` files.
+
+## Scripts
+`;
+
+describe("parseSkillMd", () => {
+  it("parses frontmatter name + description and strips the fence", () => {
+    const meta = parseSkillMd(FRONTMATTER_STYLE);
+    expect(meta.name).toBe("slides");
+    expect(meta.description).toBe(
+      "Create and edit presentation decks as single self-contained HTML files.",
+    );
+    expect(meta.body.startsWith("\n# slides")).toBe(true);
+    expect(meta.body).not.toContain("---");
+  });
+
+  it("falls back on plain markdown (no frontmatter)", () => {
+    const meta = parseSkillMd(PLAIN_STYLE);
+    expect(meta.name).toBeNull();
+    expect(meta.description).toBe(
+      "Use this skill to read or summarize `.xlsx` files.",
+    );
+    expect(meta.body).toBe(PLAIN_STYLE);
+  });
+
+  it("falls back to first paragraph when frontmatter lacks description", () => {
+    const meta = parseSkillMd("---\nname: x\n---\n# Title\n\nFirst para.\n");
+    expect(meta.name).toBe("x");
+    expect(meta.description).toBe("First para.");
+  });
+
+  it("handles empty / heading-only bodies", () => {
+    expect(parseSkillMd("# Only a title\n").description).toBeNull();
+    expect(parseSkillMd("").description).toBeNull();
+    expect(parseSkillMd("").name).toBeNull();
+  });
+});

--- a/packages/harness/src/skills/skill-md.ts
+++ b/packages/harness/src/skills/skill-md.ts
@@ -1,0 +1,57 @@
+/**
+ * SKILL.md parsing — the Claude Code skill format: optional flat YAML
+ * frontmatter (`name`, `description`, …) followed by a markdown body.
+ * Some first-party skills skip the frontmatter entirely (plain markdown),
+ * so everything degrades: name falls back to the dir name (caller's job),
+ * description falls back to the first body paragraph.
+ *
+ * Pure and zero-dependency so it is shared by the mesh server (skill
+ * catalog) and the web Library, with no DOM/Node coupling.
+ */
+
+export interface SkillMeta {
+  name: string | null;
+  description: string | null;
+  /** Markdown body with the frontmatter fence stripped. */
+  body: string;
+}
+
+/** Flat `key: value` frontmatter subset — skill files don't nest. */
+function parseFrontmatter(block: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of block.split("\n")) {
+    const m = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/);
+    if (m?.[1] && m[2] !== undefined) {
+      out[m[1].toLowerCase()] = m[2].trim();
+    }
+  }
+  return out;
+}
+
+/** First non-heading paragraph of a markdown body (description fallback). */
+function firstParagraph(body: string): string | null {
+  for (const block of body.split(/\n\s*\n/)) {
+    const text = block.trim();
+    if (!text || text.startsWith("#")) continue;
+    return text.replace(/\n/g, " ");
+  }
+  return null;
+}
+
+export function parseSkillMd(text: string): SkillMeta {
+  const m = text.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!m || m[1] === undefined) {
+    return {
+      name: null,
+      description: firstParagraph(text),
+      body: text,
+    };
+  }
+  const fm = parseFrontmatter(m[1]);
+  const body = text.slice(m[0].length);
+  return {
+    name: fm.name || null,
+    description: fm.description || firstParagraph(body),
+    body,
+  };
+}

--- a/packages/sandbox/image/skills/docx/SKILL.md
+++ b/packages/sandbox/image/skills/docx/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: docx
+description: Read and extract text, tables, and structure from .docx Word documents. Use when the user uploads or references a Word file to read or summarize.
+---
+
 # docx — Word documents
 
 Use this skill to read or summarize `.docx` files.

--- a/packages/sandbox/image/skills/file-reading/SKILL.md
+++ b/packages/sandbox/image/skills/file-reading/SKILL.md
@@ -1,18 +1,23 @@
+---
+name: file-reading
+description: Route a file to the right reader by extension (pptx, docx, xlsx, pdf, and plain text). Use as the entry point when asked to read or summarize an uploaded file of unknown type.
+---
+
 # file-reading — router by file type
 
 When asked to read or summarize a file, dispatch by extension to the
-appropriate skill under `/mnt/skills/public/`:
+appropriate skill under `org/public/core/`:
 
 | Extension     | Skill   | Script                                        |
 | ------------- | ------- | --------------------------------------------- |
-| `.pptx`       | `pptx`  | `python /mnt/skills/public/pptx/extract.py`   |
-| `.docx`       | `docx`  | `python /mnt/skills/public/docx/extract.py`   |
-| `.xlsx`       | `xlsx`  | `python /mnt/skills/public/xlsx/extract.py`   |
-| `.pdf`        | `pdf`   | `python /mnt/skills/public/pdf/extract.py`    |
+| `.pptx`       | `pptx`  | `python org/public/core/pptx/extract.py`   |
+| `.docx`       | `docx`  | `python org/public/core/docx/extract.py`   |
+| `.xlsx`       | `xlsx`  | `python org/public/core/xlsx/extract.py`   |
+| `.pdf`        | `pdf`   | `python org/public/core/pdf/extract.py`    |
 | `.txt`, `.md` | —       | `cat`                                         |
 | `.csv`        | —       | `cat` (or `column -t -s,` for alignment)      |
 | `.json`       | —       | `cat` (or `jq .` if structure matters)        |
 
 For extensions not listed, read the corresponding `SKILL.md` under
-`/mnt/skills/public/` if one exists, otherwise fall back to `file <path>` to
+`org/public/core/` if one exists, otherwise fall back to `file <path>` to
 identify the format and proceed manually.

--- a/packages/sandbox/image/skills/pdf/SKILL.md
+++ b/packages/sandbox/image/skills/pdf/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pdf
+description: Read and extract text from .pdf files, page by page. Use when the user uploads or references a PDF to read or summarize.
+---
+
 # pdf — PDF documents
 
 Use this skill to read text from `.pdf` files.

--- a/packages/sandbox/image/skills/pptx/SKILL.md
+++ b/packages/sandbox/image/skills/pptx/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pptx
+description: Read and inspect existing .pptx PowerPoint files (text, speaker notes, slide images). Use only for reading uploaded PowerPoint files — to AUTHOR a deck use the slides skill instead.
+---
+
 # pptx — PowerPoint presentations
 
 Reading and inspection of `.pptx` files. Editing and creation are not yet

--- a/packages/sandbox/image/skills/slides/SKILL.md
+++ b/packages/sandbox/image/skills/slides/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: slides
+description: Create and edit presentation decks as single self-contained HTML files with a live, editable preview and print-to-PDF export. Use when the user wants slides, a deck, or a presentation.
+---
+
 # slides — presentation decks
 
 Create and edit presentation decks as single self-contained HTML files,
@@ -11,7 +16,7 @@ with inline editing, and exports PDF by printing (the deck ships print CSS
 | ------------------------- | --------------------------------------------------------------------- |
 | Create a deck             | `slides-create --data @deck.json --output org/<slug>/decks/<name>.html` |
 | List themes / templates   | `slides-create --help`                                                 |
-| See a full data example   | `cat /mnt/skills/public/slides/examples/deck.json`                     |
+| See a full data example   | `cat org/public/core/slides/examples/deck.json`                     |
 | Edit an existing deck     | `read` the HTML, edit the `<section>` slides, write it back            |
 | Org brand templates       | add `--templates-dir org/<slug>/templates/slides`                      |
 | PDF export                | user prints from the preview — no action needed                        |
@@ -24,7 +29,7 @@ near-instantly and the user sees a live preview that updates as you work.
 
 ## Creating a deck
 
-1. Read `/mnt/skills/public/slides/examples/deck.json` once to learn the
+1. Read `org/public/core/slides/examples/deck.json` once to learn the
    data shapes.
 2. Author your own deck JSON (a file is easier to iterate than inline):
    `{ "title": …, "theme": …, "slides": [ { "template": …, "data": … } ] }`
@@ -38,7 +43,7 @@ amber accents), `bold-gradient` (vivid full-bleed gradient, glass cards).
 
 `--theme` also accepts a **path to a custom theme file** — a complete deck
 shell HTML with a `{{{slides}}}` insertion point (copy a built-in from
-`/mnt/skills/public/slides/themes/` as the starting point and retune its
+`org/public/core/slides/themes/` as the starting point and retune its
 CSS custom properties). Keep org brand themes in org-fs so they persist,
 e.g.:
 
@@ -65,7 +70,7 @@ slides-create --data @deck.json \
 | `closing`         | `heading`, `subheading?`, `cta?`                                           |
 
 This skill is built on the `templating` skill
-(`/mnt/skills/public/templating/SKILL.md`). For a one-off custom slide
+(`org/public/core/templating/SKILL.md`). For a one-off custom slide
 or deck template, render it directly with `create-from-template`; for an
 org's own slide layouts, keep them in `org/<slug>/templates/slides/` and
 pass `--templates-dir` — they resolve before the built-ins.

--- a/packages/sandbox/image/skills/templating/SKILL.md
+++ b/packages/sandbox/image/skills/templating/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: templating
+description: Render any text file (HTML, markdown, config, SQL, email) from a mustache template plus JSON data. Use when an output's shape is fixed ahead of time and only the values change.
+---
+
 # templating — fill data into text-file templates
 
 Render any text file (HTML, markdown, config, SQL, email, …) from a

--- a/packages/sandbox/image/skills/xlsx/SKILL.md
+++ b/packages/sandbox/image/skills/xlsx/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: xlsx
+description: Read and extract cell data from .xlsx Excel spreadsheets as TSV. Use when the user uploads or references an Excel file to read or summarize.
+---
+
 # xlsx — Excel spreadsheets
 
 Use this skill to read or summarize `.xlsx` files.


### PR DESCRIPTION
## What is this contribution about?

Gives the agent Claude-Code-style **progressive skill discovery** for org-fs skills. A compact `<available-skills>` catalog (id + description for every public-set and home skill) is injected into the agent's served instructions, and a new read-only `skill` tool loads a skill's full `SKILL.md` on demand. The catalog is built in `createVirtualClientFrom` and appended in `PassthroughClient.getInstructions()` — the one synchronous seam that reaches **both** the cluster engine and the desktop daemon — and it dedupes against attached `<knowledge>` skills. This replaces the old "`ls org/public/` to discover skills" prose, which fired on every run and the model often skipped.

Also: `name`/`description` frontmatter added to the 7 core skills (the catalog's descriptions), stale `/mnt/skills/public/` references updated to `org/public/core/`, and `parseSkillMd` + `csvField` consolidated into shared modules.

## Screenshots/Demonstration

Backend-only aside from one tool icon (`skill` → "Load Skill" in `TOOL_DISPLAY_MAP`); no user-facing UI surfaces.

## How to Test

1. Unit: `bun test packages/harness/src/skills packages/harness/src/decopilot/skills-block.test.ts packages/harness/src/decopilot/built-in-tools/vm-tools/skill-resolve.test.ts` (parser, block renderer, traversal-safe id resolution).
2. Integration (real Postgres) for the catalog enumeration: `DATABASE_URL=… bun test apps/mesh/src/file-storage/skill-catalog.integration.test.ts`.
3. Manual: chat with an agent and ask "what can you do?" — it lists skills from `<available-skills>` **without** an `ls org/public/` call; then it loads one via the `skill` tool (e.g. `skill({ id: 'core/slides' })`) and follows the returned `SKILL.md`. Expected on both cluster and desktop run paths.

## Migration Notes

No database migrations. The `core` public set re-syncs the updated `SKILL.md` frontmatter from `main` on the existing DBOS cron, so descriptions populate automatically.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds progressive skill discovery for org-fs and unifies the skill surface: we inject an <available-skills> catalog into served instructions and add a read‑only `skill` tool to load a skill’s `SKILL.md` on demand. The tool is now visible in automations, and attached skills are flagged inline in the catalog.

- New Features
  - Catalog: CSV of skills (public sets + home) with stable ids (`core/slides`, `home/<dir>`), flags user‑attached skills, and appends via `PassthroughClient.getInstructions()`; public portion cached process‑wide; bounded home scan; best‑effort, never throws.
  - Tool: `skill` resolves an id to `SKILL.md` safely and reads it; shown as “Load Skill” in chat and added to the automations tool picker (parity with `read_prompt`).
  - Infra: shared `parseSkillMd` and `csvField`; skills catalog built server‑side and appended in the served‑instructions seam (desktop + cluster).
  - Tests: unit coverage for the block builder and id resolver; storage‑integration test for catalog enumeration; passthrough client tests asserting the skills‑block append; desktop parity includes `skill`.

- Refactors
  - Prompt: org‑fs block no longer lists sets or tells the agent to `ls org/public/`; guidance points to `skill`.
  - Knowledge: `<knowledge>` is now files‑only; skills are highlighted in `<available-skills>`.
  - Skills: added `name`/`description` frontmatter to the 7 core skills; paths updated from `/mnt/skills/public/` to `org/public/core/`.
  - Web/server parity: Library re‑exports `parseSkillMd` to match server catalog parsing.

<sup>Written for commit 0faa029f062dcb67aa1c12f1570e8c6cf86aad03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

