### PR TITLE
feat(observability): runtime-state gauges for SSE, circuit breaker, list-cache

### DIFF
--- a/apps/mesh/src/event-bus/sse-hub.ts
+++ b/apps/mesh/src/event-bus/sse-hub.ts
@@ -17,6 +17,8 @@
  * - Pluggable broadcast: strategy handles cross-process replication
  */
 
+import { meter } from "../observability";
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -234,3 +236,13 @@ function matchesAnyPattern(eventType: string, patterns: string[]): boolean {
 
 /** Global SSE hub instance */
 export const sseHub = new SSEHub();
+
+// Live SSE connection count (sampled at scrape time). Bounded by
+// MAX_TOTAL_CONNECTIONS — chart against that cap to spot saturation, and watch
+// for a count that never drops (a listener-cleanup leak).
+meter
+  .createObservableGauge("sse_hub.connections", {
+    description: "Active SSE listeners held by this pod",
+    unit: "{connections}",
+  })
+  .addCallback((r) => r.observe(sseHub.count));

--- a/apps/mesh/src/mcp-clients/circuit-breaker.ts
+++ b/apps/mesh/src/mcp-clients/circuit-breaker.ts
@@ -15,6 +15,7 @@ import {
   CIRCUIT_BREAKER_FAILURE_THRESHOLD,
   CIRCUIT_BREAKER_MAX_ENTRIES,
 } from "../core/constants";
+import { meter } from "../observability";
 
 type CircuitState = "CLOSED" | "OPEN" | "HALF_OPEN";
 
@@ -26,6 +27,26 @@ interface CircuitEntry {
 }
 
 const circuits = new Map<string, CircuitEntry>();
+
+// Live circuit counts by state (sampled at scrape time). A rising `open` count
+// means downstream MCP servers are unreachable and requests are failing fast —
+// the signal an operator wants when proxied tools start erroring. O(n) over the
+// map (n ≤ CIRCUIT_BREAKER_MAX_ENTRIES) per scrape.
+meter
+  .createObservableGauge("mcp_circuit_breaker.circuits", {
+    description: "MCP connection circuits by state (open, half_open)",
+    unit: "{circuits}",
+  })
+  .addCallback((r) => {
+    let open = 0;
+    let halfOpen = 0;
+    for (const c of circuits.values()) {
+      if (c.state === "OPEN") open++;
+      else if (c.state === "HALF_OPEN") halfOpen++;
+    }
+    r.observe(open, { state: "open" });
+    r.observe(halfOpen, { state: "half_open" });
+  });
 
 export class CircuitOpenError extends Error {
   readonly cooldownRemainingMs: number;

--- a/apps/mesh/src/mcp-clients/mcp-list-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-list-cache.ts
@@ -97,6 +97,17 @@ export class JetStreamKVMcpListCache implements McpListCache {
 // Module-level revalidation tracking (prevents thundering herd)
 const revalidating = new Set<string>();
 
+// In-flight background list revalidations (sampled at scrape time). Sits
+// alongside the mcp_list_cache.fetches counter: a count that stays high means
+// upstream list calls aren't keeping up with staleness — refresh load worth
+// watching next to hit/miss/stale rates.
+meter
+  .createObservableGauge("mcp_list_cache.pending_revalidations", {
+    description: "In-flight background MCP list revalidations on this pod",
+    unit: "{revalidations}",
+  })
+  .addCallback((r) => r.observe(revalidating.size));
+
 // Per-(type,connection) timestamp of the last revalidation we scheduled, used to
 // throttle background revalidation. Without it, every cache hit reconnects
 // downstream — so a UI polling tools/list every few seconds hammers the upstream


### PR DESCRIPTION
## Summary

Follow-up to the MCP read-cache size gauges (#4176). Same idea, other subsystems: we hold meaningful per-pod runtime state that an operator wants on a dashboard, but emit **no metric** for it. This adds three OpenTelemetry **observable gauges** (sampled at scrape time, exported via the existing Prometheus reader on `/metrics` — no new infra):

| Metric | Type | Signal |
|---|---|---|
| `sse_hub.connections` | gauge | Active SSE listeners on the pod. Bounded by `MAX_TOTAL_CONNECTIONS` (500) — chart against the cap to spot saturation, and catch a count that never drops (listener-cleanup leak). |
| `mcp_circuit_breaker.circuits{state}` | gauge | MCP connection circuits by state (`open`, `half_open`). A rising `open` count means downstream MCP servers are unreachable and requests are failing fast — the signal you want when proxied tools start erroring. |
| `mcp_list_cache.pending_revalidations` | gauge | In-flight background list revalidations. Sits next to the existing `mcp_list_cache.fetches` counter — a count that stays high means upstream list calls aren't keeping up with staleness. |

Each is a thin read over state we already hold (SSE singleton's `count`, the circuit `Map`, the revalidation `Set`). No new tracking, no hot-path cost beyond an O(n ≤ cap) scan per scrape for the circuit gauge.

## Why these three

Picked from a broader sweep of uninstrumented runtime state, on value × safety: each is module/singleton-scoped (clean single registration) and low-cardinality. Higher-effort candidates were deliberately left out (see below).

## Testing

- `bun test` circuit-breaker + list-cache suites — 43 pass (the new `meter` import doesn't perturb module init).
- `bun run fmt` clean. `tsc` clean except a pre-existing unrelated error in `packages/sandbox` (`@nats-io/jetstream` missing).

## Not in scope (deliberate)

- **NATS connected (1/0)** — high value, but the provider is created inside `createApp` (a `let`, called >once under HMR); a gauge there risks double-registered callbacks. Needs a single-registration hook first.
- **MCP client pool size** — needs a `size` getter added to the pool; worth a small follow-up.
- **Thread-gate stuck runs / DBOS queue depth** — would require a DB query (or DBOS SDK call) on every scrape; needs care to not turn metric scraping into load.
- **MCP read-cache pending revalidations** — left out to avoid overlap with #4176, which touches that file. Trivial one-liner once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three OpenTelemetry gauges to expose per-pod runtime state via the existing Prometheus `/metrics` endpoint. Sampled at scrape time with negligible overhead to surface SSE saturation, MCP outages, and list-cache revalidation backlog.

- **New Features**
  - `sse_hub.connections`: Active SSE listeners. Compare to `MAX_TOTAL_CONNECTIONS` (500) to spot saturation or cleanup leaks.
  - `mcp_circuit_breaker.circuits{state=open|half_open}`: Circuit counts by state. Rising `open` signals downstream MCP is unreachable.
  - `mcp_list_cache.pending_revalidations`: In-flight list revalidations. Sustained highs indicate upstream isn’t keeping up.

<sup>Written for commit d79aa70d2cc99a4bbcabc0fccb024fd156a90cf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

