### PR TITLE
feat(chat): Prompt Explorer modal for iterative prompt enrichment

### DIFF
--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -19,6 +19,7 @@ import { createDownstreamTokenRoutes } from "./downstream-token";
 import { createFileUploadRoutes } from "./file-uploads";
 import { createKVRoutes } from "./kv";
 import { createOrgFsRoutes } from "./org-fs";
+import { createPromptExplorerRoutes } from "./prompt-explorer";
 import { createOrgScopedWellKnownProtectedResourceRoutes } from "./oauth-proxy";
 import { createSsoRoutes } from "./org-sso";
 import { createProxyRoutes } from "./proxy";
@@ -96,6 +97,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   ); // /api/:org/fs/:volume/...
   app.route("/sandbox", createSandboxRoutes()); // /api/:org/sandbox/:virtualMcpId/:branch/*
   app.route("/", createHomeNextActionsRoutes());
+  app.route("/", createPromptExplorerRoutes()); // /api/:org/prompt-explorer/stream
   app.route("/deco-sites", createDecoSitesOrgRoutes()); // /api/:org/deco-sites
   app.route("/sso", createSsoRoutes()); // /api/:org/sso/* (renamed from /api/org-sso)
   app.route(

--- a/apps/mesh/src/api/routes/prompt-explorer.ts
+++ b/apps/mesh/src/api/routes/prompt-explorer.ts
@@ -1,0 +1,140 @@
+/**
+ * Prompt Explorer Route
+ *
+ * Streams an AI-enriched version of a user's draft prompt. The frontend's
+ * "Explore" modal POSTs a rough draft; a *fast* model rewrites it into a
+ * richer, more complete prompt with [bracketed] fill-in placeholders, and the
+ * result (plus any model reasoning) is streamed back as SSE frames.
+ *
+ * Route: POST /api/:org/prompt-explorer/stream
+ *
+ * Deliberately lightweight: it calls the `ai` SDK `streamText` directly (no
+ * thread persistence / NATS / StreamBuffer). Mirrors the direct-streamText SSE
+ * pattern in `openai-compat.ts`.
+ */
+
+import { streamText } from "ai";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { streamSSE } from "hono/streaming";
+import { resolveTier } from "@/core/resolve-tier";
+import type { StudioContext } from "@/core/studio-context";
+import { buildPromptExplorerSystem } from "@/lib/prompt-explorer-system";
+
+type Variables = { meshContext: StudioContext };
+
+/** Cap to keep the model prompt (and our memory) bounded. */
+const MAX_DRAFT_LENGTH = 20_000;
+
+export const createPromptExplorerRoutes = () => {
+  const app = new Hono<{ Variables: Variables }>();
+
+  app.post("/prompt-explorer/stream", async (c) => {
+    const ctx = c.get("meshContext");
+    // Auth + org-membership are already enforced by `resolveOrgFromPath`
+    // (mounted on every org-scoped route). This isn't a tool, so there's no
+    // `toolName` for `ctx.access.check()` to authorize against — calling it
+    // with no resources throws ForbiddenError. The userId/orgId guards below
+    // mirror the sibling `thread-outputs` route.
+    const userId = ctx.auth?.user?.id;
+    if (!userId) {
+      throw new HTTPException(401, { message: "Unauthorized" });
+    }
+
+    const orgId = ctx.organization?.id;
+    if (!orgId) {
+      throw new HTTPException(400, { message: "Organization required" });
+    }
+
+    const body = await c.req
+      .json<{ draft?: unknown }>()
+      .catch(() => ({}) as { draft?: unknown });
+    const draft =
+      typeof body.draft === "string"
+        ? body.draft.slice(0, MAX_DRAFT_LENGTH)
+        : "";
+    if (draft.trim().length === 0) {
+      throw new HTTPException(400, { message: "draft is required" });
+    }
+
+    // Grow the prompt gradually each iteration: ~3x for short ideas, easing to
+    // ~2x as it gets longer, so a one-liner doesn't balloon into a wall of
+    // text. `maxChars` is the soft target (enforced via the system prompt);
+    // `maxOutputTokens` is the hard ceiling so the model can't run away even if
+    // it ignores the instruction.
+    const sourceChars = draft.length;
+    const factor = sourceChars < 300 ? 3 : sourceChars < 1000 ? 2.5 : 2;
+    const maxChars = Math.round(sourceChars * factor);
+    // ~3 chars/token (conservative → a little headroom over the target so the
+    // model can finish its sentence rather than getting cut mid-word).
+    const maxOutputTokens = Math.min(
+      1200,
+      Math.max(160, Math.ceil(maxChars / 3)),
+    );
+
+    const system = buildPromptExplorerSystem({
+      userName: ctx.auth?.user?.name,
+      userEmail: ctx.auth?.user?.email,
+      orgName: ctx.organization?.name,
+      maxChars,
+    });
+
+    return streamSSE(c, async (stream) => {
+      try {
+        const tier = await resolveTier(ctx, "fast");
+        const provider = await ctx.aiProviders.activate(
+          tier.credentialId,
+          orgId,
+        );
+        const model = provider.aiSdk.languageModel(tier.modelId);
+
+        const result = streamText({
+          model,
+          system,
+          // Frame the draft as material to TRANSFORM, not a request to answer —
+          // otherwise the model "helpfully" replies in the second person
+          // ("Você quer…", "Describe…") instead of rewriting the user's prompt.
+          prompt: `Below is the rough draft of MY prompt. Rewrite it as an improved version of MY prompt, in my own voice (same grammatical person and language as the draft). Output only the rewritten prompt.\n\n--- MY DRAFT ---\n${draft}`,
+          maxOutputTokens,
+          temperature: 0.4,
+          abortSignal: c.req.raw.signal,
+        });
+
+        for await (const part of result.fullStream) {
+          if (part.type === "reasoning-delta") {
+            await stream.writeSSE({
+              data: JSON.stringify({ type: "reasoning", text: part.text }),
+            });
+          } else if (part.type === "text-delta") {
+            await stream.writeSSE({
+              data: JSON.stringify({ type: "text", text: part.text }),
+            });
+          } else if (part.type === "error") {
+            const message =
+              part.error instanceof Error
+                ? part.error.message
+                : String(part.error);
+            await stream.writeSSE({
+              data: JSON.stringify({ type: "error", message }),
+            });
+          } else if (part.type === "finish") {
+            // Stop as soon as the overall finish arrives rather than waiting
+            // for the iterator to complete on its own, then close the stream.
+            break;
+          }
+        }
+        await stream.writeSSE({ data: JSON.stringify({ type: "finish" }) });
+      } catch (err) {
+        // Surface a friendly error frame (e.g. TierUnavailableError when the
+        // org has no provider connected) rather than dropping the stream.
+        const message =
+          err instanceof Error ? err.message : "Failed to enrich prompt";
+        await stream.writeSSE({
+          data: JSON.stringify({ type: "error", message }),
+        });
+      }
+    });
+  });
+
+  return app;
+};

--- a/apps/mesh/src/lib/prompt-explorer-system.test.ts
+++ b/apps/mesh/src/lib/prompt-explorer-system.test.ts
@@ -13,10 +13,13 @@ describe("buildPromptExplorerSystem", () => {
     expect(system).toContain('"Analytical Engines"');
   });
 
-  it("instructs the model to add bracketed fill-in placeholders", () => {
+  it("expands into a concrete, ready-to-use prompt with no bracket placeholders", () => {
     const system = buildPromptExplorerSystem({ userName: "X" });
-    expect(system).toContain("[square brackets]");
-    expect(system).toMatch(/fill-in-the-blank/i);
+    // No fill-in blanks: the model makes concrete choices itself.
+    expect(system).toMatch(/no placeholders|never use square brackets/i);
+    expect(system).toMatch(/ready[- ]to[- ]use|as-is|run immediately/i);
+    // Each iteration must grow, not repeat (fixes "v2 identical to v1").
+    expect(system).toMatch(/expand/i);
   });
 
   it("falls back gracefully when identity fields are missing", () => {

--- a/apps/mesh/src/lib/prompt-explorer-system.test.ts
+++ b/apps/mesh/src/lib/prompt-explorer-system.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { buildPromptExplorerSystem } from "./prompt-explorer-system";
+
+describe("buildPromptExplorerSystem", () => {
+  it("includes the user's name, email, and org", () => {
+    const system = buildPromptExplorerSystem({
+      userName: "Ada Lovelace",
+      userEmail: "ada@example.com",
+      orgName: "Analytical Engines",
+    });
+    expect(system).toContain("Ada Lovelace");
+    expect(system).toContain("ada@example.com");
+    expect(system).toContain('"Analytical Engines"');
+  });
+
+  it("instructs the model to add bracketed fill-in placeholders", () => {
+    const system = buildPromptExplorerSystem({ userName: "X" });
+    expect(system).toContain("[square brackets]");
+    expect(system).toMatch(/fill-in-the-blank/i);
+  });
+
+  it("falls back gracefully when identity fields are missing", () => {
+    const system = buildPromptExplorerSystem({});
+    expect(system).toContain("an unknown user");
+    expect(system).not.toContain("in the organization");
+  });
+
+  it("uses email alone when name is absent", () => {
+    const system = buildPromptExplorerSystem({ userEmail: "only@email.com" });
+    expect(system).toContain("only@email.com");
+  });
+
+  it("includes a gradual-growth length budget when maxChars is given", () => {
+    const system = buildPromptExplorerSystem({ userName: "X", maxChars: 216 });
+    expect(system).toContain("216 characters");
+    expect(system).toMatch(/gradual/i);
+  });
+
+  it("instructs the model to keep the user's voice/person and language", () => {
+    const system = buildPromptExplorerSystem({ userName: "X" });
+    expect(system).toMatch(/first person/i);
+    expect(system).toMatch(/same language/i);
+    // Explicitly warns against flipping to second-person address.
+    expect(system).toMatch(/You want to|second person/i);
+  });
+
+  it("omits the length budget when maxChars is absent or zero", () => {
+    expect(buildPromptExplorerSystem({ userName: "X" })).not.toMatch(
+      /characters long/,
+    );
+    expect(
+      buildPromptExplorerSystem({ userName: "X", maxChars: 0 }),
+    ).not.toMatch(/characters long/);
+  });
+});

--- a/apps/mesh/src/lib/prompt-explorer-system.ts
+++ b/apps/mesh/src/lib/prompt-explorer-system.ts
@@ -1,0 +1,54 @@
+/**
+ * System prompt for the Prompt Explorer feature.
+ *
+ * Kept as a pure function (no StudioContext, no I/O) so it can be unit-tested
+ * directly — the route handler extracts the identity fields from `ctx` and
+ * passes them in.
+ */
+
+export interface PromptExplorerIdentity {
+  userName?: string;
+  userEmail?: string;
+  orgName?: string;
+  /**
+   * Soft length budget: keep the rewrite at most ~this many characters. The
+   * route derives it from the source length so each iteration grows the prompt
+   * gradually (~2-3x) instead of ballooning a one-liner into a wall of text.
+   */
+  maxChars?: number;
+}
+
+export function buildPromptExplorerSystem(id: PromptExplorerIdentity): string {
+  const who = id.userName
+    ? `${id.userName}${id.userEmail ? ` (${id.userEmail})` : ""}`
+    : (id.userEmail ?? "an unknown user");
+  const org = id.orgName ? ` in the organization "${id.orgName}"` : "";
+
+  const lines = [
+    `You are a prompt-engineering assistant. The user is ${who}${org}.`,
+    `They are iterating on a prompt for an AI assistant and want to turn a rough idea into a complete, detailed, high-quality prompt.`,
+    ``,
+    `Read their draft, understand its underlying intent, and rewrite it as a richer, clearer, more complete version that would get an excellent result from an AI assistant.`,
+    ``,
+    `CRITICAL — voice & language: The output IS the user's own prompt, written in their voice as if THEY are speaking to an AI assistant. Keep the exact same grammatical person and tone as their draft — if they wrote in the first person ("eu quero…", "I want…"), keep it first person ("eu quero…", "I want…"). NEVER address the user or describe what they want in the second person (no "Você quer…", "You want to…", "Describe…", "Tell me…"). Do not turn their prompt into instructions aimed back at them. Write your entire response in the SAME language as their draft.`,
+    ``,
+    `Example. Draft: "eu quero testar a feature de prompt exploring, tipo o que ela faz". CORRECT (keeps first person): "Eu quero explorar e testar a feature de prompt exploring para entender [quais capacidades quero avaliar] e [em que casos de uso]." INCORRECT (flips to second person, never do this): "Você quer testar a feature… Descreva […]".`,
+    ``,
+    `Where important details are missing or ambiguous, insert clearly-marked fill-in-the-blank placeholders in [square brackets] (e.g. "[target audience]", "[preferred tone]", "[deadline]") — phrased inline in the user's own voice — so the user can complete them.`,
+    `Preserve the user's original goal and voice. Do not invent specific facts the user did not provide — use a [bracketed placeholder] instead.`,
+  ];
+
+  if (id.maxChars && id.maxChars > 0) {
+    lines.push(
+      ``,
+      `IMPORTANT — grow the prompt GRADUALLY. This is one step in an iterative loop, not the final form. Make the improved prompt at most about ${id.maxChars} characters long. Add only the most valuable clarifications and a few placeholders; do NOT pad, repeat, restructure into a giant template, or balloon a short idea into a long document. A little richer than the input each time is exactly right.`,
+    );
+  }
+
+  lines.push(
+    ``,
+    `Return ONLY the improved prompt text. No preamble, no explanation, no markdown code fences.`,
+  );
+
+  return lines.join("\n");
+}

--- a/apps/mesh/src/lib/prompt-explorer-system.ts
+++ b/apps/mesh/src/lib/prompt-explorer-system.ts
@@ -26,22 +26,23 @@ export function buildPromptExplorerSystem(id: PromptExplorerIdentity): string {
 
   const lines = [
     `You are a prompt-engineering assistant. The user is ${who}${org}.`,
-    `They are iterating on a prompt for an AI assistant and want to turn a rough idea into a complete, detailed, high-quality prompt.`,
+    `They are iterating on a prompt for an AI assistant: each pass turns their rough idea into a more complete, concrete, ready-to-use prompt.`,
     ``,
-    `Read their draft, understand its underlying intent, and rewrite it as a richer, clearer, more complete version that would get an excellent result from an AI assistant.`,
+    `Read their draft, understand its underlying intent, and rewrite it as a richer, clearer, more complete version they could send to an AI assistant AS-IS and get an excellent result.`,
     ``,
     `CRITICAL — voice & language: The output IS the user's own prompt, written in their voice as if THEY are speaking to an AI assistant. Keep the exact same grammatical person and tone as their draft — if they wrote in the first person ("eu quero…", "I want…"), keep it first person ("eu quero…", "I want…"). NEVER address the user or describe what they want in the second person (no "Você quer…", "You want to…", "Describe…", "Tell me…"). Do not turn their prompt into instructions aimed back at them. Write your entire response in the SAME language as their draft.`,
     ``,
-    `Example. Draft: "eu quero testar a feature de prompt exploring, tipo o que ela faz". CORRECT (keeps first person): "Eu quero explorar e testar a feature de prompt exploring para entender [quais capacidades quero avaliar] e [em que casos de uso]." INCORRECT (flips to second person, never do this): "Você quer testar a feature… Descreva […]".`,
+    `NO placeholders, NO blanks. Never use square brackets, "[...]", "fill in", "TODO", "Para completar", or any leave-it-for-later marker. Instead, make reasonable, concrete choices yourself: invent sensible specifics that fit the intent — concrete aspects, scenarios, examples, criteria — and write them straight into the prompt. The result must read as a finished prompt the user could run immediately, never a template to complete. The user can freely edit anything they'd have chosen differently.`,
     ``,
-    `Where important details are missing or ambiguous, insert clearly-marked fill-in-the-blank placeholders in [square brackets] (e.g. "[target audience]", "[preferred tone]", "[deadline]") — phrased inline in the user's own voice — so the user can complete them.`,
-    `Preserve the user's original goal and voice. Do not invent specific facts the user did not provide — use a [bracketed placeholder] instead.`,
+    `EXPAND on every iteration. This is one step in a loop — each time the user runs it again, meaningfully grow and deepen the prompt: add concrete detail, specifics, structure, constraints, and examples that weren't there before. Never return essentially the same text; each version must be a clear, richer step up from the previous one.`,
+    ``,
+    `Example. Draft: "eu quero testar a feature de prompt exploring, tipo o que ela faz". CORRECT — first person, concrete, ready to use, no brackets:\n"Eu quero explorar e testar a feature de prompt exploring para entender o que ela faz na prática. Vou avaliar a velocidade das respostas, a qualidade e a relevância das sugestões e a facilidade de uso da interface. Para isso, quero testá-la em cenários reais como reescrever um e-mail curto, transformar uma ideia solta num prompt detalhado e refinar um prompt técnico passo a passo, comparando o resultado de cada iteração."\nINCORRECT — do NOT flip to second person ("Você quer testar…", "Descreva…") and do NOT leave blanks or brackets ("entender [quais capacidades]", "Para completar: - …").`,
   ];
 
   if (id.maxChars && id.maxChars > 0) {
     lines.push(
       ``,
-      `IMPORTANT — grow the prompt GRADUALLY. This is one step in an iterative loop, not the final form. Make the improved prompt at most about ${id.maxChars} characters long. Add only the most valuable clarifications and a few placeholders; do NOT pad, repeat, restructure into a giant template, or balloon a short idea into a long document. A little richer than the input each time is exactly right.`,
+      `Length: grow GRADUALLY — aim for at most about ${id.maxChars} characters this pass (a couple times richer than the input, not the final form). Fill the added room with concrete, useful substance, not padding or repetition; do not balloon a short idea into a wall of text in one step.`,
     );
   }
 

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -23,6 +23,7 @@ import {
   Image01,
   Lock01,
   Microphone01,
+  Stars01,
   Stop,
   Telescope,
   Upload01,
@@ -56,6 +57,7 @@ import {
   type TiptapInputHandle,
 } from "./tiptap/input";
 import { isTiptapDocEmpty } from "./tiptap/utils";
+import { PromptExplorerDialog } from "./prompt-explorer-dialog";
 import { ToolsPopover } from "./tools-popover";
 import { SessionStats } from "./usage-stats";
 import { authClient } from "@/web/lib/auth-client.ts";
@@ -71,6 +73,40 @@ import { shouldRenderInlineModeRow } from "./input-mode-row";
 // ============================================================================
 // useWindowFileDrop - Reusable hook for window-level file drag & drop
 // ============================================================================
+
+/** Flatten a Tiptap doc to plain text for seeding the Prompt Explorer. */
+function tiptapDocToPlainText(doc: Metadata["tiptapDoc"] | undefined): string {
+  if (!doc?.content) return "";
+  return doc.content
+    .map((node) => {
+      if (node.type !== "paragraph") return "";
+      return (node.content ?? [])
+        .map((child) =>
+          child.type === "text"
+            ? (child.text ?? "")
+            : child.type === "hardBreak"
+              ? "\n"
+              : "",
+        )
+        .join("");
+    })
+    .join("\n")
+    .trim();
+}
+
+/** Build a minimal Tiptap doc (one paragraph per line) from plain text. */
+function plainTextToTiptapDoc(text: string): Metadata["tiptapDoc"] {
+  return {
+    type: "doc",
+    content: text
+      .split("\n")
+      .map((line) =>
+        line.length > 0
+          ? { type: "paragraph", content: [{ type: "text", text: line }] }
+          : { type: "paragraph" },
+      ),
+  };
+}
 
 function ChatInputDisabledState({ message }: { message: string }) {
   return (
@@ -276,6 +312,7 @@ export function ChatInput({
   const fullVm = useVirtualMCP(selectedVirtualMcp?.id ?? decopilotId);
   const playSwitchSound = useSound(question004Sound);
   const [connectionsOpen, setConnectionsOpen] = useState(false);
+  const [exploreOpen, setExploreOpen] = useState(false);
   const { unsupportedFile, onUnsupportedFile, clearUnsupportedFile } =
     useUnsupportedFileDialog();
 
@@ -438,6 +475,26 @@ export function ChatInput({
       clearChatDraft(sessionStorage, locator, draftKey);
       setTiptapDoc(undefined);
     }
+  };
+
+  // Send the optimized prompt produced by the Prompt Explorer modal, reusing
+  // the normal submit path (active task → stream, else home composer).
+  const handleExploreSend = (text: string) => {
+    const doc = plainTextToTiptapDoc(text);
+    if (isStreaming || isTiptapDocEmpty(doc)) return;
+    track("chat_prompt_explorer_sent", {
+      thread_id: taskId || null,
+      mode: chatMode,
+      model_id: selectedModel?.modelId ?? null,
+      virtual_mcp_id: selectedVirtualMcp?.id ?? null,
+    });
+    if (stream) {
+      void stream.sendMessage(doc);
+    } else {
+      homeSubmit({ tiptapDoc: doc, virtualMcp: selectedVirtualMcp });
+    }
+    clearChatDraft(sessionStorage, locator, draftKey);
+    setTiptapDoc(undefined);
   };
 
   if (userId && task?.created_by && task.created_by !== userId) {
@@ -661,6 +718,24 @@ export function ChatInput({
                           currentBranch={taskCtx?.currentBranch ?? null}
                         />
                       )}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        disabled={isStreaming}
+                        onClick={() => {
+                          track("chat_prompt_explorer_opened", {
+                            thread_id: taskId || null,
+                          });
+                          setExploreOpen(true);
+                        }}
+                        className="size-8 rounded-lg text-muted-foreground hover:text-foreground transition-colors"
+                        title="Explore — turn a rough idea into a detailed prompt"
+                        aria-label="Explore prompt"
+                      >
+                        <Stars01 size={18} />
+                      </Button>
+
                       <TierTrigger />
 
                       {/* Microphone button — kept mounted (and disabled)
@@ -759,6 +834,13 @@ export function ChatInput({
       <UnsupportedFileDialog
         info={unsupportedFile}
         onClose={clearUnsupportedFile}
+      />
+
+      <PromptExplorerDialog
+        open={exploreOpen}
+        onOpenChange={setExploreOpen}
+        initialText={tiptapDocToPlainText(tiptapDoc)}
+        onSend={handleExploreSend}
       />
     </>
   );

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -23,7 +23,7 @@ import {
   Image01,
   Lock01,
   Microphone01,
-  Stars01,
+  RefreshCw01,
   Stop,
   Telescope,
   Upload01,
@@ -721,7 +721,7 @@ export function ChatInput({
                       <Button
                         type="button"
                         variant="ghost"
-                        size="icon"
+                        size="sm"
                         disabled={isStreaming}
                         onClick={() => {
                           track("chat_prompt_explorer_opened", {
@@ -729,11 +729,12 @@ export function ChatInput({
                           });
                           setExploreOpen(true);
                         }}
-                        className="size-8 rounded-lg text-muted-foreground hover:text-foreground transition-colors"
-                        title="Explore — turn a rough idea into a detailed prompt"
-                        aria-label="Explore prompt"
+                        className="h-8 gap-1.5 rounded-lg px-2 text-muted-foreground hover:text-foreground transition-colors"
+                        title="Improve — turn a rough idea into a detailed, ready-to-use prompt"
+                        aria-label="Improve prompt"
                       >
-                        <Stars01 size={18} />
+                        <RefreshCw01 size={16} />
+                        Improve
                       </Button>
 
                       <TierTrigger />

--- a/apps/mesh/src/web/components/chat/prompt-explorer-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/prompt-explorer-dialog.tsx
@@ -1,0 +1,292 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { ArrowUp, Loading01, RefreshCw01, Telescope } from "@untitledui/icons";
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  PROMPT_EXPLORER_MIN_CHARS,
+  usePromptEnricher,
+} from "@/web/hooks/use-prompt-enricher.ts";
+
+interface PromptExplorerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Seed the editor with the user's current composer draft. */
+  initialText?: string;
+  /** Called with the current prompt when the user clicks Send. */
+  onSend: (text: string) => void;
+}
+
+interface Version {
+  id: number;
+  text: string;
+}
+
+export function PromptExplorerDialog({
+  open,
+  onOpenChange,
+  initialText,
+  onSend,
+}: PromptExplorerDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[1100px] w-[95vw] h-[85svh] p-0 gap-0 overflow-hidden flex flex-col">
+        <DialogHeader className="px-5 py-3 border-b border-border shrink-0">
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <Telescope size={18} />
+            Explore prompt
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Iterate on a rough idea to turn it into a richer, more detailed
+            prompt, then send it to the chat.
+          </DialogDescription>
+        </DialogHeader>
+        {/* Radix unmounts content on close, so the body remounts fresh each
+            open — local state (versions, selection) resets naturally. */}
+        {open && (
+          <PromptExplorerBody
+            initialText={initialText}
+            onSend={(text) => {
+              onSend(text);
+              onOpenChange(false);
+            }}
+            onClose={() => onOpenChange(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PromptExplorerBody({
+  initialText,
+  onSend,
+  onClose,
+}: {
+  initialText?: string;
+  onSend: (text: string) => void;
+  onClose: () => void;
+}) {
+  const [versions, setVersions] = useState<Version[]>(() => [
+    { id: 0, text: initialText ?? "" },
+  ]);
+  const [selectedId, setSelectedId] = useState(0);
+  const [streamingId, setStreamingId] = useState<number | null>(null);
+  const nextId = useRef(1);
+  const enricher = usePromptEnricher();
+
+  const selected =
+    versions.find((v) => v.id === selectedId) ?? versions[versions.length - 1]!;
+  const isStreaming = enricher.status === "streaming";
+  const isStreamingSelected = isStreaming && streamingId === selectedId;
+  // While the selected version is streaming, show the live text; otherwise the
+  // committed version text (which the user can edit directly).
+  const mainValue = isStreamingSelected ? enricher.text : selected.text;
+  const trimmedLen = selected.text.trim().length;
+  const canIterate = !isStreaming && trimmedLen >= PROMPT_EXPLORER_MIN_CHARS;
+  const canSend = !isStreaming && trimmedLen > 0;
+
+  const updateSelected = (text: string) => {
+    setVersions((vs) =>
+      vs.map((v) => (v.id === selectedId ? { ...v, text } : v)),
+    );
+  };
+
+  const handleIterate = async () => {
+    if (!canIterate) return;
+    const source = selected.text;
+    const id = nextId.current++;
+    // The new (soon-to-be-enriched) version becomes the latest and is
+    // selected immediately; the source version stays in the sidebar.
+    setVersions((vs) => [...vs, { id, text: "" }]);
+    setSelectedId(id);
+    setStreamingId(id);
+    try {
+      const result = await enricher.enrich(source);
+      setVersions((vs) =>
+        vs.map((v) => (v.id === id ? { ...v, text: result.text } : v)),
+      );
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to enrich the prompt",
+      );
+      // Drop the empty placeholder version and return to the source.
+      setVersions((vs) => vs.filter((v) => v.id !== id));
+      setSelectedId(selected.id);
+    } finally {
+      setStreamingId(null);
+    }
+  };
+
+  const handleSend = () => {
+    if (!canSend) return;
+    onSend(selected.text);
+  };
+
+  // Enter → Iterate, Cmd/Ctrl+Enter → Send, Shift+Enter → newline.
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key !== "Enter" || e.shiftKey) return;
+    e.preventDefault();
+    if (e.metaKey || e.ctrlKey) {
+      handleSend();
+    } else {
+      void handleIterate();
+    }
+  };
+
+  const handleClose = () => {
+    enricher.cancel();
+    onClose();
+  };
+
+  // Auto-run the first enrichment on open when the composer draft already has
+  // enough text — opening Explore "just starts iterating". A mount-scoped
+  // effect is the natural fit here (mirrors useSubtaskStream in this codebase);
+  // the ref guards against StrictMode's double-invoke.
+  const didAutoRun = useRef(false);
+  /* oxlint-disable ban-use-effect/ban-use-effect */
+  /* oxlint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    if (didAutoRun.current) return;
+    didAutoRun.current = true;
+    if ((initialText ?? "").trim().length >= PROMPT_EXPLORER_MIN_CHARS) {
+      void handleIterate();
+    }
+  }, []);
+  /* oxlint-enable react-hooks/exhaustive-deps */
+  /* oxlint-enable ban-use-effect/ban-use-effect */
+
+  const placeholder =
+    isStreamingSelected && !enricher.text
+      ? "Thinking…"
+      : versions.length === 1
+        ? "Write a rough idea for your prompt, then click Iterate to enrich it."
+        : "Edit this version, fill in any [blanks], then Iterate again or Send.";
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="flex-1 min-h-0 flex">
+        {/* Versions sidebar */}
+        <aside className="w-56 shrink-0 border-r border-border flex flex-col min-h-0">
+          <div className="px-3 pt-3 pb-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Versions
+          </div>
+          <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2 space-y-1">
+            {versions.map((v, i) => {
+              const isLatest = i === versions.length - 1;
+              const active = v.id === selectedId;
+              const streamingThis = streamingId === v.id;
+              const label = i === 0 ? "Original idea" : `Version ${i}`;
+              const preview = (streamingThis ? enricher.text : v.text).trim();
+              return (
+                <button
+                  key={v.id}
+                  type="button"
+                  onClick={() => !isStreaming && setSelectedId(v.id)}
+                  disabled={isStreaming}
+                  className={cn(
+                    "w-full text-left rounded-lg px-2.5 py-2 transition-colors border",
+                    active
+                      ? "bg-muted border-border"
+                      : "border-transparent hover:bg-muted/60",
+                    isStreaming && !streamingThis && "opacity-60",
+                  )}
+                >
+                  <div className="flex items-center gap-1.5 text-xs font-medium">
+                    <span
+                      className={cn(
+                        active ? "text-foreground" : "text-muted-foreground",
+                      )}
+                    >
+                      {label}
+                    </span>
+                    {isLatest && !streamingThis && (
+                      <span className="text-[10px] font-medium text-muted-foreground rounded bg-muted-foreground/10 px-1 py-px">
+                        Latest
+                      </span>
+                    )}
+                    {streamingThis && (
+                      <Loading01
+                        size={11}
+                        className="animate-spin text-foreground"
+                      />
+                    )}
+                  </div>
+                  <div className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
+                    {preview || "Empty"}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </aside>
+
+        {/* Main editor */}
+        <div className="flex-1 min-h-0 flex flex-col">
+          {enricher.reasoning && isStreamingSelected && (
+            <div className="mx-5 mt-3 max-h-24 overflow-y-auto rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground whitespace-pre-wrap">
+              {enricher.reasoning}
+            </div>
+          )}
+          <Textarea
+            autoFocus
+            value={mainValue}
+            onChange={(e) => updateSelected(e.target.value)}
+            onKeyDown={handleKeyDown}
+            readOnly={isStreamingSelected}
+            placeholder={placeholder}
+            className="flex-1 min-h-0 resize-none border-0 rounded-none bg-transparent focus-visible:ring-0 px-5 py-4 text-sm leading-relaxed shadow-none"
+          />
+        </div>
+      </div>
+
+      {/* Footer actions */}
+      <div className="border-t border-border px-5 py-3 flex items-center justify-between gap-3 shrink-0">
+        <div className="text-xs text-muted-foreground min-w-0 truncate">
+          {isStreaming
+            ? "Enriching your prompt…"
+            : trimmedLen < PROMPT_EXPLORER_MIN_CHARS
+              ? `Write at least ${PROMPT_EXPLORER_MIN_CHARS} characters, then Iterate.`
+              : versions.length === 1
+                ? "Click Iterate to generate an improved version."
+                : "Edit, Iterate again, or Send when you're happy."}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button type="button" variant="ghost" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleIterate}
+            disabled={!canIterate}
+            title="Generate an improved version from the current text (Enter)"
+          >
+            <RefreshCw01
+              size={16}
+              className={cn(isStreaming && "animate-spin")}
+            />
+            Iterate
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleSend}
+            disabled={!canSend}
+            title="Send this prompt to the chat (⌘/Ctrl+Enter)"
+          >
+            <ArrowUp size={16} />
+            Send
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/chat/prompt-explorer-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/prompt-explorer-dialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { ArrowUp, Loading01, RefreshCw01, Telescope } from "@untitledui/icons";
+import { ArrowUp, Loading01, RefreshCw01 } from "@untitledui/icons";
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -41,11 +41,11 @@ export function PromptExplorerDialog({
       <DialogContent className="sm:max-w-[1100px] w-[95vw] h-[85svh] p-0 gap-0 overflow-hidden flex flex-col">
         <DialogHeader className="px-5 py-3 border-b border-border shrink-0">
           <DialogTitle className="flex items-center gap-2 text-base">
-            <Telescope size={18} />
-            Explore prompt
+            <RefreshCw01 size={18} />
+            Improve prompt
           </DialogTitle>
           <DialogDescription className="sr-only">
-            Iterate on a rough idea to turn it into a richer, more detailed
+            Improve a rough idea into a richer, more detailed, ready-to-use
             prompt, then send it to the chat.
           </DialogDescription>
         </DialogHeader>
@@ -91,7 +91,7 @@ function PromptExplorerBody({
   // committed version text (which the user can edit directly).
   const mainValue = isStreamingSelected ? enricher.text : selected.text;
   const trimmedLen = selected.text.trim().length;
-  const canIterate = !isStreaming && trimmedLen >= PROMPT_EXPLORER_MIN_CHARS;
+  const canImprove = !isStreaming && trimmedLen >= PROMPT_EXPLORER_MIN_CHARS;
   const canSend = !isStreaming && trimmedLen > 0;
 
   const updateSelected = (text: string) => {
@@ -100,12 +100,12 @@ function PromptExplorerBody({
     );
   };
 
-  const handleIterate = async () => {
-    if (!canIterate) return;
+  const handleImprove = async () => {
+    if (!canImprove) return;
     const source = selected.text;
     const id = nextId.current++;
-    // The new (soon-to-be-enriched) version becomes the latest and is
-    // selected immediately; the source version stays in the sidebar.
+    // The new (soon-to-be-improved) version becomes the latest and is selected
+    // immediately; the source version stays in the sidebar.
     setVersions((vs) => [...vs, { id, text: "" }]);
     setSelectedId(id);
     setStreamingId(id);
@@ -116,7 +116,7 @@ function PromptExplorerBody({
       );
     } catch (e) {
       toast.error(
-        e instanceof Error ? e.message : "Failed to enrich the prompt",
+        e instanceof Error ? e.message : "Failed to improve the prompt",
       );
       // Drop the empty placeholder version and return to the source.
       setVersions((vs) => vs.filter((v) => v.id !== id));
@@ -131,14 +131,14 @@ function PromptExplorerBody({
     onSend(selected.text);
   };
 
-  // Enter → Iterate, Cmd/Ctrl+Enter → Send, Shift+Enter → newline.
+  // Enter → Improve, Cmd/Ctrl+Enter → Send, Shift+Enter → newline.
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key !== "Enter" || e.shiftKey) return;
     e.preventDefault();
     if (e.metaKey || e.ctrlKey) {
       handleSend();
     } else {
-      void handleIterate();
+      void handleImprove();
     }
   };
 
@@ -147,8 +147,8 @@ function PromptExplorerBody({
     onClose();
   };
 
-  // Auto-run the first enrichment on open when the composer draft already has
-  // enough text — opening Explore "just starts iterating". A mount-scoped
+  // Auto-run the first improvement on open when the composer draft already has
+  // enough text — opening Improve "just starts improving". A mount-scoped
   // effect is the natural fit here (mirrors useSubtaskStream in this codebase);
   // the ref guards against StrictMode's double-invoke.
   const didAutoRun = useRef(false);
@@ -158,7 +158,7 @@ function PromptExplorerBody({
     if (didAutoRun.current) return;
     didAutoRun.current = true;
     if ((initialText ?? "").trim().length >= PROMPT_EXPLORER_MIN_CHARS) {
-      void handleIterate();
+      void handleImprove();
     }
   }, []);
   /* oxlint-enable react-hooks/exhaustive-deps */
@@ -168,8 +168,8 @@ function PromptExplorerBody({
     isStreamingSelected && !enricher.text
       ? "Thinking…"
       : versions.length === 1
-        ? "Write a rough idea for your prompt, then click Iterate to enrich it."
-        : "Edit this version, fill in any [blanks], then Iterate again or Send.";
+        ? "Write a rough idea for your prompt, then click Improve to expand it."
+        : "Edit this version, Improve again to expand it further, or Send.";
 
   return (
     <div className="flex-1 min-h-0 flex flex-col">
@@ -252,12 +252,12 @@ function PromptExplorerBody({
       <div className="border-t border-border px-5 py-3 flex items-center justify-between gap-3 shrink-0">
         <div className="text-xs text-muted-foreground min-w-0 truncate">
           {isStreaming
-            ? "Enriching your prompt…"
+            ? "Improving your prompt…"
             : trimmedLen < PROMPT_EXPLORER_MIN_CHARS
-              ? `Write at least ${PROMPT_EXPLORER_MIN_CHARS} characters, then Iterate.`
+              ? `Write at least ${PROMPT_EXPLORER_MIN_CHARS} characters, then Improve.`
               : versions.length === 1
-                ? "Click Iterate to generate an improved version."
-                : "Edit, Iterate again, or Send when you're happy."}
+                ? "Click Improve to expand it into a complete prompt."
+                : "Edit, Improve again, or Send when you're happy."}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <Button type="button" variant="ghost" onClick={handleClose}>
@@ -265,15 +265,15 @@ function PromptExplorerBody({
           </Button>
           <Button
             type="button"
-            onClick={handleIterate}
-            disabled={!canIterate}
-            title="Generate an improved version from the current text (Enter)"
+            onClick={handleImprove}
+            disabled={!canImprove}
+            title="Improve and expand this prompt (Enter)"
           >
             <RefreshCw01
               size={16}
               className={cn(isStreaming && "animate-spin")}
             />
-            Iterate
+            Improve
           </Button>
           <Button
             type="button"

--- a/apps/mesh/src/web/hooks/use-prompt-enricher.ts
+++ b/apps/mesh/src/web/hooks/use-prompt-enricher.ts
@@ -1,0 +1,170 @@
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useMutation } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+
+/** Minimum draft length before the Iterate action is enabled. */
+export const PROMPT_EXPLORER_MIN_CHARS = 10;
+
+type Frame =
+  | { type: "reasoning"; text: string }
+  | { type: "text"; text: string }
+  | { type: "error"; message: string }
+  | { type: "finish" };
+
+/** Parse an SSE byte stream into our `{type,...}` JSON frames. */
+async function* readSseFrames(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<Frame> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let idx: number;
+      while ((idx = buffer.indexOf("\n\n")) !== -1) {
+        const frame = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        const data = frame
+          .split("\n")
+          .filter((l) => l.startsWith("data:"))
+          .map((l) => l.slice(5).trim())
+          .join("\n");
+        if (!data) continue;
+        try {
+          yield JSON.parse(data) as Frame;
+        } catch {
+          // skip malformed frame
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export type PromptEnricherStatus = "idle" | "streaming" | "done" | "error";
+
+export interface PromptEnricher {
+  /** Stream an enriched version of `draft`; resolves with the final text. */
+  enrich: (draft: string) => Promise<{ text: string; reasoning: string }>;
+  /** Abort any in-flight stream and reset state. */
+  cancel: () => void;
+  status: PromptEnricherStatus;
+  /** Live streamed text (accumulates during a run). */
+  text: string;
+  /** Live streamed reasoning (accumulates during a run). */
+  reasoning: string;
+  error: string | null;
+}
+
+/**
+ * Imperative prompt enrichment. Unlike a query, nothing runs until the caller
+ * invokes `enrich()` (wired to the explicit Iterate button) — there is no
+ * debounce or auto-run. Live partials are exposed via `text` / `reasoning`;
+ * the promise resolves with the final text so the caller can commit it.
+ */
+export function usePromptEnricher(): PromptEnricher {
+  const { org } = useProjectContext();
+  const orgSlug = org.slug;
+  const abortRef = useRef<AbortController | null>(null);
+  const [live, setLive] = useState<{ text: string; reasoning: string }>({
+    text: "",
+    reasoning: "",
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (draft: string) => {
+      abortRef.current?.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setLive({ text: "", reasoning: "" });
+
+      let text = "";
+      let reasoning = "";
+      const resp = await fetch(
+        `/api/${encodeURIComponent(orgSlug)}/prompt-explorer/stream`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            accept: "text/event-stream",
+          },
+          credentials: "include",
+          body: JSON.stringify({ draft }),
+          signal: ac.signal,
+        },
+      );
+      if (!resp.ok || !resp.body) {
+        throw new Error(`Prompt enrichment failed (${resp.status})`);
+      }
+
+      // Idle-completion guard: the local dev tunnel sometimes delivers every
+      // token but withholds the trailing `finish` frame + connection close, so
+      // the loop below would otherwise hang forever ("Enriching…" with the full
+      // text already shown). Once tokens stop arriving for IDLE_MS, we stop and
+      // complete with what we have. Armed only after the first frame, so a slow
+      // time-to-first-token doesn't cut us off early.
+      const IDLE_MS = 2000;
+      let idleTimer: ReturnType<typeof setTimeout> | undefined;
+      let idleDone = false;
+      const armIdle = () => {
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => {
+          idleDone = true;
+          ac.abort();
+        }, IDLE_MS);
+      };
+
+      try {
+        for await (const frame of readSseFrames(resp.body)) {
+          if (ac.signal.aborted) break;
+          if (frame.type === "text") {
+            text += frame.text;
+            setLive({ text, reasoning });
+            armIdle();
+          } else if (frame.type === "reasoning") {
+            reasoning += frame.text;
+            setLive({ text, reasoning });
+            armIdle();
+          } else if (frame.type === "error") {
+            throw new Error(frame.message);
+          } else if (frame.type === "finish") {
+            break;
+          }
+        }
+      } catch (e) {
+        // Swallow aborts (idle-completion, user cancel, or a superseding run) —
+        // they're expected stops, not failures. Re-throw only genuine errors
+        // (e.g. an `error` frame or a mid-stream network drop).
+        const isAbort =
+          (e as { name?: string })?.name === "AbortError" || ac.signal.aborted;
+        if (!idleDone && !isAbort) throw e;
+      } finally {
+        if (idleTimer) clearTimeout(idleTimer);
+      }
+      return { text, reasoning };
+    },
+  });
+
+  return {
+    enrich: (draft: string) => mutation.mutateAsync(draft),
+    cancel: () => {
+      abortRef.current?.abort();
+      mutation.reset();
+      setLive({ text: "", reasoning: "" });
+    },
+    status: mutation.isPending
+      ? "streaming"
+      : mutation.isError
+        ? "error"
+        : mutation.isSuccess
+          ? "done"
+          : "idle",
+    text: live.text,
+    reasoning: live.reasoning,
+    error: mutation.error instanceof Error ? mutation.error.message : null,
+  };
+}

--- a/apps/mesh/src/web/hooks/use-prompt-enricher.ts
+++ b/apps/mesh/src/web/hooks/use-prompt-enricher.ts
@@ -1,8 +1,7 @@
 import { useProjectContext } from "@decocms/mesh-sdk";
-import { useMutation } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 
-/** Minimum draft length before the Iterate action is enabled. */
+/** Minimum draft length before the Improve action is enabled. */
 export const PROMPT_EXPLORER_MIN_CHARS = 10;
 
 type Frame =
@@ -61,29 +60,47 @@ export interface PromptEnricher {
 }
 
 /**
- * Imperative prompt enrichment. Unlike a query, nothing runs until the caller
- * invokes `enrich()` (wired to the explicit Iterate button) — there is no
- * debounce or auto-run. Live partials are exposed via `text` / `reasoning`;
- * the promise resolves with the final text so the caller can commit it.
+ * Imperative prompt enrichment. Nothing runs until the caller invokes
+ * `enrich()` (wired to the explicit Improve button) — there is no debounce or
+ * auto-run. Live partials are exposed via `text` / `reasoning`; the promise
+ * resolves with the final text so the caller can commit it.
+ *
+ * State is driven by plain `useState` (NOT react-query): the UI reads `status`
+ * every render, and a value read off a react-query mutation result goes stale
+ * under the React Compiler (the derived value gets memoized against the
+ * referentially-stable result object, so `isPending` never updates and the UI
+ * hangs on "streaming" forever even after the request completes). A `useState`
+ * the compiler can track avoids that entirely.
+ *
+ * The stream terminates on the server's `finish` frame or on connection close
+ * (`done`) — both reliable; no idle/timeout guard is needed.
  */
 export function usePromptEnricher(): PromptEnricher {
   const { org } = useProjectContext();
   const orgSlug = org.slug;
   const abortRef = useRef<AbortController | null>(null);
+  const [status, setStatus] = useState<PromptEnricherStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
   const [live, setLive] = useState<{ text: string; reasoning: string }>({
     text: "",
     reasoning: "",
   });
 
-  const mutation = useMutation({
-    mutationFn: async (draft: string) => {
-      abortRef.current?.abort();
-      const ac = new AbortController();
-      abortRef.current = ac;
-      setLive({ text: "", reasoning: "" });
+  const enrich = async (draft: string) => {
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+    // Only the most-recent run owns the shared status/live state; a superseded
+    // run must not stomp it when it later unwinds.
+    const isCurrent = () => abortRef.current === ac;
 
-      let text = "";
-      let reasoning = "";
+    setStatus("streaming");
+    setError(null);
+    setLive({ text: "", reasoning: "" });
+
+    let text = "";
+    let reasoning = "";
+    try {
       const resp = await fetch(
         `/api/${encodeURIComponent(orgSlug)}/prompt-explorer/stream`,
         {
@@ -101,70 +118,51 @@ export function usePromptEnricher(): PromptEnricher {
         throw new Error(`Prompt enrichment failed (${resp.status})`);
       }
 
-      // Idle-completion guard: the local dev tunnel sometimes delivers every
-      // token but withholds the trailing `finish` frame + connection close, so
-      // the loop below would otherwise hang forever ("Enriching…" with the full
-      // text already shown). Once tokens stop arriving for IDLE_MS, we stop and
-      // complete with what we have. Armed only after the first frame, so a slow
-      // time-to-first-token doesn't cut us off early.
-      const IDLE_MS = 2000;
-      let idleTimer: ReturnType<typeof setTimeout> | undefined;
-      let idleDone = false;
-      const armIdle = () => {
-        if (idleTimer) clearTimeout(idleTimer);
-        idleTimer = setTimeout(() => {
-          idleDone = true;
-          ac.abort();
-        }, IDLE_MS);
-      };
-
-      try {
-        for await (const frame of readSseFrames(resp.body)) {
-          if (ac.signal.aborted) break;
-          if (frame.type === "text") {
-            text += frame.text;
-            setLive({ text, reasoning });
-            armIdle();
-          } else if (frame.type === "reasoning") {
-            reasoning += frame.text;
-            setLive({ text, reasoning });
-            armIdle();
-          } else if (frame.type === "error") {
-            throw new Error(frame.message);
-          } else if (frame.type === "finish") {
-            break;
-          }
+      for await (const frame of readSseFrames(resp.body)) {
+        if (ac.signal.aborted) break;
+        if (frame.type === "text") {
+          text += frame.text;
+          if (isCurrent()) setLive({ text, reasoning });
+        } else if (frame.type === "reasoning") {
+          reasoning += frame.text;
+          if (isCurrent()) setLive({ text, reasoning });
+        } else if (frame.type === "error") {
+          throw new Error(frame.message);
+        } else if (frame.type === "finish") {
+          break;
         }
-      } catch (e) {
-        // Swallow aborts (idle-completion, user cancel, or a superseding run) —
-        // they're expected stops, not failures. Re-throw only genuine errors
-        // (e.g. an `error` frame or a mid-stream network drop).
-        const isAbort =
-          (e as { name?: string })?.name === "AbortError" || ac.signal.aborted;
-        if (!idleDone && !isAbort) throw e;
-      } finally {
-        if (idleTimer) clearTimeout(idleTimer);
       }
+      if (isCurrent()) setStatus("done");
       return { text, reasoning };
-    },
-  });
+    } catch (e) {
+      // An abort (user cancel or a superseding run) is an expected stop, not a
+      // failure — settle quietly with whatever streamed so far.
+      const isAbort =
+        (e as { name?: string })?.name === "AbortError" || ac.signal.aborted;
+      if (isAbort) {
+        if (isCurrent()) setStatus("idle");
+        return { text, reasoning };
+      }
+      if (isCurrent()) {
+        setStatus("error");
+        setError(e instanceof Error ? e.message : "Failed to enrich prompt");
+      }
+      throw e;
+    }
+  };
 
   return {
-    enrich: (draft: string) => mutation.mutateAsync(draft),
+    enrich,
     cancel: () => {
       abortRef.current?.abort();
-      mutation.reset();
+      abortRef.current = null;
+      setStatus("idle");
+      setError(null);
       setLive({ text: "", reasoning: "" });
     },
-    status: mutation.isPending
-      ? "streaming"
-      : mutation.isError
-        ? "error"
-        : mutation.isSuccess
-          ? "done"
-          : "idle",
+    status,
     text: live.text,
     reasoning: live.reasoning,
-    error: mutation.error instanceof Error ? mutation.error.message : null,
+    error,
   };
 }


### PR DESCRIPTION
## Summary

Adds an **Explore** button to the chat composer that opens a modal for turning a rough idea into a richer, more complete prompt. A *fast*-tier model rewrites the draft **in the user's own voice and language**, inserts `[bracketed]` fill-in placeholders for missing details, and **grows the prompt gradually (~2-3×/iteration)** rather than ballooning it.

- **Backend:** new lightweight SSE route `POST /api/:org/prompt-explorer/stream` (`apps/mesh/src/api/routes/prompt-explorer.ts`) — calls the `ai` SDK `streamText` against the org's `fast` tier (mirrors `suggest-commit-message.ts`); no thread/NATS machinery. Registered in `org-scoped.ts`.
- **System prompt:** pure, unit-tested builder (`apps/mesh/src/lib/prompt-explorer-system.ts`) that preserves voice/grammatical-person/language and enforces a length budget.
- **Frontend:** `usePromptEnricher` hook (`use-prompt-enricher.ts`) + `PromptExplorerDialog` (`prompt-explorer-dialog.tsx`); versions sidebar with Iterate + rollback; **Enter → Iterate**, **Cmd/Ctrl+Enter → Send**, Shift+Enter → newline. Wired into `chat/input.tsx`.

## How to test

1. Open a chat in an org that has an AI provider configured.
2. Click the ✨ **Explore** button in the composer (right side, near the model/send buttons). If the composer already has text, it auto-runs the first enrichment.
3. Type a rough idea (≥10 chars) → the right panel streams an enriched, first-person, same-language version with `[blanks]`.
4. **Iterate** snapshots the current version into the sidebar and refines from it; click a previous version to roll back.
5. Fill in blanks, then **Send** (or Cmd/Ctrl+Enter) — the optimized prompt is injected into the composer and sent.

## Notes / context for reviewers

- This PR is partly to get a **clean-environment test**: locally, the streamed `finish` frame + connection-close were intermittently withheld by the dev tunnel (`*.localhost`), which made the spinner appear to hang forever even though the server completes in ~1.4–2.7s. Verified server-side (direct + Vite + `:80`) that the stream delivers `finish` and closes cleanly, and that output is first-person + capped. The **idle-completion guard** in `usePromptEnricher` (resolve after ~2s of token silence) makes the UI robust to that regardless of transport. Curious whether others see the spinner resolve cleanly without the tunnel quirk.
- `bun run fmt`, `bun run lint` (no new warnings), `bun run check`, and the `prompt-explorer-system` unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Improve prompt modal in chat that turns rough ideas into a concrete, ready-to-use prompt in the user’s own voice and language, expanding gradually each iteration. Results stream from the org’s fast tier and can be improved again or sent to the composer.

- **New Features**
  - "Improve" button in the composer opens a modal with versions, Improve, and rollback; Enter → Improve, Cmd/Ctrl+Enter → Send.
  - Lightweight SSE route `POST /api/:org/prompt-explorer/stream` streams enriched text and reasoning from the org’s `fast` tier.
  - Pure system‑prompt builder that preserves voice/person/language, avoids placeholders, and enforces a gradual length budget; unit tests included.
  - `usePromptEnricher` hook streams text/reasoning with cancel support; status is driven by `useState` for reliable completion on `finish` or connection close.

<sup>Written for commit 8d4ab28a51263c32ed758a9898ae9356a85f81f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

