### PR TITLE
fix(tests/resilience): unbreak resilience CI (org-fs collision + reconnect assertion)

### DIFF
--- a/tests/resilience/docker-compose.test.ts
+++ b/tests/resilience/docker-compose.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const composePath = join(import.meta.dir, "docker-compose.yml");
+
+describe("resilience docker-compose", () => {
+  test("NATS healthcheck does not depend on shell utilities in the image", () => {
+    const compose = readFileSync(composePath, "utf8");
+    const natsService = compose.match(
+      /^  nats:\n(?<body>(?:    .*\n|\n)*?)(?=^  [a-zA-Z0-9_-]+:)/m,
+    )?.groups?.body;
+
+    expect(natsService).toBeDefined();
+    expect(natsService).not.toContain("CMD-SHELL");
+    expect(natsService).not.toContain("wget");
+    expect(natsService).toContain('["CMD", "nats-server", "--help"]');
+  });
+});

--- a/tests/resilience/docker-compose.yml
+++ b/tests/resilience/docker-compose.yml
@@ -12,19 +12,15 @@ services:
       retries: 10
 
   nats:
-    # Use the -alpine variant (busybox sh + wget): the default nats image is
-    # distroless, so the CMD-SHELL /healthz healthcheck below can never run on
-    # it and the container is reported permanently unhealthy, aborting `up --wait`.
-    image: nats:2.14.2-alpine
+    # Keep the healthcheck independent of shell utilities: the default NATS
+    # image is distroless, and even Alpine tags should not be required just for
+    # `up --wait`.
+    image: nats:2.14.2
     command: ["-c", "/etc/nats/nats.conf"]
     volumes:
       - ./nats-config/nats.conf:/etc/nats/nats.conf:ro
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "wget -q -O- http://localhost:8222/healthz 2>/dev/null || exit 1",
-        ]
+      test: ["CMD", "nats-server", "--help"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -94,6 +90,14 @@ services:
       DECOCMS_LOCAL_MODE: "true"
       STUDIO_SANDBOX_PROVIDER: user-desktop
       ENCRYPTION_KEY: test-encryption-key-32chars-long!
+      # org-fs mounts can't work in these containers (no FUSE / rclone mount
+      # fails), and this suite exercises tunnel/WS resilience, not org-fs. With
+      # mounts enabled the daemon's first quick file op blocks on the 10s
+      # FIRST_MOUNT_WAIT_MS grace (entry.ts), which collides with the studio
+      # proxy's 10s QUICK_FILE_OP_TIMEOUT_MS (sandbox-proxy.ts) and 502s the very
+      # first write/read even on a healthy link. Disable so the daemon never
+      # expects org-fs (skips the wait) — see DISABLE_ORGFS_MOUNTS in start.ts.
+      DISABLE_ORGFS_MOUNTS: "true"
       DATA_DIR: /app/data
       NATS_PUBLIC_URL: ws://toxiproxy:3010
       NATS_ACCOUNT_JWT: eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJhdWQiOiJOQVRTIiwibmFtZSI6InR1bm5lbCIsInN1YiI6IkFDQ1JKT0dDS1BGSkpNUDNMSE9HMkk1NU5WMkpRVkZNSUlaUVRDVDNQTjZaQlhWR1M1SVFCSU1CIiwibmF0cyI6eyJzaWduaW5nX2tleXMiOlsiQUFYVVRQUUpMS05ZRVZMVlVUSEFURVVRMlA3T1hIN0FWS09UVUUyU0IyS0o2VTNJN0UySkFPVDIiXSwibGltaXRzIjp7InN1YnMiOi0xLCJjb25uIjotMSwiZGF0YSI6LTEsInBheWxvYWQiOi0xLCJpbXBvcnRzIjotMSwiZXhwb3J0cyI6LTEsIndpbGRjYXJkcyI6dHJ1ZSwibWVtX3N0b3JhZ2UiOi0xLCJkaXNrX3N0b3JhZ2UiOi0xLCJzdHJlYW1zIjotMSwiY29uc3VtZXIiOi0xfSwidHlwZSI6ImFjY291bnQiLCJ2ZXJzaW9uIjoyfSwiaXNzIjoiT0JVSDNLRzJQT1FNQVJSWEYyTVZNTkdMN1NCRDVBUE9UVkU1REJKNTZOR1A1NElaVUFMUE1QNUYiLCJpYXQiOjE3ODE5Njc5NzAsImp0aSI6ImpFMzhWWk45ZVRQVStLMlB6d2NtbWdESVgyQWE1UzVTZ2FCb1Y5RWtqM0tQVHhCOUErVTZuS2daNmp0VFpLc3EwdEx5V0F1VmpzdnNsZHpVUjZ4N1hnPT0ifQ.KXYXjyj7WzyxCOyz90dIYV_Rq8fGaIUxTP1RhGsV9mpyPZk0Pj30HvRLGilGxz6E75M0IBZkQ7vmFTKFsgeWBA

--- a/tests/resilience/scenarios/link-dispatch-log-replay.test.ts
+++ b/tests/resilience/scenarios/link-dispatch-log-replay.test.ts
@@ -19,7 +19,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 // outside the runner-handle scope, tracked for a follow-up. Keeping the
 // tests in-file (skipped) preserves the intent + instrumentation when the
 // underlying lifecycle is hardened.
-import { registerTestHooks, testState } from "../lib/setup";
+import { testState } from "../lib/setup";
 import { disableProxy, enableProxy } from "../lib/toxiproxy";
 import { PROXY_NAMES } from "../lib/toxic-presets";
 import { pollUntil } from "../lib/poll-until";
@@ -37,15 +37,15 @@ import {
   waitForLinkClaim,
 } from "../lib/link-daemon-control";
 
-registerTestHooks();
-
 const BRANCH = "main";
 const MARKER = `MARKER-${testState.orgId || "x"}-${process.pid}`;
 
 let orgSlug = "";
 let vmId = "";
 
-describe("sandbox log/event SSE replay", () => {
+// Bun still runs `beforeAll` for a `describe` whose only tests are skipped.
+// Keep the whole suite skipped so the heavy harness setup never starts in CI.
+describe.skip("sandbox log/event SSE replay", () => {
   beforeAll(async () => {
     orgSlug = await getOrgSlug(testState.orgId, testState.cookie);
     console.log(`[log-replay] orgSlug=${orgSlug} orgId=${testState.orgId}`);

--- a/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
+++ b/tests/resilience/scenarios/link-dispatch-ws-partition.test.ts
@@ -145,18 +145,17 @@ describe("sandbox↔studio WS partition", () => {
 
   test("WS restored → daemon reconnects and the sandbox responds again", async () => {
     // Self-contained: start from a connected state (afterEach from the prior
-    // test re-enabled the proxy), capture the baseline connectedAt, then sever
-    // and restore WITHIN this test so the reconnect is observable regardless of
-    // whatever proxy state the previous test left behind.
+    // test re-enabled the proxy), then sever and restore WITHIN this test so the
+    // reconnect is observable regardless of whatever proxy state the previous
+    // test left behind.
     // 90s window: after the prior test's partition the daemon's reconnect
     // backoff can grow toward its 30s cap, so re-establishing the baseline can
     // take longer than 60s under CI load.
-    const before = await waitForLinkClaim(testState.cookie, 90_000);
-    const connectedAt0 = before.connectedAt;
+    await waitForLinkClaim(testState.cookie, 90_000);
 
     await disableProxy(PROXY_NAMES.STUDIO_WS);
-    // 60s presence TTL + margin (see the "WS severed" test above for why the
-    // pull transport has no synchronous offline signal).
+    // Presence is optimistic: with the tunnel severed the live /api/links/status
+    // probe can no longer reach the daemon, so /api/links/me reads offline.
     await pollUntil(
       async () => (await getLinkClaim(testState.cookie)) === null,
       {
@@ -168,12 +167,12 @@ describe("sandbox↔studio WS partition", () => {
 
     await enableProxy(PROXY_NAMES.STUDIO_WS);
 
-    // Reconnect = a claim whose connectedAt advanced past the baseline.
+    // Reconnect = presence reads online again. There is no stored claim whose
+    // connectedAt advances under optimistic presence — the live probe
+    // succeeding once the daemon's NATS connection re-establishes IS the
+    // reconnect signal.
     await pollUntil(
-      async () => {
-        const claim = await getLinkClaim(testState.cookie);
-        return claim != null && claim.connectedAt > connectedAt0;
-      },
+      async () => (await getLinkClaim(testState.cookie)) !== null,
       { timeoutMs: 90_000, intervalMs: 1_000, label: "link-reconnect" },
     );
 


### PR DESCRIPTION
## Summary

The **Resilience Tests** workflow has been failing on `main` for days. I traced it to two independent root causes in the `sandbox↔studio WS partition` suite, both stemming from the NATS tunnel transport work (`#3854`, then `#4066`).

### 1. Baseline `write/read` 502s even on a healthy link

`#4066` bounded quick file ops at a 10s `QUICK_FILE_OP_TIMEOUT_MS` (`apps/mesh/src/api/routes/sandbox-proxy.ts`). On the daemon side, the **first** quick file op is gated on `waitForFirstMounts()` — up to 10s `FIRST_MOUNT_WAIT_MS` (`packages/sandbox/daemon/entry.ts`) — waiting for org-fs mounts to attach.

The resilience containers have **no FUSE**, so `rclone mount` always fails *after the full 10s grace*. The first `/write` therefore blocks the entire 10s and the studio proxy's 10s ceiling aborts it (`tunnel_aborted: The operation timed out`). Failure timing was exactly `10033ms`.

org-fs genuinely can't work in this environment and this suite exercises tunnel/WS resilience (not org-fs), so I disable it with `DISABLE_ORGFS_MOUNTS: "true"` on the `studio` service. The mesh then never pushes `ORGFS_CONFIG`, the daemon never sets `orgFsExpected`, and the first-mount wait is skipped entirely.

### 2. `WS restored → daemon reconnects` could never pass

Since `#3854`, link presence is an **optimistic live probe** (`/api/links/status` over the tunnel); `/api/links/me` returns only `{ hostname, cliVersion }` — there is no stored claim and **no `connectedAt`**. The test asserted `claim.connectedAt > baseline`, i.e. `undefined > undefined`, which is always `false`, so it timed out every run. Reconnect is now detected by presence reading **online again**, which matches the new model.

### Also included (concurrent resilience hardening)
- NATS service healthcheck no longer depends on shell utilities in the image, with a `docker-compose.test.ts` guard.
- `link-dispatch-log-replay` suite is `describe.skip`'d outright so its heavy `beforeAll` never runs while its only tests are already skipped.

## Testing
- `bun test tests/resilience/docker-compose.test.ts` → pass.
- `bun run fmt` / `bun run lint` → clean (0 errors).
- Full resilience suite requires Docker; CI on this PR is the real verification.

## Follow-up (not in this PR)
There is a **latent production interaction**: on a real desktop the first quick file op still pays the org-fs first-mount grace, and if mounts approach the 10s grace the op can 502 against the 10s proxy ceiling (zero margin). Worth decoupling `FIRST_MOUNT_WAIT_MS` from `QUICK_FILE_OP_TIMEOUT_MS` (or not gating non-`org/` writes on the mount) in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken Resilience CI by disabling org-fs mounts in tests and updating the reconnect check to match optimistic presence. Also makes the NATS healthcheck shell-free and skips a heavy suite to avoid unnecessary setup.

- **Bug Fixes**
  - Disable org-fs in `docker-compose.yml` with `DISABLE_ORGFS_MOUNTS: "true"` to skip first-mount waits and prevent 10s timeout collisions that 502 the first write/read.
  - Update the `sandbox↔studio WS partition` test to detect reconnect when presence reads online again; remove the `connectedAt` assertion.
  - Make the NATS healthcheck independent of shell tools by using `["CMD", "nats-server", "--help"]`; add `docker-compose.test.ts` to guard this.
  - Skip the `link-dispatch-log-replay` suite with `describe.skip` so its heavy `beforeAll` never runs.

<sup>Written for commit 668f0437067aaef07bebf6ef502390702c445cb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

