### PR TITLE
fix(ai-providers): allow local oauth callbacks across ports

### DIFF
--- a/apps/mesh/src/tools/ai-providers/oauth-url.test.ts
+++ b/apps/mesh/src/tools/ai-providers/oauth-url.test.ts
@@ -29,6 +29,18 @@ describe("AI_PROVIDER_OAUTH_URL input validation", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts localhost alias callbacks on a different local dev port", () => {
+    setBaseUrl("http://localhost:3000");
+
+    const result = AI_PROVIDER_OAUTH_URL.inputSchema.safeParse({
+      providerId: "openrouter",
+      callbackUrl:
+        "http://psi-fornacis-c5d1f5b0da4206c1.localhost:5174/oauth/callback/ai-provider",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("rejects callbacks from unrelated origins", () => {
     setBaseUrl("http://localhost:5174");
 

--- a/apps/mesh/src/tools/ai-providers/oauth-url.ts
+++ b/apps/mesh/src/tools/ai-providers/oauth-url.ts
@@ -19,13 +19,6 @@ function isLocalhostAlias(hostname: string): boolean {
   );
 }
 
-function normalizedPort(url: URL): string {
-  if (url.port) return url.port;
-  if (url.protocol === "http:") return "80";
-  if (url.protocol === "https:") return "443";
-  return "";
-}
-
 function isAllowedCallbackOrigin(callbackUrl: string): boolean {
   const settings = getSettings();
   const base = settings.baseUrl ?? `http://localhost:${settings.port}`;
@@ -36,7 +29,6 @@ function isAllowedCallbackOrigin(callbackUrl: string): boolean {
 
   return (
     callback.protocol === baseUrl.protocol &&
-    normalizedPort(callback) === normalizedPort(baseUrl) &&
     isLocalhostAlias(callback.hostname) &&
     isLocalhostAlias(baseUrl.hostname)
   );


### PR DESCRIPTION
## Summary
- allow `AI_PROVIDER_OAUTH_URL` to accept localhost and `*.localhost` callback origins even when the local dev port differs from `BASE_URL`
- keep unrelated external callback origins rejected
- add a regression test for sandbox/local callback URLs on a different port

## Testing
- bun test apps/mesh/src/tools/ai-providers/oauth-url.test.ts
- bun run check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow local OAuth callback URLs across ports for `AI_PROVIDER_OAUTH_URL`. This fixes local dev where the callback port differs from `BASE_URL`, while still blocking unrelated origins.

- **Bug Fixes**
  - Removed strict port matching; compare protocol and require `localhost`/`*.localhost` on both sides.
  - Added regression test for a `*.localhost` callback on a different port.
  - Unrelated external origins remain rejected.

<sup>Written for commit 91d4ea3c6f69cb6ed4c0eb7b9fbc8260120ffa1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

