### PR TITLE
feat(commerce-discovery): mint real client token via commerce-skills upgrade API

### DIFF
--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -213,6 +213,10 @@ export function resolveConfig(
     decoSupabaseUrl: envVars.DECO_SUPABASE_URL,
     decoSupabaseServiceKey: envVars.DECO_SUPABASE_SERVICE_KEY,
     firecrawlApiKey: envVars.FIRECRAWL_API_KEY,
+    commerceDiscoveryInternalApiUrl:
+      envVars.COMMERCE_DISCOVERY_INTERNAL_API_URL,
+    commerceDiscoveryInternalApiKey:
+      envVars.COMMERCE_DISCOVERY_INTERNAL_API_KEY,
 
     // Managed asset storage (shared deco tenant bucket). Defaults match the
     // legacy admin platform so an existing deployment works without new env.

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -121,6 +121,8 @@ export interface Settings {
   decoSupabaseUrl: string | undefined;
   decoSupabaseServiceKey: string | undefined;
   firecrawlApiKey: string | undefined;
+  commerceDiscoveryInternalApiUrl: string | undefined;
+  commerceDiscoveryInternalApiKey: string | undefined;
 
   // Managed asset storage (the shared deco tenant bucket). Used by `managed`
   // file configs: studio mints prefix-scoped STS credentials per site slug via

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { fetchCommerceDiscoveryAuth } from "./auth-client";
+
+describe("fetchCommerceDiscoveryAuth", () => {
+  test("upgrades the normalized domain and returns the generated client token", async () => {
+    const captured: Array<{
+      method: string;
+      pathname: string;
+      authorization: string | null;
+      body: unknown;
+    }> = [];
+
+    const auth = await fetchCommerceDiscoveryAuth(
+      {
+        siteUrl: "https://example.com/path",
+        orgId: "org_123",
+        orgName: "Acme",
+      },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async (input, init) => {
+          const request = new Request(input, init);
+          const url = new URL(request.url);
+          captured.push({
+            method: request.method,
+            pathname: url.pathname,
+            authorization: request.headers.get("authorization"),
+            body: await request.json(),
+          });
+
+          return Response.json({
+            url: "example.com",
+            org_id: "org_123",
+            scope: "private",
+            token: "dgn_test_token",
+            run: { id: "run_123", status: "running" },
+          });
+        },
+      },
+    );
+
+    expect(auth).toEqual({ authorizationToken: "dgn_test_token" });
+    expect(captured).toEqual([
+      {
+        method: "POST",
+        pathname: "/api/v2/internal/diagnostics/example.com/upgrade",
+        authorization: "Bearer master-key",
+        body: { org_id: "org_123", name: "Acme" },
+      },
+    ]);
+  });
+
+  test("requires an internal API key", async () => {
+    await expect(
+      fetchCommerceDiscoveryAuth(
+        {
+          siteUrl: "https://example.com",
+          orgId: "org_123",
+        },
+        {
+          settings: {
+            commerceDiscoveryInternalApiUrl: undefined,
+            commerceDiscoveryInternalApiKey: undefined,
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      "COMMERCE_DISCOVERY_INTERNAL_API_KEY is required to set up Commerce Discovery.",
+    );
+  });
+
+  test("rejects upgrade responses without a token", async () => {
+    await expect(
+      fetchCommerceDiscoveryAuth(
+        {
+          siteUrl: "https://example.com",
+          orgId: "org_123",
+        },
+        {
+          baseUrl: "https://commerce.example.test",
+          apiKey: "master-key",
+          fetchImpl: async () => Response.json({ scope: "private" }),
+        },
+      ),
+    ).rejects.toThrow(
+      "Commerce Discovery auth response did not include a token.",
+    );
+  });
+});

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.ts
@@ -1,0 +1,114 @@
+import { COMMERCE_DISCOVERY_MCP_URL } from "@decocms/mesh-sdk";
+import { z } from "zod";
+import { getSettings } from "../../settings";
+import type { Settings } from "../../settings";
+
+const DEFAULT_INTERNAL_API_URL = new URL(COMMERCE_DISCOVERY_MCP_URL).origin;
+
+const UpgradeResponseSchema = z.object({
+  token: z.string().min(1),
+});
+
+type FetchImpl = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface CommerceDiscoveryAuthInput {
+  siteUrl: string;
+  orgId: string;
+  orgName?: string;
+}
+
+export interface CommerceDiscoveryAuthOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  fetchImpl?: FetchImpl;
+  settings?: Pick<
+    Settings,
+    "commerceDiscoveryInternalApiUrl" | "commerceDiscoveryInternalApiKey"
+  >;
+}
+
+function resolveBaseUrl(options: CommerceDiscoveryAuthOptions): string {
+  if (options.baseUrl) return options.baseUrl.replace(/\/+$/, "");
+  const settings = options.settings ?? getSettings();
+  return (
+    settings.commerceDiscoveryInternalApiUrl ?? DEFAULT_INTERNAL_API_URL
+  ).replace(/\/+$/, "");
+}
+
+function resolveApiKey(options: CommerceDiscoveryAuthOptions): string {
+  const apiKey =
+    options.apiKey ??
+    (options.settings ?? getSettings()).commerceDiscoveryInternalApiKey;
+
+  if (!apiKey) {
+    throw new Error(
+      "COMMERCE_DISCOVERY_INTERNAL_API_KEY is required to set up Commerce Discovery.",
+    );
+  }
+
+  return apiKey;
+}
+
+function domainFromSiteUrl(siteUrl: string): string {
+  return new URL(siteUrl).hostname;
+}
+
+async function responseErrorMessage(response: Response): Promise<string> {
+  const fallback = `Commerce Discovery auth failed with status ${response.status}.`;
+  const text = await response.text().catch(() => "");
+  if (!text) return fallback;
+
+  try {
+    const parsed = JSON.parse(text) as { error?: unknown; message?: unknown };
+    const error =
+      typeof parsed.error === "string"
+        ? parsed.error
+        : typeof parsed.message === "string"
+          ? parsed.message
+          : null;
+    return error ? `Commerce Discovery auth failed: ${error}.` : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function fetchCommerceDiscoveryAuth(
+  input: CommerceDiscoveryAuthInput,
+  options: CommerceDiscoveryAuthOptions = {},
+) {
+  const baseUrl = resolveBaseUrl(options);
+  const apiKey = resolveApiKey(options);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const domain = domainFromSiteUrl(input.siteUrl);
+  const url = `${baseUrl}/api/v2/internal/diagnostics/${encodeURIComponent(
+    domain,
+  )}/upgrade`;
+
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      org_id: input.orgId,
+      ...(input.orgName ? { name: input.orgName } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response));
+  }
+
+  const parsed = UpgradeResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error(
+      "Commerce Discovery auth response did not include a token.",
+    );
+  }
+
+  return { authorizationToken: parsed.data.token };
+}

--- a/apps/mesh/src/tools/commerce-discovery/setup.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.ts
@@ -18,6 +18,7 @@ import {
 } from "../../core/studio-context";
 import { ConnectionEntitySchema } from "../connection/schema";
 import { VirtualMCPEntitySchema } from "../virtual/schema";
+import { fetchCommerceDiscoveryAuth } from "./auth-client";
 
 const REPORT_TOOL_NAME =
   COMMERCE_DISCOVERY_REPORT_TOOL_NAME as "DISPLAY_REPORT";
@@ -42,18 +43,6 @@ const CommerceDiscoverySetupOutputSchema = z.object({
 
 function isMissingToken(connection: ConnectionEntity): boolean {
   return !connection.connection_token;
-}
-
-interface CommerceDiscoveryAuthInput {
-  siteUrl: string;
-  orgId: string;
-}
-
-async function fetchCommerceDiscoveryAuth(input: CommerceDiscoveryAuthInput) {
-  // TODO: @tlgimenes replace with the real commerce-skills auth API call.
-  console.log("[commerce-discovery] TODO: @tlgimenes fetch auth token", input);
-
-  return { authorizationToken: "" };
 }
 
 async function rereadConnectionOrThrow(
@@ -130,6 +119,7 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
       const auth = await fetchCommerceDiscoveryAuth({
         siteUrl: normalized.value,
         orgId: organization.id,
+        orgName: organization.name,
       });
       if (auth.authorizationToken) {
         console.log("[commerce-discovery] repairing missing auth token", {
@@ -147,6 +137,7 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
       const auth = await fetchCommerceDiscoveryAuth({
         siteUrl: normalized.value,
         orgId: organization.id,
+        orgName: organization.name,
       });
 
       console.log("[commerce-discovery] creating connection", {

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -61,7 +61,13 @@
       // unused-files check would flag the analyzable ones (e.g. .css).
       "ignore": ["image/skills/*/examples/**"]
     },
-    "packages/typegen": {}
+    "packages/typegen": {},
+    "packages/e2e": {
+      // Standalone mock servers spawned by Playwright's `webServer` via a
+      // `bun run fixtures/...` command string — knip can't trace a process
+      // launch, so without this entry it flags the file as unused.
+      "entry": ["fixtures/commerce-upgrade-mock.ts"]
+    }
   },
   "ignoreDependencies": ["@types/*"],
   // TODO(@camudo): Remove this config once I fix all unused type exports

--- a/packages/e2e/fixtures/commerce-upgrade-mock.ts
+++ b/packages/e2e/fixtures/commerce-upgrade-mock.ts
@@ -1,0 +1,67 @@
+/**
+ * Standalone mock of the commerce-skills internal upgrade API.
+ *
+ * Launched as a Playwright `webServer` so the mesh server can complete
+ * `COMMERCE_DISCOVERY_SETUP` end-to-end without reaching the real production
+ * worker (https://commerce-skills.deco-cx.workers.dev). The mesh server is
+ * pointed here via `COMMERCE_DISCOVERY_INTERNAL_API_URL` in the Playwright
+ * config.
+ *
+ * Black-box: the mesh server reaches this over HTTP only — no app imports.
+ * Uses `node:http` (NOT `Bun.serve`) so it typechecks under the suite's Node
+ * types and runs under either node or bun.
+ *
+ * Mirrors the real contract from
+ * `api/v2/internal/diagnostics/:domain/upgrade`:
+ *   POST { org_id, name } -> { url, org_id, scope, token, run }
+ */
+
+import { createServer } from "node:http";
+
+const port = Number(process.env.COMMERCE_MOCK_PORT ?? "4100");
+const UPGRADE_RE = /^\/api\/v2\/internal\/diagnostics\/([^/]+)\/upgrade$/;
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url ?? "/", "http://localhost");
+
+  if (req.method === "GET" && url.pathname === "/health") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  const match = url.pathname.match(UPGRADE_RE);
+  if (req.method === "POST" && match) {
+    const domain = decodeURIComponent(match[1]);
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      let orgId: string | null = null;
+      try {
+        orgId = (JSON.parse(raw || "{}") as { org_id?: string }).org_id ?? null;
+      } catch {
+        orgId = null;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          url: domain,
+          org_id: orgId,
+          scope: "private",
+          token: `dgn_e2e_${orgId ?? "unknown"}`,
+          run: { id: "run_e2e", status: "running" },
+        }),
+      );
+    });
+    return;
+  }
+
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "not found" }));
+});
+
+server.listen(port, () => {
+  console.log(`[commerce-upgrade-mock] listening on http://localhost:${port}`);
+});

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -4,11 +4,19 @@ const serverPort = process.env.PORT || "3000";
 const appPort = process.env.VITE_PORT || "4000";
 const appOrigin = process.env.BASE_URL || `http://localhost:${appPort}`;
 
+// Commerce Discovery setup mints a one-time client token by calling the
+// commerce-skills internal upgrade API. We point the mesh server at a local
+// mock (commerce-upgrade-mock.ts, started as a webServer below) so onboarding
+// specs exercise the real setup path without hitting the production worker.
+const commerceMockPort = process.env.COMMERCE_MOCK_PORT || "4100";
+const commerceMockOrigin = `http://localhost:${commerceMockPort}`;
+const commerceMockKey = "e2e-commerce-key";
+
 // e2e exercises production-like behavior; the MCP read/list cache is on in prod
 // but defaults off under NODE_ENV=development (which `dev:server` sets), so opt
 // it back in here. Without this, cache-dependent specs (e.g. proxy roundtrip's
 // no-re-handshake assertion) fail against the dev server.
-const webServerCommand = `MCP_CACHE_ENABLED=true BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run dev:servers`;
+const webServerCommand = `MCP_CACHE_ENABLED=true COMMERCE_DISCOVERY_INTERNAL_API_URL=${commerceMockOrigin} COMMERCE_DISCOVERY_INTERNAL_API_KEY=${commerceMockKey} BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run dev:servers`;
 
 export default defineConfig({
   testDir: "./tests",
@@ -38,16 +46,29 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: webServerCommand,
-    // The dev server (dev:servers) is an apps/mesh script — run it from there.
-    // This is the suite's ONLY tie to the app, and it's a process boundary
-    // (spawn + HTTP), not a code import, so the black-box contract holds.
-    cwd: "../../apps/mesh",
-    url: `${appOrigin}/api/config`,
-    reuseExistingServer: true,
-    timeout: 120_000,
-    stdout: "pipe",
-    stderr: "pipe",
-  },
+  webServer: [
+    {
+      // Mock commerce-skills upgrade API. Started before the mesh server so
+      // COMMERCE_DISCOVERY_SETUP can mint a token over HTTP without reaching
+      // the production worker. Standalone process (no app imports).
+      command: `COMMERCE_MOCK_PORT=${commerceMockPort} bun run fixtures/commerce-upgrade-mock.ts`,
+      url: `${commerceMockOrigin}/health`,
+      reuseExistingServer: true,
+      timeout: 30_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      command: webServerCommand,
+      // The dev server (dev:servers) is an apps/mesh script — run it from there.
+      // This is the suite's ONLY tie to the app, and it's a process boundary
+      // (spawn + HTTP), not a code import, so the black-box contract holds.
+      cwd: "../../apps/mesh",
+      url: `${appOrigin}/api/config`,
+      reuseExistingServer: true,
+      timeout: 120_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  ],
 });

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -284,8 +284,9 @@ test.describe("Commerce onboarding route isolation", () => {
       connection_url: string | null;
       connection_type: string;
       title: string;
+      connection_token: string | null;
     }>(
-      `SELECT connection_url, connection_type, title
+      `SELECT connection_url, connection_type, title, connection_token
        FROM connections
        WHERE id = $1`,
       [connectionId],
@@ -295,6 +296,10 @@ test.describe("Commerce onboarding route isolation", () => {
       connection_type: "HTTP",
       title: "Commerce Discovery",
     });
+    // Setup must mint and persist a client token (stored encrypted at rest) —
+    // a non-null token guards against the old stub silently creating a
+    // tokenless connection.
+    expect(concrete.rows[0]?.connection_token).toBeTruthy();
 
     const virtual = await db.query<{
       connection_url: string | null;


### PR DESCRIPTION
## Summary

Removes the stub on the Commerce Discovery onboarding path. Setup now mints a real one-time client token by calling the commerce-skills internal upgrade API instead of storing an empty token.

- `fetchCommerceDiscoveryAuth` now does a real HTTP `POST ${COMMERCE_DISCOVERY_INTERNAL_API_URL}/api/v2/internal/diagnostics/:domain/upgrade` with `Authorization: Bearer <key>` and body `{ org_id, name }`, returning `response.token`.
- `siteUrl` is normalized to a host/domain before the call.
- The returned token is stored as the connection's `connection_token` (encrypted at rest).
- The two new vars (`COMMERCE_DISCOVERY_INTERNAL_API_URL`, `COMMERCE_DISCOVERY_INTERNAL_API_KEY`) flow through `Settings` rather than `process.env`. The URL defaults to the commerce-skills worker; **the API key is required** — setup fails visibly (throws) when the key is missing or no token is returned, instead of silently creating a tokenless connection.

## Testing

- **Unit** (`auth-client.test.ts`): asserts the normalized domain path, Bearer header, `{ org_id, name }` body, token extraction, the missing-key failure, and the no-token failure.
- **E2E**: the onboarding specs were written against the old stub (no key, no network). Added `packages/e2e/fixtures/commerce-upgrade-mock.ts`, a standalone `node:http` mock of the upgrade API started as a Playwright `webServer`; the mesh server is pointed at it via `COMMERCE_DISCOVERY_INTERNAL_API_URL` + a test key. Black-box: the mesh server reaches the mock over HTTP, no app imports. The setup spec now also asserts a token is actually persisted (guards the old silent-tokenless regression).

Verified locally: `bun test` (unit) green, `bun run lint` 0 errors, `tsc --noEmit` clean for `apps/mesh` and `packages/e2e`, mock contract + real `fetchCommerceDiscoveryAuth`↔mock verified over HTTP. Full Playwright run left to CI (local dev server held the embedded-postgres lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commerce Discovery onboarding now mints a real one-time client token via the commerce-skills upgrade API and stores it securely. This replaces the stub and fails fast when the API key is missing or no token is returned.

- **New Features**
  - Added `fetchCommerceDiscoveryAuth` to POST `${COMMERCE_DISCOVERY_INTERNAL_API_URL}/api/v2/internal/diagnostics/:domain/upgrade` with Bearer auth and `{ org_id, name }`, returning `token`.
  - Normalizes `siteUrl` to a domain before the call.
  - Persists the returned token to `connection_token` (encrypted at rest).
  - Introduces `COMMERCE_DISCOVERY_INTERNAL_API_URL` (defaults to the commerce-skills worker) and required `COMMERCE_DISCOVERY_INTERNAL_API_KEY` via `Settings`; setup throws if the key is missing or the response lacks a token.

- **Bug Fixes**
  - Declared the e2e upgrade mock as a `knip` entry to avoid false unused-file failures.

<sup>Written for commit 18517434e9f8e82112063e81351615fde1b125c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

