### PR TITLE
perf(observability): cut local NDJSON trace export burst 1000→250 spans

### DIFF
--- a/apps/mesh/src/observability/index.ts
+++ b/apps/mesh/src/observability/index.ts
@@ -373,7 +373,14 @@ export function initObservability(): void {
         ? [
             new BatchSpanProcessor(monitoringTraceExporter, {
               scheduledDelayMillis: 60_000,
-              maxExportBatchSize: 1000,
+              // Local NDJSON export is a synchronous burst (per-row
+              // JSON.stringify + Buffer.byteLength in NDJSONExporter.exportRows).
+              // 250 keeps each burst ~4x shorter, with a yield between batches,
+              // instead of blocking the loop on up to 1000 spans at once — same
+              // rationale as the monitoring-log processor below. The remote OTLP
+              // span processor stays at 1000 (network-async, batch size is just
+              // wire efficiency there).
+              maxExportBatchSize: 250,
             }),
           ]
         : []),


### PR DESCRIPTION
## Summary

The local NDJSON span exporter (`monitoringTraceExporter`) flushes up to **1000 spans per `BatchSpanProcessor` export**. `NDJSONExporter.exportRows` does a **synchronous** per-row `JSON.stringify` + `Buffer.byteLength` loop, so each export blocks the event loop proportional to batch size.

The monitoring-**log** processor was already dropped to 250 for exactly this reason (see the comment it carries at `observability/index.ts`). The local NDJSON **trace** processor was left at 1000 — a ~4x longer synchronous burst. This matches it.

The remote OTLP span processor stays at 1000: its export is network-async, so batch size there is wire efficiency, not loop-block.

## Why only this one

Scoped out of a four-item perf pass; the other three didn't hold up against the code:
- **Coalesce stream chunks** — profiler #4089 measured stream encode at 0.03% of thread, and the live durable path keys dedup/fence/finalSeq on one-msg-per-chunk; coalescing would rewrite that contract for ~no measured gain.
- **Reuse SSE encoders/buffers** — already done (`this.encoder` singleton, module-level `KEEPALIVE_BYTES`); per-chunk encode output is handed to NATS and can't be reused.
- **Cap concurrent Ajv first-compiles** — `.compile()` is synchronous, so there's no concurrency to cap; a semaphore removes zero loop-block.

## Testing

Constant + comment change to a `number` literal; no type/behavior surface beyond batch granularity. Format clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce local NDJSON trace export batch size from 1000 to 250 to shorten synchronous bursts in `NDJSONExporter.exportRows` and reduce event-loop blocking during `BatchSpanProcessor` exports. Matches the monitoring-log processor; the remote OTLP span processor stays at 1000.

<sup>Written for commit 5c2858ebdf7f1c05961579416c9d87b4b8ce8a3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

