### PR TITLE
feat(decopilot): seed default MEMORY.md template on first load

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts
@@ -206,15 +206,31 @@ describe("buildAgentSystemPrompt", () => {
     expect(joined).toContain("my-prompt");
   });
 
-  const fakeOrgFs = (files: Record<string, string>) =>
-    ({
+  const fakeOrgFs = (files: Record<string, string>) => {
+    const writes: { path: string; body: string }[] = [];
+    const fs = {
+      writes,
       read: async (volume: string, path: string) => {
         if (volume !== "home" || !(path in files)) {
           throw new Error("not a live file");
         }
         return new TextEncoder().encode(files[path]);
       },
-    }) as never;
+      stat: async (volume: string, path: string) =>
+        volume === "home" && path in files ? { path } : null,
+      write: async (
+        _volume: string,
+        path: string,
+        body: string | Uint8Array,
+      ) => {
+        const text =
+          typeof body === "string" ? body : new TextDecoder().decode(body);
+        files[path] = text;
+        writes.push({ path, body: text });
+      },
+    };
+    return fs;
+  };
 
   test("kind: 'agent' eager-loads org and user MEMORY.md blocks", async () => {
     const out = await buildAgentSystemPrompt({
@@ -261,6 +277,47 @@ describe("buildAgentSystemPrompt", () => {
     expect(joined).not.toContain("persistent organization memory index");
     expect(joined).not.toContain("persistent user memory index");
     expect(joined).not.toContain("Org fact.");
+  });
+
+  test("seeds default MEMORY.md templates on first load when absent", async () => {
+    const fs = fakeOrgFs({}); // nothing exists yet
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "agent",
+      ctx: { orgFs: fs } as never,
+      organization: { id: "org_test", slug: "acme" } as never,
+      user: { id: "u1", name: "Ada" },
+    });
+    // Both files seeded with a raw template, attributed to the current user.
+    const paths = fs.writes.map((w) => w.path).sort();
+    expect(paths).toEqual(["MEMORY.md", "users/u1/MEMORY.md"]);
+    expect(fs.writes.find((w) => w.path === "MEMORY.md")?.body).toContain(
+      "# Organization memory",
+    );
+    expect(
+      fs.writes.find((w) => w.path === "users/u1/MEMORY.md")?.body,
+    ).toContain("# User memory");
+    // Freshly seeded → nothing injected this session.
+    const joined = JSON.stringify(out);
+    expect(joined).not.toContain("persistent organization memory index");
+    expect(joined).not.toContain("persistent user memory index");
+  });
+
+  test("does not overwrite an existing file on a transient read error", async () => {
+    const fs = fakeOrgFs({ "MEMORY.md": "Real memory." });
+    // Make read fail even though the file exists (transient error).
+    fs.read = async () => {
+      throw new Error("transient");
+    };
+    await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "agent",
+      ctx: { orgFs: fs } as never,
+      organization: { id: "org_test", slug: "acme" } as never,
+      user: { id: "u1" },
+    });
+    // stat still reports the org file as present → no clobbering write for it.
+    expect(fs.writes.map((w) => w.path)).not.toContain("MEMORY.md");
   });
 
   test("kind: 'subagent' omits prompts block when passthroughClient is not provided", async () => {

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -150,13 +150,14 @@ export async function buildAgentSystemPrompt(
       : "org/<slug>";
     const userId = opts.user?.id;
     const [org, usr] = await Promise.all([
-      loadMemoryBlock(opts.ctx, "organization", "MEMORY.md", homeBase),
+      loadMemoryBlock(opts.ctx, "organization", "MEMORY.md", homeBase, userId),
       userId
         ? loadMemoryBlock(
             opts.ctx,
             "user",
             `users/${userId}/MEMORY.md`,
             homeBase,
+            userId,
           )
         : Promise.resolve(null),
     ]);
@@ -221,19 +222,32 @@ export async function buildAgentSystemPrompt(
  *  a log. Larger files are truncated with a pointer to read the rest on demand. */
 const MEMORY_INJECT_CAP = 16_000;
 
+/** Raw starter content seeded on first load so the agent's later
+ *  Read(MEMORY.md) never hits a missing file. Kept minimal — just a heading. */
+function memoryTemplate(scope: "organization" | "user"): string {
+  return scope === "organization"
+    ? "# Organization memory\n\nDurable facts shared with everyone in this organization. Keep this a concise, curated index — not a log.\n"
+    : "# User memory\n\nFacts and preferences specific to you. Keep this a concise, curated index — not a log.\n";
+}
+
 /**
  * Read a MEMORY.md index from the `home` volume and render it as a system
  * block. `scope` is "organization" (shared) or "user" (private to the current
  * user); `path` is volume-relative (e.g. "MEMORY.md" or "users/<id>/MEMORY.md")
  * and `homeBase` is the sandbox mount path ("org/<slug>") used only for display.
- * Returns null when org-fs is unavailable, the file is absent, or it is empty —
- * the orgFs prompt already tells the agent where to create it. Never throws.
+ * `actor` is the user id used to seed the file on first load.
+ *
+ * On the first load, if the file is genuinely absent it is created with a raw
+ * default template so the agent's later Read(MEMORY.md) doesn't fail. Returns
+ * null when org-fs is unavailable, the file was just seeded, or it is empty.
+ * Never throws.
  */
 async function loadMemoryBlock(
   ctx: StudioContext,
   scope: "organization" | "user",
   path: string,
   homeBase: string,
+  actor: string | undefined,
 ): Promise<string | null> {
   if (!ctx.orgFs) return null;
   let content: string;
@@ -241,7 +255,23 @@ async function loadMemoryBlock(
     const bytes = await ctx.orgFs.read("home", path);
     content = new TextDecoder().decode(bytes).trim();
   } catch {
-    return null; // not a live file yet
+    // Read failed. Seed a default template only when the file is genuinely
+    // absent — a `stat` guard so a transient read error never clobbers an
+    // existing file with the blank template. Best-effort; never throws.
+    if (actor) {
+      try {
+        const existing = await ctx.orgFs.stat("home", path);
+        if (!existing) {
+          await ctx.orgFs.write("home", path, memoryTemplate(scope), {
+            actor,
+            contentType: "text/markdown",
+          });
+        }
+      } catch {
+        // ignore — seeding is best-effort
+      }
+    }
+    return null;
   }
   if (!content) return null;
   const displayPath = `${homeBase}/${path}`;


### PR DESCRIPTION
## Summary

Follow-up to the MEMORY.md feature (#4078). On the **first** load of a memory index, if the file doesn't exist yet, seed it with a raw default template — just like Claude Code — so the agent's later `Read(MEMORY.md)` doesn't fail on a missing file.

- Seeds both `org/<slug>/MEMORY.md` and `org/<slug>/users/<userId>/MEMORY.md` with a minimal heading-only template (`# Organization memory` / `# User memory`).
- **`stat`-guarded**: only writes when the file is genuinely absent, so a transient read error never clobbers an existing file with the blank template.
- Best-effort: seeding never throws; the freshly-seeded session injects nothing (the file is empty of real knowledge), subsequent sessions read it normally.
- Attributed to the current user as the `actor`; skipped when there's no user (no actor to write as).

## Testing
- `bun test apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts` → 19/19 pass (2 new: templates seeded when absent; existing file not overwritten on transient read error).

## Affected areas
- `apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts` — `memoryTemplate()` + seed-on-miss in `loadMemoryBlock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seed default `MEMORY.md` templates on first load for organization and user memory so agent reads don’t fail on missing files. Writes only when the file is genuinely absent and attributes the write to the current user.

- **New Features**
  - Create `org/<slug>/MEMORY.md` and `org/<slug>/users/<userId>/MEMORY.md` with a minimal heading template.
  - `stat`-guarded seeding; best-effort and never throws; skipped when no user.
  - Add `memoryTemplate()` and update `loadMemoryBlock()` to seed on miss without injecting just-seeded content.

<sup>Written for commit b0d892e3bf057d8836332e06105efaeb91151e3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

