### PR TITLE
fix(sandbox): bound quick file ops during link partitions

### DIFF
--- a/apps/mesh/playwright.config.test.ts
+++ b/apps/mesh/playwright.config.test.ts
@@ -7,7 +7,7 @@ describe("resolvePlaywrightDevServerConfig", () => {
 
     expect(config.appOrigin).toBe("http://localhost:4000");
     expect(config.webServerCommand).toBe(
-      "BASE_URL=http://localhost:4000 PORT=3000 VITE_PORT=4000 bun run dev:servers",
+      "MCP_CACHE_ENABLED=true BASE_URL=http://localhost:4000 PORT=3000 VITE_PORT=4000 bun run dev:servers",
     );
   });
 
@@ -20,7 +20,7 @@ describe("resolvePlaywrightDevServerConfig", () => {
 
     expect(config.appOrigin).toBe("http://preview.localhost:4444");
     expect(config.webServerCommand).toBe(
-      "BASE_URL=http://preview.localhost:4444 PORT=3100 VITE_PORT=4444 bun run dev:servers",
+      "MCP_CACHE_ENABLED=true BASE_URL=http://preview.localhost:4444 PORT=3100 VITE_PORT=4444 bun run dev:servers",
     );
   });
 });

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -81,6 +81,31 @@ function assertSandboxBranchParam(branch: string): void {
 const SUGGEST_COMMIT_MAX_BODY_BYTES = 512 * 1024;
 const PREVIEW_INVOKE_MAX_BODY_BYTES = 64 * 1024;
 
+/**
+ * Quick interactive file ops (read/write/mkdir/unlink/rename/glob) must fail
+ * FAST when the daemon link is partitioned. Without an explicit bound they
+ * inherit the tunnel dispatch's 30s first-frame timeout (see
+ * `links/tunnel-dispatch.ts`), so a read against a severed link hangs ~30s
+ * before erroring. These ops answer in well under a second on a healthy link,
+ * so a 10s ceiling never trips when the daemon is reachable but turns a
+ * partition into a prompt 502 instead of a 30s stall. Streaming/long ops
+ * (exec, events, git/*) are intentionally NOT bounded here - the daemon itself
+ * allows up to 60s for upstream headers (see `daemon/proxy.ts`).
+ */
+const QUICK_FILE_OP_TIMEOUT_MS = 10_000;
+
+/**
+ * Abort signal for quick file ops: the inbound request's signal (client
+ * disconnect) combined with a {@link QUICK_FILE_OP_TIMEOUT_MS} fast-fail
+ * timeout so a partitioned link errors promptly rather than hanging.
+ */
+function quickFileOpSignal(c: Context<VmEnv>): AbortSignal {
+  return AbortSignal.any([
+    c.req.raw.signal,
+    AbortSignal.timeout(QUICK_FILE_OP_TIMEOUT_MS),
+  ]);
+}
+
 // ---- Shared middleware ------------------------------------------------------
 
 /**
@@ -359,22 +384,40 @@ export const createSandboxRoutes = () => {
 
   // -- File write/read (base64-encoded body) --------------------------------
   app.post("/:virtualMcpId/:branch/write", (c) =>
-    proxyDaemon(c, "/_sandbox/write", { forwardJsonBody: true }),
+    proxyDaemon(c, "/_sandbox/write", {
+      forwardJsonBody: true,
+      signal: quickFileOpSignal(c),
+    }),
   );
   app.post("/:virtualMcpId/:branch/unlink", (c) =>
-    proxyDaemon(c, "/_sandbox/unlink", { forwardJsonBody: true }),
+    proxyDaemon(c, "/_sandbox/unlink", {
+      forwardJsonBody: true,
+      signal: quickFileOpSignal(c),
+    }),
   );
   app.post("/:virtualMcpId/:branch/mkdir", (c) =>
-    proxyDaemon(c, "/_sandbox/mkdir", { forwardJsonBody: true }),
+    proxyDaemon(c, "/_sandbox/mkdir", {
+      forwardJsonBody: true,
+      signal: quickFileOpSignal(c),
+    }),
   );
   app.post("/:virtualMcpId/:branch/rename", (c) =>
-    proxyDaemon(c, "/_sandbox/rename", { forwardJsonBody: true }),
+    proxyDaemon(c, "/_sandbox/rename", {
+      forwardJsonBody: true,
+      signal: quickFileOpSignal(c),
+    }),
   );
   app.post("/:virtualMcpId/:branch/read", (c) =>
-    proxyDaemon(c, "/_sandbox/read", { forwardJsonBody: true }),
+    proxyDaemon(c, "/_sandbox/read", {
+      forwardJsonBody: true,
+      signal: quickFileOpSignal(c),
+    }),
   );
   app.post("/:virtualMcpId/:branch/glob", (c) =>
-    proxyDaemon(c, "/_sandbox/glob", { forwardJsonBody: true }),
+    proxyDaemon(c, "/_sandbox/glob", {
+      forwardJsonBody: true,
+      signal: quickFileOpSignal(c),
+    }),
   );
 
   // -- Script exec/kill -----------------------------------------------------

--- a/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
+++ b/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
@@ -125,7 +125,10 @@ describe("sandbox↔studio WS partition", () => {
     );
 
     // A tunneled read must fail FAST (not hang). Offline → 404; in-flight
-    // cut → 502 ws_closed. Either way: a non-2xx error, quickly.
+    // cut → 502 ws_closed. Either way: a non-2xx error, quickly. Quick file
+    // ops are bounded by QUICK_FILE_OP_TIMEOUT_MS (10s) in the sandbox proxy,
+    // so a partitioned read errors at ~10s instead of stalling the full 30s
+    // tunnel first-frame timeout. 15s asserts that ceiling holds with margin.
     const start = performance.now();
     const read = await sandboxPost(
       orgSlug,
@@ -145,7 +148,10 @@ describe("sandbox↔studio WS partition", () => {
     // test re-enabled the proxy), capture the baseline connectedAt, then sever
     // and restore WITHIN this test so the reconnect is observable regardless of
     // whatever proxy state the previous test left behind.
-    const before = await waitForLinkClaim(testState.cookie, 60_000);
+    // 90s window: after the prior test's partition the daemon's reconnect
+    // backoff can grow toward its 30s cap, so re-establishing the baseline can
+    // take longer than 60s under CI load.
+    const before = await waitForLinkClaim(testState.cookie, 90_000);
     const connectedAt0 = before.connectedAt;
 
     await disableProxy(PROXY_NAMES.STUDIO_WS);
@@ -168,7 +174,7 @@ describe("sandbox↔studio WS partition", () => {
         const claim = await getLinkClaim(testState.cookie);
         return claim != null && claim.connectedAt > connectedAt0;
       },
-      { timeoutMs: 60_000, intervalMs: 1_000, label: "link-reconnect" },
+      { timeoutMs: 90_000, intervalMs: 1_000, label: "link-reconnect" },
     );
 
     // The same read now succeeds with preserved content (daemon process and


### PR DESCRIPTION
## Summary
- Add a 10s fast-fail timeout for quick sandbox file operations when the daemon link is partitioned.
- Update the WS partition resilience scenario timing expectations.
- Align the Playwright config unit test with MCP_CACHE_ENABLED=true.

## Test Plan
- bunx biome format --write apps/mesh/src/api/routes/sandbox-proxy.ts tests/resilience/scenarios/link-dispatch-ws-partition.test.ts apps/mesh/playwright.config.test.ts
- bun run check
- bun test apps/mesh/playwright.config.test.ts

Note: full bun test was not completed in the sandbox because Docker-backed resilience setup did not progress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound quick sandbox file ops to a 10s fast-fail so reads/writes don’t stall ~30s during link partitions and instead return a prompt 502. Updated resilience test timing and aligned Playwright config test with `MCP_CACHE_ENABLED=true`.

- **Bug Fixes**
  - Added a 10s `QUICK_FILE_OP_TIMEOUT_MS` and `quickFileOpSignal`; applied to read/write/mkdir/unlink/rename/glob routes to fail fast on partitions.
  - Left streaming ops (exec, events, git/*) unbounded to preserve behavior.
  - Resilience test: assert quick-file-op errors within ~10s (15s ceiling) and extend reconnect waits to 90s for CI backoff.
  - Playwright config test: expect `MCP_CACHE_ENABLED=true` in the dev server command.

<sup>Written for commit 3d7c9cf67486877aba0116358c10094488103ecf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

