### PR TITLE
feat(dev-agent): Develop/Live toggle + ephemeral dev-server connection

### DIFF
--- a/apps/mesh/src/api/routes/dev-connection.ts
+++ b/apps/mesh/src/api/routes/dev-connection.ts
@@ -44,12 +44,63 @@ import {
 /** Env var the dev MCP app gates `/mcp` behind (matches the prod connection). */
 const MCP_AUTH_TOKEN_KEY = "MCP_AUTH_TOKEN";
 
+// MCP-readiness probe, memoized per dev-server URL (the URL embeds the unique
+// sandbox handle + token, so it's per-sandbox). A confirmed MCP app sticks
+// (`true` cached for the lifetime of the process); a non-MCP or still-booting
+// server is re-probed only every PROBE_BACKOFF_MS, so the hot path neither
+// re-probes a known-good server nor permanently rejects one that comes up later.
+const mcpReadyUrls = new Set<string>();
+const mcpProbedAt = new Map<string, number>();
+const PROBE_BACKOFF_MS = 10_000;
+
+/**
+ * True iff `connectionUrl` answers an MCP `initialize`. A Vite SPA fallback
+ * returns 200 with HTML, so we require a real MCP result (protocolVersion /
+ * serverInfo) — not just a 2xx.
+ */
+async function servesMcp(connectionUrl: string): Promise<boolean> {
+  if (mcpReadyUrls.has(connectionUrl)) return true;
+  const now = Date.now();
+  if (now - (mcpProbedAt.get(connectionUrl) ?? 0) < PROBE_BACKOFF_MS) {
+    return false;
+  }
+  mcpProbedAt.set(connectionUrl, now);
+  try {
+    const res = await fetch(connectionUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "mesh-dev-probe", version: "1" },
+        },
+      }),
+      signal: AbortSignal.timeout(4000),
+    });
+    const body = res.ok ? await res.text() : "";
+    const ok = /"protocolVersion"|"serverInfo"/.test(body);
+    if (ok) mcpReadyUrls.add(connectionUrl);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Resolve the synthetic dev connection for `agentId` and the acting user.
- * Returns `null` when the agent is missing/cross-org, isn't a dev agent (no
- * `metadata.liveAgentId`), or the acting user has no running sandbox for it (no
- * sandboxMap entry / no previewUrl) — every caller treats `null` as "not
- * running". A missing dev token is NOT a null condition: it just yields an
+ * Returns `null` unless the acting user has a running sandbox for this agent AND
+ * that sandbox's dev server actually speaks MCP at `/api/mcp` (probed once,
+ * memoized). Repo/pairing-agnostic — the real signal is "a sandbox serving an
+ * MCP app", so a freshly imported (or even repo-less) MCP-app sandbox surfaces
+ * its tools/views, while a Start-Website/Hydrogen sandbox (a Vite site, no MCP)
+ * does not. A missing dev token is NOT a null condition: it just yields an
  * authless connection (the default; the URL handle is the secret).
  */
 export async function resolveDevConnection(
@@ -65,14 +116,6 @@ export async function resolveDevConnection(
   if (!vm || vm.organization_id !== orgId) return null;
 
   const metadata = (vm.metadata ?? {}) as Record<string, unknown>;
-  // Gate: only a dev agent (one developing a live counterpart) gets a dev
-  // connection. The pairing ref lives on the dev agent itself
-  // (`metadata.liveAgentId`), so this is a local field check on the row already
-  // fetched — no per-request reverse lookup over the org's agents (which matters
-  // since every agent has a sandbox). A Start-Website / Hydrogen agent has a
-  // repo + sandbox too but no liveAgentId, so it's excluded.
-  if (!metadata.liveAgentId) return null;
-
   const userMap = readSandboxMap(metadata)[actingUserId];
   if (!userMap) return null;
 
@@ -93,6 +136,12 @@ export async function resolveDevConnection(
   const connection_url = token
     ? `${base}/api/mcp?token=${encodeURIComponent(token)}`
     : `${base}/api/mcp`;
+
+  // The real gate: only surface a connection if the dev server actually speaks
+  // MCP. This is what makes it repo/pairing-agnostic — any sandbox serving an
+  // MCP app qualifies, a Vite-site sandbox (Start-Website/Hydrogen) does not.
+  // Memoized per URL so the hot path doesn't re-probe (see servesMcp).
+  if (!(await servesMcp(connection_url))) return null;
 
   return {
     id: getDevConnectionId(agentId),

--- a/apps/mesh/src/api/routes/dev-connection.ts
+++ b/apps/mesh/src/api/routes/dev-connection.ts
@@ -62,6 +62,14 @@ export async function resolveDevConnection(
   if (!vm || vm.organization_id !== orgId) return null;
 
   const metadata = (vm.metadata ?? {}) as Record<string, unknown>;
+  // Gate: only a dev agent (one developing a live counterpart) gets a dev
+  // connection. The pairing ref lives on the dev agent itself
+  // (`metadata.liveAgentId`), so this is a local field check on the row already
+  // fetched — no per-request reverse lookup over the org's agents (which matters
+  // since every agent has a sandbox). A Start-Website / Hydrogen agent has a
+  // repo + sandbox too but no liveAgentId, so it's excluded.
+  if (!metadata.liveAgentId) return null;
+
   const userMap = readSandboxMap(metadata)[actingUserId];
   if (!userMap) return null;
 
@@ -69,15 +77,6 @@ export async function resolveDevConnection(
     ? pickEntryForBranch(userMap, branch)
     : pickMostRecentEntry(userMap);
   if (!picked?.entry.previewUrl) return null;
-
-  // Gate: only the dev side of a dev/live pair (an MCP app being developed)
-  // gets a dev connection. A Start-Website / Hydrogen agent also has a repo +
-  // sandbox but isn't an MCP app — it's never paired, so it's excluded. The
-  // pairing (some live agent's `metadata.devAgentId === this agent`) is the
-  // MCP-app signal. Only queried once we know a sandbox is actually running.
-  const orgAgents = await ctx.storage.virtualMcps.list(orgId);
-  const isPaired = orgAgents.some((a) => a.metadata?.devAgentId === agentId);
-  if (!isPaired) return null;
 
   // Authless by default — most dev servers run open. If the app gates /mcp
   // behind a query token (MCP_AUTH_TOKEN in runtime.env), append it: query

--- a/apps/mesh/src/api/routes/dev-connection.ts
+++ b/apps/mesh/src/api/routes/dev-connection.ts
@@ -1,0 +1,191 @@
+/**
+ * Ephemeral dev-server connection resolver.
+ *
+ * Materializes an in-memory `ConnectionEntity` for the synthetic id
+ * `dev_<virtualMcpId>`, pointing at the acting user's running sandbox dev
+ * server (`${previewUrl}/api/mcp`, authless by default). Never persisted — the
+ * proxy chokepoints call this instead of `connections.findById` when they see a
+ * `dev_` id (mirrors the `_self` synthetic-id bypass).
+ *
+ * Per-acting-user by construction: the previewUrl is read from
+ * `sandboxMap[actingUserId]`, so each member only ever reaches their own
+ * sandbox — there is no shared row to leak across users. No sandbox running for
+ * the user → `null` (callers render a "start dev server" state).
+ *
+ * Returns `null` unless the agent is the dev side of a dev/live pair (the
+ * MCP-app signal — see the gate below), so plain website/Hydrogen sandbox
+ * agents never get a dev connection.
+ *
+ * Auth: authless by default — the preview URL is open (its unguessable handle
+ * is the secret, Vercel-style). If the app gates /mcp behind a query token
+ * (`MCP_AUTH_TOKEN`), it's appended to the URL — query params survive the
+ * sandbox daemon proxy, which strips `Authorization` (so bearer/OAuth header
+ * auth needs a daemon change; deferred).
+ */
+
+import {
+  getDevConnectionId,
+  parseBranchMap,
+  type SandboxMap,
+} from "@decocms/mesh-sdk";
+import type { StudioContext } from "../../core/studio-context";
+import type { ConnectionEntity } from "../../tools/connection/schema";
+import {
+  SecretAccessDeniedError,
+  SecretNotFoundError,
+} from "../../storage/secrets";
+import { readValidatedRuntimeEnv } from "../../tools/sandbox/helpers";
+import { readSandboxMap } from "../../tools/sandbox/sandbox-map";
+import {
+  type BranchMapEntryLike,
+  selectVmEntry,
+} from "../../tools/sandbox/select-vm-entry";
+
+/** Env var the dev MCP app gates `/mcp` behind (matches the prod connection). */
+const MCP_AUTH_TOKEN_KEY = "MCP_AUTH_TOKEN";
+
+/**
+ * Resolve the synthetic dev connection for `agentId` and the acting user.
+ * Returns `null` when the agent is missing, the user has no live sandbox, or no
+ * dev token is available — every caller treats `null` as "not running".
+ */
+export async function resolveDevConnection(
+  ctx: StudioContext,
+  agentId: string,
+  actingUserId: string,
+  branch?: string,
+): Promise<ConnectionEntity | null> {
+  const orgId = ctx.organization?.id;
+  if (!orgId) return null;
+
+  const vm = await ctx.storage.virtualMcps.findById(agentId);
+  if (!vm || vm.organization_id !== orgId) return null;
+
+  const metadata = (vm.metadata ?? {}) as Record<string, unknown>;
+  const userMap = readSandboxMap(metadata)[actingUserId];
+  if (!userMap) return null;
+
+  const picked = branch
+    ? pickEntryForBranch(userMap, branch)
+    : pickMostRecentEntry(userMap);
+  if (!picked?.entry.previewUrl) return null;
+
+  // Gate: only the dev side of a dev/live pair (an MCP app being developed)
+  // gets a dev connection. A Start-Website / Hydrogen agent also has a repo +
+  // sandbox but isn't an MCP app — it's never paired, so it's excluded. The
+  // pairing (some live agent's `metadata.devAgentId === this agent`) is the
+  // MCP-app signal. Only queried once we know a sandbox is actually running.
+  const orgAgents = await ctx.storage.virtualMcps.list(orgId);
+  const isPaired = orgAgents.some((a) => a.metadata?.devAgentId === agentId);
+  if (!isPaired) return null;
+
+  // Authless by default — most dev servers run open. If the app gates /mcp
+  // behind a query token (MCP_AUTH_TOKEN in runtime.env), append it: query
+  // params survive the sandbox daemon proxy, which strips the Authorization
+  // header (so bearer/OAuth header auth is a follow-up needing a daemon change).
+  const token = await resolveDevToken(ctx, metadata, orgId, actingUserId);
+  const base = picked.entry.previewUrl.replace(/\/+$/, "");
+  // The deco runtime serves MCP at `/api/mcp` on the Vite dev server (which
+  // proxies `/api/*` to the worker); a bare `/mcp` hits Vite directly and
+  // 404s. (The deployed worker serves `/mcp` — that's prod, not the dev server.)
+  const connection_url = token
+    ? `${base}/api/mcp?token=${encodeURIComponent(token)}`
+    : `${base}/api/mcp`;
+
+  return {
+    id: getDevConnectionId(agentId),
+    organization_id: orgId,
+    title: `${vm.title} (dev)`,
+    description: "Ephemeral sandbox dev-server connection",
+    icon: vm.icon ?? null,
+    app_name: vm.title ?? null,
+    app_id: null,
+    slug: null,
+    connection_type: "HTTP",
+    connection_url,
+    // Authless, or the app's query token rides inline in connection_url —
+    // never persisted as a separate credential.
+    connection_token: null,
+    connection_headers: null,
+    oauth_config: null,
+    configuration_state: null,
+    configuration_scopes: null,
+    metadata: {
+      isDevConnection: true,
+      virtualMcpId: agentId,
+      branch: picked.branch,
+    },
+    // null forces live tool/resource discovery (the dev server hot-reloads).
+    tools: null,
+    bindings: null,
+    status: "active",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    created_by: "system",
+  };
+}
+
+function pickEntryForBranch(
+  userMap: SandboxMap[string],
+  branch: string,
+): { branch: string; entry: BranchMapEntryLike } | null {
+  const entry = selectVmEntry(
+    parseBranchMap(userMap[branch]) as Record<string, BranchMapEntryLike>,
+  );
+  return entry ? { branch, entry } : null;
+}
+
+/**
+ * No explicit branch → pick the user's most recently created sandbox across all
+ * branches. Ambiguous only when a user keeps several live branches at once; the
+ * explicit `?branch=` override (follow-up) disambiguates.
+ */
+function pickMostRecentEntry(
+  userMap: SandboxMap[string],
+): { branch: string; entry: BranchMapEntryLike } | null {
+  let best: { branch: string; entry: BranchMapEntryLike } | null = null;
+  for (const [branch, raw] of Object.entries(userMap)) {
+    const entry = selectVmEntry(
+      parseBranchMap(raw) as Record<string, BranchMapEntryLike>,
+    );
+    if (!entry) continue;
+    if (!best || (entry.createdAt ?? 0) > (best.entry.createdAt ?? 0)) {
+      best = { branch, entry };
+    }
+  }
+  return best;
+}
+
+/**
+ * Resolve `MCP_AUTH_TOKEN` from the agent's `metadata.runtime.env`: literal
+ * inline, or a vault secret (same per-user/org ACL `SANDBOX_START` enforces). A
+ * missing/unauthorized secret resolves to `null` → no dev connection.
+ */
+async function resolveDevToken(
+  ctx: StudioContext,
+  metadata: Record<string, unknown>,
+  orgId: string,
+  actingUserId: string,
+): Promise<string | null> {
+  const entry = readValidatedRuntimeEnv(metadata)?.find(
+    (e) => e.key === MCP_AUTH_TOKEN_KEY,
+  );
+  if (!entry) return null;
+  if (entry.kind === "literal") return entry.value || null;
+  try {
+    const { value } = await ctx.storage.secrets.resolveById(
+      entry.secretId,
+      orgId,
+      actingUserId,
+    );
+    return value || null;
+  } catch (err) {
+    if (
+      err instanceof SecretNotFoundError ||
+      err instanceof SecretAccessDeniedError
+    ) {
+      return null;
+    }
+    throw err;
+  }
+}

--- a/apps/mesh/src/api/routes/dev-connection.ts
+++ b/apps/mesh/src/api/routes/dev-connection.ts
@@ -46,8 +46,11 @@ const MCP_AUTH_TOKEN_KEY = "MCP_AUTH_TOKEN";
 
 /**
  * Resolve the synthetic dev connection for `agentId` and the acting user.
- * Returns `null` when the agent is missing, the user has no live sandbox, or no
- * dev token is available — every caller treats `null` as "not running".
+ * Returns `null` when the agent is missing/cross-org, isn't a dev agent (no
+ * `metadata.liveAgentId`), or the acting user has no running sandbox for it (no
+ * sandboxMap entry / no previewUrl) — every caller treats `null` as "not
+ * running". A missing dev token is NOT a null condition: it just yields an
+ * authless connection (the default; the URL handle is the secret).
  */
 export async function resolveDevConnection(
   ctx: StudioContext,

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -16,7 +16,7 @@ import { SpanStatusCode } from "@opentelemetry/api";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Context, Hono } from "hono";
 import { endTime, startTime } from "hono/timing";
-import type { StudioContext } from "../../core/studio-context";
+import { getUserId, type StudioContext } from "../../core/studio-context";
 import { managementContextStore, managementMCP } from "../../tools";
 import { serveMcpRequest } from "../utils/serve-mcp";
 import { handleAuthError } from "./oauth-proxy";
@@ -34,6 +34,9 @@ import { getConnectionCircuitStore } from "@/mcp-clients/connection-circuit-stor
 import { CONNECTION_ERROR_REPROBE_COOLDOWN_MS } from "@/core/constants";
 import { peekRpcMethod, probeDecision } from "./proxy-handshake";
 import { handleVirtualMcpRequest } from "./virtual-mcp";
+import { resolveDevConnection } from "./dev-connection";
+import { parseDevConnectionId } from "@decocms/mesh-sdk";
+import type { ConnectionEntity } from "../../tools/connection/schema";
 export { toServerClient, type MCPProxyClient } from "./mcp-proxy-factory";
 
 // Define Hono variables type
@@ -102,12 +105,28 @@ export const createProxyRoutes = () => {
       return c.json({ error: "Organization context is required" }, 403);
     }
 
-    const connection = await ctx.storage.connections.findById(
-      connectionId,
-      ctx.organization.id,
-    );
-    if (!connection || connection.organization_id !== ctx.organization.id) {
-      return c.json({ error: "Connection not found" }, 404);
+    const devAgentId = parseDevConnectionId(connectionId);
+    let connection: ConnectionEntity | null;
+    if (devAgentId) {
+      const userId = getUserId(ctx);
+      if (!userId) return c.json({ error: "Authentication required" }, 401);
+      connection = await resolveDevConnection(
+        ctx,
+        devAgentId,
+        userId,
+        c.req.query("branch") ?? undefined,
+      );
+      if (!connection) {
+        return c.json({ error: "Dev server not running" }, 503);
+      }
+    } else {
+      connection = await ctx.storage.connections.findById(
+        connectionId,
+        ctx.organization.id,
+      );
+      if (!connection || connection.organization_id !== ctx.organization.id) {
+        return c.json({ error: "Connection not found" }, 404);
+      }
     }
 
     const client = createLazyClient(
@@ -188,6 +207,42 @@ export const createProxyRoutes = () => {
           c.req.raw,
           `mcp:self:${connectionId}`,
         ),
+      );
+    }
+
+    // Dev connections (`dev_<agentId>`) resolve to the acting user's running
+    // sandbox dev server — synthetic, per-user, never persisted. Bypass
+    // findById and the handshake-probe/circuit machinery below: it keys off a
+    // persisted id and logs `connection.url` in a span, which would leak the
+    // dev token; dev servers also 5xx transiently on hot-reload.
+    const devAgentId = parseDevConnectionId(connectionId);
+    if (devAgentId) {
+      if (!ctx.organization?.id) {
+        return c.json({ error: "Organization context is required" }, 403);
+      }
+      const userId = getUserId(ctx);
+      if (!userId) return c.json({ error: "Authentication required" }, 401);
+      const connection = await resolveDevConnection(
+        ctx,
+        devAgentId,
+        userId,
+        c.req.query("branch") ?? undefined,
+      );
+      if (!connection) {
+        return c.json({ error: "Dev server not running" }, 503);
+      }
+      const server = serverFromConnection(connection, ctx, false);
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        enableJsonResponse:
+          c.req.raw.headers.get("Accept")?.includes("application/json") ??
+          false,
+      });
+      await server.connect(transport);
+      return serveMcpRequest(
+        server,
+        transport,
+        c.req.raw,
+        `mcp:dev:${connectionId}`,
       );
     }
 

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -18,9 +18,11 @@ import { createServerFromClient, getDecopilotId } from "@decocms/mesh-sdk";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Hono } from "hono";
-import type { StudioContext } from "../../core/studio-context";
+import { getUserId, type StudioContext } from "../../core/studio-context";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/core/constants";
 import { createVirtualClientFrom } from "../../mcp-clients/virtual-mcp";
+import { resolveDevConnection } from "./dev-connection";
+import type { ConnectionEntity } from "../../tools/connection/schema";
 import type { Env } from "../hono-env";
 import { serveMcpRequest } from "../utils/serve-mcp";
 
@@ -139,6 +141,24 @@ export async function handleVirtualMcpRequest(
       };
     }
 
+    // Dev-capable agents (githubRepo — a cheap pre-filter) surface their
+    // running sandbox dev server's tools in the served toolset.
+    // resolveDevConnection enforces the real gate (dev/live pairing + the
+    // acting user's own sandbox) and returns null otherwise — degrades
+    // silently. Safe on this legacy route's looser org binding: it only
+    // resolves a sandbox the acting user themselves started (gated by
+    // SANDBOX_START's ctx.access.check), so a non-member reaches nothing.
+    const actingUserId = getUserId(ctx);
+    let devConnection: ConnectionEntity | null = null;
+    if (virtualMcp.id && virtualMcp.metadata?.githubRepo?.url && actingUserId) {
+      devConnection = await resolveDevConnection(
+        ctx,
+        virtualMcp.id,
+        actingUserId,
+        c.req.query("branch") ?? undefined,
+      ).catch(() => null);
+    }
+
     // Create client from entity (always passthrough)
     const client = await ctx.tracer.startActiveSpan(
       "studio.virtual_mcp.create_client",
@@ -152,7 +172,10 @@ export async function handleVirtualMcpRequest(
             false,
             // Serves the agent's MCP (incl. the desktop daemon); surface the
             // skill catalog in the instructions it reads.
-            { includeSkillsCatalog: true },
+            {
+              includeSkillsCatalog: true,
+              additionalConnections: devConnection ? [devConnection] : [],
+            },
           );
           span.setStatus({ code: SpanStatusCode.OK });
           return result;

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -141,16 +141,18 @@ export async function handleVirtualMcpRequest(
       };
     }
 
-    // Dev-capable agents (githubRepo — a cheap pre-filter) surface their
-    // running sandbox dev server's tools in the served toolset.
-    // resolveDevConnection enforces the real gate (dev/live pairing + the
-    // acting user's own sandbox) and returns null otherwise — degrades
-    // silently. Safe on this legacy route's looser org binding: it only
-    // resolves a sandbox the acting user themselves started (gated by
-    // SANDBOX_START's ctx.access.check), so a non-member reaches nothing.
+    // Surface the dev sandbox's tools when this agent is the dev side of a
+    // dev/live pair and the acting user has a sandbox up. resolveDevConnection
+    // is the single gate — reverse lookup (some agent's `metadata.devAgentId ===
+    // this` ) + the user's own running sandbox — and returns null otherwise,
+    // cheaply (no sandbox → early return before any list query). The dev agent
+    // has no local pairing field (the single `devAgentId` ref lives on its live
+    // partner), so we can't gate on this agent's own metadata. Safe on this
+    // legacy route's looser org binding: it only resolves a sandbox the acting
+    // user themselves started.
     const actingUserId = getUserId(ctx);
     let devConnection: ConnectionEntity | null = null;
-    if (virtualMcp.id && virtualMcp.metadata?.githubRepo?.url && actingUserId) {
+    if (virtualMcp.id && actingUserId) {
       devConnection = await resolveDevConnection(
         ctx,
         virtualMcp.id,

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -141,18 +141,16 @@ export async function handleVirtualMcpRequest(
       };
     }
 
-    // Surface the dev sandbox's tools when this agent is the dev side of a
-    // dev/live pair and the acting user has a sandbox up. resolveDevConnection
-    // is the single gate — reverse lookup (some agent's `metadata.devAgentId ===
-    // this` ) + the user's own running sandbox — and returns null otherwise,
-    // cheaply (no sandbox → early return before any list query). The dev agent
-    // has no local pairing field (the single `devAgentId` ref lives on its live
-    // partner), so we can't gate on this agent's own metadata. Safe on this
+    // Surface the dev sandbox's tools when this agent is a dev agent (develops a
+    // live counterpart) and the acting user has a sandbox up. The pairing ref
+    // lives on the dev agent itself (`metadata.liveAgentId`), so this gate is a
+    // free local field check — non-dev agents skip the resolver entirely.
+    // resolveDevConnection re-checks it + the user's own sandbox. Safe on this
     // legacy route's looser org binding: it only resolves a sandbox the acting
     // user themselves started.
     const actingUserId = getUserId(ctx);
     let devConnection: ConnectionEntity | null = null;
-    if (virtualMcp.id && actingUserId) {
+    if (virtualMcp.id && virtualMcp.metadata?.liveAgentId && actingUserId) {
       devConnection = await resolveDevConnection(
         ctx,
         virtualMcp.id,

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -22,6 +22,7 @@ import { getUserId, type StudioContext } from "../../core/studio-context";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/core/constants";
 import { createVirtualClientFrom } from "../../mcp-clients/virtual-mcp";
 import { resolveDevConnection } from "./dev-connection";
+import { readSandboxMap } from "../../tools/sandbox/sandbox-map";
 import type { ConnectionEntity } from "../../tools/connection/schema";
 import type { Env } from "../hono-env";
 import { serveMcpRequest } from "../utils/serve-mcp";
@@ -141,16 +142,19 @@ export async function handleVirtualMcpRequest(
       };
     }
 
-    // Surface the dev sandbox's tools when this agent is a dev agent (develops a
-    // live counterpart) and the acting user has a sandbox up. The pairing ref
-    // lives on the dev agent itself (`metadata.liveAgentId`), so this gate is a
-    // free local field check — non-dev agents skip the resolver entirely.
-    // resolveDevConnection re-checks it + the user's own sandbox. Safe on this
-    // legacy route's looser org binding: it only resolves a sandbox the acting
-    // user themselves started.
+    // Surface the dev sandbox's tools when the acting user has a running sandbox
+    // for this agent. The cheap local pre-filter is just "does the user have a
+    // sandbox entry?" (no repo/pairing flag) — agents without a sandbox skip the
+    // resolver entirely. resolveDevConnection then confirms the dev server
+    // actually speaks MCP (probe). Safe on this legacy route's looser org
+    // binding: it only resolves a sandbox the acting user themselves started.
     const actingUserId = getUserId(ctx);
     let devConnection: ConnectionEntity | null = null;
-    if (virtualMcp.id && virtualMcp.metadata?.liveAgentId && actingUserId) {
+    if (
+      virtualMcp.id &&
+      actingUserId &&
+      readSandboxMap(virtualMcp.metadata)[actingUserId]
+    ) {
       devConnection = await resolveDevConnection(
         ctx,
         virtualMcp.id,

--- a/apps/mesh/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/mesh/src/harnesses/decopilot/harness-deps.ts
@@ -29,6 +29,7 @@ import type { VirtualMCPEntity } from "@/tools/virtual/schema";
 import type { ConnectionEntity } from "@/tools/connection/schema";
 import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
 import { resolveDevConnection } from "@/api/routes/dev-connection";
+import { readSandboxMap } from "@/tools/sandbox/sandbox-map";
 import type { SideChannelWriter } from "@decocms/harness/side-channel-writer";
 import { assembleDecopilotTools } from "./tools";
 import { buildClusterMcpToolHooks } from "@/api/routes/decopilot/cluster-mcp-tool-hooks";
@@ -152,13 +153,17 @@ export function buildClusterEnvironmentTools(args: {
           // the transport type widens the field to a loose bag so the
           // daemon can ship without the cluster's storage types.
           const vm = streamInput.virtualMcp as VirtualMCPEntity;
-          // Surface the dev sandbox's tools when this agent is a dev agent
-          // (develops a live counterpart) and the user has a sandbox up. The
-          // pairing ref lives on the dev agent itself (`metadata.liveAgentId`),
-          // so this gate is a free local field check — non-dev agents skip the
-          // resolver entirely. resolveDevConnection re-checks it + the sandbox.
+          // Surface the dev sandbox's tools when the user has a running sandbox
+          // for this agent. Cheap local pre-filter ("does the user have a
+          // sandbox entry?"), no repo/pairing flag — agents without a sandbox
+          // skip the resolver. resolveDevConnection then confirms the dev server
+          // actually speaks MCP (probe).
           let devConnection: ConnectionEntity | null = null;
-          if (vm.id && vm.metadata?.liveAgentId && streamInput.user.id) {
+          if (
+            vm.id &&
+            streamInput.user.id &&
+            readSandboxMap(vm.metadata)[streamInput.user.id]
+          ) {
             devConnection = await resolveDevConnection(
               ctx,
               vm.id,

--- a/apps/mesh/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/mesh/src/harnesses/decopilot/harness-deps.ts
@@ -152,13 +152,15 @@ export function buildClusterEnvironmentTools(args: {
           // the transport type widens the field to a loose bag so the
           // daemon can ship without the cluster's storage types.
           const vm = streamInput.virtualMcp as VirtualMCPEntity;
-          // Dev-capable agents (githubRepo — a cheap pre-filter) expose their
-          // running sandbox dev server's tools in the toolset. The real gate
-          // (dev/live pairing + the user's own sandbox) lives in
-          // resolveDevConnection, which returns null otherwise — degrades
-          // silently to no injection.
+          // Surface the dev sandbox's tools when this agent is the dev side of a
+          // dev/live pair and the user has a sandbox up. resolveDevConnection is
+          // the single gate — reverse lookup (some agent's `metadata.devAgentId
+          // === this`) + the user's own running sandbox — null otherwise. The
+          // dev agent has no local pairing field (the single `devAgentId` ref
+          // lives on its live partner), so we can't gate on this agent's own
+          // metadata.
           let devConnection: ConnectionEntity | null = null;
-          if (vm.id && vm.metadata?.githubRepo?.url && streamInput.user.id) {
+          if (vm.id && streamInput.user.id) {
             devConnection = await resolveDevConnection(
               ctx,
               vm.id,

--- a/apps/mesh/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/mesh/src/harnesses/decopilot/harness-deps.ts
@@ -26,7 +26,9 @@ import type {
 import { monitorLlmCall } from "@/monitoring/emit-llm-call";
 import { recordLlmCallMetrics } from "@/monitoring/record-llm-call-metrics";
 import type { VirtualMCPEntity } from "@/tools/virtual/schema";
+import type { ConnectionEntity } from "@/tools/connection/schema";
 import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
+import { resolveDevConnection } from "@/api/routes/dev-connection";
 import type { SideChannelWriter } from "@decocms/harness/side-channel-writer";
 import { assembleDecopilotTools } from "./tools";
 import { buildClusterMcpToolHooks } from "@/api/routes/decopilot/cluster-mcp-tool-hooks";
@@ -145,17 +147,37 @@ export function buildClusterEnvironmentTools(args: {
         // client over the run's resolved Virtual MCP. superUser/listTimeout
         // come from the caller (assembleDecopilotTools). The daemon/desktop
         // factory supplies an HTTP-backed impl at the agent's mcp.url.
-        mcpForAgent: (_agentId, opts) =>
-          createVirtualClientFrom(
-            // Cluster-side: `virtualMcp` is the real `VirtualMCPEntity`;
-            // the transport type widens the field to a loose bag so the
-            // daemon can ship without the cluster's storage types.
-            streamInput.virtualMcp as VirtualMCPEntity,
+        mcpForAgent: async (_agentId, opts) => {
+          // Cluster-side: `virtualMcp` is the real `VirtualMCPEntity`;
+          // the transport type widens the field to a loose bag so the
+          // daemon can ship without the cluster's storage types.
+          const vm = streamInput.virtualMcp as VirtualMCPEntity;
+          // Dev-capable agents (githubRepo — a cheap pre-filter) expose their
+          // running sandbox dev server's tools in the toolset. The real gate
+          // (dev/live pairing + the user's own sandbox) lives in
+          // resolveDevConnection, which returns null otherwise — degrades
+          // silently to no injection.
+          let devConnection: ConnectionEntity | null = null;
+          if (vm.id && vm.metadata?.githubRepo?.url && streamInput.user.id) {
+            devConnection = await resolveDevConnection(
+              ctx,
+              vm.id,
+              streamInput.user.id,
+              streamInput.branch ?? undefined,
+            ).catch(() => null);
+          }
+          return createVirtualClientFrom(
+            vm,
             ctx,
             "passthrough",
             opts?.superUser ?? false,
-            { listTimeoutMs: opts?.listTimeoutMs, includeSkillsCatalog: true },
-          ),
+            {
+              listTimeoutMs: opts?.listTimeoutMs,
+              includeSkillsCatalog: true,
+              additionalConnections: devConnection ? [devConnection] : [],
+            },
+          );
+        },
         provider: modelRuntime.thinking.provider,
         imageProvider:
           modelRuntime.image?.provider ?? modelRuntime.thinking.provider,

--- a/apps/mesh/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/mesh/src/harnesses/decopilot/harness-deps.ts
@@ -152,15 +152,13 @@ export function buildClusterEnvironmentTools(args: {
           // the transport type widens the field to a loose bag so the
           // daemon can ship without the cluster's storage types.
           const vm = streamInput.virtualMcp as VirtualMCPEntity;
-          // Surface the dev sandbox's tools when this agent is the dev side of a
-          // dev/live pair and the user has a sandbox up. resolveDevConnection is
-          // the single gate — reverse lookup (some agent's `metadata.devAgentId
-          // === this`) + the user's own running sandbox — null otherwise. The
-          // dev agent has no local pairing field (the single `devAgentId` ref
-          // lives on its live partner), so we can't gate on this agent's own
-          // metadata.
+          // Surface the dev sandbox's tools when this agent is a dev agent
+          // (develops a live counterpart) and the user has a sandbox up. The
+          // pairing ref lives on the dev agent itself (`metadata.liveAgentId`),
+          // so this gate is a free local field check — non-dev agents skip the
+          // resolver entirely. resolveDevConnection re-checks it + the sandbox.
           let devConnection: ConnectionEntity | null = null;
-          if (vm.id && streamInput.user.id) {
+          if (vm.id && vm.metadata?.liveAgentId && streamInput.user.id) {
             devConnection = await resolveDevConnection(
               ctx,
               vm.id,

--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -96,6 +96,12 @@ export function createLazyClient(
     { capabilities: {}, jsonSchemaValidator: sharedJsonSchemaValidator },
   );
 
+  // Dev connections point at an ephemeral sandbox dev server that hot-reloads:
+  // never serve its tool lists or ui:// reads from cache, or edits won't show.
+  const isDevConnection =
+    (connection.metadata as { isDevConnection?: boolean } | null)
+      ?.isDevConnection === true;
+
   // Shared promise for the real client (single-flight)
   let realClientPromise: Promise<Client> | null = null;
 
@@ -136,9 +142,10 @@ export function createLazyClient(
     buildCachedResult: (cached: unknown[]) => T,
   ) => {
     return async (params?: unknown, options?: RequestOptions): Promise<T> => {
-      // Bypass cache for VIRTUAL connections or paginated requests
+      // Bypass cache for VIRTUAL / dev connections or paginated requests
       if (
         connection.connection_type === "VIRTUAL" ||
+        isDevConnection ||
         !cache ||
         shouldBypassCache(params, options)
       ) {
@@ -201,7 +208,8 @@ export function createLazyClient(
   // forwarded to the live fetch but excluded from the cache key.
   // null when MCP caching is disabled (settings-gated).
   const readCache = getMcpReadCache();
-  const cacheReads = connection.connection_type !== "VIRTUAL";
+  const cacheReads =
+    connection.connection_type !== "VIRTUAL" && !isDevConnection;
 
   placeholder.callTool = async (params, resultSchema, options) => {
     const toolName = (params as { name?: unknown })?.name;

--- a/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
@@ -70,7 +70,16 @@ export async function createVirtualClientFrom(
   ctx: StudioContext,
   _strategy: "passthrough",
   superUser = false,
-  options?: { listTimeoutMs?: number; includeSkillsCatalog?: boolean },
+  options?: {
+    listTimeoutMs?: number;
+    includeSkillsCatalog?: boolean;
+    /**
+     * Pre-resolved connections to prepend to the aggregated set — e.g. the
+     * ephemeral per-user dev-server connection (`dev_<id>`). Prepended so they
+     * shadow same-named virtual-mcp tools (the aggregator dedups first-wins).
+     */
+    additionalConnections?: ConnectionEntity[];
+  },
 ): Promise<PassthroughClient> {
   // Inclusion mode: use only the connections specified in virtual MCP
   const connectionIds = virtualMcp.connections.map((c) => c.connection_id);
@@ -113,6 +122,13 @@ export async function createVirtualClientFrom(
       conn.status === "active" &&
       !isSelfReferencingVirtual(conn, virtualMcp.id),
   );
+
+  // Prepend caller-provided connections (e.g. the ephemeral dev-server
+  // connection for a dev-capable agent). Prepended so their tools win the
+  // aggregator's first-occurrence-wins dedup over any same-named tool.
+  if (options?.additionalConnections?.length) {
+    loadedConnections.unshift(...options.additionalConnections);
+  }
 
   // Agent runtimes opt into the skill catalog: enumerate the org's skills now
   // (async — the sync getInstructions() can't) and stash the rendered block so

--- a/apps/mesh/src/tools/sandbox/select-vm-entry.ts
+++ b/apps/mesh/src/tools/sandbox/select-vm-entry.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure selector for a sandbox entry out of a parsed branch map (keyed by
+ * sandboxProviderKind). Prefers a hosted (non-user-desktop) entry, else the
+ * first one present.
+ *
+ * Lives in a server-safe module (no web imports) so both the web preview
+ * context and the server-side dev-connection resolver share one selection
+ * rule. Re-exported from the web sandbox-lifecycle context for existing
+ * importers.
+ */
+
+export interface BranchMapEntryLike {
+  sandboxHandle: string;
+  previewUrl: string | null;
+  sandboxProviderKind: string;
+  /** Epoch ms the sandbox was first created; used to pick the most recent. */
+  createdAt?: number;
+}
+
+export function selectVmEntry<T extends BranchMapEntryLike>(
+  branchMap: Record<string, T>,
+): T | null {
+  const entries = Object.values(branchMap);
+  const [first] = entries;
+  if (!first) return null;
+  return entries.find((e) => e.sandboxProviderKind !== "user-desktop") ?? first;
+}

--- a/apps/mesh/src/web/components/chat/tiptap/mention-at.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention-at.tsx
@@ -19,6 +19,7 @@ import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { BaseItem, insertMention, OnSelectProps, Suggestion } from "./mention";
 import { track } from "@/web/lib/posthog-client";
+import { getDevAgentIds } from "@/web/lib/agent-capabilities";
 
 interface AtMentionProps {
   editor: Editor;
@@ -57,6 +58,8 @@ export const AtMention = ({ editor, virtualMcpId }: AtMentionProps) => {
   const queryClient = useQueryClient();
   const { org } = useProjectContext();
   const agents = useVirtualMCPs();
+  // Dev agents are reached via the Develop/Live toggle, not @-mentioned.
+  const devAgentIds = getDevAgentIds(agents);
   const client = useMCPClient({
     connectionId: virtualMcpId,
     orgId: org.id,
@@ -140,6 +143,7 @@ export const AtMention = ({ editor, virtualMcpId }: AtMentionProps) => {
           (agent) =>
             agent.status === "active" &&
             (!agent.id || !isDecopilot(agent.id)) &&
+            !devAgentIds.has(agent.id) &&
             agent.id !== virtualMcpId &&
             (agent.title.toLowerCase().includes(lq) ||
               agent.description?.toLowerCase().includes(lq)),
@@ -188,6 +192,7 @@ export const AtMention = ({ editor, virtualMcpId }: AtMentionProps) => {
         (agent) =>
           agent.status === "active" &&
           (!agent.id || !isDecopilot(agent.id)) &&
+          !devAgentIds.has(agent.id) &&
           agent.id !== virtualMcpId,
       );
       if (query.trim()) {

--- a/apps/mesh/src/web/components/dev-agent/dev-agent-control.tsx
+++ b/apps/mesh/src/web/components/dev-agent/dev-agent-control.tsx
@@ -1,0 +1,71 @@
+/**
+ * Develop/Live toggle rendered in the agent shell header — shown ONLY when the
+ * agent is part of a dev/live pair. Clicking the inactive side opens a fresh
+ * task on the linked counterpart; the dev agent is hidden from the sidebar, so
+ * this toggle is the way to it. Setting up / linking a dev agent lives in the
+ * agent settings (see DevAgentSetup), not here.
+ */
+
+import { useNavigate } from "@tanstack/react-router";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useProjectContext, useVirtualMCPs } from "@decocms/mesh-sdk";
+import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
+import { useThreadActions } from "@/web/components/chat/store/hooks";
+import { findDevPartner } from "@/web/lib/agent-capabilities";
+
+export function DevAgentControl({
+  virtualMcp,
+}: {
+  virtualMcp: VirtualMCPEntity;
+}) {
+  const allAgents = useVirtualMCPs();
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+  const { create } = useThreadActions();
+
+  const partner = findDevPartner(virtualMcp, allAgents);
+  if (!partner) return null;
+
+  const isDev = partner.mode === "dev";
+
+  /** Open a fresh task on the paired counterpart. */
+  const goToAgent = async (agentId: string) => {
+    const taskId = crypto.randomUUID();
+    try {
+      await create({ id: taskId, virtual_mcp_id: agentId });
+    } catch {
+      // The action already toasted; navigate anyway so the route loader's
+      // ensure-fallback retries the thread create.
+    }
+    navigate({
+      to: "/$org/$taskId",
+      params: { org: org.slug, taskId },
+      search: { virtualmcpid: agentId },
+    });
+  };
+
+  const segment = (label: string, active: boolean) => (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={() => {
+        if (!active) void goToAgent(partner.targetId);
+      }}
+      className={cn(
+        "px-2.5 py-1 rounded-md transition-colors",
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="inline-flex items-center rounded-lg border border-border bg-muted p-0.5 text-xs font-medium">
+      {segment("Develop", isDev)}
+      {segment("Live", !isDev)}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/dev-agent/dev-agent-setup.tsx
+++ b/apps/mesh/src/web/components/dev-agent/dev-agent-setup.tsx
@@ -51,20 +51,35 @@ export function DevAgentSetup({
     return null;
   }
 
-  const linkedId = virtualMcp.metadata?.devAgentId ?? null;
-  const linked = linkedId
-    ? (allAgents ?? []).find((a) => a.id === linkedId)
-    : null;
+  // The pairing ref lives on the dev agent (`metadata.liveAgentId`) so the
+  // server gates dev-connection injection with a local field check (no
+  // per-request reverse lookup). This view sits on the live agent, so its dev
+  // counterpart is found by reverse scan, and link/unlink writes the DEV row.
+  const linked =
+    (allAgents ?? []).find((a) => a.metadata?.liveAgentId === virtualMcp.id) ??
+    null;
+  const linkedId = linked?.id ?? null;
 
-  const setDevAgent = (devAgentId: string | null) =>
+  const stampDevAgent = (
+    devAgent: VirtualMCPEntity,
+    liveAgentId: string | null,
+  ) =>
     actions.update
       .mutateAsync({
-        id: virtualMcp.id,
-        data: { metadata: { ...virtualMcp.metadata, devAgentId } },
+        id: devAgent.id,
+        data: { metadata: { ...devAgent.metadata, liveAgentId } },
       })
       .catch(() => {
         // mutateAsync already surfaced the error via toast.
       });
+
+  const linkDevAgent = (devAgentId: string) => {
+    const devAgent = (allAgents ?? []).find((a) => a.id === devAgentId);
+    if (devAgent) void stampDevAgent(devAgent, virtualMcp.id);
+  };
+  const unlinkDevAgent = () => {
+    if (linked) void stampDevAgent(linked, null);
+  };
 
   const linkableAgents = (allAgents ?? []).filter(
     (a) =>
@@ -93,7 +108,7 @@ export function DevAgentSetup({
                 variant="outline"
                 size="sm"
                 className="shrink-0"
-                onClick={() => void setDevAgent(null)}
+                onClick={unlinkDevAgent}
               >
                 Unlink
               </Button>
@@ -116,7 +131,7 @@ export function DevAgentSetup({
                   Import from GitHub
                 </Button>
                 {linkableAgents.length > 0 ? (
-                  <Select onValueChange={(id) => void setDevAgent(id)}>
+                  <Select onValueChange={linkDevAgent}>
                     <SelectTrigger size="sm" className="w-56">
                       <SelectValue placeholder="Or link an existing dev agent…" />
                     </SelectTrigger>
@@ -140,7 +155,7 @@ export function DevAgentSetup({
         title="Import a dev agent from GitHub"
         onImportComplete={({ virtualMcpId }) => {
           setGithubOpen(false);
-          void setDevAgent(virtualMcpId);
+          linkDevAgent(virtualMcpId);
         }}
       />
     </div>

--- a/apps/mesh/src/web/components/dev-agent/dev-agent-setup.tsx
+++ b/apps/mesh/src/web/components/dev-agent/dev-agent-setup.tsx
@@ -1,0 +1,148 @@
+/**
+ * "Development agent" settings section. Lets a (live) agent link a
+ * GitHub-backed dev agent whose sandbox dev server powers the Develop/Live
+ * toggle in the header. Lives in the agent settings view — the header only
+ * shows the toggle, and only once a pair exists.
+ *
+ * Hidden for agents that are themselves a dev agent (have a `githubRepo`) or
+ * Decopilot — those don't link a separate dev counterpart.
+ */
+
+import { useState } from "react";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Card, CardContent } from "@deco/ui/components/card.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import {
+  isDecopilot,
+  useVirtualMCPActions,
+  useVirtualMCPs,
+} from "@decocms/mesh-sdk";
+import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
+import { GitHubIcon } from "@/web/components/icons/github-icon";
+import { GitHubRepoPicker } from "@/web/components/github-repo-picker.tsx";
+import {
+  agentHasClonableSource,
+  getDevAgentIds,
+} from "@/web/lib/agent-capabilities";
+
+export function DevAgentSetup({
+  virtualMcp,
+}: {
+  virtualMcp: VirtualMCPEntity;
+}) {
+  const allAgents = useVirtualMCPs();
+  const actions = useVirtualMCPActions();
+  const [githubOpen, setGithubOpen] = useState(false);
+
+  const devAgentIds = getDevAgentIds(allAgents);
+  // Only "live"-style agents set up a dev counterpart: not Decopilot, not
+  // itself a dev agent (githubRepo), and not already the dev side of a pair.
+  if (
+    isDecopilot(virtualMcp.id) ||
+    agentHasClonableSource(virtualMcp.metadata) ||
+    devAgentIds.has(virtualMcp.id)
+  ) {
+    return null;
+  }
+
+  const linkedId = virtualMcp.metadata?.devAgentId ?? null;
+  const linked = linkedId
+    ? (allAgents ?? []).find((a) => a.id === linkedId)
+    : null;
+
+  const setDevAgent = (devAgentId: string | null) =>
+    actions.update
+      .mutateAsync({
+        id: virtualMcp.id,
+        data: { metadata: { ...virtualMcp.metadata, devAgentId } },
+      })
+      .catch(() => {
+        // mutateAsync already surfaced the error via toast.
+      });
+
+  const linkableAgents = (allAgents ?? []).filter(
+    (a) =>
+      a.id !== virtualMcp.id &&
+      agentHasClonableSource(a.metadata) &&
+      !devAgentIds.has(a.id),
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h2 className="text-sm font-medium text-foreground">Development agent</h2>
+      <Card className="p-6 gap-4">
+        <CardContent className="p-0 space-y-4">
+          {linkedId ? (
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <span className="text-sm text-foreground truncate">
+                  {linked ? linked.title : linkedId}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  Linked dev agent — its sandbox dev server powers the
+                  Develop/Live toggle in the header.
+                </span>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={() => void setDevAgent(null)}
+              >
+                Unlink
+              </Button>
+            </div>
+          ) : (
+            <>
+              <span className="text-xs text-muted-foreground">
+                Link a GitHub-backed dev agent. Its sandbox dev server powers a
+                Develop/Live toggle so you can develop and test this agent's MCP
+                app.
+              </span>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={() => setGithubOpen(true)}
+                >
+                  <GitHubIcon className="size-4" />
+                  Import from GitHub
+                </Button>
+                {linkableAgents.length > 0 ? (
+                  <Select onValueChange={(id) => void setDevAgent(id)}>
+                    <SelectTrigger size="sm" className="w-56">
+                      <SelectValue placeholder="Or link an existing dev agent…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {linkableAgents.map((a) => (
+                        <SelectItem key={a.id} value={a.id}>
+                          {a.title}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : null}
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+      <GitHubRepoPicker
+        open={githubOpen}
+        onOpenChange={setGithubOpen}
+        title="Import a dev agent from GitHub"
+        onImportComplete={({ virtualMcpId }) => {
+          setGithubOpen(false);
+          void setDevAgent(virtualMcpId);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/dev-agent/dev-agent-setup.tsx
+++ b/apps/mesh/src/web/components/dev-agent/dev-agent-setup.tsx
@@ -60,25 +60,34 @@ export function DevAgentSetup({
     null;
   const linkedId = linked?.id ?? null;
 
-  const stampDevAgent = (
-    devAgent: VirtualMCPEntity,
-    liveAgentId: string | null,
-  ) =>
+  // Stamp `liveAgentId` on the dev agent's row by id. VIRTUAL_MCP_UPDATE
+  // shallow-merges metadata server-side, so we send only the changed key — no
+  // need to spread the existing metadata, which crucially lets us link a
+  // just-imported dev agent that isn't in the (async-refetched) `allAgents` list
+  // yet (the GitHub-import path).
+  const setLiveAgentId = (devAgentId: string, liveAgentId: string | null) =>
     actions.update
       .mutateAsync({
-        id: devAgent.id,
-        data: { metadata: { ...devAgent.metadata, liveAgentId } },
+        id: devAgentId,
+        // VIRTUAL_MCP_UPDATE shallow-merges metadata server-side, so send only
+        // the changed key — the merge preserves everything else, and crucially
+        // this needs no read of the dev agent's current metadata (which a
+        // just-imported agent isn't in `allAgents` for yet). The mutation type
+        // models the full metadata object, so assert through the partial.
+        data: {
+          metadata: { liveAgentId } as unknown as NonNullable<
+            VirtualMCPEntity["metadata"]
+          >,
+        },
       })
       .catch(() => {
         // mutateAsync already surfaced the error via toast.
       });
 
-  const linkDevAgent = (devAgentId: string) => {
-    const devAgent = (allAgents ?? []).find((a) => a.id === devAgentId);
-    if (devAgent) void stampDevAgent(devAgent, virtualMcp.id);
-  };
+  const linkDevAgent = (devAgentId: string) =>
+    void setLiveAgentId(devAgentId, virtualMcp.id);
   const unlinkDevAgent = () => {
-    if (linked) void stampDevAgent(linked, null);
+    if (linkedId) void setLiveAgentId(linkedId, null);
   };
 
   const linkableAgents = (allAgents ?? []).filter(

--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -29,6 +29,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { getDevAgentIds } from "@/web/lib/agent-capabilities";
 import {
   getHomeTiles,
   isDecopilot,
@@ -232,8 +233,11 @@ function DrawerBody({ search }: { search: string }) {
     .filter((a): a is VirtualMCPEntity => !!a)
     .filter(matches);
 
+  // Dev agents are reached via the Develop/Live toggle, not added to home.
+  const devAgentIds = getDevAgentIds(agents);
   const available = agents
     .filter((a) => a.id && !isDecopilot(a.id))
+    .filter((a) => !devAgentIds.has(a.id))
     .filter((a) => !home.isOnHome(a.id))
     .filter(matches)
     .sort((a, b) => (a.title ?? "").localeCompare(b.title ?? ""));

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -14,25 +14,20 @@
 import type { PreviewState } from "@/web/components/sandbox/preview/preview-state";
 import type { DrawerStatus } from "@/web/components/sandbox/preview/drawer/status-pill";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
+import {
+  selectVmEntry,
+  type BranchMapEntryLike,
+} from "@/tools/sandbox/select-vm-entry";
 
 // ---------------------------------------------------------------------------
 // Pure helpers (unit-testable)
 // ---------------------------------------------------------------------------
 
-export interface BranchMapEntryLike {
-  sandboxHandle: string;
-  previewUrl: string | null;
-  sandboxProviderKind: string;
-}
-
-export function selectVmEntry<T extends BranchMapEntryLike>(
-  branchMap: Record<string, T>,
-): T | null {
-  const entries = Object.values(branchMap);
-  const [first] = entries;
-  if (!first) return null;
-  return entries.find((e) => e.sandboxProviderKind !== "user-desktop") ?? first;
-}
+// `selectVmEntry` + `BranchMapEntryLike` moved to a server-safe module
+// (@/tools/sandbox/select-vm-entry) so the dev-connection resolver reuses the
+// exact same selection rule. Re-exported here for existing importers and the
+// co-located unit tests.
+export { selectVmEntry, type BranchMapEntryLike };
 
 export interface ShouldAutoStartArgs {
   hasActiveGithubRepo: boolean;

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -56,6 +56,7 @@ import { authClient } from "@/web/lib/auth-client";
 import { KEYS } from "@/web/lib/query-keys";
 import { usePublicConfig } from "@/web/hooks/use-public-config";
 import { getServerPinnedIds } from "@/web/hooks/use-navigate-to-agent";
+import { getDevAgentIds } from "@/web/lib/agent-capabilities";
 import {
   useSidebarAgentGroupsEmpty,
   useBumpSidebarOrderRevision,
@@ -182,9 +183,13 @@ function PinAgentPopoverContent({
 
   const navigateToNewTask = useNavigateToNewTaskWithBranchCarry(org.slug);
 
+  // Dev agents are reached via the Develop/Live toggle on their live
+  // counterpart, not as standalone browse entries.
+  const devAgentIds = getDevAgentIds(allAgents);
   const lowerSearch = search.toLowerCase();
   const userAgents = agents
     .filter((s) => !isDecopilot(s.id))
+    .filter((s) => !devAgentIds.has(s.id))
     .filter((s) => !search || s.title.toLowerCase().includes(lowerSearch));
 
   const handleSelect = (agent: VirtualMCPEntity) => {

--- a/apps/mesh/src/web/components/sidebar/task-groups/group-threads.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/group-threads.ts
@@ -97,3 +97,54 @@ export function groupThreadsByVirtualMcp(
   }
   return result;
 }
+
+/**
+ * Fold each dev agent's thread group into its live counterpart so the sidebar
+ * shows a single entry per live/dev pair. Dev threads keep their own
+ * `virtual_mcp_id` (the renderer splits them into a "Develop" sub-section).
+ * `devToLive` maps a dev agent id → its live agent id.
+ */
+export function foldDevGroupsIntoLive(
+  groups: TaskGroupData[],
+  devToLive: Map<string, string>,
+): TaskGroupData[] {
+  if (devToLive.size === 0) return groups;
+  const out: TaskGroupData[] = [];
+  const byLiveId = new Map<string, TaskGroupData>();
+  for (const g of groups) {
+    const liveId = devToLive.get(g.virtualMcpId);
+    if (liveId) {
+      // dev group → fold into its live group
+      const live = byLiveId.get(liveId);
+      if (live) {
+        live.threads = [...live.threads, ...g.threads];
+        if (g.latestUpdatedAt > live.latestUpdatedAt) {
+          live.latestUpdatedAt = g.latestUpdatedAt;
+        }
+      } else {
+        // live group not seen yet → placeholder at the dev group's position;
+        // real live threads (if any) prepend when its own group is reached.
+        const placeholder: TaskGroupData = {
+          virtualMcpId: liveId,
+          threads: [...g.threads],
+          latestUpdatedAt: g.latestUpdatedAt,
+        };
+        byLiveId.set(liveId, placeholder);
+        out.push(placeholder);
+      }
+      continue;
+    }
+    const existing = byLiveId.get(g.virtualMcpId);
+    if (existing) {
+      existing.threads = [...g.threads, ...existing.threads];
+      if (g.latestUpdatedAt > existing.latestUpdatedAt) {
+        existing.latestUpdatedAt = g.latestUpdatedAt;
+      }
+    } else {
+      const clone: TaskGroupData = { ...g, threads: [...g.threads] };
+      byLiveId.set(g.virtualMcpId, clone);
+      out.push(clone);
+    }
+  }
+  return out;
+}

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-group.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, Plus } from "@untitledui/icons";
+import { ChevronDown, ChevronRight, Code02, Plus } from "@untitledui/icons";
 import { useState } from "react";
 import type { DraggableAttributes } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
@@ -37,6 +37,12 @@ export interface TaskGroupProps {
   onToggleOrgPin?: (virtualMcpId: string, pinned: boolean) => void;
   /** Precomputed visible count for this group (avoids O(T) scan per hook). */
   groupVisibleCount?: number;
+  /** When this live group is paired with a dev agent, the dev agent's id. Its
+   *  threads (carried in `threads`, keyed by this id) render in a "Develop"
+   *  sub-section instead of a standalone sidebar group. */
+  devPartnerId?: string | null;
+  /** Precomputed visible count for the dev partner's threads. */
+  devGroupVisibleCount?: number;
   filters: SidebarFilters;
   /** When set, the group header is draggable for reordering. */
   sortable?: {
@@ -60,11 +66,26 @@ export function TaskGroup({
   onToggleOrgPin,
   filters,
   groupVisibleCount,
+  devPartnerId = null,
+  devGroupVisibleCount,
   sortable,
 }: TaskGroupProps) {
   const [expanded, setExpanded] = useGroupExpanded(virtualMcpId, false);
   const isToolCallRuns = virtualMcpId === TOOL_CALL_RUNS_GROUP_KEY;
   const isDragging = sortable?.isDragging ?? false;
+
+  // Threads carry both the live agent's and (folded-in) dev agent's threads,
+  // keyed by virtual_mcp_id. Split so the dev ones render in a "Develop"
+  // sub-section with their own pagination (keyed by the dev agent id).
+  const devThreads = devPartnerId
+    ? threads.filter((t) => t.virtual_mcp_id === devPartnerId)
+    : [];
+  const liveThreads = devPartnerId
+    ? threads.filter((t) => t.virtual_mcp_id !== devPartnerId)
+    : threads;
+  const showDevSection =
+    !!devPartnerId &&
+    (devThreads.length > 0 || (devGroupVisibleCount ?? 0) > 0);
 
   function handleToggleExpanded() {
     const next = !expanded;
@@ -162,16 +183,36 @@ export function TaskGroup({
               />
             ))
           ) : (
-            <AgentExpandedBody
-              virtualMcpId={virtualMcpId}
-              threads={threads}
-              activeTaskId={activeTaskId}
-              onSelectTask={onSelectTask}
-              onArchiveTask={onArchiveTask}
-              onNewTaskInGroup={onNewTaskInGroup}
-              filters={filters}
-              groupVisibleCount={groupVisibleCount}
-            />
+            <>
+              <AgentExpandedBody
+                virtualMcpId={virtualMcpId}
+                threads={liveThreads}
+                activeTaskId={activeTaskId}
+                onSelectTask={onSelectTask}
+                onArchiveTask={onArchiveTask}
+                onNewTaskInGroup={onNewTaskInGroup}
+                filters={filters}
+                groupVisibleCount={groupVisibleCount}
+              />
+              {showDevSection && devPartnerId && (
+                <div className="flex flex-col gap-0.5 mt-1.5">
+                  <div className="flex items-center gap-1.5 px-2 pb-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
+                    <Code02 size={11} />
+                    Develop
+                  </div>
+                  <AgentExpandedBody
+                    virtualMcpId={devPartnerId}
+                    threads={devThreads}
+                    activeTaskId={activeTaskId}
+                    onSelectTask={onSelectTask}
+                    onArchiveTask={onArchiveTask}
+                    onNewTaskInGroup={onNewTaskInGroup}
+                    filters={filters}
+                    groupVisibleCount={devGroupVisibleCount}
+                  />
+                </div>
+              )}
+            </>
           )}
         </div>
       )}

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -42,10 +42,12 @@ import {
 } from "../sidebar-agent-groups-context";
 import { SortableCollapsedTaskGroups } from "./sortable-collapsed-task-groups";
 import {
+  foldDevGroupsIntoLive,
   groupThreadsByVirtualMcp,
   groupThreadsByStatus,
   TOOL_CALL_RUNS_GROUP_KEY,
 } from "./group-threads";
+import { getLiveDevAgentMaps } from "@/web/lib/agent-capabilities";
 import { removeGroupFromOrder, syncOrdersOnOrgPinToggle } from "./stable-order";
 import { SortableTaskGroups } from "./sortable-task-groups";
 import { StatusGroup } from "./task-group";
@@ -84,6 +86,7 @@ export function TaskGroupsList({
   const { org } = useProjectContext();
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
   const agents = useVirtualMCPs();
+  const { liveToDev, devToLive } = getLiveDevAgentMaps(agents);
   const serverOrgPinnedIds = getServerPinnedIds(agents);
   const canManageOrgPin = useCanPinAgentsForOrg();
   const virtualMcpActions = useVirtualMCPActions();
@@ -162,9 +165,16 @@ export function TaskGroupsList({
     filters,
   );
 
+  // Dev agents are hidden from agent PICKERS (browse popover, @-mention, add
+  // to home). Their thread groups are folded into the live counterpart's group
+  // (rendered as a "Develop" sub-section) so dev sessions stay navigable under
+  // one entry instead of a confusing standalone group.
   const groups = useSidebarGroupOrder(
     orderScope,
-    groupThreadsByVirtualMcp(sortedThreads, decopilotId),
+    foldDevGroupsIntoLive(
+      groupThreadsByVirtualMcp(sortedThreads, decopilotId),
+      devToLive,
+    ),
     decopilotId,
     orgPinnedIds,
     orderRevision,
@@ -267,9 +277,14 @@ export function TaskGroupsList({
 
   const buildAgentGroupRenderProps = (group: (typeof groups)[number]) => {
     const filtered = typeFiltered(memberFiltered(group.threads));
+    const devPartnerId = liveToDev.get(group.virtualMcpId) ?? null;
     return {
       virtualMcpId: group.virtualMcpId,
       threads: filtered,
+      devPartnerId,
+      devGroupVisibleCount: devPartnerId
+        ? (agentThreadCounts.get(devPartnerId) ?? 0)
+        : 0,
       activeTaskId,
       filters,
       groupVisibleCount: agentThreadCounts.get(group.virtualMcpId) ?? 0,

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -15,15 +15,18 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Globe01, Monitor01 } from "@untitledui/icons";
 import { createElement, useSyncExternalStore } from "react";
 import {
+  getDevConnectionId,
   useConnections,
   useProjectContext,
   useVirtualMCP,
+  useVirtualMCPs,
 } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import {
   agentHasClonableSource,
   agentHasConnectedGithub,
+  findDevPartner,
 } from "@/web/lib/agent-capabilities";
 import { useChatTask } from "@/web/components/chat/index";
 import { useThreadManager } from "@/web/components/chat/store/hooks";
@@ -131,6 +134,7 @@ export function useMainPanelTabs(ctx: {
     main?: string;
   };
   const entity = useVirtualMCP(ctx.virtualMcpId);
+  const allAgents = useVirtualMCPs();
   const metadata = useTaskMetadata(ctx.taskId);
   const { org } = useProjectContext();
   const { currentBranch } = useChatTask();
@@ -170,7 +174,50 @@ export function useMainPanelTabs(ctx: {
 
   const entityLayout = entityUI?.layout ?? null;
   const layoutTabs = (entityLayout?.tabs ?? []) as AgentTabDef[];
-  const pinnedViews = entityUI?.pinnedViews ?? [];
+
+  // A dev agent (the dev side of a dev/live pair) inherits its LIVE partner's
+  // pinned views + default view, rewritten to render against its own ephemeral
+  // dev-server connection (`dev_<id>`). So in Develop mode you see the same
+  // views as prod, hitting the running dev server instead of the deployed app.
+  // Falls back to the agent's own pinned views otherwise.
+  const devPartner = findDevPartner(entity ?? null, allAgents);
+  const livePartner =
+    devPartner?.mode === "dev"
+      ? ((allAgents ?? []).find((a) => a.id === devPartner.targetId) ?? null)
+      : null;
+  const liveUI =
+    (
+      livePartner?.metadata as {
+        ui?: {
+          pinnedViews?: Array<{
+            connectionId: string;
+            toolName: string;
+            label: string;
+            icon?: string | null;
+          }> | null;
+          layout?: {
+            defaultMainView?: {
+              type: string;
+              id?: string;
+              toolName?: string;
+            } | null;
+          };
+        };
+      } | null
+    )?.ui ?? null;
+  const devConnId = entity?.id ? getDevConnectionId(entity.id) : null;
+  const livePinned = liveUI?.pinnedViews ?? [];
+  const inheritsLiveViews =
+    !!livePartner && !!devConnId && livePinned.length > 0;
+
+  const pinnedViews =
+    inheritsLiveViews && devConnId
+      ? livePinned.map((v) => ({ ...v, connectionId: devConnId }))
+      : (entityUI?.pinnedViews ?? []);
+  const effectiveDefaultMainView =
+    inheritsLiveViews && devConnId && liveUI?.layout?.defaultMainView
+      ? { ...liveUI.layout.defaultMainView, id: devConnId }
+      : (entityLayout?.defaultMainView ?? null);
   const expandedTools: ThreadExpandedTool[] = metadata?.expanded_tools ?? [];
   const hasActiveGithubRepo = agentHasConnectedGithub(entity);
   const hasClonableSource = agentHasClonableSource(entity?.metadata);
@@ -200,23 +247,25 @@ export function useMainPanelTabs(ctx: {
   const { activeTab: rawActiveTab, mainOpen: rawMainOpen } =
     resolveActiveTabAndOpen({
       mainParam: search.main,
-      metadata: entityLayout
-        ? {
-            defaultMainView: entityLayout.defaultMainView ?? null,
-            tabs: layoutTabs.map((t) => ({ id: t.id })),
-          }
-        : null,
+      metadata:
+        effectiveDefaultMainView || entityLayout
+          ? {
+              defaultMainView: effectiveDefaultMainView,
+              tabs: layoutTabs.map((t) => ({ id: t.id })),
+            }
+          : null,
     });
 
   const gitTabVisible =
     hasActiveGithubRepo &&
     (hasOpenPr || (prQuery.isPending && rawActiveTab === "git"));
-  const layoutForDefault = entityLayout
-    ? {
-        defaultMainView: entityLayout.defaultMainView ?? null,
-        tabs: layoutTabs.map((t) => ({ id: t.id })),
-      }
-    : null;
+  const layoutForDefault =
+    effectiveDefaultMainView || entityLayout
+      ? {
+          defaultMainView: effectiveDefaultMainView,
+          tabs: layoutTabs.map((t) => ({ id: t.id })),
+        }
+      : null;
   const activeTab =
     rawActiveTab === "git" && !gitTabVisible && !prQuery.isPending
       ? resolveDefaultTabId(layoutForDefault)

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -17,10 +17,14 @@ import { createElement, useSyncExternalStore } from "react";
 import {
   getDevConnectionId,
   useConnections,
+  useMCPClientOptional,
+  useMCPToolsListQuery,
   useProjectContext,
   useVirtualMCP,
   useVirtualMCPs,
 } from "@decocms/mesh-sdk";
+import { getUIResourceUri } from "@/mcp-apps/types";
+import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
 import { KEYS } from "@/web/lib/query-keys";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import {
@@ -175,11 +179,10 @@ export function useMainPanelTabs(ctx: {
   const entityLayout = entityUI?.layout ?? null;
   const layoutTabs = (entityLayout?.tabs ?? []) as AgentTabDef[];
 
-  // A dev agent (the dev side of a dev/live pair) inherits its LIVE partner's
-  // pinned views + default view, rewritten to render against its own ephemeral
-  // dev-server connection (`dev_<id>`). So in Develop mode you see the same
-  // views as prod, hitting the running dev server instead of the deployed app.
-  // Falls back to the agent's own pinned views otherwise.
+  // Fallback view source for a dev agent: inherit the LIVE partner's pinned
+  // views (rewritten to the dev connection) when paired. Superseded below by
+  // auto-detection from the dev server's own MCP app when its sandbox is up —
+  // so an unpaired, freshly-imported MCP app still surfaces its views.
   const devPartner = findDevPartner(entity ?? null, allAgents);
   const livePartner =
     devPartner?.mode === "dev"
@@ -210,11 +213,11 @@ export function useMainPanelTabs(ctx: {
   const inheritsLiveViews =
     !!livePartner && !!devConnId && livePinned.length > 0;
 
-  const pinnedViews =
+  const basePinnedViews =
     inheritsLiveViews && devConnId
       ? livePinned.map((v) => ({ ...v, connectionId: devConnId }))
       : (entityUI?.pinnedViews ?? []);
-  const effectiveDefaultMainView =
+  const baseDefaultMainView =
     inheritsLiveViews && devConnId && liveUI?.layout?.defaultMainView
       ? { ...liveUI.layout.defaultMainView, id: devConnId }
       : (entityLayout?.defaultMainView ?? null);
@@ -230,6 +233,38 @@ export function useMainPanelTabs(ctx: {
   // SandboxEventsProvider (desktop tabs bar lives inside VmEventsBridge).
   const vmEvents = useSandboxEvents();
   const devServerReady = vmEvents.lifecycle.phase === "running";
+
+  // Auto-detect the dev MCP app's views straight from its sandbox dev server:
+  // every tool that declares a `ui://` resource is a view, rendered against the
+  // ephemeral dev connection (`dev_<id>`). No pairing / curated pinnedViews
+  // needed — the dev server describes itself. Only queried once the dev server
+  // is up (its `/api/mcp` serves tools); supersedes the inherited-live fallback.
+  const devClient = useMCPClientOptional({
+    connectionId: devConnId ?? undefined,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const { data: devToolsResult } = useMCPToolsListQuery({
+    client: devClient as NonNullable<typeof devClient>,
+    enabled: !!devClient && devServerReady,
+  });
+  const devViews =
+    devConnId && devServerReady
+      ? (devToolsResult?.tools ?? [])
+          .filter((t) => !!getUIResourceUri(t._meta))
+          .map((t) => ({
+            connectionId: devConnId,
+            toolName: t.name,
+            label: toTitleCase(t.name),
+            icon: null as string | null,
+          }))
+      : [];
+  const firstDevView = devViews[0];
+  const pinnedViews = firstDevView ? devViews : basePinnedViews;
+  const effectiveDefaultMainView =
+    firstDevView && devConnId
+      ? { type: "ext-apps", id: devConnId, toolName: firstDevView.toolName }
+      : baseDefaultMainView;
   const decofileFetchParams =
     hasClonableSource && entity?.id && currentBranch
       ? { orgSlug: org.slug, virtualMcpId: entity.id, branch: currentBranch }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -21,7 +21,6 @@ import {
   useMCPToolsListQuery,
   useProjectContext,
   useVirtualMCP,
-  useVirtualMCPs,
 } from "@decocms/mesh-sdk";
 import { getUIResourceUri } from "@/mcp-apps/types";
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
@@ -30,7 +29,6 @@ import { useStudioTools } from "@/web/lib/studio-tools";
 import {
   agentHasClonableSource,
   agentHasConnectedGithub,
-  findDevPartner,
 } from "@/web/lib/agent-capabilities";
 import { useChatTask } from "@/web/components/chat/index";
 import { useThreadManager } from "@/web/components/chat/store/hooks";
@@ -138,7 +136,6 @@ export function useMainPanelTabs(ctx: {
     main?: string;
   };
   const entity = useVirtualMCP(ctx.virtualMcpId);
-  const allAgents = useVirtualMCPs();
   const metadata = useTaskMetadata(ctx.taskId);
   const { org } = useProjectContext();
   const { currentBranch } = useChatTask();
@@ -179,48 +176,10 @@ export function useMainPanelTabs(ctx: {
   const entityLayout = entityUI?.layout ?? null;
   const layoutTabs = (entityLayout?.tabs ?? []) as AgentTabDef[];
 
-  // Fallback view source for a dev agent: inherit the LIVE partner's pinned
-  // views (rewritten to the dev connection) when paired. Superseded below by
-  // auto-detection from the dev server's own MCP app when its sandbox is up —
-  // so an unpaired, freshly-imported MCP app still surfaces its views.
-  const devPartner = findDevPartner(entity ?? null, allAgents);
-  const livePartner =
-    devPartner?.mode === "dev"
-      ? ((allAgents ?? []).find((a) => a.id === devPartner.targetId) ?? null)
-      : null;
-  const liveUI =
-    (
-      livePartner?.metadata as {
-        ui?: {
-          pinnedViews?: Array<{
-            connectionId: string;
-            toolName: string;
-            label: string;
-            icon?: string | null;
-          }> | null;
-          layout?: {
-            defaultMainView?: {
-              type: string;
-              id?: string;
-              toolName?: string;
-            } | null;
-          };
-        };
-      } | null
-    )?.ui ?? null;
+  // The ephemeral dev connection (`dev_<id>`) the agent's sandbox dev server is
+  // served through. Its views are auto-detected from the dev server's own MCP
+  // app below — no pairing / live-partner config involved.
   const devConnId = entity?.id ? getDevConnectionId(entity.id) : null;
-  const livePinned = liveUI?.pinnedViews ?? [];
-  const inheritsLiveViews =
-    !!livePartner && !!devConnId && livePinned.length > 0;
-
-  const basePinnedViews =
-    inheritsLiveViews && devConnId
-      ? livePinned.map((v) => ({ ...v, connectionId: devConnId }))
-      : (entityUI?.pinnedViews ?? []);
-  const baseDefaultMainView =
-    inheritsLiveViews && devConnId && liveUI?.layout?.defaultMainView
-      ? { ...liveUI.layout.defaultMainView, id: devConnId }
-      : (entityLayout?.defaultMainView ?? null);
   const expandedTools: ThreadExpandedTool[] = metadata?.expanded_tools ?? [];
   const hasActiveGithubRepo = agentHasConnectedGithub(entity);
   const hasClonableSource = agentHasClonableSource(entity?.metadata);
@@ -238,7 +197,8 @@ export function useMainPanelTabs(ctx: {
   // every tool that declares a `ui://` resource is a view, rendered against the
   // ephemeral dev connection (`dev_<id>`). No pairing / curated pinnedViews
   // needed — the dev server describes itself. Only queried once the dev server
-  // is up (its `/api/mcp` serves tools); supersedes the inherited-live fallback.
+  // is up (its `/api/mcp` serves tools); when present, these override the live
+  // agent's own pinned views below.
   const devClient = useMCPClientOptional({
     connectionId: devConnId ?? undefined,
     orgId: org.id,
@@ -260,11 +220,11 @@ export function useMainPanelTabs(ctx: {
           }))
       : [];
   const firstDevView = devViews[0];
-  const pinnedViews = firstDevView ? devViews : basePinnedViews;
+  const pinnedViews = firstDevView ? devViews : (entityUI?.pinnedViews ?? []);
   const effectiveDefaultMainView =
     firstDevView && devConnId
       ? { type: "ext-apps", id: devConnId, toolName: firstDevView.toolName }
-      : baseDefaultMainView;
+      : (entityLayout?.defaultMainView ?? null);
   const decofileFetchParams =
     hasClonableSource && entity?.id && currentBranch
       ? { orgSlug: org.slug, virtualMcpId: entity.id, branch: currentBranch }

--- a/apps/mesh/src/web/lib/agent-capabilities.ts
+++ b/apps/mesh/src/web/lib/agent-capabilities.ts
@@ -46,6 +46,66 @@ export function agentShowsGithubHeaderActions(
 }
 
 /**
+ * The set of agent ids that are linked as some agent's dev agent
+ * (`metadata.devAgentId`). These are hidden from the sidebar — they're
+ * reached via the Develop/Live toggle on their live counterpart, not as
+ * standalone entries.
+ */
+export function getDevAgentIds(
+  agents: VirtualMCPEntity[] | null | undefined,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const a of agents ?? []) {
+    const devId = a.metadata?.devAgentId;
+    if (typeof devId === "string" && devId) ids.add(devId);
+  }
+  return ids;
+}
+
+/**
+ * Live↔dev agent id maps derived from `metadata.devAgentId`:
+ * - `liveToDev`: live agent id → its dev agent id (the Develop toggle target).
+ * - `devToLive`: dev agent id → its live agent id (parent).
+ * Used to fold a dev agent's sidebar thread group into its live counterpart.
+ */
+export function getLiveDevAgentMaps(
+  agents: VirtualMCPEntity[] | null | undefined,
+): { liveToDev: Map<string, string>; devToLive: Map<string, string> } {
+  const liveToDev = new Map<string, string>();
+  const devToLive = new Map<string, string>();
+  for (const a of agents ?? []) {
+    const devId = a.metadata?.devAgentId;
+    if (typeof devId === "string" && devId) {
+      liveToDev.set(a.id, devId);
+      devToLive.set(devId, a.id);
+    }
+  }
+  return { liveToDev, devToLive };
+}
+
+/**
+ * Resolve the Develop/Live partner of an agent from the loaded agent list.
+ * - `mode: "live"` when this agent links a dev agent (`metadata.devAgentId`).
+ * - `mode: "dev"` when this agent IS some agent's dev agent (reverse lookup).
+ * - `null` when the agent is not part of a dev/live pair.
+ * `targetId` is the OTHER agent in the pair — where the toggle navigates.
+ */
+export function findDevPartner(
+  agent: VirtualMCPEntity | null | undefined,
+  agents: VirtualMCPEntity[] | null | undefined,
+): { mode: "live" | "dev"; targetId: string } | null {
+  if (!agent) return null;
+  const devId = agent.metadata?.devAgentId;
+  if (typeof devId === "string" && devId) {
+    return { mode: "live", targetId: devId };
+  }
+  const parent = (agents ?? []).find(
+    (a) => a.metadata?.devAgentId === agent.id,
+  );
+  return parent ? { mode: "dev", targetId: parent.id } : null;
+}
+
+/**
  * True when the user's link daemon is online AND exposes at least one
  * CLI harness (Claude Code or Codex) that a clonable agent's chat can
  * route through. Lets the chat skip the no-provider empty state when

--- a/apps/mesh/src/web/lib/agent-capabilities.ts
+++ b/apps/mesh/src/web/lib/agent-capabilities.ts
@@ -46,26 +46,29 @@ export function agentShowsGithubHeaderActions(
 }
 
 /**
- * The set of agent ids that are linked as some agent's dev agent
- * (`metadata.devAgentId`). These are hidden from the sidebar — they're
- * reached via the Develop/Live toggle on their live counterpart, not as
- * standalone entries.
+ * The set of agent ids that are dev agents — they develop a live counterpart
+ * (`metadata.liveAgentId` is set). Hidden from the sidebar/pickers; reached via
+ * the Develop/Live toggle on their live counterpart, not as standalone entries.
+ *
+ * The pairing ref lives on the dev agent (not the live one) so "is this a dev
+ * agent?" is a local field — cheap both here and on the server hot path, where
+ * it gates ephemeral dev-connection injection without a reverse lookup.
  */
 export function getDevAgentIds(
   agents: VirtualMCPEntity[] | null | undefined,
 ): Set<string> {
   const ids = new Set<string>();
   for (const a of agents ?? []) {
-    const devId = a.metadata?.devAgentId;
-    if (typeof devId === "string" && devId) ids.add(devId);
+    const liveId = a.metadata?.liveAgentId;
+    if (typeof liveId === "string" && liveId) ids.add(a.id);
   }
   return ids;
 }
 
 /**
- * Live↔dev agent id maps derived from `metadata.devAgentId`:
+ * Live↔dev agent id maps derived from each dev agent's `metadata.liveAgentId`:
+ * - `devToLive`: dev agent id → its live agent id.
  * - `liveToDev`: live agent id → its dev agent id (the Develop toggle target).
- * - `devToLive`: dev agent id → its live agent id (parent).
  * Used to fold a dev agent's sidebar thread group into its live counterpart.
  */
 export function getLiveDevAgentMaps(
@@ -74,10 +77,10 @@ export function getLiveDevAgentMaps(
   const liveToDev = new Map<string, string>();
   const devToLive = new Map<string, string>();
   for (const a of agents ?? []) {
-    const devId = a.metadata?.devAgentId;
-    if (typeof devId === "string" && devId) {
-      liveToDev.set(a.id, devId);
-      devToLive.set(devId, a.id);
+    const liveId = a.metadata?.liveAgentId;
+    if (typeof liveId === "string" && liveId) {
+      devToLive.set(a.id, liveId);
+      liveToDev.set(liveId, a.id);
     }
   }
   return { liveToDev, devToLive };
@@ -85,8 +88,10 @@ export function getLiveDevAgentMaps(
 
 /**
  * Resolve the Develop/Live partner of an agent from the loaded agent list.
- * - `mode: "live"` when this agent links a dev agent (`metadata.devAgentId`).
- * - `mode: "dev"` when this agent IS some agent's dev agent (reverse lookup).
+ * - `mode: "dev"` when this agent IS a dev agent (`metadata.liveAgentId` set) —
+ *   the partner is its live counterpart.
+ * - `mode: "live"` when some dev agent develops this one (reverse lookup over
+ *   the loaded list) — the partner is that dev agent.
  * - `null` when the agent is not part of a dev/live pair.
  * `targetId` is the OTHER agent in the pair — where the toggle navigates.
  */
@@ -95,14 +100,14 @@ export function findDevPartner(
   agents: VirtualMCPEntity[] | null | undefined,
 ): { mode: "live" | "dev"; targetId: string } | null {
   if (!agent) return null;
-  const devId = agent.metadata?.devAgentId;
-  if (typeof devId === "string" && devId) {
-    return { mode: "live", targetId: devId };
+  const liveId = agent.metadata?.liveAgentId;
+  if (typeof liveId === "string" && liveId) {
+    return { mode: "dev", targetId: liveId };
   }
-  const parent = (agents ?? []).find(
-    (a) => a.metadata?.devAgentId === agent.id,
+  const devAgent = (agents ?? []).find(
+    (a) => a.metadata?.liveAgentId === agent.id,
   );
-  return parent ? { mode: "dev", targetId: parent.id } : null;
+  return devAgent ? { mode: "live", targetId: devAgent.id } : null;
 }
 
 /**

--- a/apps/mesh/src/web/views/virtual-mcp/header-info.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/header-info.tsx
@@ -1,6 +1,7 @@
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
 import { agentShowsGithubHeaderActions } from "@/web/lib/agent-capabilities";
 import { HeaderActions } from "../../components/thread/github/header-actions.tsx";
+import { DevAgentControl } from "../../components/dev-agent/dev-agent-control.tsx";
 import { Toolbar } from "../../layouts/agent-shell-layout/toolbar.tsx";
 
 export function VirtualMcpHeaderInfo({
@@ -11,10 +12,15 @@ export function VirtualMcpHeaderInfo({
   /** When true, skip the toolbar portal (mobile header has no Toolbar shell). */
   inline?: boolean;
 }) {
-  if (!agentShowsGithubHeaderActions(virtualMcp)) return null;
+  const content = (
+    <div className="flex items-center gap-2">
+      <DevAgentControl virtualMcp={virtualMcp} />
+      {agentShowsGithubHeaderActions(virtualMcp) ? (
+        <HeaderActions virtualMcpId={virtualMcp.id} />
+      ) : null}
+    </div>
+  );
+  if (inline) return content;
 
-  const actions = <HeaderActions virtualMcpId={virtualMcp.id} />;
-  if (inline) return actions;
-
-  return <Toolbar.Right>{actions}</Toolbar.Right>;
+  return <Toolbar.Right>{content}</Toolbar.Right>;
 }

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -104,6 +104,7 @@ import {
   agentHasClonableSource,
   agentHasConnectedGithub,
 } from "@/web/lib/agent-capabilities";
+import { DevAgentSetup } from "@/web/components/dev-agent/dev-agent-setup.tsx";
 import { FIXED_SYSTEM_TABS } from "@/web/layouts/main-panel-tabs/tab-id";
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
 import { EnvVarsField } from "@/web/components/sandbox/runtime-card/env-vars-field";
@@ -1885,6 +1886,9 @@ Define step-by-step how the agent should handle requests.
               form={form}
               flushAndSave={flushAndSave}
             />
+
+            {/* Development agent section (link a dev counterpart) */}
+            <DevAgentSetup virtualMcp={virtualMcp} />
 
             {/* Sandbox section */}
             <div className="flex flex-col gap-3">

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -236,6 +236,9 @@ export {
   // Decopilot utilities
   isDecopilot,
   getDecopilotId,
+  // Dev connection (ephemeral sandbox dev-server) utilities
+  getDevConnectionId,
+  parseDevConnectionId,
   // Site Diagnostics utilities
   isSiteDiagnostics,
   getSiteDiagnosticsId,

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -257,6 +257,18 @@ const decopilotPrefix = createWellKnownAgentPrefix("decopilot_");
 export const isDecopilot = decopilotPrefix.is;
 export const getDecopilotId = decopilotPrefix.get;
 
+// ---- Dev connection (ephemeral sandbox dev-server) ----
+// Synthetic, never-persisted connection id pointing at an agent's running
+// sandbox dev server: `dev_<virtualMcpId>`. Resolved per-acting-user at request
+// time (see apps/mesh/src/api/routes/dev-connection.ts). Mirrors the `_self`
+// synthetic-id bypass in the proxy. `dev_` doesn't collide with other
+// well-known ids (`*_self`, `*_dev-assets` uses a hyphen).
+const devConnectionPrefix = createWellKnownAgentPrefix("dev_");
+/** Mint the synthetic dev-connection id for an agent (virtual MCP) id. */
+export const getDevConnectionId = devConnectionPrefix.get;
+/** Returns the agent id when `id` is a `dev_<agentId>` connection id; else null. */
+export const parseDevConnectionId = devConnectionPrefix.is;
+
 export function getWellKnownDecopilotVirtualMCP(
   organizationId: string,
 ): VirtualMCPEntity {

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -583,6 +583,13 @@ export const VirtualMCPEntitySchema = z.object({
         .describe(
           "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
         ),
+      devAgentId: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "ID of the dev agent linked to this (live) agent. Set only on live agents; powers the Develop/Live toggle. The linked dev agent is hidden from the sidebar (reachable via the toggle).",
+        ),
       ui: VirtualMcpUISchema.nullable()
         .optional()
         .describe("UI customization settings"),
@@ -653,6 +660,13 @@ export const VirtualMCPCreateDataSchema = z.object({
         .describe(
           "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
         ),
+      devAgentId: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "ID of the dev agent linked to this (live) agent. Set only on live agents; powers the Develop/Live toggle. The linked dev agent is hidden from the sidebar (reachable via the toggle).",
+        ),
       ui: VirtualMcpUISchema.nullable()
         .optional()
         .describe("UI customization settings"),
@@ -718,6 +732,13 @@ export const VirtualMCPUpdateDataSchema = z.object({
         .optional()
         .describe(
           "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
+        ),
+      devAgentId: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "ID of the dev agent linked to this (live) agent. Set only on live agents; powers the Develop/Live toggle. The linked dev agent is hidden from the sidebar (reachable via the toggle).",
         ),
       ui: VirtualMcpUISchema.nullable()
         .optional()

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -583,12 +583,12 @@ export const VirtualMCPEntitySchema = z.object({
         .describe(
           "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
         ),
-      devAgentId: z
+      liveAgentId: z
         .string()
         .nullable()
         .optional()
         .describe(
-          "ID of the dev agent linked to this (live) agent. Set only on live agents; powers the Develop/Live toggle. The linked dev agent is hidden from the sidebar (reachable via the toggle).",
+          "ID of the live agent this (dev) agent develops. Set only on dev agents; powers the Develop/Live toggle. A dev agent is hidden from the sidebar (reached via the toggle on its live counterpart).",
         ),
       ui: VirtualMcpUISchema.nullable()
         .optional()
@@ -660,12 +660,12 @@ export const VirtualMCPCreateDataSchema = z.object({
         .describe(
           "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
         ),
-      devAgentId: z
+      liveAgentId: z
         .string()
         .nullable()
         .optional()
         .describe(
-          "ID of the dev agent linked to this (live) agent. Set only on live agents; powers the Develop/Live toggle. The linked dev agent is hidden from the sidebar (reachable via the toggle).",
+          "ID of the live agent this (dev) agent develops. Set only on dev agents; powers the Develop/Live toggle. A dev agent is hidden from the sidebar (reached via the toggle on its live counterpart).",
         ),
       ui: VirtualMcpUISchema.nullable()
         .optional()
@@ -733,12 +733,12 @@ export const VirtualMCPUpdateDataSchema = z.object({
         .describe(
           "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
         ),
-      devAgentId: z
+      liveAgentId: z
         .string()
         .nullable()
         .optional()
         .describe(
-          "ID of the dev agent linked to this (live) agent. Set only on live agents; powers the Develop/Live toggle. The linked dev agent is hidden from the sidebar (reachable via the toggle).",
+          "ID of the live agent this (dev) agent develops. Set only on dev agents; powers the Develop/Live toggle. A dev agent is hidden from the sidebar (reached via the toggle on its live counterpart).",
         ),
       ui: VirtualMcpUISchema.nullable()
         .optional()


### PR DESCRIPTION
## What is this contribution about?
Adds a **Develop/Live toggle** on an MCP-app agent's header that navigates between a "live" agent (deployed connection) and a linked "dev" agent whose sandbox runs the dev server. The dev side resolves a synthetic, per-user `dev_<agentId>` connection from the running sandbox's preview URL (authless by default, mirroring the `_self` synthetic-id bypass), so the agent's pinned views render against the local dev server instead of prod. A single `metadata.devAgentId` ref links the pair both ways; dev agents are hidden from pickers and their threads fold into the live group's "Develop" sub-section in the sidebar.

## Screenshots/Demonstration
_UI change — Develop/Live toggle in the agent header + a "Develop" thread sub-section in the sidebar. (Screencast to be added.)_

## How to Test
1. On a GitHub-imported MCP-app agent, open settings → **Setup development agent** → import/link a dev agent.
2. Open the live agent → a **Develop / Live** toggle appears in the header.
3. Toggle to **Develop**, start the sandbox dev server, and confirm the inherited pinned views render against the dev server (`dev_<id>`); **Live** renders against the deployed connection.
4. Confirm dev-mode threads show under the live agent's **Develop** sub-section in the sidebar, and dev agents are absent from browse/@-mention/home pickers.

## Migration Notes
None — additive. Adds an optional `metadata.devAgentId` field on virtual MCPs (no DB migration). The `dev_<id>` connection is ephemeral/synthetic and never persisted.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Develop/Live toggle and a per-user, ephemeral `dev_<agentId>` connection so MCP-app agents can run tools and views against a local sandbox dev server instead of production. Dev views are now auto-detected from the running dev server (probe-gated) and no longer inherit from the live agent.

- **New Features**
  - Toggle in the agent header switches between the deployed agent and a linked dev agent; the pair is stored on the DEV agent at `metadata.liveAgentId` and set up in settings (import from GitHub or link existing).
  - Synthetic `dev_<agentId>` resolves per-acting-user from the sandbox preview URL at `/api/mcp` (authless by default; appends `MCP_AUTH_TOKEN` when present), supports `?branch=`, and is gated by a memoized MCP `initialize` probe.
  - Proxy and virtual MCP routes resolve `dev_` IDs, bypass the handshake/circuit and MCP read caching, and inject the dev connection into the agent toolset for hot-reloads.
  - Dev views: when the dev server is up, tabs auto-populate from tools that declare a `ui://` resource against `dev_<agentId>` and override pinned views and the default main view; no live-inherit fallback.
  - Dev agents are hidden from browse, @-mention, and home pickers; their threads fold into the live agent’s group under a “Develop” sub-section. `@decocms/mesh-sdk` exports `getDevConnectionId` and `parseDevConnectionId`; the sandbox-entry selector is shared server/web.

- **Bug Fixes**
  - Linking a just-imported dev agent now stamps `metadata.liveAgentId` by id immediately, so the Develop/Live toggle appears without waiting for a refetch.
  - Clarified and corrected `resolveDevConnection`: a missing dev token yields an authless connection; `null` only for missing/cross-org agent, no running sandbox/preview URL, or non-MCP dev server.

<sup>Written for commit ff29149bf5e95f76a7ff79d0a312eeec77c803d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

