### PR TITLE
feat(sections-editor): add duplicate option to page variant menu

### DIFF
--- a/apps/mesh/ct/harness/variant-harnesses.tsx
+++ b/apps/mesh/ct/harness/variant-harnesses.tsx
@@ -73,6 +73,7 @@ export function PageVariantTabsHarness({
         onSelect={(index) => push({ type: "select", index })}
         onReorder={(from, to) => push({ type: "reorder", from, to })}
         onRename={(index) => push({ type: "rename", index })}
+        onDuplicate={(index) => push({ type: "duplicate", index })}
         onDelete={(index) => push({ type: "delete", index })}
         onAdd={() => push({ type: "add" })}
       />

--- a/apps/mesh/ct/tests/page-variant-tabs.ct.tsx
+++ b/apps/mesh/ct/tests/page-variant-tabs.ct.tsx
@@ -5,9 +5,9 @@ import type { PageVariant } from "@/web/components/sections-editor/page-variants
 
 /**
  * PageVariantTabs — the horizontal page-variant tab strip. Add a variant,
- * select a tab, or open a tab's actions menu to rename / delete. Delete is
- * disabled when only one variant remains. The DropdownMenu is portaled →
- * queried via `page`.
+ * select a tab, or open a tab's actions menu to rename / duplicate / delete.
+ * Delete is disabled when only one variant remains. The DropdownMenu is
+ * portaled → queried via `page`.
  */
 const TWO: PageVariant[] = [
   { label: "Default", sections: [] },
@@ -56,6 +56,20 @@ test("rename from the tab menu fires onRename", async ({ mount, page }) => {
   await expect
     .poll(() => readEvents(component))
     .toEqual([{ type: "rename", index: 1 }]);
+});
+
+test("duplicate from the tab menu fires onDuplicate", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
+  );
+  await component.getByRole("button", { name: "Actions for Mobile" }).click();
+  await page.getByRole("menuitem", { name: "Duplicate" }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "duplicate", index: 1 }]);
 });
 
 test("delete from the tab menu fires onDelete (multiple variants)", async ({

--- a/apps/mesh/src/web/components/sections-editor/page-variant-tabs.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-variant-tabs.tsx
@@ -32,7 +32,13 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { DotsHorizontal, Edit01, Plus, Trash01 } from "@untitledui/icons";
+import {
+  Copy01,
+  DotsHorizontal,
+  Edit01,
+  Plus,
+  Trash01,
+} from "@untitledui/icons";
 import { getIconComponent } from "../agent-icon";
 import { resolveEffectiveMatcherRule } from "./matcher-rules";
 import { resolveMatcherIconName } from "./matcher-icons";
@@ -98,6 +104,7 @@ function SortablePageVariantTab({
   matchers,
   onSelect,
   onRename,
+  onDuplicate,
   onDelete,
 }: {
   entry: VariantTabEntry;
@@ -109,6 +116,7 @@ function SortablePageVariantTab({
   matchers: Array<{ resolveType: string; iconName: string }>;
   onSelect: () => void;
   onRename: () => void;
+  onDuplicate: () => void;
   onDelete: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
@@ -173,6 +181,10 @@ function SortablePageVariantTab({
             <Edit01 size={14} />
             Rename
           </DropdownMenuItem>
+          <DropdownMenuItem onClick={onDuplicate}>
+            <Copy01 size={14} />
+            Duplicate
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             variant="destructive"
@@ -228,6 +240,7 @@ export function PageVariantTabs({
   onSelect,
   onReorder,
   onRename,
+  onDuplicate,
   onDelete,
   onAdd,
 }: {
@@ -240,6 +253,7 @@ export function PageVariantTabs({
   onSelect: (index: number) => void;
   onReorder: (fromIndex: number, toIndex: number) => void;
   onRename: (index: number) => void;
+  onDuplicate: (index: number) => void;
   onDelete: (index: number) => void;
   onAdd: () => void;
 }) {
@@ -354,6 +368,7 @@ export function PageVariantTabs({
                 matchers={matchers}
                 onSelect={() => handleSelect(entry.index)}
                 onRename={() => onRename(entry.index)}
+                onDuplicate={() => onDuplicate(entry.index)}
                 onDelete={() => onDelete(entry.index)}
               />
             ))}

--- a/apps/mesh/src/web/components/sections-editor/page-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.ts
@@ -215,6 +215,22 @@ export function getLastVariantIndex(
   return Array.isArray(variants) ? variants.length - 1 : 1;
 }
 
+/**
+ * Insert a clone of the variant at `variantIndex` immediately after it (rule and
+ * sections included). Returns the next variants array, or null when the source
+ * variant is missing.
+ */
+export function duplicatePageVariantEntry(
+  variants: Array<Record<string, unknown>>,
+  variantIndex: number,
+): Array<Record<string, unknown>> | null {
+  const source = variants[variantIndex];
+  if (!source) return null;
+  const next = [...variants];
+  next.splice(variantIndex + 1, 0, structuredClone(source));
+  return next;
+}
+
 /** Returns true when the variant entry carries a targeting rule. */
 export function variantHasRule(
   variant: Record<string, unknown> | undefined,

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -72,6 +72,7 @@ import {
   appendPageVariantSections,
   buildPageSectionsFromVariants,
   countSavedMatcherBlockReferences,
+  duplicatePageVariantEntry,
   getLastVariantIndex,
   isMultivariateArrayWrapper,
   parsePageVariants,
@@ -1983,6 +1984,22 @@ export function SectionsEditor({
     );
   };
 
+  const handleDuplicatePageVariant = (variantIndex: number) => {
+    mutatePageVariants(
+      (variants) => duplicatePageVariantEntry(variants, variantIndex),
+      () => {
+        // Land the user on the freshly-created clone (inserted right after).
+        setActiveVariantIndex(variantIndex + 1);
+        setSelectedSectionIndex(null);
+        setFormValue(null);
+        setActiveResolveType(null);
+        setFieldBreadcrumbs([]);
+        setRuleFormValue(null);
+        setRuleResolveType(null);
+      },
+    );
+  };
+
   const handleRenamePageVariant = async (
     variantIndex: number,
     nextName: string,
@@ -2344,6 +2361,7 @@ export function SectionsEditor({
           onSelect={selectPageVariant}
           onReorder={handleReorderPageVariants}
           onRename={setRenameVariantIndex}
+          onDuplicate={handleDuplicatePageVariant}
           onDelete={handleDeletePageVariant}
           onAdd={handleAddPageVariant}
         />


### PR DESCRIPTION
## Summary

Adds a **Duplicate** action to the page-variant tab menu (`···`), which previously offered only **Rename** and **Delete**. Section-level variants already supported Duplicate — this brings page variants in line.

Duplicating a page variant clones the source variant's rule **and** its sections, inserts the clone immediately after the source, and selects the new clone. If the source's rule references a saved matcher block, the clone shares that reference (same behavior as section-variant duplicate).

## Changes

- `page-variants.ts` — new `duplicatePageVariantEntry()` helper (structuredClone the source, splice after it), mirroring `duplicateMultivariateSectionVariant`.
- `sections-editor.tsx` — `handleDuplicatePageVariant()` runs through the existing `mutatePageVariants` persistence path, then selects the clone and resets editing state; wired into `PageVariantTabs`.
- `page-variant-tabs.tsx` — threads `onDuplicate` through and adds a "Duplicate" menu item (`Copy01` icon) between Rename and Delete.

## Testing

- Added a `duplicate from the tab menu fires onDuplicate` component test; harness logs the event.
- `bun run test:ct page-variant-tabs` → 7 passed
- `bun run check` (tsc) → passes
- `bun run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Duplicate option to the page-variant tab menu to match section-variant behavior. Duplicating clones the variant’s rule and sections, inserts the clone right after the source, selects it, and preserves any saved matcher block reference.

<sup>Written for commit 9219a2128732c9dc1f0bd28f7ac48b6e1fa341dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

