### PR TITLE
feat(models): bump Smart tier to Sonnet 5 and Thinking tier to Opus 4.8 1M

### DIFF
--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -13,10 +13,11 @@ import type {
  */
 export const DEFAULT_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
   {
-    anthropic: ["claude-sonnet-4-6", "claude-sonnet", "claude"],
+    anthropic: ["claude-sonnet-5", "claude-sonnet", "claude"],
     openrouter: [
+      "anthropic/claude-opus-4.8:extended",
       "anthropic/claude-opus-4.8",
-      "anthropic/claude-sonnet-4-6",
+      "anthropic/claude-sonnet-5",
       "anthropic/claude-sonnet",
       "anthropic/claude",
     ],
@@ -66,15 +67,15 @@ export function getFastModel(providerId: ProviderId): string | null {
  * in Simple Model Mode.
  */
 export const SMART_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
-  anthropic: ["claude-sonnet-4-6", "claude-sonnet"],
+  anthropic: ["claude-sonnet-5", "claude-sonnet"],
   openrouter: [
-    "anthropic/claude-sonnet-4.6",
+    "anthropic/claude-sonnet-5",
     "anthropic/claude-sonnet",
     "anthropic/claude-opus-4.8",
     "google/gemini-3-pro",
   ],
   deco: [
-    "anthropic/claude-sonnet-4.6",
+    "anthropic/claude-sonnet-5",
     "anthropic/claude-sonnet",
     "anthropic/claude",
   ],
@@ -91,15 +92,16 @@ export const THINKING_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
   {
     anthropic: [
       "claude-opus-4-8",
-      "claude-sonnet-4-6",
+      "claude-sonnet-5",
       "claude-sonnet",
       // Fable 5 suspended by US government directive (2026-06-13)
       "claude-fable-5",
     ],
     openrouter: [
+      "anthropic/claude-opus-4.8:extended",
       "anthropic/claude-opus-4.8",
-      "anthropic/claude-sonnet-4.6:extended",
-      "anthropic/claude-sonnet-4.6",
+      "anthropic/claude-sonnet-5:extended",
+      "anthropic/claude-sonnet-5",
       "google/gemini-3-pro",
       // Fable 5 suspended by US government directive (2026-06-13)
       "anthropic/claude-fable-5",


### PR DESCRIPTION
## Summary

- **Smart tier**: Sonnet 4.6 → Sonnet 5 across `anthropic`, `openrouter`, and `deco` provider preferences
- **Thinking tier**: adds `anthropic/claude-opus-4.8:extended` (1M context) as the primary OpenRouter preference, falling back to `anthropic/claude-opus-4.8`; sonnet fallback updated from Sonnet 4.6 → Sonnet 5
- **Default model**: updated to prefer Sonnet 5 and Opus 4.8 extended on OpenRouter

## Test plan

- [ ] `bun test packages/mesh-sdk` passes (63 tests)
- [ ] `bun run fmt` clean — no formatting changes
- [ ] OpenRouter smart tier resolves to `anthropic/claude-sonnet-5` when available
- [ ] OpenRouter thinking tier resolves to `anthropic/claude-opus-4.8:extended` when available, falls back to `anthropic/claude-opus-4.8`
- [ ] Anthropic direct smart tier resolves to `claude-sonnet-5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped Smart tier to Sonnet 5 and set Thinking tier to Opus 4.8 (1M extended) to improve default model selection and context capacity. Updates `anthropic`, `openrouter`, and `deco` preferences and fallbacks.

- **New Features**
  - Smart tier: `claude-sonnet-5` now preferred on `anthropic`, `openrouter`, and `deco`.
  - Thinking tier: `anthropic/claude-opus-4.8:extended` is primary on `openrouter`, falling back to `anthropic/claude-opus-4.8`; Sonnet fallback is now `claude-sonnet-5` (with `:extended` on `openrouter`).
  - Defaults: `DEFAULT_MODEL_PREFERENCES` now prefer `anthropic/claude-opus-4.8:extended` and `anthropic/claude-sonnet-5` on `openrouter`, and `claude-sonnet-5` on `anthropic`.

<sup>Written for commit be8bd74db2e8437d9b13d99da22af7c7bd8a879b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

