### PR TITLE
fix(harness): rebase coding workspace cwd

### DIFF
--- a/packages/sandbox/daemon/routes/dispatch.test.ts
+++ b/packages/sandbox/daemon/routes/dispatch.test.ts
@@ -273,17 +273,22 @@ describe("POST /_sandbox/dispatch", () => {
     await reader.cancel();
   });
 
-  it("rebases symbolic workspace.cwd onto the daemon's sandbox root before the harness sees it", async () => {
+  it("rebases symbolic workspace.cwd and codingWorkspace.cwd onto the daemon's sandbox root before the harness sees it", async () => {
     // The wire carries the symbolic value "/repo"; the daemon must rebase it
     // onto its own sandbox root (daemonAppRoot()) before handing the input to
     // the harness. The harness MUST receive the rebased absolute path, not the
     // wire symbol — so `effectiveCwd(input.workspace.cwd)` yields a real path.
     const runId = "run-cwd-rebase";
-    let capturedInput: { workspace?: { cwd: string } } | undefined;
+    let capturedInput:
+      | { workspace?: { cwd: string }; codingWorkspace?: { cwd?: string } }
+      | undefined;
 
     const deps = makeDeps({
       lookupHarness: (_id, input) => {
-        capturedInput = input as { workspace?: { cwd: string } };
+        capturedInput = input as {
+          workspace?: { cwd: string };
+          codingWorkspace?: { cwd?: string };
+        };
         return makeFakeHarness();
       },
     });
@@ -294,6 +299,12 @@ describe("POST /_sandbox/dispatch", () => {
         ...fixtures.FIXTURE_MINIMAL_INPUT,
         runId,
         workspace: { cwd: "/repo" },
+        codingWorkspace: {
+          repo: { owner: "deco", name: "site", connectedGithub: true },
+          branch: "main",
+          cwd: "/repo",
+          workspaceKind: "github",
+        },
       },
     });
     const res = await handleDispatchRequest(authedDispatch(body), deps);
@@ -308,6 +319,7 @@ describe("POST /_sandbox/dispatch", () => {
     expect(rebasedCwd).not.toBe("/repo");
     // Must end with /repo (rebased to the daemon's sandbox root)
     expect(rebasedCwd?.endsWith("/repo")).toBe(true);
+    expect(capturedInput?.codingWorkspace?.cwd).toBe(rebasedCwd);
   });
 
   it("wraps harness errors as an error SSE event followed by done", async () => {

--- a/packages/sandbox/daemon/routes/dispatch.ts
+++ b/packages/sandbox/daemon/routes/dispatch.ts
@@ -111,6 +111,17 @@ function writeDispatchAcceptedPrelude(
   }
 }
 
+function rebaseInputWorkspace(input: {
+  workspace: { cwd: string };
+  codingWorkspace?: { cwd?: string | null };
+}): void {
+  const cwd = rebaseWorkspaceCwd(input.workspace.cwd, daemonAppRoot());
+  input.workspace = { cwd };
+  if (input.codingWorkspace?.cwd != null) {
+    input.codingWorkspace = { ...input.codingWorkspace, cwd };
+  }
+}
+
 /** Drive a harness's stream into an SSE controller. Reused verbatim by both
  *  paths so chunk relaying / abort handling / error wrapping / `done` framing
  *  stay identical. Always emits `done` and closes the controller; never hangs.
@@ -267,11 +278,10 @@ export async function handleDispatchRequest(
         }
         const input = inputParse.data;
 
-        // Rebase the symbolic workspace.cwd onto this daemon's sandbox root
-        // (spec: "Harness Input Contract" Q4 — containment by construction).
-        input.workspace = {
-          cwd: rebaseWorkspaceCwd(input.workspace.cwd, daemonAppRoot()),
-        };
+        // Rebase the symbolic workspace cwd fields onto this daemon's sandbox
+        // root (spec: "Harness Input Contract" Q4 — containment by
+        // construction).
+        rebaseInputWorkspace(input);
 
         // 3. Tombstone check — a cancel may have landed first. Surface it as a
         //    terminal error rather than starting a doomed harness.
@@ -351,11 +361,9 @@ export async function handleDispatchRequest(
   }
   const input = inputParse.data;
 
-  // Rebase the symbolic workspace.cwd onto this daemon's sandbox root
+  // Rebase the symbolic workspace cwd fields onto this daemon's sandbox root
   // (spec: "Harness Input Contract" Q4 — containment by construction).
-  input.workspace = {
-    cwd: rebaseWorkspaceCwd(input.workspace.cwd, daemonAppRoot()),
-  };
+  rebaseInputWorkspace(input);
 
   // Tombstone check — a cancel landed before this dispatch did. Decline
   // and let the cluster surface a clear cancellation instead of starting


### PR DESCRIPTION
## Summary
- Rebase prompt-facing `codingWorkspace.cwd` alongside executable `workspace.cwd` in sandbox dispatch.
- Keeps `/repo` as the symbolic wire value while ensuring Codex and Claude Code see the absolute sandbox repo path in workspace instructions.
- Adds regression coverage for the prompt cwd matching the rebased execution cwd.

## Test Plan
- `bun test packages/sandbox/daemon/routes/dispatch.test.ts`
- `bun run fmt` (exited 0; Biome reported internal I/O diagnostics on sandbox `org/` mount files outside this repo change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebased both `codingWorkspace.cwd` and `workspace.cwd` onto the daemon’s sandbox root during dispatch. The harness now always receives an absolute repo path while the wire value stays `/repo`.

- **Bug Fixes**
  - Rebase `codingWorkspace.cwd` alongside `workspace.cwd` so both point to the same absolute path before invoking the harness.
  - Added a regression test to ensure the prompt cwd matches the rebased execution cwd.

- **Refactors**
  - Introduced `rebaseInputWorkspace()` to centralize cwd rebasing across dispatch paths.

<sup>Written for commit e12f3fae2795cdbd4a51e512cce513f2c9cd7b80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

