### PR TITLE
feat(cms-sections): add Google Maps area selector for `format: map`

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -140,6 +140,7 @@
     "@tiptap/starter-kit": "3.20.2",
     "@tiptap/suggestion": "3.20.2",
     "@types/bun": "^1.3.1",
+    "@types/google.maps": "^3.65.2",
     "@types/pg": "^8.15.6",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@untitledui/icons": "^0.0.19",

--- a/apps/mesh/src/api/routes/public-config.test.ts
+++ b/apps/mesh/src/api/routes/public-config.test.ts
@@ -11,11 +11,13 @@ import publicConfigRoutes from "./public-config";
 describe("GET /api/config", () => {
   let originalKey: string | undefined;
   let originalHost: string | undefined;
+  let originalMapsKey: string | undefined;
   const originalSettings = getSettings();
 
   beforeEach(() => {
     originalKey = process.env.POSTHOG_KEY;
     originalHost = process.env.POSTHOG_HOST;
+    originalMapsKey = process.env.GOOGLE_MAPS_API_KEY;
     setGlobalSettings(originalSettings);
   });
 
@@ -24,6 +26,8 @@ describe("GET /api/config", () => {
     else process.env.POSTHOG_KEY = originalKey;
     if (originalHost === undefined) delete process.env.POSTHOG_HOST;
     else process.env.POSTHOG_HOST = originalHost;
+    if (originalMapsKey === undefined) delete process.env.GOOGLE_MAPS_API_KEY;
+    else process.env.GOOGLE_MAPS_API_KEY = originalMapsKey;
     setGlobalSettings(originalSettings);
   });
 
@@ -61,6 +65,25 @@ describe("GET /api/config", () => {
       key: "phc_test_key",
       host: "https://eu.i.posthog.com",
     });
+  });
+
+  it("returns googleMapsApiKey when GOOGLE_MAPS_API_KEY is set", async () => {
+    process.env.GOOGLE_MAPS_API_KEY = "  maps_test_key  ";
+
+    const res = await publicConfigRoutes.request("/");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Trimmed before exposing.
+    expect(body.config.googleMapsApiKey).toBe("maps_test_key");
+  });
+
+  it("returns googleMapsApiKey: null when GOOGLE_MAPS_API_KEY is unset", async () => {
+    delete process.env.GOOGLE_MAPS_API_KEY;
+
+    const res = await publicConfigRoutes.request("/");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.config.googleMapsApiKey).toBeNull();
   });
 
   it("reports agent-sandbox runtime availability when agent-sandbox provider is configured", async () => {

--- a/apps/mesh/src/api/routes/public-config.ts
+++ b/apps/mesh/src/api/routes/public-config.ts
@@ -55,6 +55,14 @@ export type PublicConfig = {
    */
   posthog: { key: string; host: string } | null;
   /**
+   * Google Maps JS API key for the `format: map` widget (area selector).
+   * `null` when GOOGLE_MAPS_API_KEY is unset. It's a client-side token by
+   * design (the Maps JS API ships it to the browser); security relies on the
+   * key's HTTP-referrer + API restrictions in Google Cloud, not on secrecy.
+   * Read at runtime so it can be configured per environment (like posthog).
+   */
+  googleMapsApiKey: string | null;
+  /**
    * Server runtime capabilities that affect client-side affordances.
    */
   runtime: {
@@ -91,6 +99,7 @@ app.get("/", (c) => {
     brandExtractEnabled: !!getSettings().firecrawlApiKey,
     auth: buildAuthConfig(),
     posthog: buildPosthogConfig(),
+    googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY?.trim() || null,
     runtime: {
       // Local/dev mode has no cloud agent-sandbox cluster, so cloud Decopilot
       // can't run there — report it unavailable to drop it from the picker.

--- a/apps/mesh/src/web/components/sections-editor/fields/map-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/map-field.tsx
@@ -1,0 +1,208 @@
+/// <reference types="google.maps" />
+import { useRef, useState } from "react";
+import { Label } from "@deco/ui/components/label.tsx";
+import { usePublicConfig } from "@/web/hooks/use-public-config";
+import type { FieldProps } from "./field-props";
+
+const DEFAULT_CENTER = { lat: -21.9, lng: -41.42 };
+const DEFAULT_RADIUS = 100000;
+
+type MapsNs = typeof google.maps;
+
+let mapsLoadPromise: Promise<MapsNs> | null = null;
+
+// The Maps JS API key comes from the server's runtime config (/api/config,
+// sourced from the GOOGLE_MAPS_API_KEY env var) — read at request time so it's
+// configurable per environment. It's a client-side token by design: the Maps
+// JS API loads in the browser and always ships its key in the request URL, so
+// it can't be hidden and is NOT a secret. Security relies on the key's
+// HTTP-referrer + API restrictions in Google Cloud, not on secrecy.
+function loadGoogleMaps(apiKey: string): Promise<MapsNs> {
+  if (mapsLoadPromise) return mapsLoadPromise;
+  mapsLoadPromise = new Promise((resolve, reject) => {
+    if (typeof window === "undefined") {
+      reject(new Error("Google Maps requires a browser environment"));
+      return;
+    }
+    const w = window as unknown as { google?: { maps?: MapsNs } };
+    if (w.google?.maps) {
+      resolve(w.google.maps);
+      return;
+    }
+    const onReady = () => {
+      const ns = (window as unknown as { google?: { maps?: MapsNs } }).google
+        ?.maps;
+      if (ns) resolve(ns);
+      else reject(new Error("Google Maps script loaded without google.maps"));
+    };
+    const existing = document.querySelector<HTMLScriptElement>(
+      "script[data-google-maps-loader]",
+    );
+    if (existing) {
+      existing.addEventListener("load", onReady);
+      existing.addEventListener("error", () =>
+        reject(new Error("Failed to load Google Maps")),
+      );
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&v=weekly&libraries=maps`;
+    script.async = true;
+    script.defer = true;
+    script.dataset.googleMapsLoader = "true";
+    script.addEventListener("load", onReady);
+    script.addEventListener("error", () =>
+      reject(new Error("Failed to load Google Maps")),
+    );
+    document.head.appendChild(script);
+  });
+  return mapsLoadPromise;
+}
+
+function parseValue(
+  v: unknown,
+): { lat: number; lng: number; radius: number } | null {
+  if (typeof v !== "string" || !v) return null;
+  const parts = v.split(",").map(Number);
+  const [lat, lng, radius] = parts;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  return {
+    lat: lat as number,
+    lng: lng as number,
+    radius: Number.isFinite(radius) ? (radius as number) : DEFAULT_RADIUS,
+  };
+}
+
+export function MapField({ schema, value, onChange, path, label }: FieldProps) {
+  const apiKey = usePublicConfig().googleMapsApiKey;
+
+  const onChangeRef = useRef(onChange);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read only inside async map callbacks, never during render
+  onChangeRef.current = onChange;
+
+  // Pin the value at mount so live re-renders triggered by our own onChange
+  // don't tear down and recreate the map (which would defocus the user's
+  // in-progress drag).
+  const initialRef = useRef(parseValue(value));
+  const [error, setError] = useState<string | null>(null);
+
+  const setNode = (node: HTMLDivElement | null) => {
+    if (!node || !apiKey) return;
+    const state: {
+      disposed: boolean;
+      circle: google.maps.Circle | null;
+      listeners: google.maps.MapsEventListener[];
+    } = { disposed: false, circle: null, listeners: [] };
+
+    loadGoogleMaps(apiKey).then(
+      (maps) => {
+        if (state.disposed) return;
+        const init = initialRef.current;
+        const center = init ? { lat: init.lat, lng: init.lng } : DEFAULT_CENTER;
+        const radius = init?.radius ?? DEFAULT_RADIUS;
+
+        const map = new maps.Map(node, {
+          center,
+          zoom: radius ? Math.round(Math.log2(7680000 / radius)) + 1 : 4,
+          draggable: true,
+          streetViewControl: false,
+          mapTypeControl: false,
+        });
+
+        const circle = new maps.Circle({
+          strokeColor: "#2E6ED9",
+          strokeOpacity: 0.8,
+          strokeWeight: 2,
+          fillColor: "#2E6ED9",
+          fillOpacity: 0.35,
+          editable: true,
+          draggable: true,
+          map,
+          center,
+          radius,
+        });
+        state.circle = circle;
+
+        const emit = () => {
+          const c = circle.getCenter();
+          const r = circle.getRadius();
+          if (!c) return;
+          onChangeRef.current(`${c.lat()},${c.lng()},${r}`);
+        };
+
+        const pushListener = (l: google.maps.MapsEventListener | undefined) => {
+          if (l) state.listeners.push(l);
+        };
+
+        pushListener(
+          map.addListener("click", (event: google.maps.MapMouseEvent) => {
+            if (!event.latLng) return;
+            circle.setCenter({
+              lat: event.latLng.lat(),
+              lng: event.latLng.lng(),
+            });
+            if (!circle.getRadius()) circle.setRadius(DEFAULT_RADIUS);
+            emit();
+          }),
+        );
+        pushListener(circle.addListener("radius_changed", emit));
+        pushListener(circle.addListener("dragend", emit));
+      },
+      (err: unknown) => {
+        if (state.disposed) return;
+        setError(err instanceof Error ? err.message : "Failed to load map");
+      },
+    );
+
+    return () => {
+      state.disposed = true;
+      for (const l of state.listeners) {
+        try {
+          l?.remove();
+        } catch {
+          // Ignore — listener may already be detached if the maps script
+          // tore down its internal registry first.
+        }
+      }
+      state.listeners = [];
+      if (state.circle) {
+        try {
+          state.circle.setMap(null);
+        } catch {
+          // Ignore — circle's map may already be gone.
+        }
+        state.circle = null;
+      }
+    };
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="space-y-0.5">
+        <Label htmlFor={path}>{label}</Label>
+        {schema.description && (
+          <p className="text-xs leading-normal text-muted-foreground">
+            {schema.description}
+          </p>
+        )}
+      </div>
+      {!apiKey ? (
+        <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          The map picker is unavailable — set{" "}
+          <code className="font-mono">GOOGLE_MAPS_API_KEY</code> on the server
+          to enable it.
+        </div>
+      ) : error ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      ) : (
+        <div
+          ref={setNode}
+          id={path}
+          className="h-72 w-full rounded-md border border-border/60"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -12,6 +12,7 @@ import { FileField } from "./fields/file-field";
 import { ImageField } from "./fields/image-field";
 import { InlineUnionField } from "./fields/inline-union-field";
 import { LocationField } from "./fields/location-field";
+import { MapField } from "./fields/map-field";
 import { MultivariateFieldWrapper } from "./fields/multivariate-field-wrapper";
 import { isSecretBlock, SecretField } from "./fields/secret-field";
 import {
@@ -224,6 +225,11 @@ export function renderField(props: FieldProps) {
   // file-uri / video-uri → FileField (filename chip + picker, video preview)
   if (schema.format === "file-uri" || schema.format === "video-uri") {
     return <FileField key={props.path} {...props} />;
+  }
+
+  // map → MapField (Google Maps area selector encoded as "lat,lng,radius")
+  if (schema.format === "map") {
+    return <MapField key={props.path} {...props} />;
   }
 
   // dynamic-options → DynamicOptionsField (select with options from a loader)

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "3.89.3",
+      "version": "3.90.1",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -135,6 +135,7 @@
         "@tiptap/starter-kit": "3.20.2",
         "@tiptap/suggestion": "3.20.2",
         "@types/bun": "^1.3.1",
+        "@types/google.maps": "^3.65.2",
         "@types/pg": "^8.15.6",
         "@types/react-syntax-highlighter": "^15.5.13",
         "@untitledui/icons": "^0.0.19",
@@ -305,7 +306,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/std": "workspace:*",
@@ -1687,6 +1688,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/google.maps": ["@types/google.maps@3.65.2", "", {}, "sha512-e52bmOhGCQSNabFpL48iQlwJybq6rfns8NUVJ20MR7CdPlHQ2RmSCnPbJfrUYJfogrE4OiHQTZ4LXpop+eer1w=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -3130,7 +3133,7 @@
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
-    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
@@ -3653,8 +3656,6 @@
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@rjsf/shadcn/lucide-react": ["lucide-react@1.23.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw=="],
-
-    "@rjsf/shadcn/tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "@rjsf/utils/fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 


### PR DESCRIPTION
## Summary
- Adds a `MapField` widget that renders an interactive Google Map with a draggable/resizable circle for area selection, mirroring `admin/components/ui/Map.tsx`. Schema string fields tagged with `format: "map"` (the convention emitted by `MapWidget` in [deco-apps/admin/widgets.ts](https://github.com/deco-cx/apps/blob/main/admin/widgets.ts)) now render the map instead of a plain text input.
- Used by the Location matcher's `coordinates` field (`includeLocations` / `excludeLocations`) so users can pick a center + radius on the map instead of typing `"lat,lng,radius"` by hand.

## Implementation notes
- New `apps/mesh/src/web/components/sections-editor/fields/map-field.tsx`. React-19-safe (no `useEffect`): uses a ref-callback with a cleanup return and pins the initial value in a `ref` so `onChange`-driven re-renders don't tear down the map mid-drag.
- Routes `format === "map"` to `MapField` in `schema-form.tsx`, alongside the existing `image-uri` / `file-uri` / `location` handlers.
- **The Maps JS API key is a runtime server env var** (`GOOGLE_MAPS_API_KEY`), exposed to the client through `/api/config` — the exact same pattern as `POSTHOG_KEY`. Read at request time, so it's configurable per environment (dev / staging / prod) **without rebuilding the bundle**, and belongs in the runtime k8s config (deco-apps-cd), not the build. It's a client-side token *by design* — the Maps JS API loads in the browser and always ships its key in the request URL, so it can't be hidden and is **not a secret**; security relies on Google Cloud restrictions (HTTP-referrer allowlist + API restriction to "Maps JavaScript API"). When unset, the field renders an inline "unavailable" note instead of crashing.
- Adds `@types/google.maps` devDependency; the field file uses a triple-slash reference instead of widening `tsconfig.json`'s `types` array.

## Setup
- **Dev:** set `GOOGLE_MAPS_API_KEY` in `apps/mesh/.env` (read at server runtime).
- **Staging / prod:** set `GOOGLE_MAPS_API_KEY` in the runtime env (deco-apps-cd), per environment — same mechanism as `DBOS_CONDUCTOR_KEY` / `POSTHOG_KEY`. No CI/build change needed.
- Confirm the key's referrer allowlist in Google Cloud includes the target domains before enabling — without that the map fails to load.

## Test plan
- [ ] `GOOGLE_MAPS_API_KEY` set in `apps/mesh/.env`, then `bun run dev`.
- [ ] Open a variant whose rule is the Location matcher → **+ Add item** under *Include Locations* → drill in.
- [ ] *Area selection* field renders a Google Map with a blue circle.
- [ ] Drag the circle, resize via handles, click elsewhere on the map → the value updates as `lat,lng,radius`.
- [ ] Switching variants / closing & reopening the item restores the map at the saved circle.
- [ ] Unset the env var → the field shows the "unavailable" note instead of crashing.
- [ ] `GET /api/config` returns `googleMapsApiKey` (unit tests cover set/unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)