### PR TITLE
feat(decopilot): add stream encode_ms + published_chunks metrics

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -53,6 +53,26 @@ const publishErrorsCounter = meter.createCounter(
   },
 );
 
+// Per-chunk JSON.stringify+encode time. Pod-level (no org attribute) on
+// purpose: this is loop-occupancy, meant to be correlated with eventloop.delay
+// to see how much of a saturated thread is the encode path. Always-on
+// (the STREAM_ENCODE_TRACE profiler is the gated verbose-log counterpart).
+const encodeMsHistogram = meter.createHistogram("decopilot.stream.encode_ms", {
+  description: "Per-chunk JSON.stringify+encode time for decopilot stream",
+  unit: "ms",
+});
+
+// Logical chunks published (one per stream part, before fragmentation). Tagged
+// by org.id (low cardinality) so publish rate per org is visible — the proxy
+// for token throughput driving socket fan-out.
+const publishedChunksCounter = meter.createCounter(
+  "decopilot.stream.published_chunks",
+  {
+    description: "Logical decopilot stream chunks published to JetStream",
+    unit: "{chunks}",
+  },
+);
+
 // 30 min — projector-lag SLA: the stream is the sole path to the DB (Phase C),
 // so retention must outlast a projector outage long enough to catch up. Tune later.
 const MAX_AGE_NS = 30 * 60 * 1_000_000_000; // 30 min
@@ -315,14 +335,12 @@ export class NatsStreamBuffer implements StreamBuffer {
     // back together by `createTailStream`. Fragments carry raw byte slices
     // of the encoded `{ p: value }` JSON, so reassembly is byte-exact.
     const publishChunk = (value: unknown): void => {
-      let bytes: Uint8Array;
-      if (streamEncodeProfiler) {
-        const t0 = performance.now();
-        bytes = encoder.encode(JSON.stringify({ p: value }));
-        streamEncodeProfiler.record(performance.now() - t0, bytes.length);
-      } else {
-        bytes = encoder.encode(JSON.stringify({ p: value }));
-      }
+      const t0 = performance.now();
+      const bytes = encoder.encode(JSON.stringify({ p: value }));
+      const encodeMs = performance.now() - t0;
+      encodeMsHistogram.record(encodeMs);
+      publishedChunksCounter.add(1, { "org.id": orgId ?? "unknown" });
+      streamEncodeProfiler?.record(encodeMs, bytes.length);
       if (bytes.length <= MAX_PUBLISH_BYTES) {
         tracker.publish(js, subj, bytes);
         return;


### PR DESCRIPTION
## Summary

Adds two always-on OpenTelemetry instruments to the decopilot stream publish path so the LLM-streaming event-loop bottleneck is debuggable in Grafana instead of by grepping pod stdout.

- **`decopilot.stream.encode_ms`** (histogram) — per-chunk `JSON.stringify`+`TextEncoder.encode` time. **Pod-level, no attributes**, so it's meant to be overlaid on `eventloop.delay` to see how much of a saturated single thread is the encode path.
- **`decopilot.stream.published_chunks`** (counter) — logical chunks published (pre-fragmentation), tagged by `org.id`. Publish rate = proxy for token throughput driving socket fan-out.

### Why

Pod CPU% averages across cores and includes idle wait, so single-thread saturation from per-chunk encode + socket writes doesn't surface there. These flow through the same `PrometheusExporter` (`/metrics`) as the existing `decopilot.stream.publish_errors` counter — so they're queryable/alertable, no log scraping.

The gated `STREAM_ENCODE_TRACE=1` profiler still logs the verbose 10s-window breakdown; the encode timing is now computed once and reused by both, so no double work.

## Cost

- `published_chunks`: one atomic `.add(1)` per chunk.
- `encode_ms`: one `.record()` + two `performance.now()` around an encode that already runs. Negligible vs. the `stringify`/`encode` it measures.
- Memory: `encode_ms` = one fixed-bucket series (no attrs); `published_chunks` = one series per org (same cardinality as existing errors counter).

## Testing

- `bun run fmt` clean
- `tsc --noEmit` clean for the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEJ58ibWZUcYheMaTyC8UQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two always-on OpenTelemetry metrics in the Decopilot stream publish path to surface encode time and per-org publish rate in Grafana/Prometheus.

- **New Features**
  - `decopilot.stream.encode_ms` (histogram): per-chunk JSON.stringify + encode time; pod-level (no attributes) for correlation with `eventloop.delay`.
  - `decopilot.stream.published_chunks` (counter): counts logical chunks (pre-fragmentation); tagged by `org.id` to show publish rate per org.

<sup>Written for commit c39ffd3d636e27e0008dda79255ff4f46d1fd6f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

