### PR TITLE
fix(decopilot): stamp optimistic user message so the reply can't sort ahead of it

### DIFF
--- a/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
@@ -693,6 +693,35 @@ describe("submit", () => {
     expect(conn.finishReason.get()).toBe(null);
     await p;
   });
+
+  test("stamps the optimistic user message with a top-level created_at", async () => {
+    globalThis.fetch = makeFetchMock() as unknown as typeof globalThis.fetch;
+    const conn = getOrOpenStream("acme", "thread-stamp", { client: null });
+    await new Promise((r) => setTimeout(r, 20));
+
+    await conn.submit(
+      {
+        kind: "message",
+        message: {
+          id: "user-stamp",
+          role: "user",
+          parts: [{ type: "text", text: "hi" }],
+        },
+      },
+      baseOpts,
+    );
+
+    // Without the stamp the optimistic user row reads as +Infinity and the
+    // assistant reply (finite metadata/finish timestamp) sorts ahead of it →
+    // "No response was generated" on the turn that triggered the run.
+    const userRow = conn.messages.get().find((m) => m.id === "user-stamp") as
+      | (UIMessage & { created_at?: string })
+      | undefined;
+    expect(userRow?.created_at).toBeDefined();
+    expect(Number.isFinite(new Date(userRow!.created_at!).getTime())).toBe(
+      true,
+    );
+  });
 });
 
 // ─── submit() — defer POST while client-side resolutions are pending ─────────

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -156,7 +156,35 @@ function applyLocally(
   action: SubmitAction,
 ): UIMessage[] | null {
   if (action.kind === "message") {
-    return [...prev, action.message];
+    // Stamp a top-level `created_at` the moment the user submits. Without it the
+    // optimistic user row reads as +Infinity in `readTimestamp`/`mergeAndSort`,
+    // while the assistant reply gets a finite timestamp (run-start
+    // `metadata.created_at`, or its finish anchor) — so the reply sorts AHEAD of
+    // the user row that triggered it. The turn then renders empty ("No response
+    // was generated") with its answer detached under the next turn, until a
+    // refetch brings the DB `created_at`.
+    //
+    // The just-submitted message is the newest in the thread, so stamp it
+    // strictly after every existing finite timestamp — not a bare `now`, which
+    // can tie (to the millisecond) with a frozen assistant just anchored by
+    // stop(); the role tiebreak would then wrongly sort the new user ahead of
+    // that earlier assistant. A persisted refetch (incoming carries the DB
+    // `created_at`) overwrites this via `preserveCreatedAt`. No-op if a
+    // `created_at` is already present.
+    const msg = action.message as UIMessage & { created_at?: string };
+    if (msg.created_at != null) return [...prev, msg];
+    let maxMs = 0;
+    for (const m of prev) {
+      const ts = (m as { created_at?: string | number | Date }).created_at;
+      if (ts == null) continue;
+      const t = new Date(ts).getTime();
+      if (Number.isFinite(t) && t > maxMs) maxMs = t;
+    }
+    const ms = Math.max(Date.now(), maxMs + 1);
+    return [
+      ...prev,
+      { ...msg, created_at: new Date(ms).toISOString() } as UIMessage,
+    ];
   }
   // toolOutput / approval — locate the part by id on any assistant message.
   // The newest occurrence wins (the same toolCallId shouldn't appear twice


### PR DESCRIPTION
## Problem

On the **second message** of a thread, the user's turn intermittently renders **"No response was generated"** — the assistant's reply detaches and lands under the next turn. **Refreshing fixes it.** Client-side only.

## Root cause

`mergeAndSort` orders messages by `readTimestamp`, which returns `+Infinity` for any message lacking a top-level `created_at`. The optimistic **user** row added on `submit()` has no `created_at` → `+Infinity`. The **assistant** reply, however, gets a *finite* timestamp (run-start `metadata.created_at`, or its finish anchor). So the reply sorts **ahead** of the very user message that triggered it:

```
[user1, assistant1, assistant2, user2]   ← user2 = +Infinity, sorts last
```

`useMessagePairs` is positional, so `user2` pairs with `null` ("No response was generated") and `assistant2` becomes an orphan pair. A refetch fixes it because the DB user row carries a real `created_at`.

## Fix

Stamp the optimistic user message with a top-level `created_at` at submit time — it genuinely exists then and always precedes the run. The stamp is **strictly greater than every existing finite timestamp** (not a bare `now`), so it can't tie — to the millisecond — with a `stop()`-anchored assistant and lose the user-before-assistant role tiebreak. A persisted refetch overwrites it via `preserveCreatedAt` (incoming carries the DB `created_at`).

One-line change in `applyLocally`; the rest is the comment + test.

## Test

`thread-connection.test.ts` → "stamps the optimistic user message with a top-level created_at". Full suite: 57 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes message ordering by stamping a `created_at` on optimistic user messages so the assistant reply can’t sort ahead, removing the intermittent “No response was generated” on the second turn.

- **Bug Fixes**
  - On submit, set `created_at` on the optimistic user message to be strictly greater than all existing finite timestamps, preventing `+Infinity` ordering and detached replies. Refetch replaces it with the DB value via `preserveCreatedAt`.
  - Added a test to ensure the optimistic user message is stamped with a valid `created_at`.

<sup>Written for commit 0c71e642566e1f52e954d0ebe94f20bfe1ed74f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

