### PR TITLE
feat(sandbox): restore preview-fetch proxy for /.decofile

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -708,6 +708,53 @@ export const createSandboxRoutes = () => {
     },
   );
 
+  // -- Preview fetch (CORS proxy for /.decofile) ----------------------------
+  // /live/_meta is fetched directly from the preview URL by the client
+  // (the deco dev server allows CORS `*` for it). /.decofile must go through
+  // this proxy because cloud previews don't expose it cross-origin.
+  app.get("/:virtualMcpId/:branch/preview-fetch", async (c) => {
+    const runner = requireRunner(c);
+    if (runner instanceof Response) return runner;
+
+    const { claimName } = c.get("vmClaim");
+    const path = c.req.query("path");
+    if (path !== "/.decofile") {
+      return c.json({ error: "Path not allowed" }, 403);
+    }
+
+    let previewUrl: string | null;
+    try {
+      previewUrl = await runner.getPreviewUrl(claimName);
+    } catch {
+      return c.json({ error: "Preview not available" }, 502);
+    }
+    if (!previewUrl) {
+      return c.json({ error: "Preview not available" }, 502);
+    }
+
+    const base = previewUrl.replace(/\/+$/, "");
+    let upstream: Response;
+    try {
+      upstream = await fetch(`${base}${path}`);
+    } catch {
+      return c.json({ error: "Preview unreachable" }, 502);
+    }
+
+    let text: string;
+    try {
+      text = await upstream.text();
+    } catch {
+      return c.json({ error: "Preview unreachable" }, 502);
+    }
+    return new Response(text, {
+      status: upstream.status,
+      headers: {
+        "content-type":
+          upstream.headers.get("content-type") ?? "application/json",
+      },
+    });
+  });
+
   // -- Preview invoke (loader/action resolution) ------------------------------
   app.post(
     "/:virtualMcpId/:branch/preview-invoke",

--- a/apps/mesh/src/web/components/sections-editor/preview-fetch-url.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/preview-fetch-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { buildDecofileFetchUrl } from "./preview-fetch-url";
+
+const sandbox = {
+  orgSlug: "acme",
+  virtualMcpId: "vm/one",
+  branch: "feature/local-preview",
+};
+
+describe("buildDecofileFetchUrl", () => {
+  test("uses the browser-reachable preview URL for localhost desktop previews", () => {
+    expect(
+      buildDecofileFetchUrl({
+        ...sandbox,
+        previewUrl: "http://abc.localhost:7070/some-page",
+      }),
+    ).toBe("http://abc.localhost:7070/.decofile");
+  });
+
+  test("uses a browser fallback preview URL when params do not include one", () => {
+    expect(
+      buildDecofileFetchUrl({
+        ...sandbox,
+        getFallbackPreviewUrl: () => "http://abc.localhost:7070/page",
+      }),
+    ).toBe("http://abc.localhost:7070/.decofile");
+  });
+
+  test("keeps using the API proxy for non-local preview URLs", () => {
+    expect(
+      buildDecofileFetchUrl({
+        ...sandbox,
+        previewUrl: "https://abc.preview.example.com/",
+      }),
+    ).toBe(
+      "/api/acme/sandbox/vm%2Fone/feature%2Flocal-preview/preview-fetch?path=%2F.decofile",
+    );
+  });
+
+  test("falls back to the API proxy when no preview URL is available", () => {
+    expect(
+      buildDecofileFetchUrl({
+        ...sandbox,
+        previewUrl: undefined,
+      }),
+    ).toBe(
+      "/api/acme/sandbox/vm%2Fone/feature%2Flocal-preview/preview-fetch?path=%2F.decofile",
+    );
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/preview-fetch-url.ts
+++ b/apps/mesh/src/web/components/sections-editor/preview-fetch-url.ts
@@ -1,0 +1,44 @@
+interface DecofileFetchInput {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  previewUrl?: string | null;
+  getFallbackPreviewUrl?: () => string | null;
+}
+
+function isBrowserReachableLocalPreview(previewUrl: string): boolean {
+  try {
+    const { hostname } = new URL(previewUrl);
+    return (
+      hostname === "localhost" ||
+      hostname.endsWith(".localhost") ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readPreviewUrlFromDocument(): string | null {
+  if (typeof document === "undefined") return null;
+  const iframes = Array.from(document.querySelectorAll("iframe"));
+  for (const iframe of iframes) {
+    const src = iframe.getAttribute("src");
+    if (src && isBrowserReachableLocalPreview(src)) return src;
+  }
+  return null;
+}
+
+export function buildDecofileFetchUrl(input: DecofileFetchInput): string {
+  const browserPreviewUrl =
+    input.previewUrl ??
+    input.getFallbackPreviewUrl?.() ??
+    readPreviewUrlFromDocument();
+  if (browserPreviewUrl && isBrowserReachableLocalPreview(browserPreviewUrl)) {
+    return new URL("/.decofile", browserPreviewUrl).toString();
+  }
+
+  const search = new URLSearchParams({ path: "/.decofile" });
+  return `/api/${input.orgSlug}/sandbox/${encodeURIComponent(input.virtualMcpId)}/${encodeURIComponent(input.branch)}/preview-fetch?${search.toString()}`;
+}

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
+import { buildDecofileFetchUrl } from "./preview-fetch-url";
 
 interface UseDecofileParams {
   orgSlug: string;
@@ -16,12 +17,12 @@ export function useDecofile(
     ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}`
     : "";
   const fetchEnabled = options?.fetchEnabled ?? true;
-  const previewUrl = params?.previewUrl;
   return useQuery({
     queryKey: KEYS.decofile(key),
     queryFn: async () => {
-      const url = new URL("/.decofile", previewUrl!).href;
-      const res = await fetch(url, { cache: "no-store" });
+      const res = await fetch(buildDecofileFetchUrl(params!), {
+        cache: "no-store",
+      });
       if (!res.ok) {
         const err = new Error(`Failed to fetch decofile: ${res.status}`);
         (err as { status?: number }).status = res.status;
@@ -29,7 +30,7 @@ export function useDecofile(
       }
       return (await res.json()) as Record<string, unknown>;
     },
-    enabled: !!params && !!previewUrl && fetchEnabled,
+    enabled: !!params && fetchEnabled,
     staleTime: 30_000,
     // 502 = preview unreachable (sandbox starting or down). The SSE lifecycle
     // re-enables this query when the preview is back, so retrying just hammers


### PR DESCRIPTION
## Summary

- Partial revert of #4171: restore the `preview-fetch` CORS proxy route, but allow only `/.decofile`.
- `/.decofile` is not reachable cross-origin from cloud previews, so the direct fetch introduced in #4171 fails outside localhost.
- `/live/_meta` keeps fetching directly (deco dev server allows CORS `*` for it).
- New `buildDecofileFetchUrl` helper picks direct browser fetch for localhost previews and the proxy for everything else (cloud / unknown preview state).

## Test plan

- [x] `bun test apps/mesh/src/web/components/sections-editor/preview-fetch-url.test.ts` — 4/4 pass
- [x] `bun run --cwd=apps/mesh check` — clean
- [x] `bun run fmt` / `bun run lint` — clean
- [ ] Manually verify `.decofile` loads in sections editor against a cloud preview
- [ ] Manually verify `.decofile` loads in sections editor against a localhost preview (direct fetch path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the preview-fetch proxy for `/.decofile` to fix cross-origin failures in cloud previews, while keeping `/live/_meta` as a direct fetch. Ensures the sections editor loads the decofile reliably across localhost and cloud.

- **Bug Fixes**
  - Restored `/:virtualMcpId/:branch/preview-fetch` proxy, restricted to `/.decofile`.
  - Added `buildDecofileFetchUrl` to use direct fetch on localhost and the proxy elsewhere.
  - Updated sections editor hook to use the helper and not require `previewUrl` to enable fetching.
  - Added unit tests for URL selection logic.

<sup>Written for commit a86271652464a8e0431ed5c6bd215dd07294c99f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

