### PR TITLE
chore(sandbox): bump sandbox-env image tag to 1.6.1

### DIFF
--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -40,7 +40,7 @@ image:
   # instead of silently moving with `:latest`. Bump in lockstep with
   # packages/sandbox/package.json — release-studio-sandbox.yaml tags
   # images using that version. NEVER set this to "latest" in prod.
-  tag: "0.14.2"
+  tag: "1.6.1"
   # Override to Never on local kind clusters that load via `kind load`.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- Bumps `deploy/helm/sandbox-env/values.yaml` image tag from `0.14.2` to `1.6.1` to match `packages/sandbox/package.json`
- The chart tag fell behind after the Jun 10 bump — ~15 daemon releases were published to GHCR but never picked up by deployed sandboxes
- Includes all daemon changes since then, notably the `file-changed` SSE events from #4149

## Test plan

- [ ] Verify `ghcr.io/decocms/studio/studio-sandbox:1.6.1` exists
- [ ] Deploy to staging and confirm `/_sandbox/events` connects successfully
- [ ] Edit a file in the sandbox and verify `/live/_meta` is refetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `deploy/helm/sandbox-env/values.yaml` image tag from 0.14.2 to 1.6.1 to match `packages/sandbox/package.json` and deploy the latest daemon. Ensures sandboxes pick up all recent changes, including `file-changed` SSE events from #4149.

<sup>Written for commit 27d4575842034ca32134e6b589896cab42f2d304. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

