### PR TITLE
fix(decopilot): emit thread-status SSE on projector run finalize so the sidebar chip updates live

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -145,6 +145,7 @@ import {
 import type { DispatchFn } from "../links/link-dispatch-types";
 import { RunRegistry } from "./routes/decopilot/run-registry";
 import type { RunReactorDeps } from "./routes/decopilot/run-reactor";
+import { emitTerminalThreadStatus } from "./routes/decopilot/thread-status-events";
 import { SqlThreadStorage } from "../storage/threads";
 import { SqlAsyncResearchJobStorage } from "../storage/async-research-jobs";
 import { AsyncResearchJobSweeper } from "../storage/async-research-jobs-sweeper";
@@ -1524,10 +1525,28 @@ export async function createApp(options: CreateAppOptions = {}) {
           }
         : null;
     },
-    completeRunIfNotCompleted: (runId, orgId) =>
-      projectorThreadStorage.completeRunIfNotCompleted(runId, orgId),
-    markRunFailed: (runId, orgId, reason, kind) =>
-      projectorThreadStorage.markRunFailed(runId, orgId, reason, kind),
+    completeRunIfNotCompleted: async (runId, orgId) => {
+      const flipped = await projectorThreadStorage.completeRunIfNotCompleted(
+        runId,
+        orgId,
+      );
+      // Push the terminal status to the org SSE so the sidebar chip updates
+      // live. user-desktop runs finalize here (not via the run-reactor), so
+      // without this the chip stays "running" until a refetch. `flipped` is
+      // null on a no-op (already terminal) → no double-publish.
+      emitTerminalThreadStatus(sseHub, orgId, runId, flipped);
+      return flipped;
+    },
+    markRunFailed: async (runId, orgId, reason, kind) => {
+      const flipped = await projectorThreadStorage.markRunFailed(
+        runId,
+        orgId,
+        reason,
+        kind,
+      );
+      emitTerminalThreadStatus(sseHub, orgId, runId, flipped);
+      return flipped;
+    },
     persistTitle: (runId, orgId, title) =>
       projectorThreadStorage.update(runId, orgId, { title }),
     onTitleUpdated: async ({ runId, orgId, title }) => {

--- a/apps/mesh/src/api/routes/decopilot/thread-status-events.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/thread-status-events.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { SSEEvent } from "@/event-bus";
+import { emitTerminalThreadStatus } from "./thread-status-events";
+
+function fakeHub() {
+  const events: Array<{ orgId: string; event: SSEEvent }> = [];
+  return {
+    events,
+    emit: (orgId: string, event: SSEEvent) => {
+      events.push({ orgId, event });
+    },
+  };
+}
+
+describe("emitTerminalThreadStatus", () => {
+  test("emits a decopilot.thread.status event for a completed flip", () => {
+    const hub = fakeHub();
+    const emitted = emitTerminalThreadStatus(hub, "org-1", "thread-1", {
+      status: "completed",
+      title: "My thread",
+      virtual_mcp_id: "vir_x",
+      created_by: "user-1",
+      trigger_id: null,
+      branch: "main",
+      created_at: "2026-06-23T00:00:00.000Z",
+      updated_at: "2026-06-23T00:01:00.000Z",
+    });
+    expect(emitted).toBe(true);
+    expect(hub.events).toHaveLength(1);
+    expect(hub.events[0]!.orgId).toBe("org-1");
+    const ev = hub.events[0]!.event as {
+      subject: string;
+      data: { status: string };
+    };
+    expect(ev.subject).toBe("thread-1");
+    expect(ev.data.status).toBe("completed");
+  });
+
+  test("carries the failed status through", () => {
+    const hub = fakeHub();
+    emitTerminalThreadStatus(hub, "org-1", "thread-1", { status: "failed" });
+    const ev = hub.events[0]!.event as { data: { status: string } };
+    expect(ev.data.status).toBe("failed");
+  });
+
+  test("no-op (emits nothing) when the flip was a no-op (null row)", () => {
+    // A null row means the run was already terminal (e.g. a hosted run that the
+    // live path already finalized). Emitting would double-publish the status.
+    const hub = fakeHub();
+    const emitted = emitTerminalThreadStatus(hub, "org-1", "thread-1", null);
+    expect(emitted).toBe(false);
+    expect(hub.events).toHaveLength(0);
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/thread-status-events.ts
+++ b/apps/mesh/src/api/routes/decopilot/thread-status-events.ts
@@ -1,0 +1,56 @@
+import {
+  createDecopilotThreadStatusEvent,
+  type ThreadStatus,
+} from "@decocms/mesh-sdk";
+import type { SSEEvent } from "@/event-bus";
+
+/** Minimal thread-row shape needed to build a `decopilot.thread.status` event. */
+export interface TerminalThreadStatusRow {
+  status: ThreadStatus;
+  title?: string | null;
+  virtual_mcp_id?: string | null;
+  created_by?: string | null;
+  trigger_id?: string | null;
+  branch?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/**
+ * Emit the org-wide `decopilot.thread.status` SSE event for a terminal run
+ * transition performed by the durable projector.
+ *
+ * user-desktop runs finalize via the projector (`completeRunIfNotCompleted` /
+ * `markRunFailed`), NOT via the in-memory run-reactor that hosted runs use — so
+ * without this emit the sidebar status chip never receives a real-time
+ * completed/failed push and stays "running" until the next refetch (a manual
+ * refresh or the SSE reconnect recovery). This mirrors the emit the run-reactor
+ * already does for hosted runs (`run-reactor.handleTerminalStatus`).
+ *
+ * `row` is the row returned by the conditional flip (`WHERE status =
+ * 'in_progress'`): non-null only when THIS call actually transitioned the run.
+ * A null row emits nothing, so a no-op flip — e.g. a hosted run already
+ * finalized by the live path before the projector backstop ran — never
+ * double-publishes. Returns whether an event was emitted.
+ */
+export function emitTerminalThreadStatus(
+  sseHub: { emit(orgId: string, event: SSEEvent): void },
+  orgId: string,
+  runId: string,
+  row: TerminalThreadStatusRow | null,
+): boolean {
+  if (!row) return false;
+  sseHub.emit(
+    orgId,
+    createDecopilotThreadStatusEvent(runId, row.status, {
+      title: row.title ?? undefined,
+      virtualMcpId: row.virtual_mcp_id ?? undefined,
+      createdBy: row.created_by ?? undefined,
+      triggerId: row.trigger_id ?? null,
+      branch: row.branch ?? null,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }),
+  );
+  return true;
+}

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -87,7 +87,11 @@ export class OrgScopedThreadStorage {
     return this.inner.completeRunIfNotCompleted(id, this.requireOrg());
   }
 
-  markRunFailed(id: string, reason: string, kind: string): Promise<void> {
+  markRunFailed(
+    id: string,
+    reason: string,
+    kind: string,
+  ): Promise<Thread | null> {
     return this.inner.markRunFailed(id, this.requireOrg(), reason, kind);
   }
 
@@ -447,8 +451,8 @@ export class SqlThreadStorage implements ThreadStoragePort {
     organizationId: string,
     reason: string,
     kind: string,
-  ): Promise<void> {
-    await this.db
+  ): Promise<Thread | null> {
+    const rows = await this.db
       .updateTable("threads")
       .set({
         status: "failed",
@@ -462,7 +466,11 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
       .where("status", "=", "in_progress")
+      .returningAll()
       .execute();
+
+    const row = rows[0];
+    return row ? this.threadFromDbRow(row) : null;
   }
 
   async forceFailIfInProgress(


### PR DESCRIPTION
## The bug

A user-desktop chat finishes streaming in the chat pane, but the **sidebar status chip stays "running"** until you refresh the page (a refetch then shows the correct terminal status). The DB and projector finished correctly — it's purely that the real-time status push never reaches the sidebar.

## Root cause

The sidebar chip and the chat pane are fed by different channels. The chip is updated by the org-wide `decopilot.thread.status` SSE event (consumed in `thread-manager-store.ts`, which applies `parsed.data.status` to the thread). That event is emitted on terminal run transitions by `run-reactor.handleTerminalStatus` — but **only hosted runs go through the run-reactor**.

**user-desktop runs finalize via the durable projector** (`completeRunIfNotCompleted` / `markRunFailed`), out of band. In the projector runtime wiring (`app.ts`), those hooks just delegated to storage and emitted **nothing**; the only `createDecopilotThreadStatusEvent` emit on that path was in `onTitleUpdated` — which fires mid-run with an `in_progress` status. So a completed/failed user-desktop run never pushed a terminal status to the org SSE, and the chip stayed stale until the next refetch.

## The fix

Emit the `decopilot.thread.status` event from the projector's `completeRunIfNotCompleted` / `markRunFailed` runtime hooks, mirroring what the run-reactor already does for hosted runs.

- Guarded on the **conditional flip's returned row** (`WHERE status = 'in_progress'` → non-null only when *this* call actually transitioned the run), so a no-op flip — e.g. a hosted run already finalized by the live path before the projector backstop runs — never double-publishes.
- `markRunFailed` now returns the flipped `Thread` row (was `void`), symmetric with `completeRunIfNotCompleted`. It's not part of `ThreadStoragePort` and existing callers ignore the return, so this is non-breaking.
- Extracted `emitTerminalThreadStatus` (new `thread-status-events.ts`) — pure, unit-tested.

## Testing

- New `thread-status-events.test.ts`: emits a `completed`/`failed` event for a real flip; **no-op (emits nothing) when the row is null** (the no-double-publish guard). Verified RED (module missing) → GREEN.
- `apps/mesh` typecheck clean for changed files (the lone remaining error is a pre-existing ajv version skew); `bun run fmt`/`lint` clean (0 errors). Decopilot unit suite: 418 pass; the 15 failures are the pre-existing DB-integration tests (`ECONNREFUSED :5432`, no local Postgres).

Follow-up worth adding: an integration assertion that the projector path emits the terminal event (parallel to the existing `reactAll (real Postgres)` reactor tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stale sidebar status chip by emitting `decopilot.thread.status` SSE when the projector finalizes user-desktop runs, so it updates live without a refresh.

- **Bug Fixes**
  - Emit org-wide `decopilot.thread.status` from projector `completeRunIfNotCompleted` and `markRunFailed`, mirroring the run-reactor.
  - Guard on the conditional flip’s returned row to avoid double-publishing on no-op finalizations.
  - `markRunFailed` now returns the flipped `Thread` (callers unchanged); extracted `emitTerminalThreadStatus` helper with unit tests.

<sup>Written for commit a68d9988cf48de040e9e062fa51a0fba8e628a6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

