### PR TITLE
feat(sandbox): Open in VSCode/Cursor buttons

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-repo-dir.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-repo-dir.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+
+export function useSandboxRepoDir(args: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  enabled?: boolean;
+}) {
+  const { orgSlug, virtualMcpId, branch, enabled = true } = args;
+  const query = useQuery({
+    queryKey: KEYS.sandboxRepoDir(orgSlug, virtualMcpId, branch),
+    queryFn: async () => {
+      const url = `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/config`;
+      const res = await fetch(url);
+      if (!res.ok) return null;
+      const data = (await res.json()) as { repoDir?: string | null };
+      return data.repoDir ?? null;
+    },
+    enabled,
+    staleTime: Infinity,
+  });
+  return query.data ?? null;
+}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -77,6 +77,11 @@ import { derivePhaseProgress } from "./derive-phase-progress";
 import { track } from "@/web/lib/posthog-client";
 import { useSandboxRepoDir } from "../hooks/use-sandbox-repo-dir";
 
+const VSCODE_ICON_URL =
+  "https://decoims.com/decocms/01b321bd-4613-4b2c-9348-35058444d210/Visual_Studio_Code_1.35_icon.svg.png";
+const CURSOR_ICON_URL =
+  "https://decoims.com/decocms/7583d3b5-81d0-4afb-becf-6a59bbb3a68e/cursor-logo-icon-freelogovectors.net_.png";
+
 const SectionsEditor = lazy(() =>
   import("@/web/components/sections-editor/sections-editor").then((m) => ({
     default: m.SectionsEditor,
@@ -866,7 +871,7 @@ export function PreviewContent() {
                           }
                         >
                           <img
-                            src="https://decoims.com/decocms/01b321bd-4613-4b2c-9348-35058444d210/Visual_Studio_Code_1.35_icon.svg.png"
+                            src={VSCODE_ICON_URL}
                             alt="VSCode"
                             width={14}
                             height={14}
@@ -881,7 +886,7 @@ export function PreviewContent() {
                           }
                         >
                           <img
-                            src="https://decoims.com/decocms/7583d3b5-81d0-4afb-becf-6a59bbb3a68e/cursor-logo-icon-freelogovectors.net_.png"
+                            src={CURSOR_ICON_URL}
                             alt="Cursor"
                             width={14}
                             height={14}
@@ -910,7 +915,7 @@ export function PreviewContent() {
                     }
                   >
                     <img
-                      src="https://decoims.com/decocms/01b321bd-4613-4b2c-9348-35058444d210/Visual_Studio_Code_1.35_icon.svg.png"
+                      src={VSCODE_ICON_URL}
                       alt="VSCode"
                       width={14}
                       height={14}
@@ -930,7 +935,7 @@ export function PreviewContent() {
                     }
                   >
                     <img
-                      src="https://decoims.com/decocms/7583d3b5-81d0-4afb-becf-6a59bbb3a68e/cursor-logo-icon-freelogovectors.net_.png"
+                      src={CURSOR_ICON_URL}
                       alt="Cursor"
                       width={14}
                       height={14}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -75,6 +75,7 @@ import {
 import { SandboxStateCard } from "./state-card";
 import { derivePhaseProgress } from "./derive-phase-progress";
 import { track } from "@/web/lib/posthog-client";
+import { useSandboxRepoDir } from "../hooks/use-sandbox-repo-dir";
 
 const SectionsEditor = lazy(() =>
   import("@/web/components/sections-editor/sections-editor").then((m) => ({
@@ -177,6 +178,14 @@ export function PreviewContent() {
   const previewUrl = lifecycle.previewUrl;
   const lifecyclePhase = vmEvents.lifecycle.phase;
   const devServerReady = lifecyclePhase === "running";
+
+  const isDesktopSandbox = vmEntry?.sandboxProviderKind === "user-desktop";
+  const repoDir = useSandboxRepoDir({
+    orgSlug: org.slug,
+    virtualMcpId: virtualMcpId ?? "",
+    branch: branch ?? "",
+    enabled: isDesktopSandbox && devServerReady && !!virtualMcpId && !!branch,
+  });
 
   // Decofile pages for the URL bar dropdown — fetch only after dev server is up.
   const decofileParams =
@@ -846,10 +855,91 @@ export function PreviewContent() {
                         </DropdownMenuItem>
                       </>
                     )}
+                    {repoDir && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={() =>
+                            window.open(
+                              `vscode://file${repoDir}?windowId=_blank`,
+                            )
+                          }
+                        >
+                          <img
+                            src="https://decoims.com/decocms/01b321bd-4613-4b2c-9348-35058444d210/Visual_Studio_Code_1.35_icon.svg.png"
+                            alt="VSCode"
+                            width={14}
+                            height={14}
+                          />
+                          Open in VSCode
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() =>
+                            window.open(
+                              `cursor://file${repoDir}?windowId=_blank`,
+                            )
+                          }
+                        >
+                          <img
+                            src="https://decoims.com/decocms/7583d3b5-81d0-4afb-becf-6a59bbb3a68e/cursor-logo-icon-freelogovectors.net_.png"
+                            alt="Cursor"
+                            width={14}
+                            height={14}
+                          />
+                          Open in Cursor
+                        </DropdownMenuItem>
+                      </>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
             </>
+          )}
+
+          {/* IDE buttons — visible only in code mode, right-aligned */}
+          {viewMode === "code" && repoDir && (
+            <div className="ml-auto flex shrink-0 items-center gap-0.5">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Open in VSCode"
+                    onClick={() =>
+                      window.open(`vscode://file${repoDir}?windowId=_blank`)
+                    }
+                  >
+                    <img
+                      src="https://decoims.com/decocms/01b321bd-4613-4b2c-9348-35058444d210/Visual_Studio_Code_1.35_icon.svg.png"
+                      alt="VSCode"
+                      width={14}
+                      height={14}
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Open in VSCode</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Open in Cursor"
+                    onClick={() =>
+                      window.open(`cursor://file${repoDir}?windowId=_blank`)
+                    }
+                  >
+                    <img
+                      src="https://decoims.com/decocms/7583d3b5-81d0-4afb-becf-6a59bbb3a68e/cursor-logo-icon-freelogovectors.net_.png"
+                      alt="Cursor"
+                      width={14}
+                      height={14}
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Open in Cursor</TooltipContent>
+              </Tooltip>
+            </div>
           )}
         </div>
       )}

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -392,6 +392,8 @@ export const KEYS = {
   liveMeta: (previewUrl: string) => ["live-meta", previewUrl] as const,
   sandboxInvoke: (sandboxKey: string, loaderKey: string) =>
     ["sandbox-invoke", sandboxKey, loaderKey] as const,
+  sandboxRepoDir: (orgSlug: string, virtualMcpId: string, branch: string) =>
+    ["sandbox-repo-dir", orgSlug, virtualMcpId, branch] as const,
 
   // Link daemon status (user-scoped; the cluster derives the userSub
   // from the bearer session, so we don't include it in the key).

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -489,6 +489,7 @@ const configReadH = makeConfigReadHandler({
     ready: isReady(),
   }),
   getTasks: () => phaseManager.recent(20),
+  repoDir: bootConfig.repoDir,
 });
 // Closure mutates `bootConfig.daemonToken` in place so the
 // `requireToken(req, bootConfig.daemonToken)` calls below — which read the

--- a/packages/sandbox/daemon/routes/config.test.ts
+++ b/packages/sandbox/daemon/routes/config.test.ts
@@ -178,4 +178,24 @@ describe("makeConfigReadHandler", () => {
       SEED.git?.repository?.cloneUrl,
     );
   });
+
+  it("returns repoDir when provided", async () => {
+    const h = makeConfigReadHandler({
+      daemonBootId: BOOT_ID,
+      store,
+      repoDir: "/home/user/project",
+    });
+    const res = await h();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { repoDir: string | null };
+    expect(body.repoDir).toBe("/home/user/project");
+  });
+
+  it("returns null repoDir when not provided", async () => {
+    const h = makeConfigReadHandler({ daemonBootId: BOOT_ID, store });
+    const res = await h();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { repoDir: string | null };
+    expect(body.repoDir).toBeNull();
+  });
 });

--- a/packages/sandbox/daemon/routes/config.ts
+++ b/packages/sandbox/daemon/routes/config.ts
@@ -30,6 +30,8 @@ export interface ConfigDeps {
   getState?: () => DaemonState;
   /** Recent setup phases for LLM context. */
   getTasks?: () => Phase[];
+  /** Local repo directory path (exposed so the frontend can offer "Open in IDE"). */
+  repoDir?: string;
 }
 
 /** Wire-only — never persisted to TenantConfig. Stripped before `store.apply`. */
@@ -60,6 +62,7 @@ export function makeConfigReadHandler(deps: ConfigDeps) {
       orchestrator: state?.orchestrator,
       ready: state?.ready ?? false,
       tasks: deps.getTasks?.(),
+      repoDir: deps.repoDir ?? null,
     });
   };
 }


### PR DESCRIPTION
## Summary
- Expose `repoDir` from the sandbox daemon's config endpoint so the frontend knows the local repo path
- Add "Open in VSCode" and "Open in Cursor" buttons for desktop sandboxes:
  - **Code editor mode**: always-visible icon buttons in the tab bar (right-aligned)
  - **Other preview modes**: items inside the three-dot dropdown menu
- Uses `vscode://file` and `cursor://file` URI schemes with `?windowId=_blank` to open in a new editor window

## Test plan
- [ ] Start a desktop sandbox, verify the VSCode/Cursor buttons appear in code-editor mode tab bar
- [ ] Switch to preview/visual mode, verify the buttons appear in the 3-dot menu instead
- [ ] Click each button and confirm it opens the repo in a new IDE window
- [ ] Verify buttons do not appear for non-desktop (cloud) sandboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “Open in VSCode” and “Open in Cursor” buttons for desktop sandboxes by exposing the local repo path from the daemon and wiring IDE deep links in the UI. Also deduplicates icon URLs and adds tests for the new config field.

- **New Features**
  - Expose `repoDir` from the daemon’s `/config` endpoint.
  - New `useSandboxRepoDir` hook and `KEYS.sandboxRepoDir` to fetch once (desktop only, when the dev server is ready).
  - UI: code mode shows right-aligned IDE buttons; other modes show them in the three-dot menu; hidden for cloud. Uses `vscode://file${repoDir}?windowId=_blank` and `cursor://file${repoDir}?windowId=_blank`.

- **Refactors**
  - Extract VSCode/Cursor icon URLs into constants.
  - Add unit tests for `repoDir` in config (returns provided path or `null`).

<sup>Written for commit 35d451ed1a9da0fd69b6602a07950f96dbea1017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

