### PR TITLE
fix(home): open chat button now shows tile UI alongside chat

### DIFF
--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -8,17 +8,21 @@ import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { Suspense } from "react";
 import {
   getHomeTiles,
+  mcpClientQueryOptions,
   useMCPClient,
+  useMCPToolsListQuery,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ArrowRight } from "@untitledui/icons";
 import { toast } from "sonner";
 import { MCPAppRenderer } from "@/mcp-apps/mcp-app-renderer.tsx";
+import { getUIResourceUri } from "@/mcp-apps/types.ts";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { ErrorBoundary } from "@/web/components/error-boundary";
+import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import {
   type HomePromptEntry,
   type HomeTileEntry,
@@ -74,6 +78,41 @@ function entryToPrompt(entry: HomePromptEntry): Prompt {
     arguments: entry.arguments,
     _meta: entry._meta,
   };
+}
+
+/** Resolves the main-panel tab id for a home tile so "Open chat" can
+ *  open chat + the tile's UI side-by-side. Uses the non-suspending MCP
+ *  client / tools-list queries so the tile chrome renders immediately
+ *  (the queries piggy-back on TileAppPanel's cache). */
+function useTileMainTab(tile: HomeTileEntry): string | undefined {
+  const { org } = useProjectContext();
+
+  // Non-suspending — shares the same cache key as TileAppPanel's
+  // useMCPClient, so the client is typically already cached by the
+  // time the user sees the tile.
+  const { data: client } = useQuery(
+    mcpClientQueryOptions({
+      connectionId: tile.connectionId,
+      orgId: org.id,
+      orgSlug: org.slug,
+    }),
+  );
+
+  // Resolve tool name from the connection's tools when not explicitly set.
+  const { data: toolsResult } = useMCPToolsListQuery({
+    client: client!,
+    enabled: !!client && !tile.toolName,
+  });
+
+  const toolName =
+    tile.toolName ??
+    toolsResult?.tools.find(
+      (t) => getUIResourceUri(t._meta) === tile.resourceUri,
+    )?.name;
+
+  return toolName
+    ? formatPinnedViewTabId(tile.connectionId, toolName)
+    : undefined;
 }
 
 /** Bundles the prompt/blank thread launch for every surface that needs
@@ -193,12 +232,16 @@ function AgentUITile({
   // Drop the blank-fallback card — clicking the header already covers it.
   const promptChips = prompts.filter((p) => !!p.promptName);
 
+  const mainTab = useTileMainTab(tile);
+
   return (
     <div className="relative flex h-full w-full flex-col p-3">
       {!isEditMode && (
         <button
           type="button"
-          onClick={() => void startBlank()}
+          onClick={() =>
+            void startBlank(mainTab ? { main: mainTab } : undefined)
+          }
           disabled={starting}
           aria-busy={starting}
           className="mb-1 self-start rounded-md px-2 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-progress disabled:opacity-60"
@@ -325,12 +368,13 @@ function TileErrorFallback({
     tile.agentId,
   );
   const chips = prompts.filter((p) => !!p.promptName);
+  const mainTab = useTileMainTab(tile);
 
   return (
     <div className="flex h-full w-full flex-col gap-3 p-4">
       <button
         type="button"
-        onClick={() => void startBlank()}
+        onClick={() => void startBlank(mainTab ? { main: mainTab } : undefined)}
         disabled={starting || isEditMode}
         className="mb-1 self-start rounded-md px-2 py-1 text-[10px] text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-progress disabled:opacity-60"
       >

--- a/apps/mesh/src/web/hooks/use-start-thread-from-prompt.tsx
+++ b/apps/mesh/src/web/hooks/use-start-thread-from-prompt.tsx
@@ -37,7 +37,7 @@ export interface UseStartThreadFromPromptResult {
    * Start a fresh thread with `agentId` without seeding a prompt — used by the
    * fallback cards for default home agents that expose no prompts.
    */
-  startBlank: () => Promise<void>;
+  startBlank: (opts?: { main?: string }) => Promise<void>;
   /** Render this in your component to mount the args dialog. */
   dialog: ReactNode;
   /** Exposed for tests / loading states. */
@@ -140,7 +140,7 @@ export function useStartThreadFromPrompt({
     await loadAndStart(prompt, values);
   };
 
-  const startBlank = async () => {
+  const startBlank = async (opts?: { main?: string }) => {
     if (inFlightRef.current) return;
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- in-flight guard for duplicate-click prevention
     inFlightRef.current = true;
@@ -148,7 +148,7 @@ export function useStartThreadFromPrompt({
     try {
       const newId = crypto.randomUUID();
       await create({ id: newId, virtual_mcp_id: agentId });
-      setTaskId(newId, agentId);
+      setTaskId(newId, agentId, opts?.main ? { main: opts.main } : undefined);
     } catch (error) {
       console.error("[start-thread-from-prompt] startBlank failed", error);
       toast.error("Failed to start thread. Please try again.");

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -115,7 +115,7 @@ export function usePanelActions() {
   const setTaskId = (
     id: string,
     virtualMcpId?: string,
-    opts?: { autosend?: boolean },
+    opts?: { autosend?: boolean; main?: string },
   ) =>
     navWith(
       id,
@@ -123,17 +123,22 @@ export function usePanelActions() {
         const next: Record<string, unknown> = { chat: 1 };
         if (virtualMcpId) next.virtualmcpid = virtualMcpId;
         else if (prev.virtualmcpid) next.virtualmcpid = prev.virtualmcpid;
-        // Preserve system-level panel tabs (git, preview, settings, …) across
-        // thread switches, but drop per-thread tabs (expanded tool views,
-        // web-page previews, automation details) that are specific to the
-        // previous task.
-        const prevMain = prev.main;
-        if (
-          prevMain &&
-          typeof prevMain === "string" &&
-          !isPerThreadTab(prevMain)
-        ) {
-          next.main = prevMain;
+        // Explicit main tab takes priority (e.g. home tile → pinned view).
+        if (opts?.main) {
+          next.main = opts.main;
+        } else {
+          // Preserve system-level panel tabs (git, preview, settings, …) across
+          // thread switches, but drop per-thread tabs (expanded tool views,
+          // web-page previews, automation details) that are specific to the
+          // previous task.
+          const prevMain = prev.main;
+          if (
+            prevMain &&
+            typeof prevMain === "string" &&
+            !isPerThreadTab(prevMain)
+          ) {
+            next.main = prevMain;
+          }
         }
         if (opts?.autosend) next.autosend = AUTOSEND_QUERY_VALUE;
         return next;


### PR DESCRIPTION
## Summary
- The "Open chat" button on home page tiles now navigates to chat **with the tile's UI panel open** side-by-side, instead of a pure chat view
- Added `useTileMainTab` hook that resolves the pinned-view tab ID for a tile, including legacy tiles without an explicit `toolName` (resolves via `resourceUri` match against the connection's tools list)
- Extended `setTaskId` and `startBlank` to accept an optional `main` tab parameter

## Test plan
- [ ] Click "Open chat" on a home tile **with** `toolName` set → chat + UI panel open side-by-side
- [ ] Click "Open chat" on a legacy home tile **without** `toolName` → same behavior (tool name resolved from `resourceUri`)
- [ ] Click a prompt chip on a tile → still opens chat with the prompt as before
- [ ] Switching threads preserves system-level tabs (git, preview, settings) as before
- [ ] `autosend` flow from prompt cards still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The “Open chat” button on home tiles now opens chat with the tile’s UI panel side-by-side by setting the main panel tab to the tile’s pinned view. Legacy tiles without a `toolName` also work by resolving the tool from the connection’s tools list.

- **New Features**
  - Added `useTileMainTab` to compute the pinned-view tab ID without suspending; resolves legacy tiles by matching `resourceUri` via the MCP tools list in `@decocms/mesh-sdk`.
  - Extended `setTaskId` and `startBlank(opts?: { main?: string })` to accept a `main` tab; preserves system-level tabs when not specified.
  - Updated home tiles (and error fallback) to pass `main` into `startBlank`; prompt chips and `autosend` behavior remain unchanged.

<sup>Written for commit 65cf7ff818bcfe0a88ea05af543aad09daafcc93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

