### PR TITLE
fix(sections-editor): sync breadcrumb when array item label changes

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -365,6 +365,22 @@ export function ArrayField({
     const next = [...items];
     next[index] = val;
     onChange(next);
+
+    // When editing the currently selected item, the display label may change
+    // (e.g. editing the "alt" or "name" field that drives getArrayItemLabel).
+    // Update the breadcrumb so resolveArrayItemSelection keeps matching.
+    if (index === selectedIndex && selectedIndex !== null) {
+      const oldLabel = itemLabel(items[index], index);
+      const newLabel = getArrayItemLabel(val, index, itemSchema);
+      if (oldLabel !== newLabel) {
+        const crumbIndex = findBreadcrumbLabelIndex(breadcrumbPath, oldLabel);
+        if (crumbIndex >= 0) {
+          const updatedBreadcrumb = [...breadcrumbPath];
+          updatedBreadcrumb[crumbIndex] = newLabel;
+          onBreadcrumbChange?.(updatedBreadcrumb);
+        }
+      }
+    }
   };
 
   const sensors = useSensors(


### PR DESCRIPTION
## Summary
- Fixes a bug where editing a field used as an array item's display label (e.g. `alt`, `name`, `title`) would kick the user back to the array list view
- The root cause was that `resolveArrayItemSelection` matches items by label, so when the label changed the breadcrumb path became stale and no item matched
- `updateItem` now detects label changes on the selected item and updates the breadcrumb in the same render cycle

## Test plan
- [ ] Open a section with an array field (e.g. images/banners)
- [ ] Click into an array item
- [ ] Edit the field used as the item label (e.g. "Alt", "Name", "Title")
- [ ] Verify you stay inside the item editor and are NOT kicked back to the array list
- [ ] Verify the breadcrumb updates to reflect the new label as you type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in the sections editor where changing an array item's label (e.g. alt/name/title) kicked you back to the list. The breadcrumb now updates when the selected item's label changes, so you stay in the item editor and the label updates as you type.

<sup>Written for commit ac3afead0fb9c4f664fbb6810c6768324fba00cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

