### PR TITLE
fix(sections-editor): make CMS hover overlay track scroll, click, and label correctly

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
@@ -13,27 +13,16 @@ export type CmsEditorPayload = z.infer<typeof CmsEditorPayloadSchema>;
  * hover and posts the section's index — matching the decofile sections array —
  * back to the parent on click.
  *
- * Framework sections that deco injects around the page's editable sections
- * (SEO, Theme, Analytics, etc.) are NOT part of the page's sections array, so
- * they're filtered out via IGNORED_MANIFEST_KEYS to keep DOM order aligned with
- * the index the editor panel uses.
+ * deco injects framework sections (SEO, Theme, Analytics, …) around the page's
+ * editable sections, so the DOM has more top-level sections than the decofile
+ * array. Rather than hardcoding which to skip, the editor sends the expected
+ * manifest-key sequence of the editable run and we align it within the DOM
+ * (see set-labels handler), so any leading/trailing framework sections drop out
+ * automatically.
  */
-const IGNORED_MANIFEST_KEYS = [
-  "website/sections/Seo/SeoV2.tsx",
-  "site/sections/Theme/Theme.tsx",
-  "htmx/sections/htmx.tsx",
-  "website/sections/Analytics/Analytics.tsx",
-  "site/sections/Session.tsx",
-  "site/sections/Miscellaneous/CartAlert.tsx",
-] as const;
-
 export const CMS_EDITOR_SCRIPT = `(function() {
   if (window.__cmsEditorActive) return;
   window.__cmsEditorActive = true;
-
-  var IGNORED_KEYS = ${JSON.stringify(
-    Object.fromEntries(IGNORED_MANIFEST_KEYS.map((k) => [k, 1])),
-  )};
 
   var highlight = document.createElement("div");
   highlight.style.cssText = "position:absolute;pointer-events:none;outline:2px solid #06b6d4;background:rgba(6,182,212,0.06);border-radius:2px;z-index:2147483647;display:none;";
@@ -49,11 +38,50 @@ export const CMS_EDITOR_SCRIPT = `(function() {
       : true;
   };
 
-  // Resolve to the OUTERMOST page-level section: deco renders page sections as
-  // <section data-manifest-key>, but nested islands/sections carry the attribute
-  // too. Walk up and keep the last section ancestor so clicking nested content
-  // still maps to the top-level section the panel indexes. Framework sections
-  // (IGNORED_KEYS) aren't in the editable array, so treat them as no section.
+  // All top-level page sections in DOM order (deco renders page sections as
+  // <section data-manifest-key>; nested islands/sections carry the attribute
+  // too, hence the top-level filter). This is the full DOM run, framework
+  // sections included — getAllSections() narrows it to the editable window.
+  var topLevelSections = function() {
+    return Array.from(document.querySelectorAll("section[data-manifest-key]"))
+      .filter(isTopLevelSection);
+  };
+
+  // Expected manifest-key sequence of the editable sections, sent by the editor.
+  // Empty string = wildcard (e.g. multivariate, whose rendered key we can't
+  // predict). sectionOffset is where that run starts within topLevelSections().
+  var expectedKeys = [];
+  var sectionOffset = 0;
+  var recomputeOffset = function() {
+    if (!expectedKeys.length) { sectionOffset = 0; return; }
+    var domKeys = topLevelSections().map(function(s) {
+      return s.getAttribute("data-manifest-key");
+    });
+    var best = 0, bestScore = -1;
+    for (var o = 0; o + expectedKeys.length <= domKeys.length; o++) {
+      var score = 0;
+      for (var i = 0; i < expectedKeys.length; i++) {
+        var e = expectedKeys[i];
+        if (!e || e === domKeys[o + i]) score++;
+      }
+      if (score > bestScore) { bestScore = score; best = o; }
+    }
+    sectionOffset = best;
+  };
+
+  // The editable window, aligned to the decofile sections array so indexOf
+  // matches the index the editor panel uses. Until the editor sends the
+  // expected keys, fall back to the full top-level run.
+  var getAllSections = function() {
+    var all = topLevelSections();
+    return expectedKeys.length
+      ? all.slice(sectionOffset, sectionOffset + expectedKeys.length)
+      : all;
+  };
+
+  // Resolve to the OUTERMOST page-level section (clicking nested content still
+  // maps to the top-level section the panel indexes); null if it falls outside
+  // the editable window (a framework section deco injected).
   var findSection = function(el) {
     var node = el;
     var found = null;
@@ -63,16 +91,8 @@ export const CMS_EDITOR_SCRIPT = `(function() {
       }
       node = node.parentElement;
     }
-    if (found && IGNORED_KEYS[found.getAttribute("data-manifest-key")]) return null;
-    return found;
-  };
-
-  // Only top-level, non-framework page sections, in DOM order, so indexOf
-  // matches the decofile sections array the editor panel indexes into.
-  var getAllSections = function() {
-    return Array.from(document.querySelectorAll("section[data-manifest-key]"))
-      .filter(isTopLevelSection)
-      .filter(function(s) { return !IGNORED_KEYS[s.getAttribute("data-manifest-key")]; });
+    if (!found) return null;
+    return getAllSections().indexOf(found) >= 0 ? found : null;
   };
 
   // Lazy sections async-render their real section inside a wrapper, so the
@@ -217,6 +237,8 @@ export const CMS_EDITOR_SCRIPT = `(function() {
     if (e.data && e.data.type === "cms-editor::set-labels" && Array.isArray(e.data.labels)) {
       sectionLabels = e.data.labels;
       if (Array.isArray(e.data.kinds)) sectionKinds = e.data.kinds;
+      if (Array.isArray(e.data.keys)) expectedKeys = e.data.keys;
+      recomputeOffset();
       if (lastSection) {
         lastLabel = labelFor(lastSection);
         lastKind = kindFor(lastSection);

--- a/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
@@ -47,41 +47,57 @@ export const CMS_EDITOR_SCRIPT = `(function() {
       .filter(isTopLevelSection);
   };
 
-  // Expected manifest-key sequence of the editable sections, sent by the editor.
-  // Empty string = wildcard (e.g. multivariate, whose rendered key we can't
-  // predict). sectionOffset is where that run starts within topLevelSections().
-  var expectedKeys = [];
-  var sectionOffset = 0;
-  var recomputeOffset = function() {
-    if (!expectedKeys.length) { sectionOffset = 0; return; }
-    var domKeys = topLevelSections().map(function(s) {
-      return s.getAttribute("data-manifest-key");
-    });
-    var best = 0, bestScore = -1;
-    for (var o = 0; o + expectedKeys.length <= domKeys.length; o++) {
-      var score = 0;
-      for (var i = 0; i < expectedKeys.length; i++) {
-        var e = expectedKeys[i];
-        if (!e || e === domKeys[o + i]) score++;
+  // Candidate manifest keys per editable section, sent by the editor. Each
+  // entry is an array of acceptable DOM keys: [] = wildcard (e.g. multivariate,
+  // whose rendered key we can't predict); a Lazy lists both its loader key and
+  // the inner section's key, since the classic runtime keeps the Lazy wrapper
+  // at top level while TanStack renders the inner section directly.
+  var sectionCandidates = [];
+
+  // Best in-order assignment of editable sections to DOM sections, maximizing
+  // key matches (DP / LCS-style). deco injects framework sections (SEO, Theme,
+  // Session, …) that may lead, trail, OR interleave with the editable run; this
+  // skips whichever don't match, on any runtime — no hardcoded list.
+  var computeAlignment = function(tops) {
+    var N = sectionCandidates.length, M = tops.length;
+    if (!N || M < N) return tops.slice();
+    var domKeys = tops.map(function(s) { return s.getAttribute("data-manifest-key"); });
+    var match = function(i, j) {
+      var c = sectionCandidates[i];
+      if (!c || !c.length) return 1;
+      return c.indexOf(domKeys[j]) >= 0 ? 1 : 0;
+    };
+    var dp = [], bt = [], i, j;
+    for (i = 0; i <= N; i++) { dp.push(new Array(M + 1).fill(0)); bt.push(new Array(M + 1).fill(0)); }
+    for (i = 1; i <= N; i++) {
+      for (j = i; j <= M; j++) {
+        var assign = dp[i - 1][j - 1] + match(i - 1, j - 1);
+        var skip = dp[i][j - 1];
+        if (j - 1 >= i && skip >= assign) { dp[i][j] = skip; bt[i][j] = 0; }
+        else { dp[i][j] = assign; bt[i][j] = 1; }
       }
-      if (score > bestScore) { bestScore = score; best = o; }
     }
-    sectionOffset = best;
+    var res = new Array(N);
+    i = N; j = M;
+    while (i > 0) {
+      if (bt[i][j] === 1) { res[i - 1] = tops[j - 1]; i--; j--; }
+      else { j--; }
+    }
+    return res;
   };
 
-  // The editable window, aligned to the decofile sections array so indexOf
-  // matches the index the editor panel uses. Until the editor sends the
-  // expected keys, fall back to the full top-level run.
+  // Editable sections, indexed to match the decofile array the panel uses.
+  // Recomputed from the live DOM each call (cheap, rAF-throttled) so it
+  // self-heals as client-rendered/lazy sections mount. Until the editor sends
+  // candidates, fall back to the full top-level run.
   var getAllSections = function() {
-    var all = topLevelSections();
-    return expectedKeys.length
-      ? all.slice(sectionOffset, sectionOffset + expectedKeys.length)
-      : all;
+    var tops = topLevelSections();
+    return sectionCandidates.length ? computeAlignment(tops) : tops;
   };
 
   // Resolve to the OUTERMOST page-level section (clicking nested content still
-  // maps to the top-level section the panel indexes); null if it falls outside
-  // the editable window (a framework section deco injected).
+  // maps to the top-level section the panel indexes); null if it isn't in the
+  // aligned editable set (a framework section deco injected).
   var findSection = function(el) {
     var node = el;
     var found = null;
@@ -237,8 +253,7 @@ export const CMS_EDITOR_SCRIPT = `(function() {
     if (e.data && e.data.type === "cms-editor::set-labels" && Array.isArray(e.data.labels)) {
       sectionLabels = e.data.labels;
       if (Array.isArray(e.data.kinds)) sectionKinds = e.data.kinds;
-      if (Array.isArray(e.data.keys)) expectedKeys = e.data.keys;
-      recomputeOffset();
+      if (Array.isArray(e.data.keys)) sectionCandidates = e.data.keys;
       if (lastSection) {
         lastLabel = labelFor(lastSection);
         lastKind = kindFor(lastSection);

--- a/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
@@ -9,36 +9,136 @@ export type CmsEditorPayload = z.infer<typeof CmsEditorPayloadSchema>;
 
 /**
  * Self-contained script injected into the preview iframe for CMS mode.
- * Highlights full sections (elements with data-manifest-key) on hover
- * and posts the section's DOM index back to the parent on click.
+ * Highlights full page sections (top-level <section data-manifest-key>) on
+ * hover and posts the section's index — matching the decofile sections array —
+ * back to the parent on click.
+ *
+ * Framework sections that deco injects around the page's editable sections
+ * (SEO, Theme, Analytics, etc.) are NOT part of the page's sections array, so
+ * they're filtered out via IGNORED_MANIFEST_KEYS to keep DOM order aligned with
+ * the index the editor panel uses.
  */
+export const IGNORED_MANIFEST_KEYS = [
+  "website/sections/Seo/SeoV2.tsx",
+  "site/sections/Theme/Theme.tsx",
+  "htmx/sections/htmx.tsx",
+  "website/sections/Analytics/Analytics.tsx",
+  "site/sections/Session.tsx",
+  "site/sections/Miscellaneous/CartAlert.tsx",
+] as const;
+
 export const CMS_EDITOR_SCRIPT = `(function() {
   if (window.__cmsEditorActive) return;
   window.__cmsEditorActive = true;
 
+  var IGNORED_KEYS = ${JSON.stringify(
+    Object.fromEntries(IGNORED_MANIFEST_KEYS.map((k) => [k, 1])),
+  )};
+
   var highlight = document.createElement("div");
-  highlight.style.cssText = "position:fixed;pointer-events:none;outline:2px solid #06b6d4;background:rgba(6,182,212,0.06);border-radius:2px;z-index:2147483647;display:none;";
+  highlight.style.cssText = "position:absolute;pointer-events:none;outline:2px solid #06b6d4;background:rgba(6,182,212,0.06);border-radius:2px;z-index:2147483647;display:none;";
   document.body.appendChild(highlight);
 
   var badge = document.createElement("div");
-  badge.style.cssText = "position:fixed;pointer-events:none;background:#06b6d4;color:white;font:11px/1 monospace;padding:2px 6px;border-radius:2px;z-index:2147483647;display:none;white-space:nowrap;max-width:240px;overflow:hidden;text-overflow:ellipsis;";
+  badge.style.cssText = "position:absolute;pointer-events:none;background:#06b6d4;color:white;font:11px/1 monospace;padding:2px 6px;border-radius:2px;z-index:2147483647;display:none;white-space:nowrap;max-width:240px;overflow:hidden;text-overflow:ellipsis;";
   document.body.appendChild(badge);
 
-  var findSection = function(el) {
-    var node = el;
-    while (node && node !== document.body) {
-      if (node.hasAttribute && node.hasAttribute("data-manifest-key")) return node;
-      node = node.parentElement;
-    }
-    return null;
+  var isTopLevelSection = function(el) {
+    return el && el.parentElement
+      ? !el.parentElement.closest("section[data-manifest-key]")
+      : true;
   };
 
+  // Resolve to the OUTERMOST page-level section: deco renders page sections as
+  // <section data-manifest-key>, but nested islands/sections carry the attribute
+  // too. Walk up and keep the last section ancestor so clicking nested content
+  // still maps to the top-level section the panel indexes. Framework sections
+  // (IGNORED_KEYS) aren't in the editable array, so treat them as no section.
+  var findSection = function(el) {
+    var node = el;
+    var found = null;
+    while (node && node !== document.body) {
+      if (node.tagName === "SECTION" && node.hasAttribute && node.hasAttribute("data-manifest-key")) {
+        found = node;
+      }
+      node = node.parentElement;
+    }
+    if (found && IGNORED_KEYS[found.getAttribute("data-manifest-key")]) return null;
+    return found;
+  };
+
+  // Only top-level, non-framework page sections, in DOM order, so indexOf
+  // matches the decofile sections array the editor panel indexes into.
   var getAllSections = function() {
-    return Array.from(document.querySelectorAll("[data-manifest-key]"));
+    return Array.from(document.querySelectorAll("section[data-manifest-key]"))
+      .filter(isTopLevelSection)
+      .filter(function(s) { return !IGNORED_KEYS[s.getAttribute("data-manifest-key")]; });
+  };
+
+  // Lazy sections async-render their real section inside a wrapper, so the
+  // wrapper's key is just the loader. Show the inner section's key instead
+  // (falling back to the wrapper while the content hasn't loaded yet).
+  var LAZY_KEY = "website/sections/Rendering/Lazy.tsx";
+  var displayKey = function(section) {
+    var key = section.getAttribute("data-manifest-key") || "section";
+    if (key === LAZY_KEY) {
+      var inner = section.querySelector("section[data-manifest-key]");
+      if (inner) return inner.getAttribute("data-manifest-key") || key;
+    }
+    return key;
+  };
+
+  // Per-section metadata sent by the editor, aligned by index with
+  // getAllSections(). labels: names the DOM can't carry (a global section or a
+  // global inside async rendering); kinds: section type that drives the color.
+  var sectionLabels = [];
+  var sectionKinds = [];
+  var labelFor = function(section) {
+    var idx = getAllSections().indexOf(section);
+    if (idx >= 0 && sectionLabels[idx]) return sectionLabels[idx];
+    return displayKey(section);
+  };
+  var kindFor = function(section) {
+    var idx = getAllSections().indexOf(section);
+    return (idx >= 0 && sectionKinds[idx]) || "normal";
+  };
+
+  // Highlight palette by section kind: global = light purple, variant = green,
+  // normal = blue.
+  var COLORS = {
+    normal: { solid: "#06b6d4", bg: "rgba(6,182,212,0.06)", active: "rgba(6,182,212,0.18)" },
+    global: { solid: "#c084fc", bg: "rgba(192,132,252,0.10)", active: "rgba(192,132,252,0.22)" },
+    variant: { solid: "#22c55e", bg: "rgba(34,197,94,0.08)", active: "rgba(34,197,94,0.20)" }
+  };
+  var applyColor = function(kind) {
+    var c = COLORS[kind] || COLORS.normal;
+    highlight.style.outline = "2px solid " + c.solid;
+    highlight.style.background = c.bg;
+    badge.style.background = c.solid;
   };
 
   var lastSection = null;
+  var lastLabel = "";
+  var lastKind = "normal";
   var rafPending = false;
+
+  // Document-relative coordinates (rect + scroll) on absolutely-positioned
+  // nodes, so the browser scrolls the highlight together with the page
+  // natively — no per-frame JS repositioning, no scroll lag.
+  var positionHighlight = function(section) {
+    var r = section.getBoundingClientRect();
+    var top = r.top + window.scrollY;
+    var left = r.left + window.scrollX;
+    highlight.style.display = "block";
+    highlight.style.top = top + "px";
+    highlight.style.left = left + "px";
+    highlight.style.width = r.width + "px";
+    highlight.style.height = r.height + "px";
+    badge.textContent = lastLabel || displayKey(section);
+    badge.style.display = "block";
+    badge.style.top = Math.max(0, top - 20) + "px";
+    badge.style.left = left + "px";
+  };
 
   var moveHandler = function(e) {
     if (rafPending) return;
@@ -55,19 +155,28 @@ export const CMS_EDITOR_SCRIPT = `(function() {
         badge.style.display = "none";
         return;
       }
-      var r = section.getBoundingClientRect();
-      highlight.style.display = "block";
-      highlight.style.top = r.top + "px";
-      highlight.style.left = r.left + "px";
-      highlight.style.width = r.width + "px";
-      highlight.style.height = r.height + "px";
-      badge.textContent = section.getAttribute("data-manifest-key") || "section";
-      badge.style.display = "block";
-      badge.style.top = Math.max(0, r.top - 20) + "px";
-      badge.style.left = r.left + "px";
+      lastLabel = labelFor(section);
+      lastKind = kindFor(section);
+      applyColor(lastKind);
+      positionHighlight(section);
     });
   };
   document.addEventListener("mousemove", moveHandler, true);
+
+  // Window scroll is handled natively by the absolute positioning above; this
+  // only re-syncs on resize and on scrolls inside nested scroll containers
+  // (capture=true catches those), where document coordinates do shift.
+  var reposition = function() {
+    if (!lastSection || highlight.style.display === "none") return;
+    if (rafPending) return;
+    rafPending = true;
+    requestAnimationFrame(function() {
+      rafPending = false;
+      if (lastSection && highlight.style.display !== "none") positionHighlight(lastSection);
+    });
+  };
+  window.addEventListener("scroll", reposition, { capture: true, passive: true });
+  window.addEventListener("resize", reposition, { passive: true });
 
   var outHandler = function(e) {
     if (!e.relatedTarget || e.relatedTarget === document.documentElement) {
@@ -90,10 +199,11 @@ export const CMS_EDITOR_SCRIPT = `(function() {
     var sectionIndex = sections.indexOf(section);
     var manifestKey = section.getAttribute("data-manifest-key") || "";
 
-    highlight.style.outline = "2px solid #06b6d4";
-    highlight.style.background = "rgba(6,182,212,0.18)";
+    var c = COLORS[lastKind] || COLORS.normal;
+    highlight.style.outline = "2px solid " + c.solid;
+    highlight.style.background = c.active;
     setTimeout(function() {
-      highlight.style.background = "rgba(6,182,212,0.06)";
+      highlight.style.background = c.bg;
     }, 400);
 
     window.parent.postMessage({
@@ -104,12 +214,25 @@ export const CMS_EDITOR_SCRIPT = `(function() {
   document.addEventListener("click", clickHandler, true);
 
   window.addEventListener("message", function(e) {
+    if (e.data && e.data.type === "cms-editor::set-labels" && Array.isArray(e.data.labels)) {
+      sectionLabels = e.data.labels;
+      if (Array.isArray(e.data.kinds)) sectionKinds = e.data.kinds;
+      if (lastSection) {
+        lastLabel = labelFor(lastSection);
+        lastKind = kindFor(lastSection);
+        applyColor(lastKind);
+        if (highlight.style.display !== "none") positionHighlight(lastSection);
+      }
+      return;
+    }
     if (e.data && e.data.type === "cms-editor::deactivate") {
       highlight.remove();
       badge.remove();
       document.removeEventListener("mousemove", moveHandler, true);
       document.removeEventListener("mouseout", outHandler, true);
       document.removeEventListener("click", clickHandler, true);
+      window.removeEventListener("scroll", reposition, { capture: true });
+      window.removeEventListener("resize", reposition);
       window.__cmsEditorActive = false;
     }
   });

--- a/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
@@ -18,7 +18,7 @@ export type CmsEditorPayload = z.infer<typeof CmsEditorPayloadSchema>;
  * they're filtered out via IGNORED_MANIFEST_KEYS to keep DOM order aligned with
  * the index the editor panel uses.
  */
-export const IGNORED_MANIFEST_KEYS = [
+const IGNORED_MANIFEST_KEYS = [
   "website/sections/Seo/SeoV2.tsx",
   "site/sections/Theme/Theme.tsx",
   "htmx/sections/htmx.tsx",

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -128,24 +128,44 @@ const LAZY_RESOLVE_TYPE = "website/sections/Rendering/Lazy.tsx";
  * the iframe treats as "matches anything").
  */
 function resolveSectionCandidates(
-  section: { __resolveType?: unknown; section?: unknown },
+  section: { __resolveType?: unknown; section?: unknown; variants?: unknown },
   decofile: Record<string, unknown>,
 ): string[] {
-  let obj: { __resolveType?: unknown; section?: unknown } = section;
+  let obj: { __resolveType?: unknown; section?: unknown; variants?: unknown } =
+    section;
   let rt = typeof obj?.__resolveType === "string" ? obj.__resolveType : "";
   for (let i = 0; rt && i < 5; i++) {
     const block = decofile[rt];
     if (block && typeof block === "object" && "__resolveType" in block) {
       const next = (block as { __resolveType?: unknown }).__resolveType;
       if (typeof next === "string" && next && next !== rt) {
-        obj = block as { __resolveType?: unknown; section?: unknown };
+        obj = block as typeof obj;
         rt = next;
         continue;
       }
     }
     break;
   }
-  if (!rt || rt.includes("flags/multivariate")) return [];
+  if (!rt) return [];
+  // Multivariate (A/B) renders one of its variants — collect every variant's
+  // possible key so it matches whichever rendered (NOT a blind wildcard, which
+  // could otherwise grab an adjacent framework section).
+  if (rt.includes("flags/multivariate")) {
+    const variants = Array.isArray(obj.variants) ? obj.variants : [];
+    const keys: string[] = [];
+    for (const v of variants) {
+      const value = (v as { value?: unknown })?.value;
+      if (value && typeof value === "object") {
+        for (const k of resolveSectionCandidates(
+          value as { __resolveType?: unknown },
+          decofile,
+        )) {
+          if (!keys.includes(k)) keys.push(k);
+        }
+      }
+    }
+    return keys;
+  }
   if (rt === LAZY_RESOLVE_TYPE) {
     const inner =
       obj.section && typeof obj.section === "object"

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -42,6 +42,8 @@ import {
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { useDecofile } from "@/web/components/sections-editor/use-decofile";
+import { parseSections } from "@/web/components/sections-editor/parse-sections";
+import { getPageVariantSectionsAt } from "@/web/components/sections-editor/page-variants";
 import { useLiveMeta } from "@/web/components/sections-editor/use-live-meta";
 import {
   extractGlobalSections,
@@ -222,6 +224,25 @@ export function PreviewContent() {
     : currentPage?.name;
   const currentPageKey = currentPage?.key ?? null;
 
+  // Per-section metadata for the CMS hover overlay, aligned by index with the
+  // iframe's top-level section list. `label`: ONLY global (saved block)
+  // sections get a name — the DOM can't carry it (incl. globals inside async
+  // rendering); non-global sections are empty so the iframe falls back to their
+  // full resolve. `kind`: drives the highlight color (global / variant / normal).
+  const cmsSections =
+    decofile && currentPageKey
+      ? parseSections(
+          getPageVariantSectionsAt(decofile, currentPageKey, 0),
+          decofile,
+        )
+      : [];
+  const cmsSectionLabels = cmsSections.map((s) =>
+    s.isSavedBlock ? s.label : "",
+  );
+  const cmsSectionKinds = cmsSections.map((s) =>
+    s.isSavedBlock ? "global" : s.isMultivariate ? "variant" : "normal",
+  );
+
   const iframeSrcRef = useRef<string | null>(null);
   /** Path we navigated to programmatically; ignore stale iframe onLoad events. */
   const intendedPathRef = useRef<string | null>(null);
@@ -398,6 +419,17 @@ export function PreviewContent() {
     if (!win) return;
     win.postMessage(
       { type: "visual-editor::activate", script: CMS_EDITOR_SCRIPT },
+      "*",
+    );
+    // Ordered after activate, so the script's listener is registered by the
+    // time this arrives. Re-sent on every (re)injection (mode switch, page
+    // navigation, save-reload) so labels track the current page.
+    win.postMessage(
+      {
+        type: "cms-editor::set-labels",
+        labels: cmsSectionLabels,
+        kinds: cmsSectionKinds,
+      },
       "*",
     );
   };

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -116,32 +116,47 @@ const DEVICE_LABELS: Record<PreviewDeviceSize, string> = {
   desktop: "Desktop",
 };
 
+const LAZY_RESOLVE_TYPE = "website/sections/Rendering/Lazy.tsx";
+
 /**
- * The manifest key deco renders as the top-level <section data-manifest-key>
- * for a page section: saved-block references (globals) are resolved to their
- * underlying component; a Lazy stays Lazy. Multivariate flags render their
- * active variant, which we can't predict here, so they map to "" — a wildcard
- * the iframe treats as "matches anything" when aligning the editable run.
+ * Candidate top-level `data-manifest-key`s a page section can render as, used
+ * iframe-side to align the editable run within the DOM. Saved-block refs
+ * (globals) resolve to their underlying component. A Lazy returns BOTH its
+ * loader key and the inner section's key — the classic runtime keeps the Lazy
+ * wrapper at top level, TanStack renders the inner section directly. Multivariate
+ * flags render an unpredictable active variant, so they return [] (a wildcard
+ * the iframe treats as "matches anything").
  */
-function resolveDomManifestKey(
-  section: { __resolveType?: unknown },
+function resolveSectionCandidates(
+  section: { __resolveType?: unknown; section?: unknown },
   decofile: Record<string, unknown>,
-): string {
-  let rt =
-    typeof section?.__resolveType === "string" ? section.__resolveType : "";
+): string[] {
+  let obj: { __resolveType?: unknown; section?: unknown } = section;
+  let rt = typeof obj?.__resolveType === "string" ? obj.__resolveType : "";
   for (let i = 0; rt && i < 5; i++) {
     const block = decofile[rt];
-    const next =
-      block && typeof block === "object"
-        ? (block as { __resolveType?: unknown }).__resolveType
-        : undefined;
-    if (typeof next === "string" && next && next !== rt) {
-      rt = next;
-    } else {
-      break;
+    if (block && typeof block === "object" && "__resolveType" in block) {
+      const next = (block as { __resolveType?: unknown }).__resolveType;
+      if (typeof next === "string" && next && next !== rt) {
+        obj = block as { __resolveType?: unknown; section?: unknown };
+        rt = next;
+        continue;
+      }
     }
+    break;
   }
-  return rt.includes("flags/multivariate") ? "" : rt;
+  if (!rt || rt.includes("flags/multivariate")) return [];
+  if (rt === LAZY_RESOLVE_TYPE) {
+    const inner =
+      obj.section && typeof obj.section === "object"
+        ? resolveSectionCandidates(
+            obj.section as { __resolveType?: unknown },
+            decofile,
+          )
+        : [];
+    return inner.length ? [rt, ...inner] : [rt];
+  }
+  return [rt];
 }
 
 /** Deco reads `deviceHint` to force SSR device matchers (see deco `deviceOf`). */
@@ -268,11 +283,11 @@ export function PreviewContent() {
   const cmsSectionKinds = cmsSections.map((s) =>
     s.isSavedBlock ? "global" : s.isMultivariate ? "variant" : "normal",
   );
-  // Expected top-level manifest keys (saved-block refs resolved), used
-  // iframe-side to align the editable section run within the DOM — no hardcoded
-  // list of framework sections to skip.
+  // Candidate manifest keys per editable section, used iframe-side to align the
+  // editable run within the DOM (handles framework sections deco injects around
+  // OR between the editable ones) — no hardcoded list of sections to skip.
   const cmsSectionKeys = cmsRawSections.map((s) =>
-    resolveDomManifestKey(s, decofile ?? {}),
+    resolveSectionCandidates(s, decofile ?? {}),
   );
 
   const iframeSrcRef = useRef<string | null>(null);

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -116,6 +116,34 @@ const DEVICE_LABELS: Record<PreviewDeviceSize, string> = {
   desktop: "Desktop",
 };
 
+/**
+ * The manifest key deco renders as the top-level <section data-manifest-key>
+ * for a page section: saved-block references (globals) are resolved to their
+ * underlying component; a Lazy stays Lazy. Multivariate flags render their
+ * active variant, which we can't predict here, so they map to "" — a wildcard
+ * the iframe treats as "matches anything" when aligning the editable run.
+ */
+function resolveDomManifestKey(
+  section: { __resolveType?: unknown },
+  decofile: Record<string, unknown>,
+): string {
+  let rt =
+    typeof section?.__resolveType === "string" ? section.__resolveType : "";
+  for (let i = 0; rt && i < 5; i++) {
+    const block = decofile[rt];
+    const next =
+      block && typeof block === "object"
+        ? (block as { __resolveType?: unknown }).__resolveType
+        : undefined;
+    if (typeof next === "string" && next && next !== rt) {
+      rt = next;
+    } else {
+      break;
+    }
+  }
+  return rt.includes("flags/multivariate") ? "" : rt;
+}
+
 /** Deco reads `deviceHint` to force SSR device matchers (see deco `deviceOf`). */
 function withDeviceHint(url: string, device: PreviewDeviceSize): string {
   const parsed = new URL(url, window.location.href);
@@ -229,18 +257,22 @@ export function PreviewContent() {
   // sections get a name — the DOM can't carry it (incl. globals inside async
   // rendering); non-global sections are empty so the iframe falls back to their
   // full resolve. `kind`: drives the highlight color (global / variant / normal).
-  const cmsSections =
+  const cmsRawSections =
     decofile && currentPageKey
-      ? parseSections(
-          getPageVariantSectionsAt(decofile, currentPageKey, 0),
-          decofile,
-        )
+      ? getPageVariantSectionsAt(decofile, currentPageKey, 0)
       : [];
+  const cmsSections = decofile ? parseSections(cmsRawSections, decofile) : [];
   const cmsSectionLabels = cmsSections.map((s) =>
     s.isSavedBlock ? s.label : "",
   );
   const cmsSectionKinds = cmsSections.map((s) =>
     s.isSavedBlock ? "global" : s.isMultivariate ? "variant" : "normal",
+  );
+  // Expected top-level manifest keys (saved-block refs resolved), used
+  // iframe-side to align the editable section run within the DOM — no hardcoded
+  // list of framework sections to skip.
+  const cmsSectionKeys = cmsRawSections.map((s) =>
+    resolveDomManifestKey(s, decofile ?? {}),
   );
 
   const iframeSrcRef = useRef<string | null>(null);
@@ -429,6 +461,7 @@ export function PreviewContent() {
         type: "cms-editor::set-labels",
         labels: cmsSectionLabels,
         kinds: cmsSectionKinds,
+        keys: cmsSectionKeys,
       },
       "*",
     );


### PR DESCRIPTION
## Summary

Fixes several papercuts in the **Sections editor** (CMS) hover overlay in the site editor. All changes are confined to the injected iframe script (`cms-editor-script.ts`) plus the editor-side wiring that feeds it labels/kinds (`preview.tsx`).

### Bugs fixed

1. **Highlight didn't follow the section on scroll.** It used `position:fixed` with viewport-relative coords recomputed only on `mousemove`, so scrolling without moving the mouse left the highlight floating in the old spot. Now uses `position:absolute` with document coordinates (`rect + scroll`), so the browser scrolls it together with the page **natively — no lag**. A capture-phase `scroll`/`resize` listener covers nested scroll containers.

2. **Clicking opened the wrong section.** `getAllSections()` matched every `[data-manifest-key]` element — including nested islands and framework-injected sections — so the DOM index didn't line up with the decofile `sections` array the panel indexes into. Confirmed via `/.decofile`: the editable array runs `Header … Footer`; deco injects framework sections (`SeoV2`, `Theme`, `htmx`, `Analytics`, `Session`, `CartAlert`) around it that are **not** in that array. Now scopes to top-level `section[data-manifest-key]` and skips framework keys via `IGNORED_MANIFEST_KEYS`.

3. **Badge label correctness.**
   - **Global** sections (incl. globals inside async `Lazy` rendering) show their block **name** — resolved editor-side since the DOM only carries manifest paths.
   - **Normal** sections show their full resolve (`data-manifest-key`).
   - **Lazy non-globals** show the inner section's manifest key instead of `Rendering/Lazy.tsx`.

4. **Color-coded highlight by kind:** global = light purple, variant = green, normal = blue.

## Implementation notes

- Labels + kinds are derived from the decofile in `preview.tsx` (`parseSections` + `getPageVariantSectionsAt`) and sent into the iframe via `postMessage` (`cms-editor::set-labels`) on every (re)injection — mode switch, page navigation, save-reload — so they track the current page. No `useEffect`.
- The injected script keeps the click contract (`{ sectionIndex, manifestKey }`) unchanged; only DOM enumeration/positioning/labeling changed.

## Testing

- `bun run fmt`, `bun run lint` (0 errors), `tsc --noEmit` (mesh) all clean.
- Manual verification needed (script is injected into the preview iframe — reload the preview to re-inject): in CMS mode, hover + scroll without moving the mouse (highlight stays glued); click sections after nested/lazy content (opens the correct one); check badge names for globals and colors per kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CMS hover overlay in the Sections editor so the highlight tracks scroll, clicks open the correct section across runtimes, and labels/colors reflect the section type. Aligns editable sections to the DOM via subsequence matching with per-section key candidates (including `Lazy` wrapper vs inner and multivariate variant keys), so framework-injected and runtime-specific differences are ignored.

- **Bug Fixes**
  - Highlight follows scroll via absolute positioning with document coordinates; capture-phase scroll/resize covers nested scrollers.
  - Click mapping aligns the editable sequence to top-level `section[data-manifest-key]` using subsequence matching and per-section candidate keys (e.g., `Lazy` wrapper or inner key; multivariate collects each variant’s resolved keys), so indices match the decofile even with interleaved framework sections (TanStack) or wrappers; recomputes from the live DOM to self-heal as content mounts.
  - Labels are accurate: globals show saved block names (incl. inside `Lazy`); non-global `Lazy` shows the inner section key; others show the full manifest key. Labels/kinds/keys are provided via `cms-editor::set-labels`.
  - Color-coded highlight by kind: global (purple), variant (green), normal (blue).

<sup>Written for commit 8db50b8d3deff52e76269b4d37d23390592b6915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

