### PR TITLE
fix(assets): log real STS error when minting tenant credentials

### DIFF
--- a/apps/mesh/src/file-storage/tenant-credentials.ts
+++ b/apps/mesh/src/file-storage/tenant-credentials.ts
@@ -26,7 +26,7 @@ import {
   type AssumeRoleCommandOutput,
   STSClient,
 } from "@aws-sdk/client-sts";
-import { retry } from "@decocms/std";
+import { retry, RetryError } from "@decocms/std";
 import { getSettings } from "@/settings";
 import { SITE_SLUG_RE } from "@/shared/site-slug";
 
@@ -166,11 +166,34 @@ export async function provisionTenantS3Credentials(
             // refreshes the cached client's creds near expiry automatically.
           }),
         ),
-      { maxAttempts: 3 },
+      {
+        maxAttempts: 3,
+        // Don't burn retries on non-transient STS errors (e.g. AccessDenied);
+        // retry only network errors or 5xx/throttling.
+        isRetriable: (err) => {
+          const status = (err as { $metadata?: { httpStatusCode?: number } })
+            ?.$metadata?.httpStatusCode;
+          const name = (err as { name?: string })?.name ?? "";
+          return (
+            status === undefined ||
+            status >= 500 ||
+            /throttl|timeout/i.test(name)
+          );
+        },
+      },
     );
   } catch (e) {
     if (e instanceof TenantCredentialsError) throw e;
-    console.error("[tenant-credentials] AssumeRole failed:", e);
+    // Unwrap RetryError so the real STS error (AccessDenied, missing
+    // credentials, …) is logged instead of "maxAttempts exceeded". Logged
+    // server-side only — never returned to the client (it embeds the role ARN
+    // + account id).
+    const cause = e instanceof RetryError ? (e.cause ?? e) : e;
+    const detail =
+      cause instanceof Error
+        ? `${cause.name}: ${cause.message}`
+        : String(cause);
+    console.error(`[tenant-credentials] AssumeRole failed: ${detail}`);
     throw new TenantCredentialsError(500, "failed to mint tenant credentials");
   }
 


### PR DESCRIPTION
When `AssumeRole` fails, the log showed only `RetryError: Retrying exceeded the maxAttempts (3)` — the underlying STS error (AccessDenied / missing credentials) was swallowed, so a prod IAM failure was undebuggable from logs.

- Unwrap `RetryError` and log the cause `name: message` (server-side only — never returned to the client, since it embeds the role ARN + account id).
- Add `isRetriable` so non-transient STS errors (e.g. `AccessDenied`) fail fast instead of retrying 3×.

No behavior change to the credential minting itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs the real STS error when minting tenant S3 credentials and skips retries for non-transient failures, so IAM issues surface immediately. Server-side logging only; no change to client-visible behavior.

- **Bug Fixes**
  - Unwrap `RetryError` from `@decocms/std` to log the underlying `@aws-sdk/client-sts` `AssumeRole` error as "name: message".
  - Add `isRetriable` to `retry` options to only retry network/5xx/throttling errors and fail fast on `AccessDenied` or missing credentials.

<sup>Written for commit 54cf8c4ce2f7009e066b02d9892aea5040fab72b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

