### PR TITLE
fix(helm): scrape worker pods for Prometheus metrics

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.12
+version: 0.10.13
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/worker-deployment.yaml
+++ b/deploy/helm/studio/templates/worker-deployment.yaml
@@ -33,9 +33,20 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.metrics.scrape .Values.podAnnotations }}
       annotations:
+        {{- if .Values.metrics.scrape }}
+        # Worker runs the stream pump (encode/publish) and the run executors, so
+        # its metrics (decopilot.stream.*, eventloop.delay) only reach Prometheus
+        # if vmagent's kubernetes-pods job scrapes this pod too — same block as
+        # the API deployment.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.service.targetPort | default 3000 | quote }}
+        prometheus.io/path: {{ .Values.metrics.path | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-worker


### PR DESCRIPTION
## Problem

Worker pods are never scraped by Prometheus. The stream **pump** (`pump()` → `decopilot.stream.encode_ms` / `published_chunks`), the DBOS run executors (`decopilot.stream.inflight`), and the event-loop monitor (`eventloop.delay`) **all run on the worker** (`dispatchRunAndWait` is a `DBOS.runStep`). So every worker-emitted metric was invisible in Grafana — confirmed: no worker pod exports *any* series, while `eventloop.delay` shows only on the API tier despite the monitor logging multi-second stalls on workers.

Root cause: `templates/deployment.yaml` (API) emits the `prometheus.io/scrape` block gated on `.Values.metrics.scrape`, but `templates/worker-deployment.yaml` only merged `.Values.podAnnotations` — it never had the scrape block.

## Fix

Mirror the API annotation block in `worker-deployment.yaml`; bump chart `0.10.12 → 0.10.13`. Web pods are intentionally left out (nginx, no `/metrics` on :3000). Verified with `helm template` — renders `prometheus.io/scrape/port/path` on the worker pod.

## Follow-up (required, separate repo)

After this chart publishes as `0.10.13`, bump the `chart-deco-studio` dependency `0.10.12 → 0.10.13` in `decocms/deco-apps-cd` (`apps/deco-studio` + `apps/deco-studio-stg`, Chart.yaml + Chart.lock via `helm dep update`). That PR is prepared separately and must merge **after** this one publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEJ58ibWZUcYheMaTyC8UQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Prometheus scraping on worker pods by adding the scrape annotations to `worker-deployment.yaml`. Worker metrics (`decopilot.stream.*`, `eventloop.delay`) now show up; chart bumped to `0.10.13`.

- **Bug Fixes**
  - Add `prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path` to worker pods when `.Values.metrics.scrape` is true; keep `.Values.podAnnotations`.
  - No changes to web pods.
  - Bump `chart-deco-studio` version `0.10.12` → `0.10.13`.

- **Migration**
  - After release, bump `chart-deco-studio` to `0.10.13` in `decocms/deco-apps-cd` (`apps/deco-studio`, `apps/deco-studio-stg`) and run `helm dep update`.

<sup>Written for commit fcacbc2434225ef2676429eceed5b2051b341424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

