### PR TITLE
feat(commerce-onboarding): companion MCP connect cards + OAuth-tail dedup

### DIFF
--- a/apps/mesh/src/web/hooks/use-auto-install-github.ts
+++ b/apps/mesh/src/web/hooks/use-auto-install-github.ts
@@ -108,10 +108,15 @@ export function useAutoInstallGitHub(opts: {
         } catch {
           // Best-effort cleanup
         }
-        // auth.error is "no token received" when the OAuth flow returned no
-        // token; the `?? "No token received from GitHub"` covers the (currently
-        // unreachable) null-error case, matching the prior message.
-        throw new Error(auth.error ?? "No token received from GitHub");
+        // auth.error is the generic sentinel "no token received" when the
+        // OAuth flow returned no token; surface the GitHub-specific message
+        // in that case (and the null-error case), but pass through any real
+        // OAuth error message as-is.
+        throw new Error(
+          auth.error && auth.error !== "no token received"
+            ? auth.error
+            : "No token received from GitHub",
+        );
       }
 
       // Step 3: Invalidate connection queries so picker re-renders

--- a/apps/mesh/src/web/hooks/use-auto-install-github.ts
+++ b/apps/mesh/src/web/hooks/use-auto-install-github.ts
@@ -10,7 +10,7 @@ import {
   useProjectContext,
   type ConnectionEntity,
 } from "@decocms/mesh-sdk";
-import { authenticateMcp, isConnectionAuthenticated } from "@decocms/mesh-sdk";
+import { authenticateAndPersistOAuth } from "@/web/lib/authenticate-and-persist-oauth";
 import { authClient } from "@/web/lib/auth-client";
 import { useRegistryApp } from "@/web/hooks/use-registry-app";
 import { extractConnectionData } from "@/web/utils/extract-connection-data";
@@ -86,75 +86,32 @@ export function useAutoInstallGitHub(opts: {
 
       const { id } = await actions.create.mutateAsync(connectionData);
 
-      // Step 2: Check if OAuth is needed
+      // Step 2: OAuth (if needed) + persist token, via the shared helper.
       setStatus("authenticating");
-      const mcpProxyUrl = new URL(
-        `/api/${org.slug}/mcp/${id}`,
-        window.location.origin,
-      );
-      const authStatus = await isConnectionAuthenticated({
-        url: mcpProxyUrl.href,
-        token: null,
+      const auth = await authenticateAndPersistOAuth({
+        connectionId: id,
         orgId: org.id,
-      });
-
-      if (authStatus.supportsOAuth && !authStatus.isAuthenticated) {
-        // Step 3: Run OAuth flow
-        const {
-          token,
-          tokenInfo,
-          error: oauthError,
-        } = await authenticateMcp({
-          connectionId: id,
-          orgSlug: org.slug,
-          scope: "offline_access",
-        });
-
-        if (oauthError || !token) {
-          // OAuth failed or was cancelled — clean up the connection
-          try {
-            await actions.delete.mutateAsync(id);
-          } catch {
-            // Best-effort cleanup
-          }
-          throw new Error(oauthError ?? "No token received from GitHub");
-        }
-
-        // Step 4: Persist OAuth token
-        if (tokenInfo) {
-          try {
-            const response = await fetch(
-              `/api/${org.slug}/connections/${id}/oauth-token`,
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                },
-                credentials: "include",
-                body: JSON.stringify({
-                  accessToken: tokenInfo.accessToken,
-                  refreshToken: tokenInfo.refreshToken,
-                  expiresIn: tokenInfo.expiresIn,
-                  scope: tokenInfo.scope,
-                  clientId: tokenInfo.clientId,
-                  clientSecret: tokenInfo.clientSecret,
-                  tokenEndpoint: tokenInfo.tokenEndpoint,
-                }),
-              },
-            );
-            if (!response.ok) {
-              await actions.update.mutateAsync({
-                id,
-                data: { connection_token: token },
-              });
-            }
-          } catch {
-            await actions.update.mutateAsync({
+        orgSlug: org.slug,
+        persistFallback: (token) =>
+          actions.update
+            .mutateAsync({
               id,
               data: { connection_token: token },
-            });
-          }
+            })
+            .then(() => undefined),
+      });
+
+      if (auth.ran && !auth.ok) {
+        // OAuth failed or was cancelled — clean up the connection
+        try {
+          await actions.delete.mutateAsync(id);
+        } catch {
+          // Best-effort cleanup
         }
+        // auth.error is "no token received" when the OAuth flow returned no
+        // token; the `?? "No token received from GitHub"` covers the (currently
+        // unreachable) null-error case, matching the prior message.
+        throw new Error(auth.error ?? "No token received from GitHub");
       }
 
       // Step 5: Invalidate connection queries so picker re-renders

--- a/apps/mesh/src/web/hooks/use-auto-install-github.ts
+++ b/apps/mesh/src/web/hooks/use-auto-install-github.ts
@@ -114,7 +114,7 @@ export function useAutoInstallGitHub(opts: {
         throw new Error(auth.error ?? "No token received from GitHub");
       }
 
-      // Step 5: Invalidate connection queries so picker re-renders
+      // Step 3: Invalidate connection queries so picker re-renders
       invalidateVirtualMcpQueries(queryClient, org.id);
 
       setConnection(connectionData as ConnectionEntity);

--- a/apps/mesh/src/web/lib/authenticate-and-persist-oauth.ts
+++ b/apps/mesh/src/web/lib/authenticate-and-persist-oauth.ts
@@ -1,0 +1,77 @@
+import {
+  authenticateMcp,
+  isConnectionAuthenticated,
+} from "@/web/lib/mcp-oauth";
+
+export interface AuthenticateAndPersistParams {
+  connectionId: string;
+  orgId: string;
+  orgSlug: string;
+  /** Called with the raw token when the oauth-token POST fails, to persist as connection_token. */
+  persistFallback: (token: string) => Promise<void>;
+}
+
+/** Authenticate a connection via OAuth if it needs it, and persist the token.
+ * Returns { ran:false } when no OAuth was required (already authed / no OAuth support).
+ * Mirrors the tail shared by handleConnectAndAdd / useAutoInstallGitHub. */
+export async function authenticateAndPersistOAuth({
+  connectionId,
+  orgId,
+  orgSlug,
+  persistFallback,
+}: AuthenticateAndPersistParams): Promise<{
+  ran: boolean;
+  ok: boolean;
+  error: string | null;
+}> {
+  const mcpProxyUrl = new URL(
+    `/api/${orgSlug}/mcp/${connectionId}`,
+    window.location.origin,
+  );
+  const authStatus = await isConnectionAuthenticated({
+    url: mcpProxyUrl.href,
+    token: null,
+    orgId,
+  });
+
+  if (!authStatus.supportsOAuth || authStatus.isAuthenticated) {
+    return { ran: false, ok: true, error: null };
+  }
+
+  const { token, tokenInfo, error } = await authenticateMcp({
+    connectionId,
+    orgSlug,
+    scope: "offline_access",
+  });
+  if (error || !token) {
+    return { ran: true, ok: false, error: error ?? "no token received" };
+  }
+
+  if (tokenInfo) {
+    try {
+      const response = await fetch(
+        `/api/${orgSlug}/connections/${connectionId}/oauth-token`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            accessToken: tokenInfo.accessToken,
+            refreshToken: tokenInfo.refreshToken,
+            expiresIn: tokenInfo.expiresIn,
+            scope: tokenInfo.scope,
+            clientId: tokenInfo.clientId,
+            clientSecret: tokenInfo.clientSecret,
+            tokenEndpoint: tokenInfo.tokenEndpoint,
+          }),
+        },
+      );
+      if (!response.ok) await persistFallback(token);
+    } catch {
+      await persistFallback(token);
+    }
+  } else {
+    await persistFallback(token);
+  }
+  return { ran: true, ok: true, error: null };
+}

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -45,6 +45,15 @@ export const KEYS = {
   commerceDiscoveryVirtualMcp: (orgId: string, virtualMcpId: string) =>
     ["commerce-discovery", "virtual-mcp", orgId, virtualMcpId] as const,
 
+  // Commerce companion discovery (Commerce Discovery's live config schema,
+  // candidate connections satisfying a binding, and the registry batch).
+  commerceDiscoveryCompanionSchema: (orgId: string, connectionId: string) =>
+    ["commerce-discovery", "companion-schema", orgId, connectionId] as const,
+  commerceDiscoveryCompanionConnections: (orgId: string) =>
+    ["commerce-discovery", "companion-connections", orgId] as const,
+  commerceDiscoveryCompanionRegistry: (orgId: string, key: string) =>
+    ["commerce-discovery", "companion-registry", orgId, key] as const,
+
   connectionActivity: (
     connectionId: string,
     timeframe: string,

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -24,6 +24,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowRight, Loading01 } from "@untitledui/icons";
 import { Suspense, useRef, useState } from "react";
 import type { FormEvent } from "react";
+import { CompanionMcpsSection } from "./commerce-onboarding/companion-mcps-section.tsx";
 
 interface CommerceOrganization {
   id: string;
@@ -741,29 +742,12 @@ function CommerceDiscoveryReady({
         title="Commerce Discovery"
         description={`Commerce Discovery is connected for ${org.name}.`}
       />
-      <div className="grid gap-3">
-        <div className="rounded-xl card-shadow bg-background dark:bg-input/30 p-4">
-          <p className="text-sm font-medium">Companion MCPs</p>
-          <p className="mt-1 text-sm text-muted-foreground leading-5">
-            Commerce Discovery requires platform integrations such as VTEX.
-            These companion MCP requirements will be available soon.
-          </p>
-          {
-            // TODO: @tlgimenes replace placeholder with dynamic companion MCP requirements
-            // read from Commerce Discovery MCP configuration/binding metadata.
-          }
-        </div>
-      </div>
-      <Button
-        type="button"
-        size="xl"
-        className="w-full"
-        onClick={onOpenReport}
-        disabled={!reportApp.virtualMcpId}
-      >
-        See full report
-        <ArrowRight size={16} />
-      </Button>
+      <CompanionMcpsSection
+        org={org}
+        cdConnectionId={reportApp.connectionId}
+        reportDisabled={!reportApp.virtualMcpId}
+        onOpenReport={onOpenReport}
+      />
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -1,0 +1,68 @@
+import { IntegrationIcon } from "@/web/components/integration-icon";
+import { Button } from "@deco/ui/components/button.tsx";
+import { CheckCircle, Loading01 } from "@untitledui/icons";
+import type { CompanionCardModel } from "./companions-core.ts";
+
+function UnlockLine({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 p-1">
+      <CheckCircle size={14} className="shrink-0 text-muted-foreground" />
+      <p className="text-sm text-foreground">{children}</p>
+    </div>
+  );
+}
+
+export function CompanionCard({
+  card,
+  connecting,
+  disabled,
+  onConnect,
+}: {
+  card: CompanionCardModel;
+  connecting: boolean;
+  disabled: boolean;
+  onConnect: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-border bg-background/60 p-4">
+      <div className="flex items-center gap-2">
+        <IntegrationIcon icon={card.icon} name={card.title} size="md" />
+        <p className="flex-1 text-sm text-foreground">{card.title}</p>
+        {card.satisfied ? (
+          <div className="flex h-8 items-center gap-2 px-3 text-sm text-muted-foreground">
+            <CheckCircle size={16} /> Connected
+          </div>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled || connecting}
+            onClick={onConnect}
+            aria-label={`Connect ${card.title}`}
+          >
+            {connecting ? (
+              <Loading01 size={16} className="animate-spin" />
+            ) : (
+              "Connect"
+            )}
+          </Button>
+        )}
+      </div>
+      <div className="flex flex-col gap-1 px-1 py-2">
+        {card.checks !== null && (
+          <UnlockLine>+ {card.checks} checks</UnlockLine>
+        )}
+        {card.headline && <UnlockLine>{card.headline}</UnlockLine>}
+        {card.bullets.map((b) => (
+          <UnlockLine key={b}>{b}</UnlockLine>
+        ))}
+        {!card.satisfied && card.candidateConnectionId && (
+          <p className="px-1 text-xs text-muted-foreground">
+            Using your existing {card.title}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -1,0 +1,123 @@
+import { authClient } from "@/web/lib/auth-client";
+import { SELF_MCP_ALIAS_ID, useMCPClient } from "@decocms/mesh-sdk";
+import { Button } from "@deco/ui/components/button.tsx";
+import { ArrowRight } from "@untitledui/icons";
+import { CompanionCard } from "./companion-card.tsx";
+import { useCommerceCompanions } from "./use-commerce-companions.ts";
+import { useConnectCompanion } from "./use-connect-companion.ts";
+
+interface CompanionOrg {
+  id: string;
+  slug: string;
+}
+
+export function CompanionMcpsSection({
+  org,
+  cdConnectionId,
+  reportDisabled,
+  onOpenReport,
+}: {
+  org: CompanionOrg;
+  cdConnectionId: string;
+  reportDisabled: boolean;
+  onOpenReport: () => void;
+}) {
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id ?? "";
+  const selfClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  const { cards, isLoading, error } = useCommerceCompanions({
+    selfClient,
+    org,
+    cdConnectionId,
+  });
+  const {
+    connect,
+    connectingFieldKey,
+    error: connectError,
+  } = useConnectCompanion({
+    selfClient,
+    org,
+    userId,
+    cdConnectionId,
+  });
+
+  const cta = (
+    <Button
+      type="button"
+      size="xl"
+      className="w-full"
+      onClick={onOpenReport}
+      disabled={reportDisabled}
+    >
+      See full report
+      <ArrowRight size={16} />
+    </Button>
+  );
+
+  // Empty: no requirements survive → just the report CTA (section header hidden).
+  if (!isLoading && !error && cards.length === 0) {
+    return <div className="grid gap-10">{cta}</div>;
+  }
+
+  const busy = connectingFieldKey !== null;
+
+  return (
+    <div className="grid gap-6">
+      <div className="grid gap-1.5">
+        <p className="text-2xl font-medium text-foreground">
+          Unlock your full diagnostic
+        </p>
+        <p className="text-base text-muted-foreground">
+          Connect your tools to unlock 100+ checks across your funnel.
+        </p>
+      </div>
+
+      {error ? (
+        <div
+          role="alert"
+          className="rounded-2xl border border-border bg-background/60 p-4"
+        >
+          <p className="text-sm text-foreground">
+            Couldn't load companion integrations.
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Reload the page to try again.
+          </p>
+        </div>
+      ) : isLoading ? (
+        <div className="grid gap-4">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-24 animate-pulse rounded-2xl border border-border bg-muted/40"
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {connectError && (
+            <p role="alert" className="text-sm text-destructive">
+              {connectError}
+            </p>
+          )}
+          {cards.map((card) => (
+            <CompanionCard
+              key={card.fieldKey}
+              card={card}
+              connecting={connectingFieldKey === card.fieldKey}
+              disabled={busy && connectingFieldKey !== card.fieldKey}
+              onConnect={() => void connect(card)}
+            />
+          ))}
+        </div>
+      )}
+
+      {cta}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -5,6 +5,7 @@ import {
   mergeBindingValue,
   parseBindingRequirements,
   resolveCandidate,
+  unwrapToolResult,
 } from "./companions-core.ts";
 
 const bindingSchema = (type: string) => ({
@@ -101,6 +102,33 @@ describe("resolveCandidate", () => {
   });
   it("returns null when nothing matches", () => {
     expect(resolveCandidate(conns, "shopify", "deco/shopify")).toBeNull();
+  });
+});
+
+describe("unwrapToolResult", () => {
+  it("throws with the content text when isError:true", () => {
+    expect(() =>
+      unwrapToolResult({
+        isError: true,
+        content: [{ text: "validateConfiguration failed" }],
+      }),
+    ).toThrow("validateConfiguration failed");
+  });
+  it("throws a default message when isError:true with no text", () => {
+    expect(() => unwrapToolResult({ isError: true, content: [] })).toThrow(
+      "Tool call failed",
+    );
+  });
+  it("returns structuredContent when present and not error", () => {
+    expect(
+      unwrapToolResult<{ item: { id: string } }>({
+        structuredContent: { item: { id: "c1" } },
+      }),
+    ).toEqual({ item: { id: "c1" } });
+  });
+  it("returns the raw result when no structuredContent", () => {
+    const raw = { item: { id: "c1" } };
+    expect(unwrapToolResult<typeof raw>(raw)).toEqual(raw);
   });
 });
 

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildCompanionCards,
+  buildRegistryWhere,
+  mergeBindingValue,
+  parseBindingRequirements,
+  resolveCandidate,
+} from "./companions-core.ts";
+
+const bindingSchema = (type: string) => ({
+  type: "object",
+  properties: {
+    __type: { const: type, type: "string" },
+    value: { type: "string" },
+  },
+});
+
+describe("parseBindingRequirements", () => {
+  it("extracts fieldKey + bindingType, preserving order, ignoring non-binding props", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        VTEX_STORE: bindingSchema("vtex"),
+        siteUrl: { type: "string" },
+        GA: bindingSchema("google-analytics"),
+      },
+    };
+    expect(parseBindingRequirements(schema)).toEqual([
+      { fieldKey: "VTEX_STORE", bindingType: "vtex" },
+      { fieldKey: "GA", bindingType: "google-analytics" },
+    ]);
+  });
+  it("returns [] when no properties", () => {
+    expect(parseBindingRequirements({ type: "object" })).toEqual([]);
+  });
+});
+
+describe("buildRegistryWhere", () => {
+  it("returns a single comparison when only ids", () => {
+    expect(buildRegistryWhere(["deco/vtex"], [])).toEqual({
+      field: ["id"],
+      operator: "in",
+      value: ["deco/vtex"],
+    });
+  });
+  it("ORs id-set and name-set when both present", () => {
+    expect(buildRegistryWhere(["deco/vtex"], ["shopify"])).toEqual({
+      operator: "or",
+      conditions: [
+        { field: ["id"], operator: "in", value: ["deco/vtex"] },
+        { field: ["name"], operator: "in", value: ["shopify"] },
+      ],
+    });
+  });
+  it("returns undefined when both empty", () => {
+    expect(buildRegistryWhere([], [])).toBeUndefined();
+  });
+});
+
+describe("mergeBindingValue", () => {
+  it("adds the binding value without dropping existing keys", () => {
+    const prev = { GA: { __type: "google-analytics", value: "conn_ga" } };
+    expect(mergeBindingValue(prev, "VTEX_STORE", "vtex", "conn_vtex")).toEqual({
+      GA: { __type: "google-analytics", value: "conn_ga" },
+      VTEX_STORE: { __type: "vtex", value: "conn_vtex" },
+    });
+  });
+  it("treats null state as empty", () => {
+    expect(mergeBindingValue(null, "VTEX_STORE", "vtex", "c1")).toEqual({
+      VTEX_STORE: { __type: "vtex", value: "c1" },
+    });
+  });
+});
+
+describe("resolveCandidate", () => {
+  const conns = [
+    {
+      id: "c_old",
+      app_name: "vtex",
+      status: "inactive",
+      updated_at: "2026-01-01",
+    },
+    {
+      id: "c_active",
+      app_name: "vtex",
+      status: "active",
+      updated_at: "2026-02-01",
+    },
+    {
+      id: "c_byid",
+      app_id: "deco/vtex",
+      status: "inactive",
+      updated_at: "2026-03-01",
+    },
+  ];
+  it("prefers active, then most recent", () => {
+    expect(resolveCandidate(conns, "vtex", "deco/vtex")).toBe("c_active");
+  });
+  it("matches by app_id too", () => {
+    expect(resolveCandidate([conns[2]!], "vtex", "deco/vtex")).toBe("c_byid");
+  });
+  it("returns null when nothing matches", () => {
+    expect(resolveCandidate(conns, "shopify", "deco/shopify")).toBeNull();
+  });
+});
+
+describe("buildCompanionCards", () => {
+  const item = (id: string, name: string) => ({
+    id,
+    title: name,
+    server: { name, title: name, icons: [{ src: `https://x/${name}.png` }] },
+    _meta: {
+      "mcp.mesh": { friendly_name: name, short_description: `${name} desc` },
+    },
+  });
+  const curated = {
+    vtex: {
+      registryAppId: "deco/vtex",
+      checks: 49,
+      headline: "vtex value",
+      bullets: ["b1"],
+    },
+  };
+  it("intersects schema ∧ registry, enriches curated, skips missing-in-registry", () => {
+    const cards = buildCompanionCards({
+      requirements: [
+        { fieldKey: "VTEX_STORE", bindingType: "vtex" },
+        { fieldKey: "GHOST", bindingType: "not-in-registry" },
+      ],
+      itemsById: { "deco/vtex": item("deco/vtex", "VTEX") },
+      itemsByName: {},
+      connections: [],
+      configurationState: null,
+      curated,
+    });
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      fieldKey: "VTEX_STORE",
+      bindingType: "vtex",
+      title: "VTEX",
+      icon: "https://x/VTEX.png",
+      checks: 49,
+      headline: "vtex value",
+      bullets: ["b1"],
+      satisfied: false,
+      candidateConnectionId: null,
+    });
+  });
+  it("uncurated survivor renders plain (registry short_description, no checks/bullets)", () => {
+    const cards = buildCompanionCards({
+      requirements: [{ fieldKey: "SHOP", bindingType: "shopify" }],
+      itemsById: {},
+      itemsByName: { shopify: item("deco/shopify", "shopify") },
+      connections: [],
+      configurationState: null,
+      curated,
+    });
+    expect(cards[0]).toMatchObject({
+      title: "shopify",
+      headline: "shopify desc",
+      checks: null,
+      bullets: [],
+    });
+  });
+  it("marks satisfied from configuration_state and skips candidate lookup", () => {
+    const cards = buildCompanionCards({
+      requirements: [{ fieldKey: "VTEX_STORE", bindingType: "vtex" }],
+      itemsById: { "deco/vtex": item("deco/vtex", "VTEX") },
+      itemsByName: {},
+      connections: [{ id: "c_vtex", app_name: "vtex", status: "active" }],
+      configurationState: { VTEX_STORE: { __type: "vtex", value: "linked" } },
+      curated,
+    });
+    expect(cards[0]!.satisfied).toBe(true);
+    expect(cards[0]!.candidateConnectionId).toBeNull();
+  });
+  it("surfaces an unlinked candidate for reuse", () => {
+    const cards = buildCompanionCards({
+      requirements: [{ fieldKey: "VTEX_STORE", bindingType: "vtex" }],
+      itemsById: { "deco/vtex": item("deco/vtex", "VTEX") },
+      itemsByName: {},
+      connections: [{ id: "c_vtex", app_name: "vtex", status: "active" }],
+      configurationState: null,
+      curated,
+    });
+    expect(cards[0]!.satisfied).toBe(false);
+    expect(cards[0]!.candidateConnectionId).toBe("c_vtex");
+  });
+});

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -92,6 +92,20 @@ export function buildRegistryWhere(
   return { operator: "or", conditions };
 }
 
+/** Unwrap an MCP tool-call result. Throws with the tool's error text when
+ * the result is a tool-level error (Client.callTool does NOT throw on isError). */
+export function unwrapToolResult<T>(result: unknown): T {
+  const r = result as {
+    structuredContent?: unknown;
+    isError?: boolean;
+    content?: Array<{ text?: string }>;
+  };
+  if (r.isError) {
+    throw new Error(r.content?.find((c) => c.text)?.text ?? "Tool call failed");
+  }
+  return (r.structuredContent ?? result) as T;
+}
+
 /** Full read-modify-write merge: server overwrites configuration_state wholesale,
  * so we must send every existing key plus the new binding value. */
 export function mergeBindingValue(

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -1,0 +1,193 @@
+import { getGitHubAvatarUrl } from "@deco/ui/lib/github.ts";
+import type { CompanionCopy } from "./companions.ts";
+
+export interface BindingRequirement {
+  fieldKey: string;
+  bindingType: string;
+}
+
+export interface CandidateConnection {
+  id: string;
+  app_name?: string | null;
+  app_id?: string | null;
+  status?: string | null;
+  updated_at?: string | null;
+}
+
+/** Minimal structural subset of a registry item we read for a card. */
+export interface RegistryItemLike {
+  id: string;
+  title?: string;
+  server?: {
+    name?: string;
+    title?: string;
+    icons?: Array<{ src?: string }>;
+    repository?: string | { url?: string };
+  };
+  _meta?: {
+    "mcp.mesh"?: {
+      friendly_name?: string | null;
+      short_description?: string | null;
+    };
+  };
+}
+
+export interface CompanionCardModel {
+  fieldKey: string;
+  bindingType: string;
+  registryItem: RegistryItemLike;
+  title: string;
+  icon: string | null;
+  /** Curated headline if present, else the registry short_description. */
+  headline: string | null;
+  /** Curated-only; null for plain cards. */
+  checks: number | null;
+  bullets: string[];
+  satisfied: boolean;
+  candidateConnectionId: string | null;
+}
+
+type ComparisonWhere = { field: string[]; operator: "in"; value: string[] };
+type WhereExpr =
+  | ComparisonWhere
+  | { operator: "or"; conditions: ComparisonWhere[] };
+
+/** Extract binding requirements from a downstream MCP_CONFIGURATION state schema.
+ * A property is a binding field when properties.__type.const is a non-empty string
+ * (same predicate as isBindingField in mcp-configuration-form.tsx). Order preserved. */
+export function parseBindingRequirements(
+  stateSchema: Record<string, unknown>,
+): BindingRequirement[] {
+  const properties = stateSchema.properties as
+    | Record<string, unknown>
+    | undefined;
+  if (!properties) return [];
+  const reqs: BindingRequirement[] = [];
+  for (const [fieldKey, raw] of Object.entries(properties)) {
+    const schema = raw as { properties?: Record<string, unknown> } | undefined;
+    const typeProp = schema?.properties?.__type as
+      | { const?: unknown }
+      | undefined;
+    const bindingType = typeProp?.const;
+    if (typeof bindingType === "string" && bindingType.length > 0) {
+      reqs.push({ fieldKey, bindingType });
+    }
+  }
+  return reqs;
+}
+
+/** Build a registry LIST `where` matching items by id-set OR server-name-set.
+ * `["id"]` is the top-level column; `["name"]` maps to the virtual server_json->>'name'. */
+export function buildRegistryWhere(
+  ids: string[],
+  names: string[],
+): WhereExpr | undefined {
+  const conditions: ComparisonWhere[] = [];
+  if (ids.length)
+    conditions.push({ field: ["id"], operator: "in", value: ids });
+  if (names.length)
+    conditions.push({ field: ["name"], operator: "in", value: names });
+  if (conditions.length === 0) return undefined;
+  if (conditions.length === 1) return conditions[0];
+  return { operator: "or", conditions };
+}
+
+/** Full read-modify-write merge: server overwrites configuration_state wholesale,
+ * so we must send every existing key plus the new binding value. */
+export function mergeBindingValue(
+  state: Record<string, unknown> | null | undefined,
+  fieldKey: string,
+  bindingType: string,
+  connectionId: string,
+): Record<string, unknown> {
+  return {
+    ...(state ?? {}),
+    [fieldKey]: { __type: bindingType, value: connectionId },
+  };
+}
+
+/** Pick an existing org connection satisfying a binding by app identity:
+ * app_name === bindingType OR app_id === registryAppId. Prefer active, then most recent. */
+export function resolveCandidate(
+  connections: CandidateConnection[],
+  bindingType: string,
+  registryAppId: string | undefined,
+): string | null {
+  const matches = connections.filter(
+    (c) =>
+      c.app_name === bindingType ||
+      (!!registryAppId && c.app_id === registryAppId),
+  );
+  if (matches.length === 0) return null;
+  matches.sort((a, b) => {
+    const rank = (c: CandidateConnection) => (c.status === "active" ? 0 : 1);
+    if (rank(a) !== rank(b)) return rank(a) - rank(b);
+    return (b.updated_at ?? "").localeCompare(a.updated_at ?? "");
+  });
+  return matches[0]!.id;
+}
+
+function cardIcon(item: RegistryItemLike): string | null {
+  return (
+    item.server?.icons?.[0]?.src ??
+    getGitHubAvatarUrl(item.server?.repository) ??
+    null
+  );
+}
+
+function cardTitle(item: RegistryItemLike, fallback: string): string {
+  const meta = item._meta?.["mcp.mesh"];
+  return (
+    meta?.friendly_name ||
+    item.title ||
+    item.server?.title ||
+    item.server?.name ||
+    fallback
+  );
+}
+
+/** The render algorithm: intersection(requirements ∧ registry), enriched by curated copy.
+ * Registry availability is the gate — a requirement with no registry item is skipped. */
+export function buildCompanionCards(args: {
+  requirements: BindingRequirement[];
+  itemsById: Record<string, RegistryItemLike>;
+  itemsByName: Record<string, RegistryItemLike>;
+  connections: CandidateConnection[];
+  configurationState: Record<string, unknown> | null | undefined;
+  curated: Record<string, CompanionCopy>;
+}): CompanionCardModel[] {
+  const cards: CompanionCardModel[] = [];
+  for (const req of args.requirements) {
+    const curatedEntry = args.curated[req.bindingType];
+    const item = curatedEntry
+      ? args.itemsById[curatedEntry.registryAppId]
+      : args.itemsByName[req.bindingType];
+    if (!item) continue; // gate: not installable → skip
+    const linked = (
+      args.configurationState?.[req.fieldKey] as { value?: string } | undefined
+    )?.value;
+    const satisfied = !!linked;
+    cards.push({
+      fieldKey: req.fieldKey,
+      bindingType: req.bindingType,
+      registryItem: item,
+      title: cardTitle(item, req.bindingType),
+      icon: cardIcon(item),
+      headline:
+        curatedEntry?.headline ??
+        item._meta?.["mcp.mesh"]?.short_description ??
+        null,
+      checks: curatedEntry?.checks ?? null,
+      bullets: curatedEntry?.bullets ?? [],
+      satisfied,
+      candidateConnectionId: satisfied
+        ? null
+        : resolveCandidate(
+            args.connections,
+            req.bindingType,
+            curatedEntry?.registryAppId,
+          ),
+    });
+  }
+  return cards;
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -53,8 +53,8 @@ type WhereExpr =
   | { operator: "or"; conditions: ComparisonWhere[] };
 
 /** Extract binding requirements from a downstream MCP_CONFIGURATION state schema.
- * A property is a binding field when properties.__type.const is a non-empty string
- * (same predicate as isBindingField in mcp-configuration-form.tsx). Order preserved. */
+ * A property is a binding requirement when properties.__type.const is a non-empty
+ * string — the binding-type source also read by getBindingInfo. Order preserved. */
 export function parseBindingRequirements(
   stateSchema: Record<string, unknown>,
 ): BindingRequirement[] {

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -26,6 +26,7 @@ export interface RegistryItemLike {
   };
   _meta?: {
     "mcp.mesh"?: {
+      friendlyName?: string | null;
       friendly_name?: string | null;
       short_description?: string | null;
     };
@@ -152,6 +153,7 @@ function cardIcon(item: RegistryItemLike): string | null {
 function cardTitle(item: RegistryItemLike, fallback: string): string {
   const meta = item._meta?.["mcp.mesh"];
   return (
+    meta?.friendlyName ||
     meta?.friendly_name ||
     item.title ||
     item.server?.title ||

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions.ts
@@ -1,0 +1,29 @@
+export interface CompanionCopy {
+  /** Registry item id pointer, e.g. "deco/vtex" — reliable resolution path. */
+  registryAppId: string;
+  /** Static "+ N checks" number (editorial). */
+  checks: number;
+  /** Primary value line under the card. */
+  headline: string;
+  /** Extra unlock bullet lines. */
+  bullets?: string[];
+}
+
+// NOTE: copy is placeholder pending final strings from design (Figma node 8669-25470).
+export const COMMERCE_COMPANION_MCPS: Record<string, CompanionCopy> = {
+  vtex: {
+    registryAppId: "deco/vtex",
+    checks: 49,
+    headline: "Out-of-stock, thin PDPs & attribute gaps across every SKU",
+  },
+  "google-analytics": {
+    registryAppId: "deco/google-analytics",
+    checks: 49,
+    headline: "Where revenue leaks between product view and checkout",
+  },
+  "google-search-console": {
+    registryAppId: "deco/google-search-console",
+    checks: 49,
+    headline: "Search visibility & indexing gaps across your catalog",
+  },
+};

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
@@ -101,13 +101,16 @@ export function useCommerceCompanions({
     enabled: requirements.length > 0,
     queryFn: async () => {
       const where = buildRegistryWhere(registryAppIds, nameOnly);
-      return callRegistryTool<{ items: RegistryItemLike[] }>(
+      const result = await callRegistryTool<{ items: RegistryItemLike[] }>(
         WellKnownOrgMCPId.REGISTRY(org.id),
         org.id,
         org.slug,
         "COLLECTION_REGISTRY_APP_LIST",
         { ...(where ? { where } : {}), limit: 1000 },
       );
+      // callRegistryTool doesn't throw on isError; surface it here so the
+      // section renders its error state instead of silently gating out.
+      return unwrapToolResult<{ items: RegistryItemLike[] }>(result);
     },
   });
 

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
@@ -1,0 +1,146 @@
+import { KEYS } from "@/web/lib/query-keys";
+import { callRegistryTool } from "@/web/utils/registry-utils";
+import { useMCPClient, WellKnownOrgMCPId } from "@decocms/mesh-sdk";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { useQuery } from "@tanstack/react-query";
+import { COMMERCE_COMPANION_MCPS } from "./companions.ts";
+import {
+  buildCompanionCards,
+  buildRegistryWhere,
+  parseBindingRequirements,
+  type CandidateConnection,
+  type CompanionCardModel,
+  type RegistryItemLike,
+} from "./companions-core.ts";
+
+interface CompanionOrg {
+  id: string;
+  slug: string;
+}
+
+function unwrap<T>(result: unknown): T {
+  return ((result as { structuredContent?: unknown }).structuredContent ??
+    result) as T;
+}
+
+export function useCommerceCompanions({
+  selfClient,
+  org,
+  cdConnectionId,
+}: {
+  selfClient: Client;
+  org: CompanionOrg;
+  cdConnectionId: string;
+}): { cards: CompanionCardModel[]; isLoading: boolean; error: unknown } {
+  // 1) CD's live config schema (on the CD connection's OWN client).
+  const cdClient = useMCPClient({
+    connectionId: cdConnectionId,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const schemaQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryCompanionSchema(org.id, cdConnectionId),
+    queryFn: async () => {
+      const result = await cdClient.callTool({
+        name: "MCP_CONFIGURATION",
+        arguments: {},
+      });
+      return unwrap<{ stateSchema?: Record<string, unknown> }>(result);
+    },
+  });
+
+  const requirements = parseBindingRequirements(
+    schemaQuery.data?.stateSchema ?? { type: "object", properties: {} },
+  );
+  const bindingTypes = requirements.map((r) => r.bindingType);
+  const registryAppIds = requirements
+    .map((r) => COMMERCE_COMPANION_MCPS[r.bindingType]?.registryAppId)
+    .filter((v): v is string => !!v);
+  const nameOnly = requirements
+    .filter((r) => !COMMERCE_COMPANION_MCPS[r.bindingType])
+    .map((r) => r.bindingType);
+  const registryKey = [...registryAppIds, ...nameOnly].sort().join(",");
+
+  // 2) CD saved state (shared cache key with the parent connection query).
+  const cdConnectionQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryConnection(org.id, cdConnectionId),
+    queryFn: async () => {
+      const result = await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_GET",
+        arguments: { id: cdConnectionId },
+      });
+      return unwrap<{
+        item: { configuration_state?: Record<string, unknown> | null } | null;
+      }>(result);
+    },
+  });
+
+  // 3) Existing org connections that could satisfy a binding (app identity).
+  const connectionsQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryCompanionConnections(org.id),
+    enabled: requirements.length > 0,
+    queryFn: async () => {
+      const result = await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_LIST",
+        arguments: {
+          where: {
+            operator: "or",
+            conditions: [
+              { field: ["app_name"], operator: "in", value: bindingTypes },
+              { field: ["app_id"], operator: "in", value: registryAppIds },
+            ],
+          },
+          limit: 1000,
+        },
+      });
+      return unwrap<{ items: CandidateConnection[] }>(result);
+    },
+  });
+
+  // 4) Registry batch (one LIST on the Deco store).
+  const registryQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryCompanionRegistry(org.id, registryKey),
+    enabled: requirements.length > 0,
+    queryFn: async () => {
+      const where = buildRegistryWhere(registryAppIds, nameOnly);
+      return callRegistryTool<{ items: RegistryItemLike[] }>(
+        WellKnownOrgMCPId.REGISTRY(org.id),
+        org.id,
+        org.slug,
+        "COLLECTION_REGISTRY_APP_LIST",
+        { ...(where ? { where } : {}), limit: 1000 },
+      );
+    },
+  });
+
+  const itemsById: Record<string, RegistryItemLike> = {};
+  const itemsByName: Record<string, RegistryItemLike> = {};
+  for (const item of registryQuery.data?.items ?? []) {
+    itemsById[item.id] = item;
+    if (item.server?.name) itemsByName[item.server.name] = item;
+  }
+
+  const cards = buildCompanionCards({
+    requirements,
+    itemsById,
+    itemsByName,
+    connections: connectionsQuery.data?.items ?? [],
+    configurationState:
+      cdConnectionQuery.data?.item?.configuration_state ?? null,
+    curated: COMMERCE_COMPANION_MCPS,
+  });
+
+  const isLoading =
+    schemaQuery.isPending ||
+    cdConnectionQuery.isPending ||
+    (requirements.length > 0 &&
+      (connectionsQuery.isPending || registryQuery.isPending));
+  const error =
+    schemaQuery.error ??
+    cdConnectionQuery.error ??
+    connectionsQuery.error ??
+    registryQuery.error ??
+    null;
+
+  return { cards, isLoading, error };
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
@@ -8,6 +8,7 @@ import {
   buildCompanionCards,
   buildRegistryWhere,
   parseBindingRequirements,
+  unwrapToolResult,
   type CandidateConnection,
   type CompanionCardModel,
   type RegistryItemLike,
@@ -16,11 +17,6 @@ import {
 interface CompanionOrg {
   id: string;
   slug: string;
-}
-
-function unwrap<T>(result: unknown): T {
-  return ((result as { structuredContent?: unknown }).structuredContent ??
-    result) as T;
 }
 
 export function useCommerceCompanions({
@@ -45,7 +41,9 @@ export function useCommerceCompanions({
         name: "MCP_CONFIGURATION",
         arguments: {},
       });
-      return unwrap<{ stateSchema?: Record<string, unknown> }>(result);
+      return unwrapToolResult<{ stateSchema?: Record<string, unknown> }>(
+        result,
+      );
     },
   });
 
@@ -69,7 +67,7 @@ export function useCommerceCompanions({
         name: "COLLECTION_CONNECTIONS_GET",
         arguments: { id: cdConnectionId },
       });
-      return unwrap<{
+      return unwrapToolResult<{
         item: { configuration_state?: Record<string, unknown> | null } | null;
       }>(result);
     },
@@ -93,7 +91,7 @@ export function useCommerceCompanions({
           limit: 1000,
         },
       });
-      return unwrap<{ items: CandidateConnection[] }>(result);
+      return unwrapToolResult<{ items: CandidateConnection[] }>(result);
     },
   });
 

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
@@ -57,6 +57,26 @@ export function useConnectCompanion({
           userId,
           { remoteIndex: 0 },
         );
+
+        // Validate connection data based on type (same guard as
+        // use-install-from-registry.ts / add-connection-dialog.tsx /
+        // connections.tsx) — an installable-looking registry item can still
+        // lack a usable remote URL or STDIO command.
+        const isStdioConnection = data.connection_type === "STDIO";
+        const hasUrl = Boolean(data.connection_url);
+        const hasStdioConfig =
+          isStdioConnection &&
+          data.connection_headers &&
+          typeof data.connection_headers === "object" &&
+          "command" in data.connection_headers;
+
+        if (!hasUrl && !hasStdioConfig) {
+          setError(
+            `${card.title} cannot be connected: no connection method available`,
+          );
+          return;
+        }
+
         const created = await selfClient.callTool({
           name: "COLLECTION_CONNECTIONS_CREATE",
           arguments: { data },

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
@@ -7,17 +7,13 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import {
   mergeBindingValue,
+  unwrapToolResult,
   type CompanionCardModel,
 } from "./companions-core.ts";
 
 interface CompanionOrg {
   id: string;
   slug: string;
-}
-
-function unwrap<T>(result: unknown): T {
-  return ((result as { structuredContent?: unknown }).structuredContent ??
-    result) as T;
 }
 
 export function useConnectCompanion({
@@ -45,7 +41,7 @@ export function useConnectCompanion({
       name: "COLLECTION_CONNECTIONS_UPDATE",
       arguments: { id, data },
     });
-    return unwrap<{ item: unknown }>(result);
+    return unwrapToolResult<{ item: unknown }>(result);
   };
 
   async function connect(card: CompanionCardModel): Promise<void> {
@@ -65,7 +61,8 @@ export function useConnectCompanion({
           name: "COLLECTION_CONNECTIONS_CREATE",
           arguments: { data },
         });
-        companionId = unwrap<{ item: { id: string } }>(created).item.id;
+        companionId = unwrapToolResult<{ item: { id: string } }>(created).item
+          .id;
       }
       const id = companionId;
 
@@ -90,7 +87,7 @@ export function useConnectCompanion({
         arguments: { id: cdConnectionId },
       });
       const currentState =
-        unwrap<{
+        unwrapToolResult<{
           item: { configuration_state?: Record<string, unknown> | null } | null;
         }>(cdGet).item?.configuration_state ?? null;
       const merged = mergeBindingValue(

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
@@ -1,0 +1,119 @@
+import { authenticateAndPersistOAuth } from "@/web/lib/authenticate-and-persist-oauth";
+import { KEYS } from "@/web/lib/query-keys";
+import type { RegistryItem } from "@/web/components/store/types";
+import { extractConnectionData } from "@/web/utils/extract-connection-data";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  mergeBindingValue,
+  type CompanionCardModel,
+} from "./companions-core.ts";
+
+interface CompanionOrg {
+  id: string;
+  slug: string;
+}
+
+function unwrap<T>(result: unknown): T {
+  return ((result as { structuredContent?: unknown }).structuredContent ??
+    result) as T;
+}
+
+export function useConnectCompanion({
+  selfClient,
+  org,
+  userId,
+  cdConnectionId,
+}: {
+  selfClient: Client;
+  org: CompanionOrg;
+  userId: string;
+  cdConnectionId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [connectingFieldKey, setConnectingFieldKey] = useState<string | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const updateConnection = async (
+    id: string,
+    data: Record<string, unknown>,
+  ) => {
+    const result = await selfClient.callTool({
+      name: "COLLECTION_CONNECTIONS_UPDATE",
+      arguments: { id, data },
+    });
+    return unwrap<{ item: unknown }>(result);
+  };
+
+  async function connect(card: CompanionCardModel): Promise<void> {
+    setConnectingFieldKey(card.fieldKey);
+    setError(null);
+    try {
+      // Step 0: reuse an existing candidate, else install a new connection.
+      let companionId = card.candidateConnectionId;
+      if (!companionId) {
+        const data = extractConnectionData(
+          card.registryItem as unknown as RegistryItem,
+          org.id,
+          userId,
+          { remoteIndex: 0 },
+        );
+        const created = await selfClient.callTool({
+          name: "COLLECTION_CONNECTIONS_CREATE",
+          arguments: { data },
+        });
+        companionId = unwrap<{ item: { id: string } }>(created).item.id;
+      }
+      const id = companionId;
+
+      // Step 1: OAuth only if needed (reuse target may already be authed).
+      const auth = await authenticateAndPersistOAuth({
+        connectionId: id,
+        orgId: org.id,
+        orgSlug: org.slug,
+        persistFallback: (token) =>
+          updateConnection(id, { connection_token: token }).then(
+            () => undefined,
+          ),
+      });
+      if (!auth.ok) {
+        setError(`Couldn't sign in to ${card.title}: ${auth.error}`);
+        return; // keep connection, no CD write
+      }
+
+      // Step 2: link — full read-modify-write of CD configuration_state.
+      const cdGet = await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_GET",
+        arguments: { id: cdConnectionId },
+      });
+      const currentState =
+        unwrap<{
+          item: { configuration_state?: Record<string, unknown> | null } | null;
+        }>(cdGet).item?.configuration_state ?? null;
+      const merged = mergeBindingValue(
+        currentState,
+        card.fieldKey,
+        card.bindingType,
+        id,
+      );
+      await updateConnection(cdConnectionId, { configuration_state: merged });
+
+      // Step 3: refresh (flip to Connected).
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryConnection(org.id, cdConnectionId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryCompanionConnections(org.id),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setConnectingFieldKey(null);
+    }
+  }
+
+  return { connect, connectingFieldKey, error };
+}

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -119,10 +119,7 @@ import {
   extractConnectionData,
   getRegistryItemAppName,
 } from "@/web/utils/extract-connection-data";
-import {
-  isConnectionAuthenticated,
-  authenticateMcp,
-} from "@/web/lib/mcp-oauth";
+import { authenticateAndPersistOAuth } from "@/web/lib/authenticate-and-persist-oauth";
 import { KEYS } from "@/web/lib/query-keys";
 import {
   type ConnectionProviderHint,
@@ -823,82 +820,42 @@ function ConnectionResults({
 
       const { id } = await actions.create.mutateAsync(connectionData);
 
-      // Handle OAuth flow
-      const mcpProxyUrl = new URL(
-        `/api/${org.slug}/mcp/${id}`,
-        window.location.origin,
-      );
-      const authStatus = await isConnectionAuthenticated({
-        url: mcpProxyUrl.href,
-        token: null,
+      // Handle OAuth flow (if needed) + persist, via the shared helper.
+      const auth = await authenticateAndPersistOAuth({
+        connectionId: id,
         orgId: org.id,
+        orgSlug: org.slug,
+        persistFallback: (token) =>
+          actions.update
+            .mutateAsync({ id, data: { connection_token: token } })
+            .then(() => undefined),
       });
 
-      if (authStatus.supportsOAuth && !authStatus.isAuthenticated) {
-        const { token, tokenInfo, error } = await authenticateMcp({
-          connectionId: id,
-          orgSlug: org.slug,
-          scope: "offline_access",
+      if (auth.ran && !auth.ok) {
+        track("connection_oauth_failed", {
+          connection_id: id,
+          flow: "connections_page_connect",
+          error: auth.error ?? "no_token",
         });
-        if (error || !token) {
-          track("connection_oauth_failed", {
-            connection_id: id,
-            flow: "connections_page_connect",
-            error: error ?? "no_token",
-          });
-          toast.error(`Authentication failed: ${error ?? "no token received"}`);
-          return;
-        } else {
-          track("connection_oauth_succeeded", {
-            connection_id: id,
-            flow: "connections_page_connect",
-          });
-          if (tokenInfo) {
-            try {
-              const response = await fetch(
-                `/api/${org.slug}/connections/${id}/oauth-token`,
-                {
-                  method: "POST",
-                  headers: {
-                    "Content-Type": "application/json",
-                  },
-                  credentials: "include",
-                  body: JSON.stringify({
-                    accessToken: tokenInfo.accessToken,
-                    refreshToken: tokenInfo.refreshToken,
-                    expiresIn: tokenInfo.expiresIn,
-                    scope: tokenInfo.scope,
-                    clientId: tokenInfo.clientId,
-                    clientSecret: tokenInfo.clientSecret,
-                    tokenEndpoint: tokenInfo.tokenEndpoint,
-                  }),
-                },
-              );
-              if (!response.ok) {
-                await actions.update.mutateAsync({
-                  id,
-                  data: { connection_token: token },
-                });
-              } else {
-                await actions.update.mutateAsync({ id, data: {} });
-              }
-            } catch {
-              await actions.update.mutateAsync({
-                id,
-                data: { connection_token: token },
-              });
-            }
-          } else {
-            await actions.update.mutateAsync({
-              id,
-              data: { connection_token: token },
-            });
-          }
-          await queryClient.invalidateQueries({
-            queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
-          });
-          toast.success("Authentication successful");
-        }
+        toast.error(
+          `Authentication failed: ${auth.error ?? "no token received"}`,
+        );
+        return;
+      }
+
+      if (auth.ran) {
+        track("connection_oauth_succeeded", {
+          connection_id: id,
+          flow: "connections_page_connect",
+        });
+        const mcpProxyUrl = new URL(
+          `/api/${org.slug}/mcp/${id}`,
+          window.location.origin,
+        );
+        await queryClient.invalidateQueries({
+          queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
+        });
+        toast.success("Authentication successful");
       }
 
       toast.success("Connected successfully");

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -855,6 +855,7 @@ function ConnectionResults({
         await queryClient.invalidateQueries({
           queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
         });
+        invalidateConnections();
         toast.success("Authentication successful");
       }
 

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -8,10 +8,7 @@ import type { RegistryItem } from "@/web/components/store/types";
 import { useInfiniteScroll } from "@/web/hooks/use-infinite-scroll";
 import { useLocalStorage } from "@/web/hooks/use-local-storage";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
-import {
-  authenticateMcp,
-  isConnectionAuthenticated,
-} from "@/web/lib/mcp-oauth";
+import { authenticateAndPersistOAuth } from "@/web/lib/authenticate-and-persist-oauth";
 import { KEYS } from "@/web/lib/query-keys";
 import { authClient } from "@/web/lib/auth-client";
 import {
@@ -682,79 +679,40 @@ export function AddConnectionDialog({
       });
       const id = created.id;
 
-      // Handle OAuth if needed
-      const mcpProxyUrl = new URL(
-        `/api/${org.slug}/mcp/${id}`,
-        window.location.origin,
-      );
-      const authStatus = await isConnectionAuthenticated({
-        url: mcpProxyUrl.href,
-        token: null,
+      // Handle OAuth if needed + persist, via the shared helper.
+      const auth = await authenticateAndPersistOAuth({
+        connectionId: id,
         orgId: org.id,
+        orgSlug: org.slug,
+        persistFallback: (token) =>
+          connectionActions.update
+            .mutateAsync({ id, data: { connection_token: token } })
+            .then(() => undefined),
       });
 
-      if (authStatus.supportsOAuth && !authStatus.isAuthenticated) {
-        const { token, tokenInfo, error } = await authenticateMcp({
-          connectionId: id,
-          orgSlug: org.slug,
-          scope: "offline_access",
+      if (auth.ran && !auth.ok) {
+        track("connection_oauth_failed", {
+          connection_id: id,
+          flow: "clone",
+          error: auth.error ?? "no_token",
         });
-        if (error || !token) {
-          track("connection_oauth_failed", {
-            connection_id: id,
-            flow: "clone",
-            error: error ?? "no_token",
-          });
-          toast.error(`Authentication failed: ${error ?? "no token received"}`);
-          // Clean up the orphaned connection
-          await connectionActions.delete.mutateAsync(id);
-          return;
-        }
+        toast.error(
+          `Authentication failed: ${auth.error ?? "no token received"}`,
+        );
+        // Clean up the orphaned connection
+        await connectionActions.delete.mutateAsync(id);
+        return;
+      }
+
+      if (auth.ran) {
         track("connection_oauth_succeeded", {
           connection_id: id,
           flow: "clone",
         });
-        if (tokenInfo) {
-          try {
-            const response = await fetch(
-              `/api/${org.slug}/connections/${id}/oauth-token`,
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                },
-                credentials: "include",
-                body: JSON.stringify({
-                  accessToken: tokenInfo.accessToken,
-                  refreshToken: tokenInfo.refreshToken,
-                  expiresIn: tokenInfo.expiresIn,
-                  scope: tokenInfo.scope,
-                  clientId: tokenInfo.clientId,
-                  clientSecret: tokenInfo.clientSecret,
-                  tokenEndpoint: tokenInfo.tokenEndpoint,
-                }),
-              },
-            );
-            if (!response.ok) {
-              await connectionActions.update.mutateAsync({
-                id,
-                data: { connection_token: token },
-              });
-            } else {
-              await connectionActions.update.mutateAsync({ id, data: {} });
-            }
-          } catch {
-            await connectionActions.update.mutateAsync({
-              id,
-              data: { connection_token: token },
-            });
-          }
-        } else {
-          await connectionActions.update.mutateAsync({
-            id,
-            data: { connection_token: token },
-          });
-        }
+        const mcpProxyUrl = new URL(
+          `/api/${org.slug}/mcp/${id}`,
+          window.location.origin,
+        );
         await queryClient.invalidateQueries({
           queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
         });
@@ -801,83 +759,40 @@ export function AddConnectionDialog({
 
       const { id } = await connectionActions.create.mutateAsync(connectionData);
 
-      // Handle OAuth flow
-      const mcpProxyUrl = new URL(
-        `/api/${org.slug}/mcp/${id}`,
-        window.location.origin,
-      );
-      const authStatus = await isConnectionAuthenticated({
-        url: mcpProxyUrl.href,
-        token: null,
+      // Handle OAuth flow (if needed) + persist, via the shared helper.
+      const auth = await authenticateAndPersistOAuth({
+        connectionId: id,
         orgId: org.id,
+        orgSlug: org.slug,
+        persistFallback: (token) =>
+          connectionActions.update
+            .mutateAsync({ id, data: { connection_token: token } })
+            .then(() => undefined),
       });
 
-      if (authStatus.supportsOAuth && !authStatus.isAuthenticated) {
-        const { token, tokenInfo, error } = await authenticateMcp({
-          connectionId: id,
-          orgSlug: org.slug,
-          scope: "offline_access",
+      if (auth.ran && !auth.ok) {
+        track("connection_oauth_failed", {
+          connection_id: id,
+          flow: "connect_new",
+          error: auth.error ?? "no_token",
         });
-        if (error || !token) {
-          track("connection_oauth_failed", {
-            connection_id: id,
-            flow: "connect_new",
-            error: error ?? "no_token",
-          });
-          toast.warning("Couldn't sign in to this connection", {
-            description: `It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings. (${error ?? "no token received"})`,
-          });
-          trackAttach(id, connectionData.app_name ?? null, "new");
-          onAdd(id);
-          return;
-        }
+        toast.warning("Couldn't sign in to this connection", {
+          description: `It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings. (${auth.error ?? "no token received"})`,
+        });
+        trackAttach(id, connectionData.app_name ?? null, "new");
+        onAdd(id);
+        return;
+      }
+
+      if (auth.ran) {
         track("connection_oauth_succeeded", {
           connection_id: id,
           flow: "connect_new",
         });
-
-        if (tokenInfo) {
-          try {
-            const response = await fetch(
-              `/api/${org.slug}/connections/${id}/oauth-token`,
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                },
-                credentials: "include",
-                body: JSON.stringify({
-                  accessToken: tokenInfo.accessToken,
-                  refreshToken: tokenInfo.refreshToken,
-                  expiresIn: tokenInfo.expiresIn,
-                  scope: tokenInfo.scope,
-                  clientId: tokenInfo.clientId,
-                  clientSecret: tokenInfo.clientSecret,
-                  tokenEndpoint: tokenInfo.tokenEndpoint,
-                }),
-              },
-            );
-            if (!response.ok) {
-              await connectionActions.update.mutateAsync({
-                id,
-                data: { connection_token: token },
-              });
-            } else {
-              await connectionActions.update.mutateAsync({ id, data: {} });
-            }
-          } catch {
-            await connectionActions.update.mutateAsync({
-              id,
-              data: { connection_token: token },
-            });
-          }
-        } else {
-          await connectionActions.update.mutateAsync({
-            id,
-            data: { connection_token: token },
-          });
-        }
-
+        const mcpProxyUrl = new URL(
+          `/api/${org.slug}/mcp/${id}`,
+          window.location.origin,
+        );
         await queryClient.invalidateQueries({
           queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
         });
@@ -945,85 +860,41 @@ export function AddConnectionDialog({
         onCreated={async (id) => {
           setCreateOpen(false);
 
-          // Handle OAuth if needed (same flow as handleConnectAndAdd)
-          const mcpProxyUrl = new URL(
-            `/api/${org.slug}/mcp/${id}`,
-            window.location.origin,
-          );
-          const authStatus = await isConnectionAuthenticated({
-            url: mcpProxyUrl.href,
-            token: null,
+          // Handle OAuth if needed + persist, via the shared helper.
+          const auth = await authenticateAndPersistOAuth({
+            connectionId: id,
             orgId: org.id,
+            orgSlug: org.slug,
+            persistFallback: (token) =>
+              connectionActions.update
+                .mutateAsync({ id, data: { connection_token: token } })
+                .then(() => undefined),
           });
 
-          if (authStatus.supportsOAuth && !authStatus.isAuthenticated) {
-            const { token, tokenInfo, error } = await authenticateMcp({
-              connectionId: id,
-              orgSlug: org.slug,
-              scope: "offline_access",
+          if (auth.ran && !auth.ok) {
+            track("connection_oauth_failed", {
+              connection_id: id,
+              flow: "custom_create",
+              error: auth.error ?? "no_token",
             });
-            if (error || !token) {
-              track("connection_oauth_failed", {
-                connection_id: id,
-                flow: "custom_create",
-                error: error ?? "no_token",
-              });
-              toast.warning("Couldn't sign in to this connection", {
-                description: `It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings. (${error ?? "no token received"})`,
-              });
-              trackAttach(id, null, "custom");
-              onAdd(id);
-              onOpenChange(false);
-              return;
-            }
+            toast.warning("Couldn't sign in to this connection", {
+              description: `It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings. (${auth.error ?? "no token received"})`,
+            });
+            trackAttach(id, null, "custom");
+            onAdd(id);
+            onOpenChange(false);
+            return;
+          }
+
+          if (auth.ran) {
             track("connection_oauth_succeeded", {
               connection_id: id,
               flow: "custom_create",
             });
-            if (tokenInfo) {
-              try {
-                const response = await fetch(
-                  `/api/${org.slug}/connections/${id}/oauth-token`,
-                  {
-                    method: "POST",
-                    headers: {
-                      "Content-Type": "application/json",
-                    },
-                    credentials: "include",
-                    body: JSON.stringify({
-                      accessToken: tokenInfo.accessToken,
-                      refreshToken: tokenInfo.refreshToken,
-                      expiresIn: tokenInfo.expiresIn,
-                      scope: tokenInfo.scope,
-                      clientId: tokenInfo.clientId,
-                      clientSecret: tokenInfo.clientSecret,
-                      tokenEndpoint: tokenInfo.tokenEndpoint,
-                    }),
-                  },
-                );
-                if (!response.ok) {
-                  await connectionActions.update.mutateAsync({
-                    id,
-                    data: { connection_token: token },
-                  });
-                } else {
-                  await connectionActions.update.mutateAsync({
-                    id,
-                    data: {},
-                  });
-                }
-              } catch {
-                await connectionActions.update.mutateAsync({
-                  id,
-                  data: { connection_token: token },
-                });
-              }
-            } else {
-              await connectionActions.update.mutateAsync({
-                id,
-                data: { connection_token: token },
-              });
-            }
+            const mcpProxyUrl = new URL(
+              `/api/${org.slug}/mcp/${id}`,
+              window.location.origin,
+            );
             await queryClient.invalidateQueries({
               queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
             });

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -659,6 +659,21 @@ export function AddConnectionDialog({
     });
   };
 
+  // Silent refresh of the connections collection after a successful OAuth
+  // flow (no toast — just keeps cached connection/tool data fresh).
+  const invalidateConnections = () => {
+    queryClient.invalidateQueries({
+      predicate: (query) => {
+        const key = query.queryKey;
+        return (
+          key[1] === org.id &&
+          key[3] === "collection" &&
+          key[4] === "CONNECTIONS"
+        );
+      },
+    });
+  };
+
   // For connected apps: clone existing connection + add to agent
   const handleCloneAndAdd = async (base: ConnectionEntity) => {
     setConnectingItemId(base.app_name ?? base.id);
@@ -716,6 +731,7 @@ export function AddConnectionDialog({
         await queryClient.invalidateQueries({
           queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
         });
+        invalidateConnections();
       }
 
       trackAttach(id, base.app_name ?? null, "clone");
@@ -796,6 +812,7 @@ export function AddConnectionDialog({
         await queryClient.invalidateQueries({
           queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
         });
+        invalidateConnections();
         toast.success("Connected and authenticated");
       } else {
         toast.success("Connected");
@@ -898,6 +915,7 @@ export function AddConnectionDialog({
             await queryClient.invalidateQueries({
               queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
             });
+            invalidateConnections();
           }
 
           // app_name unknown for custom-create; record null and let the

--- a/packages/e2e/tests/commerce-companion-link.spec.ts
+++ b/packages/e2e/tests/commerce-companion-link.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Black-box proof that the companion-link write path — a full read-modify-write
+ * of `configuration_state` via COLLECTION_CONNECTIONS_UPDATE — does not drop
+ * sibling binding keys.
+ *
+ * Why this matters: COLLECTION_CONNECTIONS_UPDATE persists whatever
+ * `configuration_state` object it's given wholesale (see
+ * apps/mesh/src/tools/connection/update.ts: `finalState = data.configuration_state
+ * ?? {}`); it does NOT merge server-side. So any caller that links a companion
+ * MCP (adding one binding) MUST first read the current state and spread the
+ * existing bindings into the write, or it silently clobbers every other
+ * binding already configured on that connection. This test exercises exactly
+ * that read-modify-write over the real HTTP + self-MCP surface and asserts
+ * both bindings survive.
+ *
+ * `configuration_scopes` is intentionally omitted on both the create and the
+ * merge-update: a non-empty scopes array drives a downstream
+ * ON_MCP_CONFIGURATION handshake (credential vault grants, workload tokens),
+ * which is unrelated to the state-merge contract under test here.
+ */
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+interface ConnectionWithState {
+  id: string;
+  configuration_state?: Record<string, unknown> | null;
+}
+
+test("linking a companion merges configuration_state without dropping sibling bindings", async ({
+  playwright,
+}) => {
+  const ctx = await newApiContext(playwright);
+  const user = await signUpViaApi(ctx);
+
+  // 1) Create a subject connection ("the CD under test") with an initial
+  // binding value in configuration_state. configuration_scopes is omitted so
+  // no ON_MCP_CONFIGURATION handshake is attempted on create.
+  const created = await callSelfMcpTool<{ item: ConnectionWithState }>(
+    ctx,
+    user.orgSlug,
+    "COLLECTION_CONNECTIONS_CREATE",
+    {
+      data: {
+        title: `cd-under-test ${Date.now()}`,
+        connection_type: "HTTP",
+        connection_url: "https://example.invalid/mcp",
+        configuration_state: {
+          GA: { __type: "google-analytics", value: "conn_ga" },
+        },
+      },
+    },
+  );
+  const cdId = created.item.id;
+
+  // 2) Read-modify-write: GET the current state, spread the existing
+  // sibling(s), add a second binding, then UPDATE. This is exactly the
+  // pattern a companion-link step must follow — the server does not merge.
+  const got = await callSelfMcpTool<{ item: ConnectionWithState | null }>(
+    ctx,
+    user.orgSlug,
+    "COLLECTION_CONNECTIONS_GET",
+    { id: cdId },
+  );
+  const currentState = got.item?.configuration_state ?? {};
+  const merged = {
+    ...currentState,
+    VTEX_STORE: { __type: "vtex", value: "conn_vtex" },
+  };
+  await callSelfMcpTool(ctx, user.orgSlug, "COLLECTION_CONNECTIONS_UPDATE", {
+    id: cdId,
+    data: { configuration_state: merged },
+  });
+
+  // 3) Assert BOTH bindings persisted. If the caller had instead sent only
+  // the new binding (skipping the read-modify-write), the wholesale-overwrite
+  // semantics of COLLECTION_CONNECTIONS_UPDATE would have dropped GA here —
+  // that's the regression this test guards against.
+  const after = await callSelfMcpTool<{ item: ConnectionWithState | null }>(
+    ctx,
+    user.orgSlug,
+    "COLLECTION_CONNECTIONS_GET",
+    { id: cdId },
+  );
+  expect(after.item?.configuration_state).toEqual({
+    GA: { __type: "google-analytics", value: "conn_ga" },
+    VTEX_STORE: { __type: "vtex", value: "conn_vtex" },
+  });
+
+  await ctx.dispose();
+});

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -344,7 +344,11 @@ test.describe("Commerce onboarding route isolation", () => {
     ).toBeVisible({
       timeout: 20_000,
     });
-    await expect(page.getByText("Companion MCPs")).toBeVisible();
+    // The old "Companion MCPs" placeholder was replaced by the companion
+    // section, whose header is hidden when no companion requirements resolve
+    // (the case in this e2e env). The ready view is already asserted via the
+    // "See full report" CTA above; here we only guard against leaking raw
+    // connection titles into the onboarding view.
     await expect(page.getByText("Commerce Discovery MCP")).toHaveCount(0);
     await expect(page.getByText("Commerce Discovery agent")).toHaveCount(0);
   });


### PR DESCRIPTION
This PR delivers the **Commerce Companion MCPs** onboarding feature, plus a follow-on refactor that **dedups the shared OAuth tail** the feature extracted, across all five call sites.

---

# Part 1 — Commerce Companion MCPs (onboarding connect cards)

Replaces the static "Companion MCPs" placeholder on `/commerce-onboarding` with live connect cards — one per binding the Commerce Discovery (CD) MCP requires (`bindingOf('vtex')`, etc.). Each card **reuses** an existing matching org connection or **installs** a new one, runs OAuth only if needed, and **links** it into CD's `configuration_state` via a full read-modify-write `COLLECTION_CONNECTIONS_UPDATE`, which retriggers `ON_MCP_CONFIGURATION`.

**How it works**
- **Discovery (schema-driven):** reads CD's live `MCP_CONFIGURATION` state schema and extracts `BindingOf` fields.
- **Resolution:** render set = intersection(schema requirements ∧ registry items), gated by registry availability, enriched by a curated studio map (editorial copy only; identity/icon from the registry).
- **Reuse-first:** matches existing connections by app identity (`app_name`/`app_id`); never duplicates. Requires a click to link.
- **Link:** server overwrites `configuration_state` wholesale, so the client does GET → merge → UPDATE; tool errors are surfaced (never swallowed into a destructive write).

**Testing (Part 1)**
- ✅ 18 pure-logic unit tests (`companions-core.test.ts`).
- ⏳ e2e (`commerce-companion-link.spec.ts`) proving the merge preserves sibling bindings — runs in CI (needs Postgres/NATS).

---

# Part 2 — OAuth-tail dedup (follow-on refactor)

Part 1 extracted a shared `authenticateAndPersistOAuth` helper. This part folds the **five** pre-existing copy-pasted OAuth-authenticate-and-persist tails onto it:

- `useAutoInstallGitHub` (GitHub auto-install)
- `add-connection-dialog.tsx` — `handleCloneAndAdd`, `handleConnectAndAdd`, `onCreated`
- `connections.tsx` — `handleInlineConnect`

**Pure DRY, behavior-preserving per site** — each keeps its own failure policy (keep vs delete), toast strings, PostHog events, and query invalidations. One intentional delta: the redundant happy-path empty `update({ data: {} })` poke is dropped (one fewer `"Item updated successfully"` toast on OAuth-connect success). Net ~−215 lines.

The helper is unchanged. The `tokenInfo`-null branch it carries is dead code (`authenticateMcp` returns `token` ⟹ `tokenInfo`, and callers guard on `!token` first), so adoption is behavior-equivalent.

**Testing (Part 2)**
- No unit tests — these OAuth flows can't be unit-tested (mocked OAuth is banned by `TESTING.md`); real-OAuth e2e is impractical.
- ⏳ **Manual smoke required before relying on it:** the five flows above — verify success and the keep-vs-delete failure behavior for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
