### PR TITLE
feat(home): configurable tool input props for home tiles

### DIFF
--- a/apps/mesh/src/api/routes/home-next-actions.ts
+++ b/apps/mesh/src/api/routes/home-next-actions.ts
@@ -62,8 +62,11 @@ interface TileEntry {
   agentId: string;
   agentName: string;
   agentIcon: string | null;
+  tileId?: string;
   connectionId: string;
   resourceUri: string;
+  toolName?: string;
+  toolInput?: Record<string, unknown>;
   minHeight?: number;
   maxHeight?: number;
 }
@@ -106,8 +109,11 @@ async function defaultHomeAgentNextActions(
             agentId: id,
             agentName: virtualMcp.title,
             agentIcon: virtualMcp.icon,
+            tileId: t.tileId,
             connectionId: t.connectionId as string,
             resourceUri: t.resourceUri,
+            toolName: t.toolName,
+            toolInput: t.toolInput,
             minHeight: t.minHeight,
             maxHeight: t.maxHeight,
           }));

--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -37,12 +37,14 @@ import {
   useVirtualMCPActions,
   useVirtualMCPs,
   type VirtualMCPEntity,
+  type VirtualMcpHomeTile,
 } from "@decocms/mesh-sdk";
 import {
   useDefaultHomeAgents,
   useHomeAgentsWriter,
 } from "@/web/hooks/use-organization-settings";
 import { useHomeNextActions } from "@/web/hooks/use-home-next-actions";
+import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import {
@@ -61,12 +63,14 @@ import {
   Minus,
   Plus,
   SearchSm,
+  Settings01,
   X,
 } from "@untitledui/icons";
 import { toast } from "sonner";
 import { getUIResourceUri } from "@/mcp-apps/types.ts";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { IntegrationIcon } from "@/web/components/integration-icon";
+import { ToolInputForm } from "@/web/components/tool-input-form";
 import { KEYS } from "@/web/lib/query-keys";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
@@ -84,6 +88,8 @@ interface UITool {
   name: string;
   description?: string;
   resourceUri: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inputSchema?: { properties?: Record<string, any>; required?: string[] };
 }
 
 interface ConnectionUITools {
@@ -550,7 +556,7 @@ function AgentExpansion({
   agent: VirtualMCPEntity;
   home: HomeBoard;
 }) {
-  const pinned = getHomeTiles(agent.metadata?.ui);
+  const pinnedTiles = getHomeTiles(agent.metadata?.ui);
   const connectionIds = (agent.connections ?? [])
     .map((c) => c.connection_id)
     .sort();
@@ -562,7 +568,7 @@ function AgentExpansion({
         agent={agent}
         home={home}
         connectionIds={connectionIds}
-        pinnedResourceUris={new Set(pinned.map((t) => t.resourceUri))}
+        pinnedTiles={pinnedTiles}
       />
       <Suspense fallback={<PromptListSkeleton />}>
         <AgentPromptList
@@ -588,12 +594,12 @@ function AgentToolList({
   agent,
   home,
   connectionIds,
-  pinnedResourceUris,
+  pinnedTiles,
 }: {
   agent: VirtualMCPEntity;
   home: HomeBoard;
   connectionIds: string[];
-  pinnedResourceUris: Set<string>;
+  pinnedTiles: VirtualMcpHomeTile[];
 }) {
   const studio = useStudioTools();
 
@@ -611,7 +617,12 @@ function AgentToolList({
               const resourceUri = getUIResourceUri(t._meta);
               if (!resourceUri) return [];
               return [
-                { name: t.name, description: t.description, resourceUri },
+                {
+                  name: t.name,
+                  description: t.description,
+                  resourceUri,
+                  inputSchema: t.inputSchema as UITool["inputSchema"],
+                },
               ];
             });
             return {
@@ -638,70 +649,388 @@ function AgentToolList({
       </div>
     );
   }
-  // Quietly hide the section when nothing relevant exists — the prompt
-  // list below still shows up.
   if (!data || data.length === 0) return null;
 
+  // Build a lookup from connectionId+resourceUri to the UITool definition
+  // so pinned tile rows can resolve their tool's inputSchema.
+  const toolByKey = new Map<
+    string,
+    { conn: ConnectionUITools; tool: UITool }
+  >();
+  for (const conn of data) {
+    for (const tool of conn.uiTools) {
+      toolByKey.set(`${conn.id}:${tool.resourceUri}`, { conn, tool });
+    }
+  }
+
+  const hasPinned = pinnedTiles.some((tile) => {
+    const key = `${tile.connectionId}:${tile.resourceUri}`;
+    return toolByKey.has(key);
+  });
+
   return (
-    <div className="flex flex-col gap-0.5">
-      {data.map((conn) =>
-        conn.uiTools.map((tool) => (
-          <ToolRow
-            key={`${conn.id}:${tool.name}`}
-            agent={agent}
-            home={home}
-            connection={conn}
-            tool={tool}
-            isPinned={pinnedResourceUris.has(tool.resourceUri)}
-          />
-        )),
+    <div className="flex flex-col gap-2">
+      {hasPinned && (
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground px-2">
+            Pinned tiles
+          </span>
+          {pinnedTiles.map((tile) => {
+            const key = `${tile.connectionId}:${tile.resourceUri}`;
+            const match = toolByKey.get(key);
+            if (!match) return null;
+            return (
+              <PinnedTileRow
+                key={tile.tileId ?? key}
+                agent={agent}
+                home={home}
+                connection={match.conn}
+                tool={match.tool}
+                tile={tile}
+              />
+            );
+          })}
+        </div>
       )}
+      <div className="flex flex-col gap-0.5">
+        <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground px-2">
+          Add tile
+        </span>
+        {data.map((conn) =>
+          conn.uiTools.map((tool) => (
+            <AddToolRow
+              key={`add:${conn.id}:${tool.name}`}
+              agent={agent}
+              home={home}
+              connection={conn}
+              tool={tool}
+            />
+          )),
+        )}
+      </div>
     </div>
   );
 }
 
-function ToolRow({
+/** Coerce form values for persistence: JSON-parse object/array fields,
+ * convert number/integer strings. Returns null on parse error (caller
+ * should toast). */
+function coerceFormValues(
+  values: Record<string, unknown>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  properties: Record<string, any>,
+): Record<string, unknown> | null {
+  const out: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(values)) {
+    const type = properties[key]?.type;
+    if ((type === "object" || type === "array") && typeof raw === "string") {
+      if (!raw.trim()) continue;
+      try {
+        out[key] = JSON.parse(raw);
+      } catch {
+        return null;
+      }
+    } else if (
+      (type === "number" || type === "integer") &&
+      typeof raw === "string"
+    ) {
+      if (!raw.trim()) continue;
+      out[key] = Number(raw);
+    } else if (raw !== "" && raw != null) {
+      out[key] = raw;
+    }
+  }
+  return out;
+}
+
+/** Stringify toolInput values for form display: object/array values become
+ * JSON strings so they render in a Textarea. */
+function seedFormValues(
+  toolInput: Record<string, unknown> | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  properties: Record<string, any> | undefined,
+): Record<string, unknown> {
+  if (!toolInput || !properties) return {};
+  const init: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(toolInput)) {
+    const type = properties[key]?.type;
+    if (
+      (type === "object" || type === "array") &&
+      val != null &&
+      typeof val !== "string"
+    ) {
+      init[key] = JSON.stringify(val, null, 2);
+    } else {
+      init[key] = val;
+    }
+  }
+  return init;
+}
+
+/** Summarize toolInput for display in the pinned tile row. */
+function toolInputSummary(
+  toolInput: Record<string, unknown> | undefined,
+): string {
+  if (!toolInput) return "";
+  const entries = Object.entries(toolInput).filter(
+    ([, v]) => v != null && v !== "",
+  );
+  if (entries.length === 0) return "";
+  return entries
+    .slice(0, 3)
+    .map(([k, v]) => {
+      const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+      return `${k}=${s.length > 20 ? `${s.slice(0, 20)}…` : s}`;
+    })
+    .join(", ");
+}
+
+/** Row for a pinned tile instance — shows a summary, gear to edit, minus to remove. */
+function PinnedTileRow({
   agent,
   home,
   connection,
   tool,
-  isPinned,
+  tile,
 }: {
   agent: VirtualMCPEntity;
   home: HomeBoard;
   connection: ConnectionUITools;
   tool: UITool;
-  isPinned: boolean;
+  tile: VirtualMcpHomeTile;
 }) {
   const [submitting, setSubmitting] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const hasProps =
+    tool.inputSchema?.properties &&
+    Object.keys(tool.inputSchema.properties).length > 0;
 
-  const handleClick = async () => {
-    // Pinning a tile pulls the agent onto the home; block when full.
-    if (!isPinned && !home.isOnHome(agent.id) && home.atLimit) {
-      toast.error(`Home is full (${HOME_LIMIT}) — remove an agent first`);
-      return;
-    }
+  const [formValues, setFormValues] = useState<Record<string, unknown>>(() =>
+    seedFormValues(tile.toolInput, tool.inputSchema?.properties),
+  );
+
+  const handleRemove = async () => {
     setSubmitting(true);
     try {
       const baseTiles = getHomeTiles(agent.metadata?.ui);
-      const nextTiles = isPinned
-        ? baseTiles.filter((t) => t.resourceUri !== tool.resourceUri)
-        : [
-            ...baseTiles,
-            { connectionId: connection.id, resourceUri: tool.resourceUri },
-          ];
+      const nextTiles = tile.tileId
+        ? baseTiles.filter((t) => t.tileId !== tile.tileId)
+        : baseTiles.filter((t) => t !== tile);
       const nextMetadata = {
         ...(agent.metadata ?? {}),
         ui: {
           ...(agent.metadata?.ui ?? {}),
-          // Clear the legacy slot — `homeTiles` is now canonical.
           homeTile: null,
           homeTiles: nextTiles,
         },
       };
       await home.saveAgentMetadata(agent, nextMetadata);
+      setShowForm(false);
     } catch (err) {
-      console.error("[home-tiles] failed to toggle tile", err);
+      console.error("[home-tiles] failed to remove tile", err);
+      toast.error("Couldn't update home — please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSubmitting(true);
+    try {
+      let toolInput: Record<string, unknown> | undefined;
+      if (hasProps && tool.inputSchema?.properties) {
+        const coerced = coerceFormValues(
+          formValues,
+          tool.inputSchema.properties,
+        );
+        if (!coerced) {
+          toast.error("Invalid JSON in one of the fields — please fix it.");
+          setSubmitting(false);
+          return;
+        }
+        if (Object.keys(coerced).length > 0) toolInput = coerced;
+      }
+
+      const baseTiles = getHomeTiles(agent.metadata?.ui);
+      const nextTiles = baseTiles.map((t) => {
+        const isMatch = tile.tileId ? t.tileId === tile.tileId : t === tile;
+        if (!isMatch) return t;
+        return {
+          ...t,
+          toolInput,
+        };
+      });
+      const nextMetadata = {
+        ...(agent.metadata ?? {}),
+        ui: {
+          ...(agent.metadata?.ui ?? {}),
+          homeTile: null,
+          homeTiles: nextTiles,
+        },
+      };
+      await home.saveAgentMetadata(agent, nextMetadata);
+      setShowForm(false);
+    } catch (err) {
+      console.error("[home-tiles] failed to save tile", err);
+      toast.error("Couldn't update home — please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const summary = toolInputSummary(tile.toolInput);
+
+  return (
+    <div className="flex flex-col rounded-md bg-accent/20">
+      <div className="flex items-center gap-2.5 px-2 py-1">
+        <IntegrationIcon
+          icon={connection.icon}
+          name={connection.title}
+          size="xs"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm text-foreground">
+            {toTitleCase(tool.name)}
+          </div>
+          {summary && (
+            <div className="truncate text-[10px] text-muted-foreground font-mono">
+              {summary}
+            </div>
+          )}
+        </div>
+        {hasProps && (
+          <button
+            type="button"
+            onClick={() => setShowForm((v) => !v)}
+            aria-label="Configure tile props"
+            title="Configure tile props"
+            className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/60"
+          >
+            <Settings01 size={14} />
+          </button>
+        )}
+        <ToggleButton
+          isPinned
+          submitting={submitting}
+          onClick={handleRemove}
+          label="Remove from home"
+        />
+      </div>
+      {showForm && hasProps && tool.inputSchema?.properties && (
+        <div className="px-3 pb-2 pt-1 flex flex-col gap-2">
+          <ToolInputForm
+            properties={tool.inputSchema.properties}
+            required={tool.inputSchema.required}
+            values={formValues}
+            onChange={(key, value) =>
+              setFormValues((prev) => ({ ...prev, [key]: value }))
+            }
+          />
+          <div className="flex items-center gap-2 justify-end">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => setShowForm(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              className="h-7 text-xs"
+              disabled={submitting}
+              onClick={handleSave}
+            >
+              {submitting ? (
+                <Loading01 size={12} className="animate-spin" />
+              ) : (
+                "Save"
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Row to add a new tile instance of a tool. Always creates a fresh tile
+ * with a unique tileId so the same tool can be pinned multiple times with
+ * different toolInput. */
+function AddToolRow({
+  agent,
+  home,
+  connection,
+  tool,
+}: {
+  agent: VirtualMCPEntity;
+  home: HomeBoard;
+  connection: ConnectionUITools;
+  tool: UITool;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const hasProps =
+    tool.inputSchema?.properties &&
+    Object.keys(tool.inputSchema.properties).length > 0;
+  const [formValues, setFormValues] = useState<Record<string, unknown>>({});
+
+  const handleAdd = async () => {
+    // If the tool has configurable props, show the form first.
+    if (hasProps && !showForm) {
+      setShowForm(true);
+      return;
+    }
+
+    if (!home.isOnHome(agent.id) && home.atLimit) {
+      toast.error(`Home is full (${HOME_LIMIT}) — remove an agent first`);
+      return;
+    }
+
+    await saveTile();
+  };
+
+  const saveTile = async () => {
+    setSubmitting(true);
+    try {
+      let toolInput: Record<string, unknown> | undefined;
+      if (hasProps && tool.inputSchema?.properties) {
+        const coerced = coerceFormValues(
+          formValues,
+          tool.inputSchema.properties,
+        );
+        if (!coerced) {
+          toast.error("Invalid JSON in one of the fields — please fix it.");
+          setSubmitting(false);
+          return;
+        }
+        if (Object.keys(coerced).length > 0) toolInput = coerced;
+      }
+
+      const baseTiles = getHomeTiles(agent.metadata?.ui);
+      const nextTiles = [
+        ...baseTiles,
+        {
+          tileId: crypto.randomUUID(),
+          connectionId: connection.id,
+          resourceUri: tool.resourceUri,
+          toolName: tool.name,
+          ...(toolInput ? { toolInput } : {}),
+        },
+      ];
+      const nextMetadata = {
+        ...(agent.metadata ?? {}),
+        ui: {
+          ...(agent.metadata?.ui ?? {}),
+          homeTile: null,
+          homeTiles: nextTiles,
+        },
+      };
+      await home.saveAgentMetadata(agent, nextMetadata);
+      setShowForm(false);
+      setFormValues({});
+    } catch (err) {
+      console.error("[home-tiles] failed to add tile", err);
       toast.error("Couldn't update home — please try again.");
     } finally {
       setSubmitting(false);
@@ -709,21 +1038,60 @@ function ToolRow({
   };
 
   return (
-    <div className="flex items-center gap-2.5 rounded-md px-2 py-1 hover:bg-accent/40">
-      <IntegrationIcon
-        icon={connection.icon}
-        name={connection.title}
-        size="xs"
-      />
-      <div className="min-w-0 flex-1 truncate text-sm text-foreground">
-        {toTitleCase(tool.name)}
+    <div className="flex flex-col rounded-md hover:bg-accent/40">
+      <div className="flex items-center gap-2.5 px-2 py-1">
+        <IntegrationIcon
+          icon={connection.icon}
+          name={connection.title}
+          size="xs"
+        />
+        <div className="min-w-0 flex-1 truncate text-sm text-foreground">
+          {toTitleCase(tool.name)}
+        </div>
+        <ToggleButton
+          isPinned={false}
+          submitting={submitting}
+          onClick={handleAdd}
+          label="Add to home"
+        />
       </div>
-      <ToggleButton
-        isPinned={isPinned}
-        submitting={submitting}
-        onClick={handleClick}
-        label={isPinned ? "Remove from home" : "Add to home"}
-      />
+      {showForm && hasProps && tool.inputSchema?.properties && (
+        <div className="px-3 pb-2 pt-1 flex flex-col gap-2">
+          <ToolInputForm
+            properties={tool.inputSchema.properties}
+            required={tool.inputSchema.required}
+            values={formValues}
+            onChange={(key, value) =>
+              setFormValues((prev) => ({ ...prev, [key]: value }))
+            }
+          />
+          <div className="flex items-center gap-2 justify-end">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => {
+                setShowForm(false);
+                setFormValues({});
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              className="h-7 text-xs"
+              disabled={submitting}
+              onClick={saveTile}
+            >
+              {submitting ? (
+                <Loading01 size={12} className="animate-spin" />
+              ) : (
+                "Pin"
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -651,22 +651,41 @@ function AgentToolList({
   }
   if (!data || data.length === 0) return null;
 
-  // Build a lookup from connectionId+resourceUri to the UITool definition
-  // so pinned tile rows can resolve their tool's inputSchema.
+  // Build a lookup from connectionId+toolName to the UITool definition
+  // so pinned tile rows can resolve their tool's inputSchema. Keyed by
+  // toolName (not resourceUri) because multiple tools can share the same
+  // resourceUri (e.g. two VTEX tools both point to ui://vtex/dashboard).
   const toolByKey = new Map<
     string,
     { conn: ConnectionUITools; tool: UITool }
   >();
   for (const conn of data) {
     for (const tool of conn.uiTools) {
-      toolByKey.set(`${conn.id}:${tool.resourceUri}`, { conn, tool });
+      toolByKey.set(`${conn.id}:${tool.name}`, { conn, tool });
     }
   }
 
-  const hasPinned = pinnedTiles.some((tile) => {
-    const key = `${tile.connectionId}:${tile.resourceUri}`;
-    return toolByKey.has(key);
-  });
+  // Resolve a pinned tile to its UITool definition. Prefers toolName
+  // (new tiles), falls back to resourceUri match (legacy tiles).
+  const resolveToolForTile = (
+    tile: VirtualMcpHomeTile,
+  ): { conn: ConnectionUITools; tool: UITool } | undefined => {
+    if (tile.toolName && tile.connectionId) {
+      return toolByKey.get(`${tile.connectionId}:${tile.toolName}`);
+    }
+    // Legacy tiles without toolName — find first tool matching resourceUri.
+    for (const [, entry] of toolByKey) {
+      if (
+        entry.conn.id === tile.connectionId &&
+        entry.tool.resourceUri === tile.resourceUri
+      ) {
+        return entry;
+      }
+    }
+    return undefined;
+  };
+
+  const hasPinned = pinnedTiles.some((tile) => !!resolveToolForTile(tile));
 
   return (
     <div className="flex flex-col gap-2">
@@ -676,12 +695,14 @@ function AgentToolList({
             Pinned tiles
           </span>
           {pinnedTiles.map((tile) => {
-            const key = `${tile.connectionId}:${tile.resourceUri}`;
-            const match = toolByKey.get(key);
+            const match = resolveToolForTile(tile);
             if (!match) return null;
             return (
               <PinnedTileRow
-                key={tile.tileId ?? key}
+                key={
+                  tile.tileId ??
+                  `${tile.connectionId}:${tile.resourceUri}:${tile.toolName}`
+                }
                 agent={agent}
                 home={home}
                 connection={match.conn}

--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -194,45 +194,14 @@ function AgentUITile({
   const promptChips = prompts.filter((p) => !!p.promptName);
 
   return (
-    <div className="flex h-full w-full flex-col gap-3 p-3">
-      <button
-        type="button"
-        onClick={() => void startBlank()}
-        disabled={starting || isEditMode}
-        aria-busy={starting}
-        className={cn(
-          "flex items-center gap-3 rounded-lg text-left outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-progress disabled:opacity-60",
-          isEditMode && "pl-10 pr-10",
-        )}
-      >
-        <AgentAvatar icon={tile.agentIcon} name={tile.agentName} size="sm+" />
-        <div className="flex min-w-0 flex-1 flex-col">
-          <div className="truncate text-sm font-medium text-foreground">
-            {tile.agentName}
-          </div>
-          <div className="truncate text-xs text-muted-foreground">
-            {isEditMode ? "Drag to rearrange" : "Open chat"}
-          </div>
-        </div>
-      </button>
+    <div className="relative flex h-full w-full flex-col p-3">
       <div className="flex min-h-0 flex-1 gap-3 overflow-hidden">
         <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border">
-          {/* Inner boundary so the connect + resource read only block the
-              embedded panel — the tile chrome (agent name, Open chat, prompt
-              chips) renders immediately from cached tile data and stays
-              interactive while the connection establishes and the app loads.
-              The useMCPClient connect lives in TileAppPanel (below this
-              boundary) on purpose: hoisting it to the tile root would suspend
-              the whole tile on every reload, re-introducing a full-tile
-              skeleton even though the chrome needs no live connection. */}
           <Suspense fallback={<TilePanelSkeleton />}>
             <TileAppPanel tile={tile} orgId={org.id} orgSlug={org.slug} />
           </Suspense>
         </div>
         {promptChips.length > 0 && !isEditMode && tileWidth >= 2 && (
-          // Right-side column of action chips. `overflow-hidden` clips
-          // overflow gracefully so a long list never spills outside the
-          // tile — chips that don't fit are simply not shown, no scroll.
           <div className="flex w-44 shrink-0 flex-col gap-2 overflow-hidden">
             {promptChips.map((entry) => (
               <button
@@ -248,6 +217,17 @@ function AgentUITile({
           </div>
         )}
       </div>
+      {!isEditMode && (
+        <button
+          type="button"
+          onClick={() => void startBlank()}
+          disabled={starting}
+          aria-busy={starting}
+          className="absolute bottom-2 right-2 rounded-md px-2 py-1 text-[10px] text-muted-foreground opacity-0 transition-opacity hover:bg-accent/60 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-progress disabled:opacity-60"
+        >
+          Open chat
+        </button>
+      )}
       {dialog}
     </div>
   );

--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -6,7 +6,12 @@
 
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { Suspense } from "react";
-import { useMCPClient, useProjectContext } from "@decocms/mesh-sdk";
+import {
+  getHomeTiles,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import { useQueryClient } from "@tanstack/react-query";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ArrowRight } from "@untitledui/icons";
@@ -24,6 +29,8 @@ import {
   useHomeAgentsWriter,
 } from "@/web/hooks/use-organization-settings";
 import { useStartThreadFromPrompt } from "@/web/hooks/use-start-thread-from-prompt";
+import { useStudioTools } from "@/web/lib/studio-tools";
+import { KEYS } from "@/web/lib/query-keys";
 import { TileBoard } from "./tile-board/tile-board";
 import { useBoardLayout } from "./tile-board/use-board-layout";
 import type { TileInstance } from "./tile-board/types";
@@ -386,6 +393,8 @@ export function HomeGrid({ isEditMode }: HomeGridProps) {
   const homeIds = useDefaultHomeAgents()?.ids ?? [];
   const pinnedAgentIds = new Set(homeIds);
   const homeWriter = useHomeAgentsWriter();
+  const studio = useStudioTools();
+  const queryClient = useQueryClient();
 
   // Agents that have a UI tile own their prompts — those prompts render
   // inline inside the tile, not as their own grid cards.
@@ -437,12 +446,71 @@ export function HomeGrid({ isEditMode }: HomeGridProps) {
         toast.error("Couldn't remove from home — please try again."),
       );
   };
+
+  /** Remove a single tile from the agent's `homeTiles` metadata instead
+   *  of yanking the whole agent off the board. Only falls back to
+   *  removing the agent when this was the last (or only) tile. */
+  const removeSingleTile = async (tileData: HomeTileEntry) => {
+    const agentTileCount = tiles.filter(
+      (t) => t.agentId === tileData.agentId,
+    ).length;
+
+    if (agentTileCount <= 1) {
+      removeAgentFromHome(tileData.agentId);
+      return;
+    }
+
+    try {
+      const agent = await studio.call("COLLECTION_VIRTUAL_MCP_GET", {
+        id: tileData.agentId,
+      });
+      const item = agent.item;
+      if (!item) throw new Error("Agent not found");
+
+      const currentTiles = getHomeTiles(item.metadata?.ui);
+      const nextTiles = tileData.tileId
+        ? currentTiles.filter((t) => t.tileId !== tileData.tileId)
+        : currentTiles.filter(
+            (t) =>
+              t.connectionId !== tileData.connectionId ||
+              t.resourceUri !== tileData.resourceUri,
+          );
+
+      await studio.call("COLLECTION_VIRTUAL_MCP_UPDATE", {
+        id: tileData.agentId,
+        data: {
+          metadata: {
+            ...(item.metadata ?? {}),
+            ui: {
+              ...(item.metadata?.ui ?? {}),
+              homeTile: null,
+              homeTiles: nextTiles,
+            },
+          },
+        },
+      });
+
+      void queryClient.invalidateQueries({
+        queryKey: KEYS.homeNextActions(org.slug),
+      });
+    } catch {
+      toast.error("Couldn't remove tile — please try again.");
+    }
+  };
+
   const removeCandidate = (id: string) => {
     const candidate = candidatesById.get(id);
-    if (candidate && pinnedAgentIds.has(candidate.data.agentId)) {
-      removeAgentFromHome(candidate.data.agentId);
-    } else {
+    if (!candidate) return;
+
+    if (!pinnedAgentIds.has(candidate.data.agentId)) {
       layout.hideTile(id);
+      return;
+    }
+
+    if (candidate.kind === "tile") {
+      void removeSingleTile(candidate.data);
+    } else {
+      removeAgentFromHome(candidate.data.agentId);
     }
   };
 

--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -45,8 +45,10 @@ function promptCandidateId(p: HomePromptEntry): string {
 }
 
 function tileCandidateId(t: HomeTileEntry): string {
-  // Disambiguates multiple tiles pinned to the same agent by including
-  // the resource URI — each (agent, resource) pair is its own grid tile.
+  // When a tileId exists (new tiles), use it for stable identity — this
+  // allows multiple tiles backed by the same tool/resource with different
+  // toolInput to coexist. Fall back to agent+resource for legacy tiles.
+  if (t.tileId) return `tile:${t.tileId}`;
   return `tile:${t.agentId}:${t.resourceUri}`;
 }
 
@@ -267,6 +269,7 @@ function TileAppPanel({
       orgSlug={orgSlug}
       connectionId={tile.connectionId}
       client={client}
+      toolInput={tile.toolInput}
       displayMode="fullscreen"
       minHeight={tile.minHeight ?? 200}
       maxHeight={tile.maxHeight ?? 4000}

--- a/apps/mesh/src/web/components/home/tile-board/tile-board.tsx
+++ b/apps/mesh/src/web/components/home/tile-board/tile-board.tsx
@@ -109,7 +109,7 @@ export function TileBoard({
         {tiles.map((tile) => (
           <div
             key={tile.id}
-            className="bg-card card-shadow rounded-2xl overflow-hidden"
+            className="group bg-card card-shadow rounded-2xl overflow-hidden"
             style={{ minHeight: ROW_HEIGHT_PX }}
           >
             <TileErrorBoundary>{renderTile(tile)}</TileErrorBoundary>
@@ -253,7 +253,7 @@ function BoardTile({
     >
       <div
         className={cn(
-          "relative h-full bg-card card-shadow rounded-2xl overflow-hidden",
+          "group relative h-full bg-card card-shadow rounded-2xl overflow-hidden",
           isEditMode &&
             "outline outline-1 outline-transparent hover:outline-primary/40",
         )}

--- a/apps/mesh/src/web/components/tool-input-form.tsx
+++ b/apps/mesh/src/web/components/tool-input-form.tsx
@@ -1,0 +1,118 @@
+/**
+ * Compact form for editing MCP tool input properties. Renders fields
+ * from an MCP tool's `inputSchema.properties` using the same type
+ * mapping as the tool detail panel (string/number → Input, object/array
+ * → Textarea, boolean → Select).
+ *
+ * Designed to fit inside the add-tile drawer inline expansion.
+ */
+
+import { Input } from "@deco/ui/components/input.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+
+interface ToolInputFormProps {
+  /** `inputSchema.properties` from the MCP tool definition. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  properties: Record<string, any>;
+  /** Names of required fields (`inputSchema.required`). */
+  required?: string[];
+  /** Current field values. */
+  values: Record<string, unknown>;
+  /** Called when a field changes. */
+  onChange: (key: string, value: unknown) => void;
+}
+
+export function ToolInputForm({
+  properties,
+  required,
+  values,
+  onChange,
+}: ToolInputFormProps) {
+  const requiredSet = new Set(required ?? []);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {Object.entries(properties).map(([key, prop]) => (
+        <div key={key} className="flex flex-col gap-0.5">
+          <div className="flex items-center justify-between">
+            <label className="text-xs font-medium leading-none flex items-center gap-1">
+              {key}
+              {requiredSet.has(key) && (
+                <span className="text-red-500 text-[10px]">*</span>
+              )}
+            </label>
+            <span className="text-[10px] text-muted-foreground font-mono">
+              {prop.type}
+            </span>
+          </div>
+          {prop.description && (
+            <p className="text-[10px] text-muted-foreground leading-snug">
+              {prop.description}
+            </p>
+          )}
+          <FieldInput
+            type={prop.type}
+            fieldKey={key}
+            value={values[key]}
+            onChange={(v) => onChange(key, v)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FieldInput({
+  type,
+  fieldKey,
+  value,
+  onChange,
+}: {
+  type: string;
+  fieldKey: string;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  if (type === "object" || type === "array") {
+    return (
+      <Textarea
+        className="font-mono text-xs h-16"
+        value={(value as string) ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={`Enter ${fieldKey} as JSON…`}
+        rows={2}
+      />
+    );
+  }
+  if (type === "boolean") {
+    return (
+      <Select
+        value={value != null ? String(value) : ""}
+        onValueChange={(v) => onChange(v === "true")}
+      >
+        <SelectTrigger className="h-7 text-xs">
+          <SelectValue placeholder="Select…" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="true">true</SelectItem>
+          <SelectItem value="false">false</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+  }
+  return (
+    <Input
+      className="h-7 text-xs"
+      value={(value as string) ?? ""}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={`Enter ${fieldKey}…`}
+    />
+  );
+}

--- a/apps/mesh/src/web/hooks/use-home-next-actions.ts
+++ b/apps/mesh/src/web/hooks/use-home-next-actions.ts
@@ -18,8 +18,11 @@ export interface HomeTileEntry {
   agentId: string;
   agentName: string;
   agentIcon: string | null;
+  tileId?: string;
   connectionId: string;
   resourceUri: string;
+  toolName?: string;
+  toolInput?: Record<string, unknown>;
   minHeight?: number;
   maxHeight?: number;
 }

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -114,6 +114,14 @@ export type VirtualMcpUILayout = z.infer<typeof VirtualMcpUILayoutSchema>;
  */
 const VirtualMcpHomeTileSchema = z.object({
   /**
+   * Stable identifier for this tile instance. Allows multiple tiles
+   * backed by the same tool/resource with different `toolInput` to
+   * coexist on the home board. Generated via `crypto.randomUUID()` at
+   * pin time. Optional for backward compatibility with tiles saved
+   * before this field existed.
+   */
+  tileId: z.string().optional(),
+  /**
    * Optional for backward compatibility with tiles saved before this field
    * existed. The home API drops tiles that don't carry a connectionId (they
    * can't render correctly without it), but parsing must still succeed so
@@ -129,6 +137,18 @@ const VirtualMcpHomeTileSchema = z.object({
     .string()
     .describe(
       "ui:// resource URI exposed by `connectionId`. Read on the home page and rendered via MCPAppRenderer.",
+    ),
+  toolName: z
+    .string()
+    .optional()
+    .describe(
+      "Tool name — identifies which tool's inputSchema to display when editing tile props.",
+    ),
+  toolInput: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe(
+      "User-configured input props passed to MCPAppRenderer when rendering the tile.",
     ),
   minHeight: z.number().int().positive().optional(),
   maxHeight: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary
- Add `tileId`, `toolName`, and `toolInput` fields to `VirtualMcpHomeTileSchema` — stored in existing JSONB, no migration needed
- Each pinned tile gets a stable UUID (`tileId`) so the same tool can be pinned multiple times with different input configurations
- Create reusable `ToolInputForm` component that renders fields from an MCP tool's `inputSchema.properties`
- Refactor the add-tile drawer with clear "Pinned tiles" / "Add tile" sections, inline edit forms, and per-instance gear/remove controls
- Pass `toolInput` through the backend API → frontend types → `MCPAppRenderer` on the home grid

## Test plan
- [ ] Pin a UI tool with `inputSchema` properties → inline form appears → fill values → pin → tile renders with props on home
- [ ] Pin the same tool again with different input values → both tiles coexist on the home board
- [ ] Edit an existing pinned tile via the gear icon → change values → save → tile re-renders with updated props
- [ ] Remove a specific tile instance → only that instance is removed, others remain
- [ ] Pin a tool without `inputSchema` properties → pins immediately without showing form (same as before)
- [ ] Legacy tiles (without `tileId`) continue to render correctly
- [ ] `bun run check`, `bun run lint`, `bun run fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable input props for home tiles so the same UI tool can be pinned multiple times with different values. Tiles have a stable `tileId`, inline prop editing, pass `toolInput` to `MCPAppRenderer`, remove only the targeted tile, and UI tiles now hide the header with a small “Open chat” on hover.

- **New Features**
  - Added `tileId`, `toolName`, `toolInput` to `VirtualMcpHomeTileSchema` (stored in existing JSONB).
  - New `ToolInputForm` renders from a tool’s `inputSchema`, coerces JSON/number fields, and saves per-tile values.
  - Add-tile drawer shows “Pinned tiles” and “Add tile” with per-tile edit/remove; home grid uses `tileId` for identity and passes `toolInput` to `MCPAppRenderer`.
  - UI: Removed agent header from UI tiles; a small “Open chat” button appears on hover.

- **Bug Fixes**
  - Resolve pinned tiles by `toolName` (not `resourceUri`); legacy tiles fall back to `resourceUri`.
  - Removing a tile via the grid now deletes only that tile; the agent is removed only if it was the last tile.

<sup>Written for commit 69a3a1d7ae7394909f5ed086389cb3411e6e6dfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

