### PR TITLE
fix(sandbox): make proxy timeout cover full resolve+fetch

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -246,66 +246,106 @@ async function proxyDaemon(
     headers.set("content-type", "application/json");
   }
 
+  const signal = opts?.signal;
   const requestInit = {
     method,
     headers,
     body,
-    ...(opts?.signal ? { signal: opts.signal } : {}),
+    ...(signal ? { signal } : {}),
   };
 
-  let upstream: Response;
-  try {
-    upstream = await runner.proxyDaemonRequest(
+  /**
+   * Resolve the daemon, optionally retry on 404→adopt, and return the
+   * upstream response. Extracted so that the caller can race the whole
+   * operation against the abort signal — the signal on `requestInit`
+   * only covers the final `fetch`, not the record resolution /
+   * resurrection that precedes it and can take tens of seconds when a
+   * sandbox was evicted.
+   */
+  const resolveAndFetch = async (): Promise<Response> => {
+    let upstream = await runner.proxyDaemonRequest(
       claimName,
       daemonPath,
       requestInit,
     );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return c.json({ error: `Daemon unreachable: ${message}` }, 502);
-  }
 
-  if (opts?.map404to410 && upstream.status === 404) {
-    try {
-      await upstream.body?.cancel();
-    } catch {
-      /* ignore */
-    }
-    const adopted = await runner.adoptLiveClaim?.(
-      { userId, projectRef },
-      claimName,
-    );
-    if (adopted) {
+    if (opts?.map404to410 && upstream.status === 404) {
       try {
+        await upstream.body?.cancel();
+      } catch {
+        /* ignore */
+      }
+      const adopted = await runner.adoptLiveClaim?.(
+        { userId, projectRef },
+        claimName,
+      );
+      if (adopted) {
         upstream = await runner.proxyDaemonRequest(
           claimName,
           daemonPath,
           requestInit,
         );
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return c.json({ error: `Daemon unreachable: ${message}` }, 502);
+      }
+      if (upstream.status === 404) {
+        try {
+          await upstream.body?.cancel();
+        } catch {
+          /* ignore */
+        }
+        return new Response(
+          JSON.stringify({
+            error:
+              "Sandbox handle is gone. The sandbox needs to be re-provisioned.",
+          }),
+          {
+            status: 410,
+            headers: {
+              "content-type": "application/json",
+              ...SANDBOX_PROXY_CACHE_HEADERS,
+            },
+          },
+        );
       }
     }
-    if (upstream.status === 404) {
-      return c.json(
-        {
-          error:
-            "Sandbox handle is gone. The sandbox needs to be re-provisioned.",
-        },
-        410,
-        SANDBOX_PROXY_CACHE_HEADERS,
-      );
-    }
-  }
 
-  const text = await upstream.text();
-  const contentType =
-    upstream.headers.get("content-type") ?? "application/json";
-  return new Response(text, {
-    status: upstream.status,
-    headers: { "content-type": contentType, ...SANDBOX_PROXY_CACHE_HEADERS },
-  });
+    const text = await upstream.text();
+    const contentType =
+      upstream.headers.get("content-type") ?? "application/json";
+    return new Response(text, {
+      status: upstream.status,
+      headers: { "content-type": contentType, ...SANDBOX_PROXY_CACHE_HEADERS },
+    });
+  };
+
+  try {
+    // When a signal is provided, race the entire resolve+fetch operation
+    // against it. Without this, record resolution (getRecord → rehydrate,
+    // resurrectByHandle → ensure) can take tens of seconds on an evicted
+    // sandbox, and the signal only aborts the final HTTP fetch — not the
+    // K8s/port-forward work that precedes it.
+    if (signal) {
+      // Attach a no-op catch so that if the signal wins the race and
+      // resolveAndFetch later rejects (its inner fetch aborts via the
+      // same signal), the rejection is swallowed instead of surfacing
+      // as an unhandled promise rejection.
+      const work = resolveAndFetch();
+      work.catch(() => {});
+      const upstream = await Promise.race([
+        work,
+        new Promise<never>((_, reject) => {
+          if (signal.aborted) return reject(signal.reason);
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+      ]);
+      return upstream;
+    }
+    return await resolveAndFetch();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json({ error: `Daemon unreachable: ${message}` }, 502);
+  }
 }
 
 async function fetchDaemonJson<T>(

--- a/packages/sandbox/daemon/git/git-sync.ts
+++ b/packages/sandbox/daemon/git/git-sync.ts
@@ -6,7 +6,7 @@ export interface GitSyncOpts {
   env?: NodeJS.ProcessEnv;
   /** When true (default), drops to deco:1000/1000. Set false for system-level git config as root. */
   asUser?: boolean;
-  /** Kill the git process after this many ms. Default: 60 000 (60 s). */
+  /** Kill the git process after this many ms. Default: 10 000 (10 s). */
   timeoutMs?: number;
 }
 
@@ -15,7 +15,7 @@ export interface GitError extends Error {
   status: number;
 }
 
-const DEFAULT_GIT_TIMEOUT_MS = 60_000;
+const DEFAULT_GIT_TIMEOUT_MS = 10_000;
 
 export function gitSync(args: string[], opts: GitSyncOpts): string {
   const asUser = opts.asUser !== false;


### PR DESCRIPTION
## Summary
- **Race the abort signal against the entire `proxyDaemon` operation** — previously the `AbortSignal.timeout(2000)` on git/status (and `10s` on file ops) only covered the final `fetch` to the daemon, not the record resolution (`getRecord` → `rehydrate` → port-forward, or `resurrectByHandle` → `ensure`) that precedes it. When a sandbox was evicted and needed re-provisioning, the resolve phase could take ~60s while the timeout sat idle.
- **Reduce `DEFAULT_GIT_TIMEOUT_MS` from 60s to 10s** — read-only git subprocesses (`status`, `diff`, `rev-parse`) use `spawnSync` which blocks the daemon event loop; 60s is excessive and masked stuck git processes.

## Test plan
- [ ] Verify git/status returns 502 within ~2s when the sandbox is evicted (previously ~60s)
- [ ] Verify file ops (read/write/mkdir) return 502 within ~10s on a partitioned link
- [ ] Verify git publish/rebase (no signal) still work without timeout pressure
- [ ] Verify normal git/status calls on a healthy sandbox still return fast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make sandbox proxy timeouts cover the entire resolve + fetch path so failures fail fast, and reduce default git subprocess timeout to 10s to avoid long daemon blocks.

- **Bug Fixes**
  - Race the whole `proxyDaemon` resolve+fetch against the provided `AbortSignal` (not just the final fetch). On abort/failure, return 502 quickly; `git/status` now times out in ~2s and file ops in ~10s under network/sandbox issues.
  - Reduce `DEFAULT_GIT_TIMEOUT_MS` from 60s to 10s for read-only git commands to surface stuck processes sooner.

<sup>Written for commit 86e69667eac94c2c0eae0b376b53d9983a58fe2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

