### PR TITLE
fix(decopilot): record stream metrics on the live publish path

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -439,7 +439,13 @@ export class NatsStreamBuffer implements StreamBuffer {
     // `msgID` is the NATS dedup header field (Nats-Msg-Id): a seq-keyed id lets
     // an at-least-once producer re-publish without double-writing.
     const msgID = opts?.msgId;
+    // `ingestRun` (the durable producer) publishes every UI chunk through here,
+    // not through `pump()` — so the stream throughput/encode metrics must be
+    // recorded on this path or they stay flat zero while streaming works.
+    const t0 = performance.now();
     const bytes = this.encoder.encode(JSON.stringify({ p: chunk }));
+    encodeMsHistogram().record(performance.now() - t0);
+    publishedChunksCounter().add(1);
     if (bytes.length > MAX_CHUNKED_BYTES) {
       console.warn(
         `[Decopilot] dropping oversized raw chunk for thread ${taskId}: ${(


### PR DESCRIPTION
## Why the panels were still empty after #4082/#4083/#4084

The stream metrics (`decopilot.stream.encode_ms`, `published_chunks`) were instrumented in `pump()` → `publishChunk`. But the **durable producer that workers actually use** is `ingestRun` → **`publishRawChunk`** (`dispatch-run.ts:270`). Workers never hit `pump()`'s chunk path, so both metrics stayed flat zero in prod **even though streaming worked** — confirmed by `decopilot_stream_inflight` (sibling, run-registry path) recording 4 series from worker pods while `encode_ms` had 0.

So: noop-meter fix (#4083) ✅, worker scrape (#4084 + apps-cd) ✅, but the metric was in the wrong function.

## Fix

Record encode time + chunk count in `publishRawChunk` (the real path), pod-level. Verified: `bun run fmt` + `tsc` clean.

## Verify after deploy

Bump the mesh image in deco-apps-cd to a build containing this, then run any decopilot stream — `decopilot_stream_encode_ms_*` and `published_chunks_total` should appear from worker pods within a scrape interval.

## Separate live bug spotted (not fixed here)

Worker logs are dominated by `[suggest-commit-message] / [projector-consumer] scheduling failed: SyntaxError: JSON Parse error` — the commit/PR-title generator's model output is being truncated/non-JSON and the parse throws repeatedly. Worth its own fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record stream metrics on the live publish path so dashboards reflect worker traffic. We now measure encode time and count chunks in `publishRawChunk`.

- **Bug Fixes**
  - Instrument the `publishRawChunk` path used by `ingestRun` instead of the unused `pump()` chunk path.
  - Record encode duration around `TextEncoder.encode` and increment the published-chunks counter in `apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts`.

<sup>Written for commit b094a983c6a5e88fa3a1634a02ede6c9c01e34d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

