### PR TITLE
feat(link): persist local sandbox registry and prune

### DIFF
--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -65,6 +65,10 @@ const { values, positionals } = parseArgs({
       type: "boolean",
       default: false,
     },
+    prune: {
+      type: "boolean",
+      default: false,
+    },
     target: { type: "string" },
     env: { type: "string", short: "e" },
     "dry-run": {
@@ -114,6 +118,7 @@ Auth Options:
 Link Options:
   [studio-url]      Studio to link against (default: https://studio.decocms.com)
   --port <port>     Local port for the daemon (default: 5174)
+  --prune           Prune safe stale local sandboxes before starting link
 
 Backfill Options (backfill-assets):
   --target <t>          all | threads | connections | organizations (default: all)
@@ -312,6 +317,7 @@ if (command === "link") {
     tui,
     version: await getVersion(),
     hotReload: values.hot === true,
+    prune: values.prune === true,
     // Managed daemons (dev / npx --local-sandbox-provider) suppress the
     // banner — the parent dev/serve process already renders one.
     banner: process.env.DECOCMS_LINK_MANAGED !== "1",

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -16,6 +16,12 @@ import { join } from "node:path";
 import { ensureSession } from "../lib/ensure-session";
 import { startLinkDaemon, type LinkDaemonMonitor } from "../../link-daemon";
 import { formatLogLine } from "../format-log-line";
+import {
+  openLinkSandboxRegistry,
+  registryPathForDataDir,
+  type LinkSandboxRecord,
+  type LinkSandboxRegistry,
+} from "../link-sandbox-registry";
 
 export interface LinkCommandOptions {
   port?: number;
@@ -34,6 +40,8 @@ export interface LinkCommandOptions {
   banner?: boolean;
   /** Hot-reload sandbox daemons spawned by this link process. */
   hotReload?: boolean;
+  /** Prune safe stale local sandboxes before starting link. */
+  prune?: boolean;
 }
 
 /**
@@ -117,7 +125,24 @@ export async function runLinkCommand(
 
   let restoreConsole: (() => void) | undefined;
   let logFd: number | undefined;
+  let registry: LinkSandboxRegistry | undefined;
+  const closeRegistry = () => {
+    if (registry === undefined) return;
+    try {
+      registry.close();
+    } catch {
+      // already closed
+    } finally {
+      registry = undefined;
+    }
+  };
   try {
+    const sandboxRoot = join(dataDir, "sandboxes");
+    registry = openLinkSandboxRegistry({
+      path: registryPathForDataDir(dataDir),
+      managedSandboxRoot: sandboxRoot,
+    });
+
     // Login flow (may open a browser / prompt) runs with normal console.
     // Auth targets the same studio we link against.
     const session = await ensureSession({
@@ -134,6 +159,17 @@ export async function runLinkCommand(
       await assertStudioAcceptsToken(clusterBaseUrl, session.accessToken);
     }
 
+    let persistedRows: LinkSandboxRecord[] = registry.reconcile();
+    if (opts.prune) {
+      const pruneResult = registry.prune({ missing: true, merged: true });
+      if (!opts.tui) {
+        console.log(
+          `Pruned local sandboxes: removed ${pruneResult.removed.length}, skipped ${pruneResult.skipped.length}.`,
+        );
+      }
+      persistedRows = registry.reconcile();
+    }
+
     let monitor: LinkDaemonMonitor | undefined;
 
     if (opts.tui) {
@@ -148,6 +184,7 @@ export async function runLinkCommand(
         setIngress,
         setLogPath,
         setMachine,
+        setPersistedSandboxes,
       } = await import("../link-store");
 
       // link.log — the daemon's own intercepted console (cluster connection,
@@ -164,6 +201,7 @@ export async function runLinkCommand(
       logFd = openSync(logPath, "w");
       setLogPath(logPath);
 
+      setPersistedSandboxes(persistedRows);
       setClusterUrl(clusterBaseUrl);
       setCluster("connecting");
       monitor = {
@@ -178,6 +216,8 @@ export async function runLinkCommand(
       const { printBanner } = await import("../banner-art");
       printBanner(opts.version ?? "0.0.0");
     }
+
+    closeRegistry();
 
     // Standalone `deco link` isolates each sandbox daemon's output into its own
     // `<workdir>/tmp/daemon.log`. The managed/dev daemon leaves it off so its
@@ -211,5 +251,6 @@ export async function runLinkCommand(
         // already closed
       }
     }
+    closeRegistry();
   }
 }

--- a/apps/mesh/src/cli/link-app.tsx
+++ b/apps/mesh/src/cli/link-app.tsx
@@ -12,6 +12,12 @@ function statusCell(row: SandboxRow): { color: string; text: string } {
   if (row.status === "ready") return { color: "green", text: "● Live" };
   if (row.status === "spawning")
     return { color: "yellow", text: "◌ Starting…" };
+  if (row.status === "stopped") return { color: "gray", text: "■ Stopped" };
+  if (row.status === "missing") return { color: "yellow", text: "□ Missing" };
+  if (row.status === "merged") return { color: "cyan", text: "✓ Merged" };
+  if (row.status === "invalid") return { color: "red", text: "✗ Invalid" };
+  if (row.status === "failed")
+    return { color: "red", text: `✗ Failed: ${row.error ?? "failed"}` };
   return { color: "red", text: `✗ Error: ${row.error ?? ""}` };
 }
 
@@ -20,6 +26,7 @@ function statusCell(row: SandboxRow): { color: string; text: string } {
 // still separates from the next. PREVIEW URL is last and takes the rest.
 const COLS = {
   project: 18,
+  branch: 22,
   status: 14,
 } as const;
 
@@ -73,6 +80,11 @@ export function LinkApp() {
                 PROJECT
               </Text>
             </Box>
+            <Box width={COLS.branch} flexShrink={0} marginRight={1}>
+              <Text dimColor wrap="truncate-end">
+                BRANCH
+              </Text>
+            </Box>
             <Box width={COLS.status} flexShrink={0} marginRight={1}>
               <Text dimColor wrap="truncate-end">
                 STATUS
@@ -89,7 +101,12 @@ export function LinkApp() {
             return (
               <Box key={row.handle}>
                 <Box width={COLS.project} flexShrink={0} marginRight={1}>
-                  <Text wrap="truncate-end">{row.handle}</Text>
+                  <Text wrap="truncate-end">
+                    {row.projectName ?? row.handle}
+                  </Text>
+                </Box>
+                <Box width={COLS.branch} flexShrink={0} marginRight={1}>
+                  <Text wrap="truncate-end">{row.branch ?? "—"}</Text>
                 </Box>
                 <Box width={COLS.status} flexShrink={0} marginRight={1}>
                   <Text color={s.color} wrap="truncate-end">

--- a/apps/mesh/src/cli/link-sandbox-registry.test.ts
+++ b/apps/mesh/src/cli/link-sandbox-registry.test.ts
@@ -1,0 +1,686 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  type LinkSandboxRegistry,
+  openLinkSandboxRegistry,
+  registryPathForDataDir,
+} from "./link-sandbox-registry";
+
+const dirs: string[] = [];
+const registries: LinkSandboxRegistry[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "deco-link-registry-"));
+  dirs.push(dir);
+  return dir;
+}
+
+function openRegistry(path: string): LinkSandboxRegistry {
+  return trackRegistry(openLinkSandboxRegistry({ path }));
+}
+
+function trackRegistry(registry: LinkSandboxRegistry): LinkSandboxRegistry {
+  registries.push(registry);
+  return registry;
+}
+
+function closeRegistry(registry: LinkSandboxRegistry): void {
+  const index = registries.indexOf(registry);
+  if (index >= 0) {
+    registries.splice(index, 1);
+  }
+  registry.close();
+}
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`,
+    );
+  }
+}
+
+async function initRepo(path: string, defaultBranch = "main"): Promise<void> {
+  mkdirSync(path, { recursive: true });
+  await runGit(path, ["init", "-b", defaultBranch]);
+  await runGit(path, ["config", "user.email", "test@example.com"]);
+  await runGit(path, ["config", "user.name", "Test User"]);
+  writeFileSync(join(path, "README.md"), "initial\n");
+  await runGit(path, ["add", "README.md"]);
+  await runGit(path, ["commit", "-m", "initial"]);
+}
+
+afterEach(() => {
+  for (const registry of registries.splice(0).reverse()) {
+    registry.close();
+  }
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("link sandbox registry", () => {
+  it("stores and lists sandbox records by handle", () => {
+    const dataDir = tempDir();
+    const registry = openRegistry(registryPathForDataDir(dataDir));
+
+    registry.upsert({
+      handle: "abc123",
+      status: "ready",
+      sandboxPath: join(dataDir, "sandboxes", "abc123"),
+      port: 5175,
+      previewUrl: "http://abc123.localhost:5174",
+      repoCloneUrl: "https://github.com/decocms/studio.git",
+      branch: "feat/persist-link",
+      projectName: "studio",
+      error: null,
+    });
+
+    expect(registry.list()).toEqual([
+      expect.objectContaining({
+        handle: "abc123",
+        status: "ready",
+        port: 5175,
+        previewUrl: "http://abc123.localhost:5174",
+        branch: "feat/persist-link",
+        projectName: "studio",
+      }),
+    ]);
+
+    closeRegistry(registry);
+  });
+
+  it("reopens the sqlite file with existing rows", () => {
+    const dataDir = tempDir();
+    const path = registryPathForDataDir(dataDir);
+    const first = openRegistry(path);
+    first.upsert({
+      handle: "reopen",
+      status: "failed",
+      sandboxPath: join(dataDir, "sandboxes", "reopen"),
+      port: null,
+      previewUrl: null,
+      repoCloneUrl: null,
+      branch: null,
+      projectName: null,
+      error: "clone failed",
+    });
+    closeRegistry(first);
+
+    const second = openRegistry(path);
+    expect(second.list()).toEqual([
+      expect.objectContaining({
+        handle: "reopen",
+        status: "failed",
+        error: "clone failed",
+      }),
+    ]);
+    closeRegistry(second);
+  });
+
+  it("marks rows missing when the sandbox path no longer exists", () => {
+    const dataDir = tempDir();
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+
+    registry.upsert({
+      handle: "gone",
+      status: "ready",
+      sandboxPath: join(dataDir, "sandboxes", "gone"),
+      port: 1234,
+      previewUrl: "http://gone.localhost:5174",
+      repoCloneUrl: null,
+      branch: "feat/gone",
+      projectName: "studio",
+      error: null,
+    });
+
+    const rows = registry.reconcile();
+    expect(rows).toEqual([
+      expect.objectContaining({
+        handle: "gone",
+        status: "missing",
+        port: null,
+        previewUrl: null,
+      }),
+    ]);
+    expect(rows[0]?.missingSince).toBeNumber();
+  });
+
+  it("marks rows invalid when the path is outside the managed sandbox root", () => {
+    const dataDir = tempDir();
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+
+    registry.upsert({
+      handle: "bad",
+      status: "ready",
+      sandboxPath: join(dataDir, "elsewhere", "bad"),
+      port: 1234,
+      previewUrl: "http://bad.localhost:5174",
+      repoCloneUrl: null,
+      branch: null,
+      projectName: null,
+      error: null,
+    });
+
+    expect(registry.reconcile()).toEqual([
+      expect.objectContaining({
+        handle: "bad",
+        status: "invalid",
+        error: "sandbox path is outside the managed sandbox root",
+      }),
+    ]);
+  });
+
+  it("marks symlinked sandbox paths invalid when they resolve outside the managed sandbox root", () => {
+    const dataDir = tempDir();
+    const managedSandboxRoot = join(dataDir, "sandboxes");
+    const outsidePath = join(dataDir, "elsewhere", "bad");
+    const symlinkPath = join(managedSandboxRoot, "bad");
+    mkdirSync(outsidePath, { recursive: true });
+    mkdirSync(managedSandboxRoot, { recursive: true });
+    symlinkSync(outsidePath, symlinkPath, "dir");
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot,
+      }),
+    );
+
+    registry.upsert({
+      handle: "bad-symlink",
+      status: "ready",
+      sandboxPath: symlinkPath,
+      port: 1234,
+      previewUrl: "http://bad-symlink.localhost:5174",
+      repoCloneUrl: null,
+      branch: null,
+      projectName: null,
+      error: null,
+    });
+
+    expect(registry.reconcile()).toEqual([
+      expect.objectContaining({
+        handle: "bad-symlink",
+        status: "invalid",
+        error: "sandbox path is outside the managed sandbox root",
+      }),
+    ]);
+  });
+
+  it("marks existing active sandbox paths stopped", () => {
+    const dataDir = tempDir();
+    const sandboxPath = join(dataDir, "sandboxes", "active");
+    mkdirSync(sandboxPath, { recursive: true });
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+
+    registry.upsert({
+      handle: "active",
+      status: "ready",
+      sandboxPath,
+      port: 1234,
+      previewUrl: "http://active.localhost:5174",
+      repoCloneUrl: null,
+      branch: null,
+      projectName: null,
+      error: "old error",
+    });
+
+    const rows = registry.reconcile();
+    expect(rows).toEqual([
+      expect.objectContaining({
+        handle: "active",
+        status: "stopped",
+        port: null,
+        previewUrl: null,
+        error: null,
+        missingSince: null,
+      }),
+    ]);
+    expect(rows[0]?.lastSeenAt).toBeNumber();
+  });
+
+  it("preserves source metadata when reconcile stops an existing ready sandbox", () => {
+    const dataDir = tempDir();
+    const managedSandboxRoot = join(dataDir, "sandboxes");
+    const sandboxPath = join(managedSandboxRoot, "active-with-metadata");
+    mkdirSync(sandboxPath, { recursive: true });
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot,
+      }),
+    );
+
+    registry.upsert({
+      handle: "active-with-metadata",
+      status: "ready",
+      sandboxPath,
+      port: 1234,
+      previewUrl: "http://active-with-metadata.localhost:5174",
+      repoCloneUrl: "https://github.com/decocms/studio.git",
+      branch: "feat/metadata",
+      projectName: "studio",
+      error: null,
+    });
+
+    const rows = registry.reconcile();
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        handle: "active-with-metadata",
+        status: "stopped",
+        port: null,
+        previewUrl: null,
+        repoCloneUrl: "https://github.com/decocms/studio.git",
+        branch: "feat/metadata",
+        projectName: "studio",
+      }),
+    ]);
+  });
+
+  it("uses one timestamp for all updates in a single reconciliation pass", () => {
+    const dataDir = tempDir();
+    const managedSandboxRoot = join(dataDir, "sandboxes");
+    const outsidePath = join(dataDir, "elsewhere", "bad");
+    const originalDateNow = Date.now;
+    let timestamp = 1000;
+    Date.now = () => timestamp++;
+
+    try {
+      const registry = trackRegistry(
+        openLinkSandboxRegistry({
+          path: registryPathForDataDir(dataDir),
+          managedSandboxRoot,
+        }),
+      );
+
+      registry.upsert({
+        handle: "gone",
+        status: "ready",
+        sandboxPath: join(managedSandboxRoot, "gone"),
+        port: 1234,
+        previewUrl: "http://gone.localhost:5174",
+        repoCloneUrl: null,
+        branch: null,
+        projectName: null,
+        error: null,
+      });
+      registry.upsert({
+        handle: "bad",
+        status: "ready",
+        sandboxPath: outsidePath,
+        port: 1235,
+        previewUrl: "http://bad.localhost:5174",
+        repoCloneUrl: null,
+        branch: null,
+        projectName: null,
+        error: null,
+      });
+
+      const rows = registry.reconcile();
+      const gone = rows.find((row) => row.handle === "gone");
+      const bad = rows.find((row) => row.handle === "bad");
+
+      expect(gone?.status).toBe("missing");
+      expect(bad?.status).toBe("invalid");
+      expect(gone?.updatedAt).toBe(bad?.updatedAt);
+      expect(gone?.missingSince).toBe(gone?.updatedAt);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  it("prunes metadata-only rows whose sandbox path is missing", () => {
+    const dataDir = tempDir();
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+    registry.upsert({
+      handle: "missing",
+      status: "ready",
+      sandboxPath: join(dataDir, "sandboxes", "missing"),
+      port: 1,
+      previewUrl: "http://missing.localhost:5174",
+      repoCloneUrl: null,
+      branch: "feat/missing",
+      projectName: "studio",
+      error: null,
+    });
+
+    const result = registry.prune({ missing: true, merged: false });
+
+    expect(result.removed).toEqual([
+      expect.objectContaining({
+        handle: "missing",
+        reason: "missing",
+        deletedFiles: false,
+      }),
+    ]);
+    expect(registry.list()).toEqual([]);
+  });
+
+  it("skips pruning clean sandbox directories whose branch is not merged", async () => {
+    const dataDir = tempDir();
+    const sandboxPath = join(dataDir, "sandboxes", "live");
+    await initRepo(sandboxPath);
+    await runGit(sandboxPath, ["checkout", "-b", "feat/live"]);
+    writeFileSync(join(sandboxPath, "feature.txt"), "live\n");
+    await runGit(sandboxPath, ["add", "feature.txt"]);
+    await runGit(sandboxPath, ["commit", "-m", "live feature"]);
+    await runGit(sandboxPath, ["checkout", "main"]);
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+    registry.upsert({
+      handle: "live",
+      status: "stopped",
+      sandboxPath,
+      port: null,
+      previewUrl: null,
+      repoCloneUrl: null,
+      branch: "feat/live",
+      projectName: "studio",
+      error: null,
+    });
+
+    const result = registry.prune({ missing: false, merged: true });
+
+    expect(result.removed).toEqual([]);
+    expect(result.skipped).toEqual([
+      expect.objectContaining({
+        handle: "live",
+        reason: "branch_not_merged",
+        deletedFiles: false,
+      }),
+    ]);
+    expect(registry.list()).toEqual([
+      expect.objectContaining({ handle: "live" }),
+    ]);
+    expect(existsSync(sandboxPath)).toBe(true);
+  });
+
+  it("prunes clean sandbox directories whose branch is merged", async () => {
+    const dataDir = tempDir();
+    const sandboxPath = join(dataDir, "sandboxes", "done");
+    await initRepo(sandboxPath);
+    await runGit(sandboxPath, ["checkout", "-b", "feat/done"]);
+    writeFileSync(join(sandboxPath, "feature.txt"), "done\n");
+    await runGit(sandboxPath, ["add", "feature.txt"]);
+    await runGit(sandboxPath, ["commit", "-m", "done feature"]);
+    await runGit(sandboxPath, ["checkout", "main"]);
+    await runGit(sandboxPath, [
+      "merge",
+      "--no-ff",
+      "feat/done",
+      "-m",
+      "merge done",
+    ]);
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+    registry.upsert({
+      handle: "done",
+      status: "stopped",
+      sandboxPath,
+      port: null,
+      previewUrl: null,
+      repoCloneUrl: null,
+      branch: "feat/done",
+      projectName: "studio",
+      error: null,
+    });
+
+    const result = registry.prune({ missing: false, merged: true });
+
+    expect(result.removed).toEqual([
+      expect.objectContaining({
+        handle: "done",
+        reason: "merged",
+        deletedFiles: true,
+      }),
+    ]);
+    expect(result.skipped).toEqual([]);
+    expect(registry.list()).toEqual([]);
+    expect(existsSync(sandboxPath)).toBe(false);
+  });
+
+  it("prunes merged branches when the default branch is not main", async () => {
+    const dataDir = tempDir();
+    const sandboxPath = join(dataDir, "sandboxes", "trunk-done");
+    await initRepo(sandboxPath, "trunk");
+    await runGit(sandboxPath, ["checkout", "-b", "feat/trunk-done"]);
+    writeFileSync(join(sandboxPath, "feature.txt"), "done\n");
+    await runGit(sandboxPath, ["add", "feature.txt"]);
+    await runGit(sandboxPath, ["commit", "-m", "done feature"]);
+    await runGit(sandboxPath, ["checkout", "trunk"]);
+    await runGit(sandboxPath, [
+      "merge",
+      "--no-ff",
+      "feat/trunk-done",
+      "-m",
+      "merge done",
+    ]);
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+    registry.upsert({
+      handle: "trunk-done",
+      status: "stopped",
+      sandboxPath,
+      port: null,
+      previewUrl: null,
+      repoCloneUrl: null,
+      branch: "feat/trunk-done",
+      projectName: "studio",
+      error: null,
+    });
+
+    const result = registry.prune({ missing: false, merged: true });
+
+    expect(result.removed).toEqual([
+      expect.objectContaining({
+        handle: "trunk-done",
+        reason: "merged",
+        deletedFiles: true,
+      }),
+    ]);
+    expect(result.skipped).toEqual([]);
+    expect(registry.list()).toEqual([]);
+    expect(existsSync(sandboxPath)).toBe(false);
+  });
+
+  it("does not treat the checked-out non-default branch as the default branch", async () => {
+    const dataDir = tempDir();
+    const sandboxPath = join(dataDir, "sandboxes", "worktree-head");
+    await initRepo(sandboxPath);
+    await runGit(sandboxPath, ["checkout", "-b", "feat/head-risk"]);
+    writeFileSync(join(sandboxPath, "feature.txt"), "feature\n");
+    await runGit(sandboxPath, ["add", "feature.txt"]);
+    await runGit(sandboxPath, ["commit", "-m", "feature"]);
+    await runGit(sandboxPath, ["checkout", "main"]);
+    await runGit(sandboxPath, ["checkout", "-b", "work"]);
+    await runGit(sandboxPath, [
+      "merge",
+      "--no-ff",
+      "feat/head-risk",
+      "-m",
+      "merge into work only",
+    ]);
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+    registry.upsert({
+      handle: "worktree-head",
+      status: "stopped",
+      sandboxPath,
+      port: null,
+      previewUrl: null,
+      repoCloneUrl: null,
+      branch: "feat/head-risk",
+      projectName: "studio",
+      error: null,
+    });
+
+    const result = registry.prune({ missing: false, merged: true });
+
+    expect(result.removed).toEqual([]);
+    expect(result.skipped).toEqual([
+      expect.objectContaining({
+        handle: "worktree-head",
+        reason: "branch_not_merged",
+        deletedFiles: false,
+      }),
+    ]);
+    expect(registry.list()).toEqual([
+      expect.objectContaining({ handle: "worktree-head" }),
+    ]);
+    expect(existsSync(sandboxPath)).toBe(true);
+  });
+
+  it("does not prune a branch merged only into a non-default default-like branch", async () => {
+    const dataDir = tempDir();
+    const sandboxPath = join(dataDir, "sandboxes", "develop-only");
+    await initRepo(sandboxPath);
+    await runGit(sandboxPath, ["checkout", "-b", "develop"]);
+    await runGit(sandboxPath, ["checkout", "-b", "feat/develop-only"]);
+    writeFileSync(join(sandboxPath, "feature.txt"), "feature\n");
+    await runGit(sandboxPath, ["add", "feature.txt"]);
+    await runGit(sandboxPath, ["commit", "-m", "feature"]);
+    await runGit(sandboxPath, ["checkout", "develop"]);
+    await runGit(sandboxPath, [
+      "merge",
+      "--no-ff",
+      "feat/develop-only",
+      "-m",
+      "merge into develop only",
+    ]);
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+    registry.upsert({
+      handle: "develop-only",
+      status: "stopped",
+      sandboxPath,
+      port: null,
+      previewUrl: null,
+      repoCloneUrl: null,
+      branch: "feat/develop-only",
+      projectName: "studio",
+      error: null,
+    });
+
+    const result = registry.prune({ missing: false, merged: true });
+
+    expect(result.removed).toEqual([]);
+    expect(result.skipped).toEqual([
+      expect.objectContaining({
+        handle: "develop-only",
+        reason: "branch_not_merged",
+        deletedFiles: false,
+      }),
+    ]);
+    expect(registry.list()).toEqual([
+      expect.objectContaining({ handle: "develop-only" }),
+    ]);
+    expect(existsSync(sandboxPath)).toBe(true);
+  });
+
+  it("skips pruning sandbox directories with dirty worktrees", async () => {
+    const dataDir = tempDir();
+    const sandboxPath = join(dataDir, "sandboxes", "dirty");
+    await initRepo(sandboxPath);
+    await runGit(sandboxPath, ["checkout", "-b", "feat/dirty"]);
+    writeFileSync(join(sandboxPath, "feature.txt"), "dirty\n");
+    await runGit(sandboxPath, ["add", "feature.txt"]);
+    await runGit(sandboxPath, ["commit", "-m", "dirty feature"]);
+    await runGit(sandboxPath, ["checkout", "main"]);
+    await runGit(sandboxPath, [
+      "merge",
+      "--no-ff",
+      "feat/dirty",
+      "-m",
+      "merge dirty",
+    ]);
+    writeFileSync(join(sandboxPath, "uncommitted.txt"), "uncommitted\n");
+    const registry = trackRegistry(
+      openLinkSandboxRegistry({
+        path: registryPathForDataDir(dataDir),
+        managedSandboxRoot: join(dataDir, "sandboxes"),
+      }),
+    );
+    registry.upsert({
+      handle: "dirty",
+      status: "stopped",
+      sandboxPath,
+      port: null,
+      previewUrl: null,
+      repoCloneUrl: null,
+      branch: "feat/dirty",
+      projectName: "studio",
+      error: null,
+    });
+
+    const result = registry.prune({ missing: false, merged: true });
+
+    expect(result.removed).toEqual([]);
+    expect(result.skipped).toEqual([
+      expect.objectContaining({
+        handle: "dirty",
+        reason: "dirty_worktree",
+        deletedFiles: false,
+      }),
+    ]);
+    expect(registry.list()).toEqual([
+      expect.objectContaining({ handle: "dirty" }),
+    ]);
+    expect(existsSync(sandboxPath)).toBe(true);
+  });
+});

--- a/apps/mesh/src/cli/link-sandbox-registry.ts
+++ b/apps/mesh/src/cli/link-sandbox-registry.ts
@@ -1,0 +1,529 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { Database } from "bun:sqlite";
+
+export type LinkSandboxStatus =
+  | "spawning"
+  | "ready"
+  | "failed"
+  | "stopped"
+  | "missing"
+  | "merged"
+  | "invalid";
+
+export interface LinkSandboxRecord {
+  handle: string;
+  status: LinkSandboxStatus;
+  sandboxPath: string;
+  port: number | null;
+  previewUrl: string | null;
+  repoCloneUrl: string | null;
+  branch: string | null;
+  projectName: string | null;
+  error: string | null;
+  createdAt: number;
+  updatedAt: number;
+  lastSeenAt: number | null;
+  missingSince: number | null;
+}
+
+export interface LinkSandboxUpsert {
+  handle: string;
+  status: LinkSandboxStatus;
+  sandboxPath: string;
+  port?: number | null;
+  previewUrl?: string | null;
+  repoCloneUrl?: string | null;
+  branch?: string | null;
+  projectName?: string | null;
+  error?: string | null;
+}
+
+export interface LinkSandboxPruneOptions {
+  missing: boolean;
+  merged: boolean;
+}
+
+export interface LinkSandboxPruneItem {
+  handle: string;
+  sandboxPath: string;
+  reason:
+    | "missing"
+    | "merged"
+    | "outside_root"
+    | "branch_not_merged"
+    | "dirty_worktree"
+    | "git_unavailable"
+    | "no_branch";
+  deletedFiles: boolean;
+}
+
+export interface LinkSandboxPruneResult {
+  removed: LinkSandboxPruneItem[];
+  skipped: LinkSandboxPruneItem[];
+}
+
+export interface LinkSandboxRegistry {
+  upsert(row: LinkSandboxUpsert): void;
+  list(): LinkSandboxRecord[];
+  reconcile(): LinkSandboxRecord[];
+  prune(options: LinkSandboxPruneOptions): LinkSandboxPruneResult;
+  close(): void;
+}
+
+interface LinkSandboxDbRow {
+  handle: string;
+  status: string;
+  sandbox_path: string;
+  port: number | null;
+  preview_url: string | null;
+  repo_clone_url: string | null;
+  branch: string | null;
+  project_name: string | null;
+  error: string | null;
+  created_at: number;
+  updated_at: number;
+  last_seen_at: number | null;
+  missing_since: number | null;
+}
+
+function toRecord(row: LinkSandboxDbRow): LinkSandboxRecord {
+  return {
+    handle: row.handle,
+    status: row.status as LinkSandboxStatus,
+    sandboxPath: row.sandbox_path,
+    port: row.port,
+    previewUrl: row.preview_url,
+    repoCloneUrl: row.repo_clone_url,
+    branch: row.branch,
+    projectName: row.project_name,
+    error: row.error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastSeenAt: row.last_seen_at,
+    missingSince: row.missing_since,
+  };
+}
+
+function runGit(
+  cwd: string,
+  args: string[],
+): { ok: true; stdout: string } | { ok: false; code: number | null } {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error !== undefined || result.status !== 0) {
+    return { ok: false, code: result.status };
+  }
+  return { ok: true, stdout: result.stdout };
+}
+
+function gitRefExists(cwd: string, ref: string): boolean {
+  return runGit(cwd, ["show-ref", "--verify", "--quiet", ref]).ok;
+}
+
+function gitCommitExists(cwd: string, rev: string): boolean {
+  return runGit(cwd, ["rev-parse", "--verify", `${rev}^{commit}`]).ok;
+}
+
+function detectDefaultBranch(cwd: string): string | null {
+  const originHead = runGit(cwd, [
+    "symbolic-ref",
+    "--short",
+    "refs/remotes/origin/HEAD",
+  ]);
+  if (originHead.ok) {
+    const ref = originHead.stdout.trim();
+    if (ref && gitCommitExists(cwd, ref)) return ref;
+  }
+
+  for (const ref of ["main", "master", "trunk", "develop"]) {
+    if (gitRefExists(cwd, `refs/heads/${ref}`) && gitCommitExists(cwd, ref)) {
+      return ref;
+    }
+  }
+
+  return null;
+}
+
+function branchIsMergedIntoDefault(
+  cwd: string,
+  branch: string,
+): boolean | null {
+  if (!runGit(cwd, ["rev-parse", "--verify", `${branch}^{commit}`]).ok) {
+    return null;
+  }
+
+  const defaultBranch = detectDefaultBranch(cwd);
+  if (defaultBranch === null) {
+    return null;
+  }
+
+  const mergeBase = spawnSync(
+    "git",
+    ["merge-base", "--is-ancestor", branch, defaultBranch],
+    {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (mergeBase.error !== undefined) {
+    return null;
+  }
+  if (mergeBase.status === 0) return true;
+  if (mergeBase.status === 1) return false;
+  return null;
+}
+
+export function registryPathForDataDir(dataDir: string): string {
+  return join(dataDir, "link", "sandboxes.sqlite");
+}
+
+export function openLinkSandboxRegistry(opts: {
+  path: string;
+  managedSandboxRoot?: string;
+}): LinkSandboxRegistry {
+  if (opts.path !== ":memory:") {
+    mkdirSync(dirname(opts.path), { recursive: true });
+  }
+
+  const db = new Database(opts.path, { create: true });
+  const managedSandboxRoot =
+    opts.managedSandboxRoot === undefined
+      ? undefined
+      : resolve(opts.managedSandboxRoot);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA synchronous = NORMAL");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS link_sandboxes (
+      handle         TEXT    NOT NULL PRIMARY KEY,
+      status         TEXT    NOT NULL CHECK (
+        status IN (
+          'spawning',
+          'ready',
+          'failed',
+          'stopped',
+          'missing',
+          'merged',
+          'invalid'
+        )
+      ),
+      sandbox_path   TEXT    NOT NULL,
+      port           INTEGER,
+      preview_url    TEXT,
+      repo_clone_url TEXT,
+      branch         TEXT,
+      project_name   TEXT,
+      error          TEXT,
+      created_at     INTEGER NOT NULL,
+      updated_at     INTEGER NOT NULL,
+      last_seen_at   INTEGER,
+      missing_since  INTEGER
+    )
+  `);
+
+  const upsertStmt = db.query(`
+    INSERT INTO link_sandboxes (
+      handle,
+      status,
+      sandbox_path,
+      port,
+      preview_url,
+      repo_clone_url,
+      branch,
+      project_name,
+      error,
+      created_at,
+      updated_at,
+      last_seen_at,
+      missing_since
+    )
+    VALUES (
+      $handle,
+      $status,
+      $sandboxPath,
+      $port,
+      $previewUrl,
+      $repoCloneUrl,
+      $branch,
+      $projectName,
+      $error,
+      $now,
+      $now,
+      CASE
+        WHEN $status NOT IN ('missing', 'invalid') THEN $now
+        ELSE NULL
+      END,
+      CASE
+        WHEN $status = 'missing' THEN $now
+        ELSE NULL
+      END
+    )
+    ON CONFLICT(handle) DO UPDATE SET
+      status = excluded.status,
+      sandbox_path = excluded.sandbox_path,
+      port = excluded.port,
+      preview_url = excluded.preview_url,
+      -- Keep source metadata sticky across status-only updates; callers may
+      -- omit these fields when reporting lifecycle changes.
+      repo_clone_url = COALESCE(
+        excluded.repo_clone_url,
+        link_sandboxes.repo_clone_url
+      ),
+      branch = COALESCE(excluded.branch, link_sandboxes.branch),
+      project_name = COALESCE(
+        excluded.project_name,
+        link_sandboxes.project_name
+      ),
+      error = excluded.error,
+      updated_at = excluded.updated_at,
+      last_seen_at = CASE
+        WHEN excluded.status NOT IN ('missing', 'invalid')
+          THEN excluded.updated_at
+        ELSE link_sandboxes.last_seen_at
+      END,
+      missing_since = CASE
+        WHEN excluded.status = 'missing' THEN excluded.updated_at
+        WHEN excluded.status NOT IN ('missing', 'invalid') THEN NULL
+        ELSE link_sandboxes.missing_since
+      END
+  `);
+
+  const listStmt = db.query<LinkSandboxDbRow, []>(`
+    SELECT
+      handle,
+      status,
+      sandbox_path,
+      port,
+      preview_url,
+      repo_clone_url,
+      branch,
+      project_name,
+      error,
+      created_at,
+      updated_at,
+      last_seen_at,
+      missing_since
+    FROM link_sandboxes
+    ORDER BY updated_at DESC, handle ASC
+  `);
+
+  const markInvalidStmt = db.query(`
+    UPDATE link_sandboxes
+    SET
+      status = 'invalid',
+      port = NULL,
+      preview_url = NULL,
+      error = 'sandbox path is outside the managed sandbox root',
+      updated_at = $now
+    WHERE handle = $handle
+  `);
+
+  const markMissingStmt = db.query(`
+    UPDATE link_sandboxes
+    SET
+      status = 'missing',
+      port = NULL,
+      preview_url = NULL,
+      error = NULL,
+      updated_at = $now,
+      missing_since = COALESCE(missing_since, $now)
+    WHERE handle = $handle
+  `);
+
+  const markStoppedStmt = db.query(`
+    UPDATE link_sandboxes
+    SET
+      status = 'stopped',
+      port = NULL,
+      preview_url = NULL,
+      error = NULL,
+      updated_at = $now,
+      last_seen_at = $now,
+      missing_since = NULL
+    WHERE handle = $handle
+  `);
+
+  const deleteStmt = db.query(`
+    DELETE FROM link_sandboxes
+    WHERE handle = $handle
+  `);
+
+  function sandboxPathIsInsideManagedRoot(sandboxPath: string): boolean {
+    if (managedSandboxRoot === undefined) {
+      return true;
+    }
+
+    const sandboxPathExists = existsSync(sandboxPath);
+    const rootPath =
+      sandboxPathExists && existsSync(managedSandboxRoot)
+        ? realpathSync(managedSandboxRoot)
+        : managedSandboxRoot;
+    const candidatePath = sandboxPathExists
+      ? realpathSync(sandboxPath)
+      : resolve(sandboxPath);
+    const relativePath = relative(rootPath, candidatePath);
+    return (
+      relativePath === "" ||
+      (!relativePath.startsWith("..") && !isAbsolute(relativePath))
+    );
+  }
+
+  return {
+    upsert(row) {
+      upsertStmt.run({
+        $handle: row.handle,
+        $status: row.status,
+        $sandboxPath: row.sandboxPath,
+        $port: row.port ?? null,
+        $previewUrl: row.previewUrl ?? null,
+        $repoCloneUrl: row.repoCloneUrl ?? null,
+        $branch: row.branch ?? null,
+        $projectName: row.projectName ?? null,
+        $error: row.error ?? null,
+        $now: Date.now(),
+      });
+    },
+    list() {
+      return listStmt.all().map(toRecord);
+    },
+    reconcile() {
+      const now = Date.now();
+
+      for (const row of listStmt.all().map(toRecord)) {
+        if (!sandboxPathIsInsideManagedRoot(row.sandboxPath)) {
+          markInvalidStmt.run({ $handle: row.handle, $now: now });
+          continue;
+        }
+
+        if (!existsSync(row.sandboxPath)) {
+          markMissingStmt.run({ $handle: row.handle, $now: now });
+          continue;
+        }
+
+        if (
+          row.status === "spawning" ||
+          row.status === "ready" ||
+          row.status === "failed" ||
+          row.status === "missing"
+        ) {
+          markStoppedStmt.run({ $handle: row.handle, $now: now });
+        }
+      }
+
+      return listStmt.all().map(toRecord);
+    },
+    prune(options) {
+      const removed: LinkSandboxPruneItem[] = [];
+      const skipped: LinkSandboxPruneItem[] = [];
+      const rows = this.reconcile();
+
+      for (const row of rows) {
+        if (!sandboxPathIsInsideManagedRoot(row.sandboxPath)) {
+          skipped.push({
+            handle: row.handle,
+            sandboxPath: row.sandboxPath,
+            reason: "outside_root",
+            deletedFiles: false,
+          });
+          continue;
+        }
+
+        if (options.missing && row.status === "missing") {
+          deleteStmt.run({ $handle: row.handle });
+          removed.push({
+            handle: row.handle,
+            sandboxPath: row.sandboxPath,
+            reason: "missing",
+            deletedFiles: false,
+          });
+          continue;
+        }
+
+        if (!options.merged || !existsSync(row.sandboxPath)) {
+          continue;
+        }
+
+        if (row.branch === null || row.branch.trim() === "") {
+          skipped.push({
+            handle: row.handle,
+            sandboxPath: row.sandboxPath,
+            reason: "no_branch",
+            deletedFiles: false,
+          });
+          continue;
+        }
+
+        if (
+          !runGit(row.sandboxPath, ["rev-parse", "--is-inside-work-tree"]).ok
+        ) {
+          skipped.push({
+            handle: row.handle,
+            sandboxPath: row.sandboxPath,
+            reason: "git_unavailable",
+            deletedFiles: false,
+          });
+          continue;
+        }
+
+        const status = runGit(row.sandboxPath, ["status", "--porcelain"]);
+        if (!status.ok) {
+          skipped.push({
+            handle: row.handle,
+            sandboxPath: row.sandboxPath,
+            reason: "git_unavailable",
+            deletedFiles: false,
+          });
+          continue;
+        }
+        if (status.stdout.trim() !== "") {
+          skipped.push({
+            handle: row.handle,
+            sandboxPath: row.sandboxPath,
+            reason: "dirty_worktree",
+            deletedFiles: false,
+          });
+          continue;
+        }
+
+        const merged = branchIsMergedIntoDefault(row.sandboxPath, row.branch);
+        if (merged === null) {
+          skipped.push({
+            handle: row.handle,
+            sandboxPath: row.sandboxPath,
+            reason: "git_unavailable",
+            deletedFiles: false,
+          });
+          continue;
+        }
+        if (!merged) {
+          skipped.push({
+            handle: row.handle,
+            sandboxPath: row.sandboxPath,
+            reason: "branch_not_merged",
+            deletedFiles: false,
+          });
+          continue;
+        }
+
+        rmSync(row.sandboxPath, { recursive: true, force: true });
+        deleteStmt.run({ $handle: row.handle });
+        removed.push({
+          handle: row.handle,
+          sandboxPath: row.sandboxPath,
+          reason: "merged",
+          deletedFiles: true,
+        });
+      }
+
+      return { removed, skipped };
+    },
+    close() {
+      db.close();
+    },
+  };
+}

--- a/apps/mesh/src/cli/link-store.test.ts
+++ b/apps/mesh/src/cli/link-store.test.ts
@@ -1,14 +1,19 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import {
   applySandboxEvent,
   getLinkState,
+  pushSandboxEvent,
+  resetLinkStateForTests,
   type SandboxRow,
+  setPersistedSandboxes,
   setLogPath,
 } from "./link-store";
 
 function empty(): Map<string, SandboxRow> {
   return new Map();
 }
+
+afterEach(() => resetLinkStateForTests());
 
 describe("applySandboxEvent", () => {
   it("adds a spawning row then promotes it to ready with port", () => {
@@ -58,22 +63,44 @@ describe("applySandboxEvent", () => {
     expect(m.get("a")?.port).toBe(7);
   });
 
-  it("removes the row on evicted and deleted", () => {
+  it("marks known rows stopped on evicted and deleted", () => {
     let m = applySandboxEvent(empty(), {
       handle: "a",
       phase: "ready",
       port: 7,
+      previewUrl: "http://a.localhost:5174",
     });
     m = applySandboxEvent(m, { handle: "a", phase: "evicted" });
-    expect(m.has("a")).toBe(false);
+    expect(m.get("a")).toEqual(
+      expect.objectContaining({
+        status: "stopped",
+        port: null,
+        previewUrl: null,
+      }),
+    );
 
     let n = applySandboxEvent(empty(), {
       handle: "b",
       phase: "ready",
       port: 8,
+      previewUrl: "http://b.localhost:5174",
     });
     n = applySandboxEvent(n, { handle: "b", phase: "deleted" });
-    expect(n.has("b")).toBe(false);
+    expect(n.get("b")).toEqual(
+      expect.objectContaining({
+        status: "stopped",
+        port: null,
+        previewUrl: null,
+      }),
+    );
+  });
+
+  it("keeps unknown evicted and deleted rows absent", () => {
+    let m = applySandboxEvent(empty(), { handle: "a", phase: "evicted" });
+    expect(m.has("a")).toBe(false);
+
+    m = applySandboxEvent(m, { handle: "b", phase: "deleted" });
+    expect(m.has("b")).toBe(false);
   });
 });
 
@@ -81,5 +108,149 @@ describe("setLogPath", () => {
   it("stores the log path on the link state", () => {
     setLogPath("/tmp/deco/link.log");
     expect(getLinkState().logPath).toBe("/tmp/deco/link.log");
+  });
+});
+
+describe("setPersistedSandboxes", () => {
+  it("removes persisted rows that are absent from a fresh registry snapshot", () => {
+    setPersistedSandboxes([
+      {
+        handle: "old",
+        status: "stopped",
+        sandboxPath: "/tmp/deco/sandboxes/old",
+        port: null,
+        previewUrl: null,
+        repoCloneUrl: null,
+        branch: null,
+        projectName: null,
+        error: null,
+        createdAt: 1,
+        updatedAt: 2,
+        lastSeenAt: 2,
+        missingSince: null,
+      },
+    ]);
+
+    setPersistedSandboxes([]);
+
+    expect(getLinkState().sandboxes.has("old")).toBe(false);
+  });
+
+  it("preserves an existing live row over a stale persisted row", () => {
+    pushSandboxEvent({
+      handle: "old",
+      phase: "ready",
+      port: 9999,
+      previewUrl: "http://old.localhost:5174",
+    });
+
+    setPersistedSandboxes([
+      {
+        handle: "old",
+        status: "stopped",
+        sandboxPath: "/tmp/deco/sandboxes/old",
+        port: null,
+        previewUrl: null,
+        repoCloneUrl: null,
+        branch: "feat/old",
+        projectName: "studio",
+        error: null,
+        createdAt: 1,
+        updatedAt: 2,
+        lastSeenAt: 2,
+        missingSince: null,
+      },
+    ]);
+
+    expect(getLinkState().sandboxes.get("old")).toEqual(
+      expect.objectContaining({
+        status: "ready",
+        port: 9999,
+        previewUrl: "http://old.localhost:5174",
+      }),
+    );
+  });
+
+  it("hydrates stopped and missing rows from the registry", () => {
+    setPersistedSandboxes([
+      {
+        handle: "old",
+        status: "stopped",
+        sandboxPath: "/tmp/deco/sandboxes/old",
+        port: null,
+        previewUrl: null,
+        repoCloneUrl: "https://github.com/decocms/studio.git",
+        branch: "feat/old",
+        projectName: "studio",
+        error: null,
+        createdAt: 1,
+        updatedAt: 2,
+        lastSeenAt: 2,
+        missingSince: null,
+      },
+      {
+        handle: "gone",
+        status: "missing",
+        sandboxPath: "/tmp/deco/sandboxes/gone",
+        port: null,
+        previewUrl: null,
+        repoCloneUrl: null,
+        branch: null,
+        projectName: null,
+        error: null,
+        createdAt: 1,
+        updatedAt: 3,
+        lastSeenAt: null,
+        missingSince: 3,
+      },
+    ]);
+
+    expect([...getLinkState().sandboxes.values()]).toEqual([
+      expect.objectContaining({
+        handle: "old",
+        status: "stopped",
+        branch: "feat/old",
+        projectName: "studio",
+      }),
+      expect.objectContaining({
+        handle: "gone",
+        status: "missing",
+      }),
+    ]);
+  });
+
+  it("promotes a persisted stopped row when a live ready event arrives", () => {
+    setPersistedSandboxes([
+      {
+        handle: "old",
+        status: "stopped",
+        sandboxPath: "/tmp/deco/sandboxes/old",
+        port: null,
+        previewUrl: null,
+        repoCloneUrl: null,
+        branch: "feat/old",
+        projectName: "studio",
+        error: null,
+        createdAt: 1,
+        updatedAt: 2,
+        lastSeenAt: 2,
+        missingSince: null,
+      },
+    ]);
+
+    const next = applySandboxEvent(getLinkState().sandboxes, {
+      handle: "old",
+      phase: "ready",
+      port: 9999,
+      previewUrl: "http://old.localhost:5174",
+    });
+
+    expect(next.get("old")).toEqual(
+      expect.objectContaining({
+        status: "ready",
+        branch: "feat/old",
+        port: 9999,
+      }),
+    );
   });
 });

--- a/apps/mesh/src/cli/link-store.ts
+++ b/apps/mesh/src/cli/link-store.ts
@@ -4,6 +4,10 @@
  * useSyncExternalStore (no useEffect). Mirrors the cli-store pattern.
  */
 import type { SandboxEvent } from "../link-daemon/user-desktop-provider";
+import type {
+  LinkSandboxRecord,
+  LinkSandboxStatus,
+} from "./link-sandbox-registry";
 
 // Not exported — internal to this store (mirrors cli-store's CliState).
 type ClusterStatus = "connecting" | "linked" | "closed";
@@ -12,8 +16,11 @@ export interface SandboxRow {
   handle: string;
   port: number | null;
   previewUrl: string | null;
-  status: "spawning" | "ready" | "failed";
+  status: LinkSandboxStatus;
   error: string | null;
+  projectName: string | null;
+  branch: string | null;
+  sandboxPath: string | null;
 }
 
 // Not exported — mirrors cli-store's CliState.
@@ -33,41 +40,61 @@ interface LinkState {
 
 const DEFAULT_CAP = 20;
 
+function isLiveStatus(status: LinkSandboxStatus): boolean {
+  return status === "spawning" || status === "ready" || status === "failed";
+}
+
 /**
  * Pure reducer: fold a SandboxEvent into the sandbox map. `evicted`/`deleted`
- * drop the row; `failed` retains it with its error until the next `spawning`.
+ * mark known rows stopped so the TUI keeps showing local history; unknown rows
+ * remain absent. `failed` retains its error until the next `spawning`.
  */
 export function applySandboxEvent(
   sandboxes: Map<string, SandboxRow>,
   e: SandboxEvent,
 ): Map<string, SandboxRow> {
   const next = new Map(sandboxes);
+  const prev = next.get(e.handle);
   if (e.phase === "evicted" || e.phase === "deleted") {
-    next.delete(e.handle);
+    if (prev) {
+      next.set(e.handle, {
+        ...prev,
+        port: null,
+        previewUrl: null,
+        status: "stopped",
+        error: null,
+      });
+    }
     return next;
   }
-  const prev = next.get(e.handle);
   next.set(e.handle, {
     handle: e.handle,
     port: e.port ?? prev?.port ?? null,
     previewUrl: e.previewUrl ?? prev?.previewUrl ?? null,
     status: e.phase, // "spawning" | "ready" | "failed"
     error: e.phase === "failed" ? (e.error ?? "failed") : null,
+    projectName: prev?.projectName ?? null,
+    branch: prev?.branch ?? null,
+    sandboxPath: prev?.sandboxPath ?? null,
   });
   return next;
 }
 
-let state: LinkState = {
-  cluster: "connecting",
-  clusterUrl: null,
-  ingressUrl: null,
-  ingressPort: null,
-  machine: null,
-  cap: DEFAULT_CAP,
-  sandboxes: new Map(),
-  daemonError: null,
-  logPath: null,
-};
+function initialState(): LinkState {
+  return {
+    cluster: "connecting",
+    clusterUrl: null,
+    ingressUrl: null,
+    ingressPort: null,
+    machine: null,
+    cap: DEFAULT_CAP,
+    sandboxes: new Map(),
+    daemonError: null,
+    logPath: null,
+  };
+}
+
+let state: LinkState = initialState();
 
 const listeners = new Set<() => void>();
 
@@ -114,10 +141,40 @@ export function setLogPath(path: string) {
   emit();
 }
 
+export function setPersistedSandboxes(rows: LinkSandboxRecord[]) {
+  const sandboxes = new Map<string, SandboxRow>();
+  for (const row of rows) {
+    sandboxes.set(row.handle, {
+      handle: row.handle,
+      port: row.port,
+      previewUrl: row.previewUrl,
+      status: row.status,
+      error: row.error,
+      projectName: row.projectName,
+      branch: row.branch,
+      sandboxPath: row.sandboxPath,
+    });
+  }
+
+  for (const [handle, row] of state.sandboxes) {
+    if (isLiveStatus(row.status)) {
+      sandboxes.set(handle, row);
+    }
+  }
+
+  state = { ...state, sandboxes };
+  emit();
+}
+
 export function pushSandboxEvent(event: SandboxEvent) {
   state = {
     ...state,
     sandboxes: applySandboxEvent(state.sandboxes, event),
   };
   emit();
+}
+
+export function resetLinkStateForTests() {
+  state = initialState();
+  listeners.clear();
 }

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -28,6 +28,10 @@ import { loadOrCreateMachineId } from "./machine-id";
 import { getValidSession } from "../cli/lib/get-valid-session";
 import type { Session } from "../cli/lib/session";
 import {
+  openLinkSandboxRegistry,
+  registryPathForDataDir,
+} from "../cli/link-sandbox-registry";
+import {
   createDesktopSandboxProvider,
   type SandboxEvent,
   type SpawnResult,
@@ -95,245 +99,273 @@ export async function startLinkDaemon(
     perSandboxLog: opts.perSandboxLogs,
     hotReload: opts.hotReload,
   });
-  // Forward declaration so `resolvePreviewUrl` can read the ingress port
-  // once the ingress finishes binding (the ingress's `lookupSandboxPort`
-  // calls into the provider, so the two have a circular initialization).
-  let ingressPort = 0;
-  const provider = createDesktopSandboxProvider({
-    dataDir: opts.dataDir,
-    resolvePreviewUrl: (handle, port) =>
-      ingressPort > 0
-        ? `http://${handle}.localhost:${ingressPort}`
-        : `http://127.0.0.1:${port}`,
-    spawnDaemon: async (args): Promise<SpawnResult> => {
-      const env: Record<string, string> = {
-        DAEMON_BOOT_ID: randomUUID(),
-        APP_ROOT: args.workdir,
-        PROXY_PORT: String(args.port),
-        DAEMON_TOKEN: args.daemonToken,
-        // Message-offload SSRF allowlist, pushed by the cluster via the ensure
-        // body (trusted config — never a request frame). The daemon reads
-        // these at boot (`packages/sandbox/daemon/entry.ts`) and rejects any
-        // offload fetch whose host isn't listed. Empty = fail closed.
-        OFFLOAD_ALLOWED_HOSTS: args.offloadAllowedHosts.join(","),
-        ...(args.offloadAllowSameHostDev
-          ? { OFFLOAD_ALLOW_SAME_HOST_DEV: "1" }
-          : {}),
-      };
-      // org-fs mounting needs BOTH the config and a real rclone binary. Ensure
-      // rclone (downloaded + cached once) only when a mount is requested; if it
-      // can't be obtained, leave both unset so the daemon skips mounting.
-      if (args.orgFsConfigJson) {
-        const rclonePath = await ensureRclone(opts.dataDir);
-        if (rclonePath) {
-          env.ORGFS_CONFIG = args.orgFsConfigJson;
-          env.ORGFS_RCLONE_PATH = rclonePath;
-        }
-      }
-      const proc = await innerSpawn({
-        workdir: args.workdir,
-        env,
-        daemonPort: args.port,
-      });
-      return {
-        port: args.port,
-        kill: (sig) => proc.kill(sig),
-        exited: proc.exited.then(() => undefined),
-      };
-    },
-    postConfig: async (port, devPort, config, daemonToken) => {
-      // Daemon's TenantConfig wire shape is `{ git, application }`. We
-      // always pin `application.port` to the link-allocated devPort so
-      // co-tenant sandboxes can't collide on the host network; the
-      // caller-supplied workload only drives runtime + packageManager
-      // (without these the orchestrator falls through to lockfile
-      // autodetect, which on a repo with `yarn.lock` picks yarn — a
-      // package manager the desktop daemon can't reliably PATH-shim).
-      const application: Record<string, unknown> = { port: devPort };
-      if (config.workload) {
-        application.runtime = config.workload.runtime;
-        application.packageManager = {
-          name: config.workload.packageManager,
-          ...(config.workload.packageManagerPath
-            ? { path: config.workload.packageManagerPath }
-            : {}),
-        };
-      }
-      const payload: Record<string, unknown> = { application };
-      const operator = normalizeCoAuthorIdentity(config.operator ?? null);
-      if (operator) {
-        payload.operator = operator;
-      }
-      if (config.repo) {
-        payload.git = {
-          repository: {
-            cloneUrl: config.repo.cloneUrl,
-            branch: config.repo.branch,
-          },
-          ...(config.repo.userName && config.repo.userEmail
-            ? {
-                identity: {
-                  userName: config.repo.userName,
-                  userEmail: config.repo.userEmail,
-                },
-              }
-            : {}),
-        };
-      }
-      await daemonPostConfig(`http://127.0.0.1:${port}`, daemonToken, payload);
-    },
-    waitForHealth: async (port) => {
-      await waitForDaemonReady(`http://127.0.0.1:${port}`);
-    },
-    maxSandboxes: 20,
-    onEvent: opts.monitor?.onEvent,
+  const registry = openLinkSandboxRegistry({
+    path: registryPathForDataDir(opts.dataDir),
+    managedSandboxRoot: `${opts.dataDir}/sandboxes`,
   });
+  let registryClosed = false;
+  const closeRegistry = (): void => {
+    if (registryClosed) return;
+    registryClosed = true;
+    try {
+      registry.close();
+    } catch {
+      /* */
+    }
+  };
 
-  const ingress = await startLocalIngress({
-    port: opts.port,
-    lookupSandboxPort: (handle) => provider.proxyPort(handle),
-  });
-  ingressPort = ingress.port;
-  console.log(
-    `Local ingress listening on http://127.0.0.1:${ingress.port} (use http://<handle>.localhost:${ingress.port}/)`,
-  );
-  opts.monitor?.onIngress?.(ingress.port);
-
-  // The control handler reverse-proxies `/_sandbox/<handle>/*` to each
-  // spawned sandbox daemon's local port. The provider exposes `proxyPort`
-  // and `acquireDispatch` to map handle → port and track in-flight calls.
-  const controlHandler = createControlHandler({ provider });
-
-  // Shared token resolver. Re-resolves (and refreshes) the bearer before each
-  // tunnel session so a stale startup token doesn't spin forever on a 401.
-  const getAccessToken = async (): Promise<string> => {
-    const fresh = await getValidSession({
+  try {
+    // Forward declaration so `resolvePreviewUrl` can read the ingress port
+    // once the ingress finishes binding (the ingress's `lookupSandboxPort`
+    // calls into the provider, so the two have a circular initialization).
+    let ingressPort = 0;
+    const provider = createDesktopSandboxProvider({
       dataDir: opts.dataDir,
-      target: opts.clusterBaseUrl,
+      registry,
+      resolvePreviewUrl: (handle, port) =>
+        ingressPort > 0
+          ? `http://${handle}.localhost:${ingressPort}`
+          : `http://127.0.0.1:${port}`,
+      spawnDaemon: async (args): Promise<SpawnResult> => {
+        const env: Record<string, string> = {
+          DAEMON_BOOT_ID: randomUUID(),
+          APP_ROOT: args.workdir,
+          PROXY_PORT: String(args.port),
+          DAEMON_TOKEN: args.daemonToken,
+          // Message-offload SSRF allowlist, pushed by the cluster via the ensure
+          // body (trusted config — never a request frame). The daemon reads
+          // these at boot (`packages/sandbox/daemon/entry.ts`) and rejects any
+          // offload fetch whose host isn't listed. Empty = fail closed.
+          OFFLOAD_ALLOWED_HOSTS: args.offloadAllowedHosts.join(","),
+          ...(args.offloadAllowSameHostDev
+            ? { OFFLOAD_ALLOW_SAME_HOST_DEV: "1" }
+            : {}),
+        };
+        // org-fs mounting needs BOTH the config and a real rclone binary. Ensure
+        // rclone (downloaded + cached once) only when a mount is requested; if it
+        // can't be obtained, leave both unset so the daemon skips mounting.
+        if (args.orgFsConfigJson) {
+          const rclonePath = await ensureRclone(opts.dataDir);
+          if (rclonePath) {
+            env.ORGFS_CONFIG = args.orgFsConfigJson;
+            env.ORGFS_RCLONE_PATH = rclonePath;
+          }
+        }
+        const proc = await innerSpawn({
+          workdir: args.workdir,
+          env,
+          daemonPort: args.port,
+        });
+        return {
+          port: args.port,
+          kill: (sig) => proc.kill(sig),
+          exited: proc.exited.then(() => undefined),
+        };
+      },
+      postConfig: async (port, devPort, config, daemonToken) => {
+        // Daemon's TenantConfig wire shape is `{ git, application }`. We
+        // always pin `application.port` to the link-allocated devPort so
+        // co-tenant sandboxes can't collide on the host network; the
+        // caller-supplied workload only drives runtime + packageManager
+        // (without these the orchestrator falls through to lockfile
+        // autodetect, which on a repo with `yarn.lock` picks yarn — a
+        // package manager the desktop daemon can't reliably PATH-shim).
+        const application: Record<string, unknown> = { port: devPort };
+        if (config.workload) {
+          application.runtime = config.workload.runtime;
+          application.packageManager = {
+            name: config.workload.packageManager,
+            ...(config.workload.packageManagerPath
+              ? { path: config.workload.packageManagerPath }
+              : {}),
+          };
+        }
+        const payload: Record<string, unknown> = { application };
+        const operator = normalizeCoAuthorIdentity(config.operator ?? null);
+        if (operator) {
+          payload.operator = operator;
+        }
+        if (config.repo) {
+          payload.git = {
+            repository: {
+              cloneUrl: config.repo.cloneUrl,
+              branch: config.repo.branch,
+            },
+            ...(config.repo.userName && config.repo.userEmail
+              ? {
+                  identity: {
+                    userName: config.repo.userName,
+                    userEmail: config.repo.userEmail,
+                  },
+                }
+              : {}),
+          };
+        }
+        await daemonPostConfig(
+          `http://127.0.0.1:${port}`,
+          daemonToken,
+          payload,
+        );
+      },
+      waitForHealth: async (port) => {
+        await waitForDaemonReady(`http://127.0.0.1:${port}`);
+      },
+      maxSandboxes: 20,
+      onEvent: opts.monitor?.onEvent,
     });
-    if (!fresh) {
-      throw Object.assign(
-        new Error(
-          `Session for ${opts.clusterBaseUrl} is no longer valid — run \`deco auth login --target ${opts.clusterBaseUrl}\` and restart \`deco link\`.`,
-        ),
-        { fatal: true },
-      );
-    }
-    return fresh.accessToken;
-  };
 
-  // The daemon's identity + capabilities are served live over the tunnel via
-  // `GET /api/links/status`, which the cluster probes when resolving a dispatch
-  // target and checking capabilities.
-  const machineId = await loadOrCreateMachineId(opts.dataDir);
-  const cliVersion = process.env.npm_package_version ?? "0.0.0";
-  const capabilities = await detectCapabilities();
-  // While a CLI capability (claude-code / codex) is missing, re-probe every
-  // minute so installing or signing into the CLI after `decocms link` started
-  // is picked up without a daemon restart. The status handler reads the shared,
-  // grow-only array, so the next probe advertises the change.
-  const stopReprobe = startCapabilityReprobe(capabilities, {
-    onChange: (added) => {
-      console.log(
-        `[link-daemon] capabilities detected: +${added.join(",")} (now: ${capabilities.join(",")})`,
-      );
-    },
-  });
-  // Durable uplink outbox (spec §5.1). One DB per daemon under the leaf data
-  // dir (DATA_DIR is the leaf — do NOT append `.deco`; sandboxes live at
-  // `$DATA_DIR/link/sandboxes/...`). Within a session it buffers the unacked
-  // relay prefix for resend-on-reconnect.
-  const outbox = openOutbox({ path: `${opts.dataDir}/link/outbox.sqlite` });
-  // Boot sweep: a run can't survive a daemon restart (its sandbox + harness die
-  // with it), so any rows left from a prior session are dead. Clear them so a
-  // new session never inherits a wedged outbox (the field leak that filled the
-  // 64 MiB cap with 11 days of failed runs and bricked the relay).
-  outbox.clear();
-
-  // `shutdown` is declared below (it needs `cluster` in scope); the control
-  // poller can in principle deliver a frame before that line runs, so route
-  // the callback through a mutable holder instead of capturing `shutdown`
-  // directly (TDZ).
-  let onRemoteShutdown: () => void = () => {};
-
-  // Daemon-lifetime signal: bounds in-flight runs. Aborted only on shutdown —
-  // NOT on tunnel-session renewal (renewal must not kill a running build).
-  const runLifetime = new AbortController();
-
-  const clusterInput = {
-    clusterBaseUrl: opts.clusterBaseUrl,
-    getAccessToken,
-    provider,
-    outbox,
-    // The in-process control handler also serves tunnel `/_sandbox/*`
-    // requests (vm-events SSE, control RPC, vm-tools) locally.
-    controlHandler,
-    capabilities,
-    machineId,
-    cliVersion,
-    previewPort: ingress.port,
-    onConnected: () => {
-      opts.monitor?.onCluster?.("linked");
-      console.log(`Linked to ${opts.clusterBaseUrl}`);
-    },
-    onShutdown: () => onRemoteShutdown(),
-    runLifetimeSignal: runLifetime.signal,
-  };
-
-  console.log(`[link-daemon] transport=tunnel cluster=${opts.clusterBaseUrl}`);
-  const cluster: ClusterConnectionHandle =
-    await connectToClusterTunnel(clusterInput);
-  console.log("[link-daemon] active transport=tunnel");
-
-  let resolveStopped!: (code: number) => void;
-  const stopped = new Promise<number>((r) => {
-    resolveStopped = r;
-  });
-  let shuttingDown = false;
-  const shutdown = async (): Promise<void> => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    runLifetime.abort();
-    console.log("\nShutting down…");
-    stopReprobe();
-    try {
-      await cluster.close();
-    } catch {
-      /* */
-    }
-    try {
-      await ingress.stop();
-    } catch {
-      /* */
-    }
-    try {
-      await provider.shutdown();
-    } catch {
-      /* */
-    }
-    try {
-      outbox.close();
-    } catch {
-      /* */
-    }
-    resolveStopped(0);
-  };
-  process.on("SIGINT", () => void shutdown());
-  process.on("SIGTERM", () => void shutdown());
-  onRemoteShutdown = () => {
+    const ingress = await startLocalIngress({
+      port: opts.port,
+      lookupSandboxPort: (handle) => provider.proxyPort(handle),
+    });
+    ingressPort = ingress.port;
     console.log(
-      "Disconnect requested from the Studio web UI — shutting down. Run `bunx decocms@latest link` to reconnect.",
+      `Local ingress listening on http://127.0.0.1:${ingress.port} (use http://<handle>.localhost:${ingress.port}/)`,
     );
-    void shutdown();
-  };
+    opts.monitor?.onIngress?.(ingress.port);
 
-  void cluster.closed.then(() => {
-    opts.monitor?.onCluster?.("closed");
-    if (!shuttingDown) {
-      console.error("Cluster connection closed permanently; exiting.");
+    // The control handler reverse-proxies `/_sandbox/<handle>/*` to each
+    // spawned sandbox daemon's local port. The provider exposes `proxyPort`
+    // and `acquireDispatch` to map handle → port and track in-flight calls.
+    const controlHandler = createControlHandler({ provider });
+
+    // Shared token resolver. Re-resolves (and refreshes) the bearer before each
+    // tunnel session so a stale startup token doesn't spin forever on a 401.
+    const getAccessToken = async (): Promise<string> => {
+      const fresh = await getValidSession({
+        dataDir: opts.dataDir,
+        target: opts.clusterBaseUrl,
+      });
+      if (!fresh) {
+        throw Object.assign(
+          new Error(
+            `Session for ${opts.clusterBaseUrl} is no longer valid — run \`deco auth login --target ${opts.clusterBaseUrl}\` and restart \`deco link\`.`,
+          ),
+          { fatal: true },
+        );
+      }
+      return fresh.accessToken;
+    };
+
+    // The daemon's identity + capabilities are served live over the tunnel via
+    // `GET /api/links/status`, which the cluster probes when resolving a dispatch
+    // target and checking capabilities.
+    const machineId = await loadOrCreateMachineId(opts.dataDir);
+    const cliVersion = process.env.npm_package_version ?? "0.0.0";
+    const capabilities = await detectCapabilities();
+    // While a CLI capability (claude-code / codex) is missing, re-probe every
+    // minute so installing or signing into the CLI after `decocms link` started
+    // is picked up without a daemon restart. The status handler reads the shared,
+    // grow-only array, so the next probe advertises the change.
+    const stopReprobe = startCapabilityReprobe(capabilities, {
+      onChange: (added) => {
+        console.log(
+          `[link-daemon] capabilities detected: +${added.join(",")} (now: ${capabilities.join(",")})`,
+        );
+      },
+    });
+    // Durable uplink outbox (spec §5.1). One DB per daemon under the leaf data
+    // dir (DATA_DIR is the leaf — do NOT append `.deco`; sandboxes live at
+    // `$DATA_DIR/link/sandboxes/...`). Within a session it buffers the unacked
+    // relay prefix for resend-on-reconnect.
+    const outbox = openOutbox({ path: `${opts.dataDir}/link/outbox.sqlite` });
+    // Boot sweep: a run can't survive a daemon restart (its sandbox + harness die
+    // with it), so any rows left from a prior session are dead. Clear them so a
+    // new session never inherits a wedged outbox (the field leak that filled the
+    // 64 MiB cap with 11 days of failed runs and bricked the relay).
+    outbox.clear();
+
+    // `shutdown` is declared below (it needs `cluster` in scope); the control
+    // poller can in principle deliver a frame before that line runs, so route
+    // the callback through a mutable holder instead of capturing `shutdown`
+    // directly (TDZ).
+    let onRemoteShutdown: () => void = () => {};
+
+    // Daemon-lifetime signal: bounds in-flight runs. Aborted only on shutdown —
+    // NOT on tunnel-session renewal (renewal must not kill a running build).
+    const runLifetime = new AbortController();
+
+    const clusterInput = {
+      clusterBaseUrl: opts.clusterBaseUrl,
+      getAccessToken,
+      provider,
+      outbox,
+      // The in-process control handler also serves tunnel `/_sandbox/*`
+      // requests (vm-events SSE, control RPC, vm-tools) locally.
+      controlHandler,
+      capabilities,
+      machineId,
+      cliVersion,
+      previewPort: ingress.port,
+      onConnected: () => {
+        opts.monitor?.onCluster?.("linked");
+        console.log(`Linked to ${opts.clusterBaseUrl}`);
+      },
+      onShutdown: () => onRemoteShutdown(),
+      runLifetimeSignal: runLifetime.signal,
+    };
+
+    console.log(
+      `[link-daemon] transport=tunnel cluster=${opts.clusterBaseUrl}`,
+    );
+    const cluster: ClusterConnectionHandle =
+      await connectToClusterTunnel(clusterInput);
+    console.log("[link-daemon] active transport=tunnel");
+
+    let resolveStopped!: (code: number) => void;
+    const stopped = new Promise<number>((r) => {
+      resolveStopped = r;
+    });
+    let shuttingDown = false;
+    const shutdown = async (): Promise<void> => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      runLifetime.abort();
+      console.log("\nShutting down…");
+      stopReprobe();
+      try {
+        await cluster.close();
+      } catch {
+        /* */
+      }
+      try {
+        await ingress.stop();
+      } catch {
+        /* */
+      }
+      try {
+        await provider.shutdown();
+      } catch {
+        /* */
+      }
+      try {
+        outbox.close();
+      } catch {
+        /* */
+      }
+      closeRegistry();
+      resolveStopped(0);
+    };
+    process.on("SIGINT", () => void shutdown());
+    process.on("SIGTERM", () => void shutdown());
+    onRemoteShutdown = () => {
+      console.log(
+        "Disconnect requested from the Studio web UI — shutting down. Run `bunx decocms@latest link` to reconnect.",
+      );
       void shutdown();
-    }
-  });
+    };
 
-  return { stopped, stop: shutdown };
+    void cluster.closed.then(() => {
+      opts.monitor?.onCluster?.("closed");
+      if (!shuttingDown) {
+        console.error("Cluster connection closed permanently; exiting.");
+        void shutdown();
+      }
+    });
+
+    return { stopped, stop: shutdown };
+  } catch (err) {
+    closeRegistry();
+    throw err;
+  }
 }

--- a/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
@@ -3,6 +3,11 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  openLinkSandboxRegistry,
+  registryPathForDataDir,
+  type LinkSandboxRegistry,
+} from "../cli/link-sandbox-registry";
+import {
   createDesktopSandboxProvider,
   type SandboxEvent,
 } from "./user-desktop-provider";
@@ -16,6 +21,23 @@ function fakeDaemonSpawner() {
 
 function tmpDataDir(): string {
   return mkdtempSync(join(tmpdir(), "link-prov-"));
+}
+
+function fakeRegistry(): {
+  registry: LinkSandboxRegistry;
+  upserts: Parameters<LinkSandboxRegistry["upsert"]>[0][];
+} {
+  const upserts: Parameters<LinkSandboxRegistry["upsert"]>[0][] = [];
+  return {
+    upserts,
+    registry: {
+      upsert: (row) => upserts.push(row),
+      list: () => [],
+      reconcile: () => [],
+      prune: () => ({ removed: [], skipped: [] }),
+      close: () => {},
+    },
+  };
 }
 
 describe("desktop sandbox provider", () => {
@@ -157,6 +179,189 @@ describe("desktop sandbox provider", () => {
       expect(phases).toContain("ready");
       expect(phases.indexOf("spawning")).toBeLessThan(phases.indexOf("ready"));
     } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists ready and deleted lifecycle transitions to the registry", async () => {
+    const dataDir = tmpDataDir();
+    try {
+      const { registry, upserts } = fakeRegistry();
+      let portCounter = 30000;
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        registry,
+        spawnDaemon: () => fakeDaemonSpawner(),
+        postConfig: async () => {},
+        waitForHealth: async () => {},
+        pickPort: () => portCounter++,
+        resolvePreviewUrl: (handle, port) =>
+          `http://${handle}.localhost:${port}`,
+      });
+
+      await provider.ensureSandbox({
+        handle: "abc",
+        repo: {
+          cloneUrl: "https://github.com/decocms/studio.git",
+          branch: "alpha-hydrae",
+        },
+      });
+      await provider.deleteSandbox("abc");
+
+      expect(upserts).toEqual([
+        {
+          handle: "abc",
+          status: "spawning",
+          sandboxPath: join(dataDir, "sandboxes", "abc"),
+          port: null,
+          previewUrl: null,
+          repoCloneUrl: "https://github.com/decocms/studio.git",
+          branch: "alpha-hydrae",
+          projectName: "studio",
+          error: null,
+        },
+        {
+          handle: "abc",
+          status: "ready",
+          sandboxPath: join(dataDir, "sandboxes", "abc"),
+          port: 30000,
+          previewUrl: "http://abc.localhost:30000",
+          repoCloneUrl: "https://github.com/decocms/studio.git",
+          branch: "alpha-hydrae",
+          projectName: "studio",
+          error: null,
+        },
+        {
+          handle: "abc",
+          status: "stopped",
+          sandboxPath: join(dataDir, "sandboxes", "abc"),
+          port: null,
+          previewUrl: null,
+          repoCloneUrl: null,
+          branch: null,
+          projectName: null,
+          error: null,
+        },
+      ]);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not create registry rows when deleting an unknown handle", async () => {
+    const dataDir = tmpDataDir();
+    try {
+      const { registry, upserts } = fakeRegistry();
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        registry,
+        spawnDaemon: () => fakeDaemonSpawner(),
+        postConfig: async () => {},
+        waitForHealth: async () => {},
+      });
+
+      await provider.deleteSandbox("missing");
+
+      expect(upserts).toEqual([]);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists failed when setup fails before daemon health checks", async () => {
+    const dataDir = tmpDataDir();
+    try {
+      const { registry, upserts } = fakeRegistry();
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        registry,
+        spawnDaemon: () => fakeDaemonSpawner(),
+        postConfig: async () => {},
+        waitForHealth: async () => {},
+        pickPort: () => {
+          throw new Error("no port available");
+        },
+      });
+
+      await expect(
+        provider.ensureSandbox({
+          handle: "early-fail",
+          repo: {
+            cloneUrl: "git@github.com:decocms/studio.git",
+            branch: "alpha-hydrae",
+          },
+        }),
+      ).rejects.toThrow("no port available");
+
+      expect(upserts).toEqual([
+        {
+          handle: "early-fail",
+          status: "spawning",
+          sandboxPath: join(dataDir, "sandboxes", "early-fail"),
+          port: null,
+          previewUrl: null,
+          repoCloneUrl: "git@github.com:decocms/studio.git",
+          branch: "alpha-hydrae",
+          projectName: "studio",
+          error: null,
+        },
+        {
+          handle: "early-fail",
+          status: "failed",
+          sandboxPath: join(dataDir, "sandboxes", "early-fail"),
+          port: null,
+          previewUrl: null,
+          repoCloneUrl: "git@github.com:decocms/studio.git",
+          branch: "alpha-hydrae",
+          projectName: "studio",
+          error: "no port available",
+        },
+      ]);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves registry metadata after delete writes a stopped row", async () => {
+    const dataDir = tmpDataDir();
+    const registry = openLinkSandboxRegistry({
+      path: registryPathForDataDir(dataDir),
+      managedSandboxRoot: join(dataDir, "sandboxes"),
+    });
+    try {
+      let portCounter = 30000;
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        registry,
+        spawnDaemon: () => fakeDaemonSpawner(),
+        postConfig: async () => {},
+        waitForHealth: async () => {},
+        pickPort: () => portCounter++,
+      });
+
+      await provider.ensureSandbox({
+        handle: "sticky",
+        repo: {
+          cloneUrl: "https://github.com/decocms/studio.git",
+          branch: "feature/sticky",
+        },
+      });
+      await provider.deleteSandbox("sticky");
+
+      expect(registry.list()).toEqual([
+        expect.objectContaining({
+          handle: "sticky",
+          status: "stopped",
+          port: null,
+          previewUrl: null,
+          repoCloneUrl: "https://github.com/decocms/studio.git",
+          branch: "feature/sticky",
+          projectName: "studio",
+          error: null,
+        }),
+      ]);
+    } finally {
+      registry.close();
       rmSync(dataDir, { recursive: true, force: true });
     }
   });

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -20,6 +20,7 @@ import { randomBytes } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { createServer } from "node:net";
 import { join } from "node:path";
+import type { LinkSandboxRegistry } from "../cli/link-sandbox-registry";
 
 // Not exported — only referenced via SandboxEvent.phase below.
 type SandboxPhase = "spawning" | "ready" | "failed" | "evicted" | "deleted";
@@ -119,6 +120,15 @@ export interface SandboxState {
   daemonToken: string;
 }
 
+type SandboxRegistryMetadata = Pick<
+  Parameters<LinkSandboxRegistry["upsert"]>[0],
+  "repoCloneUrl" | "branch" | "projectName"
+>;
+
+type TrackedSandboxState = SandboxState & {
+  registryMetadata: SandboxRegistryMetadata;
+};
+
 export interface DesktopSandboxProvider {
   ensureSandbox(
     input: EnsureSandboxInput,
@@ -142,6 +152,7 @@ export interface DesktopSandboxProvider {
 
 export interface DesktopSandboxProviderDeps {
   dataDir: string;
+  registry?: LinkSandboxRegistry;
   spawnDaemon: (args: {
     workdir: string;
     handle: string;
@@ -223,15 +234,46 @@ function bringUpCauseMessage(err: unknown): string {
   return String(err);
 }
 
+function projectNameFromCloneUrl(cloneUrl: string | undefined): string | null {
+  if (!cloneUrl) return null;
+  const trimmed = cloneUrl.trim().replace(/\/+$/, "");
+  if (!trimmed) return null;
+  const segment = trimmed.split(/[/:]/).filter(Boolean).at(-1);
+  if (!segment) return null;
+  return segment.replace(/\.git$/i, "") || null;
+}
+
+function registryMetadataFromInput(
+  input: EnsureSandboxInput,
+): SandboxRegistryMetadata {
+  return {
+    repoCloneUrl: input.repo?.cloneUrl ?? null,
+    branch: input.repo?.branch ?? null,
+    projectName: projectNameFromCloneUrl(input.repo?.cloneUrl),
+  };
+}
+
 export function createDesktopSandboxProvider(
   deps: DesktopSandboxProviderDeps,
 ): DesktopSandboxProvider {
   const cap = deps.maxSandboxes ?? 20;
-  const sandboxes = new Map<string, SandboxState>();
+  const sandboxes = new Map<string, TrackedSandboxState>();
   const pickPort = deps.pickPort ?? allocateEphemeralPort;
   const fetcher = deps.fetchImpl ?? fetch;
   const resolvePreviewUrl =
     deps.resolvePreviewUrl ?? ((_handle, port) => `http://127.0.0.1:${port}`);
+  const sandboxPath = (handle: string): string =>
+    join(deps.dataDir, "sandboxes", handle);
+  const persist = (row: Parameters<LinkSandboxRegistry["upsert"]>[0]): void => {
+    try {
+      deps.registry?.upsert(row);
+    } catch (err) {
+      console.warn(
+        `[user-desktop] failed to persist sandbox lifecycle handle=${row.handle} status=${row.status}:`,
+        err,
+      );
+    }
+  };
 
   // Observability must never break provider control flow: a throwing
   // onEvent consumer is swallowed (the JSDoc on SandboxEvent guarantees this).
@@ -275,7 +317,7 @@ export function createDesktopSandboxProvider(
     }
   };
 
-  const evictDead = (state: SandboxState): void => {
+  const evictDead = (state: TrackedSandboxState): void => {
     console.warn(
       `[user-desktop] evicting dead daemon handle=${state.handle} port=${state.port}`,
     );
@@ -290,6 +332,15 @@ export function createDesktopSandboxProvider(
     // registered replacement and leave the new daemon process orphaned.
     if (sandboxes.get(state.handle) === state) {
       sandboxes.delete(state.handle);
+      persist({
+        handle: state.handle,
+        status: "stopped",
+        sandboxPath: sandboxPath(state.handle),
+        port: null,
+        previewUrl: null,
+        ...state.registryMetadata,
+        error: null,
+      });
       emit({ handle: state.handle, phase: "evicted" });
     }
   };
@@ -328,44 +379,67 @@ export function createDesktopSandboxProvider(
       // already gone
     }
     sandboxes.delete(victim.handle);
+    persist({
+      handle: victim.handle,
+      status: "stopped",
+      sandboxPath: sandboxPath(victim.handle),
+      port: null,
+      previewUrl: null,
+      ...victim.registryMetadata,
+      error: null,
+    });
     emit({ handle: victim.handle, phase: "evicted" });
   }
 
   const buildEntry = async (
     input: EnsureSandboxInput,
   ): Promise<{ sandboxApiUrl: string; previewUrl: string; port: number }> => {
+    const metadata = registryMetadataFromInput(input);
+    const workdir = sandboxPath(input.handle);
+    persist({
+      handle: input.handle,
+      status: "spawning",
+      sandboxPath: workdir,
+      port: null,
+      previewUrl: null,
+      ...metadata,
+      error: null,
+    });
     emit({ handle: input.handle, phase: "spawning" });
     evictIfNeeded();
-    const workdir = join(deps.dataDir, "sandboxes", input.handle);
-    await mkdir(workdir, { recursive: true });
-    console.log(
-      `[user-desktop] ensure handle=${input.handle} repo=${input.repo?.cloneUrl ?? "(none)"} branch=${input.repo?.branch ?? "(none)"} runtime=${input.workload?.runtime ?? "(autodetect)"} pm=${input.workload?.packageManager ?? "(autodetect)"}`,
-    );
-    // Two ephemeral ports per sandbox: one for the daemon's HTTP/proxy
-    // (port) and one for the dev script the orchestrator will spawn
-    // (devPort). Without a dedicated devPort, every framework's
-    // default 3000 collides with the cluster (and with other sandboxes).
-    const daemonToken = randomBytes(24).toString("hex");
-    const [port, devPort] = await Promise.all([pickPort(), pickPort()]);
-    console.log(
-      `[user-desktop] spawn handle=${input.handle} port=${port} devPort=${devPort} workdir=${workdir}`,
-    );
-    const spawned = await Promise.resolve(
-      deps.spawnDaemon({
-        workdir,
-        handle: input.handle,
-        port,
-        daemonToken,
-        // Offload SSRF allowlist from the cluster's trusted ensure body.
-        // Defaults fail closed (empty list, no loopback) so a daemon spawned
-        // by an older cluster that doesn't push these stays safe.
-        offloadAllowedHosts: input.offloadAllowedHosts ?? [],
-        offloadAllowSameHostDev: input.offloadAllowSameHostDev ?? false,
-        // org-fs mount config (desktop-only); undefined → daemon skips mounting.
-        orgFsConfigJson: input.orgFsConfigJson,
-      }),
-    );
+    let port: number | undefined;
+    let spawned: SpawnResult | null = null;
+    let daemonToken!: string;
     try {
+      await mkdir(workdir, { recursive: true });
+      console.log(
+        `[user-desktop] ensure handle=${input.handle} repo=${input.repo?.cloneUrl ?? "(none)"} branch=${input.repo?.branch ?? "(none)"} runtime=${input.workload?.runtime ?? "(autodetect)"} pm=${input.workload?.packageManager ?? "(autodetect)"}`,
+      );
+      // Two ephemeral ports per sandbox: one for the daemon's HTTP/proxy
+      // (port) and one for the dev script the orchestrator will spawn
+      // (devPort). Without a dedicated devPort, every framework's
+      // default 3000 collides with the cluster (and with other sandboxes).
+      daemonToken = randomBytes(24).toString("hex");
+      const [daemonPort, devPort] = await Promise.all([pickPort(), pickPort()]);
+      port = daemonPort;
+      console.log(
+        `[user-desktop] spawn handle=${input.handle} port=${port} devPort=${devPort} workdir=${workdir}`,
+      );
+      spawned = await Promise.resolve(
+        deps.spawnDaemon({
+          workdir,
+          handle: input.handle,
+          port,
+          daemonToken,
+          // Offload SSRF allowlist from the cluster's trusted ensure body.
+          // Defaults fail closed (empty list, no loopback) so a daemon spawned
+          // by an older cluster that doesn't push these stays safe.
+          offloadAllowedHosts: input.offloadAllowedHosts ?? [],
+          offloadAllowSameHostDev: input.offloadAllowSameHostDev ?? false,
+          // org-fs mount config (desktop-only); undefined → daemon skips mounting.
+          orgFsConfigJson: input.orgFsConfigJson,
+        }),
+      );
       try {
         await deps.waitForHealth(port);
       } catch (err) {
@@ -395,27 +469,41 @@ export function createDesktopSandboxProvider(
       }
     } catch (err) {
       console.error(
-        `[user-desktop] sandbox bring-up failed handle=${input.handle} port=${port} (killing daemon):`,
+        `[user-desktop] sandbox bring-up failed handle=${input.handle} port=${port ?? "(none)"}${spawned ? " (killing daemon)" : ""}:`,
         err,
       );
-      try {
-        spawned.kill("SIGKILL");
-      } catch {
-        // already gone
+      if (spawned) {
+        try {
+          spawned.kill("SIGKILL");
+        } catch {
+          // already gone
+        }
       }
       emit({
         handle: input.handle,
         phase: "failed",
         error: bringUpCauseMessage(err),
       });
+      persist({
+        handle: input.handle,
+        status: "failed",
+        sandboxPath: workdir,
+        port: null,
+        previewUrl: null,
+        ...metadata,
+        error: bringUpCauseMessage(err),
+      });
       throw err;
+    }
+    if (!spawned || port === undefined) {
+      throw new Error("sandbox bring-up invariant violated");
     }
     const sandboxApiUrl = `http://127.0.0.1:${port}`;
     const previewUrl = resolvePreviewUrl(input.handle, port);
     console.log(
       `[user-desktop] ready handle=${input.handle} port=${port} sandboxApiUrl=${sandboxApiUrl} previewUrl=${previewUrl}`,
     );
-    const state: SandboxState = {
+    const state: TrackedSandboxState = {
       handle: input.handle,
       port,
       process: spawned,
@@ -424,8 +512,18 @@ export function createDesktopSandboxProvider(
       lastUsedAt: Date.now(),
       activeDispatchCount: 0,
       daemonToken,
+      registryMetadata: metadata,
     };
     sandboxes.set(input.handle, state);
+    persist({
+      handle: input.handle,
+      status: "ready",
+      sandboxPath: workdir,
+      port,
+      previewUrl,
+      ...metadata,
+      error: null,
+    });
     emit({
       handle: input.handle,
       phase: "ready",
@@ -444,6 +542,15 @@ export function createDesktopSandboxProvider(
             `[user-desktop] daemon process exited unexpectedly handle=${input.handle} port=${port} — removing from cache`,
           );
           sandboxes.delete(input.handle);
+          persist({
+            handle: input.handle,
+            status: "stopped",
+            sandboxPath: workdir,
+            port: null,
+            previewUrl: null,
+            ...metadata,
+            error: null,
+          });
           emit({ handle: input.handle, phase: "evicted" });
         } else {
           console.log(
@@ -538,6 +645,17 @@ export function createDesktopSandboxProvider(
         // already gone
       }
       sandboxes.delete(handle);
+      persist({
+        handle,
+        status: "stopped",
+        sandboxPath: sandboxPath(handle),
+        port: null,
+        previewUrl: null,
+        repoCloneUrl: null,
+        branch: null,
+        projectName: null,
+        error: null,
+      });
       emit({ handle, phase: "deleted" });
     },
     async shutdown() {


### PR DESCRIPTION
## Summary
- persist local desktop sandbox state for `deco link`
- reconcile and prune stale sandbox rows and merged clean sandboxes
- hydrate the link TUI from local registry state and add `--prune`

## Verification
- bun test apps/mesh/src/cli/link-sandbox-registry.test.ts apps/mesh/src/cli/link-store.test.ts apps/mesh/src/link-daemon/user-desktop-provider.test.ts apps/mesh/src/link-daemon/control-handler.test.ts apps/mesh/src/link-daemon/handle-local-dispatch.test.ts
- bun run --cwd=apps/mesh check
- bun run fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist local `deco link` sandbox state to a local registry and hydrate the TUI from it. Add optional pruning of safe stale sandboxes with `--prune`, including Git-aware merged-branch cleanup.

- **New Features**
  - Add SQLite-backed sandbox registry under the data dir; store handle, status, path, port, preview URL, repo, branch, project, and timestamps.
  - Reconcile on start: mark missing/invalid paths and stop old live rows; hydrate the TUI from registry state.
  - TUI shows BRANCH and richer statuses: stopped, missing, merged, invalid, failed.
  - New `--prune` flag: remove metadata-only missing rows and delete clean sandboxes whose branch is merged into the default branch. Skips dirty worktrees and paths outside the managed root.
  - Daemon writes lifecycle transitions (spawning → ready/failed → stopped) to the registry; link store merges live events with persisted rows.

<sup>Written for commit 2a3be34bbf1ba0cd61c41d9281934c4a9d8b2a20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

