### PR TITLE
fix(decopilot): lazily create stream/registry OTel instruments so they export

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -41,36 +41,46 @@ import {
 import type { StreamBuffer } from "./stream-buffer";
 import { meter } from "@/observability";
 
+// `meter` is a NoopMeter until initObservability() runs at bootstrap
+// (index.ts), and this module is imported *before* that — so instruments
+// created at module top bind the noop and silently never export. Create them
+// lazily on first use, by which point `meter` has been reassigned to the real
+// provider. (This is why the metrics below historically reported no data.)
+const lazyInstrument = <T>(make: () => T): (() => T) => {
+  let v: T | undefined;
+  return () => (v ??= make());
+};
+
 // B5: counter for JetStream publish errors — tagged by org.id (low cardinality).
 // Increment happens inside createPublishTracker's catch where publish failures
 // are already sampled-logged; the counter lets alerting fire without log scraping.
-const publishErrorsCounter = meter.createCounter(
-  "decopilot.stream.publish_errors",
-  {
+const publishErrorsCounter = lazyInstrument(() =>
+  meter.createCounter("decopilot.stream.publish_errors", {
     description:
       "Number of JetStream publish failures for decopilot stream chunks",
     unit: "{errors}",
-  },
+  }),
 );
 
 // Per-chunk JSON.stringify+encode time. Pod-level (no org attribute) on
 // purpose: this is loop-occupancy, meant to be correlated with eventloop.delay
 // to see how much of a saturated thread is the encode path. Always-on
 // (the STREAM_ENCODE_TRACE profiler is the gated verbose-log counterpart).
-const encodeMsHistogram = meter.createHistogram("decopilot.stream.encode_ms", {
-  description: "Per-chunk JSON.stringify+encode time for decopilot stream",
-  unit: "ms",
-});
+const encodeMsHistogram = lazyInstrument(() =>
+  meter.createHistogram("decopilot.stream.encode_ms", {
+    description: "Per-chunk JSON.stringify+encode time for decopilot stream",
+    unit: "ms",
+  }),
+);
 
 // Logical chunks published (one per stream part, before fragmentation). Tagged
 // by org.id (low cardinality) so publish rate per org is visible — the proxy
 // for token throughput driving socket fan-out.
-const publishedChunksCounter = meter.createCounter(
-  "decopilot.stream.published_chunks",
-  {
+const publishedChunksCounter = lazyInstrument(() =>
+  meter.createCounter("decopilot.stream.published_chunks", {
     description: "Logical decopilot stream chunks published to JetStream",
     unit: "{chunks}",
-  },
+  }),
 );
 
 // 30 min — projector-lag SLA: the stream is the sole path to the DB (Phase C),
@@ -198,7 +208,7 @@ function createPublishTracker(taskId: string, orgId?: string) {
           // fire without log scraping. Tag by org.id (low cardinality); fall
           // back to "unknown" when the org context isn't available at this
           // call site (e.g. standalone test harness without a dispatch context).
-          publishErrorsCounter.add(1, { "org.id": orgId ?? "unknown" });
+          publishErrorsCounter().add(1, { "org.id": orgId ?? "unknown" });
           if (errors === 1 || errors % 100 === 0) {
             console.warn(
               `[Decopilot] JetStream publish failed for thread ${taskId} (${errors} total):`,
@@ -337,8 +347,8 @@ export class NatsStreamBuffer implements StreamBuffer {
       const t0 = performance.now();
       const bytes = encoder.encode(JSON.stringify({ p: value }));
       const encodeMs = performance.now() - t0;
-      encodeMsHistogram.record(encodeMs);
-      publishedChunksCounter.add(1, { "org.id": orgId ?? "unknown" });
+      encodeMsHistogram().record(encodeMs);
+      publishedChunksCounter().add(1, { "org.id": orgId ?? "unknown" });
       streamEncodeProfiler?.record(encodeMs, bytes.length);
       if (bytes.length <= MAX_PUBLISH_BYTES) {
         tracker.publish(js, subj, bytes);

--- a/apps/mesh/src/api/routes/decopilot/run-registry.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.ts
@@ -44,18 +44,30 @@ const INFLIGHT_END_EVENTS = new Set([
   "PREVIOUS_RUN_ABORTED",
 ]);
 
-const inflightRuns = meter.createUpDownCounter("decopilot.stream.inflight", {
-  description: "Number of in-flight decopilot stream requests",
-  unit: "{requests}",
-});
+// `meter` is a NoopMeter until initObservability() runs at bootstrap
+// (index.ts); this module is imported before that, so module-top instruments
+// bind the noop and never export. Create lazily on first use (post-init).
+const lazyInstrument = <T>(make: () => T): (() => T) => {
+  let v: T | undefined;
+  return () => (v ??= make());
+};
+
+const inflightRuns = lazyInstrument(() =>
+  meter.createUpDownCounter("decopilot.stream.inflight", {
+    description: "Number of in-flight decopilot stream requests",
+    unit: "{requests}",
+  }),
+);
 
 // I1: counter for reaper-forced run terminations — tagged by org.id and reason.
 // Incremented in reapStaleRuns whenever a stuck run is force-failed.
-const reapedRunsCounter = meter.createCounter("decopilot.run.reaped", {
-  description:
-    "Number of decopilot runs force-failed by the progress-based reaper",
-  unit: "{runs}",
-});
+const reapedRunsCounter = lazyInstrument(() =>
+  meter.createCounter("decopilot.run.reaped", {
+    description:
+      "Number of decopilot runs force-failed by the progress-based reaper",
+    unit: "{runs}",
+  }),
+);
 
 export class RunRegistry {
   private readonly states = new Map<string, RunState>();
@@ -120,12 +132,12 @@ export class RunRegistry {
       // Update inflight metric — only decrement when this registry had a
       // running state; ghost FORCE_FAIL events have no prior increment.
       if (INFLIGHT_START_EVENTS.has(event.type)) {
-        inflightRuns.add(1, { "org.id": event.orgId });
+        inflightRuns().add(1, { "org.id": event.orgId });
       } else if (
         INFLIGHT_END_EVENTS.has(event.type) &&
         stateBeforeEvent?.status.tag === "running"
       ) {
-        inflightRuns.add(-1, { "org.id": event.orgId });
+        inflightRuns().add(-1, { "org.id": event.orgId });
       }
     }
 
@@ -256,7 +268,7 @@ export class RunRegistry {
         }m) ...`,
       );
       // I1: emit metric before force-fail so it's visible even if execute() throws.
-      reapedRunsCounter.add(1, {
+      reapedRunsCounter().add(1, {
         "org.id": state.orgId,
         reason: "idle_timeout",
       });


### PR DESCRIPTION
## The bug

The decopilot stream metrics never reach Prometheus/Grafana — including the `encode_ms` + `published_chunks` from #4082, and the pre-existing `decopilot.stream.inflight` / `publish_errors` / `run.reaped`.

**Why:** `nats-stream-buffer.ts` and `run-registry.ts` create their OTel instruments at **module top**. These modules are imported during app bootstrap, *before* `initObservability()` (`index.ts:29`) reassigns the global `meter` from a `NoopMeter` to the real provider. So `meter.createHistogram(...)` runs against the noop and binds dead instruments — every `.record()`/`.add()` afterward is silently discarded.

`projector-metrics.ts` uses the identical module-top style but survives only because it's imported lazily, after init.

## Evidence (prod, `deco-studio`)

- `decopilot_stream_inflight`: **0 samples over 7 days** (streams run constantly).
- `decopilot_projector_lag_ms`: 44 series over the same 7d — control, proves scrape + streams are fine.
- New `decopilot_stream_encode_ms_*` / `published_chunks_total`: 0 series after #4082 deployed.

## The fix

Wrap each instrument in a lazy first-use factory so `meter.createX()` runs post-init against the reassigned real provider — the same approach `observability/profiling/event-loop.ts` already uses for exactly this reason. Call sites change from `counter.add(...)` to `counter().add(...)`.

Revives 5 instruments: `encode_ms`, `published_chunks`, `publish_errors`, `inflight`, `run.reaped`.

## Testing

- `bun run fmt` + `tsc --noEmit` clean.
- Behavior is verifiable post-deploy: the dashboard's "Decopilot stream (LLM streaming)" panels and `decopilot_stream_inflight` should populate once a stream runs.

## Follow-up (not in this PR)

Other early-imported modules may have the same latent bug (e.g. `record-llm-call-metrics.ts`). A systemic fix (meter proxy that returns lazy instruments) would prevent recurrence — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEJ58ibWZUcYheMaTyC8UQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Decopilot stream metrics by lazily creating OTel instruments after observability init. Restores export of encode time, published chunks, inflight, publish errors, and reaped runs to Prometheus/Grafana.

- **Bug Fixes**
  - Lazily create instruments in `nats-stream-buffer.ts` and `run-registry.ts` so `meter.createX()` runs post-init (not on the NoopMeter).
  - Updated call sites to use `instrumentFn().add/record(...)` to trigger first-use creation.
  - Revives these metrics: `decopilot.stream.encode_ms`, `decopilot.stream.published_chunks`, `decopilot.stream.publish_errors`, `decopilot.stream.inflight`, `decopilot.run.reaped`.

<sup>Written for commit 41bd7c114d2f8b0e7c39c3084ead9a7a45525419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

