### PR TITLE
feat(org-fs): push change feed over SSE instead of recycling long-poll

### DIFF
--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -30,6 +30,7 @@ import { exponentialBackoffWithJitter, sleep } from "@decocms/std";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import { streamSSE } from "hono/streaming";
 import type { NatsConnection } from "@nats-io/nats-core";
 import { ForbiddenError, UnauthorizedError } from "@/core/access-control";
 import type { StudioContext } from "@/core/studio-context";
@@ -64,6 +65,12 @@ const MAX_RECENT_LIMIT = 200;
 const DEFAULT_RECENT_LIMIT = 50;
 /** Long-poll hold time, just under the usual 30s gateway/proxy timeout. */
 const CHANGES_LONG_POLL_MS = 28_000;
+/**
+ * SSE keepalive cadence for `/changes?stream=1`. A comment frame every interval
+ * resets the gateway/proxy idle timer, so the stream stays open indefinitely
+ * (unlike the long-poll, which MUST return before the ~30s cap and reconnect).
+ */
+const CHANGES_STREAM_KEEPALIVE_MS = 15_000;
 /**
  * Spread window for the post-nudge re-query. One write fans out to every mount
  * watching that (org, volume); jittering keeps a herd from hitting the change
@@ -166,11 +173,77 @@ async function waitForChanges(
   }
 }
 
+/**
+ * Server-push variant of the change feed: an SSE stream held open indefinitely.
+ * One `changes` event per change-feed page, NDJSON-style cursor paging
+ * preserved so the consumer primes exactly like the long-poll path. Subscribes
+ * to the volume's NATS notify BEFORE the first drain (a write landing mid-
+ * catch-up is buffered for the subscription, never missed), then re-drains on
+ * every nudge. A keepalive comment defeats the gateway idle timeout, so steady
+ * state is zero reconnects — push latency is the NATS publish.
+ *
+ * Caller guarantees `nc`/`subject` are non-null (no NATS → no push to give, so
+ * the route falls back to the plain JSON page and the daemon uses its poll loop).
+ */
+function streamChanges(
+  c: Ctx,
+  fs: OrgFs,
+  nc: NatsConnection,
+  subject: string,
+  q: { volume: string; since: string; limit: number },
+): Response {
+  // Defeat proxy buffering so frames flush as written (mirrors vm-events).
+  c.header("X-Accel-Buffering", "no");
+  c.header("Content-Encoding", "identity");
+  return streamSSE(c, async (stream) => {
+    let since = q.since;
+    const sub = nc.subscribe(subject);
+    const keepalive = setInterval(() => {
+      stream.writeSSE({ event: "keepalive", data: "" }).catch(() => {
+        clearInterval(keepalive);
+      });
+    }, CHANGES_STREAM_KEEPALIVE_MS);
+    stream.onAbort(() => {
+      clearInterval(keepalive);
+      try {
+        sub.unsubscribe();
+      } catch {
+        // ignore
+      }
+    });
+
+    // Drain from `since` to the feed head, emitting one event per page and
+    // advancing the cursor. `for await` over the subscription processes one
+    // nudge at a time, so drains never interleave or double-advance `since`.
+    const drain = async () => {
+      for (;;) {
+        const page = await fs.changes(q.volume, since, q.limit);
+        await stream.writeSSE({ event: "changes", data: JSON.stringify(page) });
+        since = page.cursor;
+        if (!page.hasMore) return;
+      }
+    };
+
+    try {
+      await drain(); // catch-up: lets the consumer prime to the head
+      for await (const _msg of sub) await drain();
+    } finally {
+      clearInterval(keepalive);
+      try {
+        sub.unsubscribe();
+      } catch {
+        // ignore
+      }
+    }
+  });
+}
+
 export interface OrgFsRoutesDeps {
   /**
    * Shared NATS connection (null until connected / when unconfigured). Powers
-   * the `/changes?wait=1` long-poll and the post-write wake-up nudge. Without
-   * it, `/changes` stays a plain immediate-return feed.
+   * the `/changes?wait=1` long-poll, the `/changes?stream=1` SSE feed, and the
+   * post-write wake-up nudge. Without it, `/changes` stays a plain
+   * immediate-return feed.
    */
   getConnection?: () => NatsConnection | null;
 }
@@ -360,12 +433,18 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
 
   // Change feed since a cursor ("0" = from the beginning).
   //
+  // `?stream=1` (preferred): an SSE stream held open indefinitely, pushing a
+  // `changes` event per page on every write (NATS notify) with a keepalive to
+  // beat the idle timeout — zero reconnects while idle. Requires NATS; without
+  // it, falls through to a plain JSON page so the consumer can detect the
+  // missing stream and use its poll loop.
+  //
   // `?wait=1` long-polls: if nothing has changed since the cursor, the request
   // is held open (subscribed to the volume's NATS notify) until a write nudges
-  // it or the hold time expires, then re-queried. This lets the mount
-  // invalidator wake instantly on writes instead of polling on a timer. Without
-  // a NATS connection it degrades to an immediate return (the daemon's own
-  // poll-timeout floor backs off so it never busy-loops).
+  // it or the hold time expires, then re-queried. The legacy push path, kept
+  // for daemons that predate `stream=1`. Without NATS it degrades to an
+  // immediate return (the daemon's own poll-timeout floor backs off so it
+  // never busy-loops).
   app.get("/:volume/changes", async (c) => {
     const volume = c.req.param("volume");
     const r = await resolve(c, volume, "ORG_FS_READ");
@@ -375,8 +454,26 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       Math.max(Number(c.req.query("limit")) || DEFAULT_CHANGES_LIMIT, 1),
       MAX_CHANGES_LIMIT,
     );
+    const stream =
+      c.req.query("stream") === "1" || c.req.query("stream") === "true";
     const wait = c.req.query("wait") === "1" || c.req.query("wait") === "true";
     try {
+      if (stream) {
+        const nc = getConnection();
+        const subject = nc
+          ? orgFsChangeSubject(r.ctx.organization!.id, volume)
+          : null;
+        if (nc && subject) {
+          // The stream loops `fs.changes` internally; reject a bad cursor up
+          // front (it can't return a 400 once the SSE body has started).
+          if (!/^\d+$/.test(since)) {
+            return c.json({ error: `Invalid cursor: ${since}` }, 400);
+          }
+          return streamChanges(c, r.fs, nc, subject, { volume, since, limit });
+        }
+        // No NATS → fall through to a plain JSON page (not event-stream); the
+        // daemon detects the content-type mismatch and uses its poll loop.
+      }
       if (!wait) {
         return c.json(await r.fs.changes(volume, since, limit));
       }

--- a/apps/mesh/src/file-storage/mount/client.ts
+++ b/apps/mesh/src/file-storage/mount/client.ts
@@ -203,4 +203,74 @@ export class OrgFsClient implements OrgFsApi {
     if (!res.ok) return this.fail(res);
     return (await res.json()) as OrgFsChangePage;
   }
+
+  /**
+   * Server-push change feed: open the `/changes?stream=1` SSE stream and invoke
+   * `onPage` for each page (same shape as `changes()`), so the invalidator
+   * primes and refreshes identically to the long-poll path. Resolves when the
+   * server ends the stream (reconnect) or `signal` aborts. Throws
+   * `OrgFsApiError` on a non-OK status, or a plain Error when the server didn't
+   * answer with an event-stream (old build / no NATS) — the caller then falls
+   * back to the `changes()` poll loop.
+   */
+  async streamChanges(
+    since: string,
+    onPage: (page: OrgFsChangePage) => void | Promise<void>,
+    signal: AbortSignal,
+    opts?: { limit?: number },
+  ): Promise<void> {
+    const params: Record<string, string> = { since, stream: "1" };
+    if (opts?.limit != null) params.limit = String(opts.limit);
+    const res = await this.fetch(this.url("changes", params), {
+      headers: { ...this.headers, accept: "text/event-stream" },
+      signal,
+    });
+    if (!res.ok) return this.fail(res);
+    const contentType = res.headers.get("content-type") ?? "";
+    if (!contentType.includes("text/event-stream") || !res.body) {
+      throw new Error("org-fs change stream unavailable (no SSE response)");
+    }
+    for await (const page of readSseData<OrgFsChangePage>(res.body)) {
+      await onPage(page);
+    }
+  }
+}
+
+/**
+ * Minimal SSE reader: yields the parsed JSON of each frame's `data:` payload.
+ * Comment frames (`:keepalive`) and data-less frames yield nothing. Sufficient
+ * for this feed — every real frame is a single-line JSON `data:`.
+ */
+async function* readSseData<T>(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<T, void, unknown> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let data = "";
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl: number;
+      // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic line loop
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl).replace(/\r$/, "");
+        buf = buf.slice(nl + 1);
+        if (line === "") {
+          if (data) {
+            yield JSON.parse(data) as T;
+            data = "";
+          }
+          continue;
+        }
+        if (line.startsWith(":")) continue; // comment / keepalive
+        if (line.startsWith("data:")) data += line.slice(5).replace(/^ /, "");
+        // other fields (event:, id:) are irrelevant to this feed
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
 }

--- a/packages/sandbox/daemon/org-fs/invalidator.test.ts
+++ b/packages/sandbox/daemon/org-fs/invalidator.test.ts
@@ -74,4 +74,64 @@ describe("runInvalidator", () => {
     ]);
     expect(refreshed).toEqual(["new"]);
   });
+
+  it("stream path: primes then refreshes parents of pushed pages", async () => {
+    const ac = new AbortController();
+    const refreshed: string[] = [];
+    await runInvalidator({
+      stream: async (since, onPage) => {
+        expect(since).toBe("0"); // first connect resumes from the start
+        await onPage({
+          entries: [{ parent: "a" }],
+          cursor: "1",
+          hasMore: false,
+        }); // prime
+        await onPage({
+          entries: [{ parent: "b" }],
+          cursor: "2",
+          hasMore: false,
+        }); // real
+        ac.abort();
+      },
+      changes: async () => {
+        throw new Error("poll loop must not run while streaming");
+      },
+      refresh: async (dir) => {
+        refreshed.push(dir);
+      },
+      signal: ac.signal,
+      pollMs: 0,
+    });
+    expect(refreshed).toEqual(["b"]);
+  });
+
+  it("falls back to the poll loop when the stream errors, resuming from the cursor", async () => {
+    const ac = new AbortController();
+    const refreshed: string[] = [];
+    const polledFrom: string[] = [];
+    await runInvalidator({
+      stream: async (since, onPage) => {
+        await onPage({ entries: [], cursor: "9", hasMore: false }); // prime, advance cursor
+        throw new Error("stream dropped");
+      },
+      changes: async (since) => {
+        polledFrom.push(since);
+        if (polledFrom.length > 1) {
+          ac.abort(); // stop on the empty tail, not the data-bearing page
+          return { entries: [], cursor: since, hasMore: false };
+        }
+        return { entries: [{ parent: "p" }], cursor: "10", hasMore: false };
+      },
+      refresh: async (dir) => {
+        refreshed.push(dir);
+      },
+      signal: ac.signal,
+      pollMs: 0,
+    });
+    // Poll resumed from the stream's advanced cursor (no re-read from 0),
+    // then from the page's cursor on the tail.
+    expect(polledFrom).toEqual(["9", "10"]);
+    // ...and stayed primed, so the post-prime page refreshed.
+    expect(refreshed).toEqual(["p"]);
+  });
 });

--- a/packages/sandbox/daemon/org-fs/invalidator.ts
+++ b/packages/sandbox/daemon/org-fs/invalidator.ts
@@ -15,28 +15,42 @@
  * macOS NFS: hung writer + an empty flushed file). Refresh re-lists in place;
  * open handles and dirty cache entries survive.
  *
- * The change feed is long-polled (`changes` blocks server-side until a write
- * nudge or its hold timeout), so steady state is push-driven: no timer poll
- * while idle, and external changes surface as soon as the write commits. The
- * `pollMs` floor only kicks in if the server returns fast with nothing — i.e.
- * long-poll isn't available (NATS down) — so the loop degrades to timer polling
- * instead of busy-looping.
+ * Freshness is push-driven. Preferred path: an SSE stream (`stream`) the server
+ * holds open, pushing a page per write and a keepalive to beat the idle
+ * timeout — zero reconnects while idle. Fallback (old mesh / NATS down): the
+ * long-polled `changes` feed, which blocks server-side until a write nudge or
+ * its hold timeout; the `pollMs` floor only kicks in if it returns fast-empty,
+ * so the loop degrades to timer polling instead of busy-looping.
  *
  * Deps are injected so the loop is unit-testable without a real mesh or rclone.
  */
 
 import { sleep } from "@decocms/std";
 
+/** A change-feed page (live rows + tombstones), shared by both feed paths. */
+export interface ChangePage {
+  entries: { parent: string }[];
+  cursor: string;
+  hasMore: boolean;
+}
+
 export interface InvalidatorDeps {
   /**
    * Read the change feed from `since` ("0" = beginning). Long-polls: the call
-   * blocks until a change or the server's hold timeout.
+   * blocks until a change or the server's hold timeout. The fallback path.
    */
-  changes: (since: string) => Promise<{
-    entries: { parent: string }[];
-    cursor: string;
-    hasMore: boolean;
-  }>;
+  changes: (since: string) => Promise<ChangePage>;
+  /**
+   * Preferred path: open the SSE change stream from `since`, invoking `onPage`
+   * per page. Resolves when the server ends the stream (reconnect); rejects
+   * when streaming is unavailable (old mesh / no NATS) or on a transport error.
+   * Optional — without it the loop uses `changes` only.
+   */
+  stream?: (
+    since: string,
+    onPage: (page: ChangePage) => void | Promise<void>,
+    signal: AbortSignal,
+  ) => Promise<void>;
   /** Re-list one directory's cached entries (rclone `vfs/refresh dir=`). */
   refresh: (dir: string) => Promise<void>;
   /** Aborts the loop (mount teardown). */
@@ -48,22 +62,74 @@ export interface InvalidatorDeps {
 
 const DEFAULT_POLL_MS = 1000;
 
+/** Cursor + prime state, advanced in place as pages are consumed. */
+interface FeedState {
+  since: string;
+  /** Caught up to head once — refresh only fires for pages after this. */
+  primed: boolean;
+}
+
 /**
- * Run until `signal` aborts. First drains the feed to its head WITHOUT
- * refreshing (the mount's initial listing already reflects that state), then
- * refreshes the parent dir of every subsequent change. Never throws.
+ * Apply one change-feed page: refresh the parent dir of every change (deduped)
+ * once primed, then advance the cursor. Before prime we only drain — the
+ * mount's initial listing already reflects that state. Never throws.
+ */
+async function applyPage(
+  page: ChangePage,
+  state: FeedState,
+  deps: Pick<InvalidatorDeps, "refresh" | "signal" | "log">,
+): Promise<void> {
+  if (state.primed && page.entries.length > 0) {
+    // Dedupe: many changes in one dir collapse to a single refresh.
+    const dirs = new Set(page.entries.map((e) => e.parent));
+    for (const dir of dirs) {
+      if (deps.signal.aborted) break;
+      try {
+        await deps.refresh(dir);
+      } catch (err) {
+        deps.log?.(`vfs/refresh failed for "${dir}"`, err);
+      }
+    }
+  }
+  state.since = page.cursor;
+  if (!page.hasMore) state.primed = true; // everything after head is a real change
+}
+
+/**
+ * Run until `signal` aborts. Prefers the SSE stream; on stream failure latches
+ * over to the long-poll loop for the rest of this mount (the next mount retries
+ * the stream). Never throws.
  */
 export async function runInvalidator(deps: InvalidatorDeps): Promise<void> {
   const pollMs = deps.pollMs ?? DEFAULT_POLL_MS;
   const log = deps.log ?? (() => {});
-  let since = "0";
-  let primed = false;
+  const state: FeedState = { since: "0", primed: false };
+  // ponytail: latch streaming off after one failure; re-enabled on next mount.
+  let streaming = !!deps.stream;
 
   while (!deps.signal.aborted) {
+    if (streaming && deps.stream) {
+      try {
+        // Resolves on clean server-side end → reconnect immediately, resuming
+        // from the advanced cursor.
+        await deps.stream(
+          state.since,
+          (page) => applyPage(page, state, deps),
+          deps.signal,
+        );
+        continue;
+      } catch (err) {
+        if (deps.signal.aborted) return;
+        log("change stream unavailable, falling back to poll loop", err);
+        streaming = false;
+      }
+    }
+
+    // --- Long-poll fallback --------------------------------------------------
     const startedAt = Date.now();
-    let page: Awaited<ReturnType<InvalidatorDeps["changes"]>>;
+    let page: ChangePage;
     try {
-      page = await deps.changes(since);
+      page = await deps.changes(state.since);
     } catch (err) {
       // rclone rc not up yet, transient mesh error, etc. — back off and retry.
       log("change-feed poll failed", err);
@@ -71,32 +137,14 @@ export async function runInvalidator(deps: InvalidatorDeps): Promise<void> {
       continue;
     }
 
-    if (primed && page.entries.length > 0) {
-      // Dedupe: many changes in one dir collapse to a single refresh.
-      const dirs = new Set(page.entries.map((e) => e.parent));
-      for (const dir of dirs) {
-        if (deps.signal.aborted) break;
-        try {
-          await deps.refresh(dir);
-        } catch (err) {
-          log(`vfs/refresh failed for "${dir}"`, err);
-        }
-      }
-    }
+    await applyPage(page, state, deps);
 
-    since = page.cursor;
-    if (!page.hasMore) {
-      primed = true; // caught up to head; everything after this is a real change
-      // Long-poll already absorbs the idle wait, so don't sleep on top of it.
-      // Only back off when it returned fast-empty (long-poll unavailable / NATS
-      // down) — that prevents a busy loop without delaying real changes.
-      if (page.entries.length === 0) {
-        const elapsed = Date.now() - startedAt;
-        if (elapsed < pollMs) {
-          await sleep(pollMs - elapsed, { signal: deps.signal }).catch(
-            () => {},
-          );
-        }
+    if (!page.hasMore && page.entries.length === 0) {
+      // Long-poll already absorbs the idle wait; only back off when it returned
+      // fast-empty (long-poll unavailable) so we don't busy-loop.
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < pollMs) {
+        await sleep(pollMs - elapsed, { signal: deps.signal }).catch(() => {});
       }
     }
     // hasMore → loop immediately to drain the backlog.

--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -66,7 +66,7 @@ export type InvalidatorFactory = (opts: {
   log: (msg: string, err?: unknown) => void;
 }) => VolumeInvalidator;
 
-/** Real factory: poll the change feed → rclone `vfs/refresh` (see invalidator.ts). */
+/** Real factory: change feed → rclone `vfs/refresh` (see invalidator.ts). */
 const defaultInvalidatorFactory: InvalidatorFactory = ({
   client,
   rcUrl,
@@ -74,8 +74,11 @@ const defaultInvalidatorFactory: InvalidatorFactory = ({
 }) => {
   const ac = new AbortController();
   void runInvalidator({
-    // wait: true → server holds the request open until a write nudge or its
-    // hold timeout, so this is push-driven with the poll floor as a safety net.
+    // Preferred: SSE stream held open by the server, pushing on every write.
+    stream: (since, onPage, signal) =>
+      client.streamChanges(since, onPage, signal),
+    // Fallback when streaming is unavailable (old mesh / NATS down): the
+    // long-poll feed, with the poll floor as a safety net.
     changes: (since) => client.changes(since, { wait: true }),
     refresh: makeRcRefresh(rcUrl),
     signal: ac.signal,


### PR DESCRIPTION
## Summary

The org-fs mount invalidator long-polls `GET /api/:org/fs/:volume/changes` to learn about external writes. The long-poll already wakes instantly on writes (via a NATS notify), but it **recycles its connection every 28s** — the floor kept just under the ~30s gateway/proxy timeout. So an idle org filesystem still shows a steady drumbeat of requests, one per mounted volume, every 28s.

This replaces the recycling long-poll with a **server-held SSE stream** (`?stream=1`):

- Server subscribes to the volume's NATS notify (`mesh.org-fs.changes.{org}.{volume}`) **before** the first drain, pushes one `changes` event per change-feed page on every write, and sends a keepalive comment every 15s to defeat the idle timeout.
- The stream stays open indefinitely → **zero reconnects while idle**; push latency = the NATS publish.
- Cursor paging is preserved, so the daemon primes (drains to head without refreshing) exactly as before.

No new channel, no new dependency: reuses the existing per-write NATS notify and the same `streamSSE` primitive used by `vm-events`.

## Backwards compatibility

- **Old daemons** keep using `?wait=1` long-poll — unchanged.
- **New daemons against an old mesh, or with NATS down**: the server answers `?stream=1` with a plain JSON page (not `text/event-stream`); the client detects the mismatch and the invalidator latches over to its long-poll loop for the rest of the mount (next mount retries the stream). Resumes from the advanced cursor — no re-read from 0.

## Changes

- `apps/mesh/src/api/routes/org-fs.ts` — `streamChanges()` + `?stream=1` branch.
- `apps/mesh/src/file-storage/mount/client.ts` — `streamChanges()` + minimal SSE reader.
- `packages/sandbox/daemon/org-fs/invalidator.ts` — extracted `applyPage`; prefer stream, latch to poll on failure.
- `packages/sandbox/daemon/org-fs/mount-manager.ts` — wire the stream with poll fallback.

## Testing

- `bun test packages/sandbox/daemon/org-fs/invalidator.test.ts` — 6 pass (added: stream-path prime+refresh; stream-error → poll fallback resuming from cursor).
- `bun run check` (apps/mesh + packages/sandbox) — clean.
- SSE parser validated against hono's actual `writeSSE` wire format; keepalive frames yield nothing.
- Not run: live e2e against a real mesh (needs PG+NATS). The existing route integration test doesn't cover `/changes`.

## Follow-ups

- Collapse the per-volume streams into one org-level stream if held-connection count becomes a concern (separate change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch org-fs change delivery to SSE (`?stream=1`) so mounts get push updates without 28s long‑poll reconnects. Idle volumes keep one open stream; push latency matches the NATS publish and cursor paging is unchanged.

- **New Features**
  - API: `GET /api/:org/fs/:volume/changes?stream=1` sends SSE with one `changes` event per page and a 15s keepalive; subscribes to `mesh.org-fs.changes.{org}.{volume}`; falls back to a JSON page when NATS is unavailable.
  - Client: added `OrgFsClient.streamChanges()` with a minimal SSE reader that ignores keepalives and yields JSON pages.
  - Daemon: invalidator prefers the stream, applies pages via a new `applyPage`, and latches to long‑poll on stream failure, resuming from the advanced cursor.
  - Tests: added stream prime/refresh and stream‑error → poll‑fallback cases; existing checks remain green.

<sup>Written for commit 3d6064a06c6eeed85dc68b68cb441256fae6b561. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

