### PR TITLE
fix(dispatch): reap gate workflows orphaned by a deploy

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1568,6 +1568,11 @@ export async function createApp(options: CreateAppOptions = {}) {
       listStuckRuns: (cutoffIso) => reaperStorage.listStuckRuns(cutoffIso),
       forceFailIfInProgress: (id, orgId) =>
         reaperStorage.forceFailIfInProgress(id, orgId),
+      listOrphanedGateWorkflows: (cutoffMs) =>
+        reaperStorage.listOrphanedGateWorkflows(cutoffMs),
+      cancelGateWorkflow: async (workflowId) => {
+        await DBOS.cancelWorkflows([workflowId]);
+      },
     });
     registerThreadGateReaperWorkflow();
   }

--- a/apps/mesh/src/dispatch-queue/thread-gate-reaper.integration.test.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-reaper.integration.test.ts
@@ -121,6 +121,9 @@ describe("reapStuckRunsSweep (real Postgres)", () => {
       listStuckRuns: (cutoffIso) => storage.listStuckRuns(cutoffIso),
       forceFailIfInProgress: (id, org) =>
         storage.forceFailIfInProgress(id, org),
+      listOrphanedGateWorkflows: (cutoffMs) =>
+        storage.listOrphanedGateWorkflows(cutoffMs),
+      cancelGateWorkflow: async () => {},
     };
   }
 

--- a/apps/mesh/src/dispatch-queue/thread-gate-reaper.test.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-reaper.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import {
+  reapOrphanedGatesSweep,
+  type ThreadGateReaperRuntime,
+} from "./thread-gate-reaper";
+
+function fakeRuntime(
+  overrides: Partial<ThreadGateReaperRuntime> = {},
+): ThreadGateReaperRuntime {
+  return {
+    listStuckRuns: async () => [],
+    forceFailIfInProgress: async () => false,
+    listOrphanedGateWorkflows: async () => [],
+    cancelGateWorkflow: async () => {},
+    ...overrides,
+  };
+}
+
+describe("reapOrphanedGatesSweep", () => {
+  it("cancels each orphaned gate past the grace and returns the count", async () => {
+    const cancelled: string[] = [];
+    let cutoffSeen = -1;
+    const rt = fakeRuntime({
+      listOrphanedGateWorkflows: async (cutoffMs) => {
+        cutoffSeen = cutoffMs;
+        return ["thread-run:t1:m1", "thread-run:t2:m2"];
+      },
+      cancelGateWorkflow: async (id) => {
+        cancelled.push(id);
+      },
+    });
+
+    const reaped = await reapOrphanedGatesSweep(rt, 1_000_000, 60_000);
+
+    // The sweep hands the storage a "dispatch completed before" cutoff of now - grace.
+    expect(cutoffSeen).toBe(1_000_000 - 60_000);
+    expect(cancelled).toEqual(["thread-run:t1:m1", "thread-run:t2:m2"]);
+    expect(reaped).toBe(2);
+  });
+
+  it("no-ops when nothing is orphaned", async () => {
+    let cancels = 0;
+    const rt = fakeRuntime({
+      listOrphanedGateWorkflows: async () => [],
+      cancelGateWorkflow: async () => {
+        cancels++;
+      },
+    });
+
+    const reaped = await reapOrphanedGatesSweep(rt, 5_000_000, 60_000);
+
+    expect(reaped).toBe(0);
+    expect(cancels).toBe(0);
+  });
+});

--- a/apps/mesh/src/dispatch-queue/thread-gate-reaper.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-reaper.ts
@@ -29,6 +29,19 @@ import { meter } from "@/observability";
  */
 const REAPER_STUCK_TIMEOUT_MS = 45 * 60 * 1000;
 
+/**
+ * 5 min. Grace after a gate's `dispatchRunAndWait` step COMPLETES before we
+ * treat a still-`PENDING` gate as orphaned. Once dispatch returns, the only
+ * remaining work is `consumeRunProjection` (reads the retained stream, writes
+ * parts) — seconds, not minutes. A gate still PENDING minutes after its
+ * dispatch completed means the executor driving it died (e.g. a deploy rolled
+ * the worker pod) and DBOS's own recovery never re-adopted it — so it sits
+ * forever, holding the per-thread queue slot and bricking the thread. This
+ * grace is generously larger than any real projection so a live run that just
+ * finished dispatching is never reaped mid-projection.
+ */
+const ORPHAN_GATE_GRACE_MS = 5 * 60 * 1000;
+
 /** Every minute (crontab granularity floor). */
 const REAPER_CRONTAB = "* * * * *";
 
@@ -37,6 +50,17 @@ export interface ThreadGateReaperRuntime {
     cutoffIso: string,
   ): Promise<Array<{ id: string; organizationId: string }>>;
   forceFailIfInProgress(id: string, organizationId: string): Promise<boolean>;
+  /**
+   * Cross-org scan for orphaned gate workflows: `threadGateWorkflow`s still
+   * `PENDING` on the `thread-gate` queue whose `dispatchRunAndWait` step
+   * completed before `dispatchCompletedBeforeMs`. Returns the DBOS workflow
+   * ids to cancel. Reads `dbos.workflow_status` + `dbos.operation_outputs`.
+   */
+  listOrphanedGateWorkflows(
+    dispatchCompletedBeforeMs: number,
+  ): Promise<string[]>;
+  /** Cancel a gate workflow (frees its per-thread queue partition slot). */
+  cancelGateWorkflow(workflowId: string): Promise<void>;
 }
 
 let runtime: ThreadGateReaperRuntime | null = null;
@@ -49,6 +73,15 @@ const reapedCounter = meter.createCounter("decopilot.gate.reaped", {
   description: "Runs force-failed by the cross-pod thread-gate reaper",
   unit: "{runs}",
 });
+
+const orphanedGateReapedCounter = meter.createCounter(
+  "decopilot.gate.orphan_reaped",
+  {
+    description:
+      "Orphaned gate workflows cancelled by the cross-pod reaper (dispatch done, executor dead)",
+    unit: "{workflows}",
+  },
+);
 
 /**
  * One sweep: find stuck runs as of `nowMs`, force-fail each, return how many
@@ -82,6 +115,43 @@ export async function reapStuckRunsSweep(
   return reaped;
 }
 
+/**
+ * One sweep for orphaned gate workflows: cancel every `threadGateWorkflow`
+ * whose `dispatchRunAndWait` completed before `nowMs - graceMs` yet is still
+ * `PENDING`. Cancelling frees the per-thread queue partition slot so the
+ * thread's ENQUEUED turns drain. Pure w.r.t. the injected runtime.
+ *
+ * Distinct from `reapStuckRunsSweep`, which targets the RUN (force-fails a run
+ * whose progress stalled, so a gate WAITING in `dispatchRunAndWait` unblocks).
+ * This one targets the WORKFLOW after `dispatchRunAndWait` already returned —
+ * the run completed but its executor died before projecting, so nothing ever
+ * flips the workflow terminal. The run reaper cannot see this (the run is not
+ * `in_progress`); only a workflow-layer sweep frees the gate.
+ */
+export async function reapOrphanedGatesSweep(
+  rt: ThreadGateReaperRuntime,
+  nowMs: number,
+  graceMs: number = ORPHAN_GATE_GRACE_MS,
+): Promise<number> {
+  const cutoffMs = nowMs - graceMs;
+  const workflowIds = await rt.listOrphanedGateWorkflows(cutoffMs);
+  let reaped = 0;
+  for (const workflowId of workflowIds) {
+    await rt.cancelGateWorkflow(workflowId);
+    reaped++;
+    orphanedGateReapedCounter.add(1);
+    console.warn(
+      JSON.stringify({
+        msg: "thread-gate-reaper",
+        event: "orphaned-gate-reaped",
+        workflowId,
+        cutoffMs,
+      }),
+    );
+  }
+  return reaped;
+}
+
 async function reaperWorkflowFn(
   _scheduledTime: Date,
   currentTime: Date,
@@ -98,6 +168,15 @@ async function reaperWorkflowFn(
       } catch (err) {
         // A sweep failure must never kill the schedule.
         console.error("[thread-gate-reaper] sweep failed", err);
+      }
+      try {
+        const n = await reapOrphanedGatesSweep(rt, currentTime.getTime());
+        if (n > 0) {
+          console.log(`[thread-gate-reaper] cancelled ${n} orphaned gate(s)`);
+        }
+      } catch (err) {
+        // A sweep failure must never kill the schedule.
+        console.error("[thread-gate-reaper] orphaned-gate sweep failed", err);
       }
     },
     { name: "threadGateReaperSweep" },

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -514,6 +514,38 @@ export class SqlThreadStorage implements ThreadStoragePort {
     return rows.map((r) => ({ id: r.id, organizationId: r.organization_id }));
   }
 
+  /**
+   * Cross-org scan for ORPHANED gate workflows: `threadGateWorkflow`s still
+   * `PENDING` on the `thread-gate` queue whose `dispatchRunAndWait` step
+   * completed before `dispatchCompletedBeforeMs`. Such a gate finished its run
+   * but its executor died before projecting (e.g. a deploy rolled the worker),
+   * and DBOS's own recovery never re-adopted it — so it holds the per-thread
+   * partition slot forever. Returns the DBOS workflow ids for the reaper to
+   * cancel. Reads the DBOS system tables (same database, `dbos` schema).
+   * Names are the stable DBOS identifiers from thread-gate-workflow.ts
+   * (`threadGateWorkflow`, step `dispatchRunAndWait`) and queue-names.ts
+   * (`thread-gate`). Used ONLY by the cross-pod reaper — not org-scoped.
+   */
+  async listOrphanedGateWorkflows(
+    dispatchCompletedBeforeMs: number,
+  ): Promise<string[]> {
+    const rows = await sql<{ workflow_uuid: string }>`
+      SELECT ws.workflow_uuid
+      FROM dbos.workflow_status ws
+      WHERE ws.name = 'threadGateWorkflow'
+        AND ws.status = 'PENDING'
+        AND ws.queue_name = 'thread-gate'
+        AND EXISTS (
+          SELECT 1 FROM dbos.operation_outputs oo
+          WHERE oo.workflow_uuid = ws.workflow_uuid
+            AND oo.function_name = 'dispatchRunAndWait'
+            AND oo.completed_at_epoch_ms IS NOT NULL
+            AND oo.completed_at_epoch_ms < ${dispatchCompletedBeforeMs}
+        )
+    `.execute(this.db);
+    return rows.rows.map((r) => r.workflow_uuid);
+  }
+
   async delete(id: string, organizationId: string): Promise<void> {
     await this.db
       .deleteFrom("threads")


### PR DESCRIPTION
## Summary

A cluster rollout that recycles the **worker pod mid-run** leaves the `threadGateWorkflow` driving that run **orphaned**: `dispatchRunAndWait` completes (the run finished on the desktop — daemon logs `dispatch complete`), then the executor dies before `consumeRunProjection`. DBOS's own recovery does **not** re-adopt the dead executor's `PENDING` workflow (conductor recovery isn't firing; a worker redeploy has nothing to re-drive its in-flight gates). So the workflow sits `PENDING` forever, holding the per-thread queue partition (`concurrency=1`) — every later message on that thread piles up `ENQUEUED` and **the thread is bricked** until manually cancelled.

Traced live on studio-stg (thread `1f1c620e`): executor `b0ddbf15` went silent at the exact instant a rollout replaced its pod; the gate's steps were `trackMessageStarted[ok] dispatchRunAndWait[ok]` with no `consumeRunProjection`, frozen `PENDING` for ~9 min with two real user messages stuck behind it.

### Why the existing reaper doesn't catch it

`thread-gate-reaper.ts`'s `reapStuckRunsSweep` targets stuck **runs** — it force-fails a run whose progress stalled, which unblocks a gate *waiting inside* `dispatchRunAndWait`. It can't see this case: the run already **completed**, so it isn't `in_progress`. The orphan is at the **workflow** layer, after dispatch returned.

## Fix

New companion sweep `reapOrphanedGatesSweep`: cancel any `threadGateWorkflow` still `PENDING` on the `thread-gate` queue whose `dispatchRunAndWait` step completed **more than 5 min ago** (`dbos.operation_outputs.completed_at_epoch_ms`). Cancelling frees the partition slot so the `ENQUEUED` backlog drains.

The grace keyed on the **step's own completion timestamp** is immune to false positives:
- a run still dispatching has no completed `dispatchRunAndWait` → not matched;
- one that just finished and is projecting is well inside the 5-min grace (projection is seconds) → not matched;
- a long run's executor liveness is irrelevant (per-gate signal, not thread-update or executor-heartbeat based).

Runs behind the existing `LINK_DURABLE_REAPER` flag, alongside the run-status sweep.

⚠️ **Deploy note:** `LINK_DURABLE_REAPER` is currently **unset in stg** — the whole reaper safety-net (both sweeps) is dormant there. Enable `LINK_DURABLE_REAPER=1` for this to take effect.

## Testing

- New pure unit test `thread-gate-reaper.test.ts`: sweep passes `now - grace` as the cutoff, cancels each returned orphan, returns the count; no-ops when empty. RED (missing export) → GREEN.
- `bun test apps/mesh/src/dispatch-queue/thread-gate-reaper.test.ts` → **2 pass**. (The `real Postgres` integration tests need a DB — they run in CI.)
- `bun run lint` → 0 errors; `bun run fmt` applied; typecheck: no new errors from these files.
- The SQL discriminator was validated against the live studio-stg `dbos` schema during diagnosis.

## Companion

Companion to #4204 (sandbox reaped mid-run). That one stops a **live** run from being killed; this one frees a thread **bricked after the run already finished**. Both are symptoms of cluster-side workflow fragility across deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancels orphaned `threadGateWorkflow`s left `PENDING` after worker redeploys so per-thread queues unblock and stuck messages drain. Adds a safe sweep that targets completed dispatches where the executor died before projection.

- **Bug Fixes**
  - Added `reapOrphanedGatesSweep` to cancel gates still `PENDING` with `dispatchRunAndWait` completed >5 min ago on the `thread-gate` queue.
  - Implemented cross-org scan `listOrphanedGateWorkflows` and cancellation via `DBOS.cancelWorkflows`.
  - Runs alongside the stuck-run sweep under `LINK_DURABLE_REAPER`.

- **Migration**
  - Set `LINK_DURABLE_REAPER=1` to enable the sweep (stg currently unset).

<sup>Written for commit b969f080c2896de65f44a24f56145e21b0022f83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

