### PR TITLE
fix(nginx): stop ejecting healthy api processes on app-level 5xx

### DIFF
--- a/deploy/helm/studio/files/api-nginx.conf
+++ b/deploy/helm/studio/files/api-nginx.conf
@@ -3,6 +3,17 @@ map $http_upgrade $connection_upgrade {
   ''      "";
 }
 
+# Two in-pod Bun API processes. max_fails is left at the default (1) so a
+# genuinely dead/booting process is still ejected on a real connect/read error
+# and traffic fails over to its sibling. Crucially, `proxy_next_upstream` below
+# does NOT list http_502/503/504: app-level 5xx (e.g. a 503 circuit-breaker for
+# an unreachable downstream MCP, or a 502 "Preview not available" for a dead
+# sandbox) are VALID responses, not process-health signals. If they were listed,
+# a single such response would count toward max_fails and eject an otherwise
+# healthy process; with both processes returning the same app-5xx for the same
+# dead downstream, nginx ejects both -> "no live upstreams" -> the whole front
+# door 502s, including unrelated DB-only endpoints. Keep app-5xx out of the
+# passive-health path.
 upstream studio_api {
   zone studio_api 64k;
   server 127.0.0.1:3000 max_conns=128;
@@ -36,7 +47,7 @@ server {
     proxy_connect_timeout 5s;
     proxy_send_timeout 3600s;
     proxy_read_timeout 3600s;
-    proxy_next_upstream error timeout http_502 http_503 http_504;
+    proxy_next_upstream error timeout;
     proxy_next_upstream_tries 2;
     proxy_buffering off;
     proxy_request_buffering off;
@@ -77,7 +88,7 @@ server {
     proxy_connect_timeout 5s;
     proxy_send_timeout 3600s;
     proxy_read_timeout 3600s;
-    proxy_next_upstream error timeout http_502 http_503 http_504;
+    proxy_next_upstream error timeout;
     proxy_next_upstream_tries 2;
     proxy_buffering off;
     proxy_request_buffering off;


### PR DESCRIPTION
## Summary

`studio-stg.decocms.com` returned **intermittent 502s on innocent DB-only endpoints** — `COLLECTION_CONNECTIONS_LIST`, `COLLECTION_THREAD_MESSAGES_LIST`, `/fs/*/changes`, `/auth/custom/my-capabilities` — while `/healthz` (nginx-local) stayed **200** and the api processes were healthy and near-idle. The 502s were collateral damage from nginx's passive-health load balancing, not a downstream or a node issue.

## Root cause

The combo `nginx` upstream fronts the two in-pod Bun api processes (`127.0.0.1:3000`, `:3001`) with the **default `max_fails=1 fail_timeout=10s`**, and both `location` blocks set `proxy_next_upstream error timeout http_502 http_503 http_504`.

Per nginx semantics, an upstream `5xx` counts toward `max_fails` **only when it's listed in `proxy_next_upstream`**. So an **application-level 5xx** — a `503` circuit-breaker for an unreachable downstream MCP (`conn_...`), or a `502 "Preview not available"` for a dead desktop sandbox (`vir_...`) — was being treated as the *api process* failing, ejecting it (`upstream server temporarily disabled`). Both processes run the same code and returned the same app-5xx for the same dead downstream, so nginx ejected **both** → `no live upstreams` → **every request 502'd** for the fail-timeout window, including endpoints that never touch a downstream.

## Adversarial verification

This was checked against the live pod by an independent pass that tried to *disprove* it (looking for a stalled/dead process instead). nginx **1.27.5** error log:
- `no live upstreams` ×441, `upstream server temporarily disabled` ×17
- **15 of 17 ejections were `while reading response header from upstream`** — nginx connected, sent the request, and read a response header
- **zero** `upstream timed out` / `prematurely closed connection` / `recv() failed`, and `proxy_read_timeout` is `3600s`

So the only possible ejection trigger in the read-header phase was an `http_50x` status in `proxy_next_upstream` — confirming app-5xx misclassification, not a process stall. (The only real `connect() failed` events were `/metrics` during boot, unrelated.) The cascade was caught in a single second: api-0 disabled (preview-fetch 502) → api-1 disabled (preview-fetch 502) → `no live upstreams` for `COLLECTION_CONNECTIONS_LIST` et al. The dead sandbox's `410`s (not in `proxy_next_upstream`) did **not** eject; its `502`s did.

## Change

Drop `http_502 http_503 http_504` from `proxy_next_upstream` in both `location` blocks (leave `error timeout`):

```nginx
proxy_next_upstream error timeout;   # was: error timeout http_502 http_503 http_504
```

- App-level 5xx no longer count toward `max_fails`, so a dead downstream/sandbox can't eject a healthy api process → no `no live upstreams` cascade → no spurious 502s on unrelated endpoints.
- `max_fails` is **left at the default** (not set to `0`), so a genuinely dead/booting process is still ejected on a real `error`/`timeout` and traffic fails over to its sibling — no ~90s boot-window regression that `max_fails=0` would introduce.
- Also stops the pointless retry of a deterministic app-5xx onto the sibling process (it would just double the load and return the same 5xx).

Config is baked into the `studio-nginx` image via `apps/mesh/Dockerfile.nginx` (`COPY ... /etc/nginx/conf.d/default.conf`), so this ships on the next image build — no chart/ConfigMap change required.

## Testing

- Config-only change; `nginx -t` parses (`proxy_next_upstream error timeout;` is valid).
- Post-rollout verify on stg: nginx error log should show **no** `no live upstreams` / `temporarily disabled` while a downstream MCP or sandbox is dead, and `COLLECTION_CONNECTIONS_LIST` should never 502 when the api processes are healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `nginx` from ejecting healthy API processes on app-level 5xx by removing 502/503/504 from `proxy_next_upstream`. This stops cascade “no live upstreams” 502s on unrelated endpoints while keeping failover on real errors/timeouts.

- **Bug Fixes**
  - Set `proxy_next_upstream` to `error timeout` in both `location` blocks to avoid treating app 5xx as process failures.
  - Keep default `max_fails` so true connect/read errors still fail over; ships via `studio-nginx` image config.

<sup>Written for commit 75fb28207a63307b6b7e8f6e3f0a599bad6f222d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

