### PR TITLE
feat(observability): profile multi-second event-loop stalls to name the culprit

### DIFF
--- a/apps/mesh/src/observability/profiling/event-loop-profiler.ts
+++ b/apps/mesh/src/observability/profiling/event-loop-profiler.ts
@@ -1,0 +1,139 @@
+import { Session } from "node:inspector";
+
+/**
+ * Off-thread CPU sampling profiler used to NAME what synchronously blocks the
+ * event loop. The timer-drift monitor in `event-loop.ts` can only detect a
+ * stall *after* it ends (the timer fires late), by which point the blocking
+ * code has returned — so a stack captured then is useless. The V8/JSC sampling
+ * profiler runs on its own thread, so it keeps sampling the main-thread stack
+ * while JS is blocked; the blocking frames are the trailing samples of the
+ * profile. (Verified to capture a synchronously-blocked stack under Bun.)
+ *
+ * Opt-in via EVENT_LOOP_PROFILE=1 — continuous sampling has a cost, so it is
+ * off by default and meant to be switched on to catch a known-recurring stall.
+ */
+
+type CallFrame = { functionName: string; url: string; lineNumber: number };
+type ProfileNode = { id: number; callFrame: CallFrame; children?: number[] };
+type CpuProfile = {
+  nodes: ProfileNode[];
+  samples: number[];
+  timeDeltas: number[];
+};
+
+let session: Session | null = null;
+let available = false;
+// Profiler.stop/start are async; guard so a periodic reset and a stall capture
+// can't issue overlapping stop/start to the same session.
+let busy = false;
+
+function post(
+  method: string,
+  params?: unknown,
+): Promise<{ profile?: CpuProfile }> {
+  return new Promise((resolve, reject) =>
+    session!.post(
+      method,
+      params as never,
+      (err: Error | null, res: { profile?: CpuProfile }) =>
+        err ? reject(err) : resolve(res),
+    ),
+  );
+}
+
+/** Connect and start continuous sampling. Returns false (gracefully) if the
+ *  runtime has no working inspector profiler, so the caller can carry on. */
+export async function startStallProfiler(intervalUs: number): Promise<boolean> {
+  try {
+    session = new Session();
+    session.connect();
+    await post("Profiler.enable");
+    await post("Profiler.setSamplingInterval", { interval: intervalUs });
+    await post("Profiler.start");
+    available = true;
+    return true;
+  } catch {
+    available = false;
+    session = null;
+    return false;
+  }
+}
+
+/** Hottest leaf in the trailing `windowMs` of samples, as a leaf→root stack. */
+function hottestStack(profile: CpuProfile, windowMs: number): string[] | null {
+  const { nodes, samples, timeDeltas } = profile;
+  if (!samples?.length) return null;
+  const byId = new Map<number, ProfileNode>();
+  const parent = new Map<number, number>();
+  for (const n of nodes) {
+    byId.set(n.id, n);
+    for (const c of n.children ?? []) parent.set(c, n.id);
+  }
+  // The stall ended ~now and we stop right after, so the blocking samples are
+  // the tail. Walk back over `windowMs` of sample time (timeDeltas are µs).
+  const windowUs = Math.max(1, windowMs) * 1000;
+  let acc = 0;
+  const counts = new Map<number, number>();
+  for (let i = samples.length - 1; i >= 0; i--) {
+    acc += timeDeltas[i] ?? 0;
+    counts.set(samples[i], (counts.get(samples[i]) ?? 0) + 1);
+    if (acc >= windowUs) break;
+  }
+  let hotId = -1;
+  let hotN = 0;
+  for (const [id, n] of counts) {
+    if (n > hotN) {
+      hotN = n;
+      hotId = id;
+    }
+  }
+  if (hotId < 0) return null;
+  const stack: string[] = [];
+  const seen = new Set<number>();
+  let cur: number | undefined = hotId;
+  while (cur != null && !seen.has(cur)) {
+    seen.add(cur);
+    const n = byId.get(cur);
+    if (!n) break;
+    const f = n.callFrame;
+    const where = f.url ? ` ${f.url}:${f.lineNumber + 1}` : "";
+    stack.push(`${f.functionName || "(anonymous)"}${where}`);
+    cur = parent.get(cur);
+  }
+  return stack;
+}
+
+/** Stop, extract the hot stack from the trailing window, restart with a fresh
+ *  buffer for the next stall. Returns null if unavailable/in-flight. */
+export async function captureStallStack(
+  windowMs: number,
+): Promise<string[] | null> {
+  if (!available || !session || busy) return null;
+  busy = true;
+  try {
+    const { profile } = await post("Profiler.stop");
+    const stack = profile ? hottestStack(profile, windowMs) : null;
+    await post("Profiler.start");
+    return stack;
+  } catch {
+    available = false;
+    return null;
+  } finally {
+    busy = false;
+  }
+}
+
+/** Discard accumulated samples so the buffer doesn't grow unbounded between the
+ *  (rare) stalls. Safe to call on a timer — no-op while a capture is in flight. */
+export async function resetStallProfiler(): Promise<void> {
+  if (!available || !session || busy) return;
+  busy = true;
+  try {
+    await post("Profiler.stop");
+    await post("Profiler.start");
+  } catch {
+    available = false;
+  } finally {
+    busy = false;
+  }
+}

--- a/apps/mesh/src/observability/profiling/event-loop-profiler.ts
+++ b/apps/mesh/src/observability/profiling/event-loop-profiler.ts
@@ -29,14 +29,13 @@ let busy = false;
 
 function post(
   method: string,
-  params?: unknown,
+  params?: Record<string, unknown>,
 ): Promise<{ profile?: CpuProfile }> {
   return new Promise((resolve, reject) =>
-    session!.post(
-      method,
-      params as never,
-      (err: Error | null, res: { profile?: CpuProfile }) =>
-        err ? reject(err) : resolve(res),
+    session!.post(method, params, (err, res) =>
+      err
+        ? reject(err)
+        : resolve((res ?? {}) as unknown as { profile?: CpuProfile }),
     ),
   );
 }
@@ -76,7 +75,8 @@ function hottestStack(profile: CpuProfile, windowMs: number): string[] | null {
   const counts = new Map<number, number>();
   for (let i = samples.length - 1; i >= 0; i--) {
     acc += timeDeltas[i] ?? 0;
-    counts.set(samples[i], (counts.get(samples[i]) ?? 0) + 1);
+    const id = samples[i];
+    if (id !== undefined) counts.set(id, (counts.get(id) ?? 0) + 1);
     if (acc >= windowUs) break;
   }
   let hotId = -1;

--- a/apps/mesh/src/observability/profiling/event-loop.ts
+++ b/apps/mesh/src/observability/profiling/event-loop.ts
@@ -1,5 +1,10 @@
 import { meter } from "../index";
 import { safeMemoryUsage } from "./safe-memory";
+import {
+  captureStallStack,
+  resetStallProfiler,
+  startStallProfiler,
+} from "./event-loop-profiler";
 
 /**
  * Event-loop delay monitor (timer-drift technique).
@@ -53,6 +58,33 @@ export function startEventLoopMonitor(): () => void {
   const intervalMs = Number(process.env.EVENT_LOOP_INTERVAL_MS ?? 250);
   const spikeMs = Number(process.env.EVENT_LOOP_SPIKE_MS ?? 100);
 
+  // Opt-in stack profiling: on a stall above `profileMs`, capture the stack the
+  // main thread was actually blocked in (metrics proved encode/throughput are
+  // NOT the cause, so the multi-second blocks are silent synchronous CPU work
+  // that only an off-thread profiler can name). Higher threshold than spikeMs:
+  // only the severe, kill-causing blocks are worth a profile.
+  const profileEnabled = process.env.EVENT_LOOP_PROFILE === "1";
+  const profileMs = Number(process.env.EVENT_LOOP_PROFILE_MS ?? 1000);
+  const profileIntervalUs = Number(
+    process.env.EVENT_LOOP_PROFILE_INTERVAL_US ?? 1000,
+  );
+  // Discard accumulated samples between the (rare) stalls so the profile buffer
+  // stays bounded. The reset timer can't fire mid-block, so it never splits a
+  // stall's samples across buffers.
+  const PROFILE_RESET_MS = 30_000;
+  let lastProfileResetAt = performance.now();
+  if (profileEnabled) {
+    void startStallProfiler(profileIntervalUs).then((ok) => {
+      console.warn(
+        JSON.stringify({
+          msg: "event-loop-profiler",
+          status: ok ? "started" : "unavailable",
+          intervalUs: profileIntervalUs,
+        }),
+      );
+    });
+  }
+
   // Create the instrument here, not at module top: `meter` is a no-op until
   // initObservability() reassigns it, and module-top capture binds the dead
   // pre-init meter (instruments never export). This runs post-init.
@@ -85,6 +117,29 @@ export function startEventLoopMonitor(): () => void {
           external: m?.external,
         }),
       );
+    }
+
+    if (profileEnabled) {
+      if (drift > profileMs) {
+        // Capture the stack the loop was blocked in (the stall's trailing
+        // samples). Async — log when it resolves; never block the monitor.
+        void captureStallStack(Math.round(drift)).then((stack) => {
+          if (stack?.length) {
+            console.warn(
+              JSON.stringify({
+                msg: "event-loop-stall-profile",
+                ts: new Date().toISOString(),
+                lagMs: Math.round(drift),
+                stack,
+              }),
+            );
+          }
+        });
+        lastProfileResetAt = now;
+      } else if (now - lastProfileResetAt > PROFILE_RESET_MS) {
+        void resetStallProfiler();
+        lastProfileResetAt = now;
+      }
     }
   }, intervalMs);
   timer.unref?.();

--- a/apps/mesh/src/observability/profiling/event-loop.ts
+++ b/apps/mesh/src/observability/profiling/event-loop.ts
@@ -65,8 +65,11 @@ export function startEventLoopMonitor(): () => void {
   // only the severe, kill-causing blocks are worth a profile.
   const profileEnabled = process.env.EVENT_LOOP_PROFILE === "1";
   const profileMs = Number(process.env.EVENT_LOOP_PROFILE_MS ?? 1000);
+  // 10ms sampling: naming a multi-second block needs ~tens of samples, not
+  // thousands, so this keeps the stack-walk overhead ~10x lower than 1ms while
+  // still resolving the culprit. Override for finer resolution if ever needed.
   const profileIntervalUs = Number(
-    process.env.EVENT_LOOP_PROFILE_INTERVAL_US ?? 1000,
+    process.env.EVENT_LOOP_PROFILE_INTERVAL_US ?? 10_000,
   );
   // Discard accumulated samples between the (rare) stalls so the profile buffer
   // stays bounded. The reset timer can't fire mid-block, so it never splits a


### PR DESCRIPTION
## Why

The stream metrics proved the original hypothesis wrong: chunk encode is **0.03% of a thread** at peak and throughput is **~7 chunks/s** — not the bottleneck. Yet workers/API pods still hit **2–8s synchronous event-loop blocks** that fail the liveness probe → SIGKILL (the exit-137 kills, worker = most-restarted tier). Those blocks **log nothing**, so neither metrics nor logs can localize them.

A timer-drift monitor only detects a stall *after* it ends, when the blocking code has already returned — so a stack captured then is the wrong stack. The fix is an **off-thread CPU sampler**: the V8/JSC sampling profiler runs on its own thread and keeps sampling the main-thread stack *while JS is blocked*; the blocking frames are the profile's trailing samples.

## What

- `event-loop-profiler.ts`: opt-in `node:inspector` sampler. `startStallProfiler` (continuous), `captureStallStack(windowMs)` (stop → hottest leaf→root stack in the trailing window → restart), `resetStallProfiler` (bound the buffer). Degrades gracefully (logs `unavailable`) if the runtime lacks a working profiler.
- `event-loop.ts`: when `EVENT_LOOP_PROFILE=1`, on a stall above `EVENT_LOOP_PROFILE_MS` (default 1000ms) it logs `event-loop-stall-profile` with the captured stack. Buffer reset every 30s (the reset timer can't fire mid-block, so it never splits a stall). Off by default; existing behavior unchanged.

## Validated under Bun (locally, 1.3.11)
- Profiler connects and samples a synchronously-blocked main thread (5546 samples in a 1.5s block).
- The real module captured a blocking `JSON.parse` as `parse → bigJsonParseBlock <file>:<line> → (module)`.

## How to use
Set `EVENT_LOOP_PROFILE=1` (alongside `EVENT_LOOP_MONITOR=1`) on the **worker** pods. Next ≥1s stall logs the culprit stack with file:line. Grep `event-loop-stall-profile`.

I'll verify it fires in pod logs after deploy before calling this done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEJ58ibWZUcYheMaTyC8UQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in event-loop stall profiler using `node:inspector` CPU sampling to capture and log the blocking stack for multi-second stalls. Off by default; enable with `EVENT_LOOP_MONITOR=1` and `EVENT_LOOP_PROFILE=1`.

- **New Features**
  - Added `event-loop-profiler.ts` to start/reset/capture profiles using off-thread sampling; extracts the hottest leaf→root stack from the trailing window.
  - Integrated with the event-loop monitor: when `EVENT_LOOP_PROFILE=1` and a stall exceeds `EVENT_LOOP_PROFILE_MS` (default 1000ms), logs `event-loop-stall-profile` with the culprit stack; profile interval defaults to 10ms (`EVENT_LOOP_PROFILE_INTERVAL_US` to override); buffer resets every 30s; logs `unavailable` if the profiler cannot start.

- **Bug Fixes**
  - Adjusted types and index guards to pass strict TS config in `event-loop-profiler.ts`; no behavior changes.

<sup>Written for commit c4dc87a35fca0d59e778a417c98eef29cbb40923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

