### PR TITLE
fix(auth): authorize API keys solely by their own allowlist (no owner-role widening)

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -397,6 +397,12 @@ async function mintMcpEndpoint(
 }> {
   const apiKey = await ctx.boundAuth.apiKey.create({
     name: apiKeyName,
+    // The per-run key is the agent's own callback credential — it proxies to
+    // `/mcp/virtual-mcp/<agentId>` (a `vir_*` resource) and acts on behalf of
+    // the user for the duration of the run, so it needs full access. With no
+    // implicit default (auth/index.ts), the scope must be explicit; wildcard
+    // matches the prior behavior (full access via the admin bypass).
+    permissions: { "*": ["*"] },
     expiresIn: MCP_KEY_TTL_SECONDS,
     metadata: {
       organization: {

--- a/apps/mesh/src/auth/api-key-permissions.test.ts
+++ b/apps/mesh/src/auth/api-key-permissions.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { checkApiKeyPermission } from "./api-key-permissions";
+
+describe("checkApiKeyPermission", () => {
+  it("grants when the exact (resource, tool) is in the allowlist", () => {
+    expect(
+      checkApiKeyPermission(
+        { self: ["ORGANIZATION_GET"] },
+        { self: ["ORGANIZATION_GET"] },
+      ),
+    ).toBe(true);
+  });
+
+  it("denies a tool outside the allowlist (the escalation we block)", () => {
+    expect(
+      checkApiKeyPermission(
+        { self: ["ORGANIZATION_GET"] },
+        { self: ["API_KEY_CREATE"] },
+      ),
+    ).toBe(false);
+  });
+
+  it("denies when the resource is not granted at all", () => {
+    expect(
+      checkApiKeyPermission(
+        { self: ["ORGANIZATION_GET"] },
+        { conn_123: ["SEND_MESSAGE"] },
+      ),
+    ).toBe(false);
+  });
+
+  it("grants every tool for a resource with a wildcard", () => {
+    expect(checkApiKeyPermission({ self: ["*"] }, { self: ["ANYTHING"] })).toBe(
+      true,
+    );
+  });
+
+  it("honors a wildcard `*` resource granting all tools (full key)", () => {
+    expect(
+      checkApiKeyPermission({ "*": ["*"] }, { conn_9: ["SEND_MESSAGE"] }),
+    ).toBe(true);
+    expect(checkApiKeyPermission({ "*": ["*"] }, { self: ["ANYTHING"] })).toBe(
+      true,
+    );
+  });
+
+  it("denies everything for an empty / absent allowlist (fail-closed)", () => {
+    expect(checkApiKeyPermission({}, { self: ["ORGANIZATION_GET"] })).toBe(
+      false,
+    );
+  });
+
+  it("requires ALL requested tools to be covered", () => {
+    expect(
+      checkApiKeyPermission(
+        { self: ["ORGANIZATION_GET"] },
+        { self: ["ORGANIZATION_GET", "API_KEY_CREATE"] },
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/mesh/src/auth/api-key-permissions.ts
+++ b/apps/mesh/src/auth/api-key-permissions.ts
@@ -1,0 +1,58 @@
+/**
+ * API-key authorization.
+ *
+ * An API key is authorized SOLELY by its own stored `permissions` allowlist
+ * ({ resource: [tools] }) — the owner's org role never widens it. A full-access
+ * key carries an explicit wildcard (`{ "*": ["*"] }` or `{ self: ["*"] }`); a
+ * key with no allowlist grants nothing (fail-closed). There is intentionally no
+ * "default permission" fallback: every key is created with an explicit scope
+ * (see API_KEY_CREATE and the internal minters), so "a key without a scope"
+ * does not exist.
+ */
+
+import type { Permission } from "../storage/types";
+
+/**
+ * Does an API key's stored allowlist grant the requested permission?
+ *
+ * Both are `{ resource: [tools] }` maps. Every (resource, tool) in `requested`
+ * must be covered by `granted` — directly, by a per-resource `"*"`, or by a
+ * wildcard `"*"` resource (itself optionally `"*"` for all tools). Returns false
+ * on the first uncovered entry (fail-closed); an empty/absent allowlist grants
+ * nothing.
+ */
+export function checkApiKeyPermission(
+  granted: Permission,
+  requested: Permission,
+): boolean {
+  for (const [resource, tools] of Object.entries(requested)) {
+    const grantedTools = granted[resource];
+
+    if (!grantedTools || grantedTools.length === 0) {
+      // No grant for this resource — fall back to a wildcard `"*"` resource.
+      const wildcardTools = granted["*"];
+      if (!wildcardTools || wildcardTools.length === 0) {
+        return false;
+      }
+      if (wildcardTools.includes("*")) {
+        continue; // wildcard resource grants every tool
+      }
+      const wildcardSet = new Set(wildcardTools);
+      for (const tool of tools) {
+        if (!wildcardSet.has(tool)) return false;
+      }
+      continue;
+    }
+
+    if (grantedTools.includes("*")) {
+      continue; // wildcard grants all tools for this resource
+    }
+
+    const grantedSet = new Set(grantedTools);
+    for (const tool of tools) {
+      if (!grantedSet.has(tool)) return false;
+    }
+  }
+
+  return true;
+}

--- a/apps/mesh/src/auth/dev-link-session.ts
+++ b/apps/mesh/src/auth/dev-link-session.ts
@@ -115,6 +115,9 @@ export async function bootstrapDevLinkSession(
       body: {
         name: "dev-link (auto-minted by bun run dev)",
         userId: user.id,
+        // Dev loopback acting as the user — full access. With no implicit
+        // default (auth/index.ts), the scope must be explicit.
+        permissions: { "*": ["*"] },
         // 30 days — re-minted on file deletion, far longer than any
         // single dev session.
         expiresIn: 60 * 60 * 24 * 30,

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -311,20 +311,10 @@ const plugins = [
       }
       return null;
     },
-    permissions: {
-      defaultPermissions: {
-        self: [
-          "ORGANIZATION_LIST",
-          "ORGANIZATION_GET", // Organization read access
-          "ORGANIZATION_MEMBER_LIST", // Member read access
-          "COLLECTION_CONNECTIONS_LIST",
-          "COLLECTION_CONNECTIONS_GET", // Connection read access
-          "API_KEY_CREATE", // API key creation
-          "API_KEY_LIST", // API key listing (metadata only)
-          // Note: API_KEY_UPDATE and API_KEY_DELETE are not default - users must explicitly request
-        ],
-      },
-    },
+    // No `defaultPermissions`: every key is created with an explicit scope (the
+    // API_KEY_CREATE tool requires `permissions`, and the internal minters pass
+    // their own). A key is authorized solely by its allowlist — see
+    // auth/api-key-permissions.ts. A key with no allowlist grants nothing.
     rateLimit: {
       enabled: false,
     },

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -143,6 +143,51 @@ describe("AccessControl", () => {
       expect(ac.granted()).toBe(true);
     });
 
+    it("does NOT bypass the admin role for an API-key principal", async () => {
+      // A key scoped to ORGANIZATION_GET is authorized solely by that allowlist —
+      // the owner's admin/owner role must not widen it. The flag lives on
+      // boundAuth, which enforces the key's permissions.
+      const keyBoundAuth = {
+        ...createMockBoundAuth({ self: ["ORGANIZATION_GET"] }),
+        isApiKeyPrincipal: true,
+      } as BoundAuthClient;
+
+      const allowed = new AccessControl(
+        "user_1",
+        "ORGANIZATION_GET",
+        keyBoundAuth,
+        "admin", // owner is an admin — must NOT grant beyond the allowlist
+      );
+      await allowed.check();
+      expect(allowed.granted()).toBe(true);
+
+      const denied = new AccessControl(
+        "user_1",
+        "API_KEY_CREATE", // out of scope — the exact escalation we are blocking
+        keyBoundAuth,
+        "admin",
+      );
+      await expect(denied.check()).rejects.toThrow(ForbiddenError);
+      expect(denied.granted()).toBe(false);
+    });
+
+    it("still bypasses the admin role for a non-API-key principal (session)", async () => {
+      // isApiKeyPrincipal unset (browser session / MCP OAuth) → admin bypass.
+      const boundAuth = {
+        ...createMockBoundAuth({ self: ["ORGANIZATION_GET"] }),
+        isApiKeyPrincipal: false,
+      } as BoundAuthClient;
+
+      const ac = new AccessControl(
+        "user_1",
+        "API_KEY_CREATE",
+        boundAuth,
+        "owner",
+      );
+      await ac.check();
+      expect(ac.granted()).toBe(true);
+    });
+
     it("should check connection-specific permissions", async () => {
       const ac = new AccessControl(
         "user_1",
@@ -225,6 +270,21 @@ describe("AccessControl", () => {
         createMockBoundAuth({}),
         undefined, // not a member of this org → no role
       );
+
+      await expect(ac.check()).rejects.toThrow(ForbiddenError);
+      expect(ac.granted()).toBe(false);
+    });
+
+    it("does NOT grant basic-usage to an API-key principal (allowlist only)", async () => {
+      // An API key is a capability, not a member — it takes the api-key codepath
+      // and is decided solely by its allowlist, so a basic-usage tool NOT in the
+      // key's scope is denied even though the owner is an admin.
+      const keyBoundAuth = {
+        ...createMockBoundAuth({}), // key grants nothing
+        isApiKeyPrincipal: true,
+      } as BoundAuthClient;
+
+      const ac = new AccessControl("user_1", tool, keyBoundAuth, "admin");
 
       await expect(ac.check()).rejects.toThrow(ForbiddenError);
       expect(ac.granted()).toBe(false);

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -181,51 +181,58 @@ export class AccessControl {
       return false;
     }
 
-    // Basic-usage tools are granted to every authenticated org MEMBER at
-    // runtime, regardless of their role. Resolving them here — instead of
-    // baking them into each role's stored permission — means the set evolves
-    // with a one-line edit to BASIC_USAGE_TOOLS, with no role-backfill
-    // migration.
-    //
-    // Both signals are required and checked explicitly:
-    //   - `userId`: a verified authenticated principal. `boundAuth` is NOT a
-    //     proxy for auth — it's constructed for every request, including
-    //     anonymous ones, so it must never gate this grant.
-    //   - `role`: derived from the caller's membership row in the target org
-    //     (context-factory / resolveOrgFromPath); set only for members. The old
-    //     bake-in model denied non-members implicitly (no role → no stored
-    //     permission), so we keep that boundary explicit here.
+    // Two kinds of principal, each with its OWN self-contained rule:
+    //   - API key   → the key's stored allowlist is the whole decision. It is a
+    //     capability, not a member: no role, no basic-usage, no Better Auth.
+    //   - everyone else (session / MCP OAuth / mesh JWT) → membership floor +
+    //     admin/owner bypass + Better Auth grants.
+    return this.boundAuth?.isApiKeyPrincipal
+      ? this.checkApiKeyAccess(resource)
+      : this.checkMemberAccess(resource);
+  }
+
+  /**
+   * API-key authorization: the key's stored allowlist is the entire decision.
+   * Never inherits the owner's role, basic-usage floor, or any Better Auth
+   * grant — so a "read-only" key minted by an admin can't act beyond its scope.
+   * See auth/api-key-permissions.ts (`checkApiKeyPermission`).
+   */
+  private async checkApiKeyAccess(resource: string): Promise<boolean> {
+    // `isApiKeyPrincipal` is only set on a real bound client, so this is
+    // defensive; the dispatcher already routed non-bound principals away.
+    if (!this.boundAuth) return false;
+    return this.boundAuth.hasPermission({ [this.connectionId]: [resource] });
+  }
+
+  /**
+   * Member authorization (session / MCP OAuth / mesh JWT).
+   *
+   * Basic-usage tools are granted to every authenticated org MEMBER regardless
+   * of role — resolved here, not baked into each role, so the set evolves with
+   * a one-line edit to BASIC_USAGE_TOOLS. Both signals are required: `userId`
+   * (a verified principal — `boundAuth` exists for every request, even
+   * anonymous, so it must not gate this) and `role` (set only for members).
+   * Admin/owner bypass everything; everyone else falls through to the stored /
+   * Better Auth grant.
+   */
+  private async checkMemberAccess(resource: string): Promise<boolean> {
     if (this.userId && this.role && BASIC_USAGE_TOOLS.has(resource)) {
       return true;
     }
-
-    // Admin and owner roles bypass all checks (they have full access)
     if (this.role === "admin" || this.role === "owner") {
       return true;
     }
-
-    // No bound auth client = deny (should not happen in normal flow)
     if (!this.boundAuth) {
       return false;
     }
-
-    // Build permission check - use connectionId as the resource key
-    const permissionToCheck: Record<string, string[]> = {};
-    if (this.connectionId) {
-      permissionToCheck[this.connectionId] = [resource];
-    }
-
-    // Delegate to the bound auth client. When an organizationId is set
-    // (path-resolved org), pass it through so Better Auth uses it instead of
-    // the session's active org. Pass `this.role` too: it is the member's role
-    // for THIS org (constructor + resolveOrgFromPath keep role and
-    // organizationId in lock-step), so boundAuth can resolve built-in roles
-    // in-memory without a Better Auth round-trip. admin/owner already returned
-    // above, so this only accelerates the `user` role; custom roles fall back.
-    return this.boundAuth.hasPermission(permissionToCheck, {
-      organizationId: this.organizationId,
-      role: this.role,
-    });
+    // Pass `this.role` so boundAuth can resolve built-in roles in-memory (no
+    // Better Auth round-trip); admin/owner already returned above, so this only
+    // accelerates the `user` role. `organizationId` (path-resolved org) makes
+    // Better Auth check the right org instead of the session's active one.
+    return this.boundAuth.hasPermission(
+      { [this.connectionId]: [resource] },
+      { organizationId: this.organizationId, role: this.role },
+    );
   }
 
   /**

--- a/apps/mesh/src/core/context-factory.bound-auth.test.ts
+++ b/apps/mesh/src/core/context-factory.bound-auth.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the API-key authorization wired into `createBoundAuthClient`.
+ * These exercise only the in-memory decision branches (API-key allowlist / role
+ * bypass), none of which call Better Auth — so a minimal stubbed `auth` is enough.
+ */
+import { describe, expect, it } from "bun:test";
+import { createBoundAuthClient } from "./context-factory";
+import type { BetterAuthInstance } from "./studio-context";
+
+const stubAuth = { api: {} } as unknown as BetterAuthInstance;
+
+describe("createBoundAuthClient — API-key authorization", () => {
+  it("authorizes an API key SOLELY by its allowlist, ignoring the owner role", async () => {
+    const client = createBoundAuthClient({
+      auth: stubAuth,
+      headers: new Headers(),
+      role: "admin", // owner is an admin — must NOT widen the key
+      permissions: { self: ["ORGANIZATION_GET"] },
+      apiKeyId: "key_1",
+    });
+
+    expect(client.isApiKeyPrincipal).toBe(true);
+    expect(await client.hasPermission({ self: ["ORGANIZATION_GET"] })).toBe(
+      true,
+    );
+    // The exact escalation the report found — denied even for an admin owner.
+    expect(await client.hasPermission({ self: ["API_KEY_CREATE"] })).toBe(
+      false,
+    );
+  });
+
+  it("treats a wildcard key as full access (explicit full key)", async () => {
+    const client = createBoundAuthClient({
+      auth: stubAuth,
+      headers: new Headers(),
+      role: "user",
+      permissions: { "*": ["*"] },
+      apiKeyId: "key_2",
+    });
+
+    expect(client.isApiKeyPrincipal).toBe(true);
+    expect(await client.hasPermission({ self: ["API_KEY_CREATE"] })).toBe(true);
+    expect(await client.hasPermission({ vir_x: ["SEND_MESSAGE"] })).toBe(true);
+  });
+
+  it("denies an API key with no allowlist (fail-closed)", async () => {
+    const client = createBoundAuthClient({
+      auth: stubAuth,
+      headers: new Headers(),
+      role: "owner",
+      permissions: undefined,
+      apiKeyId: "key_3",
+    });
+
+    expect(client.isApiKeyPrincipal).toBe(true);
+    expect(await client.hasPermission({ self: ["ORGANIZATION_GET"] })).toBe(
+      false,
+    );
+  });
+
+  it("keeps the admin/owner role bypass for a non-API-key principal", async () => {
+    const client = createBoundAuthClient({
+      auth: stubAuth,
+      headers: new Headers(),
+      role: "admin",
+      permissions: { self: ["ORGANIZATION_GET"] }, // e.g. a mesh JWT payload
+      // no apiKeyId — not an API key principal
+    });
+
+    expect(client.isApiKeyPrincipal).toBe(false);
+    expect(await client.hasPermission({ self: ["API_KEY_CREATE"] })).toBe(true);
+  });
+});

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -181,55 +181,6 @@ type HasPermissionAPI = (params: {
 }) => Promise<{ success?: boolean; error?: unknown } | null>;
 
 /**
- * Check if API key permissions grant access to the requested permission
- * API key permissions are a simple { resource: [tools] } map
- */
-function checkApiKeyPermission(
-  apiKeyPermissions: Permission,
-  requestedPermission: Permission,
-): boolean {
-  for (const [resource, tools] of Object.entries(requestedPermission)) {
-    // Check if the API key has permission for this resource
-    const grantedTools = apiKeyPermissions[resource];
-
-    // No permission for this resource at all
-    if (!grantedTools || grantedTools.length === 0) {
-      // Also check wildcard resource "*"
-      const wildcardTools = apiKeyPermissions["*"];
-      if (!wildcardTools || wildcardTools.length === 0) {
-        return false;
-      }
-      // Check if wildcard grants the tools
-      if (wildcardTools.includes("*")) {
-        continue; // Wildcard grants all tools
-      }
-      const wildcardSet = new Set(wildcardTools);
-      for (const tool of tools) {
-        if (!wildcardSet.has(tool)) {
-          return false;
-        }
-      }
-      continue;
-    }
-
-    // Wildcard grants all tools for this resource
-    if (grantedTools.includes("*")) {
-      continue;
-    }
-
-    // Check each requested tool
-    const grantedSet = new Set(grantedTools);
-    for (const tool of tools) {
-      if (!grantedSet.has(tool)) {
-        return false;
-      }
-    }
-  }
-
-  return true;
-}
-
-/**
  * Auth context needed to create a bound auth client
  *
  * Two permission flows:
@@ -242,6 +193,7 @@ export interface AuthContext {
   role?: string; // User's role (for built-in role bypass)
   permissions?: Permission; // Permissions from API key or custom role (MCP OAuth)
   userId?: string; // User ID for server-side API key operations
+  apiKeyId?: string; // Set when the principal authenticated with an API key
 }
 
 /**
@@ -253,17 +205,32 @@ export interface AuthContext {
  * 2. Browser sessions → delegate to Better Auth's hasPermission API
  */
 export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
-  const { auth, headers, role, permissions, userId } = ctx;
+  const { auth, headers, role, permissions, userId, apiKeyId } = ctx;
+
+  // An API key is authorized SOLELY by its own stored allowlist — the owner's
+  // admin/owner role never widens it, or a "read-only" key minted by an admin
+  // would silently act with full org power. A full-access key carries an
+  // explicit wildcard. Only genuine API keys (apiKeyId present) are gated this
+  // way; browser sessions, MCP OAuth, and mesh JWTs keep the role-based path.
+  const isApiKeyPrincipal = !!apiKeyId;
 
   // Get hasPermission from Better Auth's organization plugin (for browser sessions)
   const hasPermissionApi = (auth.api as { hasPermission?: HasPermissionAPI })
     .hasPermission;
 
   return {
+    isApiKeyPrincipal,
     hasPermission: async (
       requestedPermission: Permission,
       options?: { organizationId?: string; role?: string },
     ): Promise<boolean> => {
+      // API key → its allowlist IS the authorization. Checked before the role
+      // bypass so the owner's role can never widen it. No allowlist → grants
+      // nothing (fail-closed).
+      if (isApiKeyPrincipal) {
+        return checkApiKeyPermission(permissions ?? {}, requestedPermission);
+      }
+
       // Only owner/admin bypass all permission checks (full org access). The
       // built-in `user` role is enforced like any member: it gets basic-usage
       // (granted out-of-band in AccessControl) plus its explicit Better Auth /
@@ -476,6 +443,7 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
 import { createMCPProxy } from "@/api/routes/mcp-proxy-factory";
 import { ConnectionEntity } from "@/tools/connection/schema";
 import { ADMIN_ROLES, BUILTIN_ROLES } from "../auth/roles";
+import { checkApiKeyPermission } from "../auth/api-key-permissions";
 import {
   getCachedBuiltinRoleStatements,
   resolveBuiltinRolePermission,
@@ -1407,6 +1375,7 @@ export async function createStudioContextFactory(
       role: authResult.role,
       permissions: authResult.permissions,
       userId: authResult.user?.id, // For server-side API key operations
+      apiKeyId: authResult.apiKeyId, // Enables scoped-key enforcement
     });
 
     // Build auth object for StudioContext

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -91,6 +91,16 @@ export interface BoundAuthClient {
     options?: { organizationId?: string; role?: string },
   ): Promise<boolean>;
 
+  /**
+   * True when the principal authenticated with an API key. Such a principal is
+   * authorized SOLELY by the key's stored allowlist — it must NOT inherit the
+   * owner's admin/owner role. Both `hasPermission` here and the role bypass in
+   * `AccessControl.checkResource` read this single flag so every call site
+   * (REST + MCP) agrees. Absent/false for browser sessions, MCP OAuth, and mesh
+   * JWTs, which keep the role-based behavior.
+   */
+  isApiKeyPrincipal?: boolean;
+
   // Organization APIs (bound with headers)
   organization: {
     create(data: {

--- a/apps/mesh/src/file-storage/mount/provisioning.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.ts
@@ -109,6 +109,7 @@ export async function mintOrgFsConfigJson(
       apiKey: {
         create(data: {
           name: string;
+          permissions?: Record<string, string[]>;
           expiresIn?: number;
           metadata?: Record<string, unknown>;
         }): Promise<{ key: string }>;
@@ -120,6 +121,10 @@ export async function mintOrgFsConfigJson(
   try {
     const apiKey = await ctx.boundAuth.apiKey.create({
       name: `orgfs-${opts.orgSlug}`,
+      // The mount only needs management/self tools; the actual file ops
+      // (ORG_FS_READ/WRITE) are granted to every member via basic-usage. With
+      // no implicit default (auth/index.ts), the scope must be explicit.
+      permissions: { self: ["*"] },
       expiresIn: ORG_FS_KEY_TTL_SECONDS,
       metadata: { organization: { id: opts.orgId, slug: opts.orgSlug } },
     });

--- a/apps/mesh/src/tools/apiKeys/schema.ts
+++ b/apps/mesh/src/tools/apiKeys/schema.ts
@@ -73,8 +73,8 @@ export const ApiKeyCreateInputSchema = z.object({
     .min(1)
     .max(64)
     .describe("Human-readable name for the API key"),
-  permissions: PermissionSchema.optional().describe(
-    'Permissions to grant. Format: { resource: [actions] }. Resource is "self" for management tools or "conn_<UUID>" for connection-specific tools. Actions are tool names (e.g., ["API_KEY_CREATE"]) or ["*"] for all. Example: { "self": ["API_KEY_CREATE", "COLLECTION_CONNECTIONS_LIST"] }. Defaults to read-only permissions.',
+  permissions: PermissionSchema.describe(
+    'Permissions to grant (REQUIRED — there is no implicit default). Format: { resource: [actions] }. Resource is "self" for management tools or "conn_<UUID>" for connection-specific tools. Actions are tool names (e.g., ["ORGANIZATION_GET"]) or ["*"] for all. Example: { "self": ["ORGANIZATION_GET", "COLLECTION_CONNECTIONS_LIST"] }. The key is authorized solely by this allowlist; the creator\'s role does not widen it.',
   ),
   expiresIn: z
     .number()

--- a/packages/e2e/tests/apikey-scope-enforcement.spec.ts
+++ b/packages/e2e/tests/apikey-scope-enforcement.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * E2E: an API key is authorized SOLELY by its own allowlist — never by the
+ * owner's org role.
+ *
+ * Regression for the privilege-escalation bug where the admin/owner role bypass
+ * fired before a key's stored `permissions` were checked — so a "read-only" key
+ * minted by an admin acted with full org power (could call API_KEY_CREATE,
+ * MONITORING_STATS, etc.). See apps/mesh/src/auth/api-key-permissions.ts.
+ *
+ * Contract proven over HTTP only:
+ *   - a key scoped to one tool is denied an out-of-scope tool (403), including
+ *     the exact escalation (API_KEY_CREATE), even though the owner is an admin;
+ *   - a key is a capability, not a member: even a basic-usage tool outside the
+ *     key's allowlist is denied (no membership floor for keys);
+ *   - a key with an explicit wildcard still has full access (not denied);
+ *   - there is no "key without a scope": API_KEY_CREATE requires `permissions`.
+ */
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+test.describe("API key scope enforcement", () => {
+  test("a key is capped at its allowlist regardless of the owner's role", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+    // The owner is admin/owner of their auto-created org. Mint a key scoped to a
+    // single tool. (Scoped keys are created server-side via the tool — Better
+    // Auth blocks `permissions` on cookie/client requests — and the owner's
+    // admin role authorizes the cookie-session call here.)
+    const createScoped = await ownerCtx.post(
+      `/api/${owner.orgSlug}/tools/API_KEY_CREATE`,
+      {
+        data: {
+          name: `scoped-${stamp}`,
+          permissions: { self: ["AUTOMATION_LIST"] },
+        },
+      },
+    );
+    expect(
+      createScoped.ok(),
+      `API_KEY_CREATE(scoped): HTTP ${createScoped.status()} — ${await createScoped.text().catch(() => "")}`,
+    ).toBe(true);
+    const scopedKey = ((await createScoped.json()) as { key?: string }).key;
+    expect(scopedKey, "scoped key value returned").toBeTruthy();
+
+    // A key with an explicit wildcard is a full key.
+    const createFull = await ownerCtx.post(
+      `/api/${owner.orgSlug}/tools/API_KEY_CREATE`,
+      { data: { name: `full-${stamp}`, permissions: { "*": ["*"] } } },
+    );
+    expect(
+      createFull.ok(),
+      `API_KEY_CREATE(full): HTTP ${createFull.status()}`,
+    ).toBe(true);
+    const fullKey = ((await createFull.json()) as { key?: string }).key;
+    expect(fullKey, "full key value returned").toBeTruthy();
+
+    // There is no "key without a scope": permissions are required.
+    const createNoScope = await ownerCtx.post(
+      `/api/${owner.orgSlug}/tools/API_KEY_CREATE`,
+      { data: { name: `noscope-${stamp}` } },
+    );
+    expect(
+      createNoScope.status(),
+      `API_KEY_CREATE without permissions should be 400, got ${createNoScope.status()}`,
+    ).toBe(400);
+
+    // Bearer-auth context with no session cookie → auth is purely the API key.
+    const apiCtx = await newApiContext(playwright);
+    const auth = (key: string) => ({ Authorization: `Bearer ${key}` });
+
+    // In allowlist → allowed (the key authenticates and works).
+    const inScope = await apiCtx.post(
+      `/api/${owner.orgSlug}/tools/AUTOMATION_LIST`,
+      { headers: auth(scopedKey!), data: {} },
+    );
+    expect(
+      inScope.ok(),
+      `scoped AUTOMATION_LIST: HTTP ${inScope.status()}`,
+    ).toBe(true);
+
+    // Out of allowlist AND not a basic-usage tool → DENIED, even though the
+    // owner is an admin. This is the fix.
+    const outOfScope = await apiCtx.post(
+      `/api/${owner.orgSlug}/tools/MONITORING_STATS`,
+      { headers: auth(scopedKey!), data: {} },
+    );
+    expect(
+      outOfScope.status(),
+      `scoped MONITORING_STATS should be 403, got ${outOfScope.status()}`,
+    ).toBe(403);
+    const deniedBody = (await outOfScope.json()) as { error?: string };
+    expect(deniedBody.error ?? "").toMatch(
+      /access denied|permission|forbidden/i,
+    );
+
+    // A key is a capability, not a member: a basic-usage tool (granted to every
+    // member) that is NOT in the key's allowlist is still DENIED. The key takes
+    // its own codepath and never gets the membership floor.
+    const basicUsageOutOfScope = await apiCtx.post(
+      `/api/${owner.orgSlug}/tools/COLLECTION_CONNECTIONS_LIST`,
+      { headers: auth(scopedKey!), data: {} },
+    );
+    expect(
+      basicUsageOutOfScope.status(),
+      `scoped key COLLECTION_CONNECTIONS_LIST should be 403, got ${basicUsageOutOfScope.status()}`,
+    ).toBe(403);
+
+    // The exact escalation from the report: a scoped key must not mint keys.
+    const escalate = await apiCtx.post(
+      `/api/${owner.orgSlug}/tools/API_KEY_CREATE`,
+      {
+        headers: auth(scopedKey!),
+        data: {
+          name: `should-not-work-${stamp}`,
+          permissions: { self: ["*"] },
+        },
+      },
+    );
+    expect(
+      escalate.status(),
+      `scoped API_KEY_CREATE should be 403, got ${escalate.status()}`,
+    ).toBe(403);
+
+    // A wildcard key keeps full access (not denied) → full keys aren't broken.
+    const fullReach = await apiCtx.post(
+      `/api/${owner.orgSlug}/tools/MONITORING_STATS`,
+      { headers: auth(fullKey!), data: {} },
+    );
+    expect(
+      fullReach.status(),
+      `wildcard key MONITORING_STATS must not be 403, got ${fullReach.status()}`,
+    ).not.toBe(403);
+
+    await ownerCtx.dispose();
+    await apiCtx.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a **broken-access-control / privilege-escalation** bug (High): an API key whose **owner** is an org `admin`/`owner` silently inherited full org access — the admin/owner role bypass fired before the key's `permissions` allowlist was ever checked. A "read-only" key minted by an admin could call any tool (`API_KEY_CREATE`, `ORGANIZATION_*`, secrets, member mgmt). Found by an agent run and verified in prod (a read-only key minted a new admin-capable key via `API_KEY_CREATE`).

## The model

**An API key is authorized solely by its own `permissions` allowlist. The owner's role never widens it, and there is no membership floor — a key is a capability, not a member.** A full-access key carries an explicit wildcard (`{ "*": ["*"] }` / `{ self: ["*"] }`); a key with no allowlist grants nothing. There is no implicit "default permission" fallback — **"a key without a scope" no longer exists.**

`AccessControl.checkResource` dispatches to one of two self-contained codepaths by principal type — so each is simple to reason about in isolation:

- **API key** → `checkApiKeyAccess`: the key's allowlist is the entire decision (`checkApiKeyPermission`). No role, no admin/owner bypass, no basic-usage, no Better Auth.
- **member** (session / MCP OAuth / mesh JWT) → `checkMemberAccess`: the existing membership-floor + admin/owner bypass + Better Auth path, unchanged.

The flag lives on `boundAuth.isApiKeyPrincipal`, so REST (`/api/:org/tools/:name`) and MCP (`/mcp`) share one signal; `createBoundAuthClient.hasPermission` mirrors the same split.

## Other changes

- **Remove `defaultPermissions`** from the Better Auth apiKey plugin; **`API_KEY_CREATE` now requires `permissions`.**
- **Internal minters that relied on the default now pass an explicit scope:** per-run agent MCP key (`dispatch-run.ts`) + dev-link (`dev-link-session.ts`) act as the user → `{ "*": ["*"] }`; org-fs mount (`provisioning.ts`) → `{ self: ["*"] }` (which covers its `ORG_FS_READ/WRITE` checks directly). The `<org>_self` connection key was already `{ self: ["*"] }`, so self/loopback (Studio Pack, automations) is unaffected.

Because a key is now exactly its allowlist (not allowlist ∪ basic-usage), internal keys carry a wildcard and are unaffected; **user-scoped keys are tightened to precisely what they were scoped to.** Browser sessions, MCP OAuth, and mesh JWTs are unchanged.

### Prod migration

Internal keys are short-TTL (per-run / org-fs) or 30-day (dev-link) → re-mint with explicit scope, **no backfill**. Existing user keys keep their stored `permissions` and are enforced against exactly that.

## Tests

- `apps/mesh/src/auth/api-key-permissions.test.ts` — `checkApiKeyPermission`.
- `apps/mesh/src/core/access-control.test.ts` + `context-factory.bound-auth.test.ts` — API-key principal does NOT bypass admin and does NOT get the basic-usage floor; member principal still does; wildcard = full; no-allowlist = deny.
- `packages/e2e/tests/apikey-scope-enforcement.spec.ts` — black-box HTTP: scoped key → 403 on `MONITORING_STATS`, `API_KEY_CREATE`, and a basic-usage tool outside its allowlist; wildcard key keeps access; create without `permissions` → 400.

`tsc` + `oxlint` clean. Unit tests (auth + core) green except the pre-existing DB-gated `context-factory.integration.test.ts`. Playwright e2e validated by CI.

## Related / follow-up
- **Complementary:** #4119 (creation-time: non-admins can't grant wildcard) — disjoint files, trial-merges clean. The two compose (creation-time + runtime).
- **Operational:** two keys exposed in the originating thread should be revoked (tracked out-of-band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
