### PR TITLE
fix(sections-editor): align decofile cache key with save/delete mutations

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -6,7 +6,6 @@ interface UseDecofileParams {
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
-  previewUrl?: string | null;
 }
 
 export function useDecofile(
@@ -14,7 +13,7 @@ export function useDecofile(
   options?: { fetchEnabled?: boolean },
 ) {
   const key = params
-    ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}/${params.previewUrl ?? ""}`
+    ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}`
     : "";
   const fetchEnabled = options?.fetchEnabled ?? true;
   return useQuery({


### PR DESCRIPTION
## Summary
- `useDecofile` query key included a trailing `/${previewUrl ?? ""}` that no caller ever provided, producing keys like `"org/mcp/branch/"`
- `useSaveBlock` and `useDeleteBlock` built their cache key as `"org/mcp/branch"` (no trailing slash)
- The mismatch meant optimistic updates from saves never reached the query the component reads, so the form reverted to stale data after array reorders, variant deletes, and other mutations
- Removed the unused `previewUrl` suffix so both sides target the same cache entry

## Test plan
- [x] `bun test apps/mesh/src/web/components/sections-editor/` — 278 tests pass
- [ ] Verify array reorder in form persists visually without needing a page refresh
- [ ] Verify variant delete updates the form immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the `useDecofile` query cache key with save/delete mutations so optimistic updates update the form instead of reverting to stale data. Removes the unused `previewUrl` suffix from the key.

- **Bug Fixes**
  - Dropped the trailing `/${previewUrl ?? ""}` from `useDecofile` so the key is `${orgSlug}/${virtualMcpId}/${branch}`, matching `useSaveBlock` and `useDeleteBlock`.
  - Optimistic updates now hit the correct cache entry; array reorders and variant deletes reflect in the form immediately.

<sup>Written for commit d4b4178d7360d0c4788b00a2868decda26fcdcce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

