### PR TITLE
fix(services): retry transient MinIO bucket provisioning to stop studio boot crash-loop

### DIFF
--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -17,7 +17,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "fs";
-import { exponentialBackoffWithJitter, sleep } from "@decocms/std";
+import { exponentialBackoffWithJitter, retry, sleep } from "@decocms/std";
 import { chmod, unlink } from "fs/promises";
 import { createRequire } from "module";
 import { createConnection, createServer } from "net";
@@ -980,7 +980,29 @@ async function provisionMinioBucket(endpoint: string): Promise<void> {
   });
 
   try {
-    await client.send(new CreateBucketCommand({ Bucket: MINIO_DEV_BUCKET }));
+    // Right after a MinIO (re)start — e.g. a container restart in the
+    // resilience suite — the health endpoint can report ready a beat before the
+    // S3 API accepts connections, so the first CreateBucket races into
+    // ECONNREFUSED/ECONNRESET and the AWS SDK gives up after its 3 internal
+    // retries. Left unhandled that rejection propagates out of `buildSettings`
+    // and kills studio boot, and under `restart: unless-stopped` it crash-loops
+    // (each ~30s cycle blowing the pod-crash scenario's health-wait budget).
+    // Ride out only transient connect-level failures here; genuine errors
+    // (auth/config, BucketAlreadyOwnedByUs/Exists) are not retriable and fall
+    // through to the handling below unchanged.
+    await retry(
+      () => client.send(new CreateBucketCommand({ Bucket: MINIO_DEV_BUCKET })),
+      {
+        maxAttempts: 5,
+        minTimeout: 200,
+        maxTimeout: 3_000,
+        isRetriable: (err) =>
+          err instanceof Error &&
+          /ECONNREFUSED|ECONNRESET|EPIPE|socket|fetch failed|timed out|network/i.test(
+            `${(err as { name?: string }).name ?? ""} ${err.message}`,
+          ),
+      },
+    );
   } catch (e: unknown) {
     // BucketAlreadyOwnedByUs / BucketAlreadyExists — fine, it's persistent.
     const name =


### PR DESCRIPTION
## Summary

Fixes the flaky `link-dispatch-pod-crash` resilience scenario (the one red run on commit `995421a9f` — which was itself a false alarm; that commit only touched the `deco link` TUI / link-daemon and never runs on studio's boot path).

**Root cause:** On boot in local mode, `buildSettings → ensureServices → ensureMinio → provisionMinioBucket` issues an S3 `CreateBucketCommand`. Right after a MinIO (re)start — e.g. a container restart during the pod-crash scenario — the health endpoint reports ready a beat before the S3 API accepts connections, so the first call races into `ECONNREFUSED`/`ECONNRESET` and the AWS SDK gives up after its 3 internal retries. That rejection was **uncaught** in `buildSettings`, killing studio boot; under `restart: unless-stopped` it crash-loops, and each ~30s cycle eats the scenario's 120s `waitForStudioHealthy` budget.

**Fix:** Wrap the `CreateBucket` in `retry()` (`@decocms/std`), retrying **only** transient connect-level failures. Genuine errors (auth/config, `BucketAlreadyOwnedByUs`/`BucketAlreadyExists`) remain non-retriable and fall through to the existing handling unchanged, so a truly dead MinIO still aborts startup loudly.

## Testing

- `bun run fmt` ✅
- `tsc --noEmit` (mesh) ✅
- Full end-to-end verification is the resilience suite itself (Docker), which runs on merge to `main`. Since the crash-loop was intermittent (1 red in ~40 runs), we'll watch `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry MinIO bucket provisioning on transient network errors to prevent studio boot crash-loops after MinIO restarts. This stabilizes local boot and stops flakes in the `link-dispatch-pod-crash` resilience test.

- **Bug Fixes**
  - Wrap S3 `CreateBucket` in `retry()` from `@decocms/std`, retrying only connect-level failures (`ECONNREFUSED`, `ECONNRESET`, `EPIPE`, socket/timeouts) with bounded backoff.
  - Do not retry genuine errors (auth/config, `BucketAlreadyOwnedByUs`, `BucketAlreadyExists`) so real misconfigurations still fail fast.

<sup>Written for commit 967210c2db0ae97daafcb80cac949481d6d9dc67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

