### PR TITLE
fix(connection-detail): guard chartData access with optional chaining

### DIFF
--- a/apps/mesh/src/web/components/details/connection/connection-activity.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-activity.tsx
@@ -142,10 +142,10 @@ function ActivityChart({ connectionId, orgId, timeframe }: ActivityChartProps) {
           </ChartContainer>
           <div className="flex justify-between px-3 mt-1 pb-3">
             <span className="text-[10px] text-muted-foreground">
-              {chartData[0]?.label}
+              {chartData?.[0]?.label}
             </span>
             <span className="text-[10px] text-muted-foreground">
-              {chartData[chartData.length - 1]?.label}
+              {chartData?.[chartData.length - 1]?.label}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot read properties of undefined (reading '0')` crash on the connection detail page
- Add optional chaining (`?.`) before array index access on `chartData` for the chart axis labels

## Test plan
- [ ] Open a connection detail page with no monitoring data and verify no crash
- [ ] Open a connection detail page with monitoring data and verify axis labels render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash on the connection detail page when `chartData` is undefined by guarding index access with optional chaining for the axis labels. This avoids the runtime TypeError and keeps the page rendering even without monitoring data.

<sup>Written for commit 22c23136ec05b83602fb8d5e11b9c78dd4768e15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

