### PR TITLE
fix(ui): prevent ViewModeToggle label overlap in Calendar tab

### DIFF
--- a/packages/ui/src/components/view-mode-toggle.tsx
+++ b/packages/ui/src/components/view-mode-toggle.tsx
@@ -28,14 +28,17 @@ interface ViewModeToggleProps<T extends string = string> {
 const sizeConfig = {
   sm: {
     button: "size-7",
+    buttonWithLabel: "h-7",
     icon: "size-4",
   },
   md: {
     button: "size-9",
+    buttonWithLabel: "h-9",
     icon: "size-5",
   },
   lg: {
     button: "size-12",
+    buttonWithLabel: "h-12",
     icon: "size-6",
   },
 };
@@ -83,8 +86,11 @@ export function ViewModeToggle<T extends string = string>({
             onClick={() => onValueChange(option.value)}
             className={cn(
               "relative z-10 flex items-center justify-center gap-2 rounded-lg transition-colors [transition-timing-function:var(--ease-out-cubic)] duration-200",
-              fullWidth ? "flex-1 h-12 px-4" : config.button,
-              !fullWidth && option.label ? "px-3" : "",
+              fullWidth
+                ? "flex-1 h-12 px-4"
+                : option.label
+                  ? cn(config.buttonWithLabel, "px-3")
+                  : config.button,
             )}
           >
             <span


### PR DESCRIPTION
## Summary
- `ViewModeToggle` buttons used `size-7` (a 28×28px square) regardless of whether the option had a label, so labeled buttons like Calendar/Timeline got squeezed to 28px wide and the text overlapped.
- Added a `buttonWithLabel` variant (`h-7` / `h-9` / `h-12`) so labeled buttons constrain only height and grow horizontally with the text + `px-3` padding. Icon-only buttons keep the square `size-*` behavior, and the sliding indicator was already width-driven via inline style so it stays aligned.

## Test plan
- [ ] Open Content tab → Calendar collection and confirm the Calendar/Timeline toggle renders the two labels side by side without overlap.
- [ ] Verify the sliding indicator still tracks the active button.
- [ ] Spot-check icon-only `ViewModeToggle` usages (preview view-mode toggle) to confirm they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes label overlap in the Calendar/Timeline ViewModeToggle by letting labeled buttons grow horizontally while keeping icon-only buttons square. The sliding indicator remains aligned.

- **Bug Fixes**
  - Added `buttonWithLabel` variant (`h-7`/`h-9`/`h-12`) with `px-3` so labeled buttons size to their text; icon-only buttons keep `size-*`.
  - Preserves full-width behavior and the indicator tracking.

<sup>Written for commit 6e8c76bdc2e1011d506b48fc84906ea33363bd21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

