### PR TITLE
fix(auth): attribute self/loopback writes to the forwarded acting user

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -599,6 +599,66 @@ async function resolveAndCacheRole(
   return role;
 }
 
+/**
+ * Resolve the on-behalf-of user for a self/loopback call.
+ *
+ * When mesh calls its own management server (the `<org>_self` connection — e.g.
+ * a Studio Pack agent invoking COLLECTION_VIRTUAL_MCP_CREATE), the outbound
+ * request authenticates with that connection's API key (owned by the org
+ * creator) but ALSO forwards the REAL acting user in an `x-mesh-token` JWT (see
+ * `buildRequestHeaders`). Without honoring it, every write routed through a
+ * Studio Pack agent is attributed to the org creator instead of the user who
+ * actually acted (wrong `created_by`/`updated_by`).
+ *
+ * `x-mesh-token` is only ever set by mesh's own outbound header builder, so an
+ * inbound API-key request carrying one is always a self/loopback call. We use
+ * the forwarded user for IDENTITY/attribution; the API key's permissions remain
+ * the authorizing capability (the caller keeps `permissions`/`apiKeyId`).
+ */
+async function resolveOnBehalfOfUser(
+  req: Request,
+  db: Kysely<Database>,
+  timings: NonNullable<FactoryOptions["timings"]>,
+  apiKeyOrgId: string | undefined,
+  memberRoleCache?: MemberRoleCache,
+): Promise<AuthenticatedUser | undefined> {
+  const meshToken = req.headers.get("x-mesh-token");
+  if (!meshToken) return undefined;
+
+  const payload = await timings.measure("auth_verify_onbehalf_mesh_jwt", () =>
+    verifyMeshToken(meshToken),
+  );
+  if (!payload?.sub) return undefined;
+
+  // Defensive: only honor a forwarded user scoped to the SAME org the API key
+  // authorizes. A cross-org token (never expected for self calls) is ignored.
+  const tokenOrgId = payload.metadata?.organizationId;
+  if (apiKeyOrgId && tokenOrgId && tokenOrgId !== apiKeyOrgId) {
+    return undefined;
+  }
+
+  // Re-resolve the actor's role for the org (authoritative + cached) rather
+  // than trusting the JWT's snapshot. Authorization is unaffected either way —
+  // it's decided by the API key's stored permissions, not this role — so an
+  // undefined role (e.g. non-member) is harmless.
+  const role = apiKeyOrgId
+    ? await resolveAndCacheRole(
+        db,
+        timings,
+        payload.sub,
+        apiKeyOrgId,
+        memberRoleCache,
+      )
+    : (payload.user?.role ?? undefined);
+
+  return {
+    id: payload.sub,
+    email: payload.user?.email,
+    name: payload.user?.name,
+    role,
+  };
+}
+
 async function authenticateRequest(
   req: Request,
   auth: BetterAuthInstance,
@@ -845,10 +905,24 @@ async function authenticateRequest(
           );
         }
 
+        // On-behalf-of: a self/loopback call authenticates with the
+        // connection's API key but forwards the real acting user in
+        // `x-mesh-token`. Credit that user (attribution) while keeping the API
+        // key's permissions as the authorizing capability.
+        const onBehalfOf = await resolveOnBehalfOfUser(
+          req,
+          db,
+          timings,
+          orgMetadata?.id,
+          memberRoleCache,
+        );
+
         return {
           apiKeyId: result.key.id,
-          user: { id: result.key.userId, role }, // Include userId and role from membership
-          role,
+          // On-behalf-of fully replaces the principal (id + role) so user/role
+          // stay consistent; the actor never inherits the key owner's role.
+          user: onBehalfOf ?? { id: result.key.userId, role },
+          role: onBehalfOf ? onBehalfOf.role : role,
           permissions, // Store the API key's permissions
           organization: orgMetadata
             ? {


### PR DESCRIPTION
## What is this contribution about?
Self/loopback MCP calls (e.g. a Studio Pack manager agent invoking `COLLECTION_VIRTUAL_MCP_CREATE` against the org's `<org>_self` connection) authenticate with that connection's API key, which is owned by the org creator, but they also forward the real acting user in an `x-mesh-token` JWT. The API-key auth path previously ignored that token, so every write routed through such an agent was attributed to the org creator instead of the user who actually acted (wrong `created_by`/`updated_by`). This change honors `x-mesh-token` for identity/attribution while keeping the API key's stored permissions as the authorizing capability; the on-behalf-of principal fully replaces id + role (so they stay consistent), and cross-org forwarded tokens are ignored.

## Screenshots/Demonstration
N/A — backend attribution change, no UI.

## How to Test
1. As a non-org-creator member, use a Studio Pack manager agent (e.g. Agent Manager) to create an agent/virtual MCP.
2. Inspect the new `connections` row (or the agent in the UI).
3. Expected: `created_by` is the acting user, not the org creator/seed user.

## Migration Notes
No schema migration. Only corrects attribution going forward; existing mis-attributed rows are not retroactively fixed by this PR.

## Review Checklist
- [x] PR title is clear and descriptive
- [ ] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misattribution for self/loopback MCP writes by crediting the real acting user from `x-mesh-token` while still authorizing with the connection API key. Ensures `created_by`/`updated_by` reflect the user who acted, not the org creator.

- **Bug Fixes**
  - Honor `x-mesh-token` in the API-key auth path for identity on self calls.
  - Replace principal (id + role) with the forwarded user; no role inheritance from the key owner.
  - Validate token org matches the API key’s org; ignore cross-org tokens.
  - Resolve the actor’s org role via cache/DB; permissions continue to come from the API key.

- **Migration**
  - No schema changes. Only affects new writes; existing rows are not backfilled.

<sup>Written for commit 22b20c60f1f478c4d70ce86a9c6b415327a3be47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

