### PR TITLE
feat(decopilot): progressive-disclosure skill index (Claude Code style)

### DIFF
--- a/apps/mesh/src/file-storage/org-fs.ts
+++ b/apps/mesh/src/file-storage/org-fs.ts
@@ -102,6 +102,12 @@ export class OrgFs {
     );
   }
 
+  /** Every live file in a volume (recursive, flat). */
+  async listFiles(volume: string): Promise<OrgFsEntry[]> {
+    assertValidVolume(volume);
+    return this.manifest.listVolumeFiles(this.organizationId, volume);
+  }
+
   /** Raw bytes of a file. Throws if the path is not a live file. */
   async read(volume: string, path: string): Promise<Uint8Array> {
     const entry = await this.requireFile(volume, path);

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -31,7 +31,11 @@ import {
   buildSystemMessages,
   type SystemMessage,
 } from "@decocms/harness/decopilot/system-prompt";
-import { listPromptsBlock, listConnectionsBlock } from "./prompt";
+import {
+  listPromptsBlock,
+  listConnectionsBlock,
+  listSkillsBlock,
+} from "./prompt";
 import { buildAgentsBlock } from "@decocms/harness/decopilot/agents-block";
 import { renderUserContextBlock } from "@decocms/harness/decopilot/user-context-block";
 import type { ConnectionsBlockTool } from "@decocms/harness/decopilot/connections-block";
@@ -147,6 +151,11 @@ export async function buildAgentSystemPrompt(
       opts.organization.slug,
     ),
   );
+
+  // Progressive-disclosure skill index (Claude Code style): names +
+  // descriptions of every installed skill so the agent knows when to reach
+  // for one; the SKILL.md body loads on demand via the read tool.
+  add("skills", await listSkillsBlock(opts.ctx));
 
   if (opts.kind === "agent") {
     if (opts.isDecopilot) {

--- a/apps/mesh/src/harnesses/decopilot/prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/prompt.ts
@@ -24,6 +24,16 @@ import {
   buildConnectionsBlock,
   type ConnectionsBlockTool,
 } from "@decocms/harness/decopilot/connections-block";
+import {
+  buildSkillsBlock,
+  parseSkillFrontmatter,
+  type SkillEntry,
+} from "@decocms/harness/decopilot/skills-block";
+import {
+  buildPublicOrgFs,
+  getPublicSets,
+  publicVolumeForSet,
+} from "@/file-storage/public-sets";
 
 /**
  * listPromptsBlock — fetches the MCP's prompt catalog via the passthrough
@@ -70,4 +80,81 @@ export async function listConnectionsBlock(
 ): Promise<string | null> {
   if (!data || data.tools.length === 0) return null;
   return buildConnectionsBlock(data.tools, data.connectionTitleMap);
+}
+
+const decoder = new TextDecoder();
+// Per-pod cache of parsed skills, keyed by `<volume>:<seq>`. Public skill sets
+// are deployment-stable and only change on a sync (which bumps the volume's
+// seq), so a hit avoids re-reading every SKILL.md from object storage on each
+// message. ponytail: per-pod, unbounded-but-pruned-per-volume; move extraction
+// into skill-set-sync if cross-pod or cold-start latency ever matters.
+const skillsCache = new Map<string, SkillEntry[]>();
+
+function skillDirName(entryPath: string): string {
+  // "pdf/SKILL.md" → "pdf"; "a/b/SKILL.md" → "b"
+  const segs = entryPath.split("/");
+  return segs[segs.length - 2] ?? entryPath;
+}
+
+function firstProseLine(body: string): string {
+  for (const raw of body.split("\n")) {
+    const line = raw.trim();
+    if (line && !line.startsWith("#") && line !== "---") return line;
+  }
+  return "";
+}
+
+async function skillsForSet(
+  ctx: StudioContext,
+  set: string,
+): Promise<SkillEntry[]> {
+  const volume = publicVolumeForSet(set);
+  const fs = buildPublicOrgFs(ctx);
+  const seq = await fs.latestSeq(volume);
+  const key = `${volume}:${seq}`;
+  const cached = skillsCache.get(key);
+  if (cached) return cached;
+
+  const files = await fs.listFiles(volume);
+  const skillMds = files.filter(
+    (f) => f.path === "SKILL.md" || f.path.endsWith("/SKILL.md"),
+  );
+  const entries = await Promise.all(
+    skillMds.map(async (f): Promise<SkillEntry> => {
+      const text = decoder.decode(await fs.read(volume, f.path));
+      const fm = parseSkillFrontmatter(text);
+      return {
+        name: `${set}/${fm.name ?? skillDirName(f.path)}`,
+        description: fm.description ?? firstProseLine(text),
+        path: `org/public/${set}/${f.path}`,
+      };
+    }),
+  );
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const k of skillsCache.keys()) {
+    if (k.startsWith(`${volume}:`)) skillsCache.delete(k);
+  }
+  skillsCache.set(key, entries);
+  return entries;
+}
+
+/**
+ * listSkillsBlock — builds the `<available-skills>` progressive-disclosure
+ * index from the deployment's public skill sets (mounted at `org/public/<set>`).
+ * Returns null when no skills exist. Never throws — a failure here must not
+ * break the prompt, so it degrades to null.
+ */
+export async function listSkillsBlock(
+  ctx: StudioContext,
+): Promise<string | null> {
+  try {
+    const sets = await Promise.all(
+      getPublicSets().map((s) => skillsForSet(ctx, s.set)),
+    );
+    return buildSkillsBlock(sets.flat());
+  } catch (err) {
+    console.warn("[listSkillsBlock] Failed to list skills:", err);
+    return null;
+  }
 }

--- a/packages/harness/src/decopilot/prompts-block.ts
+++ b/packages/harness/src/decopilot/prompts-block.ts
@@ -21,7 +21,7 @@ for it — the content is already loaded. Follow its instructions directly.
 Only call read_prompt for prompts whose content is NOT yet in the conversation.
 </prompts-usage>`;
 
-function csvField(s: string | null | undefined): string {
+export function csvField(s: string | null | undefined): string {
   if (s == null || s === "") return "";
   if (
     s.includes(",") ||

--- a/packages/harness/src/decopilot/skills-block.test.ts
+++ b/packages/harness/src/decopilot/skills-block.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { buildSkillsBlock, parseSkillFrontmatter } from "./skills-block";
+
+describe("parseSkillFrontmatter", () => {
+  it("parses name and description", () => {
+    expect(
+      parseSkillFrontmatter(
+        "---\nname: pdf\ndescription: Read PDFs.\n---\n# pdf\n",
+      ),
+    ).toEqual({ name: "pdf", description: "Read PDFs." });
+  });
+
+  it("strips surrounding quotes", () => {
+    expect(
+      parseSkillFrontmatter("---\nname: \"x\"\ndescription: 'y, z'\n---\n"),
+    ).toEqual({ name: "x", description: "y, z" });
+  });
+
+  it("returns {} with no frontmatter", () => {
+    expect(parseSkillFrontmatter("# just a heading\n")).toEqual({});
+  });
+
+  it("returns {} on unterminated frontmatter", () => {
+    expect(parseSkillFrontmatter("---\nname: x\n")).toEqual({});
+  });
+});
+
+describe("buildSkillsBlock", () => {
+  it("returns null when empty", () => {
+    expect(buildSkillsBlock([])).toBeNull();
+  });
+
+  it("renders a CSV index with header and usage", () => {
+    const out = buildSkillsBlock([
+      {
+        name: "core/pdf",
+        description: "Read PDFs.",
+        path: "org/public/core/pdf/SKILL.md",
+      },
+    ]);
+    expect(out).toContain("<available-skills>\nname,description,path");
+    expect(out).toContain("core/pdf,Read PDFs.,org/public/core/pdf/SKILL.md");
+    expect(out).toContain("<skills-usage>");
+  });
+
+  it("quotes fields containing commas", () => {
+    const out = buildSkillsBlock([
+      { name: "core/x", description: "reads a, b, c", path: "p" },
+    ]);
+    expect(out).toContain('"reads a, b, c"');
+  });
+});

--- a/packages/harness/src/decopilot/skills-block.ts
+++ b/packages/harness/src/decopilot/skills-block.ts
@@ -1,0 +1,56 @@
+/**
+ * Builds the <available-skills> system-prompt block — the progressive-
+ * disclosure index of the org's installed skills (Claude Code style): every
+ * skill's name + description is listed up front so the agent knows WHEN to
+ * reach for one, but the body (SKILL.md) is loaded on demand via `read`.
+ *
+ * Returns null when there are no skills, so the block drops out entirely.
+ */
+
+import { csvField } from "./prompts-block";
+
+export interface SkillEntry {
+  /** Disambiguated id, `<set>/<skill>` (e.g. `core/pdf`). */
+  name: string;
+  description: string;
+  /** Sandbox path to the SKILL.md, for the agent to `read`. */
+  path: string;
+}
+
+const USAGE = `<skills-usage>
+Each skill is a folder with a SKILL.md. The table above is the index — read a
+skill's SKILL.md (via the read tool, at the listed path) BEFORE applying it,
+and only when the task matches its description. Do not read skills you don't need.
+</skills-usage>`;
+
+/**
+ * Parse the leading YAML frontmatter of a SKILL.md. Intentionally NOT a full
+ * YAML parser — SKILL frontmatter is flat `key: value` lines, so a line scan
+ * is enough. Returns {} when there's no frontmatter.
+ * ponytail: flat key:value only; add a real YAML dep if skills ever need nesting.
+ */
+export function parseSkillFrontmatter(text: string): {
+  name?: string;
+  description?: string;
+} {
+  if (!text.startsWith("---")) return {};
+  const end = text.indexOf("\n---", 3);
+  if (end === -1) return {};
+  const out: Record<string, string> = {};
+  for (const line of text.slice(3, end).split("\n")) {
+    const [, key, val] = /^([A-Za-z][\w-]*):\s*(.*)$/.exec(line.trim()) ?? [];
+    if (key) out[key] = (val ?? "").replace(/^(["'])(.*)\1$/u, "$2");
+  }
+  return out;
+}
+
+export function buildSkillsBlock(skills: SkillEntry[]): string | null {
+  if (skills.length === 0) return null;
+  const rows = skills.map(
+    (s) => `${csvField(s.name)},${csvField(s.description)},${csvField(s.path)}`,
+  );
+  return (
+    `\n\n<available-skills>\nname,description,path\n${rows.join("\n")}\n</available-skills>` +
+    `\n\n${USAGE}`
+  );
+}

--- a/packages/sandbox/image/skills/docx/SKILL.md
+++ b/packages/sandbox/image/skills/docx/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: docx
+description: Read or summarize Microsoft Word .docx files (plain-text extraction).
+---
+
 # docx — Word documents
 
 Use this skill to read or summarize `.docx` files.

--- a/packages/sandbox/image/skills/file-reading/SKILL.md
+++ b/packages/sandbox/image/skills/file-reading/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: file-reading
+description: Router that dispatches a file to the right reader skill by extension (.pdf, .docx, .xlsx, .pptx, and plain-text formats).
+---
+
 # file-reading — router by file type
 
 When asked to read or summarize a file, dispatch by extension to the

--- a/packages/sandbox/image/skills/pdf/SKILL.md
+++ b/packages/sandbox/image/skills/pdf/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pdf
+description: Extract text from PDF files, page by page.
+---
+
 # pdf — PDF documents
 
 Use this skill to read text from `.pdf` files.

--- a/packages/sandbox/image/skills/pptx/SKILL.md
+++ b/packages/sandbox/image/skills/pptx/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pptx
+description: Read and inspect existing PowerPoint .pptx files. NOT for authoring slide decks — use the slides skill for that.
+---
+
 # pptx — PowerPoint presentations
 
 Reading and inspection of `.pptx` files. Editing and creation are not yet

--- a/packages/sandbox/image/skills/slides/SKILL.md
+++ b/packages/sandbox/image/skills/slides/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: slides
+description: Create and edit presentation decks as self-contained HTML with a live editable preview and PDF export. Use for any slides/deck/presentation request.
+---
+
 # slides — presentation decks
 
 Create and edit presentation decks as single self-contained HTML files,

--- a/packages/sandbox/image/skills/templating/SKILL.md
+++ b/packages/sandbox/image/skills/templating/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: templating
+description: Render text files (HTML, markdown, SQL, email, config…) from a mustache template plus JSON data.
+---
+
 # templating — fill data into text-file templates
 
 Render any text file (HTML, markdown, config, SQL, email, …) from a

--- a/packages/sandbox/image/skills/xlsx/SKILL.md
+++ b/packages/sandbox/image/skills/xlsx/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: xlsx
+description: Read or summarize Excel .xlsx spreadsheets.
+---
+
 # xlsx — Excel spreadsheets
 
 Use this skill to read or summarize `.xlsx` files.


### PR DESCRIPTION
## Summary

Closes the main gap between our skills and Claude Code skills: **progressive disclosure**.

Today the decopilot harness ships skills as `SKILL.md` files mounted at `org/public/<set>/`, but the agent only learns one exists by manually `ls`-ing `org/public/` and reading each file — a buried hint in the `bash` tool description. There's no up-front index, so skills it never browses are invisible, and discovery burns a turn.

This brings us to the CC model:

- **Frontmatter** — CC-style YAML (`name`, `description`) on the 7 core `SKILL.md` files (pdf, docx, xlsx, pptx, file-reading, templating, slides). Synced into `org/public/core` from this repo.
- **`<available-skills>` block** — a CSV index of every installed skill's `name,description,path` injected into the system prompt. The agent sees *what* skills exist and *when* to reach for each; the SKILL.md body still loads on demand via `read` (true progressive disclosure, cheap context).
- **`listSkillsBlock`** — enumerates `org/public/<set>` from the synced public org-fs, parses frontmatter, renders the block. Cached per-pod keyed by the volume's change-feed `seq`, so it doesn't re-read every SKILL.md from object storage on each message. Never throws — degrades to no block on failure.
- Missing frontmatter (e.g. external storefront skills, not yet updated) degrades gracefully: name from the folder, description from the first prose line.

## What's intentionally NOT here

- **A dedicated `Skill` tool** — the index + existing `read` tool cover it. Add only if the model mis-loads.
- **Per-skill `allowed-tools` / `model` scoping** — CC has it; we don't need it yet.
- **Org/user-authored skills + install UX** — the editable `org/<slug>/` mount is the natural home; add when someone authors one.
- Frontmatter on the external `storefront` skill repo — separate repo, separate PR; the parser already tolerates its absence.

## Testing

- Unit tests for the pure parts (`parseSkillFrontmatter`, `buildSkillsBlock`) — `bun test packages/harness/src/decopilot/skills-block.test.ts` (7 pass).
- `bun run --cwd apps/mesh check` + harness typecheck clean.
- `bun run fmt` / `bun run lint` clean (the 3 lint warnings are pre-existing cross-tree imports in unrelated files).
- The IO path (`listSkillsBlock` reading org-fs) is e2e territory per TESTING.md — not unit-tested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132vccvCFt1Ed9DAiPdZSmY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a progressive-disclosure skills index (Claude Code style) so the agent sees skill names and descriptions up front and loads `SKILL.md` only when needed. Improves discovery and reduces wasted turns.

- **New Features**
  - Injects an `<available-skills>` CSV block into the system prompt with `name,description,path`.
  - Adds `listSkillsBlock` to enumerate `org/public/<set>` from the public org-fs; cached per pod by volume `seq`; returns null on failure.
  - Adds YAML frontmatter (`name`, `description`) to core skills (`pdf`, `docx`, `xlsx`, `pptx`, `file-reading`, `templating`, `slides`) with graceful fallback when missing.
  - Exposes `OrgFs.listFiles` and exports `csvField` for CSV rendering.
  - Introduces `parseSkillFrontmatter` and `buildSkillsBlock` in `@decocms/harness/decopilot/skills-block` with unit tests.

<sup>Written for commit 40bc15a77d12522fadf4d08232ce5f51263c563a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

