### PR TITLE
refactor(org-fs): mount the org home folder at a fixed `org/home`

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/library.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/library.mdx
@@ -29,7 +29,7 @@ The Library and the agent sandbox are two views of the same filesystem. Inside a
 
 | Library volume | Sandbox path |
 |---|---|
-| Home | `org/<your-org>/` |
+| Home | `org/home/` |
 | Uploads | `org/upload` |
 | Outputs | `org/output` |
 | Public sets | `org/public/<set>` |

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/library.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/library.mdx
@@ -29,7 +29,7 @@ A Library e o sandbox do agent são duas visões do mesmo filesystem. Dentro de 
 
 | Volume da Library | Caminho no sandbox |
 |---|---|
-| Home | `org/<your-org>/` |
+| Home | `org/home/` |
 | Uploads | `org/upload` |
 | Outputs | `org/output` |
 | Public sets | `org/public/<set>` |

--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -9,28 +9,19 @@ export { generateMessageId } from "@decocms/harness/decopilot/harness-constants"
  * Teaches the org filesystem layout. Skill discovery now lives in the
  * `<available-skills>` catalog + the `skill` tool, so this block no longer
  * enumerates sets or tells the agent to `ls org/public/` — it just names the
- * mount points. Stable per org (slug only), so it stays in the cached prompt
- * prefix across that org's runs.
+ * mount points. The home folder mounts at the fixed `org/home/` (same path for
+ * every org), so this block is identical across orgs and fully cache-stable.
  *
  * Portable pure function kept mesh-side (consumed by the cluster
- * `build-agent-system-prompt` with the org slug). org-fs is mounted into every
- * sandbox now, so it is emitted unconditionally.
+ * `build-agent-system-prompt`). org-fs is mounted into every sandbox now, so it
+ * is emitted unconditionally.
  */
-export function buildOrgFilesystemPrompt(
-  orgSlug?: string,
-  userId?: string,
-): string {
-  // Name the home folder directly so the agent never runs `ls org/` just to
-  // learn its own slug — that discovery step was firing even on bare greetings.
-  const home = orgSlug
-    ? `\`org/${orgSlug}/\``
-    : "the folder named after your organization (its slug is the single entry under `org/`)";
-  const homeBase = orgSlug ? `org/${orgSlug}` : "your org's home folder";
-  const orgMemoryPath = `\`${homeBase}/MEMORY.md\``;
-  const userMemoryPath = `\`${homeBase}/users/${userId ?? "<your-user-id>"}/MEMORY.md\``;
+export function buildOrgFilesystemPrompt(userId?: string): string {
+  const orgMemoryPath = "`org/home/MEMORY.md`";
+  const userMemoryPath = `\`org/home/users/${userId ?? "<your-user-id>"}/MEMORY.md\``;
   return `<organization-filesystem>
 The organization filesystem is mounted at \`org/\` in your sandbox (when available):
-- ${home} — the org's shared home folder, editable and shared across every agent, member, and run. Organize it freely with subfolders. Consult it only when a task needs background you don't already have (past decisions, preferences, project facts, gotchas) — then read it first. Do NOT browse it in response to greetings, small talk, or questions you can answer directly. Record durable knowledge here as you learn it; prefer small focused markdown files over one big log, and update stale notes instead of appending duplicates.
+- \`org/home/\` — the org's shared home folder, editable and shared across every agent, member, and run. Organize it freely with subfolders. Consult it only when a task needs background you don't already have (past decisions, preferences, project facts, gotchas) — then read it first. Do NOT browse it in response to greetings, small talk, or questions you can answer directly. Record durable knowledge here as you learn it; prefer small focused markdown files over one big log, and update stale notes instead of appending duplicates.
 - ${orgMemoryPath} — the ORGANIZATION memory index: durable facts shared with everyone in this org. Auto-loaded into context at the start of every session (its current contents appear in the <organization-memory> block when it exists).
 - ${userMemoryPath} — your USER memory index: facts and preferences specific to the current user, not shared with other members. Auto-loaded each session (shown in the <user-memory> block when it exists).
 Keep both indexes concise — a curated list of durable facts and one-line pointers to deeper notes elsewhere in the home folder. When you learn something worth remembering across sessions, edit the matching file (user-specific → user memory; org-wide → organization memory); update existing lines instead of appending duplicates.

--- a/apps/mesh/src/file-storage/home-mount.ts
+++ b/apps/mesh/src/file-storage/home-mount.ts
@@ -1,20 +1,30 @@
 /**
- * Mount path for the org's `home` volume — shared by sandbox provisioning
- * (the actual mount) and the Library UI (the card label), so the name the
- * user sees always matches the path the agent sees. Dependency-free on
- * purpose: the web bundle imports this directly.
+ * The org `home` volume's identity, split into two concerns:
+ *
+ *   - HOME_MOUNT_PATH — the fixed path the agent/sandbox sees it mounted at
+ *     (`org/home/`). Stable across every org so prompts, skills, and code can
+ *     hardcode the path instead of templating the slug.
+ *   - homeDisplayName — the human label the Library shows for the same folder
+ *     (the org's slug), so members recognize it as their own.
+ *
+ * Dependency-free on purpose: the web bundle imports this directly.
  */
 
+/** The agent-facing mount path for the org's `home` volume — always `home`,
+ *  so `org/home/` is a stable, hardcodable path in prompts/skills/code. */
+export const HOME_MOUNT_PATH = "home";
+
 /** Other names that live directly under `org/` — a slug matching one of
- *  these would shadow it. */
+ *  these would shadow it in the Library's folder list. */
 const RESERVED_HOME_PATHS = new Set(["output", "upload", "public", "home"]);
 /** One safe path segment, no traversal/hidden dirs (mirrors thread-links). */
 const SAFE_MOUNT_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
-/** The org's own slug (immutable), so the agent sees `org/<slug>/`. Falls
- *  back to a literal `home` when the slug would collide with another `org/`
- *  entry or isn't a safe segment. */
-export function homeMountPath(orgSlug: string): string {
+/** Display label for the home folder in the Library — the org's own slug,
+ *  falling back to a literal `home` when the slug would collide with another
+ *  `org/` entry or isn't a safe segment. Display-only: the path the agent
+ *  reads/writes is always `HOME_MOUNT_PATH`. */
+export function homeDisplayName(orgSlug: string): string {
   if (RESERVED_HOME_PATHS.has(orgSlug) || !SAFE_MOUNT_SEGMENT.test(orgSlug)) {
     return "home";
   }

--- a/apps/mesh/src/file-storage/mount/provisioning.test.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { homeMountPath } from "../home-mount";
+import { homeDisplayName } from "../home-mount";
 import { buildOrgFsConfig } from "./provisioning";
 
 describe("buildOrgFsConfig", () => {
-  it("returns home (slug-mounted) + outputs + uploads with the given identity", () => {
+  it("returns home (fixed org/home) + outputs + uploads with the given identity", () => {
     const c = buildOrgFsConfig({
       baseUrl: "https://cluster.example",
       orgSlug: "acme",
@@ -12,7 +12,7 @@ describe("buildOrgFsConfig", () => {
     expect(c.orgSlug).toBe("acme");
     expect(c.token).toBe("tok_abc");
     expect(c.mounts).toEqual([
-      { volume: "home", path: "acme" },
+      { volume: "home", path: "home" },
       { volume: "outputs", path: ".outputs" },
       { volume: "uploads", path: ".uploads" },
     ]);
@@ -26,18 +26,18 @@ describe("buildOrgFsConfig", () => {
   });
 });
 
-describe("homeMountPath", () => {
-  it("uses the org slug as the mount path", () => {
-    expect(homeMountPath("acme")).toBe("acme");
-    expect(homeMountPath("my-org.2")).toBe("my-org.2");
+describe("homeDisplayName", () => {
+  it("uses the org slug as the Library label", () => {
+    expect(homeDisplayName("acme")).toBe("acme");
+    expect(homeDisplayName("my-org.2")).toBe("my-org.2");
   });
 
   it("falls back to 'home' for reserved or unsafe slugs", () => {
     for (const bad of ["output", "upload", "public", "home"]) {
-      expect(homeMountPath(bad)).toBe("home");
+      expect(homeDisplayName(bad)).toBe("home");
     }
     for (const bad of [".hidden", "a/b", "", "..", "with space"]) {
-      expect(homeMountPath(bad)).toBe("home");
+      expect(homeDisplayName(bad)).toBe("home");
     }
   });
 });

--- a/apps/mesh/src/file-storage/mount/provisioning.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.ts
@@ -7,12 +7,13 @@
  * becomes per-agent configurable. Three volumes (org skills are deliberately
  * NOT a cloud volume — skills belong in versioned repos, surfaced through
  * the read-only public sets):
- *   - `home`    → mounted at `<appRoot>/org/<orgSlug>` (visible, editable):
+ *   - `home`    → mounted at `<appRoot>/org/home` (visible, editable):
  *     the org's shared home folder, free-form — members and agents organize
  *     it with whatever subfolders they want, and knowledge accumulates
- *     across every run (no per-thread scoping). The volume NAME is the
- *     stable `home` (uniform keyspace across orgs); only the mount path
- *     carries the slug, which is immutable by design (see CLAUDE.md).
+ *     across every run (no per-thread scoping). Both the volume NAME and the
+ *     mount path are the fixed `home`, so `org/home/` is a stable path that
+ *     prompts, skills, and code can hardcode. The Library shows the org's
+ *     slug as this folder's display label (see `homeDisplayName`).
  *   - `outputs` → mounted at `<appRoot>/org/.outputs` (hidden); the daemon
  *     repoints a per-run symlink `<appRoot>/org/output → .outputs/<threadId>`
  *     so the agent sees a bare `output/` that is, externally, that thread's
@@ -23,7 +24,7 @@
  *     folder appear in the sandbox with no copy step.
  */
 
-import { homeMountPath } from "../home-mount";
+import { HOME_MOUNT_PATH } from "../home-mount";
 import {
   getPublicSets,
   isPublicVolume,
@@ -53,15 +54,12 @@ const DEFAULT_MOUNTS: ReadonlyArray<{ volume: string; path: string }> = [
  * The sandbox path an org-fs (volume, path) is reachable at inside a run —
  * the inverse of the mount table above. Lets server-side code (e.g. the agent
  * knowledge block) tell the agent exactly where to read an attached file.
+ * Slug-independent: the home volume always mounts at the fixed `org/home`.
  * `path` "" returns the volume's mount root.
  */
-export function orgFsSandboxPath(
-  volume: string,
-  path: string,
-  orgSlug: string,
-): string {
+export function orgFsSandboxPath(volume: string, path: string): string {
   let base: string;
-  if (volume === "home") base = `org/${homeMountPath(orgSlug)}`;
+  if (volume === "home") base = `org/${HOME_MOUNT_PATH}`;
   else if (volume === "outputs") base = `org/${ORG_FS_OUTPUTS_MOUNT_PATH}`;
   else if (volume === "uploads") base = `org/${ORG_FS_UPLOADS_MOUNT_PATH}`;
   else if (isPublicVolume(volume)) {
@@ -82,8 +80,8 @@ export function buildOrgFsConfig(opts: {
     orgSlug: opts.orgSlug,
     token: opts.token,
     mounts: [
-      // The org's home folder mounts under the org's own name.
-      { volume: "home", path: homeMountPath(opts.orgSlug) },
+      // The org's home folder mounts at the fixed `org/home` (hardcodable path).
+      { volume: "home", path: HOME_MOUNT_PATH },
       ...DEFAULT_MOUNTS.map((m) => ({ ...m })),
       ...(opts.publicSets ?? []).map((set) => ({
         volume: publicVolumeForSet(set),

--- a/apps/mesh/src/file-storage/skill-catalog.ts
+++ b/apps/mesh/src/file-storage/skill-catalog.ts
@@ -3,7 +3,7 @@
  * can be surfaced up front (the `<available-skills>` block) for Claude-Code
  * style progressive discovery. Reads the same `SKILL.md` folders the sandbox
  * mounts: the shared read-only public sets (`org/public/<set>/`) plus the
- * org's own home volume (`org/<slug>/`).
+ * org's own home volume (`org/home/`).
  *
  * Each entry carries a collision-free `id` (`<set>/<dir>` for public,
  * `home/<dir>` for home) that doubles as the `skill` tool's argument and maps
@@ -127,8 +127,7 @@ async function buildPublicEntries(
         name: s.name,
         description: s.description,
         source: `public:${set}`,
-        // org-independent for public volumes (slug arg is ignored).
-        sandboxPath: orgFsSandboxPath(volume, s.dirPath, ""),
+        sandboxPath: orgFsSandboxPath(volume, s.dirPath),
       });
     }
   }
@@ -151,11 +150,10 @@ function buildOrgFs(ctx: StudioContext, orgId: string): OrgFs {
   return new OrgFs(storage, ctx.storage.orgFsEntries, orgId);
 }
 
-/** Home skills: bounded probe of `org/<slug>/*` and `org/<slug>/skills/*`. */
+/** Home skills: bounded probe of `org/home/*` and `org/home/skills/*`. */
 async function buildHomeEntries(
   ctx: StudioContext,
   orgId: string,
-  orgSlug: string,
   budget: { remaining: number },
 ): Promise<SkillCatalogEntry[]> {
   const home = buildOrgFs(ctx, orgId);
@@ -168,7 +166,7 @@ async function buildHomeEntries(
     name: s.name,
     description: s.description,
     source: "home",
-    sandboxPath: orgFsSandboxPath(HOME_VOLUME, s.dirPath, orgSlug),
+    sandboxPath: orgFsSandboxPath(HOME_VOLUME, s.dirPath),
   }));
 }
 
@@ -180,12 +178,11 @@ async function buildHomeEntries(
 export async function buildSkillCatalog(
   ctx: StudioContext,
   orgId: string,
-  orgSlug: string,
 ): Promise<SkillCatalogEntry[]> {
   const budget = { remaining: MAX_SKILLS };
   const [pub, home] = await Promise.all([
     buildPublicEntries(ctx, budget),
-    buildHomeEntries(ctx, orgId, orgSlug, budget),
+    buildHomeEntries(ctx, orgId, budget),
   ]);
   return [...pub, ...home].sort(
     (a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id),

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -135,19 +135,17 @@ export async function buildAgentSystemPrompt(
   add("codingWorkspace", buildCodingWorkspacePrompt(opts.codingWorkspace));
 
   // Org filesystem layout. org-fs is mounted into every sandbox now (desktop +
-  // cluster), so this is unconditional. Passing the slug lets the prompt name
-  // `org/<slug>/` directly instead of telling the agent to `ls org/` to
-  // discover it. Skills are surfaced separately via the <available-skills>
-  // catalog (served instructions). Stable per org, so still cache-safe.
-  add("orgFs", buildOrgFilesystemPrompt(opts.organization.slug, opts.user?.id));
+  // cluster), so this is unconditional. The home folder mounts at the fixed
+  // `org/home/` for every org, so the prompt names it directly (no `ls org/`
+  // discovery, no per-org slug). Skills are surfaced separately via the
+  // <available-skills> catalog (served instructions). Fully cache-stable.
+  add("orgFs", buildOrgFilesystemPrompt(opts.user?.id));
 
   // Eager-load the MEMORY.md indexes (Claude-Code-style persistent memory):
   // one shared org-wide, one private to the current user. Parent agent only —
   // subagents get a focused task, not the whole memory.
   if (opts.kind === "agent") {
-    const homeBase = opts.organization.slug
-      ? `org/${opts.organization.slug}`
-      : "org/<slug>";
+    const homeBase = "org/home";
     const userId = opts.user?.id;
     const [org, usr] = await Promise.all([
       loadMemoryBlock(opts.ctx, "organization", "MEMORY.md", homeBase, userId),
@@ -234,7 +232,7 @@ function memoryTemplate(scope: "organization" | "user"): string {
  * Read a MEMORY.md index from the `home` volume and render it as a system
  * block. `scope` is "organization" (shared) or "user" (private to the current
  * user); `path` is volume-relative (e.g. "MEMORY.md" or "users/<id>/MEMORY.md")
- * and `homeBase` is the sandbox mount path ("org/<slug>") used only for display.
+ * and `homeBase` is the sandbox mount path ("org/home") used only for display.
  * `actor` is the user id used to seed the file on first load.
  *
  * On the first load, if the file is genuinely absent it is created with a raw

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/html-artifact-buffer.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/html-artifact-buffer.ts
@@ -1,6 +1,6 @@
 /**
  * HTML-artifact buffer (cluster glue) — fast-path mirror for `write`/`edit`
- * tool calls on `org/<slug>/{decks,pages}/<name>.html`. The sandbox mount's
+ * tool calls on `org/home/{decks,pages}/<name>.html`. The sandbox mount's
  * vfs write-back takes seconds to reach org-fs; mirroring the tool's full
  * content server-side at step end makes the live preview (and the change-feed
  * watcher, which emits the `data-deck-updated` part) see the bytes
@@ -14,7 +14,7 @@
  */
 
 import type { StudioContext } from "@/core/studio-context";
-import { homeMountPath } from "@/file-storage/home-mount";
+import { HOME_MOUNT_PATH } from "@/file-storage/home-mount";
 import { matchHtmlArtifactToolPath } from "@decocms/harness/decopilot/built-in-tools/vm-tools/html-artifact-paths";
 import type { HtmlArtifactBuffer } from "@decocms/harness/decopilot/built-in-tools/vm-tools/types";
 
@@ -29,7 +29,7 @@ export function createHtmlArtifactBuffer(
   const orgSlug = ctx.organization?.slug ?? null;
   const actor = ctx.auth?.user?.id ?? null;
   if (!orgFs || !orgSlug || !actor) return NOOP;
-  const mountDir = homeMountPath(orgSlug);
+  const mountDir = HOME_MOUNT_PATH;
   // Stamp the writing chat so the watcher can scope its preview to this
   // run instead of every org-wide change (the home volume is shared).
   const threadId = ctx.metadata?.threadId ?? null;

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/html-artifact-watcher.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/vm-tools/html-artifact-watcher.ts
@@ -5,7 +5,7 @@
  * side panel opens/refreshes the live preview.
  *
  * Detection is change-feed based rather than tool-based: every sandbox
- * write to the mounted `org/<slug>/` path flows through the WebDAV serve
+ * write to the mounted `org/home/` path flows through the WebDAV serve
  * layer into `OrgFs.write` and the manifest change feed, so artifacts
  * created via bash (the `slides-create` CLI) are caught the same as
  * `write`-tool edits. The cursor snapshots at run start; `sweep()` is hooked
@@ -18,7 +18,7 @@
  */
 
 import type { StudioContext } from "@/core/studio-context";
-import { homeMountPath } from "@/file-storage/home-mount";
+import { HOME_MOUNT_PATH } from "@/file-storage/home-mount";
 import { matchOwnHtmlArtifact } from "@decocms/harness/decopilot/built-in-tools/vm-tools/html-artifact-paths";
 import type { UIMessageStreamWriter } from "ai";
 
@@ -50,7 +50,7 @@ export function createHtmlArtifactWatcher(
   if (!orgFs || !orgSlug || !ownerId) {
     return { sweep: async () => {} };
   }
-  const mountDir = homeMountPath(orgSlug);
+  const mountDir = HOME_MOUNT_PATH;
   // The home volume is org-wide and shared across every chat and member; emit
   // only entries this run produced. Exact thread match for tool-written decks
   // (the deck-buffer stamps `thread_id`); same-user fallback for unstamped

--- a/apps/mesh/src/harnesses/decopilot/tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/tools.ts
@@ -111,7 +111,7 @@ export interface AssembleDecopilotToolsExtras {
    *  the chat provider when the org's `deep_research` tier shares the chat
    *  credential. */
   deepResearchProvider: MeshProvider | null;
-  /** Per-turn HTML-artifact fast-path mirror (`org/<slug>/{decks,pages}/
+  /** Per-turn HTML-artifact fast-path mirror (`org/home/{decks,pages}/
    *  *.html`) — flushed into org-fs at step-end by the dispatch layer. */
   htmlArtifactBuffer?: HtmlArtifactBuffer;
   /** Usage roll-up sink (Task 17) — forwarded to the `subtask` built-in so a

--- a/apps/mesh/src/mcp-clients/virtual-mcp/knowledge.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/knowledge.ts
@@ -35,7 +35,6 @@ function describe(file: KnowledgeFile): string {
  */
 function buildKnowledgeBlock(
   knowledge: KnowledgeFile[] | null | undefined,
-  orgSlug: string,
 ): string | null {
   // Skills go in the <available-skills> catalog, not here.
   const docs = (knowledge ?? []).filter((f) => f.kind !== "skill");
@@ -44,7 +43,7 @@ function buildKnowledgeBlock(
   const docInventory = docs
     .map(
       (f) =>
-        `- ${f.name} (${describe(f)}), read it at \`${orgFsSandboxPath(f.volume, f.path, orgSlug)}\``,
+        `- ${f.name} (${describe(f)}), read it at \`${orgFsSandboxPath(f.volume, f.path)}\``,
     )
     .join("\n");
 
@@ -62,9 +61,8 @@ function buildKnowledgeBlock(
 export function withKnowledge(
   instructions: string | undefined,
   knowledge: KnowledgeFile[] | null | undefined,
-  orgSlug: string,
 ): string | undefined {
-  const block = buildKnowledgeBlock(knowledge, orgSlug);
+  const block = buildKnowledgeBlock(knowledge);
   if (!block) return instructions;
   return instructions ? `${instructions}\n\n${block}` : block;
 }

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -139,7 +139,6 @@ export class PassthroughClient extends GatewayClient {
     const base = withKnowledge(
       this.options.virtualMcp.metadata?.instructions ?? undefined,
       this.options.virtualMcp.metadata?.knowledge,
-      this.ctx.organization?.slug ?? "",
     );
     // Append the pre-rendered <available-skills> catalog (built async in the
     // factory). Same seam, same both-paths guarantee as the knowledge block.

--- a/apps/mesh/src/mcp-clients/virtual-mcp/skills-instructions.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/skills-instructions.ts
@@ -27,9 +27,8 @@ export async function renderSkillsCatalogBlock(
 ): Promise<string | null> {
   const orgId = ctx.organization?.id;
   if (!orgId) return null;
-  const orgSlug = ctx.organization?.slug ?? "";
   try {
-    const entries = await buildSkillCatalog(ctx, orgId, orgSlug);
+    const entries = await buildSkillCatalog(ctx, orgId);
     if (entries.length === 0) return null;
 
     // Skills the user attached to this agent, matched to catalog entries by
@@ -37,7 +36,7 @@ export async function renderSkillsCatalogBlock(
     const attached = new Set(
       (virtualMcp.metadata?.knowledge ?? [])
         .filter((k) => k.kind === "skill")
-        .map((k) => orgFsSandboxPath(k.volume, k.path, orgSlug)),
+        .map((k) => orgFsSandboxPath(k.volume, k.path)),
     );
     const configuredIds = entries
       .filter((e) => attached.has(e.sandboxPath))

--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -49,7 +49,7 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { homeMountPath } from "@/file-storage/home-mount";
+import { homeDisplayName } from "@/file-storage/home-mount";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { FileTypeIcon } from "@/web/components/file-type-icon";
 import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
@@ -296,12 +296,12 @@ function RootView({
             <VolumeFolderCard
               key={v.id}
               volume={v.id}
-              // The home volume presents as the org itself — through the same
-              // helper provisioning uses, so the label always matches the
-              // sandbox mount (incl. the reserved-slug fallback to "home",
-              // which avoids two cards both named e.g. "public").
+              // The home volume presents as the org itself: its display label is
+              // the org slug (with a reserved-slug fallback to "home" so two
+              // cards aren't both named e.g. "public"). The agent-facing mount
+              // path is always `org/home/` regardless of this label.
               displayName={
-                v.id === "home" ? homeMountPath(org.slug) : undefined
+                v.id === "home" ? homeDisplayName(org.slug) : undefined
               }
               description={v.description}
               glyph={v.glyph}

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/html-artifact-paths.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/html-artifact-paths.ts
@@ -3,7 +3,7 @@
  * watcher (org-fs change-feed entries) and any tool-path detection.
  *
  * Convention: HTML artifacts the user should see live in the org home
- * volume, which sandboxes see mounted at `org/<homeMountPath>/`:
+ * volume, which sandboxes see mounted at the fixed `org/home/`:
  *   - `decks/<name>.html` — presentation decks (the `slides` skill)
  *   - `pages/<name>.html` — standalone pages (landing pages, one-pagers)
  * The Studio web UI previews (and for decks, edits) the same files.
@@ -80,8 +80,10 @@ export function matchOwnHtmlArtifact(
 
 /**
  * Match a SANDBOX tool path (`write`/`edit`/bash cwd-relative or absolute)
- * against the mounted deck dir, e.g. `org/acme/decks/launch.html` or
- * `/app/repo/org/acme/decks/launch.html`. Returns the volume-relative ref.
+ * against the mounted deck dir, e.g. `org/home/decks/launch.html` or
+ * `/app/repo/org/home/decks/launch.html`. `homeMountPath` is the fixed `home`
+ * (kept as a param so the matcher stays pure/testable). Returns the
+ * volume-relative ref.
  */
 export function matchHtmlArtifactToolPath(
   rawPath: string,

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
@@ -39,7 +39,6 @@ export function createVmTools(params: VmToolsParams) {
     toolOutputMap,
     needsApproval,
     pendingImages,
-    ctx,
   } = params;
   const approvalFor = (mutating: boolean) => (mutating ? needsApproval : false);
 
@@ -92,7 +91,7 @@ export function createVmTools(params: VmToolsParams) {
     inputSchema: zodSchema(WriteInputSchema),
     execute: async (input) => {
       const daemonResult = await call("/_sandbox/write", input);
-      // Fast path: mirror `org/<slug>/{decks,pages}/*.html` content into
+      // Fast path: mirror `org/home/{decks,pages}/*.html` content into
       // org-fs server-side at step end (skips the mount's slow vfs write-back)
       // so the live-preview watcher sees the bytes in the same step.
       htmlArtifactBuffer?.enqueue(input.path, input.content);
@@ -156,7 +155,7 @@ export function createVmTools(params: VmToolsParams) {
     description: SKILL_DESCRIPTION,
     inputSchema: zodSchema(SkillInputSchema),
     execute: async ({ id }) => {
-      const path = resolveSkillPath(id, ctx.organization?.slug);
+      const path = resolveSkillPath(id);
       if (!path) {
         return {
           error: `Invalid skill id "${id}". Use an id from <available-skills>.`,

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -111,12 +111,12 @@ export const WRITE_DESCRIPTION =
   // (durable, Library-visible, deck editing).
   "Viewable HTML artifacts get a LIVE PREVIEW in the chat side panel " +
   "and persist in the org's shared folder when written under " +
-  "`org/<your-org-slug>/` (lowercase-kebab names):\n" +
-  "- Presentation decks / slides → `org/<your-org-slug>/decks/<name>.html` " +
+  "`org/home/` (lowercase-kebab names):\n" +
+  "- Presentation decks / slides → `org/home/decks/<name>.html` " +
   "— load the slides skill (`skill({ id: 'core/slides' })`) FIRST " +
   "and create the deck with its CLI.\n" +
   "- Standalone pages (landing pages, brand kits, one-pagers) → " +
-  "`org/<your-org-slug>/pages/<name>.html` — single self-contained " +
+  "`org/home/pages/<name>.html` — single self-contained " +
   "HTML file.\n" +
   "HTML written anywhere else will not render a preview.";
 
@@ -142,8 +142,8 @@ export const BASH_DESCRIPTION =
   "Execute a shell command in the VM's project directory. " +
   "Working directory is the project root. Timeout default 30s, max 2min.\n\n" +
   "The organization filesystem is mounted at `org/`:\n" +
-  "- `org/<your-org-slug>/` — the org's shared home folder (editable, " +
-  "shared across runs; `ls org/` shows the actual name). Organize it " +
+  "- `org/home/` — the org's shared home folder (editable, " +
+  "shared across runs). Organize it " +
   "freely; check it before non-trivial work and record durable facts, " +
   "decisions, and learnings as small markdown files.\n" +
   "- `org/public/<set>/` — curated read-only skill sets, mounted here. Your " +

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/skill-resolve.test.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/skill-resolve.test.ts
@@ -3,39 +3,31 @@ import { resolveSkillPath } from "./skill-resolve";
 
 describe("resolveSkillPath", () => {
   test("resolves a public-set skill", () => {
-    expect(resolveSkillPath("core/slides", "acme")).toBe(
+    expect(resolveSkillPath("core/slides")).toBe(
       "org/public/core/slides/SKILL.md",
     );
   });
 
   test("resolves a nested public id", () => {
-    expect(resolveSkillPath("storefront/seo/audit", "acme")).toBe(
+    expect(resolveSkillPath("storefront/seo/audit")).toBe(
       "org/public/storefront/seo/audit/SKILL.md",
     );
   });
 
-  test("resolves a home skill against the org slug", () => {
-    expect(resolveSkillPath("home/skills/onboarding", "acme")).toBe(
-      "org/acme/skills/onboarding/SKILL.md",
+  test("resolves a home skill against the fixed org/home path", () => {
+    expect(resolveSkillPath("home/skills/onboarding")).toBe(
+      "org/home/skills/onboarding/SKILL.md",
     );
-    expect(resolveSkillPath("home/foo", "acme")).toBe("org/acme/foo/SKILL.md");
-  });
-
-  test("falls back to literal `home` for reserved/unsafe/empty slugs", () => {
-    expect(resolveSkillPath("home/foo", "public")).toBe(
-      "org/home/foo/SKILL.md",
-    );
-    expect(resolveSkillPath("home/foo", "")).toBe("org/home/foo/SKILL.md");
-    expect(resolveSkillPath("home/foo", null)).toBe("org/home/foo/SKILL.md");
+    expect(resolveSkillPath("home/foo")).toBe("org/home/foo/SKILL.md");
   });
 
   test("rejects traversal, absolute, and malformed ids", () => {
-    expect(resolveSkillPath("../etc/passwd", "acme")).toBeNull();
-    expect(resolveSkillPath("core/../../secret", "acme")).toBeNull();
-    expect(resolveSkillPath("/core/slides", "acme")).toBeNull();
-    expect(resolveSkillPath("core/", "acme")).toBeNull();
-    expect(resolveSkillPath("core", "acme")).toBeNull();
-    expect(resolveSkillPath("", "acme")).toBeNull();
-    expect(resolveSkillPath("core/sli des", "acme")).toBeNull();
+    expect(resolveSkillPath("../etc/passwd")).toBeNull();
+    expect(resolveSkillPath("core/../../secret")).toBeNull();
+    expect(resolveSkillPath("/core/slides")).toBeNull();
+    expect(resolveSkillPath("core/")).toBeNull();
+    expect(resolveSkillPath("core")).toBeNull();
+    expect(resolveSkillPath("")).toBeNull();
+    expect(resolveSkillPath("core/sli des")).toBeNull();
   });
 });

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/skill-resolve.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/skill-resolve.ts
@@ -5,43 +5,21 @@
  * than escaping a skill scope.
  *
  *   core/slides        → org/public/core/slides/SKILL.md
- *   home/skills/foo    → org/<home-base>/skills/foo/SKILL.md
+ *   home/skills/foo    → org/home/skills/foo/SKILL.md
  */
 
 /** One safe path segment — no traversal, hidden dirs, or empties. */
 const SAFE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
-/** Names that live directly under `org/` and would shadow a home slug. */
-const RESERVED_HOME_PATHS = new Set(["output", "upload", "public", "home"]);
-
-/**
- * The org's home mount base under `org/` — the slug, falling back to literal
- * `home` when the slug collides with a reserved name or isn't a safe segment.
- * Mirrors `homeMountPath` in apps/mesh/src/file-storage/home-mount.ts (kept in
- * sync by hand — the harness package can't import mesh).
- */
-function homeMountBase(orgSlug: string): string {
-  if (
-    !orgSlug ||
-    RESERVED_HOME_PATHS.has(orgSlug) ||
-    !SAFE_SEGMENT.test(orgSlug)
-  ) {
-    return "home";
-  }
-  return orgSlug;
-}
-
-export function resolveSkillPath(
-  id: string,
-  orgSlug: string | null | undefined,
-): string | null {
+export function resolveSkillPath(id: string): string | null {
   const parts = id.split("/");
   if (parts.length < 2) return null;
   if (!parts.every((p) => SAFE_SEGMENT.test(p))) return null;
   const [scope, ...rest] = parts;
   const restPath = rest.join("/");
   if (scope === "home") {
-    return `org/${homeMountBase(orgSlug ?? "")}/${restPath}/SKILL.md`;
+    // The org home volume always mounts at the fixed `org/home/`.
+    return `org/home/${restPath}/SKILL.md`;
   }
   // Any other scope is a public set name → org/public/<set>/<rest>.
   return `org/public/${scope}/${restPath}/SKILL.md`;

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/types.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/types.ts
@@ -19,7 +19,7 @@ export interface PendingImage {
 }
 
 /**
- * Fast-path mirror for live HTML artifacts (`org/<slug>/{decks,pages}/
+ * Fast-path mirror for live HTML artifacts (`org/home/{decks,pages}/
  * <name>.html`). `write`/`edit` enqueue the full post-write content; the
  * cluster flush writes it server-side into org-fs, skipping the sandbox
  * mount's multi-second vfs write-back so the preview (and the change-feed

--- a/packages/sandbox/image/skills/brand/SKILL.md
+++ b/packages/sandbox/image/skills/brand/SKILL.md
@@ -11,14 +11,14 @@ everything that generates output consumes it.
 | Task | How |
 | --- | --- |
 | See a complete example | read `examples/tokens.css` and `examples/brand.md` (in this skill folder) |
-| Create a brand | write the files into `org/<slug>/brands/<name>/` (steps below) |
-| Build a deck theme | `slides-create … --theme org/<slug>/brands/<name>/slides-theme.html` (see the `slides` skill) |
+| Create a brand | write the files into `org/home/brands/<name>/` (steps below) |
+| Build a deck theme | `slides-create … --theme org/home/brands/<name>/slides-theme.html` (see the `slides` skill) |
 | Edit later | the user edits it in Studio's Library → Brands (or you rewrite the files) |
 
 ## Convention
 
-A brand is `org/<slug>/brands/<name>/` (run `ls org/` for the slug; `<name>`
-is lowercase kebab, e.g. `acme`):
+A brand is `org/home/brands/<name>/` (`<name>` is lowercase kebab, e.g.
+`acme`):
 
 | File | What |
 | --- | --- |
@@ -100,18 +100,18 @@ inlined (decks must be self-contained). Build it once:
    ```sh
    slides-create --data @deck.json \
      --theme <retuned-theme.html> \
-     --output org/<slug>/brands/<name>/slides-theme.html
+     --output org/home/brands/<name>/slides-theme.html
    ```
 
 Decks then use it: `slides-create --theme
-org/<slug>/brands/<name>/slides-theme.html …` (full flow in the `slides` skill).
+org/home/brands/<name>/slides-theme.html …` (full flow in the `slides` skill).
 
 ## Building a brand — workflow
 
 1. **Gather inputs:** brand name, a primary color (+ any secondary/accent),
    fonts, voice notes, logo. Ask for what's missing; infer sensible defaults
    from the primary (neutral ramp, semantic colors).
-2. `mkdir org/<slug>/brands/<name>/`.
+2. `mkdir org/home/brands/<name>/`.
 3. Write **`tokens.css`** — copy the example, swap in the colors/fonts, build
    the ramps around the seed colors.
 4. Write **`brand.md`** — the bible, with real canonical copy examples.

--- a/packages/sandbox/image/skills/slides/SKILL.md
+++ b/packages/sandbox/image/skills/slides/SKILL.md
@@ -14,18 +14,18 @@ with inline editing, and exports PDF by printing (the deck ships print CSS
 
 | Task                      | How                                                                   |
 | ------------------------- | --------------------------------------------------------------------- |
-| Create a deck             | `slides-create --data @deck.json --output org/<slug>/decks/<name>.html` |
+| Create a deck             | `slides-create --data @deck.json --output org/home/decks/<name>.html`   |
 | List themes / templates   | `slides-create --help`                                                 |
 | See a full data example   | `cat org/public/core/slides/examples/deck.json`                     |
 | Edit an existing deck     | `read` the HTML, edit the `<section>` slides, write it back            |
-| Org brand templates       | add `--templates-dir org/<slug>/templates/slides`                      |
+| Org brand templates       | add `--templates-dir org/home/templates/slides`                        |
 | PDF export                | user prints from the preview — no action needed                        |
 
 ## Path convention
 
-Decks live at `org/<slug>/decks/<name>.html` (run `ls org/` for the org
-slug; `<name>` is lowercase kebab). Files written there sync to Studio
-near-instantly and the user sees a live preview that updates as you work.
+Decks live at `org/home/decks/<name>.html` (`<name>` is lowercase kebab).
+Files written there sync to Studio near-instantly and the user sees a live
+preview that updates as you work.
 
 ## Creating a deck
 
@@ -33,7 +33,7 @@ near-instantly and the user sees a live preview that updates as you work.
    data shapes.
 2. Author your own deck JSON (a file is easier to iterate than inline):
    `{ "title": …, "theme": …, "slides": [ { "template": …, "data": … } ] }`
-3. Render: `slides-create --data @deck.json --output org/<slug>/decks/<name>.html`
+3. Render: `slides-create --data @deck.json --output org/home/decks/<name>.html`
 4. Iterate content by editing the **HTML output** (see lifecycle below),
    or re-render with `-f` only while the user hasn't touched the deck.
 
@@ -56,9 +56,9 @@ Keep org brand themes in org-fs so they persist, e.g.:
 
 ```sh
 slides-create --data @deck.json \
-  --theme org/<slug>/templates/slides/brand-theme.html \
-  --templates-dir org/<slug>/templates/slides \
-  --output org/<slug>/decks/q3.html
+  --theme org/home/templates/slides/brand-theme.html \
+  --templates-dir org/home/templates/slides \
+  --output org/home/decks/q3.html
 ```
 
 ### Brand folders
@@ -95,7 +95,7 @@ edit a brand, use the `brand` skill):
 This skill is built on the `templating` skill
 (`org/public/core/templating/SKILL.md`). For a one-off custom slide
 or deck template, render it directly with `create-from-template`; for an
-org's own slide layouts, keep them in `org/<slug>/templates/slides/` and
+org's own slide layouts, keep them in `org/home/templates/slides/` and
 pass `--templates-dir` — they resolve before the built-ins.
 
 ## Lifecycle — templates create, edits go to the HTML

--- a/packages/sandbox/image/skills/slides/SKILL.md
+++ b/packages/sandbox/image/skills/slides/SKILL.md
@@ -63,8 +63,8 @@ slides-create --data @deck.json \
 
 ### Brand folders
 
-If the org has a brand at `org/<slug>/brands/<name>/` (check with
-`ls org/<slug>/brands/`), honor it before any built-in theme (to *create* or
+If the org has a brand at `org/home/brands/<name>/` (check with
+`ls org/home/brands/`), honor it before any built-in theme (to *create* or
 edit a brand, use the `brand` skill):
 
 - **`tokens.css`** — the brand's `--brand-*` CSS custom properties. Inline
@@ -72,7 +72,7 @@ edit a brand, use the `brand` skill):
   org-fs file by URL — preview iframes carry no cookies). A brand theme shell
   maps deck variables onto them, e.g. `--deck-accent: var(--brand-primary);`.
 - **`slides-theme.html`** — if present it's a ready deck shell for this brand;
-  pass it as `--theme org/<slug>/brands/<name>/slides-theme.html`.
+  pass it as `--theme org/home/brands/<name>/slides-theme.html`.
 - **`brand.md`** — voice, tone, do's and don'ts; read it and follow it when
   writing slide copy.
 - **`logo.*`** — the brand logo; place it on the title/closing slides.

--- a/packages/sandbox/image/skills/slides/slides-create.mjs
+++ b/packages/sandbox/image/skills/slides/slides-create.mjs
@@ -53,7 +53,7 @@ function usage() {
       "         [--theme <name>] [--templates-dir <dir>] [-f]",
       "",
       "  --data           Deck description: inline JSON or @path/to/deck.json",
-      "  --output         Path to write the deck HTML (e.g. org/<slug>/decks/launch.html)",
+      "  --output         Path to write the deck HTML (e.g. org/home/decks/launch.html)",
       "  --theme          Built-in theme name OR path to a custom theme .html",
       '                   (overrides the data\'s "theme" field)',
       "  --templates-dir  Extra directory to resolve slide templates from (checked first)",
@@ -151,7 +151,7 @@ function resolveSlideTemplate(name, templatesDir) {
  * `--theme` (or the data's "theme" field) accepts either a built-in name
  * (`ink-dark`) or a path to a custom theme shell file — a complete deck
  * HTML with a `{{{slides}}}` insertion point. Org brand themes live in
- * org-fs (e.g. `org/<slug>/templates/slides/brand-theme.html`) and inject
+ * org-fs (e.g. `org/home/templates/slides/brand-theme.html`) and inject
  * the same way slide templates do via --templates-dir.
  */
 function resolveThemePath(value) {

--- a/packages/sandbox/image/skills/templating/SKILL.md
+++ b/packages/sandbox/image/skills/templating/SKILL.md
@@ -62,5 +62,5 @@ create-from-template --template list.template.html \
 - Use `--strict` while developing a template to catch typos in key names;
   drop it when optional keys are intentional.
 - Templates are plain text files — author your own anywhere (the org home
-  folder under `org/<slug>/templates/` is a good durable place for
+  folder under `org/home/templates/` is a good durable place for
   organization-wide templates).


### PR DESCRIPTION
## Summary

The org home volume mounted into each sandbox at `org/<slug>/`, so the slug leaked into every agent-facing surface — the system prompt, skills, tool descriptions, and the knowledge/skill-path builders all had to thread the org slug through and template the path. Static content (skills, docs) couldn't reference the home path literally either.

This mounts the home volume at a **fixed `org/home/`** for every org. The Library still shows the org **slug** as the folder's display label, so nothing changes for humans browsing files — only the agent-facing path is normalized.

### Why this is safe (no data migration)
The org-fs volume was *already* named the stable `home`; only the **sandbox mount path** carried the slug. The actual bytes live in the `home` volume (S3-backed, keyed by org id) and surface through an ephemeral, re-provisioned rclone/WebDAV mount. So this is a pure presentation change — the same data now appears at `org/home/` instead of `org/<slug>/`.

Legacy `org/<slug>/…` file references in **historical chat messages** still resolve: `org-file-ref` keeps its backward-compat path that maps both `org/<slug>/` and `org/home/` to the home volume.

## What changed
- **`home-mount.ts`** — split the old `homeMountPath` into `HOME_MOUNT_PATH` (the fixed `home` mount path) and `homeDisplayName` (the slug-with-fallback **Library label**).
- **`provisioning.ts`** — home mounts at `org/home`; `orgFsSandboxPath` drops its now-unused `orgSlug` arg.
- **Prompt / tool text** — `buildOrgFilesystemPrompt`, the BASH/WRITE tool descriptions, and the org-fs system block now hardcode `org/home/`. The block is identical across all orgs → fully cache-stable.
- **Builders** — dropped the dead `orgSlug` thread from `buildSkillCatalog`, `buildKnowledgeBlock`/`withKnowledge`, and `resolveSkillPath` (home skills now resolve to `org/home/<rest>/SKILL.md`).
- **HTML-artifact watcher/buffer** — mirror dir is the fixed `home`.
- **Skills + docs** — `slides`/`templating` SKILL.md, `slides-create.mjs`, and the Library docs reference `org/home/`.
- **Library UI** — unchanged label behavior (org slug), now via `homeDisplayName`.

## Testing
- `bun run check` — green across all workspaces.
- `bun run lint` — 0 errors (3 pre-existing, unrelated warnings).
- `bun run fmt` — clean.
- Unit tests for the touched areas pass (`provisioning`, `skill-resolve`, `html-artifact-paths`, `build-agent-system-prompt`, `org-file-ref`, harness built-in-tools). The only failing mesh tests are Postgres-dependent integration tests (`ECONNREFUSED 127.0.0.1:5432`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts each org’s home folder at the fixed path `org/home/` in every sandbox. This removes slug templating across prompts, tools, skills, and builders; the Library still shows the slug as the folder label, and no data migration is needed.

- **Refactors**
  - Added `HOME_MOUNT_PATH = "home"` and `homeDisplayName(orgSlug)`; provisioning mounts home at `org/home`; `orgFsSandboxPath` no longer takes a slug.
  - `buildOrgFilesystemPrompt` hardcodes `org/home/` and drops the slug; the org-fs block is identical across orgs (cache-stable).
  - Removed slug threading from `buildSkillCatalog`, knowledge blocks, and `resolveSkillPath` (home entries resolve to `org/home/.../SKILL.md`).
  - Switched HTML artifact buffer/watcher and path matchers to `org/home/{decks,pages}`; tool descriptions updated accordingly.
  - Updated docs and skills to reference `org/home/` (slides, templating, brand, `slides-create.mjs`); legacy `org/<slug>/...` paths still resolve via the compatibility mapping.

<sup>Written for commit bac40092c95cf80562bb82a88cb55420d5be331c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

