### PR TITLE
fix(sandbox): guard repoDir for Open in Cursor/VSCode buttons

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -250,12 +250,16 @@ export function PreviewContent() {
   const devServerReady = lifecyclePhase === "running";
 
   const isDesktopSandbox = vmEntry?.sandboxProviderKind === "user-desktop";
-  const repoDir = useSandboxRepoDir({
+  const rawRepoDir = useSandboxRepoDir({
     orgSlug: org.slug,
     virtualMcpId: virtualMcpId ?? "",
     branch: branch ?? "",
     enabled: isDesktopSandbox && devServerReady && !!virtualMcpId && !!branch,
   });
+  // Guard the value, not just the query: React Query's staleTime=Infinity cache
+  // can retain a stale repoDir after the provider kind changes from desktop to
+  // agent-sandbox, whose daemon reports a container-internal path ("/app/repo").
+  const repoDir = isDesktopSandbox ? rawRepoDir : null;
 
   // Decofile pages for the URL bar dropdown — fetch only after dev server is up.
   const decofileParams =


### PR DESCRIPTION
## Summary
- "Open in Cursor/VSCode" buttons were using `repoDir` from the sandbox daemon, which returns the container-internal path `/app/repo` when running as `agent-sandbox` — a path that doesn't exist on the user's machine
- The existing `enabled` guard on the React Query was insufficient: `staleTime: Infinity` can retain cached data after provider kind changes, and provider disagreements between frontend and proxy can cause the query to hit a container daemon while the UI thinks it's a desktop sandbox
- Added a secondary guard on the returned value so the buttons are hidden whenever the sandbox is not `user-desktop`

## Test plan
- [ ] Open an agent with an `agent-sandbox` (remote) sandbox running
- [ ] Verify "Open in Cursor" and "Open in VSCode" buttons are not visible
- [ ] Open an agent with a `user-desktop` (local) sandbox running
- [ ] Verify the buttons appear and open the correct local path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard the returned repoDir and hide "Open in Cursor" / "Open in VSCode" unless the sandbox is `user-desktop`, preventing broken container paths like `/app/repo` from remote sandboxes. This also avoids stale React Query data (`staleTime: Infinity`) or provider mismatches from surfacing a remote path.

<sup>Written for commit 19be19c783683a2149ecaf2ddafb6e8ef9f4b412. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

