### PR TITLE
feat(commerce-onboarding): inline config for well-known companion MCPs

### DIFF
--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -53,6 +53,12 @@ export const KEYS = {
     ["commerce-discovery", "companion-connections", orgId] as const,
   commerceDiscoveryCompanionRegistry: (orgId: string, key: string) =>
     ["commerce-discovery", "companion-registry", orgId, key] as const,
+  commerceDiscoveryCompanionConfig: (orgId: string, connectionId: string) =>
+    ["commerce-discovery", "companion-config", orgId, connectionId] as const,
+  commerceDiscoveryGaSummaries: (orgId: string, connectionId: string) =>
+    ["commerce-discovery", "ga-summaries", orgId, connectionId] as const,
+  commerceDiscoveryGscSites: (orgId: string, connectionId: string) =>
+    ["commerce-discovery", "gsc-sites", orgId, connectionId] as const,
 
   connectionActivity: (
     connectionId: string,

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -82,7 +82,7 @@ export default function CommerceOnboardingRoute() {
  */
 const CommerceSiteHostContext = createContext<string | null>(null);
 
-const useCommerceSiteHost = () => useContext(CommerceSiteHostContext);
+export const useCommerceSiteHost = () => useContext(CommerceSiteHostContext);
 
 function siteUrlToHost(siteUrl?: string): string | null {
   if (!siteUrl) return null;

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -1,6 +1,8 @@
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { Button } from "@deco/ui/components/button.tsx";
 import { CheckCircle, Loading01 } from "@untitledui/icons";
+import { CompanionConfigSection } from "./companion-config-section.tsx";
+import { getCompanionConfig } from "./companion-config-registry.ts";
 import type { CompanionCardModel } from "./companions-core.ts";
 
 /**
@@ -42,12 +44,19 @@ export function CompanionCard({
   connecting,
   disabled,
   onConnect,
+  orgId,
+  orgSlug,
+  siteHost,
 }: {
   card: CompanionCardModel;
   connecting: boolean;
   disabled: boolean;
   onConnect: () => void;
+  orgId: string;
+  orgSlug: string;
+  siteHost: string | null;
 }) {
+  const configEntry = getCompanionConfig(card.bindingType);
   return (
     <div className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-4">
       <div className="flex items-center gap-2">
@@ -94,6 +103,15 @@ export function CompanionCard({
           </p>
         )}
       </div>
+      {card.satisfied && card.linkedConnectionId && configEntry && (
+        <CompanionConfigSection
+          entry={configEntry}
+          card={{ ...card, linkedConnectionId: card.linkedConnectionId }}
+          orgId={orgId}
+          orgSlug={orgSlug}
+          siteHost={siteHost}
+        />
+      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-config-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-config-core.test.ts
@@ -47,6 +47,26 @@ describe("parseAccountSummaries", () => {
     ]);
   });
 
+  it("accepts the unwrapped top-level accountSummaries shape", () => {
+    expect(
+      parseAccountSummaries({
+        accountSummaries: [
+          {
+            displayName: "Acct One",
+            propertySummaries: [
+              { property: "properties/100", displayName: "Site A" },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        account: "Acct One",
+        options: [{ value: "properties/100", label: "Site A" }],
+      },
+    ]);
+  });
+
   it("returns [] for malformed/empty input", () => {
     expect(parseAccountSummaries(null)).toEqual([]);
     expect(parseAccountSummaries({})).toEqual([]);
@@ -82,6 +102,16 @@ describe("parseListSites", () => {
       { siteUrl: "https://www.bite.com.br/" },
       { siteUrl: "sc-domain:deco.site" },
     ]);
+  });
+
+  it("accepts the raw Search Console siteEntry shape", () => {
+    expect(
+      parseListSites({
+        siteEntry: [
+          { siteUrl: "sc-domain:deco.site", permissionLevel: "siteOwner" },
+        ],
+      }),
+    ).toEqual([{ siteUrl: "sc-domain:deco.site" }]);
   });
 
   it("returns [] for malformed input", () => {

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-config-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-config-core.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "bun:test";
+import {
+  flattenGaOptions,
+  isConfigured,
+  matchVerifiedSite,
+  mergeConfigState,
+  parseAccountSummaries,
+  parseListSites,
+} from "./companion-config-core.ts";
+
+const GA_RAW = {
+  response: {
+    accountSummaries: [
+      {
+        account: "accounts/1",
+        displayName: "Acct One",
+        propertySummaries: [
+          { property: "properties/100", displayName: "Site A" },
+        ],
+      },
+      {
+        account: "accounts/2",
+        displayName: "Acct Two",
+        propertySummaries: [
+          { property: "properties/200", displayName: "Site B" },
+          { property: "properties/201", displayName: "Site C" },
+        ],
+      },
+    ],
+  },
+};
+
+describe("parseAccountSummaries", () => {
+  it("groups properties under account displayName, preserving order", () => {
+    expect(parseAccountSummaries(GA_RAW)).toEqual([
+      {
+        account: "Acct One",
+        options: [{ value: "properties/100", label: "Site A" }],
+      },
+      {
+        account: "Acct Two",
+        options: [
+          { value: "properties/200", label: "Site B" },
+          { value: "properties/201", label: "Site C" },
+        ],
+      },
+    ]);
+  });
+
+  it("returns [] for malformed/empty input", () => {
+    expect(parseAccountSummaries(null)).toEqual([]);
+    expect(parseAccountSummaries({})).toEqual([]);
+    expect(
+      parseAccountSummaries({ response: { accountSummaries: [] } }),
+    ).toEqual([]);
+  });
+});
+
+describe("flattenGaOptions", () => {
+  it("flattens all options across groups", () => {
+    const groups = parseAccountSummaries(GA_RAW);
+    expect(flattenGaOptions(groups).map((o) => o.value)).toEqual([
+      "properties/100",
+      "properties/200",
+      "properties/201",
+    ]);
+  });
+});
+
+describe("parseListSites", () => {
+  it("extracts siteUrl entries", () => {
+    const raw = {
+      sites: [
+        {
+          siteUrl: "https://www.bite.com.br/",
+          permissionLevel: "siteFullUser",
+        },
+        { siteUrl: "sc-domain:deco.site", permissionLevel: "siteOwner" },
+      ],
+    };
+    expect(parseListSites(raw)).toEqual([
+      { siteUrl: "https://www.bite.com.br/" },
+      { siteUrl: "sc-domain:deco.site" },
+    ]);
+  });
+
+  it("returns [] for malformed input", () => {
+    expect(parseListSites(null)).toEqual([]);
+    expect(parseListSites({})).toEqual([]);
+  });
+});
+
+describe("matchVerifiedSite", () => {
+  const sites = [
+    { siteUrl: "https://www.bite.com.br/" },
+    { siteUrl: "sc-domain:deco.site" },
+    { siteUrl: "https://shop.example.com/" },
+  ];
+
+  it("matches an sc-domain property by host", () => {
+    expect(matchVerifiedSite("deco.site", sites)).toBe("sc-domain:deco.site");
+  });
+
+  it("matches a URL-prefix property ignoring www", () => {
+    expect(matchVerifiedSite("bite.com.br", sites)).toBe(
+      "https://www.bite.com.br/",
+    );
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(matchVerifiedSite("nope.com", sites)).toBeNull();
+  });
+
+  it("returns null for a null host", () => {
+    expect(matchVerifiedSite(null, sites)).toBeNull();
+  });
+
+  it("returns null when the host is ambiguous (multiple matches)", () => {
+    const ambiguous = [
+      { siteUrl: "sc-domain:dup.com" },
+      { siteUrl: "https://dup.com/" },
+    ];
+    expect(matchVerifiedSite("dup.com", ambiguous)).toBeNull();
+  });
+});
+
+describe("isConfigured", () => {
+  it("true when anchor field is a non-empty value", () => {
+    expect(isConfigured({ propertyId: "properties/1" }, "propertyId")).toBe(
+      true,
+    );
+    expect(isConfigured({ accountName: "mystore" }, "accountName")).toBe(true);
+  });
+
+  it("false when missing, empty, or null", () => {
+    expect(isConfigured({}, "propertyId")).toBe(false);
+    expect(isConfigured({ propertyId: "" }, "propertyId")).toBe(false);
+    expect(isConfigured({ propertyId: null }, "propertyId")).toBe(false);
+    expect(isConfigured(null, "propertyId")).toBe(false);
+  });
+});
+
+describe("mergeConfigState", () => {
+  it("shallow-merges patch over existing state", () => {
+    expect(
+      mergeConfigState({ a: 1, propertyId: "old" }, { propertyId: "new" }),
+    ).toEqual({ a: 1, propertyId: "new" });
+  });
+
+  it("treats null/undefined state as empty", () => {
+    expect(mergeConfigState(null, { siteUrl: "x" })).toEqual({ siteUrl: "x" });
+  });
+});

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-config-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-config-core.ts
@@ -24,11 +24,16 @@ interface RawAccountSummary {
 
 /** Parse get-account-summaries structuredContent into grouped options.
  * Shape: { response: { accountSummaries: [{ displayName, propertySummaries:
- * [{ property, displayName }] }] } }. Groups with no properties are dropped. */
+ * [{ property, displayName }] }] } }. Also accepts the raw GA Admin API
+ * top-level `{ accountSummaries }` shape, in case the MCP forwards it
+ * unwrapped. Groups with no properties are dropped. */
 export function parseAccountSummaries(raw: unknown): GaPropertyGroup[] {
-  const summaries = (
-    raw as { response?: { accountSummaries?: unknown } } | null | undefined
-  )?.response?.accountSummaries;
+  const wrapper = raw as
+    | { response?: { accountSummaries?: unknown }; accountSummaries?: unknown }
+    | null
+    | undefined;
+  const summaries =
+    wrapper?.response?.accountSummaries ?? wrapper?.accountSummaries;
   if (!Array.isArray(summaries)) return [];
   const groups: GaPropertyGroup[] = [];
   for (const acc of summaries as RawAccountSummary[]) {
@@ -59,9 +64,15 @@ export function flattenGaOptions(
   return groups.flatMap((g) => g.options);
 }
 
-/** Parse list_sites structuredContent { sites: [{ siteUrl }] }. */
+/** Parse list_sites structuredContent { sites: [{ siteUrl }] }. Also accepts
+ * the raw Search Console API `{ siteEntry: [...] }` shape, in case the MCP
+ * forwards it unwrapped. */
 export function parseListSites(raw: unknown): VerifiedSite[] {
-  const sites = (raw as { sites?: unknown } | null | undefined)?.sites;
+  const wrapper = raw as
+    | { sites?: unknown; siteEntry?: unknown }
+    | null
+    | undefined;
+  const sites = wrapper?.sites ?? wrapper?.siteEntry;
   if (!Array.isArray(sites)) return [];
   return (sites as Array<{ siteUrl?: unknown }>)
     .filter((s) => typeof s?.siteUrl === "string" && s.siteUrl.length > 0)

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-config-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-config-core.ts
@@ -1,0 +1,111 @@
+export interface GaPropertyOption {
+  /** Full GA resource name, e.g. "properties/273245903". */
+  value: string;
+  label: string;
+}
+
+export interface GaPropertyGroup {
+  account: string;
+  options: GaPropertyOption[];
+}
+
+export interface VerifiedSite {
+  siteUrl: string;
+}
+
+interface RawPropertySummary {
+  property?: unknown;
+  displayName?: unknown;
+}
+interface RawAccountSummary {
+  displayName?: unknown;
+  propertySummaries?: unknown;
+}
+
+/** Parse get-account-summaries structuredContent into grouped options.
+ * Shape: { response: { accountSummaries: [{ displayName, propertySummaries:
+ * [{ property, displayName }] }] } }. Groups with no properties are dropped. */
+export function parseAccountSummaries(raw: unknown): GaPropertyGroup[] {
+  const summaries = (
+    raw as { response?: { accountSummaries?: unknown } } | null | undefined
+  )?.response?.accountSummaries;
+  if (!Array.isArray(summaries)) return [];
+  const groups: GaPropertyGroup[] = [];
+  for (const acc of summaries as RawAccountSummary[]) {
+    const props = acc?.propertySummaries;
+    if (!Array.isArray(props)) continue;
+    const options: GaPropertyOption[] = [];
+    for (const p of props as RawPropertySummary[]) {
+      if (typeof p?.property === "string" && p.property.length > 0) {
+        options.push({
+          value: p.property,
+          label: typeof p.displayName === "string" ? p.displayName : p.property,
+        });
+      }
+    }
+    if (options.length === 0) continue;
+    groups.push({
+      account:
+        typeof acc?.displayName === "string" ? acc.displayName : "Account",
+      options,
+    });
+  }
+  return groups;
+}
+
+export function flattenGaOptions(
+  groups: GaPropertyGroup[],
+): GaPropertyOption[] {
+  return groups.flatMap((g) => g.options);
+}
+
+/** Parse list_sites structuredContent { sites: [{ siteUrl }] }. */
+export function parseListSites(raw: unknown): VerifiedSite[] {
+  const sites = (raw as { sites?: unknown } | null | undefined)?.sites;
+  if (!Array.isArray(sites)) return [];
+  return (sites as Array<{ siteUrl?: unknown }>)
+    .filter((s) => typeof s?.siteUrl === "string" && s.siteUrl.length > 0)
+    .map((s) => ({ siteUrl: s.siteUrl as string }));
+}
+
+/** Normalize a verified siteUrl to a bare host for comparison.
+ * "sc-domain:example.com" -> "example.com"; "https://www.x.com/" -> "x.com". */
+function siteUrlToHost(siteUrl: string): string | null {
+  const stripWww = (h: string) => h.replace(/^www\./, "").toLowerCase();
+  if (siteUrl.startsWith("sc-domain:")) {
+    return stripWww(siteUrl.slice("sc-domain:".length));
+  }
+  try {
+    return stripWww(new URL(siteUrl).hostname);
+  } catch {
+    return null;
+  }
+}
+
+/** Pick the single verified siteUrl whose host matches `host`.
+ * Returns null when host is null, nothing matches, or the match is ambiguous
+ * (more than one verified property shares the host). */
+export function matchVerifiedSite(
+  host: string | null,
+  sites: VerifiedSite[],
+): string | null {
+  if (!host) return null;
+  const target = host.replace(/^www\./, "").toLowerCase();
+  const matches = sites.filter((s) => siteUrlToHost(s.siteUrl) === target);
+  return matches.length === 1 ? matches[0]!.siteUrl : null;
+}
+
+export function isConfigured(
+  state: Record<string, unknown> | null | undefined,
+  anchorField: string,
+): boolean {
+  const v = state?.[anchorField];
+  return typeof v === "string" ? v.length > 0 : v != null;
+}
+
+export function mergeConfigState(
+  state: Record<string, unknown> | null | undefined,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...(state ?? {}), ...patch };
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-config-registry.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-config-registry.ts
@@ -1,0 +1,65 @@
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { FC } from "react";
+import { matchVerifiedSite, parseListSites } from "./companion-config-core.ts";
+import { unwrapToolResult } from "./companions-core.ts";
+import { GoogleAnalyticsRenderer } from "./config-renderers/google-analytics.tsx";
+import { GoogleSearchConsoleRenderer } from "./config-renderers/google-search-console.tsx";
+import type { CompanionConfigRendererProps } from "./config-renderers/types.ts";
+import { VtexRenderer } from "./config-renderers/vtex.tsx";
+
+export interface CompanionConfigContext {
+  /** Onboarding site host (from CommerceSiteHostContext), for GSC matching. */
+  siteHost: string | null;
+  /** Downstream connection id being configured. */
+  connectionId: string;
+  orgId: string;
+  orgSlug: string;
+}
+
+export interface CompanionConfigEntry {
+  bindingType: string;
+  /** Downstream config_state key whose presence means "configured". */
+  anchorField: string;
+  /**
+   * Optional: run once for a connected+unconfigured card to compute a patch to
+   * auto-save. May call the downstream MCP via `client`. Returns null to skip.
+   */
+  autoResolve?: (args: {
+    client: Client;
+    ctx: CompanionConfigContext;
+  }) => Promise<Record<string, unknown> | null>;
+  Renderer: FC<CompanionConfigRendererProps>;
+}
+
+export const COMPANION_CONFIG: Record<string, CompanionConfigEntry> = {
+  "google-analytics": {
+    bindingType: "google-analytics",
+    anchorField: "propertyId",
+    Renderer: GoogleAnalyticsRenderer,
+  },
+  "google-search-console": {
+    bindingType: "google-search-console",
+    anchorField: "siteUrl",
+    autoResolve: async ({ client, ctx }) => {
+      const result = await client.callTool({
+        name: "list_sites",
+        arguments: {},
+      });
+      const { sites } = unwrapToolResult<{ sites?: unknown }>(result);
+      const match = matchVerifiedSite(ctx.siteHost, parseListSites({ sites }));
+      return match ? { siteUrl: match } : null;
+    },
+    Renderer: GoogleSearchConsoleRenderer,
+  },
+  vtex: {
+    bindingType: "vtex",
+    anchorField: "accountName",
+    Renderer: VtexRenderer,
+  },
+};
+
+export function getCompanionConfig(
+  bindingType: string,
+): CompanionConfigEntry | undefined {
+  return COMPANION_CONFIG[bindingType];
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-config-registry.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-config-registry.ts
@@ -31,7 +31,7 @@ export interface CompanionConfigEntry {
   Renderer: FC<CompanionConfigRendererProps>;
 }
 
-export const COMPANION_CONFIG: Record<string, CompanionConfigEntry> = {
+const COMPANION_CONFIG: Record<string, CompanionConfigEntry> = {
   "google-analytics": {
     bindingType: "google-analytics",
     anchorField: "propertyId",

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-config-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-config-section.tsx
@@ -71,8 +71,11 @@ export function CompanionConfigSection({
           saving={saving}
           error={error}
           onSave={(patch) => {
-            save(patch);
-            setEditing(false);
+            // Collapse the form only after the write is durably persisted;
+            // on failure keep it open so the inline error stays visible.
+            void save(patch).then((ok) => {
+              if (ok) setEditing(false);
+            });
           }}
         />
       )}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-config-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-config-section.tsx
@@ -1,0 +1,81 @@
+import { CheckCircle, Loading01 } from "@untitledui/icons";
+import { useState } from "react";
+import type { CompanionConfigEntry } from "./companion-config-registry.ts";
+import type { CompanionCardModel } from "./companions-core.ts";
+import { useCompanionConfig } from "./use-companion-config.ts";
+
+/** Rendered under a connected + registered companion card. Shows the saved
+ * value with an Edit escape hatch, or the config form when unconfigured. The
+ * root's callback ref drives the one-shot GSC auto-resolve after commit. */
+export function CompanionConfigSection({
+  entry,
+  card,
+  orgId,
+  orgSlug,
+  siteHost,
+}: {
+  entry: CompanionConfigEntry;
+  card: CompanionCardModel & { linkedConnectionId: string };
+  orgId: string;
+  orgSlug: string;
+  siteHost: string | null;
+}) {
+  const {
+    configured,
+    currentValue,
+    gaGroups,
+    gaError,
+    verifiedSites,
+    saving,
+    error,
+    save,
+    maybeAutoResolve,
+    isLoading,
+  } = useCompanionConfig({
+    entry,
+    connectionId: card.linkedConnectionId,
+    orgId,
+    orgSlug,
+    siteHost,
+  });
+  const [editing, setEditing] = useState(false);
+
+  const { Renderer } = entry;
+
+  return (
+    <div ref={maybeAutoResolve} className="px-1 pt-1">
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loading01 size={14} className="animate-spin" /> Loading setup…
+        </div>
+      ) : configured && !editing ? (
+        <div className="flex items-center gap-2">
+          <CheckCircle size={14} className="shrink-0 text-blue-500" />
+          <p className="flex-1 truncate text-sm text-muted-foreground">
+            {(currentValue[entry.anchorField] as string) ?? ""}
+          </p>
+          <button
+            type="button"
+            className="text-sm text-muted-foreground underline underline-offset-2"
+            onClick={() => setEditing(true)}
+          >
+            Edit
+          </button>
+        </div>
+      ) : (
+        <Renderer
+          currentValue={currentValue}
+          gaGroups={gaGroups}
+          gaError={gaError}
+          verifiedSites={verifiedSites}
+          saving={saving}
+          error={error}
+          onSave={(patch) => {
+            save(patch);
+            setEditing(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -3,6 +3,7 @@ import { authClient } from "@/web/lib/auth-client";
 import { SELF_MCP_ALIAS_ID, useMCPClient } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { ArrowRight } from "@untitledui/icons";
+import { useCommerceSiteHost } from "../commerce-onboarding.tsx";
 import { CompanionCard, CompanionCardSkeleton } from "./companion-card.tsx";
 import { useCommerceCompanions } from "./use-commerce-companions.ts";
 import { useConnectCompanion } from "./use-connect-companion.ts";
@@ -25,6 +26,7 @@ export function CompanionMcpsSection({
 }) {
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id ?? "";
+  const siteHost = useCommerceSiteHost();
   const selfClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
@@ -122,6 +124,9 @@ export function CompanionMcpsSection({
                 connecting={connectingFieldKey === card.fieldKey}
                 disabled={busy && connectingFieldKey !== card.fieldKey}
                 onConnect={() => void connect(card)}
+                orgId={org.id}
+                orgSlug={org.slug}
+                siteHost={siteHost}
               />
             ))}
           </div>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -201,6 +201,7 @@ describe("buildCompanionCards", () => {
     });
     expect(cards[0]!.satisfied).toBe(true);
     expect(cards[0]!.candidateConnectionId).toBeNull();
+    expect(cards[0]!.linkedConnectionId).toBe("linked");
   });
   it("surfaces an unlinked candidate for reuse", () => {
     const cards = buildCompanionCards({
@@ -213,5 +214,6 @@ describe("buildCompanionCards", () => {
     });
     expect(cards[0]!.satisfied).toBe(false);
     expect(cards[0]!.candidateConnectionId).toBe("c_vtex");
+    expect(cards[0]!.linkedConnectionId).toBeNull();
   });
 });

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -46,6 +46,8 @@ export interface CompanionCardModel {
   bullets: string[];
   satisfied: boolean;
   candidateConnectionId: string | null;
+  /** Downstream connection id linked into CD (the config_state value), or null. */
+  linkedConnectionId: string | null;
 }
 
 type ComparisonWhere = { field: string[]; operator: "in"; value: string[] };
@@ -203,6 +205,7 @@ export function buildCompanionCards(args: {
             req.bindingType,
             curatedEntry?.registryAppId,
           ),
+      linkedConnectionId: linked ?? null,
     });
   }
   return cards;

--- a/apps/mesh/src/web/routes/commerce-onboarding/config-renderers/google-analytics.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/config-renderers/google-analytics.tsx
@@ -1,0 +1,121 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { Loading01 } from "@untitledui/icons";
+import { useState } from "react";
+import { flattenGaOptions } from "../companion-config-core.ts";
+import type { CompanionConfigRendererProps } from "./types.ts";
+
+export function GoogleAnalyticsRenderer({
+  currentValue,
+  gaGroups,
+  gaError,
+  saving,
+  error,
+  onSave,
+}: CompanionConfigRendererProps) {
+  const saved = (currentValue.propertyId as string | undefined) ?? "";
+  // Single property → auto-select as the initial value (still editable).
+  const flat = flattenGaOptions(gaGroups);
+  const initial = saved || (flat.length === 1 ? flat[0]!.value : "");
+  const [selected, setSelected] = useState(initial);
+
+  if (gaError || gaGroups.length === 0) {
+    // Escape hatch: manual propertyId entry when listing failed/empty.
+    return (
+      <ConfigRow error={error}>
+        <div className="flex flex-1 items-center gap-2">
+          <Input
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+            placeholder="properties/1234567"
+            className="flex-1"
+          />
+          <SaveButton
+            saving={saving}
+            disabled={!selected}
+            onClick={() => onSave({ propertyId: selected })}
+          />
+        </div>
+      </ConfigRow>
+    );
+  }
+
+  return (
+    <ConfigRow error={error}>
+      <div className="flex flex-1 items-center gap-2">
+        <Select value={selected} onValueChange={setSelected}>
+          <SelectTrigger size="sm" className="flex-1">
+            <SelectValue placeholder="Select a property..." />
+          </SelectTrigger>
+          <SelectContent>
+            {gaGroups.map((group) => (
+              <SelectGroup key={group.account}>
+                <SelectLabel>{group.account}</SelectLabel>
+                {group.options.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            ))}
+          </SelectContent>
+        </Select>
+        <SaveButton
+          saving={saving}
+          disabled={!selected}
+          onClick={() => onSave({ propertyId: selected })}
+        />
+      </div>
+    </ConfigRow>
+  );
+}
+
+function ConfigRow({
+  children,
+  error,
+}: {
+  children: React.ReactNode;
+  error: string | null;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      {children}
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function SaveButton({
+  saving,
+  disabled,
+  onClick,
+}: {
+  saving: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      disabled={disabled || saving}
+      onClick={onClick}
+    >
+      {saving ? <Loading01 size={16} className="animate-spin" /> : "Save"}
+    </Button>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/config-renderers/google-search-console.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/config-renderers/google-search-console.tsx
@@ -1,0 +1,65 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { Loading01 } from "@untitledui/icons";
+import { useState } from "react";
+import type { CompanionConfigRendererProps } from "./types.ts";
+
+export function GoogleSearchConsoleRenderer({
+  currentValue,
+  verifiedSites,
+  saving,
+  error,
+  onSave,
+}: CompanionConfigRendererProps) {
+  const saved = (currentValue.siteUrl as string | undefined) ?? "";
+  const [value, setValue] = useState(saved);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex flex-1 items-center gap-2">
+        {verifiedSites.length > 0 ? (
+          <Select value={value} onValueChange={setValue}>
+            <SelectTrigger size="sm" className="flex-1">
+              <SelectValue placeholder="Select a verified site..." />
+            </SelectTrigger>
+            <SelectContent>
+              {verifiedSites.map((s) => (
+                <SelectItem key={s.siteUrl} value={s.siteUrl}>
+                  {s.siteUrl}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <Input
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="sc-domain:example.com"
+            className="flex-1"
+          />
+        )}
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={!value || saving}
+          onClick={() => onSave({ siteUrl: value })}
+        >
+          {saving ? <Loading01 size={16} className="animate-spin" /> : "Save"}
+        </Button>
+      </div>
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/config-renderers/types.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/config-renderers/types.ts
@@ -1,0 +1,16 @@
+import type {
+  GaPropertyGroup,
+  VerifiedSite,
+} from "../companion-config-core.ts";
+
+export interface CompanionConfigRendererProps {
+  /** Current downstream configuration_state (already loaded). */
+  currentValue: Record<string, unknown>;
+  gaGroups: GaPropertyGroup[];
+  gaError: boolean;
+  verifiedSites: VerifiedSite[];
+  saving: boolean;
+  error: string | null;
+  /** Persist a shallow patch onto the downstream configuration_state. */
+  onSave: (patch: Record<string, unknown>) => void;
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/config-renderers/vtex.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/config-renderers/vtex.tsx
@@ -1,0 +1,60 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Loading01 } from "@untitledui/icons";
+import { useState } from "react";
+import type { CompanionConfigRendererProps } from "./types.ts";
+
+export function VtexRenderer({
+  currentValue,
+  saving,
+  error,
+  onSave,
+}: CompanionConfigRendererProps) {
+  const [accountName, setAccountName] = useState(
+    (currentValue.accountName as string | undefined) ?? "",
+  );
+  const [appKey, setAppKey] = useState(
+    (currentValue.appKey as string | undefined) ?? "",
+  );
+  const [appToken, setAppToken] = useState(
+    (currentValue.appToken as string | undefined) ?? "",
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Input
+        value={accountName}
+        onChange={(e) => setAccountName(e.target.value)}
+        placeholder="Account name"
+      />
+      <Input
+        type="password"
+        value={appKey}
+        onChange={(e) => setAppKey(e.target.value)}
+        placeholder="App key"
+      />
+      <Input
+        type="password"
+        value={appToken}
+        onChange={(e) => setAppToken(e.target.value)}
+        placeholder="App token"
+      />
+      <div className="flex items-center justify-end">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={saving}
+          onClick={() => onSave({ accountName, appKey, appToken })}
+        >
+          {saving ? <Loading01 size={16} className="animate-spin" /> : "Save"}
+        </Button>
+      </div>
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-companion-config.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-companion-config.ts
@@ -1,5 +1,5 @@
 import { KEYS } from "@/web/lib/query-keys";
-import { useMCPClient } from "@decocms/mesh-sdk";
+import { SELF_MCP_ALIAS_ID, useMCPClient } from "@decocms/mesh-sdk";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import {
@@ -31,15 +31,24 @@ export function useCompanionConfig({
   siteHost: string | null;
 }) {
   const queryClient = useQueryClient();
-  const client = useMCPClient({ connectionId, orgId, orgSlug });
+  // Two clients: the SELF/management MCP serves the COLLECTION_CONNECTIONS_*
+  // tools (reading/writing the connection row), while the downstream connection
+  // serves its own data tools (get-account-summaries / list_sites). The GA/VTEX
+  // MCP servers do NOT expose the management collection tools.
+  const selfClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId,
+    orgSlug,
+  });
+  const downstreamClient = useMCPClient({ connectionId, orgId, orgSlug });
   const [error, setError] = useState<string | null>(null);
   const autoResolvedRef = useRef(false);
 
-  // Downstream connection's own configuration_state.
+  // Downstream connection's own configuration_state (management tool → self).
   const stateQuery = useQuery({
     queryKey: KEYS.commerceDiscoveryCompanionConfig(orgId, connectionId),
     queryFn: async () => {
-      const result = await client.callTool({
+      const result = await selfClient.callTool({
         name: "COLLECTION_CONNECTIONS_GET",
         arguments: { id: connectionId },
       });
@@ -51,12 +60,12 @@ export function useCompanionConfig({
     stateQuery.data?.item?.configuration_state ?? {};
   const configured = isConfigured(currentValue, entry.anchorField);
 
-  // GA: account summaries → grouped options.
+  // GA: account summaries → grouped options (downstream data tool).
   const gaQuery = useQuery({
     queryKey: KEYS.commerceDiscoveryGaSummaries(orgId, connectionId),
     enabled: entry.bindingType === "google-analytics",
     queryFn: async () => {
-      const result = await client.callTool({
+      const result = await downstreamClient.callTool({
         name: "get-account-summaries",
         arguments: {},
       });
@@ -64,23 +73,23 @@ export function useCompanionConfig({
     },
   });
 
-  // GSC: verified sites (for the Edit select + auto-resolve source).
+  // GSC: verified sites for the Edit select + auto-resolve source (downstream).
   const gscQuery = useQuery({
     queryKey: KEYS.commerceDiscoveryGscSites(orgId, connectionId),
     enabled: entry.bindingType === "google-search-console",
     queryFn: async () => {
-      const result = await client.callTool({
+      const result = await downstreamClient.callTool({
         name: "list_sites",
         arguments: {},
       });
-      return parseListSites(unwrapToolResult<{ sites?: unknown }>(result));
+      return parseListSites(unwrapToolResult(result));
     },
   });
 
   const saveMutation = useMutation({
     mutationFn: async (patch: Record<string, unknown>) => {
       const merged = mergeConfigState(currentValue, patch);
-      const result = await client.callTool({
+      const result = await selfClient.callTool({
         name: "COLLECTION_CONNECTIONS_UPDATE",
         arguments: { id: connectionId, data: { configuration_state: merged } },
       });
@@ -96,7 +105,17 @@ export function useCompanionConfig({
       setError(err instanceof Error ? err.message : String(err)),
   });
 
-  const save = (patch: Record<string, unknown>) => saveMutation.mutate(patch);
+  // Returns whether the save succeeded so callers can defer collapsing the
+  // edit form until the write is durably persisted (keeps the form + error
+  // visible on failure).
+  const save = async (patch: Record<string, unknown>): Promise<boolean> => {
+    try {
+      await saveMutation.mutateAsync(patch);
+      return true;
+    } catch {
+      return false;
+    }
+  };
 
   // One-shot auto-resolve (GSC), fired from a callback ref on the section root
   // (not during render — the .current guard lives inside this function, which
@@ -116,11 +135,11 @@ export function useCompanionConfig({
     autoResolvedRef.current = true;
     void entry
       .autoResolve({
-        client,
+        client: downstreamClient,
         ctx: { siteHost, connectionId, orgId, orgSlug },
       })
       .then((patch) => {
-        if (patch) save(patch);
+        if (patch) void save(patch);
       })
       .catch(() => {
         /* non-blocking: user can still fill via the Edit escape hatch */

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-companion-config.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-companion-config.ts
@@ -1,0 +1,142 @@
+import { KEYS } from "@/web/lib/query-keys";
+import { useMCPClient } from "@decocms/mesh-sdk";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import {
+  type GaPropertyGroup,
+  type VerifiedSite,
+  isConfigured,
+  mergeConfigState,
+  parseAccountSummaries,
+  parseListSites,
+} from "./companion-config-core.ts";
+import type { CompanionConfigEntry } from "./companion-config-registry.ts";
+import { unwrapToolResult } from "./companions-core.ts";
+
+interface DownstreamConnection {
+  configuration_state?: Record<string, unknown> | null;
+}
+
+export function useCompanionConfig({
+  entry,
+  connectionId,
+  orgId,
+  orgSlug,
+  siteHost,
+}: {
+  entry: CompanionConfigEntry;
+  connectionId: string;
+  orgId: string;
+  orgSlug: string;
+  siteHost: string | null;
+}) {
+  const queryClient = useQueryClient();
+  const client = useMCPClient({ connectionId, orgId, orgSlug });
+  const [error, setError] = useState<string | null>(null);
+  const autoResolvedRef = useRef(false);
+
+  // Downstream connection's own configuration_state.
+  const stateQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryCompanionConfig(orgId, connectionId),
+    queryFn: async () => {
+      const result = await client.callTool({
+        name: "COLLECTION_CONNECTIONS_GET",
+        arguments: { id: connectionId },
+      });
+      return unwrapToolResult<{ item: DownstreamConnection | null }>(result);
+    },
+  });
+
+  const currentValue: Record<string, unknown> =
+    stateQuery.data?.item?.configuration_state ?? {};
+  const configured = isConfigured(currentValue, entry.anchorField);
+
+  // GA: account summaries → grouped options.
+  const gaQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryGaSummaries(orgId, connectionId),
+    enabled: entry.bindingType === "google-analytics",
+    queryFn: async () => {
+      const result = await client.callTool({
+        name: "get-account-summaries",
+        arguments: {},
+      });
+      return parseAccountSummaries(unwrapToolResult(result));
+    },
+  });
+
+  // GSC: verified sites (for the Edit select + auto-resolve source).
+  const gscQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryGscSites(orgId, connectionId),
+    enabled: entry.bindingType === "google-search-console",
+    queryFn: async () => {
+      const result = await client.callTool({
+        name: "list_sites",
+        arguments: {},
+      });
+      return parseListSites(unwrapToolResult<{ sites?: unknown }>(result));
+    },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async (patch: Record<string, unknown>) => {
+      const merged = mergeConfigState(currentValue, patch);
+      const result = await client.callTool({
+        name: "COLLECTION_CONNECTIONS_UPDATE",
+        arguments: { id: connectionId, data: { configuration_state: merged } },
+      });
+      return unwrapToolResult<{ item: unknown }>(result);
+    },
+    onSuccess: async () => {
+      setError(null);
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryCompanionConfig(orgId, connectionId),
+      });
+    },
+    onError: (err) =>
+      setError(err instanceof Error ? err.message : String(err)),
+  });
+
+  const save = (patch: Record<string, unknown>) => saveMutation.mutate(patch);
+
+  // One-shot auto-resolve (GSC), fired from a callback ref on the section root
+  // (not during render — the .current guard lives inside this function, which
+  // runs after commit). Mirrors triggerInitialSetup in commerce-onboarding.tsx;
+  // useEffect and render-time ref access are both banned in this app.
+  const maybeAutoResolve = (node: HTMLElement | null) => {
+    if (
+      !node ||
+      autoResolvedRef.current ||
+      !entry.autoResolve ||
+      configured ||
+      stateQuery.isPending ||
+      saveMutation.isPending
+    ) {
+      return;
+    }
+    autoResolvedRef.current = true;
+    void entry
+      .autoResolve({
+        client,
+        ctx: { siteHost, connectionId, orgId, orgSlug },
+      })
+      .then((patch) => {
+        if (patch) save(patch);
+      })
+      .catch(() => {
+        /* non-blocking: user can still fill via the Edit escape hatch */
+      });
+  };
+
+  return {
+    configured,
+    currentValue,
+    gaGroups: (gaQuery.data ?? []) as GaPropertyGroup[],
+    gaError: !!gaQuery.error,
+    verifiedSites: (gscQuery.data ?? []) as VerifiedSite[],
+    saving: saveMutation.isPending,
+    error,
+    save,
+    maybeAutoResolve,
+    isLoading: stateQuery.isPending,
+  };
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-companion-config.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-companion-config.ts
@@ -137,6 +137,14 @@ export function useCompanionConfig({
     error,
     save,
     maybeAutoResolve,
-    isLoading: stateQuery.isPending,
+    // Hold the renderer until the MCP-specific data it initializes from (GA
+    // grouped options / GSC verified sites) is ready too — otherwise the GA
+    // card would mount on the manual-fallback branch and miss single-property
+    // auto-select. gaQuery/gscQuery are only consulted for their own binding
+    // (both are `enabled`-gated, so isPending is meaningful there).
+    isLoading:
+      stateQuery.isPending ||
+      (entry.bindingType === "google-analytics" && gaQuery.isPending) ||
+      (entry.bindingType === "google-search-console" && gscQuery.isPending),
   };
 }

--- a/packages/e2e/tests/commerce-companion-link.spec.ts
+++ b/packages/e2e/tests/commerce-companion-link.spec.ts
@@ -89,3 +89,59 @@ test("linking a companion merges configuration_state without dropping sibling bi
 
   await ctx.dispose();
 });
+
+test("companion config persists downstream configuration_state via read-modify-write", async ({
+  playwright,
+}) => {
+  const ctx = await newApiContext(playwright);
+  const user = await signUpViaApi(ctx);
+
+  // Create a downstream companion connection with no config yet.
+  const created = await callSelfMcpTool<{ item: ConnectionWithState }>(
+    ctx,
+    user.orgSlug,
+    "COLLECTION_CONNECTIONS_CREATE",
+    {
+      data: {
+        title: `vtex-companion ${Date.now()}`,
+        connection_type: "HTTP",
+        connection_url: "https://example.invalid/mcp",
+      },
+    },
+  );
+  const connId = created.item.id;
+
+  // Simulate the config Save: read current state, merge a patch, update — the
+  // exact read-modify-write the useCompanionConfig save path performs.
+  const got = await callSelfMcpTool<{ item: ConnectionWithState | null }>(
+    ctx,
+    user.orgSlug,
+    "COLLECTION_CONNECTIONS_GET",
+    { id: connId },
+  );
+  const merged = {
+    ...(got.item?.configuration_state ?? {}),
+    accountName: "mystore",
+    appKey: "vtexappkey-abc",
+    appToken: "token-xyz",
+  };
+  await callSelfMcpTool(ctx, user.orgSlug, "COLLECTION_CONNECTIONS_UPDATE", {
+    id: connId,
+    data: { configuration_state: merged },
+  });
+
+  // Assert persistence, tenant-scoped to this connection.
+  const after = await callSelfMcpTool<{ item: ConnectionWithState | null }>(
+    ctx,
+    user.orgSlug,
+    "COLLECTION_CONNECTIONS_GET",
+    { id: connId },
+  );
+  expect(after.item?.configuration_state).toMatchObject({
+    accountName: "mystore",
+    appKey: "vtexappkey-abc",
+    appToken: "token-xyz",
+  });
+
+  await ctx.dispose();
+});


### PR DESCRIPTION
## Summary

Adds inline, per-MCP configuration to the well-known companion cards on `/commerce-onboarding`. After a companion (VTEX, Google Analytics, Google Search Console) is connected, its card now renders a tailored form that fills the **downstream connection's own** `configuration_state` — the piece the connect+link flow never populated, which left "Connected" integrations unusable (GA with no `propertyId`, VTEX with no credentials).

Scope is intentionally narrow: an onboarding-only registry hardcoded to these three binding types. Any other requirement keeps today's connect-only behavior. No shared-form or backend changes.

### Per-MCP behavior
- **Google Analytics** → property selector grouped by account, sourced from the connected GA MCP's `get-account-summaries`; single property auto-selects; stores the full `properties/XXX`. Falls back to a manual `propertyId` input on list error/empty.
- **Google Search Console** → auto-fills `siteUrl` by matching the onboarding host against the GSC MCP's `list_sites` (handles both `sc-domain:` and URL-prefix forms); zero-click on a unique match, else a verified-sites select. 
- **VTEX** → `accountName` + masked `appKey`/`appToken`; persisted blindly (validation deferred).

Every configured value keeps an **Edit** escape hatch. The "See full report" CTA is **not** gated on config completeness.

### How config is saved
Writes `configuration_state` on the downstream connection via `COLLECTION_CONNECTIONS_UPDATE` (full read-modify-write). The mesh's update tool then invokes the MCP's `ON_MCP_CONFIGURATION` lifecycle callback server-side — the client never calls it directly. No new tools or backend changes.

## Architecture
- `companion-config-core.ts` — pure transforms (GA summaries → grouped options, GSC `list_sites` host match, `isConfigured`, `mergeConfigState`). Fully unit-tested.
- `companion-config-registry.ts` — the onboarding-only map (anchor field + optional async `autoResolve` + renderer) keyed by binding type.
- `use-companion-config.ts` — loads downstream state + MCP-specific data, runs the one-shot GSC auto-resolve (callback-ref, no `useEffect`), saves.
- `config-renderers/{google-analytics,google-search-console,vtex}.tsx` — the three forms.
- `companion-config-section.tsx` + `companion-card.tsx` — renders the section under connected+registered cards.

## Testing
- **Unit (`bun test`)**: 14 new cases for the core helpers + 2 model assertions for `linkedConnectionId`. Full commerce-onboarding folder: 32 pass. Typecheck + lint clean.
- **E2E**: added a persistence test to `commerce-companion-link.spec.ts` asserting the downstream `configuration_state` survives the read-modify-write, tenant-scoped.

## ⚠️ Verification caveats (could not run locally)
This sandbox has no Postgres, so the full stack won't boot:
- **The E2E test was authored but not executed locally** (server fails at `localhost:5432` → sign-up 500; the sibling tests fail identically). It mirrors the passing sibling's contract and must be validated by **CI**.
- **No manual UI pass** was done (needs the server + real Google/VTEX OAuth). Recommend a manual QA on a DB-backed env for the three cards.

GA/GSC auto-fetch paths depend on live Google APIs + a matching verified site/property, so they're covered by unit tests rather than e2e by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inline configuration for well-known companion MCPs (VTEX, Google Analytics, Google Search Console) on `/commerce-onboarding`. After connecting, users can fill required fields that persist to the downstream connection’s `configuration_state`, making these integrations usable.

- **New Features**
  - Inline forms appear under connected cards via an onboarding-only registry (GA, GSC, VTEX).
  - Google Analytics: property selector from `get-account-summaries` with single-property auto-select and a manual fallback.
  - Google Search Console: auto-fills `siteUrl` by matching the onboarding host against `list_sites`, with a verified-sites select when needed.
  - VTEX: `accountName`, `appKey`, and `appToken` inputs with an Edit escape hatch.
  - Saving uses read-modify-write to update the downstream `configuration_state`; no backend changes.

- **Bug Fixes**
  - Route `COLLECTION_CONNECTIONS_GET/UPDATE` via the self MCP client; use the downstream client only for data tools (`get-account-summaries`, `list_sites`).
  - Gate the renderer on GA/GSC data to avoid a brief manual-fallback flash.
  - Collapse the Edit form only after a successful save so inline errors remain visible on failure.
  - Accept both wrapped and raw GA (`accountSummaries`) and GSC (`siteEntry`) tool shapes for robustness.
  - Resolves “connected but unusable” companions by populating missing `configuration_state` (e.g., GA `propertyId`, VTEX credentials).

<sup>Written for commit 9366bf8bb17aa9f03a1c8b56363b8f14b8d06e44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

