### PR TITLE
fix(org-fs): stop macOS NFS mounts hanging + nagging after rclone dies

### DIFF
--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -14,7 +14,7 @@ import { InstallState } from "./install/install-state";
 import { LifecycleManager } from "./lifecycle/manager";
 import { readConfig } from "./persistence";
 import { MountManager } from "./org-fs/mount-manager";
-import { createRcloneMounter } from "./org-fs/mounter";
+import { createRcloneMounter, detachMount } from "./org-fs/mounter";
 import { parseOrgFsConfig } from "./org-fs/config";
 import { repointOutputLink, repointUploadLink } from "./org-fs/thread-links";
 import { ensureRepoOrgLink } from "./org-fs/repo-link";
@@ -890,11 +890,15 @@ async function repointOutputLinkForRun(threadId: string): Promise<boolean> {
   return true;
 }
 
-process.on("SIGTERM", async () => {
+let shuttingDown = false;
+async function shutdown(): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
   taskManager.shutdown();
   branchStatus.stop();
   // Best-effort unmount before exit (rclone --daemon detaches, so it would
-  // otherwise outlive us). Abrupt SIGKILL/pod-delete skips this — tolerated.
+  // otherwise outlive us). A truly abrupt SIGKILL skips this — the sync `exit`
+  // handler below and the next boot's reclaim are the backstops.
   if (mountManager) {
     await mountManager.stop().catch(() => {});
   }
@@ -915,4 +919,26 @@ process.on("SIGTERM", async () => {
     }
   }
   process.exit(0);
+}
+
+// SIGINT too: the user Ctrl-C'ing the `decocms link` terminal signals the whole
+// process group, and without a handler the default action skips the unmount —
+// leaving a stale macOS NFS mount that hangs and pops the reconnect dialog.
+process.on("SIGTERM", () => void shutdown());
+process.on("SIGINT", () => void shutdown());
+
+// Last-resort synchronous detach for any path that bypassed shutdown() (a raw
+// process.exit, or shutdown() not finishing). After stop() ran, list() is empty
+// so this is a no-op; it only does work on the residual exit path. `umount -f`
+// is the non-blocking force-detach — detaching the kernel mount is what stops
+// the hang/dialog; the orphaned rclone child then exits on its own.
+const isMac = process.platform === "darwin";
+process.on("exit", () => {
+  for (const { mountPath } of mountManager?.list() ?? []) {
+    try {
+      detachMount(mountPath, isMac);
+    } catch {
+      // best-effort
+    }
+  }
 });

--- a/packages/sandbox/daemon/org-fs/mount-manager.test.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { sleep } from "@decocms/std";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   type InvalidatorFactory,
@@ -68,20 +69,39 @@ describe("parseOrgFsConfig", () => {
 function fakeMounter(opts: { failVolumes?: Set<string> } = {}) {
   const calls: { webdavUrl: string; mountPath: string }[] = [];
   const unmounted: string[] = [];
+  // mountPath -> resolver for that mount's `exited`, so a test can simulate an
+  // unexpected rclone death with crash(mountPath).
+  const exiters = new Map<string, (code: number) => void>();
   const mounter: Mounter = {
     async mount({ webdavUrl, mountPath }) {
       calls.push({ webdavUrl, mountPath });
       // Fail volumes whose mount path ends with a flagged segment.
       for (const v of opts.failVolumes ?? [])
         if (mountPath.endsWith(`/${v}`)) throw new Error(`forced fail ${v}`);
+      let resolveExit!: (code: number) => void;
+      const exited = new Promise<number>((res) => {
+        resolveExit = res;
+      });
+      exiters.set(mountPath, resolveExit);
       return {
+        exited,
         async unmount() {
           unmounted.push(mountPath);
+          resolveExit(0); // mirrors the real handle: unmount resolves exited
         },
       };
     },
   };
-  return { mounter, calls, unmounted };
+  /** Simulate an unexpected rclone death for the mount at `mountPath`. */
+  const crash = (mountPath: string) => exiters.get(mountPath)?.(1);
+  return { mounter, calls, unmounted, crash };
+}
+
+/** Poll until `cond` holds (or throw). For the fire-and-forget death watcher. */
+async function waitUntil(cond: () => boolean, timeoutMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond() && Date.now() < deadline) await sleep(5);
+  if (!cond()) throw new Error("condition not met in time");
 }
 
 const config = (
@@ -187,6 +207,43 @@ describe("MountManager", () => {
     await mm.start(config([{ volume: "evil", path: "../../etc" }]), appRoot);
     expect(calls.length).toBe(0);
     expect(inv.started).toEqual([]);
+    expect(mm.list()).toEqual([]);
+  });
+
+  it("self-heals: an unexpected rclone exit reclaims + remounts once", async () => {
+    const { mounter, calls, unmounted, crash } = fakeMounter();
+    const inv = fakeInvalidators();
+    const mm = new MountManager(mounter, () => {}, inv.factory);
+    await mm.start(config([{ volume: "skills", path: "skills" }]), appRoot);
+    const path = join(appRoot, "org/skills");
+    expect(calls.length).toBe(1);
+
+    // rclone crashes → reclaim the stale mount, then remount once.
+    crash(path);
+    await waitUntil(() => calls.length === 2);
+    expect(unmounted).toContain(path);
+    expect(mm.list().map((m) => m.volume)).toEqual(["skills"]);
+    // a fresh invalidator for the remount (started twice total: orig + remount)
+    expect(inv.started.filter((s) => s.volume === "skills").length).toBe(2);
+
+    // a SECOND crash does not remount again (one-shot self-heal).
+    crash(path);
+    await waitUntil(() => mm.list().length === 0);
+    expect(calls.length).toBe(2);
+
+    await mm.stop();
+  });
+
+  it("does not remount when the exit comes from a deliberate stop()", async () => {
+    const { mounter, calls } = fakeMounter();
+    const inv = fakeInvalidators();
+    const mm = new MountManager(mounter, () => {}, inv.factory);
+    await mm.start(config([{ volume: "skills", path: "skills" }]), appRoot);
+    expect(calls.length).toBe(1);
+
+    await mm.stop(); // unmount() resolves exited, but `closing` blocks the watcher
+    await sleep(20); // let any stray watcher microtask run
+    expect(calls.length).toBe(1); // no remount
     expect(mm.list()).toEqual([]);
   });
 });

--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -24,7 +24,7 @@ import { safePath } from "../paths";
 // import style entry.ts uses for harness factories).
 import { OrgFsClient } from "../../../../apps/mesh/src/file-storage/mount/client";
 import { createWebdavHandler } from "../../../../apps/mesh/src/file-storage/mount/webdav";
-import type { OrgFsMountConfig } from "./config";
+import type { OrgFsMountConfig, OrgFsVolumeMount } from "./config";
 import { makeRcRefresh, runInvalidator } from "./invalidator";
 
 export type { OrgFsMountConfig, OrgFsVolumeMount } from "./config";
@@ -32,6 +32,12 @@ export type { OrgFsMountConfig, OrgFsVolumeMount } from "./config";
 /** A handle to an established OS mount. */
 export interface MountHandle {
   unmount(): Promise<void>;
+  /**
+   * Resolves when the underlying mount process exits. Lets MountManager notice
+   * an unexpected rclone death (crash/OOM with the daemon still alive) and
+   * self-heal before the mount goes stale. Optional: fakes/tests may omit it.
+   */
+  exited?: Promise<number>;
 }
 
 /**
@@ -90,6 +96,12 @@ interface ActiveMount {
   stopServer: () => void;
   handle: MountHandle;
   invalidator: VolumeInvalidator;
+  /**
+   * Set before any intentional teardown (`stop()` or the death watcher's own
+   * cleanup) so the `handle.exited` watcher can tell a deliberate unmount apart
+   * from a crash and not fight it / re-mount over it.
+   */
+  closing: boolean;
 }
 
 /** Bind :0 to grab a free loopback port for rclone's rc, then release it. */
@@ -122,6 +134,9 @@ export function resolveMountPath(appRoot: string, p: string): string | null {
 
 export class MountManager {
   private active: ActiveMount[] = [];
+  private config: OrgFsMountConfig | null = null;
+  private appRoot = "";
+  private stopped = false;
 
   constructor(
     private readonly mounter: Mounter,
@@ -132,66 +147,137 @@ export class MountManager {
 
   /** Serve + mount every configured volume. Never throws. */
   async start(config: OrgFsMountConfig, appRoot: string): Promise<void> {
+    this.config = config;
+    this.appRoot = appRoot;
+    this.stopped = false;
     for (const m of config.mounts) {
+      await this.mountOne(m);
+    }
+  }
+
+  /**
+   * Serve + mount a single volume and register it in `active`. Never throws.
+   * `canRemount` gates the death-watcher's one-shot self-heal: the initial
+   * mount allows it, a watcher-triggered remount does not (bounds it to a
+   * single retry — see "Out of scope" follow-up for backoff).
+   */
+  private async mountOne(
+    m: OrgFsVolumeMount,
+    canRemount = true,
+  ): Promise<void> {
+    const config = this.config;
+    if (!config || this.stopped) return;
+    try {
+      const mountPath = resolveMountPath(this.appRoot, m.path);
+      if (!mountPath) {
+        this.log(`skip ${m.volume}: mount path "${m.path}" escapes appRoot`);
+        return;
+      }
+      mkdirSync(mountPath, { recursive: true });
+
+      const client = new OrgFsClient({
+        baseUrl: config.baseUrl,
+        orgSlug: config.orgSlug,
+        volume: m.volume,
+        token: config.token,
+      });
+      // Loopback only; rclone is the sole client and it sits behind it.
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: createWebdavHandler(client),
+      });
+      const webdavUrl = `http://127.0.0.1:${server.port}`;
+
       try {
-        const mountPath = resolveMountPath(appRoot, m.path);
-        if (!mountPath) {
-          this.log(`skip ${m.volume}: mount path "${m.path}" escapes appRoot`);
-          continue;
-        }
-        mkdirSync(mountPath, { recursive: true });
-
-        const client = new OrgFsClient({
-          baseUrl: config.baseUrl,
-          orgSlug: config.orgSlug,
+        const rcAddr = `127.0.0.1:${await freePort()}`;
+        const handle = await this.mounter.mount({
+          webdavUrl,
+          mountPath,
+          rcAddr,
+          readonly: m.readonly,
+        });
+        // Near-realtime freshness: feed-driven vfs/refresh against rclone's rc.
+        const invalidator = this.startInvalidator({
+          client,
+          rcUrl: `http://${rcAddr}`,
           volume: m.volume,
-          token: config.token,
+          log: this.log,
         });
-        // Loopback only; rclone is the sole client and it sits behind it.
-        const server = Bun.serve({
-          port: 0,
-          hostname: "127.0.0.1",
-          fetch: createWebdavHandler(client),
+        const entry: ActiveMount = {
+          volume: m.volume,
+          mountPath,
+          stopServer: () => server.stop(true),
+          handle,
+          invalidator,
+          closing: false,
+        };
+        this.active.push(entry);
+        // Self-heal: an unexpected rclone death (crash/OOM, daemon still alive)
+        // would leave a stale mount that hangs/nags. Watch the child's exit and
+        // reclaim + remount once. A deliberate unmount sets `closing` first, so
+        // this only fires on a real crash.
+        void handle.exited?.then(() => {
+          void this.onRcloneExit(entry, m, canRemount);
         });
-        const webdavUrl = `http://127.0.0.1:${server.port}`;
-
-        try {
-          const rcAddr = `127.0.0.1:${await freePort()}`;
-          const handle = await this.mounter.mount({
-            webdavUrl,
-            mountPath,
-            rcAddr,
-            readonly: m.readonly,
-          });
-          // Near-realtime freshness: feed-driven vfs/refresh against rclone's rc.
-          const invalidator = this.startInvalidator({
-            client,
-            rcUrl: `http://${rcAddr}`,
-            volume: m.volume,
-            log: this.log,
-          });
-          this.active.push({
-            volume: m.volume,
-            mountPath,
-            stopServer: () => server.stop(true),
-            handle,
-            invalidator,
-          });
-          this.log(`mounted ${m.volume} at ${mountPath}`);
-        } catch (err) {
-          server.stop(true);
-          this.log(`mount failed for ${m.volume} (skipped)`, err);
-        }
+        this.log(`mounted ${m.volume} at ${mountPath}`);
       } catch (err) {
+        server.stop(true);
         this.log(`mount failed for ${m.volume} (skipped)`, err);
       }
+    } catch (err) {
+      this.log(`mount failed for ${m.volume} (skipped)`, err);
     }
+  }
+
+  /**
+   * React to an unexpected rclone exit: drop the entry, reclaim the now-stale
+   * kernel mount (rclone is already gone, so `unmount()` just force-detaches),
+   * then remount once if allowed. Never throws.
+   */
+  private async onRcloneExit(
+    entry: ActiveMount,
+    m: OrgFsVolumeMount,
+    canRemount: boolean,
+  ): Promise<void> {
+    if (entry.closing) return; // deliberate teardown — not a crash
+    const idx = this.active.indexOf(entry);
+    if (idx === -1) return; // already removed
+    entry.closing = true;
+    this.active.splice(idx, 1);
+    this.log(`rclone for ${entry.volume} exited unexpectedly; reclaiming`);
+    try {
+      entry.invalidator.stop();
+    } catch {
+      // already stopped
+    }
+    try {
+      await entry.handle.unmount();
+    } catch (err) {
+      this.log(`reclaim unmount failed for ${entry.volume}`, err);
+    }
+    try {
+      entry.stopServer();
+    } catch {
+      // server already stopped
+    }
+    if (this.stopped || !canRemount) {
+      if (!canRemount)
+        this.log(`not remounting ${entry.volume} (retried once)`);
+      return;
+    }
+    this.log(`remounting ${entry.volume}`);
+    await this.mountOne(m, false); // the remount itself does not re-remount
   }
 
   /** Unmount everything and stop the WebDAV servers. Never throws. */
   async stop(): Promise<void> {
+    this.stopped = true;
     const mounts = this.active;
     this.active = [];
+    // Flag intent before any unmount so each handle.exited watcher sees a
+    // deliberate teardown and doesn't try to reclaim/remount.
+    for (const a of mounts) a.closing = true;
     await Promise.all(
       mounts.map(async (a) => {
         try {

--- a/packages/sandbox/daemon/org-fs/mounter.test.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { buildMountArgs } from "./mounter";
+
+describe("buildMountArgs", () => {
+  it("macOS: nfsmount with soft + bounded timeo (no-hang) options", () => {
+    const args = buildMountArgs({ isMac: true, mountPath: "/ws/org/skills" });
+    expect(args.slice(0, 3)).toEqual(["nfsmount", "wd:", "/ws/org/skills"]);
+    const optIdx = args.indexOf("--option");
+    expect(optIdx).toBeGreaterThan(-1);
+    // soft + bounded timeo/retrans turn the macOS NFS hard-mount hang (and the
+    // "Server connections interrupted" dialog) into a fast, recoverable error.
+    expect(args[optIdx + 1]).toBe(
+      "actimeo=1,locallocks,soft,timeo=100,retrans=2,nobrowse",
+    );
+    expect(args).toContain("--vfs-cache-mode");
+    expect(args).toContain("full");
+    expect(args).toContain("--vfs-write-back");
+    expect(args).toContain("--dir-cache-time");
+  });
+
+  it("Linux: mount, no --option, --allow-other only when requested", () => {
+    const base = buildMountArgs({ isMac: false, mountPath: "/app/org/x" });
+    expect(base.slice(0, 3)).toEqual(["mount", "wd:", "/app/org/x"]);
+    expect(base).not.toContain("--option");
+    expect(base).not.toContain("--allow-other");
+    const shared = buildMountArgs({
+      isMac: false,
+      mountPath: "/app/org/x",
+      allowOther: true,
+    });
+    expect(shared).toContain("--allow-other");
+  });
+
+  it("rcAddr adds the rc control flags", () => {
+    const args = buildMountArgs({
+      isMac: true,
+      mountPath: "/m",
+      rcAddr: "127.0.0.1:5572",
+    });
+    expect(args).toContain("--rc");
+    expect(args[args.indexOf("--rc-addr") + 1]).toBe("127.0.0.1:5572");
+    expect(args).toContain("--rc-no-auth");
+  });
+
+  it("readonly adds --read-only and exec file perms; default omits them", () => {
+    const ro = buildMountArgs({ isMac: true, mountPath: "/m", readonly: true });
+    expect(ro).toContain("--read-only");
+    expect(ro[ro.indexOf("--file-perms") + 1]).toBe("0755");
+    expect(buildMountArgs({ isMac: true, mountPath: "/m" })).not.toContain(
+      "--read-only",
+    );
+  });
+});

--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -17,6 +17,14 @@
  * API instead of awaiting the launcher's exit. `unmount()` detaches the OS
  * mount and kills the child.
  *
+ * macOS staleness: an NFS mount survives the rclone process that served it, so
+ * any ungraceful exit (SIGKILL, crash, sleep) leaves a ghost mount that hangs
+ * I/O and pops the "Server connections interrupted" dialog. Two defenses live
+ * here: `mount()` force-detaches any stale mount at the path before mounting
+ * (reclaim), and the macOS mount is `soft` with a bounded `timeo` so a dead
+ * server fails fast instead of hanging forever (FUSE on Linux already does this
+ * via ENOTCONN).
+ *
  * `rclonePath` must point at a real rclone binary with mount support (the
  * Homebrew build notably lacks it). When rclone isn't available the daemon
  * should not construct this — see MountManager (mounting is then skipped).
@@ -28,6 +36,105 @@ import type { MountHandle, Mounter } from "./mount-manager";
 /** How long to wait for the mount to attach before giving up. */
 const READY_TIMEOUT_MS = 15_000;
 const READY_POLL_MS = 200;
+
+/**
+ * macOS `mount_nfs` options (passed through rclone `nfsmount --option`):
+ *  - actimeo=1: the macOS NFS client caches dir/file attributes ~5s by default,
+ *    which would mask the invalidator's freshness; 1s is cheap against a
+ *    loopback server.
+ *  - locallocks: rclone's NFS server has no lock daemon (NLM), so apps that take
+ *    file locks (sqlite, editors) would hang against it. The mount is strictly
+ *    single-client (loopback), so client-local lock semantics are exact.
+ *  - soft: return an I/O error once a request exhausts its retransmissions
+ *    instead of blocking forever. Safe here because the server is loopback —
+ *    healthy it answers in microseconds, dead it refuses the connection — so
+ *    this only ever trips when rclone is genuinely gone, turning the classic NFS
+ *    hard-mount hang (+ persistent reconnect dialog) into a fast, recoverable
+ *    error. Writes land in rclone's local VFS cache first, so a slow mesh never
+ *    makes a write slow enough to trip this.
+ *  - timeo=100 (tenths of a sec → 10s) / retrans=2: generous per-request
+ *    headroom so a legitimately slow read (first open of a large uncached file
+ *    that rclone must fetch whole from the mesh) is not killed, while still
+ *    bounding a dead-server hang to ~tens of seconds. Tuning knob: lower timeo
+ *    for snappier dead-mount recovery only if large-read tests still pass.
+ *  - nobrowse: keep the volume out of the Finder sidebar/desktop, reducing the
+ *    surface for Finder-driven reconnect prompts.
+ */
+const MAC_NFS_OPTIONS =
+  "actimeo=1,locallocks,soft,timeo=100,retrans=2,nobrowse";
+
+/**
+ * Build the full rclone argv (everything after the binary path). Pure so the
+ * option set is unit-testable without spawning rclone.
+ */
+export function buildMountArgs(opts: {
+  isMac: boolean;
+  mountPath: string;
+  /** FUSE `--allow-other` (Linux only). */
+  allowOther?: boolean;
+  readonly?: boolean;
+  rcAddr?: string;
+}): string[] {
+  const mountArgs = opts.isMac
+    ? ["nfsmount", "wd:", opts.mountPath, "--option", MAC_NFS_OPTIONS]
+    : [
+        "mount",
+        "wd:",
+        opts.mountPath,
+        ...(opts.allowOther ? ["--allow-other"] : []),
+      ];
+  const rcArgs = opts.rcAddr
+    ? ["--rc", "--rc-addr", opts.rcAddr, "--rc-no-auth"]
+    : [];
+  // Public sets: enforce read-only at the mount, and blanket-exec perms (the
+  // manifest carries no mode bits; skill helper scripts need +x).
+  const roArgs = opts.readonly ? ["--read-only", "--file-perms", "0755"] : [];
+  return [
+    ...mountArgs,
+    "--vfs-cache-mode",
+    "full",
+    // Flush closed files fast: agent outputs become chips/visible to the org
+    // ~1s after close instead of rclone's 5s default. Files written
+    // incrementally still upload after write-quiescence.
+    "--vfs-write-back",
+    "1s",
+    // Safety-net TTL if the invalidator isn't running or misses a change; the
+    // change-feed-driven vfs/refresh (invalidator.ts) is what makes external
+    // writes show up in ~1s.
+    "--dir-cache-time",
+    "10s",
+    ...rcArgs,
+    ...roArgs,
+  ];
+}
+
+/**
+ * Force-detach whatever is mounted at `mountPath` (best-effort, never throws).
+ * Used both to tear down our own mount and to reclaim a stale ghost left by a
+ * previously-killed session before mounting fresh. On a path that isn't a mount
+ * point every command exits non-zero and we simply move on.
+ */
+export function detachMount(mountPath: string, isMac: boolean): void {
+  // NFS + FUSE both unmount via `umount`; on Linux `fusermount -u` is the
+  // unprivileged path, so try it first there.
+  const cmds: string[][] = isMac
+    ? [["umount", "-f", mountPath]]
+    : [
+        ["fusermount", "-u", mountPath],
+        ["umount", mountPath],
+      ];
+  for (const cmd of cmds) {
+    // `umount -f` is the non-blocking force path, but bound it anyway: this
+    // runs on every mount (reclaim) and at shutdown, and a wedged kernel
+    // unmount must never hang the daemon.
+    const p = Bun.spawnSync(cmd, {
+      stdout: "ignore",
+      stderr: "ignore",
+      timeout: 5000,
+    });
+    if (p.exitCode === 0) break;
+  }
+}
 
 export function createRcloneMounter(
   rclonePath: string,
@@ -41,57 +148,27 @@ export function createRcloneMounter(
   const isMac = process.platform === "darwin";
   return {
     async mount({ webdavUrl, mountPath, rcAddr, readonly }) {
-      const args = isMac
-        ? // actimeo=1: the macOS NFS client caches dir/file attributes ~5s by
-          // default, which would mask the invalidator's freshness; 1s is cheap
-          // against a loopback server.
-          // locallocks: rclone's NFS server has no lock daemon (NLM), so apps
-          // that take file locks (sqlite, editors) would hang against it. The
-          // mount is strictly single-client (loopback), so client-local lock
-          // semantics are exact.
-          ["nfsmount", "wd:", mountPath, "--option", "actimeo=1,locallocks"]
-        : [
-            "mount",
-            "wd:",
-            mountPath,
-            ...(opts.allowOther ? ["--allow-other"] : []),
-          ];
-      const rcArgs = rcAddr
-        ? ["--rc", "--rc-addr", rcAddr, "--rc-no-auth"]
-        : [];
-      // Public sets: enforce read-only at the mount, and blanket-exec perms
-      // (the manifest carries no mode bits; skill helper scripts need +x).
-      const roArgs = readonly ? ["--read-only", "--file-perms", "0755"] : [];
-      const proc = Bun.spawn(
-        [
-          rclonePath,
-          ...args,
-          "--vfs-cache-mode",
-          "full",
-          // Flush closed files fast: agent outputs become chips/visible to
-          // the org ~1s after close instead of rclone's 5s default. Files
-          // written incrementally still upload after write-quiescence.
-          "--vfs-write-back",
-          "1s",
-          // Safety-net TTL if the invalidator isn't running or misses a change;
-          // the change-feed-driven vfs/refresh (invalidator.ts) is what makes
-          // external writes show up in ~1s.
-          "--dir-cache-time",
-          "10s",
-          ...rcArgs,
-          ...roArgs,
-        ],
-        {
-          env: {
-            ...process.env,
-            RCLONE_CONFIG_WD_TYPE: "webdav",
-            RCLONE_CONFIG_WD_URL: webdavUrl,
-            RCLONE_CONFIG_WD_VENDOR: "other",
-          },
-          stdout: "ignore",
-          stderr: "ignore",
+      // Reclaim: clear a stale mount from a prior killed session so we don't
+      // layer a fresh mount over a hung one (no-op on a clean path).
+      detachMount(mountPath, isMac);
+
+      const args = buildMountArgs({
+        isMac,
+        mountPath,
+        allowOther: opts.allowOther,
+        readonly,
+        rcAddr,
+      });
+      const proc = Bun.spawn([rclonePath, ...args], {
+        env: {
+          ...process.env,
+          RCLONE_CONFIG_WD_TYPE: "webdav",
+          RCLONE_CONFIG_WD_URL: webdavUrl,
+          RCLONE_CONFIG_WD_VENDOR: "other",
         },
-      );
+        stdout: "ignore",
+        stderr: "ignore",
+      });
       try {
         await waitForMount(proc, rcAddr, args[0]!, mountPath);
       } catch (err) {
@@ -152,20 +229,12 @@ function makeHandle(
   isMac: boolean,
 ): MountHandle {
   return {
+    // Surfaced so MountManager can watch for an unexpected rclone death and
+    // self-heal (reclaim + remount) before the mount goes stale.
+    exited: proc.exited,
     async unmount() {
-      // Detach the OS mount first; NFS + FUSE both unmount via `umount`, and on
-      // Linux `fusermount -u` is the unprivileged path, so try it first there.
-      const cmds: string[][] = isMac
-        ? [["umount", "-f", mountPath]]
-        : [
-            ["fusermount", "-u", mountPath],
-            ["umount", mountPath],
-          ];
-      for (const cmd of cmds) {
-        const p = Bun.spawnSync(cmd, { stdout: "ignore", stderr: "ignore" });
-        if (p.exitCode === 0) break;
-      }
-      // Then stop the foreground rclone child.
+      // Detach the OS mount first, then stop the foreground rclone child.
+      detachMount(mountPath, isMac);
       try {
         proc.kill();
       } catch {


### PR DESCRIPTION
## What is this contribution about?
On macOS the org-fs NFS mount outlived the rclone process that served it, so any ungraceful exit (SIGKILL, crash, sleep, Ctrl-C of the `decocms link` terminal) left a ghost mount that hung the agent on writes and popped the "Server connections interrupted" dialog — mac-only, since Linux/FUSE fails fast with `ENOTCONN`. This adds four additive layers: **(A)** reclaim a stale mount before mounting, **(B)** unmount on `SIGINT` + a synchronous `exit` handler (not just `SIGTERM`), **(C)** mount `soft` with a bounded `timeo` so a dead loopback server fails fast instead of hanging forever, and **(D)** a per-mount watcher that remounts once if rclone crashes mid-session. The mac mount-option construction was extracted into a pure, unit-tested `buildMountArgs`, and `detachMount` now bounds its `umount -f` with a 5s timeout.

## Screenshots/Demonstration
No UI changes. Validated on-device against a real loopback NFS mount: a write into a `kill -9`'d mount now returns an error in **~6.8s** instead of hanging forever, with no persistent reconnect dialog.

## How to Test
1. `bun test packages/sandbox/daemon/org-fs/` → 35 pass (new `mounter.test.ts` for `buildMountArgs`, plus two self-heal/remount cases in `mount-manager.test.ts`).
2. On a Mac with a live mount: `kill -9` the `rclone nfsmount` process, then write into the mount → expect a fast error (not an infinite hang) and the "Server connections interrupted" dialog should not persist; re-mounting reclaims the ghost.
3. Ctrl-C the `decocms link` terminal (SIGINT) and, separately, a provider eviction (SIGTERM) → both unmount cleanly, no stale mount on next boot.

## Migration Notes
None — additive, runtime-only; Linux/FUSE and the cluster sidecar paths are unchanged.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS org-fs mounts hanging and showing the reconnect dialog after `rclone` dies. Mounts now fail fast, clean up on exit, and self-heal once if `rclone` crashes (Linux/FUSE unchanged).

- **Bug Fixes**
  - Reclaim any stale mount before mounting via `detachMount` (bounded `umount -f`).
  - Unmount on `SIGINT` and in a synchronous `exit` handler, not just `SIGTERM`.
  - macOS: mount NFS as `soft` with bounded `timeo`/`retrans` to avoid infinite hangs.
  - Watch the `rclone` child; on unexpected exit, reclaim and remount once (no retry on deliberate stop).
  - Extracted and unit-tested `buildMountArgs`; added remount/self-heal tests.

<sup>Written for commit 9f4debf06eb8a493eb9ed1cf283db16ef80bcad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

