### PR TITLE
fix(decopilot): record stream metrics on the link-daemon publish path

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -40,6 +40,7 @@ import {
 } from "./projector-stream-messages";
 import type { StreamBuffer } from "./stream-buffer";
 import { meter } from "@/observability";
+import { encodeMsHistogram, publishedChunksCounter } from "./stream-metrics";
 
 // `meter` is a NoopMeter until initObservability() runs at bootstrap
 // (index.ts), and this module is imported *before* that — so instruments
@@ -62,26 +63,9 @@ const publishErrorsCounter = lazyInstrument(() =>
   }),
 );
 
-// Per-chunk JSON.stringify+encode time. Pod-level (no org attribute) on
-// purpose: this is loop-occupancy, meant to be correlated with eventloop.delay
-// to see how much of a saturated thread is the encode path. Always-on
-// (the STREAM_ENCODE_TRACE profiler is the gated verbose-log counterpart).
-const encodeMsHistogram = lazyInstrument(() =>
-  meter.createHistogram("decopilot.stream.encode_ms", {
-    description: "Per-chunk JSON.stringify+encode time for decopilot stream",
-    unit: "ms",
-  }),
-);
-
-// Logical chunks published (one per stream part, before fragmentation). Tagged
-// by org.id (low cardinality) so publish rate per org is visible — the proxy
-// for token throughput driving socket fan-out.
-const publishedChunksCounter = lazyInstrument(() =>
-  meter.createCounter("decopilot.stream.published_chunks", {
-    description: "Logical decopilot stream chunks published to JetStream",
-    unit: "{chunks}",
-  }),
-);
+// encode_ms + published_chunks live in ./stream-metrics so the link-daemon's
+// direct-nats-publisher (the path agent-sandbox runs actually take) feeds the
+// same instruments instead of double-registering them.
 
 // 30 min — projector-lag SLA: the stream is the sole path to the DB (Phase C),
 // so retention must outlast a projector outage long enough to catch up. Tune later.

--- a/apps/mesh/src/api/routes/decopilot/stream-metrics.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-metrics.ts
@@ -1,0 +1,35 @@
+import { meter } from "@/observability";
+
+// Shared OTel instruments for the decopilot stream producer. Two modules
+// publish chunks: `nats-stream-buffer.ts` (pump/publishRawChunk) and the
+// link-daemon's `direct-nats-publisher.ts` (the path agent-sandbox runs
+// actually take). Defining the instruments once here keeps both producers
+// feeding the same metric instead of double-registering the same name.
+//
+// `meter` is a NoopMeter until initObservability() runs at bootstrap, and
+// these modules are imported before that — so create the instruments lazily
+// on first use, by which point `meter` is the real provider. (Module-top
+// creation binds the dead noop meter and silently never exports.)
+const lazyInstrument = <T>(make: () => T): (() => T) => {
+  let v: T | undefined;
+  return () => (v ??= make());
+};
+
+// Per-chunk JSON.stringify+encode time, pod-level (no attributes) so it can be
+// correlated with eventloop.delay to see how much of a saturated thread is the
+// encode path.
+export const encodeMsHistogram = lazyInstrument(() =>
+  meter.createHistogram("decopilot.stream.encode_ms", {
+    description: "Per-chunk JSON.stringify+encode time for decopilot stream",
+    unit: "ms",
+  }),
+);
+
+// Logical chunks published to JetStream — the proxy for token throughput
+// driving socket fan-out.
+export const publishedChunksCounter = lazyInstrument(() =>
+  meter.createCounter("decopilot.stream.published_chunks", {
+    description: "Logical decopilot stream chunks published to JetStream",
+    unit: "{chunks}",
+  }),
+);

--- a/apps/mesh/src/link-daemon/direct-nats-publisher.ts
+++ b/apps/mesh/src/link-daemon/direct-nats-publisher.ts
@@ -8,6 +8,10 @@ import {
   streamSubject,
   CHECKPOINT_DEBOUNCE_MS,
 } from "../api/routes/decopilot/projector-stream-messages";
+import {
+  encodeMsHistogram,
+  publishedChunksCounter,
+} from "../api/routes/decopilot/stream-metrics";
 
 export interface DirectNatsPublisher {
   publishLine(input: {
@@ -34,11 +38,17 @@ export function createDirectNatsPublisher(input: {
   return {
     async publishLine({ runId, fenceToken, line }) {
       if (line.event.type === "ui-message-chunk") {
-        await input.js.publish(
-          streamSubject(runId),
-          encoder.encode(JSON.stringify({ p: line.event.chunk })),
-          { msgID: buildChunkMsgId({ runId, fenceToken, seq: line.seq }) },
-        );
+        // The live producer for agent-sandbox runs: encode+publish each UI
+        // chunk here. Record encode time + count so the stream metrics fire on
+        // this path (NatsStreamBuffer.pump/publishRawChunk are not exercised
+        // for these runs).
+        const t0 = performance.now();
+        const bytes = encoder.encode(JSON.stringify({ p: line.event.chunk }));
+        encodeMsHistogram().record(performance.now() - t0);
+        publishedChunksCounter().add(1);
+        await input.js.publish(streamSubject(runId), bytes, {
+          msgID: buildChunkMsgId({ runId, fenceToken, seq: line.seq }),
+        });
         return "published";
       }
       if (line.event.type === "error") {


### PR DESCRIPTION
## The actual root cause (after #4082/#4083/#4085 didn't populate the panels)

Agent-sandbox runs don't publish chunks through `NatsStreamBuffer` at all. They go through the **link-daemon's** `direct-nats-publisher.ts` → `publishLine` (`createDirectNatsPublisher`, wired in `handle-local-dispatch.ts:109,345`). I'd instrumented `pump().publishChunk` (#4082) and `publishRawChunk` (#4085) — neither runs for these runs.

### Why this was provable, not another guess
`decopilot_stream_projector_lag` exports fine (the projector **consumes** these exact chunk messages) and `inflight` exports fine — but `encode_ms`/`published_chunks` were flat zero. The only consistent explanation: chunks are published by a producer that isn't `NatsStreamBuffer`. `grep` for `JSON.stringify({ p: ... })` to `streamSubject(...)` returns **exactly two** producers — `nats-stream-buffer.ts` and `direct-nats-publisher.ts`. The sandbox path uses the latter.

## Fix
- New `stream-metrics.ts` holds the two shared lazy instruments (avoids double-registering the same metric name).
- `nats-stream-buffer.ts` imports them instead of defining them.
- `direct-nats-publisher.ts` records encode time + chunk count in `publishLine`.

Now **both** (and only) chunk-publish paths feed the metric. `fmt` + `tsc` clean.

## Verify after deploy
Bump the mesh image in deco-apps-cd, run any decopilot/agent-sandbox stream → `decopilot_stream_encode_ms_*` + `published_chunks_total` appear from worker pods within a scrape interval. I'll confirm live rather than declare done on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEJ58ibWZUcYheMaTyC8UQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record stream encode and chunk metrics on the link-daemon publish path so agent-sandbox runs emit telemetry correctly. Both publish paths now feed `decopilot.stream.encode_ms` and `decopilot.stream.published_chunks`.

- **Bug Fixes**
  - Record encode time and chunk count in `createDirectNatsPublisher.publishLine` so the sandbox path reports metrics.

- **Refactors**
  - Added `stream-metrics.ts` with lazy OTel instruments and imported it in both `nats-stream-buffer.ts` and `direct-nats-publisher.ts` to avoid double registration and keep metrics unified.

<sup>Written for commit 4f07f5da2f5468ff90434e462b0b17787251f718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

