### PR TITLE
feat(blog): add extraProps key/value list to post settings

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
@@ -41,7 +41,17 @@ import { BlogSandboxProvider } from "./blog-sandbox-context";
 import { InsertBlockDivider } from "./block-picker";
 import { BlockRow } from "./blocks/block-row";
 import { type RawBlock } from "./blocks/block-registry";
-import { InlineText, str } from "./blocks/primitives";
+import { AddButton, InlineText, RemoveButton, str } from "./blocks/primitives";
+
+type ExtraProp = { key: string; value: string };
+
+function asExtraProps(value: unknown): ExtraProp[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => ({
+    key: str((item as Record<string, unknown>)?.key),
+    value: str((item as Record<string, unknown>)?.value),
+  }));
+}
 
 type BlockItem = { id: string; block: RawBlock };
 
@@ -292,8 +302,58 @@ function PostSettings({
           selected={post.categories}
           onChange={(v) => onChange("categories", v)}
         />
+        <ExtraPropsField
+          value={post.extraProps}
+          onChange={(v) => onChange("extraProps", v)}
+        />
       </CollapsibleContent>
     </Collapsible>
+  );
+}
+
+function ExtraPropsField({
+  value,
+  onChange,
+}: {
+  value: unknown;
+  onChange: (value: ExtraProp[]) => void;
+}) {
+  const items = asExtraProps(value);
+  const set = (i: number, patch: Partial<ExtraProp>) =>
+    onChange(items.map((p, idx) => (idx === i ? { ...p, ...patch } : p)));
+
+  return (
+    <div className="space-y-2">
+      <Label>Extra props</Label>
+      {items.length > 0 && (
+        <ul className="space-y-2">
+          {items.map((prop, i) => (
+            <li key={i} className="group/item flex items-center gap-2">
+              <Input
+                value={prop.key}
+                onChange={(e) => set(i, { key: e.target.value })}
+                placeholder="key"
+                className="h-9 flex-1"
+              />
+              <Input
+                value={prop.value}
+                onChange={(e) => set(i, { value: e.target.value })}
+                placeholder="value"
+                className="h-9 flex-1"
+              />
+              <RemoveButton
+                label="Remove prop"
+                onClick={() => onChange(items.filter((_, idx) => idx !== i))}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+      <AddButton
+        label="Add prop"
+        onClick={() => onChange([...items, { key: "", value: "" }])}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds an "Extra props" section to the blog Post settings panel.
- Stores `post.extraProps` as an array of `{ key: string; value: string }`, edited as a list of key + value inputs with add/remove controls.
- Reuses the existing `AddButton`/`RemoveButton` primitives so it autosaves through the same flow as the other post fields.

## Test plan
- [ ] Open a post in the blog editor, expand **Post settings**, add a few extra props, reload and confirm they persist.
- [ ] Remove a prop and confirm it disappears from the saved payload.
- [ ] Confirm existing fields (excerpt, slug, date, cover, authors, categories) still save correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Extra props section to Post settings so authors can add arbitrary key/value metadata to a post. Data is saved to `post.extraProps` and persists via the existing autosave flow.

- **New Features**
  - Edit extra props as a list of key/value inputs with add/remove controls.
  - Normalizes incoming data with `asExtraProps` to ensure a safe array shape.

<sup>Written for commit 38aa0985370dbf6c2fe94f5202a6d77389765e47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

