### PR TITLE
fix(decopilot): prior turn renders empty after sending the next message

### DIFF
--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -986,6 +986,31 @@ export class ThreadConnection {
       this.status.set({ kind: "ready" });
     }
     if (last && !discard) {
+      // Anchor the finished assistant with a top-level `created_at`. A streamed
+      // message that never received one reads as +Infinity in `mergeAndSort`;
+      // on the NEXT submit the role tiebreak (user before assistant) then sorts
+      // the new user row ahead of this reply — the prior turn renders empty and
+      // its answer lands under the new turn. Prefer the run-start metadata
+      // timestamp when present, else stamp finish time. Mirrors the cancel-path
+      // anchor; a later persisted refetch (which carries the DB `created_at`)
+      // overwrites this via upsert. No-op once a top-level `created_at` exists.
+      const anchorId = last.id;
+      this.messages.update((msgs) => {
+        const i = msgs.findIndex((m) => m.id === anchorId);
+        if (i === -1) return msgs;
+        const row = msgs[i] as UIMessage & { created_at?: string };
+        if (row.created_at != null) return msgs;
+        const metaTs = (
+          row.metadata as { created_at?: string | number | Date } | undefined
+        )?.created_at;
+        const created_at =
+          metaTs != null
+            ? new Date(metaTs).toISOString()
+            : new Date().toISOString();
+        const next = [...msgs];
+        next[i] = { ...row, created_at } as UIMessage;
+        return next;
+      });
       this.observer?.onFinish?.(last, this.messages.get(), finishReason);
     }
   }


### PR DESCRIPTION
## The bug

Send a message, wait for the reply, send a second one in the same thread: the **first** turn renders "No response was generated" and its answer appears nested under the second turn (and a hard refresh can show the first message duplicated/odd).

The backend is fine — the persisted `thread_message_parts` rows for affected threads are correctly ordered and non-duplicated (verified against a real two-turn run). This is purely the **live in-memory ordering** in the chat store.

`thread-connection.ts` sorts messages with `readTimestamp`: top-level `created_at` → `metadata.created_at` → **`+Infinity`**. A *streamed* assistant that finishes without a top-level `created_at` reads as `+Infinity`. On the next submit, `mergeAndSort`'s role tiebreak (`user` before `assistant` on equal timestamps) sorts the **new user row ahead of the prior assistant** → the prior turn looks empty and its reply lands under the new turn.

`cancel()` already anchors a timestamp-less assistant (it stamps `created_at` so the next submit can't jump ahead of it), but **normal completion never did** — that asymmetry is the bug.

## The fix

When an assistant's substream completes (`foldSubStream`), anchor it with a top-level `created_at` (its run-start `metadata.created_at` if present, else finish time) — mirroring the cancel-path anchor. A later persisted refetch still overwrites it with the authoritative DB `created_at` via the upsert merge, and it's a no-op once a top-level `created_at` already exists.

## Testing

- Manual: two-turn conversation no longer empties the prior turn.
- The persisted order/data is unchanged (this only touches in-memory live ordering); a hard refresh was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat turn ordering that made the previous assistant turn show “No response was generated” after sending the next message. Completed streamed assistant messages are now stamped with a top-level `created_at` so they sort correctly.

- **Bug Fixes**
  - Stamp a top-level `created_at` when a streamed assistant finishes (use `metadata.created_at` if present, else finish time).
  - Prevent the `+Infinity` timestamp from pushing the prior reply below the next user message in `mergeAndSort`.
  - Persistence is unchanged; this only adjusts live in-memory ordering.

<sup>Written for commit 2e4e860296306c04063df66447adc78db9ee61d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

