### PR TITLE
fix(sidebar): always pin decopilot in sidebar

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/group-threads.test.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/group-threads.test.ts
@@ -84,7 +84,7 @@ describe("groupThreadsByVirtualMcp", () => {
     expect(result[0]?.threads.map((th) => th.id)).toEqual(["a", "b", "c"]);
   });
 
-  it("does not insert decopilot when it has no threads", () => {
+  it("always pins decopilot first even when it has no threads", () => {
     const result = groupThreadsByVirtualMcp(
       [
         t({
@@ -95,7 +95,11 @@ describe("groupThreadsByVirtualMcp", () => {
       ],
       "vm-decopilot",
     );
-    expect(result.map((g) => g.virtualMcpId)).toEqual(["vm-other"]);
+    expect(result.map((g) => g.virtualMcpId)).toEqual([
+      "vm-decopilot",
+      "vm-other",
+    ]);
+    expect(result[0]!.threads).toEqual([]);
   });
 
   it("buckets threads without virtual_mcp_id under a synthetic 'tool-call-runs' group at the end", () => {
@@ -123,9 +127,11 @@ describe("groupThreadsByVirtualMcp", () => {
     expect(result).toEqual([]);
   });
 
-  it("returns an empty array when no threads even with decopilot id", () => {
+  it("returns decopilot group with no threads when no threads exist", () => {
     const result = groupThreadsByVirtualMcp([], "vm-decopilot");
-    expect(result).toEqual([]);
+    expect(result).toEqual([
+      { virtualMcpId: "vm-decopilot", threads: [], latestUpdatedAt: "" },
+    ]);
   });
 });
 

--- a/apps/mesh/src/web/components/sidebar/task-groups/group-threads.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/group-threads.ts
@@ -48,7 +48,7 @@ export function groupThreadsByStatus(threads: Task[]): StatusGroupData[] {
  * order in `useSidebarGroupOrder` / `computeDisplayGroups`.
  *
  * Ordering (before user order is applied):
- *  - Decopilot first when it has threads.
+ *  - Decopilot always first (pinned even with no threads).
  *  - Other active groups by max(updated_at) desc.
  *  - Threads without virtual_mcp_id under TOOL_CALL_RUNS_GROUP_KEY last.
  */
@@ -90,7 +90,16 @@ export function groupThreadsByVirtualMcp(
   );
 
   const result: TaskGroupData[] = [];
-  if (decopilot && decopilot.threads.length > 0) result.push(decopilot);
+  // Decopilot is always pinned at the top, even with no threads.
+  if (decopilotVirtualMcpId) {
+    result.push(
+      decopilot ?? {
+        virtualMcpId: decopilotVirtualMcpId,
+        threads: [],
+        latestUpdatedAt: "",
+      },
+    );
+  }
   result.push(...remaining);
   if (toolCallRuns && toolCallRuns.threads.length > 0) {
     result.push(toolCallRuns);

--- a/apps/mesh/src/web/components/sidebar/task-groups/stable-order.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/stable-order.ts
@@ -5,8 +5,9 @@
  * - Org-pinned agents (`connections.pinned` + `sidebar.org-pinned-order.<orgId>`)
  * - Personal agents (`sidebar.group-order.<orgId>.<userId>`)
  *
- * Agents with tasks but not in either list do not appear. Decopilot and
- * tool-call runs still render when they have threads (fixed groups).
+ * Agents with tasks but not in either list do not appear. Decopilot is
+ * always pinned (even with no threads); tool-call runs render when they
+ * have threads. Both are fixed (non-reorderable) groups.
  */
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { TOOL_CALL_RUNS_GROUP_KEY, type TaskGroupData } from "./group-threads";

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -259,7 +259,7 @@ export function TaskGroupsList({
     const isNonAgentGroup =
       virtualMcpId === decopilotId || virtualMcpId === TOOL_CALL_RUNS_GROUP_KEY;
     return {
-      isOrgPinned: orgPinnedSet.has(virtualMcpId),
+      isOrgPinned: isNonAgentGroup || orgPinnedSet.has(virtualMcpId),
       canManageOrgPin: isNonAgentGroup ? false : canManageOrgPin,
       onToggleOrgPin: isNonAgentGroup ? undefined : handleToggleOrgPin,
     };


### PR DESCRIPTION
## Summary
- Decopilot now always appears at the top of the sidebar, even when it has no threads
- Removed the "Hide" option from decopilot's context menu (it's a fixed group that should never be hidden)

## Test plan
- [ ] Open sidebar with no decopilot threads — decopilot group should still be visible at the top
- [ ] Right-click decopilot group — context menu should only show "New task" and "Settings", no "Hide"
- [ ] Other agents should still have the "Hide" option when not org-pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decopilot is now always pinned at the top of the sidebar, even with no threads, and it can’t be hidden. This makes Decopilot always visible and accessible.

- **Bug Fixes**
  - `groupThreadsByVirtualMcp`: always creates a Decopilot group (empty if needed) and orders it first.
  - `TaskGroupsList`: treats Decopilot and tool-call runs as fixed/org-pinned; removes “Hide” from Decopilot’s menu. Other agents keep “Hide”.
  - Tests updated to cover empty-state pinning and ordering.

<sup>Written for commit 09643b74651d914045ca158a9c9616834d443bf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

