### PR TITLE
feat(commerce-onboarding): blur/fade companion list scroll edge

### DIFF
--- a/apps/mesh/src/web/components/scroll-reveal.tsx
+++ b/apps/mesh/src/web/components/scroll-reveal.tsx
@@ -1,33 +1,28 @@
 import { cn } from "@deco/ui/lib/utils.ts";
-import { ChevronDown } from "@untitledui/icons";
 import { type ReactNode, useState } from "react";
 
 interface ScrollRevealProps {
   children: ReactNode;
-  /** Classes for the scrollable container (e.g. `max-h-[60vh]`). */
+  /** Classes for the scrollable container (e.g. `max-h-[60vh] overflow-y-auto`). */
   className?: string;
-  /** Label for the reveal affordance. */
-  label?: string;
 }
 
 /**
- * Wraps scrollable content and shows a "Show more" pill whenever the content is
- * not scrolled to the bottom. Without it, an `overflow-y-auto` container silently
- * hides items below the fold — users can't tell there's more to scroll to.
+ * Wraps scrollable content and blurs/fades its bottom edge whenever the content
+ * is not scrolled all the way down. Without it, an `overflow-y-auto` container
+ * silently cuts items off at the fold — users can't tell there's more below.
+ *
+ * The affordance is purely visual (`pointer-events-none`): the blurred fade
+ * hints at more content underneath while scrolling stays on the wheel /
+ * trackpad / keyboard as usual.
  *
  * Detection is wired through a React 19 callback ref (with cleanup) rather than
  * `useEffect`, which is banned in this codebase.
  */
-export function ScrollReveal({
-  children,
-  className,
-  label = "Show more",
-}: ScrollRevealProps) {
-  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+export function ScrollReveal({ children, className }: ScrollRevealProps) {
   const [atBottom, setAtBottom] = useState(true);
 
   const containerRef = (node: HTMLDivElement | null) => {
-    setContainer(node);
     if (!node) {
       return;
     }
@@ -53,42 +48,21 @@ export function ScrollReveal({
     };
   };
 
-  const scrollDown = () => {
-    container?.scrollBy({
-      top: container.clientHeight * 0.8,
-      behavior: "smooth",
-    });
-  };
-
   return (
     <div className="relative">
       <div ref={containerRef} className={className}>
         {children}
       </div>
       <div
-        aria-hidden={atBottom}
+        aria-hidden
         className={cn(
-          "pointer-events-none absolute inset-x-0 bottom-0 flex justify-center pb-2 pt-10",
+          "pointer-events-none absolute inset-x-0 bottom-0 h-[213px]",
           "bg-gradient-to-t from-background to-transparent",
+          "backdrop-blur-[2px] [mask-image:linear-gradient(to_top,black,transparent)]",
           "transition-opacity duration-200",
           atBottom ? "opacity-0" : "opacity-100",
         )}
-      >
-        <button
-          type="button"
-          onClick={scrollDown}
-          tabIndex={atBottom ? -1 : 0}
-          className={cn(
-            "flex items-center gap-1 rounded-full border bg-background px-3 py-1",
-            "text-xs font-medium text-muted-foreground shadow-sm",
-            "transition-colors hover:text-foreground",
-            atBottom ? "pointer-events-none" : "pointer-events-auto",
-          )}
-        >
-          {label}
-          <ChevronDown size={14} />
-        </button>
-      </div>
+      />
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -1,3 +1,4 @@
+import { ScrollReveal } from "@/web/components/scroll-reveal";
 import { authClient } from "@/web/lib/auth-client";
 import { SELF_MCP_ALIAS_ID, useMCPClient } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -99,22 +100,24 @@ export function CompanionMcpsSection({
           ))}
         </div>
       ) : (
-        <div className="grid gap-4">
-          {connectError && (
-            <p role="alert" className="text-sm text-destructive">
-              {connectError}
-            </p>
-          )}
-          {cards.map((card) => (
-            <CompanionCard
-              key={card.fieldKey}
-              card={card}
-              connecting={connectingFieldKey === card.fieldKey}
-              disabled={busy && connectingFieldKey !== card.fieldKey}
-              onConnect={() => void connect(card)}
-            />
-          ))}
-        </div>
+        <ScrollReveal className="-mx-1 max-h-[45vh] overflow-y-auto px-1">
+          <div className="grid gap-4">
+            {connectError && (
+              <p role="alert" className="text-sm text-destructive">
+                {connectError}
+              </p>
+            )}
+            {cards.map((card) => (
+              <CompanionCard
+                key={card.fieldKey}
+                card={card}
+                connecting={connectingFieldKey === card.fieldKey}
+                disabled={busy && connectingFieldKey !== card.fieldKey}
+                onConnect={() => void connect(card)}
+              />
+            ))}
+          </div>
+        </ScrollReveal>
       )}
 
       {cta}


### PR DESCRIPTION
## Summary
- Reworks `ScrollReveal` to fade/blur the bottom edge of scrollable content instead of showing a "Show more" pill.
- The affordance is a masked `backdrop-blur` gradient (213px transparent→solid ramp per the Figma spec), fully `pointer-events-none` — scrolling stays on wheel/trackpad/keyboard.
- Wraps the companion cards list in `CompanionMcpsSection` with `ScrollReveal`.

## Testing
- `bun run fmt`
- Visual only; no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the “Show more” pill with a masked bottom blur/fade on scrollable content to hint at more items while keeping native scrolling. Applies this to the commerce onboarding companion list.

- **New Features**
  - `ScrollReveal` now shows a 213px transparent→solid gradient with subtle backdrop blur (`pointer-events-none`) that auto-hides at the bottom.
  - Wrapped the companion cards grid in `ScrollReveal` with `max-h-[45vh] overflow-y-auto`; visual-only change.

<sup>Written for commit 5a29acbe1742da59e456b7a1280b3007aa7aaa72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

