### PR TITLE
fix(virtual-mcp): allow editing instructions on GitHub-imported agents

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -1794,31 +1794,29 @@ Define step-by-step how the agent should handle requests.
                 <h2 className="text-sm font-medium text-foreground">
                   Instructions
                 </h2>
-                {!hasGithubRepo && (
-                  <div className="flex items-center gap-2">
-                    {!form.watch("metadata.instructions")?.trim() && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleInsertTemplate}
-                      >
-                        + Prompt template
-                      </Button>
-                    )}
+                <div className="flex items-center gap-2">
+                  {!form.watch("metadata.instructions")?.trim() && (
                     <Button
                       variant="outline"
                       size="sm"
-                      disabled={
-                        isImproving ||
-                        !form.watch("metadata.instructions")?.trim()
-                      }
-                      onClick={handleImprovePrompt}
+                      onClick={handleInsertTemplate}
                     >
-                      <Stars01 size={13} />
-                      Improve
+                      + Prompt template
                     </Button>
-                  </div>
-                )}
+                  )}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={
+                      isImproving ||
+                      !form.watch("metadata.instructions")?.trim()
+                    }
+                    onClick={handleImprovePrompt}
+                  >
+                    <Stars01 size={13} />
+                    Improve
+                  </Button>
+                </div>
               </div>
               <Controller
                 name="metadata.instructions"
@@ -1835,7 +1833,6 @@ Define step-by-step how the agent should handle requests.
                         field.onBlur();
                         flushAndSave();
                       }}
-                      disabled={hasGithubRepo}
                       placeholder="Define how this agent should behave, what tone to use, any constraints or guidelines..."
                       className="min-h-[200px] max-h-[360px] overflow-auto resize-none text-base text-muted-foreground placeholder:text-muted-foreground/40 leading-relaxed border-0 shadow-none px-4 py-3 pr-11 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent"
                       style={{ boxShadow: "none" }}


### PR DESCRIPTION
## Summary
- Remove the `hasGithubRepo` gate that disabled the instructions textarea and hid the "Prompt template" / "Improve" buttons for agents imported from GitHub repositories
- Users can now edit agent instructions regardless of whether the agent was imported from GitHub

## Test plan
- [ ] Import a website from GitHub and verify the instructions textarea is editable
- [ ] Verify "Prompt template" and "Improve" buttons appear for GitHub-imported agents
- [ ] Verify non-GitHub agents still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow editing instructions for GitHub‑imported agents and restore the “Prompt template” and “Improve” actions by removing the `hasGithubRepo` gate in the Virtual MCP editor.

- **Bug Fixes**
  - Removed `hasGithubRepo` checks so the instructions textarea is always editable.
  - Show “Prompt template” and “Improve” buttons for GitHub-imported agents.

<sup>Written for commit f3d9b9cd5c3d176b3516fbfdc08fa3ba0bcc9d4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

