### PR TITLE
feat(blog-editor): blog block picker fixes + duplicate action

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/block-picker.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/block-picker.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { Plus } from "@untitledui/icons";
+import { Box, Plus } from "@untitledui/icons";
+import type { ComponentType, SVGProps } from "react";
 import {
   Command,
   CommandEmpty,
@@ -14,12 +15,76 @@ import {
   PopoverTrigger,
 } from "@deco/ui/components/popover.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
-import type { BlogBlockType } from "./blog-data";
+import { getIconComponent } from "@/web/components/agent-icon";
+import type { BlogBlockSource, BlogBlockType } from "./blog-data";
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement> & { size?: number }>;
+
+const GROUP_LABEL: Record<BlogBlockSource, string> = {
+  app: "Blocks",
+  site: "Custom blocks",
+};
+
+function BlockIcon({
+  iconName,
+  iconUrl,
+  alt,
+}: {
+  iconName: string;
+  iconUrl?: string;
+  alt: string;
+}) {
+  const Icon: IconComponent = getIconComponent(iconName) ?? Box;
+  return (
+    <div className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-muted">
+      {iconUrl ? (
+        <img src={iconUrl} alt={alt} className="size-5 object-contain" />
+      ) : (
+        <Icon size={16} className="text-muted-foreground" />
+      )}
+    </div>
+  );
+}
+
+function BlockItem({
+  type,
+  onInsert,
+}: {
+  type: BlogBlockType;
+  onInsert: (resolveType: string) => void;
+}) {
+  return (
+    <CommandItem
+      value={`${type.title} ${type.resolveType} ${type.description ?? ""}`}
+      onSelect={() => onInsert(type.resolveType)}
+      className="flex items-center gap-2.5"
+    >
+      <BlockIcon
+        iconName={type.iconName}
+        iconUrl={type.iconUrl}
+        alt={type.title}
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="text-sm font-medium">{type.title}</span>
+        {type.description && (
+          <span className="truncate text-xs text-muted-foreground">
+            {type.description}
+          </span>
+        )}
+      </div>
+    </CommandItem>
+  );
+}
 
 /**
  * The WordPress-style "insert here" affordance: a thin hover zone with a
  * centered ⊕ that opens a searchable block-type picker and inserts at
  * this position. Always visible (not just on hover) when `alwaysShow`.
+ *
+ * Blocks are grouped by source: built-ins from the `deco-cms/blog` app
+ * under "Blocks", and site-defined sections (`site/sections/Blog/Post/*`)
+ * under "Custom blocks". If only one source is present the heading is
+ * omitted to keep the picker compact.
  */
 export function InsertBlockDivider({
   blockTypes,
@@ -31,6 +96,21 @@ export function InsertBlockDivider({
   alwaysShow?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+
+  const appBlocks: BlogBlockType[] = [];
+  const siteBlocks: BlogBlockType[] = [];
+  for (const type of blockTypes) {
+    (type.source === "site" ? siteBlocks : appBlocks).push(type);
+  }
+
+  const handleInsert = (resolveType: string) => {
+    onInsert(resolveType);
+    setOpen(false);
+  };
+
+  // Only label groups when both are present — a lone group with a heading
+  // looks heavy in a narrow popover.
+  const showHeadings = appBlocks.length > 0 && siteBlocks.length > 0;
 
   return (
     <div
@@ -62,31 +142,37 @@ export function InsertBlockDivider({
             <Plus size={14} />
           </button>
         </PopoverTrigger>
-        <PopoverContent className="w-64 p-0" align="center">
+        <PopoverContent className="w-80 p-0" align="center">
           <Command>
             <CommandInput placeholder="Search blocks…" />
-            <CommandList>
+            <CommandList className="max-h-80">
               <CommandEmpty>No blocks found.</CommandEmpty>
-              <CommandGroup>
-                {blockTypes.map((type) => (
-                  <CommandItem
-                    key={type.resolveType}
-                    value={`${type.title} ${type.resolveType}`}
-                    onSelect={() => {
-                      onInsert(type.resolveType);
-                      setOpen(false);
-                    }}
-                    className="flex flex-col items-start gap-0.5"
-                  >
-                    <span className="text-sm font-medium">{type.title}</span>
-                    {type.description && (
-                      <span className="line-clamp-1 text-xs text-muted-foreground">
-                        {type.description}
-                      </span>
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
+              {siteBlocks.length > 0 && (
+                <CommandGroup
+                  heading={showHeadings ? GROUP_LABEL.site : undefined}
+                >
+                  {siteBlocks.map((type) => (
+                    <BlockItem
+                      key={type.resolveType}
+                      type={type}
+                      onInsert={handleInsert}
+                    />
+                  ))}
+                </CommandGroup>
+              )}
+              {appBlocks.length > 0 && (
+                <CommandGroup
+                  heading={showHeadings ? GROUP_LABEL.app : undefined}
+                >
+                  {appBlocks.map((type) => (
+                    <BlockItem
+                      key={type.resolveType}
+                      type={type}
+                      onInsert={handleInsert}
+                    />
+                  ))}
+                </CommandGroup>
+              )}
             </CommandList>
           </Command>
         </PopoverContent>

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-row.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-row.tsx
@@ -1,4 +1,5 @@
-import { DotsGrid, Trash01 } from "@untitledui/icons";
+import { useState } from "react";
+import { Copy01, DotsGrid, Trash01 } from "@untitledui/icons";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@deco/ui/lib/utils.js";
@@ -6,10 +7,19 @@ import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 import { BlockEditor, type RawBlock } from "./block-registry";
 
 /**
- * One block in the post document. Borderless (Notion-style) — the gutter on
- * the left reveals a drag handle and delete on hover; the body renders the
- * block's native inline editor. Dragging is bound to the handle only so it
- * never fights with selecting/editing the block text.
+ * Pixel height below which the row can't fit three 24px buttons stacked
+ * vertically with 4px gaps (3*24 + 2*4 = 80, plus the 6px top inset).
+ * Short blocks (divider, empty paragraph, single-line heading) fall under
+ * this and switch to the inline action layout.
+ */
+const SHORT_ROW_THRESHOLD_PX = 80;
+
+/**
+ * One block in the post document. Borderless (Notion-style) — the left
+ * gutter reveals a drag handle on hover; for tall blocks the duplicate
+ * and delete buttons stack underneath, but for short blocks they move to
+ * the right edge inline so they don't overflow below the row. Dragging
+ * is bound to the handle only so it never fights with text editing.
  */
 export function BlockRow({
   id,
@@ -17,12 +27,14 @@ export function BlockRow({
   meta,
   onChange,
   onDelete,
+  onDuplicate,
 }: {
   id: string;
   block: RawBlock;
   meta: LiveMeta;
   onChange: (next: RawBlock) => void;
   onDelete: () => void;
+  onDuplicate: () => void;
 }) {
   const {
     attributes,
@@ -33,27 +45,59 @@ export function BlockRow({
     isDragging,
   } = useSortable({ id });
 
+  const [isShort, setIsShort] = useState(false);
+
   return (
     <div
-      ref={setNodeRef}
+      // React 19 ref callback: wires dnd-kit's setNodeRef and starts a
+      // ResizeObserver in the same hook. Returning the cleanup tells React
+      // to disconnect when the element unmounts.
+      ref={(el) => {
+        setNodeRef(el);
+        if (!el) return;
+        const ro = new ResizeObserver(([entry]) => {
+          if (!entry) return;
+          setIsShort(entry.contentRect.height < SHORT_ROW_THRESHOLD_PX);
+        });
+        ro.observe(el);
+        return () => ro.disconnect();
+      }}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,
       }}
       className={cn(
-        "group/row relative rounded-md py-1.5 pl-12 pr-2 transition-colors hover:bg-muted/40",
+        "group/row relative rounded-md py-1.5 pl-12 transition-colors hover:bg-muted/40",
+        // Short rows host duplicate+delete inline on the right, so reserve
+        // gutter there too. Tall rows only need a small right margin.
+        isShort ? "pr-20" : "pr-2",
         isDragging && "opacity-50",
       )}
     >
-      <div className="absolute left-1 top-1.5 flex flex-col items-center gap-1 opacity-0 transition-opacity group-hover/row:opacity-100">
+      <button
+        type="button"
+        aria-label="Drag to reorder"
+        className="absolute left-1 top-1.5 flex h-6 w-6 cursor-grab items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground active:cursor-grabbing group-hover/row:opacity-100"
+        {...attributes}
+        {...listeners}
+      >
+        <DotsGrid size={14} />
+      </button>
+      <div
+        className={cn(
+          "absolute flex gap-1 opacity-0 transition-opacity group-hover/row:opacity-100",
+          isShort
+            ? "right-2 top-1.5 flex-row"
+            : "left-1 top-9 flex-col items-center",
+        )}
+      >
         <button
           type="button"
-          aria-label="Drag to reorder"
-          className="flex h-6 w-6 cursor-grab items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground active:cursor-grabbing"
-          {...attributes}
-          {...listeners}
+          aria-label="Duplicate block"
+          onClick={onDuplicate}
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground cursor-pointer"
         >
-          <DotsGrid size={14} />
+          <Copy01 size={14} />
         </button>
         <button
           type="button"

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
@@ -1,5 +1,39 @@
 import { describe, expect, test } from "bun:test";
-import { blockComponentName } from "./blog-data";
+import { blockComponentName, discoverBlogBlockTypes } from "./blog-data";
+import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+
+function metaWith(resolveTypes: string[]): LiveMeta {
+  const group: Record<string, { $ref?: string }> = {};
+  for (const rt of resolveTypes) group[rt] = {};
+  return {
+    manifest: { blocks: { sections: group } },
+    schema: {},
+  };
+}
+
+/** Build a LiveMeta where each resolveType points at a $ref with explicit
+ *  schema metadata (title/description/icon). Mirrors how `@title` / `@icon`
+ *  JSDoc on a section flows through the manifest in production. */
+function metaWithSchemas(
+  entries: Array<{
+    resolveType: string;
+    title?: string;
+    description?: string;
+    icon?: string;
+  }>,
+): LiveMeta {
+  const group: Record<string, { $ref?: string }> = {};
+  const definitions: Record<string, Record<string, unknown>> = {};
+  for (const { resolveType, ...md } of entries) {
+    const refKey = `Def_${Object.keys(definitions).length}`;
+    group[resolveType] = { $ref: `#/definitions/${refKey}` };
+    definitions[refKey] = md;
+  }
+  return {
+    manifest: { blocks: { sections: group } },
+    schema: { definitions },
+  };
+}
 
 describe("blockComponentName", () => {
   test("extracts from standard blog block paths", () => {
@@ -20,5 +54,138 @@ describe("blockComponentName", () => {
   test("strips .ts and .jsx extensions", () => {
     expect(blockComponentName("blog/sections/blocks/Code.ts")).toBe("Code");
     expect(blockComponentName("blog/sections/blocks/Video.jsx")).toBe("Video");
+  });
+});
+
+describe("discoverBlogBlockTypes", () => {
+  test("picks up site/sections/Blog/Post/* blocks (Deno site convention)", () => {
+    const out = discoverBlogBlockTypes(
+      metaWith([
+        "site/sections/Blog/Post/CustomParagraph.tsx",
+        "site/sections/Header.tsx",
+      ]),
+    );
+    expect(out.map((b) => b.resolveType)).toEqual([
+      "site/sections/Blog/Post/CustomParagraph.tsx",
+    ]);
+  });
+
+  test("picks up deco-cms/blog app blocks", () => {
+    const out = discoverBlogBlockTypes(
+      metaWith(["blog/sections/blocks/Paragraph.tsx"]),
+    );
+    expect(out.map((b) => b.resolveType)).toEqual([
+      "blog/sections/blocks/Paragraph.tsx",
+    ]);
+  });
+
+  test("dedupes and sorts by title", () => {
+    const out = discoverBlogBlockTypes(
+      metaWith([
+        "site/sections/Blog/Post/Zeta.tsx",
+        "blog/sections/blocks/Alpha.tsx",
+        "site/sections/Blog/Post/Zeta.tsx",
+      ]),
+    );
+    expect(out.map((b) => b.title)).toEqual(["Alpha", "Zeta"]);
+  });
+
+  test("tags source as 'app' for blog/sections/blocks and 'site' otherwise", () => {
+    const out = discoverBlogBlockTypes(
+      metaWith([
+        "blog/sections/blocks/Paragraph.tsx",
+        "site/sections/Blog/Post/Paragraph.tsx",
+      ]),
+    );
+    const bySource = Object.fromEntries(
+      out.map((b) => [b.resolveType, b.source]),
+    );
+    expect(bySource["blog/sections/blocks/Paragraph.tsx"]).toBe("app");
+    expect(bySource["site/sections/Blog/Post/Paragraph.tsx"]).toBe("site");
+  });
+
+  test("known component names get catalog defaults (title, description, icon)", () => {
+    const paragraph = discoverBlogBlockTypes(
+      metaWith(["site/sections/Blog/Post/Paragraph.tsx"]),
+    )[0]!;
+    expect(paragraph.title).toBe("Paragraph");
+    expect(paragraph.description).toBe("Rich text content");
+    expect(paragraph.iconName).toBe("Pilcrow01");
+  });
+
+  test("unknown component names get fallback icon and no description", () => {
+    const custom = discoverBlogBlockTypes(
+      metaWith(["site/sections/Blog/Post/MyWeirdBlock.tsx"]),
+    )[0]!;
+    expect(custom.title).toBe("MyWeirdBlock");
+    expect(custom.description).toBeUndefined();
+    expect(custom.iconName).toBe("Box");
+  });
+
+  test("app blocks: catalog wins over schema title/description/icon", () => {
+    const block = discoverBlogBlockTypes(
+      metaWithSchemas([
+        {
+          resolveType: "blog/sections/blocks/BlockImage.tsx",
+          title: "BlockImage",
+          description: "raw schema description",
+          icon: "SomeOtherIcon",
+        },
+      ]),
+    )[0]!;
+    expect(block.title).toBe("Image");
+    expect(block.description).toBe("Image with optional caption");
+    expect(block.iconName).toBe("Image01");
+  });
+
+  test("site blocks: @title and @description from schema win over catalog", () => {
+    const block = discoverBlogBlockTypes(
+      metaWithSchemas([
+        {
+          resolveType: "site/sections/Blog/Post/Paragraph.tsx",
+          title: "My fancy paragraph",
+          description: "Custom description from the site",
+        },
+      ]),
+    )[0]!;
+    expect(block.title).toBe("My fancy paragraph");
+    expect(block.description).toBe("Custom description from the site");
+  });
+
+  test("site blocks: @icon as URL is exposed as iconUrl, not iconName", () => {
+    const out = discoverBlogBlockTypes(
+      metaWithSchemas([
+        {
+          resolveType: "site/sections/Blog/Post/CustomA.tsx",
+          icon: "https://example.com/icon.svg",
+        },
+        {
+          resolveType: "site/sections/Blog/Post/CustomB.tsx",
+          icon: "data:image/svg+xml;base64,PHN2Zy8+",
+        },
+        {
+          resolveType: "site/sections/Blog/Post/CustomC.tsx",
+          icon: "/static/icon.png",
+        },
+      ]),
+    );
+    expect(out.map((b) => b.iconUrl)).toEqual([
+      "https://example.com/icon.svg",
+      "data:image/svg+xml;base64,PHN2Zy8+",
+      "/static/icon.png",
+    ]);
+  });
+
+  test("site blocks: @icon as plain string is treated as untitled icon name", () => {
+    const block = discoverBlogBlockTypes(
+      metaWithSchemas([
+        {
+          resolveType: "site/sections/Blog/Post/CustomD.tsx",
+          icon: "Star01",
+        },
+      ]),
+    )[0]!;
+    expect(block.iconName).toBe("Star01");
+    expect(block.iconUrl).toBeUndefined();
   });
 });

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -19,9 +19,6 @@ const BLOG_LOADER_RESOLVE_TYPES = {
   category: "blog/loaders/Category.ts",
 } as const;
 
-/** Prefix every blog content block (Paragraph, Heading, …) shares. */
-const BLOG_BLOCK_PREFIX = "blog/sections/blocks/";
-
 export type BlogKind = "posts" | "authors" | "categories";
 
 export const BLOG_KINDS: readonly BlogKind[] = [
@@ -239,17 +236,168 @@ export function emptyBlogPayload(kind: BlogKind): Record<string, unknown> {
   }
 }
 
+export type BlogBlockSource = "app" | "site";
+
 export interface BlogBlockType {
   resolveType: string;
   title: string;
   description?: string;
-  icon?: string;
+  /** @untitledui/icons component name; resolved via getIconComponent. */
+  iconName: string;
+  /** URL when the section declares `@icon` as an image (http(s)/data/absolute). */
+  iconUrl?: string;
+  /** "app" = deco-cms/blog built-ins; "site" = section defined by this site. */
+  source: BlogBlockSource;
 }
 
 /**
- * Discover the content block types a post can contain
- * (`blog/sections/blocks/*`) from the live manifest, with title/icon
- * metadata for the inserter UI.
+ * Defaults for the well-known blog block component names. Used to give
+ * the inserter pretty labels, descriptions and icons.
+ *
+ * For **app blocks** (`blog/sections/blocks/*`) the catalog overrides the
+ * schema metadata — built-in schemas typically just echo the class name
+ * (e.g. "BlockImage"), and we want the friendly label ("Image") instead.
+ *
+ * For **site blocks** (`site/sections/Blog/Post/*`) the schema's `@title`
+ * / `@description` / `@icon` win — site authors should be in control of
+ * their own block presentation. The catalog only fills in when the schema
+ * omits a field.
+ */
+const KNOWN_BLOG_BLOCK_CATALOG: Record<
+  string,
+  { title: string; description: string; iconName: string }
+> = {
+  Paragraph: {
+    title: "Paragraph",
+    description: "Rich text content",
+    iconName: "Pilcrow01",
+  },
+  Heading: {
+    title: "Heading",
+    description: "Section title (H1–H6)",
+    iconName: "HeadingSquare",
+  },
+  Quote: {
+    title: "Quote",
+    description: "Pull quote",
+    iconName: "MessageTextSquare02",
+  },
+  Code: {
+    title: "Code",
+    description: "Code block with syntax highlighting",
+    iconName: "Code02",
+  },
+  List: {
+    title: "List",
+    description: "Bulleted or numbered list",
+    iconName: "List",
+  },
+  BlockImage: {
+    title: "Image",
+    description: "Image with optional caption",
+    iconName: "Image01",
+  },
+  Video: {
+    title: "Video",
+    description: "Embedded video",
+    iconName: "PlayCircle",
+  },
+  Divider: {
+    title: "Divider",
+    description: "Horizontal divider",
+    iconName: "Divider",
+  },
+  Cta: {
+    title: "Call to action",
+    description: "Button linking to a URL",
+    iconName: "CursorClick01",
+  },
+  Callout: {
+    title: "Callout",
+    description: "Highlighted note, tip or warning",
+    iconName: "Lightbulb02",
+  },
+  Stat: {
+    title: "Stat",
+    description: "Single key metric",
+    iconName: "BarChartSquareUp",
+  },
+  StatGroup: {
+    title: "Stat group",
+    description: "Row of metrics",
+    iconName: "BarChartSquare02",
+  },
+  CardGroup: {
+    title: "Card group",
+    description: "Grid of cards",
+    iconName: "LayoutGrid01",
+  },
+  Checklist: {
+    title: "Checklist",
+    description: "List of check items",
+    iconName: "CheckSquare",
+  },
+  Steps: {
+    title: "Steps",
+    description: "Step-by-step guide",
+    iconName: "LayersThree01",
+  },
+  Comparison: {
+    title: "Comparison",
+    description: "Side-by-side comparison",
+    iconName: "Columns03",
+  },
+  ProductCard: {
+    title: "Product card",
+    description: "Single product",
+    iconName: "Tag01",
+  },
+  ProductShelf: {
+    title: "Product shelf",
+    description: "Row of products",
+    iconName: "ShoppingBag01",
+  },
+};
+
+const FALLBACK_BLOG_BLOCK_ICON = "Box";
+
+function blogBlockSource(resolveType: string): BlogBlockSource {
+  return resolveType.startsWith("site/") ? "site" : "app";
+}
+
+/**
+ * Schema `icon` strings can be either an @untitledui/icons component name
+ * (e.g. "Pilcrow01") or an image URL declared via `@icon`. URLs start
+ * with a protocol, `data:`, or an absolute path.
+ */
+function isImageUrl(icon: string): boolean {
+  return (
+    icon.startsWith("http://") ||
+    icon.startsWith("https://") ||
+    icon.startsWith("data:") ||
+    icon.startsWith("/")
+  );
+}
+
+/**
+ * Pick the first defined value among the candidates. Used to express
+ * precedence chains compactly without `??` ladders that obscure intent.
+ */
+function pick<T>(...candidates: Array<T | undefined>): T | undefined {
+  for (const c of candidates) {
+    if (c !== undefined) return c;
+  }
+  return undefined;
+}
+
+/**
+ * Discover the content block types a post can contain from the live
+ * manifest, with title/icon metadata for the inserter UI. Recognizes both
+ * the `deco-cms/blog` app blocks (`blog/sections/blocks/*`) and
+ * site-defined blog blocks (`site/sections/Blog/Post/*`), matching the
+ * same set that `isBlogPostBlockResolveType` accepts everywhere else.
+ *
+ * Precedence depends on the block's source — see KNOWN_BLOG_BLOCK_CATALOG.
  */
 export function discoverBlogBlockTypes(meta: LiveMeta): BlogBlockType[] {
   const seen = new Set<string>();
@@ -257,16 +405,43 @@ export function discoverBlogBlockTypes(meta: LiveMeta): BlogBlockType[] {
   const groups = meta.manifest?.blocks ?? {};
   for (const group of Object.values(groups)) {
     for (const resolveType of Object.keys(group)) {
-      if (!resolveType.startsWith(BLOG_BLOCK_PREFIX) || seen.has(resolveType)) {
+      if (!isBlogPostBlockResolveType(resolveType) || seen.has(resolveType)) {
         continue;
       }
       seen.add(resolveType);
       const md = resolveBlockSchemaMetadata(resolveType, meta);
+      const name = blockComponentName(resolveType);
+      const catalog = KNOWN_BLOG_BLOCK_CATALOG[name];
+      const source = blogBlockSource(resolveType);
+
+      // Site blocks: schema's @title/@description/@icon wins. App blocks:
+      // catalog wins (built-in schemas just echo class names like "BlockImage").
+      const title =
+        (source === "site"
+          ? pick(md.title, catalog?.title)
+          : pick(catalog?.title, md.title)) ?? name;
+      const description =
+        source === "site"
+          ? pick(md.description, catalog?.description)
+          : pick(catalog?.description, md.description);
+
+      // `@icon` on a site block can be a URL (rendered as <img>) or an
+      // @untitledui/icons component name. App blocks always use the
+      // catalog icon — built-in schemas don't carry useful icon hints.
+      const rawIcon = source === "site" ? md.icon : undefined;
+      const iconUrl = rawIcon && isImageUrl(rawIcon) ? rawIcon : undefined;
+      const iconName =
+        iconUrl !== undefined
+          ? (catalog?.iconName ?? FALLBACK_BLOG_BLOCK_ICON)
+          : (pick(rawIcon, catalog?.iconName) ?? FALLBACK_BLOG_BLOCK_ICON);
+
       out.push({
         resolveType,
-        title: md.title ?? blockComponentName(resolveType),
-        description: md.description,
-        icon: md.icon,
+        title,
+        description,
+        iconName,
+        iconUrl,
+        source,
       });
     }
   }

--- a/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
@@ -117,6 +117,20 @@ export function PostEditor({
     syncBlocks(blockItems.filter((_, i) => i !== index));
   };
 
+  // structuredClone deep-copies the block payload so the duplicate doesn't
+  // share nested references (e.g. arrays inside ProductShelf) with the
+  // original — editing one would otherwise mutate the other.
+  const duplicateAt = (index: number) => {
+    const source = blockItems[index];
+    if (!source) return;
+    const next = [...blockItems];
+    next.splice(index + 1, 0, {
+      id: uid(),
+      block: structuredClone(source.block),
+    });
+    syncBlocks(next);
+  };
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
     useSensor(KeyboardSensor, {
@@ -191,6 +205,7 @@ export function PostEditor({
                         meta={meta}
                         onChange={(v) => updateAt(index, v)}
                         onDelete={() => removeAt(index)}
+                        onDuplicate={() => duplicateAt(index)}
                       />
                       <InsertBlockDivider
                         blockTypes={blockTypes}


### PR DESCRIPTION
## Summary

- Discover site-defined blog blocks (`site/sections/Blog/Post/*`), not just the `deco-cms/blog` app blocks — fixes the "No blocks found" picker on Deno sites that ship their own sections.
- Group the inserter into **Blocks** (built-ins) and **Custom blocks** (site-defined) with icons, pretty titles and short descriptions.
- Built-ins use a catalog keyed by component name (e.g. `BlockImage` → "Image"); custom blocks honor `@title` / `@description` / `@icon` from the section's JSDoc, with `@icon` rendered as `<img>` when it looks like a URL (http(s) / data: / absolute path).
- Add a **Duplicate block** action next to drag/delete. Uses `structuredClone` so nested arrays/objects don't share references with the original.
- Gutter layout adapts to row height: tall rows keep drag/duplicate/delete stacked on the left; short rows (divider, empty paragraph, single-line heading) move duplicate+delete inline to the right so the actions never overflow below the row.

## Test plan

- [x] `bun test apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts` — 13/13 pass (5 new tests cover source tagging, catalog precedence per source, URL icons, and untitled-icon-name fallback).
- [x] `bunx tsc --noEmit` (apps/mesh) — 0 errors.
- [x] `bun run fmt` — clean.
- [x] `bun run lint` — no new warnings (3 pre-existing in unrelated files).
- [x] Manual: open a post in a Deno site that defines `site/sections/Blog/Post/CustomParagraph.tsx`, confirm the section appears under "Custom blocks" with the right title/icon.
- [x] Manual: insert a divider/short heading and verify duplicate/delete render inline on the right; insert a tall block (rich text with multiple lines) and verify they stay stacked on the left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the blog block picker by discovering site-defined blocks and adding icons with clear titles. Adds a Duplicate block action and adapts row actions based on height.

- **New Features**
  - Groups picker into “Blocks” (built-ins) and “Custom blocks” with icons, titles, and short descriptions. Built-ins use a catalog by component name; site blocks use `@title`, `@description`, and `@icon` (URL icons render as images).
  - Adds Duplicate block next to drag/delete, using `structuredClone` to avoid shared references.
  - Adaptive gutter: tall rows keep stacked actions on the left; short rows move duplicate/delete inline on the right.

- **Bug Fixes**
  - Picker now discovers `site/sections/Blog/Post/*` in addition to `blog/sections/blocks/*`, fixing the “No blocks found” issue on Deno sites with custom sections.

<sup>Written for commit 82b59ccc7fbc152bfad497e8097898946347f34d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

