### PR TITLE
chore(skills): point remaining skill docs at org/public/core

### DIFF
--- a/packages/sandbox/image/skills/docx/SKILL.md
+++ b/packages/sandbox/image/skills/docx/SKILL.md
@@ -15,7 +15,7 @@ Print text content from a `.docx` as plain text. Paragraphs are separated by
 blank lines; tables are rendered with tab-separated cells.
 
 ```
-python /mnt/skills/public/docx/extract.py <path-to-file.docx>
+python org/public/core/docx/extract.py <path-to-file.docx>
 ```
 
 ## Direct python-docx usage

--- a/packages/sandbox/image/skills/pdf/SKILL.md
+++ b/packages/sandbox/image/skills/pdf/SKILL.md
@@ -14,7 +14,7 @@ Use this skill to read text from `.pdf` files.
 Print text content from a `.pdf`, page by page.
 
 ```
-python /mnt/skills/public/pdf/extract.py <path-to-file.pdf>
+python org/public/core/pdf/extract.py <path-to-file.pdf>
 ```
 
 Output is plain text with `--- page N ---` separators. PDFs that are pure

--- a/packages/sandbox/image/skills/pptx/SKILL.md
+++ b/packages/sandbox/image/skills/pptx/SKILL.md
@@ -9,7 +9,7 @@ Reading and inspection of `.pptx` files. Editing and creation are not yet
 supported.
 
 > **Making a presentation, slide deck, or "slides"?** This is NOT the
-> skill — use the **`slides`** skill (`/mnt/skills/public/slides/SKILL.md`),
+> skill — use the **`slides`** skill (`org/public/core/slides/SKILL.md`),
 > which authors HTML decks with a live, editable preview. Reach for `pptx`
 > ONLY when the user explicitly works with a PowerPoint `.pptx` file —
 > reading one they uploaded, or when they specifically ask for `.pptx`

--- a/packages/sandbox/image/skills/slides/slides-create.mjs
+++ b/packages/sandbox/image/skills/slides/slides-create.mjs
@@ -22,7 +22,7 @@
  * Studio's /deck-runtime/v1/deck-viewer.js.
  *
  * Built on the `templating` skill's mustache engine — see
- * /mnt/skills/public/templating/SKILL.md for the template syntax.
+ * org/public/core/templating/SKILL.md for the template syntax.
  */
 
 import {

--- a/packages/sandbox/image/skills/xlsx/SKILL.md
+++ b/packages/sandbox/image/skills/xlsx/SKILL.md
@@ -15,7 +15,7 @@ Print sheet contents from an `.xlsx` as TSV. Each sheet is preceded by a
 `--- sheet "<name>" ---` header.
 
 ```
-python /mnt/skills/public/xlsx/extract.py <path-to-file.xlsx>
+python org/public/core/xlsx/extract.py <path-to-file.xlsx>
 ```
 
 Empty trailing rows and columns are trimmed. Cell values are stringified;


### PR DESCRIPTION
## What is this contribution about?
Core skills are now synced into the `org/public/core` mount (see `public-sets.ts`), which replaces the image-baked `/mnt/skills/public` for skill discovery. `main` already migrated the `file-reading` and `slides` docs; this finishes the job for the remaining agent-facing references in `xlsx`, `pdf`, `docx`, `pptx` and the `slides-create` comment. The Dockerfile bake and the `_bin` bare commands (`slides-create`, `pptx-*`) still run from `/mnt/skills` and are intentionally left as-is — retiring those is a separate executable-distribution change.

## How to Test
1. `grep -rn "/mnt/skills" packages/sandbox/image/skills/*/SKILL.md` → no matches.
2. The only remaining `/mnt/skills` refs are the Dockerfile, `_bin/*` wrappers, and the `skills-features.md` tracking doc (all load-bearing / accurate).

## Migration Notes
Docs-only change; takes effect for agents on the next sandbox image rebuild / skill-set sync. No DB migration, no behavior change.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update skill docs and inline comments to use the `org/public/core` mount instead of `/mnt/skills/public` for `docx`, `pdf`, `pptx`, `xlsx`, and `slides-create`. Docs-only; no behavior changes—remaining `/mnt/skills` refs in the Dockerfile and `_bin` wrappers are intentional.

<sup>Written for commit 9ada8352d315a1ad8899b7ea8df1b9d8f4818e11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

