### PR TITLE
fix(commerce-onboarding): scroll org list when overflowing

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -210,11 +210,13 @@ function CommerceOnboardingContent({
             title="Choose an organization"
             description="Select where commerce diagnostics should continue."
           />
-          <OrganizationChoice
-            organizations={activeOrganizations}
-            selectLabel="Continue"
-            onSelected={(organization) => setSelectedOrg(organization)}
-          />
+          <div className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
+            <OrganizationChoice
+              organizations={activeOrganizations}
+              selectLabel="Continue"
+              onSelected={(organization) => setSelectedOrg(organization)}
+            />
+          </div>
         </div>
       </AuthSplitLayout>
     );
@@ -258,18 +260,20 @@ function CommerceOnboardingContent({
             title="Choose an organization"
             description="Your email can access more than one organization. Choose where commerce setup should continue."
           />
-          <OrganizationChoice
-            organizations={ensureResult.organizations}
-            domain={ensureResult.domain ?? undefined}
-            onJoined={(organization, slug) => {
-              invalidateOrganizationListCache();
-              setSelectedOrg({ ...organization, slug });
-              navigate({
-                to: "/commerce-onboarding",
-                search: { org: slug, siteUrl },
-              });
-            }}
-          />
+          <div className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
+            <OrganizationChoice
+              organizations={ensureResult.organizations}
+              domain={ensureResult.domain ?? undefined}
+              onJoined={(organization, slug) => {
+                invalidateOrganizationListCache();
+                setSelectedOrg({ ...organization, slug });
+                navigate({
+                  to: "/commerce-onboarding",
+                  search: { org: slug, siteUrl },
+                });
+              }}
+            />
+          </div>
         </div>
       </AuthSplitLayout>
     );


### PR DESCRIPTION
## Summary
On `/commerce-onboarding`, when a user has many organizations the org list grew past the centered `min-h-screen` layout and overflowed off-screen.

Wraps both `OrganizationChoice` render sites (the multi-org selection case and the ambiguous-email case) in a `max-h-[60vh] overflow-y-auto` scroll container. `-mx-1 px-1` keeps the cards' `card-shadow` from being clipped by the scroll edge.

## Testing
- `bun run fmt` ✓
- Manual: verify the list scrolls within the panel when many orgs are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflowing organization lists on `/commerce-onboarding` by making the list scroll within the panel. Long lists stay in view, and card shadows are preserved.

- **Bug Fixes**
  - Wrapped both `OrganizationChoice` render paths in a `max-h-[60vh] overflow-y-auto` container.
  - Added `-mx-1 px-1` to prevent `card-shadow` clipping at the scroll edge.

<sup>Written for commit e16eb4efa78f36d5d85e01a1a4a322272378edeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

