### PR TITLE
feat(observability): emit MCP read cache size gauges

### DIFF
--- a/apps/mesh/src/mcp-clients/mcp-read-cache.test.ts
+++ b/apps/mesh/src/mcp-clients/mcp-read-cache.test.ts
@@ -475,4 +475,34 @@ describe("InMemoryMcpReadCache", () => {
     expect(toolBg).toBe(true); // stale → revalidated
     expect(resBg).toBe(false); // still fresh → not revalidated
   });
+
+  test("stats() tracks entry count and bytes, decremented on eviction", async () => {
+    // maxEntries=1 forces an eviction so bytes can't only ever grow.
+    const { cache } = newCache({ maxEntries: 1 });
+    expect(cache.stats()).toEqual({ entries: 0, bytes: 0 });
+
+    await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: { a: 1 },
+      fetchLive: async () => ({ value: "first" }),
+    });
+    const afterFirst = cache.stats();
+    expect(afterFirst.entries).toBe(1);
+    expect(afterFirst.bytes).toBeGreaterThan(0);
+
+    // Second distinct key evicts the first (LRU) — entries stays at 1, bytes
+    // reflect only the surviving entry (proves the running sum is decremented).
+    await cache.fetch({
+      type: TOOL,
+      connectionId: CONN,
+      scope: ORG,
+      params: { b: 22222 },
+      fetchLive: async () => ({ value: "second" }),
+    });
+    const afterSecond = cache.stats();
+    expect(afterSecond.entries).toBe(1);
+    expect(afterSecond.bytes).toBe(JSON.stringify({ value: "second" }).length);
+  });
 });

--- a/apps/mesh/src/mcp-clients/mcp-read-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-read-cache.ts
@@ -133,6 +133,11 @@ export class InMemoryMcpReadCache {
     private readonly maxTotalBytes: number = READ_CACHE_MAX_TOTAL_BYTES,
   ) {}
 
+  /** Current size snapshot for observability (cheap O(1) reads). */
+  stats(): { entries: number; bytes: number } {
+    return { entries: this.store.size, bytes: this.totalBytes };
+  }
+
   /** Delete a key and keep the byte accounting in sync. */
   private deleteKey(key: string): void {
     const e = this.store.get(key);
@@ -274,6 +279,22 @@ export class InMemoryMcpReadCache {
 
 // Per-pod singleton — pure in-memory, no external deps.
 const readCache = new InMemoryMcpReadCache();
+
+// Cache-size gauges (sampled at collection time). The cache OOM'd pods before,
+// so its live entry count and byte footprint are the signals a Grafana
+// dashboard charts against the READ_CACHE_MAX_ENTRIES / _TOTAL_BYTES caps.
+meter
+  .createObservableGauge("mcp_read_cache.entries", {
+    description: "Current entry count in the per-pod MCP read cache",
+    unit: "{entries}",
+  })
+  .addCallback((r) => r.observe(readCache.stats().entries));
+meter
+  .createObservableGauge("mcp_read_cache.bytes", {
+    description: "Approximate total bytes held in the per-pod MCP read cache",
+    unit: "By",
+  })
+  .addCallback((r) => r.observe(readCache.stats().bytes));
 
 /**
  * MCP read/list caching. On by default in production, off in development;


### PR DESCRIPTION
## Summary

We cache a lot in memory, but the dominant in-memory cache — the per-pod **MCP read cache** (`mcp-read-cache.ts`) — only emitted a fetch-outcome *counter* (`mcp_read_cache.fetches`). It tracks an entry count and a running byte sum, capped at `READ_CACHE_MAX_ENTRIES` (2000) and `READ_CACHE_MAX_TOTAL_BYTES` (256 MiB), and it has **OOM'd pods before** — yet there was no metric for its actual size.

This adds two OpenTelemetry **observable gauges**, sampled at collection time:

| Metric | Unit | Meaning |
|---|---|---|
| `mcp_read_cache.entries` | `{entries}` | current entry count |
| `mcp_read_cache.bytes` | `By` | approximate total bytes held |

They export through the existing Prometheus reader on `/metrics` — no new infra. In Grafana you can now chart each against its cap (e.g. `mcp_read_cache_bytes / (256*1024*1024)`) to watch headroom and catch the growth that caused past OOMs.

Backed by a new O(1) `stats()` method on `InMemoryMcpReadCache`. Created at module load like the existing `cacheCounter`, so it lands on the real meter (instruments are registered after `initObservability()`).

## Testing

- `bun test apps/mesh/src/mcp-clients/mcp-read-cache.test.ts` — 13 pass. New test asserts `stats()` tracks count + bytes and **decrements** bytes on LRU eviction.
- `bun run fmt` clean.

## Not in scope (follow-up)

Other in-memory caches lack size metrics too — `api-key-manager` (already has `getApiKeysCount()`, just no gauge), the studio-dbos-conductor registry, and the Slack MCP config cache. The read cache is the one with a known OOM history and real byte accounting, so it's the highest-value target; the rest can follow the same gauge pattern if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose MCP read cache size with two OpenTelemetry gauges to track entries and bytes, helping detect growth before OOMs. Metrics are exported via the existing Prometheus `/metrics` endpoint.

- **New Features**
  - Added observable gauges: `mcp_read_cache.entries` (`{entries}`) and `mcp_read_cache.bytes` (`By`).
  - Added O(1) `stats()` on `InMemoryMcpReadCache` to provide live counts and bytes.
  - Works with existing observability pipeline; chart in Grafana against cache caps to watch headroom.

<sup>Written for commit abb9a719b870395159815a6c80b65c823eaa0b79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

