### PR TITLE
fix(helm): render startupProbe (dead config) — boot-storm protection for studio pods

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.10.13
+version: 0.10.14
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -135,6 +135,10 @@ spec:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/studio/templates/worker-deployment.yaml
+++ b/deploy/helm/studio/templates/worker-deployment.yaml
@@ -138,6 +138,10 @@ spec:
             {{- with .Values.worker.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## The bug

`deco-apps-cd` values define a `studio.startupProbe` (path `/health`, `failureThreshold: 24` → ~120s boot tolerance), but **the chart never renders it** — `deployment.yaml`/`worker-deployment.yaml` only template `livenessProbe` + `readinessProbe`. So in prod the pods have **no startupProbe** (confirmed via `kubectl get deploy`), and rely on `livenessProbe` (`initialDelaySeconds: 30`, `failureThreshold: 3`, `periodSeconds: 10` → ~30s tolerance) during boot.

## Why it matters

Profiler #4089 captured the real blocks: a **startup storm of synchronous crypto/auth/parse** — Better Auth `setCookieCache` (13s), `jose` JWT sign (6s), `pg` SCRAM HMAC, large `JSON.parse` (8.4s, worker), recursive resolve (11.8s) — in the first ~90s of a pod's life. With no startupProbe, that storm races `livenessProbe` and can trip 3 consecutive failures → SIGKILL → restart → re-storm. Wiring the existing (intended) startupProbe gives the 120s boot grace it's supposed to have.

## Change

`{{- with .Values.startupProbe }}` block added to both deployment templates (gated, no-op if unset); chart `0.10.13 → 0.10.14`. Verified with `helm template` — renders on api + worker.

## Follow-up (companion deco-apps-cd PR)
Dep bump `0.10.13 → 0.10.14` + worker memory `700Mi → 1.5Gi` (stops the OOMKills — transient `JSON.parse` allocations spike past 700Mi between scrapes). The deeper Class-2 fix (node CPU starvation from prod+stg co-location on ~2-core nodes — the 20–122s freezes) needs CPU-request/anti-affinity scheduling changes, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEJ58ibWZUcYheMaTyC8UQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render `startupProbe` from values into the studio app and worker deployments to give pods proper startup grace and avoid liveness-probe restarts during boot storms. Bumps chart to `0.10.14`.

- **Bug Fixes**
  - Template `startupProbe` via `{{- with .Values.startupProbe }}` in `deployment.yaml` and `worker-deployment.yaml` (no-op if unset).
  - Keeps existing `livenessProbe`/`readinessProbe`; verified with `helm template` for both deployments.

<sup>Written for commit ebff98e696a6d72c4db93d91ce4f417dc95a0c62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

