### PR TITLE
fix(dbos): re-enqueue orphaned PENDING workflows on graceful shutdown

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -310,6 +310,44 @@ if (settings.localMode) {
 
 let shuttingDown = false;
 
+// A workflow this pod is actively executing is PENDING and bound to this pod's
+// executor_id (= podName). When the pod exits, that binding never releases: a
+// new pod's launch recovery only reclaims its OWN executor_id, and the queue
+// poller only dequeues ENQUEUED rows — so a PENDING row owned by a departed pod
+// strands forever (the rollout wedge). The Conductor can't be relied on to
+// recover a gracefully-deregistered executor. So on the way out, flip our own
+// PENDING queued workflows back to ENQUEUED on their original queue (preserving
+// partition concurrency); ENQUEUED has no executor binding, so the next pod's
+// poller inherits them — now, or whenever one comes up. Idempotent: a resumed
+// workflow replays recorded step outputs, same guarantee as crash recovery.
+async function handoffMyPendingWorkflows() {
+  try {
+    const mine = await DBOS.listWorkflows({
+      status: ["PENDING"],
+      executorId: DBOS.executorID,
+    });
+    const byQueue = new Map<string, string[]>();
+    for (const wf of mine) {
+      if (!wf.queueName) continue; // non-queued workflows have no re-enqueue path
+      const ids = byQueue.get(wf.queueName);
+      if (ids) ids.push(wf.workflowID);
+      else byQueue.set(wf.queueName, [wf.workflowID]);
+    }
+    if (byQueue.size === 0) return;
+    let total = 0;
+    for (const [queueName, ids] of byQueue) {
+      await DBOS.resumeWorkflows(ids, { queueName });
+      total += ids.length;
+    }
+    console.log(
+      `[shutdown] re-enqueued ${total} in-flight workflow(s) for pickup by another pod`,
+    );
+  } catch (err) {
+    // Best-effort: a handoff failure must never block the rest of shutdown.
+    console.error("[shutdown] workflow handoff failed:", err);
+  }
+}
+
 async function gracefulShutdown(signal: string) {
   if (shuttingDown) return;
   shuttingDown = true;
@@ -351,8 +389,19 @@ async function gracefulShutdown(signal: string) {
     //    graceful drain indefinitely).
     await server.stop(true);
 
-    // Drain DBOS before app.shutdown closes mesh's pg pool — in-flight steps use it.
-    await DBOS.shutdown();
+    // 4. Hand off whatever we're still executing. The drain above doubles as a
+    //    natural-completion window, so anything still PENDING here is a
+    //    long-running workflow that won't finish in the grace budget. Re-enqueue
+    //    it while DBOS is still launched (listWorkflows/resumeWorkflows need it).
+    await handoffMyPendingWorkflows();
+
+    // 5. Drain DBOS before app.shutdown closes mesh's pg pool — in-flight steps
+    //    use it. Cap the drain: awaitRunningWorkflows() blocks on the very
+    //    workflows we just handed off (resume doesn't cancel the local promise),
+    //    so left unbounded it burns the whole budget and starves app.shutdown.
+    //    We've already re-enqueued the work, so abandoning the local copy is safe.
+    const dbosDrainCapMs = 15_000;
+    await Promise.race([DBOS.shutdown(), sleep(dbosDrainCapMs)]);
     await app.shutdown();
   } catch (err) {
     console.error("[shutdown] Error during shutdown:", err);


### PR DESCRIPTION
## Problem

Every rollout strands in-flight workflows in `PENDING` forever.

A workflow a pod is actively executing is `PENDING` and bound to that pod's `executor_id` — which we set to the podName (`index.ts` / `dbos/config.ts`, unique per pod). When the pod exits, nothing ever releases that binding:

- DBOS's launch-time recovery is hard-scoped to **its own** executor ID (`dbos-executor.js`: `recoverPendingWorkflows([this.executorID])`), so a new pod never reclaims a departed pod's rows.
- The queue poller only dequeues `ENQUEUED` rows, never `PENDING`.
- `DBOS.shutdown()` **deregisters from the Conductor**, and there's no evidence the Conductor recovers a *gracefully*-deregistered executor's leftover `PENDING` work. Empirically it doesn't — the rows sit forever (the thread-gate "accepted and queued" wedge).

So the only cross-pod recovery path is the Conductor, and it isn't firing for the graceful-shutdown (rollout) case. Mesh can't rely on it.

## Fix

On `SIGTERM`, after the LB drain window (which doubles as a natural-completion window for short workflows), the **departing pod hands off its own work**: list our still-`PENDING` workflows and flip them back to `ENQUEUED` on their **original queue** via `DBOS.resumeWorkflows(ids, { queueName })` (preserving per-partition concurrency).

`ENQUEUED` has no executor binding, so the next pod's poller inherits them — during the rollout overlap, or whenever the next pod comes up. This needs **no live sibling at handoff time** and **no liveness oracle** (the departing pod re-enqueues only its *own* rows, so no cross-pod ownership guessing — this is not the boot-sweep pattern removed in #3917).

Also caps `DBOS.shutdown()`'s drain: `awaitRunningWorkflows()` blocks on the very workflows we just handed off (resume doesn't cancel the local promise), so left unbounded it burns the whole grace budget and starves `app.shutdown()` (mesh pg pool close). We've already re-enqueued the work, so abandoning the local copy is safe.

### Why not "error the workflows"?

`ERROR` is terminal — recovery targets `PENDING`, so erroring buries them. The correct transition is `PENDING → ENQUEUED`, which is exactly what DBOS's own internal recovery does (`clearQueueAssignment`); `resumeWorkflows({ queueName })` is the public API that performs it.

## Safety

- **Idempotent**: a resumed workflow replays recorded step outputs — same guarantee crash recovery relies on. The brief window where the dying pod and a sibling both "have" the workflow is bounded and step-guarded.
- **Version-aware**: `resume` preserves `application_version`, and queue dequeue filters by it — so pickup works across a rollout as long as `DBOS_WORKFLOW_VERSION` is unchanged (the normal case). A deploy that bumps the version leaves rows as `ENQUEUED`-on-old-version for a fork/migration — still strictly more recoverable than `PENDING`-on-dead-pod, and consistent with the existing pinning contract.
- **Scope**: fixes graceful shutdown (rollouts, the reported bug). Hard crashes (OOM/SIGKILL/node loss) never run the handler and still depend on the Conductor / a future boot sweep — out of scope here.
- Handoff is best-effort/try-caught: a failure never blocks the rest of shutdown.

## Testing notes

Logic is a graceful-shutdown side effect (no pure unit surface). Verify on staging by rolling the deployment and confirming: (1) `[shutdown] re-enqueued N in-flight workflow(s)` in the terminating pod's logs, and (2) no `PENDING` rows tagged to dead podNames survive the rollout (`SELECT status, executor_id FROM dbos.workflow_status WHERE status='PENDING'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enqueues this pod’s `PENDING` queued workflows on graceful shutdown to prevent stranded work during rollouts, and caps the shutdown drain to avoid blocking `app.shutdown()`.

- **Bug Fixes**
  - On `SIGTERM`, after the drain window, list this executor’s `PENDING` workflows and `resumeWorkflows` to `ENQUEUED` on their original queues (preserves partition concurrency).
  - Cap `DBOS.shutdown()` drain to 15s with `Promise.race` so it doesn’t block on handed-off workflows; proceed to `app.shutdown()`.
  - Best-effort and safe: grouped by queue, logs re-enqueued count; non-queued workflows are skipped.

<sup>Written for commit 347b166d9b1fa35353e39a8d24e687dbccb08b0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

