### PR TITLE
docs(commerce-onboarding): commerce setup phase design (follow-up to #4190)

### DIFF
--- a/docs/superpowers/specs/2026-06-30-commerce-setup-phase-design.md
+++ b/docs/superpowers/specs/2026-06-30-commerce-setup-phase-design.md
@@ -1,0 +1,63 @@
+# Commerce Setup Phase Design
+
+> Follow-up to `2026-06-30-commerce-onboarding-design.md` (PR #4190), which built the auth + org-resolution foundation and explicitly deferred *"the final commerce-specific UI and the exact MCPs installed during commerce setup"* to a subsequent spec. **This is that spec.**
+
+## Goal
+
+Define what `CommerceSetup` does once `/commerce-onboarding` has resolved a selected organization: take the diagnostic the visitor saw on the public landing page, attach it to their org, enrich it with their connected data sources, and render the **full report inside Studio** (not on the marketing site). The public landing renders only the free/public teaser; the full report lives in the Studio/MCP app.
+
+## Context (what already exists)
+
+- **Foundation — PR #4190:** the `/commerce-onboarding` route authenticates the user (`/login?next=/commerce-onboarding`), resolves the org (auto-select / picker / local recovery via `ensureUserOrganization`), and hands a selected org to `CommerceSetup({ org })`. `CommerceSetup` is currently a placeholder.
+- **Credential vault — PR #4190 + the runtime `createStudioVaultClient`:** Studio leases downstream connection tokens/config to workers via `POST /api/:org/vault/connections/:connectionId/{access-token,configuration}`, gated by `credential:*:read` grants on a workload token.
+- **Engine (`commerce-discovery`):**
+  - Public read: `GET /api/v2/public/diagnostics/:domain` (anonymous) — the teaser the landing already renders.
+  - Upgrade: `POST /api/v2/internal/diagnostics/:domain/upgrade { org_id }` (master key) — links the diagnostic to the org, mints a per-(org,url) **`dgn_` client token**, sets `scope=private`, and re-runs (cached public subs kept; private subs added).
+  - Org-scoped read: the **token-MCP** `get_my_diagnostic` / `list_my_diagnostics`, pinned to one `(org, url)` by the `dgn_` token.
+  - Credentials pull (#72, merged): the engine resolves private-diagnostic creds (VTEX today; GA4/GSC planned) from **Studio Vault** via the runtime config binding + `org_provider_connection`.
+
+## The domain handoff (no cookie)
+
+The diagnostic domain rides the **existing `next` URL convention**, not a cookie:
+
+```
+landing public report  ──CTA──►  <studio>/commerce-onboarding?domain=<domain>
+   (signed out)        ──────►  /login?next=/commerce-onboarding?domain=<domain>  ──►  back to the route
+```
+
+`/commerce-onboarding` already types `domain?: string | null`; this spec adds it to the route's `useSearch` and threads it into `CommerceSetup({ org, domain })`. If `domain` is absent (user arrived without a prior scan), `CommerceSetup` offers a URL-entry step that triggers a fresh public scan first.
+
+## Commerce Setup phase — data flow
+
+Once `CommerceSetup` has `{ org, domain }`:
+
+1. **Claim the diagnostic for the org.** Call the engine `POST /api/v2/internal/diagnostics/:domain/upgrade { org_id }` (server-side, master key held by Studio — never the browser). The engine links the org, mints the `dgn_` token, flips `scope=private`, and re-runs. Idempotent: re-visiting `/commerce-onboarding` for the same `(org, domain)` is safe.
+2. **Persist the `dgn_` token** against the org's commerce-discovery connection so the Studio app can read the report later (this is the report's home — no Studio reports table).
+3. **Install / ensure the commerce data-source MCPs.** Ensure the org has the connections the private report needs (VTEX, GA4, GSC, …) and that the commerce-discovery engine is granted `credential:configuration:read` on them, so the engine's `ExternalCredentialProvider` (#72) can pull their config from the vault. Selecting these connections on the engine's runtime config is what populates `org_provider_connection` engine-side.
+4. **Render the full report in Studio.** Read the diagnostic via the token-MCP `get_my_diagnostic` and render the deck inside the Studio app. As private subs resolve (creds present), the report gains private sections on top of the public ones.
+5. **Paywall (blur).** The first sections render; the rest are blurred with a "See full report" CTA → checkout (see Billing). Gating is enforced Studio-side over the engine's per-section visibility/entitlement.
+
+## What this spec requires from the engine (cross-repo)
+
+- GA4 + GSC credential providers (mirror the merged VTEX #72) — tracked in `commerce-discovery` `docs/superpowers/plans/2026-06-30-ga4-gsc-studio-vault-provider.md`. Needs the GA4/GSC binding ids + MCP config field names.
+- Private-sub **verdict mappers** so private subs emit findings (not just raw data) into the summary/sections.
+- A **per-section entitlement/tier** concept on the engine `Section` for the paywall (today only all-or-nothing `public_blocked` + public/private visibility).
+
+## Billing (paywall)
+
+Out of scope for the first cut, but the gate attaches here: a `report_entitlements` record per `(org, url)` and a checkout (reuse the AI-gateway credit rail or a dedicated Stripe surface — decision pending). Until billing exists, `CommerceSetup` can show the full report ungated behind the connect step.
+
+## Route isolation & idempotency
+
+Inherits #4190's rules: `/commerce-onboarding` never redirects to `/onboarding`; the setup phase is **repeatable** — a returning user can revisit `/commerce-onboarding?domain=` (or pick a domain) and resume. The `/upgrade` call and connection-ensure are idempotent.
+
+## Out of scope
+
+- The exact visual design of the full-report view in Studio.
+- The final billing processor decision (Stripe vs gateway).
+- The GA4/GSC engine providers and verdict mappers (tracked in `commerce-discovery`).
+
+## Testing
+
+- Unit: `domain` search-param threading; idempotent `/upgrade` call wrapper; entitlement gate decision.
+- E2E: public teaser CTA → `/login?next=/commerce-onboarding?domain=` → authenticated `/commerce-onboarding` resolves org → `CommerceSetup` claims the diagnostic and renders the (gated) full report; revisiting is idempotent.


### PR DESCRIPTION
## What

Follow-up design spec to **#4190** (`commerce-onboarding-design.md`), which built the auth + org-resolution foundation and explicitly deferred the commerce-specific setup phase + MCP list to *"a subsequent commerce setup spec."* This is that spec.

Defines what `CommerceSetup` does once `/commerce-onboarding` has a selected org:
1. **Domain handoff (no cookie)** — the diagnostic domain rides the existing `next`/`?domain=` URL convention into the route.
2. **Claim** — server-side `POST /api/v2/internal/diagnostics/:domain/upgrade { org_id }` on the commerce-discovery engine → links the org, mints the `dgn_` token, flips `scope=private`, re-runs.
3. **Connect** — ensure the org's VTEX/GA4/GSC connections so the engine pulls their config from the Studio Vault (#72).
4. **Render the full report inside Studio** via the token-MCP `get_my_diagnostic` (the public landing only shows the teaser).
5. **Paywall** — first sections shown, rest blurred, "See full report" → checkout.

Docs only (force-added under `docs/superpowers/specs/`, matching #4190). Cross-repo deps (GA4/GSC vault providers, private verdict mappers, per-section entitlement) tracked in `commerce-discovery`.

Relates to: #4190 (foundation), commerce-discovery #72 (VTEX vault creds) + #65 (/api/v2 engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a design spec for the commerce setup phase, defining how `CommerceSetup` converts a public diagnostic into a full, org-linked report inside Studio with connection setup and paywall gating. Follow-up to #4190; docs-only, no runtime changes.

- **Design**
  - Domain handoff via `next`/`?domain=` (no cookie) into `/commerce-onboarding`.
  - Server-side claim: `POST /api/v2/internal/diagnostics/:domain/upgrade { org_id }` to mint `dgn_` token, set private scope, re-run (idempotent).
  - Ensure VTEX/GA4/GSC connections via Studio Vault so the engine can pull config.
  - Render the full report in Studio via token-MCP `get_my_diagnostic`; public site shows only the teaser.
  - Paywall: first sections visible, rest blurred with “See full report” → checkout (gate lives in Studio).

- **Cross-Repo Dependencies**
  - GA4/GSC vault credential providers (mirror VTEX provider).
  - Private-sub verdict mappers to emit findings.
  - Per-section entitlement/tier on engine sections for gating.

<sup>Written for commit 94f883ef04f6f094dd4009069506f3dd63fdbe5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

