### PR TITLE
ci(resilience): retry infrastructure startup on Docker Hub pull flakes

### DIFF
--- a/.github/workflows/resilience.yml
+++ b/.github/workflows/resilience.yml
@@ -34,7 +34,23 @@ jobs:
         run: bun install
 
       - name: Start infrastructure
-        run: docker compose -f tests/resilience/docker-compose.yml up -d --build --wait
+        # `up --build --wait` pulls base images (postgres, nats, toxiproxy) from
+        # Docker Hub, which intermittently times out ("registry-1.docker.io:
+        # context deadline exceeded") and fails the whole job before any test
+        # runs. Retry the startup a few times, tearing down between attempts so
+        # each retry starts clean.
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose -f tests/resilience/docker-compose.yml up -d --build --wait; then
+              echo "Infrastructure started (attempt $attempt)"
+              exit 0
+            fi
+            echo "::warning::Infrastructure startup failed (attempt $attempt); tearing down and retrying in 15s..."
+            docker compose -f tests/resilience/docker-compose.yml down -v || true
+            sleep 15
+          done
+          echo "::error::Infrastructure failed to start after 3 attempts"
+          exit 1
 
       - name: Run resilience tests
         run: bun test tests/resilience/scenarios/ --serial --timeout 900000


### PR DESCRIPTION
## Summary

The latest **Resilience Tests** run on `main` ([run 28336347939](https://github.com/decocms/studio/actions/runs/28336347939)) failed at ~44s — not in a test, but in the `Start infrastructure` step:

```
nats Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
postgres  Interrupted
Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
##[error]Process completed with exit code 1.
```

Every prior run on `main` succeeded (~8min). This is a transient Docker Hub registry pull timeout while `docker compose up --build --wait` fetches the base images (postgres, nats, toxiproxy). There was **no retry**, so a single registry hiccup turns the whole main build red before any resilience scenario runs.

## Fix

Wrap the infra startup in a 3-attempt retry loop, tearing down (`down -v`) between attempts so each retry starts from a clean state. A transient registry flake now recovers instead of failing CI.

## Testing notes

- YAML validated (`yaml.safe_load`).
- This workflow only triggers on `push` to `main` and `workflow_dispatch`, so it does not run on this PR. The change is to CI infra (retry logic) and takes effect once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the resilience workflow tolerate Docker Hub pull timeouts by retrying infrastructure startup instead of failing the job early. This prevents flaky reds before any tests run.

- **Bug Fixes**
  - Retries `docker compose up --build --wait` up to 3 times with a 15s delay between tries.
  - Runs `docker compose down -v` between attempts to start clean.
  - Adds clear warning/error logs during retries.

<sup>Written for commit a6dcc6943d89e517f58c21b38cdfc26b0854853a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

