### PR TITLE
feat(blog): add description and sections to category editor

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/block-document.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/block-document.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import { discoverBlogBlockTypes } from "./blog-data";
+import { InsertBlockDivider } from "./block-picker";
+import { BlockRow } from "./blocks/block-row";
+import { type RawBlock } from "./blocks/block-registry";
+
+type BlockItem = { id: string; block: RawBlock };
+
+export function asBlocks(value: unknown): RawBlock[] {
+  return Array.isArray(value) ? (value as RawBlock[]) : [];
+}
+
+/**
+ * Notion-style block document: a vertical list of inline-editable blocks
+ * with ⊕ insert affordances between rows and drag-to-reorder. The caller
+ * owns the persisted `value`; this component owns the dnd-kit identity
+ * (`uid()`-keyed `BlockItem`s) so reorders don't lose React keys.
+ */
+export function BlockDocument({
+  value,
+  onChange,
+  meta,
+  emptyMessage = "No content yet. Use ⊕ to add your first block.",
+}: {
+  value: RawBlock[];
+  onChange: (next: RawBlock[]) => void;
+  meta: LiveMeta;
+  emptyMessage?: string;
+}) {
+  const blockTypes = discoverBlogBlockTypes(meta);
+
+  const [blockItems, setBlockItems] = useState<BlockItem[]>(() =>
+    value.map((blk) => ({ id: uid(), block: blk })),
+  );
+
+  const ids = blockItems.map((x) => x.id);
+  const blocks = blockItems.map((x) => x.block);
+
+  const syncBlocks = (items: BlockItem[]) => {
+    setBlockItems(items);
+    onChange(items.map((x) => x.block));
+  };
+
+  const insertAt = (index: number, resolveType: string) => {
+    const next = [...blockItems];
+    next.splice(index, 0, { id: uid(), block: { __resolveType: resolveType } });
+    syncBlocks(next);
+  };
+
+  const updateAt = (index: number, value: RawBlock) => {
+    syncBlocks(
+      blockItems.map((item, i) =>
+        i === index ? { ...item, block: value } : item,
+      ),
+    );
+  };
+
+  const removeAt = (index: number) => {
+    syncBlocks(blockItems.filter((_, i) => i !== index));
+  };
+
+  // structuredClone deep-copies the block payload so the duplicate doesn't
+  // share nested references (e.g. arrays inside ProductShelf) with the
+  // original — editing one would otherwise mutate the other.
+  const duplicateAt = (index: number) => {
+    const source = blockItems[index];
+    if (!source) return;
+    const next = [...blockItems];
+    next.splice(index + 1, 0, {
+      id: uid(),
+      block: structuredClone(source.block),
+    });
+    syncBlocks(next);
+  };
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = blockItems.findIndex((x) => x.id === String(active.id));
+    const newIndex = blockItems.findIndex((x) => x.id === String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+    syncBlocks(arrayMove(blockItems, oldIndex, newIndex));
+  };
+
+  return (
+    <div className="mt-2">
+      {blocks.length === 0 && (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          {emptyMessage}
+        </p>
+      )}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+          <InsertBlockDivider
+            blockTypes={blockTypes}
+            onInsert={(rt) => insertAt(0, rt)}
+            alwaysShow={blocks.length === 0}
+          />
+          {blockItems.map(({ id, block: blk }, index) => (
+            <div key={id}>
+              <BlockRow
+                id={id}
+                block={blk}
+                meta={meta}
+                onChange={(v) => updateAt(index, v)}
+                onDelete={() => removeAt(index)}
+                onDuplicate={() => duplicateAt(index)}
+              />
+              <InsertBlockDivider
+                blockTypes={blockTypes}
+                onInsert={(rt) => insertAt(index + 1, rt)}
+              />
+            </div>
+          ))}
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+}
+
+function uid(): string {
+  return crypto.randomUUID();
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -228,7 +228,12 @@ export function emptyBlogPayload(kind: BlogKind): Record<string, unknown> {
         avatar: "",
       };
     case "categories":
-      return { name: "New category", slug: `category-${randomHex(8)}` };
+      return {
+        name: "New category",
+        slug: `category-${randomHex(8)}`,
+        description: "",
+        sections: [],
+      };
     default: {
       const _exhaustive: never = kind;
       throw new Error(`Unhandled blog kind: ${String(_exhaustive)}`);

--- a/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
@@ -1,0 +1,99 @@
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import { buildBlogBlock, getBlogPayload } from "./blog-data";
+import { useSaveBlogBlock } from "./use-blog-mutations";
+import { useAutosave } from "./use-autosave";
+import { SaveStatus } from "./save-status";
+import { BlogSandboxProvider } from "./blog-sandbox-context";
+import { asBlocks, BlockDocument } from "./block-document";
+import { InlineText, str } from "./blocks/primitives";
+
+/**
+ * Notion-style category editor: large inline name + slug input + inline
+ * description + the same block document used by posts. Mirrors PostEditor's
+ * layout so authors edit categories with the same affordances.
+ */
+export function CategoryEditor({
+  orgSlug,
+  virtualMcpId,
+  branch,
+  blockKey,
+  block,
+  meta,
+}: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  blockKey: string;
+  block: Record<string, unknown> | undefined;
+  meta: LiveMeta;
+}) {
+  const save = useSaveBlogBlock({ orgSlug, virtualMcpId, branch });
+  const initial = getBlogPayload(block, "categories");
+
+  const [category, setCategory] = useAutosave(initial, (next) => {
+    save.mutate({
+      blockKey,
+      data: buildBlogBlock(blockKey, "categories", next),
+    });
+  });
+
+  const setField = (key: string, value: unknown) =>
+    setCategory({ ...category, [key]: value });
+
+  return (
+    <BlogSandboxProvider
+      orgSlug={orgSlug}
+      virtualMcpId={virtualMcpId}
+      branch={branch}
+    >
+      <div className="flex h-full flex-col">
+        <div className="flex h-12 shrink-0 items-center justify-between border-b px-6">
+          <span className="truncate text-sm font-medium">
+            {str(category.name) || "Untitled category"}
+          </span>
+          <SaveStatus isPending={save.isPending} isError={save.isError} />
+        </div>
+
+        <div className="min-w-0 flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-3xl px-8 py-8">
+            <InlineText
+              value={str(category.name)}
+              onChange={(v) => setField("name", v)}
+              placeholder="Category name"
+              className="py-1 text-3xl font-bold text-foreground"
+            />
+
+            <div className="mt-4 space-y-2">
+              <Label htmlFor="category-slug">Slug</Label>
+              <Input
+                id="category-slug"
+                value={str(category.slug)}
+                onChange={(e) => setField("slug", e.target.value)}
+                placeholder="my-category"
+                className="h-10"
+              />
+            </div>
+
+            <InlineText
+              value={str(category.description)}
+              onChange={(v) => setField("description", v)}
+              placeholder="Add a description…"
+              className="mt-4 text-base text-muted-foreground"
+            />
+
+            <div className="mt-6 border-t" />
+
+            <BlockDocument
+              value={asBlocks(category.sections)}
+              onChange={(next) => setField("sections", next)}
+              meta={meta}
+              emptyMessage="This category has no content yet. Use ⊕ to add your first block."
+            />
+          </div>
+        </div>
+      </div>
+    </BlogSandboxProvider>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
@@ -1,21 +1,6 @@
 import { useState } from "react";
 import { ChevronDown, Settings01 } from "@untitledui/icons";
 import {
-  DndContext,
-  type DragEndEvent,
-  KeyboardSensor,
-  PointerSensor,
-  closestCenter,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  arrayMove,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -28,19 +13,12 @@ import { cn } from "@deco/ui/lib/utils.js";
 import { ImageField } from "@/web/components/sections-editor/fields/image-field";
 import { StringField } from "@/web/components/sections-editor/fields/string-field";
 import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
-import {
-  buildBlogBlock,
-  discoverBlogBlockTypes,
-  getBlogPayload,
-  listBlogPayloads,
-} from "./blog-data";
+import { buildBlogBlock, getBlogPayload, listBlogPayloads } from "./blog-data";
 import { useSaveBlogBlock } from "./use-blog-mutations";
 import { useAutosave } from "./use-autosave";
 import { SaveStatus } from "./save-status";
 import { BlogSandboxProvider } from "./blog-sandbox-context";
-import { InsertBlockDivider } from "./block-picker";
-import { BlockRow } from "./blocks/block-row";
-import { type RawBlock } from "./blocks/block-registry";
+import { asBlocks, BlockDocument } from "./block-document";
 import { AddButton, InlineText, RemoveButton, str } from "./blocks/primitives";
 
 type ExtraProp = { key: string; value: string };
@@ -51,12 +29,6 @@ function asExtraProps(value: unknown): ExtraProp[] {
     key: str((item as Record<string, unknown>)?.key),
     value: str((item as Record<string, unknown>)?.value),
   }));
-}
-
-type BlockItem = { id: string; block: RawBlock };
-
-function asBlocks(value: unknown): RawBlock[] {
-  return Array.isArray(value) ? (value as RawBlock[]) : [];
 }
 
 /**
@@ -89,73 +61,8 @@ export function PostEditor({
     save.mutate({ blockKey, data: buildBlogBlock(blockKey, "posts", next) });
   });
 
-  const blockTypes = discoverBlogBlockTypes(meta);
-
-  // Ids and blocks are co-located in one piece of state so dnd-kit's
-  // sortable identity never drifts from the block list. All mutations go
-  // through syncBlocks which updates both atomically.
-  const [blockItems, setBlockItems] = useState<BlockItem[]>(() =>
-    asBlocks(initial.sections).map((blk) => ({ id: uid(), block: blk })),
-  );
-
-  const ids = blockItems.map((x) => x.id);
-  const blocks = blockItems.map((x) => x.block);
-
-  const syncBlocks = (items: BlockItem[]) => {
-    setBlockItems(items);
-    setPost({ ...post, sections: items.map((x) => x.block) });
-  };
-
   const setField = (key: string, value: unknown) =>
     setPost({ ...post, [key]: value });
-
-  const insertAt = (index: number, resolveType: string) => {
-    const next = [...blockItems];
-    next.splice(index, 0, { id: uid(), block: { __resolveType: resolveType } });
-    syncBlocks(next);
-  };
-
-  const updateAt = (index: number, value: RawBlock) => {
-    syncBlocks(
-      blockItems.map((item, i) =>
-        i === index ? { ...item, block: value } : item,
-      ),
-    );
-  };
-
-  const removeAt = (index: number) => {
-    syncBlocks(blockItems.filter((_, i) => i !== index));
-  };
-
-  // structuredClone deep-copies the block payload so the duplicate doesn't
-  // share nested references (e.g. arrays inside ProductShelf) with the
-  // original — editing one would otherwise mutate the other.
-  const duplicateAt = (index: number) => {
-    const source = blockItems[index];
-    if (!source) return;
-    const next = [...blockItems];
-    next.splice(index + 1, 0, {
-      id: uid(),
-      block: structuredClone(source.block),
-    });
-    syncBlocks(next);
-  };
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
-  );
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
-    const oldIndex = blockItems.findIndex((x) => x.id === String(active.id));
-    const newIndex = blockItems.findIndex((x) => x.id === String(over.id));
-    if (oldIndex === -1 || newIndex === -1) return;
-    syncBlocks(arrayMove(blockItems, oldIndex, newIndex));
-  };
 
   return (
     <BlogSandboxProvider
@@ -186,55 +93,17 @@ export function PostEditor({
 
             <div className="mt-6 border-t" />
 
-            {/* Block document */}
-            <div className="mt-2">
-              {blocks.length === 0 && (
-                <p className="py-6 text-center text-sm text-muted-foreground">
-                  This post has no content yet. Use ⊕ to add your first block.
-                </p>
-              )}
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-              >
-                <SortableContext
-                  items={ids}
-                  strategy={verticalListSortingStrategy}
-                >
-                  <InsertBlockDivider
-                    blockTypes={blockTypes}
-                    onInsert={(rt) => insertAt(0, rt)}
-                    alwaysShow={blocks.length === 0}
-                  />
-                  {blockItems.map(({ id, block: blk }, index) => (
-                    <div key={id}>
-                      <BlockRow
-                        id={id}
-                        block={blk}
-                        meta={meta}
-                        onChange={(v) => updateAt(index, v)}
-                        onDelete={() => removeAt(index)}
-                        onDuplicate={() => duplicateAt(index)}
-                      />
-                      <InsertBlockDivider
-                        blockTypes={blockTypes}
-                        onInsert={(rt) => insertAt(index + 1, rt)}
-                      />
-                    </div>
-                  ))}
-                </SortableContext>
-              </DndContext>
-            </div>
+            <BlockDocument
+              value={asBlocks(post.sections)}
+              onChange={(next) => setField("sections", next)}
+              meta={meta}
+              emptyMessage="This post has no content yet. Use ⊕ to add your first block."
+            />
           </div>
         </div>
       </div>
     </BlogSandboxProvider>
   );
-}
-
-function uid(): string {
-  return crypto.randomUUID();
 }
 
 function PostSettings({

--- a/apps/mesh/src/web/components/sandbox/content/blog/record-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/record-editor.tsx
@@ -8,7 +8,7 @@ import { useSaveBlogBlock } from "./use-blog-mutations";
 import { useAutosave } from "./use-autosave";
 import { SaveStatus } from "./save-status";
 
-type RecordKind = Extract<BlogKind, "authors" | "categories">;
+type RecordKind = Extract<BlogKind, "authors">;
 
 interface FieldDef {
   key: string;
@@ -30,15 +30,10 @@ const FIELDS: Record<RecordKind, FieldDef[]> = {
     { key: "company", label: "Company", widget: "text" },
     { key: "avatar", label: "Avatar", widget: "image" },
   ],
-  categories: [
-    { key: "name", label: "Name", widget: "text" },
-    { key: "slug", label: "Slug", widget: "text", placeholder: "my-category" },
-  ],
 };
 
 const TITLE: Record<RecordKind, string> = {
   authors: "Author",
-  categories: "Category",
 };
 
 export function RecordEditor({

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -129,6 +129,10 @@ const RecordEditor = lazy(() =>
   import("./blog/record-editor").then((m) => ({ default: m.RecordEditor })),
 );
 
+const CategoryEditor = lazy(() =>
+  import("./blog/category-editor").then((m) => ({ default: m.CategoryEditor })),
+);
+
 const SectionsEditor = lazy(() =>
   import("@/web/components/sections-editor/sections-editor").then((m) => ({
     default: m.SectionsEditor,
@@ -800,14 +804,23 @@ function ContentBrowserReady({
                 decofile={decofile}
                 meta={meta}
               />
-            ) : selection.collection === "authors" ||
-              selection.collection === "categories" ? (
-              <RecordEditor
-                key={`${selection.collection}:${selection.key}`}
+            ) : selection.collection === "categories" ? (
+              <CategoryEditor
+                key={`category:${selection.key}`}
                 orgSlug={orgSlug}
                 virtualMcpId={virtualMcpId}
                 branch={branch}
-                kind={selection.collection}
+                blockKey={selection.key}
+                block={decofile[selection.key] as Record<string, unknown>}
+                meta={meta}
+              />
+            ) : selection.collection === "authors" ? (
+              <RecordEditor
+                key={`authors:${selection.key}`}
+                orgSlug={orgSlug}
+                virtualMcpId={virtualMcpId}
+                branch={branch}
+                kind="authors"
                 blockKey={selection.key}
                 block={decofile[selection.key] as Record<string, unknown>}
               />


### PR DESCRIPTION
## Summary
- Extracts the post editor's DnD block document into a reusable `<BlockDocument>` component (no behavior change for posts).
- Adds a new `CategoryEditor` modeled on `PostEditor`: large inline name, slug input, inline description, and the same block document used by posts.
- Narrows the shared `RecordEditor` to authors only and routes the categories collection through the new editor in `content-browser.tsx`.
- Updates `emptyBlogPayload("categories")` to seed `description: ""` and `sections: []`.

## Test plan
- [ ] Open an existing post → confirm the block document still loads, reorders via drag, inserts/duplicates/removes blocks, and autosaves (regression check on the extraction).
- [ ] Open a category → see name (inline title), slug input, description (inline subtitle), and the block-document section. Add, edit, reorder, and remove blocks; reload and confirm everything persists.
- [ ] Open an author → unchanged form (name/email/jobTitle/company/avatar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Notion-style `CategoryEditor` with inline name, slug, description, and block-based sections using a new shared `BlockDocument`. `PostEditor` now uses `BlockDocument` (no behavior change), and new categories are seeded with `description` and `sections`.

- **New Features**
  - Added `CategoryEditor` with inline title, slug, description, and a block document for `sections`.
  - Seeded new categories with `description: ""` and `sections: []`.
  - Routed categories to `CategoryEditor` in `content-browser.tsx`.

- **Refactors**
  - Extracted the post body DnD into shared `BlockDocument` and replaced the inline implementation in `PostEditor`.
  - Narrowed `RecordEditor` to `authors` only.

<sup>Written for commit 6cbbfe17166832d9acc4806cb922a172d5da542b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

