### PR TITLE
feat(ai-providers): include studio user email in gateway JWT for top-up

### DIFF
--- a/apps/mesh/src/auth/jwt.ts
+++ b/apps/mesh/src/auth/jwt.ts
@@ -120,10 +120,12 @@ export async function verifyMeshToken(
  * only need the user identity, not the full proxy-token metadata.
  *
  * @param userId - The authenticated user's ID
+ * @param email - The authenticated user's email (forwarded to Stripe checkout)
  * @param expiresIn - Expiration time in seconds (default: 1 hour)
  */
 export async function mintGatewayJwt(
   userId: string,
+  email?: string,
   expiresIn = 3600,
 ): Promise<string> {
   const settings = getSettings();
@@ -134,7 +136,11 @@ export async function mintGatewayJwt(
     );
   }
   const secret = new TextEncoder().encode(gwSecret);
-  return await new SignJWT({ iss: "mesh", sub: userId })
+  return await new SignJWT({
+    iss: "mesh",
+    sub: userId,
+    ...(email && { email }),
+  })
     .setProtectedHeader({ alg: "HS256", typ: "JWT" })
     .setIssuedAt()
     .setExpirationTime(Math.floor(Date.now() / 1000) + expiresIn)

--- a/apps/mesh/src/tools/ai-providers/topup-url.ts
+++ b/apps/mesh/src/tools/ai-providers/topup-url.ts
@@ -45,7 +45,7 @@ export const AI_PROVIDER_TOPUP_URL = defineTool({
       );
     }
 
-    const meshJwt = await mintGatewayJwt(userId);
+    const meshJwt = await mintGatewayJwt(userId, ctx.auth.user?.email);
 
     const url = await adapter.getTopUpUrl(
       meshJwt,


### PR DESCRIPTION
## Summary
When a studio user adds credits via `AI_PROVIDER_TOPUP_URL`, mint the gateway JWT with their email so the AI Gateway can prefill it as the Stripe checkout `customer_email`.

Pairs with decocms/ai-gateway#8, which reads the `email` claim and forwards it to Stripe.

## Changes
- `mintGatewayJwt(userId, email?, expiresIn?)` — adds an optional `email` claim (omitted when absent; existing callers unchanged)
- `AI_PROVIDER_TOPUP_URL` passes `ctx.auth.user?.email`

## Testing
- `tsc --noEmit` — changed files clean
- `bun run fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the authenticated studio user’s email to the gateway JWT used by `AI_PROVIDER_TOPUP_URL` so the AI Gateway can prefill Stripe’s `customer_email` during top-ups. The new `email` claim is optional; existing `mintGatewayJwt` callers continue to work unchanged.

<sup>Written for commit 0cc620477a2798f50717518e2d71d2ddd603d4b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

