### PR TITLE
fix(security): apply CSP sandbox to SVG responses to prevent stored XSS

### DIFF
--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -348,7 +348,13 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       // also runs with an opaque origin — its scripts can't make
       // credentialed same-origin calls. allow-modals keeps window.print()
       // working for the deck PDF-export path.
-      if (contentType.startsWith("text/html")) {
+      //
+      // SVG files can contain <script> elements that execute at the
+      // application origin — same CSP sandbox treatment as HTML.
+      if (
+        contentType.startsWith("text/html") ||
+        contentType === "image/svg+xml"
+      ) {
         headers["Content-Security-Policy"] =
           "sandbox allow-scripts allow-modals";
       }


### PR DESCRIPTION
## Summary

**Critical: Stored XSS via SVG upload in org filesystem — session hijacking.**

The org-fs read endpoint (`GET /api/:org/fs/:volume/read?path=*.svg`) served SVG files with `Content-Type: image/svg+xml` but **no Content-Security-Policy header**. The existing CSP sandbox only matched `text/html` (line 351). Since SVG natively supports `<script>` elements, any org member could upload a malicious SVG that executes JavaScript at the full application origin when viewed.

### Attack chain
1. Upload SVG with `<script>` via `PUT /api/:org/fs/:volume/file?path=exploit.svg`
2. Victim opens the read URL — script executes at `studio.decocms.com` origin
3. Script calls `/api/auth/get-session` (same-origin, credentialed) → raw session token in response body
4. Token exfiltrated → full session hijacking

### Fix
One-line change: extend the CSP sandbox condition to also match `image/svg+xml`:

```diff
- if (contentType.startsWith("text/html")) {
+ if (contentType.startsWith("text/html") || contentType === "image/svg+xml") {
```

The `sandbox allow-scripts allow-modals` policy gives the SVG an opaque origin, preventing credentialed same-origin requests while still allowing legitimate SVG animations/scripts.

## Test plan

- [x] `bun run fmt` — passes
- [x] `bun run lint` — passes (0 errors)
- [ ] Verify SVG served from org-fs now includes `Content-Security-Policy: sandbox allow-scripts allow-modals`
- [ ] Verify SVG `<script>` can no longer call `/api/auth/get-session` with credentials
- [ ] Verify HTML files still get the same CSP sandbox
- [ ] Verify non-script SVGs (logos, icons) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied CSP sandbox to SVG responses in the org-fs read endpoint to block stored XSS via inline scripts. This gives SVGs an opaque origin, preventing credentialed same-origin requests and session token theft.

- **Bug Fixes**
  - Extend CSP check to include `image/svg+xml` and set `Content-Security-Policy: sandbox allow-scripts allow-modals` on SVG responses.
  - HTML behavior is unchanged. Non-script SVGs still render as expected.

<sup>Written for commit 782651ceb45dfe78595485edfa01b7e0f15b2f09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

