### PR TITLE
feat(commerce-onboarding): split connect screen with a schedule-a-meeting panel

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -31,6 +31,10 @@ import { ArrowRight, Loading01 } from "@untitledui/icons";
 import { createContext, Suspense, useContext, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { CompanionMcpsSection } from "./commerce-onboarding/companion-mcps-section.tsx";
+import {
+  ScheduleMeetingBanner,
+  ScheduleMeetingVisual,
+} from "./commerce-onboarding/schedule-meeting.tsx";
 import { SiteBadge } from "./commerce-onboarding/site-badge.tsx";
 
 interface CommerceOrganization {
@@ -480,7 +484,7 @@ function CommerceSetup({
   initialSiteUrl?: string;
 }) {
   return (
-    <AuthSplitLayout>
+    <AuthSplitLayout visual={<ScheduleMeetingVisual />}>
       <QueryErrorResetBoundary>
         {({ reset }) => (
           <ErrorBoundary
@@ -803,6 +807,9 @@ function CommerceDiscoveryReady({
         reportDisabled={!reportApp.virtualMcpId}
         onOpenReport={onOpenReport}
       />
+      {/* The right-side ScheduleMeetingVisual is hidden on mobile, so surface the
+          human escape hatch as a collapsed banner pinned below the connect flow. */}
+      <ScheduleMeetingBanner className="md:hidden" />
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -688,6 +688,7 @@ function CommerceSetupContent({
             onSiteUrlChange={setSiteUrlInput}
             onSubmit={handleSubmit}
           />
+          <ScheduleMeetingBanner className="md:hidden" />
         </div>
       );
     }
@@ -712,6 +713,7 @@ function CommerceSetupContent({
         ) : (
           <LoadingState label="Setting up Commerce Discovery..." />
         )}
+        <ScheduleMeetingBanner className="md:hidden" />
       </div>
     );
   }
@@ -729,6 +731,7 @@ function CommerceSetupContent({
         onSiteUrlChange={setSiteUrlInput}
         onSubmit={handleSubmit}
       />
+      <ScheduleMeetingBanner className="md:hidden" />
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -484,11 +484,11 @@ function CommerceSetup({
   initialSiteUrl?: string;
 }) {
   return (
-    <AuthSplitLayout visual={<ScheduleMeetingVisual />}>
-      <QueryErrorResetBoundary>
-        {({ reset }) => (
-          <ErrorBoundary
-            fallback={({ error, resetError }) => (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          fallback={({ error, resetError }) => (
+            <AuthSplitLayout>
               <CommerceSetupErrorState
                 orgName={org.name}
                 message={
@@ -501,21 +501,25 @@ function CommerceSetup({
                   resetError();
                 }}
               />
-            )}
+            </AuthSplitLayout>
+          )}
+        >
+          <Suspense
+            fallback={
+              <AuthSplitLayout>
+                <LoadingState label="Connecting workspace..." />
+              </AuthSplitLayout>
+            }
           >
-            <Suspense
-              fallback={<LoadingState label="Connecting workspace..." />}
-            >
-              <CommerceSetupContent
-                key={`${org.id}:${initialSiteUrl ?? ""}`}
-                org={org}
-                initialSiteUrl={initialSiteUrl}
-              />
-            </Suspense>
-          </ErrorBoundary>
-        )}
-      </QueryErrorResetBoundary>
-    </AuthSplitLayout>
+            <CommerceSetupContent
+              key={`${org.id}:${initialSiteUrl ?? ""}`}
+              org={org}
+              initialSiteUrl={initialSiteUrl}
+            />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   );
 }
 
@@ -675,64 +679,67 @@ function CommerceSetupContent({
 
     if (!normalized.ok) {
       return (
-        <div className="grid gap-10">
-          <CommerceHeader
-            title="Commerce diagnostics"
-            description={`Commerce setup will continue for ${org.name}.`}
-          />
-          <InlineError message={normalized.error} />
-          <SiteUrlForm
-            siteUrl={siteUrlInput}
-            error={inlineError}
-            isSubmitting={setupMutation.isPending}
-            onSiteUrlChange={setSiteUrlInput}
-            onSubmit={handleSubmit}
-          />
-          <ScheduleMeetingBanner className="md:hidden" />
-        </div>
-      );
-    }
-
-    return (
-      <div ref={triggerInitialSetup} className="grid gap-10">
-        <CommerceHeader
-          title="Commerce diagnostics"
-          description={`Commerce Discovery is being prepared for ${normalized.value}.`}
-        />
-        {inlineError ? (
-          <>
-            <InlineError message={inlineError} />
+        <AuthSplitLayout>
+          <div className="grid gap-10">
+            <CommerceHeader
+              title="Commerce diagnostics"
+              description={`Commerce setup will continue for ${org.name}.`}
+            />
+            <InlineError message={normalized.error} />
             <SiteUrlForm
               siteUrl={siteUrlInput}
-              error={null}
+              error={inlineError}
               isSubmitting={setupMutation.isPending}
               onSiteUrlChange={setSiteUrlInput}
               onSubmit={handleSubmit}
             />
-          </>
-        ) : (
-          <LoadingState label="Setting up Commerce Discovery..." />
-        )}
-        <ScheduleMeetingBanner className="md:hidden" />
-      </div>
+          </div>
+        </AuthSplitLayout>
+      );
+    }
+
+    return (
+      <AuthSplitLayout>
+        <div ref={triggerInitialSetup} className="grid gap-10">
+          <CommerceHeader
+            title="Commerce diagnostics"
+            description={`Commerce Discovery is being prepared for ${normalized.value}.`}
+          />
+          {inlineError ? (
+            <>
+              <InlineError message={inlineError} />
+              <SiteUrlForm
+                siteUrl={siteUrlInput}
+                error={null}
+                isSubmitting={setupMutation.isPending}
+                onSiteUrlChange={setSiteUrlInput}
+                onSubmit={handleSubmit}
+              />
+            </>
+          ) : (
+            <LoadingState label="Setting up Commerce Discovery..." />
+          )}
+        </div>
+      </AuthSplitLayout>
     );
   }
 
   return (
-    <div className="grid gap-10">
-      <CommerceHeader
-        title="Commerce diagnostics"
-        description={`Commerce setup will continue for ${org.name}.`}
-      />
-      <SiteUrlForm
-        siteUrl={siteUrlInput}
-        error={inlineError}
-        isSubmitting={setupMutation.isPending}
-        onSiteUrlChange={setSiteUrlInput}
-        onSubmit={handleSubmit}
-      />
-      <ScheduleMeetingBanner className="md:hidden" />
-    </div>
+    <AuthSplitLayout>
+      <div className="grid gap-10">
+        <CommerceHeader
+          title="Commerce diagnostics"
+          description={`Commerce setup will continue for ${org.name}.`}
+        />
+        <SiteUrlForm
+          siteUrl={siteUrlInput}
+          error={inlineError}
+          isSubmitting={setupMutation.isPending}
+          onSiteUrlChange={setSiteUrlInput}
+          onSubmit={handleSubmit}
+        />
+      </div>
+    </AuthSplitLayout>
   );
 }
 
@@ -799,21 +806,26 @@ function CommerceDiscoveryReady({
   onOpenReport: () => void;
 }) {
   return (
-    // On mobile fill the viewport (minus AuthSplitLayout's p-6 = 3rem) as a flex
-    // column so the header pins to the top, the cards fill the middle, and the
-    // "See full report" CTA pins to the bottom. On md+ revert to the centered grid.
-    <div className="flex h-[calc(100dvh-3rem)] flex-col gap-10 md:grid md:h-auto">
-      <CommerceHeader />
-      <CompanionMcpsSection
-        org={org}
-        cdConnectionId={reportApp.connectionId}
-        reportDisabled={!reportApp.virtualMcpId}
-        onOpenReport={onOpenReport}
-      />
-      {/* The right-side ScheduleMeetingVisual is hidden on mobile, so surface the
-          human escape hatch as a collapsed banner pinned below the connect flow. */}
-      <ScheduleMeetingBanner className="md:hidden" />
-    </div>
+    // The "connect your tools" screen is the only one that swaps the placeholder
+    // visual for the schedule-a-meeting panel (md+); every other setup screen
+    // keeps the default AuthSplitLayout placeholder.
+    <AuthSplitLayout visual={<ScheduleMeetingVisual />}>
+      {/* On mobile fill the viewport (minus AuthSplitLayout's p-6 = 3rem) as a flex
+          column so the header pins to the top, the cards fill the middle, and the
+          "See full report" CTA pins to the bottom. On md+ revert to the centered grid. */}
+      <div className="flex h-[calc(100dvh-3rem)] flex-col gap-10 md:grid md:h-auto">
+        <CommerceHeader />
+        <CompanionMcpsSection
+          org={org}
+          cdConnectionId={reportApp.connectionId}
+          reportDisabled={!reportApp.virtualMcpId}
+          onOpenReport={onOpenReport}
+        />
+        {/* The right-side ScheduleMeetingVisual is hidden on mobile, so surface the
+            human escape hatch as a collapsed banner pinned below the connect flow. */}
+        <ScheduleMeetingBanner className="md:hidden" />
+      </div>
+    </AuthSplitLayout>
   );
 }
 

--- a/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
@@ -1,0 +1,153 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { ArrowUpRight, ChevronDown, User01 } from "@untitledui/icons";
+import { useState } from "react";
+
+/**
+ * Where "Schedule a meeting" sends people who'd rather have us run the
+ * diagnostic live, don't have access to their tools yet, or aren't ready to
+ * grant it. Books onto the deco commerce team calendar. Swap the URL to
+ * repoint the calendar.
+ */
+const SCHEDULE_MEETING_URL =
+  "https://decocms-tanstack.deco-cx.workers.dev/agendar";
+
+const HEADLINE = "Rather have us walk you through it?";
+const BODY =
+  "Book a 20-minute call and we'll run the diagnostic with you, live.";
+
+function ScheduleMeetingCta({
+  size = "lg",
+  className,
+}: {
+  size?: "lg" | "xl";
+  className?: string;
+}) {
+  return (
+    <Button
+      asChild
+      variant="outline"
+      size={size}
+      className={cn("w-full", className)}
+    >
+      <a href={SCHEDULE_MEETING_URL} target="_blank" rel="noreferrer">
+        Schedule a meeting
+        <ArrowUpRight size={16} />
+      </a>
+    </Button>
+  );
+}
+
+function ConnectionNode({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative z-10 flex h-12 w-12 items-center justify-center rounded-full border border-border bg-card card-shadow">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Animated "you → deco" connection: two nodes joined by a hairline wire with a
+ * dot travelling across it and a ring blooming from the deco end as it lands.
+ * Kept monochrome so the green deco mark is the only spot of colour.
+ */
+function ConnectionAnimation() {
+  return (
+    <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-muted/40 px-7 py-7">
+      <ConnectionNode>
+        <User01 size={20} className="text-muted-foreground" />
+      </ConnectionNode>
+
+      {/* Hairline wire + travelling dot */}
+      <div className="relative mx-4 h-px flex-1 bg-border">
+        <span
+          className="absolute top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground animate-connection-travel"
+          aria-hidden
+        />
+      </div>
+
+      <div className="relative">
+        <span
+          className="absolute inset-0 rounded-full border border-foreground/40 animate-connection-arrive"
+          aria-hidden
+        />
+        <ConnectionNode>
+          <img
+            src="/logos/deco logo.svg"
+            alt="deco"
+            className="h-6 w-6 dark:hidden"
+          />
+          <img
+            src="/logos/deco logo negative.svg"
+            alt="deco"
+            className="hidden h-6 w-6 dark:block"
+          />
+        </ConnectionNode>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Right-hand panel for the commerce onboarding split screen (md+ only, it lives
+ * in the AuthSplitLayout `visual` slot). The "or" to the connect-your-tools
+ * flow on the left: a human escape hatch for people who resist granting access.
+ */
+export function ScheduleMeetingVisual() {
+  return (
+    <div className="relative flex h-full w-full items-center justify-center p-10">
+      <div className="flex w-full max-w-[380px] flex-col gap-6 rounded-3xl border border-border bg-card p-8 card-shadow">
+        <ConnectionAnimation />
+        <div className="grid gap-2">
+          <h2 className="text-xl font-medium leading-7 text-foreground">
+            {HEADLINE}
+          </h2>
+          <p className="text-base leading-6 text-muted-foreground">{BODY}</p>
+        </div>
+        <ScheduleMeetingCta size="xl" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Mobile counterpart of {@link ScheduleMeetingVisual}. On small screens the
+ * split disappears and connecting tools is the priority, so this collapses to a
+ * quiet row that expands to reveal the call CTA on tap.
+ */
+export function ScheduleMeetingBanner({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className={cn("rounded-2xl border border-border bg-card", className)}>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-3 p-4 text-left"
+      >
+        <span className="flex items-center gap-2.5">
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <User01 size={14} />
+          </span>
+          <span className="text-sm font-medium text-foreground">
+            Prefer to talk to a human?
+          </span>
+        </span>
+        <ChevronDown
+          size={18}
+          className={cn(
+            "text-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open && (
+        <div className="grid gap-3 px-4 pb-4">
+          <p className="text-sm leading-5 text-muted-foreground">{BODY}</p>
+          <ScheduleMeetingCta />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { ArrowUpRight, ChevronDown, User01 } from "@untitledui/icons";
-import { useState } from "react";
+import { ArrowUpRight, User01 } from "@untitledui/icons";
 
 /**
  * Where "Schedule a meeting" sends people who'd rather have us run the
@@ -112,42 +111,32 @@ export function ScheduleMeetingVisual() {
 
 /**
  * Mobile counterpart of {@link ScheduleMeetingVisual}. On small screens the
- * split disappears and connecting tools is the priority, so this collapses to a
- * quiet row that expands to reveal the call CTA on tap.
+ * split disappears, so this is a compact, tappable banner that opens the
+ * scheduling flow directly — quieter than the full card, still inviting.
  */
 export function ScheduleMeetingBanner({ className }: { className?: string }) {
-  const [open, setOpen] = useState(false);
-
   return (
-    <div className={cn("rounded-2xl border border-border bg-card", className)}>
-      <button
-        type="button"
-        onClick={() => setOpen((value) => !value)}
-        aria-expanded={open}
-        className="flex w-full items-center justify-between gap-3 p-4 text-left"
-      >
-        <span className="flex items-center gap-2.5">
-          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-muted-foreground">
-            <User01 size={14} />
-          </span>
-          <span className="text-sm font-medium text-foreground">
-            Prefer to talk to a human?
-          </span>
-        </span>
-        <ChevronDown
-          size={18}
-          className={cn(
-            "text-muted-foreground transition-transform",
-            open && "rotate-180",
-          )}
-        />
-      </button>
-      {open && (
-        <div className="grid gap-3 px-4 pb-4">
-          <p className="text-sm leading-5 text-muted-foreground">{BODY}</p>
-          <ScheduleMeetingCta />
-        </div>
+    <a
+      href={SCHEDULE_MEETING_URL}
+      target="_blank"
+      rel="noreferrer"
+      className={cn(
+        "flex items-center gap-4 rounded-2xl border border-border bg-card p-5 card-shadow transition-colors hover:bg-accent",
+        className,
       )}
-    </div>
+    >
+      <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <User01 size={20} />
+      </span>
+      <span className="flex flex-1 flex-col gap-0.5">
+        <span className="text-base font-medium leading-5 text-foreground">
+          Prefer to talk to a human?
+        </span>
+        <span className="text-sm leading-5 text-muted-foreground">
+          Book a call and we'll run the diagnostic with you.
+        </span>
+      </span>
+      <ArrowUpRight size={18} className="shrink-0 text-muted-foreground" />
+    </a>
   );
 }

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -275,6 +275,10 @@
   --text-sm: 0.8125rem;
 
   --animate-device-icon-pop: device-icon-pop 150ms var(--ease-out-cubic) both;
+  --animate-connection-travel: connection-travel 2.6s var(--ease-in-out-cubic)
+    infinite;
+  --animate-connection-arrive: connection-arrive 2.6s var(--ease-out-cubic)
+    infinite;
 }
 
 /* Animations */
@@ -313,6 +317,42 @@
   }
 }
 
+/* A dot travelling along the wire from the "you" node to the "deco" node on the
+   commerce onboarding "schedule a meeting" card — reads as a live connection. */
+@keyframes connection-travel {
+  0% {
+    left: 0%;
+    opacity: 0;
+  }
+  25% {
+    opacity: 1;
+  }
+  75% {
+    opacity: 1;
+  }
+  100% {
+    left: 100%;
+    opacity: 0;
+  }
+}
+
+/* A single ring that blooms out of the deco node exactly as the dot lands,
+   completing the "message delivered" beat. Same period keeps it in sync. */
+@keyframes connection-arrive {
+  0%,
+  72% {
+    transform: scale(0.85);
+    opacity: 0;
+  }
+  84% {
+    opacity: 0.4;
+  }
+  100% {
+    transform: scale(1.5);
+    opacity: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   @keyframes device-icon-pop {
     from {
@@ -320,6 +360,21 @@
     }
     to {
       opacity: 1;
+    }
+  }
+
+  /* Park the dot mid-wire and drop the ring instead of animating. */
+  @keyframes connection-travel {
+    0%,
+    100% {
+      left: 50%;
+      opacity: 1;
+    }
+  }
+  @keyframes connection-arrive {
+    0%,
+    100% {
+      opacity: 0;
     }
   }
 }


### PR DESCRIPTION
## What is this contribution about?
The commerce onboarding "connect your data sources" screen previously showed a decorative placeholder image on the right. This splits it into a real second half: connect-your-tools stays on the left, and the right becomes a "Schedule a meeting" panel, a human escape hatch for people who don't yet have tool access or are hesitant to grant it. On mobile the split collapses to a quiet, tap-to-expand banner below the connect flow so granting access stays the priority. The panel uses a monochrome "you → deco" connection animation (a travelling dot with a synced arrival ring, `prefers-reduced-motion` aware) with the green deco mark as the only accent, and the CTA links to `https://decocms-tanstack.deco-cx.workers.dev/agendar`.

## Screenshots/Demonstration
> Desktop: connect flow (left) + Schedule a meeting card with the connection animation (right). Mobile: connect flow with the collapsed "Prefer to talk to a human?" banner pinned below it.

## How to Test
1. Run `bun run dev` and open `http://localhost:4000/commerce-onboarding?siteUrl=https://fila.com.br`.
2. Desktop (md+): confirm the right panel shows the animated connection card; click "Schedule a meeting" and confirm it opens the scheduling page in a new tab.
3. Resize below ~768px: the right panel disappears and a collapsed banner appears below the connect flow; tapping it reveals the same CTA. Verify the animation is suppressed under reduced-motion.

## Migration Notes
> Not applicable.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the commerce onboarding connect-your-tools screen to add a right-side “Schedule a meeting” panel on desktop and a tappable banner on mobile, shown only on that screen. Adds a simple “you → deco” connection animation and a CTA to the scheduling page.

- **New Features**
  - Added `ScheduleMeetingVisual` to the connect screen’s `AuthSplitLayout` right pane (md+); CTA opens the scheduling URL in a new tab; includes reduced-motion aware “you → deco” animation.
  - Added `ScheduleMeetingBanner` on mobile for the connect screen; now a larger, single-tap card that opens the scheduling flow directly.

- **Bug Fixes**
  - Scoped the panel and banner to the connect-your-tools step only; URL entry, setting up, and error screens keep the default placeholder and show no mobile banner.

<sup>Written for commit 5456dd0f1acbd5e0f2f9188125803c46805645ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

