### PR TITLE
refactor(helm): name the front-door container <name>-web not -nginx

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.11.1
+version: 0.11.2
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -63,7 +63,10 @@ spec:
       securityContext:
         {{- include "chart-deco-studio.podSecurityContext" . | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}-nginx
+        # The front-door / web tier. Runs the nginx image (serves the SPA +
+        # proxies to the API sidecars); named "-web" for the user-facing web
+        # tier rather than the implementation (nginx).
+        - name: {{ .Chart.Name }}-web
           {{- with .Values.nginx.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## Summary

The combo pod's front-door container renders as `studio-nginx` (via the deco-apps-cd `studio` alias). Rename it to `{{ .Chart.Name }}-web` → **`studio-web`**, so the container is named for its tier (web / front door) rather than its implementation. The API sidecars are unchanged (`studio-api-0`, `studio-api-1`).

## Notes

- **Cosmetic only.** The container still runs the `studio-nginx` image, its port stays named `http` (8080), and the NLB selector, probes, and metrics scrape are untouched.
- No runbook/doc references the container by name — the only `studio-nginx` literals in the repo are the **image** (`docker build -t studio-nginx`), which is unchanged.
- Chart `0.11.1 → 0.11.2`. Merging publishes `oci://ghcr.io/decocms/chart-deco-studio:0.11.2`.

## Verification

`helm template` → combo containers render as `<name>-web`, `<name>-api-0`, `<name>-api-1` (i.e. `studio-web` / `studio-api-0` / `studio-api-1` under the deco-apps-cd alias).

## Follow-up

To land on staging, bump `apps/deco-studio-stg/Chart.yaml` dep `chart-deco-studio` `0.11.1 → 0.11.2` + `helm dependency update` in deco-apps-cd (cosmetic rollout — recreates the combo pod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the front-door container in the `chart-deco-studio` Helm chart from `<name>-nginx` to `<name>-web` to use tier-based naming. No runtime behavior changes; chart version bumped to `0.11.2`.

- **Refactors**
  - Container name is now `{{ .Chart.Name }}-web` (e.g., `studio-web`).
  - API sidecar names remain `<name>-api-0` and `<name>-api-1`.
  - Image, port `http` (8080), NLB selector, probes, and metrics scraping unchanged.

- **Migration**
  - Bump `chart-deco-studio` to `0.11.2` in `apps/deco-studio-stg/Chart.yaml` and run `helm dependency update` in `deco-apps-cd`.
  - Expect a cosmetic rollout that recreates the combo pod.

<sup>Written for commit 30cfda7d07eeabf0b37ae382a3e814061e9acb2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

