### PR TITLE
perf(mcp-utils): compile Ajv validators lazily to kill listTools compile-burst stall

### DIFF
--- a/packages/mcp-utils/src/shared-schema-validator.ts
+++ b/packages/mcp-utils/src/shared-schema-validator.ts
@@ -75,14 +75,27 @@ class MemoizingJsonSchemaValidator {
     const cached = this.#byRef.get(schema);
     if (cached) return cached as Validator<T>;
 
-    const key = stableStringify(schema);
-    let compiled = this.#cache.get(key);
-    if (!compiled) {
-      compiled = this.#ajv.compile(schema);
-      this.#cache.set(key, compiled);
-    }
-    const validate = compiled;
+    // Compile LAZILY on first validate, not here. The MCP SDK's
+    // `Client.listTools()` calls `cacheToolMetadata()`, which loops over EVERY
+    // listed tool and calls `getValidator(tool.outputSchema)` in one
+    // synchronous tick. Compiling eagerly here stacked N cold Ajv compiles in
+    // that single tick — a measured 326ms event-loop stall on a large
+    // aggregated listTools (the "16 → ~600ms" burst the createAjv() comment
+    // predicts). Deferring to first `validate()` means the loop only allocates
+    // N closures; each schema's compile happens later, one-per-tick, when a
+    // tool is actually called and its output validated — and tools that are
+    // listed but never called cost nothing. Still bounded + content-keyed.
+    let validate: ValidateFunction | undefined;
     const validator: Validator<T> = (input: unknown): ValidatorResult<T> => {
+      if (!validate) {
+        const key = stableStringify(schema);
+        let compiled = this.#cache.get(key);
+        if (!compiled) {
+          compiled = this.#ajv.compile(schema);
+          this.#cache.set(key, compiled);
+        }
+        validate = compiled;
+      }
       if (validate(input)) {
         return { valid: true, data: input as T, errorMessage: undefined };
       }


### PR DESCRIPTION
## Evidence

A prod `event-loop-stall-profile` (EVENT_LOOP_PROFILE=1 on `deco-studio`) named the frame behind a **326ms** event-loop stall:

```
listTools → cacheToolMetadata → getValidator → _compileSchemaEnv (Ajv compile)
```

## Cause

The MCP SDK's `Client.listTools()` calls `cacheToolMetadata()`, which loops over **every listed tool** and calls `getValidator(tool.outputSchema)`. Our shared validator (`shared-schema-validator.ts`) compiled **eagerly** inside `getValidator`, so a large aggregated `listTools` stacks N cold Ajv compiles in a single synchronous tick — exactly the "16 → ~600ms" burst that `createAjv()`'s own comment predicts.

## Fix

Defer compile to first `validate()`. `getValidator` now returns a closure that compiles on first invocation:
- `cacheToolMetadata`'s loop only allocates N closures — no compile burst at list time.
- Each schema compiles later, **one-per-tick**, when a tool is actually called and its output validated.
- Tools that are listed but never called cost **zero** compile.
- Cache stays content-keyed + bounded; the `byRef` fast path is unchanged.

This is the *correct* form of the original "cap concurrent Ajv compiles" idea — a concurrency cap is a no-op (compile is synchronous; handlers can't interleave one), but spreading the compiles across ticks via laziness directly removes the burst.

## Testing

Added `shared-schema-validator.test.ts` (pure unit, no mocks):
- valid/invalid validation correctness
- proof of deferral: `getValidator` on a compile-throwing `$ref` does **not** throw until the validator is invoked
- byRef identity + correctness

`bun test` → 3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compile `ajv` validators lazily in `mcp-utils`, moving work from `getValidator` to the first `validate()` call to eliminate the `Client.listTools()` compile burst (~326ms event-loop stalls). Cache stays content-keyed and bounded, the by-ref fast path is unchanged, and tools never invoked now incur zero compile cost.

<sup>Written for commit f2bc80cac7a7307a8b0e0f85f9611818e26633e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

