### PR TITLE
fix(web): default sandbox provider to null

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -548,7 +548,7 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
     : null;
   const pendingHarnessId = effectivePins?.harness ?? null;
   const pendingSandboxProviderKind: SandboxProviderKind | null =
-    effectivePins?.sandbox ?? "agent-sandbox";
+    effectivePins?.sandbox ?? null;
 
   // Tiptap doc (transient UI state)
   const [tiptapDoc, setTiptapDoc] = useState<Metadata["tiptapDoc"]>(undefined);


### PR DESCRIPTION
## Summary
- Default `pendingSandboxProviderKind` to `null` instead of `"agent-sandbox"` so the sandbox provider is not force-pinned when no explicit preference is set.

## Test plan
- [ ] Verify chat context initializes without a sandbox provider pinned by default
- [ ] Verify explicit sandbox pin via `effectivePins` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `pendingSandboxProviderKind` to null instead of `agent-sandbox` to avoid force-pinning a sandbox provider when no preference is set. Explicit sandbox pins via `effectivePins` still work as expected.

<sup>Written for commit 021f08aa69f592b967b83de27f2d3baa78031ff6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

