### PR TITLE
fix(sandbox): raise git spawn timeout to 30s to avoid publish ETIMEDOUT

### DIFF
--- a/packages/sandbox/daemon/git/git-sync.ts
+++ b/packages/sandbox/daemon/git/git-sync.ts
@@ -6,7 +6,7 @@ export interface GitSyncOpts {
   env?: NodeJS.ProcessEnv;
   /** When true (default), drops to deco:1000/1000. Set false for system-level git config as root. */
   asUser?: boolean;
-  /** Kill the git process after this many ms. Default: 10 000 (10 s). */
+  /** Kill the git process after this many ms. Default: 30 000 (30 s). */
   timeoutMs?: number;
 }
 
@@ -15,7 +15,7 @@ export interface GitError extends Error {
   status: number;
 }
 
-const DEFAULT_GIT_TIMEOUT_MS = 10_000;
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
 
 export function gitSync(args: string[], opts: GitSyncOpts): string {
   const asUser = opts.asUser !== false;


### PR DESCRIPTION
## Summary

Fixes the intermittent `spawnSync git ... ETIMEDOUT` error surfaced by the sandbox's **Publish to production** modal.

Every git call in the daemon funnels through `gitSync` (`packages/sandbox/daemon/git/git-sync.ts`), which runs `spawnSync` with a **hardcoded 10s timeout**. That ceiling was tuned for local probes (`status`, `rev-parse`, `diff`), but it also applies to **network fetches** — including the `fetch -p origin <base>` run during publish (`rebase-onto-base.ts:331`). A cold TLS connection, large base history, GitHub latency, or slow container egress pushes the fetch past 10s, so `spawnSync` kills git and Node throws `ETIMEDOUT` — which the publish modal reports as a failure.

This bumps the default from 10s → **30s**. Since call sites can still override `timeoutMs`, local probes remain free to opt into a tighter bound later; this just stops premature kills of the network path.

## Testing
- `bun run fmt` — clean
- `bun test packages/sandbox/daemon/git/` — 22 pass, 0 fail

## Affected areas
Sandbox daemon git operations (publish, rebase-onto-base, PR diff fetches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the default git spawn timeout in the sandbox daemon from 10s to 30s to stop intermittent `spawnSync git ... ETIMEDOUT` during Publish to production. Updates `gitSync` in `packages/sandbox/daemon/git/git-sync.ts`; call sites can still override `timeoutMs`.

<sup>Written for commit 4e0e84b42c0eb910a641c46831bc1ef08f299270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

