### PR TITLE
fix(cms-sections): allow drilling into array items inside variant rule

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -4,6 +4,7 @@ import { KEYS } from "@/web/lib/query-keys";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
 import {
   ChevronDown,
+  ChevronLeft,
   ChevronRight,
   ChevronUp,
   Code01,
@@ -106,6 +107,95 @@ import {
 import { PageJsonDialog } from "./page-json-dialog";
 import { createReferencedBlockSaver } from "./save-referenced-block";
 import { formatMatcher } from "./format-matcher";
+
+/**
+ * Editor for a variant's matcher rule (e.g. Include/Exclude Locations).
+ * Owns its own breadcrumb state so users can drill into array items inside
+ * the rule without affecting the section editor's breadcrumb. Caller is
+ * expected to remount via `key` when the variant or rule resolveType changes.
+ */
+function VariantRuleForm({
+  schema,
+  value,
+  onChange,
+  meta,
+  decofile,
+  onSaveReferencedBlock,
+  sandbox,
+}: {
+  schema: SchemaProperty;
+  value: Record<string, unknown>;
+  onChange: (v: unknown) => void;
+  meta?: LiveMeta;
+  decofile?: Record<string, unknown>;
+  onSaveReferencedBlock?: (
+    blockKey: string,
+    data: Record<string, unknown>,
+  ) => void;
+  sandbox?: SandboxConfig | null;
+}) {
+  const [breadcrumbPath, setBreadcrumbPath] = useState<string[]>([]);
+
+  return (
+    <div className="space-y-2">
+      {breadcrumbPath.length > 0 && (
+        <nav
+          aria-label="Variant rule breadcrumb"
+          className="flex min-w-0 items-center gap-1 overflow-hidden text-xs"
+        >
+          <button
+            type="button"
+            onClick={() => setBreadcrumbPath([])}
+            className="flex shrink-0 items-center gap-0.5 rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            title="Back to rule"
+          >
+            <ChevronLeft className="size-3.5" />
+          </button>
+          {breadcrumbPath.map((crumb, index) => {
+            const isLast = index === breadcrumbPath.length - 1;
+            return (
+              <span
+                key={`${crumb}-${index}`}
+                className="flex min-w-0 items-center gap-1 overflow-hidden"
+              >
+                {index > 0 && (
+                  <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" />
+                )}
+                <button
+                  type="button"
+                  onClick={() =>
+                    setBreadcrumbPath(breadcrumbPath.slice(0, index + 1))
+                  }
+                  title={crumb}
+                  className={cn(
+                    "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+                    isLast
+                      ? "font-medium text-foreground"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {crumb}
+                </button>
+              </span>
+            );
+          })}
+        </nav>
+      )}
+      <SchemaForm
+        schema={schema}
+        value={value}
+        onChange={onChange}
+        basePath=""
+        breadcrumbPath={breadcrumbPath}
+        onBreadcrumbChange={setBreadcrumbPath}
+        meta={meta}
+        decofile={decofile}
+        onSaveReferencedBlock={onSaveReferencedBlock}
+        sandbox={sandbox}
+      />
+    </div>
+  );
+}
 
 function SchemaFormPanel({
   activeSchema,
@@ -2319,11 +2409,15 @@ export function SectionsEditor({
                   />
                   {sectionRuleSchema && sectionRuleFormValue && (
                     <div className="pt-1">
-                      <SchemaForm
+                      <VariantRuleForm
+                        key={`${selectedSectionIndex ?? "none"}:${safeSectionVariantIndex}:${sectionRuleResolveType ?? ""}`}
                         schema={sectionRuleSchema}
                         value={sectionRuleFormValue}
                         onChange={handleSectionRuleFormChange}
-                        basePath=""
+                        meta={meta ?? undefined}
+                        decofile={decofile}
+                        onSaveReferencedBlock={saveReferencedBlock}
+                        sandbox={sandbox}
                       />
                     </div>
                   )}
@@ -2406,11 +2500,15 @@ export function SectionsEditor({
                   />
                   {ruleSchema && ruleFormValue && (
                     <div className="space-y-3">
-                      <SchemaForm
+                      <VariantRuleForm
+                        key={`${safeVariantIndex}:${ruleResolveType ?? ""}`}
                         schema={ruleSchema}
                         value={ruleFormValue}
                         onChange={handleRuleFormChange}
-                        basePath=""
+                        meta={meta ?? undefined}
+                        decofile={decofile}
+                        onSaveReferencedBlock={saveReferencedBlock}
+                        sandbox={sandbox}
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- The variant rule editor in `sections-editor.tsx` mounted `SchemaForm` without wiring `breadcrumbPath` / `onBreadcrumbChange`, so clicking an item inside an array field nested in the rule (e.g. *Include Locations* under the Location matcher) was a silent no-op — `ArrayField.openItem` calls `onBreadcrumbChange?.(...)` which short-circuited on undefined.
- Introduces `VariantRuleForm`, a small wrapper that owns its own breadcrumb state and renders a back-nav header (chevron + clickable trail) when the user drills in, so the section editor's breadcrumb stays scoped to the section while rule sub-navigation is independent.
- Replaces both bare `SchemaForm` usages in the variant rule panels (page-level and section-level). `key` prop ties breadcrumb state to the active variant + matcher resolveType, so it resets cleanly on switch.

## Test plan
- [ ] Open a page with multiple variants → pick a non-default variant.
- [ ] Set the variant rule to the **Location** matcher.
- [ ] **+ Add item** under *Include Locations*, then click the new row — should drill into the item editor with `← Include Locations > Item 1` crumbs above the form.
- [ ] Click the back-arrow / `Include Locations` crumb → returns to the array view.
- [ ] Same flow under *Exclude Locations*.
- [ ] Same flow inside a section-level variant rule.
- [ ] Switch variants → breadcrumb resets cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the variant rule editor so clicking items in array fields (e.g., Include/Exclude Locations in the Location matcher) opens the item editor. Adds local breadcrumb/back navigation scoped to the rule and resets cleanly when switching variants or matchers.

- **Bug Fixes**
  - Introduced VariantRuleForm that owns breadcrumb state and shows a back nav when drilling into items.
  - Replaced bare SchemaForm in page-level and section-level variant rule panels; wired breadcrumbPath/onBreadcrumbChange.
  - Reset rule navigation state with a key tied to the active variant and matcher resolveType.

<sup>Written for commit d5e80e978293d076928e596067f4c27d0dca3328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

