### PR TITLE
fix(harness): increase fallback title limit

### DIFF
--- a/packages/harness/src/decopilot/title-generator.test.ts
+++ b/packages/harness/src/decopilot/title-generator.test.ts
@@ -64,11 +64,11 @@ describe("genTitle fallback", () => {
       timeoutMs: 10, // tiny self-timeout; no parent abort, no finish()
     });
     const result = await handle.promise;
-    // First 10 chars of "Build a complex dashboard app" → "Build a co".
-    expect(result).toBe("Build a co");
+    // First 32 chars of "Build a complex dashboard app".
+    expect(result).toBe("Build a complex dashboard app");
   });
 
-  test("when the LLM throws, falls back to userMessage.slice(0, 10).trim()", async () => {
+  test("when the LLM throws, falls back to userMessage.slice(0, 32).trim()", async () => {
     const abortController = new AbortController();
     const handle = genTitle({
       abortSignal: abortController.signal,
@@ -77,12 +77,11 @@ describe("genTitle fallback", () => {
     });
     handle.finish();
     const result = await handle.promise;
-    // First 10 chars of "Fix the login button on mobile devices please"
-    // are "Fix the lo"; trimmed.
-    expect(result).toBe("Fix the lo");
+    // First 32 chars of "Fix the login button on mobile devices please".
+    expect(result).toBe("Fix the login button on mobile d");
   });
 
-  test("user message under 10 chars is returned verbatim (trimmed)", async () => {
+  test("user message under 32 chars is returned verbatim (trimmed)", async () => {
     const abortController = new AbortController();
     const handle = genTitle({
       abortSignal: abortController.signal,
@@ -94,16 +93,16 @@ describe("genTitle fallback", () => {
     expect(result).toBe("hi");
   });
 
-  test("user message exactly 10 chars is returned verbatim", async () => {
+  test("user message exactly 32 chars is returned verbatim", async () => {
     const abortController = new AbortController();
     const handle = genTitle({
       abortSignal: abortController.signal,
       model: makeFailingModel(new Error("boom")),
-      userMessage: "0123456789",
+      userMessage: "01234567890123456789012345678901",
     });
     handle.finish();
     const result = await handle.promise;
-    expect(result).toBe("0123456789");
+    expect(result).toBe("01234567890123456789012345678901");
   });
 
   test("empty user message falls back to 'New chat'", async () => {
@@ -142,7 +141,7 @@ describe("genTitle fallback", () => {
     });
     handle.finish();
     const result = await handle.promise;
-    expect(result).toBe("Fix the lo");
+    expect(result).toBe("Fix the login button on mobile d");
   });
 
   test("parent abort resolves to null (no fallback emitted)", async () => {

--- a/packages/harness/src/decopilot/title-generator.ts
+++ b/packages/harness/src/decopilot/title-generator.ts
@@ -47,6 +47,7 @@ const POST_STREAM_GRACE_MS = 10_000;
 // chat" for the whole run — it should surface the deterministic fallback
 // promptly so a title appears soon after submit.
 const TITLE_GEN_TIMEOUT_MS = 20_000;
+const FALLBACK_TITLE_MAX_CHARS = 32;
 
 export function genTitle(config: {
   /** Optional: aborts title generation when the parent stream is cancelled.
@@ -90,13 +91,13 @@ export function genTitle(config: {
   };
 
   // Fallback used when the LLM call errors or produces unusable output.
-  // Spec: take the literal first 10 characters of the user message, trim,
+  // Spec: take the literal first 32 characters of the user message, trim,
   // and fall through to "New chat" if there's no usable letter/digit.
   // Short, deterministic, and cheap; the user can rename the thread at
-  // any time. 10 chars was picked over the previous 60-char first-line
+  // any time. 32 chars was picked over the previous 60-char first-line
   // shape to keep failed/empty titles visually compact in the sidebar.
   const fallbackTitle = (() => {
-    const candidate = userMessage.slice(0, 10).trim();
+    const candidate = userMessage.slice(0, FALLBACK_TITLE_MAX_CHARS).trim();
     return hasUsableText(candidate) ? candidate : "New chat";
   })();
 


### PR DESCRIPTION
## Summary
- increase title-generation fallback cap from 10 to 32 characters
- update fallback unit test expectations

## Testing
- bun test packages/harness/src/decopilot/title-generator.test.ts --timeout 5000
- bun run fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the fallback title limit from 10 to 32 characters to preserve more context in thread titles when the LLM fails or times out. Adds `FALLBACK_TITLE_MAX_CHARS` and updates unit tests to reflect the new limit.

<sup>Written for commit 5f7419eaca95cd9a463a219f3b441a36c8c4b619. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

