### PR TITLE
fix(decopilot): project on same-fence terminal status (v2 reply-less turn)

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/consume-run-projection.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/consume-run-projection.test.ts
@@ -1,12 +1,64 @@
 import { describe, expect, it } from "bun:test";
-import { isTerminalStatus } from "./consume-run-projection";
+import { consumeRunProjection } from "./consume-run-projection";
+import {
+  type ProjectorRunRow,
+  type ProjectorWorkflowRuntime,
+  setProjectorWorkflowRuntime,
+} from "./projector-workflow";
 
-describe("isTerminalStatus", () => {
-  it("is true for completed/failed/requires_action (run is over for the consumer)", () => {
-    // The entry guard returns on these — consume already wrote them.
-    expect(isTerminalStatus("completed")).toBe(true);
-    expect(isTerminalStatus("failed")).toBe(true);
-    expect(isTerminalStatus("requires_action")).toBe(true);
-    expect(isTerminalStatus("in_progress")).toBe(false);
+/**
+ * Minimal runtime stub. The entry-guard tests only reach `resolveRun` and
+ * `getJetStream` — every other method stays unreached, so we cast a tiny object
+ * rather than stub the whole runtime. `getJetStream` returns null on purpose:
+ * when the guard lets the run through, consume hits the JetStream lookup and
+ * throws "JetStream unavailable" — that throw is our "it proceeded" signal.
+ */
+function installRuntime(row: ProjectorRunRow | null): void {
+  setProjectorWorkflowRuntime({
+    resolveRun: async () => row,
+    getJetStream: () => null,
+  } as unknown as ProjectorWorkflowRuntime);
+}
+
+function runRow(over: Partial<ProjectorRunRow>): ProjectorRunRow {
+  return {
+    orgId: "org_1",
+    createdBy: "user_1",
+    version: 2,
+    status: "in_progress",
+    runFenceToken: "fence-A",
+    title: null,
+    ...over,
+  };
+}
+
+describe("consumeRunProjection entry guard", () => {
+  it("PROCEEDS when the row is terminal but the fence still matches (same-fence early-terminal must not skip)", async () => {
+    // runId === threadId, so the thread's status is shared across turns. A
+    // hosted onFinish (or a prior turn) can leave the thread terminal while
+    // THIS fence's {done} is still unprojected. Skipping on terminal status
+    // would strand the turn ("No response was generated") and leak the done
+    // sentinel. The guard must gate on the live fence, not the status.
+    installRuntime(runRow({ status: "completed", runFenceToken: "fence-A" }));
+    await expect(
+      consumeRunProjection({ runId: "thrd_1", fenceToken: "fence-A" }),
+    ).rejects.toThrow("JetStream unavailable");
+  });
+
+  it("SKIPS when a newer fence owns the row (stale older attempt), even while in_progress", async () => {
+    // A different live fence means this projector event belongs to an older
+    // run attempt; it must not materialize over the newer attempt — regardless
+    // of the (non-terminal) status.
+    installRuntime(runRow({ status: "in_progress", runFenceToken: "fence-B" }));
+    await expect(
+      consumeRunProjection({ runId: "thrd_1", fenceToken: "fence-A" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("PROCEEDS for a fresh same-fence run (in_progress)", async () => {
+    installRuntime(runRow({ status: "in_progress", runFenceToken: "fence-A" }));
+    await expect(
+      consumeRunProjection({ runId: "thrd_1", fenceToken: "fence-A" }),
+    ).rejects.toThrow("JetStream unavailable");
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/consume-run-projection.ts
+++ b/apps/mesh/src/api/routes/decopilot/consume-run-projection.ts
@@ -2,17 +2,8 @@ import {
   getProjectorWorkflowRuntime,
   projectFromJetStreamStep,
   runProjectorWorkflowBody,
+  shouldSkipProjection,
 } from "./projector-workflow";
-
-/** Statuses on which the consume step's entry guard returns — consume is the
- *  sole writer of these, so a terminal status means projection already finished. */
-export function isTerminalStatus(status: string): boolean {
-  return (
-    status === "completed" ||
-    status === "failed" ||
-    status === "requires_action"
-  );
-}
 
 export interface ConsumeRunProjectionOptions {
   runId: string;
@@ -36,7 +27,24 @@ export async function consumeRunProjection(
   const row = await rt.resolveRun(runId);
   const fenceToken = opts.fenceToken ?? row?.runFenceToken;
   if (!row || row.version !== 2 || fenceToken == null) return;
-  if (isTerminalStatus(row.status)) return; // recovery: we already finished this run
+  // Skip ONLY when a newer fence has superseded this attempt — the same
+  // per-fence check the projector body uses. A terminal status is NOT a skip
+  // signal: `runId === threadId`, so the thread's status is shared across turns,
+  // and a hosted onFinish (or a prior turn) can leave it terminal while THIS
+  // fence's `{done}` is still unprojected. Gating on thread status here stranded
+  // such turns ("No response was generated") and leaked the done sentinel; the
+  // live-fence check projects the run while it still needs it and skips only
+  // genuinely-stale attempts. (Recovery is handled by DBOS step memoization —
+  // a completed consume step is not re-run.)
+  if (
+    shouldSkipProjection({
+      status: row.status,
+      runFenceToken: row.runFenceToken,
+      fenceToken,
+    })
+  ) {
+    return;
+  }
 
   const js = rt.getJetStream();
   if (!js) throw new Error("JetStream unavailable for consume step");


### PR DESCRIPTION
## Summary

Fixes a v2 projection gap where a turn could complete on the daemon/harness but render **reply-less** ("No response was generated") in the UI, leaving an orphaned `{done}` sentinel retained in JetStream.

`consumeRunProjection` (the sole projector + terminal-status writer) had a **second, fence-blind entry guard**:

```ts
if (isTerminalStatus(row.status)) return; // recovery: we already finished this run
```

Because **`runId === threadId`**, `row.status` is the *thread's* status, shared across every turn. So a turn whose `{done}` had not yet been projected got skipped whenever the thread already showed a terminal status — set by a **prior turn**, or by a **same-fence early `onFinish`** that marks the run completed before the projector consumes its `{done}`. The turn's assistant output was never projected → reply-less turn + leaked done sentinel.

The projector body already handles this correctly via `shouldSkipProjection`, whose own comment spells it out:

> *Terminal status alone is not stale: hosted onFinish can mark the run completed/failed before the projector consumes the same-fence `{done}`. A different live fence still means this projector event belongs to an older run attempt…*

The outer guard in `consumeRunProjection` **defeated** that downstream check. This PR makes the consume entry guard use the same per-fence `shouldSkipProjection` — skip **only** when a *newer fence* has superseded this attempt, never on terminal status alone.

Recovery idempotency is unaffected: a completed `consumeRunProjection` step is memoized by DBOS and not re-run.

## How it was found

Investigated a specific failed `user-desktop` thread on `studio-stg`: the link log showed the run **completed cleanly** (`work settled elapsedMs=29484`), the daemon side was fine, but the thread had a reply-less first turn and an orphaned `{done}` sentinel (`finalSeq:27`) still buffered in NATS with the assistant turn never projected. A monitoring sweep found this is a recurring class (orphaned-done husks + `completed` threads holding un-purged sentinels), pointing at the consume guard rather than the projector consumer (which was fully caught up).

## Changes

- `consume-run-projection.ts` — remove `isTerminalStatus`; entry guard now calls `shouldSkipProjection({ status, runFenceToken, fenceToken })`.
- `consume-run-projection.test.ts` — replace the pure `isTerminalStatus` test with **behavioral guard tests**: proceeds on same-fence-terminal (the bug), skips on newer-fence-stale, proceeds on fresh same-fence (TDD red→green).

## Replay safety

Change is inside the consume **step body** — same step sequence and recorded I/O — so it is DBOS-replay-safe: **no `DBOS_WORKFLOW_VERSION` bump and no workflow-source-snapshot re-baseline** (guard test stays green).

## Testing

- New guard tests 3/3 (red before the fix).
- Related projector/dispatch tests 45/45; full decopilot + dispatch-queue unit sweep (CI-style, one-per-file) green.
- `bun run check` (typecheck, all workspaces) exit 0; `bun run fmt` clean; DBOS workflow-source-guard green.

## Follow-up

This addresses the **same-fence early-terminal** class. If a given orphaned-`{done}` turn was instead caused by a *missing* `setRunFence` reset (the row's fence never advanced), that's a separate gap — staging monitoring should show the Case-C drip stop after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a v2 projection bug where a turn could complete but show "No response was generated". The consume guard now checks the live fence so same‑fence terminal turns still project and `{done}` sentinels are cleared from JetStream.

- **Bug Fixes**
  - Replaced `isTerminalStatus(row.status)` in `consumeRunProjection` with per-fence `shouldSkipProjection({ status, runFenceToken, fenceToken })`, skipping only when a newer fence supersedes the attempt.
  - Prevents reply-less turns and orphaned `{done}` in `JetStream`.

<sup>Written for commit f0cd9925e7f54d53a3f2a4a9d7f60d3e07aee0c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

