### PR TITLE
perf(decopilot): decode projector run log incrementally to cut worker memory spike

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/projector-run-log.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-run-log.test.ts
@@ -295,6 +295,46 @@ describe("readProjectorRunLog", () => {
     expect(unsubscribed()).toBe(true);
   });
 
+  test("reassembles a fragmented chunk delivered through the stream", async () => {
+    // The streaming reader decodes incrementally; a fragmented chunk (raw byte
+    // slices that aren't valid JSON alone) must still reassemble across arrivals.
+    const full = JSON.stringify({
+      p: { type: "text-delta", delta: "hello world" },
+    });
+    const frag = (idx: number, raw: string): ReaderMsg => {
+      const headers: Record<string, string> = {
+        "Nats-Msg-Id": `run_1:fence_a:1:frag:${idx}`,
+        "Dp-Frag-Total": "2",
+        "Dp-Frag-Idx": String(idx),
+      };
+      return {
+        subject: "decopilot.stream.run_1",
+        data: enc.encode(raw),
+        headers: { get: (name: string) => headers[name] },
+      };
+    };
+    const { js } = fakeJetStream((push) => {
+      push(frag(0, full.slice(0, 20)));
+      push(frag(1, full.slice(20)));
+      push(readerMsg("run_1:fence_a:done:1", { done: true, finalSeq: 1 }));
+    });
+
+    const result = await readProjectorRunLog({
+      js,
+      runId: "run_1",
+      fenceToken: "fence_a",
+      finalSeq: 1,
+      idleTimeoutMs: 1000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.chunks).toEqual([
+        { type: "text-delta", delta: "hello world" } as UIMessageChunk,
+      ]);
+    }
+  });
+
   test("falls back to a best-effort reconstruct when the log is idle and incomplete", async () => {
     const { js } = fakeJetStream((push) => {
       // The {done} marker never arrives; the idle timeout fires.

--- a/apps/mesh/src/api/routes/decopilot/projector-run-log.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-run-log.ts
@@ -41,10 +41,100 @@ function decodePayload(data: Uint8Array): unknown {
   return JSON.parse(new TextDecoder().decode(data));
 }
 
+interface ChunkCollector {
+  /** Decode one retained message into the running chunk map (idempotent). */
+  push(message: ProjectorRetainedMessage): void;
+  /** seq → decoded chunk for every seq ≤ `upTo` seen so far. */
+  readonly chunks: Map<number, UIMessageChunk>;
+  /** finalSeq from the `done` envelope once seen, else null. */
+  readonly doneFinalSeq: number | null;
+}
+
 /**
- * Shared helper: decodes messages and reassembles fragments, returning a map
- * of seq → UIMessageChunk for all seqs up to `upTo`. Also returns the
- * finalSeq from the `done` envelope if one was seen (null otherwise).
+ * Stateful, incremental version of the decode/reassemble loop. Feed it one
+ * retained message at a time; it decodes each chunk ONCE on arrival and keeps
+ * only the decoded `UIMessageChunk` (plus in-flight fragment parts), never the
+ * raw message bytes.
+ *
+ * Streaming readers (`readProjectorRunLog` / `readProjectorRunRange`) use this
+ * so they don't retain the whole run's raw payload AND don't `JSON.parse` the
+ * entire log in one synchronous burst at `done` — that transient allocation
+ * spike (large run payloads) is what OOMKilled the worker between metric
+ * scrapes and stalled the event loop into the liveness probe. Spreading the
+ * decode across arrivals flattens the peak; only the decoded chunks (the
+ * projection's actual output) stay resident.
+ */
+function createChunkCollector(
+  runId: string,
+  fenceToken: string,
+  upTo: number,
+): ChunkCollector {
+  const chunks = new Map<number, UIMessageChunk>();
+  const fragments = new Map<number, { total: number; parts: Uint8Array[] }>();
+  let doneFinalSeq: number | null = null;
+
+  return {
+    chunks,
+    get doneFinalSeq() {
+      return doneFinalSeq;
+    },
+    push(message) {
+      if (runIdFromSubject(message.subject) !== runId) return;
+      const parsed = parseRunStreamMsgId(message.msgId);
+      if (
+        !parsed ||
+        parsed.runId !== runId ||
+        parsed.fenceToken !== fenceToken
+      ) {
+        return;
+      }
+
+      if (parsed.kind === "done") {
+        const payload = decodePayload(message.data);
+        if (isDoneEnvelope(payload)) {
+          doneFinalSeq = parsed.finalSeq;
+        }
+        return;
+      }
+
+      if (parsed.kind !== "chunk") return;
+
+      if (parsed.seq > upTo) return;
+      const total = Number(message.headers?.get(FRAG_TOTAL_HEADER) ?? "0");
+      if (parsed.fragmentIndex !== null || total > 0) {
+        const index =
+          parsed.fragmentIndex ??
+          Number(message.headers?.get(FRAG_INDEX_HEADER) ?? "0");
+        const existing = fragments.get(parsed.seq) ?? {
+          total,
+          parts: new Array(total),
+        };
+        existing.parts[index] = message.data;
+        fragments.set(parsed.seq, existing);
+        if (existing.parts.filter(Boolean).length === existing.total) {
+          const payload = decodePayload(concat(existing.parts));
+          if (payload && typeof payload === "object" && "p" in payload) {
+            chunks.set(parsed.seq, (payload as { p: UIMessageChunk }).p);
+          }
+          // Drop the raw fragment parts now that the chunk is decoded.
+          fragments.delete(parsed.seq);
+        }
+        return;
+      }
+
+      const payload = decodePayload(message.data);
+      if (payload && typeof payload === "object" && "p" in payload) {
+        chunks.set(parsed.seq, (payload as { p: UIMessageChunk }).p);
+      }
+    },
+  };
+}
+
+/**
+ * Batch helper: decodes messages and reassembles fragments, returning a map
+ * of seq → UIMessageChunk for all seqs up to `upTo`, plus the finalSeq from the
+ * `done` envelope if one was seen. Thin wrapper over {@link createChunkCollector}
+ * so the batch reconstruct paths and the streaming readers share one decoder.
  */
 function collectChunks(
   messages: ProjectorRetainedMessage[],
@@ -55,55 +145,43 @@ function collectChunks(
   chunks: Map<number, UIMessageChunk>;
   doneFinalSeq: number | null;
 } {
-  const chunks = new Map<number, UIMessageChunk>();
-  const fragments = new Map<number, { total: number; parts: Uint8Array[] }>();
-  let doneFinalSeq: number | null = null;
+  const collector = createChunkCollector(runId, fenceToken, upTo);
+  for (const message of messages) collector.push(message);
+  return { chunks: collector.chunks, doneFinalSeq: collector.doneFinalSeq };
+}
 
-  for (const message of messages) {
-    if (runIdFromSubject(message.subject) !== runId) continue;
-    const parsed = parseRunStreamMsgId(message.msgId);
-    if (!parsed || parsed.runId !== runId || parsed.fenceToken !== fenceToken) {
-      continue;
-    }
-
-    if (parsed.kind === "done") {
-      const payload = decodePayload(message.data);
-      if (isDoneEnvelope(payload)) {
-        doneFinalSeq = parsed.finalSeq;
-      }
-      continue;
-    }
-
-    if (parsed.kind !== "chunk") continue;
-
-    if (parsed.seq > upTo) continue;
-    const total = Number(message.headers?.get(FRAG_TOTAL_HEADER) ?? "0");
-    if (parsed.fragmentIndex !== null || total > 0) {
-      const index =
-        parsed.fragmentIndex ??
-        Number(message.headers?.get(FRAG_INDEX_HEADER) ?? "0");
-      const existing = fragments.get(parsed.seq) ?? {
-        total,
-        parts: new Array(total),
-      };
-      existing.parts[index] = message.data;
-      fragments.set(parsed.seq, existing);
-      if (existing.parts.filter(Boolean).length === existing.total) {
-        const payload = decodePayload(concat(existing.parts));
-        if (payload && typeof payload === "object" && "p" in payload) {
-          chunks.set(parsed.seq, (payload as { p: UIMessageChunk }).p);
-        }
-      }
-      continue;
-    }
-
-    const payload = decodePayload(message.data);
-    if (payload && typeof payload === "object" && "p" in payload) {
-      chunks.set(parsed.seq, (payload as { p: UIMessageChunk }).p);
-    }
+/** Order the contiguous seq 1..finalSeq run, requiring a matching `done`. */
+function orderFullRun(
+  chunks: Map<number, UIMessageChunk>,
+  doneFinalSeq: number | null,
+  finalSeq: number,
+): ReconstructResult {
+  // Only accept the `done` marker if its finalSeq matches exactly.
+  if (doneFinalSeq !== finalSeq) return { ok: false, error: "missing done" };
+  const out: UIMessageChunk[] = [];
+  for (let seq = 1; seq <= finalSeq; seq++) {
+    const chunk = chunks.get(seq);
+    if (!chunk) return { ok: false, error: `missing seq ${seq}` };
+    out.push(chunk);
   }
+  return { ok: true, chunks: out, chunkCount: out.length };
+}
 
-  return { chunks, doneFinalSeq };
+/** Order the contiguous prefix fromSeq+1..toSeq, no `done` required. */
+function orderRange(
+  chunks: Map<number, UIMessageChunk>,
+  fromSeq: number,
+  toSeq: number,
+): ReconstructRangeResult {
+  const out: UIMessageChunk[] = [];
+  let seq = fromSeq;
+  for (let s = fromSeq + 1; s <= toSeq; s++) {
+    const c = chunks.get(s);
+    if (!c) break; // gap: stop at contiguous prefix (no error, no done needed)
+    out.push(c);
+    seq = s;
+  }
+  return { ok: true, chunks: out, lastContiguousSeq: seq };
 }
 
 export function reconstructProjectorRun(input: {
@@ -118,17 +196,7 @@ export function reconstructProjectorRun(input: {
     input.fenceToken,
     input.finalSeq,
   );
-
-  // Only accept the `done` marker if its finalSeq matches exactly.
-  if (doneFinalSeq !== input.finalSeq)
-    return { ok: false, error: "missing done" };
-  const out: UIMessageChunk[] = [];
-  for (let seq = 1; seq <= input.finalSeq; seq++) {
-    const chunk = chunks.get(seq);
-    if (!chunk) return { ok: false, error: `missing seq ${seq}` };
-    out.push(chunk);
-  }
-  return { ok: true, chunks: out, chunkCount: out.length };
+  return orderFullRun(chunks, doneFinalSeq, input.finalSeq);
 }
 
 export function reconstructProjectorRunRange(input: {
@@ -144,15 +212,7 @@ export function reconstructProjectorRunRange(input: {
     input.fenceToken,
     input.toSeq,
   );
-  const out: UIMessageChunk[] = [];
-  let seq = input.fromSeq;
-  for (let s = input.fromSeq + 1; s <= input.toSeq; s++) {
-    const c = chunks.get(s);
-    if (!c) break; // gap: stop at contiguous prefix (no error, no done needed)
-    out.push(c);
-    seq = s;
-  }
-  return { ok: true, chunks: out, lastContiguousSeq: seq };
+  return orderRange(chunks, input.fromSeq, input.toSeq);
 }
 
 export async function readProjectorRunRange(input: {
@@ -168,7 +228,12 @@ export async function readProjectorRunRange(input: {
     deliver_policy: DeliverPolicy.All,
   });
   const sub = await consumer.consume();
-  const messages: ProjectorRetainedMessage[] = [];
+  // Decode incrementally and drop each raw message; retain only decoded chunks.
+  const collector = createChunkCollector(
+    input.runId,
+    input.fenceToken,
+    input.toSeq,
+  );
   const idleTimeoutMs = input.idleTimeoutMs ?? 5000;
   let idle: ReturnType<typeof setTimeout> | null = null;
   const resetIdle = () => {
@@ -180,15 +245,14 @@ export async function readProjectorRunRange(input: {
     resetIdle();
     for await (const m of sub) {
       resetIdle();
-      messages.push({
+      const msgId = m.headers?.get("Nats-Msg-Id") || undefined;
+      collector.push({
         subject: m.subject,
         data: m.data,
-        msgId: m.headers?.get("Nats-Msg-Id") || undefined,
+        msgId,
         headers: m.headers,
       });
-      const parsed = parseRunStreamMsgId(
-        m.headers?.get("Nats-Msg-Id") || undefined,
-      );
+      const parsed = parseRunStreamMsgId(msgId);
       if (parsed && "seq" in parsed && parsed.seq >= input.toSeq) {
         sub.stop();
         break;
@@ -197,7 +261,7 @@ export async function readProjectorRunRange(input: {
   } finally {
     if (idle) clearTimeout(idle);
   }
-  return reconstructProjectorRunRange({ ...input, messages });
+  return orderRange(collector.chunks, input.fromSeq, input.toSeq);
 }
 
 export async function readProjectorRunLog(input: {
@@ -214,7 +278,17 @@ export async function readProjectorRunLog(input: {
     deliver_policy: DeliverPolicy.All,
   });
   const sub = await consumer.consume();
-  const messages: ProjectorRetainedMessage[] = [];
+  // Decode each message ONCE on arrival into the collector and let the raw
+  // bytes go (never retain the whole run's payload). The fold that builds the
+  // ordered output runs only once `done` arrives — O(N), on already-decoded
+  // chunks, no JSON.parse burst. This is the worker hot path: the old retain-
+  // all + parse-everything-at-`done` shape spiked allocation (OOMKill between
+  // metric scrapes) and stalled the event loop into the liveness probe.
+  const collector = createChunkCollector(
+    input.runId,
+    input.fenceToken,
+    input.finalSeq,
+  );
   const idleTimeoutMs = input.idleTimeoutMs ?? 1000;
   let idle: ReturnType<typeof setTimeout> | null = null;
   let timedOut = false;
@@ -232,26 +306,23 @@ export async function readProjectorRunLog(input: {
     for await (const m of sub) {
       resetIdle();
       const msgId = m.headers?.get("Nats-Msg-Id") || undefined;
-      messages.push({
+      collector.push({
         subject: m.subject,
         data: m.data,
         msgId,
         headers: m.headers,
       });
-      // reconstructProjectorRun re-parses the WHOLE accumulated log; it can only
-      // succeed once the `done` envelope (final message) has arrived — every
-      // earlier call returns "missing done". Folding on every message is O(N²)
-      // JSON.parse on the event loop and stalls it for tens of seconds on long
-      // runs. Gate the fold on the cheap msgId parse → fold once, O(N).
+      // The ordered fold can only succeed once the `done` envelope (final
+      // message) has arrived. Gate it on the cheap msgId parse so we order
+      // once, at `done`, instead of on every message.
       const parsed = parseRunStreamMsgId(msgId);
       if (parsed?.kind !== "done" || parsed.finalSeq !== input.finalSeq)
         continue;
-      const current = reconstructProjectorRun({
-        runId: input.runId,
-        fenceToken: input.fenceToken,
-        finalSeq: input.finalSeq,
-        messages,
-      });
+      const current = orderFullRun(
+        collector.chunks,
+        collector.doneFinalSeq,
+        input.finalSeq,
+      );
       if (current.ok) {
         sub.stop();
         return current;
@@ -262,11 +333,6 @@ export async function readProjectorRunLog(input: {
   }
 
   return timedOut
-    ? reconstructProjectorRun({
-        runId: input.runId,
-        fenceToken: input.fenceToken,
-        finalSeq: input.finalSeq,
-        messages,
-      })
+    ? orderFullRun(collector.chunks, collector.doneFinalSeq, input.finalSeq)
     : { ok: false, error: "reader stopped before done" };
 }

--- a/apps/mesh/src/cli/commands/auth/login.test.ts
+++ b/apps/mesh/src/cli/commands/auth/login.test.ts
@@ -92,9 +92,13 @@ function mockTarget(target: string) {
       /^[A-Za-z0-9_-]+$/,
     );
     issuedCode = `code_${Math.random().toString(36).slice(2, 8)}`;
-    // Simulate the browser hitting the CLI callback after auth.
+    // Simulate the browser hitting the CLI callback after auth. Don't follow
+    // the callback server's 302 to `${target}/cli/auth-success` — that's a real
+    // external host; following it makes a live network call (flaky / slow in CI).
     await new Promise((r) => setTimeout(r, 10));
-    await fetch(`${redirectUri}?code=${issuedCode}&state=${state}`);
+    await fetch(`${redirectUri}?code=${issuedCode}&state=${state}`, {
+      redirect: "manual",
+    });
   });
 
   return {
@@ -168,7 +172,8 @@ describe("loginCommand", () => {
       const callback = parsed.searchParams.get("redirect_uri")!;
       const state = parsed.searchParams.get("state")!;
       await new Promise((r) => setTimeout(r, 10));
-      await fetch(`${callback}?code=c&state=${state}`);
+      // Don't follow the callback server's 302 to the external success page.
+      await fetch(`${callback}?code=c&state=${state}`, { redirect: "manual" });
     });
     const code = await loginCommand({
       dataDir: dir,

--- a/apps/mesh/src/cli/lib/ensure-session.test.ts
+++ b/apps/mesh/src/cli/lib/ensure-session.test.ts
@@ -94,7 +94,14 @@ function mockOAuth() {
     const state = parsed.searchParams.get("state")!;
     code = "code_test";
     await new Promise((r) => setTimeout(r, 10));
-    await fetch(`${redirectUri}?code=${code}&state=${state}`);
+    // Deliver the callback to the local server, but DON'T follow its 302 to
+    // `${target}/cli/auth-success` — that's a real external studio host
+    // (e.g. studio-stg.decocms.com), and following it makes a live network
+    // call that hangs in CI until the 5s test timeout. The local server has
+    // already resolved waitForCallback before sending the redirect.
+    await fetch(`${redirectUri}?code=${code}&state=${state}`, {
+      redirect: "manual",
+    });
   });
 
   return { fetchMock, openBrowser };


### PR DESCRIPTION
## Summary

Memory follow-up to **#4096** (which fixed the O(N²) *CPU* fold on the projector run-log reader). The **memory** half of that same worker hot path was untouched.

`readProjectorRunLog` / `readProjectorRunRange` — run on the **`worker` dispatch-role pods** via the `PROJECTOR_QUEUE` DBOS workflow — retained **every raw NATS message of the whole run** in a `messages[]` array and then `JSON.parse`d the entire log in **one synchronous burst at `done`**. On long/large runs that materializes raw bytes + parse scratch + all decoded chunks **in the same tick**:

- a transient allocation spike → the exact failure `deco-apps-cd` records on the worker tier:
  > `700Mi → 1.5Gi: workers OOMKilled (exit 137) under transient JSON.parse allocation spikes (large run payloads)` — and bumped again to 2Gi during the 2026-06-24 incident.
- a fresh event-loop stall right when the run finalizes (liveness pressure).

## What changed

Extract the decode/reassemble loop into a stateful `createChunkCollector` that the streaming readers feed **one message at a time**:

- each chunk is **decoded once on arrival**; only the decoded `UIMessageChunk` stays resident,
- the **raw bytes are dropped immediately** (completed fragment parts too),
- the ordered fold still runs **once, at `done`**, but now over already-decoded chunks — **no parse burst**.

Peak drops from `~(raw + 2× decoded, allocated together)` to `~(decoded, accumulated gradually)`, flattening the spike that OOMs the worker between 30s metric scrapes.

## Why it's safe

Behavior is **identical**. The batch `reconstructProjectorRun` / `reconstructProjectorRunRange` are now thin wrappers over the same collector + shared `orderFullRun` / `orderRange`, so the existing **pure unit tests are an exact regression oracle**. Added one test covering fragment reassembly through the streaming reader (the new incremental path).

## Testing

- `bun test` projector-run-log + projector-consumer → **18 pass, 0 fail**
- `tsc --noEmit` (mesh) clean · `oxlint` clean · `biome format` clean · `knip` clean

## Notes / context

This targets the **residual** memory issue after the in-flight CPU fixes (#4096, #4100) and the infra mitigation already applied in prod (worker mem 1.5Gi→2Gi, image rolled back 3.54.0→3.53.1). It does not change the projection output, the wire format, or the queue/workflow wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Incrementally decodes projector run logs to remove the JSON.parse burst, cutting peak memory and preventing worker OOM/stalls on long runs. Behavior and output remain the same.

- **Refactors**
  - Introduced `createChunkCollector` to decode each message once and drop raw bytes immediately (handles fragment reassembly).
  - Updated `readProjectorRunLog` and `readProjectorRunRange` to stream into the collector; order once at done via `orderFullRun` / `orderRange`.
  - Kept `reconstructProjectorRun*` as thin wrappers over the shared logic and added a test for fragmented chunk reassembly.

- **Bug Fixes**
  - CLI auth tests: stop following the callback 302 to external studio by using `{ redirect: "manual" }` in mocks; tests are now hermetic and fast.

<sup>Written for commit 8c8197b1916fe99ac463c5c225abdf4d4519eb07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

