### PR TITLE
fix(sandbox): add 2s timeout to git/status proxy requests

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -93,6 +93,7 @@ const PREVIEW_INVOKE_MAX_BODY_BYTES = 64 * 1024;
  * allows up to 60s for upstream headers (see `daemon/proxy.ts`).
  */
 const QUICK_FILE_OP_TIMEOUT_MS = 10_000;
+const GIT_STATUS_TIMEOUT_MS = 2_000;
 
 /**
  * Abort signal for quick file ops: the inbound request's signal (client
@@ -527,10 +528,20 @@ export const createSandboxRoutes = () => {
     proxyDaemon(c, "/_sandbox/git/status", {
       method: "GET",
       map404to410: true,
+      signal: AbortSignal.any([
+        c.req.raw.signal,
+        AbortSignal.timeout(GIT_STATUS_TIMEOUT_MS),
+      ]),
     }),
   );
   app.post("/:virtualMcpId/:branch/git/status", (c) =>
-    proxyDaemon(c, "/_sandbox/git/status", { map404to410: true }),
+    proxyDaemon(c, "/_sandbox/git/status", {
+      map404to410: true,
+      signal: AbortSignal.any([
+        c.req.raw.signal,
+        AbortSignal.timeout(GIT_STATUS_TIMEOUT_MS),
+      ]),
+    }),
   );
   app.post("/:virtualMcpId/:branch/git/diff", (c) =>
     proxyDaemon(c, "/_sandbox/git/diff", {


### PR DESCRIPTION
## Summary
- Add a 2s timeout (`GIT_STATUS_TIMEOUT_MS`) to both GET and POST `git/status` proxy handlers
- Previously inherited the daemon's 60s headers timeout, causing long hangs when the sandbox link is partitioned
- Uses the same `AbortSignal.any` pattern as `quickFileOpSignal` for file ops

## Test plan
- [ ] Verify git status responds within 2s on a healthy sandbox
- [ ] Verify a partitioned sandbox returns 502 promptly instead of hanging ~60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 2s timeout to the GET and POST `git/status` proxy handlers to prevent long hangs and return a prompt 502 when the sandbox link is partitioned.

- **Bug Fixes**
  - Introduced `GIT_STATUS_TIMEOUT_MS` (2,000 ms).
  - Used `AbortSignal.any` to combine the request signal with the timeout for both `git/status` handlers.

<sup>Written for commit fff4bd38968735f52bf52e10fb13e02da52da01d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

