### PR TITLE
fix(mesh): unify agent skill picker with the runtime skill catalog

### DIFF
--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -463,7 +463,9 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
     const denied = await checkPermission(c, ctx, "ORG_FS_READ");
     if (denied) return denied;
     try {
-      return c.json({ skills: await buildSkillCatalog(ctx, ctx.organization.id) });
+      return c.json({
+        skills: await buildSkillCatalog(ctx, ctx.organization.id),
+      });
     } catch (err) {
       return fsErrorResponse(c, err);
     }

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -57,6 +57,7 @@ import {
   getPublicSets,
   isPublicVolume,
 } from "@/file-storage/public-sets";
+import { buildSkillCatalog } from "@/file-storage/skill-catalog";
 import { detectContentType } from "@/object-storage/key-utils";
 
 type Variables = { meshContext: StudioContext };
@@ -442,6 +443,27 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       return c.json({
         entries: await ctx.orgFs.recentWithEffectivePublic(limit),
       });
+    } catch (err) {
+      return fsErrorResponse(c, err);
+    }
+  });
+
+  // Attachable skills — the SAME catalog the runtime surfaces in
+  // <available-skills> (buildSkillCatalog: home + home/skills + public sets), so
+  // the agent link picker and the run can never drift on what "a skill" is.
+  // Volume-less; lives above the `/:volume/*` routes. Member-gated read.
+  app.get("/skills", async (c) => {
+    const ctx = c.get("meshContext");
+    if (!ctx.auth?.user?.id) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    if (!ctx.organization?.id) {
+      return c.json({ error: "Organization required" }, 400);
+    }
+    const denied = await checkPermission(c, ctx, "ORG_FS_READ");
+    if (denied) return denied;
+    try {
+      return c.json({ skills: await buildSkillCatalog(ctx, ctx.organization.id) });
     } catch (err) {
       return fsErrorResponse(c, err);
     }

--- a/apps/mesh/src/file-storage/skill-catalog.ts
+++ b/apps/mesh/src/file-storage/skill-catalog.ts
@@ -37,6 +37,10 @@ export interface SkillCatalogEntry {
   source: string;
   /** Sandbox path of the skill folder (e.g. `org/public/core/slides`). */
   sandboxPath: string;
+  /** OrgFs volume the skill lives on (`home` or `public-<set>`). */
+  volume: string;
+  /** Volume-relative dir path (e.g. `skills/foo`) — used to attach as agent knowledge. */
+  path: string;
 }
 
 /** Total SKILL.md reads per build — a backstop against a pathological tree. */
@@ -128,6 +132,8 @@ async function buildPublicEntries(
         description: s.description,
         source: `public:${set}`,
         sandboxPath: orgFsSandboxPath(volume, s.dirPath),
+        volume,
+        path: s.dirPath,
       });
     }
   }
@@ -167,6 +173,8 @@ async function buildHomeEntries(
     description: s.description,
     source: "home",
     sandboxPath: orgFsSandboxPath(HOME_VOLUME, s.dirPath),
+    volume: HOME_VOLUME,
+    path: s.dirPath,
   }));
 }
 

--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -168,9 +168,11 @@ export interface OrgFsSkill {
 }
 
 /**
- * Skill folders (dirs containing SKILL.md) across the home volume and the
- * deployment's public skill sets — the attachable-skill set for agent
- * knowledge. Lists each volume's root and keeps the `hasSkill` dirs.
+ * The attachable-skill set for agent knowledge — the SAME catalog the runtime
+ * surfaces in `<available-skills>` (server-side `buildSkillCatalog`: the org's
+ * home root, `home/skills/*`, and the deployment's public sets). Consuming the
+ * shared `/fs/skills` endpoint keeps the picker and the run from ever drifting
+ * on what counts (and where) as a skill.
  */
 export function useOrgFsSkills(opts?: { enabled?: boolean }) {
   const { org } = useProjectContext();
@@ -178,23 +180,13 @@ export function useOrgFsSkills(opts?: { enabled?: boolean }) {
     queryKey: KEYS.orgFsSkills(org.id),
     enabled: opts?.enabled,
     queryFn: async (): Promise<OrgFsSkill[]> => {
-      const setsRes = await fsFetch(
-        `/api/${encodeURIComponent(org.slug)}/fs/public-sets`,
+      const res = await fsFetch(
+        `/api/${encodeURIComponent(org.slug)}/fs/skills`,
       );
-      const { sets } = (await setsRes.json()) as { sets: string[] };
-      const volumes = ["home", ...sets.map((s) => `public-${s}`)];
-      const perVolume = await Promise.all(
-        volumes.map(async (volume) => {
-          const res = await fsFetch(
-            fsUrl(org.slug, volume, "list", { path: "" }),
-          );
-          const { entries } = (await res.json()) as { entries: OrgFsEntry[] };
-          return entries
-            .filter((e) => e.kind === "dir" && e.hasSkill)
-            .map((e) => ({ volume, path: e.path }));
-        }),
-      );
-      return perVolume.flat();
+      const { skills } = (await res.json()) as {
+        skills: Array<{ volume: string; path: string }>;
+      };
+      return skills.map((s) => ({ volume: s.volume, path: s.path }));
     },
   });
 }


### PR DESCRIPTION
## Problem
The agent's **"link skills"** picker didn't show skills placed in `org/home/skills/<name>/SKILL.md`, even though the agent could load them at run time.

Root cause: two divergent discovery code paths.
- **Picker** (`useOrgFsSkills`, web) reimplemented discovery client-side — it listed only each volume's **root** (`path: ""`), so `home/skills/*` was never seen.
- **Runtime** (`buildSkillCatalog`, server) scans `home` **and** `home/skills` **and** the public sets for the `<available-skills>` block.

So a skill in `home/skills/` was attachable-at-runtime but invisible in the picker.

## Fix — one source of truth
Make `buildSkillCatalog` (already the runtime's catalog) back the picker too:
- **`GET /api/:org/fs/skills`** (org-fs routes) returns `buildSkillCatalog(ctx, orgId)` — member-gated read, volume-less (sits above `/:volume/*`).
- `SkillCatalogEntry` now carries `{ volume, path }` (the volume-relative dir) so the picker can attach the skill as agent knowledge.
- `useOrgFsSkills` consumes the endpoint instead of listing volume roots.

The picker and the run can no longer drift on what counts as a skill or where it lives (`home/`, `home/skills/`, or public sets).

## Notes
- Additive only: `SkillCatalogEntry` gains two fields; existing consumers (`skills-instructions.ts`) and the `detectSkills` tests are unaffected (their `toEqual`s are on `DetectedSkill`, unchanged).
- No workflow-registering files touched → no DBOS source-guard re-baseline.
- I couldn't run the monorepo `bun install`/`tsc` locally — **please let CI typecheck.** The change is small and in-scope (`checkPermission`/`fsErrorResponse`/`buildSkillCatalog` all already imported/available in the routes module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the agent “link skills” picker with the runtime skill catalog so the picker shows exactly the skills available at run time, including `home/skills/*` and public sets. Fixes missing skills caused by client-side discovery.

- **Bug Fixes**
  - Added `GET /api/:org/fs/skills` that returns `buildSkillCatalog`; member-gated read.
  - Extended `SkillCatalogEntry` with `volume` and `path` for correct attachment.
  - Updated `useOrgFsSkills` to consume the endpoint; removes client-side root listing.
  - Standardized the `/fs/skills` route JSON response formatting (no behavior change).

<sup>Written for commit f1da4b660e20d74ec738c5406a20ac833472a31d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

