### PR TITLE
fix(ai-providers): allow localhost sandbox oauth callbacks

### DIFF
--- a/apps/mesh/src/tools/ai-providers/oauth-url.test.ts
+++ b/apps/mesh/src/tools/ai-providers/oauth-url.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { getSettings, setGlobalSettings } from "../../settings";
+import type { Settings } from "../../settings/types";
+import { AI_PROVIDER_OAUTH_URL } from "./oauth-url";
+
+const originalSettings = getSettings();
+
+function setBaseUrl(baseUrl: string): void {
+  setGlobalSettings({
+    ...getSettings(),
+    baseUrl,
+  } as Settings);
+}
+
+afterEach(() => {
+  setGlobalSettings(originalSettings);
+});
+
+describe("AI_PROVIDER_OAUTH_URL input validation", () => {
+  it("accepts localhost subdomain callbacks for local sandbox origins", () => {
+    setBaseUrl("http://localhost:5174");
+
+    const result = AI_PROVIDER_OAUTH_URL.inputSchema.safeParse({
+      providerId: "openrouter",
+      callbackUrl:
+        "http://psi-fornacis-c5d1f5b0da4206c1.localhost:5174/oauth/callback/ai-provider",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects callbacks from unrelated origins", () => {
+    setBaseUrl("http://localhost:5174");
+
+    const result = AI_PROVIDER_OAUTH_URL.inputSchema.safeParse({
+      providerId: "openrouter",
+      callbackUrl: "https://evil.example/oauth/callback/ai-provider",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/mesh/src/tools/ai-providers/oauth-url.ts
+++ b/apps/mesh/src/tools/ai-providers/oauth-url.ts
@@ -9,6 +9,39 @@ import {
 } from "../../ai-providers/pkce";
 import { getSettings } from "../../settings";
 
+function isLocalhostAlias(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname === "::1"
+  );
+}
+
+function normalizedPort(url: URL): string {
+  if (url.port) return url.port;
+  if (url.protocol === "http:") return "80";
+  if (url.protocol === "https:") return "443";
+  return "";
+}
+
+function isAllowedCallbackOrigin(callbackUrl: string): boolean {
+  const settings = getSettings();
+  const base = settings.baseUrl ?? `http://localhost:${settings.port}`;
+  const callback = new URL(callbackUrl);
+  const baseUrl = new URL(base);
+
+  if (callback.origin === baseUrl.origin) return true;
+
+  return (
+    callback.protocol === baseUrl.protocol &&
+    normalizedPort(callback) === normalizedPort(baseUrl) &&
+    isLocalhostAlias(callback.hostname) &&
+    isLocalhostAlias(baseUrl.hostname)
+  );
+}
+
 export const AI_PROVIDER_OAUTH_URL = defineTool({
   name: "AI_PROVIDER_OAUTH_URL",
   description:
@@ -20,9 +53,7 @@ export const AI_PROVIDER_OAUTH_URL = defineTool({
       .url()
       .refine(
         (url) => {
-          const settings = getSettings();
-          const base = settings.baseUrl ?? `http://localhost:${settings.port}`;
-          return new URL(url).origin === new URL(base).origin;
+          return isAllowedCallbackOrigin(url);
         },
         { message: "callbackUrl must be on the same origin as BASE_URL" },
       ),


### PR DESCRIPTION
## Summary
- Allows AI provider OAuth callback validation to treat loopback localhost aliases, including `*.localhost`, as equivalent when protocol and port match.
- Adds regression coverage for Studio-on-Studio sandbox callback origins while preserving rejection of unrelated external origins.

## Test Plan
- `bun test apps/mesh/src/tools/ai-providers/oauth-url.test.ts`
- `bunx biome format --write apps/mesh/src/tools/ai-providers/oauth-url.ts apps/mesh/src/tools/ai-providers/oauth-url.test.ts`

Note: `bun run fmt` exited 0, but Biome emitted an internal RPC diagnostic for an unrelated `org/public/storefront/ecommerce-qa/scripts/check-slugs.ts` path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows AI provider OAuth callbacks from localhost aliases (e.g., *.localhost, 127.0.0.1, ::1) when protocol and port match, fixing sandbox flows while keeping external origins blocked.

- **Bug Fixes**
  - Accept loopback localhost aliases if protocol and port match the app’s `BASE_URL`.
  - Normalize ports (80/443) for accurate comparisons.
  - Add tests covering accepted localhost subdomains and rejection of unrelated origins.

<sup>Written for commit dfb8a75fd30f39dc19ec5edfde1b52f0bdc2744d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

