### PR TITLE
feat(org-fs): password-protected file/folder sharing

### DIFF
--- a/apps/mesh/migrations/121-org-fs-share-password.ts
+++ b/apps/mesh/migrations/121-org-fs-share-password.ts
@@ -1,0 +1,34 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Password-protected sharing for org-fs entries — a gate layered on top of the
+ * link-accessible `read_public` flag (migration 120). See
+ * `.context/file-share-password-spec.md`.
+ *
+ * - `share_password_hash`: scrypt hash of the share password. Null on a
+ *   published entry means fully public; set means the `/read` proxy serves an
+ *   interstitial password form before the bytes.
+ * - `share_secret`: random per-node token mixed into the unlock cookie's
+ *   signature. Rotated on every password change so previously-issued unlock
+ *   cookies stop validating (password change logs everyone out).
+ *
+ * Both null by default and meaningless unless `read_public` is true. Like the
+ * public flag, they live on files AND dirs (a folder password gates its whole
+ * subtree, resolved most-specific-node-wins at read time). Never exposed to
+ * clients — the API surfaces only a derived `shareMode`.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("org_fs_entry")
+    .addColumn("share_password_hash", "text")
+    .addColumn("share_secret", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("org_fs_entry")
+    .dropColumn("share_password_hash")
+    .dropColumn("share_secret")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -119,6 +119,7 @@ import * as migration117orgfileconfigssiteslug from "./117-org-file-configs-site
 import * as migration118organizationdomainsmultiverify from "./118-organization-domains-multi-verify.ts";
 import * as migration119organizationjoinrequests from "./119-organization-join-requests.ts";
 import * as migration120orgfsreadpublic from "./120-org-fs-read-public.ts";
+import * as migration121orgfssharepassword from "./121-org-fs-share-password.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -263,6 +264,7 @@ const migrations: Record<string, Migration> = {
     migration118organizationdomainsmultiverify,
   "119-organization-join-requests": migration119organizationjoinrequests,
   "120-org-fs-read-public": migration120orgfsreadpublic,
+  "121-org-fs-share-password": migration121orgfssharepassword,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -6,15 +6,19 @@ import { isOrgArchived } from "../../core/org-archived";
 import { isBrowserNavigation } from "../utils/browser-navigation";
 
 /**
- * The org-fs read proxy (`GET .../fs/:volume/read`) serves files flagged
- * read_public to anyone — so a signed-in user who isn't a member of the owning
- * org must still reach it. This detects that one route so the membership gate
- * below can defer to it; the route serves only public files and still gates
- * everything else on ORG_FS_READ (which a non-member fails → 403). Every other
+ * Public-share endpoints a non-member must still reach: the read proxy
+ * (`GET .../fs/:volume/read`, serves public/password files) and the password
+ * unlock (`POST .../fs/:volume/unlock`). The membership gate below defers to
+ * these; the routes themselves serve only shared content and still gate
+ * everything else on ORG_FS_READ (a non-member fails → 403). Every other
  * org-scoped route stays member-gated.
  */
-function isPublicReadPath(c: Context): boolean {
-  return c.req.method === "GET" && /\/fs\/[^/]+\/read$/.test(c.req.path);
+function isPublicSharePath(c: Context): boolean {
+  const p = c.req.path;
+  return (
+    (c.req.method === "GET" && /\/fs\/[^/]+\/read$/.test(p)) ||
+    (c.req.method === "POST" && /\/fs\/[^/]+\/unlock$/.test(p))
+  );
 }
 
 export const resolveOrgFromPath: MiddlewareHandler<{
@@ -80,10 +84,10 @@ export const resolveOrgFromPath: MiddlewareHandler<{
       .executeTakeFirst();
 
     if (!membership) {
-      // A public file read is reachable by anyone, including signed-in
-      // non-members — let it fall through to the route (which serves only
-      // read_public files and 403s the rest). All other routes stay gated.
-      if (!isPublicReadPath(c)) {
+      // Public-share reads + password unlock are reachable by anyone, incl.
+      // signed-in non-members — let them fall through to the route (which serves
+      // only shared content and 403s the rest). All other routes stay gated.
+      if (!isPublicSharePath(c)) {
         // Bounce browser navigations into the SPA so OrgAccessGate shows the
         // styled "No access" screen (with invite/auto-join handling) instead of
         // raw JSON in the address bar.

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -114,8 +114,18 @@ function byteResponse(
 
 /** Unlock cookie lifetime. */
 const UNLOCK_TTL_SEC = 60 * 60 * 12;
-/** Failed unlock attempts per (ip, org, volume, path) before a lockout. */
-const UNLOCK_MAX_ATTEMPTS = 10;
+/**
+ * Per (IP, share) attempt cap — the normal-case limiter. Best-effort: the
+ * client IP can be spoofed via X-Forwarded-For when not behind a trusted proxy,
+ * which is why the per-share cap is the real backstop.
+ */
+const UNLOCK_IP_MAX = 10;
+/**
+ * Per-share attempt cap across ALL IPs — bounds brute-force even when the
+ * per-IP limit is evaded by rotating X-Forwarded-For. Generous enough to
+ * tolerate a few users + typos without locking out a legitimate share.
+ */
+const UNLOCK_SHARE_MAX = 50;
 const UNLOCK_WINDOW_MS = 5 * 60 * 1000;
 
 /**
@@ -124,16 +134,16 @@ const UNLOCK_WINDOW_MS = 5 * 60 * 1000;
  * stays bounded. Good enough for a v1 gate; revisit if it needs to be global.
  */
 const unlockAttempts = new Map<string, { count: number; resetAt: number }>();
-function unlockAllowed(key: string): boolean {
+function overLimit(key: string, max: number): boolean {
   const e = unlockAttempts.get(key);
-  return !e || Date.now() > e.resetAt || e.count < UNLOCK_MAX_ATTEMPTS;
+  return !!e && Date.now() <= e.resetAt && e.count >= max;
 }
-function recordUnlockFail(key: string): void {
-  const now = Date.now();
-  if (unlockAttempts.size > 5000) {
-    for (const [k, v] of unlockAttempts)
-      if (now > v.resetAt) unlockAttempts.delete(k);
-  }
+function unlockAllowed(ipKey: string, shareKey: string): boolean {
+  return (
+    !overLimit(ipKey, UNLOCK_IP_MAX) && !overLimit(shareKey, UNLOCK_SHARE_MAX)
+  );
+}
+function bumpAttempt(key: string, now: number): void {
   const e = unlockAttempts.get(key);
   if (!e || now > e.resetAt) {
     unlockAttempts.set(key, { count: 1, resetAt: now + UNLOCK_WINDOW_MS });
@@ -141,11 +151,24 @@ function recordUnlockFail(key: string): void {
     e.count++;
   }
 }
+function recordUnlockFail(ipKey: string, shareKey: string): void {
+  const now = Date.now();
+  if (unlockAttempts.size > 5000) {
+    for (const [k, v] of unlockAttempts)
+      if (now > v.resetAt) unlockAttempts.delete(k);
+  }
+  bumpAttempt(ipKey, now);
+  bumpAttempt(shareKey, now);
+}
 
 function clientIp(c: Ctx): string {
+  // cf-connecting-ip is set by Cloudflare and not client-spoofable behind it;
+  // x-real-ip by many reverse proxies. The leftmost x-forwarded-for is
+  // client-supplied (spoofable) — last resort only.
   return (
-    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
+    c.req.header("cf-connecting-ip") ||
     c.req.header("x-real-ip") ||
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
     "unknown"
   );
 }
@@ -783,8 +806,10 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       // password is one credential for the whole subtree, so all of its
       // sub-paths must share one attempt budget — otherwise an attacker
       // multiplies the lockout by guessing sibling paths under the same share.
-      const rlKey = `${clientIp(c)}|${orgId}|${volume}|${access.govPath}`;
-      if (!unlockAllowed(rlKey)) {
+      // Per-IP (normal case) + per-share (backstop vs X-Forwarded-For spoofing).
+      const ipKey = `${clientIp(c)}|${orgId}|${volume}|${access.govPath}`;
+      const shareKey = `share|${orgId}|${volume}|${access.govPath}`;
+      if (!unlockAllowed(ipKey, shareKey)) {
         return passwordFormResponse(
           c,
           {
@@ -801,8 +826,11 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
         .catch(() => ({}) as Record<string, unknown>);
       const password =
         typeof formBody.password === "string" ? formBody.password : "";
-      if (!password || !verifySharePassword(password, access.passwordHash)) {
-        recordUnlockFail(rlKey);
+      if (
+        !password ||
+        !(await verifySharePassword(password, access.passwordHash))
+      ) {
+        recordUnlockFail(ipKey, shareKey);
         return passwordFormResponse(
           c,
           { orgSlug, volume, path, error: "Incorrect password." },

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -30,15 +30,23 @@ import { exponentialBackoffWithJitter, sleep } from "@decocms/std";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import { getCookie, setCookie } from "hono/cookie";
 import type { NatsConnection } from "@nats-io/nats-core";
 import { ForbiddenError, UnauthorizedError } from "@/core/access-control";
 import type { StudioContext } from "@/core/studio-context";
-import type { OrgFs } from "@/file-storage/org-fs";
+import type { OrgFs, ReadAccess } from "@/file-storage/org-fs";
 import {
   OrgFsNotFoundError,
   OrgFsQuotaError,
   OrgFsValidationError,
 } from "@/file-storage/org-fs";
+import {
+  signUnlockToken,
+  unlockCookieName,
+  verifySharePassword,
+  verifyUnlockToken,
+} from "@/file-storage/share-password";
+import type { ShareMode } from "@/storage/org-fs";
 import {
   notifyOrgFsChange,
   orgFsChangeSubject,
@@ -100,6 +108,112 @@ function byteResponse(
     headers["Content-Security-Policy"] = "sandbox allow-scripts allow-modals";
   }
   return c.body(Buffer.from(bytes), 200, headers);
+}
+
+// --- Password share gate -------------------------------------------------
+
+/** Unlock cookie lifetime. */
+const UNLOCK_TTL_SEC = 60 * 60 * 12;
+/** Failed unlock attempts per (ip, org, volume, path) before a lockout. */
+const UNLOCK_MAX_ATTEMPTS = 10;
+const UNLOCK_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * In-memory unlock rate limiter — per-instance, so it blunts brute-force on a
+ * single share but doesn't coordinate across replicas. Lazily swept so the map
+ * stays bounded. Good enough for a v1 gate; revisit if it needs to be global.
+ */
+const unlockAttempts = new Map<string, { count: number; resetAt: number }>();
+function unlockAllowed(key: string): boolean {
+  const e = unlockAttempts.get(key);
+  return !e || Date.now() > e.resetAt || e.count < UNLOCK_MAX_ATTEMPTS;
+}
+function recordUnlockFail(key: string): void {
+  const now = Date.now();
+  if (unlockAttempts.size > 5000) {
+    for (const [k, v] of unlockAttempts)
+      if (now > v.resetAt) unlockAttempts.delete(k);
+  }
+  const e = unlockAttempts.get(key);
+  if (!e || now > e.resetAt) {
+    unlockAttempts.set(key, { count: 1, resetAt: now + UNLOCK_WINDOW_MS });
+  } else {
+    e.count++;
+  }
+}
+
+function clientIp(c: Ctx): string {
+  return (
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
+    c.req.header("x-real-ip") ||
+    "unknown"
+  );
+}
+
+function requestIsSecure(c: Ctx): boolean {
+  if (c.req.header("x-forwarded-proto") === "https") return true;
+  try {
+    return new URL(c.req.url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** A valid, non-stale unlock cookie for a password-gated read? */
+function isUnlocked(
+  c: Ctx,
+  org: string,
+  volume: string,
+  access: Extract<ReadAccess, { access: "password" }>,
+): boolean {
+  const token = getCookie(c, unlockCookieName(org, volume, access.govPath));
+  if (!token) return false;
+  const res = verifyUnlockToken(token, {
+    org,
+    volume,
+    secret: access.secret,
+    nowSec: Math.floor(Date.now() / 1000),
+  });
+  return res?.govPath === access.govPath;
+}
+
+const escapeHtml = (s: string): string =>
+  s.replace(/[&<>"']/g, (ch) => `&#${ch.charCodeAt(0)};`);
+
+/** The interstitial password page served before a gated file (never the
+ *  sandbox CSP — the form must POST). */
+function passwordFormResponse(
+  c: Ctx,
+  opts: { orgSlug: string; volume: string; path: string; error?: string },
+  status: 401 | 429 = 401,
+): Response {
+  const action = `/api/${encodeURIComponent(opts.orgSlug)}/fs/${encodeURIComponent(
+    opts.volume,
+  )}/unlock?path=${encodeURIComponent(opts.path)}`;
+  const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Password required</title><style>
+:root{color-scheme:light dark}
+body{margin:0;min-height:100vh;display:grid;place-items:center;font:15px/1.5 ui-sans-serif,system-ui,sans-serif;background:#f6f6f7;color:#18181b}
+@media(prefers-color-scheme:dark){body{background:#0b0b0c;color:#fafafa}}
+form{width:min(92vw,360px);padding:28px;border-radius:14px;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.1),0 8px 30px rgba(0,0,0,.08);display:flex;flex-direction:column;gap:14px}
+@media(prefers-color-scheme:dark){form{background:#161618}}
+h1{margin:0;font-size:16px}
+p{margin:0;font-size:13px;color:#71717a}
+input{padding:10px 12px;border-radius:9px;border:1px solid #d4d4d8;font-size:14px;background:transparent;color:inherit}
+@media(prefers-color-scheme:dark){input{border-color:#3f3f46}}
+button{padding:10px 12px;border-radius:9px;border:0;background:#18181b;color:#fff;font-size:14px;font-weight:500;cursor:pointer}
+@media(prefers-color-scheme:dark){button{background:#fafafa;color:#18181b}}
+.err{color:#dc2626;font-size:13px}
+</style></head><body><form method="post" action="${escapeHtml(action)}">
+<h1>🔒 Password required</h1>
+<p>This file is shared with a password. Enter it to view.</p>
+${opts.error ? `<div class="err">${escapeHtml(opts.error)}</div>` : ""}
+<input type="password" name="password" placeholder="Password" autofocus autocomplete="current-password" required>
+<button type="submit">Unlock</button>
+</form></body></html>`;
+  return c.body(html, status, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
 }
 
 /** Translate an OrgFs error into an explicit JSON response (never thrown). */
@@ -365,18 +479,19 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   // Read a file: `?presign=1` returns a presigned URL (the mount's byte path);
   // otherwise the bytes are streamed through mesh (convenient for the UI/dev).
   //
-  // Public fast-path: a file flagged `read_public` streams to ANYONE — no auth,
-  // no membership. resolveOrgFromPath binds ctx.orgFs to the path-resolved org
-  // even for anonymous / non-member callers and lets them reach this route (its
-  // public-read carve-out), so the same proxy URL the org uses works for the
-  // open internet once a file is published. `?presign` stays member-only:
-  // presigned URLs bypass mesh and aren't part of the share surface. `public-*`
-  // skill volumes are excluded — they're a separate, member-gated mechanism.
+  // Share fast-path: resolveOrgFromPath binds ctx.orgFs and lets anonymous /
+  // non-member callers reach this route (its public-share carve-out). A
+  // `public` file streams to anyone; a `password` file streams only with a
+  // valid unlock cookie, else returns the interstitial form. Everything else
+  // (private, or password-without-cookie for a member) falls through to the
+  // member-gated read — members never see the password prompt. `?presign` stays
+  // member-only; `public-*` skill volumes are a separate, member-gated path.
   app.get("/:volume/read", async (c) => {
     const volume = c.req.param("volume");
     const path = c.req.query("path") ?? "";
     const ctx = c.get("meshContext");
 
+    let access: ReadAccess = { access: "private" };
     if (
       !c.req.query("presign") &&
       ctx.organization?.id &&
@@ -384,18 +499,22 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       isValidVolume(volume) &&
       !isPublicVolume(volume)
     ) {
-      // Own flag OR inherited from a published ancestor folder. A failure
-      // probing visibility falls through to the authed read, never 500s.
-      const publiclyReadable = await ctx.orgFs
-        .isPubliclyReadable(volume, path)
-        .catch(() => false);
-      if (publiclyReadable) {
+      // A probe failure falls through to the member-gated read, never 500s.
+      access = await ctx.orgFs
+        .resolveReadAccess(volume, path)
+        .catch(() => ({ access: "private" as const }));
+      const serveOpen =
+        access.access === "public" ||
+        (access.access === "password" &&
+          isUnlocked(c, ctx.organization.id, volume, access));
+      if (serveOpen) {
         try {
+          // Public files may be shared-cached; password content must not be.
           return byteResponse(
             c,
             await ctx.orgFs.read(volume, path),
             path,
-            true,
+            access.access === "public",
           );
         } catch (err) {
           return fsErrorResponse(c, err);
@@ -403,8 +522,19 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       }
     }
 
+    // Member-gated. A non-member/anonymous hitting a password file gets the
+    // unlock form; a member reading it bypasses the prompt entirely.
     const r = await resolve(c, volume, "ORG_FS_READ");
-    if (!r.ok) return r.res;
+    if (!r.ok) {
+      if (access.access === "password") {
+        return passwordFormResponse(c, {
+          orgSlug: ctx.organization?.slug ?? "",
+          volume,
+          path,
+        });
+      }
+      return r.res;
+    }
     try {
       if (c.req.query("presign")) {
         return c.json({ url: await r.fs.presignRead(volume, path) });
@@ -564,11 +694,12 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
     },
   );
 
-  // Toggle an entry's public-read flag. Body: { public: boolean }. Works on a
-  // file (publishes it) or a dir (publishes its whole subtree — /read inherits
-  // from public ancestor dirs). Gated on ORG_FS_WRITE — you can publish what
-  // you can write — and rejected on read-only `public-*` volumes by resolve().
-  // No `seq` bump: visibility is metadata, not content.
+  // Set an entry's share mode. Body: { mode: 'private'|'public'|'password',
+  // password? } (back-compat: { public: boolean }). Works on a file (shares it)
+  // or a dir (shares its whole subtree). Gated on ORG_FS_WRITE — you can share
+  // what you can write — and rejected on read-only `public-*` volumes by
+  // resolve(). Setting/changing the password rotates the node secret, so
+  // outstanding unlock cookies stop working. No `seq` bump.
   app.post(
     "/:volume/public",
     bodyLimit({
@@ -581,19 +712,118 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       if (!r.ok) return r.res;
       const path = c.req.query("path") ?? "";
       const body = (await c.req.json().catch(() => null)) as {
+        mode?: unknown;
         public?: unknown;
+        password?: unknown;
       } | null;
-      if (!body || typeof body.public !== "boolean") {
-        return c.json({ error: "Body must be { public: boolean }" }, 400);
+      const mode: ShareMode | null =
+        body?.mode === "private" ||
+        body?.mode === "public" ||
+        body?.mode === "password"
+          ? body.mode
+          : typeof body?.public === "boolean"
+            ? body.public
+              ? "public"
+              : "private"
+            : null;
+      if (!mode) {
+        return c.json(
+          {
+            error:
+              "Body must be { mode: 'private'|'public'|'password', password? }",
+          },
+          400,
+        );
       }
+      const password =
+        typeof body?.password === "string" ? body.password : undefined;
       try {
-        const entry = await r.fs.setReadPublic(volume, path, body.public, {
+        const entry = await r.fs.setShareMode(volume, path, mode, {
           actor: r.ctx.auth!.user!.id,
+          password,
         });
         return c.json({ entry });
       } catch (err) {
         return fsErrorResponse(c, err);
       }
+    },
+  );
+
+  // Unlock a password-gated share: verify the password, set the scoped unlock
+  // cookie, redirect back to the file. No auth (the public-facing gate);
+  // rate-limited per IP+path. resolveOrgFromPath's carve-out lets non-members
+  // reach it. Returns the form (with an error) on a bad/rate-limited attempt.
+  app.post(
+    "/:volume/unlock",
+    bodyLimit({
+      maxSize: MAX_JSON_BODY_BYTES,
+      onError: (c) => c.json({ error: "Request body too large" }, 413),
+    }),
+    async (c) => {
+      const volume = c.req.param("volume");
+      const path = c.req.query("path") ?? "";
+      const ctx = c.get("meshContext");
+      const orgId = ctx.organization?.id;
+      const orgSlug = ctx.organization?.slug ?? "";
+      if (
+        !orgId ||
+        !ctx.orgFs ||
+        !isValidVolume(volume) ||
+        isPublicVolume(volume)
+      ) {
+        return c.json({ error: "Not found" }, 404);
+      }
+      const rlKey = `${clientIp(c)}|${orgId}|${volume}|${path}`;
+      if (!unlockAllowed(rlKey)) {
+        return passwordFormResponse(
+          c,
+          {
+            orgSlug,
+            volume,
+            path,
+            error: "Too many attempts — wait a few minutes.",
+          },
+          429,
+        );
+      }
+      const access = await ctx.orgFs
+        .resolveReadAccess(volume, path)
+        .catch(() => ({ access: "private" as const }));
+      if (access.access !== "password") {
+        return c.json({ error: "Not password-protected" }, 404);
+      }
+      const formBody = await c.req
+        .parseBody()
+        .catch(() => ({}) as Record<string, unknown>);
+      const password =
+        typeof formBody.password === "string" ? formBody.password : "";
+      if (!password || !verifySharePassword(password, access.passwordHash)) {
+        recordUnlockFail(rlKey);
+        return passwordFormResponse(
+          c,
+          { orgSlug, volume, path, error: "Incorrect password." },
+          401,
+        );
+      }
+      const nowSec = Math.floor(Date.now() / 1000);
+      const token = signUnlockToken({
+        o: orgId,
+        v: volume,
+        p: access.govPath,
+        s: access.secret,
+        e: nowSec + UNLOCK_TTL_SEC,
+      });
+      setCookie(c, unlockCookieName(orgId, volume, access.govPath), token, {
+        httpOnly: true,
+        secure: requestIsSecure(c),
+        sameSite: "Lax",
+        path: `/api/${encodeURIComponent(orgSlug)}/fs/${encodeURIComponent(volume)}/read`,
+        maxAge: UNLOCK_TTL_SEC,
+      });
+      return c.redirect(
+        `/api/${encodeURIComponent(orgSlug)}/fs/${encodeURIComponent(volume)}/read?path=${encodeURIComponent(path)}`,
+        303,
+      );
     },
   );
 

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -773,7 +773,17 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       ) {
         return c.json({ error: "Not found" }, 404);
       }
-      const rlKey = `${clientIp(c)}|${orgId}|${volume}|${path}`;
+      const access = await ctx.orgFs
+        .resolveReadAccess(volume, path)
+        .catch(() => ({ access: "private" as const }));
+      if (access.access !== "password") {
+        return c.json({ error: "Not password-protected" }, 404);
+      }
+      // Rate-limit on the GOVERNING node, not the requested path: a folder
+      // password is one credential for the whole subtree, so all of its
+      // sub-paths must share one attempt budget — otherwise an attacker
+      // multiplies the lockout by guessing sibling paths under the same share.
+      const rlKey = `${clientIp(c)}|${orgId}|${volume}|${access.govPath}`;
       if (!unlockAllowed(rlKey)) {
         return passwordFormResponse(
           c,
@@ -785,12 +795,6 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
           },
           429,
         );
-      }
-      const access = await ctx.orgFs
-        .resolveReadAccess(volume, path)
-        .catch(() => ({ access: "private" as const }));
-      if (access.access !== "password") {
-        return c.json({ error: "Not password-protected" }, 404);
       }
       const formBody = await c.req
         .parseBody()

--- a/apps/mesh/src/file-storage/org-fs.integration.test.ts
+++ b/apps/mesh/src/file-storage/org-fs.integration.test.ts
@@ -485,8 +485,12 @@ describe("OrgFs service (integration)", () => {
     if (access.access === "password") {
       expect(access.govPath).toBe("secret.pdf");
       expect(access.secret.length).toBeGreaterThan(0);
-      expect(verifySharePassword("hunter2", access.passwordHash)).toBe(true);
-      expect(verifySharePassword("nope", access.passwordHash)).toBe(false);
+      expect(await verifySharePassword("hunter2", access.passwordHash)).toBe(
+        true,
+      );
+      expect(await verifySharePassword("nope", access.passwordHash)).toBe(
+        false,
+      );
     }
   });
 
@@ -520,7 +524,7 @@ describe("OrgFs service (integration)", () => {
     expect(access.access).toBe("password");
     if (access.access === "password") {
       expect(access.govPath).toBe("vault");
-      expect(verifySharePassword("pw", access.passwordHash)).toBe(true);
+      expect(await verifySharePassword("pw", access.passwordHash)).toBe(true);
     }
   });
 
@@ -552,8 +556,8 @@ describe("OrgFs service (integration)", () => {
       throw new Error("expected password access");
     }
     expect(a2.secret).not.toBe(a1.secret);
-    expect(verifySharePassword("two", a2.passwordHash)).toBe(true);
-    expect(verifySharePassword("one", a2.passwordHash)).toBe(false);
+    expect(await verifySharePassword("two", a2.passwordHash)).toBe(true);
+    expect(await verifySharePassword("one", a2.passwordHash)).toBe(false);
   });
 
   afterAll(async () => {

--- a/apps/mesh/src/file-storage/org-fs.integration.test.ts
+++ b/apps/mesh/src/file-storage/org-fs.integration.test.ts
@@ -33,6 +33,7 @@ import { DevObjectStorage } from "../object-storage/dev-object-storage";
 import { S3Service } from "../object-storage/s3-service";
 import { OrgFsEntryStorage } from "../storage/org-fs";
 import { OrgFs, OrgFsQuotaError, OrgFsValidationError } from "./org-fs";
+import { verifySharePassword } from "./share-password";
 
 const ORG = "org_fs_svc";
 const ACTOR = "user_fs_svc";
@@ -468,6 +469,91 @@ describe("OrgFs service (integration)", () => {
     await fs.write("home", "site/index.html", "page2", { actor: ACTOR });
     expect((await fs.stat("home", "site"))?.readPublic).toBe(false);
     expect(await fs.isPubliclyReadable("home", "site/index.html")).toBe(false);
+  });
+
+  // --- Password sharing ---------------------------------------------------
+
+  it("password mode gates a file with a verifiable hash + secret", async () => {
+    await fs.write("home", "secret.pdf", "data", { actor: ACTOR });
+    await fs.setShareMode("home", "secret.pdf", "password", {
+      actor: ACTOR,
+      password: "hunter2",
+    });
+    expect((await fs.stat("home", "secret.pdf"))?.shareMode).toBe("password");
+    const access = await fs.resolveReadAccess("home", "secret.pdf");
+    expect(access.access).toBe("password");
+    if (access.access === "password") {
+      expect(access.govPath).toBe("secret.pdf");
+      expect(access.secret.length).toBeGreaterThan(0);
+      expect(verifySharePassword("hunter2", access.passwordHash)).toBe(true);
+      expect(verifySharePassword("nope", access.passwordHash)).toBe(false);
+    }
+  });
+
+  it("password mode requires a password", async () => {
+    await fs.write("home", "x.txt", "y", { actor: ACTOR });
+    expect(
+      fs.setShareMode("home", "x.txt", "password", { actor: ACTOR }),
+    ).rejects.toThrow();
+  });
+
+  it("resolveReadAccess: private / public / back to private", async () => {
+    await fs.write("home", "a.txt", "1", { actor: ACTOR });
+    expect((await fs.resolveReadAccess("home", "a.txt")).access).toBe(
+      "private",
+    );
+    await fs.setShareMode("home", "a.txt", "public", { actor: ACTOR });
+    expect((await fs.resolveReadAccess("home", "a.txt")).access).toBe("public");
+    await fs.setShareMode("home", "a.txt", "private", { actor: ACTOR });
+    expect((await fs.resolveReadAccess("home", "a.txt")).access).toBe(
+      "private",
+    );
+  });
+
+  it("a password folder gates its whole subtree (inherited govern node)", async () => {
+    await fs.write("home", "vault/doc.pdf", "x", { actor: ACTOR });
+    await fs.setShareMode("home", "vault", "password", {
+      actor: ACTOR,
+      password: "pw",
+    });
+    const access = await fs.resolveReadAccess("home", "vault/doc.pdf");
+    expect(access.access).toBe("password");
+    if (access.access === "password") {
+      expect(access.govPath).toBe("vault");
+      expect(verifySharePassword("pw", access.passwordHash)).toBe(true);
+    }
+  });
+
+  it("most-specific wins: a public file inside a password folder is public", async () => {
+    await fs.write("home", "vault/open.txt", "x", { actor: ACTOR });
+    await fs.setShareMode("home", "vault", "password", {
+      actor: ACTOR,
+      password: "pw",
+    });
+    await fs.setShareMode("home", "vault/open.txt", "public", { actor: ACTOR });
+    expect((await fs.resolveReadAccess("home", "vault/open.txt")).access).toBe(
+      "public",
+    );
+  });
+
+  it("changing the password rotates the node secret (invalidates old cookies)", async () => {
+    await fs.write("home", "s.txt", "x", { actor: ACTOR });
+    await fs.setShareMode("home", "s.txt", "password", {
+      actor: ACTOR,
+      password: "one",
+    });
+    const a1 = await fs.resolveReadAccess("home", "s.txt");
+    await fs.setShareMode("home", "s.txt", "password", {
+      actor: ACTOR,
+      password: "two",
+    });
+    const a2 = await fs.resolveReadAccess("home", "s.txt");
+    if (a1.access !== "password" || a2.access !== "password") {
+      throw new Error("expected password access");
+    }
+    expect(a2.secret).not.toBe(a1.secret);
+    expect(verifySharePassword("two", a2.passwordHash)).toBe(true);
+    expect(verifySharePassword("one", a2.passwordHash)).toBe(false);
   });
 
   afterAll(async () => {

--- a/apps/mesh/src/file-storage/org-fs.ts
+++ b/apps/mesh/src/file-storage/org-fs.ts
@@ -1,7 +1,11 @@
 import { createHash } from "node:crypto";
 import type { BoundObjectStorage } from "../object-storage/bound-object-storage";
 import { detectContentType } from "../object-storage/key-utils";
-import type { OrgFsEntry, OrgFsEntryStorage } from "../storage/org-fs";
+import type {
+  OrgFsEntry,
+  OrgFsEntryStorage,
+  ShareMode,
+} from "../storage/org-fs";
 import {
   ancestorsOf,
   assertValidVolume,
@@ -10,6 +14,21 @@ import {
   normalizeFsPath,
   parentOf,
 } from "./org-fs-path";
+import { generateShareSecret, hashSharePassword } from "./share-password";
+
+/** What the `/read` proxy should do for a given path. */
+export type ReadAccess =
+  | { access: "private" }
+  | { access: "public" }
+  | {
+      access: "password";
+      /** Node the password sits on — the unlock cookie's scope. */
+      govPath: string;
+      /** Current secret version (rotated on password change). */
+      secret: string;
+      /** scrypt hash (server-only — never sent to clients). */
+      passwordHash: string;
+    };
 
 const DEFAULT_CHANGES_LIMIT = 500;
 const LIST_PAGE_SIZE = 1000;
@@ -109,16 +128,16 @@ export class OrgFs {
   }
 
   /**
-   * Toggle an entry's public-read flag. Works on a file (publishes that file)
-   * or a dir (publishes its whole subtree — the read path inherits from public
-   * ancestor dirs). A public file/subtree is served by `/read` to anyone, no
-   * auth. Throws if the path is not a live entry.
+   * Set an entry's share mode. `private`/`public` clear any password;
+   * `password` requires `opts.password`, hashes it, and rotates the node's
+   * secret (invalidating previously-issued unlock cookies). Works on a file or
+   * a dir (a dir governs its whole subtree). Throws if the path is not live.
    */
-  async setReadPublic(
+  async setShareMode(
     volume: string,
     path: string,
-    readPublic: boolean,
-    opts: { actor: string },
+    mode: ShareMode,
+    opts: { actor: string; password?: string },
   ): Promise<OrgFsEntry> {
     assertValidVolume(volume);
     const normalized = normalizeFsPath(path);
@@ -128,11 +147,25 @@ export class OrgFs {
       normalized,
     );
     if (!entry) throw new OrgFsNotFoundError(`No such path: ${normalized}`);
-    const updated = await this.manifest.setReadPublic({
+
+    let passwordHash: string | null = null;
+    let shareSecret: string | null = null;
+    if (mode === "password") {
+      if (!opts.password) {
+        throw new OrgFsValidationError(
+          "A password is required to set password mode",
+        );
+      }
+      passwordHash = hashSharePassword(opts.password);
+      shareSecret = generateShareSecret();
+    }
+    const updated = await this.manifest.setShareMode({
       organizationId: this.organizationId,
       volume,
       path: entry.path,
-      readPublic,
+      readPublic: mode !== "private",
+      passwordHash,
+      shareSecret,
       actor: opts.actor,
     });
     // The stat above proved the row exists and is live; the update can only
@@ -141,6 +174,48 @@ export class OrgFs {
       throw new OrgFsNotFoundError(`No such path: ${entry.path}`);
     }
     return updated;
+  }
+
+  /** Public/private convenience over setShareMode (clears any password). */
+  async setReadPublic(
+    volume: string,
+    path: string,
+    readPublic: boolean,
+    opts: { actor: string },
+  ): Promise<OrgFsEntry> {
+    return this.setShareMode(volume, path, readPublic ? "public" : "private", {
+      actor: opts.actor,
+    });
+  }
+
+  /**
+   * What the `/read` proxy should do for `path`: private (member-gated),
+   * public (serve to anyone), or password (serve the form/check the cookie).
+   * Resolves the most-specific published node (self or ancestor) — its
+   * password decides public-vs-gated.
+   */
+  async resolveReadAccess(volume: string, path: string): Promise<ReadAccess> {
+    assertValidVolume(volume);
+    const normalized = normalizeFsPath(path);
+    const entry = await this.manifest.get(
+      this.organizationId,
+      volume,
+      normalized,
+    );
+    if (!entry || entry.kind !== "file") return { access: "private" };
+    const gov = await this.manifest.resolveGoverningShare({
+      organizationId: this.organizationId,
+      volume,
+      candidatePaths: [normalized, ...ancestorsOf(normalized)],
+    });
+    if (!gov) return { access: "private" };
+    if (!gov.passwordHash) return { access: "public" };
+    return {
+      access: "password",
+      govPath: gov.path,
+      secret: gov.secret ?? "",
+      passwordHash: gov.passwordHash,
+    };
   }
 
   /**

--- a/apps/mesh/src/file-storage/org-fs.ts
+++ b/apps/mesh/src/file-storage/org-fs.ts
@@ -156,7 +156,7 @@ export class OrgFs {
           "A password is required to set password mode",
         );
       }
-      passwordHash = hashSharePassword(opts.password);
+      passwordHash = await hashSharePassword(opts.password);
       shareSecret = generateShareSecret();
     }
     const updated = await this.manifest.setShareMode({

--- a/apps/mesh/src/file-storage/share-password.test.ts
+++ b/apps/mesh/src/file-storage/share-password.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import {
+  generateShareSecret,
+  hashSharePassword,
+  signUnlockToken,
+  unlockCookieName,
+  verifySharePassword,
+  verifyUnlockToken,
+} from "./share-password";
+
+describe("share-password", () => {
+  it("hashes and verifies a password", () => {
+    const h = hashSharePassword("hunter2");
+    expect(h.startsWith("scrypt$")).toBe(true);
+    expect(verifySharePassword("hunter2", h)).toBe(true);
+    expect(verifySharePassword("wrong", h)).toBe(false);
+  });
+
+  it("salts — same password yields distinct hashes", () => {
+    expect(hashSharePassword("x")).not.toBe(hashSharePassword("x"));
+  });
+
+  it("rejects malformed stored hashes without throwing", () => {
+    expect(verifySharePassword("x", "garbage")).toBe(false);
+    expect(verifySharePassword("x", "scrypt$zz$zz")).toBe(false);
+  });
+
+  it("share secrets are random", () => {
+    expect(generateShareSecret()).not.toBe(generateShareSecret());
+  });
+
+  it("signs and verifies an unlock token", () => {
+    const t = signUnlockToken({
+      o: "org",
+      v: "home",
+      p: "deck",
+      s: "sec1",
+      e: 1100,
+    });
+    expect(
+      verifyUnlockToken(t, {
+        org: "org",
+        volume: "home",
+        secret: "sec1",
+        nowSec: 1000,
+      }),
+    ).toEqual({ govPath: "deck" });
+  });
+
+  it("rejects a rotated secret, expiry, org/volume mismatch, and tampering", () => {
+    const t = signUnlockToken({
+      o: "org",
+      v: "home",
+      p: "deck",
+      s: "old",
+      e: 2000,
+    });
+    const base = { org: "org", volume: "home", secret: "old", nowSec: 1000 };
+    // rotated secret
+    expect(verifyUnlockToken(t, { ...base, secret: "new" })).toBeNull();
+    // expired
+    expect(verifyUnlockToken(t, { ...base, nowSec: 3000 })).toBeNull();
+    // org / volume mismatch
+    expect(verifyUnlockToken(t, { ...base, org: "other" })).toBeNull();
+    expect(verifyUnlockToken(t, { ...base, volume: "uploads" })).toBeNull();
+    // tampered mac / malformed
+    expect(verifyUnlockToken(`${t}x`, base)).toBeNull();
+    expect(verifyUnlockToken("nodot", base)).toBeNull();
+  });
+
+  it("cookie name is stable, namespaced, and node-specific", () => {
+    const n = unlockCookieName("org", "home", "deck");
+    expect(n).toBe(unlockCookieName("org", "home", "deck"));
+    expect(n.startsWith("fsu_")).toBe(true);
+    expect(n).not.toBe(unlockCookieName("org", "home", "other"));
+  });
+});

--- a/apps/mesh/src/file-storage/share-password.test.ts
+++ b/apps/mesh/src/file-storage/share-password.test.ts
@@ -9,20 +9,20 @@ import {
 } from "./share-password";
 
 describe("share-password", () => {
-  it("hashes and verifies a password", () => {
-    const h = hashSharePassword("hunter2");
+  it("hashes and verifies a password", async () => {
+    const h = await hashSharePassword("hunter2");
     expect(h.startsWith("scrypt$")).toBe(true);
-    expect(verifySharePassword("hunter2", h)).toBe(true);
-    expect(verifySharePassword("wrong", h)).toBe(false);
+    expect(await verifySharePassword("hunter2", h)).toBe(true);
+    expect(await verifySharePassword("wrong", h)).toBe(false);
   });
 
-  it("salts — same password yields distinct hashes", () => {
-    expect(hashSharePassword("x")).not.toBe(hashSharePassword("x"));
+  it("salts — same password yields distinct hashes", async () => {
+    expect(await hashSharePassword("x")).not.toBe(await hashSharePassword("x"));
   });
 
-  it("rejects malformed stored hashes without throwing", () => {
-    expect(verifySharePassword("x", "garbage")).toBe(false);
-    expect(verifySharePassword("x", "scrypt$zz$zz")).toBe(false);
+  it("rejects malformed stored hashes without throwing", async () => {
+    expect(await verifySharePassword("x", "garbage")).toBe(false);
+    expect(await verifySharePassword("x", "scrypt$zz$zz")).toBe(false);
   });
 
   it("share secrets are random", () => {

--- a/apps/mesh/src/file-storage/share-password.ts
+++ b/apps/mesh/src/file-storage/share-password.ts
@@ -7,25 +7,32 @@
  * which is embedded in the token, so previously-issued cookies stop verifying.
  */
 
-import {
-  createHmac,
-  randomBytes,
-  scryptSync,
-  timingSafeEqual,
-} from "node:crypto";
+import { createHmac, randomBytes, scrypt, timingSafeEqual } from "node:crypto";
+import { promisify } from "node:util";
 import { getSettings } from "../settings";
 
 const SCRYPT_KEYLEN = 64;
+// Async scrypt — the `/unlock` route is public and unauthenticated, so the sync
+// variant would block the event loop ~tens of ms per attempt and serialize
+// concurrent unlocks.
+const scryptAsync = promisify(scrypt) as (
+  password: string,
+  salt: Buffer,
+  keylen: number,
+) => Promise<Buffer>;
 
 /** scrypt hash as `scrypt$<saltHex>$<derivedHex>`. */
-export function hashSharePassword(password: string): string {
+export async function hashSharePassword(password: string): Promise<string> {
   const salt = randomBytes(16);
-  const derived = scryptSync(password, salt, SCRYPT_KEYLEN);
+  const derived = await scryptAsync(password, salt, SCRYPT_KEYLEN);
   return `scrypt$${salt.toString("hex")}$${derived.toString("hex")}`;
 }
 
 /** Constant-time verify against a `hashSharePassword` output. */
-export function verifySharePassword(password: string, stored: string): boolean {
+export async function verifySharePassword(
+  password: string,
+  stored: string,
+): Promise<boolean> {
   const parts = stored.split("$");
   if (parts.length !== 3 || parts[0] !== "scrypt") return false;
   const salt = Buffer.from(parts[1]!, "hex");
@@ -35,7 +42,7 @@ export function verifySharePassword(password: string, stored: string): boolean {
   if (salt.length === 0 || expected.length === 0) return false;
   let derived: Buffer;
   try {
-    derived = scryptSync(password, salt, expected.length);
+    derived = await scryptAsync(password, salt, expected.length);
   } catch {
     return false;
   }

--- a/apps/mesh/src/file-storage/share-password.ts
+++ b/apps/mesh/src/file-storage/share-password.ts
@@ -1,0 +1,132 @@
+/**
+ * Crypto for password-protected org-fs sharing — scrypt password hashes and
+ * HMAC-signed unlock tokens. See `.context/file-share-password-spec.md`.
+ *
+ * The hash + per-node `share_secret` live in the manifest; the unlock token is
+ * carried in an httpOnly cookie. A password change rotates the node's secret,
+ * which is embedded in the token, so previously-issued cookies stop verifying.
+ */
+
+import {
+  createHmac,
+  randomBytes,
+  scryptSync,
+  timingSafeEqual,
+} from "node:crypto";
+import { getSettings } from "../settings";
+
+const SCRYPT_KEYLEN = 64;
+
+/** scrypt hash as `scrypt$<saltHex>$<derivedHex>`. */
+export function hashSharePassword(password: string): string {
+  const salt = randomBytes(16);
+  const derived = scryptSync(password, salt, SCRYPT_KEYLEN);
+  return `scrypt$${salt.toString("hex")}$${derived.toString("hex")}`;
+}
+
+/** Constant-time verify against a `hashSharePassword` output. */
+export function verifySharePassword(password: string, stored: string): boolean {
+  const parts = stored.split("$");
+  if (parts.length !== 3 || parts[0] !== "scrypt") return false;
+  const salt = Buffer.from(parts[1]!, "hex");
+  const expected = Buffer.from(parts[2]!, "hex");
+  // Reject malformed/empty hashes — otherwise a zero-length expected hash would
+  // timing-safe-equal an empty derivation and accept any password.
+  if (salt.length === 0 || expected.length === 0) return false;
+  let derived: Buffer;
+  try {
+    derived = scryptSync(password, salt, expected.length);
+  } catch {
+    return false;
+  }
+  return (
+    expected.length === derived.length && timingSafeEqual(expected, derived)
+  );
+}
+
+/** Random per-node secret; rotated on every password change. */
+export function generateShareSecret(): string {
+  return randomBytes(16).toString("hex");
+}
+
+// --- unlock token (HMAC over the governing node + secret + expiry) ---------
+
+let signingKey: Buffer | null = null;
+function getSigningKey(): Buffer {
+  if (signingKey) return signingKey;
+  let secret: string | undefined;
+  try {
+    const settings = getSettings();
+    secret = settings.meshJwtSecret ?? settings.betterAuthSecret;
+  } catch {
+    // Settings not initialized (e.g. unit tests) — fall back like auth/jwt.ts.
+    secret = undefined;
+  }
+  signingKey = secret ? Buffer.from(secret) : randomBytes(32);
+  return signingKey;
+}
+
+interface UnlockClaims {
+  /** org id */ o: string;
+  /** volume */ v: string;
+  /** governing node path */ p: string;
+  /** node share_secret version */ s: string;
+  /** expiry, epoch seconds */ e: number;
+}
+
+export function signUnlockToken(claims: UnlockClaims): string {
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  const mac = createHmac("sha256", getSigningKey())
+    .update(payload)
+    .digest("base64url");
+  return `${payload}.${mac}`;
+}
+
+/**
+ * Verify a token for a governing node. Returns its path on success, else null.
+ * Fails closed on a stale secret (rotation), expiry, or org/volume mismatch.
+ */
+export function verifyUnlockToken(
+  token: string,
+  expect: { org: string; volume: string; secret: string; nowSec: number },
+): { govPath: string } | null {
+  const dot = token.indexOf(".");
+  if (dot < 0) return null;
+  const payload = token.slice(0, dot);
+  const mac = Buffer.from(token.slice(dot + 1));
+  const expected = Buffer.from(
+    createHmac("sha256", getSigningKey()).update(payload).digest("base64url"),
+  );
+  if (mac.length !== expected.length || !timingSafeEqual(mac, expected)) {
+    return null;
+  }
+  let claims: UnlockClaims;
+  try {
+    claims = JSON.parse(Buffer.from(payload, "base64url").toString());
+  } catch {
+    return null;
+  }
+  if (
+    claims.o !== expect.org ||
+    claims.v !== expect.volume ||
+    claims.s !== expect.secret ||
+    typeof claims.e !== "number" ||
+    claims.e < expect.nowSec
+  ) {
+    return null;
+  }
+  return { govPath: claims.p };
+}
+
+/** Opaque, stable cookie name for a governing share node (not a secret). */
+export function unlockCookieName(
+  org: string,
+  volume: string,
+  govPath: string,
+): string {
+  const h = createHmac("sha256", "fsunlock-name")
+    .update(`${org}:${volume}:${govPath}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `fsu_${h}`;
+}

--- a/apps/mesh/src/storage/org-fs.ts
+++ b/apps/mesh/src/storage/org-fs.ts
@@ -20,9 +20,14 @@ export interface OrgFsEntry {
   updatedAt: string;
   /** Chat/run that last wrote this file; null when not tied to a dispatch. */
   threadId: string | null;
-  /** When true, the `/read` proxy serves this file to anyone (no auth). */
+  /** When true, the `/read` proxy serves this entry by link (own flag). */
   readPublic: boolean;
+  /** This node's own share mode, derived from read_public + password presence.
+   *  The raw password hash is NEVER exposed — only this derived label. */
+  shareMode: ShareMode;
 }
+
+export type ShareMode = "private" | "public" | "password";
 
 type OrgFsEntryRow = {
   organization_id: string;
@@ -40,6 +45,7 @@ type OrgFsEntryRow = {
   updated_at: Date | string;
   thread_id: string | null;
   read_public: boolean;
+  share_password_hash: string | null;
 };
 
 function toIso(value: Date | string | null): string | null {
@@ -64,6 +70,11 @@ function rowToEntry(row: OrgFsEntryRow): OrgFsEntry {
     updatedAt: toIso(row.updated_at) ?? "",
     threadId: row.thread_id,
     readPublic: row.read_public,
+    shareMode: !row.read_public
+      ? "private"
+      : row.share_password_hash
+        ? "password"
+        : "public",
   };
 }
 
@@ -83,6 +94,9 @@ const COLUMNS = [
   "updated_at",
   "thread_id",
   "read_public",
+  // Selected to DERIVE shareMode in rowToEntry; the raw hash is dropped there
+  // and never reaches the DTO/API.
+  "share_password_hash",
 ] as const satisfies readonly (keyof OrgFsEntryTable)[];
 
 /** Bump `seq` to the next value of the global sequence on every write. */
@@ -370,18 +384,20 @@ export class OrgFsEntryStorage {
   }
 
   /**
-   * Set an entry's public-read flag. Works on files and dirs: a public dir
-   * publishes its whole subtree (the read route inherits from public ancestor
-   * dirs). Returns the updated entry, or null if no live entry exists at the
-   * path. Deliberately does NOT bump `seq`: visibility is metadata, not
-   * content, so the change feed (mount invalidation) stays quiet — only
-   * `updated_by`/`updated_at` move, recording who toggled it.
+   * Set an entry's share mode (read_public + password hash + secret) in one
+   * update. Works on files and dirs: a public/password dir governs its whole
+   * subtree (reads resolve the most-specific public ancestor). Returns the
+   * updated entry, or null if no live entry exists. Deliberately does NOT bump
+   * `seq`: visibility is metadata, not content, so the change feed (mount
+   * invalidation) stays quiet — only `updated_by`/`updated_at` move.
    */
-  async setReadPublic(params: {
+  async setShareMode(params: {
     organizationId: string;
     volume: string;
     path: string;
     readPublic: boolean;
+    passwordHash: string | null;
+    shareSecret: string | null;
     actor: string;
   }): Promise<OrgFsEntry | null> {
     const now = new Date();
@@ -389,6 +405,8 @@ export class OrgFsEntryStorage {
       .updateTable("org_fs_entry")
       .set({
         read_public: params.readPublic,
+        share_password_hash: params.passwordHash,
+        share_secret: params.shareSecret,
         updated_by: params.actor,
         updated_at: now,
       })
@@ -399,6 +417,42 @@ export class OrgFsEntryStorage {
       .returning(COLUMNS)
       .executeTakeFirst();
     return row ? rowToEntry(row as OrgFsEntryRow) : null;
+  }
+
+  /**
+   * Among `candidatePaths` (a node + its ancestors), the most-specific live
+   * public node and its password hash/secret — the node that governs a read's
+   * share semantics. Null when none is published.
+   */
+  async resolveGoverningShare(params: {
+    organizationId: string;
+    volume: string;
+    candidatePaths: string[];
+  }): Promise<{
+    path: string;
+    passwordHash: string | null;
+    secret: string | null;
+  } | null> {
+    if (params.candidatePaths.length === 0) return null;
+    const rows = await this.db
+      .selectFrom("org_fs_entry")
+      .where("organization_id", "=", params.organizationId)
+      .where("volume", "=", params.volume)
+      .where("read_public", "=", true)
+      .where("deleted_at", "is", null)
+      .where("path", "in", params.candidatePaths)
+      .select(["path", "share_password_hash", "share_secret"])
+      .execute();
+    if (rows.length === 0) return null;
+    // Most-specific (longest path) wins — a node's own setting overrides an
+    // inherited one.
+    rows.sort((a, b) => b.path.length - a.path.length);
+    const gov = rows[0]!;
+    return {
+      path: gov.path,
+      passwordHash: gov.share_password_hash,
+      secret: gov.share_secret,
+    };
   }
 
   /**

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -383,6 +383,14 @@ export interface OrgFsEntryTable {
    *  inherit from a published ancestor). Defaults to false (org-only).
    *  Preserved across in-place overwrites; reset to false on delete + recreate. */
   read_public: ColumnType<boolean, boolean | undefined, boolean>;
+  /** scrypt hash of the share password. Null on a published entry = fully
+   *  public; set = the proxy serves a password form first. Never sent to
+   *  clients. Meaningless unless `read_public`. */
+  share_password_hash: string | null;
+  /** Random per-node token mixed into unlock-cookie signatures; rotated on
+   *  every password change so old cookies stop validating. Null when not
+   *  password-protected. */
+  share_secret: string | null;
 }
 
 /** Public DTO for a file config — never exposes access key / secret key. */

--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -28,7 +28,11 @@ export interface OrgFsEntry {
   /** Public via own flag OR a published ancestor folder (inherited). What the
    *  UI should signal; `readPublic && !effectivePublic` never happens. */
   effectivePublic?: boolean;
+  /** This entry's own share mode (private / public / password). */
+  shareMode?: ShareMode;
 }
+
+export type ShareMode = "private" | "public" | "password";
 
 export interface OrgFsUsage {
   files: number;
@@ -251,24 +255,26 @@ export function useOrgFsWriteText(volume: string) {
 }
 
 /**
- * Toggle a file's public-read flag — share to anyone with the link, or revoke.
- * Optimistically flips the cached `stat` so the Share toggle reacts instantly,
- * then revalidates (rolling back on error).
+ * Set a file/folder's share mode (private / public / password). Password mode
+ * carries the new password (which rotates the node secret server-side).
+ * Optimistically updates the cached `stat` so the dialog reacts instantly, then
+ * revalidates (rolling back on error).
  */
-export function useOrgFsSetPublic(volume: string) {
+export function useOrgFsSetShareMode(volume: string) {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (input: {
       path: string;
-      public: boolean;
+      mode: ShareMode;
+      password?: string;
     }): Promise<OrgFsEntry> => {
       const res = await fsFetch(
         fsUrl(org.slug, volume, "public", { path: input.path }),
         {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ public: input.public }),
+          body: JSON.stringify({ mode: input.mode, password: input.password }),
         },
       );
       return ((await res.json()) as { entry: OrgFsEntry }).entry;
@@ -277,13 +283,19 @@ export function useOrgFsSetPublic(volume: string) {
       const key = KEYS.orgFsStat(org.id, volume, input.path);
       await queryClient.cancelQueries({ queryKey: key });
       const previous = queryClient.getQueryData<OrgFsEntry | null>(key);
-      // Flip effectivePublic too: with only readPublic updated, unpublishing
+      // Flip effectivePublic too: with only readPublic updated, going private
       // leaves effectivePublic stale-true, so the dialog briefly reads as
-      // inherited-public (switch snaps back on). The refetch corrects the rare
-      // case where a published ancestor still covers it.
+      // inherited-public. The refetch corrects the rare case where a published
+      // ancestor still covers it.
+      const isPublic = input.mode !== "private";
       queryClient.setQueryData<OrgFsEntry | null>(key, (old) =>
         old
-          ? { ...old, readPublic: input.public, effectivePublic: input.public }
+          ? {
+              ...old,
+              readPublic: isPublic,
+              effectivePublic: isPublic,
+              shareMode: input.mode,
+            }
           : old,
       );
       return { key, previous };

--- a/apps/mesh/src/web/layouts/library/cards.tsx
+++ b/apps/mesh/src/web/layouts/library/cards.tsx
@@ -16,6 +16,7 @@ import {
   Download01,
   Folder,
   Globe01,
+  Key01,
   Share07,
   Trash01,
   Zap,
@@ -92,18 +93,22 @@ function ShareMenuItem({ onShare }: { onShare: () => void }) {
   );
 }
 
-/** How a card is public: by its own flag, or inherited from a parent folder. */
-export type PublicState = "own" | "inherited";
+/** How a card is shared: public/password by its own flag, or inherited. */
+export type PublicState = "public" | "password" | "inherited";
 
-/** Small badge marking a public (or publicly-inherited) file/folder. */
+/** Small badge marking a shared file/folder (globe = public, key = password,
+ *  muted globe = inherited from a parent). */
 function PublicBadge({ state }: { state: PublicState }) {
   const label =
-    state === "inherited"
-      ? "Public — inside a shared folder"
-      : "Public — anyone with the link can view";
+    state === "password"
+      ? "Password-protected — link + password to view"
+      : state === "inherited"
+        ? "Shared via a parent folder"
+        : "Public — anyone with the link can view";
+  const Icon = state === "password" ? Key01 : Globe01;
   return (
     <span title={label} className="mt-0.5 flex shrink-0 items-center">
-      <Globe01
+      <Icon
         size={12}
         className={cn(
           state === "inherited" ? "text-muted-foreground/60" : "text-primary",

--- a/apps/mesh/src/web/layouts/library/file-share-button.tsx
+++ b/apps/mesh/src/web/layouts/library/file-share-button.tsx
@@ -135,6 +135,54 @@ function ShareControls({
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const copyRow = url ? (
+    <div className="flex items-center gap-2 rounded-md border border-input bg-muted/50 px-2 py-1.5">
+      <code className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
+        {url}
+      </code>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-6 shrink-0"
+        onClick={handleCopy}
+        aria-label="Copy link"
+      >
+        {copied ? (
+          <Check size={12} className="text-green-600" />
+        ) : (
+          <Copy01 size={12} />
+        )}
+      </Button>
+    </div>
+  ) : null;
+
+  // Inherited from a published parent folder: read-only here. The mode control
+  // is hidden because the parent governs the read — setting this node to "Org
+  // only" wouldn't actually restrict it (the parent still serves it), so the
+  // owner manages sharing on the parent, not here.
+  if (inherited) {
+    return (
+      <div className="flex w-full min-w-0 flex-col gap-3">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <Globe01 size={16} />
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium text-foreground">
+              Shared via a parent folder
+            </span>
+            <span className="text-xs text-muted-foreground">
+              Anyone with the link can view{" "}
+              {isDir ? "files in this folder" : "this file"}. Manage sharing on
+              the parent folder.
+            </span>
+          </div>
+        </div>
+        {copyRow}
+      </div>
+    );
+  }
+
   return (
     <div className="flex w-full min-w-0 flex-col gap-3">
       <div className="grid grid-cols-3 gap-1 rounded-lg bg-muted p-1">
@@ -194,33 +242,7 @@ function ShareControls({
         </form>
       )}
 
-      {inherited && (
-        <p className="rounded-md bg-muted/50 px-2.5 py-2 text-xs text-muted-foreground">
-          Also shared via a parent folder — a setting here applies to just this{" "}
-          {subject}.
-        </p>
-      )}
-
-      {url && effective && (
-        <div className="flex items-center gap-2 rounded-md border border-input bg-muted/50 px-2 py-1.5">
-          <code className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
-            {url}
-          </code>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-6 shrink-0"
-            onClick={handleCopy}
-            aria-label="Copy link"
-          >
-            {copied ? (
-              <Check size={12} className="text-green-600" />
-            ) : (
-              <Copy01 size={12} />
-            )}
-          </Button>
-        </div>
-      )}
+      {effective && copyRow}
     </div>
   );
 }

--- a/apps/mesh/src/web/layouts/library/file-share-button.tsx
+++ b/apps/mesh/src/web/layouts/library/file-share-button.tsx
@@ -1,14 +1,15 @@
 /**
- * Share controls for Library files and folders — copy the proxy link and flip
- * visibility between org-only and public.
+ * Share controls for Library files and folders — pick a visibility mode and
+ * copy the proxy link.
  *
- * A public file serves to anyone with its link; a public folder publishes its
- * whole subtree (the read proxy inherits from public ancestor folders), so a
- * page and its co-located assets go public together. Toggling never moves
+ * Three modes: org-only (private), public (anyone with the link), and password
+ * (anyone with the link AND the password — the `/read` proxy serves a form
+ * first). On a folder the mode governs the whole subtree (the read proxy
+ * resolves the most-specific published ancestor). Changing mode never moves
  * anything — the same `/api/:org/fs/:volume/read?path=…` link just changes who
  * it works for.
  *
- * Three surfaces share one body (`ShareControls`): `FileShareButton` (the
+ * Two surfaces share one body (`ShareControls`): `FileShareButton` (the
  * preview-toolbar popover) and `ShareDialog` (opened from Library cards).
  */
 
@@ -19,61 +20,92 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@deco/ui/components/popover.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
-import { Check, Copy01, Globe01, Lock01, Share07 } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  Check,
+  Copy01,
+  Globe01,
+  Key01,
+  Lock01,
+  Share07,
+} from "@untitledui/icons";
 import { useState } from "react";
 import { toast } from "sonner";
-import { useOrgFsSetPublic, useOrgFsStat } from "@/web/hooks/use-org-fs";
+import {
+  type ShareMode,
+  useOrgFsSetShareMode,
+  useOrgFsStat,
+} from "@/web/hooks/use-org-fs";
 
 export interface ShareTarget {
   volume: string;
   /** In-volume path of the file or folder. */
   path: string;
   kind: "file" | "dir";
-  /** Last-known public state — seeds the toggle until the live stat loads. */
-  readPublic: boolean;
+  /** Last-known own mode — seeds the control until the live stat loads. */
+  shareMode: ShareMode;
+  /** Last-known effective-public (own or inherited) — seeds the inherited note. */
+  effectivePublic: boolean;
   /** Absolute proxy link to copy. Files only; folders have no single URL. */
   url?: string;
 }
 
-/** The shared body: a visibility switch and (for files) a copy-link row. */
-function ShareControls({ volume, path, kind, readPublic, url }: ShareTarget) {
-  const setPublic = useOrgFsSetPublic(volume);
-  // Read live state so the switch reflects the optimistic toggle immediately
-  // (the mutation writes this exact stat key), falling back to the seed value
-  // while it loads.
+const MODES: { mode: ShareMode; label: string; Icon: typeof Globe01 }[] = [
+  { mode: "private", label: "Org only", Icon: Lock01 },
+  { mode: "public", label: "Public", Icon: Globe01 },
+  { mode: "password", label: "Password", Icon: Key01 },
+];
+
+/** The shared body: a 3-way mode control, an optional password field, and (for
+ *  files) a copy-link row. */
+function ShareControls({
+  volume,
+  path,
+  kind,
+  shareMode,
+  effectivePublic,
+  url,
+}: ShareTarget) {
+  const setShareMode = useOrgFsSetShareMode(volume);
+  // Read live state so the control reflects the optimistic change immediately
+  // (the mutation writes this exact stat key), seeding from the snapshot.
   const { data: entry } = useOrgFsStat(volume, path);
-  const own = entry?.readPublic ?? readPublic;
-  // Public via own flag OR a published ancestor folder. Inherited = public but
-  // not by its own flag — managed on the parent, not here.
-  const effective = entry?.effectivePublic ?? own;
-  const inherited = effective && !own;
-  const [copied, setCopied] = useState(false);
+  const ownMode: ShareMode = entry?.shareMode ?? shareMode;
+  const effective = entry?.effectivePublic ?? effectivePublic;
+  const inherited = effective && ownMode === "private";
   const isDir = kind === "dir";
   const subject = isDir ? "folder" : "file";
 
-  const handleToggle = (next: boolean) => {
-    setPublic.mutate(
-      { path, public: next },
+  const [showPassword, setShowPassword] = useState(false);
+  const [password, setPassword] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const apply = (mode: ShareMode, pw?: string) => {
+    setShareMode.mutate(
+      { path, mode, password: pw },
       {
-        onSuccess: () =>
+        onSuccess: () => {
+          setShowPassword(false);
+          setPassword("");
           toast.success(
-            next
-              ? isDir
-                ? "Anyone with the link can now view files in this folder"
-                : "Anyone with the link can now view this file"
-              : `This ${subject} is now org-only`,
-          ),
+            mode === "private"
+              ? `This ${subject} is now org-only`
+              : mode === "public"
+                ? `Anyone with the link can now view this ${subject}`
+                : `This ${subject} is now password-protected`,
+          );
+        },
         onError: (err) =>
           toast.error(
             err instanceof Error ? err.message : "Failed to update sharing",
@@ -81,6 +113,19 @@ function ShareControls({ volume, path, kind, readPublic, url }: ShareTarget) {
       },
     );
   };
+
+  // Password mode reveals the field and applies on submit; the others apply at
+  // once.
+  const selectMode = (mode: ShareMode) => {
+    if (mode === "password") {
+      setShowPassword(true);
+      return;
+    }
+    setShowPassword(false);
+    apply(mode);
+  };
+
+  const activeMode: ShareMode = showPassword ? "password" : ownMode;
 
   const handleCopy = async () => {
     if (!url) return;
@@ -92,40 +137,71 @@ function ShareControls({ volume, path, kind, readPublic, url }: ShareTarget) {
 
   return (
     <div className="flex w-full min-w-0 flex-col gap-3">
-      <div className="flex items-start gap-3">
-        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-          {effective ? <Globe01 size={16} /> : <Lock01 size={16} />}
-        </div>
-        <div className="flex min-w-0 flex-1 flex-col">
-          <span className="text-sm font-medium text-foreground">
-            {effective ? "Anyone with the link" : "Only your organization"}
-          </span>
-          <span className="text-xs text-muted-foreground">
-            {effective
-              ? inherited
-                ? "Public because it's inside a shared folder."
-                : isDir
-                  ? "Anyone on the internet can view files in this folder via their link."
-                  : "Anyone on the internet with the link can view this file."
-              : `Only members of your organization can open ${
-                  isDir ? "these files" : "this link"
-                }.`}
-          </span>
-        </div>
-        <Switch
-          checked={inherited ? true : own}
-          disabled={setPublic.isPending || inherited}
-          onCheckedChange={handleToggle}
-          aria-label={`Make ${subject} public`}
-        />
+      <div className="grid grid-cols-3 gap-1 rounded-lg bg-muted p-1">
+        {MODES.map(({ mode, label, Icon }) => (
+          <button
+            key={mode}
+            type="button"
+            disabled={setShareMode.isPending}
+            onClick={() => selectMode(mode)}
+            className={cn(
+              "flex flex-col items-center gap-1 rounded-md px-2 py-2 text-xs font-medium transition-colors disabled:opacity-60",
+              activeMode === mode
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <Icon size={15} />
+            {label}
+          </button>
+        ))}
       </div>
+
+      <p className="text-xs text-muted-foreground">
+        {activeMode === "private"
+          ? `Only members of your organization can open ${isDir ? "these files" : "this link"}.`
+          : activeMode === "public"
+            ? isDir
+              ? "Anyone on the internet can view files in this folder via their link."
+              : "Anyone on the internet with the link can view this file."
+            : `Anyone with the link AND the password can view ${isDir ? "files in this folder" : "this file"}.`}
+      </p>
+
+      {activeMode === "password" && (
+        <form
+          className="flex items-center gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (password) apply("password", password);
+          }}
+        >
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder={ownMode === "password" ? "New password" : "Password"}
+            autoComplete="new-password"
+            className="h-8 text-xs"
+          />
+          <Button
+            type="submit"
+            size="sm"
+            className="shrink-0"
+            disabled={!password || setShareMode.isPending}
+          >
+            {ownMode === "password" ? "Update" : "Set"}
+          </Button>
+        </form>
+      )}
+
       {inherited && (
         <p className="rounded-md bg-muted/50 px-2.5 py-2 text-xs text-muted-foreground">
-          This {subject} is public because a parent folder is shared — manage it
-          from that folder.
+          Also shared via a parent folder — a setting here applies to just this{" "}
+          {subject}.
         </p>
       )}
-      {url && (
+
+      {url && effective && (
         <div className="flex items-center gap-2 rounded-md border border-input bg-muted/50 px-2 py-1.5">
           <code className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
             {url}
@@ -153,12 +229,14 @@ function ShareControls({ volume, path, kind, readPublic, url }: ShareTarget) {
 export function FileShareButton({
   volume,
   path,
-  readPublic,
+  shareMode,
+  effectivePublic,
   url,
 }: {
   volume: string;
   path: string;
-  readPublic: boolean;
+  shareMode: ShareMode;
+  effectivePublic: boolean;
   url: string;
 }) {
   return (
@@ -178,7 +256,8 @@ export function FileShareButton({
           volume={volume}
           path={path}
           kind="file"
-          readPublic={readPublic}
+          shareMode={shareMode}
+          effectivePublic={effectivePublic}
           url={url}
         />
       </PopoverContent>

--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -55,6 +55,7 @@ import { HeaderTabButton } from "@/web/layouts/main-panel-tabs/header-tab-button
 import { KEYS } from "@/web/lib/query-keys";
 import {
   type OrgFsEntry,
+  type ShareMode,
   useOrgFsFileUrl,
   useOrgFsList,
   useOrgFsMutations,
@@ -91,12 +92,15 @@ function publicFileUrl(path: string): string {
   return `${window.location.origin}${path}`;
 }
 
-/** Badge state for a list entry: published here, inherited, or neither. */
+/** Badge state for a list entry: shared here (public/password), inherited from
+ *  a parent, or not shared. */
 function publicStateOf(e: {
+  shareMode?: ShareMode;
   readPublic?: boolean;
   effectivePublic?: boolean;
 }): PublicState | undefined {
-  if (e.readPublic) return "own";
+  if (e.shareMode === "password") return "password";
+  if (e.shareMode === "public" || e.readPublic) return "public";
   if (e.effectivePublic) return "inherited";
   return undefined;
 }
@@ -238,7 +242,8 @@ function RootView({
       volume: e.volume,
       path: e.path,
       kind: "file",
-      readPublic: e.readPublic ?? false,
+      shareMode: e.shareMode ?? "private",
+      effectivePublic: e.effectivePublic ?? false,
       url: publicFileUrl(fileUrl(e.volume, e.path)),
     });
 
@@ -420,7 +425,8 @@ function VolumeView({
             volume,
             path: entry.path,
             kind: entry.kind,
-            readPublic: entry.readPublic ?? false,
+            shareMode: entry.shareMode ?? "private",
+            effectivePublic: entry.effectivePublic ?? false,
             url:
               entry.kind === "file"
                 ? publicFileUrl(fileUrl(volume, entry.path))

--- a/apps/mesh/src/web/layouts/library/preview-content.tsx
+++ b/apps/mesh/src/web/layouts/library/preview-content.tsx
@@ -111,7 +111,8 @@ export function LibraryFilePreview({
               <FileShareButton
                 volume={volume ?? ""}
                 path={filePath}
-                readPublic={entry.readPublic ?? false}
+                shareMode={entry.shareMode ?? "private"}
+                effectivePublic={entry.effectivePublic ?? false}
                 url={window.location.origin + file.downloadUrl}
               />
               {seeInLibrary}
@@ -159,7 +160,8 @@ export function LibraryFilePreview({
             <FileShareButton
               volume={volume ?? ""}
               path={filePath}
-              readPublic={entry?.readPublic ?? false}
+              shareMode={entry?.shareMode ?? "private"}
+              effectivePublic={entry?.effectivePublic ?? false}
               url={window.location.origin + file.downloadUrl}
             />
             <Tooltip>


### PR DESCRIPTION
Follow-up to #4125 (merged). A third share mode — **password** — on top of public sharing. The `/read` proxy serves an interstitial password form before content; one unlock (a signed, scoped cookie) covers the node the password sits on — a single file, or a whole folder + its assets — mirroring public. Most-specific published node governs.

## How it works
- **Crypto** (`share-password.ts`): scrypt hash/verify, a per-node `share_secret`, and HMAC unlock tokens signed with `MESH_JWT_SECRET`. Rotation + expiry + org/volume binding all fail closed.
- **Storage/service**: `shareMode` (private/public/password) is *derived* in the DTO — the password hash never leaves the server. `resolveGoverningShare` finds the most-specific published node; `resolveReadAccess` returns private/public/password (+ govPath/secret).
- **Proxy**: `GET /read` checks the unlock cookie → serves or returns the form. `POST /unlock` verifies the password (scrypt, **rate-limited**) and sets a scoped `httpOnly; SameSite=Lax` cookie. `POST /public` now takes `{ mode, password? }` (back-compat: `{ public }`). A non-member/anonymous gets the form; a **member bypasses it** (reads via `ORG_FS_READ`). Password content is never shared-cached.
- **UI**: `ShareControls` becomes a 3-way control (Org only / Public / Password) with a set/update password field; the card badge gains a password (key) tier.
- **Tests**: crypto unit (7) + integration (governing resolution, folder inheritance, most-specific override, password-change rotation).

## Decisions made (open to push-back)
1. **Overlay on `read_public`**, not a `share_mode` enum — reuses #4125 whole.
2. **Gated on `ORG_FS_WRITE`** (same as public). `ORG_FS_PUBLISH` deliberately **not** built here — kept as the governance/agent follow-up.
3. **Members bypass the password** (it's for outside-the-org sharing).
4. **Rate limit** = in-memory, per-instance, 10 / 5 min per (IP, path).
5. Password change **rotates** the secret; **most-specific** node governs.

## Migration
`121-org-fs-share-password` adds `share_password_hash` + `share_secret` (both nullable). Auto-runs on boot / `bun run migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)