### PR TITLE
feat(content): blog post filters + bulk category editor

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { blockComponentName, discoverBlogBlockTypes } from "./blog-data";
+import {
+  addCategoryToPost,
+  blockComponentName,
+  buildBlogBlock,
+  discoverBlogBlockTypes,
+  listPostsWithMeta,
+  replaceCategoryOnPost,
+} from "./blog-data";
 import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+
+/** Build a decofile keyed by post block id, from `{ slug → payload }`. */
+function decofileWithPosts(
+  posts: Record<string, Record<string, unknown>>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, payload] of Object.entries(posts)) {
+    out[key] = buildBlogBlock(key, "posts", payload);
+  }
+  return out;
+}
 
 function metaWith(resolveTypes: string[]): LiveMeta {
   const group: Record<string, { $ref?: string }> = {};
@@ -187,5 +205,133 @@ describe("discoverBlogBlockTypes", () => {
     )[0]!;
     expect(block.iconName).toBe("Star01");
     expect(block.iconUrl).toBeUndefined();
+  });
+});
+
+describe("listPostsWithMeta", () => {
+  test("extracts title, slug, date, category slugs and author emails", () => {
+    const decofile = decofileWithPosts({
+      "collections/blog/posts/a": {
+        title: "Hello",
+        slug: "hello",
+        date: "2024-01-02",
+        categories: [{ name: "News", slug: "news" }],
+        authors: [{ name: "Ada", email: "ada@x.com" }],
+      },
+    });
+    expect(listPostsWithMeta(decofile)).toEqual([
+      {
+        key: "collections/blog/posts/a",
+        title: "Hello",
+        slug: "hello",
+        date: "2024-01-02",
+        categorySlugs: ["news"],
+        authorEmails: ["ada@x.com"],
+      },
+    ]);
+  });
+
+  test("tolerates plain-string categories/authors and falls back to Untitled", () => {
+    const decofile = decofileWithPosts({
+      "collections/blog/posts/a": {
+        categories: ["news", "tips"],
+        authors: ["ada@x.com"],
+      },
+    });
+    const [meta] = listPostsWithMeta(decofile);
+    expect(meta!.title).toBe("Untitled post");
+    expect(meta!.categorySlugs).toEqual(["news", "tips"]);
+    expect(meta!.authorEmails).toEqual(["ada@x.com"]);
+  });
+
+  test("drops malformed refs without slug/email", () => {
+    const decofile = decofileWithPosts({
+      "collections/blog/posts/a": {
+        title: "P",
+        categories: [{ name: "No slug" }, { name: "News", slug: "news" }],
+        authors: [{ name: "No email" }],
+      },
+    });
+    const [meta] = listPostsWithMeta(decofile);
+    expect(meta!.categorySlugs).toEqual(["news"]);
+    expect(meta!.authorEmails).toEqual([]);
+  });
+
+  test("ignores non-post blocks", () => {
+    const decofile = {
+      ...decofileWithPosts({
+        "collections/blog/posts/a": { title: "P", slug: "p" },
+      }),
+      "collections/blog/categories/c": buildBlogBlock(
+        "collections/blog/categories/c",
+        "categories",
+        { name: "News", slug: "news" },
+      ),
+    };
+    expect(listPostsWithMeta(decofile).map((p) => p.key)).toEqual([
+      "collections/blog/posts/a",
+    ]);
+  });
+});
+
+describe("addCategoryToPost", () => {
+  test("appends a new category and keeps existing ones", () => {
+    const payload = { categories: [{ name: "News", slug: "news" }] };
+    const next = addCategoryToPost(payload, { name: "Tips", slug: "tips" });
+    expect(next.categories).toEqual([
+      { name: "News", slug: "news" },
+      { name: "Tips", slug: "tips" },
+    ]);
+  });
+
+  test("initializes categories when the post has none", () => {
+    const next = addCategoryToPost(
+      { title: "P" },
+      { name: "News", slug: "news" },
+    );
+    expect(next).toEqual({
+      title: "P",
+      categories: [{ name: "News", slug: "news" }],
+    });
+  });
+
+  test("is idempotent — adding a present slug does not duplicate", () => {
+    const payload = { categories: [{ name: "News", slug: "news" }] };
+    const next = addCategoryToPost(payload, { name: "News", slug: "news" });
+    expect(next.categories).toEqual([{ name: "News", slug: "news" }]);
+  });
+
+  test("does not mutate the input payload", () => {
+    const payload = { categories: [{ name: "News", slug: "news" }] };
+    addCategoryToPost(payload, { name: "Tips", slug: "tips" });
+    expect(payload.categories).toEqual([{ name: "News", slug: "news" }]);
+  });
+});
+
+describe("replaceCategoryOnPost", () => {
+  test("replaces all categories with the chosen one", () => {
+    const payload = {
+      categories: [
+        { name: "News", slug: "news" },
+        { name: "Tips", slug: "tips" },
+      ],
+    };
+    const next = replaceCategoryOnPost(payload, {
+      name: "Guides",
+      slug: "guides",
+    });
+    expect(next.categories).toEqual([{ name: "Guides", slug: "guides" }]);
+  });
+
+  test("sets the category when the post had none", () => {
+    const next = replaceCategoryOnPost({}, { name: "News", slug: "news" });
+    expect(next.categories).toEqual([{ name: "News", slug: "news" }]);
+  });
+
+  test("is a no-op when it already has exactly that category", () => {
+    const payload = { categories: [{ name: "News", slug: "news" }] };
+    expect(replaceCategoryOnPost(payload, { name: "News", slug: "news" })).toBe(
+      payload,
+    );
   });
 });

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -187,6 +187,107 @@ export function blogBlockFilePath(key: string): string {
   return `.deco/blocks/${encodeURIComponent(key)}.json`;
 }
 
+// ------------------ Post metadata + category mutation ------------------
+
+/** A single category reference, denormalized on a post payload. */
+export interface CategoryRef {
+  name: string;
+  slug: string;
+}
+
+/** Compact metadata for a post, used by the posts list filters/sort. */
+export interface PostMeta {
+  /** Decofile key (block id). */
+  key: string;
+  title: string;
+  slug: string;
+  /** Raw `date` string from the payload (ISO date, possibly empty). */
+  date: string;
+  /** Slugs of the post's categories (denormalized). */
+  categorySlugs: string[];
+  /** Emails of the post's authors (denormalized). */
+  authorEmails: string[];
+}
+
+function toArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/**
+ * A category on a post can be a plain slug string or a `{ name, slug }`
+ * object (deco denormalizes the latter). Tolerate both.
+ */
+function categorySlugOf(item: unknown): string {
+  if (typeof item === "string") return item;
+  const rec = asRecord(item);
+  return rec ? str(rec.slug) : "";
+}
+
+/** Authors are denormalized as `{ name, email }`; tolerate plain strings. */
+function authorEmailOf(item: unknown): string {
+  if (typeof item === "string") return item;
+  const rec = asRecord(item);
+  return rec ? str(rec.email) : "";
+}
+
+/**
+ * All posts paired with the metadata the posts list filters and sorts on.
+ * Reads the denormalized `categories`/`authors` arrays, tolerating either
+ * strings or `{slug}`/`{email}` objects.
+ */
+export function listPostsWithMeta(
+  decofile: Record<string, unknown>,
+): PostMeta[] {
+  return listBlogPayloads(decofile, "posts").map(({ key, payload }) => ({
+    key,
+    title: str(payload.title) || "Untitled post",
+    slug: str(payload.slug),
+    date: str(payload.date),
+    categorySlugs: toArray(payload.categories)
+      .map(categorySlugOf)
+      .filter(Boolean),
+    authorEmails: toArray(payload.authors).map(authorEmailOf).filter(Boolean),
+  }));
+}
+
+/**
+ * Append a category to a post payload, keyed by slug. Idempotent — a slug
+ * already present yields an equivalent payload (no duplicate). Pure: returns
+ * a new payload, never mutates the input.
+ */
+export function addCategoryToPost(
+  payload: Record<string, unknown>,
+  category: CategoryRef,
+): Record<string, unknown> {
+  const categories = toArray(payload.categories);
+  if (categories.some((c) => categorySlugOf(c) === category.slug)) {
+    return payload;
+  }
+  return {
+    ...payload,
+    categories: [...categories, { name: category.name, slug: category.slug }],
+  };
+}
+
+/**
+ * Replace a post's categories with exactly the given one. Pure: returns a new
+ * payload, never mutates the input. Used by the bulk "replace" mode to migrate
+ * posts to a single category in one step.
+ */
+export function replaceCategoryOnPost(
+  payload: Record<string, unknown>,
+  category: CategoryRef,
+): Record<string, unknown> {
+  const current = toArray(payload.categories);
+  if (current.length === 1 && categorySlugOf(current[0]) === category.slug) {
+    return payload;
+  }
+  return {
+    ...payload,
+    categories: [{ name: category.name, slug: category.slug }],
+  };
+}
+
 function randomHex(length: number): string {
   const bytes = new Uint8Array(Math.ceil(length / 2));
   crypto.getRandomValues(bytes);

--- a/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
@@ -1,7 +1,9 @@
+import { ArrowRight, File02 } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
-import { buildBlogBlock, getBlogPayload } from "./blog-data";
+import { buildBlogBlock, getBlogPayload, listPostsWithMeta } from "./blog-data";
 import { useSaveBlogBlock } from "./use-blog-mutations";
 import { useAutosave } from "./use-autosave";
 import { SaveStatus } from "./save-status";
@@ -20,14 +22,18 @@ export function CategoryEditor({
   branch,
   blockKey,
   block,
+  decofile,
   meta,
+  onManagePosts,
 }: {
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
   blockKey: string;
   block: Record<string, unknown> | undefined;
+  decofile: Record<string, unknown>;
   meta: LiveMeta;
+  onManagePosts: (slug: string) => void;
 }) {
   const save = useSaveBlogBlock({ orgSlug, virtualMcpId, branch });
   const initial = getBlogPayload(block, "categories");
@@ -41,6 +47,12 @@ export function CategoryEditor({
 
   const setField = (key: string, value: unknown) =>
     setCategory({ ...category, [key]: value });
+
+  const slug = str(category.slug);
+  const postCount = slug
+    ? listPostsWithMeta(decofile).filter((p) => p.categorySlugs.includes(slug))
+        .length
+    : 0;
 
   return (
     <BlogSandboxProvider
@@ -85,6 +97,31 @@ export function CategoryEditor({
                 placeholder="Short description for this category"
                 className="h-10"
               />
+            </div>
+
+            <div className="mt-6 flex items-center justify-between gap-3 rounded-lg border bg-muted/30 px-4 py-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <File02 size={16} className="shrink-0 text-muted-foreground" />
+                <span className="text-sm">
+                  {postCount} {postCount === 1 ? "post" : "posts"} in this
+                  category
+                </span>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!slug}
+                title={
+                  slug
+                    ? "Jump to the posts list filtered by this category"
+                    : "Set a slug to manage this category's posts"
+                }
+                onClick={() => onManagePosts(slug)}
+              >
+                Manage posts
+                <ArrowRight size={14} />
+              </Button>
             </div>
 
             <div className="mt-6 border-t" />

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -1,8 +1,9 @@
-import { Suspense, lazy, useState } from "react";
+import { Suspense, forwardRef, lazy, useState } from "react";
 import { type Query } from "@tanstack/react-query";
 import {
   AlertCircle,
   BookOpen01,
+  ChevronDown,
   Code01,
   Copy01,
   DotsHorizontal,
@@ -16,10 +17,12 @@ import {
   Plus,
   SearchLg,
   Settings01,
+  SwitchVertical01,
   Tag01,
   CreditCardSearch,
   Trash01,
   Users01,
+  X,
 } from "@untitledui/icons";
 import { toast } from "sonner";
 import {
@@ -33,13 +36,37 @@ import {
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
+import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@deco/ui/components/radio-group.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import {
   Tooltip,
@@ -102,6 +129,8 @@ import { SectionRenameDialog } from "./section-rename-dialog";
 import {
   type BlogEntry,
   type BlogKind,
+  type CategoryRef,
+  addCategoryToPost,
   BLOG_KINDS,
   BLOG_SINGULAR,
   buildBlogBlock,
@@ -109,6 +138,9 @@ import {
   generateBlogKey,
   getBlogPayload,
   isBlogKind,
+  listBlogPayloads,
+  listPostsWithMeta,
+  replaceCategoryOnPost,
   scanBlogEntries,
 } from "./blog/blog-data";
 import {
@@ -173,7 +205,10 @@ type DeleteTarget =
   | { kind: "page"; key: string; label: string }
   | { kind: "section"; key: string; label: string }
   | { kind: "blog"; blogKind: BlogKind; key: string; label: string }
+  | { kind: "blog-bulk"; keys: string[]; count: number }
   | null;
+
+type PostSort = "date-desc" | "date-asc" | "az" | "za";
 
 export function ContentBrowser() {
   const inset = useInsetContext();
@@ -287,11 +322,25 @@ function ContentBrowserReady({
   // Page that should open with the inline SEO form in SectionsEditor.
   const [openPageSeoKey, setOpenPageSeoKey] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
-  // Reset search when switching collections (derived-state sync pattern)
+  // Posts-only filter/sort + bulk selection state.
+  const [postCategoryFilter, setPostCategoryFilter] = useState<string | null>(
+    null,
+  );
+  const [postAuthorFilter, setPostAuthorFilter] = useState<string | null>(null);
+  const [postSort, setPostSort] = useState<PostSort>("date-desc");
+  const [selectedPostKeys, setSelectedPostKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+  // Reset search + post filters/selection when switching collections
+  // (derived-state sync pattern).
   const [prevCollection, setPrevCollection] = useState(activeCollection);
   if (prevCollection !== activeCollection) {
     setPrevCollection(activeCollection);
     setSearchQuery("");
+    setPostCategoryFilter(null);
+    setPostAuthorFilter(null);
+    setPostSort("date-desc");
+    setSelectedPostKeys(new Set());
   }
 
   const {
@@ -362,6 +411,10 @@ function ContentBrowserReady({
   const [renameSectionKey, setRenameSectionKey] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget>(null);
   const [jsonPageKey, setJsonPageKey] = useState<string | null>(null);
+  // "Update category" bulk dialog — holds the count of posts it will act on.
+  const [categoryDialog, setCategoryDialog] = useState<{
+    count: number;
+  } | null>(null);
 
   if (decofileLoading || metaLoading) {
     return (
@@ -385,6 +438,19 @@ function ContentBrowserReady({
   const blogEntries = isBlogKind(activeCollection)
     ? allBlogEntries[activeCollection]
     : [];
+
+  // Category choices for the bulk "Update category" dialog (parent scope, since
+  // the dialog renders here rather than inside ItemList).
+  const bulkCategoryChoices: CategoryRef[] = (
+    showBlog ? listBlogPayloads(decofile, "categories") : []
+  )
+    .map(({ key, payload }) => {
+      const slug = typeof payload.slug === "string" ? payload.slug : "";
+      const name = typeof payload.name === "string" ? payload.name : "";
+      return { slug: slug || key, name: name || slug || key };
+    })
+    .filter((c) => c.slug)
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   if (!hasEditableDecoContent(decofile, meta) && !showBlog) {
     return (
@@ -631,11 +697,105 @@ function ContentBrowserReady({
     }
   };
 
+  // ------------------ Posts: filter jump + bulk actions ------------------
+  const togglePostSelection = (key: string) => {
+    setSelectedPostKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  // Land on the posts list pre-filtered by a category (from the category
+  // editor). Sync `prevCollection` here so the collection-change reset
+  // above doesn't immediately clear the filter we're setting.
+  const handleManagePosts = (slug: string) => {
+    setActiveCollection("posts");
+    setPrevCollection("posts");
+    setSelection(null);
+    setOpenPageSeoKey(null);
+    setSearchQuery("");
+    setPostCategoryFilter(slug);
+    setPostAuthorFilter(null);
+    setPostSort("date-desc");
+    setSelectedPostKeys(new Set());
+  };
+
+  // Apply a pure category mutation to every selected post and persist
+  // sequentially — each mutation's optimistic onMutate patches the shared
+  // decofile cache key, so sequential writes avoid lost updates. The mutation
+  // helpers return the SAME payload object on a no-op, so reference equality
+  // tells us which posts actually changed. Returns the changed count.
+  const applyBulkCategory = async (
+    mode: "add" | "replace",
+    category: CategoryRef,
+  ): Promise<number> => {
+    const keys = [...selectedPostKeys];
+    let changed = 0;
+    for (const key of keys) {
+      const block = decofile[key] as Record<string, unknown> | undefined;
+      const payload = getBlogPayload(block, "posts");
+      const next =
+        mode === "add"
+          ? addCategoryToPost(payload, category)
+          : replaceCategoryOnPost(payload, category);
+      if (next === payload) continue;
+      await saveBlogBlock.mutateAsync({
+        blockKey: key,
+        data: buildBlogBlock(key, "posts", next),
+      });
+      changed += 1;
+    }
+    return changed;
+  };
+
+  // Driven by the "Update category" dialog: applies the chosen mode, reports
+  // the outcome, then closes the dialog and clears the selection.
+  const runBulkCategoryUpdate = async (
+    mode: "add" | "replace",
+    category: CategoryRef,
+  ) => {
+    const total = selectedPostKeys.size;
+    try {
+      const changed = await applyBulkCategory(mode, category);
+      const verb = mode === "add" ? "Added to" : "Moved";
+      const unchanged = total - changed;
+      toast.success(
+        `${verb} ${changed} ${changed === 1 ? "post" : "posts"}` +
+          (unchanged > 0 ? ` (${unchanged} already set)` : ""),
+      );
+      setSelectedPostKeys(new Set());
+      setCategoryDialog(null);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Bulk update failed");
+    }
+  };
+
   // ------------------ Delete ------------------
   const confirmDelete = async () => {
     if (!deleteTarget) return;
-    const { kind, key, label } = deleteTarget;
     try {
+      if (deleteTarget.kind === "blog-bulk") {
+        for (const key of deleteTarget.keys) {
+          await deleteBlogBlock.mutateAsync({ blockKey: key });
+        }
+        toast.success(
+          `Deleted ${deleteTarget.count} ${
+            deleteTarget.count === 1 ? "post" : "posts"
+          }`,
+        );
+        if (selection && deleteTarget.keys.includes(selection.key)) {
+          setSelection(null);
+        }
+        setSelectedPostKeys(new Set());
+        setDeleteTarget(null);
+        return;
+      }
+      const { kind, key, label } = deleteTarget;
       if (kind === "blog") {
         await deleteBlogBlock.mutateAsync({ blockKey: key });
       } else {
@@ -656,7 +816,9 @@ function ContentBrowserReady({
   const deleteNoun =
     deleteTarget?.kind === "blog"
       ? BLOG_SINGULAR[deleteTarget.blogKind]
-      : (deleteTarget?.kind ?? "item");
+      : deleteTarget?.kind === "blog-bulk"
+        ? `${deleteTarget.count} ${deleteTarget.count === 1 ? "post" : "posts"}`
+        : (deleteTarget?.kind ?? "item");
   return (
     <div className="flex h-full w-full">
       <CollectionsSidebar
@@ -680,6 +842,32 @@ function ContentBrowserReady({
           decofile={decofile}
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
+          postCategoryFilter={postCategoryFilter}
+          postAuthorFilter={postAuthorFilter}
+          postSort={postSort}
+          onPostCategoryFilterChange={(slug) => {
+            setPostCategoryFilter(slug);
+            setSelectedPostKeys(new Set());
+          }}
+          onPostAuthorFilterChange={(email) => {
+            setPostAuthorFilter(email);
+            setSelectedPostKeys(new Set());
+          }}
+          onPostSortChange={setPostSort}
+          selectedPostKeys={selectedPostKeys}
+          onTogglePostSelect={togglePostSelection}
+          onSelectAllPosts={(keys) => setSelectedPostKeys(new Set(keys))}
+          onClearPostSelection={() => setSelectedPostKeys(new Set())}
+          onBulkUpdateCategory={() =>
+            setCategoryDialog({ count: selectedPostKeys.size })
+          }
+          onBulkDeletePosts={() =>
+            setDeleteTarget({
+              kind: "blog-bulk",
+              keys: [...selectedPostKeys],
+              count: selectedPostKeys.size,
+            })
+          }
           selection={selection}
           onSelect={(next) => {
             setSelection(next);
@@ -813,7 +1001,9 @@ function ContentBrowserReady({
                 branch={branch}
                 blockKey={selection.key}
                 block={decofile[selection.key] as Record<string, unknown>}
+                decofile={decofile}
                 meta={meta}
+                onManagePosts={handleManagePosts}
               />
             ) : selection.collection === "authors" ? (
               <RecordEditor
@@ -937,6 +1127,21 @@ function ContentBrowserReady({
         />
       )}
 
+      {/* Bulk "Update category" dialog */}
+      {categoryDialog && (
+        <BulkCategoryDialog
+          count={categoryDialog.count}
+          categories={bulkCategoryChoices}
+          isPending={saveBlogBlock.isPending}
+          onApply={(mode, category) =>
+            void runBulkCategoryUpdate(mode, category)
+          }
+          onOpenChange={(open) => {
+            if (!open && !saveBlogBlock.isPending) setCategoryDialog(null);
+          }}
+        />
+      )}
+
       {/* Delete confirmation */}
       <AlertDialog
         open={!!deleteTarget}
@@ -950,9 +1155,13 @@ function ContentBrowserReady({
             <AlertDialogDescription>
               {deleteTarget?.kind === "section"
                 ? `"${deleteTarget.label}" will be removed. Pages that still reference it will lose this section.`
-                : deleteTarget
-                  ? `"${deleteTarget.label}" will be removed permanently. This can't be undone.`
-                  : null}
+                : deleteTarget?.kind === "blog-bulk"
+                  ? `${deleteTarget.count} ${
+                      deleteTarget.count === 1 ? "post" : "posts"
+                    } will be removed permanently. This can't be undone.`
+                  : deleteTarget
+                    ? `"${deleteTarget.label}" will be removed permanently. This can't be undone.`
+                    : null}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -1129,6 +1338,18 @@ function ItemList({
   previewUrl,
   searchQuery,
   onSearchChange,
+  postCategoryFilter,
+  postAuthorFilter,
+  postSort,
+  onPostCategoryFilterChange,
+  onPostAuthorFilterChange,
+  onPostSortChange,
+  selectedPostKeys,
+  onTogglePostSelect,
+  onSelectAllPosts,
+  onClearPostSelection,
+  onBulkUpdateCategory,
+  onBulkDeletePosts,
   selection,
   onSelect,
   onCreate,
@@ -1154,6 +1375,18 @@ function ItemList({
   previewUrl: string | null;
   searchQuery: string;
   onSearchChange: (q: string) => void;
+  postCategoryFilter: string | null;
+  postAuthorFilter: string | null;
+  postSort: PostSort;
+  onPostCategoryFilterChange: (slug: string | null) => void;
+  onPostAuthorFilterChange: (email: string | null) => void;
+  onPostSortChange: (sort: PostSort) => void;
+  selectedPostKeys: Set<string>;
+  onTogglePostSelect: (key: string) => void;
+  onSelectAllPosts: (keys: string[]) => void;
+  onClearPostSelection: () => void;
+  onBulkUpdateCategory: () => void;
+  onBulkDeletePosts: () => void;
   selection: Selection;
   onSelect: (next: Selection) => void;
   onCreate: () => void;
@@ -1197,6 +1430,83 @@ function ItemList({
       e.label.toLowerCase().includes(q) ||
       e.subtitle.toLowerCase().includes(q),
   );
+
+  // Posts get their own filter/sort pipeline driven by denormalized
+  // category/author metadata, so the plain `blogEntries` path is skipped.
+  const isPostsCollection = activeCollection === "posts";
+  const asStr = (v: unknown) => (typeof v === "string" ? v : "");
+  const postsWithMeta = isPostsCollection ? listPostsWithMeta(decofile) : [];
+
+  // Live counts per category/author so the filter dropdowns can show how
+  // many posts each option matches (and hide the ones that match none).
+  const categoryCounts = new Map<string, number>();
+  const authorCounts = new Map<string, number>();
+  for (const p of postsWithMeta) {
+    for (const slug of p.categorySlugs) {
+      categoryCounts.set(slug, (categoryCounts.get(slug) ?? 0) + 1);
+    }
+    for (const email of p.authorEmails) {
+      authorCounts.set(email, (authorCounts.get(email) ?? 0) + 1);
+    }
+  }
+  const categoryOptions = (
+    isPostsCollection ? listBlogPayloads(decofile, "categories") : []
+  )
+    .map(({ key, payload }) => {
+      const slug = asStr(payload.slug) || key;
+      return {
+        slug,
+        name: asStr(payload.name) || asStr(payload.slug) || key,
+        count: categoryCounts.get(slug) ?? 0,
+      };
+    })
+    .filter((c) => c.slug);
+  const authorOptions = (
+    isPostsCollection ? listBlogPayloads(decofile, "authors") : []
+  )
+    .map(({ key, payload }) => {
+      const email = asStr(payload.email);
+      return {
+        email,
+        name: asStr(payload.name) || asStr(payload.email) || key,
+        count: authorCounts.get(email) ?? 0,
+      };
+    })
+    .filter((a) => a.email);
+  const sortedPosts = postsWithMeta
+    .filter(
+      (p) =>
+        !q ||
+        p.title.toLowerCase().includes(q) ||
+        p.slug.toLowerCase().includes(q),
+    )
+    .filter(
+      (p) =>
+        !postCategoryFilter || p.categorySlugs.includes(postCategoryFilter),
+    )
+    .filter(
+      (p) => !postAuthorFilter || p.authorEmails.includes(postAuthorFilter),
+    )
+    .sort((a, b) => {
+      if (postSort === "az") return a.title.localeCompare(b.title);
+      if (postSort === "za") return b.title.localeCompare(a.title);
+      // ISO date strings sort lexically; empty dates sink to the bottom.
+      const cmp = a.date.localeCompare(b.date);
+      return postSort === "date-asc" ? cmp : -cmp;
+    });
+  const selectionCount = selectedPostKeys.size;
+  const visiblePostKeys = sortedPosts.map((p) => p.key);
+  const allVisibleSelected =
+    visiblePostKeys.length > 0 &&
+    visiblePostKeys.every((k) => selectedPostKeys.has(k));
+  const selectionActive = selectionCount > 0;
+  const toggleSelectAll = () => {
+    if (allVisibleSelected) {
+      onClearPostSelection();
+    } else {
+      onSelectAllPosts(visiblePostKeys);
+    }
+  };
 
   const placeholder = `Search ${activeCollection}…`;
   const createTooltip = isBlogKind(activeCollection)
@@ -1249,6 +1559,31 @@ function ItemList({
           </Tooltip>
         )}
       </div>
+      {isPostsCollection &&
+        (selectionActive ? (
+          <PostSelectionToolbar
+            count={selectionCount}
+            allSelected={allVisibleSelected}
+            onToggleSelectAll={toggleSelectAll}
+            onUpdateCategory={onBulkUpdateCategory}
+            onDelete={onBulkDeletePosts}
+            onClear={onClearPostSelection}
+          />
+        ) : (
+          <PostFilterBar
+            categories={categoryOptions}
+            authors={authorOptions}
+            categoryFilter={postCategoryFilter}
+            authorFilter={postAuthorFilter}
+            sort={postSort}
+            hasPosts={postsWithMeta.length > 0}
+            allSelected={allVisibleSelected}
+            onToggleSelectAll={toggleSelectAll}
+            onCategoryFilterChange={onPostCategoryFilterChange}
+            onAuthorFilterChange={onPostAuthorFilterChange}
+            onSortChange={onPostSortChange}
+          />
+        ))}
       {/* Force Radix's inner `display:table` content wrapper back to block so
           long titles truncate instead of widening the viewport. */}
       <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
@@ -1380,6 +1715,48 @@ function ItemList({
                 );
               })
             )
+          ) : isPostsCollection ? (
+            sortedPosts.length === 0 ? (
+              <ListEmpty
+                hasItems={postsWithMeta.length > 0}
+                emptyLabel="No posts yet."
+                emptyHint='Click "+" to create your first post.'
+              />
+            ) : (
+              sortedPosts.map((post) => {
+                const entry: BlogEntry = {
+                  key: post.key,
+                  kind: "posts",
+                  label: post.title,
+                  subtitle: post.slug,
+                };
+                return (
+                  <ItemRow
+                    key={post.key}
+                    icon={File02}
+                    title={post.title}
+                    subtitle={post.slug}
+                    active={
+                      selection?.collection === "posts" &&
+                      selection.key === post.key
+                    }
+                    selectable
+                    selectionActive={selectionActive}
+                    selected={selectedPostKeys.has(post.key)}
+                    onToggleSelect={() => onTogglePostSelect(post.key)}
+                    onClick={() =>
+                      onSelect({ collection: "posts", key: post.key })
+                    }
+                    menu={
+                      <ItemActions
+                        onDuplicate={() => onDuplicateBlog(entry)}
+                        onDelete={() => onDeleteBlog(entry)}
+                      />
+                    }
+                  />
+                );
+              })
+            )
           ) : filteredBlog.length === 0 ? (
             <ListEmpty
               hasItems={blogEntries.length > 0}
@@ -1427,6 +1804,432 @@ function ItemList({
   );
 }
 
+// Sentinel for the "no filter" radio option (Radix forbids empty values).
+const ALL_FILTER = "__all__";
+
+const POST_SORT_LABELS: Record<PostSort, string> = {
+  "date-desc": "Newest first",
+  "date-asc": "Oldest first",
+  az: "Title A–Z",
+  za: "Title Z–A",
+};
+
+const POST_SORT_SHORT: Record<PostSort, string> = {
+  "date-desc": "Newest",
+  "date-asc": "Oldest",
+  az: "A–Z",
+  za: "Z–A",
+};
+
+type CategoryOption = { slug: string; name: string; count: number };
+type AuthorOption = { email: string; name: string; count: number };
+
+/**
+ * Compact, icon-led filter trigger: just the icon when no filter is applied,
+ * icon + highlighted value once one is. Forwards props/ref so it can be used
+ * directly as a `DropdownMenuTrigger asChild` child.
+ */
+const FilterChipTrigger = forwardRef<
+  HTMLButtonElement,
+  {
+    icon: React.ComponentType<{ size?: number; className?: string }>;
+    active: boolean;
+    value?: string;
+  } & React.ComponentProps<typeof Button>
+>(function FilterChipTrigger(
+  { icon: Icon, active, value, className, ...props },
+  ref,
+) {
+  return (
+    <Button
+      ref={ref}
+      type="button"
+      variant="ghost"
+      size="sm"
+      className={cn(
+        "h-7 gap-1 px-1.5 text-xs",
+        active ? "text-foreground" : "text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <Icon size={14} className="shrink-0" />
+      {value && <span className="min-w-0 flex-1 truncate">{value}</span>}
+      <ChevronDown size={12} className="shrink-0 opacity-60" />
+    </Button>
+  );
+});
+
+function OptionCount({ count }: { count: number }) {
+  return (
+    <span className="ml-auto pl-3 text-xs text-muted-foreground tabular-nums">
+      {count}
+    </span>
+  );
+}
+
+function PostFilterBar({
+  categories,
+  authors,
+  categoryFilter,
+  authorFilter,
+  sort,
+  hasPosts,
+  allSelected,
+  onToggleSelectAll,
+  onCategoryFilterChange,
+  onAuthorFilterChange,
+  onSortChange,
+}: {
+  categories: CategoryOption[];
+  authors: AuthorOption[];
+  categoryFilter: string | null;
+  authorFilter: string | null;
+  sort: PostSort;
+  hasPosts: boolean;
+  allSelected: boolean;
+  onToggleSelectAll: () => void;
+  onCategoryFilterChange: (slug: string | null) => void;
+  onAuthorFilterChange: (email: string | null) => void;
+  onSortChange: (sort: PostSort) => void;
+}) {
+  const activeCategory = categories.find((c) => c.slug === categoryFilter);
+  const activeAuthor = authors.find((a) => a.email === authorFilter);
+
+  return (
+    <div className="flex min-w-0 items-center gap-0.5 overflow-hidden border-b px-2 py-1.5">
+      <SelectAllControl
+        checked={allSelected}
+        disabled={!hasPosts}
+        onToggle={onToggleSelectAll}
+      />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <FilterChipTrigger
+            icon={Tag01}
+            active={!!categoryFilter}
+            value={activeCategory?.name}
+            className="min-w-0 shrink"
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="max-h-80 w-56 overflow-y-auto"
+        >
+          <DropdownMenuLabel>Filter by category</DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={categoryFilter ?? ALL_FILTER}
+            onValueChange={(v) =>
+              onCategoryFilterChange(v === ALL_FILTER ? null : v)
+            }
+          >
+            <DropdownMenuRadioItem value={ALL_FILTER}>
+              All categories
+            </DropdownMenuRadioItem>
+            {categories.map((c) => (
+              <DropdownMenuRadioItem key={c.slug} value={c.slug}>
+                <span className="min-w-0 flex-1 truncate">{c.name}</span>
+                <OptionCount count={c.count} />
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <FilterChipTrigger
+            icon={Users01}
+            active={!!authorFilter}
+            value={activeAuthor?.name}
+            className="min-w-0 shrink"
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="max-h-80 w-56 overflow-y-auto"
+        >
+          <DropdownMenuLabel>Filter by author</DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={authorFilter ?? ALL_FILTER}
+            onValueChange={(v) =>
+              onAuthorFilterChange(v === ALL_FILTER ? null : v)
+            }
+          >
+            <DropdownMenuRadioItem value={ALL_FILTER}>
+              All authors
+            </DropdownMenuRadioItem>
+            {authors.map((a) => (
+              <DropdownMenuRadioItem key={a.email} value={a.email}>
+                <span className="min-w-0 flex-1 truncate">{a.name}</span>
+                <OptionCount count={a.count} />
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <FilterChipTrigger
+            icon={SwitchVertical01}
+            active
+            value={POST_SORT_SHORT[sort]}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44">
+          <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={sort}
+            onValueChange={(v) => onSortChange(v as PostSort)}
+          >
+            {(Object.keys(POST_SORT_LABELS) as PostSort[]).map((value) => (
+              <DropdownMenuRadioItem key={value} value={value}>
+                {POST_SORT_LABELS[value]}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+/** Tooltip-wrapped "select all" checkbox shared by the filter bar + toolbar. */
+function SelectAllControl({
+  checked,
+  disabled,
+  onToggle,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="flex shrink-0 items-center px-1.5"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Checkbox
+            checked={checked}
+            disabled={disabled}
+            onCheckedChange={() => onToggle()}
+            aria-label={checked ? "Deselect all posts" : "Select all posts"}
+          />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {checked ? "Deselect all" : "Select all"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function PostSelectionToolbar({
+  count,
+  allSelected,
+  onToggleSelectAll,
+  onUpdateCategory,
+  onDelete,
+  onClear,
+}: {
+  count: number;
+  allSelected: boolean;
+  onToggleSelectAll: () => void;
+  onUpdateCategory: () => void;
+  onDelete: () => void;
+  onClear: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-0.5 border-b bg-accent/40 px-2 py-1.5">
+      <SelectAllControl checked={allSelected} onToggle={onToggleSelectAll} />
+      <span className="text-xs font-medium tabular-nums">{count} selected</span>
+      <div className="ml-auto flex items-center gap-0.5">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+              onClick={onUpdateCategory}
+              aria-label="Update category for selected posts"
+            >
+              <Tag01 size={14} />
+              Category
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Update category</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-destructive hover:text-destructive"
+              onClick={onDelete}
+              aria-label="Delete selected posts"
+            >
+              <Trash01 size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Delete selected</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onClear}
+              aria-label="Clear selection"
+            >
+              <X size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Clear selection</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Dialog for the bulk "Update category" action: pick a category, then choose
+ * whether to add it (keeping existing categories) or replace all categories
+ * with it (a one-step migration). Holds its own selection/mode state so the
+ * parent only deals with the final apply.
+ */
+function BulkCategoryDialog({
+  count,
+  categories,
+  isPending,
+  onApply,
+  onOpenChange,
+}: {
+  count: number;
+  categories: CategoryRef[];
+  isPending: boolean;
+  onApply: (mode: "add" | "replace", category: CategoryRef) => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [slug, setSlug] = useState<string>(categories[0]?.slug ?? "");
+  const [mode, setMode] = useState<"add" | "replace">("add");
+  const selected = categories.find((c) => c.slug === slug);
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Update category</DialogTitle>
+          <DialogDescription>
+            Choose a category to apply to {count}{" "}
+            {count === 1 ? "post" : "posts"}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label>Category</Label>
+            {categories.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No categories yet — create one in the Categories collection.
+              </p>
+            ) : (
+              <Select value={slug} onValueChange={setSlug}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a category" />
+                </SelectTrigger>
+                <SelectContent>
+                  {categories.map((c) => (
+                    <SelectItem key={c.slug} value={c.slug}>
+                      <span className="truncate">{c.name}</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+
+          <RadioGroup
+            value={mode}
+            onValueChange={(v) => setMode(v as "add" | "replace")}
+            className="gap-2"
+          >
+            <Label
+              htmlFor="cat-mode-add"
+              className="flex cursor-pointer items-start gap-2.5 rounded-lg border p-3"
+            >
+              <RadioGroupItem
+                value="add"
+                id="cat-mode-add"
+                className="mt-0.5"
+              />
+              <span className="space-y-0.5">
+                <span className="block text-sm font-medium">Add category</span>
+                <span className="block text-xs text-muted-foreground">
+                  Keep existing categories and add this one.
+                </span>
+              </span>
+            </Label>
+            <Label
+              htmlFor="cat-mode-replace"
+              className="flex cursor-pointer items-start gap-2.5 rounded-lg border p-3"
+            >
+              <RadioGroupItem
+                value="replace"
+                id="cat-mode-replace"
+                className="mt-0.5"
+              />
+              <span className="space-y-0.5">
+                <span className="block text-sm font-medium">
+                  Replace category
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  Remove all current categories and set only this one.
+                </span>
+              </span>
+            </Label>
+          </RadioGroup>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!selected || isPending}
+            onClick={() =>
+              selected &&
+              onApply(mode, { name: selected.name, slug: selected.slug })
+            }
+          >
+            {isPending ? (
+              <>
+                <Loading01 size={14} className="animate-spin" />
+                Updating…
+              </>
+            ) : (
+              "Apply"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function ItemRow({
   icon: Icon,
   logoUrl,
@@ -1435,6 +2238,10 @@ function ItemRow({
   active,
   variantCount,
   trailing,
+  selectable,
+  selectionActive,
+  selected,
+  onToggleSelect,
   onClick,
   menu,
 }: {
@@ -1449,6 +2256,10 @@ function ItemRow({
   active: boolean;
   variantCount?: number;
   trailing?: React.ReactNode;
+  selectable?: boolean;
+  selectionActive?: boolean;
+  selected?: boolean;
+  onToggleSelect?: () => void;
   onClick: () => void;
   menu?: React.ReactNode;
 }) {
@@ -1491,6 +2302,23 @@ function ItemRow({
         active ? "bg-accent text-accent-foreground" : "hover:bg-muted",
       )}
     >
+      {selectable && (
+        <span
+          className={cn(
+            "flex shrink-0 items-center pl-2.5 transition-opacity",
+            selected || selectionActive
+              ? "opacity-100"
+              : "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Checkbox
+            checked={selected}
+            onCheckedChange={() => onToggleSelect?.()}
+            aria-label={`Select ${title}`}
+          />
+        </span>
+      )}
       <button
         type="button"
         onClick={onClick}


### PR DESCRIPTION
## Summary

Adds richer post management to the Content tab's Blog area:

- **Posts filter/sort bar** (compact, in the list header): filter by **category** and **author**, sort by **date** (newest/oldest) or **title** (A→Z / Z→A). Each filter dropdown shows per-option post counts.
- **Bulk selection + actions** on the Posts list: row checkboxes + select-all, with a selection toolbar offering:
  - **Update category** dialog — pick a category, then toggle **Add** (keep existing categories) vs **Replace** (set only this one; one-step migration).
  - **Delete** selected posts (confirmation dialog).
- **Category editor** now shows how many posts are in the category and a **"Manage posts"** button that jumps to the Posts list pre-filtered by that category.

## Implementation notes

- Blog data lives client-side in the decofile (React Query); all changes persist through the existing `useSaveBlogBlock` / `useDeleteBlogBlock` mutations and the `/sandbox/.../write` route — no new MCP tools, storage, or migrations.
- Pure, unit-tested helpers in `blog-data.ts`: `listPostsWithMeta`, `addCategoryToPost`, `replaceCategoryOnPost` (idempotent — return the same object on a no-op, so bulk apply detects real changes by reference equality).
- Bulk writes run **sequentially** so each optimistic cache patch lands without lost updates.

## Testing

- `bun test blog-data.test.ts` — 24 pass / 0 fail
- `tsc --noEmit` (apps/mesh) — clean
- `bun run fmt` / `bun run lint` — clean (only pre-existing warnings in unrelated files)

Manual: select posts → Update category (Add then Replace) and Delete; category editor "Manage posts" jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds post filters, sorting, and bulk editing to the Blog Posts list, plus a post count and quick “Manage posts” jump from the Category editor. This improves post management without changing storage or APIs.

- **New Features**
  - Compact Posts filter/sort bar: filter by category and author; sort by date (newest/oldest) or title (A–Z/Z–A). Dropdowns show per-option post counts.
  - Bulk selection on Posts: row checkboxes + select-all; “Update category” dialog with Add vs Replace modes; bulk delete with confirmation.
  - Category editor: shows post count and a “Manage posts” button that opens the Posts list pre-filtered by that category.

<sup>Written for commit 47887d5b1c777c2a067b1a609b859c253f5ec985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

