### PR TITLE
fix(codex): run harness with full sandbox access

### DIFF
--- a/packages/harness/src/codex/model/index.test.ts
+++ b/packages/harness/src/codex/model/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { resolveCodexModelId } from "./index";
+import { buildCodexDefaultSettings, resolveCodexModelId } from "./index";
 
 describe("resolveCodexModelId", () => {
   it("resolves current Codex CLI model IDs", () => {
@@ -17,6 +17,14 @@ describe("resolveCodexModelId", () => {
     );
     expect(() => resolveCodexModelId("codex:gpt-5.2")).toThrow(
       "Unknown Codex model ID",
+    );
+  });
+});
+
+describe("buildCodexDefaultSettings", () => {
+  it("runs Codex without sandbox restrictions", () => {
+    expect(buildCodexDefaultSettings({}).sandboxPolicy).toBe(
+      "danger-full-access",
     );
   });
 });

--- a/packages/harness/src/codex/model/index.ts
+++ b/packages/harness/src/codex/model/index.ts
@@ -37,6 +37,18 @@ export function createCodexModel(
     resume?: string;
   },
 ): { model: LanguageModelV3; provider: CodexAppServerProvider } {
+  const defaultSettings = buildCodexDefaultSettings(options);
+
+  const provider = createCodexAppServer({
+    defaultSettings,
+  });
+
+  return { model: provider(modelId), provider };
+}
+
+type CodexModelOptions = NonNullable<Parameters<typeof createCodexModel>[1]>;
+
+export function buildCodexDefaultSettings(options?: CodexModelOptions) {
   const mcpServers = options?.mcpServers
     ? Object.fromEntries(
         Object.entries(options.mcpServers).map(([name, config]) => [
@@ -57,27 +69,25 @@ export function createCodexModel(
     approvalPolicy = "never";
   }
 
-  const provider = createCodexAppServer({
-    defaultSettings: {
-      mcpServers,
-      approvalPolicy,
-      cwd: options?.cwd ?? process.cwd(),
-      rmcpClient: true,
-      sandboxPolicy: "workspace-write",
-      // Persistent so the FIRST turn creates a non-ephemeral, resumable
-      // on-disk thread (stateless mode would create an ephemeral one).
-      threadMode: "persistent",
-      ...(options?.resume ? { resume: options.resume } : {}),
-      connectionTimeoutMs: 30_000,
-      requestTimeoutMs: 300_000,
-      idleTimeoutMs: 60_000,
-      ...(options?.developerInstructions
-        ? { developerInstructions: options.developerInstructions }
-        : {}),
-    },
-  });
-
-  return { model: provider(modelId), provider };
+  return {
+    mcpServers,
+    approvalPolicy,
+    cwd: options?.cwd ?? process.cwd(),
+    rmcpClient: true,
+    sandboxPolicy: "danger-full-access",
+    // Persistent so the FIRST turn creates a non-ephemeral, resumable
+    // on-disk thread (stateless mode would create an ephemeral one).
+    threadMode: "persistent",
+    ...(options?.resume ? { resume: options.resume } : {}),
+    connectionTimeoutMs: 30_000,
+    requestTimeoutMs: 300_000,
+    idleTimeoutMs: 60_000,
+    ...(options?.developerInstructions
+      ? { developerInstructions: options.developerInstructions }
+      : {}),
+  } satisfies NonNullable<
+    Parameters<typeof createCodexAppServer>[0]
+  >["defaultSettings"];
 }
 
 /** Map composite model IDs to SDK model names. */


### PR DESCRIPTION
## Summary
- Run the Codex harness with danger-full-access sandbox policy.
- Extract Codex default settings into a testable helper.
- Add coverage that locks Codex to full sandbox access.

## Test Plan
- bunx biome format --write packages/harness/src/codex/model/index.ts packages/harness/src/codex/model/index.test.ts
- bun test packages/harness/src/codex/model/index.test.ts

Note: full bun test was attempted but blocked waiting for the resilience Studio health environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Codex harness to run with full sandbox access by default (`sandboxPolicy: "danger-full-access"`). Also extracts default settings into a helper and adds tests to lock this behavior.

- **Refactors**
  - Moved default settings into `buildCodexDefaultSettings` for reuse and testability.
  - Added a unit test to ensure the harness uses full sandbox access by default.

<sup>Written for commit ee4ec25b53cb33b71e1e4ae490256b36ee0de279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

