### PR TITLE
fix(link-daemon): heartbeat the chunk-relay upload to survive CDN idle timeout

### DIFF
--- a/apps/mesh/src/link-daemon/chunk-relay.test.ts
+++ b/apps/mesh/src/link-daemon/chunk-relay.test.ts
@@ -207,6 +207,61 @@ describe("relayDispatchSSEAsChunkStream", () => {
     await relayPromise;
   });
 
+  it("writes a newline heartbeat into the POST body during idle gaps (defeats a CDN idle timeout)", async () => {
+    const sse = pushableSSEBody();
+    const heartbeatSeen = Promise.withResolvers<void>();
+    const realLines: RelayLine[] = [];
+
+    const relayPromise = relayDispatchSSEAsChunkStream({
+      dispatchBody: sse.body,
+      runId: "run_hb",
+      // Tiny interval so the idle gap below trips a heartbeat deterministically.
+      heartbeatMs: 5,
+      post: async (body): Promise<RelayPostResult> => {
+        if (typeof body === "string") throw new Error("expected a stream");
+        const reader = body.getReader();
+        const dec = new TextDecoder();
+        let buf = "";
+        let last = 0;
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += dec.decode(value, { stream: true });
+          let nl = buf.indexOf("\n");
+          while (nl !== -1) {
+            const line = buf.slice(0, nl);
+            buf = buf.slice(nl + 1);
+            if (line.length === 0) {
+              // A bare "\n" = the keepalive heartbeat (a blank NDJSON line).
+              heartbeatSeen.resolve();
+            } else {
+              const parsed = relayLineSchema.parse(JSON.parse(line));
+              realLines.push(parsed);
+              last = parsed.seq;
+            }
+            nl = buf.indexOf("\n");
+          }
+        }
+        return { ok: true, lastSeq: last };
+      },
+    });
+
+    // First real line, then stay idle (source open, no events) so the relay
+    // body must emit heartbeat newlines to keep bytes flowing.
+    sse.push(CHUNK_A);
+    await heartbeatSeen.promise;
+    sse.push(DONE);
+    sse.close();
+    await relayPromise;
+
+    // Heartbeats are transient wire bytes: they never become relay lines, so
+    // seq numbering is untouched.
+    expect(realLines).toEqual([
+      { seq: 1, event: CHUNK_A },
+      { seq: 2, event: DONE },
+    ]);
+  }, 2000);
+
   it("reconnects after a dropped POST and resends the full buffered prefix", async () => {
     const sse = pushableSSEBody();
     const attempts: { fromSeq: number; lines: RelayLine[] }[] = [];

--- a/apps/mesh/src/link-daemon/chunk-relay.ts
+++ b/apps/mesh/src/link-daemon/chunk-relay.ts
@@ -30,7 +30,7 @@
  *   cancelled, in-flight/queued POST attempts stop, and the relay rejects
  *   with the abort reason.
  */
-import { retry, RetryError } from "@decocms/std";
+import { retry, RetryError, sleep } from "@decocms/std";
 import { parseDispatchSSEEvents } from "../harnesses/parse-dispatch-sse";
 import type { DispatchSSEEvent } from "../links/protocol";
 import type { RelayLine } from "../links/protocol/relay";
@@ -94,9 +94,30 @@ export interface RelayDispatchSSEAsChunkStreamInput {
     maxTimeout?: number;
     jitter?: number;
   };
+  /**
+   * Idle-gap keepalive interval for the streaming POST body, in ms. When the
+   * relay has no new line to send for this long (a model think-gap / between
+   * steps), it writes a blank NDJSON line (`"\n"`) into the request body so the
+   * upload keeps emitting bytes. A long-lived streaming POST that writes nothing
+   * during an idle gap is reset by an intermediary idle timeout — in the field a
+   * Cloudflare edge ~15s idle timeout fires a fast `ECONNRESET` ("socket
+   * connection closed unexpectedly"), and because each retry resends from seq 1
+   * and goes idle again, a single >15s think-gap can make a run never finish.
+   * The blank line is a no-op on the wire: the cluster's `ndjsonLines` parser
+   * trims and skips empty lines, so it never becomes a relay line and seq
+   * numbering / prefix-replay are untouched. Default 10s (margin under 15s);
+   * tests override with a tiny value.
+   */
+  heartbeatMs?: number;
 }
 
 const encoder = new TextEncoder();
+
+/** Default keepalive cadence — comfortably under the ~15s CDN idle timeout. */
+const DEFAULT_HEARTBEAT_MS = 10_000;
+
+/** Blank NDJSON line: keeps bytes flowing; the cluster parser skips it. */
+const HEARTBEAT_BYTES = encoder.encode("\n");
 
 /**
  * Relay a sandbox dispatch SSE body to the cluster as seq-numbered NDJSON
@@ -194,6 +215,8 @@ export async function relayDispatchSSEAsChunkStream(
     throw pumpError;
   });
 
+  const heartbeatMs = input.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+
   // ── Attempt bodies: replay the durable prefix, then follow live ──────────
   const createAttemptBody = (): ReadableStream<Uint8Array> => {
     let cursor = 0; // highest wireSeq already enqueued; replay from cursor+1
@@ -231,7 +254,30 @@ export async function relayDispatchSSEAsChunkStream(
             controller.close();
             return;
           }
-          await waiter;
+          // Idle: no buffered line and the pump is still running. Wait for the
+          // next line, but if the gap exceeds `heartbeatMs` emit a blank-line
+          // keepalive so the streaming upload keeps writing bytes and a CDN
+          // idle timeout (Cloudflare ~15s) can't reset it. `sleep`'s timer is
+          // cancelled (via its signal) the moment a line arrives, so an active
+          // run never accumulates timers.
+          const hbAbort = new AbortController();
+          const winner = await Promise.race([
+            waiter.then(() => "line" as const),
+            sleep(heartbeatMs, { signal: hbAbort.signal })
+              .then(() => "heartbeat" as const)
+              // Aborted (a line won the race) → fall through and re-check state.
+              .catch(() => "line" as const),
+          ]);
+          hbAbort.abort();
+          if (winner === "heartbeat") {
+            try {
+              controller.enqueue(HEARTBEAT_BYTES);
+            } catch {
+              // Consumer cancelled this attempt's upload — durable rows remain.
+              return;
+            }
+            return;
+          }
         }
       },
     });


### PR DESCRIPTION
## Summary

`bunx decocms link` was failing with frequent `ECONNRESET` / "socket connection closed unexpectedly" errors on the chunk-relay upload (`[relay-diag] cluster-POST attempt errored … /links/runs/<runId>/chunks`).

**Root cause (verified live against `studio-stg`, not guessed):** each run is uploaded via a single long-lived streaming POST (`duplex:"half"`) held open for the whole run. During any idle gap (model think-time, between steps) `createAttemptBody` wrote **zero bytes**. Cloudflare fronts the relay host and resets any connection idle for ~15s.

Evidence:
| Probe | Result |
|---|---|
| Idle streaming-POST **through Cloudflare** | `ECONNRESET` at **15.06s** (reproduced exactly) |
| Same probe **straight to origin NLB** (CF bypassed) | responds ~1s, **no 15s wall** |
| API pod logs | hundreds of `500 "The connection was closed."` on `/chunks`, **same runIds looping** |
| Pods | all `Running`, 0 restarts — not a crash |

So the trigger is the heartbeat-less upload, not an infra misconfiguration. **Amplifier:** every retry resends from seq 1, goes idle again, and dies — a single >15s think-gap can make a run loop forever (observed zombie runs storming for minutes).

## Fix

Emit a blank NDJSON line (`"\n"`) into the request body whenever the relay has no line to send for `heartbeatMs` (default **10s**, margin under CF's 15s). The cluster's `ndjsonLines` parser already trims and skips empty lines, so:
- the heartbeat **never becomes a relay line** — seq numbering and full-prefix replay are untouched,
- **no server/API change is needed** (existing test `ndjsonLines › skips blank lines` already covers it).

The keepalive timer is cancelled (via its `AbortSignal`) the instant a real line arrives, so an active run never accumulates timers. Uses `sleep` from `@decocms/std` (no hand-rolled `setTimeout`).

## Testing
- New unit test: `writes a newline heartbeat into the POST body during idle gaps` (RED → GREEN via TDD; asserts heartbeats flow during idle gaps **and** that they don't perturb seq numbering).
- `bun test apps/mesh/src/link-daemon/ …/link-ingest-routes.test.ts` → **174 pass, 0 fail**.
- `bun run check` (typecheck) clean; `bun run lint` clean for changed files; `bun run fmt` applied.

## Affected areas
`apps/mesh/src/link-daemon/chunk-relay.ts` only (the production daemon path picks up the 10s default automatically). No schema/migration/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the chunk-relay upload alive by sending newline heartbeats during idle gaps to avoid CDN idle resets. This stops recurring ECONNRESETs and lets long runs in `bunx decocms link` finish reliably.

- **Bug Fixes**
  - Emit a blank NDJSON line ("\n") every 10s of inactivity (configurable `heartbeatMs`) in the streaming POST to `/links/runs/<runId>/chunks`.
  - Heartbeats are ignored by the cluster parser, so seq numbering and prefix replay are unchanged; no server changes.
  - Heartbeat timer aborts as soon as a real line arrives; uses `sleep` from `@decocms/std`.
  - Added a unit test to verify heartbeats and stable seqs.

<sup>Written for commit 032bbee5d3d7b30b8a528a892bc4b475d6de6086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

