### PR TITLE
fix(decopilot): ack unparseable projector fragments instead of looping forever

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/projector-consumer.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-consumer.test.ts
@@ -25,8 +25,20 @@ function source() {
       term: async () => {},
     });
   };
+  const pushRaw = (subject: string, raw: string, msgId?: string) => {
+    msgs.push({
+      subject,
+      data: new TextEncoder().encode(raw),
+      msgId,
+      ack: async () => {
+        acked.push(raw);
+      },
+      term: async () => {},
+    });
+  };
   return {
     push,
+    pushRaw,
     acked,
     iterable: (async function* () {
       for (const m of msgs) yield m;
@@ -54,6 +66,27 @@ describe("projector scheduler consumer", () => {
 
     expect(s.acked).toHaveLength(1);
     expect(scheduled).toEqual([]);
+  });
+
+  test("acks an unparseable fragment instead of looping on it", async () => {
+    const s = source();
+    // A fragmented chunk delivers a raw byte-slice of `{"p":...}` JSON, which
+    // is not valid JSON on its own. It must be acked-and-skipped, NOT left
+    // unacked (which would make JetStream redeliver the poison fragment forever
+    // — the prod stdout-spam bug).
+    s.pushRaw(
+      "decopilot.stream.run_1",
+      '{"p":{"text":"unter',
+      "run_1:fence_a:1",
+    );
+
+    await consumeProjectorMessages({
+      messages: s.iterable,
+      resolveOrgId: async () => "org_1",
+      enqueueProjectRun: async () => {},
+    });
+
+    expect(s.acked).toHaveLength(1);
   });
 
   test("schedules done and acks only after enqueue succeeds", async () => {

--- a/apps/mesh/src/api/routes/decopilot/projector-consumer.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-consumer.ts
@@ -114,7 +114,20 @@ export async function consumeProjectorMessages(
         await msg.ack();
         continue;
       }
-      const payload = JSON.parse(decoder.decode(msg.data)) as unknown;
+      // A fragmented chunk arrives as a raw byte-slice of the encoded
+      // `{p: value}` JSON (see NatsStreamBuffer.publishChunk), so an individual
+      // fragment is NOT valid JSON. The done/checkpoint markers we care about
+      // are tiny and never fragmented, so a parse failure is always a chunk we
+      // ack-and-skip anyway — never a transient error to redeliver. Acking here
+      // (instead of falling to the outer catch, which leaves it UNACKED) stops
+      // JetStream from redelivering the poison fragment forever.
+      let payload: unknown;
+      try {
+        payload = JSON.parse(decoder.decode(msg.data)) as unknown;
+      } catch {
+        await msg.ack();
+        continue;
+      }
       if (isCheckpointEnvelope(payload)) {
         if (options.enqueueProjectCheckpoint) {
           const parsed = parseRunStreamMsgId(msg.msgId);


### PR DESCRIPTION
## Summary

Prod pods were spamming stdout with `[projector-consumer] scheduling failed: SyntaxError: JSON Parse error: Unterminated string` (and `Unexpected identifier "f96Tlgti…"`) on a tight loop.

**Root cause:** the producer (`NatsStreamBuffer`) splits oversized stream chunks into multiple NATS fragment messages, each a raw byte-slice of the encoded `{"p":…}` JSON — not valid JSON on its own. The tail consumer reassembles fragments before parsing; the **projector consumer did not** — it `JSON.parse`'d every raw message (`projector-consumer.ts:117`). A fragment slice cut mid-string throws `Unterminated string`; one starting mid-value throws `Unexpected identifier "…"`.

The `catch` deliberately leaves the message **unacked** so JetStream redelivers it — correct for *transient* enqueue failures, but fatal for an un-parseable fragment that will **never** parse. So JetStream redelivered the same poison fragment forever → infinite stdout spam.

(The `cli.js:112182` code-frame in the logs is a red herring — just where the bundle's giant minified line lands, not the real call site.)

## Fix

Wrap the parse so a failure **acks-and-skips** instead of falling to the redeliver-forever catch. A parse failure is always a chunk fragment the consumer skips anyway; the done/checkpoint markers it actually cares about are tiny and never fragmented.

## Testing

- New unit test: an unparseable fragment is acked (not left for redelivery).
- `bun test apps/mesh/src/api/routes/decopilot/projector-consumer.test.ts` — 9 pass.

## Follow-up

Skipped header-based fragment detection (`Dp-Frag-Total`); add if the consumer ever needs to distinguish fragments from genuinely-corrupt payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the projector consumer from looping on unparseable NATS fragments by acking and skipping them. This prevents JetStream redelivery storms and noisy stdout logs.

- **Bug Fixes**
  - Wrap JSON parsing in try/catch; on failure, ack and continue instead of leaving the message unacked.
  - Added a unit test to verify unparseable fragments are acked.

<sup>Written for commit c939a27f03eb0535223958d7b0366a88ef1590cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

