### PR TITLE
fix(sections-editor): guard cyclic Section-picker unions to prevent CMS memory blow-up

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -749,3 +749,81 @@ describe("resolveSchema – @hide on block-ref fields", () => {
     expect(props?.visibleField?.hidden).toBeUndefined();
   });
 });
+
+describe("resolveSchema – cyclic Section-picker unions (memory blow-up guard)", () => {
+  /**
+   * Builds a `__SECTION_REF__`-style "pick any section" union where every
+   * section carries a `menuSection: Section` field pointing back at the same
+   * union. Before the cycle guard this recursed ~exponentially (depth 8 ×
+   * branching 110 × cyclic re-entry) and blew up the browser (multi-GB).
+   */
+  function cyclicSectionMeta(sectionCount: number): LiveMeta {
+    const definitions: Record<string, unknown> = {};
+    const anyOf: Array<{ $ref: string }> = [];
+
+    for (let i = 0; i < sectionCount; i++) {
+      const rt = `site/sections/S${i}.tsx`;
+      const wrapperKey = `W${i}`;
+      const propsKey = `P${i}`;
+      anyOf.push({ $ref: `#/definitions/${wrapperKey}` });
+      definitions[wrapperKey] = {
+        title: rt,
+        allOf: [{ $ref: `#/definitions/${propsKey}` }],
+        properties: { __resolveType: { type: "string", enum: [rt] } },
+      };
+      definitions[propsKey] = {
+        type: "object",
+        properties: {
+          title: { type: "string", title: "Title" },
+          // back-reference to the same union → cycle
+          menuSection: { $ref: "#/definitions/__SECTION_REF__", title: "Menu" },
+        },
+      };
+    }
+    definitions.__SECTION_REF__ = { title: "Section", anyOf };
+
+    return {
+      manifest: {
+        blocks: {
+          sections: { "site/sections/S0.tsx": { $ref: "#/definitions/W0" } },
+        },
+      },
+      schema: { definitions },
+    };
+  }
+
+  test("resolves a large cyclic section union without blowing up", () => {
+    const meta = cyclicSectionMeta(110);
+    const start = Date.now();
+    const resolved = resolveSchema("site/sections/S0.tsx", meta);
+    const elapsed = Date.now() - start;
+
+    const menu = resolved?.properties?.menuSection;
+    expect(menu?.type).toBe("block-ref");
+    // Option list is still emitted (selector works)…
+    expect(menu?.anyOfRefs?.length).toBe(110);
+    // …but oversized unions are lazy: no eager per-branch schema.
+    expect(menu?.anyOfRefs?.every((r) => r.schema === undefined)).toBe(true);
+    // And it completes basically instantly rather than hanging.
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  test("small cyclic union still terminates and cuts the cycle", () => {
+    const meta = cyclicSectionMeta(3);
+    const resolved = resolveSchema("site/sections/S0.tsx", meta);
+
+    const menu = resolved?.properties?.menuSection;
+    expect(menu?.type).toBe("block-ref");
+    expect(menu?.anyOfRefs?.length).toBe(3);
+    // Under the eager threshold, branch schemas are materialized one level…
+    const branch = menu?.anyOfRefs?.[0]?.schema;
+    expect(branch?.properties?.title?.type).toBe("string");
+    // …but the branch's own menuSection does NOT re-expand its options
+    // (cycle guard), so recursion stays bounded.
+    const nestedMenu = branch?.properties?.menuSection;
+    expect(nestedMenu?.type).toBe("block-ref");
+    expect(nestedMenu?.anyOfRefs?.every((r) => r.schema === undefined)).toBe(
+      true,
+    );
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -808,6 +808,34 @@ describe("resolveSchema – cyclic Section-picker unions (memory blow-up guard)"
     expect(elapsed).toBeLessThan(1000);
   });
 
+  test("large type-discriminated union keeps eager branch schemas", () => {
+    // Type-discriminated branches (distinguished by a `type` field, no module
+    // __resolveType) have no lazy resolver, so their schemas must stay eager
+    // even when the union exceeds the section-selector threshold.
+    const branchCount = 50;
+    const anyOf = Array.from({ length: branchCount }, (_, i) => ({
+      type: "object",
+      properties: {
+        type: { type: "string", const: `variant-${i}` },
+        label: { type: "string", title: "Label" },
+      },
+    }));
+    const meta = metaWithSchema({
+      type: "object",
+      properties: { card: { anyOf } },
+    });
+
+    const card = resolveSchema("site/sections/Test.tsx", meta)?.properties
+      ?.card;
+    expect(card?.type).toBe("block-ref");
+    expect(card?.discriminatorKey).toBe("type");
+    expect(card?.anyOfRefs?.length).toBe(branchCount);
+    // Every branch keeps its nested fields (no lazy fallback exists).
+    expect(
+      card?.anyOfRefs?.every((r) => r.schema?.properties?.label !== undefined),
+    ).toBe(true);
+  });
+
   test("small cyclic union still terminates and cuts the cycle", () => {
     const meta = cyclicSectionMeta(3);
     const resolved = resolveSchema("site/sections/S0.tsx", meta);

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -401,14 +401,22 @@ export function resolveSchema(
      * Build a union branch's nested schema, unless doing so would recurse into
      * a cycle or expand an oversized selector. Returns `undefined` in those
      * cases so the branch is resolved lazily on selection.
+     *
+     * The oversized-union skip only applies when branches are `lazilyResolvable`
+     * — i.e. keyed by a module `__resolveType` that `resolveSchema()` can
+     * re-resolve on selection (section/loader selectors). Type-discriminated
+     * unions (keyed by a `type` discriminator, no module resolveType) have no
+     * lazy fallback, so their branch schemas must stay eager regardless of
+     * count; only the cycle/depth guards apply to them.
      */
     const eagerBranchSchema = (
       branch: RawSchema,
       branchDepth: number,
       branchCount: number,
+      lazilyResolvable = true,
     ): SchemaProperty | undefined =>
       !cyclicUnion &&
-      branchCount <= MAX_ANYOF_EAGER_SCHEMA_BRANCHES &&
+      (!lazilyResolvable || branchCount <= MAX_ANYOF_EAGER_SCHEMA_BRANCHES) &&
       branchDepth < MAX_BUILD_PROPERTY_DEPTH
         ? buildProperty(branch, branchDepth, unionSeen)
         : undefined;
@@ -621,7 +629,9 @@ export function resolveSchema(
                   ? def.description
                   : undefined,
               discriminatorValue,
-              schema: eagerBranchSchema(def, depth + 1, nonNull.length),
+              // Type-discriminated branches have no module resolveType to
+              // re-resolve from, so keep them eager regardless of union size.
+              schema: eagerBranchSchema(def, depth + 1, nonNull.length, false),
             };
           });
           return {

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -76,6 +76,17 @@ const MAX_COLLECT_PROPS_DEPTH = 12;
 /** Max recursion while building nested field schemas. */
 const MAX_BUILD_PROPERTY_DEPTH = 8;
 
+/**
+ * Above this branch count, a block-ref union (e.g. the `__SECTION_REF__`
+ * "pick any section" selector, which lists every section in the site) is
+ * treated as lazy: we emit the option list but skip materializing each
+ * branch's nested `schema`. The selected branch is resolved on demand via
+ * `resolveSchema()` at selection time, so nothing is lost — and we avoid a
+ * combinatorial blow-up when many of those sections have their own `Section`
+ * field pointing back at the same union.
+ */
+const MAX_ANYOF_EAGER_SCHEMA_BRANCHES = 40;
+
 function isArraySchemaBranch(schema: RawSchema): boolean {
   const t = schema.type;
   return t === "array" || (Array.isArray(t) && t.includes("array"));
@@ -357,16 +368,50 @@ export function resolveSchema(
    * Converts a raw schema entry into a typed SchemaProperty, resolving
    * nested properties for object types (up to depth 3).
    */
-  const buildProperty = (v: RawSchema, depth = 0): SchemaProperty => {
+  const buildProperty = (
+    v: RawSchema,
+    depth = 0,
+    seen: Set<string> = new Set(),
+  ): SchemaProperty => {
     let resolved = v;
+    let vRefKey: string | undefined;
     if (typeof v.$ref === "string") {
       resolved = resolveRef(v.$ref);
       const refKey = v.$ref.split("/").pop() ?? "";
+      vRefKey = refKey;
       if (refKey === VIDEO_WIDGET_REF_KEY && !resolved.format) {
         resolved = { ...resolved, format: "video-uri" };
       }
     }
     resolved = unwrapRefAliases(resolved);
+
+    // Cycle guard for recursive block-ref unions. The `__SECTION_REF__`
+    // "pick any section" selector lists every section, and 20+ of those
+    // sections themselves have a `Section` field pointing back at the same
+    // union. Without this guard, eagerly materializing each branch's nested
+    // `schema` recurses ~exponentially and blows up browser memory (multi-GB).
+    // When we re-enter a union already on the current path, we still emit the
+    // selector's option list but skip the per-branch nested schema — the UI
+    // resolves the selected branch lazily via resolveSchema().
+    const cyclicUnion = vRefKey !== undefined && seen.has(vRefKey);
+    const unionSeen =
+      vRefKey !== undefined ? new Set([...seen, vRefKey]) : seen;
+
+    /**
+     * Build a union branch's nested schema, unless doing so would recurse into
+     * a cycle or expand an oversized selector. Returns `undefined` in those
+     * cases so the branch is resolved lazily on selection.
+     */
+    const eagerBranchSchema = (
+      branch: RawSchema,
+      branchDepth: number,
+      branchCount: number,
+    ): SchemaProperty | undefined =>
+      !cyclicUnion &&
+      branchCount <= MAX_ANYOF_EAGER_SCHEMA_BRANCHES &&
+      branchDepth < MAX_BUILD_PROPERTY_DEPTH
+        ? buildProperty(branch, branchDepth, unionSeen)
+        : undefined;
 
     // Extract enum values from anyOf/oneOf const/enum branches
     let enumFromConsts: unknown[] | undefined;
@@ -476,7 +521,7 @@ export function resolveSchema(
             resolveRef,
           );
           if (isConfigArray && nonNull.length > 1) {
-            const built = buildProperty(arrayBranch, depth + 1);
+            const built = buildProperty(arrayBranch, depth + 1, unionSeen);
             return {
               ...built,
               type: "array",
@@ -491,7 +536,7 @@ export function resolveSchema(
             };
           }
           if (hasPageMultivariateLoader) {
-            const built = buildProperty(arrayBranch, depth + 1);
+            const built = buildProperty(arrayBranch, depth + 1, unionSeen);
             return {
               ...built,
               type: "array",
@@ -523,10 +568,7 @@ export function resolveSchema(
                 typeof branch.description === "string"
                   ? branch.description
                   : undefined,
-              schema:
-                depth + 1 < MAX_BUILD_PROPERTY_DEPTH
-                  ? buildProperty(branch, depth + 1)
-                  : undefined,
+              schema: eagerBranchSchema(branch, depth + 1, nonNull.length),
             };
           });
 
@@ -536,9 +578,12 @@ export function resolveSchema(
             (a) => !loaderBranches.includes(a),
           );
           const plainSchema =
-            nonLoaderBranches.length === 1 &&
-            depth + 1 < MAX_BUILD_PROPERTY_DEPTH
-              ? buildProperty(nonLoaderBranches[0]!, depth + 1)
+            nonLoaderBranches.length === 1
+              ? eagerBranchSchema(
+                  nonLoaderBranches[0]!,
+                  depth + 1,
+                  nonNull.length,
+                )
               : undefined;
 
           return {
@@ -576,10 +621,7 @@ export function resolveSchema(
                   ? def.description
                   : undefined,
               discriminatorValue,
-              schema:
-                depth + 1 < MAX_BUILD_PROPERTY_DEPTH
-                  ? buildProperty(def, depth + 1)
-                  : undefined,
+              schema: eagerBranchSchema(def, depth + 1, nonNull.length),
             };
           });
           return {
@@ -657,10 +699,7 @@ export function resolveSchema(
                   ? def.description
                   : undefined,
               discriminatorValue,
-              schema:
-                depth + 1 < MAX_BUILD_PROPERTY_DEPTH
-                  ? buildProperty(def, depth + 1)
-                  : undefined,
+              schema: eagerBranchSchema(def, depth + 1, nonNull.length),
             });
           }
           return {
@@ -697,7 +736,11 @@ export function resolveSchema(
       if (nestedEntries.length > 0) {
         nestedProperties = {};
         for (const [k, raw] of nestedEntries) {
-          nestedProperties[k] = buildProperty(raw as RawSchema, depth + 1);
+          nestedProperties[k] = buildProperty(
+            raw as RawSchema,
+            depth + 1,
+            unionSeen,
+          );
         }
       }
     }
@@ -713,7 +756,7 @@ export function resolveSchema(
         if (typeof rawItems.$ref === "string") {
           rawItems = resolveRef(rawItems.$ref);
         }
-        itemsSchema = buildProperty(rawItems, depth + 1);
+        itemsSchema = buildProperty(rawItems, depth + 1, unionSeen);
         if (
           typeof rawItems.title === "string" &&
           rawItems.title.includes("{{")


### PR DESCRIPTION
## Summary

Opening a section with a `Section`-typed field (e.g. `InstitutionalPage`'s `menuSection`) made the CMS editor consume **multiple GB of memory** and hang for a long time before rendering. This fixes the schema resolver so those sections open instantly.

## Root cause

In the `/live/_meta` schema resolver (`resolve-schema.ts`, `buildProperty`):

- A `Section` field resolves to the `__SECTION_REF__` union, which lists **every section in the site** (110+ on casaevideo).
- For each branch the resolver **eagerly materialized the branch's nested `schema`** — and **20+ of those sections themselves have a `Section` field** pointing back at the same union.
- `buildProperty` had **no cycle guard** (only `collectProps` did). With branching factor ~110 and cyclic re-entry bounded only by `MAX_BUILD_PROPERTY_DEPTH = 8`, expansion grew combinatorially → multi-GB.

## Fix

Both changes are safe because a selected branch is resolved **lazily** via `resolveSchema()` in `any-of-field.tsx` at selection time (`resolveNestedBlockRefSchema`), so the pre-computed per-branch `schema` was only an optimization:

1. **Cycle guard** (`seen`/`unionSeen`) threaded through `buildProperty`, mirroring the existing `collectProps` guard. Re-entering a union already on the current path still emits the option list but skips per-branch schema.
2. **Oversized unions** (>40 branches, e.g. the "pick any section" selector) are treated as lazy: the option list is emitted without materializing each branch's schema.

## Testing

- Added 2 regression tests: a 110-section cyclic union resolves instantly without blowing up; a small cyclic union terminates while cutting the cycle.
- `bun test apps/mesh/src/web/components/sections-editor/` → **348 pass** (0 fail)
- `tsc --noEmit` clean on touched files; `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory blow-up in the CMS when opening sections with `Section`-typed fields by guarding cyclic unions and lazily resolving large unions. Section editors now open instantly instead of hanging.

- **Bug Fixes**
  - Added a cycle guard in `buildProperty` to prevent re-expanding the same union; still shows options but skips per-branch schema on re-entry.
  - Marked oversized unions (>40 branches, e.g. `__SECTION_REF__`) as lazy only when branches are lazily resolvable via module `__resolveType`; type-discriminated unions keep eager branch schemas to preserve nested fields.
  - Added regression tests for large (110-branch) and small cyclic unions, plus a 50-branch type-discriminated union to ensure eager schemas remain.

<sup>Written for commit 43cf9de31ddcd946aca10ac6751a6e1492581e4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

