### PR TITLE
fix(variant-calendar): show page-level flags and honor time-of-day in month grid

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.test.ts
@@ -22,6 +22,8 @@ function makeVariant(
     variantIndex: 0,
     start: new Date(start),
     end: new Date(end),
+    openStart: false,
+    openEnd: false,
     label: blockKey,
     flagResolveType: "website/flags/multivariate/section.ts",
   };
@@ -193,5 +195,25 @@ describe("placeWeekSegments", () => {
     ]);
     expect(placed[0]?.leftUnits).toBe(0);
     expect(placed[0]?.widthUnits).toBe(7);
+  });
+
+  it("clamps the left edge but keeps a fractional right edge", () => {
+    // Starts before the week (left clamped to 0), ends 6am on the 9th →
+    // widthUnits 2.25, distinct from the whole-day span of 3.
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-06-01T00:00:00", "2026-06-09T06:00:00"),
+    ]);
+    expect(placed[0]?.span).toBe(3);
+    expect(placed[0]?.leftUnits).toBe(0);
+    expect(placed[0]?.widthUnits).toBeCloseTo(2.25, 5);
+  });
+
+  it("skips a zero-width segment ending exactly at the week's start", () => {
+    // Campaign already over by Sunday 00:00 — must not render a `minWidth`
+    // sliver on this week (regression guard for the ghost-bar bug).
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-06-01T00:00:00", "2026-06-07T00:00:00"),
+    ]);
+    expect(placed).toEqual([]);
   });
 });

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.test.ts
@@ -165,4 +165,33 @@ describe("placeWeekSegments", () => {
     expect(aSeg?.lane).toBe(0);
     expect(zSeg?.lane).toBe(1);
   });
+
+  it("carries hour-precise fractional extent (ending mid-day)", () => {
+    // Sun 2026-06-07 week. Ends noon on the 9th → last day only half-filled,
+    // even though the whole-day `span` still counts the 9th as covered.
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-06-07T00:00:00", "2026-06-09T12:00:00"),
+    ]);
+    expect(placed[0]?.span).toBe(3);
+    expect(placed[0]?.leftUnits).toBe(0);
+    expect(placed[0]?.widthUnits).toBeCloseTo(2.5, 5);
+  });
+
+  it("reflects a mid-day start and end within a single day", () => {
+    // Mon 2026-06-08, 6am → 6pm: column 1, quarter-in, half-a-day wide.
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-06-08T06:00:00", "2026-06-08T18:00:00"),
+    ]);
+    expect(placed[0]?.leftUnits).toBeCloseTo(1.25, 5);
+    expect(placed[0]?.widthUnits).toBeCloseTo(0.5, 5);
+  });
+
+  it("clips fractional extent to the visible week", () => {
+    // Spans well before and after the week → full 0..7 width, no overflow.
+    const placed = placeWeekSegments(week, [
+      makeVariant("2026-06-01T00:00:00", "2026-06-20T00:00:00"),
+    ]);
+    expect(placed[0]?.leftUnits).toBe(0);
+    expect(placed[0]?.widthUnits).toBe(7);
+  });
 });

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.ts
@@ -164,6 +164,10 @@ export function placeWeekSegments(
       unitsFromWeekStart(new Date(rightMs), weekStart) - leftUnits,
       0,
     );
+    // A zero-width visual (e.g. a campaign ending exactly at this week's
+    // Sunday 00:00, already over) must not render — otherwise `minWidth`
+    // would paint a stray sliver on a week the variant doesn't cover.
+    if (widthUnits <= 0) continue;
     segments.push({ variant, startCol, span, leftUnits, widthUnits });
   }
   // Sort by start (ascending), then span desc (long bars take low lanes),

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/date-utils.ts
@@ -62,6 +62,24 @@ export function diffInDays(a: Date, b: Date): number {
 }
 
 /**
+ * Fraction of the day already elapsed at `d`, in `[0, 1)` — e.g. noon → 0.5.
+ * Clamped so DST-shortened/lengthened days (23h/25h) can't spill past the
+ * day's own column when combined with the DST-correct `diffInDays`.
+ */
+function fractionOfDay(d: Date): number {
+  const frac = (d.getTime() - startOfDay(d).getTime()) / DAY_MS;
+  return Math.min(Math.max(frac, 0), 1);
+}
+
+/**
+ * Position of `d` measured in day-columns from `weekStart`, carrying the
+ * intra-day fraction — e.g. Tuesday 6am in a Sunday-start week → `2.25`.
+ */
+function unitsFromWeekStart(d: Date, weekStart: Date): number {
+  return diffInDays(d, weekStart) + fractionOfDay(d);
+}
+
+/**
  * 6-week (Sun → Sat) grid covering `monthStart`. Trailing weeks that fall
  * entirely in the next month are trimmed so February etc. doesn't render
  * an all-blank final row.
@@ -95,6 +113,15 @@ export interface PlacedSegment {
   span: number;
   /** Row within the week's stacked-bar area, assigned greedily. */
   lane: number;
+  /**
+   * Hour-precise left edge in day-column units from the week start, clipped
+   * to the visible Sun..Sat range (0..7). Unlike `startCol` this carries the
+   * intra-day fraction, so a variant starting at noon on Tuesday is `2.5`.
+   * Used for horizontal rendering; `startCol`/`span` drive lane packing.
+   */
+  leftUnits: number;
+  /** Hour-precise width in day-column units (0..7), clipped to the week. */
+  widthUnits: number;
 }
 
 /**
@@ -109,6 +136,8 @@ export function placeWeekSegments(
 ): PlacedSegment[] {
   const weekStart = startOfDay(weekDays[0]!);
   const weekEndExclusive = addDays(weekStart, 7);
+  const weekStartMs = weekStart.getTime();
+  const weekEndMs = weekEndExclusive.getTime();
   const segments: Array<Omit<PlacedSegment, "lane">> = [];
   for (const variant of variants) {
     const vStart = startOfDay(variant.start);
@@ -124,7 +153,18 @@ export function placeWeekSegments(
     const startCol = diffInDays(segStart, weekStart);
     const span = diffInDays(segEnd, segStart) + 1;
     if (span <= 0) continue;
-    segments.push({ variant, startCol, span });
+    // Hour-precise horizontal extent from the real timestamps, clipped to
+    // the visible week. This is what makes a bar end mid-cell (e.g. a
+    // campaign ending 10am shows ~40% into its last day) instead of
+    // filling whole day columns like `startCol`/`span` do.
+    const leftMs = Math.max(variant.start.getTime(), weekStartMs);
+    const rightMs = Math.min(variant.end.getTime(), weekEndMs);
+    const leftUnits = unitsFromWeekStart(new Date(leftMs), weekStart);
+    const widthUnits = Math.max(
+      unitsFromWeekStart(new Date(rightMs), weekStart) - leftUnits,
+      0,
+    );
+    segments.push({ variant, startCol, span, leftUnits, widthUnits });
   }
   // Sort by start (ascending), then span desc (long bars take low lanes),
   // then blockKey for determinism.

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
@@ -57,6 +57,51 @@ describe("extractScheduledVariants", () => {
     expect(out[1]?.blockKey).toBe("Alerta");
   });
 
+  it("extracts page-level `website/flags/multivariate.ts` variants", () => {
+    // Mirrors a real decofile: the page's `sections` field is a page-level
+    // multivariate flag (no `/section.ts` subpath), and each variant's
+    // `value` is an array of section blocks rather than a single object.
+    const decofile = {
+      "pages-Home-000001": {
+        name: "Home",
+        path: "/",
+        __resolveType: "website/pages/Page.tsx",
+        sections: {
+          __resolveType: "website/flags/multivariate.ts",
+          variants: [
+            {
+              rule: {
+                __resolveType: "website/matchers/date.ts",
+                start: "2026-06-30T23:00:00.000Z",
+                end: "2026-07-03T13:00:00.000Z",
+              },
+              value: [
+                { __resolveType: "Header" },
+                { __resolveType: "site/sections/Landing/Hero.tsx" },
+                { __resolveType: "Footer" },
+              ],
+            },
+            {
+              rule: {
+                __resolveType: "website/matchers/location.ts",
+                includeLocations: [],
+              },
+              value: [{ __resolveType: "Header" }],
+            },
+          ],
+        },
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    // Only the date-gated variant lands on the calendar.
+    expect(out).toHaveLength(1);
+    expect(out[0]?.blockKey).toBe("pages-Home-000001");
+    expect(out[0]?.blockLabel).toBe("Home");
+    expect(out[0]?.flagResolveType).toBe("website/flags/multivariate.ts");
+    expect(out[0]?.start.toISOString()).toBe("2026-06-30T23:00:00.000Z");
+    expect(out[0]?.end.toISOString()).toBe("2026-07-03T13:00:00.000Z");
+  });
+
   it("finds nested multivariate flags inside arrays/objects", () => {
     const decofile = {
       "Category Banner - 01": {

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
@@ -98,6 +98,10 @@ describe("extractScheduledVariants", () => {
     expect(out[0]?.blockKey).toBe("pages-Home-000001");
     expect(out[0]?.blockLabel).toBe("Home");
     expect(out[0]?.flagResolveType).toBe("website/flags/multivariate.ts");
+    // Page-level flags carry no inner path, so the label is the page name
+    // rather than the raw "sections" field.
+    expect(out[0]?.innerPath).toBe("");
+    expect(out[0]?.label).toBe("Home");
     expect(out[0]?.start.toISOString()).toBe("2026-06-30T23:00:00.000Z");
     expect(out[0]?.end.toISOString()).toBe("2026-07-03T13:00:00.000Z");
   });

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.test.ts
@@ -102,6 +102,89 @@ describe("extractScheduledVariants", () => {
     expect(out[0]?.end.toISOString()).toBe("2026-07-03T13:00:00.000Z");
   });
 
+  it("includes open-ended variants (start-only) and flags them", () => {
+    const decofile = {
+      Promo: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "website/matchers/date.ts",
+              start: "2026-06-01T00:00:00.000Z",
+              // no `end` → runs indefinitely
+            },
+            value: { title: "Launch (ongoing)" },
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.label).toBe("Launch (ongoing)");
+    expect(out[0]?.openStart).toBe(false);
+    expect(out[0]?.openEnd).toBe(true);
+    expect(out[0]?.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("includes open-ended variants (end-only) and flags them", () => {
+    const decofile = {
+      Sunset: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "website/matchers/date.ts",
+              // no `start` → runs since forever
+              end: "2026-07-01T00:00:00.000Z",
+            },
+            value: { title: "Until launch" },
+          },
+        ],
+      },
+    };
+    const out = extractScheduledVariants(decofile);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.openStart).toBe(true);
+    expect(out[0]?.openEnd).toBe(false);
+    expect(out[0]?.end.toISOString()).toBe("2026-07-01T00:00:00.000Z");
+  });
+
+  it("excludes an always-on date matcher with neither start nor end", () => {
+    const decofile = {
+      AlwaysOn: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [
+          {
+            rule: { __resolveType: "website/matchers/date.ts" },
+            value: { title: "no bounds" },
+          },
+        ],
+      },
+    };
+    expect(extractScheduledVariants(decofile)).toEqual([]);
+  });
+
+  it("does not treat `multivariateFoo.ts` as a variant container", () => {
+    // Regression guard for the widened regex: only `multivariate.ts` or
+    // `multivariate/<kind>.ts` count — not an arbitrary `multivariate*.ts`.
+    const decofile = {
+      NotAFlag: {
+        __resolveType: "website/flags/multivariateFoo.ts",
+        variants: [
+          {
+            rule: {
+              __resolveType: "website/matchers/date.ts",
+              start: "2026-06-01T00:00:00.000Z",
+              end: "2026-06-10T00:00:00.000Z",
+            },
+            value: { title: "should not appear" },
+          },
+        ],
+      },
+    };
+    expect(extractScheduledVariants(decofile)).toEqual([]);
+  });
+
   it("finds nested multivariate flags inside arrays/objects", () => {
     const decofile = {
       "Category Banner - 01": {

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
@@ -40,6 +40,12 @@ const OPEN_END = new Date(8_640_000_000_000_000);
 // `$live/flags/multivariate/section.ts` all match.
 const MULTIVARIATE_FLAG_PATTERN = /\/flags\/multivariate(?:\/[^/]+)?\.ts$/;
 
+// The page-level flag (no `/kind` subpath): `<scope>/flags/multivariate.ts`.
+// It lives at a page's conventional `sections` field and *is* the page's
+// variant, so it carries no meaningful inner path (which would otherwise read
+// as the literal field name "sections").
+const PAGE_LEVEL_FLAG_PATTERN = /\/flags\/multivariate\.ts$/;
+
 export interface ScheduledVariant {
   /** Top-level decofile key the variant lives under (used for grouping/color). */
   blockKey: string;
@@ -212,9 +218,13 @@ function walkAndCollect(
   out: ScheduledVariant[],
 ): void {
   if (isVariantContainer(node)) {
-    const innerPath = formatInnerPath(innerSegments);
     const variants = (node as { variants: unknown[] }).variants;
     const flagResolveType = (node as { __resolveType: string }).__resolveType;
+    // Page-level flags have no meaningful inner path — the label then falls
+    // back to the page name (`blockLabel`) instead of the field name.
+    const innerPath = PAGE_LEVEL_FLAG_PATTERN.test(flagResolveType)
+      ? ""
+      : formatInnerPath(innerSegments);
     variants.forEach((variant, variantIndex) => {
       if (!variant || typeof variant !== "object") return;
       const v = variant as Record<string, unknown>;

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
@@ -24,11 +24,13 @@ const MULTI_MATCHER_TYPES = new Set([
   "$live/matchers/MatchMulti.ts",
 ]);
 
-// Non-anchored on purpose: matches `<scope>/flags/multivariate/<x>.ts` for
-// any scope, so `website/flags/multivariate/section.ts`,
+// Non-anchored on purpose: matches `<scope>/flags/multivariate.ts` (the
+// page-level flag) as well as `<scope>/flags/multivariate/<x>.ts` for any
+// scope, so `website/flags/multivariate.ts`,
+// `website/flags/multivariate/section.ts`,
 // `site/flags/multivariate/etcMediaKitContent.ts`, and the legacy
 // `$live/flags/multivariate/section.ts` all match.
-const MULTIVARIATE_FLAG_PATTERN = /\/flags\/multivariate\/[^/]+\.ts$/;
+const MULTIVARIATE_FLAG_PATTERN = /\/flags\/multivariate(?:\/[^/]+)?\.ts$/;
 
 export interface ScheduledVariant {
   /** Top-level decofile key the variant lives under (used for grouping/color). */

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/extract-variants.ts
@@ -24,6 +24,14 @@ const MULTI_MATCHER_TYPES = new Set([
   "$live/matchers/MatchMulti.ts",
 ]);
 
+// Sentinels for open-ended ranges (campaign with only a `start`, or only an
+// `end`). `new Date(±8.64e15)` are the min/max representable Date values, so
+// they clamp cleanly to any visible window and sort to the extremes without
+// special-casing the layout math. Openness is tracked explicitly via the
+// `openStart`/`openEnd` flags so rendering/tooltips never sniff for these.
+const OPEN_START = new Date(-8_640_000_000_000_000);
+const OPEN_END = new Date(8_640_000_000_000_000);
+
 // Non-anchored on purpose: matches `<scope>/flags/multivariate.ts` (the
 // page-level flag) as well as `<scope>/flags/multivariate/<x>.ts` for any
 // scope, so `website/flags/multivariate.ts`,
@@ -42,6 +50,10 @@ export interface ScheduledVariant {
   variantIndex: number;
   start: Date;
   end: Date;
+  /** True when the variant has no `start` (runs since forever, open on the left). */
+  openStart: boolean;
+  /** True when the variant has no `end` (runs indefinitely, open on the right). */
+  openEnd: boolean;
   /** Best-effort short label from the variant's `value`, or a path-derived fallback. */
   label: string;
   /** The flag's `__resolveType`, e.g. `website/flags/multivariate/image.ts`. */
@@ -69,26 +81,39 @@ function humanizeBlockKey(key: string): string {
   return label;
 }
 
-function readDateRange(rule: unknown): { start: Date; end: Date } | null {
-  if (!rule || typeof rule !== "object") return null;
-  const { start, end } = rule as { start?: unknown; end?: unknown };
-  if (typeof start !== "string" || typeof end !== "string") return null;
-  const startDate = new Date(start);
-  const endDate = new Date(end);
-  if (
-    Number.isNaN(startDate.getTime()) ||
-    Number.isNaN(endDate.getTime()) ||
-    endDate.getTime() <= startDate.getTime()
-  ) {
-    return null;
-  }
-  return { start: startDate, end: endDate };
+interface DateRange {
+  start: Date;
+  end: Date;
+  openStart: boolean;
+  openEnd: boolean;
 }
 
-function collectDateRanges(
-  rule: unknown,
-  out: Array<{ start: Date; end: Date }>,
-): void {
+function readDateRange(rule: unknown): DateRange | null {
+  if (!rule || typeof rule !== "object") return null;
+  const { start, end } = rule as { start?: unknown; end?: unknown };
+  const hasStart = typeof start === "string";
+  const hasEnd = typeof end === "string";
+  // Both sides absent → an always-on variant with no time axis; it belongs
+  // off the calendar (same as audience/device matchers).
+  if (!hasStart && !hasEnd) return null;
+  const startDate = hasStart ? new Date(start) : OPEN_START;
+  const endDate = hasEnd ? new Date(end) : OPEN_END;
+  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+    return null;
+  }
+  // Only enforce ordering when both ends are real dates.
+  if (hasStart && hasEnd && endDate.getTime() <= startDate.getTime()) {
+    return null;
+  }
+  return {
+    start: startDate,
+    end: endDate,
+    openStart: !hasStart,
+    openEnd: !hasEnd,
+  };
+}
+
+function collectDateRanges(rule: unknown, out: DateRange[]): void {
   if (!rule || typeof rule !== "object") return;
   const rt = (rule as { __resolveType?: unknown }).__resolveType;
   if (typeof rt !== "string") return;
@@ -193,7 +218,7 @@ function walkAndCollect(
     variants.forEach((variant, variantIndex) => {
       if (!variant || typeof variant !== "object") return;
       const v = variant as Record<string, unknown>;
-      const ranges: Array<{ start: Date; end: Date }> = [];
+      const ranges: DateRange[] = [];
       collectDateRanges(v.rule, ranges);
       if (ranges.length === 0) return;
       const valueLabel = readValueLabel(v.value);
@@ -206,6 +231,8 @@ function walkAndCollect(
           variantIndex,
           start: range.start,
           end: range.end,
+          openStart: range.openStart,
+          openEnd: range.openEnd,
           label,
           flagResolveType,
         });

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
@@ -46,7 +46,9 @@ const RANGE_FORMAT = new Intl.DateTimeFormat("en", {
 });
 
 function formatRangeForTooltip(v: ScheduledVariant): string {
-  return `${RANGE_FORMAT.format(v.start)} → ${RANGE_FORMAT.format(v.end)}`;
+  const startText = v.openStart ? "Always" : RANGE_FORMAT.format(v.start);
+  const endText = v.openEnd ? "Ongoing" : RANGE_FORMAT.format(v.end);
+  return `${startText} → ${endText}`;
 }
 
 /**
@@ -73,22 +75,43 @@ function VariantTooltipBody({ variant }: { variant: ScheduledVariant }) {
   );
 }
 
+// Width of the gradient that fades an open-ended bar's edge into "continues".
+const FADE_WIDTH = 16;
+
+/** CSS mask that fades the given edge(s) of a bar toward transparent. */
+function edgeFadeMask(
+  fadeStart: boolean,
+  fadeEnd: boolean,
+): string | undefined {
+  const start = fadeStart ? "transparent" : `#000 0`;
+  const end = fadeEnd ? "transparent" : `#000 100%`;
+  if (!fadeStart && !fadeEnd) return undefined;
+  return `linear-gradient(to right, ${start}, #000 ${FADE_WIDTH}px, #000 calc(100% - ${FADE_WIDTH}px), ${end})`;
+}
+
 /**
  * One colored bar with its hover tooltip. The caller owns positioning via
  * `style` (top/left/width/height or %-based equivalents) and what shows
- * inside the bar via `children`.
+ * inside the bar via `children`. `fadeStart`/`fadeEnd` render an open-ended
+ * edge as a gradient (and drop that side's rounded corner) to signal the
+ * campaign continues beyond the visible window.
  */
 function VariantBar({
   variant,
   color,
   style,
   children,
+  fadeStart = false,
+  fadeEnd = false,
 }: {
   variant: ScheduledVariant;
   color: BlockColor;
   style: React.CSSProperties;
   children: React.ReactNode;
+  fadeStart?: boolean;
+  fadeEnd?: boolean;
 }) {
+  const mask = edgeFadeMask(fadeStart, fadeEnd);
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -98,6 +121,15 @@ function VariantBar({
             background: color.bg,
             color: color.text,
             borderRadius: 4,
+            ...(fadeStart && {
+              borderTopLeftRadius: 0,
+              borderBottomLeftRadius: 0,
+            }),
+            ...(fadeEnd && {
+              borderTopRightRadius: 0,
+              borderBottomRightRadius: 0,
+            }),
+            ...(mask && { maskImage: mask, WebkitMaskImage: mask }),
             ...style,
           }}
         >
@@ -209,6 +241,9 @@ function EmptyState() {
 const LANE_HEIGHT = 20;
 const LANE_GAP = 2;
 const HEADER_HEIGHT = 28;
+// Floor so a very short (sub-hour) campaign stays visible/clickable even when
+// its fractional width would otherwise round to nothing.
+const MIN_BAR_WIDTH = 6;
 
 function CalendarView({
   monthStart,
@@ -281,18 +316,23 @@ function CalendarView({
                 // timestamps fall within the day, not at whole-day columns.
                 const leftPct = (seg.leftUnits / 7) * 100;
                 const widthPct = (seg.widthUnits / 7) * 100;
+                // Fade only where an open-ended variant meets the edge of the
+                // whole visible grid — the first week's left / last week's
+                // right. Mid-grid week wraps are continuations, not open ends.
+                const fadeStart = seg.variant.openStart && wi === 0;
+                const fadeEnd = seg.variant.openEnd && wi === weeks.length - 1;
                 return (
                   <VariantBar
                     key={`${wi}-${idx}`}
                     variant={seg.variant}
                     color={color}
+                    fadeStart={fadeStart}
+                    fadeEnd={fadeEnd}
                     style={{
                       top,
                       left: `calc(${leftPct}% + 2px)`,
                       width: `calc(${widthPct}% - 4px)`,
-                      // Keep a very short campaign visible/clickable even when
-                      // its fractional width would otherwise round to nothing.
-                      minWidth: 6,
+                      minWidth: MIN_BAR_WIDTH,
                       height: LANE_HEIGHT,
                     }}
                   >
@@ -464,6 +504,8 @@ function TimelineView({
                         <VariantBar
                           variant={v}
                           color={color}
+                          fadeStart={v.openStart}
+                          fadeEnd={v.openEnd}
                           style={{
                             top: "50%",
                             transform: "translateY(-50%)",

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
@@ -277,8 +277,10 @@ function CalendarView({
               {segments.map((seg, idx) => {
                 const color = colorFromMap(colorMap, seg.variant.blockKey);
                 const top = HEADER_HEIGHT + seg.lane * (LANE_HEIGHT + LANE_GAP);
-                const leftPct = (seg.startCol / 7) * 100;
-                const widthPct = (seg.span / 7) * 100;
+                // Hour-precise: the bar starts/ends where the variant's
+                // timestamps fall within the day, not at whole-day columns.
+                const leftPct = (seg.leftUnits / 7) * 100;
+                const widthPct = (seg.widthUnits / 7) * 100;
                 return (
                   <VariantBar
                     key={`${wi}-${idx}`}
@@ -288,6 +290,9 @@ function CalendarView({
                       top,
                       left: `calc(${leftPct}% + 2px)`,
                       width: `calc(${widthPct}% - 4px)`,
+                      // Keep a very short campaign visible/clickable even when
+                      // its fractional width would otherwise round to nothing.
+                      minWidth: 6,
                       height: LANE_HEIGHT,
                     }}
                   >

--- a/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/variant-calendar/variant-calendar.tsx
@@ -14,7 +14,9 @@ import {
 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
+import { Label } from "@deco/ui/components/label.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { Switch } from "@deco/ui/components/switch.tsx";
 import {
   Tooltip,
   TooltipContent,
@@ -148,8 +150,15 @@ export function VariantCalendar({
 }) {
   const [view, setView] = useState<ViewMode>("calendar");
   const [cursor, setCursor] = useState<Date>(() => startOfMonth(new Date()));
+  // Open-ended ("ongoing") variants fill the grid to the edge everywhere and
+  // add noise, so they're hidden by default behind an opt-in toggle.
+  const [showOngoing, setShowOngoing] = useState(false);
 
-  const variants = extractScheduledVariants(decofile);
+  const allVariants = extractScheduledVariants(decofile);
+  const ongoingCount = allVariants.filter((v) => v.openEnd).length;
+  const variants = showOngoing
+    ? allVariants
+    : allVariants.filter((v) => !v.openEnd);
   const colorMap = buildBlockColorMap(variants.map((v) => v.blockKey));
 
   const goToday = () => setCursor(startOfMonth(new Date()));
@@ -189,26 +198,43 @@ export function VariantCalendar({
             {MONTHS[cursor.getMonth()]} {cursor.getFullYear()}
           </h2>
         </div>
-        <ViewModeToggle<ViewMode>
-          value={view}
-          onValueChange={setView}
-          options={[
-            {
-              value: "calendar",
-              icon: <Calendar />,
-              label: "Calendar",
-            },
-            {
-              value: "timeline",
-              icon: <Activity />,
-              label: "Timeline",
-            },
-          ]}
-        />
+        <div className="flex items-center gap-4">
+          {ongoingCount > 0 && (
+            <div className="flex items-center gap-2">
+              <Switch
+                id="show-ongoing"
+                checked={showOngoing}
+                onCheckedChange={setShowOngoing}
+              />
+              <Label
+                htmlFor="show-ongoing"
+                className="text-xs text-muted-foreground cursor-pointer"
+              >
+                Show ongoing ({ongoingCount})
+              </Label>
+            </div>
+          )}
+          <ViewModeToggle<ViewMode>
+            value={view}
+            onValueChange={setView}
+            options={[
+              {
+                value: "calendar",
+                icon: <Calendar />,
+                label: "Calendar",
+              },
+              {
+                value: "timeline",
+                icon: <Activity />,
+                label: "Timeline",
+              },
+            ]}
+          />
+        </div>
       </div>
 
       {variants.length === 0 ? (
-        <EmptyState />
+        <EmptyState hiddenOngoing={showOngoing ? 0 : ongoingCount} />
       ) : view === "calendar" ? (
         <CalendarView
           monthStart={cursor}
@@ -226,14 +252,27 @@ export function VariantCalendar({
   );
 }
 
-function EmptyState() {
+function EmptyState({ hiddenOngoing = 0 }: { hiddenOngoing?: number }) {
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground p-6">
       <Calendar size={24} className="text-muted-foreground/60" />
-      <div>No scheduled variants.</div>
-      <div className="text-xs text-muted-foreground/80">
-        Variants gated by a date matcher appear here.
-      </div>
+      {hiddenOngoing > 0 ? (
+        <>
+          <div>No dated variants in view.</div>
+          <div className="text-xs text-muted-foreground/80">
+            {hiddenOngoing} ongoing{" "}
+            {hiddenOngoing === 1 ? "variant is" : "variants are"} hidden —
+            enable “Show ongoing” to view.
+          </div>
+        </>
+      ) : (
+        <>
+          <div>No scheduled variants.</div>
+          <div className="text-xs text-muted-foreground/80">
+            Variants gated by a date matcher appear here.
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two fixes to the **Content → Calendar** view (`apps/mesh/src/web/components/sandbox/content/variant-calendar/`), found while debugging a real `.decofile` whose scheduled campaign wasn't showing up.

### 1. Page-level multivariate flags were never extracted
`extractScheduledVariants` gated variant containers on `MULTIVARIATE_FLAG_PATTERN`, which only matched **subpath** flags — `.../flags/multivariate/<kind>.ts` (e.g. `section.ts`, `image.ts`). The **page-level** flag `website/flags/multivariate.ts` (the `PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE` the codebase already defines) has no subpath, so it never matched and its date-gated variants never reached the calendar — an empty calendar even with a valid, currently-active campaign.

Fix: make the subpath optional.
```diff
-const MULTIVARIATE_FLAG_PATTERN = /\/flags\/multivariate\/[^/]+\.ts$/;
+const MULTIVARIATE_FLAG_PATTERN = /\/flags\/multivariate(?:\/[^/]+)?\.ts$/;
```
Still matches `section.ts`/`image.ts`/custom `site/...`/legacy `$live/...`, and does **not** match `multivariateXYZ.ts`.

### 2. Month grid ignored time-of-day
Month-grid bars snapped to whole day columns (`startCol`/`span`), so a campaign ending at 10am filled its entire last day. `placeWeekSegments` now also emits hour-precise `leftUnits`/`widthUnits` (clipped to the visible Sun..Sat week), and the bar renders from those — matching what the Timeline view already did. Lane packing still uses the integer `startCol`/`span`, so stacking is unchanged. A `minWidth` keeps very short campaigns visible/clickable; the existing `truncate` handles label ellipsis.

**Before:** bar occupies whole start/end days. **After:** e.g. `2026-06-30T23:00Z → 2026-07-03T13:00Z` (BRT 20h → 10h) starts ~83% into Tue 30 and ends ~42% into Fri 03.

## Testing
- `bun test .../variant-calendar/` — **34 pass / 0 fail** (new cases: page-level `website/flags/multivariate.ts` extraction; fractional extent ending mid-day, mid-day start+end, and week-edge clipping).
- `bun run fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Content → Calendar to include page-level and open-ended campaigns, render month-grid bars with hour precision, hide ongoing items by default, and label page-level variants by page name. Campaigns now show correct times with clean edges and no ghost slivers.

- **New Features**
  - Hide ongoing variants by default; add a “Show ongoing (N)” toggle and improved empty state when only hidden ongoing items exist.

- **Bug Fixes**
  - Variant extraction: widen multivariate flag match to include page-level `.../flags/multivariate.ts`; accept date matchers with only `start` or only `end` (mark as open with “Always”/“Ongoing”); still exclude always-on (no start/end).
  - Month grid: render from hour-precise `leftUnits`/`widthUnits` (clipped to the week), skip zero-width week segments to avoid stray slivers, fade open edges, keep a small `minWidth`; lane packing still uses `startCol`/`span`.
  - Labels: page-level flags carry no inner path; label falls back to the page name (not “sections”).

<sup>Written for commit e54e27ee6ce054b365217cff6a0ee53c2ed0f017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

