### PR TITLE
feat(vault): add runtime configuration reads

### DIFF
--- a/apps/mesh/src/api/routes/credential-vault.integration.test.ts
+++ b/apps/mesh/src/api/routes/credential-vault.integration.test.ts
@@ -16,6 +16,7 @@ import { CredentialVault } from "../../encryption/credential-vault";
 import { setGlobalSettings, getSettings } from "../../settings";
 import {
   CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+  CREDENTIAL_CONFIGURATION_READ_SCOPE,
   ConnectionCredentialVaultStorage,
 } from "../../storage/connection-credential-vault";
 import { DownstreamTokenStorage } from "../../storage/downstream-token";
@@ -97,6 +98,39 @@ describe("Credential Vault Routes", () => {
           updated_at: now,
         },
         {
+          id: "conn_configuration_target",
+          organization_id: "org_1",
+          created_by: "user_1",
+          title: "Configuration Target",
+          connection_type: "HTTP",
+          connection_url: "https://configuration.example.test/mcp",
+          configuration_state: await new CredentialVault(
+            getSettings().encryptionKey,
+          ).encrypt(
+            JSON.stringify({
+              apiKey: "configuration-secret",
+              accountId: "acct_123",
+            }),
+          ),
+          configuration_scopes: JSON.stringify(["self::TOOL"]),
+          status: "active",
+          pinned: false,
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: "conn_empty_configuration_target",
+          organization_id: "org_1",
+          created_by: "user_1",
+          title: "Empty Configuration Target",
+          connection_type: "HTTP",
+          connection_url: "https://empty-configuration.example.test/mcp",
+          status: "active",
+          pinned: false,
+          created_at: now,
+          updated_at: now,
+        },
+        {
           id: "conn_inactive_granted",
           organization_id: "org_1",
           created_by: "user_1",
@@ -134,6 +168,14 @@ describe("Credential Vault Routes", () => {
         {
           targetConnectionId: "conn_inactive_granted",
           scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+        },
+        {
+          targetConnectionId: "conn_configuration_target",
+          scope: CREDENTIAL_CONFIGURATION_READ_SCOPE,
+        },
+        {
+          targetConnectionId: "conn_empty_configuration_target",
+          scope: CREDENTIAL_CONFIGURATION_READ_SCOPE,
         },
       ],
     });
@@ -205,6 +247,82 @@ describe("Credential Vault Routes", () => {
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
     );
     expect(body.scope).toBe("read write");
+  });
+
+  it("exchanges a workload token for a granted downstream MCP configuration", async () => {
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/org_1/vault/connections/conn_configuration_target/configuration",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${workloadToken}` },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Pragma")).toBe("no-cache");
+    const body = (await res.json()) as {
+      type: string;
+      state: Record<string, unknown>;
+      scopes: string[];
+    };
+    expect(body).toEqual({
+      type: "mcp_configuration",
+      state: {
+        apiKey: "configuration-secret",
+        accountId: "acct_123",
+      },
+      scopes: ["self::TOOL"],
+    });
+  });
+
+  it("returns empty configuration state and scopes for granted targets without saved configuration", async () => {
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/org_1/vault/connections/conn_empty_configuration_target/configuration",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${workloadToken}` },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      type: "mcp_configuration",
+      state: {},
+      scopes: [],
+    });
+  });
+
+  it("does not allow an access-token grant to read configuration", async () => {
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/org_1/vault/connections/conn_target/configuration",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${workloadToken}` },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("does not allow a configuration grant to read an access token", async () => {
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/org_1/vault/connections/conn_configuration_target/access-token",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${workloadToken}` },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(403);
   });
 
   it("rejects access when the subject lacks a grant to the target", async () => {

--- a/apps/mesh/src/api/routes/credential-vault.integration.test.ts
+++ b/apps/mesh/src/api/routes/credential-vault.integration.test.ts
@@ -170,6 +170,10 @@ describe("Credential Vault Routes", () => {
           scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
         },
         {
+          targetConnectionId: "conn_inactive_granted",
+          scope: CREDENTIAL_CONFIGURATION_READ_SCOPE,
+        },
+        {
           targetConnectionId: "conn_configuration_target",
           scope: CREDENTIAL_CONFIGURATION_READ_SCOPE,
         },
@@ -323,6 +327,20 @@ describe("Credential Vault Routes", () => {
     );
 
     expect(res.status).toBe(403);
+  });
+
+  it("returns 404 for inactive configuration targets only after a grant exists", async () => {
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/org_1/vault/connections/conn_inactive_granted/configuration",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${workloadToken}` },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(404);
   });
 
   it("rejects access when the subject lacks a grant to the target", async () => {

--- a/apps/mesh/src/api/routes/credential-vault.integration.test.ts
+++ b/apps/mesh/src/api/routes/credential-vault.integration.test.ts
@@ -131,6 +131,20 @@ describe("Credential Vault Routes", () => {
           updated_at: now,
         },
         {
+          id: "conn_invalid_configuration_target",
+          organization_id: "org_1",
+          created_by: "user_1",
+          title: "Invalid Configuration Target",
+          connection_type: "HTTP",
+          connection_url: "https://invalid-configuration.example.test/mcp",
+          configuration_state: "not-valid-ciphertext",
+          configuration_scopes: JSON.stringify(["self::TOOL"]),
+          status: "active",
+          pinned: false,
+          created_at: now,
+          updated_at: now,
+        },
+        {
           id: "conn_inactive_granted",
           organization_id: "org_1",
           created_by: "user_1",
@@ -179,6 +193,10 @@ describe("Credential Vault Routes", () => {
         },
         {
           targetConnectionId: "conn_empty_configuration_target",
+          scope: CREDENTIAL_CONFIGURATION_READ_SCOPE,
+        },
+        {
+          targetConnectionId: "conn_invalid_configuration_target",
           scope: CREDENTIAL_CONFIGURATION_READ_SCOPE,
         },
       ],
@@ -341,6 +359,23 @@ describe("Credential Vault Routes", () => {
     );
 
     expect(res.status).toBe(404);
+  });
+
+  it("does not return empty configuration when saved configuration cannot be decrypted", async () => {
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/org_1/vault/connections/conn_invalid_configuration_target/configuration",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${workloadToken}` },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(424);
+    await expect(res.json()).resolves.toEqual({
+      error: "MCP configuration could not be decrypted",
+    });
   });
 
   it("rejects access when the subject lacks a grant to the target", async () => {

--- a/apps/mesh/src/api/routes/credential-vault.ts
+++ b/apps/mesh/src/api/routes/credential-vault.ts
@@ -1,7 +1,10 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import type { StudioContext } from "@/core/studio-context";
 import { getValidDownstreamAccessToken } from "@/oauth/token-refresh";
-import { CREDENTIAL_ACCESS_TOKEN_READ_SCOPE } from "@/storage/connection-credential-vault";
+import {
+  CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+  CREDENTIAL_CONFIGURATION_READ_SCOPE,
+} from "@/storage/connection-credential-vault";
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
 
 type Variables = {
@@ -19,48 +22,72 @@ function serializeExpiresAt(value: Date | string | null): string | null {
   return value instanceof Date ? value.toISOString() : value;
 }
 
+async function authorizeVaultRequest(
+  c: Context<{ Variables: Variables }>,
+  targetConnectionId: string,
+  scope: string,
+): Promise<
+  | { ok: true; ctx: StudioContext; organizationId: string }
+  | { ok: false; response: Response }
+> {
+  const token = bearerToken(c.req.header("authorization"));
+  if (!token) {
+    return { ok: false, response: c.json({ error: "Unauthorized" }, 401) };
+  }
+
+  const ctx = c.get("meshContext");
+  const organizationId = ctx.organization?.id;
+  if (!organizationId) {
+    return {
+      ok: false,
+      response: c.json({ error: "Organization context required" }, 403),
+    };
+  }
+
+  const workloadToken =
+    await ctx.storage.connectionCredentialVault.authenticateWorkloadToken(
+      token,
+    );
+  if (!workloadToken || workloadToken.organizationId !== organizationId) {
+    return { ok: false, response: c.json({ error: "Unauthorized" }, 401) };
+  }
+
+  const subject = await ctx.storage.connections.findById(
+    workloadToken.subjectConnectionId,
+    organizationId,
+  );
+  if (!subject || subject.status !== "active") {
+    return { ok: false, response: c.json({ error: "Unauthorized" }, 401) };
+  }
+
+  const hasGrant = await ctx.storage.connectionCredentialVault.hasGrant({
+    organizationId,
+    subjectConnectionId: workloadToken.subjectConnectionId,
+    targetConnectionId,
+    scope,
+  });
+  if (!hasGrant) {
+    return { ok: false, response: c.json({ error: "Forbidden" }, 403) };
+  }
+
+  return { ok: true, ctx, organizationId };
+}
+
 export const createCredentialVaultRoutes = () => {
   const app = new Hono<{ Variables: Variables }>();
 
   app.post("/vault/connections/:connectionId/access-token", async (c) => {
-    const token = bearerToken(c.req.header("authorization"));
-    if (!token) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-
-    const ctx = c.get("meshContext");
-    const organizationId = ctx.organization?.id;
-    if (!organizationId) {
-      return c.json({ error: "Organization context required" }, 403);
-    }
-
-    const workloadToken =
-      await ctx.storage.connectionCredentialVault.authenticateWorkloadToken(
-        token,
-      );
-    if (!workloadToken || workloadToken.organizationId !== organizationId) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-
-    const subject = await ctx.storage.connections.findById(
-      workloadToken.subjectConnectionId,
-      organizationId,
-    );
-    if (!subject || subject.status !== "active") {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-
     const targetConnectionId = c.req.param("connectionId");
-    const hasGrant = await ctx.storage.connectionCredentialVault.hasGrant({
-      organizationId,
-      subjectConnectionId: workloadToken.subjectConnectionId,
+    const authz = await authorizeVaultRequest(
+      c,
       targetConnectionId,
-      scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
-    });
-    if (!hasGrant) {
-      return c.json({ error: "Forbidden" }, 403);
+      CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+    );
+    if (!authz.ok) {
+      return authz.response;
     }
 
+    const { ctx, organizationId } = authz;
     const target = await ctx.storage.connections.findById(
       targetConnectionId,
       organizationId,
@@ -95,6 +122,35 @@ export const createCredentialVaultRoutes = () => {
       accessToken: result.accessToken,
       expiresAt: serializeExpiresAt(downstreamToken?.expiresAt ?? null),
       scope: downstreamToken?.scope ?? null,
+    });
+  });
+
+  app.post("/vault/connections/:connectionId/configuration", async (c) => {
+    const targetConnectionId = c.req.param("connectionId");
+    const authz = await authorizeVaultRequest(
+      c,
+      targetConnectionId,
+      CREDENTIAL_CONFIGURATION_READ_SCOPE,
+    );
+    if (!authz.ok) {
+      return authz.response;
+    }
+
+    const { ctx, organizationId } = authz;
+    const target = await ctx.storage.connections.findById(
+      targetConnectionId,
+      organizationId,
+    );
+    if (!target || target.status !== "active") {
+      return c.json({ error: "Connection not found" }, 404);
+    }
+
+    c.header("Cache-Control", "no-store");
+    c.header("Pragma", "no-cache");
+    return c.json({
+      type: "mcp_configuration",
+      state: target.configuration_state ?? {},
+      scopes: target.configuration_scopes ?? [],
     });
   });
 

--- a/apps/mesh/src/api/routes/credential-vault.ts
+++ b/apps/mesh/src/api/routes/credential-vault.ts
@@ -22,6 +22,22 @@ function serializeExpiresAt(value: Date | string | null): string | null {
   return value instanceof Date ? value.toISOString() : value;
 }
 
+function parseConfigurationScopes(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.filter((scope): scope is string => typeof scope === "string");
+  }
+  if (typeof value !== "string") return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((scope): scope is string => typeof scope === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
 async function authorizeVaultRequest(
   c: Context<{ Variables: Variables }>,
   targetConnectionId: string,
@@ -137,20 +153,45 @@ export const createCredentialVaultRoutes = () => {
     }
 
     const { ctx, organizationId } = authz;
-    const target = await ctx.storage.connections.findById(
-      targetConnectionId,
-      organizationId,
-    );
+    const target = await ctx.db
+      .selectFrom("connections")
+      .select(["status", "configuration_state", "configuration_scopes"])
+      .where("id", "=", targetConnectionId)
+      .where("organization_id", "=", organizationId)
+      .executeTakeFirst();
     if (!target || target.status !== "active") {
       return c.json({ error: "Connection not found" }, 404);
+    }
+
+    let configurationState: Record<string, unknown> = {};
+    if (target.configuration_state) {
+      try {
+        const decryptedJson = await ctx.vault.decrypt(
+          target.configuration_state,
+        );
+        const parsed = JSON.parse(decryptedJson) as unknown;
+        if (
+          typeof parsed !== "object" ||
+          parsed === null ||
+          Array.isArray(parsed)
+        ) {
+          throw new Error("MCP configuration state is not an object");
+        }
+        configurationState = parsed as Record<string, unknown>;
+      } catch {
+        return c.json(
+          { error: "MCP configuration could not be decrypted" },
+          424,
+        );
+      }
     }
 
     c.header("Cache-Control", "no-store");
     c.header("Pragma", "no-cache");
     return c.json({
       type: "mcp_configuration",
-      state: target.configuration_state ?? {},
-      scopes: target.configuration_scopes ?? [],
+      state: configurationState,
+      scopes: parseConfigurationScopes(target.configuration_scopes),
     });
   });
 

--- a/apps/mesh/src/storage/connection-credential-vault.ts
+++ b/apps/mesh/src/storage/connection-credential-vault.ts
@@ -9,6 +9,8 @@ import type { Database } from "./types";
 
 export const CREDENTIAL_ACCESS_TOKEN_READ_SCOPE =
   "credential:access-token:read" as const;
+export const CREDENTIAL_CONFIGURATION_READ_SCOPE =
+  "credential:configuration:read" as const;
 
 type WorkloadTokenRow = Selectable<Database["connection_workload_tokens"]>;
 

--- a/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
@@ -27,6 +27,7 @@ import { ConnectionStorage } from "../../storage/connection";
 import {
   ConnectionCredentialVaultStorage,
   CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+  CREDENTIAL_CONFIGURATION_READ_SCOPE,
 } from "../../storage/connection-credential-vault";
 import { DownstreamTokenStorage } from "../../storage/downstream-token";
 import * as fetchToolsModule from "./fetch-tools";
@@ -442,6 +443,69 @@ describe("Connection Tools", () => {
   });
 
   describe("COLLECTION_CONNECTIONS_UPDATE (credential vault grants)", () => {
+    it("derives separate grants for downstream access token and configuration scopes", async () => {
+      await ctx.storage.connections.create({
+        id: "conn_vault_configuration_target",
+        organization_id: "org_123",
+        created_by: "user_1",
+        title: "Vault Configuration Target",
+        connection_type: "HTTP",
+        connection_url: "https://vault-configuration-target.invalid/mcp",
+        status: "active",
+      });
+
+      const subject = await ctx.storage.connections.create({
+        id: "conn_vault_configuration_subject",
+        organization_id: "org_123",
+        created_by: "user_1",
+        title: "Vault Configuration Subject",
+        connection_type: "HTTP",
+        connection_url: "https://vault-configuration-subject.invalid/mcp",
+        status: "active",
+      });
+
+      setMockMcpClient({
+        callTool: vi.fn().mockResolvedValue({}),
+      });
+
+      await COLLECTION_CONNECTIONS_UPDATE.execute(
+        {
+          id: subject.id,
+          data: {
+            configuration_state: {
+              github: {
+                __type: "@deco/github",
+                value: "conn_vault_configuration_target",
+              },
+            },
+            configuration_scopes: [
+              `github::${CREDENTIAL_ACCESS_TOKEN_READ_SCOPE}`,
+              `github::${CREDENTIAL_CONFIGURATION_READ_SCOPE}`,
+            ],
+          },
+        },
+        ctx,
+      );
+
+      await expect(
+        ctx.storage.connectionCredentialVault.hasGrant({
+          organizationId: "org_123",
+          subjectConnectionId: subject.id,
+          targetConnectionId: "conn_vault_configuration_target",
+          scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+        }),
+      ).resolves.toBe(true);
+
+      await expect(
+        ctx.storage.connectionCredentialVault.hasGrant({
+          organizationId: "org_123",
+          subjectConnectionId: subject.id,
+          targetConnectionId: "conn_vault_configuration_target",
+          scope: CREDENTIAL_CONFIGURATION_READ_SCOPE,
+        }),
+      ).resolves.toBe(true);
+    });
+
     it("replaces credential grants and creates a workload token from configuration scopes", async () => {
       const subject = await ctx.storage.connections.create({
         id: "conn_vault_subject",

--- a/apps/mesh/src/tools/connection/credential-grants.ts
+++ b/apps/mesh/src/tools/connection/credential-grants.ts
@@ -2,9 +2,17 @@ import {
   getReferencedConnectionIds,
   parseScope,
 } from "@/auth/configuration-scopes";
-import { CREDENTIAL_ACCESS_TOKEN_READ_SCOPE } from "@/storage/connection-credential-vault";
+import {
+  CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+  CREDENTIAL_CONFIGURATION_READ_SCOPE,
+} from "@/storage/connection-credential-vault";
 import type { StudioContext } from "../../core/studio-context";
 import { prop } from "./json-path";
+
+const CREDENTIAL_READ_SCOPES = new Set<string>([
+  CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+  CREDENTIAL_CONFIGURATION_READ_SCOPE,
+]);
 
 /**
  * Inject the well-known "SELF" sentinel into state when any SELF:: scopes are
@@ -40,7 +48,7 @@ export function deriveCredentialGrants(
     }
 
     const [key, scopeName] = parseScope(scope);
-    if (scopeName !== CREDENTIAL_ACCESS_TOKEN_READ_SCOPE) {
+    if (!CREDENTIAL_READ_SCOPES.has(scopeName)) {
       continue;
     }
 
@@ -60,7 +68,7 @@ export function deriveCredentialGrants(
 
     grants.set(`${targetConnectionId}:${scopeName}`, {
       targetConnectionId,
-      scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+      scope: scopeName,
     });
   }
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -381,6 +381,7 @@ refresh tokens and client secrets stay in Studio's vault.
 import {
   BindingOf,
   CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+  CREDENTIAL_CONFIGURATION_READ_SCOPE,
   createStudioVaultClient,
   withRuntime,
   type ConfigurationScope,
@@ -396,6 +397,7 @@ export default withRuntime({
     state: stateSchema,
     scopes: [
       `github::${CREDENTIAL_ACCESS_TOKEN_READ_SCOPE}`,
+      `github::${CREDENTIAL_CONFIGURATION_READ_SCOPE}`,
     ] satisfies ConfigurationScope[],
     onInstall: async (env, { vault }) => {
       if (!vault) return;
@@ -410,6 +412,29 @@ export default withRuntime({
     },
   },
 });
+```
+
+Use `credential:configuration:read` when the target MCP stores provider
+credentials or provider settings in its saved MCP configuration instead of
+OAuth. This returns the decrypted configuration state Studio has already saved
+for that target connection; it does not call the target MCP's
+`MCP_CONFIGURATION` discovery tool.
+
+```typescript
+const configuration = await client.getConfiguration(github);
+
+console.log(configuration.state);
+console.log(configuration.scopes);
+```
+
+Returned configuration:
+
+```typescript
+type StudioMcpConfiguration = {
+  type: "mcp_configuration";
+  state: Record<string, unknown>;
+  scopes: string[];
+};
 ```
 
 ## Event Handlers

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -369,7 +369,9 @@ export default withRuntime({
 });
 ```
 
-### Studio Vault Access Tokens
+### Studio Vault Reads
+
+#### Access Token Reads
 
 Background workers can request current downstream OAuth access tokens from
 Studio during `configuration.onInstall`. Add
@@ -381,7 +383,6 @@ refresh tokens and client secrets stay in Studio's vault.
 import {
   BindingOf,
   CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
-  CREDENTIAL_CONFIGURATION_READ_SCOPE,
   createStudioVaultClient,
   withRuntime,
   type ConfigurationScope,
@@ -397,7 +398,6 @@ export default withRuntime({
     state: stateSchema,
     scopes: [
       `github::${CREDENTIAL_ACCESS_TOKEN_READ_SCOPE}`,
-      `github::${CREDENTIAL_CONFIGURATION_READ_SCOPE}`,
     ] satisfies ConfigurationScope[],
     onInstall: async (env, { vault }) => {
       if (!vault) return;
@@ -414,17 +414,47 @@ export default withRuntime({
 });
 ```
 
+#### Configuration Reads
+
 Use `credential:configuration:read` when the target MCP stores provider
 credentials or provider settings in its saved MCP configuration instead of
-OAuth. This returns the decrypted configuration state Studio has already saved
-for that target connection; it does not call the target MCP's
+OAuth. Add `credential:configuration:read` for the configured binding key. This
+returns the decrypted configuration state Studio has already saved for that
+target connection; it does not call the target MCP's
 `MCP_CONFIGURATION` discovery tool.
 
 ```typescript
-const configuration = await client.getConfiguration(github);
+import {
+  BindingOf,
+  CREDENTIAL_CONFIGURATION_READ_SCOPE,
+  createStudioVaultClient,
+  withRuntime,
+  type ConfigurationScope,
+} from "@decocms/runtime";
+import { z } from "zod";
 
-console.log(configuration.state);
-console.log(configuration.scopes);
+const stateSchema = z.object({
+  github: BindingOf<Registry, "@deco/github">("@deco/github"),
+});
+
+export default withRuntime({
+  configuration: {
+    state: stateSchema,
+    scopes: [
+      `github::${CREDENTIAL_CONFIGURATION_READ_SCOPE}`,
+    ] satisfies ConfigurationScope[],
+    onInstall: async (env, { vault }) => {
+      if (!vault) return;
+
+      const { github } = env.MESH_REQUEST_CONTEXT.state;
+      const client = createStudioVaultClient(vault);
+      const configuration = await client.getConfiguration(github);
+
+      console.log(configuration.state);
+      console.log(configuration.scopes);
+    },
+  },
+});
 ```
 
 Returned configuration:

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -385,12 +385,13 @@ import {
   CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
   createStudioVaultClient,
   withRuntime,
+  type BindingRegistry,
   type ConfigurationScope,
 } from "@decocms/runtime";
 import { z } from "zod";
 
 const stateSchema = z.object({
-  github: BindingOf<Registry, "@deco/github">("@deco/github"),
+  github: BindingOf<BindingRegistry, "@deco/github">("@deco/github"),
 });
 
 export default withRuntime({
@@ -429,12 +430,13 @@ import {
   CREDENTIAL_CONFIGURATION_READ_SCOPE,
   createStudioVaultClient,
   withRuntime,
+  type BindingRegistry,
   type ConfigurationScope,
 } from "@decocms/runtime";
 import { z } from "zod";
 
 const stateSchema = z.object({
-  github: BindingOf<Registry, "@deco/github">("@deco/github"),
+  github: BindingOf<BindingRegistry, "@deco/github">("@deco/github"),
 });
 
 export default withRuntime({

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -451,9 +451,15 @@ export default withRuntime({
       const { github } = env.MESH_REQUEST_CONTEXT.state;
       const client = createStudioVaultClient(vault);
       const configuration = await client.getConfiguration(github);
+      const apiKey = configuration.state.apiKey;
 
-      console.log(configuration.state);
-      console.log(configuration.scopes);
+      if (typeof apiKey !== "string") {
+        throw new Error("GitHub configuration is missing apiKey");
+      }
+
+      await fetch("https://api.github.com/user", {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
     },
   },
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -49,6 +49,7 @@ export {
 export {
   createStudioVaultClient,
   type StudioAccessToken,
+  type StudioVaultClient,
   type StudioMcpConfiguration,
   type StudioVaultClientOptions,
 } from "./vault.ts";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -46,6 +46,7 @@ export {
 export {
   createStudioVaultClient,
   type StudioAccessToken,
+  type StudioMcpConfiguration,
   type StudioVaultClientOptions,
 } from "./vault.ts";
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -17,6 +17,7 @@ import {
 } from "./tools.ts";
 export {
   CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+  CREDENTIAL_CONFIGURATION_READ_SCOPE,
   createPrompt,
   createPublicPrompt,
   type Prompt,
@@ -32,8 +33,10 @@ export {
   type CreatedResource,
   ensureAuthenticated,
   type BindingCredentialAccessTokenReadScope,
+  type BindingCredentialConfigurationReadScope,
   type ConfigurationScope,
   type CredentialAccessTokenReadScope,
+  type CredentialConfigurationReadScope,
 } from "./tools.ts";
 import type { Binding } from "./wrangler.ts";
 export { proxyConnectionForId, BindingOf, AgentOf } from "./bindings.ts";

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -382,13 +382,20 @@ export interface OnChangeCallback<TState> {
  */
 export const CREDENTIAL_ACCESS_TOKEN_READ_SCOPE =
   "credential:access-token:read" as const;
+export const CREDENTIAL_CONFIGURATION_READ_SCOPE =
+  "credential:configuration:read" as const;
 
 export type CredentialAccessTokenReadScope =
   typeof CREDENTIAL_ACCESS_TOKEN_READ_SCOPE;
+export type CredentialConfigurationReadScope =
+  typeof CREDENTIAL_CONFIGURATION_READ_SCOPE;
 
 export type BindingCredentialAccessTokenReadScope<
   TStateKey extends string = string,
 > = `${TStateKey}::${CredentialAccessTokenReadScope}`;
+export type BindingCredentialConfigurationReadScope<
+  TStateKey extends string = string,
+> = `${TStateKey}::${CredentialConfigurationReadScope}`;
 
 /**
  * Configuration scopes use `STATE_KEY::SCOPE`, where `STATE_KEY` points at a
@@ -396,7 +403,10 @@ export type BindingCredentialAccessTokenReadScope<
  * capability names. `credential:access-token:read` is the standard Studio Vault
  * scope for leasing a downstream OAuth access token for direct API calls.
  */
-export type ConfigurationScope = BindingCredentialAccessTokenReadScope | string;
+export type ConfigurationScope =
+  | BindingCredentialAccessTokenReadScope
+  | BindingCredentialConfigurationReadScope
+  | string;
 
 /**
  * OAuth 2.0 Token Exchange Parameters

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -382,6 +382,25 @@ export interface OnChangeCallback<TState> {
  */
 export const CREDENTIAL_ACCESS_TOKEN_READ_SCOPE =
   "credential:access-token:read" as const;
+
+/**
+ * Canonical scope value for reading saved MCP configuration state from
+ * Studio's credential vault for a configured binding.
+ *
+ * Use it in configuration scopes as
+ * `${STATE_KEY}::credential:configuration:read`, where `STATE_KEY` points at a
+ * `BindingOf(...)` value in configuration state. This scope is intentionally
+ * separate from OAuth access-token reads because some MCPs store provider
+ * settings or credentials in configuration state instead of OAuth.
+ *
+ * The runtime vault client returns Studio's already-saved configuration state;
+ * it does not call the target MCP's `MCP_CONFIGURATION` discovery tool.
+ *
+ * @example
+ * ```ts
+ * const scopes = ["github::credential:configuration:read"] satisfies ConfigurationScope[];
+ * ```
+ */
 export const CREDENTIAL_CONFIGURATION_READ_SCOPE =
   "credential:configuration:read" as const;
 
@@ -400,8 +419,9 @@ export type BindingCredentialConfigurationReadScope<
 /**
  * Configuration scopes use `STATE_KEY::SCOPE`, where `STATE_KEY` points at a
  * value in the MCP configuration state. Most scopes are MCP-specific tool or
- * capability names. `credential:access-token:read` is the standard Studio Vault
- * scope for leasing a downstream OAuth access token for direct API calls.
+ * capability names. `credential:access-token:read` leases a downstream OAuth
+ * access token for direct API calls, and `credential:configuration:read` reads
+ * the target connection's saved MCP configuration state.
  */
 export type ConfigurationScope =
   | BindingCredentialAccessTokenReadScope

--- a/packages/runtime/src/vault.test.ts
+++ b/packages/runtime/src/vault.test.ts
@@ -96,4 +96,70 @@ describe("createStudioVaultClient", () => {
       "Studio vault token request failed: 403",
     );
   });
+
+  it("requests and returns MCP configuration for a connection binding", async () => {
+    let requestUrl: string | URL | Request | undefined;
+    let requestInit: RequestInit | undefined;
+    const fetch = Object.assign(
+      async (
+        input: Parameters<typeof globalThis.fetch>[0],
+        init: Parameters<typeof globalThis.fetch>[1],
+      ) => {
+        requestUrl = input;
+        requestInit = init;
+
+        return Response.json({
+          type: "mcp_configuration",
+          state: { apiKey: "secret", accountId: "acct_123" },
+          scopes: ["self::TOOL"],
+        });
+      },
+      { preconnect: globalThis.fetch.preconnect },
+    ) satisfies typeof globalThis.fetch;
+
+    const client = createStudioVaultClient({
+      baseUrl: "https://studio.test",
+      org: "acme",
+      token: "stv_prefix_secret",
+      fetch,
+    });
+
+    const configuration = await client.getConfiguration({
+      __type: "@deco/github",
+      value: "conn_github",
+    });
+
+    expect(requestUrl).toBe(
+      "https://studio.test/api/acme/vault/connections/conn_github/configuration",
+    );
+    expect(requestInit?.method).toBe("POST");
+    expect(requestInit?.headers).toEqual({
+      Authorization: "Bearer stv_prefix_secret",
+      "Content-Type": "application/json",
+    });
+    expect(requestInit?.body).toBe("{}");
+    expect(configuration).toEqual({
+      type: "mcp_configuration",
+      state: { apiKey: "secret", accountId: "acct_123" },
+      scopes: ["self::TOOL"],
+    });
+  });
+
+  it("throws when Studio rejects the configuration request", async () => {
+    const fetch = Object.assign(
+      async () => new Response(null, { status: 403 }),
+      { preconnect: globalThis.fetch.preconnect },
+    ) satisfies typeof globalThis.fetch;
+
+    const client = createStudioVaultClient({
+      baseUrl: "https://studio.test",
+      org: "acme",
+      token: "stv_prefix_secret",
+      fetch,
+    });
+
+    expect(client.getConfiguration("conn_github")).rejects.toThrow(
+      "Studio vault configuration request failed: 403",
+    );
+  });
 });

--- a/packages/runtime/src/vault.ts
+++ b/packages/runtime/src/vault.ts
@@ -1,12 +1,17 @@
 import type { Binding } from "./bindings.ts";
 
 export interface StudioVaultClientOptions {
+  /** Studio API base URL, usually the `baseUrl` value from the vault bootstrap. */
   baseUrl: string;
+  /** Organization slug used in Studio's org-scoped API paths. */
   org: string;
+  /** Workload token from Studio's vault bootstrap. Store it only in private runtime storage. */
   token: string;
+  /** Optional fetch implementation for tests or non-standard runtimes. */
   fetch?: typeof fetch;
 }
 
+/** Current downstream OAuth access token leased from Studio's vault. */
 export interface StudioAccessToken {
   type: "oauth_access_token";
   tokenType: "Bearer" | string;
@@ -15,20 +20,60 @@ export interface StudioAccessToken {
   scope: string | null;
 }
 
+/**
+ * Saved MCP configuration state decrypted by Studio for a granted target
+ * connection.
+ *
+ * This reads the target connection's saved `configuration_state`; it does not
+ * call the target MCP's `MCP_CONFIGURATION` discovery tool. Treat `state` as
+ * sensitive because some MCPs store provider API keys or other credentials in
+ * configuration state instead of OAuth.
+ */
 export interface StudioMcpConfiguration {
   type: "mcp_configuration";
   state: Record<string, unknown>;
   scopes: string[];
 }
 
-export const createStudioVaultClient = (
-  options: StudioVaultClientOptions,
-): {
+export interface StudioVaultClient {
+  /**
+   * Read a current downstream OAuth access token for a granted target
+   * connection.
+   *
+   * The runtime configuration must declare
+   * `${STATE_KEY}::credential:access-token:read`, where `STATE_KEY` points to a
+   * `BindingOf(...)` value. Studio refreshes the downstream OAuth credential
+   * when possible and returns only the access token; refresh tokens and OAuth
+   * client secrets remain inside Studio.
+   */
   getAccessToken: (connection: string | Binding) => Promise<StudioAccessToken>;
+
+  /**
+   * Read saved MCP configuration state for a granted target connection.
+   *
+   * Use this when the target MCP stores provider settings or credentials in its
+   * Studio configuration instead of OAuth. The runtime configuration must
+   * declare `${STATE_KEY}::credential:configuration:read`, where `STATE_KEY`
+   * points to a `BindingOf(...)` value. The returned configuration may contain
+   * secrets, so avoid logging it and persist the vault bootstrap only in private
+   * runtime storage.
+   */
   getConfiguration: (
     connection: string | Binding,
   ) => Promise<StudioMcpConfiguration>;
-} => {
+}
+
+/**
+ * Create a client for Studio vault reads from the `vault` bootstrap passed to
+ * `configuration.onInstall` or `configuration.onChange`.
+ *
+ * Prefer passing the resolved `BindingOf(...)` value to client methods so the
+ * read stays tied to the connection selected in configuration state. Raw
+ * connection ids are accepted for advanced cases.
+ */
+export const createStudioVaultClient = (
+  options: StudioVaultClientOptions,
+): StudioVaultClient => {
   const baseUrl = options.baseUrl.replace(/\/$/, "");
   const fetchImpl = options.fetch ?? globalThis.fetch;
 

--- a/packages/runtime/src/vault.ts
+++ b/packages/runtime/src/vault.ts
@@ -15,37 +15,61 @@ export interface StudioAccessToken {
   scope: string | null;
 }
 
+export interface StudioMcpConfiguration {
+  type: "mcp_configuration";
+  state: Record<string, unknown>;
+  scopes: string[];
+}
+
 export const createStudioVaultClient = (
   options: StudioVaultClientOptions,
 ): {
   getAccessToken: (connection: string | Binding) => Promise<StudioAccessToken>;
+  getConfiguration: (
+    connection: string | Binding,
+  ) => Promise<StudioMcpConfiguration>;
 } => {
   const baseUrl = options.baseUrl.replace(/\/$/, "");
   const fetchImpl = options.fetch ?? globalThis.fetch;
 
-  return {
-    getAccessToken: async (connection) => {
-      const connectionId =
-        typeof connection === "string" ? connection : connection.value;
-      const response = await fetchImpl(
-        `${baseUrl}/api/${encodeURIComponent(options.org)}/vault/connections/${encodeURIComponent(connectionId)}/access-token`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${options.token}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({}),
+  const connectionIdFor = (connection: string | Binding): string =>
+    typeof connection === "string" ? connection : connection.value;
+
+  const postVaultRequest = async <T>(
+    connection: string | Binding,
+    suffix: "access-token" | "configuration",
+    errorLabel: "token" | "configuration",
+  ): Promise<T> => {
+    const connectionId = connectionIdFor(connection);
+    const response = await fetchImpl(
+      `${baseUrl}/api/${encodeURIComponent(options.org)}/vault/connections/${encodeURIComponent(connectionId)}/${suffix}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${options.token}`,
+          "Content-Type": "application/json",
         },
+        body: JSON.stringify({}),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Studio vault ${errorLabel} request failed: ${response.status}`,
       );
+    }
 
-      if (!response.ok) {
-        throw new Error(
-          `Studio vault token request failed: ${response.status}`,
-        );
-      }
+    return (await response.json()) as T;
+  };
 
-      return (await response.json()) as StudioAccessToken;
-    },
+  return {
+    getAccessToken: async (connection) =>
+      postVaultRequest<StudioAccessToken>(connection, "access-token", "token"),
+    getConfiguration: async (connection) =>
+      postVaultRequest<StudioMcpConfiguration>(
+        connection,
+        "configuration",
+        "configuration",
+      ),
   };
 };


### PR DESCRIPTION
## Summary
- add explicit `credential:configuration:read` grants alongside access-token grants for binding-scoped vault reads
- expose granted saved MCP configuration through the org-scoped vault API and runtime `getConfiguration()` client
- document runtime vault reads in `@decocms/runtime` through package README examples and exported TSDoc on the vault client/scope APIs

## Test Plan
- [x] `bun test packages/runtime/src/vault.test.ts`
- [x] `bun run check`
- [x] `bun run lint` (0 errors; existing warnings only)
- [x] `bun run fmt:check`
- [x] `bun run --cwd=apps/docs check`
- [x] `bun run --cwd=packages/runtime check`

## Notes
- DB-backed vault integration tests could not run locally because Postgres was unavailable on `localhost:5432`; this should run in CI with the expected test infrastructure.
