### PR TITLE
fix(sandbox): never surface container repoDir for IDE deep links

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.test.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { redactRepoDir } from "./sandbox-proxy";
+
+describe("redactRepoDir", () => {
+  it("nulls a container-internal repoDir while preserving other fields", () => {
+    const input = JSON.stringify({
+      bootId: "boot-1",
+      ready: true,
+      repoDir: "/app/repo",
+    });
+    const out = JSON.parse(redactRepoDir(input));
+    expect(out).toEqual({ bootId: "boot-1", ready: true, repoDir: null });
+  });
+
+  it("nulls repoDir even when it is already null (no-op semantics)", () => {
+    const out = JSON.parse(redactRepoDir(JSON.stringify({ repoDir: null })));
+    expect(out.repoDir).toBeNull();
+  });
+
+  it("leaves a payload without a repoDir key untouched", () => {
+    const input = JSON.stringify({ bootId: "boot-1", ready: false });
+    expect(redactRepoDir(input)).toBe(input);
+  });
+
+  it("passes through non-JSON bodies unchanged", () => {
+    expect(redactRepoDir("not json")).toBe("not json");
+    expect(redactRepoDir("")).toBe("");
+  });
+
+  it("passes through JSON that is not an object", () => {
+    expect(redactRepoDir("[1,2,3]")).toBe("[1,2,3]");
+    expect(redactRepoDir('"repoDir"')).toBe('"repoDir"');
+  });
+});

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -521,6 +521,9 @@ export const createSandboxRoutes = () => {
       method: "PUT",
       forwardJsonBody: true,
       map404to410: true,
+      // No `redactRepoDirUnlessDesktop` here: the PUT response echoes the
+      // written TenantConfig (git/operator/application), which carries no
+      // `repoDir` — only the GET read handler surfaces it.
     }),
   );
 

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -228,6 +228,16 @@ async function proxyDaemon(
     signal?: AbortSignal;
     /** Map 404 to 410 (sandbox needs re-provision). */
     map404to410?: boolean;
+    /**
+     * Null out `repoDir` in the JSON response unless the resolved runner is
+     * `user-desktop`. Every daemon reports `repoDir` as its own
+     * container-internal path (`/app/repo` on agent-sandbox); only a desktop
+     * link daemon's path exists on the user's machine. The frontend uses this
+     * to build `vscode://file<repoDir>` deep links — surfacing a container path
+     * pops a "Path does not exist" error. Authoritative because it keys off the
+     * resolved runner, immune to a stale/racing frontend provider-kind.
+     */
+    redactRepoDirUnlessDesktop?: boolean;
   },
 ) {
   const runner = requireRunner(c);
@@ -308,7 +318,11 @@ async function proxyDaemon(
       }
     }
 
-    const text = await upstream.text();
+    const rawText = await upstream.text();
+    const text =
+      opts?.redactRepoDirUnlessDesktop && runner.kind !== "user-desktop"
+        ? redactRepoDir(rawText)
+        : rawText;
     const contentType =
       upstream.headers.get("content-type") ?? "application/json";
     return new Response(text, {
@@ -346,6 +360,28 @@ async function proxyDaemon(
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ error: `Daemon unreachable: ${message}` }, 502);
   }
+}
+
+/**
+ * Set `repoDir` to null in a daemon config JSON payload. Returns the input
+ * unchanged if it isn't a JSON object with a `repoDir` key, so a non-JSON or
+ * error body passes through untouched.
+ */
+export function redactRepoDir(text: string): string {
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      "repoDir" in parsed
+    ) {
+      return JSON.stringify({ ...parsed, repoDir: null });
+    }
+  } catch {
+    /* not JSON — leave as-is */
+  }
+  return text;
 }
 
 async function fetchDaemonJson<T>(
@@ -475,6 +511,9 @@ export const createSandboxRoutes = () => {
     proxyDaemon(c, "/_sandbox/config", {
       method: "GET",
       map404to410: true,
+      // A container path (`/app/repo`) is never openable on the user's
+      // machine — only surface `repoDir` for the desktop link daemon.
+      redactRepoDirUnlessDesktop: true,
     }),
   );
   app.put("/:virtualMcpId/:branch/config", (c) =>


### PR DESCRIPTION
## Problema

Em produção, os botões **"Open in VSCode/Cursor"** do preview do sandbox disparavam um popup do editor: **"Path does not exist — The path '/app/repo' does not exist on this computer."**

### Causa raiz

O endpoint `GET /_sandbox/config` do daemon **sempre** reporta `repoDir` como o caminho interno do próprio container (`/app/repo` no provider `agent-sandbox`). Só o daemon **user-desktop** reporta um caminho real na máquina do usuário. Os botões montam `vscode://file<repoDir>`, então um caminho de container gera o erro acima.

O guard existente no frontend (`isDesktopSandbox ? rawRepoDir : null`, #4168) só se sustenta enquanto o provider-kind em cache do frontend concorda com o backend. Quando o `vmEntry.sandboxProviderKind` está defasado/em corrida — frontend ainda acredita ser `user-desktop` enquanto o backend resolve o sandbox como `agent-sandbox` — o `/config` retorna `/app/repo`, `isDesktopSandbox` (desatualizado) fica `true`, o valor passa pelo guard, e o `staleTime: Infinity` fixa isso no cache.

## Correção

Corrigido de forma **autoritativa no servidor**, onde o runner *resolvido* é conhecido e imune a qualquer cache/corrida do frontend. A rota `GET /config` agora zera o `repoDir` sempre que o runner resolvido não for `user-desktop` (`redactRepoDirUnlessDesktop`). Um caminho de container não chega mais ao frontend, então os botões não renderizam para um caminho não-abrível e o cache nunca guarda `/app/repo` num contexto que se acredita ser desktop.

O guard do frontend foi mantido como segunda camada complementar.

## Mudanças

- `apps/mesh/src/api/routes/sandbox-proxy.ts` — nova opção `redactRepoDirUnlessDesktop` no `proxyDaemon`, helper puro `redactRepoDir` (exportado) e a flag ligada na rota GET do config.
- `apps/mesh/src/api/routes/sandbox-proxy.test.ts` — testes unitários para `redactRepoDir` (lógica pura, sem mocks).

## Testes / áreas afetadas

- `bun test apps/mesh/src/api/routes/sandbox-proxy.test.ts` — 5 passando
- `bun run check` (tsc) limpo
- `bun run lint` — 0 erros
- `bun run fmt` aplicado

Sem necessidade de migração: quem tiver `/app/repo` no cache em memória do React Query recebe valor limpo no próximo reload (cache não é persistido).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent “Path does not exist” popups by never exposing container `repoDir` from sandbox config. The server now redacts `repoDir` unless the resolved runner is `user-desktop`, so IDE deep links only target real local paths.

- **Bug Fixes**
  - Added `redactRepoDirUnlessDesktop` to server `proxyDaemon` for `GET /_sandbox/config`; documented why `PUT /_sandbox/config` skips redaction (it echoes TenantConfig and has no `repoDir`).
  - Sanitizes responses with new `redactRepoDir`, ensuring container paths like `/app/repo` never reach the UI.
  - Removes cache/race exposure; the frontend guard stays as a backup.

<sup>Written for commit 4813f0665cb77b4c2c283a296a411f2a7a36fef9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

