### PR TITLE
feat(home): make Open chat button always visible on tiles

### DIFF
--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -195,6 +195,17 @@ function AgentUITile({
 
   return (
     <div className="relative flex h-full w-full flex-col p-3">
+      {!isEditMode && (
+        <button
+          type="button"
+          onClick={() => void startBlank()}
+          disabled={starting}
+          aria-busy={starting}
+          className="mb-1 self-start rounded-md px-2 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-progress disabled:opacity-60"
+        >
+          Open chat
+        </button>
+      )}
       <div className="flex min-h-0 flex-1 gap-3 overflow-hidden">
         <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border">
           <Suspense fallback={<TilePanelSkeleton />}>
@@ -217,17 +228,6 @@ function AgentUITile({
           </div>
         )}
       </div>
-      {!isEditMode && (
-        <button
-          type="button"
-          onClick={() => void startBlank()}
-          disabled={starting}
-          aria-busy={starting}
-          className="absolute bottom-2 right-2 rounded-md px-2 py-1 text-[10px] text-muted-foreground opacity-0 transition-opacity hover:bg-accent/60 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-progress disabled:opacity-60"
-        >
-          Open chat
-        </button>
-      )}
       {dialog}
     </div>
   );
@@ -332,20 +332,9 @@ function TileErrorFallback({
         type="button"
         onClick={() => void startBlank()}
         disabled={starting || isEditMode}
-        className={cn(
-          "flex items-center gap-3 rounded-lg text-left outline-none focus-visible:ring-2 focus-visible:ring-ring",
-          isEditMode && "pl-10 pr-10",
-        )}
+        className="mb-1 self-start rounded-md px-2 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-progress disabled:opacity-60"
       >
-        <AgentAvatar icon={tile.agentIcon} name={tile.agentName} size="sm+" />
-        <div className="flex min-w-0 flex-1 flex-col">
-          <div className="truncate text-sm font-medium text-foreground">
-            {tile.agentName}
-          </div>
-          <div className="truncate text-xs text-muted-foreground">
-            UI unavailable — open chat
-          </div>
-        </div>
+        Open chat
       </button>
       {chips.length > 0 && !isEditMode && (
         <div className="grid grid-cols-1 gap-2 overflow-hidden sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- Move the "Open chat" button from a hover-only overlay (bottom-right) to always visible at the top-left of agent UI tiles
- Simplify the error fallback tile to show just the "Open chat" button instead of the agent avatar, name, and "UI unavailable" text

## Test plan
- [ ] Verify "Open chat" button is visible on agent UI tiles without hovering
- [ ] Verify button is hidden in edit mode
- [ ] Verify clicking the button opens a blank chat thread
- [ ] Verify error fallback tiles show the simplified "Open chat" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the "Open chat" button on agent tiles at the top-left, and simplify the error fallback to show only this button. This removes the hover-only action and makes starting chats obvious; the button stays hidden in edit mode.

- **New Features**
  - "Open chat" button is always visible when not editing, positioned top-left with proper hover/focus states.
  - Removed the hover-only bottom-right button.
  - Error fallback tile now shows just the "Open chat" button (no avatar/name), and clicking opens a blank chat thread.

<sup>Written for commit 68bb16a22f31d216380bb5d20ddb1163f79ba7f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

