### PR TITLE
Preview org file references in chat

### DIFF
--- a/apps/mesh/src/web/components/chat/markdown.tsx
+++ b/apps/mesh/src/web/components/chat/markdown.tsx
@@ -8,10 +8,12 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { markdownComponents as sharedMarkdownComponents } from "@deco/ui/components/markdown.tsx";
 import { Check, Copy01 } from "@untitledui/icons";
 import { ImageLightbox } from "./image-lightbox.tsx";
 import { resolveOrgFileBrowsePath } from "./org-file-ref.ts";
+import { formatLibraryFileTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 // @ts-ignore - correct
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism/index.js";
 
@@ -201,19 +203,24 @@ type MdProps = {
 const INLINE_CODE_CLASS =
   "px-1 py-0.5 bg-background border border-border rounded text-[14px] font-mono break-all";
 
-// Opens an org file in the Library preview overlay (`?preview=<browse path>`)
-// without leaving the conversation. `useNavigate`/`useParams` are router-level,
-// so this stays safe on every surface that renders MemoizedMarkdown.
+// Opens an org file referenced in chat without leaving the conversation,
+// mirroring the Library's panel/dialog split: desktop opens the file as a
+// main-panel side tab (`?main=library-file:<path>`), mobile opens the dialog
+// overlay (`?preview=<path>`, rendered by OrgFilePreviewMount).
 function useOpenOrgFile() {
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const { org } = useParams({ strict: false }) as { org?: string };
   const open = (browsePath: string) =>
     navigate({
       to: ".",
-      search: (prev: Record<string, unknown>) => ({
-        ...prev,
-        preview: browsePath,
-      }),
+      search: (prev: Record<string, unknown>) => {
+        if (isMobile) return { ...prev, preview: browsePath };
+        // Desktop: side tab. Drop any stale `?preview=` so the two models
+        // never both resolve to a file at once.
+        const { preview: _omit, ...rest } = prev;
+        return { ...rest, main: formatLibraryFileTabId(browsePath) };
+      },
     });
   return { orgSlug: org, open };
 }

--- a/apps/mesh/src/web/components/chat/markdown.tsx
+++ b/apps/mesh/src/web/components/chat/markdown.tsx
@@ -1,19 +1,24 @@
 /* eslint-disable ban-memoization/ban-memoization */
 import { marked } from "marked";
-import React, { memo, useCallback, useMemo, useRef, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { useNavigate, useParams } from "@tanstack/react-router";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { markdownComponents as sharedMarkdownComponents } from "@deco/ui/components/markdown.tsx";
 import { Check, Copy01 } from "@untitledui/icons";
 import { ImageLightbox } from "./image-lightbox.tsx";
 import { resolveOrgFileBrowsePath } from "./org-file-ref.ts";
-import { formatLibraryFileTabId } from "@/web/layouts/main-panel-tabs/tab-id";
+import { OrgFileOpenContext } from "./org-file-open-context.tsx";
 // @ts-ignore - correct
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism/index.js";
 
@@ -203,39 +208,21 @@ type MdProps = {
 const INLINE_CODE_CLASS =
   "px-1 py-0.5 bg-background border border-border rounded text-[14px] font-mono break-all";
 
-// Opens an org file referenced in chat without leaving the conversation,
-// mirroring the Library's panel/dialog split: desktop opens the file as a
-// main-panel side tab (`?main=library-file:<path>`), mobile opens the dialog
-// overlay (`?preview=<path>`, rendered by OrgFilePreviewMount).
-function useOpenOrgFile() {
-  const navigate = useNavigate();
-  const isMobile = useIsMobile();
-  const { org } = useParams({ strict: false }) as { org?: string };
-  const open = (browsePath: string) =>
-    navigate({
-      to: ".",
-      search: (prev: Record<string, unknown>) => {
-        if (isMobile) return { ...prev, preview: browsePath };
-        // Desktop: side tab. Drop any stale `?preview=` so the two models
-        // never both resolve to a file at once.
-        const { preview: _omit, ...rest } = prev;
-        return { ...rest, main: formatLibraryFileTabId(browsePath) };
-      },
-    });
-  return { orgSlug: org, open };
-}
-
 // Inline code that names an org file becomes a clickable chip; everything else
 // keeps the plain code styling. Block code (rendered via `pre > code`, and the
-// fenced blocks MemoizedMarkdown pre-splits) is never linkified.
+// fenced blocks MemoizedMarkdown pre-splits) is never linkified. The chip is
+// clickable ONLY under an OrgFileOpenProvider (the chat shell) — elsewhere the
+// nav can't resolve, so it stays plain rather than a dead click.
 function MarkdownCode({ node: _n, className, children, ...p }: MdProps) {
-  const { orgSlug, open } = useOpenOrgFile();
+  const ctx = useContext(OrgFileOpenContext);
   const isBlock =
     typeof className === "string" && className.includes("language-");
   const text = typeof children === "string" ? children : null;
   const browsePath =
-    !isBlock && text ? resolveOrgFileBrowsePath(text, orgSlug) : null;
-  if (!browsePath) {
+    ctx && !isBlock && text
+      ? resolveOrgFileBrowsePath(text, ctx.orgSlug)
+      : null;
+  if (!ctx || !browsePath) {
     return (
       <code className={INLINE_CODE_CLASS} {...p}>
         {children}
@@ -245,7 +232,7 @@ function MarkdownCode({ node: _n, className, children, ...p }: MdProps) {
   return (
     <button
       type="button"
-      onClick={() => open(browsePath)}
+      onClick={() => ctx.open(browsePath)}
       className={cn(
         INLINE_CODE_CLASS,
         "text-primary-dark hover:underline cursor-pointer",
@@ -259,22 +246,24 @@ function MarkdownCode({ node: _n, className, children, ...p }: MdProps) {
 
 // Markdown links whose href is an org file path open the in-chat preview;
 // all other links keep their external-tab behavior. `animate` routes the label
-// through the streaming word-fade animator.
+// through the streaming word-fade animator. Like MarkdownCode, the in-chat
+// preview is wired only under an OrgFileOpenProvider.
 function MarkdownAnchor({
   node: _n,
   children,
   animate,
   ...p
 }: MdProps & { animate?: boolean }) {
-  const { orgSlug, open } = useOpenOrgFile();
+  const ctx = useContext(OrgFileOpenContext);
   const href = typeof p.href === "string" ? p.href : undefined;
-  const browsePath = href ? resolveOrgFileBrowsePath(href, orgSlug) : null;
+  const browsePath =
+    ctx && href ? resolveOrgFileBrowsePath(href, ctx.orgSlug) : null;
   const label = animate ? animateText(children) : children;
-  if (browsePath) {
+  if (ctx && browsePath) {
     return (
       <button
         type="button"
-        onClick={() => open(browsePath)}
+        onClick={() => ctx.open(browsePath)}
         className="text-primary-dark hover:underline break-all font-medium cursor-pointer"
       >
         {label}

--- a/apps/mesh/src/web/components/chat/markdown.tsx
+++ b/apps/mesh/src/web/components/chat/markdown.tsx
@@ -5,10 +5,13 @@ import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { useNavigate, useParams } from "@tanstack/react-router";
 import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
 import { markdownComponents as sharedMarkdownComponents } from "@deco/ui/components/markdown.tsx";
 import { Check, Copy01 } from "@untitledui/icons";
 import { ImageLightbox } from "./image-lightbox.tsx";
+import { resolveOrgFileBrowsePath } from "./org-file-ref.ts";
 // @ts-ignore - correct
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism/index.js";
 
@@ -131,9 +134,12 @@ function Table(props: React.HTMLAttributes<HTMLTableElement>) {
 const remarkPluginsMemo = [remarkGfm];
 const rehypePluginsMemo = [rehypeRaw];
 
-// Extend shared markdown components with chat-specific overrides (table with CSV copy, image lightbox)
+// Extend shared markdown components with chat-specific overrides (table with CSV
+// copy, image lightbox, clickable org-file references).
 const markdownComponents = {
   ...sharedMarkdownComponents,
+  code: (props: MdProps) => <MarkdownCode {...props} />,
+  a: (props: MdProps) => <MarkdownAnchor {...props} />,
   table: (props: React.HTMLAttributes<HTMLTableElement>) => (
     <Table {...props} />
   ),
@@ -191,6 +197,95 @@ type MdProps = {
   children?: React.ReactNode;
 } & Record<string, unknown>;
 
+// Inline-code styling, mirrored from the shared design-system `code` override.
+const INLINE_CODE_CLASS =
+  "px-1 py-0.5 bg-background border border-border rounded text-[14px] font-mono break-all";
+
+// Opens an org file in the Library preview overlay (`?preview=<browse path>`)
+// without leaving the conversation. `useNavigate`/`useParams` are router-level,
+// so this stays safe on every surface that renders MemoizedMarkdown.
+function useOpenOrgFile() {
+  const navigate = useNavigate();
+  const { org } = useParams({ strict: false }) as { org?: string };
+  const open = (browsePath: string) =>
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        preview: browsePath,
+      }),
+    });
+  return { orgSlug: org, open };
+}
+
+// Inline code that names an org file becomes a clickable chip; everything else
+// keeps the plain code styling. Block code (rendered via `pre > code`, and the
+// fenced blocks MemoizedMarkdown pre-splits) is never linkified.
+function MarkdownCode({ node: _n, className, children, ...p }: MdProps) {
+  const { orgSlug, open } = useOpenOrgFile();
+  const isBlock =
+    typeof className === "string" && className.includes("language-");
+  const text = typeof children === "string" ? children : null;
+  const browsePath =
+    !isBlock && text ? resolveOrgFileBrowsePath(text, orgSlug) : null;
+  if (!browsePath) {
+    return (
+      <code className={INLINE_CODE_CLASS} {...p}>
+        {children}
+      </code>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => open(browsePath)}
+      className={cn(
+        INLINE_CODE_CLASS,
+        "text-primary-dark hover:underline cursor-pointer",
+      )}
+      title="Open file"
+    >
+      {children}
+    </button>
+  );
+}
+
+// Markdown links whose href is an org file path open the in-chat preview;
+// all other links keep their external-tab behavior. `animate` routes the label
+// through the streaming word-fade animator.
+function MarkdownAnchor({
+  node: _n,
+  children,
+  animate,
+  ...p
+}: MdProps & { animate?: boolean }) {
+  const { orgSlug, open } = useOpenOrgFile();
+  const href = typeof p.href === "string" ? p.href : undefined;
+  const browsePath = href ? resolveOrgFileBrowsePath(href, orgSlug) : null;
+  const label = animate ? animateText(children) : children;
+  if (browsePath) {
+    return (
+      <button
+        type="button"
+        onClick={() => open(browsePath)}
+        className="text-primary-dark hover:underline break-all font-medium cursor-pointer"
+      >
+        {label}
+      </button>
+    );
+  }
+  return (
+    <a
+      {...p}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary-dark hover:underline break-all font-medium"
+    >
+      {label}
+    </a>
+  );
+}
+
 // Same design-system styling as `markdownComponents`, but text-bearing elements
 // route their text through `animateText`. Used only while a message streams.
 const animatedComponents = {
@@ -235,16 +330,7 @@ const animatedComponents = {
       {animateText(children)}
     </li>
   ),
-  a: ({ node: _n, children, ...p }: MdProps) => (
-    <a
-      {...p}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-primary-dark hover:underline break-all font-medium"
-    >
-      {animateText(children)}
-    </a>
-  ),
+  a: (props: MdProps) => <MarkdownAnchor {...props} animate />,
 } as typeof markdownComponents;
 
 const MemoizedMarkdownBlock = memo(

--- a/apps/mesh/src/web/components/chat/org-file-open-context.tsx
+++ b/apps/mesh/src/web/components/chat/org-file-open-context.tsx
@@ -1,0 +1,53 @@
+/**
+ * Supplies the "open an org file referenced in chat" behavior to the markdown
+ * renderer. The router/media hooks live here — once per provider — instead of
+ * in every inline `<code>`/`<a>` leaf (which `MemoizedMarkdown` renders across
+ * chat messages, file previews and PR tabs).
+ *
+ * Mounted by the agent shell, so it covers the chat and its main panel. On
+ * surfaces WITHOUT a provider (e.g. the Library's own file/skill previews on
+ * `/$org/files`, which has no main panel and no `?main=` key) the context is
+ * null and org-file references render as plain code — clickable only where the
+ * navigation actually resolves.
+ */
+
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { createContext, type ReactNode } from "react";
+import { formatLibraryFileTabId } from "@/web/layouts/main-panel-tabs/tab-id";
+
+export interface OrgFileOpenValue {
+  /** Current org slug, for resolving `org/<slug>/…` references. */
+  orgSlug: string | undefined;
+  /** Open a Library browse path ("<volume>/<path…>"). */
+  open: (browsePath: string) => void;
+}
+
+export const OrgFileOpenContext = createContext<OrgFileOpenValue | null>(null);
+
+export function OrgFileOpenProvider({ children }: { children: ReactNode }) {
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+  const { org } = useParams({ strict: false }) as { org?: string };
+
+  // Mirror the Library's panel/dialog split: desktop opens the file as a
+  // main-panel side tab (`?main=library-file:<path>`); mobile opens the dialog
+  // overlay (`?preview=<path>`, rendered by OrgFilePreviewMount).
+  const open = (browsePath: string) =>
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => {
+        if (isMobile) return { ...prev, preview: browsePath };
+        // Desktop: side tab. Drop any stale `?preview=` so the two models
+        // never both resolve to a file at once.
+        const { preview: _omit, ...rest } = prev;
+        return { ...rest, main: formatLibraryFileTabId(browsePath) };
+      },
+    });
+
+  return (
+    <OrgFileOpenContext.Provider value={{ orgSlug: org, open }}>
+      {children}
+    </OrgFileOpenContext.Provider>
+  );
+}

--- a/apps/mesh/src/web/components/chat/org-file-ref.test.ts
+++ b/apps/mesh/src/web/components/chat/org-file-ref.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { resolveOrgFileBrowsePath } from "./org-file-ref";
+
+const SLUG = "acme";
+
+describe("resolveOrgFileBrowsePath", () => {
+  it("maps the org home folder to the home volume", () => {
+    expect(resolveOrgFileBrowsePath("org/acme/MEMORY.md", SLUG)).toBe(
+      "home/MEMORY.md",
+    );
+    expect(
+      resolveOrgFileBrowsePath("org/acme/decks/q3-launch.html", SLUG),
+    ).toBe("home/decks/q3-launch.html");
+    expect(resolveOrgFileBrowsePath("org/acme/users/u_1/MEMORY.md", SLUG)).toBe(
+      "home/users/u_1/MEMORY.md",
+    );
+  });
+
+  it("maps the slug-reserved `home` fallback", () => {
+    expect(resolveOrgFileBrowsePath("org/home/notes/x.md", SLUG)).toBe(
+      "home/notes/x.md",
+    );
+  });
+
+  it("maps public sets, preserving the public/<set> prefix", () => {
+    expect(
+      resolveOrgFileBrowsePath("org/public/core/skills/index.ts", SLUG),
+    ).toBe("public/core/skills/index.ts");
+  });
+
+  it("strips a trailing :line(:col) citation", () => {
+    expect(resolveOrgFileBrowsePath("org/acme/src/x.ts:42", SLUG)).toBe(
+      "home/src/x.ts",
+    );
+    expect(resolveOrgFileBrowsePath("org/acme/src/x.ts:42:7", SLUG)).toBe(
+      "home/src/x.ts",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(resolveOrgFileBrowsePath("  org/acme/a.md  ", SLUG)).toBe(
+      "home/a.md",
+    );
+  });
+
+  it("skips thread-scoped upload/output mounts (they have their own chips)", () => {
+    expect(resolveOrgFileBrowsePath("org/upload/report.pdf", SLUG)).toBeNull();
+    expect(resolveOrgFileBrowsePath("org/output/deck.html", SLUG)).toBeNull();
+  });
+
+  it("skips directories and extension-less basenames", () => {
+    expect(resolveOrgFileBrowsePath("org/acme/notes", SLUG)).toBeNull();
+    expect(resolveOrgFileBrowsePath("org/acme/notes/", SLUG)).toBeNull();
+    expect(resolveOrgFileBrowsePath("org/public/core", SLUG)).toBeNull();
+  });
+
+  it("skips unknown top-level volumes and non-org text", () => {
+    expect(resolveOrgFileBrowsePath("org/other/x.md", SLUG)).toBeNull();
+    expect(resolveOrgFileBrowsePath("src/index.ts", SLUG)).toBeNull();
+    expect(resolveOrgFileBrowsePath("https://x.com/a.md", SLUG)).toBeNull();
+    // multi-word prose that merely contains a path is not a single token
+    expect(
+      resolveOrgFileBrowsePath("see org/acme/a.md please", SLUG),
+    ).toBeNull();
+  });
+
+  it("does not link the org/<slug> home root when the slug is unknown", () => {
+    expect(resolveOrgFileBrowsePath("org/acme/a.md", undefined)).toBeNull();
+    // but home/ and public/ are slug-independent and still resolve
+    expect(resolveOrgFileBrowsePath("org/home/a.md", undefined)).toBe(
+      "home/a.md",
+    );
+  });
+
+  it("requires an in-volume file (bare home/public roots are not links)", () => {
+    expect(resolveOrgFileBrowsePath("org/acme", SLUG)).toBeNull();
+    expect(resolveOrgFileBrowsePath("org/acme/", SLUG)).toBeNull();
+  });
+});

--- a/apps/mesh/src/web/components/chat/org-file-ref.ts
+++ b/apps/mesh/src/web/components/chat/org-file-ref.ts
@@ -1,0 +1,55 @@
+/**
+ * Maps an agent-emitted org-filesystem path (the `org/…` namespace the sandbox
+ * mounts) to a Library browse path (`<volume>/<dir…>`), so a file reference the
+ * agent prints in chat can open in the Library preview.
+ *
+ * Namespace → volume mapping (mirrors file-storage/mount/provisioning.ts):
+ *   org/<orgSlug>/<rest…>    → home/<rest…>
+ *   org/home/<rest…>         → home/<rest…>        (slug-reserved fallback)
+ *   org/public/<set>/<rest…> → public/<set>/<rest…>
+ *
+ * Thread-scoped mounts (`org/upload/…`, `org/output/…`) are intentionally NOT
+ * linked: they resolve through a per-run symlink into a thread subtree, so the
+ * volume path can't be derived from the text alone — and those files already
+ * surface as their own chips (thread outputs / produced files).
+ */
+
+// Trailing `:line` / `:line:col` citation suffix (the `path:line` convention).
+const LINE_SUFFIX = /:\d+(?::\d+)?$/;
+// A dotted basename, so directory mentions (`org/acme/notes`) aren't linked.
+const HAS_EXTENSION = /\.[A-Za-z0-9]+$/;
+
+/**
+ * @returns the Library browse path (`home/x.md`, `public/core/y.ts`) or null
+ * when `raw` isn't a recognizable, previewable org file path.
+ */
+export function resolveOrgFileBrowsePath(
+  raw: string,
+  orgSlug: string | undefined,
+): string | null {
+  const text = raw.trim().replace(LINE_SUFFIX, "");
+  // Single-token path under the org/ mount; a trailing slash marks a directory.
+  if (!text || /\s/.test(text) || !text.startsWith("org/")) return null;
+  if (text.endsWith("/")) return null;
+
+  const segments = text.split("/").filter(Boolean);
+  // org / <vol> / <at least one in-volume segment>.
+  if (segments.length < 3) return null;
+  const basename = segments.at(-1);
+  if (!basename || !HAS_EXTENSION.test(basename)) return null;
+
+  const top = segments[1];
+
+  // org/public/<set>/<rest…> → public/<set>/<rest…>
+  if (top === "public") {
+    if (segments.length < 4) return null; // need a set and a file under it
+    return segments.slice(1).join("/");
+  }
+
+  // org/<orgSlug>/<rest…> or org/home/<rest…> → home/<rest…>
+  if (top === "home" || (!!orgSlug && top === orgSlug)) {
+    return `home/${segments.slice(2).join("/")}`;
+  }
+
+  return null;
+}

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -238,6 +238,9 @@ const unifiedChatSearchSchema = z.object({
   virtualmcpid: z.string().optional(),
   tab: z.string().optional(),
   main: z.string().optional(),
+  /** Open the Library file-preview overlay over the chat (browse-grammar path
+   *  "<volume>/<path…>"). Set by clickable org-file refs in agent messages. */
+  preview: z.string().optional(),
   id: z.string().optional(),
   toolName: z.string().optional(),
   tasks: z.number().optional(),

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -74,6 +74,7 @@ import {
 import { useEnsureTask } from "@/web/hooks/use-ensure-task";
 import { ShellRouteLoading } from "@/web/layouts/shell-route-loading";
 import { OrgFilePreviewMount } from "./org-file-preview";
+import { OrgFileOpenProvider } from "@/web/components/chat/org-file-open-context";
 
 // ---------------------------------------------------------------------------
 // Types & Context
@@ -468,8 +469,10 @@ function AgentInsetProvider() {
 export default function AgentShellLayout() {
   return (
     <Suspense fallback={<ShellRouteLoading />}>
-      <AgentInsetProvider />
-      <OrgFilePreviewMount />
+      <OrgFileOpenProvider>
+        <AgentInsetProvider />
+        <OrgFilePreviewMount />
+      </OrgFileOpenProvider>
     </Suspense>
   );
 }

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -73,6 +73,7 @@ import {
 } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 import { useEnsureTask } from "@/web/hooks/use-ensure-task";
 import { ShellRouteLoading } from "@/web/layouts/shell-route-loading";
+import { OrgFilePreviewMount } from "./org-file-preview";
 
 // ---------------------------------------------------------------------------
 // Types & Context
@@ -468,6 +469,7 @@ export default function AgentShellLayout() {
   return (
     <Suspense fallback={<ShellRouteLoading />}>
       <AgentInsetProvider />
+      <OrgFilePreviewMount />
     </Suspense>
   );
 }

--- a/apps/mesh/src/web/layouts/agent-shell-layout/org-file-preview.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/org-file-preview.tsx
@@ -1,18 +1,22 @@
 /**
- * Renders the Library file-preview overlay over the chat when `?preview=<browse
+ * Mobile-only Library file-preview overlay over the chat when `?preview=<browse
  * path>` is set — the param a clickable org-file reference in an agent message
- * navigates to (see chat/markdown.tsx). Reuses the Library's URL-driven dialog
- * so the preview survives reload and closing returns to the conversation.
+ * navigates to on mobile (see chat/markdown.tsx). Desktop opens the file as a
+ * main-panel side tab instead (`?main=library-file:<path>`), mirroring the
+ * Library's own panel/dialog split. Reuses the Library's URL-driven dialog so
+ * the preview survives reload and closing returns to the conversation.
  */
 
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { LibraryPreviewDialog } from "@/web/layouts/library/preview-dialog";
 
 export function OrgFilePreviewMount() {
+  const isMobile = useIsMobile();
   const navigate = useNavigate();
   const { preview } = useSearch({ strict: false }) as { preview?: string };
 
-  if (!preview) return null;
+  if (!isMobile || !preview) return null;
 
   return (
     <LibraryPreviewDialog

--- a/apps/mesh/src/web/layouts/agent-shell-layout/org-file-preview.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/org-file-preview.tsx
@@ -1,0 +1,32 @@
+/**
+ * Renders the Library file-preview overlay over the chat when `?preview=<browse
+ * path>` is set — the param a clickable org-file reference in an agent message
+ * navigates to (see chat/markdown.tsx). Reuses the Library's URL-driven dialog
+ * so the preview survives reload and closing returns to the conversation.
+ */
+
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { LibraryPreviewDialog } from "@/web/layouts/library/preview-dialog";
+
+export function OrgFilePreviewMount() {
+  const navigate = useNavigate();
+  const { preview } = useSearch({ strict: false }) as { preview?: string };
+
+  if (!preview) return null;
+
+  return (
+    <LibraryPreviewDialog
+      previewPath={preview}
+      showSeeInLibrary
+      onClose={() =>
+        navigate({
+          to: ".",
+          search: (prev: Record<string, unknown>) => {
+            const { preview: _omit, ...rest } = prev;
+            return rest;
+          },
+        })
+      }
+    />
+  );
+}

--- a/apps/mesh/src/web/layouts/library/preview-content.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-content.tsx
@@ -1,0 +1,196 @@
+/**
+ * Shared body for the two Library file-preview surfaces — the near-fullscreen
+ * dialog (mobile / shared links) and the right-side panel (desktop Library +
+ * chat side tab). Resolves the entry via `stat`, renders the shared FilePreview
+ * (or the handshake-upgrading HtmlPreviewPanel for HTML), plus a toolbar with
+ * download / open-in-new-tab and an optional "See in library" jump.
+ *
+ * Only the chrome differs, and the caller owns it: the dialog wraps this in
+ * <DialogContent> and supplies a built-in close X (so this renders a sr-only/
+ * inline <DialogTitle> for a11y and a spacer to clear that X), while the panel
+ * wraps it in a plain column and gets an explicit close button here.
+ */
+
+import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { DialogTitle } from "@deco/ui/components/dialog.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { Download01, LinkExternal01, XClose } from "@untitledui/icons";
+import { useParams } from "@tanstack/react-router";
+import {
+  FilePreview,
+  FilePreviewShimmer,
+  formatSize,
+} from "@/web/components/file-preview";
+import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
+import { FileTypeIcon } from "@/web/components/file-type-icon";
+import {
+  entryMarker,
+  useOrgFsDownloadUrl,
+  useOrgFsStat,
+} from "@/web/hooks/use-org-fs";
+import { basename, parseLibraryPath } from "./location";
+import { SeeInLibraryLink } from "./see-in-library-link";
+
+const isHtml = (name: string) => /\.html?$/i.test(name);
+
+export type LibraryPreviewVariant = "dialog" | "panel";
+
+export interface LibraryPreviewProps {
+  /** Browse-grammar path of the open file ("<volume>/<path...>"). */
+  previewPath: string;
+  onClose: () => void;
+  /** Render a "See in library" link (set when previewing outside the Library). */
+  showSeeInLibrary?: boolean;
+}
+
+function CloseButton({ onClose }: { onClose: () => void }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="ghost" size="icon" onClick={onClose}>
+          <XClose size={14} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Close</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function LibraryFilePreview({
+  previewPath,
+  onClose,
+  showSeeInLibrary = false,
+  variant,
+}: LibraryPreviewProps & { variant: LibraryPreviewVariant }) {
+  const location = parseLibraryPath(previewPath);
+  const { volume, dirPath: filePath } = location;
+  const { data: entry, isPending } = useOrgFsStat(volume, filePath);
+  const downloadUrl = useOrgFsDownloadUrl(volume ?? "");
+  const filename = basename(filePath);
+  const { org } = useParams({ strict: false }) as { org?: string };
+  const isDialog = variant === "dialog";
+
+  const seeInLibrary =
+    showSeeInLibrary && org ? (
+      <SeeInLibraryLink org={org} previewPath={previewPath} />
+    ) : null;
+
+  const file =
+    entry && entry.kind === "file"
+      ? {
+          key: previewPath,
+          filename,
+          size: entry.size,
+          downloadUrl: downloadUrl(entry.path),
+        }
+      : null;
+
+  // HTML hands the whole panel (toolbar included) to the shared surface so it
+  // is pixel-identical to the chat deck tab. The dialog keeps a sr-only title
+  // for a11y and a spacer to clear its built-in close X; the panel appends an
+  // explicit close button. Keyed per file: the editor hook holds per-file
+  // state (source cache, debounced saves) that must not survive a path switch.
+  if (file && entry && isHtml(filename)) {
+    return (
+      <>
+        {isDialog && <DialogTitle className="sr-only">{filename}</DialogTitle>}
+        <HtmlPreviewPanel
+          key={previewPath}
+          readUrl={file.downloadUrl}
+          marker={entryMarker(entry)}
+          title={filename}
+          savePath={volume === "home" ? filePath : undefined}
+          trailing={
+            <>
+              {seeInLibrary}
+              {isDialog ? (
+                <div className="w-8 shrink-0" />
+              ) : (
+                <CloseButton onClose={onClose} />
+              )}
+            </>
+          }
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className={cn(
+          "flex shrink-0 items-center gap-1 border-b border-border/60",
+          // Dialog clears its built-in close X with pr-12; panel owns its close.
+          isDialog ? "h-11 py-1 pr-12 pl-2" : "h-9 px-2",
+        )}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-2">
+          <FileTypeIcon filename={filename} className="h-4.5 w-3.5 shrink-0" />
+          {isDialog ? (
+            <DialogTitle className="truncate text-xs font-medium text-foreground">
+              {filename}
+            </DialogTitle>
+          ) : (
+            <span className="truncate text-xs font-medium text-foreground">
+              {filename}
+            </span>
+          )}
+          {file && (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {formatSize(file.size)}
+            </span>
+          )}
+        </div>
+        {seeInLibrary}
+        {file && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon" asChild>
+                  <a href={file.downloadUrl} download={file.filename}>
+                    <Download01 size={14} />
+                  </a>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Download</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() =>
+                    window.open(file.downloadUrl, "_blank", "noopener")
+                  }
+                >
+                  <LinkExternal01 size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Open in new tab</TooltipContent>
+            </Tooltip>
+          </>
+        )}
+        {!isDialog && <CloseButton onClose={onClose} />}
+      </div>
+      <div className="relative min-h-0 flex-1 bg-background">
+        {file ? (
+          <FilePreview file={file} />
+        ) : isPending ? (
+          <FilePreviewShimmer />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-2">
+            <FileTypeIcon filename={filename} className="h-7.5 w-6" />
+            <span className="text-sm text-muted-foreground">
+              This file is no longer available.
+            </span>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/mesh/src/web/layouts/library/preview-dialog.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-dialog.tsx
@@ -1,100 +1,21 @@
 /**
- * Library file preview — near-fullscreen dialog over the shared FilePreview
- * viewer. URL-driven (`?preview=<browse path>`) so a preview link survives
- * reload: the entry is re-resolved via `stat`, not read off list caches.
+ * Library file preview — near-fullscreen dialog over the shared
+ * LibraryFilePreview body (mobile chat overlay / shared `?preview=` links).
+ * URL-driven so a preview link survives reload: the entry is re-resolved via
+ * `stat`, not read off list caches. The desktop surface is preview-panel.tsx.
  */
 
-import { Button } from "@deco/ui/components/button.tsx";
+import { Dialog, DialogContent } from "@deco/ui/components/dialog.tsx";
 import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { Download01, Folder, LinkExternal01 } from "@untitledui/icons";
-import { Link, useParams } from "@tanstack/react-router";
-import {
-  FilePreview,
-  FilePreviewShimmer,
-  formatSize,
-} from "@/web/components/file-preview";
-import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
-import { FileTypeIcon } from "@/web/components/file-type-icon";
-import {
-  entryMarker,
-  useOrgFsDownloadUrl,
-  useOrgFsStat,
-} from "@/web/hooks/use-org-fs";
-import { basename, parseLibraryPath } from "./location";
-
-const isHtml = (name: string) => /\.html?$/i.test(name);
-
-/** Jump to the file's folder in the Library page. Shown only when the preview
- *  is opened away from the Library itself (e.g. over a chat conversation). */
-function SeeInLibraryLink({
-  org,
-  previewPath,
-}: {
-  org: string;
-  previewPath: string;
-}) {
-  const parentPath = previewPath.split("/").slice(0, -1).join("/");
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      asChild
-      className="shrink-0 gap-1.5 text-xs text-muted-foreground"
-    >
-      <Link
-        to="/$org/files"
-        params={{ org }}
-        search={{ path: parentPath, preview: previewPath }}
-      >
-        <Folder size={14} />
-        See in library
-      </Link>
-    </Button>
-  );
-}
+  LibraryFilePreview,
+  type LibraryPreviewProps,
+} from "./preview-content";
 
 export function LibraryPreviewDialog({
   previewPath,
   onClose,
   showSeeInLibrary = false,
-}: {
-  /** Browse-grammar path of the open file ("<volume>/<path...>"). */
-  previewPath: string;
-  onClose: () => void;
-  /** Render a "See in library" link (set when previewing outside the Library). */
-  showSeeInLibrary?: boolean;
-}) {
-  const location = parseLibraryPath(previewPath);
-  const { volume, dirPath: filePath } = location;
-  const { data: entry, isPending } = useOrgFsStat(volume, filePath);
-  const downloadUrl = useOrgFsDownloadUrl(volume ?? "");
-  const filename = basename(filePath);
-  const { org } = useParams({ strict: false }) as { org?: string };
-
-  const seeInLibrary =
-    showSeeInLibrary && org ? (
-      <SeeInLibraryLink org={org} previewPath={previewPath} />
-    ) : null;
-
-  const file =
-    entry && entry.kind === "file"
-      ? {
-          key: previewPath,
-          filename,
-          size: entry.size,
-          downloadUrl: downloadUrl(entry.path),
-        }
-      : null;
-
+}: LibraryPreviewProps) {
   return (
     <Dialog
       open
@@ -103,91 +24,12 @@ export function LibraryPreviewDialog({
       }}
     >
       <DialogContent className="flex h-[88vh] w-[94vw] max-w-none! flex-col gap-0 overflow-hidden p-0 sm:max-w-5xl!">
-        {file && entry && isHtml(filename) ? (
-          // HTML uses the shared handshake-upgrading panel (same single
-          // toolbar as the chat deck tab). sr-only title keeps the dialog
-          // accessible; the spacer clears the dialog's built-in close X.
-          <>
-            <DialogTitle className="sr-only">{filename}</DialogTitle>
-            <HtmlPreviewPanel
-              key={previewPath}
-              readUrl={file.downloadUrl}
-              marker={entryMarker(entry)}
-              title={filename}
-              savePath={volume === "home" ? filePath : undefined}
-              trailing={
-                <>
-                  {seeInLibrary}
-                  <div className="w-8 shrink-0" />
-                </>
-              }
-            />
-          </>
-        ) : (
-          <>
-            <div className="flex h-11 shrink-0 items-center gap-1 border-b border-border/60 py-1 pr-12 pl-2">
-              <div className="flex min-w-0 flex-1 items-center gap-2 px-2">
-                <FileTypeIcon
-                  filename={filename}
-                  className="h-4.5 w-3.5 shrink-0"
-                />
-                <DialogTitle className="truncate text-xs font-medium text-foreground">
-                  {filename}
-                </DialogTitle>
-                {file && (
-                  <span className="shrink-0 text-xs text-muted-foreground">
-                    {formatSize(file.size)}
-                  </span>
-                )}
-              </div>
-              {seeInLibrary}
-              {file && (
-                <>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="ghost" size="icon" asChild>
-                        <a href={file.downloadUrl} download={file.filename}>
-                          <Download01 size={14} />
-                        </a>
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">Download</TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() =>
-                          window.open(file.downloadUrl, "_blank", "noopener")
-                        }
-                      >
-                        <LinkExternal01 size={14} />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      Open in new tab
-                    </TooltipContent>
-                  </Tooltip>
-                </>
-              )}
-            </div>
-            <div className="relative min-h-0 flex-1 bg-background">
-              {file ? (
-                <FilePreview file={file} />
-              ) : isPending ? (
-                <FilePreviewShimmer />
-              ) : (
-                <div className="flex h-full flex-col items-center justify-center gap-2">
-                  <FileTypeIcon filename={filename} className="h-7.5 w-6" />
-                  <span className="text-sm text-muted-foreground">
-                    This file is no longer available.
-                  </span>
-                </div>
-              )}
-            </div>
-          </>
-        )}
+        <LibraryFilePreview
+          previewPath={previewPath}
+          onClose={onClose}
+          showSeeInLibrary={showSeeInLibrary}
+          variant="dialog"
+        />
       </DialogContent>
     </Dialog>
   );

--- a/apps/mesh/src/web/layouts/library/preview-dialog.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-dialog.tsx
@@ -15,7 +15,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
-import { Download01, LinkExternal01 } from "@untitledui/icons";
+import { Download01, Folder, LinkExternal01 } from "@untitledui/icons";
+import { Link, useParams } from "@tanstack/react-router";
 import {
   FilePreview,
   FilePreviewShimmer,
@@ -32,19 +33,57 @@ import { basename, parseLibraryPath } from "./location";
 
 const isHtml = (name: string) => /\.html?$/i.test(name);
 
+/** Jump to the file's folder in the Library page. Shown only when the preview
+ *  is opened away from the Library itself (e.g. over a chat conversation). */
+function SeeInLibraryLink({
+  org,
+  previewPath,
+}: {
+  org: string;
+  previewPath: string;
+}) {
+  const parentPath = previewPath.split("/").slice(0, -1).join("/");
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      asChild
+      className="shrink-0 gap-1.5 text-xs text-muted-foreground"
+    >
+      <Link
+        to="/$org/files"
+        params={{ org }}
+        search={{ path: parentPath, preview: previewPath }}
+      >
+        <Folder size={14} />
+        See in library
+      </Link>
+    </Button>
+  );
+}
+
 export function LibraryPreviewDialog({
   previewPath,
   onClose,
+  showSeeInLibrary = false,
 }: {
   /** Browse-grammar path of the open file ("<volume>/<path...>"). */
   previewPath: string;
   onClose: () => void;
+  /** Render a "See in library" link (set when previewing outside the Library). */
+  showSeeInLibrary?: boolean;
 }) {
   const location = parseLibraryPath(previewPath);
   const { volume, dirPath: filePath } = location;
   const { data: entry, isPending } = useOrgFsStat(volume, filePath);
   const downloadUrl = useOrgFsDownloadUrl(volume ?? "");
   const filename = basename(filePath);
+  const { org } = useParams({ strict: false }) as { org?: string };
+
+  const seeInLibrary =
+    showSeeInLibrary && org ? (
+      <SeeInLibraryLink org={org} previewPath={previewPath} />
+    ) : null;
 
   const file =
     entry && entry.kind === "file"
@@ -76,7 +115,12 @@ export function LibraryPreviewDialog({
               marker={entryMarker(entry)}
               title={filename}
               savePath={volume === "home" ? filePath : undefined}
-              trailing={<div className="w-8 shrink-0" />}
+              trailing={
+                <>
+                  {seeInLibrary}
+                  <div className="w-8 shrink-0" />
+                </>
+              }
             />
           </>
         ) : (
@@ -96,6 +140,7 @@ export function LibraryPreviewDialog({
                   </span>
                 )}
               </div>
+              {seeInLibrary}
               {file && (
                 <>
                   <Tooltip>

--- a/apps/mesh/src/web/layouts/library/preview-panel.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-panel.tsx
@@ -1,160 +1,33 @@
 /**
- * Library file preview panel — right-side panel over the shared FilePreview
- * viewer, mirroring the chat's file tab (toolbar + preview). URL-driven
- * (`?preview=<browse path>`) so a preview link survives reload: the entry
- * is re-resolved via `stat`, not read off list caches.
+ * Library file preview panel — right-side panel over the shared
+ * LibraryFilePreview body, mirroring the chat's file tab (toolbar + preview).
+ * Used by the desktop Library and the chat org-file side tab. URL-driven so a
+ * preview link survives reload: the entry is re-resolved via `stat`, not read
+ * off list caches. The mobile/overlay surface is preview-dialog.tsx.
  *
- * HTML files render the shared HtmlPreviewPanel instead — the SAME single
- * toolbar the chat deck tab shows (URL/copy/open, upgrading with rail/
- * edit/download on the deck-viewer handshake), with the Library's close
- * action appended via `trailing` (download lives in the shared toolbar).
- * Only home-volume files get a savePath (the inline editor persists to
- * the home volume).
+ * HTML files render the shared HtmlPreviewPanel — the SAME single toolbar the
+ * chat deck tab shows — with the close action appended; only home-volume files
+ * are writable (the inline editor persists to the home volume).
  */
 
-import { Button } from "@deco/ui/components/button.tsx";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { Download01, LinkExternal01, XClose } from "@untitledui/icons";
-import {
-  FilePreview,
-  FilePreviewShimmer,
-  formatSize,
-} from "@/web/components/file-preview";
-import { HtmlPreviewPanel } from "@/web/components/deck/html-preview-panel";
-import { FileTypeIcon } from "@/web/components/file-type-icon";
-import {
-  entryMarker,
-  useOrgFsDownloadUrl,
-  useOrgFsStat,
-} from "@/web/hooks/use-org-fs";
-import { basename, parseLibraryPath } from "./location";
-
-const isHtml = (name: string) => /\.html?$/i.test(name);
-
-function PreviewClose({ onClose }: { onClose: () => void }) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button variant="ghost" size="icon" onClick={onClose}>
-          <XClose size={14} />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">Close</TooltipContent>
-    </Tooltip>
-  );
-}
+  LibraryFilePreview,
+  type LibraryPreviewProps,
+} from "./preview-content";
 
 export function LibraryPreviewPanel({
   previewPath,
   onClose,
-}: {
-  /** Browse-grammar path of the open file ("<volume>/<path...>"). */
-  previewPath: string;
-  onClose: () => void;
-}) {
-  const location = parseLibraryPath(previewPath);
-  const { volume, dirPath: filePath } = location;
-  const { data: entry, isPending } = useOrgFsStat(volume, filePath);
-  const downloadUrl = useOrgFsDownloadUrl(volume ?? "");
-  const filename = basename(filePath);
-
-  const file =
-    entry && entry.kind === "file"
-      ? {
-          key: previewPath,
-          filename,
-          size: entry.size,
-          downloadUrl: downloadUrl(entry.path),
-        }
-      : null;
-
-  // HTML: hand the whole panel (toolbar included) to the shared surface so
-  // it is pixel-identical to the chat deck tab.
-  if (file && entry && isHtml(filename)) {
-    return (
-      // Keyed per file: the editor hook holds per-file state (source
-      // cache, debounced saves, handshake) that must never survive a
-      // ?preview= switch — a pending save would PUT to the new path.
-      <HtmlPreviewPanel
-        key={previewPath}
-        readUrl={file.downloadUrl}
-        marker={entryMarker(entry)}
-        title={filename}
-        savePath={volume === "home" ? filePath : undefined}
-        trailing={<PreviewClose onClose={onClose} />}
-      />
-    );
-  }
-
+  showSeeInLibrary = false,
+}: LibraryPreviewProps) {
   return (
     <div className="flex h-full w-full flex-col bg-background">
-      <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border/60 px-2">
-        <div className="flex min-w-0 flex-1 items-center gap-2 px-2">
-          <FileTypeIcon filename={filename} className="h-4.5 w-3.5 shrink-0" />
-          <span className="truncate text-xs font-medium text-foreground">
-            {filename}
-          </span>
-          {file && (
-            <span className="shrink-0 text-xs text-muted-foreground">
-              {formatSize(file.size)}
-            </span>
-          )}
-        </div>
-        {file && (
-          <>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" asChild>
-                  <a href={file.downloadUrl} download={file.filename}>
-                    <Download01 size={14} />
-                  </a>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Download</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() =>
-                    window.open(file.downloadUrl, "_blank", "noopener")
-                  }
-                >
-                  <LinkExternal01 size={14} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Open in new tab</TooltipContent>
-            </Tooltip>
-          </>
-        )}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={onClose}>
-              <XClose size={14} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Close</TooltipContent>
-        </Tooltip>
-      </div>
-      <div className="relative min-h-0 flex-1">
-        {file ? (
-          <FilePreview file={file} />
-        ) : isPending ? (
-          <FilePreviewShimmer />
-        ) : (
-          <div className="flex h-full flex-col items-center justify-center gap-2">
-            <FileTypeIcon filename={filename} className="h-7.5 w-6" />
-            <span className="text-sm text-muted-foreground">
-              This file is no longer available.
-            </span>
-          </div>
-        )}
-      </div>
+      <LibraryFilePreview
+        previewPath={previewPath}
+        onClose={onClose}
+        showSeeInLibrary={showSeeInLibrary}
+        variant="panel"
+      />
     </div>
   );
 }

--- a/apps/mesh/src/web/layouts/library/see-in-library-link.tsx
+++ b/apps/mesh/src/web/layouts/library/see-in-library-link.tsx
@@ -1,0 +1,37 @@
+/**
+ * "See in library" — jumps to a file's folder in the Library page, with the
+ * file itself opened in preview. Shown only when a file is previewed away
+ * from the Library (over a chat conversation: the mobile dialog and the
+ * desktop main-panel tab). Shared by preview-dialog and preview-panel.
+ */
+
+import { Button } from "@deco/ui/components/button.tsx";
+import { Folder } from "@untitledui/icons";
+import { Link } from "@tanstack/react-router";
+
+export function SeeInLibraryLink({
+  org,
+  previewPath,
+}: {
+  org: string;
+  previewPath: string;
+}) {
+  const parentPath = previewPath.split("/").slice(0, -1).join("/");
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      asChild
+      className="shrink-0 gap-1.5 text-xs text-muted-foreground"
+    >
+      <Link
+        to="/$org/files"
+        params={{ org }}
+        search={{ path: parentPath, preview: previewPath }}
+      >
+        <Folder size={14} />
+        See in library
+      </Link>
+    </Button>
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -18,11 +18,13 @@ import { AutomationTab } from "./automation-tab";
 import { AutomationsListTab } from "./automations-list-tab";
 import { FileTab } from "./file-tab";
 import { DeckTab } from "./deck-tab";
+import { LibraryFileTab } from "./library-file-tab";
 import { MainPanelLoading } from "./main-panel-loading";
 import {
   isLegacySettingsTab,
   parseDeckTabId,
   parseFileTabId,
+  parseLibraryFileTabId,
   parsePinnedViewTabId,
 } from "./tab-id";
 import { ErrorBoundary } from "@/web/components/error-boundary";
@@ -90,6 +92,13 @@ function TabBody({
   const fileTab = parseFileTabId(activeTab);
   if (fileTab) {
     return <FileTab fileKey={fileTab.key} taskId={taskId} />;
+  }
+
+  const libraryFileTab = parseLibraryFileTabId(activeTab);
+  if (libraryFileTab) {
+    return (
+      <LibraryFileTab key={libraryFileTab.path} path={libraryFileTab.path} />
+    );
   }
 
   const pinnedView = parsePinnedViewTabId(activeTab);

--- a/apps/mesh/src/web/layouts/main-panel-tabs/library-file-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/library-file-tab.tsx
@@ -1,0 +1,29 @@
+/**
+ * LibraryFileTab — main-panel side preview of an org Library file referenced
+ * from a chat message (`?main=library-file:<encoded browse path>`).
+ *
+ * Thin adapter over the shared LibraryPreviewPanel — the SAME side panel the
+ * desktop Library uses — with the "See in library" jump enabled since the
+ * preview is opened away from the Library itself. On mobile the chat opens the
+ * dialog form (OrgFilePreviewMount) instead, mirroring the Library's split.
+ */
+
+import { useNavigate } from "@tanstack/react-router";
+import { LibraryPreviewPanel } from "@/web/layouts/library/preview-panel";
+
+export function LibraryFileTab({ path }: { path: string }) {
+  const navigate = useNavigate();
+  const onClose = () =>
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, main: "0" }),
+      replace: true,
+    });
+  return (
+    <LibraryPreviewPanel
+      previewPath={path}
+      onClose={onClose}
+      showSeeInLibrary
+    />
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from "bun:test";
 import {
   formatDeckTabId,
   formatFileTabId,
+  formatLibraryFileTabId,
   isLegacySettingsTab,
   isPerThreadTab,
   parseAutomationTabId,
   parseDeckTabId,
   parseFileTabId,
+  parseLibraryFileTabId,
   resolveDefaultTabId,
   resolveActiveTabAndOpen,
   resolveTabClickTarget,
@@ -81,6 +83,36 @@ describe("deck tab id", () => {
 
   test("deck tabs are per-thread", () => {
     expect(isPerThreadTab(formatDeckTabId("decks/a.html"))).toBe(true);
+  });
+});
+
+describe("library file tab id", () => {
+  test("round-trips Library browse paths (home + public sets)", () => {
+    for (const path of [
+      "home/docs/spec final.md",
+      "public/core/skills/a.ts",
+      "uploads/My.File_2.csv",
+    ]) {
+      expect(parseLibraryFileTabId(formatLibraryFileTabId(path))).toEqual({
+        path,
+      });
+    }
+  });
+
+  test("non-library-file tab → null", () => {
+    expect(parseLibraryFileTabId("settings")).toBeNull();
+    expect(parseLibraryFileTabId("file:home%2Fa.md")).toBeNull();
+    expect(parseLibraryFileTabId("deck:decks%2Fa.html")).toBeNull();
+    expect(parseLibraryFileTabId(undefined)).toBeNull();
+    expect(parseLibraryFileTabId("library-file:")).toBeNull();
+  });
+
+  test("malformed percent-encoding → null, not a throw", () => {
+    expect(parseLibraryFileTabId("library-file:%E0%A4%A")).toBeNull();
+  });
+
+  test("library file tabs are per-thread", () => {
+    expect(isPerThreadTab(formatLibraryFileTabId("home/a.md"))).toBe(true);
   });
 });
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
@@ -10,6 +10,7 @@
  *   - Ephemeral automation: "automation:<id>"
  *   - Ephemeral file preview: "file:<encoded output key>" (thread output viewer)
  *   - Ephemeral deck preview: "deck:<encoded home-volume path>" (slides skill)
+ *   - Ephemeral Library file preview: "library-file:<encoded browse path>"
  *   - "0" = closed sentinel (not an actual tab id)
  *
  * The "settings" tab bundles what used to be separate instructions,
@@ -119,6 +120,30 @@ export function parseFileTabId(
   }
 }
 
+export interface LibraryFileTabParsed {
+  /** Library browse path, e.g. `home/docs/a.md` or `public/core/a.ts`. */
+  path: string;
+}
+
+/** Browse paths carry `/`, so the tab id encodes them to keep the
+ *  `<kind>:<rest>` grammar unambiguous in the `?main=` URL param. */
+export function formatLibraryFileTabId(path: string): string {
+  return `library-file:${encodeURIComponent(path)}`;
+}
+
+export function parseLibraryFileTabId(
+  tabId: string | undefined,
+): LibraryFileTabParsed | null {
+  if (!tabId || !tabId.startsWith("library-file:")) return null;
+  const encoded = tabId.slice("library-file:".length);
+  if (!encoded) return null;
+  try {
+    return { path: decodeURIComponent(encoded) };
+  } catch {
+    return null;
+  }
+}
+
 export const FIXED_SYSTEM_TABS = [
   "settings",
   "automations",
@@ -136,13 +161,15 @@ const FIXED_SYSTEM_TAB_SET = new Set<string>(FIXED_SYSTEM_TABS);
  *   - "automation:<id>"               (ephemeral automation detail)
  *   - "file:<encoded key>"            (ephemeral thread-output file preview)
  *   - "deck:<encoded path>"           (ephemeral HTML-artifact preview/editor)
+ *   - "library-file:<encoded path>"   (ephemeral org Library file preview)
  */
 export function isPerThreadTab(tabId: string): boolean {
   return (
     tabId.startsWith("app:") ||
     tabId.startsWith("automation:") ||
     tabId.startsWith("file:") ||
-    tabId.startsWith("deck:")
+    tabId.startsWith("deck:") ||
+    tabId.startsWith("library-file:")
   );
 }
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -45,6 +45,7 @@ import {
   parseAutomationTabId,
   parseDeckTabId,
   parseFileTabId,
+  parseLibraryFileTabId,
   resolveActiveTabAndOpen,
   resolveDefaultTabId,
   resolveTabClickTarget,
@@ -330,9 +331,35 @@ export function useMainPanelTabs(ctx: {
       ]
     : [];
 
+  // Ephemeral Library file-preview tab (`?main=library-file:<path>`): an org
+  // file referenced from a chat message, opened as a side panel on desktop.
+  // Same pill semantics as file/deck previews; title is the basename.
+  const libraryFileTabParsed = parseLibraryFileTabId(activeTab);
+  const libraryFileName = libraryFileTabParsed
+    ? (libraryFileTabParsed.path.split("/").pop() ?? libraryFileTabParsed.path)
+    : null;
+  const libraryFileTabs: Tab[] = libraryFileName
+    ? [
+        {
+          id: activeTab,
+          title: libraryFileName,
+          kind: "file",
+          icon: {
+            kind: "component",
+            Component: (props) =>
+              createElement(FileTypeIcon, {
+                filename: libraryFileName,
+                ...props,
+              }),
+          },
+        },
+      ]
+    : [];
+
   const tabs: Tab[] = [
     ...fileTabs,
     ...deckTabs,
+    ...libraryFileTabs,
     ...layoutTabs.map((t) => ({
       id: t.id,
       title: t.title,


### PR DESCRIPTION
## What is this contribution about?
Adds clickable org filesystem references in chat messages so inline code and markdown links like `org/<slug>/file.md` open the Library preview overlay without leaving the conversation. It also adds a resolver with unit coverage and a "See in library" action when the shared preview dialog is opened from chat.

## Screenshots/Demonstration
Not included; reviewers can verify the UI by opening an agent message that references an org file path.

## How to Test
1. Run `bun test apps/mesh/src/web/components/chat/org-file-ref.test.ts`.
2. In the app, open a chat message containing `org/<org-slug>/some-file.md` or `[file](org/<org-slug>/some-file.md)`.
3. Expected outcome: selecting the reference opens the preview overlay, and "See in library" navigates to the file in Library.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make org filesystem references in chat clickable to open Library previews in place. Desktop opens a side tab; mobile shows the overlay. Links only activate in chat via a provider to avoid dead clicks elsewhere.

- **New Features**
  - Inline code and markdown links like `org/<slug>/file.md` open previews: mobile via `?preview=<volume/path>`, desktop via `?main=library-file:<path>`.
  - Adds `resolveOrgFileBrowsePath` with tests (maps org → `home`/`public`, strips `:line(:col)`, ignores `upload`/`output`, requires a file extension). Adds `library-file:` tab support (`formatLibraryFileTabId`/`parseLibraryFileTabId`) and `LibraryFileTab`; wired into main-panel tabs with title/icon; per-thread.

- **Refactors**
  - Extracts shared preview body into `LibraryFilePreview` used by both dialog and panel; HTML uses `HtmlPreviewPanel`; “See in library” moved to `SeeInLibraryLink`.
  - Introduces `OrgFileOpenProvider` and `OrgFilePreviewMount`: linkification is gated to chat surfaces to prevent dead clicks and reduce per-leaf hook work; mobile reads `?preview` over chat and URL-driven state survives reload and closes cleanly.

<sup>Written for commit 688dae1f1126184c12f924218b0ddd57686e49bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

