### PR TITLE
fix(mesh): auto-reload on vite:preloadError during rolling deploys

### DIFF
--- a/apps/mesh/index.html
+++ b/apps/mesh/index.html
@@ -3,6 +3,19 @@
   <head>
     <meta name="theme-color" content="#f6f4ed" />
     <script>
+      // Reload once on modulepreload 404 (rolling deployment — old pod missing new chunk).
+      // Shares the cooldown key with ChunkErrorBoundary to prevent double-reload loops.
+      window.addEventListener('vite:preloadError', function() {
+        var key = '__mesh_chunk_reload_ts';
+        var last = sessionStorage.getItem(key);
+        var now = Date.now();
+        if (!last || now - Number(last) > 10000) {
+          sessionStorage.setItem(key, String(now));
+          location.reload();
+        }
+      });
+    </script>
+    <script>
       // Apply dark mode class before first paint to prevent flash
       (function() {
         try {


### PR DESCRIPTION
## What is this contribution about?
During rolling deployments, a client that loaded `index.html` from one pod can request a hashed JS chunk from a pod running a different version, getting a 404 (`vite:preloadError`). This adds a tiny inline handler in `index.html` that auto-reloads the page once on that event, fetching a consistent asset set. It shares the `__mesh_chunk_reload_ts` cooldown key (10s) with the existing `ChunkErrorBoundary` so the two mechanisms never double-reload, and it deliberately omits `preventDefault()` so the boundary still acts as the fallback when the cooldown blocks a reload.

## Screenshots/Demonstration
N/A — no visible UI change in the normal path.

## How to Test
1. Build the client and serve it, then deploy a new version with different chunk hashes (or manually 404 a `modulepreload` asset).
2. With the old HTML loaded, navigate to a route that triggers the missing chunk.
3. Expected: the page reloads once automatically and loads successfully; repeated failures within 10s fall through to the `ChunkErrorBoundary` "New version available" screen instead of looping.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-reload the app once on `vite:preloadError` during rolling deploys to fetch a consistent set of assets and avoid broken routes.

- **Bug Fixes**
  - Listen for `vite:preloadError` in `index.html` and reload once.
  - Share a 10s cooldown (`__mesh_chunk_reload_ts`) with `ChunkErrorBoundary` to prevent double reloads.
  - Skip `preventDefault()` so the boundary shows the fallback if the cooldown blocks a reload.

<sup>Written for commit cc35cb2bf614493052c0a3ae54f7d1896fa7f56b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

