### PR TITLE
feat(sandbox): invalidate liveMeta/decofile via SSE on file changes

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -29,7 +29,9 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useProjectContext } from "@decocms/mesh-sdk";
+import { KEYS } from "@/web/lib/query-keys";
 
 import type {
   ClaimFailureReason,
@@ -123,6 +125,7 @@ const DAEMON_EVENT_TYPES: readonly DaemonEventName[] = [
   "scripts",
   "branch",
   "reload",
+  "file-changed",
 ] as const;
 // `log` is broadcast separately — same SSE stream, different shape.
 const LOG_EVENT = "log" as const;
@@ -178,6 +181,7 @@ export function SandboxEventsProvider({
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
+  const queryClient = useQueryClient();
   const [phase, setPhase] = useState<ClaimPhase | null>(null);
   const [lifecycle, setLifecycle] = useState<LifecycleState>({ phase: "idle" });
   const [status, setStatus] = useState<DaemonStatus>({ state: "running" });
@@ -348,6 +352,32 @@ export function SandboxEventsProvider({
               }
             }
             return;
+          case "file-changed": {
+            const { path: filePath } =
+              payload as DaemonEventPayload<"file-changed">;
+            const cacheKey = `${org.slug}/${virtualMcpId}/${branch}`;
+            if (filePath.startsWith(".deco/")) {
+              void queryClient.invalidateQueries({
+                queryKey: KEYS.decofile(cacheKey),
+              });
+            } else {
+              // liveMeta keys include previewUrl as suffix
+              // (e.g. ["live-meta", "org/vmcp/branch/https://..."])
+              // — use predicate to match all liveMeta entries for
+              // this sandbox regardless of previewUrl.
+              void queryClient.invalidateQueries({
+                predicate: (query) => {
+                  const key = query.queryKey;
+                  return (
+                    key[0] === "live-meta" &&
+                    typeof key[1] === "string" &&
+                    key[1].startsWith(`${cacheKey}/`)
+                  );
+                },
+              });
+            }
+            return;
+          }
         }
       } catch {
         // ignore parse errors
@@ -467,7 +497,14 @@ export function SandboxEventsProvider({
       directEs?.close();
       if (reconnectTimer) clearTimeout(reconnectTimer);
     };
-  }, [virtualMcpId, branch, org.slug, enabled, directDaemonEventsUrl]);
+  }, [
+    virtualMcpId,
+    branch,
+    org.slug,
+    enabled,
+    directDaemonEventsUrl,
+    queryClient,
+  ]);
 
   const value: SandboxEventsValue = {
     phase,

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -30,9 +30,7 @@ describe("file-explorer utils", () => {
     expect(validateExplorerEntryName("ok.ts")).toBeNull();
     expect(validateExplorerEntryName("../evil")).toMatch(/cannot contain/);
     expect(validateExplorerEntryName("a/b")).toMatch(/cannot contain/);
-    expect(validateExplorerEntryName(".env")).toMatch(
-      /cannot start with a dot/,
-    );
+    expect(validateExplorerEntryName(".env")).toBeNull();
     expect(validateExplorerEntryName("")).toMatch(/required/i);
   });
 

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -65,9 +65,6 @@ export function validateExplorerEntryName(name: string): string | null {
   ) {
     return "Name cannot contain /, \\, or ..";
   }
-  if (trimmed.startsWith(".")) {
-    return "Name cannot start with a dot";
-  }
   return null;
 }
 

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -331,14 +331,38 @@ const getDevPort = (): number | null =>
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
   portSniffer.current() ?? store.read()?.application?.port ?? null;
 const { appRoot, repoDir } = bootConfig;
+let fileChangedDebounce: ReturnType<typeof setTimeout> | null = null;
+let pendingPaths = new Set<string>();
+
+function emitFileChanged(filePath: string) {
+  pendingPaths.add(filePath);
+  if (fileChangedDebounce) clearTimeout(fileChangedDebounce);
+  fileChangedDebounce = setTimeout(() => {
+    fileChangedDebounce = null;
+    for (const p of pendingPaths) {
+      broadcaster.emit("file-changed", { path: p });
+    }
+    pendingPaths = new Set();
+  }, 300);
+}
+
+// Filesystem watcher callback — fires for any repo file change (editor, build
+// tool, agent write, etc.) detected by BranchStatusMonitor's recursive
+// fs.watch. Shares the same debounce as onWorkingTreeWrite so rapid edits
+// (save + HMR rewrite) coalesce into one SSE burst.
+branchStatus.onFileChanged = (filePath: string) => {
+  emitFileChanged(filePath);
+};
+
 const fsDeps = {
   appRoot,
   repoDir,
-  onWorkingTreeWrite: () => {
+  onWorkingTreeWrite: (filePath: string) => {
     if (process.env.DEBUG_SAVE_CHANGES === "1") {
       console.log("[branch-status] fs write/edit → refresh", { repoDir });
     }
     branchStatus.refresh();
+    emitFileChanged(filePath);
   },
 };
 const readH = makeReadHandler(fsDeps);

--- a/packages/sandbox/daemon/events/types.ts
+++ b/packages/sandbox/daemon/events/types.ts
@@ -65,6 +65,7 @@ export interface DaemonEventMap {
   scripts: { scripts: string[] };
   branch: { meta: BranchMeta };
   reload: Record<string, never>;
+  "file-changed": { path: string };
 }
 
 export type DaemonEventName = keyof DaemonEventMap;

--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -42,6 +42,8 @@ export class BranchStatusMonitor {
   private watchInitialized = false;
   /** Boot-dirty paths → working-tree content hash at `armBaseline()`. */
   private dirtyBaseline: Map<string, string> | null = null;
+  /** Optional callback fired when the repo watcher detects a file change. */
+  onFileChanged: ((path: string) => void) | null = null;
 
   constructor(
     private readonly config: Config,
@@ -162,6 +164,9 @@ export class BranchStatusMonitor {
             return;
           }
           this.schedule();
+          if (typeof filename === "string") {
+            this.onFileChanged?.(filename);
+          }
         },
       );
       this.repoWatcher.on("error", () => {});

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -301,15 +301,18 @@ describe("fs handlers", () => {
     expect(body.files).toContain(".deco/blocks/foo.json");
   });
 
-  it("glob: excludes sensitive dotfiles outside .deco", async () => {
+  it("glob: shows dotfiles but excludes GLOB_EXCLUDE_DIRS", async () => {
     writeFileSync(join(appRoot, ".env"), "SECRET=1");
     mkdirSync(join(appRoot, ".deco/blocks"), { recursive: true });
     writeFileSync(join(appRoot, ".deco/blocks/foo.json"), "{}");
+    mkdirSync(join(appRoot, ".git"), { recursive: true });
+    writeFileSync(join(appRoot, ".git/config"), "");
     const h = makeGlobHandler({ appRoot, repoDir: appRoot });
     const res = await h(post("/_sandbox/glob", { pattern: "**/*" }));
     const body = (await res.json()) as { files: string[] };
-    expect(body.files).not.toContain(".env");
+    expect(body.files).toContain(".env");
     expect(body.files).toContain(".deco/blocks/foo.json");
+    expect(body.files).not.toContain(".git/config");
   });
 
   it("glob: includes empty directories without placeholder files", async () => {

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -28,7 +28,7 @@ export interface FsDeps {
    * checkout or remote change). Lets the daemon refresh branch dirty state
    * without waiting for the `.git/` watcher poll.
    */
-  onWorkingTreeWrite?: () => void;
+  onWorkingTreeWrite?: (path: string) => void;
 }
 
 function spawnOpts(
@@ -198,7 +198,7 @@ export function makeWriteHandler(deps: FsDeps) {
     if (!filePath) return jsonResponse({ error: "Path escapes app root" }, 400);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, body.content, "utf-8");
-    deps.onWorkingTreeWrite?.();
+    deps.onWorkingTreeWrite?.(body.path ?? "");
     return jsonResponse({
       ok: true,
       bytesWritten: Buffer.byteLength(body.content, "utf-8"),
@@ -253,7 +253,7 @@ export function makeUnlinkHandler(deps: FsDeps) {
         return jsonResponse({ error: (err as Error).message }, 500);
       }
     }
-    if (existed) deps.onWorkingTreeWrite?.();
+    if (existed) deps.onWorkingTreeWrite?.(body.path ?? "");
     return jsonResponse({ ok: true, existed });
   };
 }
@@ -279,7 +279,7 @@ export function makeMkdirHandler(deps: FsDeps) {
     } catch (err) {
       return jsonResponse({ error: (err as Error).message }, 500);
     }
-    deps.onWorkingTreeWrite?.();
+    deps.onWorkingTreeWrite?.(body.path);
     return jsonResponse({ ok: true });
   };
 }
@@ -330,7 +330,7 @@ export function makeRenameHandler(deps: FsDeps) {
     } catch (err) {
       return jsonResponse({ error: (err as Error).message }, 500);
     }
-    deps.onWorkingTreeWrite?.();
+    deps.onWorkingTreeWrite?.(body.to!);
     return jsonResponse({ ok: true });
   };
 }
@@ -381,7 +381,7 @@ export function makeEditHandler(deps: FsDeps) {
       ? content.replaceAll(body.old_string, body.new_string)
       : content.replace(body.old_string, body.new_string);
     fs.writeFileSync(filePath, updated, "utf-8");
-    deps.onWorkingTreeWrite?.();
+    deps.onWorkingTreeWrite?.(body.path ?? "");
     return jsonResponse({
       ok: true,
       replacements: replaceAll ? count : 1,
@@ -797,11 +797,6 @@ function walkRepoWithinMaxDepth(
 function isGlobPathAllowed(rel: string): boolean {
   for (const seg of rel.split("/")) {
     if (GLOB_EXCLUDE_DIRS.has(seg)) return false;
-    // Surface `.deco/**` and explorer `.gitkeep` folder markers without
-    // exposing other dotfiles (`.env`, `.npmrc`, …).
-    if (seg.startsWith(".") && seg !== ".deco" && seg !== ".gitkeep") {
-      return false;
-    }
   }
   return true;
 }


### PR DESCRIPTION
## Summary

- Daemon emits a new `file-changed` SSE event (debounced 300ms) when files change in the repo, both via API routes (`/write`, `/edit`, `/unlink`, `/mkdir`, `/rename`) and via `fs.watch` on the working tree (direct editor edits, build tools, etc.)
- UI handles the event to invalidate the correct React Query cache: `.deco/` changes invalidate `decofile`, all other changes invalidate `liveMeta`
- File explorer now shows hidden files (`.env`, `.npmrc`, `.prettierrc`, etc.) — dangerous directories (`.git`, `.ssh`, `.aws`, `.gnupg`) remain excluded via `GLOB_EXCLUDE_DIRS`
- Users can now create dotfiles/dotfolders from the file explorer UI

## Test plan

- [ ] Edit a `.tsx` file in the sandbox → verify `/live/_meta` is refetched
- [ ] Edit a file inside `.deco/blocks/` → verify `/.decofile` is refetched
- [ ] Edit multiple files in quick succession → verify debounce coalesces events (no request spam)
- [ ] Verify hidden files (`.env`, `.npmrc`) appear in the file explorer
- [ ] Verify `.git/` contents do NOT appear in the file explorer
- [ ] Verify creating a file starting with `.` is allowed in the file explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a debounced `file-changed` SSE from the sandbox daemon and update the UI to invalidate the correct caches so `liveMeta`/`decofile` stay in sync. Also show hidden files in the file explorer and allow creating dotfiles, while still excluding sensitive directories.

- New Features
  - Daemon broadcasts `file-changed` SSE (debounced 300ms) for API writes (`/write`, `/edit`, `/unlink`, `/mkdir`, `/rename`) and working-tree edits via `fs.watch` using a shared debounce.
  - UI listens and invalidates `@tanstack/react-query` keys: `.deco/**` → `decofile`; all other paths → all `liveMeta` entries for the sandbox.
  - File explorer shows dotfiles and allows dotfile/dotfolder creation; still excludes `.git`, `.ssh`, `.aws`, `.gnupg`.

<sup>Written for commit d7805cfb69cab62f1d705381810091fa4ccf08f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

