### PR TITLE
fix(commerce-discovery): point report view tab at real upstream tool

### DIFF
--- a/apps/mesh/src/tools/commerce-discovery/setup.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.ts
@@ -20,7 +20,7 @@ import { ConnectionEntitySchema } from "../connection/schema";
 import { VirtualMCPEntitySchema } from "../virtual/schema";
 
 const REPORT_TOOL_NAME =
-  COMMERCE_DISCOVERY_REPORT_TOOL_NAME as "DISPLAY_REPORT";
+  COMMERCE_DISCOVERY_REPORT_TOOL_NAME as "get_my_diagnostic";
 
 const CommerceDiscoverySetupInputSchema = z.object({
   siteUrl: z.string().min(1).describe("Website URL to configure."),

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -384,7 +384,8 @@ test.describe("Commerce onboarding route isolation", () => {
       (url) =>
         url.pathname.startsWith(`/${user.orgSlug}/`) &&
         url.searchParams.get("virtualmcpid") === virtualMcpId &&
-        url.searchParams.get("main") === `app:${connectionId}:DISPLAY_REPORT` &&
+        url.searchParams.get("main") ===
+          `app:${connectionId}:get_my_diagnostic` &&
         url.searchParams.get("chat") === "0",
       { timeout: 20_000 },
     );

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -37,7 +37,7 @@ export const WellKnownOrgMCPId = {
 
 export const COMMERCE_DISCOVERY_MCP_URL =
   "https://commerce-skills.deco-cx.workers.dev/api/mcp";
-export const COMMERCE_DISCOVERY_REPORT_TOOL_NAME = "DISPLAY_REPORT";
+export const COMMERCE_DISCOVERY_REPORT_TOOL_NAME = "get_my_diagnostic";
 export const COMMERCE_DISCOVERY_ICON =
   "https://api.iconify.design/lucide:chart-no-axes-combined.svg?color=%23171717";
 


### PR DESCRIPTION
## Summary

The auto-generated Commerce Discovery view tab (created during the `/commerce-onboarding` flow) pinned its main view to a report tool named `DISPLAY_REPORT`. The upstream commerce-discovery MCP (`https://commerce-skills.deco-cx.workers.dev/api/mcp`) actually exposes that view under a single tool named `get_my_diagnostic`, which returns the MCP App UI view.

As a result the Virtual MCP's `pinnedViews` / `layout.defaultMainView` and the `?main=app:<connectionId>:DISPLAY_REPORT` tab URL targeted a non-existent tool, so the report tab rendered nothing.

This retargets `COMMERCE_DISCOVERY_REPORT_TOOL_NAME` — the single source of truth that flows into the Virtual MCP `pinnedViews`, `defaultMainView`, `selected_tools`, and the `COMMERCE_DISCOVERY_SETUP` output — to `get_my_diagnostic`.

## Changes
- `packages/mesh-sdk/src/lib/constants.ts` — `COMMERCE_DISCOVERY_REPORT_TOOL_NAME` → `"get_my_diagnostic"`
- `apps/mesh/src/tools/commerce-discovery/setup.ts` — matching `as`/`z.literal` type for the setup output's `reportApp.toolName`
- `packages/e2e/tests/commerce-onboarding.spec.ts` — black-box assertion on the resulting `?main=app:<connectionId>:get_my_diagnostic` tab URL

## Testing
- `bun run fmt` — clean
- `bun run check` — all workspaces type-check (exit 0)

## Notes
- Unrelated companion-MCP `TODO` at `commerce-onboarding.tsx:760` (placeholder companion-MCP requirements) intentionally left as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Commerce Discovery report tab by pointing the main view to the real upstream tool `get_my_diagnostic` instead of `DISPLAY_REPORT`. This restores the report UI in the auto-generated tab during `/commerce-onboarding`.

- **Bug Fixes**
  - Set `COMMERCE_DISCOVERY_REPORT_TOOL_NAME` to `get_my_diagnostic`, aligning pinned views and default main view.
  - Updated setup type and e2e test to assert `?main=app:<connectionId>:get_my_diagnostic`.

<sup>Written for commit d7dbb2b1a2c4fc99907c90719b374d143a4b9250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

