### PR TITLE
Lock CMS file picker to site bucket

### DIFF
--- a/apps/mesh/ct/harness/stubs/file-picker-dialog.tsx
+++ b/apps/mesh/ct/harness/stubs/file-picker-dialog.tsx
@@ -17,11 +17,13 @@ export function FilePickerDialog({
   onOpenChange,
   mode,
   onSelect,
+  lockedConfigId: _lockedConfigId,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   mode: "image" | "any" | string;
   onSelect: (url: string) => void;
+  lockedConfigId?: string | null;
 }): ReactNode {
   if (!open) return null;
   return (

--- a/apps/mesh/src/web/components/file-picker/file-picker-dialog.tsx
+++ b/apps/mesh/src/web/components/file-picker/file-picker-dialog.tsx
@@ -52,6 +52,7 @@ interface FilePickerDialogProps {
   onOpenChange: (open: boolean) => void;
   mode: FilePickerMode;
   onSelect: (publicUrl: string) => void;
+  lockedConfigId?: string | null;
 }
 
 export const LAST_CONFIG_KEY = "file-picker:last-config-id";
@@ -77,6 +78,7 @@ export function FilePickerDialog(props: FilePickerDialogProps) {
           <Suspense fallback={<Skeleton className="h-64 w-full" />}>
             <PickerBody
               mode={props.mode}
+              lockedConfigId={props.lockedConfigId}
               onSelect={(url) => {
                 props.onSelect(url);
                 props.onOpenChange(false);
@@ -100,15 +102,24 @@ function PickerError({ error }: { error: Error }) {
 
 function PickerBody({
   mode,
+  lockedConfigId,
   onSelect,
 }: {
   mode: FilePickerMode;
+  lockedConfigId?: string | null;
   onSelect: (url: string) => void;
 }) {
   const configs = useFileConfigs();
 
   if (configs.length === 0) {
     return <NoConfigsEmpty />;
+  }
+
+  if (lockedConfigId) {
+    const locked = configs.find((config) => config.id === lockedConfigId);
+    if (locked) {
+      return <BucketPanel config={locked} mode={mode} onSelect={onSelect} />;
+    }
   }
 
   if (configs.length === 1) {

--- a/apps/mesh/src/web/components/file-picker/match-site-slug-config.test.ts
+++ b/apps/mesh/src/web/components/file-picker/match-site-slug-config.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import type { FileConfigInfo } from "@/web/hooks/use-file-configs";
+import { matchSiteSlugConfig } from "./match-site-slug-config";
+
+function config(
+  id: string,
+  overrides: Partial<FileConfigInfo>,
+): FileConfigInfo {
+  return {
+    id,
+    name: id,
+    description: null,
+    bucket: `${id}-bucket`,
+    region: "auto",
+    endpoint: null,
+    forcePathStyle: false,
+    prefix: null,
+    publicUrlBase: null,
+    credentialType: "static",
+    refreshUrl: null,
+    siteSlug: null,
+    createdBy: "test",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedBy: "test",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("matchSiteSlugConfig", () => {
+  test("matches managed siteSlug", () => {
+    const matching = config("managed", { siteSlug: "storefront" });
+    expect(
+      matchSiteSlugConfig(
+        [config("other", { siteSlug: "other" }), matching],
+        "storefront",
+      ),
+    ).toBe(matching);
+  });
+
+  test("matches bucket named after the slug", () => {
+    const matching = config("bucket", { bucket: "storefront" });
+    expect(matchSiteSlugConfig([matching], "storefront")).toBe(matching);
+  });
+
+  test("matches deco-assets bucket named after the slug", () => {
+    const matching = config("assets", { bucket: "deco-assets-storefront" });
+    expect(matchSiteSlugConfig([matching], "storefront")).toBe(matching);
+  });
+
+  test("matches case-insensitively", () => {
+    const matching = config("mixed", {
+      bucket: "DECO-ASSETS-StoreFront",
+      siteSlug: "STOREFRONT",
+    });
+    expect(matchSiteSlugConfig([matching], "storefront")).toBe(matching);
+  });
+
+  test("returns null for an empty slug", () => {
+    expect(matchSiteSlugConfig([config("one", {})], "")).toBeNull();
+  });
+
+  test("returns null when nothing matches", () => {
+    expect(
+      matchSiteSlugConfig([config("one", { siteSlug: "other" })], "storefront"),
+    ).toBeNull();
+  });
+
+  test("returns the first matching config", () => {
+    const first = config("first", { siteSlug: "storefront" });
+    const second = config("second", { bucket: "storefront" });
+    expect(matchSiteSlugConfig([first, second], "storefront")).toBe(first);
+  });
+});

--- a/apps/mesh/src/web/components/file-picker/match-site-slug-config.ts
+++ b/apps/mesh/src/web/components/file-picker/match-site-slug-config.ts
@@ -1,0 +1,24 @@
+import type { FileConfigInfo } from "@/web/hooks/use-file-configs";
+
+/**
+ * Find the file config that owns a site slug so the CMS picker can lock to it.
+ * Matches managed tenancy siteSlug and BYOB bucket naming conventions.
+ */
+export function matchSiteSlugConfig(
+  configs: FileConfigInfo[],
+  siteSlug: string | null | undefined,
+): FileConfigInfo | null {
+  if (!siteSlug) return null;
+
+  const slug = siteSlug.toLowerCase();
+  return (
+    configs.find((config) => {
+      const bucket = config.bucket.toLowerCase();
+      return (
+        config.siteSlug?.toLowerCase() === slug ||
+        bucket === slug ||
+        bucket === `deco-assets-${slug}`
+      );
+    }) ?? null
+  );
+}

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -67,6 +67,7 @@ type VirtualMCPCreateOutput = {
     metadata?: {
       ui?: { slug?: string } | null;
       migrated_project_slug?: string;
+      siteSlug?: string | null;
     } | null;
   };
 };
@@ -253,6 +254,7 @@ export function ImportFromDecoDialog({
 
         const projectIcon = connBody.icon ?? null;
         const slug = generateSlug(siteName);
+        const siteSlug = siteName.toLowerCase();
 
         // 2. Create a space (virtual MCP) wired to both admin-mcp and GitHub.
         const result = (await client.callTool({
@@ -269,7 +271,7 @@ export function ImportFromDecoDialog({
                 enabled_plugins: [],
                 // Link the agent to its asset site so the CMS resolves uploads
                 // to the managed storage for this slug.
-                siteSlug: siteName,
+                siteSlug,
                 githubRepo: {
                   owner: githubRepo.owner,
                   name: githubRepo.name,

--- a/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
@@ -6,6 +6,7 @@ export interface SandboxConfig {
   virtualMcpId: string;
   branch: string;
   previewUrl?: string;
+  siteSlug?: string | null;
 }
 
 export interface FieldProps {

--- a/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
@@ -9,6 +9,7 @@ import {
   FilePickerDialog,
   LAST_CONFIG_KEY,
 } from "@/web/components/file-picker/file-picker-dialog";
+import { matchSiteSlugConfig } from "@/web/components/file-picker/match-site-slug-config";
 import { useFileConfigsQuery } from "@/web/hooks/use-file-configs";
 import { useFilePickerUpload } from "@/web/hooks/use-file-picker";
 import { extractUrl } from "./extract-url";
@@ -44,6 +45,7 @@ export function FileField({
   onChange,
   path,
   label,
+  sandbox,
 }: FieldProps) {
   const isVideo = schema.format === "video-uri";
   const strValue = extractUrl(value);
@@ -54,8 +56,13 @@ export function FileField({
 
   const configsQuery = useFileConfigsQuery();
   const upload = useFilePickerUpload();
+  const lockedConfig = matchSiteSlugConfig(
+    configsQuery.data?.configs ?? [],
+    sandbox?.siteSlug,
+  );
 
   function resolveTargetConfigId(): string | null {
+    if (lockedConfig) return lockedConfig.id;
     const configs = configsQuery.data?.configs ?? [];
     if (configs.length === 1) return configs[0]!.id;
     if (configs.length === 0) return null;
@@ -238,6 +245,7 @@ export function FileField({
         onOpenChange={setPickerOpen}
         mode="any"
         onSelect={(url) => onChange(url)}
+        lockedConfigId={lockedConfig?.id ?? null}
       />
     </div>
   );

--- a/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
@@ -9,6 +9,7 @@ import {
   FilePickerDialog,
   LAST_CONFIG_KEY,
 } from "@/web/components/file-picker/file-picker-dialog";
+import { matchSiteSlugConfig } from "@/web/components/file-picker/match-site-slug-config";
 import { useFileConfigsQuery } from "@/web/hooks/use-file-configs";
 import { useFilePickerUpload } from "@/web/hooks/use-file-picker";
 import { extractUrl } from "./extract-url";
@@ -44,6 +45,7 @@ export function ImageField({
   onChange,
   path,
   label,
+  sandbox,
 }: FieldProps) {
   const strValue = extractUrl(value);
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -55,6 +57,10 @@ export function ImageField({
 
   const configsQuery = useFileConfigsQuery();
   const upload = useFilePickerUpload();
+  const lockedConfig = matchSiteSlugConfig(
+    configsQuery.data?.configs ?? [],
+    sandbox?.siteSlug,
+  );
 
   /**
    * Reset the load/error tracking when the underlying URL changes. Used
@@ -78,6 +84,7 @@ export function ImageField({
    *     so the user can configure / pick a bucket explicitly
    */
   function resolveTargetConfigId(): string | null {
+    if (lockedConfig) return lockedConfig.id;
     const configs = configsQuery.data?.configs ?? [];
     if (configs.length === 1) return configs[0]!.id;
     if (configs.length === 0) return null;
@@ -271,6 +278,7 @@ export function ImageField({
         onOpenChange={setPickerOpen}
         mode="image"
         onSelect={(url) => setValue(url)}
+        lockedConfigId={lockedConfig?.id ?? null}
       />
     </div>
   );

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
+import { useInsetContext } from "@/web/layouts/agent-shell-layout";
 import {
   ChevronDown,
   ChevronRight,
@@ -476,6 +477,11 @@ export function SectionsEditor({
     useDecofile(previewFetchParams);
   const { data: meta, isLoading: metaLoading } =
     useLiveMeta(previewFetchParams);
+  const inset = useInsetContext();
+  const agentSiteSlug =
+    inset?.entity?.id === virtualMcpId
+      ? (inset.entity.metadata?.siteSlug ?? null)
+      : null;
 
   const [selectedSectionIndex, setSelectedSectionIndex] = useState<
     number | null
@@ -833,6 +839,7 @@ export function SectionsEditor({
     virtualMcpId,
     branch,
     previewUrl: previewUrl ?? undefined,
+    siteSlug: agentSiteSlug,
   };
 
   const activeSchema =


### PR DESCRIPTION
## What is this contribution about?
Lock CMS image, video, and file pickers to the imported deco site's managed asset bucket when an agent has `metadata.siteSlug`.

## Screenshots/Demonstration
No screenshots; this updates picker behavior and upload targeting.

## How to Test
1. Import a deco site or use an agent with `metadata.siteSlug` matching a file config.
2. Open image/file fields in the preview or Content tab CMS editor.
3. Expected outcome: the picker opens directly to the matching bucket with no bucket tabs, and drag-drop uploads target that bucket.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock CMS image/video/file pickers to the imported site's asset bucket when an agent has `metadata.siteSlug`. The picker opens directly to that bucket (no tabs) and all uploads target it.

- **New Features**
  - Added `matchSiteSlugConfig` to resolve the bucket by `siteSlug`, bucket name equal to the slug, or `deco-assets-<slug>` (case-insensitive).
  - Introduced `lockedConfigId` in `FilePickerDialog`; when set, the picker shows only that bucket.
  - `ImportFromDecoDialog` now stores a lowercased `siteSlug` in agent metadata and the editor sandbox.
  - `ImageField` and `FileField` lock selection and uploads to the resolved bucket when a `siteSlug` is present.
  - Added tests for the matching logic.

<sup>Written for commit a3f2f3a9c38aad5213b07ed8cef8c2ab4521560c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

