### PR TITLE
fix(link): don't reap a sandbox with an in-flight dispatch

### DIFF
--- a/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
@@ -248,6 +248,46 @@ describe("desktop sandbox provider", () => {
     }
   });
 
+  it("refuses to delete a sandbox while a dispatch is in flight (a reap must not kill a live run)", async () => {
+    const dataDir = tmpDataDir();
+    try {
+      let killed = 0;
+      let portCounter = 30000;
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        spawnDaemon: () => ({
+          port: 12345,
+          kill: () => {
+            killed++;
+          },
+        }),
+        postConfig: async () => {},
+        waitForHealth: async () => {},
+        pickPort: () => portCounter++,
+      });
+      await provider.ensureSandbox({ handle: "abc", repo: undefined });
+
+      // A run is streaming on the sandbox — the work item holds the dispatch.
+      const release = provider.acquireDispatch("abc");
+
+      // A transient FS-op timeout reaps the handle (DELETE /api/sandboxes/abc)
+      // mid-dispatch. The live sandbox MUST survive: killing it closes the SSE
+      // pump and the run dies with "missing seq" at projection.
+      await provider.deleteSandbox("abc");
+      expect(killed).toBe(0);
+      expect(provider.hasHandle("abc")).toBe(true);
+      expect(provider.proxyPort("abc")).toBe(30000);
+
+      // Once the dispatch settles and releases the pin, delete proceeds.
+      release();
+      await provider.deleteSandbox("abc");
+      expect(killed).toBe(1);
+      expect(provider.hasHandle("abc")).toBe(false);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not create registry rows when deleting an unknown handle", async () => {
     const dataDir = tmpDataDir();
     try {

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -6,9 +6,11 @@
  * eviction.
  *
  * Idle sandboxes are evicted when the population exceeds `maxSandboxes`
- * (default 20). Sandboxes with active dispatches are pinned — eviction
- * skips them and we tolerate going temporarily over the cap. The daemon's
- * proxy hits call `provider.recordHit`, keeping warm sandboxes warm.
+ * (default 20). Sandboxes with active dispatches are pinned — both LRU
+ * eviction AND explicit `deleteSandbox` skip them (a reap mid-run would
+ * close the SSE pump and fail the dispatch), and we tolerate going
+ * temporarily over the cap. The daemon's proxy hits call
+ * `provider.recordHit`, keeping warm sandboxes warm.
  *
  * The actual process spawn / config-post / health-probe are passed in
  * as deps so the production wiring (apps/mesh/src/link-daemon/index.ts)
@@ -635,6 +637,19 @@ export function createDesktopSandboxProvider(
       if (!s) {
         console.log(
           `[user-desktop] delete handle=${handle} (not found, no-op)`,
+        );
+        return;
+      }
+      // Never reap a sandbox with a run in flight. The cluster's FS hook reaps
+      // on `DaemonUnreachable` (e.g. a git-status poll that timed out against a
+      // busy-but-alive daemon); honoring that mid-dispatch SIGTERMs the sandbox,
+      // closes its SSE pump, and the run dies with "missing seq" at projection.
+      // The dispatch pin already shields LRU eviction — this extends it to the
+      // explicit delete path. The cluster's follow-up `ensureSandbox` cache-hits
+      // the still-alive sandbox, so a transient timeout self-heals via retry.
+      if (s.activeDispatchCount > 0) {
+        console.warn(
+          `[user-desktop] delete handle=${handle} port=${s.port} REFUSED — ${s.activeDispatchCount} active dispatch(es) in flight`,
         );
         return;
       }


### PR DESCRIPTION
## Summary

A user-desktop chat turn could end with a terminal `consumeRunProjection` error `missing seq N` ("can't finish work in this thread") because the **live sandbox was killed mid-run**.

**Causal chain (traced end-to-end on studio-stg):**
1. Cluster projector `reconstructProjectorRun` (`projector-run-log.ts`) needs a contiguous chunk stream `1..finalSeq`; a missing chunk → `missing seq N` → `consumeRunProjection` step errors → gate workflow `ERROR` → turn output lost.
2. The stream was cut because the sandbox→daemon SSE pump closed (`[relay-diag] ROOT=SANDBOX-SSE-pump … socket connection was closed unexpectedly`).
3. …because the daemon got `DELETE /api/sandboxes/<handle>` mid-run. The cluster's FS hook (`sandbox-fs-hooks.ts`) reaps on `DaemonUnreachable` — and a routine sidebar `git/status` poll that merely **times out** against a busy (not dead) daemon is classified as unreachable (`502 {"error":"Daemon unreachable: The operation timed out."}`).
4. The daemon's `deleteSandbox` (`user-desktop-provider.ts`) SIGTERMed the sandbox **unconditionally**, even with a run streaming on it.

Observed killing **3 runs back-to-back** on one handle; a different handle with shorter runs survived.

## Fix

The `activeDispatchCount` pin already shields a sandbox from LRU eviction; the explicit `deleteSandbox` path ignored it. Honor the pin there too — refuse (log + no-op) while a dispatch is in flight. The cluster's follow-up `ensureSandbox` cache-hits the still-alive sandbox, so a transient timeout self-heals via retry; the sandbox is reapable again once the run settles and releases the pin.

This is the critical layer (a reap can no longer kill a live run). A contributing issue remains as follow-up: the FS hook classifies a mere *timeout* as `DaemonUnreachable` and reaps too eagerly — now harmless to in-flight runs, but still causes an unnecessary respawn between turns.

## Testing

- New unit test in `user-desktop-provider.test.ts`: with a dispatch held, `deleteSandbox` must not kill the sandbox; after release it deletes normally. **RED** (`killed=1`) before the fix → **GREEN** after.
- `bun test apps/mesh/src/link-daemon/{user-desktop-provider,control-handler}.test.ts` → **20 pass, 0 fail**
- `bun run lint` → 0 errors; `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop reaping live sandboxes during active runs. `deleteSandbox` now respects `activeDispatchCount` to prevent killing a sandbox mid-dispatch, avoiding SSE cuts and projector `missing seq N` errors.

- **Bug Fixes**
  - `deleteSandbox` no-ops and logs when `activeDispatchCount > 0`; sandbox is deletable once the dispatch releases.
  - Added unit test in `apps/mesh/src/link-daemon/user-desktop-provider.test.ts` to verify refusal during dispatch and normal delete after release.

<sup>Written for commit 9ea8bdc6efb76eb45612f42fd8487b0b2d6b5b47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

