### PR TITLE
fix(resilience): use nats:2.14.2-alpine so the healthcheck can run

### DIFF
--- a/tests/resilience/docker-compose.yml
+++ b/tests/resilience/docker-compose.yml
@@ -12,7 +12,10 @@ services:
       retries: 10
 
   nats:
-    image: nats:2.14.2
+    # Use the -alpine variant (busybox sh + wget): the default nats image is
+    # distroless, so the CMD-SHELL /healthz healthcheck below can never run on
+    # it and the container is reported permanently unhealthy, aborting `up --wait`.
+    image: nats:2.14.2-alpine
     command: ["-c", "/etc/nats/nats.conf"]
     volumes:
       - ./nats-config/nats.conf:/etc/nats/nats.conf:ro


### PR DESCRIPTION
## Summary

The resilience CI job fails at the **Start infrastructure** step (`docker compose ... up -d --build --wait`) before any scenario runs.

The `nats` service healthcheck is a `CMD-SHELL` running `wget` against `/healthz`, but the default `nats:2.14.2` image is **distroless** — no shell, no `wget`. The healthcheck can never execute, so the container is reported permanently unhealthy and `up --wait` aborts the whole job.

```
$ docker run --rm --entrypoint sh nats:2.14.2 -c 'echo hi'
exec: "sh": executable file not found in $PATH
```

## Fix

Switch to `nats:2.14.2-alpine` (busybox `sh` + `wget`).

## Testing

- `nats:2.14.2-alpine` confirmed to ship `/bin/sh` and `/usr/bin/wget`
- `docker compose -f tests/resilience/docker-compose.yml up -d --wait nats` → container reaches **Healthy**, exit 0
- Audited every other healthcheck: `nats` was the only distroless-image trap (`postgres:15-alpine` has a shell, `toxiproxy` uses `CMD` against its binary, bun-based services have shells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `nats:2.14.2-alpine` for the resilience `nats` service so the CMD-SHELL `/healthz` healthcheck can run. This fixes CI failing at “Start infrastructure” by avoiding the distroless `nats:2.14.2` image that lacks `sh` and `wget`, allowing `docker compose ... --wait` to succeed.

<sup>Written for commit d89d225abb851def64d2141073a77ae03f298001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

