### PR TITLE
fix(link): disable Bun's fetch timeout on the desktop loopback dispatch SSE

### DIFF
--- a/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
@@ -179,6 +179,11 @@ describe("handleLocalDispatch", () => {
     expect(dispatchHeaders.authorization).toBe(`Bearer ${DAEMON_TOKEN}`);
     expect(dispatchHeaders["content-type"]).toBe("application/json");
     expect(dispatchHeaders.accept).toBe("text/event-stream");
+    // Bun's fetch default-times-out a long-lived stream; the harness SSE can
+    // idle for minutes (slow tool call / deep reasoning), so the read would trip
+    // `TimeoutError: The operation timed out` and the run dies as
+    // `local_dispatch_failed`. The loopback dispatch MUST disable it.
+    expect((dispatchCall!.init as { timeout?: boolean }).timeout).toBe(false);
 
     // Verify the dispatch body shape: { harnessId, input }
     const dispatchBodyStr = dispatchCall!.init.body as string;

--- a/apps/mesh/src/link-daemon/handle-local-dispatch.ts
+++ b/apps/mesh/src/link-daemon/handle-local-dispatch.ts
@@ -262,20 +262,29 @@ export async function handleLocalDispatch(
     }, dispatchStartTimeoutMs);
   }
 
+  // `timeout: false` is a Bun fetch option (not in the standard RequestInit).
+  // Bun default-times-out a long-lived stream, but the harness SSE legitimately
+  // idles for minutes during a slow tool call or deep reasoning — without this
+  // the body read trips `TimeoutError: The operation timed out` and the whole
+  // turn dies as `local_dispatch_failed` (observed on both codex AND claude-code).
+  // A genuine hang is still bounded by the run abort signal + the cluster
+  // reaper. Matches the agent-sandbox client (provider/agent-sandbox/client.ts).
+  const dispatchInit: RequestInit & { timeout?: boolean } = {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${deps.sandboxDaemonToken}`,
+      "content-type": "application/json",
+      accept: "text/event-stream",
+    },
+    body: dispatchBody,
+    signal: dispatchSignal,
+    timeout: false,
+  };
   let dispatchRes: Response;
   try {
     dispatchRes = await fetcher(
       `${deps.sandboxDispatchUrl}/_sandbox/dispatch`,
-      {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${deps.sandboxDaemonToken}`,
-          "content-type": "application/json",
-          accept: "text/event-stream",
-        },
-        body: dispatchBody,
-        signal: dispatchSignal,
-      },
+      dispatchInit as RequestInit,
     );
   } catch (err) {
     if (timeoutController.signal.aborted && !deps.signal?.aborted) {


### PR DESCRIPTION
## The bug

Desktop runs were dying with:
```
local_dispatch_failed: desktop harness dispatch failed before producing a terminal result; send the message again
```
The daemon log shows `ROOT=SANDBOX-SSE-pump … TimeoutError: The operation timed out`, then `[dispatch] done … aborted=true` and the harness exits cleanly (`code=0`). So the harness didn't crash — the daemon's read of the loopback `/_sandbox/dispatch` SSE **timed out** and aborted the run.

Confirmed on two threads with **different harnesses and very different durations**:

| harness | pre-stall chunks | total before timeout |
|---|---|---|
| codex | 1021 | ~34 min |
| claude-code | 208 | ~9 min |

Harness-agnostic + variable durations ⇒ it's an **idle read timeout**, not a turn cap.

## Root cause

The daemon's loopback fetch (`handle-local-dispatch.ts`) reads the harness SSE **without `timeout: false`**, so it inherits **Bun's default fetch timeout**. A harness turn that legitimately idles for minutes — a slow tool call, deep reasoning, or (as in one case) a tool call hung against a momentarily-502'ing cluster MCP — emits no SSE bytes and trips `TimeoutError`.

The codebase already knows about this: the **agent-sandbox** client disables it for streaming fetches —
```ts
// provider/agent-sandbox/client.ts
...(init.stream ? { timeout: false } : {}),
```
— but the **desktop link-daemon** loopback dispatch never got the same treatment.

## The fix

Set `timeout: false` on the loopback dispatch fetch (a Bun option, added via a type-augmented init cast like the agent-sandbox client). A genuine hang is still bounded by the run abort signal and the cross-pod reaper, so this doesn't make stuck runs immortal — it just stops killing legitimately-slow ones.

## Testing

- Extended the dispatch-fetch unit test to assert the loopback dispatch is called with `timeout: false` (RED→GREEN).
- All 167 `link-daemon` tests pass; typecheck/fmt/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop runs aborting with local_dispatch_failed by disabling the default `Bun` fetch timeout on the loopback `/_sandbox/dispatch` SSE. Long idle periods during tool calls no longer trigger `TimeoutError`.

- **Bug Fixes**
  - Set `timeout: false` on the loopback SSE fetch in `handle-local-dispatch.ts` (matching agent-sandbox streaming behavior).
  - Added a unit test to assert the loopback dispatch sets `timeout: false`.

<sup>Written for commit 6fffae7eac34f4b836c5ab879cd0b09440d661a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

