### PR TITLE
fix(sections-editor): debounce decofile invalidation to keep new page variants

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -229,6 +229,7 @@ export function SandboxEventsProvider({
     let reconnectAttempt = 0;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let liveMetaDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let decofileDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     let studioEs: EventSource | null = null;
     let directEs: EventSource | null = null;
 
@@ -358,9 +359,21 @@ export function SandboxEventsProvider({
               payload as DaemonEventPayload<"file-changed">;
             const cacheKey = `${org.slug}/${virtualMcpId}/${branch}`;
             if (filePath.startsWith(".deco/")) {
-              void queryClient.invalidateQueries({
-                queryKey: KEYS.decofile(cacheKey),
-              });
+              // Debounce decofile invalidation for the same reason as liveMeta
+              // below: writing a `.deco/` block emits `file-changed`, but the
+              // dev server needs a moment to rebuild before `/.decofile`
+              // reflects the write. Refetching immediately re-reads the stale
+              // pre-rebuild config and clobbers the optimistic cache update from
+              // useSaveBlock — so a freshly added page variant briefly appears,
+              // then vanishes until a manual reload. Waiting lets the rebuild
+              // land first.
+              if (decofileDebounceTimer) clearTimeout(decofileDebounceTimer);
+              decofileDebounceTimer = setTimeout(() => {
+                decofileDebounceTimer = null;
+                void queryClient.invalidateQueries({
+                  queryKey: KEYS.decofile(cacheKey),
+                });
+              }, 1_000);
             } else {
               // Debounce liveMeta invalidation so the dev server has time to
               // rebuild before we hit /live/_meta. Rapid successive
@@ -501,6 +514,7 @@ export function SandboxEventsProvider({
       directEs?.close();
       if (reconnectTimer) clearTimeout(reconnectTimer);
       if (liveMetaDebounceTimer) clearTimeout(liveMetaDebounceTimer);
+      if (decofileDebounceTimer) clearTimeout(decofileDebounceTimer);
     };
   }, [
     virtualMcpId,


### PR DESCRIPTION
## Summary

Fixes the bug where adding a page variant briefly shows the variant in the form, then reverts to "no variants" — until a manual page reload, after which the variant correctly appears.

## Root cause

The variants UI is derived entirely from the `decofile` query cache (`sections-editor.tsx` → `parsePageVariantsForEditor(pageData?.sections, ...)`); there is no local variant state, so the query cache is the source of truth.

When a variant is added:

1. `handleAddPageVariant` → `saveBlock.mutate` optimistically updates the `decofile` cache with the new `sections` (variant appears). ✅
2. The `.deco/` file write emits a `file-changed` SSE event.
3. In `sandbox-events-context.tsx`, the `file-changed` handler **immediately** invalidated the `decofile` query, refetching `/.decofile` from the dev server.
4. The dev server hadn't rebuilt yet, so the refetch returned **stale** pre-write config (no variant) and clobbered the optimistic cache → the form reverts to "no variants". ❌
5. A later manual reload reads fresh config → variant appears. ✅

The `liveMeta` invalidation immediately below this code already debounces 1s for **exactly** this reason (its comment: "so the dev server has time to rebuild before we hit /live/_meta"). The `decofile` invalidation lacked that debounce.

## Fix

Apply the same 1s debounce to the `decofile` invalidation for `.deco/` file changes (timer declared alongside `liveMetaDebounceTimer` and cleared on cleanup). The refetch now happens after the rebuild lands, so it no longer clobbers the optimistic update.

## Caveat

This is a timing-based fix consistent with the existing `liveMeta` pattern. If the dev server rebuild ever exceeds 1s the race could resurface; fully eliminating it would require distinguishing our own writes from external edits to skip the refetch — a larger change. The debounce resolves the observed case.

## Testing

- `bun run fmt` — clean
- `bun run check` (tsc) — passes

The event-handler logic lives inside a React effect with `queryClient`, so per the repo's two-tier testing policy it's not a pure-logic unit test (existing test file only covers pure helpers). Manual/e2e verification recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debounced `decofile` invalidation on `.deco/` file changes by 1s to avoid stale refetches that overwrote optimistic updates. New page variants now stay visible right after creation without a manual reload.

- **Bug Fixes**
  - Added `decofileDebounceTimer` and a 1s delay before invalidating `KEYS.decofile(...)` on `.deco/` changes.
  - Cleared the debounce on cleanup; mirrors the existing `liveMeta` debounce so the dev server can rebuild first.

<sup>Written for commit 3ebd09b3ac329f4fce483ba02c552af77b9af697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

