### PR TITLE
refactor(link): hardcode MAX_OUTBOX_BYTES at 512 MiB (drop the env override)

### DIFF
--- a/apps/mesh/src/link-daemon/outbox.test.ts
+++ b/apps/mesh/src/link-daemon/outbox.test.ts
@@ -175,10 +175,10 @@ describe("outbox boot sweep (clear)", () => {
 });
 
 describe("outbox cap (loud-fail backstop)", () => {
-  it("MAX_OUTBOX_BYTES defaults to 512 MiB (env-tunable backstop, not the per-run limit)", () => {
+  it("MAX_OUTBOX_BYTES is 512 MiB (stalled-publisher backstop, not the per-run limit)", () => {
     // Bumped from the legacy 64 MiB once rolling ackSeq truncation bounded the
     // outbox to the in-flight window; this is now only a stalled-publisher
-    // backstop. Env override (DECO_LINK_MAX_OUTBOX_BYTES) is unset in tests.
+    // backstop.
     expect(MAX_OUTBOX_BYTES).toBe(512 * 1024 * 1024);
   });
 

--- a/apps/mesh/src/link-daemon/outbox.ts
+++ b/apps/mesh/src/link-daemon/outbox.ts
@@ -32,11 +32,9 @@ import { assertBunRuntime } from "./outbox-runtime";
  * the pump has buffered but the publisher hasn't confirmed yet — so this is now
  * a backstop for a stalled publisher, not the per-run size limit it used to be.
  * The old 64 MiB value capped the WHOLE run (terminal-only truncation) and was
- * too small for long/verbose agent runs; default bumped to 512 MiB and made
- * env-tunable (`DECO_LINK_MAX_OUTBOX_BYTES`, bytes) for ops without a rebuild.
+ * too small for long/verbose agent runs; bumped to 512 MiB.
  */
-export const MAX_OUTBOX_BYTES =
-  Number(process.env.DECO_LINK_MAX_OUTBOX_BYTES) || 512 * 1024 * 1024;
+export const MAX_OUTBOX_BYTES = 512 * 1024 * 1024;
 
 export interface OutboxAppend {
   runId: string;


### PR DESCRIPTION
Follow-up to #4106. The `DECO_LINK_MAX_OUTBOX_BYTES` knob is unnecessary — with rolling truncation the cap is just a stalled-publisher backstop and 512 MiB is plenty. Make it a plain constant.

```ts
export const MAX_OUTBOX_BYTES = 512 * 1024 * 1024;
```

Tests/typecheck/fmt/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardcode the outbox cap to 512 MiB and remove the `DECO_LINK_MAX_OUTBOX_BYTES` env override. With rolling truncation, this cap is only a stalled-publisher backstop now.

- **Refactors**
  - Make `MAX_OUTBOX_BYTES` a 512 MiB constant and update tests.

- **Migration**
  - `DECO_LINK_MAX_OUTBOX_BYTES` is no longer read; remove it from configs.

<sup>Written for commit dc7f6a97e43e9f6fc4a13dc027ce180143accdcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

