### PR TITLE
fix(blog): stop paragraph blocks from jittering while typing

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-row.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-row.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Copy01, DotsGrid, Trash01 } from "@untitledui/icons";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -7,19 +6,14 @@ import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 import { BlockEditor, type RawBlock } from "./block-registry";
 
 /**
- * Pixel height below which the row can't fit three 24px buttons stacked
- * vertically with 4px gaps (3*24 + 2*4 = 80, plus the 6px top inset).
- * Short blocks (divider, empty paragraph, single-line heading) fall under
- * this and switch to the inline action layout.
- */
-const SHORT_ROW_THRESHOLD_PX = 80;
-
-/**
  * One block in the post document. Borderless (Notion-style) — the left
- * gutter reveals a drag handle on hover; for tall blocks the duplicate
- * and delete buttons stack underneath, but for short blocks they move to
- * the right edge inline so they don't overflow below the row. Dragging
- * is bound to the handle only so it never fights with text editing.
+ * gutter reveals a drag handle on hover; the duplicate and delete buttons
+ * appear as a hover overlay at the top-right. The block's horizontal
+ * padding is constant (it never depends on the row's height) so typing in a
+ * paragraph never reflows the text — measuring height to switch the layout
+ * made blocks near the threshold jitter as the wrap width changed per
+ * keystroke. Dragging is bound to the handle only so it never fights with
+ * text editing.
  */
 export function BlockRow({
   id,
@@ -45,32 +39,15 @@ export function BlockRow({
     isDragging,
   } = useSortable({ id });
 
-  const [isShort, setIsShort] = useState(false);
-
   return (
     <div
-      // React 19 ref callback: wires dnd-kit's setNodeRef and starts a
-      // ResizeObserver in the same hook. Returning the cleanup tells React
-      // to disconnect when the element unmounts.
-      ref={(el) => {
-        setNodeRef(el);
-        if (!el) return;
-        const ro = new ResizeObserver(([entry]) => {
-          if (!entry) return;
-          setIsShort(entry.contentRect.height < SHORT_ROW_THRESHOLD_PX);
-        });
-        ro.observe(el);
-        return () => ro.disconnect();
-      }}
+      ref={setNodeRef}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,
       }}
       className={cn(
-        "group/row relative rounded-md py-1.5 pl-12 transition-colors hover:bg-muted/40",
-        // Short rows host duplicate+delete inline on the right, so reserve
-        // gutter there too. Tall rows only need a small right margin.
-        isShort ? "pr-20" : "pr-2",
+        "group/row relative rounded-md py-1.5 pl-12 pr-2 transition-colors hover:bg-muted/40",
         isDragging && "opacity-50",
       )}
     >
@@ -83,14 +60,7 @@ export function BlockRow({
       >
         <DotsGrid size={14} />
       </button>
-      <div
-        className={cn(
-          "absolute flex gap-1 opacity-0 transition-opacity group-hover/row:opacity-100",
-          isShort
-            ? "right-2 top-1.5 flex-row"
-            : "left-1 top-9 flex-col items-center",
-        )}
-      >
+      <div className="absolute right-1 top-1 z-10 flex flex-row gap-0.5 rounded-md bg-background/80 opacity-0 backdrop-blur-sm transition-opacity group-hover/row:opacity-100">
         <button
           type="button"
           aria-label="Duplicate block"


### PR DESCRIPTION
## Summary
- Fixes paragraph blocks visibly jittering/reflowing while typing in the blog post editor.
- The block row reserved its right padding based on the measured row height (`isShort ? pr-20 : pr-2`), driven by a `ResizeObserver` that was also recreated on every render via an inline ref callback. Paragraphs hovering around the ~80px threshold flipped `isShort` on nearly every keystroke, changing the text wrap width by 72px and reflowing the text per character.
- Decouples horizontal padding from row height: constant `pl-12 pr-2`, removes the `ResizeObserver`/`isShort` state (and the `SHORT_ROW_THRESHOLD_PX` constant), and renders the duplicate/delete actions as a hover overlay at the top-right instead of reserving width.

## Why
Tying the text column width to the block's height meant any height change (typing, wrapping) could change the wrap width, and near the threshold it oscillated per keystroke — the visible "tweaking". Block actions only show on hover, so overlaying them needs no reserved horizontal space.

## Changes
- `apps/mesh/src/web/components/sandbox/content/blog/blocks/block-row.tsx` — constant padding, drop ResizeObserver/isShort, hover-overlay actions.

## Test plan
- [x] `bun run fmt`
- [x] Type check (no errors in the changed file)
- [ ] Manual: open a blog post, type a long paragraph that crosses ~3 lines — text grows smoothly with no horizontal reflow/jitter; hover still reveals drag handle (left) and duplicate/delete (top-right).

## Notes
- This changes tall blocks' action buttons from left-stacked to a top-right hover overlay (now consistent for all block heights).
- A secondary potential source of post-typing re-renders (the optimistic decofile cache write in `onMutate`, 700ms after the last keystroke) is left untouched; happy to address in a follow-up if any residual flash remains.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops paragraph blocks from jittering while typing in the blog editor by removing height-based padding and layout switching. Uses constant padding (`pl-12 pr-2`), drops the `ResizeObserver`/`isShort` state, and shows duplicate/delete as a top-right hover overlay.

<sup>Written for commit 12bf02a6f94dd5d97267e46b9a69edf8fb0417ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

