### PR TITLE
feat(content): add variant calendar view to Content tab

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -3,6 +3,7 @@ import { type Query } from "@tanstack/react-query";
 import {
   AlertCircle,
   BookOpen01,
+  Calendar,
   ChevronDown,
   Code01,
   Copy01,
@@ -183,9 +184,22 @@ const AddSectionModal = lazy(() =>
   })),
 );
 
+const VariantCalendar = lazy(() =>
+  import("./variant-calendar/variant-calendar").then((m) => ({
+    default: m.VariantCalendar,
+  })),
+);
+
 const VARIANT_GREEN = "oklch(0.65 0.15 160)";
 
-type CollectionId = "pages" | "sections" | "apps" | "site" | "seo" | BlogKind;
+type CollectionId =
+  | "pages"
+  | "sections"
+  | "apps"
+  | "site"
+  | "seo"
+  | "calendar"
+  | BlogKind;
 
 type Selection =
   | { collection: "pages"; key: string; path: string }
@@ -831,91 +845,93 @@ function ContentBrowserReady({
           setOpenPageSeoKey(null);
         }}
       />
-      {activeCollection !== "seo" && activeCollection !== "site" && (
-        <ItemList
-          activeCollection={activeCollection}
-          pages={pages}
-          sections={globalSections}
-          appCatalog={appCatalog}
-          appCatalogLoading={appCatalogLoading}
-          blogEntries={blogEntries}
-          decofile={decofile}
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          postCategoryFilter={postCategoryFilter}
-          postAuthorFilter={postAuthorFilter}
-          postSort={postSort}
-          onPostCategoryFilterChange={(slug) => {
-            setPostCategoryFilter(slug);
-            setSelectedPostKeys(new Set());
-          }}
-          onPostAuthorFilterChange={(email) => {
-            setPostAuthorFilter(email);
-            setSelectedPostKeys(new Set());
-          }}
-          onPostSortChange={setPostSort}
-          selectedPostKeys={selectedPostKeys}
-          onTogglePostSelect={togglePostSelection}
-          onSelectAllPosts={(keys) => setSelectedPostKeys(new Set(keys))}
-          onClearPostSelection={() => setSelectedPostKeys(new Set())}
-          onBulkUpdateCategory={() =>
-            setCategoryDialog({ count: selectedPostKeys.size })
-          }
-          onBulkDeletePosts={() =>
-            setDeleteTarget({
-              kind: "blog-bulk",
-              keys: [...selectedPostKeys],
-              count: selectedPostKeys.size,
-            })
-          }
-          selection={selection}
-          onSelect={(next) => {
-            setSelection(next);
-            setOpenPageSeoKey(null);
-          }}
-          previewUrl={previewUrl}
-          onCreate={() => {
-            if (activeCollection === "pages") {
-              openCreatePage();
-            } else if (isBlogKind(activeCollection)) {
-              void handleCreateBlog(activeCollection);
-            } else if (!previewUrl) {
-              toast.error("Start the preview dev server to add sections.");
-            } else {
-              setAddSectionOpen(true);
+      {activeCollection !== "seo" &&
+        activeCollection !== "site" &&
+        activeCollection !== "calendar" && (
+          <ItemList
+            activeCollection={activeCollection}
+            pages={pages}
+            sections={globalSections}
+            appCatalog={appCatalog}
+            appCatalogLoading={appCatalogLoading}
+            blogEntries={blogEntries}
+            decofile={decofile}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            postCategoryFilter={postCategoryFilter}
+            postAuthorFilter={postAuthorFilter}
+            postSort={postSort}
+            onPostCategoryFilterChange={(slug) => {
+              setPostCategoryFilter(slug);
+              setSelectedPostKeys(new Set());
+            }}
+            onPostAuthorFilterChange={(email) => {
+              setPostAuthorFilter(email);
+              setSelectedPostKeys(new Set());
+            }}
+            onPostSortChange={setPostSort}
+            selectedPostKeys={selectedPostKeys}
+            onTogglePostSelect={togglePostSelection}
+            onSelectAllPosts={(keys) => setSelectedPostKeys(new Set(keys))}
+            onClearPostSelection={() => setSelectedPostKeys(new Set())}
+            onBulkUpdateCategory={() =>
+              setCategoryDialog({ count: selectedPostKeys.size })
             }
-          }}
-          onDuplicatePage={openDuplicatePage}
-          onRenamePage={openRenamePage}
-          onAddPageVariant={handleAddPageVariant}
-          onDeletePage={(page) =>
-            setDeleteTarget({ kind: "page", key: page.key, label: page.name })
-          }
-          onEditPageSeo={(page) => {
-            setSelection({
-              collection: "pages",
-              key: page.key,
-              path: page.path,
-            });
-            setOpenPageSeoKey(page.key);
-          }}
-          onViewPageJson={(page) => setJsonPageKey(page.key)}
-          onDuplicateSection={handleDuplicateSection}
-          onRenameSection={(s) => setRenameSectionKey(s.key)}
-          onDeleteSection={(s) =>
-            setDeleteTarget({ kind: "section", key: s.key, label: s.name })
-          }
-          onDuplicateBlog={handleDuplicateBlog}
-          onDeleteBlog={(e) =>
-            setDeleteTarget({
-              kind: "blog",
-              blogKind: e.kind,
-              key: e.key,
-              label: e.label,
-            })
-          }
-        />
-      )}
+            onBulkDeletePosts={() =>
+              setDeleteTarget({
+                kind: "blog-bulk",
+                keys: [...selectedPostKeys],
+                count: selectedPostKeys.size,
+              })
+            }
+            selection={selection}
+            onSelect={(next) => {
+              setSelection(next);
+              setOpenPageSeoKey(null);
+            }}
+            previewUrl={previewUrl}
+            onCreate={() => {
+              if (activeCollection === "pages") {
+                openCreatePage();
+              } else if (isBlogKind(activeCollection)) {
+                void handleCreateBlog(activeCollection);
+              } else if (!previewUrl) {
+                toast.error("Start the preview dev server to add sections.");
+              } else {
+                setAddSectionOpen(true);
+              }
+            }}
+            onDuplicatePage={openDuplicatePage}
+            onRenamePage={openRenamePage}
+            onAddPageVariant={handleAddPageVariant}
+            onDeletePage={(page) =>
+              setDeleteTarget({ kind: "page", key: page.key, label: page.name })
+            }
+            onEditPageSeo={(page) => {
+              setSelection({
+                collection: "pages",
+                key: page.key,
+                path: page.path,
+              });
+              setOpenPageSeoKey(page.key);
+            }}
+            onViewPageJson={(page) => setJsonPageKey(page.key)}
+            onDuplicateSection={handleDuplicateSection}
+            onRenameSection={(s) => setRenameSectionKey(s.key)}
+            onDeleteSection={(s) =>
+              setDeleteTarget({ kind: "section", key: s.key, label: s.name })
+            }
+            onDuplicateBlog={handleDuplicateBlog}
+            onDeleteBlog={(e) =>
+              setDeleteTarget({
+                kind: "blog",
+                blogKind: e.kind,
+                key: e.key,
+                label: e.label,
+              })
+            }
+          />
+        )}
       <div className="flex-1 min-w-0">
         <Suspense
           fallback={
@@ -927,7 +943,9 @@ function ContentBrowserReady({
             </div>
           }
         >
-          {activeCollection === "site" ? (
+          {activeCollection === "calendar" ? (
+            <VariantCalendar decofile={decofile} />
+          ) : activeCollection === "site" ? (
             siteApp ? (
               <AppEditor
                 key={`site:${siteApp.key}`}
@@ -1232,6 +1250,13 @@ function CollectionsSidebar({
           label="Apps"
           count={counts.apps}
           active={active === "apps"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="calendar"
+          icon={Calendar}
+          label="Calendar"
+          active={active === "calendar"}
           onSelect={onSelect}
         />
         {showBlog && (

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "bun:test";
+import {
+  addDays,
+  addMonths,
+  buildMonthWeeks,
+  diffInDays,
+  placeWeekSegments,
+  startOfDay,
+  startOfMonth,
+} from "./date-utils";
+import type { ScheduledVariant } from "./extract-variants";
+
+function makeVariant(
+  start: string,
+  end: string,
+  blockKey = "Block",
+): ScheduledVariant {
+  return {
+    blockKey,
+    blockLabel: blockKey,
+    innerPath: "",
+    variantIndex: 0,
+    start: new Date(start),
+    end: new Date(end),
+    label: blockKey,
+    flagResolveType: "website/flags/multivariate/section.ts",
+  };
+}
+
+describe("startOfDay / startOfMonth / addMonths / addDays", () => {
+  it("startOfDay zeroes the time portion without mutating the input", () => {
+    const input = new Date("2026-06-15T13:45:30.500");
+    const out = startOfDay(input);
+    expect(out.getHours()).toBe(0);
+    expect(out.getMinutes()).toBe(0);
+    expect(out.getSeconds()).toBe(0);
+    expect(out.getMilliseconds()).toBe(0);
+    // Input untouched.
+    expect(input.getHours()).toBe(13);
+  });
+
+  it("startOfMonth returns the first day at midnight local", () => {
+    const out = startOfMonth(new Date(2026, 5, 17));
+    expect(out.getFullYear()).toBe(2026);
+    expect(out.getMonth()).toBe(5);
+    expect(out.getDate()).toBe(1);
+  });
+
+  it("addMonths normalizes to the first of the target month", () => {
+    expect(addMonths(new Date(2026, 0, 31), 1).getMonth()).toBe(1);
+    expect(addMonths(new Date(2026, 11, 1), 1).getFullYear()).toBe(2027);
+    expect(addMonths(new Date(2026, 0, 1), -1).getFullYear()).toBe(2025);
+  });
+
+  it("addDays handles month rollover", () => {
+    const out = addDays(new Date(2026, 0, 31), 1);
+    expect(out.getMonth()).toBe(1);
+    expect(out.getDate()).toBe(1);
+  });
+});
+
+describe("diffInDays", () => {
+  it("returns whole days between two dates regardless of clock time", () => {
+    expect(
+      diffInDays(new Date("2026-06-15T23:59:59"), new Date("2026-06-15")),
+    ).toBe(0);
+    expect(
+      diffInDays(new Date("2026-06-16T00:00:01"), new Date("2026-06-15")),
+    ).toBe(1);
+    expect(diffInDays(new Date("2026-06-15"), new Date("2026-06-16"))).toBe(-1);
+  });
+
+  it("crosses a DST spring-forward without losing a day (US locale)", () => {
+    // US DST starts 2026-03-08. Without rounding, 7 days * 86_400_000 ms
+    // would drop to 6.96, which floor()/trunc() would round to 6. We use
+    // Math.round so DST is absorbed correctly.
+    const a = new Date(2026, 2, 1);
+    const b = new Date(2026, 2, 8);
+    expect(diffInDays(b, a)).toBe(7);
+  });
+});
+
+describe("buildMonthWeeks", () => {
+  it("starts every week on Sunday", () => {
+    const weeks = buildMonthWeeks(new Date(2026, 5, 1));
+    for (const week of weeks) {
+      expect(week[0]!.getDay()).toBe(0);
+      expect(week).toHaveLength(7);
+    }
+  });
+
+  it("the very first day is on or before monthStart", () => {
+    const monthStart = new Date(2026, 5, 1);
+    const weeks = buildMonthWeeks(monthStart);
+    expect(weeks[0]![0]!.getTime()).toBeLessThanOrEqual(monthStart.getTime());
+  });
+
+  it("trims trailing weeks that fall entirely in the next month", () => {
+    // Feb 2026: starts Sunday, ends Saturday — fits in 4 weeks → trim 2.
+    const weeks = buildMonthWeeks(new Date(2026, 1, 1));
+    expect(weeks.length).toBeGreaterThanOrEqual(4);
+    expect(weeks.length).toBeLessThanOrEqual(6);
+    for (const week of weeks) {
+      const someInMonth = week.some((d) => d.getMonth() === 1);
+      expect(someInMonth).toBe(true);
+    }
+  });
+
+  it("includes weeks containing leading next-month days when the month spills", () => {
+    // June 2026 starts on Monday and ends on Tuesday — the last visible
+    // week must include 2026-06-30, even though most of it is July.
+    const weeks = buildMonthWeeks(new Date(2026, 5, 1));
+    const lastWeek = weeks[weeks.length - 1]!;
+    expect(lastWeek.some((d) => d.getMonth() === 5)).toBe(true);
+  });
+});
+
+describe("placeWeekSegments", () => {
+  const week = buildMonthWeeks(new Date(2026, 5, 7))[0]!; // Sun 2026-06-07
+
+  it("clips a variant to the week and assigns lane 0 when alone", () => {
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-06-01T00:00:00", "2026-06-09T23:59:59"),
+    ]);
+    expect(placed).toHaveLength(1);
+    expect(placed[0]).toMatchObject({ startCol: 0, span: 3, lane: 0 });
+  });
+
+  it("separates overlapping variants into distinct lanes", () => {
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-06-08T00:00:00", "2026-06-10T23:59:59", "A"),
+      makeVariant("2026-06-09T00:00:00", "2026-06-11T23:59:59", "B"),
+    ]);
+    expect(placed).toHaveLength(2);
+    const lanes = placed.map((p) => p.lane).sort();
+    expect(lanes).toEqual([0, 1]);
+  });
+
+  it("reuses a lane when one segment ends before the next starts", () => {
+    // A: Mon..Tue, B: Wed..Thu — no overlap; both should sit on lane 0.
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-06-08T00:00:00", "2026-06-09T23:59:59", "A"),
+      makeVariant("2026-06-10T00:00:00", "2026-06-11T23:59:59", "B"),
+    ]);
+    expect(placed).toHaveLength(2);
+    for (const p of placed) expect(p.lane).toBe(0);
+  });
+
+  it("skips variants outside the week", () => {
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-05-01T00:00:00", "2026-05-15T00:00:00"),
+      makeVariant("2026-07-01T00:00:00", "2026-07-15T00:00:00"),
+    ]);
+    expect(placed).toEqual([]);
+  });
+
+  it("sorts ties deterministically by blockKey", () => {
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-06-08T00:00:00", "2026-06-09T23:59:59", "Z-block"),
+      makeVariant("2026-06-08T00:00:00", "2026-06-09T23:59:59", "A-block"),
+    ]);
+    // Two segments at same start+span → A-block takes the lower lane (0).
+    const aSeg = placed.find((p) => p.variant.blockKey === "A-block");
+    const zSeg = placed.find((p) => p.variant.blockKey === "Z-block");
+    expect(aSeg?.lane).toBe(0);
+    expect(zSeg?.lane).toBe(1);
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.ts
@@ -1,0 +1,149 @@
+/**
+ * Pure date / layout helpers for the Variant Calendar. Kept separate from
+ * the view component so they can be unit-tested without the React tree.
+ *
+ * All functions are locale-independent and operate on `Date` objects in the
+ * user's local timezone. `diffInDays` uses `Math.round` so DST transitions
+ * (23h or 25h days) still resolve to the correct integer day count.
+ */
+import type { ScheduledVariant } from "./extract-variants";
+
+export const WEEKDAYS = [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
+] as const;
+
+export const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function startOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+export function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+export function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1);
+}
+
+export function addDays(d: Date, n: number): Date {
+  const out = new Date(d);
+  out.setDate(out.getDate() + n);
+  return out;
+}
+
+export function diffInDays(a: Date, b: Date): number {
+  return Math.round(
+    (startOfDay(a).getTime() - startOfDay(b).getTime()) / DAY_MS,
+  );
+}
+
+/**
+ * 6-week (Sun → Sat) grid covering `monthStart`. Trailing weeks that fall
+ * entirely in the next month are trimmed so February etc. doesn't render
+ * an all-blank final row.
+ */
+export function buildMonthWeeks(monthStart: Date): Date[][] {
+  const gridStart = addDays(monthStart, -monthStart.getDay());
+  const weeks: Date[][] = [];
+  for (let w = 0; w < 6; w++) {
+    const days: Date[] = [];
+    for (let d = 0; d < 7; d++) {
+      days.push(addDays(gridStart, w * 7 + d));
+    }
+    weeks.push(days);
+  }
+  while (
+    weeks.length > 0 &&
+    weeks[weeks.length - 1]!.every(
+      (day) => day.getMonth() !== monthStart.getMonth(),
+    )
+  ) {
+    weeks.pop();
+  }
+  return weeks;
+}
+
+export interface PlacedSegment {
+  variant: ScheduledVariant;
+  /** 0-indexed column (0 = Sunday) where the segment starts inside the week. */
+  startCol: number;
+  /** Number of columns the segment spans inside the week (1..7). */
+  span: number;
+  /** Row within the week's stacked-bar area, assigned greedily. */
+  lane: number;
+}
+
+/**
+ * Greedy lane packing for one week. Each variant overlapping the week is
+ * clipped to the visible Sun..Sat span and assigned to the first lane
+ * whose previous segment ends at-or-before the new segment's start (so
+ * a variant ending Tuesday and another starting Tuesday share a lane).
+ */
+export function placeWeekSegments(
+  weekDays: Date[],
+  variants: ScheduledVariant[],
+): PlacedSegment[] {
+  const weekStart = startOfDay(weekDays[0]!);
+  const weekEndExclusive = addDays(weekStart, 7);
+  const segments: Array<Omit<PlacedSegment, "lane">> = [];
+  for (const variant of variants) {
+    const vStart = startOfDay(variant.start);
+    const vEnd = startOfDay(variant.end);
+    if (vEnd.getTime() < weekStart.getTime()) continue;
+    if (vStart.getTime() >= weekEndExclusive.getTime()) continue;
+    const segStart =
+      vStart.getTime() < weekStart.getTime() ? weekStart : vStart;
+    const segEnd =
+      vEnd.getTime() >= weekEndExclusive.getTime()
+        ? addDays(weekEndExclusive, -1)
+        : vEnd;
+    const startCol = diffInDays(segStart, weekStart);
+    const span = diffInDays(segEnd, segStart) + 1;
+    if (span <= 0) continue;
+    segments.push({ variant, startCol, span });
+  }
+  // Sort by start (ascending), then span desc (long bars take low lanes),
+  // then blockKey for determinism.
+  segments.sort(
+    (a, b) =>
+      a.startCol - b.startCol ||
+      b.span - a.span ||
+      a.variant.blockKey.localeCompare(b.variant.blockKey),
+  );
+  const laneEnds: number[] = [];
+  const placed: PlacedSegment[] = [];
+  for (const seg of segments) {
+    let lane = laneEnds.findIndex((end) => end <= seg.startCol);
+    if (lane === -1) {
+      lane = laneEnds.length;
+      laneEnds.push(0);
+    }
+    laneEnds[lane] = seg.startCol + seg.span;
+    placed.push({ ...seg, lane });
+  }
+  return placed;
+}

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
@@ -124,6 +124,176 @@ describe("extractScheduledVariants", () => {
     expect(out[0]?.label).toBe("mídia kit novidades");
   });
 
+  it("supports legacy $live matcher aliases", () => {
+    const decofile = {
+      Legacy: {
+        __resolveType: "$live/flags/multivariate/section.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "$live/matchers/MatchMulti.ts",
+              op: "and",
+              matchers: [
+                {
+                  __resolveType: "$live/matchers/MatchDate.ts",
+                  start: "2026-06-01T00:00:00.000Z",
+                  end: "2026-06-10T00:00:00.000Z",
+                },
+              ],
+            },
+            value: { __resolveType: "site/sections/Foo.tsx", title: "legacy" },
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.blockKey).toBe("Legacy");
+    expect(out[0]?.label).toBe("legacy");
+  });
+
+  it("emits one entry per date matcher inside a multi.ts rule", () => {
+    const decofile = {
+      DualWindow: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "website/matchers/multi.ts",
+              op: "or",
+              matchers: [
+                {
+                  __resolveType: "website/matchers/date.ts",
+                  start: "2026-06-01T00:00:00.000Z",
+                  end: "2026-06-05T00:00:00.000Z",
+                },
+                {
+                  __resolveType: "website/matchers/date.ts",
+                  start: "2026-07-01T00:00:00.000Z",
+                  end: "2026-07-05T00:00:00.000Z",
+                },
+              ],
+            },
+            value: { title: "Two windows" },
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    expect(out[1]?.start.toISOString()).toBe("2026-07-01T00:00:00.000Z");
+    expect(out.every((v) => v.label === "Two windows")).toBe(true);
+  });
+
+  it("walks into variant.value to find nested multivariate flags", () => {
+    const decofile = {
+      Outer: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "website/matchers/date.ts",
+              start: "2026-06-01T00:00:00.000Z",
+              end: "2026-06-10T00:00:00.000Z",
+            },
+            value: {
+              __resolveType: "site/sections/Banner.tsx",
+              image: {
+                __resolveType: "website/flags/multivariate/image.ts",
+                variants: [
+                  {
+                    rule: {
+                      __resolveType: "website/matchers/date.ts",
+                      start: "2026-06-15T00:00:00.000Z",
+                      end: "2026-06-20T00:00:00.000Z",
+                    },
+                    value: "https://example.com/inner.jpg",
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out).toHaveLength(2);
+    const inner = out.find((v) =>
+      v.flagResolveType.includes("multivariate/image"),
+    );
+    expect(inner).toBeDefined();
+    expect(inner?.label).toBe("inner.jpg");
+    expect(inner?.innerPath).toContain("variants[0] · value · image");
+  });
+
+  it("humanizes pages-* block keys for display", () => {
+    const decofile = {
+      "pages-Bazar%20Melhores%20Descontos-743529": {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "website/matchers/date.ts",
+              start: "2026-06-01T00:00:00.000Z",
+              end: "2026-06-10T00:00:00.000Z",
+            },
+            value: {},
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.blockLabel).toBe("Bazar Melhores Descontos");
+    // blockKey itself stays raw for stable color/grouping.
+    expect(out[0]?.blockKey).toBe("pages-Bazar%20Melhores%20Descontos-743529");
+  });
+
+  it("falls back to the section's resolveType when no value label is available", () => {
+    const decofile = {
+      Section: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "website/matchers/date.ts",
+              start: "2026-06-01T00:00:00.000Z",
+              end: "2026-06-10T00:00:00.000Z",
+            },
+            value: {
+              __resolveType: "site/sections/NewSearch/ProductListGallery.tsx",
+            },
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out[0]?.label).toBe("ProductListGallery");
+  });
+
+  it("truncates very long plain-string values to 80 chars", () => {
+    const longString = "x".repeat(200);
+    const decofile = {
+      Block: {
+        __resolveType: "website/flags/multivariate/image.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "website/matchers/date.ts",
+              start: "2026-06-01T00:00:00.000Z",
+              end: "2026-06-10T00:00:00.000Z",
+            },
+            value: longString,
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out[0]?.label.length).toBeLessThanOrEqual(80);
+    expect(out[0]?.label.endsWith("…")).toBe(true);
+  });
+
   it("returns empty when decofile is null", () => {
     expect(extractScheduledVariants(null)).toEqual([]);
   });

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import { colorForBlock, extractScheduledVariants } from "./extract-variants";
+
+describe("extractScheduledVariants", () => {
+  it("emits one entry per date matcher and sorts by start", () => {
+    const decofile = {
+      Alerta: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "website/matchers/multi.ts",
+              op: "and",
+              matchers: [
+                { __resolveType: "ETC Segment" },
+                {
+                  __resolveType: "website/matchers/date.ts",
+                  start: "2026-06-15T13:01:00.000Z",
+                  end: "2026-07-01T02:59:00.000Z",
+                },
+              ],
+            },
+            value: {
+              __resolveType: "site/sections/Content/Alert.tsx",
+              config: { typeAlert: { message: "30% OFF" } },
+            },
+          },
+          {
+            rule: {
+              __resolveType: "website/matchers/date.ts",
+              start: "2026-06-01T00:00:00.000Z",
+              end: "2026-06-08T00:00:00.000Z",
+            },
+            value: {
+              __resolveType: "site/sections/Content/Alert.tsx",
+              title: "Early bird",
+            },
+          },
+        ],
+      },
+      // No variants resolver — should be ignored even if it has a `variants` field
+      Other: {
+        __resolveType: "site/sections/Other.tsx",
+        variants: [{ rule: {} }],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.label).toBe("Early bird");
+    expect(out[0]?.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    expect(out[1]?.label).toBe("30% OFF");
+    expect(out[1]?.blockKey).toBe("Alerta");
+  });
+
+  it("returns empty when decofile is null", () => {
+    expect(extractScheduledVariants(null)).toEqual([]);
+  });
+
+  it("skips variants whose date range is missing or inverted", () => {
+    const decofile = {
+      A: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          { rule: { __resolveType: "website/matchers/always.ts" }, value: {} },
+          {
+            rule: {
+              __resolveType: "website/matchers/date.ts",
+              start: "2026-06-10T00:00:00.000Z",
+              end: "2026-06-01T00:00:00.000Z",
+            },
+            value: {},
+          },
+        ],
+      },
+    };
+    expect(extractScheduledVariants(decofile)).toEqual([]);
+  });
+});
+
+describe("colorForBlock", () => {
+  it("is stable for the same key", () => {
+    expect(colorForBlock("Alerta")).toEqual(colorForBlock("Alerta"));
+  });
+  it("differs across keys", () => {
+    expect(colorForBlock("Alerta").bg).not.toBe(
+      colorForBlock("Category Banner - 01").bg,
+    );
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
@@ -38,7 +38,7 @@ describe("extractScheduledVariants", () => {
           },
         ],
       },
-      // No variants resolver — should be ignored even if it has a `variants` field
+      // No multivariate flag resolver — should be ignored even if it has a `variants` field
       Other: {
         __resolveType: "site/sections/Other.tsx",
         variants: [{ rule: {} }],
@@ -48,8 +48,76 @@ describe("extractScheduledVariants", () => {
     expect(out).toHaveLength(2);
     expect(out[0]?.label).toBe("Early bird");
     expect(out[0]?.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    expect(out[0]?.innerPath).toBe("");
     expect(out[1]?.label).toBe("30% OFF");
     expect(out[1]?.blockKey).toBe("Alerta");
+  });
+
+  it("finds nested multivariate flags inside arrays/objects", () => {
+    const decofile = {
+      "Category Banner - 01": {
+        __resolveType: "site/sections/Images/BannerCollection.tsx",
+        banners: [
+          {
+            image: {
+              mobile: {
+                __resolveType: "website/flags/multivariate/image.ts",
+                variants: [
+                  {
+                    rule: {
+                      __resolveType: "website/matchers/date.ts",
+                      start: "2026-06-24T13:00:00.000Z",
+                      end: "2026-07-08T02:59:00.000Z",
+                    },
+                    value:
+                      "https://cdn.example.com/site/2026/06_JUNHO/banner-mobile.jpg",
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.blockKey).toBe("Category Banner - 01");
+    expect(out[0]?.innerPath).toBe("banners[0] · image · mobile");
+    expect(out[0]?.flagResolveType).toBe("website/flags/multivariate/image.ts");
+    // URL value → last path segment as label
+    expect(out[0]?.label).toBe("banner-mobile.jpg");
+  });
+
+  it("supports custom *-scoped multivariate flag resolveTypes", () => {
+    const decofile = {
+      ETCMediaKits: {
+        __resolveType: "site/sections/MediaKits.tsx",
+        mediaKits: [
+          {
+            content: {
+              __resolveType: "site/flags/multivariate/etcMediaKitContent.ts",
+              variants: [
+                {
+                  value: {
+                    matcher: ["/farm-etc/novidades"],
+                    desktop: { media: { alt: "mídia kit novidades" } },
+                  },
+                  rule: {
+                    __resolveType: "website/matchers/date.ts",
+                    start: "2026-06-25T17:05:00.000Z",
+                    end: "2026-07-02T13:00:00.000Z",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.blockKey).toBe("ETCMediaKits");
+    expect(out[0]?.label).toBe("mídia kit novidades");
   });
 
   it("returns empty when decofile is null", () => {

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { colorForBlock, extractScheduledVariants } from "./extract-variants";
+import {
+  buildBlockColorMap,
+  colorFromMap,
+  extractScheduledVariants,
+} from "./extract-variants";
 
 describe("extractScheduledVariants", () => {
   it("emits one entry per date matcher and sorts by start", () => {
@@ -145,13 +149,25 @@ describe("extractScheduledVariants", () => {
   });
 });
 
-describe("colorForBlock", () => {
-  it("is stable for the same key", () => {
-    expect(colorForBlock("Alerta")).toEqual(colorForBlock("Alerta"));
+describe("buildBlockColorMap", () => {
+  it("assigns the same color to the same key", () => {
+    const map = buildBlockColorMap(["Alerta", "Other"]);
+    expect(colorFromMap(map, "Alerta")).toEqual(colorFromMap(map, "Alerta"));
   });
-  it("differs across keys", () => {
-    expect(colorForBlock("Alerta").bg).not.toBe(
-      colorForBlock("Category Banner - 01").bg,
-    );
+  it("gives every distinct key a distinct color", () => {
+    const keys = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"];
+    const map = buildBlockColorMap(keys);
+    const bgs = keys.map((k) => colorFromMap(map, k).bg);
+    expect(new Set(bgs).size).toBe(keys.length);
+  });
+  it("is stable across input ordering", () => {
+    const a = buildBlockColorMap(["A", "B", "C"]);
+    const b = buildBlockColorMap(["C", "A", "B"]);
+    expect(colorFromMap(a, "A")).toEqual(colorFromMap(b, "A"));
+    expect(colorFromMap(a, "B")).toEqual(colorFromMap(b, "B"));
+  });
+  it("falls back when the key is unknown", () => {
+    const map = buildBlockColorMap(["A"]);
+    expect(colorFromMap(map, "missing").bg).toBeDefined();
   });
 });

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
@@ -247,24 +247,49 @@ export function extractScheduledVariants(
   return out.sort((a, b) => a.start.getTime() - b.start.getTime());
 }
 
-/**
- * Deterministic, repo-wide-stable color per block key. Variants from the
- * same block share a color so the calendar reads as "this campaign across
- * its blocks" rather than per-row noise.
- */
-export function colorForBlock(blockKey: string): {
+export interface BlockColor {
   bg: string;
   text: string;
   border: string;
-} {
-  let hash = 0;
-  for (let i = 0; i < blockKey.length; i++) {
-    hash = (hash * 31 + blockKey.charCodeAt(i)) | 0;
-  }
-  const hue = ((hash % 360) + 360) % 360;
-  return {
-    bg: `oklch(0.62 0.14 ${hue})`,
-    text: "white",
-    border: `oklch(0.50 0.14 ${hue})`,
-  };
+}
+
+/**
+ * Builds a stable per-block color map. Block keys are sorted and assigned
+ * hues using the golden-angle sequence (137.508°), which maximizes visual
+ * separation regardless of how many distinct blocks we have. Hashing the
+ * key directly into a hue (the previous approach) was prone to collisions
+ * — different blocks could land on nearby or identical hues.
+ *
+ * Same blockKey always gets the same color **for the same set of inputs**;
+ * adding a new block re-sorts and may shift colors. Stability across
+ * renders comes from the input being derived deterministically from the
+ * decofile, not from the key in isolation.
+ */
+export function buildBlockColorMap(
+  blockKeys: Iterable<string>,
+): Map<string, BlockColor> {
+  const sorted = [...new Set(blockKeys)].sort();
+  const map = new Map<string, BlockColor>();
+  sorted.forEach((key, i) => {
+    const hue = (i * 137.508) % 360;
+    map.set(key, {
+      bg: `oklch(0.62 0.14 ${hue})`,
+      text: "white",
+      border: `oklch(0.50 0.14 ${hue})`,
+    });
+  });
+  return map;
+}
+
+const FALLBACK_COLOR: BlockColor = {
+  bg: "oklch(0.62 0.14 0)",
+  text: "white",
+  border: "oklch(0.50 0.14 0)",
+};
+
+export function colorFromMap(
+  map: Map<string, BlockColor>,
+  blockKey: string,
+): BlockColor {
+  return map.get(blockKey) ?? FALLBACK_COLOR;
 }

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
@@ -1,10 +1,17 @@
 /**
- * Pure helpers for the Variant Calendar view. Pulls scheduled variants out of
- * a decofile by recursively scanning each block's `variants[].rule` for
- * `website/matchers/date.ts` matchers (also nested inside `multi.ts`/legacy
- * `$live` aliases). Each emitted entry corresponds to one (block, variant,
- * date-range) tuple — a variant with two date matchers becomes two rows so
- * each can be drawn on the calendar independently.
+ * Pure helpers for the Variant Calendar view. Walks every decofile block
+ * recursively and emits one entry per (variant container, date matcher)
+ * pair. A "variant container" is any object whose `__resolveType` looks
+ * like `<scope>/flags/multivariate/<kind>.ts` and that has a `variants`
+ * array; this covers top-level section flags (`website/flags/multivariate/
+ * section.ts`), image-field flags nested inside other blocks
+ * (`website/flags/multivariate/image.ts`), and site-specific custom flags
+ * (e.g. `site/flags/multivariate/etcMediaKitContent.ts`).
+ *
+ * Date matchers are extracted from each variant's `rule`, including those
+ * nested inside `website/matchers/multi.ts` and legacy `$live` aliases.
+ * Variants without any date matcher are skipped — those run on every page
+ * load and have no place on a time axis.
  */
 
 const DATE_MATCHER_TYPES = new Set([
@@ -17,19 +24,43 @@ const MULTI_MATCHER_TYPES = new Set([
   "$live/matchers/MatchMulti.ts",
 ]);
 
-const FLAG_RESOLVE_TYPES = new Set([
-  "website/flags/multivariate/section.ts",
-  "website/flags/audience.ts",
-  "$live/flags/Flag.ts",
-]);
+const MULTIVARIATE_FLAG_PATTERN = /\/flags\/multivariate\/[^/]+\.ts$/;
 
 export interface ScheduledVariant {
+  /** Top-level decofile key the variant lives under (used for grouping/color). */
   blockKey: string;
+  /** Display-friendly version of `blockKey` — URL-decoded, page-prefix stripped. */
+  blockLabel: string;
+  /** Human-readable path inside the block, empty for top-level containers. */
+  innerPath: string;
   variantIndex: number;
   start: Date;
   end: Date;
+  /** Best-effort short label from the variant's `value`, or a path-derived fallback. */
   label: string;
-  resolveType: string | null;
+  /** The flag's `__resolveType`, e.g. `website/flags/multivariate/image.ts`. */
+  flagResolveType: string;
+}
+
+/**
+ * Turns a raw decofile key into something a human can read at a glance.
+ * Examples:
+ *   "Alerta"                                       → "Alerta"
+ *   "pages-Bazar%20Melhores%20Descontos-743529"    → "Bazar Melhores Descontos"
+ *   "Category Banner - 01"                         → "Category Banner - 01"
+ */
+function humanizeBlockKey(key: string): string {
+  let label = key;
+  // Strip `pages-` prefix and trailing numeric id (e.g. `-743529`).
+  if (label.startsWith("pages-")) {
+    label = label.slice("pages-".length).replace(/-\d+$/, "");
+  }
+  try {
+    label = decodeURIComponent(label);
+  } catch {
+    // Leave as-is when not valid percent-encoded text.
+  }
+  return label;
 }
 
 function readDateRange(rule: unknown): { start: Date; end: Date } | null {
@@ -68,58 +99,91 @@ function collectDateRanges(
   }
 }
 
+function isVariantContainer(node: unknown): node is {
+  __resolveType: string;
+  variants: unknown[];
+} {
+  if (!node || typeof node !== "object") return false;
+  const rt = (node as { __resolveType?: unknown }).__resolveType;
+  if (typeof rt !== "string") return false;
+  if (!MULTIVARIATE_FLAG_PATTERN.test(rt)) return false;
+  const variants = (node as { variants?: unknown }).variants;
+  return Array.isArray(variants);
+}
+
 function readValueLabel(value: unknown): string | null {
+  // Plain string values (e.g. image URLs in `website/flags/multivariate/image.ts`)
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return null;
+    // For URLs, return the last meaningful path segment without query string.
+    try {
+      const u = new URL(trimmed);
+      const segments = u.pathname.split("/").filter(Boolean);
+      const last = segments[segments.length - 1];
+      if (last) return decodeURIComponent(last);
+    } catch {
+      // not a URL; fall through
+    }
+    return trimmed.length > 80 ? `${trimmed.slice(0, 77)}…` : trimmed;
+  }
   if (!value || typeof value !== "object") return null;
   const v = value as Record<string, unknown>;
+  const config = v.config as Record<string, unknown> | undefined;
+  const desktop = v.desktop as Record<string, unknown> | undefined;
+  const desktopMedia = desktop?.media as Record<string, unknown> | undefined;
   const candidates: unknown[] = [
     v.title,
     v.name,
     v.label,
-    (v.config as Record<string, unknown> | undefined)?.title,
-    (v.config as Record<string, unknown> | undefined)?.name,
-    (
-      (v.config as Record<string, unknown> | undefined)?.typeAlert as
-        | Record<string, unknown>
-        | undefined
-    )?.message,
+    v.alt,
+    config?.title,
+    config?.name,
+    (config?.typeAlert as Record<string, unknown> | undefined)?.message,
+    desktopMedia?.alt,
+    Array.isArray(v.matcher) ? (v.matcher as unknown[])[0] : undefined,
   ];
   for (const c of candidates) {
     if (typeof c === "string" && c.trim().length > 0) return c.trim();
   }
+  // Last resort: derive a label from the section's resolveType, e.g.
+  // "site/sections/NewSearch/ProductListGallery.tsx" → "ProductListGallery".
+  const rt = v.__resolveType;
+  if (typeof rt === "string") {
+    const last = rt.split("/").pop() ?? rt;
+    const stripped = last.replace(/\.(tsx?|jsx?)$/i, "");
+    if (stripped.length > 0) return stripped;
+  }
   return null;
 }
 
-function readResolveType(value: unknown): string | null {
-  if (!value || typeof value !== "object") return null;
-  const rt = (value as { __resolveType?: unknown }).__resolveType;
-  return typeof rt === "string" ? rt : null;
+function formatInnerPath(segments: Array<string | number>): string {
+  // "/banners/0/image/mobile" → "banners[0] · image · mobile"
+  const parts: string[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]!;
+    if (typeof seg === "number") {
+      // Attach index to previous segment.
+      if (parts.length > 0) parts[parts.length - 1] += `[${seg}]`;
+      else parts.push(`[${seg}]`);
+    } else {
+      parts.push(seg);
+    }
+  }
+  return parts.join(" · ");
 }
 
-/**
- * Walk every block in the decofile and emit one ScheduledVariant per
- * (variant, date-matcher) pair. Variants without any date matcher are
- * skipped — those run on every page load (e.g. always/audience-only) and
- * have no place on a time axis.
- */
-export function extractScheduledVariants(
-  decofile: Record<string, unknown> | null | undefined,
-): ScheduledVariant[] {
-  if (!decofile) return [];
-  const out: ScheduledVariant[] = [];
-  for (const [blockKey, block] of Object.entries(decofile)) {
-    if (!block || typeof block !== "object") continue;
-    const b = block as Record<string, unknown>;
-    const variants = b.variants;
-    if (!Array.isArray(variants)) continue;
-    // Only treat as a variant container when the block uses the multivariate
-    // flag resolver — other blocks may incidentally hold a `variants` field.
-    const blockResolveType = b.__resolveType;
-    if (
-      typeof blockResolveType !== "string" ||
-      !FLAG_RESOLVE_TYPES.has(blockResolveType)
-    ) {
-      continue;
-    }
+function walkAndCollect(
+  node: unknown,
+  blockKey: string,
+  blockLabel: string,
+  innerSegments: Array<string | number>,
+  out: ScheduledVariant[],
+): void {
+  if (isVariantContainer(node)) {
+    const innerPath = formatInnerPath(innerSegments);
+    const variants = (node as { variants: unknown[] }).variants;
+    const flagResolveType = (node as { __resolveType: string }).__resolveType;
     variants.forEach((variant, variantIndex) => {
       if (!variant || typeof variant !== "object") return;
       const v = variant as Record<string, unknown>;
@@ -127,19 +191,58 @@ export function extractScheduledVariants(
       collectDateRanges(v.rule, ranges);
       if (ranges.length === 0) return;
       const valueLabel = readValueLabel(v.value);
-      const resolveType = readResolveType(v.value);
-      const label = valueLabel ?? blockKey;
+      const label = valueLabel ?? (innerPath || blockLabel);
       for (const range of ranges) {
         out.push({
           blockKey,
+          blockLabel,
+          innerPath,
           variantIndex,
           start: range.start,
           end: range.end,
           label,
-          resolveType,
+          flagResolveType,
         });
       }
     });
+    // Recurse into variant values too — a variant's value can itself
+    // contain nested multivariate flags (rare but legal).
+    for (let i = 0; i < variants.length; i++) {
+      const v = variants[i];
+      if (v && typeof v === "object") {
+        walkAndCollect(
+          (v as { value?: unknown }).value,
+          blockKey,
+          blockLabel,
+          [...innerSegments, "variants", i, "value"],
+          out,
+        );
+      }
+    }
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      walkAndCollect(node[i], blockKey, blockLabel, [...innerSegments, i], out);
+    }
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const [k, v] of Object.entries(node)) {
+      // Skip __resolveType so we don't recurse into it as a string field.
+      if (k === "__resolveType") continue;
+      walkAndCollect(v, blockKey, blockLabel, [...innerSegments, k], out);
+    }
+  }
+}
+
+export function extractScheduledVariants(
+  decofile: Record<string, unknown> | null | undefined,
+): ScheduledVariant[] {
+  if (!decofile) return [];
+  const out: ScheduledVariant[] = [];
+  for (const [blockKey, block] of Object.entries(decofile)) {
+    walkAndCollect(block, blockKey, humanizeBlockKey(blockKey), [], out);
   }
   return out.sort((a, b) => a.start.getTime() - b.start.getTime());
 }

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
@@ -24,6 +24,10 @@ const MULTI_MATCHER_TYPES = new Set([
   "$live/matchers/MatchMulti.ts",
 ]);
 
+// Non-anchored on purpose: matches `<scope>/flags/multivariate/<x>.ts` for
+// any scope, so `website/flags/multivariate/section.ts`,
+// `site/flags/multivariate/etcMediaKitContent.ts`, and the legacy
+// `$live/flags/multivariate/section.ts` all match.
 const MULTIVARIATE_FLAG_PATTERN = /\/flags\/multivariate\/[^/]+\.ts$/;
 
 export interface ScheduledVariant {

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
@@ -1,0 +1,167 @@
+/**
+ * Pure helpers for the Variant Calendar view. Pulls scheduled variants out of
+ * a decofile by recursively scanning each block's `variants[].rule` for
+ * `website/matchers/date.ts` matchers (also nested inside `multi.ts`/legacy
+ * `$live` aliases). Each emitted entry corresponds to one (block, variant,
+ * date-range) tuple — a variant with two date matchers becomes two rows so
+ * each can be drawn on the calendar independently.
+ */
+
+const DATE_MATCHER_TYPES = new Set([
+  "website/matchers/date.ts",
+  "$live/matchers/MatchDate.ts",
+]);
+
+const MULTI_MATCHER_TYPES = new Set([
+  "website/matchers/multi.ts",
+  "$live/matchers/MatchMulti.ts",
+]);
+
+const FLAG_RESOLVE_TYPES = new Set([
+  "website/flags/multivariate/section.ts",
+  "website/flags/audience.ts",
+  "$live/flags/Flag.ts",
+]);
+
+export interface ScheduledVariant {
+  blockKey: string;
+  variantIndex: number;
+  start: Date;
+  end: Date;
+  label: string;
+  resolveType: string | null;
+}
+
+function readDateRange(rule: unknown): { start: Date; end: Date } | null {
+  if (!rule || typeof rule !== "object") return null;
+  const { start, end } = rule as { start?: unknown; end?: unknown };
+  if (typeof start !== "string" || typeof end !== "string") return null;
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  if (
+    Number.isNaN(startDate.getTime()) ||
+    Number.isNaN(endDate.getTime()) ||
+    endDate.getTime() <= startDate.getTime()
+  ) {
+    return null;
+  }
+  return { start: startDate, end: endDate };
+}
+
+function collectDateRanges(
+  rule: unknown,
+  out: Array<{ start: Date; end: Date }>,
+): void {
+  if (!rule || typeof rule !== "object") return;
+  const rt = (rule as { __resolveType?: unknown }).__resolveType;
+  if (typeof rt !== "string") return;
+  if (DATE_MATCHER_TYPES.has(rt)) {
+    const range = readDateRange(rule);
+    if (range) out.push(range);
+    return;
+  }
+  if (MULTI_MATCHER_TYPES.has(rt)) {
+    const matchers = (rule as { matchers?: unknown }).matchers;
+    if (Array.isArray(matchers)) {
+      for (const m of matchers) collectDateRanges(m, out);
+    }
+  }
+}
+
+function readValueLabel(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  const candidates: unknown[] = [
+    v.title,
+    v.name,
+    v.label,
+    (v.config as Record<string, unknown> | undefined)?.title,
+    (v.config as Record<string, unknown> | undefined)?.name,
+    (
+      (v.config as Record<string, unknown> | undefined)?.typeAlert as
+        | Record<string, unknown>
+        | undefined
+    )?.message,
+  ];
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim().length > 0) return c.trim();
+  }
+  return null;
+}
+
+function readResolveType(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const rt = (value as { __resolveType?: unknown }).__resolveType;
+  return typeof rt === "string" ? rt : null;
+}
+
+/**
+ * Walk every block in the decofile and emit one ScheduledVariant per
+ * (variant, date-matcher) pair. Variants without any date matcher are
+ * skipped — those run on every page load (e.g. always/audience-only) and
+ * have no place on a time axis.
+ */
+export function extractScheduledVariants(
+  decofile: Record<string, unknown> | null | undefined,
+): ScheduledVariant[] {
+  if (!decofile) return [];
+  const out: ScheduledVariant[] = [];
+  for (const [blockKey, block] of Object.entries(decofile)) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as Record<string, unknown>;
+    const variants = b.variants;
+    if (!Array.isArray(variants)) continue;
+    // Only treat as a variant container when the block uses the multivariate
+    // flag resolver — other blocks may incidentally hold a `variants` field.
+    const blockResolveType = b.__resolveType;
+    if (
+      typeof blockResolveType !== "string" ||
+      !FLAG_RESOLVE_TYPES.has(blockResolveType)
+    ) {
+      continue;
+    }
+    variants.forEach((variant, variantIndex) => {
+      if (!variant || typeof variant !== "object") return;
+      const v = variant as Record<string, unknown>;
+      const ranges: Array<{ start: Date; end: Date }> = [];
+      collectDateRanges(v.rule, ranges);
+      if (ranges.length === 0) return;
+      const valueLabel = readValueLabel(v.value);
+      const resolveType = readResolveType(v.value);
+      const label = valueLabel ?? blockKey;
+      for (const range of ranges) {
+        out.push({
+          blockKey,
+          variantIndex,
+          start: range.start,
+          end: range.end,
+          label,
+          resolveType,
+        });
+      }
+    });
+  }
+  return out.sort((a, b) => a.start.getTime() - b.start.getTime());
+}
+
+/**
+ * Deterministic, repo-wide-stable color per block key. Variants from the
+ * same block share a color so the calendar reads as "this campaign across
+ * its blocks" rather than per-row noise.
+ */
+export function colorForBlock(blockKey: string): {
+  bg: string;
+  text: string;
+  border: string;
+} {
+  let hash = 0;
+  for (let i = 0; i < blockKey.length; i++) {
+    hash = (hash * 31 + blockKey.charCodeAt(i)) | 0;
+  }
+  const hue = ((hash % 360) + 360) % 360;
+  return {
+    bg: `oklch(0.62 0.14 ${hue})`,
+    text: "white",
+    border: `oklch(0.50 0.14 ${hue})`,
+  };
+}

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
@@ -1,0 +1,578 @@
+/**
+ * Variant Calendar — displays every scheduled variant from the decofile on a
+ * month grid (Google-Calendar style) or a Gantt-style timeline. The data
+ * source is `extractScheduledVariants`, which only emits variants gated by a
+ * `website/matchers/date.ts` rule; non-time-scoped variants (audience,
+ * device, etc.) intentionally don't appear.
+ */
+import { useState } from "react";
+import { Calendar, ChevronLeft, ChevronRight } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import {
+  colorForBlock,
+  extractScheduledVariants,
+  type ScheduledVariant,
+} from "./extract-variants";
+
+type ViewMode = "calendar" | "timeline";
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function startOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1);
+}
+
+function addDays(d: Date, n: number): Date {
+  const out = new Date(d);
+  out.setDate(out.getDate() + n);
+  return out;
+}
+
+function diffInDays(a: Date, b: Date): number {
+  return Math.round(
+    (startOfDay(a).getTime() - startOfDay(b).getTime()) / DAY_MS,
+  );
+}
+
+function buildMonthWeeks(monthStart: Date): Date[][] {
+  // 6-week grid starting on Sunday (matches the screenshot mockup).
+  const gridStart = addDays(monthStart, -monthStart.getDay());
+  const weeks: Date[][] = [];
+  for (let w = 0; w < 6; w++) {
+    const days: Date[] = [];
+    for (let d = 0; d < 7; d++) {
+      days.push(addDays(gridStart, w * 7 + d));
+    }
+    weeks.push(days);
+  }
+  // Drop the trailing week if it falls entirely in the next month.
+  while (
+    weeks.length > 0 &&
+    weeks[weeks.length - 1]!.every(
+      (day) => day.getMonth() !== monthStart.getMonth(),
+    )
+  ) {
+    weeks.pop();
+  }
+  return weeks;
+}
+
+interface PlacedSegment {
+  variant: ScheduledVariant;
+  startCol: number; // 0-indexed column (0=Sunday)
+  span: number; // 1..7
+  lane: number;
+}
+
+function placeWeekSegments(
+  weekDays: Date[],
+  variants: ScheduledVariant[],
+): PlacedSegment[] {
+  const weekStart = startOfDay(weekDays[0]!);
+  const weekEndExclusive = addDays(weekStart, 7);
+  const segments: Array<Omit<PlacedSegment, "lane">> = [];
+  for (const variant of variants) {
+    const vStart = startOfDay(variant.start);
+    const vEnd = startOfDay(variant.end);
+    if (vEnd.getTime() < weekStart.getTime()) continue;
+    if (vStart.getTime() >= weekEndExclusive.getTime()) continue;
+    const segStart =
+      vStart.getTime() < weekStart.getTime() ? weekStart : vStart;
+    const segEnd =
+      vEnd.getTime() >= weekEndExclusive.getTime()
+        ? addDays(weekEndExclusive, -1)
+        : vEnd;
+    const startCol = diffInDays(segStart, weekStart);
+    const span = diffInDays(segEnd, segStart) + 1;
+    if (span <= 0) continue;
+    segments.push({ variant, startCol, span });
+  }
+  // Sort by start, then by span desc — long bars take lower lanes.
+  segments.sort(
+    (a, b) =>
+      a.startCol - b.startCol ||
+      b.span - a.span ||
+      a.variant.blockKey.localeCompare(b.variant.blockKey),
+  );
+  const laneEnds: number[] = []; // exclusive end column for each lane
+  const placed: PlacedSegment[] = [];
+  for (const seg of segments) {
+    let lane = laneEnds.findIndex((end) => end <= seg.startCol);
+    if (lane === -1) {
+      lane = laneEnds.length;
+      laneEnds.push(0);
+    }
+    laneEnds[lane] = seg.startCol + seg.span;
+    placed.push({ ...seg, lane });
+  }
+  return placed;
+}
+
+function formatRangeForTooltip(v: ScheduledVariant): string {
+  const fmt = new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+  return `${fmt.format(v.start)} → ${fmt.format(v.end)}`;
+}
+
+export function VariantCalendar({
+  decofile,
+}: {
+  decofile: Record<string, unknown> | null | undefined;
+}) {
+  const [view, setView] = useState<ViewMode>("calendar");
+  const [cursor, setCursor] = useState<Date>(() => startOfMonth(new Date()));
+
+  const variants = extractScheduledVariants(decofile);
+  const blockKeys = Array.from(new Set(variants.map((v) => v.blockKey)));
+
+  const goToday = () => setCursor(startOfMonth(new Date()));
+  const goPrev = () =>
+    setCursor((c) =>
+      view === "calendar" ? addMonths(c, -1) : addMonths(c, -3),
+    );
+  const goNext = () =>
+    setCursor((c) => (view === "calendar" ? addMonths(c, 1) : addMonths(c, 3)));
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <div className="flex items-center justify-between px-4 h-12 border-b shrink-0">
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={goToday}>
+            Today
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            onClick={goPrev}
+            aria-label="Previous"
+          >
+            <ChevronLeft size={16} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            onClick={goNext}
+            aria-label="Next"
+          >
+            <ChevronRight size={16} />
+          </Button>
+          <h2 className="ml-2 text-base font-semibold">
+            {MONTHS[cursor.getMonth()]} {cursor.getFullYear()}
+          </h2>
+        </div>
+        <div className="flex items-center gap-3">
+          <BlockLegend blockKeys={blockKeys} />
+          <div className="flex rounded-md border bg-muted p-0.5">
+            <button
+              type="button"
+              onClick={() => setView("calendar")}
+              className={cn(
+                "px-3 py-1 text-xs font-medium rounded-sm transition-colors cursor-pointer",
+                view === "calendar"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              Calendar
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("timeline")}
+              className={cn(
+                "px-3 py-1 text-xs font-medium rounded-sm transition-colors cursor-pointer",
+                view === "timeline"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              Timeline
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {variants.length === 0 ? (
+        <EmptyState />
+      ) : view === "calendar" ? (
+        <CalendarView monthStart={cursor} variants={variants} />
+      ) : (
+        <TimelineView monthStart={cursor} variants={variants} />
+      )}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground p-6">
+      <Calendar size={24} className="text-muted-foreground/60" />
+      <div>No scheduled variants.</div>
+      <div className="text-xs text-muted-foreground/80">
+        Variants gated by a date matcher appear here.
+      </div>
+    </div>
+  );
+}
+
+function BlockLegend({ blockKeys }: { blockKeys: string[] }) {
+  if (blockKeys.length === 0) return null;
+  const visible = blockKeys.slice(0, 4);
+  const hidden = blockKeys.length - visible.length;
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      {visible.map((key) => {
+        const c = colorForBlock(key);
+        return (
+          <span key={key} className="flex items-center gap-1.5">
+            <span
+              className="inline-block h-2.5 w-5 rounded-sm"
+              style={{ background: c.bg }}
+            />
+            <span className="truncate max-w-[120px]">{key}</span>
+          </span>
+        );
+      })}
+      {hidden > 0 && <span>+{hidden}</span>}
+    </div>
+  );
+}
+
+const LANE_HEIGHT = 20;
+const LANE_GAP = 2;
+const HEADER_HEIGHT = 28;
+
+function CalendarView({
+  monthStart,
+  variants,
+}: {
+  monthStart: Date;
+  variants: ScheduledVariant[];
+}) {
+  const weeks = buildMonthWeeks(monthStart);
+  const today = startOfDay(new Date());
+
+  return (
+    <ScrollArea className="flex-1">
+      <div className="min-w-[840px]">
+        <div className="grid grid-cols-7 border-b text-xs text-muted-foreground sticky top-0 bg-background z-10">
+          {WEEKDAYS.map((wd) => (
+            <div
+              key={wd}
+              className="px-2 py-2 text-center uppercase tracking-wide"
+            >
+              {wd}
+            </div>
+          ))}
+        </div>
+        {weeks.map((week, wi) => {
+          const segments = placeWeekSegments(week, variants);
+          const laneCount = segments.reduce(
+            (m, s) => Math.max(m, s.lane + 1),
+            0,
+          );
+          const rowHeight =
+            HEADER_HEIGHT + laneCount * (LANE_HEIGHT + LANE_GAP) + 8;
+          return (
+            <div
+              key={wi}
+              className="grid grid-cols-7 relative border-b"
+              style={{ height: rowHeight }}
+            >
+              {week.map((day, di) => {
+                const isCurrentMonth = day.getMonth() === monthStart.getMonth();
+                const isToday = day.getTime() === today.getTime();
+                return (
+                  <div
+                    key={di}
+                    className={cn(
+                      "border-r last:border-r-0 px-2 pt-1.5 text-xs",
+                      isCurrentMonth
+                        ? "bg-background"
+                        : "bg-muted/30 text-muted-foreground",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1",
+                        isToday &&
+                          "bg-primary text-primary-foreground font-semibold",
+                      )}
+                    >
+                      {day.getDate()}
+                    </span>
+                  </div>
+                );
+              })}
+              {segments.map((seg, idx) => {
+                const color = colorForBlock(seg.variant.blockKey);
+                const top = HEADER_HEIGHT + seg.lane * (LANE_HEIGHT + LANE_GAP);
+                const leftPct = (seg.startCol / 7) * 100;
+                const widthPct = (seg.span / 7) * 100;
+                return (
+                  <Tooltip key={`${wi}-${idx}`}>
+                    <TooltipTrigger asChild>
+                      <div
+                        className="absolute flex items-center px-2 text-[11px] font-medium truncate cursor-default"
+                        style={{
+                          top,
+                          left: `calc(${leftPct}% + 2px)`,
+                          width: `calc(${widthPct}% - 4px)`,
+                          height: LANE_HEIGHT,
+                          background: color.bg,
+                          color: color.text,
+                          borderRadius: 4,
+                        }}
+                      >
+                        <span className="truncate">
+                          {seg.variant.blockKey}
+                          <span className="opacity-70">
+                            {" · "}
+                            {seg.variant.label}
+                          </span>
+                        </span>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <div className="text-xs">
+                        <div className="font-semibold">
+                          {seg.variant.blockKey}
+                        </div>
+                        <div className="text-muted-foreground">
+                          {seg.variant.label}
+                        </div>
+                        <div className="mt-1">
+                          {formatRangeForTooltip(seg.variant)}
+                        </div>
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </ScrollArea>
+  );
+}
+
+const TIMELINE_MONTHS = 4;
+const ROW_HEIGHT = 32;
+const ROW_LABEL_WIDTH = 240;
+
+function TimelineView({
+  monthStart,
+  variants,
+}: {
+  monthStart: Date;
+  variants: ScheduledVariant[];
+}) {
+  const rangeStart = monthStart;
+  const rangeEnd = addMonths(monthStart, TIMELINE_MONTHS);
+  const today = new Date();
+
+  // Group variants by block for the row layout.
+  const byBlock = new Map<string, ScheduledVariant[]>();
+  for (const v of variants) {
+    const arr = byBlock.get(v.blockKey) ?? [];
+    arr.push(v);
+    byBlock.set(v.blockKey, arr);
+  }
+  const sortedBlocks = Array.from(byBlock.entries()).sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  );
+
+  const totalMs = rangeEnd.getTime() - rangeStart.getTime();
+  const pctOf = (d: Date) => {
+    const clamped = Math.max(
+      rangeStart.getTime(),
+      Math.min(rangeEnd.getTime(), d.getTime()),
+    );
+    return ((clamped - rangeStart.getTime()) / totalMs) * 100;
+  };
+
+  const monthHeaders = Array.from({ length: TIMELINE_MONTHS }, (_, i) =>
+    addMonths(rangeStart, i),
+  );
+
+  const todayPct =
+    today.getTime() >= rangeStart.getTime() &&
+    today.getTime() <= rangeEnd.getTime()
+      ? pctOf(today)
+      : null;
+
+  return (
+    <ScrollArea className="flex-1">
+      <div className="min-w-[900px] relative">
+        <div className="flex border-b sticky top-0 bg-background z-10">
+          <div
+            className="shrink-0 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground border-r"
+            style={{ width: ROW_LABEL_WIDTH }}
+          >
+            Variant / Block
+          </div>
+          <div
+            className="flex-1 grid"
+            style={{
+              gridTemplateColumns: `repeat(${TIMELINE_MONTHS}, minmax(0, 1fr))`,
+            }}
+          >
+            {monthHeaders.map((m, i) => (
+              <div
+                key={i}
+                className="px-2 py-2 text-xs uppercase tracking-wide text-muted-foreground border-r last:border-r-0"
+              >
+                {MONTHS[m.getMonth()]?.slice(0, 3)} {m.getFullYear()}
+              </div>
+            ))}
+          </div>
+        </div>
+        {todayPct !== null && (
+          <div
+            className="pointer-events-none absolute top-0 bottom-0 w-px bg-primary/70 z-[5]"
+            style={{
+              left: `calc(${ROW_LABEL_WIDTH}px + (100% - ${ROW_LABEL_WIDTH}px) * ${todayPct} / 100)`,
+            }}
+          >
+            <span className="absolute -top-0.5 -translate-x-1/2 rounded-sm bg-primary px-1.5 py-px text-[10px] font-medium text-primary-foreground">
+              Today
+            </span>
+          </div>
+        )}
+        {sortedBlocks.map(([blockKey, blockVariants]) => {
+          const color = colorForBlock(blockKey);
+          return (
+            <div key={blockKey}>
+              <div
+                className="flex items-center bg-muted/40 border-b text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                style={{ height: 28 }}
+              >
+                <div
+                  className="px-3 truncate"
+                  style={{ width: ROW_LABEL_WIDTH }}
+                >
+                  {blockKey}
+                </div>
+              </div>
+              {blockVariants.map((v, i) => (
+                <div
+                  key={i}
+                  className="flex border-b items-center"
+                  style={{ height: ROW_HEIGHT }}
+                >
+                  <div
+                    className="flex items-center gap-2 px-3 text-sm border-r shrink-0"
+                    style={{ width: ROW_LABEL_WIDTH }}
+                  >
+                    <span
+                      className="inline-block h-2 w-2 rounded-full shrink-0"
+                      style={{ background: color.bg }}
+                    />
+                    <span className="truncate text-foreground/80">
+                      {v.label}
+                    </span>
+                  </div>
+                  <div className="relative flex-1 h-full">
+                    {/* month gridlines */}
+                    <div
+                      className="absolute inset-0 grid"
+                      style={{
+                        gridTemplateColumns: `repeat(${TIMELINE_MONTHS}, minmax(0, 1fr))`,
+                      }}
+                    >
+                      {monthHeaders.map((_, mi) => (
+                        <div
+                          key={mi}
+                          className="border-r last:border-r-0 border-border/40"
+                        />
+                      ))}
+                    </div>
+                    {(() => {
+                      const segStart = Math.max(
+                        v.start.getTime(),
+                        rangeStart.getTime(),
+                      );
+                      const segEnd = Math.min(
+                        v.end.getTime(),
+                        rangeEnd.getTime(),
+                      );
+                      if (segEnd <= segStart) return null;
+                      const left = pctOf(new Date(segStart));
+                      const width = pctOf(new Date(segEnd)) - left;
+                      return (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div
+                              className="absolute top-1/2 -translate-y-1/2 flex items-center px-2 text-[11px] font-medium truncate cursor-default"
+                              style={{
+                                left: `${left}%`,
+                                width: `calc(${width}% - 2px)`,
+                                height: 22,
+                                background: color.bg,
+                                color: color.text,
+                                borderRadius: 4,
+                              }}
+                            >
+                              <span className="truncate">{v.label}</span>
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <div className="text-xs">
+                              <div className="font-semibold">{v.blockKey}</div>
+                              <div className="text-muted-foreground">
+                                {v.label}
+                              </div>
+                              <div className="mt-1">
+                                {formatRangeForTooltip(v)}
+                              </div>
+                            </div>
+                          </TooltipContent>
+                        </Tooltip>
+                      );
+                    })()}
+                  </div>
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
@@ -157,13 +157,6 @@ export function VariantCalendar({
   const [cursor, setCursor] = useState<Date>(() => startOfMonth(new Date()));
 
   const variants = extractScheduledVariants(decofile);
-  const blocks: Array<{ key: string; label: string }> = [];
-  const seenBlockKeys = new Set<string>();
-  for (const v of variants) {
-    if (seenBlockKeys.has(v.blockKey)) continue;
-    seenBlockKeys.add(v.blockKey);
-    blocks.push({ key: v.blockKey, label: v.blockLabel });
-  }
 
   const goToday = () => setCursor(startOfMonth(new Date()));
   const goPrev = () =>
@@ -203,7 +196,6 @@ export function VariantCalendar({
           </h2>
         </div>
         <div className="flex items-center gap-3">
-          <BlockLegend blocks={blocks} />
           <div className="flex rounded-md border bg-muted p-0.5">
             <button
               type="button"
@@ -252,33 +244,6 @@ function EmptyState() {
       <div className="text-xs text-muted-foreground/80">
         Variants gated by a date matcher appear here.
       </div>
-    </div>
-  );
-}
-
-function BlockLegend({
-  blocks,
-}: {
-  blocks: Array<{ key: string; label: string }>;
-}) {
-  if (blocks.length === 0) return null;
-  const visible = blocks.slice(0, 4);
-  const hidden = blocks.length - visible.length;
-  return (
-    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      {visible.map(({ key, label }) => {
-        const c = colorForBlock(key);
-        return (
-          <span key={key} className="flex items-center gap-1.5">
-            <span
-              className="inline-block h-2.5 w-5 rounded-sm"
-              style={{ background: c.bg }}
-            />
-            <span className="truncate max-w-[120px]">{label}</span>
-          </span>
-        );
-      })}
-      {hidden > 0 && <span>+{hidden}</span>}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
@@ -6,7 +6,12 @@
  * device, etc.) intentionally don't appear.
  */
 import { useState } from "react";
-import { Calendar, ChevronLeft, ChevronRight } from "@untitledui/icons";
+import {
+  Activity,
+  Calendar,
+  ChevronLeft,
+  ChevronRight,
+} from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
@@ -15,6 +20,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
+import { ViewModeToggle } from "@deco/ui/components/view-mode-toggle.tsx";
 import {
   type BlockColor,
   buildBlockColorMap,
@@ -22,132 +28,85 @@ import {
   extractScheduledVariants,
   type ScheduledVariant,
 } from "./extract-variants";
+import {
+  addMonths,
+  buildMonthWeeks,
+  MONTHS,
+  placeWeekSegments,
+  startOfDay,
+  startOfMonth,
+  WEEKDAYS,
+} from "./date-utils";
 
 type ViewMode = "calendar" | "timeline";
 
-const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
-const MONTHS = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-] as const;
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-function startOfDay(d: Date): Date {
-  const out = new Date(d);
-  out.setHours(0, 0, 0, 0);
-  return out;
-}
-
-function startOfMonth(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), 1);
-}
-
-function addMonths(d: Date, n: number): Date {
-  return new Date(d.getFullYear(), d.getMonth() + n, 1);
-}
-
-function addDays(d: Date, n: number): Date {
-  const out = new Date(d);
-  out.setDate(out.getDate() + n);
-  return out;
-}
-
-function diffInDays(a: Date, b: Date): number {
-  return Math.round(
-    (startOfDay(a).getTime() - startOfDay(b).getTime()) / DAY_MS,
-  );
-}
-
-function buildMonthWeeks(monthStart: Date): Date[][] {
-  // 6-week grid starting on Sunday (matches the screenshot mockup).
-  const gridStart = addDays(monthStart, -monthStart.getDay());
-  const weeks: Date[][] = [];
-  for (let w = 0; w < 6; w++) {
-    const days: Date[] = [];
-    for (let d = 0; d < 7; d++) {
-      days.push(addDays(gridStart, w * 7 + d));
-    }
-    weeks.push(days);
-  }
-  // Drop the trailing week if it falls entirely in the next month.
-  while (
-    weeks.length > 0 &&
-    weeks[weeks.length - 1]!.every(
-      (day) => day.getMonth() !== monthStart.getMonth(),
-    )
-  ) {
-    weeks.pop();
-  }
-  return weeks;
-}
-
-interface PlacedSegment {
-  variant: ScheduledVariant;
-  startCol: number; // 0-indexed column (0=Sunday)
-  span: number; // 1..7
-  lane: number;
-}
-
-function placeWeekSegments(
-  weekDays: Date[],
-  variants: ScheduledVariant[],
-): PlacedSegment[] {
-  const weekStart = startOfDay(weekDays[0]!);
-  const weekEndExclusive = addDays(weekStart, 7);
-  const segments: Array<Omit<PlacedSegment, "lane">> = [];
-  for (const variant of variants) {
-    const vStart = startOfDay(variant.start);
-    const vEnd = startOfDay(variant.end);
-    if (vEnd.getTime() < weekStart.getTime()) continue;
-    if (vStart.getTime() >= weekEndExclusive.getTime()) continue;
-    const segStart =
-      vStart.getTime() < weekStart.getTime() ? weekStart : vStart;
-    const segEnd =
-      vEnd.getTime() >= weekEndExclusive.getTime()
-        ? addDays(weekEndExclusive, -1)
-        : vEnd;
-    const startCol = diffInDays(segStart, weekStart);
-    const span = diffInDays(segEnd, segStart) + 1;
-    if (span <= 0) continue;
-    segments.push({ variant, startCol, span });
-  }
-  // Sort by start, then by span desc — long bars take lower lanes.
-  segments.sort(
-    (a, b) =>
-      a.startCol - b.startCol ||
-      b.span - a.span ||
-      a.variant.blockKey.localeCompare(b.variant.blockKey),
-  );
-  const laneEnds: number[] = []; // exclusive end column for each lane
-  const placed: PlacedSegment[] = [];
-  for (const seg of segments) {
-    let lane = laneEnds.findIndex((end) => end <= seg.startCol);
-    if (lane === -1) {
-      lane = laneEnds.length;
-      laneEnds.push(0);
-    }
-    laneEnds[lane] = seg.startCol + seg.span;
-    placed.push({ ...seg, lane });
-  }
-  return placed;
-}
+const RANGE_FORMAT = new Intl.DateTimeFormat("en", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
 
 function formatRangeForTooltip(v: ScheduledVariant): string {
-  const fmt = new Intl.DateTimeFormat("en", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  });
-  return `${fmt.format(v.start)} → ${fmt.format(v.end)}`;
+  return `${RANGE_FORMAT.format(v.start)} → ${RANGE_FORMAT.format(v.end)}`;
+}
+
+/**
+ * The Radix tooltip body shown by both calendar and timeline bars. Pulls
+ * `blockLabel` / `innerPath` / `label` / formatted range; suppresses
+ * duplicate lines when the variant has no nested path or the label
+ * coincides with the block name.
+ */
+function VariantTooltipBody({ variant }: { variant: ScheduledVariant }) {
+  return (
+    <TooltipContent>
+      <div className="text-xs">
+        <div className="font-semibold">{variant.blockLabel}</div>
+        {variant.innerPath && (
+          <div className="text-muted-foreground">{variant.innerPath}</div>
+        )}
+        {variant.label !== variant.blockLabel &&
+          variant.label !== variant.innerPath && (
+            <div className="text-muted-foreground">{variant.label}</div>
+          )}
+        <div className="mt-1">{formatRangeForTooltip(variant)}</div>
+      </div>
+    </TooltipContent>
+  );
+}
+
+/**
+ * One colored bar with its hover tooltip. The caller owns positioning via
+ * `style` (top/left/width/height or %-based equivalents) and what shows
+ * inside the bar via `children`.
+ */
+function VariantBar({
+  variant,
+  color,
+  style,
+  children,
+}: {
+  variant: ScheduledVariant;
+  color: BlockColor;
+  style: React.CSSProperties;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className="absolute flex items-center px-2 text-[11px] font-medium truncate cursor-default"
+          style={{
+            background: color.bg,
+            color: color.text,
+            borderRadius: 4,
+            ...style,
+          }}
+        >
+          <span className="truncate">{children}</span>
+        </div>
+      </TooltipTrigger>
+      <VariantTooltipBody variant={variant} />
+    </Tooltip>
+  );
 }
 
 export function VariantCalendar({
@@ -198,34 +157,22 @@ export function VariantCalendar({
             {MONTHS[cursor.getMonth()]} {cursor.getFullYear()}
           </h2>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="flex rounded-md border bg-muted p-0.5">
-            <button
-              type="button"
-              onClick={() => setView("calendar")}
-              className={cn(
-                "px-3 py-1 text-xs font-medium rounded-sm transition-colors cursor-pointer",
-                view === "calendar"
-                  ? "bg-background text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              Calendar
-            </button>
-            <button
-              type="button"
-              onClick={() => setView("timeline")}
-              className={cn(
-                "px-3 py-1 text-xs font-medium rounded-sm transition-colors cursor-pointer",
-                view === "timeline"
-                  ? "bg-background text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              Timeline
-            </button>
-          </div>
-        </div>
+        <ViewModeToggle<ViewMode>
+          value={view}
+          onValueChange={setView}
+          options={[
+            {
+              value: "calendar",
+              icon: <Calendar />,
+              label: "Calendar",
+            },
+            {
+              value: "timeline",
+              icon: <Activity />,
+              label: "Timeline",
+            },
+          ]}
+        />
       </div>
 
       {variants.length === 0 ? (
@@ -333,53 +280,25 @@ function CalendarView({
                 const leftPct = (seg.startCol / 7) * 100;
                 const widthPct = (seg.span / 7) * 100;
                 return (
-                  <Tooltip key={`${wi}-${idx}`}>
-                    <TooltipTrigger asChild>
-                      <div
-                        className="absolute flex items-center px-2 text-[11px] font-medium truncate cursor-default"
-                        style={{
-                          top,
-                          left: `calc(${leftPct}% + 2px)`,
-                          width: `calc(${widthPct}% - 4px)`,
-                          height: LANE_HEIGHT,
-                          background: color.bg,
-                          color: color.text,
-                          borderRadius: 4,
-                        }}
-                      >
-                        <span className="truncate">
-                          {seg.variant.blockLabel}
-                          {seg.variant.label !== seg.variant.blockLabel && (
-                            <span className="opacity-70">
-                              {" · "}
-                              {seg.variant.label}
-                            </span>
-                          )}
-                        </span>
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <div className="text-xs">
-                        <div className="font-semibold">
-                          {seg.variant.blockLabel}
-                        </div>
-                        {seg.variant.innerPath && (
-                          <div className="text-muted-foreground">
-                            {seg.variant.innerPath}
-                          </div>
-                        )}
-                        {seg.variant.label !== seg.variant.blockLabel &&
-                          seg.variant.label !== seg.variant.innerPath && (
-                            <div className="text-muted-foreground">
-                              {seg.variant.label}
-                            </div>
-                          )}
-                        <div className="mt-1">
-                          {formatRangeForTooltip(seg.variant)}
-                        </div>
-                      </div>
-                    </TooltipContent>
-                  </Tooltip>
+                  <VariantBar
+                    key={`${wi}-${idx}`}
+                    variant={seg.variant}
+                    color={color}
+                    style={{
+                      top,
+                      left: `calc(${leftPct}% + 2px)`,
+                      width: `calc(${widthPct}% - 4px)`,
+                      height: LANE_HEIGHT,
+                    }}
+                  >
+                    {seg.variant.blockLabel}
+                    {seg.variant.label !== seg.variant.blockLabel && (
+                      <span className="opacity-70">
+                        {" · "}
+                        {seg.variant.label}
+                      </span>
+                    )}
+                  </VariantBar>
                 );
               })}
             </div>
@@ -537,44 +456,19 @@ function TimelineView({
                       const left = pctOf(new Date(segStart));
                       const width = pctOf(new Date(segEnd)) - left;
                       return (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <div
-                              className="absolute top-1/2 -translate-y-1/2 flex items-center px-2 text-[11px] font-medium truncate cursor-default"
-                              style={{
-                                left: `${left}%`,
-                                width: `calc(${width}% - 2px)`,
-                                height: 22,
-                                background: color.bg,
-                                color: color.text,
-                                borderRadius: 4,
-                              }}
-                            >
-                              <span className="truncate">{v.label}</span>
-                            </div>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <div className="text-xs">
-                              <div className="font-semibold">
-                                {v.blockLabel}
-                              </div>
-                              {v.innerPath && (
-                                <div className="text-muted-foreground">
-                                  {v.innerPath}
-                                </div>
-                              )}
-                              {v.label !== v.blockLabel &&
-                                v.label !== v.innerPath && (
-                                  <div className="text-muted-foreground">
-                                    {v.label}
-                                  </div>
-                                )}
-                              <div className="mt-1">
-                                {formatRangeForTooltip(v)}
-                              </div>
-                            </div>
-                          </TooltipContent>
-                        </Tooltip>
+                        <VariantBar
+                          variant={v}
+                          color={color}
+                          style={{
+                            top: "50%",
+                            transform: "translateY(-50%)",
+                            left: `${left}%`,
+                            width: `calc(${width}% - 2px)`,
+                            height: 22,
+                          }}
+                        >
+                          {v.label}
+                        </VariantBar>
                       );
                     })()}
                   </div>

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
@@ -16,7 +16,9 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import {
-  colorForBlock,
+  type BlockColor,
+  buildBlockColorMap,
+  colorFromMap,
   extractScheduledVariants,
   type ScheduledVariant,
 } from "./extract-variants";
@@ -157,6 +159,7 @@ export function VariantCalendar({
   const [cursor, setCursor] = useState<Date>(() => startOfMonth(new Date()));
 
   const variants = extractScheduledVariants(decofile);
+  const colorMap = buildBlockColorMap(variants.map((v) => v.blockKey));
 
   const goToday = () => setCursor(startOfMonth(new Date()));
   const goPrev = () =>
@@ -228,9 +231,17 @@ export function VariantCalendar({
       {variants.length === 0 ? (
         <EmptyState />
       ) : view === "calendar" ? (
-        <CalendarView monthStart={cursor} variants={variants} />
+        <CalendarView
+          monthStart={cursor}
+          variants={variants}
+          colorMap={colorMap}
+        />
       ) : (
-        <TimelineView monthStart={cursor} variants={variants} />
+        <TimelineView
+          monthStart={cursor}
+          variants={variants}
+          colorMap={colorMap}
+        />
       )}
     </div>
   );
@@ -255,9 +266,11 @@ const HEADER_HEIGHT = 28;
 function CalendarView({
   monthStart,
   variants,
+  colorMap,
 }: {
   monthStart: Date;
   variants: ScheduledVariant[];
+  colorMap: Map<string, BlockColor>;
 }) {
   const weeks = buildMonthWeeks(monthStart);
   const today = startOfDay(new Date());
@@ -315,7 +328,7 @@ function CalendarView({
                 );
               })}
               {segments.map((seg, idx) => {
-                const color = colorForBlock(seg.variant.blockKey);
+                const color = colorFromMap(colorMap, seg.variant.blockKey);
                 const top = HEADER_HEIGHT + seg.lane * (LANE_HEIGHT + LANE_GAP);
                 const leftPct = (seg.startCol / 7) * 100;
                 const widthPct = (seg.span / 7) * 100;
@@ -384,9 +397,11 @@ const ROW_LABEL_WIDTH = 240;
 function TimelineView({
   monthStart,
   variants,
+  colorMap,
 }: {
   monthStart: Date;
   variants: ScheduledVariant[];
+  colorMap: Map<string, BlockColor>;
 }) {
   const rangeStart = monthStart;
   const rangeEnd = addMonths(monthStart, TIMELINE_MONTHS);
@@ -461,7 +476,7 @@ function TimelineView({
           </div>
         )}
         {sortedBlocks.map(([blockKey, blockVariants]) => {
-          const color = colorForBlock(blockKey);
+          const color = colorFromMap(colorMap, blockKey);
           const blockLabel = blockVariants[0]?.blockLabel ?? blockKey;
           return (
             <div key={blockKey}>

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
@@ -298,7 +298,7 @@ function CalendarView({
   const today = startOfDay(new Date());
 
   return (
-    <ScrollArea className="flex-1">
+    <ScrollArea className="flex-1 min-h-0">
       <div className="min-w-[840px]">
         <div className="grid grid-cols-7 border-b text-xs text-muted-foreground sticky top-0 bg-background z-10">
           {WEEKDAYS.map((wd) => (
@@ -458,7 +458,7 @@ function TimelineView({
       : null;
 
   return (
-    <ScrollArea className="flex-1">
+    <ScrollArea className="flex-1 min-h-0">
       <div className="min-w-[900px] relative">
         <div className="flex border-b sticky top-0 bg-background z-10">
           <div

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
@@ -157,7 +157,13 @@ export function VariantCalendar({
   const [cursor, setCursor] = useState<Date>(() => startOfMonth(new Date()));
 
   const variants = extractScheduledVariants(decofile);
-  const blockKeys = Array.from(new Set(variants.map((v) => v.blockKey)));
+  const blocks: Array<{ key: string; label: string }> = [];
+  const seenBlockKeys = new Set<string>();
+  for (const v of variants) {
+    if (seenBlockKeys.has(v.blockKey)) continue;
+    seenBlockKeys.add(v.blockKey);
+    blocks.push({ key: v.blockKey, label: v.blockLabel });
+  }
 
   const goToday = () => setCursor(startOfMonth(new Date()));
   const goPrev = () =>
@@ -197,7 +203,7 @@ export function VariantCalendar({
           </h2>
         </div>
         <div className="flex items-center gap-3">
-          <BlockLegend blockKeys={blockKeys} />
+          <BlockLegend blocks={blocks} />
           <div className="flex rounded-md border bg-muted p-0.5">
             <button
               type="button"
@@ -250,13 +256,17 @@ function EmptyState() {
   );
 }
 
-function BlockLegend({ blockKeys }: { blockKeys: string[] }) {
-  if (blockKeys.length === 0) return null;
-  const visible = blockKeys.slice(0, 4);
-  const hidden = blockKeys.length - visible.length;
+function BlockLegend({
+  blocks,
+}: {
+  blocks: Array<{ key: string; label: string }>;
+}) {
+  if (blocks.length === 0) return null;
+  const visible = blocks.slice(0, 4);
+  const hidden = blocks.length - visible.length;
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      {visible.map((key) => {
+      {visible.map(({ key, label }) => {
         const c = colorForBlock(key);
         return (
           <span key={key} className="flex items-center gap-1.5">
@@ -264,7 +274,7 @@ function BlockLegend({ blockKeys }: { blockKeys: string[] }) {
               className="inline-block h-2.5 w-5 rounded-sm"
               style={{ background: c.bg }}
             />
-            <span className="truncate max-w-[120px]">{key}</span>
+            <span className="truncate max-w-[120px]">{label}</span>
           </span>
         );
       })}
@@ -360,22 +370,32 @@ function CalendarView({
                         }}
                       >
                         <span className="truncate">
-                          {seg.variant.blockKey}
-                          <span className="opacity-70">
-                            {" · "}
-                            {seg.variant.label}
-                          </span>
+                          {seg.variant.blockLabel}
+                          {seg.variant.label !== seg.variant.blockLabel && (
+                            <span className="opacity-70">
+                              {" · "}
+                              {seg.variant.label}
+                            </span>
+                          )}
                         </span>
                       </div>
                     </TooltipTrigger>
                     <TooltipContent>
                       <div className="text-xs">
                         <div className="font-semibold">
-                          {seg.variant.blockKey}
+                          {seg.variant.blockLabel}
                         </div>
-                        <div className="text-muted-foreground">
-                          {seg.variant.label}
-                        </div>
+                        {seg.variant.innerPath && (
+                          <div className="text-muted-foreground">
+                            {seg.variant.innerPath}
+                          </div>
+                        )}
+                        {seg.variant.label !== seg.variant.blockLabel &&
+                          seg.variant.label !== seg.variant.innerPath && (
+                            <div className="text-muted-foreground">
+                              {seg.variant.label}
+                            </div>
+                          )}
                         <div className="mt-1">
                           {formatRangeForTooltip(seg.variant)}
                         </div>
@@ -477,6 +497,7 @@ function TimelineView({
         )}
         {sortedBlocks.map(([blockKey, blockVariants]) => {
           const color = colorForBlock(blockKey);
+          const blockLabel = blockVariants[0]?.blockLabel ?? blockKey;
           return (
             <div key={blockKey}>
               <div
@@ -487,7 +508,7 @@ function TimelineView({
                   className="px-3 truncate"
                   style={{ width: ROW_LABEL_WIDTH }}
                 >
-                  {blockKey}
+                  {blockLabel}
                 </div>
               </div>
               {blockVariants.map((v, i) => (
@@ -554,10 +575,20 @@ function TimelineView({
                           </TooltipTrigger>
                           <TooltipContent>
                             <div className="text-xs">
-                              <div className="font-semibold">{v.blockKey}</div>
-                              <div className="text-muted-foreground">
-                                {v.label}
+                              <div className="font-semibold">
+                                {v.blockLabel}
                               </div>
+                              {v.innerPath && (
+                                <div className="text-muted-foreground">
+                                  {v.innerPath}
+                                </div>
+                              )}
+                              {v.label !== v.blockLabel &&
+                                v.label !== v.innerPath && (
+                                  <div className="text-muted-foreground">
+                                    {v.label}
+                                  </div>
+                                )}
                               <div className="mt-1">
                                 {formatRangeForTooltip(v)}
                               </div>


### PR DESCRIPTION
## Summary
- New **Calendar** sidebar item inside the Content tab, rendering every scheduled variant from `.decofile` (any block whose resolver is `website/flags/multivariate/section.ts`).
- Two views toggled in the header:
  - **Calendar** — Sun-Sat month grid; multi-day variants render as horizontal bars with greedy lane packing per week.
  - **Timeline** — 4-month Gantt-style grouped by block, with a "Today" vertical marker.
- Variants are extracted by walking `variants[].rule` and pulling any `website/matchers/date.ts` (also from inside `website/matchers/multi.ts` and legacy `\$live` aliases). Non-time-scoped variants (audience/device only) are intentionally skipped.
- Color is a deterministic per-block hash so a campaign reads as one color across all its blocks.

## Files
- `extract-variants.ts` — pure extractor + `colorForBlock` (covered by `extract-variants.test.ts`, 5 tests).
- `variant-calendar.tsx` — the two views, header, legend, view toggle.
- `content-browser.tsx` — wires the sidebar entry and routes to the view; the rest of the file's diff is Biome re-indenting the `<ItemList>` block (the wrapping `&&` now spans multiple lines).

## Test plan
- [ ] Open Content tab → Calendar; switch between Calendar / Timeline.
- [ ] Today / prev / next nav moves the period (1 month in Calendar, 3 months in Timeline).
- [ ] Variants spanning multiple weeks render as separate bars per week with no overlaps.
- [ ] Hovering a bar shows a tooltip with the formatted range.
- [ ] `bun test apps/mesh/src/web/components/sandbox/content/variant-calendar` → 5 pass.
- [ ] `bun run check` → 0 errors.
- [ ] `bun run lint` → no new warnings.

## Follow-ups
- Clicking a bar could jump to the corresponding block in `selection` state.
- Could derive locale (week start, month/day labels) from project settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Calendar view in the Content tab to visualize scheduled `.decofile` variants as a month grid or 4‑month timeline. Also refactors calendar logic into tested helpers and adopts `@deco/ui` `ViewModeToggle` for the view switch.

- **New Features**
  - Adds a "Calendar" sidebar item and route in the Content tab.
  - Calendar: Sun–Sat month grid with multi-day bars and greedy lane packing per week.
  - Timeline: 4 months, grouped by block, with a "Today" marker.
  - Navigation: Today / Previous / Next (1 month for Calendar, 3 months for Timeline), plus tooltips with formatted ranges.

- **Bug Fixes**
  - Extractor walks the entire decofile and finds any `*/flags/multivariate/*.ts` container (incl. nested arrays/objects and custom site flags), pulling date matchers from `website/matchers/multi.ts` and `$live` aliases; skips non-time-scoped variants.
  - Humanizes page block keys (strips `pages-…` IDs and URL-decodes), adds inner-path labels, and derives smarter value labels (e.g., last URL segment).
  - Calendar/Timeline now scroll within the available height (`min-h-0`) to prevent overflow and clipping.
  - Removed an unused legend from the calendar header.
  - Per-block colors are now distinct via golden‑angle hue assignment to avoid collisions.

<sup>Written for commit 28b4233d61db4da544c2d19322161a64877f9bd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

