### PR TITLE
fix(link): dynamic NATS authenticator re-mints creds on reconnect

### DIFF
--- a/apps/mesh/src/link-daemon/cluster-connection-tunnel.test.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-tunnel.test.ts
@@ -3,7 +3,9 @@ import {
   buildNatsConnectOptions,
   connectNats,
   connectToClusterTunnel,
+  createNatsAuthenticator,
   createTunnelCommandFetch,
+  createTunnelSessionSource,
   fetchLinkSession,
   isRetriableSessionError,
   LinkSessionRequestError,
@@ -300,6 +302,120 @@ describe("connectNats", () => {
     });
 
     expect(calls).toEqual(["tcp"]);
+  });
+});
+
+describe("createNatsAuthenticator (dynamic)", () => {
+  const sessionWithToken = (token: string): LinkSessionResponse => ({
+    connection: { urls: ["nats://127.0.0.1:4222"], token },
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    tunnelHostname: "user-test.link",
+  });
+  const sessionWithCreds: LinkSessionResponse = {
+    connection: { urls: ["nats://127.0.0.1:4222"], credentials: "creds-blob" },
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    tunnelHostname: "user-test.link",
+  };
+
+  it("returns undefined when the session has neither creds nor token", () => {
+    expect(createNatsAuthenticator(() => sessionWithoutAuth)).toBeUndefined();
+  });
+
+  it("builds a creds authenticator function when credentials are present", () => {
+    expect(typeof createNatsAuthenticator(() => sessionWithCreds)).toBe(
+      "function",
+    );
+  });
+
+  it("re-reads the latest session on EVERY call (token reflects re-mint)", () => {
+    let current = sessionWithToken("T1");
+    const auth = createNatsAuthenticator(() => current);
+    expect((auth as (nonce?: string) => { auth_token?: string })?.()).toEqual({
+      auth_token: "T1",
+    });
+    // Simulate a background re-mint swapping the held session.
+    current = sessionWithToken("T2");
+    expect((auth as (nonce?: string) => { auth_token?: string })?.()).toEqual({
+      auth_token: "T2",
+    });
+  });
+});
+
+describe("createTunnelSessionSource", () => {
+  const sessionExpiringAt = (
+    expiresAtMs: number,
+    creds: string,
+  ): LinkSessionResponse => ({
+    connection: { urls: ["nats://127.0.0.1:4222"], credentials: creds },
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    tunnelHostname: "user-test.link",
+  });
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it("dedupes concurrent refreshes (single-flight) and swaps current()", async () => {
+    let calls = 0;
+    const next = sessionExpiringAt(200_000, "creds-2");
+    const source = createTunnelSessionSource({
+      initial: sessionExpiringAt(100_000, "creds-1"),
+      fetchSession: async () => {
+        calls += 1;
+        return next;
+      },
+      now: () => 0,
+    });
+
+    expect(source.current().connection.credentials).toBe("creds-1");
+    await Promise.all([source.refresh(), source.refresh(), source.refresh()]);
+    expect(calls).toBe(1);
+    expect(source.current().connection.credentials).toBe("creds-2");
+  });
+
+  it("getForAuth re-mints only within the refresh margin", async () => {
+    let calls = 0;
+    let nowMs = 0;
+    const expiresAtMs = 100_000;
+    const source = createTunnelSessionSource({
+      initial: sessionExpiringAt(expiresAtMs, "c1"),
+      fetchSession: async () => {
+        calls += 1;
+        return sessionExpiringAt(expiresAtMs + 100_000, "c2");
+      },
+      now: () => nowMs,
+      refreshMarginMs: 30_000,
+    });
+
+    // Far from expiry → no re-mint.
+    nowMs = 0;
+    source.getForAuth();
+    await flush();
+    expect(calls).toBe(0);
+
+    // Inside the 30s margin → kicks a re-mint (fire-and-forget).
+    nowMs = expiresAtMs - 10_000;
+    source.getForAuth();
+    await flush();
+    expect(calls).toBe(1);
+  });
+
+  it("getForAuth returns the current creds even when the re-mint fails, and a later call retries", async () => {
+    let calls = 0;
+    const source = createTunnelSessionSource({
+      initial: sessionExpiringAt(100_000, "c1"),
+      fetchSession: async () => {
+        calls += 1;
+        throw new Error("mint failed");
+      },
+      now: () => 200_000, // past expiry → always stale
+    });
+
+    const first = source.getForAuth();
+    expect(first.connection.credentials).toBe("c1");
+    await flush();
+    expect(calls).toBe(1);
+    // inFlight cleared on failure → a later call retries rather than wedging.
+    expect(() => source.getForAuth()).not.toThrow();
+    await flush();
+    expect(calls).toBe(2);
   });
 });
 

--- a/apps/mesh/src/link-daemon/cluster-connection-tunnel.ts
+++ b/apps/mesh/src/link-daemon/cluster-connection-tunnel.ts
@@ -413,27 +413,51 @@ export function createTunnelCommandFetch(input: {
   };
 }
 
-function createNatsAuthenticator(
-  session: LinkSessionResponse,
+/**
+ * Build a NATS authenticator that re-reads the LATEST session on every
+ * (re)connect via `getSession`, instead of capturing one static credentials
+ * blob. The NATS client invokes the authenticator on each connection attempt
+ * (`maxReconnectAttempts: -1`), so when the session has been re-minted in the
+ * background, an auto-reconnect after a credentials-expiry kick presents the
+ * FRESH JWT and self-heals — rather than looping forever on the dead creds
+ * (the field failure: a tunnel-relay run died on `ClosedConnectionError` after
+ * `UserAuthenticationExpiredError` because the static authenticator could only
+ * ever re-present the already-expired token). The factory (creds vs token) is
+ * chosen once from the initial session — the cluster never switches auth modes
+ * within a daemon's lifetime — but the VALUE is read live on each call.
+ */
+export function createNatsAuthenticator(
+  getSession: () => LinkSessionResponse,
 ):
   | ReturnType<typeof credsAuthenticator>
   | ReturnType<typeof tokenAuthenticator>
   | undefined {
-  if (session.connection.credentials) {
-    return credsAuthenticator(
-      new TextEncoder().encode(session.connection.credentials),
+  const initial = getSession();
+  if (initial.connection.credentials) {
+    const encoder = new TextEncoder();
+    return credsAuthenticator(() =>
+      encoder.encode(getSession().connection.credentials ?? ""),
     );
   }
-  if (session.connection.token) {
-    return tokenAuthenticator(session.connection.token);
+  if (initial.connection.token) {
+    return tokenAuthenticator(() => getSession().connection.token ?? "");
   }
   return undefined;
 }
 
 export function buildNatsConnectOptions(
   session: LinkSessionResponse,
+  /**
+   * Live view of the current session for the authenticator. Defaults to the
+   * static `session` (back-compat); production passes a
+   * {@link TunnelSessionSource}'s `getForAuth` so reconnects use re-minted
+   * creds. Connection-level fields (urls, inbox prefix) come from `session` and
+   * are stable across re-mints (same hostname/URLs) — only the credentials
+   * rotate.
+   */
+  getSession: () => LinkSessionResponse = () => session,
 ): ConnectionOptions {
-  const authenticator = createNatsAuthenticator(session);
+  const authenticator = createNatsAuthenticator(getSession);
   return {
     servers: session.connection.urls,
     ...(authenticator ? { authenticator } : {}),
@@ -472,9 +496,11 @@ const defaultWebSocketConnect: NatsConnector = (options) => wsconnect(options);
 export async function connectNats(
   session: LinkSessionResponse,
   deps: ConnectNatsDeps = {},
+  /** Live session view for the authenticator (see buildNatsConnectOptions). */
+  getSession: () => LinkSessionResponse = () => session,
 ): Promise<NatsConnection> {
   const useWebSocket = isWebSocketSession(session);
-  const options = buildNatsConnectOptions(session);
+  const options = buildNatsConnectOptions(session, getSession);
   if (useWebSocket) {
     options.ignoreClusterUpdates = true;
   }
@@ -482,6 +508,79 @@ export async function connectNats(
     ? (deps.connectWebSocket ?? defaultWebSocketConnect)
     : (deps.connectTcp ?? connectTcp);
   return await connector(options);
+}
+
+/**
+ * Default lead time before a session's hard expiry at which the authenticator
+ * proactively re-mints, so a NATS (re)connect is never handed an already-expired
+ * JWT. Sits comfortably inside the daemon-side 60s renewal skew but is checked
+ * lazily on each auth call, so it also covers the case the renewal timer missed
+ * (laptop sleep / wall-clock jump) — exactly when self-healing matters.
+ */
+const SESSION_REFRESH_MARGIN_MS = 30_000;
+
+/**
+ * A live, refreshable view of the tunnel session credentials shared with the
+ * NATS authenticator. `current()` is the latest minted session; `getForAuth()`
+ * is the synchronous accessor the authenticator calls on every (re)connect —
+ * it returns the current session and, when the creds are within the refresh
+ * margin of expiry, kicks a single-flight background re-mint so the NEXT
+ * connection attempt presents fresh creds. `refresh()` forces a re-mint now.
+ */
+export interface TunnelSessionSource {
+  current(): LinkSessionResponse;
+  refresh(): Promise<void>;
+  getForAuth(): LinkSessionResponse;
+}
+
+export function createTunnelSessionSource(opts: {
+  initial: LinkSessionResponse;
+  /** Re-mints a fresh session (creds + expiry). Typically the retrying fetch. */
+  fetchSession: () => Promise<LinkSessionResponse>;
+  now?: () => number;
+  refreshMarginMs?: number;
+}): TunnelSessionSource {
+  const now = opts.now ?? (() => Date.now());
+  const marginMs = opts.refreshMarginMs ?? SESSION_REFRESH_MARGIN_MS;
+  let session = opts.initial;
+  // Single-flight: concurrent auth calls + the timer must not stampede the mint
+  // endpoint. While one re-mint is in flight, every caller awaits the same one.
+  let inFlight: Promise<void> | null = null;
+
+  const refresh = (): Promise<void> => {
+    if (inFlight) return inFlight;
+    inFlight = (async () => {
+      try {
+        session = await opts.fetchSession();
+      } catch (err) {
+        // A re-mint failure must never reject the synchronous auth path; keep
+        // the current creds (a still-live connection is unaffected) and let a
+        // later call retry once `inFlight` is cleared.
+        console.warn(
+          "[cluster-connection-tunnel] session refresh failed; keeping current creds",
+          err,
+        );
+      } finally {
+        inFlight = null;
+      }
+    })();
+    return inFlight;
+  };
+
+  const isStale = (): boolean => {
+    const expiresAtMs = Date.parse(session.expiresAt);
+    if (!Number.isFinite(expiresAtMs)) return false;
+    return now() >= expiresAtMs - marginMs;
+  };
+
+  return {
+    current: () => session,
+    refresh,
+    getForAuth: () => {
+      if (isStale()) void refresh();
+      return session;
+    },
+  };
 }
 
 export function sessionRenewDelayMs(
@@ -545,7 +644,21 @@ export async function connectToClusterTunnel(
 
   const startActive = async (): Promise<ActiveTunnelConnection> => {
     const session = await fetchSessionWithRetry();
-    const nc = await (deps.connectNats ?? connectNats)(session);
+    // Live credentials view for the authenticator: a NATS auto-reconnect that
+    // fires after the JWT expires (e.g. the daemon-side renewal timer was paused
+    // by laptop sleep, so the server kicks the connection with
+    // UserAuthenticationExpiredError) re-presents FRESH creds re-minted in the
+    // background, instead of looping forever on the dead token.
+    const sessionSource = createTunnelSessionSource({
+      initial: session,
+      fetchSession: fetchSessionWithRetry,
+      now: () => now().getTime(),
+    });
+    const nc = await (deps.connectNats ?? connectNats)(
+      session,
+      undefined,
+      sessionSource.getForAuth,
+    );
     liveNc = nc;
     monitorNatsStatus(nc, session.tunnelHostname, now);
     const ac = new AbortController();


### PR DESCRIPTION
## Problem

A desktop-relay run died in the field (staging thread `11bda36e`) with:

```
[relay-diag] ROOT=CLUSTER-RELAY runId=11bda36e… retried=true name=ClosedConnectionError msg=closed connection
[link-work] local dispatch failed … ClosedConnectionError: closed connection
```

Root cause traced through the daemon log: the NATS tunnel uses **short-lived session credentials** (`NATS_TUNNEL_SESSION_TTL_SECONDS=900` → a 15-min JWT), and the authenticator captured **one static creds blob** at connect time (`createNatsAuthenticator(session)`). NATS is configured `maxReconnectAttempts: -1`.

When the JWT expired **before** the daemon-side renewal timer recycled the connection — the renewal `sleep(840s)` paused by **laptop sleep** while the JWT's wall-clock `exp` passed — the server kicked the connection (`UserAuthenticationExpiredError → staleConnection → disconnect`) and NATS auto-reconnected **forever re-presenting the same dead token**, never self-healing. A ~68-min run sitting on that connection then drained its ~2.5-min relay retry budget and failed terminally; the harness output was discarded.

## Fix (scoped: just the dynamic authenticator)

Make the authenticator read the **latest** session on every (re)connect via a getter, fed by a single-flight `TunnelSessionSource` that:
- re-mints fresh creds in the background (single-flight — concurrent auth calls + the timer share one mint), and
- proactively refreshes within **30s** of expiry (`getForAuth()`), checked lazily on each auth call so it also covers the case the renewal timer missed (sleep / wall-clock jump).

The factory (creds vs token) is still chosen once — the cluster never switches auth modes within a daemon's lifetime — but the **value is live**. So an auto-reconnect after an expiry kick now presents a freshly-minted JWT and recovers in a retry or two instead of looping on dead creds.

### Out of scope
- The **14-min renewal recycle** is untouched. Cutting routine reconnects (e.g. a longer TTL) is a separate change.
- The **publish path** already re-sources the live connection per attempt (`handle-local-dispatch.ts:349-356`), so no change there.

## Testing
- New unit tests (`cluster-connection-tunnel.test.ts`): dynamic authenticator re-reads the session each call (token reflects re-mint); `createTunnelSessionSource` single-flight dedup, margin-gated `getForAuth` re-mint, and resilience when a re-mint throws (returns current creds, later call retries).
- `bun test apps/mesh/src/link-daemon/` → **167 pass / 0 fail** (no regressions).
- `bun run --cwd apps/mesh check` clean; `bun run fmt`/`lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite reconnect loop in the NATS tunnel by making the authenticator read fresh session credentials on every connect. Expired JWTs are now re-minted on reconnect, so the link self-heals instead of failing with ClosedConnectionError.

- **Bug Fixes**
  - Authenticator now reads the latest session on each connect via a getter; factory (creds vs token) is chosen once but values are live.
  - Added `createTunnelSessionSource` with single-flight refresh and a 30s expiry margin; `getForAuth()` returns current creds and triggers a background refresh; resilient to mint failures.
  - Wired the live session into `buildNatsConnectOptions`, `connectNats`, and `connectToClusterTunnel` to use fresh creds on reconnect.

<sup>Written for commit 94b54eb431dde7dc01a51d01bf94c4e4723e5271. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

