### PR TITLE
fix(helm): combo-only nginx.frontDoorLabels so the NLB front-door label never lands on the worker

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.11.0
+version: 0.11.1
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -44,6 +44,13 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        # Front-door selector label(s) for the NLB. Applied to the combo
+        # (nginx + API) pods ONLY — deliberately NOT in worker-deployment.yaml —
+        # so labelling the front door never registers the worker as a public
+        # NLB target. See nginx.frontDoorLabels in values.yaml.
+        {{- with .Values.nginx.frontDoorLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -106,6 +106,12 @@ nginx:
         - ALL
     readOnlyRootFilesystem: false
   preStopSleepSeconds: 15
+  # Labels stamped onto the combo (nginx + API) pods so a front-door
+  # LoadBalancer (e.g. the deco-apps-cd NLB) can select them by a stable label
+  # instead of app.kubernetes.io/name. Applied to the combo deployment ONLY
+  # (never the worker), so the raw-API worker is never registered as a public
+  # target. Empty by default; set e.g. { decocms.com/frontdoor: "true" }.
+  frontDoorLabels: {}
 
 configMap:
   meshConfig:


### PR DESCRIPTION
## Summary

Chart `0.11.0` (#4109, the "nginx front door") folded nginx into the main combo
deployment and **deleted the separate web tier**, but left no way to put the NLB's
`decocms.com/frontdoor` selector label on the combo pods *alone*. The only
pod-label hook, `.Values.podLabels`, is rendered by **both** `deployment.yaml`
(combo) **and** `worker-deployment.yaml` (worker). Because the front-door NLB
selector is name-agnostic and the worker's container port is also named `http`,
labelling the front door via `podLabels` would register the raw-API **worker** as
a public NLB target.

This gap caused a **staging outage**: when Argo pruned the old web pods (which were
the only pods carrying `decocms.com/frontdoor=true`), nothing relabelled the combo
pods, so the NLB selector matched zero pods and `studio-stg.decocms.com` returned
HTTP 520.

## Change

- Add a dedicated **`nginx.frontDoorLabels`** value, rendered **only** on the combo
  deployment's pod template (deliberately *not* in `worker-deployment.yaml`). Empty
  by default. Set `nginx.frontDoorLabels.decocms.com/frontdoor: "true"` to make the
  combo pods the NLB front door.
- Bump chart `0.11.0 → 0.11.1` (merging publishes `oci://ghcr.io/decocms/chart-deco-studio:0.11.1` via `publish-chart.yml`).

## Verification

```
helm template t deploy/helm/studio \
  --set nginx.frontDoorLabels.decocms\.com/frontdoor=true \
  --set database.engine=postgresql --set database.url=x --set worker.enabled=true
```
→ `decocms.com/frontdoor` appears on the **combo** Deployment pod template and **NOT**
on the `-worker` Deployment. (Confirmed by parsing the rendered manifests.)

## Follow-up (deco-apps-cd, after 0.11.1 publishes)

`apps/deco-studio-stg/`:
- `Chart.yaml`: dep `chart-deco-studio` `0.11.0 → 0.11.1`, then `helm dependency update`
- `values.yaml` under `studio:`: set `nginx.frontDoorLabels.decocms.com/frontdoor: "true"`,
  pin `nginx.image.tag` (currently floats to `latest`), `replicaCount: 2` (combo is now
  sole front door + API → avoid SPOF), and remove the dead `studio.web.*` block
- revert the emergency `nlb-service.yaml` selector back to the `decocms.com/frontdoor` label
  and refresh its stale `web.enabled` comment

> Prod (`deco-studio`) is still on the old web-split chart `0.10.14` and will need the
> same migration later — do not replicate until staging is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes NLB front-door labeling so only the combo (nginx+API) pods receive the selector label, never the worker. Adds `nginx.frontDoorLabels` and releases chart 0.11.1 to prevent worker exposure and avoid outages.

- **Bug Fixes**
  - Added `nginx.frontDoorLabels`, applied only to the combo deployment pod template (not the worker).
  - Prevents the NLB from selecting worker pods on port `http` after the web tier removal.
  - Bumped chart to `0.11.1`.

- **Migration**
  - Upgrade to `chart-deco-studio` `0.11.1` and set `nginx.frontDoorLabels.decocms.com/frontdoor: "true"`.
  - Update the NLB Service selector to use the `decocms.com/frontdoor` label and adjust replicas if the combo serves as the sole front door.

<sup>Written for commit d71474545a5ab64caf2aaf4900bb7bf9c9785c97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

