### PR TITLE
fix(sandbox): keep booting visual overlaid until dev server is up

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -362,6 +362,19 @@ export function PreviewContent() {
   const previewState = lifecycle.previewState;
   const userStopped = lifecycle.userStopped;
 
+  // The recorded previewUrl flips previewState to "iframe" as soon as the
+  // sandbox handle exists — well before the public preview proxy is routable
+  // and actually serving, so the iframe renders blank during the initial boot.
+  // Keep the booting visual overlaid (absolute, z-30, above the warming iframe)
+  // until the dev server has come up. `progress.status === "doing"` is true for
+  // exactly the forward boot phases (provision → clone → install → starting);
+  // it flips to "done" at `running` and "failed" on a terminal error, so both
+  // the live app and the daemon's auto-reloading status/crash page still fall
+  // through to the iframe unobscured.
+  const showBootingOverlay =
+    previewState.kind === "starting" ||
+    (previewState.kind === "iframe" && progress.status === "doing");
+
   const iframeSrc =
     previewState.kind === "iframe"
       ? withVariantMatcherOverride(
@@ -1183,7 +1196,7 @@ export function PreviewContent() {
               "flex justify-center bg-muted/30",
           )}
         >
-          {previewState.kind === "starting" && (
+          {showBootingOverlay && (
             <div className="absolute inset-0 z-30">
               <SandboxStateCard
                 kind="starting"


### PR DESCRIPTION
## Summary

When a sandbox is first being provisioned, the **Preview** panel sometimes shows a completely blank white screen with **no load state** (see the reported screenshot: the sandbox is still running `bun install` while the preview area is blank).

**Root cause:** `computePreviewState` flips `previewState` to `"iframe"` as soon as a `previewUrl` exists — and that URL is recorded in the branch-map as soon as the sandbox handle is created, *well before* the public preview proxy (`*.preview-studio.decocms.com`) is routable and actually serving. During that window the `BootingVisual` (which only rendered for `kind === "starting"`) disappears and the iframe loads a URL that serves nothing yet → blank screen.

## Fix

Keep the `BootingVisual` overlaid (`absolute inset-0 z-30`, above the warming iframe) while the boot advances, gating on the existing phase progress:

```ts
const showBootingOverlay =
  previewState.kind === "starting" ||
  (previewState.kind === "iframe" && progress.status === "doing");
```

`progress.status === "doing"` (from `derivePhaseProgress`) is true for exactly the forward boot phases (provision → clone → install → starting). It flips to:
- `"done"` at `running` → overlay clears, the live app shows;
- `"failed"` on a terminal error (`crashed` / `start-failed`) → overlay clears, the iframe shows the daemon's auto-reloading status/crash page.

So the initial blank window is covered by the animated load state, without regressing the running-app view or the daemon-served failure pages.

## Testing

- `bun run fmt` — clean
- `tsc --noEmit` (typecheck) — passes
- `bun run lint` — 0 errors (only pre-existing warnings in unrelated files)
- No unit test was coupled to the changed JSX condition.

## Follow-up (out of scope)

During this window the drawer status pill reads "running" (since `computeDrawerStatus` derives only from `previewState`) while the preview shows "booting". Threading `progress` into `computeDrawerStatus` would make the pill coherent, but touches `sandbox-lifecycle-context` and its unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the sandbox Preview from showing a blank white screen during boot by keeping the booting overlay visible until the dev server is actually serving.

- **Bug Fixes**
  - Overlay shows when `previewState.kind === "starting"` or when `previewState.kind === "iframe"` and `progress.status === "doing"`.
  - Overlay clears when progress is `"done"` (running) or `"failed"`, allowing the app or daemon status/crash page to show.

<sup>Written for commit 11e7962f46bd019fb81cea48ddfe909e23ae6f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

