### PR TITLE
fix(dispatch-queue): use real DBOS executor id in thread-gate shutdown handoff

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -345,8 +345,18 @@ let shuttingDown = false;
  * Best-effort: any failure is logged and swallowed so shutdown still completes.
  * Only covers GRACEFUL termination — a hard SIGKILL (OOM, node loss) skips this
  * handler, and those orphans still need Conductor recovery or a sweep.
+ *
+ * `executorId` MUST be the real runtime executor id (`DBOS.executorID`),
+ * captured by the caller BEFORE `DBOS.shutdown()`. Two gotchas make this
+ * non-obvious: (1) when a Conductor is configured (as in prod/stg) DBOS
+ * IGNORES the `executorID` we pass to `setConfig` and substitutes a random
+ * UUID (`dbos.js` "Always use a generated executor ID in Conductor"), so
+ * `settings.podName` never matches the `executor_id` stored on our rows; and
+ * (2) `DBOS.shutdown()` resets `DBOS.executorID` back to `'local'`, so reading
+ * it after shutdown would filter on the wrong id. Filtering on the wrong id
+ * silently matches zero gates and the handoff no-ops (the original bug).
  */
-async function handOffInFlightThreadGates() {
+async function handOffInFlightThreadGates(executorId: string) {
   let client: Awaited<ReturnType<typeof DBOSClient.create>> | undefined;
   try {
     client = await DBOSClient.create({
@@ -359,15 +369,22 @@ async function handOffInFlightThreadGates() {
     const orphaned = await client.listWorkflows({
       status: "PENDING",
       queueName: THREAD_GATE_QUEUE,
-      executorId: settings.podName,
+      executorId,
       loadInput: false,
       loadOutput: false,
     });
-    if (orphaned.length === 0) return;
+    // Always log the count (even 0) so the handoff is observable — a silent
+    // early-return is exactly what hid the executor-id filter bug the first time.
+    if (orphaned.length === 0) {
+      console.log(
+        `[shutdown] no in-flight thread-gate gates to hand off (executor ${executorId})`,
+      );
+      return;
+    }
     const ids = orphaned.map((w) => w.workflowID);
     await client.resumeWorkflows(ids, { queueName: THREAD_GATE_QUEUE });
     console.log(
-      `[shutdown] re-enqueued ${ids.length} in-flight thread-gate gate(s) for re-adoption by a live executor:`,
+      `[shutdown] re-enqueued ${ids.length} in-flight thread-gate gate(s) for re-adoption by a live executor (from ${executorId}):`,
       ids,
     );
   } catch (err) {
@@ -418,13 +435,18 @@ async function gracefulShutdown(signal: string) {
     //    graceful drain indefinitely).
     await server.stop(true);
 
+    // Capture the REAL executor id before DBOS.shutdown() resets it to 'local'.
+    // With a Conductor configured this is a random UUID (NOT settings.podName),
+    // and it's what our workflow rows are stamped with. See
+    // handOffInFlightThreadGates for why this matters.
+    const executorId = DBOS.executorID;
     // Drain DBOS before app.shutdown closes mesh's pg pool — in-flight steps use it.
     await DBOS.shutdown();
     // Re-enqueue our own in-flight thread-gate gates so a live pod adopts them
     // instead of stranding them PENDING on this dead executor (which bricks the
     // thread). Runs after DBOS.shutdown() so our stopped poller can't re-grab
     // them. See handOffInFlightThreadGates for the full rationale.
-    await handOffInFlightThreadGates();
+    await handOffInFlightThreadGates(executorId);
     await app.shutdown();
   } catch (err) {
     console.error("[shutdown] Error during shutdown:", err);


### PR DESCRIPTION
## Follow-up to #4236 — which shipped but **did not work**

#4236 added a graceful-shutdown handoff that re-enqueues this executor's in-flight `thread-gate` gates so a live pod adopts them instead of stranding them `PENDING`. It merged and deployed, but threads **kept stranding on every deploy**. Root cause:

The handoff filtered `listWorkflows({ executorId: settings.podName })`. But when a **DBOS Conductor is configured** (prod + stg), DBOS **ignores** the `executorID` we pass to `setConfig` and substitutes a random UUID:

```js
// @dbos-inc/dbos-sdk dbos.js
if (options?.conductorKey) {
  // Always use a generated executor ID in Conductor.
  globalParams.executorID = randomUUID();
}
```

That random UUID is what every workflow row's `executor_id` is stamped with. `settings.podName` (`deco-…-api-0`) therefore matched **zero** rows, so the handoff silently returned and no gate was ever handed off.

**Verified on studio-stg:** stored `executor_id` values are UUIDs (`b7f9fa5a`, `85eff206`, …), while `POD_NAME` is `deco-studio-stg-<rs>-<pod>-api-0`. They never match.

## Fix

- Capture the **real** executor id via the public `DBOS.executorID` getter, **before** `DBOS.shutdown()` — shutdown resets `globalParams.executorID` back to `'local'`, so reading it afterward would filter on the wrong id too. The captured id is threaded into `handOffInFlightThreadGates(executorId)`.
- **Always log the handoff count, even 0.** The original silent early-return on zero matches is exactly what hid this bug — a `re-enqueued 0` / `no gates to hand off (executor <uuid>)` line would have made it obvious on the first post-deploy pod log.

Works in both modes: with a Conductor, `DBOS.executorID` is the generated UUID; in local dev (no Conductor) it's `settings.podName` — matching how rows are stamped in each case.

## Testing

- `bun run fmt`, `bun run lint` (0 errors), `tsc --noEmit` (clean for the changed file).
- Final validation is observing the next graceful rollout's pod logs for the `[shutdown] re-enqueued N …` line and confirming no new stranded gates. (Until this rolls out, orphans are still cleared manually.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the thread-gate graceful shutdown handoff by using the real `DBOS` executor id to prevent stranded gates during deploys. Captures `DBOS.executorID` before shutdown and logs the handoff result for visibility.

- **Bug Fixes**
  - Capture `DBOS.executorID` before `DBOS.shutdown()` and pass it to the handoff so `listWorkflows` filters by the actual UUID used by the Conductor (not `settings.podName`).
  - Always log the handoff count (including 0) to make issues observable in pod logs.

<sup>Written for commit 645576063458f309960ea421b10bdaf017d08429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

