### PR TITLE
feat(blog): add "See preview" button to the post editor

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-preview-url.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-preview-url.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import {
+  applyBlogPageSlug,
+  buildBlogPostPreviewUrl,
+  findBlogPageSlug,
+  firstCategorySlug,
+} from "./blog-preview-url";
+
+describe("findBlogPageSlug", () => {
+  it("reads pageSlug from the blog app block", () => {
+    const decofile = {
+      blog: {
+        __resolveType: "site/apps/deco/blog.ts",
+        pageSlug: "/blogteste/:category/:slug",
+      },
+    };
+    expect(findBlogPageSlug(decofile)).toBe("/blogteste/:category/:slug");
+  });
+
+  it("ignores collection blocks and non-blog apps", () => {
+    const decofile = {
+      "collections/blog/posts/abc": {
+        __resolveType: "blog/loaders/Blogpost.ts",
+        pageSlug: "/should-not-use",
+      },
+      "deco-vtex": { __resolveType: "site/apps/deco/vtex.ts" },
+    };
+    expect(findBlogPageSlug(decofile)).toBeNull();
+  });
+
+  it("returns null when the blog app has no pageSlug", () => {
+    const decofile = {
+      blog: { __resolveType: "site/apps/deco/blog.ts", postsPerPage: 10 },
+    };
+    expect(findBlogPageSlug(decofile)).toBeNull();
+  });
+});
+
+describe("firstCategorySlug", () => {
+  it("returns the first category slug", () => {
+    expect(
+      firstCategorySlug({ categories: [{ name: "News", slug: "news" }] }),
+    ).toBe("news");
+  });
+
+  it("returns empty string when there are no categories", () => {
+    expect(firstCategorySlug({ categories: [] })).toBe("");
+    expect(firstCategorySlug({})).toBe("");
+  });
+});
+
+describe("applyBlogPageSlug", () => {
+  it("substitutes category and slug", () => {
+    expect(
+      applyBlogPageSlug("/blogteste/:category/:slug", {
+        category: "news",
+        slug: "my-post",
+      }),
+    ).toBe("/blogteste/news/my-post");
+  });
+
+  it("url-encodes param values", () => {
+    expect(
+      applyBlogPageSlug("/blog/:slug", { category: "", slug: "hello world" }),
+    ).toBe("/blog/hello%20world");
+  });
+
+  it("supports optional params", () => {
+    expect(
+      applyBlogPageSlug("/blog/:category?/:slug?", {
+        category: "news",
+        slug: "my-post",
+      }),
+    ).toBe("/blog/news/my-post");
+  });
+
+  it("returns null when a required param is missing", () => {
+    expect(
+      applyBlogPageSlug("/blog/:category/:slug", {
+        category: "",
+        slug: "my-post",
+      }),
+    ).toBeNull();
+    expect(
+      applyBlogPageSlug("/blog/:category/:slug", {
+        category: "news",
+        slug: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("leaves templates without params untouched", () => {
+    expect(applyBlogPageSlug("/blog", { category: "", slug: "" })).toBe(
+      "/blog",
+    );
+  });
+});
+
+describe("buildBlogPostPreviewUrl", () => {
+  const decofile = {
+    blog: {
+      __resolveType: "site/apps/deco/blog.ts",
+      pageSlug: "/blogteste/:category/:slug",
+    },
+  };
+
+  it("builds an absolute preview url", () => {
+    expect(
+      buildBlogPostPreviewUrl({
+        decofile,
+        post: { slug: "my-post", categories: [{ slug: "news" }] },
+        previewBaseUrl: "https://abc.preview.example.com",
+      }),
+    ).toBe("https://abc.preview.example.com/blogteste/news/my-post");
+  });
+
+  it("returns null without a preview origin", () => {
+    expect(
+      buildBlogPostPreviewUrl({
+        decofile,
+        post: { slug: "my-post", categories: [{ slug: "news" }] },
+        previewBaseUrl: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when a required param is missing", () => {
+    expect(
+      buildBlogPostPreviewUrl({
+        decofile,
+        post: { slug: "my-post", categories: [] },
+        previewBaseUrl: "https://abc.preview.example.com",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no blog app block", () => {
+    expect(
+      buildBlogPostPreviewUrl({
+        decofile: {},
+        post: { slug: "my-post" },
+        previewBaseUrl: "https://abc.preview.example.com",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-preview-url.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-preview-url.ts
@@ -1,0 +1,84 @@
+const str = (value: unknown): string =>
+  typeof value === "string" ? value : "";
+
+/**
+ * The deco blog app block exposes a `pageSlug` route template such as
+ * `/blogteste/:category/:slug`. We read it from whichever decofile block
+ * resolves to the blog app (`site/apps/<vendor>/blog.ts`) and substitute the
+ * `:category` / `:slug` params with the post being edited so a "See preview"
+ * button can open the live sandbox page for that post.
+ */
+const BLOG_APP_RESOLVE_TYPE = /\/blog\.tsx?$/;
+
+export function findBlogPageSlug(
+  decofile: Record<string, unknown>,
+): string | null {
+  for (const [key, val] of Object.entries(decofile)) {
+    if (key.includes("/")) continue;
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+    const obj = val as Record<string, unknown>;
+    if (typeof obj.__resolveType !== "string") continue;
+    if (!BLOG_APP_RESOLVE_TYPE.test(obj.__resolveType)) continue;
+    const slug = str(obj.pageSlug);
+    if (slug) return slug;
+  }
+  return null;
+}
+
+export function firstCategorySlug(post: Record<string, unknown>): string {
+  const categories = post.categories;
+  if (!Array.isArray(categories) || categories.length === 0) return "";
+  const first = categories[0] as Record<string, unknown> | null;
+  return str(first?.slug);
+}
+
+/**
+ * Substitutes `:category` / `:slug` (optionally suffixed with `?`) in the
+ * route template. Returns `null` when a required param is missing so callers
+ * can disable the preview action instead of opening a broken URL.
+ */
+export function applyBlogPageSlug(
+  template: string,
+  params: { category: string; slug: string },
+): string | null {
+  let path = template;
+  if (/:category\??/.test(path)) {
+    if (!params.category) return null;
+    path = path.replace(/:category\??/g, encodeURIComponent(params.category));
+  }
+  if (/:slug\??/.test(path)) {
+    if (!params.slug) return null;
+    path = path.replace(/:slug\??/g, encodeURIComponent(params.slug));
+  }
+  return path;
+}
+
+/**
+ * Builds the absolute preview URL for a post, or `null` when it can't be
+ * built (no blog app block, no preview origin, or a missing route param).
+ */
+export function buildBlogPostPreviewUrl({
+  decofile,
+  post,
+  previewBaseUrl,
+}: {
+  decofile: Record<string, unknown>;
+  post: Record<string, unknown>;
+  previewBaseUrl: string | null | undefined;
+}): string | null {
+  if (!previewBaseUrl) return null;
+  const template = findBlogPageSlug(decofile);
+  if (!template) return null;
+
+  const path = applyBlogPageSlug(template, {
+    category: firstCategorySlug(post),
+    slug: str(post.slug),
+  });
+  if (!path) return null;
+
+  try {
+    return new URL(path, previewBaseUrl).href;
+  } catch {
+    return null;
+  }
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { ChevronDown, Settings01 } from "@untitledui/icons";
+import { ChevronDown, LinkExternal01, Settings01 } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
 import {
   Collapsible,
   CollapsibleContent,
@@ -14,6 +15,7 @@ import { ImageField } from "@/web/components/sections-editor/fields/image-field"
 import { StringField } from "@/web/components/sections-editor/fields/string-field";
 import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 import { buildBlogBlock, getBlogPayload, listBlogPayloads } from "./blog-data";
+import { buildBlogPostPreviewUrl } from "./blog-preview-url";
 import { useSaveBlogBlock } from "./use-blog-mutations";
 import { useAutosave } from "./use-autosave";
 import { SaveStatus } from "./save-status";
@@ -45,6 +47,7 @@ export function PostEditor({
   block,
   decofile,
   meta,
+  previewBaseUrl,
 }: {
   orgSlug: string;
   virtualMcpId: string;
@@ -53,6 +56,7 @@ export function PostEditor({
   block: Record<string, unknown> | undefined;
   decofile: Record<string, unknown>;
   meta: LiveMeta;
+  previewBaseUrl?: string | null;
 }) {
   const save = useSaveBlogBlock({ orgSlug, virtualMcpId, branch });
   const initial = getBlogPayload(block, "posts");
@@ -63,6 +67,12 @@ export function PostEditor({
 
   const setField = (key: string, value: unknown) =>
     setPost({ ...post, [key]: value });
+
+  const previewUrl = buildBlogPostPreviewUrl({
+    decofile,
+    post,
+    previewBaseUrl,
+  });
 
   return (
     <BlogSandboxProvider
@@ -75,7 +85,28 @@ export function PostEditor({
           <span className="truncate text-sm font-medium">
             {str(post.title) || "Untitled post"}
           </span>
-          <SaveStatus isPending={save.isPending} isError={save.isError} />
+          <div className="flex shrink-0 items-center gap-3">
+            <SaveStatus isPending={save.isPending} isError={save.isError} />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!previewUrl}
+              title={
+                previewUrl
+                  ? "Open the post preview in a new tab"
+                  : "Set the post slug (and its category) plus the blog app's pageSlug to preview"
+              }
+              onClick={() => {
+                if (previewUrl) {
+                  window.open(previewUrl, "_blank", "noopener,noreferrer");
+                }
+              }}
+            >
+              <LinkExternal01 size={14} />
+              See preview
+            </Button>
+          </div>
         </div>
 
         <div className="min-w-0 flex-1 overflow-y-auto">

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -803,6 +803,7 @@ function ContentBrowserReady({
                 block={decofile[selection.key] as Record<string, unknown>}
                 decofile={decofile}
                 meta={meta}
+                previewBaseUrl={previewUrl}
               />
             ) : selection.collection === "categories" ? (
               <CategoryEditor


### PR DESCRIPTION
## Summary
- Adds a **"See preview"** button to the blog post editor header that opens the post's live sandbox page in a new tab.
- The URL is built from the blog app block's `pageSlug` route template (e.g. `/blogteste/:category/:slug`) read from the decofile, substituting `:category`/`:slug` with the post's current form values, resolved against the sandbox preview origin.
- The button is disabled (with an explanatory tooltip) when there's no preview origin, no `pageSlug` on the blog app, or a required route param (slug / category) is missing.

## Changes
- `blog/blog-preview-url.ts` (new) — pure helpers: `findBlogPageSlug`, `firstCategorySlug`, `applyBlogPageSlug`, `buildBlogPostPreviewUrl`.
- `blog/post-editor.tsx` — accepts `previewBaseUrl`, computes the preview URL, renders the button.
- `content-browser.tsx` — passes the sandbox `previewUrl` into `PostEditor` (same source other editors already use).
- `blog/blog-preview-url.test.ts` (new) — 14 unit tests covering slug substitution, optional params, missing params, and URL composition.

## Test plan
- [x] `bun test` for `blog-preview-url.test.ts` (14 passing)
- [x] `bun run fmt`
- [ ] Manual: open a blog post in the Content tab, confirm the button opens the correct `/category/slug` page; verify it's disabled when slug/category are empty or the sandbox preview isn't ready.

## Notes
- If a `pageSlug` requires `:category` but no category is selected, the button stays disabled rather than producing a broken URL like `/blogteste//my-post`. Happy to switch to a fallback (e.g. `sem-categoria`) if preferred.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “See preview” button to the blog post editor that opens the post’s sandbox page in a new tab. The URL is built from the blog app’s `pageSlug` template and current form values; the button is disabled if the preview origin, `pageSlug`, or required params are missing.

- **New Features**
  - Added helpers in `blog-preview-url.ts`: `findBlogPageSlug`, `firstCategorySlug`, `applyBlogPageSlug`, `buildBlogPostPreviewUrl`.
  - Updated `post-editor.tsx` to accept `previewBaseUrl`, compute the preview URL, and render the button that opens a new tab.
  - `content-browser.tsx` now passes the sandbox `previewUrl` to `PostEditor`.
  - Added 14 unit tests covering slug substitution, optional params, missing params, and URL composition.

<sup>Written for commit f7ae81c23efeebb4b7cddb6567b80bdca82156e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

