### PR TITLE
fix(dispatch-queue): re-enqueue in-flight thread-gate gates on graceful shutdown

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -36,7 +36,7 @@ initObservability();
 // via a DBOS data source. The `dbos` schema is auto-created on launch.
 // setConfig must run before any module registers workflows; launch happens
 // after the app graph is loaded so all DBOS.registerWorkflow calls are in.
-const { DBOS } = await import("@dbos-inc/dbos-sdk");
+const { DBOS, DBOSClient } = await import("@dbos-inc/dbos-sdk");
 // DBOS uses its own pg client (separate from mesh's pool), so the `sslmode`
 // must travel in the URL. RDS's pg_hba.conf rejects unencrypted connections
 // with `no pg_hba.conf entry for host ... no encryption` when this is missing.
@@ -310,6 +310,73 @@ if (settings.localMode) {
 
 let shuttingDown = false;
 
+/**
+ * Hand off this executor's in-flight thread-gate gates so a live pod adopts
+ * them, instead of leaving them PENDING on this (dying) executor forever.
+ *
+ * WHY THIS EXISTS. The thread-gate queue is `concurrency=1` per thread
+ * partition; a `threadGateWorkflow` holds that slot the whole time it is
+ * PENDING. When a rolling deploy replaces this pod mid-run, `DBOS.shutdown()`
+ * just stops the executor and walks away — the in-flight gate is left PENDING
+ * on a now-dead `executor_id`. Nothing re-adopts it: self-recovery only covers
+ * an executor's OWN id (new pods have new ids), and the external Conductor is
+ * observed NOT to recover gracefully-deregistered executors (their orphans sit
+ * PENDING indefinitely). That stranded PENDING head blocks the partition, so
+ * every later message on the thread piles up ENQUEUED and never runs — the
+ * thread is bricked until someone cancels the head by hand.
+ *
+ * The fix: on the way out, flip our own in-flight gates PENDING → ENQUEUED
+ * (`resumeWorkflows`, which preserves the DBOS journal and the queue partition
+ * key). A live executor's queue poller then re-dispatches each gate and it
+ * REPLAYS from the journal: the already-recorded `trackMessageStarted` and
+ * `dispatchRunAndWait` steps return their cached outputs, so it resumes right
+ * at `consumeRunProjection` — no work redone, no double dispatch, for the
+ * overwhelming common case where dispatch had already completed. (Edge: if the
+ * pod died mid-`dispatchRunAndWait`, replay re-runs it; the work-item publish
+ * is idempotent on the persisted `runFenceToken`, so a redelivery collapses
+ * rather than opening a second daemon run.)
+ *
+ * Runs AFTER `DBOS.shutdown()` on purpose: once this executor's queue poller is
+ * stopped, a re-enqueued gate can only be claimed by a LIVE executor, so we
+ * can't re-grab (and re-orphan) our own gates in a shutdown race. Uses a
+ * standalone `DBOSClient` (its own sysdb connection) because mesh's DBOS
+ * executor is already torn down at this point.
+ *
+ * Best-effort: any failure is logged and swallowed so shutdown still completes.
+ * Only covers GRACEFUL termination — a hard SIGKILL (OOM, node loss) skips this
+ * handler, and those orphans still need Conductor recovery or a sweep.
+ */
+async function handOffInFlightThreadGates() {
+  let client: Awaited<ReturnType<typeof DBOSClient.create>> | undefined;
+  try {
+    client = await DBOSClient.create({
+      systemDatabaseUrl: withSslmode(
+        settings.databaseUrl,
+        settings.databasePgSsl,
+      ),
+      systemDatabaseSchemaName: "dbos",
+    });
+    const orphaned = await client.listWorkflows({
+      status: "PENDING",
+      queueName: THREAD_GATE_QUEUE,
+      executorId: settings.podName,
+      loadInput: false,
+      loadOutput: false,
+    });
+    if (orphaned.length === 0) return;
+    const ids = orphaned.map((w) => w.workflowID);
+    await client.resumeWorkflows(ids, { queueName: THREAD_GATE_QUEUE });
+    console.log(
+      `[shutdown] re-enqueued ${ids.length} in-flight thread-gate gate(s) for re-adoption by a live executor:`,
+      ids,
+    );
+  } catch (err) {
+    console.error("[shutdown] thread-gate handoff failed:", err);
+  } finally {
+    await client?.destroy().catch(() => {});
+  }
+}
+
 async function gracefulShutdown(signal: string) {
   if (shuttingDown) return;
   shuttingDown = true;
@@ -353,6 +420,11 @@ async function gracefulShutdown(signal: string) {
 
     // Drain DBOS before app.shutdown closes mesh's pg pool — in-flight steps use it.
     await DBOS.shutdown();
+    // Re-enqueue our own in-flight thread-gate gates so a live pod adopts them
+    // instead of stranding them PENDING on this dead executor (which bricks the
+    // thread). Runs after DBOS.shutdown() so our stopped poller can't re-grab
+    // them. See handOffInFlightThreadGates for the full rationale.
+    await handOffInFlightThreadGates();
     await app.shutdown();
   } catch (err) {
     console.error("[shutdown] Error during shutdown:", err);


### PR DESCRIPTION
## Problem

A rolling deploy that replaces a pod **mid-run** leaves that pod's in-flight `threadGateWorkflow` stuck `PENDING` on a now-dead `executor_id`, and **nothing ever re-adopts it**:

- **Self-recovery only covers an executor's own id** (`dbos-executor.js` `recoverPendingWorkflows([this.executorID])`) — new pods get new ids, so they never look at the dead executor's workflows.
- **Cross-executor recovery is delegated entirely to the external DBOS Conductor** (`app.ts` "Orphan/crash recovery is owned by the external DBOS Conductor now"), which is observed **not** to recover *gracefully-deregistered* executors — their orphans sit `PENDING` indefinitely (`recovery_attempts` never advances past the initial start).

Because the `thread-gate` queue is **concurrency=1 per thread partition**, that one stranded `PENDING` head **blocks the partition forever**: every later message on the thread piles up `ENQUEUED` and never dispatches. The thread is bricked until the head is cancelled by hand.

This was hit **7+ times on `studio-stg` in a single day** — essentially once per deploy, on whichever thread happened to have a turn in flight. Every orphan had the same fingerprint: steps `trackMessageStarted > dispatchRunAndWait` recorded, never reached `consumeRunProjection`, `application_version` pinned to `3` on both the dead and live executors (so **not** version stranding).

## Fix

In `gracefulShutdown`, **after `DBOS.shutdown()`**, flip this executor's own in-flight thread-gate gates `PENDING → ENQUEUED` via `DBOS`'s `resumeWorkflows` (through a standalone `DBOSClient`). `resumeWorkflows` preserves the DBOS journal (`operation_outputs`) and the `queue_partition_key`, so a live executor's queue poller re-dispatches each gate and it **replays from the journal**: the recorded `trackMessageStarted` / `dispatchRunAndWait` steps return their cached outputs and it resumes right at `consumeRunProjection` — **no work redone, no double dispatch** for the overwhelming common case where dispatch had already completed.

Key design points:
- **Runs after `DBOS.shutdown()`** on purpose — once this executor's queue poller is stopped, a re-enqueued gate can only be claimed by a **live** executor, so we can't re-grab (and re-orphan) our own gates in a shutdown race. A standalone `DBOSClient` (its own sysdb connection) is used because the mesh DBOS executor is already torn down.
- **Best-effort:** any failure is logged and swallowed so shutdown still completes.
- **Edge (mid-dispatch death):** if the pod died *during* `dispatchRunAndWait` (before it recorded), replay re-runs it — but the work-item publish is idempotent on the persisted `runFenceToken`, so a redelivery collapses rather than opening a second daemon run.

## Limitation / follow-ups

- Covers **graceful** termination only. A hard `SIGKILL` (OOM, node loss) skips the handler; those orphans still need Conductor recovery or a periodic sweep. Graceful rollouts are what's biting today, so this closes the observed gap.
- No automated test: this is a process-shutdown I/O hook with no clean unit seam (the repo's `TESTING.md` forbids mocks in unit tests, and an e2e that SIGTERMs the server mid-gate is a larger lift). The core operation is the batched equivalent of the manual `resumeWorkflows`/`cancelWorkflow` DB surgery that's been verified by hand repeatedly this week. An e2e for graceful-shutdown handoff is a reasonable follow-up.

## Testing

- `bun run fmt`, `bun run lint` (0 errors), `tsc --noEmit` (clean for the changed file) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents thread partitions from getting stuck after rolling deploys by re-enqueuing in-flight thread-gate workflows on graceful shutdown. Live executors re-adopt the gates and resume from the DBOS journal, avoiding duplicate work.

- **Bug Fixes**
  - After `DBOS.shutdown()`, use a standalone `DBOSClient` to `resumeWorkflows` for this executor’s `PENDING` thread-gate gates, flipping them to `ENQUEUED`.
  - Preserves the queue partition key and journal so processing resumes at `consumeRunProjection` with cached outputs.
  - Best-effort with error logging; only covers graceful termination (not hard `SIGKILL` cases).
  - Added `DBOSClient` import from `@dbos-inc/dbos-sdk` and invoked the handoff in `gracefulShutdown`.

<sup>Written for commit 6d917c43c7468a7e29c4771d4efe7b85cf7d02c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

