### PR TITLE
feat(harness): resumable CLI sessions for Codex + Claude Code (fix Codex context-window crash)

### DIFF
--- a/apps/mesh/e2e/fixtures/relay-chunks.ts
+++ b/apps/mesh/e2e/fixtures/relay-chunks.ts
@@ -44,10 +44,14 @@ export interface BuildTurnOptions {
   usage?: HarnessTurnUsage;
   /**
    * When set, the final `finish` chunk carries `codingAgentSessionId` +
-   * `codingAgentProvider: "claude-code"` — the shape `lookupResumeSessionRef`
-   * reads back on the NEXT turn to populate `harnessInput.resumeSessionRef`.
+   * `codingAgentProvider` — the shape `resolveCliSessionRef` reads back on the
+   * NEXT turn to populate `harnessInput.resumeSessionRef`. Defaults to
+   * `"claude-code"` when unset (matches the original fixture behaviour).
+   * Pass `"codex"` when emulating a Codex harness relay.
    */
   codingAgentSessionId?: string;
+  /** Provider name stored alongside the session id. Defaults to `"claude-code"`. */
+  codingAgentProvider?: "claude-code" | "codex";
 }
 
 /** A single UIMessageChunk wrapped as the daemon's relay event. */
@@ -99,7 +103,8 @@ function buildTurnEvents(opts: BuildTurnOptions): unknown[] {
   if (opts.usage) messageMetadata.usage = opts.usage;
   if (opts.codingAgentSessionId) {
     messageMetadata.codingAgentSessionId = opts.codingAgentSessionId;
-    messageMetadata.codingAgentProvider = "claude-code";
+    messageMetadata.codingAgentProvider =
+      opts.codingAgentProvider ?? "claude-code";
   }
   const finishChunk: Record<string, unknown> = { type: "finish" };
   if (Object.keys(messageMetadata).length > 0) {

--- a/apps/mesh/e2e/tests/cli-session-resume.spec.ts
+++ b/apps/mesh/e2e/tests/cli-session-resume.spec.ts
@@ -388,14 +388,15 @@ test.describe("CLI session resume (codex, desktop-link relay)", () => {
       // (b2) delta: only the new user message, not turn 1's text
       const wireMessages = t2.workItem.harnessInput.messages as Array<{
         role: string;
-        content: unknown;
       }>;
       const userMessages = wireMessages.filter((m) => m.role === "user");
       expect(
         userMessages.length,
         "delta must contain exactly one user message (turn 2 only)",
       ).toBe(1);
-      const contentStr = JSON.stringify(userMessages[0]!.content);
+      // Materialized UIMessages carry text in `parts`, not a `content` field —
+      // stringify the whole message so the assertion is shape-agnostic.
+      const contentStr = JSON.stringify(userMessages[0]);
       expect(contentStr).toContain(turn2UserText);
       expect(contentStr).not.toContain(turn1UserText);
     } finally {
@@ -465,8 +466,10 @@ test.describe("CLI session resume (codex, desktop-link relay)", () => {
         const parts = await fetchParts(db, runId);
         const errorPart = parts.find((p) => p.kind === "error");
         expect(errorPart, "error part persisted").toBeTruthy();
-        const payload = errorPart!.payload as { message?: string } | null;
-        expect(payload?.message ?? "").toMatch(/session expired/i);
+        // `emitError` stores the error payload as a text part:
+        // `{ type: "text", text: "Error: <code>: <message>" }`.
+        const payload = errorPart!.payload as { text?: string } | null;
+        expect(payload?.text ?? "").toMatch(/session expired/i);
       }).toPass({ timeout: 20_000, intervals: [250, 500, 1000, 2000] });
     } finally {
       await daemon?.close();

--- a/apps/mesh/e2e/tests/cli-session-resume.spec.ts
+++ b/apps/mesh/e2e/tests/cli-session-resume.spec.ts
@@ -6,8 +6,12 @@
  *       `codingAgentProvider: "codex"` lands on the persisted assistant message
  *       metadata so the NEXT dispatch can read it back.
  *   (b) A second turn's dispatch work item carries
- *       `harnessInput.resumeSessionRef` equal to the first turn's session id —
- *       i.e., the cluster correctly threads a Codex session across turns.
+ *       `harnessInput.resumeSessionRef` equal to the first turn's session id
+ *       AND `harnessInput.messages` is the DELTA only (user messages after the
+ *       session anchor, not the full transcript). Both together prove the
+ *       codex resume round-trip: `resolveCliSessionRef` finds the session id
+ *       and `computeCliDelta` strips prior history so the CLI doesn't receive
+ *       messages it already knows about (which would cause "ran out of room").
  *   (c) A "stale session" error relay (what the daemon sends when the codex
  *       harness throws `CliSessionExpiredError`) persists an error part whose
  *       message matches /session expired/i and transitions the run to "failed".
@@ -301,12 +305,16 @@ test.describe("CLI session resume (codex, desktop-link relay)", () => {
     }
   });
 
-  test("second turn: dispatch work item carries resumeSessionRef from the prior codex session", async ({
+  test("second turn: dispatch work item carries resumeSessionRef AND only the delta (not full history)", async ({
     authedPage,
   }) => {
     // Drives TWO turns on one codex-pinned thread and asserts the second
     // work item's harnessInput.resumeSessionRef equals the first turn's
-    // relayed session id — proving the round-trip across the v2 read path.
+    // relayed session id AND harnessInput.messages is the delta only (the
+    // new user message after the session anchor, not the full transcript).
+    // Together these prove the codex resume round-trip:
+    //   - resolveCliSessionRef → correct session id on the work item
+    //   - computeCliDelta → CLI receives only what it doesn't already know
     test.setTimeout(CASE_TIMEOUT_MS * 2);
     const { page, orgSlug, user } = authedPage;
     const api = page.context().request;
@@ -322,6 +330,9 @@ test.describe("CLI session resume (codex, desktop-link relay)", () => {
         orgId,
       );
 
+      const turn1UserText = "Remember the number 42. Reply 'ok'.";
+      const turn2UserText = "What number did I ask you to remember?";
+
       // ── Turn 1: relay a finish carrying a codex session id ────────────
       const t1 = await dispatchCodexAndClaimWorkItem(
         api,
@@ -329,7 +340,7 @@ test.describe("CLI session resume (codex, desktop-link relay)", () => {
         agentId,
         threadId,
         daemon,
-        "Remember the number 42. Reply 'ok'.",
+        turn1UserText,
       );
       const sessionId = `codex-session-${Date.now()}`;
       const { body: body1 } = buildTurnRelayBody({
@@ -361,15 +372,32 @@ test.describe("CLI session resume (codex, desktop-link relay)", () => {
       }).toPass({ timeout: 20_000, intervals: [250, 500, 1000, 2000] });
 
       // ── Turn 2: the work item must resume the prior codex session ──────
+      // and carry only the delta (turn-2 user message), not the full history.
       const t2 = await dispatchCodexAndClaimWorkItem(
         api,
         orgSlug,
         agentId,
         threadId,
         daemon,
-        "What number did I ask you to remember?",
+        turn2UserText,
       );
+
+      // (b) resumeSessionRef round-trip
       expect(t2.workItem.harnessInput.resumeSessionRef).toBe(sessionId);
+
+      // (b2) delta: only the new user message, not turn 1's text
+      const wireMessages = t2.workItem.harnessInput.messages as Array<{
+        role: string;
+        content: unknown;
+      }>;
+      const userMessages = wireMessages.filter((m) => m.role === "user");
+      expect(
+        userMessages.length,
+        "delta must contain exactly one user message (turn 2 only)",
+      ).toBe(1);
+      const contentStr = JSON.stringify(userMessages[0]!.content);
+      expect(contentStr).toContain(turn2UserText);
+      expect(contentStr).not.toContain(turn1UserText);
     } finally {
       await daemon?.close();
       await db.end();

--- a/apps/mesh/e2e/tests/cli-session-resume.spec.ts
+++ b/apps/mesh/e2e/tests/cli-session-resume.spec.ts
@@ -1,0 +1,448 @@
+/**
+ * E2E: CLI session resume — codex harness, desktop-link relay path.
+ *
+ * Validates that:
+ *   (a) A first turn's relay carrying `codingAgentSessionId` +
+ *       `codingAgentProvider: "codex"` lands on the persisted assistant message
+ *       metadata so the NEXT dispatch can read it back.
+ *   (b) A second turn's dispatch work item carries
+ *       `harnessInput.resumeSessionRef` equal to the first turn's session id —
+ *       i.e., the cluster correctly threads a Codex session across turns.
+ *   (c) A "stale session" error relay (what the daemon sends when the codex
+ *       harness throws `CliSessionExpiredError`) persists an error part whose
+ *       message matches /session expired/i and transitions the run to "failed".
+ *
+ * Architecture note: the relay driver is the SAME `consumeHarnessStream`
+ * kernel both hosted and daemon-relayed paths feed. These tests drive it
+ * through the pull-relay path (daemon tunnel → POST /chunks) exactly as
+ * `harness-conformance.spec.ts` does — the only codex-specific detail is
+ * `harness_id = 'codex'` on the thread row and
+ * `codingAgentProvider: "codex"` in the relayed finish chunk.
+ *
+ * Scenario (c) note: the relay driver cannot restart a real daemon process or
+ * wipe `~/.codex/sessions`. Instead we inject the exact error relay body that
+ * the daemon sends after catching `CliSessionExpiredError` — a
+ * `harness_crashed` error event whose `message` is "Session expired — start a
+ * new thread." (see `packages/sandbox/daemon/routes/dispatch.ts:142`). This
+ * faithfully exercises the cluster-side error-part persistence and run-status
+ * transition without requiring a live daemon restart.
+ */
+
+import { expect, test } from "../fixtures/test";
+import { connectDevDb } from "../fixtures/db";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import {
+  createTunnelLinkDaemon,
+  type TunnelLinkDaemon,
+} from "../fixtures/links-presence";
+import {
+  buildErrorRelayBody,
+  buildTurnRelayBody,
+} from "../fixtures/relay-chunks";
+import { DEFAULT_THREAD_TITLE } from "@decocms/harness/decopilot/prompt-constants";
+import type { APIRequestContext } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Helpers (mirror harness-conformance.spec.ts)
+// ---------------------------------------------------------------------------
+
+type Db = Awaited<ReturnType<typeof connectDevDb>>;
+
+async function orgIdForSlug(db: Db, slug: string): Promise<string> {
+  const { rows } = await db.query<{ id: string }>(
+    `SELECT id FROM "organization" WHERE slug = $1`,
+    [slug],
+  );
+  const id = rows[0]?.id;
+  if (!id) throw new Error(`no organization row for slug ${slug}`);
+  return id;
+}
+
+async function fetchThreadStatus(
+  db: Db,
+  threadId: string,
+): Promise<string | null> {
+  const { rows } = await db.query<{ status: string }>(
+    `SELECT status FROM threads WHERE id = $1`,
+    [threadId],
+  );
+  return rows[0]?.status ?? null;
+}
+
+async function fetchParts(
+  db: Db,
+  runId: string,
+): Promise<
+  Array<{ kind: string; role: string; payload: unknown; metadata: unknown }>
+> {
+  const { rows } = await db.query<{
+    kind: string;
+    role: string;
+    payload: unknown;
+    metadata: unknown;
+  }>(
+    `SELECT kind, role, payload, metadata FROM thread_message_parts WHERE run_id = $1 ORDER BY seq`,
+    [runId],
+  );
+  return rows;
+}
+
+/** Read back the folded messages via the real v2 read-path tool. */
+async function listMessages(
+  api: APIRequestContext,
+  orgSlug: string,
+  threadId: string,
+): Promise<
+  Array<{ id: string; role: string; parts: unknown[]; metadata: unknown }>
+> {
+  const result = await callSelfMcpTool<{
+    items: Array<{
+      id: string;
+      role: string;
+      parts: unknown[];
+      metadata: unknown;
+    }>;
+    totalCount: number;
+  }>(api, orgSlug, "COLLECTION_THREAD_MESSAGES_LIST", {
+    thread_id: threadId,
+  });
+  return result.items;
+}
+
+/**
+ * Create an agent (virtual MCP) + a v2 thread pinned to user-desktop /
+ * CODEX so POST /messages routes to the pull gate without per-request model
+ * resolution. Mirrors createPullThread in harness-conformance.spec.ts but
+ * pins harness_id to "codex".
+ */
+async function createCodexPullThread(
+  api: APIRequestContext,
+  db: Db,
+  orgSlug: string,
+  orgId: string,
+): Promise<{ agentId: string; threadId: string }> {
+  const agent = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_VIRTUAL_MCP_CREATE",
+    {
+      data: {
+        title: "CLI Session Resume E2E Agent",
+        connections: [],
+        status: "active",
+        pinned: false,
+      },
+    },
+  );
+  const agentId = agent.item.id;
+
+  const thread = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_THREADS_CREATE",
+    { data: { virtual_mcp_id: agentId } },
+  );
+  const threadId = thread.item.id;
+
+  // Pin the pull-transport columns with harness_id = 'codex'. The dispatch
+  // route reads harness_id off this row to route the work item to the daemon.
+  await db.query(
+    `UPDATE threads
+     SET message_storage_version = 2,
+         harness_id              = 'codex',
+         sandbox_provider_kind   = 'user-desktop',
+         title                   = $3
+     WHERE id = $1
+       AND organization_id = $2`,
+    [threadId, orgId, DEFAULT_THREAD_TITLE],
+  );
+
+  return { agentId, threadId };
+}
+
+interface WorkItem {
+  runId: string;
+  threadId: string;
+  orgId: string;
+  userId: string;
+  runFenceToken: string;
+  harnessInput: Record<string, unknown>;
+  messagesRef?: { url: string; bytes: number; sha256: string };
+}
+
+/**
+ * Trigger a dispatch by POSTing a user message with harnessId: "codex",
+ * then wait for the tunnel daemon to receive the matching work item.
+ */
+async function dispatchCodexAndClaimWorkItem(
+  api: APIRequestContext,
+  orgSlug: string,
+  agentId: string,
+  threadId: string,
+  daemon: TunnelLinkDaemon,
+  messageText: string,
+): Promise<{ runId: string; workItem: WorkItem }> {
+  const dispatchRes = await api.post(
+    `/api/${orgSlug}/decopilot/threads/${threadId}/messages`,
+    {
+      data: {
+        messages: [
+          { role: "user", parts: [{ type: "text", text: messageText }] },
+        ],
+        agent: { id: agentId },
+        branch: "ephemeral",
+        temperature: 0.5,
+        harnessId: "codex",
+        sandboxProviderKind: "user-desktop",
+      },
+      headers: { "content-type": "application/json" },
+    },
+  );
+  expect(dispatchRes.status()).toBe(202);
+  const { taskId: runId } = (await dispatchRes.json()) as { taskId: string };
+  expect(runId).toBeTruthy();
+
+  const workItem = await daemon.nextWorkItem(runId);
+  expect(workItem.runId).toBe(runId);
+  expect(workItem.threadId).toBe(threadId);
+  expect(typeof workItem.runFenceToken).toBe("string");
+  expect(workItem.runFenceToken.length).toBeGreaterThan(0);
+
+  return { runId, workItem: workItem as unknown as WorkItem };
+}
+
+/** POST a canned NDJSON chunk-relay body as the fake daemon. */
+function postRelay(
+  api: APIRequestContext,
+  orgSlug: string,
+  runId: string,
+  fenceToken: string,
+  body: string,
+  fromSeq = 1,
+) {
+  return api.post(`/api/${orgSlug}/links/runs/${runId}/chunks`, {
+    headers: {
+      "content-type": "application/x-ndjson",
+      "x-fence-token": fenceToken,
+      "x-relay-from": String(fromSeq),
+    },
+    data: body,
+  });
+}
+
+// Per-test budget: setup + dispatch + claim work item + relay + reads.
+const CASE_TIMEOUT_MS = 130_000;
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+test.describe("CLI session resume (codex, desktop-link relay)", () => {
+  test("first turn: relayed codingAgentSessionId + codingAgentProvider:codex persist on the assistant message metadata", async ({
+    authedPage,
+  }) => {
+    test.setTimeout(CASE_TIMEOUT_MS);
+    const { page, orgSlug, user } = authedPage;
+    const api = page.context().request;
+    const db = await connectDevDb();
+    let daemon: TunnelLinkDaemon | null = null;
+    try {
+      daemon = await createTunnelLinkDaemon(api, user.userId, ["codex"]);
+      const orgId = await orgIdForSlug(db, orgSlug);
+      const { agentId, threadId } = await createCodexPullThread(
+        api,
+        db,
+        orgSlug,
+        orgId,
+      );
+      const { runId, workItem } = await dispatchCodexAndClaimWorkItem(
+        api,
+        orgSlug,
+        agentId,
+        threadId,
+        daemon,
+        "Remember the number 42.",
+      );
+
+      const sessionId = `codex-session-${Date.now()}`;
+      const { body } = buildTurnRelayBody({
+        messageId: `msg_resume_t1_${Date.now()}`,
+        text: "ok",
+        codingAgentSessionId: sessionId,
+        codingAgentProvider: "codex",
+      });
+      const res = await postRelay(
+        api,
+        orgSlug,
+        runId,
+        workItem.runFenceToken,
+        body,
+      );
+      expect(res.status()).toBe(200);
+
+      // The session id + provider must land on the assistant message
+      // metadata so the NEXT turn's dispatch can read it back. Persistence
+      // is async (durable projector); poll until both have projected.
+      await expect(async () => {
+        expect(await fetchThreadStatus(db, runId)).toBe("completed");
+        const items = await listMessages(api, orgSlug, threadId);
+        const assistant = items.find((m) => m.role === "assistant");
+        expect(assistant, "assistant message projected").toBeTruthy();
+        const meta = assistant!.metadata as {
+          codingAgentSessionId?: string;
+          codingAgentProvider?: string;
+        };
+        expect(meta.codingAgentSessionId).toBe(sessionId);
+        expect(meta.codingAgentProvider).toBe("codex");
+      }).toPass({ timeout: 20_000, intervals: [250, 500, 1000, 2000] });
+    } finally {
+      await daemon?.close();
+      await db.end();
+    }
+  });
+
+  test("second turn: dispatch work item carries resumeSessionRef from the prior codex session", async ({
+    authedPage,
+  }) => {
+    // Drives TWO turns on one codex-pinned thread and asserts the second
+    // work item's harnessInput.resumeSessionRef equals the first turn's
+    // relayed session id — proving the round-trip across the v2 read path.
+    test.setTimeout(CASE_TIMEOUT_MS * 2);
+    const { page, orgSlug, user } = authedPage;
+    const api = page.context().request;
+    const db = await connectDevDb();
+    let daemon: TunnelLinkDaemon | null = null;
+    try {
+      daemon = await createTunnelLinkDaemon(api, user.userId, ["codex"]);
+      const orgId = await orgIdForSlug(db, orgSlug);
+      const { agentId, threadId } = await createCodexPullThread(
+        api,
+        db,
+        orgSlug,
+        orgId,
+      );
+
+      // ── Turn 1: relay a finish carrying a codex session id ────────────
+      const t1 = await dispatchCodexAndClaimWorkItem(
+        api,
+        orgSlug,
+        agentId,
+        threadId,
+        daemon,
+        "Remember the number 42. Reply 'ok'.",
+      );
+      const sessionId = `codex-session-${Date.now()}`;
+      const { body: body1 } = buildTurnRelayBody({
+        messageId: `msg_resume_round1_${Date.now()}`,
+        text: "ok",
+        codingAgentSessionId: sessionId,
+        codingAgentProvider: "codex",
+      });
+      const res1 = await postRelay(
+        api,
+        orgSlug,
+        t1.runId,
+        t1.workItem.runFenceToken,
+        body1,
+      );
+      expect(res1.status()).toBe(200);
+
+      // Turn 1 must be terminal AND the session id must be folded onto the
+      // assistant message metadata before turn 2 dispatches — poll until
+      // both have projected (the async durable projector writes them).
+      await expect(async () => {
+        expect(await fetchThreadStatus(db, t1.runId)).toBe("completed");
+        const afterT1 = await listMessages(api, orgSlug, threadId);
+        const assistantT1 = afterT1.find((m) => m.role === "assistant");
+        expect(
+          (assistantT1!.metadata as { codingAgentSessionId?: string })
+            .codingAgentSessionId,
+        ).toBe(sessionId);
+      }).toPass({ timeout: 20_000, intervals: [250, 500, 1000, 2000] });
+
+      // ── Turn 2: the work item must resume the prior codex session ──────
+      const t2 = await dispatchCodexAndClaimWorkItem(
+        api,
+        orgSlug,
+        agentId,
+        threadId,
+        daemon,
+        "What number did I ask you to remember?",
+      );
+      expect(t2.workItem.harnessInput.resumeSessionRef).toBe(sessionId);
+    } finally {
+      await daemon?.close();
+      await db.end();
+    }
+  });
+
+  test("stale codex session relay propagates as a session-expired error", async ({
+    authedPage,
+  }) => {
+    // A real desktop daemon, when the codex harness throws
+    // `CliSessionExpiredError`, sends to the cluster:
+    //   { type: "error", code: "harness_crashed",
+    //     message: "Session expired — start a new thread." }
+    // (see packages/sandbox/daemon/routes/dispatch.ts:142).
+    //
+    // We inject that relay body directly — the relay driver has no mechanism to
+    // restart a real daemon process or wipe `~/.codex/sessions`. This exercises
+    // the SAME cluster-side code path: error-part persistence + run-status
+    // transition to "failed".
+    test.setTimeout(CASE_TIMEOUT_MS);
+    const { page, orgSlug, user } = authedPage;
+    const api = page.context().request;
+    const db = await connectDevDb();
+    let daemon: TunnelLinkDaemon | null = null;
+    try {
+      daemon = await createTunnelLinkDaemon(api, user.userId, ["codex"]);
+      const orgId = await orgIdForSlug(db, orgSlug);
+      const { agentId, threadId } = await createCodexPullThread(
+        api,
+        db,
+        orgSlug,
+        orgId,
+      );
+
+      const { runId, workItem } = await dispatchCodexAndClaimWorkItem(
+        api,
+        orgSlug,
+        agentId,
+        threadId,
+        daemon,
+        "What number?",
+      );
+
+      // Inject the error relay body the daemon sends after catching
+      // CliSessionExpiredError ("Session expired — start a new thread.").
+      const { body } = buildErrorRelayBody({
+        messageId: `msg_stale_${Date.now()}`,
+        code: "harness_crashed",
+        message: "Session expired — start a new thread.",
+      });
+      const res = await postRelay(
+        api,
+        orgSlug,
+        runId,
+        workItem.runFenceToken,
+        body,
+      );
+      expect(res.status()).toBe(200);
+
+      // The kernel's onError path persists an error part + transitions the run
+      // to "failed". Both are written by the async durable projector — poll
+      // until they land.
+      await expect(async () => {
+        expect(await fetchThreadStatus(db, runId)).toBe("failed");
+        const parts = await fetchParts(db, runId);
+        const errorPart = parts.find((p) => p.kind === "error");
+        expect(errorPart, "error part persisted").toBeTruthy();
+        const payload = errorPart!.payload as { message?: string } | null;
+        expect(payload?.message ?? "").toMatch(/session expired/i);
+      }).toPass({ timeout: 20_000, intervals: [250, 500, 1000, 2000] });
+    } finally {
+      await daemon?.close();
+      await db.end();
+    }
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/cli-session-messages.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/cli-session-messages.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import {
+  cliProviderName,
+  computeCliDelta,
+  resolveCliSessionRef,
+} from "./cli-session-messages";
+import type { ChatMessage } from "./types";
+
+const user = (id: string, text: string): ChatMessage =>
+  ({ id, role: "user", parts: [{ type: "text", text }] }) as ChatMessage;
+
+const assistant = (
+  id: string,
+  sessionId?: string,
+  provider?: string,
+): ChatMessage =>
+  ({
+    id,
+    role: "assistant",
+    parts: [{ type: "text", text: "ok" }],
+    ...(sessionId
+      ? {
+          metadata: {
+            codingAgentSessionId: sessionId,
+            codingAgentProvider: provider,
+          },
+        }
+      : {}),
+  }) as ChatMessage;
+
+describe("cliProviderName", () => {
+  it("maps harness ids to provider names", () => {
+    expect(cliProviderName("codex")).toBe("codex");
+    expect(cliProviderName("claude-code")).toBe("claude-code");
+    expect(cliProviderName("decopilot")).toBeUndefined();
+  });
+});
+
+describe("resolveCliSessionRef", () => {
+  it("returns undefined for decopilot", () => {
+    expect(
+      resolveCliSessionRef([assistant("a", "s1", "codex")], "decopilot"),
+    ).toBeUndefined();
+  });
+  it("returns the latest matching-provider session id", () => {
+    const msgs = [
+      user("u1", "hi"),
+      assistant("a1", "s1", "codex"),
+      user("u2", "more"),
+      assistant("a2", "s2", "codex"),
+    ];
+    expect(resolveCliSessionRef(msgs, "codex")).toBe("s2");
+  });
+  it("ignores session ids from a different provider", () => {
+    const msgs = [
+      user("u1", "hi"),
+      assistant("a1", "ccsession", "claude-code"),
+    ];
+    expect(resolveCliSessionRef(msgs, "codex")).toBeUndefined();
+  });
+  it("returns undefined on a first turn (no assistant yet)", () => {
+    expect(resolveCliSessionRef([user("u1", "hi")], "codex")).toBeUndefined();
+  });
+});
+
+describe("computeCliDelta", () => {
+  it("first turn: returns the only user message", () => {
+    const msgs = [user("u1", "hi")];
+    expect(computeCliDelta(msgs, "codex").map((m) => m.id)).toEqual(["u1"]);
+  });
+  it("resumed turn: returns only user messages after the last session anchor", () => {
+    const msgs = [
+      user("u1", "hi"),
+      assistant("a1", "s1", "codex"),
+      user("u2", "second"),
+    ];
+    expect(computeCliDelta(msgs, "codex").map((m) => m.id)).toEqual(["u2"]);
+  });
+  it("queued messages: returns all user messages after the anchor", () => {
+    const msgs = [
+      user("u1", "hi"),
+      assistant("a1", "s1", "codex"),
+      user("u2", "second"),
+      user("u3", "third"),
+    ];
+    expect(computeCliDelta(msgs, "codex").map((m) => m.id)).toEqual([
+      "u2",
+      "u3",
+    ]);
+  });
+  it("anchor from a different provider is ignored (treated as first turn)", () => {
+    const msgs = [
+      user("u1", "hi"),
+      assistant("a1", "ccsession", "claude-code"),
+      user("u2", "second"),
+    ];
+    expect(computeCliDelta(msgs, "codex").map((m) => m.id)).toEqual([
+      "u1",
+      "u2",
+    ]);
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/cli-session-messages.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/cli-session-messages.test.ts
@@ -76,6 +76,13 @@ describe("computeCliDelta", () => {
     ];
     expect(computeCliDelta(msgs, "codex").map((m) => m.id)).toEqual(["u2"]);
   });
+  it("resumed turn with no trailing user message: returns an empty delta", () => {
+    // History tail is a completed assistant anchor with no new user input.
+    // The dispatcher turns this empty delta into a defined PermanentRunError
+    // rather than sending zero messages to the CLI.
+    const msgs = [user("u1", "hi"), assistant("a1", "s1", "codex")];
+    expect(computeCliDelta(msgs, "codex")).toEqual([]);
+  });
   it("queued messages: returns all user messages after the anchor", () => {
     const msgs = [
       user("u1", "hi"),

--- a/apps/mesh/src/api/routes/decopilot/cli-session-messages.ts
+++ b/apps/mesh/src/api/routes/decopilot/cli-session-messages.ts
@@ -1,0 +1,62 @@
+import type { HarnessId } from "@decocms/harness/types";
+import type { ChatMessage } from "./types";
+
+type CliProvider = "claude-code" | "codex";
+
+interface CliSessionMeta {
+  codingAgentSessionId?: string;
+  codingAgentProvider?: string;
+}
+
+/** Provider name stored in assistant message metadata for a CLI harness. */
+export function cliProviderName(harnessId: HarnessId): CliProvider | undefined {
+  if (harnessId === "codex") return "codex";
+  if (harnessId === "claude-code") return "claude-code";
+  return undefined;
+}
+
+/** Index of the most recent assistant message carrying a session id for this
+ *  harness's provider, or -1 if none. */
+function lastAnchorIndex(
+  messages: ChatMessage[],
+  provider: CliProvider,
+): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    const meta = msg?.metadata as CliSessionMeta | undefined;
+    if (
+      msg?.role === "assistant" &&
+      meta?.codingAgentSessionId &&
+      meta?.codingAgentProvider === provider
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/** Most-recent on-disk session id for this harness, for resume. */
+export function resolveCliSessionRef(
+  messages: ChatMessage[],
+  harnessId: HarnessId,
+): string | undefined {
+  const provider = cliProviderName(harnessId);
+  if (!provider) return undefined;
+  const idx = lastAnchorIndex(messages, provider);
+  if (idx === -1) return undefined;
+  const meta = messages[idx]?.metadata as CliSessionMeta | undefined;
+  return meta?.codingAgentSessionId;
+}
+
+/** User messages to send this turn: everything after the last session anchor
+ *  (normally one). With no anchor (first turn) → all user messages. */
+export function computeCliDelta(
+  messages: ChatMessage[],
+  harnessId: HarnessId,
+): ChatMessage[] {
+  const provider = cliProviderName(harnessId);
+  if (!provider) return messages;
+  const idx = lastAnchorIndex(messages, provider);
+  const after = idx === -1 ? messages : messages.slice(idx + 1);
+  return after.filter((m) => m.role === "user");
+}

--- a/apps/mesh/src/api/routes/decopilot/cli-session-messages.ts
+++ b/apps/mesh/src/api/routes/decopilot/cli-session-messages.ts
@@ -1,18 +1,19 @@
 import type { HarnessId } from "@decocms/harness/types";
+import {
+  type CliProvider,
+  cliProviderName,
+} from "@decocms/harness/cli-harness";
 import type { ChatMessage } from "./types";
 
-type CliProvider = "claude-code" | "codex";
+// `cliProviderName` is the single source of truth for the `HarnessId → provider`
+// map (shared with the harness write side via `@decocms/harness/cli-harness`).
+// Re-exported so this module stays the one-stop place for CLI session-ref/delta
+// helpers.
+export { cliProviderName };
 
 interface CliSessionMeta {
   codingAgentSessionId?: string;
   codingAgentProvider?: string;
-}
-
-/** Provider name stored in assistant message metadata for a CLI harness. */
-export function cliProviderName(harnessId: HarnessId): CliProvider | undefined {
-  if (harnessId === "codex") return "codex";
-  if (harnessId === "claude-code") return "claude-code";
-  return undefined;
 }
 
 /** Index of the most recent assistant message carrying a session id for this

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1175,7 +1175,17 @@ async function prepareRun(
       windowSize,
     );
 
-    const resumeSessionRef = resolveCliSessionRef(allMessages, harnessId);
+    // CLI-harness delta + resume only holds on the long-lived desktop daemon:
+    // the on-disk session survives between turns *only* on user-desktop. On any
+    // other sandbox kind there is no persistent rollout to resume, so fall back
+    // to the full-transcript path (pre-resume behavior) rather than silently
+    // dropping history or pointing the CLI at a session that isn't there.
+    const cliResumable =
+      isCliHarness(harnessId) && target.sandboxProviderKind === "user-desktop";
+
+    const resumeSessionRef = cliResumable
+      ? resolveCliSessionRef(allMessages, harnessId)
+      : undefined;
 
     const organization = ctx.organization!;
     const streamStartAt = Date.now();
@@ -1202,10 +1212,25 @@ async function prepareRun(
     // forward materialized UIMessages so each harness decides how to convert
     // them.
     // CLI harnesses (codex, claude-code) resume an on-disk session and only
-    // need the new user message(s); decopilot still gets the full transcript.
-    const messagesForHarness = isCliHarness(harnessId)
+    // need the new user message(s); decopilot — and any CLI harness not on
+    // user-desktop — still gets the full transcript (see `cliResumable`).
+    const messagesForHarness = cliResumable
       ? computeCliDelta(allMessages, harnessId)
       : allMessages;
+
+    // A resumable CLI turn must carry at least the new user message(s). An empty
+    // delta means a resumed turn whose history tail is already a completed
+    // assistant anchor — there is no new user input to forward. Sending zero
+    // messages would drive an empty CLI turn (or a downstream "empty prompt"
+    // crash the stale-session guard would not catch), so surface a defined
+    // permanent error instead of silently degrading.
+    if (cliResumable && messagesForHarness.length === 0) {
+      throw new PermanentRunError(
+        "empty_request",
+        "No new user message to send to the CLI harness (resumed turn with empty delta).",
+      );
+    }
+
     const materializedMessages = await resolveStorageRefs(
       messagesForHarness,
       ctx,

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -73,6 +73,7 @@ import {
   classifyStreamError,
   stringifyError,
 } from "@decocms/harness/decopilot/stream-error";
+import { isCliHarness } from "@decocms/harness/cli-harness";
 import { DEFAULT_WINDOW_SIZE, generateMessageId } from "./constants";
 import { mintRunFenceToken } from "./dispatch-fence";
 import { loadAndMergeMessages } from "./conversation";
@@ -108,6 +109,7 @@ import { resolveThreadStatus } from "./status";
 import type { StreamBuffer } from "./stream-buffer";
 import type { ChatMessage, ModelsConfig as ClientModelsConfig } from "./types";
 import type { CancelBroadcast } from "./cancel-broadcast";
+import { computeCliDelta, resolveCliSessionRef } from "./cli-session-messages";
 import { getInternalUrl, getPublicUrl } from "@/core/server-constants";
 import { mintOrgFsConfigJson } from "@/file-storage/mount/provisioning";
 import { meter, traced } from "@/observability";
@@ -350,35 +352,6 @@ export function buildCodingWorkspaceInput(input: {
     cwd: input.workspace.cwd,
     workspaceKind: repo ? "github" : "unknown",
   };
-}
-
-/**
- * Find the last coding-agent session id stored on a prior assistant
- * message. Today only claude-code uses this — codex spawns a new process
- * per request, so its threadId can't be resumed. The provider filter
- * guards against picking up a codex threadId when the user switches
- * provider mid-thread.
- */
-function lookupResumeSessionRef(
-  messages: ChatMessage[],
-  harnessId: HarnessId,
-): string | undefined {
-  if (harnessId !== "claude-code") return undefined;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    const meta = msg?.metadata as {
-      codingAgentSessionId?: string;
-      codingAgentProvider?: string;
-    };
-    if (
-      msg?.role === "assistant" &&
-      meta?.codingAgentSessionId &&
-      meta?.codingAgentProvider === "claude-code"
-    ) {
-      return meta.codingAgentSessionId;
-    }
-  }
-  return undefined;
 }
 
 async function resolveSecretModelSource(
@@ -1202,7 +1175,7 @@ async function prepareRun(
       windowSize,
     );
 
-    const resumeSessionRef = lookupResumeSessionRef(allMessages, harnessId);
+    const resumeSessionRef = resolveCliSessionRef(allMessages, harnessId);
 
     const organization = ctx.organization!;
     const streamStartAt = Date.now();
@@ -1228,7 +1201,15 @@ async function prepareRun(
     // `toModelOutput` handlers) runs inside the decopilot harness itself; we
     // forward materialized UIMessages so each harness decides how to convert
     // them.
-    const materializedMessages = await resolveStorageRefs(allMessages, ctx);
+    // CLI harnesses (codex, claude-code) resume an on-disk session and only
+    // need the new user message(s); decopilot still gets the full transcript.
+    const messagesForHarness = isCliHarness(harnessId)
+      ? computeCliDelta(allMessages, harnessId)
+      : allMessages;
+    const materializedMessages = await resolveStorageRefs(
+      messagesForHarness,
+      ctx,
+    );
 
     ensureModelCompatibility(input.models, materializedMessages);
 

--- a/packages/harness/src/claude-code/index.ts
+++ b/packages/harness/src/claude-code/index.ts
@@ -237,7 +237,7 @@ export const claudeCodeHarnessFactory: HarnessFactory = {
             `[claude-code] stream error model=${sdkModelId} cwd=${cwd ?? "(default)"}:`,
             stringifyError(err),
           );
-          if (isStaleSessionError(err)) {
+          if (input.resumeSessionRef && isStaleSessionError(err)) {
             throw new CliSessionExpiredError(err);
           }
           throw err;

--- a/packages/harness/src/claude-code/index.ts
+++ b/packages/harness/src/claude-code/index.ts
@@ -43,6 +43,10 @@ import { buildCurrentContextPrompt } from "../decopilot/system-prompt";
 import { mergeTitleResult, shouldGenerateTitle } from "../title-merge";
 import { genTitle } from "../decopilot/title-generator";
 import { stringifyError } from "../decopilot/stream-error";
+import {
+  CliSessionExpiredError,
+  isStaleSessionError,
+} from "../cli-session-error";
 import type {
   Harness,
   HarnessContext,
@@ -233,6 +237,9 @@ export const claudeCodeHarnessFactory: HarnessFactory = {
             `[claude-code] stream error model=${sdkModelId} cwd=${cwd ?? "(default)"}:`,
             stringifyError(err),
           );
+          if (isStaleSessionError(err)) {
+            throw new CliSessionExpiredError(err);
+          }
           throw err;
         }
       },

--- a/packages/harness/src/cli-harness.test.ts
+++ b/packages/harness/src/cli-harness.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { isCliHarness } from "./cli-harness";
+
+describe("isCliHarness", () => {
+  it("is true for codex", () => {
+    expect(isCliHarness("codex")).toBe(true);
+  });
+  it("is true for claude-code", () => {
+    expect(isCliHarness("claude-code")).toBe(true);
+  });
+  it("is false for decopilot", () => {
+    expect(isCliHarness("decopilot")).toBe(false);
+  });
+});

--- a/packages/harness/src/cli-harness.ts
+++ b/packages/harness/src/cli-harness.ts
@@ -1,11 +1,30 @@
 import type { HarnessId } from "./types";
 
 /**
+ * Provider name persisted in assistant-message metadata
+ * (`codingAgentProvider`) for a CLI harness. Single source of truth for the
+ * `HarnessId → provider` map: both the WRITE side (cli stream metadata) and
+ * the READ side (`resolveCliSessionRef` / `computeCliDelta`) derive from this,
+ * so resume can never silently break on a map mismatch.
+ */
+export type CliProvider = "claude-code" | "codex";
+
+/**
+ * Provider name for a CLI harness, or `undefined` for non-CLI harnesses
+ * (`decopilot`, which runs in-process with no resumable on-disk session).
+ */
+export function cliProviderName(harnessId: HarnessId): CliProvider | undefined {
+  if (harnessId === "codex") return "codex";
+  if (harnessId === "claude-code") return "claude-code";
+  return undefined;
+}
+
+/**
  * True for harnesses that run an external CLI subprocess with its own
  * on-disk, resumable session (codex, claude-code). These harnesses receive
  * only the delta + a resume ref per turn instead of the full transcript.
  * `decopilot` runs in-process and keeps the full-transcript dispatch path.
  */
 export function isCliHarness(harnessId: HarnessId): boolean {
-  return harnessId === "codex" || harnessId === "claude-code";
+  return cliProviderName(harnessId) !== undefined;
 }

--- a/packages/harness/src/cli-harness.ts
+++ b/packages/harness/src/cli-harness.ts
@@ -1,0 +1,11 @@
+import type { HarnessId } from "./types";
+
+/**
+ * True for harnesses that run an external CLI subprocess with its own
+ * on-disk, resumable session (codex, claude-code). These harnesses receive
+ * only the delta + a resume ref per turn instead of the full transcript.
+ * `decopilot` runs in-process and keeps the full-transcript dispatch path.
+ */
+export function isCliHarness(harnessId: HarnessId): boolean {
+  return harnessId === "codex" || harnessId === "claude-code";
+}

--- a/packages/harness/src/cli-session-error.test.ts
+++ b/packages/harness/src/cli-session-error.test.ts
@@ -48,9 +48,7 @@ describe("isStaleSessionError", () => {
   // Stale message carried in err.cause
   it("matches when stale message is in err.cause.message", () => {
     const cause = new Error("No conversation found with session ID abc123");
-    const err = new Error("process exited with code 1");
-    // @ts-ignore - setting cause manually for test
-    err.cause = cause;
+    const err = new Error("process exited with code 1", { cause });
     expect(isStaleSessionError(err)).toBe(true);
   });
 
@@ -59,9 +57,7 @@ describe("isStaleSessionError", () => {
     const cause = Object.assign(new Error("exit code 1"), {
       stderr: "No conversation found with session ID abc123",
     });
-    const err = new Error("process exited with code 1");
-    // @ts-ignore - setting cause manually for test
-    err.cause = cause;
+    const err = new Error("process exited with code 1", { cause });
     expect(isStaleSessionError(err)).toBe(true);
   });
 

--- a/packages/harness/src/cli-session-error.test.ts
+++ b/packages/harness/src/cli-session-error.test.ts
@@ -28,6 +28,50 @@ describe("isStaleSessionError", () => {
   it("is false for non-errors", () => {
     expect(isStaleSessionError(undefined)).toBe(false);
   });
+
+  // Claude Code APICallError shape: generic message + stale info in data.stderr
+  it("matches claude-code APICallError with stale message in data.stderr", () => {
+    const err = Object.assign(new Error("process exited with code 1"), {
+      data: { stderr: "No conversation found with session ID abc123" },
+    });
+    expect(isStaleSessionError(err)).toBe(true);
+  });
+
+  // Claude Code shape with stale message in err.stderr directly
+  it("matches claude-code error with stale message in err.stderr", () => {
+    const err = Object.assign(new Error("process exited with code 1"), {
+      stderr: "No conversation found with session ID abc123",
+    });
+    expect(isStaleSessionError(err)).toBe(true);
+  });
+
+  // Stale message carried in err.cause
+  it("matches when stale message is in err.cause.message", () => {
+    const cause = new Error("No conversation found with session ID abc123");
+    const err = new Error("process exited with code 1");
+    // @ts-ignore - setting cause manually for test
+    err.cause = cause;
+    expect(isStaleSessionError(err)).toBe(true);
+  });
+
+  // Stale message in err.cause.stderr
+  it("matches when stale message is in err.cause.stderr", () => {
+    const cause = Object.assign(new Error("exit code 1"), {
+      stderr: "No conversation found with session ID abc123",
+    });
+    const err = new Error("process exited with code 1");
+    // @ts-ignore - setting cause manually for test
+    err.cause = cause;
+    expect(isStaleSessionError(err)).toBe(true);
+  });
+
+  // Negative: unrelated data/stderr should not match
+  it("is false when data.stderr contains only unrelated content", () => {
+    const err = Object.assign(new Error("process exited with code 1"), {
+      data: { stderr: "network timeout connecting to server" },
+    });
+    expect(isStaleSessionError(err)).toBe(false);
+  });
 });
 
 describe("CliSessionExpiredError", () => {

--- a/packages/harness/src/cli-session-error.test.ts
+++ b/packages/harness/src/cli-session-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import {
+  CliSessionExpiredError,
+  isStaleSessionError,
+} from "./cli-session-error";
+
+describe("isStaleSessionError", () => {
+  it("matches codex stale-thread message", () => {
+    expect(
+      isStaleSessionError(
+        new Error(
+          "Thread 'abc' not found after server restart. Create a new thread by omitting threadId.",
+        ),
+      ),
+    ).toBe(true);
+  });
+  it("matches generic 'thread not found'", () => {
+    expect(isStaleSessionError(new Error("thread xyz not found"))).toBe(true);
+  });
+  it("matches claude-code 'no conversation found'", () => {
+    expect(
+      isStaleSessionError(new Error("No conversation found with session id")),
+    ).toBe(true);
+  });
+  it("is false for unrelated errors", () => {
+    expect(isStaleSessionError(new Error("network timeout"))).toBe(false);
+  });
+  it("is false for non-errors", () => {
+    expect(isStaleSessionError(undefined)).toBe(false);
+  });
+});
+
+describe("CliSessionExpiredError", () => {
+  it("has a stable name and default message", () => {
+    const e = new CliSessionExpiredError();
+    expect(e.name).toBe("CliSessionExpiredError");
+    expect(e.message).toBe("Session expired — start a new thread.");
+  });
+  it("carries a cause", () => {
+    const cause = new Error("thread not found");
+    expect(new CliSessionExpiredError(cause).cause).toBe(cause);
+  });
+});

--- a/packages/harness/src/cli-session-error.ts
+++ b/packages/harness/src/cli-session-error.ts
@@ -10,6 +10,12 @@ export class CliSessionExpiredError extends Error {
   }
 }
 
+// Patterns verified against the Codex provider: /thread.*not found/i and
+// /not found after server restart/i. The claude-code patterns
+// (/no conversation found/i and /session.*not found/i) are best-effort —
+// they have NOT been verified against the native `claude --resume` binary's
+// actual stale-session stderr and may need adjustment once a real stale
+// resume output is captured.
 const STALE_PATTERNS = [
   /thread.*not found/i,
   /not found after server restart/i,
@@ -17,10 +23,40 @@ const STALE_PATTERNS = [
   /session.*not found/i,
 ];
 
+/** Extract string fields from an unknown value for stale-session detection. */
+function collectHaystrings(value: unknown): string[] {
+  const parts: string[] = [];
+  if (typeof value === "string") {
+    parts.push(value);
+    return parts;
+  }
+  if (value == null || typeof value !== "object") return parts;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj["message"] === "string") parts.push(obj["message"]);
+  if (typeof obj["stderr"] === "string") parts.push(obj["stderr"]);
+  if (obj["data"] != null) {
+    try {
+      parts.push(JSON.stringify(obj["data"]));
+    } catch {
+      // not serialisable — skip
+    }
+  }
+  return parts;
+}
+
 /** True when an error indicates a missing/stale resumable session/thread. */
 export function isStaleSessionError(err: unknown): boolean {
-  const message =
-    err instanceof Error ? err.message : typeof err === "string" ? err : "";
-  if (!message) return false;
-  return STALE_PATTERNS.some((re) => re.test(message));
+  const haystrings = collectHaystrings(err);
+
+  // One level deep into cause (no unbounded recursion)
+  if (err != null && typeof err === "object") {
+    const obj = err as Record<string, unknown>;
+    if (obj["cause"] != null) {
+      haystrings.push(...collectHaystrings(obj["cause"]));
+    }
+  }
+
+  const haystack = haystrings.join("\n");
+  if (!haystack) return false;
+  return STALE_PATTERNS.some((re) => re.test(haystack));
 }

--- a/packages/harness/src/cli-session-error.ts
+++ b/packages/harness/src/cli-session-error.ts
@@ -1,0 +1,26 @@
+/**
+ * Thrown when a CLI harness cannot resume its on-disk session (e.g. the
+ * desktop daemon was restarted and the rollout is gone). Surfaced to the
+ * user as a turn error; there is no replay/fallback by design.
+ */
+export class CliSessionExpiredError extends Error {
+  constructor(cause?: unknown) {
+    super("Session expired — start a new thread.", { cause });
+    this.name = "CliSessionExpiredError";
+  }
+}
+
+const STALE_PATTERNS = [
+  /thread.*not found/i,
+  /not found after server restart/i,
+  /no conversation found/i,
+  /session.*not found/i,
+];
+
+/** True when an error indicates a missing/stale resumable session/thread. */
+export function isStaleSessionError(err: unknown): boolean {
+  const message =
+    err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  if (!message) return false;
+  return STALE_PATTERNS.some((re) => re.test(message));
+}

--- a/packages/harness/src/cli-session-error.ts
+++ b/packages/harness/src/cli-session-error.ts
@@ -35,11 +35,7 @@ function collectHaystrings(value: unknown): string[] {
   if (typeof obj["message"] === "string") parts.push(obj["message"]);
   if (typeof obj["stderr"] === "string") parts.push(obj["stderr"]);
   if (obj["data"] != null) {
-    try {
-      parts.push(JSON.stringify(obj["data"]));
-    } catch {
-      // not serialisable — skip
-    }
+    parts.push(...collectHaystrings(obj["data"]));
   }
   return parts;
 }

--- a/packages/harness/src/cli-stream-metadata.ts
+++ b/packages/harness/src/cli-stream-metadata.ts
@@ -1,10 +1,11 @@
 import type { TextStreamPart, ToolSet } from "ai";
+import type { CliProvider } from "./cli-harness";
 import type { HarnessStreamInput } from "./types";
 import { createUsageAccumulator } from "./usage-accumulator";
 
 export interface CliMetadataOptions {
   input: HarnessStreamInput;
-  providerName: "claude-code" | "codex";
+  providerName: CliProvider;
   providerMetadataKey: "claude-code" | "codex-app-server";
   extractSessionId: (metadata: unknown) => string | undefined;
 }

--- a/packages/harness/src/codex/index.ts
+++ b/packages/harness/src/codex/index.ts
@@ -6,12 +6,12 @@
  *  - Does NOT register built-in tools (the CLI manages its own tools and
  *    reaches mesh's MCP endpoint directly).
  *  - Does NOT build a system prompt (the CLI has its own).
- *  - Does NOT support resume. Per the inline source at
- *    `apps/mesh/src/api/routes/decopilot/stream-core.ts` lines 969–971:
- *    "Codex thread resume is not supported because each request spawns a
- *    new codexAppServer process. Thread IDs are local to a process and
- *    cannot be resumed by a different one." Any `input.resumeSessionRef`
- *    is therefore intentionally ignored.
+ *  - Supports resume: each turn spawns a fresh codex app-server process, but
+ *    `resume: input.resumeSessionRef` reloads the on-disk thread (the app
+ *    server persists rollouts under HOME, which survives the per-turn
+ *    subprocess on the long-lived desktop daemon). `threadMode: "persistent"`
+ *    (set in createCodexModel) makes the first turn's thread non-ephemeral so
+ *    it can be resumed next turn.
  *
  * CRITICAL: createCodexModel returns `{ model, provider }` where
  * `provider` is a spawned child process (codex app-server). It MUST be
@@ -135,6 +135,7 @@ export const codexHarnessFactory: HarnessFactory = {
           isPlanMode: input.mode === "plan",
           cwd,
           developerInstructions,
+          resume: input.resumeSessionRef,
         });
 
         try {

--- a/packages/harness/src/codex/index.ts
+++ b/packages/harness/src/codex/index.ts
@@ -42,6 +42,10 @@ import { buildCodingWorkspacePrompt } from "../coding-workspace-prompt";
 import { effectiveCwd } from "../workspace-cwd";
 import { extractUserText, prepCliMessages } from "../cli-message-prep";
 import { createCliMessageMetadata } from "../cli-stream-metadata";
+import {
+  CliSessionExpiredError,
+  isStaleSessionError,
+} from "../cli-session-error";
 import { mergeTitleResult, shouldGenerateTitle } from "../title-merge";
 import { buildCurrentContextPrompt } from "../decopilot/system-prompt";
 import { genTitle } from "../decopilot/title-generator";
@@ -238,6 +242,11 @@ export const codexHarnessFactory: HarnessFactory = {
             for await (const chunk of merged) {
               yield chunk;
             }
+          } catch (err) {
+            if (isStaleSessionError(err)) {
+              throw new CliSessionExpiredError(err);
+            }
+            throw err;
           } finally {
             titleHandle?.finish();
             await titleSetup?.closed.catch(() => {});

--- a/packages/harness/src/codex/index.ts
+++ b/packages/harness/src/codex/index.ts
@@ -243,7 +243,7 @@ export const codexHarnessFactory: HarnessFactory = {
               yield chunk;
             }
           } catch (err) {
-            if (isStaleSessionError(err)) {
+            if (input.resumeSessionRef && isStaleSessionError(err)) {
               throw new CliSessionExpiredError(err);
             }
             throw err;

--- a/packages/harness/src/codex/model/index.ts
+++ b/packages/harness/src/codex/model/index.ts
@@ -33,6 +33,8 @@ export function createCodexModel(
      *  instead of the cloned repo, so file edits land in the wrong tree. */
     cwd?: string;
     developerInstructions?: string;
+    /** On-disk thread id to resume. Omit on the first turn. */
+    resume?: string;
   },
 ): { model: LanguageModelV3; provider: CodexAppServerProvider } {
   const mcpServers = options?.mcpServers
@@ -62,6 +64,10 @@ export function createCodexModel(
       cwd: options?.cwd ?? process.cwd(),
       rmcpClient: true,
       sandboxPolicy: "workspace-write",
+      // Persistent so the FIRST turn creates a non-ephemeral, resumable
+      // on-disk thread (stateless mode would create an ephemeral one).
+      threadMode: "persistent",
+      ...(options?.resume ? { resume: options.resume } : {}),
       connectionTimeoutMs: 30_000,
       requestTimeoutMs: 300_000,
       idleTimeoutMs: 60_000,


### PR DESCRIPTION
## Summary

Makes the **Codex** and **Claude Code** CLI harnesses run as **persistent, resumable sessions**. The cluster now sends only the **new user message + a session ref** to CLI harnesses instead of replaying the full transcript every turn; the desktop CLI's own on-disk session is the conversation memory.

This fixes the recurring **`harness_crashed: Codex ran out of room in the model's context window`**. Root cause: Codex ran stateless — every turn spawned a fresh `codex app-server` and replayed the entire transcript as one giant one-shot prompt, so Codex's own cross-turn auto-compaction could never engage and long threads marched straight into the 272K ceiling. With persistent threads, Codex owns the rollout and compacts across turns.

Scope: **desktop-link only** (long-lived daemon ⇒ the on-disk session survives between turns). No full-transcript fallback by design; a missing/stale session surfaces a clean error.

## What changed

- **`isCliHarness` predicate** (`@decocms/harness/cli-harness`) — gates the new path; decopilot is untouched.
- **Dispatch** (`apps/mesh/.../dispatch-run.ts`) — for CLI harnesses, materialize and send only the delta (`computeCliDelta`) + `resumeSessionRef` (`resolveCliSessionRef`, now codex-aware). Decopilot keeps the full-transcript path byte-for-byte.
- **Codex model wrapper** — `threadMode: "persistent"` (so turn-1 creates a *resumable* on-disk thread, not an ephemeral one) + `resume` option.
- **Codex harness** — passes `resume: input.resumeSessionRef`; removed the stale "resume not supported" comment. (Claude Code already passed `resume`; it now simply receives the delta.)
- **`CliSessionExpiredError`** — both harnesses map a stale/missing session (daemon restarted) to a typed error ("Session expired — start a new thread"). Detection scans `message` / `stderr` / `data` / one level of `cause` (covers Claude Code's `APICallError` shape) and only reclassifies when the turn was actually a resume attempt.

## Testing

- **Unit (`bun test`):** 24 passing — `isCliHarness`, `resolveCliSessionRef`/`computeCliDelta` (first-turn, multi-message-queue, cross-provider), and `isStaleSessionError` (codex/claude-code/stderr/data/cause shapes + negatives).
- **Typecheck:** `bun run check` green across all workspaces.
- **E2E:** `apps/mesh/e2e/tests/cli-session-resume.spec.ts` added (first-turn session capture, delta-only second turn, stale-session error). Requires live Postgres + NATS to run: `bun run --cwd=apps/mesh test:e2e cli-session-resume`.

## Affected areas

`packages/harness` (codex + claude-code harnesses, new cli-harness/cli-session-error helpers), `apps/mesh` dispatch + e2e. Decopilot path is unaffected.

## Follow-ups (not blockers)

- `computeCliDelta` empty-delta guard for a *future* CLI-harness resume/retry path that drops the triggering user message (latent; not currently reachable).
- Verify Claude Code's real stale-`--resume` stderr against the best-effort patterns (the patterns are documented as unverified against the native binary).
- e2e scenario (c) exercises cluster-side error persistence; the harness-side `isStaleSessionError` mapping is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `codex` and `claude-code` run as persistent, resumable CLI sessions on desktop-link. We send only new user messages plus a `resumeSessionRef` to the CLI, fixing Codex context-window crashes on long threads; `decopilot` still gets the full transcript.

- **New Features**
  - Send delta-only messages and a `resumeSessionRef` to CLI harnesses on `user-desktop` using `computeCliDelta` and `resolveCliSessionRef`; non-desktop runs fall back to the full transcript.
  - Single source of truth for CLI providers in `@decocms/harness/cli-harness` (`cliProviderName`, `CliProvider`, `isCliHarness`); used by both metadata write and read paths.
  - Codex: `threadMode: "persistent"` and `resume: input.resumeSessionRef`; Claude Code continues to resume. Both reclassify stale/missing sessions to `CliSessionExpiredError` only when resuming, detecting via `message`/`stderr`/`data`/one-level `cause`.
  - Guard empty deltas on resumable turns by throwing a `PermanentRunError` instead of dispatching zero messages.
  - Tests: new Codex E2E for session capture, delta-only resume, and stale-session relay; unit tests for `cli-session-messages`, `isCliHarness`, and stale-session detection; relay fixture now allows `codingAgentProvider` (defaults to `"claude-code"`).

- **Bug Fixes**
  - E2E: fix assertions to read text from `parts` and error text from `payload.text` in the session-resume spec.

<sup>Written for commit bf47eb5750a9a9b07ec4eefb6635d06cd99e010d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

