### PR TITLE
fix(sandbox): debounce /live/_meta refetch on file-changed events

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -228,6 +228,7 @@ export function SandboxEventsProvider({
     let disposed = false;
     let reconnectAttempt = 0;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let liveMetaDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     let studioEs: EventSource | null = null;
     let directEs: EventSource | null = null;
 
@@ -361,20 +362,23 @@ export function SandboxEventsProvider({
                 queryKey: KEYS.decofile(cacheKey),
               });
             } else {
-              // liveMeta keys include previewUrl as suffix
-              // (e.g. ["live-meta", "org/vmcp/branch/https://..."])
-              // — use predicate to match all liveMeta entries for
-              // this sandbox regardless of previewUrl.
-              void queryClient.invalidateQueries({
-                predicate: (query) => {
-                  const key = query.queryKey;
-                  return (
-                    key[0] === "live-meta" &&
-                    typeof key[1] === "string" &&
-                    key[1].startsWith(`${cacheKey}/`)
-                  );
-                },
-              });
+              // Debounce liveMeta invalidation by 2s so the dev server has
+              // time to rebuild before we hit /live/_meta. Rapid successive
+              // file-changed events reset the timer.
+              if (liveMetaDebounceTimer) clearTimeout(liveMetaDebounceTimer);
+              liveMetaDebounceTimer = setTimeout(() => {
+                liveMetaDebounceTimer = null;
+                void queryClient.invalidateQueries({
+                  predicate: (query) => {
+                    const key = query.queryKey;
+                    return (
+                      key[0] === "live-meta" &&
+                      typeof key[1] === "string" &&
+                      key[1].startsWith(`${cacheKey}/`)
+                    );
+                  },
+                });
+              }, 2_000);
             }
             return;
           }
@@ -496,6 +500,7 @@ export function SandboxEventsProvider({
       studioEs?.close();
       directEs?.close();
       if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (liveMetaDebounceTimer) clearTimeout(liveMetaDebounceTimer);
     };
   }, [
     virtualMcpId,


### PR DESCRIPTION
## Summary
- Adds a 2-second debounce to the `liveMeta` query invalidation triggered by `file-changed` SSE events in `sandbox-events-context.tsx`
- Gives the dev server time to rebuild before hitting `/live/_meta`, avoiding stale/incomplete responses
- Rapid successive file changes coalesce into a single refetch after the last change settles

## Test plan
- [ ] Edit a file in the sandbox and verify `/live/_meta` is fetched ~2s after the last change (not immediately)
- [ ] Verify rapid edits (multiple saves) result in a single refetch, not one per save
- [ ] Verify `.deco/` file changes still invalidate the decofile query immediately (no debounce)
- [ ] Verify unmounting/switching branches cleans up the debounce timer (no stale invalidations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a 2-second debounce to `liveMeta` query invalidation on `file-changed` SSE events so `/live/_meta` refetch waits for dev server rebuilds and avoids stale data. Rapid edits now coalesce into a single refetch.

- **Bug Fixes**
  - Debounce `liveMeta` invalidation by 2s; successive events reset the timer.
  - Keep `.deco/` changes immediate (`decofile` query still invalidates without debounce).
  - Clear the debounce timer on unmount or branch switch to prevent stale refetches.

<sup>Written for commit 0a539463c83743d7efaecff30e9d08d30f4f8cb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

