### PR TITLE
fix(file-picker): snapshot selected files before resetting the input

### DIFF
--- a/apps/mesh/src/web/components/file-picker/file-picker-dialog.tsx
+++ b/apps/mesh/src/web/components/file-picker/file-picker-dialog.tsx
@@ -288,11 +288,11 @@ function BucketPanel({
           multiple
           className="hidden"
           onChange={(e) => {
-            // Snapshot the selection and reset the input synchronously
-            // so the user can re-select the same file later — a native
-            // <input type="file"> won't fire onChange if the value
-            // hasn't changed since the previous selection.
-            const files = e.target.files;
+            // Copy the File refs out BEFORE resetting: `e.target.files` is a
+            // live FileList and `e.target.value = ""` (which lets the user
+            // re-pick the same file) empties it, so a bare reference would be
+            // length 0 by the time handleFiles runs.
+            const files = Array.from(e.target.files ?? []);
             e.target.value = "";
             handleFiles(files);
           }}


### PR DESCRIPTION
## Summary

Click-to-select uploads in the CMS image/file picker (`FilePickerDialog` → `BucketPanel`) never fired — you'd pick a PNG/SVG and nothing happened, with **no upload request in the network tab**.

The `<input type="file">` `onChange` captured a *reference* to the live `FileList`, then reset `e.target.value = ""` (so the same file can be re-picked). In Chromium that reset empties the referenced `FileList` **before** `handleFiles` reads it, so the handler sees a zero-length list, hits its `if (list.length === 0) return;` guard, and never calls `upload.mutateAsync` — hence no request.

Drag-drop was unaffected because it reads `e.dataTransfer.files` and never resets the input.

Pre-existing since the picker shipped (#3469); not related to the recent bucket-pin change.

## Fix

Snapshot the `File` refs into an array with `Array.from(e.target.files ?? [])` **before** resetting — the same idiom already used in `image-upload.tsx` and `icon-picker.tsx`. The `File` objects stay valid after the reset.

## Testing

- Manual: CMS image/file field → **Browse** → click the drop zone → pick a PNG/SVG → the `POST /api/:org/file-configs/:id/upload` request now fires and the asset appears in the grid.
- Drag-drop continues to work as before.

(Hard to cover in the existing component tests since they stub `FilePickerDialog`; this lives in `BucketPanel`, which needs the real picker hooks — manual/e2e is the practical check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Click-to-select uploads in the CMS file picker now work. We snapshot selected files before resetting the input so Chromium doesn’t clear them.

- **Bug Fixes**
  - Use `Array.from(e.target.files ?? [])` before `e.target.value = ""` in `BucketPanel`.
  - Ensures `handleFiles` receives files and allows re-selecting the same file.
  - Drag-and-drop behavior unchanged.

<sup>Written for commit fe50b41c5fdebab2190b920c1d2c19b5b73af038. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

