### PR TITLE
feat(commerce-discovery): pin Commerce Discovery virtual MCP to sidebar by default

### DIFF
--- a/apps/mesh/src/tools/commerce-discovery/setup.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.ts
@@ -200,6 +200,12 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
       }
     }
 
+    if (!virtualMcp.pinned) {
+      virtualMcp = await ctx.storage.virtualMcps.update(virtualMcp.id, userId, {
+        pinned: true,
+      });
+    }
+
     return {
       connection,
       virtualMcp,

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -305,8 +305,9 @@ test.describe("Commerce onboarding route isolation", () => {
       connection_url: string | null;
       connection_type: string;
       title: string;
+      pinned: boolean;
     }>(
-      `SELECT connection_url, connection_type, title
+      `SELECT connection_url, connection_type, title, pinned
        FROM connections
        WHERE id = $1`,
       [virtualMcpId],
@@ -315,6 +316,7 @@ test.describe("Commerce onboarding route isolation", () => {
       connection_url: `virtual://${virtualMcpId}`,
       connection_type: "VIRTUAL",
       title: "Commerce Discovery",
+      pinned: true,
     });
   });
 

--- a/packages/mesh-sdk/src/lib/constants.test.ts
+++ b/packages/mesh-sdk/src/lib/constants.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { StudioPackAgentId, isStudioPackAgent } from "./constants";
+import {
+  StudioPackAgentId,
+  getWellKnownCommerceDiscoveryVirtualMCP,
+  isStudioPackAgent,
+} from "./constants";
 
 describe("StudioPackAgentId", () => {
   test("generates the Store Manager id with the org suffix", () => {
@@ -22,5 +26,13 @@ describe("isStudioPackAgent", () => {
     expect(isStudioPackAgent(undefined)).toBe(false);
     expect(isStudioPackAgent("vir_abc")).toBe(false);
     expect(isStudioPackAgent("decopilot_org_xyz")).toBe(false);
+  });
+});
+
+describe("getWellKnownCommerceDiscoveryVirtualMCP", () => {
+  test("pins the Commerce Discovery agent to the org sidebar", () => {
+    expect(
+      getWellKnownCommerceDiscoveryVirtualMCP("org_xyz", "conn_xyz").pinned,
+    ).toBe(true);
   });
 });

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -372,7 +372,7 @@ export function getWellKnownCommerceDiscoveryVirtualMCP(
     description: "Commerce report and diagnostics",
     icon: COMMERCE_DISCOVERY_ICON,
     status: "active",
-    pinned: false,
+    pinned: true,
     metadata: {
       type: "commerce-discovery",
       isDefault: false,


### PR DESCRIPTION
## Summary

- Sets `pinned: true` in the `getWellKnownCommerceDiscoveryVirtualMCP` SDK constant so the Commerce Discovery agent always appears pinned in the sidebar
- `COMMERCE_DISCOVERY_SETUP` tool now explicitly pins the virtual MCP if it was created without the flag (idempotent guard)
- E2E test updated to assert `pinned: true` on the connections row after setup
- Unit test added for `getWellKnownCommerceDiscoveryVirtualMCP` asserting the `pinned` field

## Test plan

- [ ] `bun test packages/mesh-sdk/src/lib/constants.test.ts` — new unit test passes
- [ ] E2E commerce-onboarding spec passes with `pinned: true` assertion
- [ ] Verify Commerce Discovery appears pinned in the sidebar after running setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Commerce Discovery virtual MCP to the sidebar by default. Setup also enforces pinning so the agent is always visible.

- **New Features**
  - Set `pinned: true` in `getWellKnownCommerceDiscoveryVirtualMCP`.
  - `COMMERCE_DISCOVERY_SETUP` idempotently updates existing agents to pinned.
  - Updated E2E and unit tests to assert `pinned: true`.

<sup>Written for commit cb1125dad29cfed31aa42e673190cc4100273833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

