### PR TITLE
fix(security): restrict OAuth redirect_uri localhost bypass to local mode

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -421,11 +421,13 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
         const redirectUrl = new URL(redirectUri);
         const allowedOriginObj = new URL(allowedOrigin);
 
-        // Check if redirect_uri origin matches the allowed origin
+        // Check if redirect_uri origin matches the allowed origin.
+        // Localhost is only allowed in local mode — in production, an attacker
+        // could set redirect_uri=http://localhost:8080/steal to intercept
+        // OAuth authorization codes on shared hosts or cloud environments.
         const isAllowed =
           redirectUrl.origin === allowedOriginObj.origin ||
-          // Allow localhost for development
-          redirectUrl.hostname === "localhost";
+          (getSettings().localMode && redirectUrl.hostname === "localhost");
 
         if (!isAllowed) {
           return c.json(


### PR DESCRIPTION
## Summary

The OAuth authorize endpoint at `app.ts:425-428` allowed `redirect_uri` to any `localhost` URL regardless of environment:

```typescript
const isAllowed =
  redirectUrl.origin === allowedOriginObj.origin ||
  redirectUrl.hostname === "localhost";  // ← always allowed, even in production
```

In production (cloud/container deployments), an attacker could set `redirect_uri=http://localhost:8080/steal` and intercept OAuth authorization codes if they can bind that port — possible on shared hosts, cloud VMs, or via browser extensions.

### Fix

Gate the localhost exception behind `localMode`:

```diff
- redirectUrl.hostname === "localhost";
+ (getSettings().localMode && redirectUrl.hostname === "localhost");
```

Production only allows redirect_uri matching the configured `baseUrl` origin. Local dev (`bun run dev` / `--local-mode`) continues to allow localhost.

## Test plan

- [x] `bun run fmt` — passes
- [x] `bun run lint` — passes (0 errors)
- [ ] Verify OAuth flow works in production with `redirect_uri` matching `baseUrl`
- [ ] Verify `redirect_uri=http://localhost:8080/steal` is rejected in production
- [ ] Verify localhost redirect_uri still works in local mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts OAuth `redirect_uri` localhost allowance to local mode to close a production security gap. Prevents leaking authorization codes via `http://localhost/...` in cloud or container deployments.

- **Bug Fixes**
  - Gate `localhost` redirects behind `getSettings().localMode`; production now requires origin to match `baseUrl`.
  - Updated validation in `apps/mesh/src/api/app.ts` and added clear comments on the risk and behavior.

<sup>Written for commit 798c8f1c4134d2e8b5efd590c45d1bcded4cd1a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

