### PR TITLE
fix(web): truncate org names and reveal scrollable org list on mobile

### DIFF
--- a/apps/mesh/src/web/components/organization-choice.tsx
+++ b/apps/mesh/src/web/components/organization-choice.tsx
@@ -107,7 +107,7 @@ export function OrganizationChoice({
   const pendingRequestSlug = requestJoinMutation.variables?.slug ?? null;
 
   return (
-    <div className="grid gap-2">
+    <div className="grid grid-cols-1 gap-2">
       {organizations.map((org) => {
         const isJoining =
           joinOrgMutation.isPending && pendingJoinSlug === org.slug;

--- a/apps/mesh/src/web/components/scroll-reveal.tsx
+++ b/apps/mesh/src/web/components/scroll-reveal.tsx
@@ -1,0 +1,94 @@
+import { cn } from "@deco/ui/lib/utils.ts";
+import { ChevronDown } from "@untitledui/icons";
+import { type ReactNode, useState } from "react";
+
+interface ScrollRevealProps {
+  children: ReactNode;
+  /** Classes for the scrollable container (e.g. `max-h-[60vh]`). */
+  className?: string;
+  /** Label for the reveal affordance. */
+  label?: string;
+}
+
+/**
+ * Wraps scrollable content and shows a "Show more" pill whenever the content is
+ * not scrolled to the bottom. Without it, an `overflow-y-auto` container silently
+ * hides items below the fold — users can't tell there's more to scroll to.
+ *
+ * Detection is wired through a React 19 callback ref (with cleanup) rather than
+ * `useEffect`, which is banned in this codebase.
+ */
+export function ScrollReveal({
+  children,
+  className,
+  label = "Show more",
+}: ScrollRevealProps) {
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const [atBottom, setAtBottom] = useState(true);
+
+  const containerRef = (node: HTMLDivElement | null) => {
+    setContainer(node);
+    if (!node) {
+      return;
+    }
+
+    const measure = () => {
+      const reachedBottom =
+        node.scrollHeight - node.scrollTop - node.clientHeight < 8;
+      setAtBottom(reachedBottom);
+    };
+
+    measure();
+    node.addEventListener("scroll", measure, { passive: true });
+    // Re-measure when the container or its content changes size.
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    for (const child of Array.from(node.children)) {
+      observer.observe(child);
+    }
+
+    return () => {
+      node.removeEventListener("scroll", measure);
+      observer.disconnect();
+    };
+  };
+
+  const scrollDown = () => {
+    container?.scrollBy({
+      top: container.clientHeight * 0.8,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <div className="relative">
+      <div ref={containerRef} className={className}>
+        {children}
+      </div>
+      <div
+        aria-hidden={atBottom}
+        className={cn(
+          "pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-2 pt-10",
+          "bg-gradient-to-t from-background to-transparent",
+          "transition-opacity duration-200",
+          atBottom ? "opacity-0" : "opacity-100",
+        )}
+      >
+        <button
+          type="button"
+          onClick={scrollDown}
+          tabIndex={atBottom ? -1 : 0}
+          className={cn(
+            "flex items-center gap-1 rounded-full border bg-background px-3 py-1",
+            "text-xs font-medium text-muted-foreground shadow-sm",
+            "transition-colors hover:text-foreground",
+            atBottom ? "pointer-events-none" : "pointer-events-auto",
+          )}
+        >
+          {label}
+          <ChevronDown size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -2,6 +2,7 @@ import { normalizeCommerceSiteUrl } from "@/commerce-discovery/site-url";
 import { AuthEntry } from "@/web/components/auth-entry";
 import { AuthSplitLayout } from "@/web/components/auth-split-layout";
 import { OrganizationChoice } from "@/web/components/organization-choice";
+import { ScrollReveal } from "@/web/components/scroll-reveal";
 import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import {
   authClient,
@@ -253,13 +254,13 @@ function CommerceOnboardingContent({
             title="Choose an organization"
             description="Select where commerce diagnostics should continue."
           />
-          <div className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
+          <ScrollReveal className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
             <OrganizationChoice
               organizations={activeOrganizations}
               selectLabel="Continue"
               onSelected={(organization) => setSelectedOrg(organization)}
             />
-          </div>
+          </ScrollReveal>
         </div>
       </AuthSplitLayout>
     );
@@ -303,7 +304,7 @@ function CommerceOnboardingContent({
             title="Choose an organization"
             description="Your email can access more than one organization. Choose where commerce setup should continue."
           />
-          <div className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
+          <ScrollReveal className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
             <OrganizationChoice
               organizations={ensureResult.organizations}
               domain={ensureResult.domain ?? undefined}
@@ -316,7 +317,7 @@ function CommerceOnboardingContent({
                 });
               }}
             />
-          </div>
+          </ScrollReveal>
         </div>
       </AuthSplitLayout>
     );


### PR DESCRIPTION
## Summary
Fixes two mobile issues on the org-select screens.

- **Org name truncation** — the rows in `OrganizationChoice` used a bare `grid`, whose `auto`-sized column expanded to fit the non-wrapping (`truncate`) org name. That overflowed the row and pushed the **Continue** button off-screen on narrow viewports. Switching to `grid-cols-1` (`minmax(0, 1fr)`) lets the existing `min-w-0` + `truncate` finally take effect. Applies everywhere `OrganizationChoice` is used.
- **"Show more" scroll affordance** — new reusable `ScrollReveal` wrapper that shows a "Show more ⌄" pill (with a bottom gradient fade) whenever an `overflow-y-auto` list isn't scrolled to the bottom, so users know there are more orgs below the fold. It fades out and stops capturing clicks once you reach the end. Wired into both `commerce-onboarding` org choosers (the only spots with a `max-h-[60vh]` scroller). Detection uses a React 19 callback ref with cleanup (`scroll` listener + `ResizeObserver`) — no `useEffect`, per repo rules.

## Testing
- `bun run fmt` ✅
- `bun run lint` ✅ (0 errors)
- `bun run check` (tsc --noEmit) ✅

Screenshots: pending manual mobile-viewport pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile overflow in organization selection and adds a “Show more” scroll hint for long org lists. Keeps the Continue button visible and makes extra organizations discoverable on small screens.

- **Bug Fixes**
  - In `OrganizationChoice`, switch to `grid grid-cols-1` so `min-w-0` + `truncate` work and org names don’t push the Continue button off-screen.

- **New Features**
  - Added reusable `ScrollReveal` that shows a “Show more ⌄” pill over `overflow-y-auto` lists until the bottom is reached; used in both `commerce-onboarding` org choosers via a React 19 callback ref with `scroll` + `ResizeObserver` (no `useEffect`).

<sup>Written for commit 53c07453c567d34db3c77a425dd885244014d7c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

