### PR TITLE
fix(commerce-onboarding): fill-height mobile layout and matching skeletons

### DIFF
--- a/apps/mesh/src/web/components/scroll-reveal.tsx
+++ b/apps/mesh/src/web/components/scroll-reveal.tsx
@@ -5,6 +5,12 @@ interface ScrollRevealProps {
   children: ReactNode;
   /** Classes for the scrollable container (e.g. `max-h-[60vh] overflow-y-auto`). */
   className?: string;
+  /**
+   * Classes for the outer `relative` wrapper. Use this to let the scroller grow
+   * inside a flex column (e.g. `flex min-h-0 flex-1 flex-col`) so the fade can
+   * fill available height instead of a fixed `max-h`.
+   */
+  wrapperClassName?: string;
 }
 
 /**
@@ -19,7 +25,11 @@ interface ScrollRevealProps {
  * Detection is wired through a React 19 callback ref (with cleanup) rather than
  * `useEffect`, which is banned in this codebase.
  */
-export function ScrollReveal({ children, className }: ScrollRevealProps) {
+export function ScrollReveal({
+  children,
+  className,
+  wrapperClassName,
+}: ScrollRevealProps) {
   const [atBottom, setAtBottom] = useState(true);
 
   const containerRef = (node: HTMLDivElement | null) => {
@@ -49,15 +59,21 @@ export function ScrollReveal({ children, className }: ScrollRevealProps) {
   };
 
   return (
-    <div className="relative">
+    <div className={cn("relative", wrapperClassName)}>
       <div ref={containerRef} className={className}>
         {children}
       </div>
       <div
         aria-hidden
         className={cn(
-          "pointer-events-none absolute inset-x-0 bottom-0 h-[213px]",
-          "bg-gradient-to-t from-background to-transparent",
+          // `-bottom-px` (not `bottom-0`) so the fully-opaque bottom of the fade
+          // over-covers the scroller's sub-pixel clip edge — otherwise a 1px
+          // sliver of scrolled content leaks out below the gradient.
+          "pointer-events-none absolute inset-x-0 -bottom-px h-[213px]",
+          // Fade to the sidebar surface these scrollers sit on (AuthSplitLayout)
+          // so the solid end blends into the panel — and the 1px overshoot above
+          // stays invisible — instead of showing a lighter `background` band.
+          "bg-gradient-to-t from-sidebar to-transparent",
           "backdrop-blur-[2px] [mask-image:linear-gradient(to_top,black,transparent)]",
           "transition-opacity duration-200",
           atBottom ? "opacity-0" : "opacity-100",

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -791,7 +791,10 @@ function CommerceDiscoveryReady({
   onOpenReport: () => void;
 }) {
   return (
-    <div className="grid gap-10">
+    // On mobile fill the viewport (minus AuthSplitLayout's p-6 = 3rem) as a flex
+    // column so the header pins to the top, the cards fill the middle, and the
+    // "See full report" CTA pins to the bottom. On md+ revert to the centered grid.
+    <div className="flex h-[calc(100dvh-3rem)] flex-col gap-10 md:grid md:h-auto">
       <CommerceHeader />
       <CompanionMcpsSection
         org={org}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -3,6 +3,31 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { CheckCircle, Loading01 } from "@untitledui/icons";
 import type { CompanionCardModel } from "./companions-core.ts";
 
+/**
+ * Loading placeholder that mirrors {@link CompanionCard}'s box model (same
+ * wrapper, icon row, and two unlock lines) so its height matches a real card
+ * instead of a short generic block.
+ */
+export function CompanionCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-4">
+      <div className="flex items-center gap-2">
+        <div className="size-12 shrink-0 animate-pulse rounded-lg bg-muted/60" />
+        <div className="h-4 w-32 animate-pulse rounded bg-muted/60" />
+        <div className="ml-auto h-8 w-20 animate-pulse rounded-lg bg-muted/60" />
+      </div>
+      <div className="flex flex-col gap-1 px-1 py-2">
+        <div className="p-1">
+          <div className="h-5 w-40 animate-pulse rounded bg-muted/60" />
+        </div>
+        <div className="p-1">
+          <div className="h-5 w-56 animate-pulse rounded bg-muted/60" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function UnlockLine({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex items-center gap-2 p-1">

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -3,7 +3,7 @@ import { authClient } from "@/web/lib/auth-client";
 import { SELF_MCP_ALIAS_ID, useMCPClient } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { ArrowRight } from "@untitledui/icons";
-import { CompanionCard } from "./companion-card.tsx";
+import { CompanionCard, CompanionCardSkeleton } from "./companion-card.tsx";
 import { useCommerceCompanions } from "./use-commerce-companions.ts";
 import { useConnectCompanion } from "./use-connect-companion.ts";
 
@@ -62,13 +62,21 @@ export function CompanionMcpsSection({
 
   // Empty: no requirements survive → just the report CTA (section header hidden).
   if (!isLoading && !error && cards.length === 0) {
-    return <div className="grid gap-10">{cta}</div>;
+    // On mobile the parent gives us a full-height flex column, so pin the CTA to
+    // the bottom; on md+ fall back to the natural grid.
+    return (
+      <div className="flex min-h-0 flex-1 flex-col justify-end gap-10 md:grid md:flex-none">
+        {cta}
+      </div>
+    );
   }
 
   const busy = connectingFieldKey !== null;
 
   return (
-    <div className="grid gap-6">
+    // On mobile this grows to fill the parent's full-height column (header pinned
+    // top, CTA pinned bottom, cards scroll in between); on md+ it's the compact grid.
+    <div className="flex min-h-0 flex-1 flex-col gap-6 md:grid md:flex-none">
       <div className="grid gap-1.5">
         <p className="text-2xl font-medium text-foreground">
           Unlock your full diagnostic
@@ -91,16 +99,16 @@ export function CompanionMcpsSection({
           </p>
         </div>
       ) : isLoading ? (
-        <div className="grid gap-4">
+        <div className="flex min-h-0 flex-1 flex-col gap-4">
           {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              className="h-24 animate-pulse rounded-2xl border border-border bg-muted/40"
-            />
+            <CompanionCardSkeleton key={i} />
           ))}
         </div>
       ) : (
-        <ScrollReveal className="-mx-1 max-h-[45vh] overflow-y-auto px-1">
+        <ScrollReveal
+          wrapperClassName="flex min-h-0 flex-1 flex-col md:block"
+          className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1 md:max-h-[45vh] md:flex-none"
+        >
           <div className="grid gap-4">
             {connectError && (
               <p role="alert" className="text-sm text-destructive">


### PR DESCRIPTION
## Summary
- Make the discovery-ready screen a full-height flex column on mobile so the header pins to the top, cards scroll in the middle, and the "See full report" CTA pins to the bottom; revert to the centered grid on `md+`.
- Add a `wrapperClassName` prop to `ScrollReveal` so the scroller can grow inside a flex column, and fade the gradient to the `sidebar` surface (with a `-bottom-px` overshoot) to avoid a lighter band and a 1px content sliver leaking below the fade.
- Give loading companion cards a `CompanionCardSkeleton` that mirrors the real card's box model instead of a short generic block.

## Testing
- `bun run fmt`

## Affected areas
Commerce onboarding UI (`apps/mesh/src/web/routes/commerce-onboarding/*`, `scroll-reveal.tsx`). UI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile layout of the Commerce Onboarding discovery-ready screen to fill the viewport (header top, cards scroll, CTA bottom) while keeping the centered grid on md+. Adds `wrapperClassName` to `ScrollReveal`, switches the fade to the `sidebar` surface to remove a 1px leak, and introduces a matching `CompanionCardSkeleton`.

- **Bug Fixes**
  - Mobile discovery-ready screen now fills height; header is pinned, cards scroll, CTA is pinned.
  - `ScrollReveal` gradient uses `-bottom-px` and fades to `sidebar`, removing the lighter band and 1px content sliver.

- **New Features**
  - `ScrollReveal` supports `wrapperClassName` to grow inside flex columns.
  - Added `CompanionCardSkeleton` to match real card height and layout during loading.

<sup>Written for commit 83a03fc663b688bbd10b832a2b1cb774d21eb5d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

