### PR TITLE
fix(decopilot): namespace projected message ids by fence so 2nd-turn responses aren't dropped

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/consume-harness-stream.ts
+++ b/apps/mesh/src/api/routes/decopilot/consume-harness-stream.ts
@@ -67,21 +67,25 @@ export interface ConsumeHarnessStreamOptions {
   sanitizeErrorText?: (error: unknown) => string;
   /**
    * Message id for the error part the kernel synthesizes on a stream error.
-   * MUST be deterministic per run (`error-${runId}`) so the SAME error message
-   * dedupes across re-projection attempts, DBOS step retries, daemon
-   * full-prefix resends, and the live/projector double-write — the
-   * deterministic-id idempotency `projectRun` relies on. Defaults to a random
-   * UUID only for callers with no run identity (none persist on retry).
+   * MUST be deterministic per turn (`error-${runId}:${fenceToken}`, see
+   * message-ids.ts) so the SAME error message dedupes across re-projection
+   * attempts, DBOS step retries, daemon full-prefix resends, and the
+   * live/projector double-write — the deterministic-id idempotency `projectRun`
+   * relies on — while DISTINCT turns of the same thread never collide. Defaults
+   * to a random UUID only for callers with no run identity (none persist on
+   * retry).
    */
   errorMessageId?: string;
   /**
    * Id generator for the reassembled assistant message(s). The projector passes
-   * a DETERMINISTIC generator (`${runId}:msg:${n}`) so every re-fold of the same
-   * run — terminal projection, checkpoint passes, and reconnect-replay
-   * redelivery — reassembles the SAME message id and therefore the SAME part row
-   * ids (`${runId}:${messageId}:${seq}`), which `ON CONFLICT (id) DO NOTHING`
-   * dedupes. Omitted on the live path → the SDK's default random id (no
-   * persistence-idempotency requirement there).
+   * a DETERMINISTIC generator (`${runId}:${fenceToken}:msg:${n}`, see
+   * message-ids.ts) so every re-fold of the same turn — terminal projection,
+   * checkpoint passes, and reconnect-replay redelivery — reassembles the SAME
+   * message id and therefore the SAME part row ids
+   * (`${runId}:${messageId}:${seq}`), which `ON CONFLICT (id) DO NOTHING`
+   * dedupes. The fence token namespaces each turn so distinct turns of the same
+   * thread (runId == threadId is stable) never collide. Omitted on the live
+   * path → the SDK's default random id (no persistence-idempotency there).
    */
   generateMessageId?: () => string;
 }

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -76,6 +76,7 @@ import {
 import { isCliHarness } from "@decocms/harness/cli-harness";
 import { DEFAULT_WINDOW_SIZE, generateMessageId } from "./constants";
 import { mintRunFenceToken } from "./dispatch-fence";
+import { synthesizedErrorMessageId } from "./message-ids";
 import { loadAndMergeMessages } from "./conversation";
 import { PartEmitter } from "./part-emitter";
 import { ProgressBumpThrottle } from "./progress-bump";
@@ -1414,9 +1415,13 @@ async function prepareRun(
                 )
             : undefined,
           chunks: dispatchHarnessChunks(),
-          // Deterministic per run so a synthesized error message dedupes
-          // across projector retries.
-          errorMessageId: `error-${mem.thread.id}`,
+          // Deterministic per turn (runId + fence) so a synthesized error
+          // message dedupes across the live write + projector retries while
+          // distinct turns of the same thread never collide. See message-ids.ts.
+          errorMessageId: synthesizedErrorMessageId(
+            mem.thread.id,
+            runFenceToken,
+          ),
           title: {
             currentThreadTitle: mem.thread.title,
             threadId: mem.thread.id,

--- a/apps/mesh/src/api/routes/decopilot/ingest-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/ingest-run.ts
@@ -30,6 +30,7 @@ import {
   type HarnessStreamPersistence,
   type HarnessStreamTitleOptions,
 } from "./consume-harness-stream";
+import { assistantMessageIdGenerator } from "./message-ids";
 import { buildChunkMsgId } from "./projector-stream-messages";
 import { CHECKPOINT_DEBOUNCE_MS } from "./nats-stream-buffer";
 import type { StreamBuffer } from "./stream-buffer";
@@ -174,13 +175,12 @@ export async function ingestRun(
   }
 
   // Deterministic assistant-message ids, IDENTICAL to the durable projector's
-  // scheme (`${runId}:msg:${n}` in fold order — see project-run.ts). The live
-  // ingest persistence and the projector both fold the same chunk stream, so
-  // matching ids mean their part rows collide on `ON CONFLICT (id) DO NOTHING`
-  // instead of duplicating. Without this the live write used a random SDK id and
-  // the projector a deterministic one → the same run persisted twice.
-  let msgCounter = 0;
-  const generateMessageId = () => `${runId}:msg:${msgCounter++}`;
+  // scheme (`${runId}:${fenceToken}:msg:${n}` in fold order — see
+  // message-ids.ts). The live ingest persistence and the projector both fold the
+  // same chunk stream under the same fence, so matching ids mean their part rows
+  // collide on `ON CONFLICT (id) DO NOTHING` instead of duplicating. The fence
+  // also keeps DISTINCT turns of the same thread (runId == threadId) disjoint.
+  const generateMessageId = assistantMessageIdGenerator(runId, fenceToken);
 
   const { uiStream, whenComplete } = consumeHarnessStream({
     chunks: dedupedChunks(),

--- a/apps/mesh/src/api/routes/decopilot/message-ids.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/message-ids.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assistantMessageIdGenerator,
+  synthesizedErrorMessageId,
+} from "./message-ids";
+
+describe("projector/live message ids", () => {
+  test("distinct turns of one thread never collide", () => {
+    // runId == threadId is reused on EVERY turn; only the per-turn fence token
+    // differs. Under the old `${runId}:msg:${n}` scheme both turns produced
+    // "thread-1:msg:0", so turn 2's parts collided with turn 1's and were
+    // silently dropped by ON CONFLICT (id) DO NOTHING ("No response generated").
+    const turn1 = assistantMessageIdGenerator("thread-1", "fence-a");
+    const turn2 = assistantMessageIdGenerator("thread-1", "fence-b");
+    expect(turn1()).not.toBe(turn2());
+    expect(synthesizedErrorMessageId("thread-1", "fence-a")).not.toBe(
+      synthesizedErrorMessageId("thread-1", "fence-b"),
+    );
+  });
+
+  test("re-folding the SAME turn yields identical ids (idempotent dedupe preserved)", () => {
+    // Terminal projection, checkpoint passes, and the live+projector double
+    // write all re-fold the same (runId, fenceToken) → identical ids → the
+    // ON CONFLICT (id) DO NOTHING dedupe relied on by #4044 still holds.
+    const a = assistantMessageIdGenerator("thread-1", "fence-a");
+    const b = assistantMessageIdGenerator("thread-1", "fence-a");
+    expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+    expect(synthesizedErrorMessageId("t", "f")).toBe(
+      synthesizedErrorMessageId("t", "f"),
+    );
+  });
+
+  test("ids increment in fold order and carry the fence namespace", () => {
+    const gen = assistantMessageIdGenerator("t", "f");
+    expect([gen(), gen()]).toEqual(["t:f:msg:0", "t:f:msg:1"]);
+    expect(synthesizedErrorMessageId("t", "f")).toBe("error-t:f");
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/message-ids.ts
+++ b/apps/mesh/src/api/routes/decopilot/message-ids.ts
@@ -1,0 +1,50 @@
+/**
+ * Deterministic id scheme for projected assistant messages and synthesized
+ * error messages.
+ *
+ * Ids are namespaced by `(runId, fenceToken)`. The fence token is minted fresh
+ * per TURN (run attempt), while `runId === threadId` is STABLE across every
+ * turn of a thread. Including the fence makes each turn its own id namespace:
+ *
+ *   - The SAME turn re-folded — terminal projection, checkpoint passes, and the
+ *     live + projector double-write — reassembles IDENTICAL ids, so the part
+ *     row ids (`${runId}:${messageId}:${seq}`) collide on `ON CONFLICT (id) DO
+ *     NOTHING` and dedupe (the invariant introduced by #4044).
+ *
+ *   - DISTINCT turns of the same thread can NEVER collide. Before this, the id
+ *     was `${runId}:msg:${n}` with the counter reset to 0 each fold, so turn 2's
+ *     assistant message was `${runId}:msg:0` — byte-identical to turn 1's — and
+ *     its part rows were silently discarded by `ON CONFLICT DO NOTHING`. When
+ *     turn 2 folded to ≤ turn 1's part count it was erased entirely and the UI
+ *     rendered "No response was generated" even though the harness produced (and
+ *     relayed) a full response.
+ *
+ * Both the durable projector (`project-run.ts`) and the live ingest path
+ * (`ingest-run.ts`, `dispatch-run.ts`) MUST use these helpers so their ids match
+ * within a turn and differ across turns.
+ */
+
+/**
+ * Build a deterministic, fold-ordered assistant-message-id generator for one
+ * run attempt. Successive calls yield `${runId}:${fenceToken}:msg:0`,
+ * `:msg:1`, … in fold order.
+ */
+export function assistantMessageIdGenerator(
+  runId: string,
+  fenceToken: string,
+): () => string {
+  let index = 0;
+  return () => `${runId}:${fenceToken}:msg:${index++}`;
+}
+
+/**
+ * Deterministic id for the error part the kernel synthesizes when a run's chunk
+ * source throws. Namespaced per turn so the live and projector paths dedupe the
+ * SAME error within a turn while distinct turns never collide.
+ */
+export function synthesizedErrorMessageId(
+  runId: string,
+  fenceToken: string,
+): string {
+  return `error-${runId}:${fenceToken}`;
+}

--- a/apps/mesh/src/api/routes/decopilot/project-run.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/project-run.test.ts
@@ -39,6 +39,7 @@ describe("projectRun", () => {
     const dlq: Array<{ runId: string; error: unknown }> = [];
     const result = await projectRun({
       runId: "run_1",
+      fenceToken: "fence_1",
       chunks: helloChunks(),
       persistence: okPersistence(),
       onDlq: async (runId, error) => {
@@ -63,6 +64,7 @@ describe("projectRun", () => {
     };
     const result = await projectRun({
       runId: "run_1",
+      fenceToken: "fence_1",
       chunks: helloChunks(),
       persistence: poison,
       onDlq: async (runId, error) => {
@@ -94,6 +96,7 @@ describe("projectRun", () => {
     const dlq: Array<{ runId: string; error: unknown }> = [];
     const result = await projectRun({
       runId: "run_1",
+      fenceToken: "fence_1",
       chunks: errorChunks(),
       persistence,
       onDlq: async (runId, error) => {
@@ -114,6 +117,7 @@ describe("projectRun", () => {
     // A healthy run: outcome.failed=false.
     const result = await projectRun({
       runId: "r1",
+      fenceToken: "fence_1",
       chunks: helloChunks(),
       persistence: okPersistence(),
       onDlq: async () => {},
@@ -121,6 +125,60 @@ describe("projectRun", () => {
     });
     expect(result.ok).toBe(true);
     expect(result.outcome?.failed).toBe(false);
+  });
+
+  test("two turns of one thread (same runId, different fence) persist DISJOINT message ids", async () => {
+    // Regression for the cross-turn collision that dropped a fully-generated
+    // 2nd-turn response ("No response was generated"). runId == threadId is
+    // STABLE across turns; only the per-turn fence differs. Under the old
+    // `${runId}:msg:${n}` scheme both turns emitted "thread_1:msg:0", so turn
+    // 2's part rows collided with turn 1's and ON CONFLICT DO NOTHING dropped
+    // them. The fence namespace makes the two turns disjoint.
+    const capture = () => {
+      const ids: string[] = [];
+      const persistence: HarnessStreamPersistence = {
+        emitStepParts: async (m) => {
+          ids.push(m.id);
+        },
+        emitFinal: async (m) => {
+          ids.push(m.id);
+        },
+        emitError: async () => {},
+      };
+      return { ids, persistence };
+    };
+
+    const turn1 = capture();
+    await projectRun({
+      runId: "thread_1",
+      fenceToken: "fence_a",
+      chunks: helloChunks(),
+      persistence: turn1.persistence,
+      onDlq: async () => {},
+      backoffMs: () => 0,
+    });
+
+    const turn2 = capture();
+    await projectRun({
+      runId: "thread_1",
+      fenceToken: "fence_b",
+      chunks: helloChunks(),
+      persistence: turn2.persistence,
+      onDlq: async () => {},
+      backoffMs: () => 0,
+    });
+
+    expect(turn1.ids.length).toBeGreaterThan(0);
+    expect(turn2.ids.length).toBeGreaterThan(0);
+    expect(turn1.ids.every((id) => id.startsWith("thread_1:fence_a:"))).toBe(
+      true,
+    );
+    expect(turn2.ids.every((id) => id.startsWith("thread_1:fence_b:"))).toBe(
+      true,
+    );
+    // No message id appears in BOTH turns → ON CONFLICT DO NOTHING can never
+    // drop turn 2's rows against turn 1's.
+    expect(turn1.ids.some((id) => turn2.ids.includes(id))).toBe(false);
   });
 
   test("a transient failure that recovers before exhaustion succeeds without DLQ", async () => {
@@ -136,6 +194,7 @@ describe("projectRun", () => {
     };
     const result = await projectRun({
       runId: "run_1",
+      fenceToken: "fence_1",
       chunks: helloChunks(),
       persistence: flaky,
       onDlq: async () => {

--- a/apps/mesh/src/api/routes/decopilot/project-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/project-run.ts
@@ -2,6 +2,10 @@ import type { UIMessage, UIMessageChunk } from "ai";
 import { exponentialBackoffWithJitter, sleep } from "@decocms/std";
 import type { HarnessStreamPersistence } from "./consume-harness-stream";
 import {
+  assistantMessageIdGenerator,
+  synthesizedErrorMessageId,
+} from "./message-ids";
+import {
   projectChunks,
   type ProjectChunksResult,
   type ProjectTitleOptions,
@@ -15,6 +19,10 @@ const BACKOFF_CAP_MS = 5000;
 
 export interface ProjectRunOptions {
   runId: string;
+  /** Per-turn run fence token. Namespaces the assistant/error message ids so
+   *  distinct turns of the same thread (runId == threadId is stable) never
+   *  collide while the same turn's re-folds stay idempotent. See message-ids.ts. */
+  fenceToken: string;
   /** Materialized chunks for this run (replayed identically on each attempt;
    *  PartEmitter deterministic ids make re-projection idempotent). */
   chunks: UIMessageChunk[];
@@ -68,23 +76,30 @@ export async function projectRun(
   let lastError: unknown = null;
   for (let attempt = 0; attempt < PROJECT_RUN_MAX_ATTEMPTS; attempt++) {
     try {
-      // Deterministic assistant-message ids, reset per fold. Every projection of
-      // this run (terminal, checkpoint, and reconnect-replay redelivery) folds
-      // the same chunks in the same order, so the Nth message gets the SAME id
-      // each time → identical part row ids (`${runId}:${messageId}:${seq}`) →
-      // ON CONFLICT DO NOTHING dedupes instead of duplicating parts. The SDK's
-      // default random id would differ per fold and double the rows on replay.
-      let msgCounter = 0;
-      const generateMessageId = () => `${options.runId}:msg:${msgCounter++}`;
+      // Deterministic assistant-message ids in fold order, namespaced per turn
+      // by (runId, fenceToken). Every projection of this turn (terminal,
+      // checkpoint, and reconnect-replay redelivery) folds the same chunks in
+      // the same order, so the Nth message gets the SAME id each time →
+      // identical part row ids (`${runId}:${messageId}:${seq}`) → ON CONFLICT DO
+      // NOTHING dedupes instead of duplicating parts. The fence keeps DISTINCT
+      // turns of the same thread disjoint (see message-ids.ts).
+      const generateMessageId = assistantMessageIdGenerator(
+        options.runId,
+        options.fenceToken,
+      );
       const outcome = await projectChunks({
         chunks: (async function* () {
           yield* options.chunks;
         })(),
         persistence: options.persistence,
         sanitizeErrorText: options.sanitizeErrorText,
-        // Deterministic per run so an error message dedupes across this loop's
-        // attempts, DBOS step retries, and the live-path write (same id).
-        errorMessageId: `error-${options.runId}`,
+        // Deterministic per turn so an error message dedupes across this loop's
+        // attempts, DBOS step retries, and the live-path write (same id) while
+        // distinct turns never collide.
+        errorMessageId: synthesizedErrorMessageId(
+          options.runId,
+          options.fenceToken,
+        ),
         generateMessageId,
         title: options.title,
         originalMessages: options.originalMessages,

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
@@ -195,6 +195,7 @@ async function projectFromJetStreamStep(
   }
   const result = await projectRun({
     runId: input.runId,
+    fenceToken: input.fenceToken,
     chunks: reconstructed.chunks,
     persistence: await persistenceFor(input.runId, orgId, rt.messageParts),
     onDlq: async (_runId, error) => {
@@ -459,6 +460,7 @@ async function projectCheckpointFromJetStreamStep(
   if (!range.ok || range.chunks.length === 0) return { projected: false };
   const result = await projectRun({
     runId: input.runId,
+    fenceToken: input.fenceToken,
     chunks: range.chunks,
     // Non-terminal persistence: writes step parts but skips the finish anchor.
     persistence: await checkpointPersistenceFor(


### PR DESCRIPTION
## The bug

On a multi-turn thread, the **2nd (and later) turn renders "No response was generated"** even though the harness produced a full response. Confirmed end-to-end against a real staging thread (`24b9cd84…`, codex / user-desktop):

- Desktop daemon relayed the turn in full — `[dispatch] done harness=codex chunks=1059 aborted=false` (no reconnect, no error).
- The codex session rollout shows a complete answer ending in `task_complete`.
- The cluster **consumed** the chunks (`projected_seq` advanced) but persisted **zero** `thread_message_parts` for the turn.

So the messages were generated and uploaded fine; they were dropped **on the cluster during folding**.

## Root cause

The durable projector (`project-run.ts`) and the live ingest path (`ingest-run.ts` / `dispatch-run.ts`) assign deterministic assistant/error message ids `${runId}:msg:${n}` with the counter **reset to 0 on every fold**. Part row ids are `${runId}:${messageId}:${seq}`, persisted with `ON CONFLICT (id) DO NOTHING` (`thread-message-parts.ts:53`).

But **`runId === threadId` is stable across every turn** (the per-turn *fence token* scopes the chunk msgIds and `projected_seq`, not the message/part ids — `dispatch-run.ts` `runId: mem.thread.id`). So:

- Turn 1's assistant message → `…:msg:0`, parts seq `0…22`.
- Turn 2's assistant message → **also `…:msg:0`**, parts seq `0…k`.

Turn 2's part ids collide id-for-id with turn 1's already-persisted rows → `ON CONFLICT DO NOTHING` discards them. When turn 2 folds to ≤ turn 1's part count it's erased entirely → "No response was generated".

The intended idempotency (dedupe re-folds of the *same* run across DBOS retries / checkpoints / the live+projector double-write) accidentally dedupes *different turns* of the same thread.

**Empirical fingerprint** (staging): threads on this id scheme keep only `msg:0` regardless of user-turn count (observed `userTurns=5 → assistantMsgs=1`). `user-desktop` is the most exposed because the projector is the sole part writer there (the cluster never consumes the live UI stream).

## The fix

Namespace the deterministic assistant + synthesized-error ids by the **per-turn fence token**, matching the existing fence-scoped chunk msgId scheme:

- `${runId}:${fenceToken}:msg:${n}`
- `error-${runId}:${fenceToken}`

Applied on **both** sides so they still match within a turn (preserving #4044's live+projector dedupe invariant: same fence → same ids) while distinct turns become disjoint:

- Projector: `project-run.ts` (+ `fenceToken` threaded from `projector-workflow.ts` to both the terminal and checkpoint `projectRun` calls).
- Live ingest: `ingest-run.ts`, `dispatch-run.ts`.
- Shared helpers extracted to `message-ids.ts`.

No backwards-compat shim — existing rows keep their old ids; the read path folds by `message_id` and doesn't care about the format.

## Relationship to #4042 / #4044

This is the cross-turn re-emission case **#4044 explicitly flagged as follow-up** ("a resume turn can still re-emit the assistant's cumulative parts… tracking separately"). #4042 added inline live persistence + the empty-message guard (which is why a collided turn shows a blank "No response generated" rather than a stray bubble); #4044 fixed the *within-turn* hosted duplicate and notes the relay/desktop path "was never affected" by *that* divergence. Neither addressed the cross-turn id collision — this does.

## Testing

- New unit `message-ids.test.ts`: cross-turn ids differ; same-turn re-folds are identical (idempotent dedupe preserved).
- New regression in `project-run.test.ts`: two `projectRun` turns (same `runId`, different fence) persist **disjoint** message ids. Verified RED against the old scheme (ids collided) → GREEN with the fix.
- `bun run fmt`, `bun run lint` (0 errors), and `apps/mesh` typecheck clean for changed files. Existing decopilot unit tests pass; the only local failures are DB-integration tests (need Postgres) and a pre-existing ajv version skew.

Follow-up worth adding: a two-turn relay e2e (in the spirit of #4042's `harness-conformance` case) asserting both turns persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped 2nd-turn (and later) responses by namespacing projected assistant and synthesized-error message IDs with the per-turn fence token. This prevents cross-turn ID collisions while keeping within-turn dedupe/idempotency intact.

- **Bug Fixes**
  - Assistant IDs now use `${runId}:${fenceToken}:msg:${n}` and error IDs use `error-${runId}:${fenceToken}` via new helpers in `message-ids.ts`.
  - Applied to both paths: projector (`project-run.ts`, `projector-workflow.ts`) and live ingest (`ingest-run.ts`, `dispatch-run.ts`); updated comments in `consume-harness-stream.ts`.
  - Added tests (`message-ids.test.ts`, `project-run.test.ts`) to verify cross-turn disjointness and same-turn idempotency.
  - No migration needed; existing data remains valid since reads fold by `message_id`.

<sup>Written for commit 0c8c9ace4fe3390d00483b634bab6db634b03af9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

