### PR TITLE
feat(web): add DynamicOptions widget for sections editor

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -136,6 +136,7 @@ export function AnyOfField({
   meta,
   decofile,
   onSaveReferencedBlock,
+  sandbox,
 }: FieldProps) {
   const baseRefs = (schema.anyOfRefs ?? []).filter((r) => r.resolveType !== "");
   const savedRef =
@@ -296,6 +297,7 @@ export function AnyOfField({
         meta={meta}
         decofile={decofile}
         onSaveReferencedBlock={onSaveReferencedBlock}
+        sandbox={sandbox}
       />
     ) : null;
 

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -251,6 +251,7 @@ export function ArrayField({
   previewBaseUrl,
   onAddSectionItem,
   onRequestAddSection,
+  sandbox,
 }: FieldProps) {
   const items = Array.isArray(value) ? value : [];
   const itemSchema = schema.items;
@@ -456,6 +457,7 @@ export function ArrayField({
             previewBaseUrl={previewBaseUrl}
             onAddSectionItem={onAddSectionItem}
             onRequestAddSection={onRequestAddSection}
+            sandbox={sandbox}
           />
         ) : editorSchema ? (
           renderField({
@@ -474,6 +476,7 @@ export function ArrayField({
             previewBaseUrl,
             onAddSectionItem,
             onRequestAddSection,
+            sandbox,
           })
         ) : null}
       </div>

--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeOptions } from "./dynamic-options-field";
+
+describe("normalizeOptions", () => {
+  test("returns empty array for non-array input", () => {
+    expect(normalizeOptions(null)).toEqual([]);
+    expect(normalizeOptions(undefined)).toEqual([]);
+    expect(normalizeOptions("hello")).toEqual([]);
+    expect(normalizeOptions(42)).toEqual([]);
+    expect(normalizeOptions({})).toEqual([]);
+  });
+
+  test("returns empty array for empty array", () => {
+    expect(normalizeOptions([])).toEqual([]);
+  });
+
+  test("converts string items to {value, label}", () => {
+    expect(normalizeOptions(["a", "b"])).toEqual([
+      { value: "a", label: "a" },
+      { value: "b", label: "b" },
+    ]);
+  });
+
+  test("passes through object items with value field", () => {
+    const input = [
+      { value: "x", label: "Option X" },
+      { value: "y", label: "Option Y", image: "https://img.test/y.png" },
+    ];
+    expect(normalizeOptions(input)).toEqual([
+      { value: "x", label: "Option X", image: undefined },
+      { value: "y", label: "Option Y", image: "https://img.test/y.png" },
+    ]);
+  });
+
+  test("uses String(value) as label when label is missing", () => {
+    expect(normalizeOptions([{ value: 123 }])).toEqual([
+      { value: "123", label: "123", image: undefined },
+    ]);
+  });
+
+  test("ignores items without value field", () => {
+    expect(normalizeOptions([{ label: "no value" }, null, 42])).toEqual([]);
+  });
+
+  test("handles mixed string and object items", () => {
+    const result = normalizeOptions([
+      "plain",
+      { value: "obj", label: "Object" },
+    ]);
+    expect(result).toEqual([
+      { value: "plain", label: "plain" },
+      { value: "obj", label: "Object", image: undefined },
+    ]);
+  });
+
+  test("ignores non-string image values", () => {
+    expect(normalizeOptions([{ value: "v", image: 123 }])).toEqual([
+      { value: "v", label: "v", image: undefined },
+    ]);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
@@ -21,13 +21,13 @@ import { Label } from "@deco/ui/components/label.tsx";
 import { KEYS } from "@/web/lib/query-keys";
 import type { FieldProps } from "./field-props";
 
-interface DynamicOption {
+export interface DynamicOption {
   value: string;
   label?: string;
   image?: string;
 }
 
-function normalizeOptions(data: unknown): DynamicOption[] {
+export function normalizeOptions(data: unknown): DynamicOption[] {
   if (!Array.isArray(data)) return [];
   const result: DynamicOption[] = [];
   for (const item of data) {
@@ -56,21 +56,37 @@ async function fetchDynamicOptions(
   }
   const base = previewUrl.replace(/\/+$/, "");
   const url = `${base}/deco/invoke/${loaderPath}`;
-  console.log("[DynamicOptions] fetching", { url, payload });
   const res = await fetch(url, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(payload),
   });
   if (!res.ok) {
-    console.error("[DynamicOptions] fetch failed", res.status, res.statusText);
     throw new Error(`Failed to fetch dynamic options: ${res.status}`);
   }
   const data = await res.json();
-  console.log("[DynamicOptions] raw response", data);
-  const normalized = normalizeOptions(data);
-  console.log("[DynamicOptions] normalized options", normalized);
-  return normalized;
+  return normalizeOptions(data);
+}
+
+function FieldHeader({
+  path,
+  label,
+  description,
+}: {
+  path: string;
+  label: string;
+  description?: string;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <Label htmlFor={path}>{label}</Label>
+      {description && (
+        <p className="text-xs leading-normal text-muted-foreground">
+          {description}
+        </p>
+      )}
+    </div>
+  );
 }
 
 export function DynamicOptionsField({
@@ -85,31 +101,38 @@ export function DynamicOptionsField({
   const previewUrl = sandbox?.previewUrl;
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  console.log("[DynamicOptions] render", {
-    path,
-    format: schema.format,
-    options: schema.options,
-    loaderPath,
-    previewUrl,
-    hasSandbox: !!sandbox,
-    value,
-  });
-
-  const sandboxKey = sandbox
-    ? `${sandbox.orgSlug}/${sandbox.virtualMcpId}/${sandbox.branch}`
-    : "";
-
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+
+  // Track mounted state for debounce safety.
+  // We assign to the ref in the render body so it resets on each render,
+  // and use a cleanup ref pattern: the ref starts true and is set false
+  // via a finalizer callback stored in another ref.
+  // Since useEffect is banned, we rely on the ref being checked in the
+  // setTimeout callback — if the component re-mounts with new props,
+  // the old closure's mountedRef will have been replaced.
+  const cleanupRef = useRef<(() => void) | null>(null);
+  if (!cleanupRef.current) {
+    const mounted = mountedRef;
+    cleanupRef.current = () => {
+      mounted.current = false;
+    };
+  }
 
   const handleSearchChange = (next: string) => {
     setSearch(next);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      setDebouncedSearch(next);
+      if (mountedRef.current) {
+        setDebouncedSearch(next);
+      }
     }, 300);
   };
+
+  const sandboxKey = sandbox
+    ? `${sandbox.orgSlug}/${sandbox.virtualMcpId}/${sandbox.branch}`
+    : "";
 
   const query = useQuery({
     queryKey: KEYS.sandboxInvoke(
@@ -122,7 +145,7 @@ export function DynamicOptionsField({
         loaderPath!,
         debouncedSearch || undefined,
       ),
-    enabled: !!previewUrl && !!loaderPath,
+    enabled: !!previewUrl && !!loaderPath && open,
     staleTime: 60_000,
     retry: 1,
   });
@@ -135,36 +158,11 @@ export function DynamicOptionsField({
   if (!previewUrl || !loaderPath) {
     return (
       <div className="space-y-2">
-        <div className="space-y-0.5">
-          <Label htmlFor={path}>{label}</Label>
-          {schema.description && (
-            <p className="text-xs leading-normal text-muted-foreground">
-              {schema.description}
-            </p>
-          )}
-        </div>
-        <Input
-          id={path}
-          type="text"
-          value={currentValue}
-          onChange={(e) => onChange(e.target.value)}
+        <FieldHeader
+          path={path}
+          label={label}
+          description={schema.description}
         />
-      </div>
-    );
-  }
-
-  // No options available and not loading — show text input fallback
-  if (options.length === 0 && !query.isLoading) {
-    return (
-      <div className="space-y-2">
-        <div className="space-y-0.5">
-          <Label htmlFor={path}>{label}</Label>
-          {schema.description && (
-            <p className="text-xs leading-normal text-muted-foreground">
-              {schema.description}
-            </p>
-          )}
-        </div>
         <Input
           id={path}
           type="text"
@@ -177,14 +175,7 @@ export function DynamicOptionsField({
 
   return (
     <div className="space-y-2">
-      <div className="space-y-0.5">
-        <Label htmlFor={path}>{label}</Label>
-        {schema.description && (
-          <p className="text-xs leading-normal text-muted-foreground">
-            {schema.description}
-          </p>
-        )}
-      </div>
+      <FieldHeader path={path} label={label} description={schema.description} />
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
@@ -207,10 +198,10 @@ export function DynamicOptionsField({
                   {selectedOption.label ?? selectedOption.value}
                 </span>
               </span>
+            ) : currentValue ? (
+              <span className="truncate">{currentValue}</span>
             ) : (
-              <span className="text-muted-foreground">
-                {query.isLoading ? "Loading..." : "Select..."}
-              </span>
+              <span className="text-muted-foreground">Select...</span>
             )}
             <ChevronSelectorVertical className="size-4 shrink-0 opacity-50" />
           </Button>

--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
@@ -103,30 +103,12 @@ export function DynamicOptionsField({
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const mountedRef = useRef(true);
-
-  // Track mounted state for debounce safety.
-  // We assign to the ref in the render body so it resets on each render,
-  // and use a cleanup ref pattern: the ref starts true and is set false
-  // via a finalizer callback stored in another ref.
-  // Since useEffect is banned, we rely on the ref being checked in the
-  // setTimeout callback — if the component re-mounts with new props,
-  // the old closure's mountedRef will have been replaced.
-  const cleanupRef = useRef<(() => void) | null>(null);
-  if (!cleanupRef.current) {
-    const mounted = mountedRef;
-    cleanupRef.current = () => {
-      mounted.current = false;
-    };
-  }
 
   const handleSearchChange = (next: string) => {
     setSearch(next);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      if (mountedRef.current) {
-        setDebouncedSearch(next);
-      }
+      setDebouncedSearch(next);
     }, 300);
   };
 

--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
@@ -1,0 +1,271 @@
+import { useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Check, ChevronSelectorVertical } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@deco/ui/components/command.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import { KEYS } from "@/web/lib/query-keys";
+import type { FieldProps } from "./field-props";
+
+interface DynamicOption {
+  value: string;
+  label?: string;
+  image?: string;
+}
+
+function normalizeOptions(data: unknown): DynamicOption[] {
+  if (!Array.isArray(data)) return [];
+  const result: DynamicOption[] = [];
+  for (const item of data) {
+    if (typeof item === "string") {
+      result.push({ value: item, label: item });
+    } else if (item && typeof item === "object" && "value" in item) {
+      const obj = item as Record<string, unknown>;
+      result.push({
+        value: String(obj.value),
+        label: typeof obj.label === "string" ? obj.label : String(obj.value),
+        image: typeof obj.image === "string" ? obj.image : undefined,
+      });
+    }
+  }
+  return result;
+}
+
+async function fetchDynamicOptions(
+  previewUrl: string,
+  loaderPath: string,
+  term?: string,
+): Promise<DynamicOption[]> {
+  const payload: Record<string, unknown> = {};
+  if (term) {
+    payload.term = term;
+  }
+  const base = previewUrl.replace(/\/+$/, "");
+  const url = `${base}/deco/invoke/${loaderPath}`;
+  console.log("[DynamicOptions] fetching", { url, payload });
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    console.error("[DynamicOptions] fetch failed", res.status, res.statusText);
+    throw new Error(`Failed to fetch dynamic options: ${res.status}`);
+  }
+  const data = await res.json();
+  console.log("[DynamicOptions] raw response", data);
+  const normalized = normalizeOptions(data);
+  console.log("[DynamicOptions] normalized options", normalized);
+  return normalized;
+}
+
+export function DynamicOptionsField({
+  schema,
+  value,
+  onChange,
+  path,
+  label,
+  sandbox,
+}: FieldProps) {
+  const loaderPath = schema.options;
+  const previewUrl = sandbox?.previewUrl;
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  console.log("[DynamicOptions] render", {
+    path,
+    format: schema.format,
+    options: schema.options,
+    loaderPath,
+    previewUrl,
+    hasSandbox: !!sandbox,
+    value,
+  });
+
+  const sandboxKey = sandbox
+    ? `${sandbox.orgSlug}/${sandbox.virtualMcpId}/${sandbox.branch}`
+    : "";
+
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  const handleSearchChange = (next: string) => {
+    setSearch(next);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedSearch(next);
+    }, 300);
+  };
+
+  const query = useQuery({
+    queryKey: KEYS.sandboxInvoke(
+      sandboxKey,
+      `dynamic-options:${loaderPath ?? ""}:${debouncedSearch}`,
+    ),
+    queryFn: () =>
+      fetchDynamicOptions(
+        previewUrl!,
+        loaderPath!,
+        debouncedSearch || undefined,
+      ),
+    enabled: !!previewUrl && !!loaderPath,
+    staleTime: 60_000,
+    retry: 1,
+  });
+
+  const options = query.data ?? [];
+  const currentValue = typeof value === "string" ? value : "";
+  const selectedOption = options.find((opt) => opt.value === currentValue);
+
+  // Fallback to text input when preview is not available
+  if (!previewUrl || !loaderPath) {
+    return (
+      <div className="space-y-2">
+        <div className="space-y-0.5">
+          <Label htmlFor={path}>{label}</Label>
+          {schema.description && (
+            <p className="text-xs leading-normal text-muted-foreground">
+              {schema.description}
+            </p>
+          )}
+        </div>
+        <Input
+          id={path}
+          type="text"
+          value={currentValue}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </div>
+    );
+  }
+
+  // No options available and not loading — show text input fallback
+  if (options.length === 0 && !query.isLoading) {
+    return (
+      <div className="space-y-2">
+        <div className="space-y-0.5">
+          <Label htmlFor={path}>{label}</Label>
+          {schema.description && (
+            <p className="text-xs leading-normal text-muted-foreground">
+              {schema.description}
+            </p>
+          )}
+        </div>
+        <Input
+          id={path}
+          type="text"
+          value={currentValue}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="space-y-0.5">
+        <Label htmlFor={path}>{label}</Label>
+        {schema.description && (
+          <p className="text-xs leading-normal text-muted-foreground">
+            {schema.description}
+          </p>
+        )}
+      </div>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="h-10 w-full justify-between font-normal"
+          >
+            {selectedOption ? (
+              <span className="flex min-w-0 items-center gap-2">
+                {selectedOption.image && (
+                  <img
+                    src={selectedOption.image}
+                    alt=""
+                    referrerPolicy="no-referrer"
+                    className="h-6 w-6 shrink-0 rounded object-cover"
+                  />
+                )}
+                <span className="truncate">
+                  {selectedOption.label ?? selectedOption.value}
+                </span>
+              </span>
+            ) : (
+              <span className="text-muted-foreground">
+                {query.isLoading ? "Loading..." : "Select..."}
+              </span>
+            )}
+            <ChevronSelectorVertical className="size-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="p-0"
+          style={{ width: "var(--radix-popover-trigger-width)" }}
+        >
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="Search..."
+              className="h-9"
+              value={search}
+              onValueChange={handleSearchChange}
+            />
+            <CommandList>
+              <CommandEmpty>
+                {query.isLoading ? "Loading..." : "No results found."}
+              </CommandEmpty>
+              <CommandGroup>
+                {options.map((opt) => (
+                  <CommandItem
+                    key={opt.value}
+                    value={opt.value}
+                    onSelect={() => {
+                      onChange(opt.value === currentValue ? "" : opt.value);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      {opt.image && (
+                        <img
+                          src={opt.image}
+                          alt=""
+                          referrerPolicy="no-referrer"
+                          className="h-9 w-9 shrink-0 rounded object-cover"
+                        />
+                      )}
+                      <span className="truncate">{opt.label ?? opt.value}</span>
+                    </span>
+                    <Check
+                      className={cn(
+                        "ml-auto size-4 shrink-0",
+                        currentValue === opt.value
+                          ? "opacity-100"
+                          : "opacity-0",
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
@@ -22,4 +22,10 @@ export interface FieldProps {
     blockKey: string,
     data: Record<string, unknown>,
   ) => void;
+  sandbox?: {
+    orgSlug: string;
+    virtualMcpId: string;
+    branch: string;
+    previewUrl?: string;
+  } | null;
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
@@ -1,6 +1,13 @@
 import type { LiveMeta, SchemaProperty } from "../resolve-schema";
 import type { SectionCatalogEntry } from "../section-catalog";
 
+export interface SandboxConfig {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  previewUrl?: string;
+}
+
 export interface FieldProps {
   schema: SchemaProperty;
   value: unknown;
@@ -22,10 +29,5 @@ export interface FieldProps {
     blockKey: string,
     data: Record<string, unknown>,
   ) => void;
-  sandbox?: {
-    orgSlug: string;
-    virtualMcpId: string;
-    branch: string;
-    previewUrl?: string;
-  } | null;
+  sandbox?: SandboxConfig | null;
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/object-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/object-field.tsx
@@ -18,6 +18,7 @@ export function ObjectField({
   previewBaseUrl,
   onAddSectionItem,
   onRequestAddSection,
+  sandbox,
 }: FieldProps) {
   const [open, setOpen] = useState(false);
   const objValue =
@@ -77,6 +78,7 @@ export function ObjectField({
             previewBaseUrl={previewBaseUrl}
             onAddSectionItem={onAddSectionItem}
             onRequestAddSection={onRequestAddSection}
+            sandbox={sandbox}
           />
         </div>
       )}

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -105,6 +105,47 @@ describe("resolveSchema – nullable unions inherit leaf metadata", () => {
       ?.image;
     expect(image?.default).toBeNull();
   });
+
+  test("preserves options on dynamic-options field", () => {
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        collection: {
+          type: "string",
+          format: "dynamic-options",
+          options: "vtex/loaders/collections/list.ts",
+        },
+      },
+    });
+
+    const collection = resolveSchema("site/sections/Test.tsx", meta)?.properties
+      ?.collection;
+    expect(collection?.format).toBe("dynamic-options");
+    expect(collection?.options).toBe("vtex/loaders/collections/list.ts");
+  });
+
+  test("preserves options through nullable union", () => {
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        collection: {
+          anyOf: [
+            {
+              type: "string",
+              format: "dynamic-options",
+              options: "vtex/loaders/collections/list.ts",
+            },
+            { type: "null" },
+          ],
+        },
+      },
+    });
+
+    const collection = resolveSchema("site/sections/Test.tsx", meta)?.properties
+      ?.collection;
+    expect(collection?.format).toBe("dynamic-options");
+    expect(collection?.options).toBe("vtex/loaders/collections/list.ts");
+  });
 });
 
 describe("resolveSchema – app resolveType aliases", () => {

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -27,6 +27,8 @@ export interface SchemaProperty {
   titleBy?: string;
   /** Mustache template for array-item thumbnails (from schema `@image`) */
   image?: string;
+  /** Loader path for dynamic-options fields (from schema `@options`) */
+  options?: string;
   /**
    * Present on "block-ref" fields — a union of compatible block types
    * (loaders, sections, etc.). The UI renders a selector instead of
@@ -749,6 +751,25 @@ export function resolveSchema(
         typeof resolved.image === "string"
           ? resolved.image
           : fromLeaf<string>("image"),
+      options: (() => {
+        const opt =
+          typeof resolved.options === "string"
+            ? resolved.options
+            : fromLeaf<string>("options");
+        if (
+          typeof resolved.format === "string" &&
+          resolved.format === "dynamic-options"
+        ) {
+          console.log("[buildProperty] dynamic-options field", {
+            format: resolved.format,
+            options: opt,
+            rawOptions: resolved.options,
+            leafOptions: fromLeaf<string>("options"),
+            vOptions: v.options,
+          });
+        }
+        return opt;
+      })(),
     };
   };
 

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -751,25 +751,10 @@ export function resolveSchema(
         typeof resolved.image === "string"
           ? resolved.image
           : fromLeaf<string>("image"),
-      options: (() => {
-        const opt =
-          typeof resolved.options === "string"
-            ? resolved.options
-            : fromLeaf<string>("options");
-        if (
-          typeof resolved.format === "string" &&
-          resolved.format === "dynamic-options"
-        ) {
-          console.log("[buildProperty] dynamic-options field", {
-            format: resolved.format,
-            options: opt,
-            rawOptions: resolved.options,
-            leafOptions: fromLeaf<string>("options"),
-            vOptions: v.options,
-          });
-        }
-        return opt;
-      })(),
+      options:
+        typeof resolved.options === "string"
+          ? resolved.options
+          : fromLeaf<string>("options"),
     };
   };
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -185,16 +185,8 @@ export function renderField(props: FieldProps) {
   }
 
   // dynamic-options → DynamicOptionsField (select with options from a loader)
-  if (schema.format === "dynamic-options") {
-    console.log("[renderField] dynamic-options match", {
-      path: props.path,
-      format: schema.format,
-      options: schema.options,
-      hasSandbox: !!props.sandbox,
-    });
-    if (schema.options) {
-      return <DynamicOptionsField key={props.path} {...props} />;
-    }
+  if (schema.format === "dynamic-options" && schema.options) {
+    return <DynamicOptionsField key={props.path} {...props} />;
   }
 
   // Enum (including extracted const enums)

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -7,6 +7,7 @@ import { EnumField } from "./fields/enum-field";
 import { ArrayField } from "./fields/array-field";
 import { ObjectField } from "./fields/object-field";
 import { AnyOfField } from "./fields/any-of-field";
+import { DynamicOptionsField } from "./fields/dynamic-options-field";
 import { FileField } from "./fields/file-field";
 import { ImageField } from "./fields/image-field";
 import { isSecretBlock, SecretField } from "./fields/secret-field";
@@ -183,6 +184,19 @@ export function renderField(props: FieldProps) {
     return <FileField key={props.path} {...props} />;
   }
 
+  // dynamic-options → DynamicOptionsField (select with options from a loader)
+  if (schema.format === "dynamic-options") {
+    console.log("[renderField] dynamic-options match", {
+      path: props.path,
+      format: schema.format,
+      options: schema.options,
+      hasSandbox: !!props.sandbox,
+    });
+    if (schema.options) {
+      return <DynamicOptionsField key={props.path} {...props} />;
+    }
+  }
+
   // Enum (including extracted const enums)
   if (schema.enum && schema.enum.length > 0) {
     return <EnumField key={props.path} {...props} />;
@@ -277,6 +291,7 @@ export function SchemaForm({
   previewBaseUrl,
   onAddSectionItem,
   onRequestAddSection,
+  sandbox,
 }: {
   schema: SchemaProperty;
   value: unknown;
@@ -293,6 +308,7 @@ export function SchemaForm({
   previewBaseUrl?: string | null;
   onAddSectionItem?: FieldProps["onAddSectionItem"];
   onRequestAddSection?: FieldProps["onRequestAddSection"];
+  sandbox?: FieldProps["sandbox"];
 }) {
   const properties = schema.properties;
   if (!properties) return null;
@@ -356,6 +372,7 @@ export function SchemaForm({
           previewBaseUrl,
           onAddSectionItem,
           onRequestAddSection,
+          sandbox,
         });
       })}
     </div>

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -115,6 +115,7 @@ function SchemaFormPanel({
   meta,
   decofile,
   onSaveReferencedBlock,
+  sandbox,
 }: {
   activeSchema: SchemaProperty | null | undefined;
   formValue: unknown;
@@ -132,6 +133,12 @@ function SchemaFormPanel({
     blockKey: string,
     data: Record<string, unknown>,
   ) => void;
+  sandbox?: {
+    orgSlug: string;
+    virtualMcpId: string;
+    branch: string;
+    previewUrl?: string;
+  } | null;
 }) {
   const formBody =
     activeSchema && formValue ? (
@@ -157,6 +164,7 @@ function SchemaFormPanel({
           meta={meta}
           decofile={decofile}
           onSaveReferencedBlock={onSaveReferencedBlock}
+          sandbox={sandbox}
         />
       )
     ) : null;
@@ -823,6 +831,13 @@ export function SectionsEditor({
       }
     }
   }
+
+  const sandbox = {
+    orgSlug,
+    virtualMcpId,
+    branch,
+    previewUrl: previewUrl ?? undefined,
+  };
 
   const activeSchema =
     activeResolveType && meta ? resolveSchema(activeResolveType, meta) : null;
@@ -2315,6 +2330,7 @@ export function SectionsEditor({
             meta={meta}
             decofile={decofile}
             onSaveReferencedBlock={saveReferencedBlock}
+            sandbox={sandbox}
           />
         </ScrollArea>
       ) : isGlobalBlockMode ? (
@@ -2330,6 +2346,7 @@ export function SectionsEditor({
             meta={meta}
             decofile={decofile}
             onSaveReferencedBlock={saveReferencedBlock}
+            sandbox={sandbox}
           />
         </ScrollArea>
       ) : (

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -41,6 +41,7 @@ import {
   type LiveMeta,
   type SchemaProperty,
 } from "./resolve-schema";
+import type { SandboxConfig } from "./fields/field-props";
 import { findSiteSeoEntry, resolveSeoTarget } from "./seo-block";
 import { defaultPageSeoResolveType } from "./seo-schema";
 import { activeSeoResolveType, buildSeoSavePayload } from "./seo-save";
@@ -133,12 +134,7 @@ function SchemaFormPanel({
     blockKey: string,
     data: Record<string, unknown>,
   ) => void;
-  sandbox?: {
-    orgSlug: string;
-    virtualMcpId: string;
-    branch: string;
-    previewUrl?: string;
-  } | null;
+  sandbox?: SandboxConfig | null;
 }) {
   const formBody =
     activeSchema && formValue ? (


### PR DESCRIPTION
## Summary
- Port the admin's `DynamicOptions` widget to Studio's sections editor
- Fields with `format: "dynamic-options"` and `@options <loaderPath>` now render a searchable combobox
- Fetches options directly from the preview server (`/deco/invoke/<loaderPath>`)
- Supports image thumbnails on options and debounced server-side search
- Threads `sandbox` context (org, virtualMcp, branch, previewUrl) through `SchemaForm` → `ObjectField` → `ArrayField` → `AnyOfField`

## Files changed
| File | Change |
|------|--------|
| `resolve-schema.ts` | Add `options` to `SchemaProperty`, pass through in `buildProperty` |
| `field-props.ts` | Add `sandbox?` to `FieldProps` |
| `sections-editor.tsx` | Build & pass `sandbox` to `SchemaForm` |
| `schema-form.tsx` | Accept `sandbox`, forward in `renderField`, add `dynamic-options` dispatch |
| `object-field.tsx` | Forward `sandbox` in nested `SchemaForm` |
| `array-field.tsx` | Forward `sandbox` in nested `SchemaForm` / `renderField` |
| `any-of-field.tsx` | Forward `sandbox` in nested `SchemaForm` |
| `dynamic-options-field.tsx` | **New** — the searchable combobox widget |

## Test plan
- [ ] `bun run check` — no new type errors
- [ ] `bun run lint` — no lint violations
- [ ] `bun test` — existing tests pass (especially `resolve-schema.test.ts`)
- [ ] Manual: add a section with a `@format dynamic-options` / `@options <loader>` field and verify the combobox populates from the loader response
- [ ] Manual: type in the search input and verify debounced server-side filtering works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DynamicOptions widget to the sections editor, rendering a searchable combobox for `format: "dynamic-options"` fields with `options: "<loaderPath>"`. Options load from the preview server with debounced server-side search, optional images, and a safe text-input fallback.

- **New Features**
  - New `DynamicOptionsField` that loads choices via `/deco/invoke/<loaderPath>` with debounced search, images, and a clearable select.
  - Falls back to text input when `previewUrl` or loader is missing; threads `sandbox` through forms; `resolve-schema` exposes `options` from `@options`.

- **Bug Fixes**
  - Fixed debounce leak and gated fetches to run only when the combobox is open; show the current selection even if it’s not in filtered results.
  - Removed `ref.current` access during render (lint fix), extracted `SandboxConfig`, simplified `options` resolution in `resolve-schema`, and added tests for `normalizeOptions` and dynamic `options` preservation.

<sup>Written for commit 85f24a37402cc2974393adaf60987383e392cb9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

