### PR TITLE
fix(cli): stop CLI auth tests from following the callback 302 to a live studio host

### DIFF
--- a/apps/mesh/src/cli/commands/auth/login.test.ts
+++ b/apps/mesh/src/cli/commands/auth/login.test.ts
@@ -92,9 +92,13 @@ function mockTarget(target: string) {
       /^[A-Za-z0-9_-]+$/,
     );
     issuedCode = `code_${Math.random().toString(36).slice(2, 8)}`;
-    // Simulate the browser hitting the CLI callback after auth.
+    // Simulate the browser hitting the CLI callback after auth. Don't follow
+    // the callback server's 302 to `${target}/cli/auth-success` — that's a real
+    // external host; following it makes a live network call (flaky / slow in CI).
     await new Promise((r) => setTimeout(r, 10));
-    await fetch(`${redirectUri}?code=${issuedCode}&state=${state}`);
+    await fetch(`${redirectUri}?code=${issuedCode}&state=${state}`, {
+      redirect: "manual",
+    });
   });
 
   return {
@@ -168,7 +172,8 @@ describe("loginCommand", () => {
       const callback = parsed.searchParams.get("redirect_uri")!;
       const state = parsed.searchParams.get("state")!;
       await new Promise((r) => setTimeout(r, 10));
-      await fetch(`${callback}?code=c&state=${state}`);
+      // Don't follow the callback server's 302 to the external success page.
+      await fetch(`${callback}?code=c&state=${state}`, { redirect: "manual" });
     });
     const code = await loginCommand({
       dataDir: dir,

--- a/apps/mesh/src/cli/lib/ensure-session.test.ts
+++ b/apps/mesh/src/cli/lib/ensure-session.test.ts
@@ -94,7 +94,14 @@ function mockOAuth() {
     const state = parsed.searchParams.get("state")!;
     code = "code_test";
     await new Promise((r) => setTimeout(r, 10));
-    await fetch(`${redirectUri}?code=${code}&state=${state}`);
+    // Deliver the callback to the local server, but DON'T follow its 302 to
+    // `${target}/cli/auth-success` — that's a real external studio host
+    // (e.g. studio-stg.decocms.com), and following it makes a live network
+    // call that hangs in CI until the 5s test timeout. The local server has
+    // already resolved waitForCallback before sending the redirect.
+    await fetch(`${redirectUri}?code=${code}&state=${state}`, {
+      redirect: "manual",
+    });
   });
 
   return { fetchMock, openBrowser };


### PR DESCRIPTION
## Problem

The `test` CI job is **red** — `apps/mesh/src/cli/lib/ensure-session.test.ts` →
`ensureSession > re-logs in against the requested studio when the cached session is for a different one`
**times out after 5000ms**, failing the whole job (exit 1).

## Root cause

The OAuth callback server (`oauth-callback.ts`) responds to the callback with a **302 → `${target}/cli/auth-success`**, a real external studio host. The browser-callback simulations in these unit tests deliver the code with the **global `fetch`**, which **follows that redirect**:

```js
await fetch(`${redirectUri}?code=${code}&state=${state}`); // ← follows 302 to studio
```

That turns a hermetic unit test into a **live network call**. The failing test is the only interactive-login test that passes `target: https://studio-stg.decocms.com` — and that host **hangs in CI**, so `await openBrowser(url)` (login.ts) never returns and the test hits the 5s timeout. The prod-target tests passed only because the live prod success page happens to respond fast.

This is environment-dependent, so it fails on **any** branch right now (not specific to one PR).

## Fix

Pass `{ redirect: "manual" }` to the callback `fetch` in all three browser mocks (`ensure-session.test.ts` + `login.test.ts`). The local server has already resolved `waitForCallback` **before** emitting the 302, so the authorization code is still delivered — we just don't chase the external success page.

The CLI auth suite is now **hermetic and fast** (5.6s → <0.1s) and no longer depends on any studio host being reachable.

## Testing

- `bun test ensure-session.test.ts login.test.ts oauth-callback.test.ts` → **15 pass, 0 fail** (was 1 fail / timeout), ran in ~0.1s.
- Re-ran ensure-session 3× → deterministic pass.
- `tsc --noEmit` (mesh) · `oxlint` · `biome format` all clean.

No production code changed — the real CLI still opens a browser that follows the redirect to the success page as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops CLI auth tests from following the OAuth callback 302 to external studio hosts, removing flaky live network calls that caused CI timeouts. Unit tests only; CLI behavior unchanged; suite runs in ~0.1s.

- **Bug Fixes**
  - In `apps/mesh/src/cli/commands/auth/login.test.ts` and `apps/mesh/src/cli/lib/ensure-session.test.ts`, deliver the callback with `fetch(..., { redirect: "manual" })`.
  - The local server resolves `waitForCallback` before sending the 302, so the code is received without hitting `${target}/cli/auth-success`.

<sup>Written for commit ac6b73c90de7bd504924ff6453f069dc26fd63bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

