### PR TITLE
fix(sidebar): remove logo header from desktop sidebar

### DIFF
--- a/apps/mesh/src/web/components/sidebar/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/index.tsx
@@ -2,10 +2,8 @@ import { ErrorBoundary } from "@/web/components/error-boundary";
 import { useProjectSidebarItems } from "@/web/hooks/use-project-sidebar-items";
 import { Suspense } from "react";
 import { Separator } from "@deco/ui/components/separator.tsx";
-import { useSidebar } from "@deco/ui/components/sidebar.tsx";
 import { NavigationSidebar } from "./navigation";
 import { MobileNavigationSidebar } from "./navigation-mobile";
-import { SidebarLogoHeader } from "./sidebar-logo-header";
 import { SidebarInboxFooter } from "./footer/inbox";
 import { SidebarInboxFooterMobile } from "./footer/inbox-mobile";
 import { TaskGroupsList } from "./task-groups/task-groups-list";
@@ -21,13 +19,11 @@ export type {
 
 export function StudioSidebar() {
   const sections = useProjectSidebarItems();
-  const { toggleSidebar } = useSidebar();
 
   return (
     <SidebarAgentGroupsProvider>
       <NavigationSidebar
         sections={sections}
-        header={<SidebarLogoHeader onToggle={toggleSidebar} />}
         footer={<SidebarInboxFooter />}
         additionalContent={
           <ErrorBoundary>

--- a/apps/mesh/src/web/components/sidebar/navigation.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation.tsx
@@ -18,7 +18,6 @@ import { track } from "@/web/lib/posthog-client";
 
 interface NavigationSidebarProps {
   sections: SidebarSection[];
-  header?: ReactNode;
   footer?: ReactNode;
   additionalContent?: ReactNode;
   variant?: "sidebar" | "floating" | "inset";
@@ -94,7 +93,6 @@ function SidebarSectionRenderer({ section }: { section: SidebarSection }) {
  */
 function NavigationSidebarInner({
   sections,
-  header,
   footer,
   additionalContent,
   variant = "sidebar",
@@ -102,7 +100,6 @@ function NavigationSidebarInner({
 }: NavigationSidebarProps) {
   return (
     <Sidebar variant={variant}>
-      {header}
       <SidebarContent
         className={cn(
           "flex flex-col flex-1 px-2 py-2 gap-0.5",


### PR DESCRIPTION
## Summary
The `SidebarLogoHeader` (deco logo + sidebar toggle + linked-desktop indicator) was intended for the **mobile drawer only**, but it also rendered on **desktop** via the `NavigationSidebar` `header` prop, leaking into desktop breakpoints.

This removes it from the desktop `StudioSidebar`. Since that was the **only** consumer of `NavigationSidebar`'s `header` prop, the prop is removed from `NavigationSidebar` entirely. Mobile keeps the header via `MobileNavigationSidebar` (`navigation-mobile.tsx`), which is untouched.

## Changes
- `sidebar/index.tsx` — drop `header={<SidebarLogoHeader … />}` from desktop `StudioSidebar`; remove now-unused `useSidebar`/`SidebarLogoHeader` imports and `toggleSidebar`.
- `sidebar/navigation.tsx` — remove the now-dead `header` prop (interface field, destructure, render slot).

## Testing
- `tsc --noEmit` passes clean (no unused-import/type errors).
- `bun run fmt` — no changes.
- Desktop `StudioSidebar` only mounts when `!isMobile` (`org-shell-layout/index.tsx`), so the header now never renders on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the logo/toggle header from the desktop sidebar so the mobile-only header no longer appears on desktop. Also removed the unused `header` prop from `NavigationSidebar`; mobile keeps the header via `MobileNavigationSidebar`.

<sup>Written for commit f8dd1708af4db465f6ca4d0d9d4112fb0ba624a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

