### PR TITLE
feat(web): refine shell header and sidebar controls

### DIFF
--- a/apps/mesh/src/web/components/sidebar/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/index.tsx
@@ -36,7 +36,7 @@ export function StudioSidebar() {
               }
             >
               <Separator className="mb-2" />
-              <TaskGroupsList />
+              <TaskGroupsList onNavigate={onClose} />
             </Suspense>
           </ErrorBoundary>
         }

--- a/apps/mesh/src/web/components/sidebar/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/index.tsx
@@ -36,7 +36,7 @@ export function StudioSidebar() {
               }
             >
               <Separator className="mb-2" />
-              <TaskGroupsList onNavigate={onClose} />
+              <TaskGroupsList />
             </Suspense>
           </ErrorBoundary>
         }
@@ -65,7 +65,7 @@ export function StudioSidebarMobile({ onClose }: { onClose: () => void }) {
               }
             >
               <Separator className="mb-2" />
-              <TaskGroupsList />
+              <TaskGroupsList onNavigate={onClose} />
             </Suspense>
           </ErrorBoundary>
         }

--- a/apps/mesh/src/web/components/sidebar/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/index.tsx
@@ -2,8 +2,10 @@ import { ErrorBoundary } from "@/web/components/error-boundary";
 import { useProjectSidebarItems } from "@/web/hooks/use-project-sidebar-items";
 import { Suspense } from "react";
 import { Separator } from "@deco/ui/components/separator.tsx";
+import { useSidebar } from "@deco/ui/components/sidebar.tsx";
 import { NavigationSidebar } from "./navigation";
 import { MobileNavigationSidebar } from "./navigation-mobile";
+import { SidebarLogoHeader } from "./sidebar-logo-header";
 import { SidebarInboxFooter } from "./footer/inbox";
 import { SidebarInboxFooterMobile } from "./footer/inbox-mobile";
 import { TaskGroupsList } from "./task-groups/task-groups-list";
@@ -19,11 +21,13 @@ export type {
 
 export function StudioSidebar() {
   const sections = useProjectSidebarItems();
+  const { toggleSidebar } = useSidebar();
 
   return (
     <SidebarAgentGroupsProvider>
       <NavigationSidebar
         sections={sections}
+        header={<SidebarLogoHeader onToggle={toggleSidebar} />}
         footer={<SidebarInboxFooter />}
         additionalContent={
           <ErrorBoundary>

--- a/apps/mesh/src/web/components/sidebar/navigation-mobile.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation-mobile.tsx
@@ -1,9 +1,7 @@
-import { DEFAULT_LOGO, usePublicConfig } from "@/web/hooks/use-public-config";
 import {
   SidebarContent,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -12,29 +10,8 @@ import {
 import { cn } from "@deco/ui/lib/utils.ts";
 import { type ReactNode, Suspense } from "react";
 import { SidebarCollapsibleGroup } from "./sidebar-group";
+import { SidebarLogoHeader } from "./sidebar-logo-header";
 import type { NavigationSidebarItem, SidebarSection } from "./types";
-
-function MobileLogoHeader() {
-  const config = usePublicConfig();
-  const logo = config.logo ?? DEFAULT_LOGO;
-  const lightSrc = typeof logo === "string" ? logo : logo.light;
-  const darkSrc = typeof logo === "string" ? logo : logo.dark;
-
-  return (
-    <SidebarHeader className="flex flex-row items-center shrink-0 h-12 px-3 pb-0">
-      <img
-        src={lightSrc}
-        alt="Logo"
-        className="size-6 object-contain dark:hidden"
-      />
-      <img
-        src={darkSrc}
-        alt="Logo"
-        className="size-6 object-contain hidden dark:block"
-      />
-    </SidebarHeader>
-  );
-}
 
 function MobileNavigationItem({
   item,
@@ -132,8 +109,8 @@ export function MobileNavigationSidebar({
       className="bg-sidebar flex h-full w-full flex-col"
       data-sidebar="sidebar"
     >
-      <Suspense fallback={<div className="h-10 shrink-0" />}>
-        <MobileLogoHeader />
+      <Suspense fallback={<div className="h-12 shrink-0" />}>
+        <SidebarLogoHeader onToggle={onClose} />
       </Suspense>
       <SidebarContent className="flex flex-col flex-1 px-2 py-2 gap-0">
         {sections.map((section, index) => (

--- a/apps/mesh/src/web/components/sidebar/navigation.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation.tsx
@@ -18,6 +18,7 @@ import { track } from "@/web/lib/posthog-client";
 
 interface NavigationSidebarProps {
   sections: SidebarSection[];
+  header?: ReactNode;
   footer?: ReactNode;
   additionalContent?: ReactNode;
   variant?: "sidebar" | "floating" | "inset";
@@ -93,6 +94,7 @@ function SidebarSectionRenderer({ section }: { section: SidebarSection }) {
  */
 function NavigationSidebarInner({
   sections,
+  header,
   footer,
   additionalContent,
   variant = "sidebar",
@@ -100,6 +102,7 @@ function NavigationSidebarInner({
 }: NavigationSidebarProps) {
   return (
     <Sidebar variant={variant}>
+      {header}
       <SidebarContent
         className={cn(
           "flex flex-col flex-1 px-2 py-2 gap-0.5",

--- a/apps/mesh/src/web/components/sidebar/sidebar-logo-header.tsx
+++ b/apps/mesh/src/web/components/sidebar/sidebar-logo-header.tsx
@@ -1,0 +1,69 @@
+import { DEFAULT_LOGO, usePublicConfig } from "@/web/hooks/use-public-config";
+import { SidebarHeader } from "@deco/ui/components/sidebar.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { LayoutLeft } from "@untitledui/icons";
+import { LinkedDesktopIndicator } from "@/web/components/header/linked-desktop-indicator";
+import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
+
+interface SidebarLogoHeaderProps {
+  /** Collapse / close the sidebar. */
+  onToggle: () => void;
+  className?: string;
+}
+
+/**
+ * Logo + sidebar-collapse toggle + linked-desktop indicator rendered at the top
+ * of the sidebar panel. Pixel-matches the shell toolbar header (logo, trigger,
+ * desktop indicator), so the row lines up with the header at every breakpoint:
+ *
+ *   - Row: `h-12`, `pt-0.25`, vertically centered (mirrors `ToolbarHeader`).
+ *     We must set every padding side explicitly because `SidebarHeader`
+ *     defaults to `p-2`, which would otherwise push the row down.
+ *   - Logo left edge sits at 1rem: container `pl-1` + logo wrapper `pl-1` +
+ *     inner `px-2` — the same nesting as `ToolbarLogoLink` > `ToolbarLogoInner`.
+ *   - Gap: `gap-2` on mobile / `gap-0.5` on desktop (mobile header grid gap vs
+ *     desktop `ToolbarLeftColumn` gap).
+ *   - Buttons use `ToolbarIconButton` (`size-10 md:size-7`) — the exact button
+ *     used by the header trigger and the desktop indicator.
+ */
+export function SidebarLogoHeader({
+  onToggle,
+  className,
+}: SidebarLogoHeaderProps) {
+  const config = usePublicConfig();
+  const logo = config.logo ?? DEFAULT_LOGO;
+  const lightSrc = typeof logo === "string" ? logo : logo.light;
+  const darkSrc = typeof logo === "string" ? logo : logo.dark;
+
+  return (
+    <SidebarHeader
+      className={cn(
+        "flex flex-row items-center gap-2 md:gap-0.5 shrink-0 h-12 pl-1 pr-2 pt-0.25 pb-0",
+        // The desktop sidebar collapses to a narrow icon rail where a logo +
+        // toggle row can't fit; hide it there (the toolbar trigger reopens it).
+        // The mobile drawer is always expanded, so it stays visible.
+        "group-data-[collapsible=icon]/sidebar:hidden",
+        className,
+      )}
+    >
+      <span className="flex items-center shrink-0 pl-1">
+        <span className="flex items-center shrink-0 px-2">
+          <img
+            src={lightSrc}
+            alt="Logo"
+            className="size-6 object-contain dark:hidden"
+          />
+          <img
+            src={darkSrc}
+            alt="Logo"
+            className="size-6 object-contain hidden dark:block"
+          />
+        </span>
+      </span>
+      <ToolbarIconButton onClick={onToggle} aria-label="Toggle sidebar">
+        <LayoutLeft size={16} />
+      </ToolbarIconButton>
+      <LinkedDesktopIndicator />
+    </SidebarHeader>
+  );
+}

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -73,7 +73,11 @@ const GROUP_BY_LABELS: Record<GroupBy, string> = {
   status: "Status",
 };
 
-export function TaskGroupsList() {
+export function TaskGroupsList({
+  onNavigate,
+}: {
+  onNavigate?: () => void;
+} = {}) {
   const { data: session } = authClient.useSession();
   const currentUserId = session?.user?.id;
   const sidebarUserId = currentUserId ?? "anon";
@@ -128,6 +132,9 @@ export function TaskGroupsList() {
     taskId?: string;
   };
   const activeTaskId = params.taskId ?? null;
+  const closeAfterNavigation = () => {
+    onNavigate?.();
+  };
 
   const sortedThreads = [...visibleThreads].sort((a, b) =>
     (b.updated_at ?? "").localeCompare(a.updated_at ?? ""),
@@ -191,6 +198,7 @@ export function TaskGroupsList() {
         t.virtual_mcp_id === task.virtual_mcp_id &&
         t.created_by === currentUserId,
     );
+    closeAfterNavigation();
     if (next) {
       setTaskId(next.id, next.virtual_mcp_id);
     } else {
@@ -200,12 +208,14 @@ export function TaskGroupsList() {
 
   const handleNewInGroup = (virtualMcpId: string) => {
     track("sidebar_group_new_clicked", { virtual_mcp_id: virtualMcpId });
+    closeAfterNavigation();
     createNewTask(virtualMcpId);
   };
 
   const navigateToAgent = useNavigateToAgent();
   const handleShowSettings = (virtualMcpId: string) => {
     track("sidebar_group_settings_clicked", { virtual_mcp_id: virtualMcpId });
+    closeAfterNavigation();
     navigateToAgent(virtualMcpId, { search: { main: "instructions" } });
   };
 
@@ -263,7 +273,10 @@ export function TaskGroupsList() {
       activeTaskId,
       filters,
       groupVisibleCount: agentThreadCounts.get(group.virtualMcpId) ?? 0,
-      onSelectTask: (t: Task) => setTaskId(t.id, t.virtual_mcp_id),
+      onSelectTask: (t: Task) => {
+        closeAfterNavigation();
+        setTaskId(t.id, t.virtual_mcp_id);
+      },
       onArchiveTask: handleArchive,
       onNewTaskInGroup: handleNewInGroup,
       onShowSettings: handleShowSettings,
@@ -419,7 +432,10 @@ export function TaskGroupsList() {
                 status={group.status}
                 threads={group.threads}
                 activeTaskId={activeTaskId}
-                onSelectTask={(t) => setTaskId(t.id, t.virtual_mcp_id)}
+                onSelectTask={(t) => {
+                  closeAfterNavigation();
+                  setTaskId(t.id, t.virtual_mcp_id);
+                }}
                 onArchiveTask={handleArchive}
                 filters={filters}
               />

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -41,18 +41,8 @@ import { useChatPrefs } from "@/web/components/chat/context";
 import { ChatPanel } from "@/web/components/chat/side-panel-chat";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
-import { StudioSidebarMobile } from "@/web/components/sidebar";
-import { useSidebar } from "@deco/ui/components/sidebar.tsx";
-import { Sheet, SheetContent, SheetTitle } from "@deco/ui/components/sheet.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
-import {
-  AlertCircle,
-  Edit05,
-  Loading01,
-  Menu01,
-  MessageCircle01,
-} from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.js";
+import { AlertCircle, Loading01 } from "@untitledui/icons";
 import {
   getWellKnownDecopilotVirtualMCP,
   useProjectContext,
@@ -72,6 +62,7 @@ import { Toolbar } from "./toolbar";
 import { ChatMainPanelGroup } from "./chat-main-panel-group";
 import { ToggleButtons } from "./toggle-buttons";
 import { MainPanelTabsBar } from "@/web/layouts/main-panel-tabs/main-panel-tabs-bar";
+import { MobileMainPanelTabSelect } from "@/web/layouts/main-panel-tabs/mobile-main-panel-tab-select";
 import { MainPanelWithDrawer } from "@/web/layouts/main-panel-tabs/main-panel-with-drawer";
 import { VirtualMcpHeaderInfo } from "../../views/virtual-mcp/header-info.tsx";
 import { SandboxEventsProvider } from "@/web/components/sandbox/hooks/sandbox-events-context.tsx";
@@ -132,69 +123,6 @@ function NewTaskBridge({
     };
   });
   return null;
-}
-
-function MobileToolbar({
-  onOpenSidebar,
-  virtualMcpId,
-  taskId,
-  mainOpen,
-  onToggleMain,
-  onNewTask,
-  entity,
-  hasActiveGithubRepo,
-}: {
-  onOpenSidebar: () => void;
-  virtualMcpId: string;
-  taskId: string;
-  mainOpen: boolean;
-  onToggleMain: () => void;
-  onNewTask: () => void;
-  entity: VirtualMCPEntity | null;
-  hasActiveGithubRepo: boolean;
-}) {
-  return (
-    <div className="shrink-0 flex items-center gap-1 px-2 h-12 bg-background border-b border-border">
-      <button
-        type="button"
-        onClick={onOpenSidebar}
-        className="flex size-8 shrink-0 items-center justify-center rounded-md text-foreground/60 hover:bg-accent hover:text-foreground transition-colors"
-        aria-label="Open menu"
-      >
-        <Menu01 size={20} />
-      </button>
-      <div className="flex-1 min-w-0 overflow-x-auto [scrollbar-width:none]">
-        <MainPanelTabsBar virtualMcpId={virtualMcpId} taskId={taskId} />
-      </div>
-      <div className="flex items-center gap-0.5 shrink-0">
-        {entity && hasActiveGithubRepo ? (
-          <VirtualMcpHeaderInfo virtualMcp={entity} inline />
-        ) : null}
-        <button
-          type="button"
-          onClick={onToggleMain}
-          aria-pressed={!mainOpen}
-          className={cn(
-            "flex size-7 shrink-0 items-center justify-center rounded-md transition-colors",
-            !mainOpen
-              ? "bg-accent text-foreground"
-              : "text-foreground/60 hover:bg-accent hover:text-foreground",
-          )}
-          title="Chat"
-        >
-          <MessageCircle01 size={16} />
-        </button>
-        <button
-          type="button"
-          onClick={onNewTask}
-          className="flex size-7 shrink-0 items-center justify-center rounded-md text-foreground/60 hover:bg-accent hover:text-foreground transition-colors"
-          title="New task"
-        >
-          <Edit05 size={16} />
-        </button>
-      </div>
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -320,9 +248,6 @@ function AgentInsetProvider() {
     isAgentRoute: true,
   });
 
-  const { setOpenMobile, openMobile: mobileSidebarOpen } = useSidebar();
-  const setMobileSidebarOpen = setOpenMobile;
-
   const onNewTask = useRef<(() => void) | null>(null);
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — subscribes to document keydown for ⇧⌘S new-task shortcut; DOM event listener has no React 19 alternative
@@ -402,28 +327,6 @@ function AgentInsetProvider() {
 
   // Mobile layout — unchanged semantics, just inlined here for clarity.
   if (isMobile) {
-    const mobileSidebarSheet = (
-      <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
-        <SheetContent
-          side="left"
-          hideCloseButton
-          className="w-[calc(100vw-3rem)] sm:max-w-md! p-0"
-        >
-          <SheetTitle className="sr-only">Navigation</SheetTitle>
-          <div className="flex h-full">
-            <div
-              className="w-full bg-sidebar flex flex-col overflow-y-auto group/sidebar"
-              data-state="expanded"
-            >
-              <StudioSidebarMobile
-                onClose={() => setMobileSidebarOpen(false)}
-              />
-            </div>
-          </div>
-        </SheetContent>
-      </Sheet>
-    );
-
     return (
       <InsetContext value={insetContextValue}>
         <div className="flex flex-col flex-1 min-w-0 bg-background min-h-0">
@@ -445,16 +348,19 @@ function AgentInsetProvider() {
                 key={layout.taskId}
                 taskId={layout.taskId}
               >
-                <MobileToolbar
-                  onOpenSidebar={() => setMobileSidebarOpen(true)}
-                  virtualMcpId={chatVirtualMcpId}
-                  taskId={layout.taskId}
-                  mainOpen={layout.mainOpen}
-                  onToggleMain={layout.toggleMain}
-                  onNewTask={layout.createNewTask}
-                  entity={entity}
-                  hasActiveGithubRepo={hasActiveGithubRepo}
-                />
+                <Toolbar.Toggles>
+                  <ToggleButtons
+                    chatOpen={!layout.mainOpen}
+                    toggleChat={layout.toggleMain}
+                    onNewTask={layout.createNewTask}
+                  />
+                </Toolbar.Toggles>
+                <Toolbar.Tabs>
+                  <MobileMainPanelTabSelect
+                    virtualMcpId={chatVirtualMcpId}
+                    taskId={layout.taskId}
+                  />
+                </Toolbar.Tabs>
                 <Suspense fallback={<Chat.Skeleton />}>
                   <div className="flex-1 min-h-0 overflow-hidden">
                     {layout.mainOpen ? (
@@ -487,7 +393,6 @@ function AgentInsetProvider() {
                   </div>
                 </Suspense>
               </Chat.ActiveTaskProvider>
-              {mobileSidebarSheet}
             </VmEventsBridge>
           </Chat.Provider>
         </div>

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -353,6 +353,7 @@ function AgentInsetProvider() {
                     chatOpen={!layout.mainOpen}
                     toggleChat={layout.toggleMain}
                     onNewTask={layout.createNewTask}
+                    newTaskFirst
                   />
                 </Toolbar.Toggles>
                 <Toolbar.Tabs>

--- a/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
@@ -11,43 +11,64 @@ export interface ToggleButtonsProps {
   chatOpen: boolean;
   toggleChat: () => void;
   onNewTask?: () => void;
+  /**
+   * When true, render the New task button before the Chat button. Used on
+   * mobile, where new thread sits on the left and chat on the right.
+   */
+  newTaskFirst?: boolean;
 }
 
 export function ToggleButtons({
   chatOpen,
   toggleChat,
   onNewTask,
+  newTaskFirst = false,
 }: ToggleButtonsProps) {
+  const chatButton = (
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <ToolbarIconButton
+          onClick={() => {
+            track("agent_toolbar_toggled", {
+              button: "chat",
+              next_state: !chatOpen ? "open" : "closed",
+            });
+            toggleChat();
+          }}
+          aria-pressed={chatOpen}
+          aria-label="Chat"
+          active={chatOpen}
+        >
+          <MessageCircle01 size={16} />
+        </ToolbarIconButton>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Chat</TooltipContent>
+    </Tooltip>
+  );
+
+  const newTaskButton = onNewTask && (
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <ToolbarIconButton onClick={onNewTask} aria-label="New task">
+          <Edit05 size={16} />
+        </ToolbarIconButton>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">New task</TooltipContent>
+    </Tooltip>
+  );
+
   return (
     <>
-      <Tooltip delayDuration={300}>
-        <TooltipTrigger asChild>
-          <ToolbarIconButton
-            onClick={() => {
-              track("agent_toolbar_toggled", {
-                button: "chat",
-                next_state: !chatOpen ? "open" : "closed",
-              });
-              toggleChat();
-            }}
-            aria-pressed={chatOpen}
-            aria-label="Chat"
-            active={chatOpen}
-          >
-            <MessageCircle01 size={16} />
-          </ToolbarIconButton>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Chat</TooltipContent>
-      </Tooltip>
-      {onNewTask && (
-        <Tooltip delayDuration={300}>
-          <TooltipTrigger asChild>
-            <ToolbarIconButton onClick={onNewTask} aria-label="New task">
-              <Edit05 size={16} />
-            </ToolbarIconButton>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">New task</TooltipContent>
-        </Tooltip>
+      {newTaskFirst ? (
+        <>
+          {newTaskButton}
+          {chatButton}
+        </>
+      ) : (
+        <>
+          {chatButton}
+          {newTaskButton}
+        </>
       )}
     </>
   );

--- a/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
@@ -14,10 +14,18 @@
  * <Toolbar.Toggles> / <Toolbar.Right> (createPortal). Never suspends itself.
  */
 
-import { createContext, Suspense, use, useState, type ReactNode } from "react";
+import {
+  createContext,
+  Suspense,
+  use,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
 import { createPortal } from "react-dom";
 import { Link, useParams } from "@tanstack/react-router";
 import { ChevronLeft, ChevronRight } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
 import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
 import { DEFAULT_LOGO, usePublicConfig } from "@/web/hooks/use-public-config";
 
@@ -77,9 +85,19 @@ export function Toolbar({ children }: { children?: ReactNode }) {
  * mode; in a regular browser tab the fallbacks (0 left/right, 3rem height)
  * give the standard h-12 toolbar.
  */
-function ToolbarHeader({ children }: { children?: ReactNode }) {
+function ToolbarHeader({
+  children,
+  className,
+  ...props
+}: ComponentProps<"div">) {
   return (
-    <div className="app-titlebar wco-drag shrink-0 grid grid-cols-3 items-center pl-1 pr-2 pt-0.25 h-12 bg-sidebar">
+    <div
+      className={cn(
+        "app-titlebar wco-drag shrink-0 grid grid-cols-3 items-center pl-1 pr-2 pt-0.25 h-12 bg-sidebar",
+        className,
+      )}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -186,9 +204,14 @@ function ToolbarCenter({ children }: { children: ReactNode }) {
   return createPortal(children, centerEl);
 }
 
-function ToolbarTabsSlot() {
+function ToolbarTabsSlot({ className }: { className?: string }) {
   const { setTabsEl } = useToolbarCtx();
-  return <div ref={setTabsEl} className="shrink-0 flex items-center" />;
+  return (
+    <div
+      ref={setTabsEl}
+      className={cn("shrink-0 flex items-center", className)}
+    />
+  );
 }
 
 function ToolbarTabs({ children }: { children: ReactNode }) {
@@ -197,12 +220,12 @@ function ToolbarTabs({ children }: { children: ReactNode }) {
   return createPortal(children, tabsEl);
 }
 
-function ToolbarTogglesSlot() {
+function ToolbarTogglesSlot({ className }: { className?: string }) {
   const { setTogglesEl } = useToolbarCtx();
   // `display: contents` keeps the div as a portal target (we need the
   // ref) but produces no layout box, so the toggle buttons become direct
   // flex children of Toolbar.LeftColumn and inherit its gap.
-  return <div ref={setTogglesEl} className="contents" />;
+  return <div ref={setTogglesEl} className={cn("contents", className)} />;
 }
 
 function ToolbarToggles({ children }: { children: ReactNode }) {

--- a/apps/mesh/src/web/layouts/main-panel-tabs/header-tab-button.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/header-tab-button.tsx
@@ -8,9 +8,9 @@
  * title is discoverable on hover in both states.
  */
 
-import { Package } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
 import type { TabIcon } from "./resolve-tab-icon";
+import { TabIconGlyph } from "./tab-icon-glyph";
 
 export function HeaderTabButton({
   title,
@@ -38,24 +38,11 @@ export function HeaderTabButton({
       )}
     >
       <span className="flex size-5 items-center justify-center shrink-0">
-        <Icon icon={icon} />
+        <TabIconGlyph icon={icon} />
       </span>
       <span className="whitespace-nowrap text-sm font-medium leading-none">
         {title}
       </span>
     </button>
   );
-}
-
-function Icon({ icon }: { icon: TabIcon }) {
-  if (icon.kind === "component") {
-    const { Component } = icon;
-    return <Component className="size-4" />;
-  }
-  if (icon.kind === "url") {
-    return (
-      <img src={icon.src} alt="" className="size-4 rounded-sm object-cover" />
-    );
-  }
-  return <Package className="size-4" />;
 }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/mobile-main-panel-tab-select.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/mobile-main-panel-tab-select.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { resolveMobileMainPanelTabSelectLabel } from "./mobile-main-panel-tab-select";
+
+const tabs = [
+  { id: "preview", title: "Preview" },
+  { id: "settings", title: "Settings" },
+];
+
+describe("resolveMobileMainPanelTabSelectLabel", () => {
+  test("shows the active tab while the main panel is open", () => {
+    expect(
+      resolveMobileMainPanelTabSelectLabel({
+        tabs,
+        activeTab: "settings",
+        mainOpen: true,
+      }),
+    ).toBe("Settings");
+  });
+
+  test("shows Main view for transient open tabs that are not selectable", () => {
+    expect(
+      resolveMobileMainPanelTabSelectLabel({
+        tabs,
+        activeTab: "file:model-output%2Fpreview.pdf",
+        mainOpen: true,
+      }),
+    ).toBe("Main view");
+  });
+
+  test("shows the default active tab while the main panel is closed", () => {
+    expect(
+      resolveMobileMainPanelTabSelectLabel({
+        tabs,
+        activeTab: "settings",
+        mainOpen: false,
+      }),
+    ).toBe("Settings");
+  });
+
+  test("falls back to the first tab while closed when the default tab is unavailable", () => {
+    expect(
+      resolveMobileMainPanelTabSelectLabel({
+        tabs,
+        activeTab: "git",
+        mainOpen: false,
+      }),
+    ).toBe("Preview");
+  });
+
+  test("falls back to Main view when there are no tabs", () => {
+    expect(
+      resolveMobileMainPanelTabSelectLabel({
+        tabs: [],
+        activeTab: "settings",
+        mainOpen: false,
+      }),
+    ).toBe("Main view");
+  });
+});

--- a/apps/mesh/src/web/layouts/main-panel-tabs/mobile-main-panel-tab-select.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/mobile-main-panel-tab-select.tsx
@@ -10,6 +10,7 @@ import {
   resolveAutomationsPillClickTarget,
 } from "./tab-id";
 import { useMainPanelTabs, type Tab } from "./use-main-panel-tabs";
+import { TabIconGlyph } from "./tab-icon-glyph";
 import { track } from "@/web/lib/posthog-client";
 
 const MOBILE_SELECT_SENTINEL = "__mobile-main-panel-tab-select__";
@@ -45,6 +46,8 @@ export function MobileMainPanelTabSelect({
     activeTab,
     mainOpen,
   });
+  const selectedTab =
+    tabs.find((tab) => tab.id === activeTab) ?? (!mainOpen ? tabs[0] : null);
   const automationsActive = isAutomationsPillActive({ activeTab, mainOpen });
 
   const handleSelect = (id: string) => {
@@ -72,11 +75,24 @@ export function MobileMainPanelTabSelect({
 
   return (
     <Select value={MOBILE_SELECT_SENTINEL} onValueChange={handleSelect}>
+      {/*
+        Clean, borderless trigger: the SelectTrigger's default box-shadow
+        "border" is the `card-shadow` utility, which reads var(--card-shadow).
+        We null that variable on this element (`[--card-shadow:none]`) instead
+        of `card-shadow-none`, which is not a real utility.
+      */}
       <SelectTrigger
         aria-label="Main panel tab"
-        className="h-10 w-full min-w-0 max-w-[9rem] rounded-md bg-transparent px-2 text-xs shadow-none card-shadow-none"
+        className="h-10! w-full min-w-0 max-w-[7.5rem] rounded-md border-0 bg-transparent px-1.5 text-xs shadow-none [--card-shadow:none]"
       >
-        <span className="min-w-0 truncate">{label}</span>
+        <span className="flex min-w-0 items-center gap-1.5">
+          {selectedTab && (
+            <span className="flex size-4 shrink-0 items-center justify-center">
+              <TabIconGlyph icon={selectedTab.icon} />
+            </span>
+          )}
+          <span className="min-w-0 truncate">{label}</span>
+        </span>
       </SelectTrigger>
       <SelectContent align="end" className="w-56">
         <SelectItem
@@ -89,7 +105,12 @@ export function MobileMainPanelTabSelect({
         </SelectItem>
         {tabs.map((tab: Tab) => (
           <SelectItem key={tab.id} value={tab.id}>
-            {tab.title}
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="flex size-5 shrink-0 items-center justify-center">
+                <TabIconGlyph icon={tab.icon} />
+              </span>
+              <span className="min-w-0 truncate">{tab.title}</span>
+            </span>
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/mesh/src/web/layouts/main-panel-tabs/mobile-main-panel-tab-select.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/mobile-main-panel-tab-select.tsx
@@ -1,0 +1,98 @@
+import { useNavigate } from "@tanstack/react-router";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@deco/ui/components/select.tsx";
+import {
+  isAutomationsPillActive,
+  resolveAutomationsPillClickTarget,
+} from "./tab-id";
+import { useMainPanelTabs, type Tab } from "./use-main-panel-tabs";
+import { track } from "@/web/lib/posthog-client";
+
+const MOBILE_SELECT_SENTINEL = "__mobile-main-panel-tab-select__";
+
+export function resolveMobileMainPanelTabSelectLabel({
+  tabs,
+  activeTab,
+  mainOpen,
+}: {
+  tabs: Array<{ id: string; title: string }>;
+  activeTab: string;
+  mainOpen: boolean;
+}): string {
+  const active = tabs.find((tab) => tab.id === activeTab);
+  if (mainOpen) return active?.title ?? "Main view";
+  return active?.title ?? tabs[0]?.title ?? "Main view";
+}
+
+export function MobileMainPanelTabSelect({
+  virtualMcpId,
+  taskId,
+}: {
+  virtualMcpId: string;
+  taskId: string;
+}) {
+  const navigate = useNavigate();
+  const { tabs, activeTab, mainOpen, setActiveTab } = useMainPanelTabs({
+    virtualMcpId,
+    taskId,
+  });
+  const label = resolveMobileMainPanelTabSelectLabel({
+    tabs,
+    activeTab,
+    mainOpen,
+  });
+  const automationsActive = isAutomationsPillActive({ activeTab, mainOpen });
+
+  const handleSelect = (id: string) => {
+    if (id === MOBILE_SELECT_SENTINEL) return;
+    const clicked = tabs.find((tab) => tab.id === id);
+    track("main_panel_tab_clicked", {
+      virtual_mcp_id: virtualMcpId,
+      tab_id: id,
+      tab_kind: clicked?.kind ?? null,
+      was_active:
+        id === "automations" ? automationsActive : mainOpen && activeTab === id,
+      source: "mobile_select",
+    });
+    if (id === "automations") {
+      const target = resolveAutomationsPillClickTarget({ activeTab, mainOpen });
+      navigate({
+        to: ".",
+        search: (prev: Record<string, unknown>) => ({ ...prev, main: target }),
+        replace: true,
+      });
+      return;
+    }
+    setActiveTab(id);
+  };
+
+  return (
+    <Select value={MOBILE_SELECT_SENTINEL} onValueChange={handleSelect}>
+      <SelectTrigger
+        aria-label="Main panel tab"
+        className="h-10 w-full min-w-0 max-w-[9rem] rounded-md bg-transparent px-2 text-xs shadow-none card-shadow-none"
+      >
+        <span className="min-w-0 truncate">{label}</span>
+      </SelectTrigger>
+      <SelectContent align="end" className="w-56">
+        <SelectItem
+          value={MOBILE_SELECT_SENTINEL}
+          disabled
+          hideCheck
+          className="hidden"
+        >
+          {label}
+        </SelectItem>
+        {tabs.map((tab: Tab) => (
+          <SelectItem key={tab.id} value={tab.id}>
+            {tab.title}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-icon-glyph.test.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-icon-glyph.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { LayoutAlt04 } from "@untitledui/icons";
+import { TabIconGlyph } from "./tab-icon-glyph";
+
+describe("TabIconGlyph", () => {
+  test("renders component icons", () => {
+    const html = renderToStaticMarkup(
+      <TabIconGlyph icon={{ kind: "component", Component: LayoutAlt04 }} />,
+    );
+
+    expect(html).toContain("<svg");
+  });
+
+  test("renders URL icons as decorative images", () => {
+    const html = renderToStaticMarkup(
+      <TabIconGlyph
+        icon={{ kind: "url", src: "https://example.com/icon.png" }}
+      />,
+    );
+
+    expect(html).toContain("<img");
+    expect(html).toContain('src="https://example.com/icon.png"');
+    expect(html).toContain('alt=""');
+  });
+
+  test("renders a fallback icon", () => {
+    const html = renderToStaticMarkup(
+      <TabIconGlyph icon={{ kind: "fallback" }} />,
+    );
+
+    expect(html).toContain("<svg");
+  });
+});

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-icon-glyph.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-icon-glyph.tsx
@@ -1,0 +1,15 @@
+import { Package } from "@untitledui/icons";
+import type { TabIcon } from "./resolve-tab-icon";
+
+export function TabIconGlyph({ icon }: { icon: TabIcon }) {
+  if (icon.kind === "component") {
+    const { Component } = icon;
+    return <Component className="size-4" />;
+  }
+  if (icon.kind === "url") {
+    return (
+      <img src={icon.src} alt="" className="size-4 rounded-sm object-cover" />
+    );
+  }
+  return <Package className="size-4" />;
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-overflow-menu.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-overflow-menu.tsx
@@ -8,13 +8,14 @@
  */
 
 import { useState } from "react";
-import { DotsHorizontal, Package } from "@untitledui/icons";
+import { DotsHorizontal } from "@untitledui/icons";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@deco/ui/components/popover.tsx";
 import type { TabIcon } from "./resolve-tab-icon";
+import { TabIconGlyph } from "./tab-icon-glyph";
 
 type OverflowTab = {
   id: string;
@@ -58,7 +59,7 @@ export function TabOverflowMenu({
                 className="w-full flex items-center gap-2 px-3 py-2 rounded-md hover:bg-accent text-sm text-foreground"
               >
                 <span className="flex size-5 items-center justify-center shrink-0">
-                  <OverflowIcon icon={tab.icon} />
+                  <TabIconGlyph icon={tab.icon} />
                 </span>
                 <span className="truncate">{tab.title}</span>
               </button>
@@ -68,17 +69,4 @@ export function TabOverflowMenu({
       </PopoverContent>
     </Popover>
   );
-}
-
-function OverflowIcon({ icon }: { icon: TabIcon }) {
-  if (icon.kind === "component") {
-    const { Component } = icon;
-    return <Component className="size-4" />;
-  }
-  if (icon.kind === "url") {
-    return (
-      <img src={icon.src} alt="" className="size-4 rounded-sm object-cover" />
-    );
-  }
-  return <Package className="size-4" />;
 }

--- a/apps/mesh/src/web/layouts/org-plugin-layout.tsx
+++ b/apps/mesh/src/web/layouts/org-plugin-layout.tsx
@@ -22,7 +22,7 @@ export default function OrgPluginLayout() {
     return (
       <Suspense
         fallback={
-          <div className="flex flex-col items-center justify-center h-full">
+          <div className="flex flex-col items-center justify-center h-full w-full">
             <Loading01
               size={32}
               className="animate-spin text-muted-foreground mb-4"
@@ -54,7 +54,7 @@ export default function OrgPluginLayout() {
   return (
     <Suspense
       fallback={
-        <div className="flex flex-col items-center justify-center h-full">
+        <div className="flex flex-col items-center justify-center h-full w-full">
           <Loading01
             size={32}
             className="animate-spin text-muted-foreground mb-4"

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -58,24 +58,39 @@ export default function OrgShellLayout() {
         <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
           <ChatPrefsProvider>
             <div className="app-shell-root flex flex-col h-dvh overflow-hidden">
-              <Toolbar.Header>
-                <Toolbar.LeftColumn>
-                  <Toolbar.LogoLink />
-                  <SidebarTriggerButton />
-                  <span className="hidden md:contents">
-                    <Toolbar.Nav />
-                  </span>
-                  <Toolbar.TogglesSlot />
-                  <LinkedDesktopIndicator />
-                </Toolbar.LeftColumn>
-                <Toolbar.CenterSlot />
-                <Toolbar.RightColumn>
-                  <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] flex justify-end">
-                    <Toolbar.TabsSlot />
+              {isMobile ? (
+                <Toolbar.Header className="grid-cols-1 px-1 pr-1">
+                  <div className="grid w-full grid-cols-[auto_auto_auto_1fr_auto_auto_minmax(6.5rem,9rem)] items-center gap-1">
+                    <Toolbar.LogoLink />
+                    <SidebarTriggerButton />
+                    <LinkedDesktopIndicator />
+                    <div aria-hidden className="min-w-0" />
+                    <Toolbar.TogglesSlot />
+                    <Toolbar.TabsSlot className="min-w-0 justify-self-end" />
                   </div>
+                  <Toolbar.CenterSlot />
                   <Toolbar.RightSlot />
-                </Toolbar.RightColumn>
-              </Toolbar.Header>
+                </Toolbar.Header>
+              ) : (
+                <Toolbar.Header>
+                  <Toolbar.LeftColumn>
+                    <Toolbar.LogoLink />
+                    <SidebarTriggerButton />
+                    <span className="hidden md:contents">
+                      <Toolbar.Nav />
+                    </span>
+                    <Toolbar.TogglesSlot />
+                    <LinkedDesktopIndicator />
+                  </Toolbar.LeftColumn>
+                  <Toolbar.CenterSlot />
+                  <Toolbar.RightColumn>
+                    <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] flex justify-end">
+                      <Toolbar.TabsSlot />
+                    </div>
+                    <Toolbar.RightSlot />
+                  </Toolbar.RightColumn>
+                </Toolbar.Header>
+              )}
               <SidebarLayout
                 ref={wrapperRef}
                 className="flex-1 bg-sidebar relative min-h-0"

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -60,7 +60,7 @@ export default function OrgShellLayout() {
             <div className="app-shell-root flex flex-col h-dvh overflow-hidden">
               {isMobile ? (
                 <Toolbar.Header className="grid-cols-1 px-1 pr-1">
-                  <div className="grid w-full grid-cols-[auto_auto_auto_1fr_auto_auto_minmax(6.5rem,9rem)] items-center gap-1">
+                  <div className="grid w-full grid-cols-[auto_auto_auto_1fr_auto_auto_auto] items-center gap-2">
                     <Toolbar.LogoLink />
                     <SidebarTriggerButton />
                     <LinkedDesktopIndicator />

--- a/apps/mesh/src/web/layouts/plugin-layout.tsx
+++ b/apps/mesh/src/web/layouts/plugin-layout.tsx
@@ -152,7 +152,7 @@ export function PluginLayout({
   // Show loading state while fetching config
   if (isLoadingConfig) {
     return (
-      <div className="flex flex-col items-center justify-center h-full">
+      <div className="flex flex-col items-center justify-center h-full w-full">
         <Loading01
           size={32}
           className="animate-spin text-muted-foreground mb-4"

--- a/apps/mesh/src/web/layouts/shell-controls.tsx
+++ b/apps/mesh/src/web/layouts/shell-controls.tsx
@@ -30,7 +30,7 @@ export function MobileSidebarSheet({ renderSidebar }: MobileSidebarSheetProps) {
       <SheetContent
         side="left"
         hideCloseButton
-        className="w-[calc(100vw-3rem)] sm:max-w-md! p-0"
+        className="w-screen max-w-none! p-0"
       >
         <SheetTitle className="sr-only">Navigation</SheetTitle>
         {renderSidebar({ onClose: () => setOpenMobile(false) })}

--- a/apps/mesh/src/web/layouts/shell-route-loading.tsx
+++ b/apps/mesh/src/web/layouts/shell-route-loading.tsx
@@ -4,7 +4,7 @@ export function ShellRouteLoading() {
   return (
     <div
       data-testid="shell-route-loading"
-      className="absolute inset-0 flex items-center justify-center"
+      className="absolute inset-0 h-full w-full flex items-center justify-center"
     >
       <Loading01 size={20} className="animate-spin text-muted-foreground" />
     </div>


### PR DESCRIPTION
## Summary
Polish pass on the shell header and sidebar controls (mobile + desktop).

- **Mobile header button order** — new task on the left, chat on the right. `ToggleButtons` gains a `newTaskFirst` prop; desktop order is unchanged.
- **Sidebar logo header** — new shared `SidebarLogoHeader` (deco logo + collapse toggle + linked-desktop indicator) at the top of the sidebar, used by both the mobile drawer and the desktop sidebar. Pixel-aligned to the toolbar header (`h-12`, `pt-0.25`, nested `pl-1`/`px-2` logo, `gap-2` mobile / `gap-0.5` desktop, shared `ToolbarIconButton`). Auto-hides on the collapsed desktop icon rail.
- **Shared `TabIconGlyph`** — extracted from the duplicated icon renderers in `header-tab-button` and `tab-overflow-menu`; reused by the mobile tab select.
- **Mobile tab select** — forced `h-10!` so it matches the header icon buttons (the default `data-[size=default]:h-8` out-specifies a plain `h-10`), and removed the `card-shadow` "border" via `[--card-shadow:none]` for a cleaner trigger.

## Testing
- `bun run --cwd apps/mesh check` → pass (exit 0)
- `bun test .../tab-icon-glyph.test.tsx` → 3 pass
- `bun run fmt` clean for all changed files (the only `fmt:check` miss is `org/public/storefront/...check-slugs.ts`, outside this repo's tree and untouched here).

## Notes
On desktop, the top toolbar still renders its own logo / sidebar trigger / desktop indicator above the sidebar's new header row, so those appear in both places when the sidebar is expanded. Happy to hide the toolbar copies on desktop in a follow-up if the duplication looks off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the shell header and sidebar on mobile and desktop to align visuals, simplify controls, and improve navigation. Adds a shared sidebar logo header, a mobile tab selector, and reorders mobile toggle buttons for better ergonomics.

- **New Features**
  - Added a shared `SidebarLogoHeader` (logo + collapse toggle + linked‑desktop indicator) at the top of the sidebar; used in both mobile drawer and desktop, and auto‑hides in the collapsed rail.
  - Mobile header polish: introduced `MobileMainPanelTabSelect` with consistent h-10 and a clean, borderless trigger; toggles reordered so New task is left and Chat is right via `newTaskFirst`.
  - Extracted `TabIconGlyph` to deduplicate icon rendering across tab controls and menus.

- **Bug Fixes**
  - Mobile sidebar now closes after selecting a task or opening settings; navigation close is correctly wired to `StudioSidebarMobile` only.
  - Mobile drawer opens full‑width; plugin and shell loading spinners are properly centered.
  - Mobile tab select label resolves correctly for transient tabs; tests added.

<sup>Written for commit c33f0f854ca98b6cb614466c920158bb70bdb3d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

