### PR TITLE
feat(commerce-onboarding): site-branded login and onboarding headers

### DIFF
--- a/apps/mesh/src/web/components/auth-entry.tsx
+++ b/apps/mesh/src/web/components/auth-entry.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import { retry, RetryError } from "@decocms/std";
 import { SplashScreen } from "@/web/components/splash-screen";
 import { UnifiedAuthForm } from "@/web/components/unified-auth-form";
@@ -9,6 +10,12 @@ export interface AuthEntryProps {
   callbackUrl: string;
   redirectUrl?: string | null;
   allowAutoLogin?: boolean;
+  /** Title for the default view of the email/social auth form. */
+  title?: string;
+  /** Subtitle for the default view; `null` hides it. */
+  subtitle?: string | null;
+  /** Brand element rendered above the auth form header. */
+  brand?: ReactNode;
 }
 
 class RetriableAutoLoginResponse {
@@ -124,6 +131,9 @@ export function AuthEntry({
   callbackUrl,
   redirectUrl,
   allowAutoLogin = true,
+  title,
+  subtitle,
+  brand,
 }: AuthEntryProps) {
   const {
     sso,
@@ -152,7 +162,13 @@ export function AuthEntry({
     socialProviders.enabled
   ) {
     return (
-      <UnifiedAuthForm redirectUrl={redirectUrl} callbackUrl={callbackUrl} />
+      <UnifiedAuthForm
+        redirectUrl={redirectUrl}
+        callbackUrl={callbackUrl}
+        title={title}
+        subtitle={subtitle}
+        brand={brand}
+      />
     );
   }
 

--- a/apps/mesh/src/web/components/integration-icon.tsx
+++ b/apps/mesh/src/web/components/integration-icon.tsx
@@ -9,6 +9,12 @@ interface IntegrationIconProps {
   size?: Size;
   className?: string;
   fallbackIcon?: ReactNode;
+  /**
+   * How the logo fills the box. "cover" (default) crops to fill edge-to-edge;
+   * "contain" fits the whole logo inside, which pairs with container padding
+   * to give the logo breathing room.
+   */
+  fit?: "cover" | "contain";
 }
 
 const SIZE_CLASSES = {
@@ -56,6 +62,7 @@ export function IntegrationIcon({
   size = "md",
   className,
   fallbackIcon,
+  fit = "cover",
 }: IntegrationIconProps) {
   // Delegate icon:// and URL-with-color to AgentAvatar for colored rendering
   if (icon?.startsWith("icon://") || icon?.includes("#agentcolor=")) {
@@ -79,6 +86,7 @@ export function IntegrationIcon({
       size={size}
       className={className}
       fallbackIcon={fallbackIcon}
+      fit={fit}
     />
   );
 }
@@ -89,6 +97,7 @@ function IntegrationIconStateful({
   size = "md",
   className,
   fallbackIcon,
+  fit = "cover",
 }: IntegrationIconProps) {
   const [loaded, setLoaded] = useState(false);
   const showImage = Boolean(icon) && loaded;
@@ -105,7 +114,11 @@ function IntegrationIconStateful({
       <img
         src={icon || undefined}
         alt={name}
-        className={cn("h-full w-full object-cover", !showImage && "hidden")}
+        className={cn(
+          "h-full w-full",
+          fit === "contain" ? "object-contain" : "object-cover",
+          !showImage && "hidden",
+        )}
         onError={() => setLoaded(false)}
         onLoad={() => setLoaded(true)}
       />

--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -19,6 +19,22 @@ interface UnifiedAuthFormProps {
    * Used when redirectUrl is not set. Defaults to "/".
    */
   callbackUrl?: string;
+  /**
+   * Title for the default sign-in/sign-up view. Contextual views
+   * (forgot password, OTP sent) keep their own titles.
+   * Defaults to "Welcome to deco".
+   */
+  title?: string;
+  /**
+   * Subtitle for the default sign-in/sign-up view. `undefined` keeps the
+   * default text; `null` hides the subtitle entirely.
+   * Defaults to "Sign in or create a new account".
+   */
+  subtitle?: string | null;
+  /**
+   * Brand element rendered above the header. Defaults to the deco logo.
+   */
+  brand?: React.ReactNode;
 }
 
 type FormView = "signIn" | "signUp" | "forgotPassword" | "emailOtp";
@@ -26,6 +42,9 @@ type FormView = "signIn" | "signUp" | "forgotPassword" | "emailOtp";
 export function UnifiedAuthForm({
   redirectUrl,
   callbackUrl = "/",
+  title,
+  subtitle,
+  brand,
 }: UnifiedAuthFormProps) {
   const { emailAndPassword, resetPassword, emailOtp, socialProviders } =
     useAuthConfig();
@@ -294,36 +313,42 @@ export function UnifiedAuthForm({
     ? "Reset your password"
     : isEmailOtp && otpSent
       ? "Enter verification code"
-      : "Welcome to deco";
+      : (title ?? "Welcome to deco");
 
   const headerSubtitle = isForgotPassword
     ? "We'll send you a reset link"
     : isEmailOtp && otpSent
       ? `Code sent to ${email}`
-      : "Sign in or create a new account";
+      : subtitle === undefined
+        ? "Sign in or create a new account"
+        : subtitle;
 
   return (
     <div className="w-full grid gap-10">
-      {/* Logo */}
-      <div>
-        <img
-          src="/logos/deco logo.svg"
-          alt="Deco"
-          className="h-12 w-12 dark:hidden"
-        />
-        <img
-          src="/logos/deco logo negative.svg"
-          alt="Deco"
-          className="h-12 w-12 hidden dark:block"
-        />
-      </div>
+      {/* Brand */}
+      {brand ?? (
+        <div>
+          <img
+            src="/logos/deco logo.svg"
+            alt="Deco"
+            className="h-12 w-12 dark:hidden"
+          />
+          <img
+            src="/logos/deco logo negative.svg"
+            alt="Deco"
+            className="h-12 w-12 hidden dark:block"
+          />
+        </div>
+      )}
 
       {/* Header */}
       <div className="space-y-2">
         <h1 className="text-2xl font-medium leading-8">{headerTitle}</h1>
-        <p className="text-base text-muted-foreground leading-6">
-          {headerSubtitle}
-        </p>
+        {headerSubtitle && (
+          <p className="text-base text-muted-foreground leading-6">
+            {headerSubtitle}
+          </p>
+        )}
       </div>
 
       {/* Error message */}

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -337,8 +337,8 @@ function CommerceHeader({
   title,
   description,
 }: {
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
 }) {
   return (
     <div className="grid gap-10">
@@ -352,12 +352,16 @@ function CommerceHeader({
         alt="Deco"
         className="h-12 w-12 hidden dark:block"
       />
-      <div className="space-y-2">
-        <h1 className="text-2xl font-medium leading-8">{title}</h1>
-        <p className="text-base text-muted-foreground leading-6">
-          {description}
-        </p>
-      </div>
+      {(title || description) && (
+        <div className="space-y-2">
+          {title && <h1 className="text-2xl font-medium leading-8">{title}</h1>}
+          {description && (
+            <p className="text-base text-muted-foreground leading-6">
+              {description}
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -738,10 +742,7 @@ function CommerceDiscoveryReady({
 }) {
   return (
     <div className="grid gap-10">
-      <CommerceHeader
-        title="Commerce Discovery"
-        description={`Commerce Discovery is connected for ${org.name}.`}
-      />
+      <CommerceHeader />
       <CompanionMcpsSection
         org={org}
         cdConnectionId={reportApp.connectionId}

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -25,6 +25,7 @@ import { ArrowRight, Loading01 } from "@untitledui/icons";
 import { Suspense, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { CompanionMcpsSection } from "./commerce-onboarding/companion-mcps-section.tsx";
+import { SiteBadge } from "./commerce-onboarding/site-badge.tsx";
 
 interface CommerceOrganization {
   id: string;
@@ -92,9 +93,20 @@ function CommerceOnboardingPage() {
         ? "/commerce-onboarding"
         : `${window.location.pathname}${window.location.search}`;
 
+    const normalizedSite = siteUrl ? normalizeCommerceSiteUrl(siteUrl) : null;
+    const siteHost = normalizedSite?.ok
+      ? new URL(normalizedSite.value).hostname
+      : null;
+
     return (
       <AuthSplitLayout>
-        <AuthEntry callbackUrl={callbackUrl} allowAutoLogin={false} />
+        <AuthEntry
+          callbackUrl={callbackUrl}
+          allowAutoLogin={false}
+          title="Unlock your full diagnostic"
+          subtitle={null}
+          brand={siteHost ? <SiteBadge host={siteHost} /> : undefined}
+        />
       </AuthSplitLayout>
     );
   }

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -22,7 +22,7 @@ import {
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowRight, Loading01 } from "@untitledui/icons";
-import { Suspense, useRef, useState } from "react";
+import { createContext, Suspense, useContext, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { CompanionMcpsSection } from "./commerce-onboarding/companion-mcps-section.tsx";
 import { SiteBadge } from "./commerce-onboarding/site-badge.tsx";
@@ -74,10 +74,45 @@ export default function CommerceOnboardingRoute() {
   return <CommerceOnboardingPage />;
 }
 
+/**
+ * Hostname derived from the `siteUrl` query param (e.g. "fila.com.br"),
+ * provided to the whole onboarding experience so every header renders the
+ * deco + site badge. `null` when no valid `siteUrl` is present.
+ */
+const CommerceSiteHostContext = createContext<string | null>(null);
+
+const useCommerceSiteHost = () => useContext(CommerceSiteHostContext);
+
+function siteUrlToHost(siteUrl?: string): string | null {
+  if (!siteUrl) return null;
+  const normalized = normalizeCommerceSiteUrl(siteUrl);
+  return normalized.ok ? new URL(normalized.value).hostname : null;
+}
+
 function CommerceOnboardingPage() {
   const search = useSearch({ from: "/commerce-onboarding" });
   const { org: requestedOrgSlug, siteUrl } = search;
+  const siteHost = siteUrlToHost(siteUrl);
+
+  return (
+    <CommerceSiteHostContext.Provider value={siteHost}>
+      <CommerceOnboardingScreens
+        requestedOrgSlug={requestedOrgSlug}
+        siteUrl={siteUrl}
+      />
+    </CommerceSiteHostContext.Provider>
+  );
+}
+
+function CommerceOnboardingScreens({
+  requestedOrgSlug,
+  siteUrl,
+}: {
+  requestedOrgSlug?: string;
+  siteUrl?: string;
+}) {
   const { data: session, isPending: sessionLoading } = authClient.useSession();
+  const siteHost = useCommerceSiteHost();
 
   if (sessionLoading) {
     return (
@@ -92,11 +127,6 @@ function CommerceOnboardingPage() {
       typeof window === "undefined"
         ? "/commerce-onboarding"
         : `${window.location.pathname}${window.location.search}`;
-
-    const normalizedSite = siteUrl ? normalizeCommerceSiteUrl(siteUrl) : null;
-    const siteHost = normalizedSite?.ok
-      ? new URL(normalizedSite.value).hostname
-      : null;
 
     return (
       <AuthSplitLayout>
@@ -352,18 +382,25 @@ function CommerceHeader({
   title?: string;
   description?: string;
 }) {
+  const siteHost = useCommerceSiteHost();
   return (
     <div className="grid gap-10">
-      <img
-        src="/logos/deco logo.svg"
-        alt="Deco"
-        className="h-12 w-12 dark:hidden"
-      />
-      <img
-        src="/logos/deco logo negative.svg"
-        alt="Deco"
-        className="h-12 w-12 hidden dark:block"
-      />
+      {siteHost ? (
+        <SiteBadge host={siteHost} />
+      ) : (
+        <div>
+          <img
+            src="/logos/deco logo.svg"
+            alt="Deco"
+            className="h-12 w-12 dark:hidden"
+          />
+          <img
+            src="/logos/deco logo negative.svg"
+            alt="Deco"
+            className="h-12 w-12 hidden dark:block"
+          />
+        </div>
+      )}
       {(title || description) && (
         <div className="space-y-2">
           {title && <h1 className="text-2xl font-medium leading-8">{title}</h1>}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -6,7 +6,7 @@ import type { CompanionCardModel } from "./companions-core.ts";
 function UnlockLine({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex items-center gap-2 p-1">
-      <CheckCircle size={14} className="shrink-0 text-muted-foreground" />
+      <CheckCircle size={14} className="shrink-0 text-blue-500" />
       <p className="text-sm text-foreground">{children}</p>
     </div>
   );
@@ -26,7 +26,13 @@ export function CompanionCard({
   return (
     <div className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-4">
       <div className="flex items-center gap-2">
-        <IntegrationIcon icon={card.icon} name={card.title} size="md" />
+        <IntegrationIcon
+          icon={card.icon}
+          name={card.title}
+          size="md"
+          fit="contain"
+          className="p-2"
+        />
         <p className="flex-1 text-sm text-foreground">{card.title}</p>
         {card.satisfied ? (
           <div className="flex h-8 items-center gap-2 px-3 text-sm text-muted-foreground">

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -24,7 +24,7 @@ export function CompanionCard({
   onConnect: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-2 rounded-2xl border border-border bg-background/60 p-4">
+    <div className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-4">
       <div className="flex items-center gap-2">
         <IntegrationIcon icon={card.icon} name={card.title} size="md" />
         <p className="flex-1 text-sm text-foreground">{card.title}</p>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -80,7 +80,7 @@ export function CompanionMcpsSection({
       {error ? (
         <div
           role="alert"
-          className="rounded-2xl border border-border bg-background/60 p-4"
+          className="rounded-2xl border border-border bg-card p-4"
         >
           <p className="text-sm text-foreground">
             Couldn't load companion integrations.

--- a/apps/mesh/src/web/routes/commerce-onboarding/site-badge.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/site-badge.tsx
@@ -1,0 +1,28 @@
+/**
+ * Brand row for the commerce onboarding login screen:
+ * deco logo / site favicon + domain. Rendered when a `siteUrl` query param
+ * is present. `host` must be a clean hostname (e.g. "fila.com.br").
+ */
+export function SiteBadge({ host }: { host: string }) {
+  const faviconUrl = `https://www.google.com/s2/favicons?domain=${host}&sz=128`;
+
+  return (
+    <div className="flex items-center gap-3">
+      <img
+        src="/logos/deco logo.svg"
+        alt="Deco"
+        className="h-7 w-7 dark:hidden"
+      />
+      <img
+        src="/logos/deco logo negative.svg"
+        alt="Deco"
+        className="h-7 w-7 hidden dark:block"
+      />
+      <div className="h-6 w-px -rotate-12 bg-border" aria-hidden="true" />
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-border bg-white">
+        <img src={faviconUrl} alt="" className="h-5 w-5" loading="lazy" />
+      </div>
+      <span className="text-lg font-medium text-foreground">{host}</span>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/site-badge.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/site-badge.tsx
@@ -18,7 +18,7 @@ export function SiteBadge({ host }: { host: string }) {
         alt="Deco"
         className="h-7 w-7 hidden dark:block"
       />
-      <div className="h-6 w-px -rotate-12 bg-border" aria-hidden="true" />
+      <div className="h-6 w-px rotate-12 bg-border" aria-hidden="true" />
       <div className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-border bg-white">
         <img src={faviconUrl} alt="" className="h-5 w-5" loading="lazy" />
       </div>


### PR DESCRIPTION
## Summary
Match the `/commerce-onboarding` experience to the Figma "Unlock your full diagnostic" design, branding it with the target site.

- **Site-branded headers:** when the `siteUrl` query param is present, every screen in the route (login, org choice, setup, ready) renders a `SiteBadge` — the deco logo `/` the site favicon `domain` — instead of the plain deco logo. The host is derived once and shared via a small React context, so all `CommerceHeader`s pick it up without prop-drilling. Falls back to the deco logo when no valid `siteUrl` is present.
- **Login copy:** the logged-out screen shows "Unlock your full diagnostic" with no subtitle. This is done through new optional `title` / `subtitle` / `brand` props on the shared `AuthEntry` + `UnifiedAuthForm`, whose defaults preserve the existing `/login` UI exactly (that route is untouched).
- **Ready-state dedupe:** removed the redundant `Commerce Discovery` title/description above the companion section (which renders its own heading). `CommerceHeader` now takes optional `title`/`description`.
- **Card polish:** companion + error cards use the `bg-card` token; checklist checks are `blue-500`; integration logos gain padding via `IntegrationIcon`'s new `fit="contain"` (default stays `cover`).

`/login` is unchanged — verified the shared components' defaults reproduce the previous title, subtitle, and logo.

## Testing
- ✅ `bun run fmt:check` — clean
- ✅ `tsc --noEmit` (apps/mesh) — 0 errors
- ✅ `bun run lint` — 0 errors
- Manually verified in-browser: logged-out with/without `siteUrl`, post-login "Commerce diagnostics" header (all render the badge / correct fallback), badge separator renders as `/`, and `/login` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)