### PR TITLE
refactor(commerce-onboarding): suspense setup queries + scroll-fade hairline fix

### DIFF
--- a/apps/mesh/src/web/components/scroll-reveal.tsx
+++ b/apps/mesh/src/web/components/scroll-reveal.tsx
@@ -66,15 +66,23 @@ export function ScrollReveal({
       <div
         aria-hidden
         className={cn(
-          // `-bottom-px` (not `bottom-0`) so the fully-opaque bottom of the fade
-          // over-covers the scroller's sub-pixel clip edge — otherwise a 1px
-          // sliver of scrolled content leaks out below the gradient.
+          // `-bottom-px` (not `bottom-0`) so the fade over-covers the scroller's
+          // sub-pixel clip edge instead of stopping a fraction of a pixel short.
           "pointer-events-none absolute inset-x-0 -bottom-px h-[213px]",
           // Fade to the sidebar surface these scrollers sit on (AuthSplitLayout)
-          // so the solid end blends into the panel — and the 1px overshoot above
-          // stays invisible — instead of showing a lighter `background` band.
-          "bg-gradient-to-t from-sidebar to-transparent",
-          "backdrop-blur-[2px] [mask-image:linear-gradient(to_top,black,transparent)]",
+          // so the solid end blends into the panel instead of showing a lighter
+          // `background` band.
+          //
+          // The `6px` first stop on BOTH the color gradient and the mask is the
+          // fix for the hairline leak: a CSS gradient holds its first stop's
+          // value for everything before it, so `… 6px, transparent` is fully
+          // opaque from 0–6px, then ramps. Without the plateau the ramp only
+          // reaches 100% at the very bottom edge, leaving the scroller's clip
+          // line (~1px above it) at ~99% coverage — enough for the hard cut edge
+          // of the last card to bleed through as a 1px sliver at any DPR. The
+          // plateau guarantees the clip line sits inside the solid zone.
+          "bg-gradient-to-t from-sidebar from-[6px] to-transparent",
+          "backdrop-blur-[2px] [mask-image:linear-gradient(to_top,black_6px,transparent)]",
           "transition-opacity duration-200",
           atBottom ? "opacity-0" : "opacity-100",
         )}

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -1,5 +1,6 @@
 import { normalizeCommerceSiteUrl } from "@/commerce-discovery/site-url";
 import { AuthEntry } from "@/web/components/auth-entry";
+import { ErrorBoundary } from "@/web/components/error-boundary";
 import { AuthSplitLayout } from "@/web/components/auth-split-layout";
 import { OrganizationChoice } from "@/web/components/organization-choice";
 import { ScrollReveal } from "@/web/components/scroll-reveal";
@@ -20,7 +21,11 @@ import {
   useMCPClient,
   WellKnownOrgMCPId,
 } from "@decocms/mesh-sdk";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  QueryErrorResetBoundary,
+  useMutation,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowRight, Loading01 } from "@untitledui/icons";
 import { createContext, Suspense, useContext, useRef, useState } from "react";
@@ -476,14 +481,60 @@ function CommerceSetup({
 }) {
   return (
     <AuthSplitLayout>
-      <Suspense fallback={<LoadingState label="Connecting workspace..." />}>
-        <CommerceSetupContent
-          key={`${org.id}:${initialSiteUrl ?? ""}`}
-          org={org}
-          initialSiteUrl={initialSiteUrl}
-        />
-      </Suspense>
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary
+            fallback={({ error, resetError }) => (
+              <CommerceSetupErrorState
+                orgName={org.name}
+                message={
+                  error instanceof Error
+                    ? error.message
+                    : "We could not check Commerce Discovery setup."
+                }
+                onRetry={() => {
+                  reset();
+                  resetError();
+                }}
+              />
+            )}
+          >
+            <Suspense
+              fallback={<LoadingState label="Connecting workspace..." />}
+            >
+              <CommerceSetupContent
+                key={`${org.id}:${initialSiteUrl ?? ""}`}
+                org={org}
+                initialSiteUrl={initialSiteUrl}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
     </AuthSplitLayout>
+  );
+}
+
+function CommerceSetupErrorState({
+  orgName,
+  message,
+  onRetry,
+}: {
+  orgName: string;
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="grid gap-10">
+      <CommerceHeader
+        title="Commerce diagnostics"
+        description={`Commerce setup will continue for ${orgName}.`}
+      />
+      <InlineError message={message} />
+      <Button type="button" size="xl" className="w-full" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
   );
 }
 
@@ -509,7 +560,7 @@ function CommerceSetupContent({
   const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
   const virtualMcpId = getCommerceDiscoveryAgentId(org.id);
 
-  const connectionQuery = useQuery({
+  const connectionQuery = useSuspenseQuery({
     queryKey: KEYS.commerceDiscoveryConnection(org.id, connectionId),
     queryFn: async () => {
       const result = await selfClient.callTool({
@@ -521,7 +572,7 @@ function CommerceSetupContent({
     retry: false,
   });
 
-  const virtualMcpQuery = useQuery({
+  const virtualMcpQuery = useSuspenseQuery({
     queryKey: KEYS.commerceDiscoveryVirtualMcp(org.id, virtualMcpId),
     queryFn: async () => {
       const result = await selfClient.callTool({
@@ -557,11 +608,7 @@ function CommerceSetupContent({
     },
   });
 
-  const setupQueriesLoading =
-    connectionQuery.isPending || virtualMcpQuery.isPending;
-  const setupQueriesError = connectionQuery.error ?? virtualMcpQuery.error;
-  const setupReady =
-    !!connectionQuery.data?.item && !!virtualMcpQuery.data?.item;
+  const setupReady = !!connectionQuery.data.item && !!virtualMcpQuery.data.item;
 
   const runSetup = (rawSiteUrl: string) => {
     const normalized = normalizeCommerceSiteUrl(rawSiteUrl);
@@ -574,13 +621,7 @@ function CommerceSetupContent({
   };
 
   const triggerInitialSetup = (node: HTMLDivElement | null) => {
-    if (
-      !node ||
-      autoSetupStartedRef.current ||
-      setupQueriesLoading ||
-      setupReady ||
-      !initialSiteUrl
-    ) {
+    if (!node || autoSetupStartedRef.current || setupReady || !initialSiteUrl) {
       return;
     }
 
@@ -614,46 +655,6 @@ function CommerceSetupContent({
       },
     });
   };
-
-  if (setupQueriesLoading) {
-    return (
-      <div className="grid gap-10">
-        <CommerceHeader
-          title="Commerce diagnostics"
-          description={`Commerce setup will continue for ${org.name}.`}
-        />
-        <LoadingState label="Checking Commerce Discovery setup..." />
-      </div>
-    );
-  }
-
-  if (setupQueriesError) {
-    const message =
-      setupQueriesError instanceof Error
-        ? setupQueriesError.message
-        : "We could not check Commerce Discovery setup.";
-
-    return (
-      <div className="grid gap-10">
-        <CommerceHeader
-          title="Commerce diagnostics"
-          description={`Commerce setup will continue for ${org.name}.`}
-        />
-        <InlineError message={message} />
-        <Button
-          type="button"
-          size="xl"
-          className="w-full"
-          onClick={() => {
-            void connectionQuery.refetch();
-            void virtualMcpQuery.refetch();
-          }}
-        >
-          Retry
-        </Button>
-      </div>
-    );
-  }
 
   if (setupReady) {
     return (


### PR DESCRIPTION
This PR bundles two `/commerce-onboarding` improvements.

---

## 1. Suspense-based setup queries — remove the loading flash

### Problem
Moving from org-select into connection setup flashed **two sequential loading screens**: the `useMCPClient` suspense fallback (`"Connecting workspace..."`) mounted first, then — once resolved — `CommerceSetupContent` rendered a *second* `LoadingState` (`"Checking Commerce Discovery setup..."`) driven by the `isPending` state of two plain `useQuery` reads. Two mounts, two labels, visible flicker.

### Fix
Convert the Commerce Discovery **connection** and **virtual MCP** reads from `useQuery` → `useSuspenseQuery`. They now suspend up to the *same* `<Suspense>` boundary in `CommerceSetup`, so a **single** fallback covers the entire setup load. The `setupQueriesLoading`/`setupQueriesError` branches and the `.data?.item` guards collapse (`data` is always defined under suspense).

Retry UX is preserved by wrapping the boundary in the existing `ErrorBoundary` (render-fallback) + TanStack's `QueryErrorResetBoundary`: retry calls `reset()` (clears the suspense queries' error state → refetch) then `resetError()` (re-renders the boundary). The new `CommerceSetupErrorState` mirrors the old inline error screen exactly (header + `InlineError` + Retry).

### Scope / safety
- One file (`apps/mesh/src/web/routes/commerce-onboarding.tsx`). The two queries were **local inline** `useQuery` calls, not shared hooks.
- The shared query *key* (`commerceDiscoveryConnection`, also used by the companion hooks) is cache-level only — `useSuspenseQuery` and `useQuery` interoperate on the same cache, so invalidation/refetch across the companion hooks is unaffected.
- The setup mutation's `onSuccess` still calls `refetch()` (suspense queries return it).
- Note: the `ErrorBoundary` now also catches `useMCPClient` failures inline (previously bubbled to the route boundary) — a net improvement, with a working retry.
- `bun run fmt`, `bun run check` (tsc), and `bun run lint` pass (0 errors).

---

## 2. Eliminate the 1px content hairline under the scroll fade

Fixes the 1px sliver of card content that leaks through the bottom of the `ScrollReveal` fade on `/commerce-onboarding` (the "Unlock your full diagnostic" state). A prior PR tried to fix this with a `-bottom-px` overshoot, but the hairline persisted.

### Root cause
`ScrollReveal`'s fade overlay (`apps/mesh/src/web/components/scroll-reveal.tsx`) is a single absolutely-positioned div whose color gradient (`from-sidebar → transparent`) and mask (`black → transparent`) both ramp **continuously**, only reaching 100% opacity at the fade's very bottom edge. The `-bottom-px` overshoot pushed that edge 1px below the scroller, but the scroller's clip line sits ~1px *above* it — right on the ramp at ~99% coverage. At `devicePixelRatio: 2`, ~1% of the last card's hard clip edge composites into a visible 1px hairline. Nudging the overshoot can't fix it because the ramp is always slightly transparent at the clip line.

The fade fades to `from-sidebar`, which matches the panel behind it exactly, so this was never a *background-color* leak — it's the scrolled content's sharp cut edge bleeding through.

### Fix
Add a **6px fully-opaque plateau** to both the color gradient and the mask (`… 6px, transparent`). A CSS gradient holds its first stop's value for everything before it, so 0–6px is 100% solid, then ramps above. The clip line is now guaranteed to sit inside the fully-covered zone at any DPR. The soft fade affordance is unchanged (it just starts 6px higher over a 213px overlay — imperceptible).

### Testing
- Reproduced the state on staging (`studio-stg`), forcing the companion-card list to overflow, and inspected computed geometry/coverage numerically to confirm the ~99% clip-line coverage.
- Applied the fix inline on the live page first to confirm the soft fade still looks correct, then wrote it into the component.
- The hairline elimination is guaranteed by construction (100% coverage at the clip line) rather than by pixel-diff, since screenshot downscaling + `backdrop-filter` re-rasterization made a reliable 1px visual diff impractical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates the 1px content hairline under the bottom scroll fade on the commerce onboarding “Unlock your full diagnostic” panel by adding a 6px fully opaque plateau to the `ScrollReveal` gradient/mask at the scroller clip line. Refactors setup to `useSuspenseQuery` with `QueryErrorResetBoundary` + `ErrorBoundary` to remove the loading flash and keep a single retryable error state.

<sup>Written for commit 49b11762ff6a3b8e545849988c546dd36f8d8bb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
