### PR TITLE
fix(decopilot): fold projector run log once at `done`, not per-message (O(N²)→O(N))

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/projector-run-log.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-run-log.ts
@@ -231,12 +231,21 @@ export async function readProjectorRunLog(input: {
     resetIdle();
     for await (const m of sub) {
       resetIdle();
+      const msgId = m.headers?.get("Nats-Msg-Id") || undefined;
       messages.push({
         subject: m.subject,
         data: m.data,
-        msgId: m.headers?.get("Nats-Msg-Id") || undefined,
+        msgId,
         headers: m.headers,
       });
+      // reconstructProjectorRun re-parses the WHOLE accumulated log; it can only
+      // succeed once the `done` envelope (final message) has arrived — every
+      // earlier call returns "missing done". Folding on every message is O(N²)
+      // JSON.parse on the event loop and stalls it for tens of seconds on long
+      // runs. Gate the fold on the cheap msgId parse → fold once, O(N).
+      const parsed = parseRunStreamMsgId(msgId);
+      if (parsed?.kind !== "done" || parsed.finalSeq !== input.finalSeq)
+        continue;
       const current = reconstructProjectorRun({
         runId: input.runId,
         fenceToken: input.fenceToken,


### PR DESCRIPTION
## Summary
`readProjectorRunLog` re-parsed the **entire** accumulated NATS message log from scratch on **every** received message: inside `for await (const m of sub)` it called `reconstructProjectorRun(messages)` → `collectChunks` → `JSON.parse(TextDecoder().decode(...))` per message. For an N-chunk run that's `1+2+…+N = N²/2` synchronous `JSON.parse` calls on the event loop, with no yielding.

`reconstructProjectorRun` can only succeed once the `done` envelope (final message) has arrived — every earlier call returns `"missing done"`. So every pre-`done` fold was guaranteed-false wasted work.

**Fix:** gate the expensive fold on the cheap `parseRunStreamMsgId` msgId check (a string split, no `JSON.parse`). The O(N) fold now runs **once**, at `done`, instead of once per message. Behavior-preserving — the success path was already impossible before `done`.

## Evidence
From the `EVENT_LOOP_PROFILE=1` stall profiler (#4089) in prod, 6h window:
- **87 of 128** event-loop stalls were this exact parse path.
- p50 3.2s, **p99 96s, worst 122s** — long enough to trip the `/health/live` liveness probe → SIGKILL (137) → pod restarts.

## Testing
- `bun test apps/mesh/src/api/routes/decopilot/projector-run-log.test.ts` → 8/8 pass.
- `bun run check` clean, `bun run fmt` applied.

## Follow-ups (not in this PR)
- The single fold at `done` is still O(N) sync; if a single huge run still stalls, fold incrementally / yield. (YAGNI until measured.)
- Other distinct frames remain in the profile (recursive resolve `cli.js:109736`, OTel proto `encode`, jose/pg-TLS at boot) and the Class-2 node-CPU-starvation freezes — separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEJ58ibWZUcYheMaTyC8UQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fold projector run log only once when the final `done` message arrives, instead of on every NATS message. This reduces parsing from O(N²) to O(N) and removes event-loop stalls that caused restarts.

- **Bug Fixes**
  - Gate the fold on `parseRunStreamMsgId`; run `reconstructProjectorRun` only at `done` with matching `finalSeq`.
  - Removes repeated full-log `JSON.parse` per message; behavior unchanged before `done`.

<sup>Written for commit 9c09a06f705b76d8d7a7a595d4ebf4706680c468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

