### PR TITLE
fix(github): show merge button when PR is open and commits already pushed

### DIFF
--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -314,15 +314,28 @@ describe("selectHeaderButton", () => {
     expect(r.action).toBe("create-pr");
   });
 
-  test("unpushed commits with open PR → Save changes", () => {
+  test("unpushed commits with open PR (different head) → Save changes", () => {
     const r = selectHeaderButton(
       happyInput({
-        branch: ready({ unpushed: 2, aheadOfBase: 2 }),
-        pr: pr(),
+        branch: ready({ unpushed: 2, aheadOfBase: 2, headSha: "local999" }),
+        pr: pr({ headSha: "remote888" }),
       }),
     );
     expect(r.label).toBe("Save changes");
     expect(r.action).toBe("commit-and-push");
+  });
+
+  test("false-positive unpushed (headSha matches PR) → falls through to merge", () => {
+    const r = selectHeaderButton(
+      happyInput({
+        branch: ready({ unpushed: 1, aheadOfBase: 1, headSha: "abc123" }),
+        pr: pr({ headSha: "abc123" }),
+        reviews: reviews(),
+      }),
+    );
+    expect(r.label).toBe("Publish to production");
+    expect(r.action).toBe("merge-split");
+    expect(r.variant).toBe("success");
   });
 
   test("ahead of base + closed non-merged PR → Reopen PR", () => {

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -178,7 +178,15 @@ export function selectHeaderButton(
     };
   }
 
-  if (ready.unpushed > 0) {
+  // `unpushed` can be a false positive when the sandbox hasn't fetched the
+  // remote tracking ref (origin/<branch> missing). If the PR's head SHA
+  // matches the local HEAD, the commits are already on the remote — skip
+  // the push gate and fall through to the PR/merge logic below.
+  const trulyUnpushed =
+    ready.unpushed > 0 &&
+    !(pr && ready.headSha && pr.headSha && ready.headSha === pr.headSha);
+
+  if (trulyUnpushed) {
     if (!pr) {
       return {
         label: "Submit for review",

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -186,7 +186,12 @@ function isBlocksGenJsonPath(path: string): boolean {
   return path === "blocks.gen.json" || path.endsWith("/blocks.gen.json");
 }
 
-/** Publish (squash-merge) is only allowed for CMS JSON under `.deco/` (plus generated blocks). */
+/** Auto-generated Tailwind CSS output. */
+function isTailwindCssPath(path: string): boolean {
+  return path === "static/tailwind.css" || path.endsWith("/static/tailwind.css");
+}
+
+/** Publish (squash-merge) is only allowed for CMS JSON under `.deco/` (plus generated assets). */
 export function isDecoOnlyDiff(
   diff: GitDiffResult | null | undefined,
 ): boolean {
@@ -194,7 +199,11 @@ export function isDecoOnlyDiff(
   const paths = Object.keys(diff.diffs);
   if (paths.length === 0) return false;
   return paths.every(
-    (p) => p === ".deco" || p.startsWith(".deco/") || isBlocksGenJsonPath(p),
+    (p) =>
+      p === ".deco" ||
+      p.startsWith(".deco/") ||
+      isBlocksGenJsonPath(p) ||
+      isTailwindCssPath(p),
   );
 }
 

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -188,7 +188,9 @@ function isBlocksGenJsonPath(path: string): boolean {
 
 /** Auto-generated Tailwind CSS output. */
 function isTailwindCssPath(path: string): boolean {
-  return path === "static/tailwind.css" || path.endsWith("/static/tailwind.css");
+  return (
+    path === "static/tailwind.css" || path.endsWith("/static/tailwind.css")
+  );
 }
 
 /** Publish (squash-merge) is only allowed for CMS JSON under `.deco/` (plus generated assets). */


### PR DESCRIPTION
## Summary
- **False-positive unpushed detection**: when the sandbox hasn't fetched `origin/<branch>`, the daemon reports `unpushed = aheadOfBase` even though the commits are already on GitHub. The header button incorrectly showed "Save changes" instead of the merge action. Now compares `headSha` with the PR's head SHA to detect the false positive and falls through to the merge/PR logic.
- **Allow direct publish for `static/tailwind.css`**: generated Tailwind CSS output can now be published directly alongside `.deco/` files and `blocks.gen.json`.

## Test plan
- [x] Existing `panel-state` tests updated and passing (40/40)
- [ ] Verify in a sandbox with an open PR and no local changes that the header shows the merge button instead of "Save changes"
- [ ] Verify `static/tailwind.css` changes can be published directly without "Submit for review"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the header to show the merge action when a PR is open and commits are already on GitHub, even if local state reports “unpushed.” Also allows direct publish of generated `static/tailwind.css` and formats `apps/mesh/src/web/components/thread/github/sandbox-git-api.ts`.

- **Bug Fixes**
  - Handle false-positive “unpushed” by comparing local `headSha` with the PR’s head SHA and falling through to PR/merge logic.

- **New Features**
  - Permit direct publish of `static/tailwind.css` alongside `.deco/` files and `blocks.gen.json`.

<sup>Written for commit 400fb6138d0509f2bfd9e9e64dbc20fc7e52cf34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

