### PR TITLE
feat(harness): tell local CLI harnesses background tasks are unsupported

### DIFF
--- a/packages/harness/src/claude-code/index.ts
+++ b/packages/harness/src/claude-code/index.ts
@@ -38,6 +38,7 @@ import { extractUserText, prepCliMessages } from "../cli-message-prep";
 import { createCliMessageMetadata } from "../cli-stream-metadata";
 import { buildCodingWorkspacePrompt } from "../coding-workspace-prompt";
 import { buildCurrentContextPrompt } from "../current-context-prompt";
+import { NO_BACKGROUND_TASKS_PROMPT } from "../no-background-tasks-prompt";
 import { mergeTitleResult, shouldGenerateTitle } from "../title-merge";
 import { genTitle } from "../title-generator";
 import { stringifyError } from "../stream-error";
@@ -86,6 +87,7 @@ export function buildClaudeCodeSystemPrompt(input: {
     input.agentInstructions?.trim()
       ? `<agent-instructions>\n${input.agentInstructions.trim()}\n</agent-instructions>`
       : null,
+    NO_BACKGROUND_TASKS_PROMPT,
     buildCurrentContextPrompt(input.now ?? new Date()),
   ].filter((part): part is string => Boolean(part?.trim()));
 

--- a/packages/harness/src/codex/index.ts
+++ b/packages/harness/src/codex/index.ts
@@ -48,6 +48,7 @@ import {
 } from "../cli-session-error";
 import { mergeTitleResult, shouldGenerateTitle } from "../title-merge";
 import { buildCurrentContextPrompt } from "../current-context-prompt";
+import { NO_BACKGROUND_TASKS_PROMPT } from "../no-background-tasks-prompt";
 import { genTitle } from "../title-generator";
 import type {
   Harness,
@@ -90,6 +91,7 @@ export function buildCodexDeveloperInstructions(input: {
     input.agentInstructions?.trim()
       ? `<agent-instructions>\n${input.agentInstructions.trim()}\n</agent-instructions>`
       : null,
+    NO_BACKGROUND_TASKS_PROMPT,
     buildCurrentContextPrompt(input.now ?? new Date()),
   ].filter((part): part is string => Boolean(part?.trim()));
 

--- a/packages/harness/src/no-background-tasks-prompt.ts
+++ b/packages/harness/src/no-background-tasks-prompt.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared system-prompt fragment: this environment does NOT support background
+ * tasks. The harness must run every command in the foreground and wait for it
+ * to finish — do not use `run_in_background` (or `&`, `nohup`, `disown`, etc.)
+ * to detach work, and do not rely on background shells / `BashOutput` polling.
+ * Backgrounded processes are not tracked and will not be reachable.
+ *
+ * Shared across CLI harnesses (claude-code, codex) so the guidance stays in one
+ * place.
+ */
+export const NO_BACKGROUND_TASKS_PROMPT = `<important>
+Background tasks are NOT supported in this environment. Always run commands in the foreground and wait for them to complete. Do NOT use \`run_in_background\`, background shells, \`&\`, \`nohup\`, or \`disown\` to detach work — backgrounded processes are not tracked and will not be reachable.
+</important>`;


### PR DESCRIPTION
## Summary
- Local CLI harnesses (claude-code, codex) currently do **not** support background tasks, but nothing in the system prompt told the model that. As a result the harness could try to detach work (`run_in_background`, `&`, `nohup`, `disown`, background shells), which is not tracked and becomes unreachable.
- Adds a shared `NO_BACKGROUND_TASKS_PROMPT` fragment and injects it into both harness system prompts so all commands run in the foreground.

## Changes
- New `packages/harness/src/no-background-tasks-prompt.ts` — single shared constant so the guidance stays consistent across harnesses.
- Wired into `buildClaudeCodeSystemPrompt` (`claude-code/index.ts`) and `buildCodexDeveloperInstructions` (`codex/index.ts`), placed after agent-instructions and before the current-context prompt.
- `decopilot` is the in-app agent (not a local CLI harness) and is intentionally left out.

## Testing
- `bun run --cwd=packages/harness check` (tsc --noEmit) passes.
- `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared `NO_BACKGROUND_TASKS_PROMPT` to the `claude-code` and `codex` CLI harness system prompts to forbid background tasks, so all commands run in the foreground and remain reachable. This prevents detached work via `run_in_background`, `&`, `nohup`, or `disown`; `decopilot` is unchanged.

<sup>Written for commit 9c6ebfebd42e57989e7ba77fb1194401958dd539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

