### PR TITLE
fix(library): use container queries for card grid breakpoints

### DIFF
--- a/apps/mesh/src/web/layouts/library/cards.tsx
+++ b/apps/mesh/src/web/layouts/library/cards.tsx
@@ -183,7 +183,12 @@ function CardHeader({
           )}
         </div>
         {subtitle && (
-          <span className="text-xs text-muted-foreground">{subtitle}</span>
+          <span
+            className="truncate text-xs text-muted-foreground"
+            title={subtitle}
+          >
+            {subtitle}
+          </span>
         )}
       </div>
       {actions}

--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -108,8 +108,10 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 
 function CardsGrid({ children }: { children: React.ReactNode }) {
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {children}
+    <div className="@container">
+      <div className="grid grid-cols-1 gap-3 @sm:grid-cols-2 @lg:grid-cols-3">
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What is this contribution about?

The library page card grid used viewport-based breakpoints (`sm:grid-cols-2`, `lg:grid-cols-3`), which respond to the full window width rather than the panel's own width. Since the library renders inside a resizable panel, the grid columns would never adapt correctly when the panel was narrow. Switching to Tailwind v4 container queries (`@sm:grid-cols-2`, `@lg:grid-cols-3`) makes the grid respond to its container's width instead.

## Screenshots/Demonstration

Before: cards stuck in 1 column on narrow panels, with folder names and subtitles wrapping awkwardly due to insufficient width.
After: grid adapts to the panel width — 2 columns at 384px, 3 columns at 512px.

## How to Test

1. Open the Library page (`/$org/files`)
2. Resize the library panel to a narrow width
3. Verify the card grid reflows from 3 → 2 → 1 columns based on panel width, not window width

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Library card grid respond to the panel width using Tailwind container queries. Added an `@container` wrapper and switched `sm:`/`lg:` to `@sm`/`@lg` for 1 → 2 → 3 columns, and truncated the card subtitle with `truncate` + `title` to prevent wrapping on narrow cards.

<sup>Written for commit 4400d2ae0c6d391df9cac4ac3e3274f09b052629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

