### PR TITLE
fix(commerce-onboarding): fit the connect-tools screen nicely on mobile

### DIFF
--- a/apps/mesh/src/web/components/auth-split-layout.tsx
+++ b/apps/mesh/src/web/components/auth-split-layout.tsx
@@ -10,11 +10,13 @@ interface AuthSplitLayoutProps {
   visual?: ReactNode;
   /**
    * Vertical alignment of the left column. Defaults to `"center"`. Use
-   * `"top"` for tall content (e.g. the connect-tools screen) so it scrolls
-   * from the top on mobile instead of being centered and clipped by the
-   * browser chrome; desktop stays centered.
+   * `"fill"` for tall app-shell content (e.g. the connect-tools screen): on
+   * mobile the column becomes exactly one dynamic-viewport tall and hands its
+   * inner content area a flex context, so a child can use `flex-1`/`h-full` to
+   * fill the available space (header pinned, body scrolls, footer pinned)
+   * without hardcoding this component's padding. Desktop stays centered.
    */
-  align?: "center" | "top";
+  align?: "center" | "fill";
 }
 
 export function AuthSplitLayout({
@@ -22,19 +24,37 @@ export function AuthSplitLayout({
   visual,
   align = "center",
 }: AuthSplitLayoutProps) {
+  const fill = align === "fill";
   return (
-    <main className="flex min-h-screen w-full">
+    <main
+      className={cn(
+        "flex w-full",
+        // A fill screen owns exactly the visible (dynamic) viewport on mobile so
+        // its pinned footer never sits behind the browser chrome; min-h-screen
+        // elsewhere lets short screens still cover the fold.
+        fill ? "min-h-[100dvh] md:min-h-screen" : "min-h-screen",
+      )}
+    >
       <section
         className={cn(
-          "flex flex-1 justify-center bg-sidebar px-6 md:px-10 md:py-10",
-          align === "top"
-            ? "items-start pt-4 pb-8 md:items-center"
-            : "items-center py-6",
+          "flex flex-1 flex-col items-center bg-sidebar px-6 md:justify-center md:px-10 md:py-10",
+          fill
+            ? "h-[100dvh] justify-start pt-4 pb-8 md:h-auto"
+            : "justify-center py-6",
         )}
       >
-        <div className="w-full max-w-[440px]">{children}</div>
+        <div
+          className={cn(
+            "w-full max-w-[440px]",
+            // Give the content a flex column that fills the padded viewport so
+            // children fill via flex-1 instead of duplicating the padding above.
+            fill && "flex min-h-0 flex-1 flex-col md:block md:flex-none",
+          )}
+        >
+          {children}
+        </div>
       </section>
-      <aside className="relative hidden md:flex flex-1 overflow-hidden bg-muted">
+      <aside className="relative hidden flex-1 overflow-hidden bg-muted md:flex">
         {visual ?? (
           <img
             src="/onboarding-placeholder.png"

--- a/apps/mesh/src/web/components/auth-split-layout.tsx
+++ b/apps/mesh/src/web/components/auth-split-layout.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@deco/ui/lib/utils.ts";
 import type { ReactNode } from "react";
 
 interface AuthSplitLayoutProps {
@@ -7,12 +8,30 @@ interface AuthSplitLayoutProps {
    * pass a node here to drop in an image or any other visual.
    */
   visual?: ReactNode;
+  /**
+   * Vertical alignment of the left column. Defaults to `"center"`. Use
+   * `"top"` for tall content (e.g. the connect-tools screen) so it scrolls
+   * from the top on mobile instead of being centered and clipped by the
+   * browser chrome; desktop stays centered.
+   */
+  align?: "center" | "top";
 }
 
-export function AuthSplitLayout({ children, visual }: AuthSplitLayoutProps) {
+export function AuthSplitLayout({
+  children,
+  visual,
+  align = "center",
+}: AuthSplitLayoutProps) {
   return (
     <main className="flex min-h-screen w-full">
-      <section className="flex flex-1 items-center justify-center bg-sidebar p-6 md:p-10">
+      <section
+        className={cn(
+          "flex flex-1 justify-center bg-sidebar px-6 md:px-10 md:py-10",
+          align === "top"
+            ? "items-start pt-4 pb-8 md:items-center"
+            : "items-center py-6",
+        )}
+      >
         <div className="w-full max-w-[440px]">{children}</div>
       </section>
       <aside className="relative hidden md:flex flex-1 overflow-hidden bg-muted">

--- a/apps/mesh/src/web/components/scroll-reveal.tsx
+++ b/apps/mesh/src/web/components/scroll-reveal.tsx
@@ -68,7 +68,7 @@ export function ScrollReveal({
         className={cn(
           // `-bottom-px` (not `bottom-0`) so the fade over-covers the scroller's
           // sub-pixel clip edge instead of stopping a fraction of a pixel short.
-          "pointer-events-none absolute inset-x-0 -bottom-px h-[213px]",
+          "pointer-events-none absolute inset-x-0 -bottom-px h-[72px]",
           // Fade to the sidebar surface these scrollers sit on (AuthSplitLayout)
           // so the solid end blends into the panel instead of showing a lighter
           // `background` band.
@@ -82,7 +82,7 @@ export function ScrollReveal({
           // of the last card to bleed through as a 1px sliver at any DPR. The
           // plateau guarantees the clip line sits inside the solid zone.
           "bg-gradient-to-t from-sidebar from-[6px] to-transparent",
-          "backdrop-blur-[2px] [mask-image:linear-gradient(to_top,black_6px,transparent)]",
+          "backdrop-blur-[1px] [mask-image:linear-gradient(to_top,black_6px,transparent)]",
           "transition-opacity duration-200",
           atBottom ? "opacity-0" : "opacity-100",
         )}

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -809,11 +809,11 @@ function CommerceDiscoveryReady({
     // The "connect your tools" screen is the only one that swaps the placeholder
     // visual for the schedule-a-meeting panel (md+); every other setup screen
     // keeps the default AuthSplitLayout placeholder.
-    <AuthSplitLayout visual={<ScheduleMeetingVisual />}>
-      {/* On mobile fill the viewport (minus AuthSplitLayout's p-6 = 3rem) as a flex
-          column so the header pins to the top, the cards fill the middle, and the
-          "See full report" CTA pins to the bottom. On md+ revert to the centered grid. */}
-      <div className="flex h-[calc(100dvh-3rem)] flex-col gap-10 md:grid md:h-auto">
+    <AuthSplitLayout align="top" visual={<ScheduleMeetingVisual />}>
+      {/* Natural top-aligned stack: on mobile the page scrolls (align="top"
+          keeps the header near the top and nothing gets clipped by the browser
+          chrome); on md+ the right panel carries the schedule visual. */}
+      <div className="flex flex-col gap-8">
         <CommerceHeader />
         <CompanionMcpsSection
           org={org}
@@ -822,7 +822,7 @@ function CommerceDiscoveryReady({
           onOpenReport={onOpenReport}
         />
         {/* The right-side ScheduleMeetingVisual is hidden on mobile, so surface the
-            human escape hatch as a collapsed banner pinned below the connect flow. */}
+            human escape hatch as a banner below the connect flow. */}
         <ScheduleMeetingBanner className="md:hidden" />
       </div>
     </AuthSplitLayout>

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -819,15 +819,14 @@ function CommerceDiscoveryReady({
     // visual for the schedule-a-meeting panel (md+); every other setup screen
     // keeps the default AuthSplitLayout placeholder.
     <AuthSplitLayout
-      align="top"
+      align="fill"
       visual={<ScheduleMeetingVisual href={meetingUrl} />}
     >
-      {/* Mobile: fill the viewport (minus AuthSplitLayout's pt-4+pb-8 = 3rem) as a
-          flex column — header pinned top, cards scroll in the middle, and the
-          footer (report CTA + talk-to-a-human banner) pinned to the bottom.
-          align="top" avoids the vh/dvh centering that used to clip the footer.
+      {/* align="fill" hands us a flex column sized to the visible viewport, so we
+          just flex-1 into it — header pinned top, cards scroll in the middle, and
+          the footer (report CTA + talk-to-a-human banner) pinned to the bottom.
           On md+ it collapses back to a natural block (right panel has the card). */}
-      <div className="flex h-[calc(100dvh-3rem)] flex-col gap-6 md:block md:h-auto">
+      <div className="flex min-h-0 flex-1 flex-col gap-6 md:block">
         <CommerceHeader />
         <CompanionMcpsSection
           org={org}

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -32,6 +32,7 @@ import { createContext, Suspense, useContext, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { CompanionMcpsSection } from "./commerce-onboarding/companion-mcps-section.tsx";
 import {
+  buildScheduleMeetingUrl,
   ScheduleMeetingBanner,
   ScheduleMeetingVisual,
 } from "./commerce-onboarding/schedule-meeting.tsx";
@@ -670,6 +671,7 @@ function CommerceSetupContent({
         org={org}
         reportApp={reportApp}
         onOpenReport={openReport}
+        siteUrl={initialSiteUrl ?? siteUrlInput}
       />
     );
   }
@@ -800,30 +802,52 @@ function CommerceDiscoveryReady({
   org,
   reportApp,
   onOpenReport,
+  siteUrl,
 }: {
   org: CommerceOrganization;
   reportApp: CommerceDiscoveryReportApp;
   onOpenReport: () => void;
+  siteUrl?: string;
 }) {
+  const { data: session } = authClient.useSession();
+  const meetingUrl = buildScheduleMeetingUrl({
+    siteUrl,
+    email: session?.user?.email,
+  });
   return (
     // The "connect your tools" screen is the only one that swaps the placeholder
     // visual for the schedule-a-meeting panel (md+); every other setup screen
     // keeps the default AuthSplitLayout placeholder.
-    <AuthSplitLayout align="top" visual={<ScheduleMeetingVisual />}>
-      {/* Natural top-aligned stack: on mobile the page scrolls (align="top"
-          keeps the header near the top and nothing gets clipped by the browser
-          chrome); on md+ the right panel carries the schedule visual. */}
-      <div className="flex flex-col gap-8">
+    <AuthSplitLayout
+      align="top"
+      visual={<ScheduleMeetingVisual href={meetingUrl} />}
+    >
+      {/* Mobile: fill the viewport (minus AuthSplitLayout's pt-4+pb-8 = 3rem) as a
+          flex column — header pinned top, cards scroll in the middle, and the
+          footer (report CTA + talk-to-a-human banner) pinned to the bottom.
+          align="top" avoids the vh/dvh centering that used to clip the footer.
+          On md+ it collapses back to a natural block (right panel has the card). */}
+      <div className="flex h-[calc(100dvh-3rem)] flex-col gap-6 md:block md:h-auto">
         <CommerceHeader />
         <CompanionMcpsSection
           org={org}
           cdConnectionId={reportApp.connectionId}
-          reportDisabled={!reportApp.virtualMcpId}
-          onOpenReport={onOpenReport}
         />
-        {/* The right-side ScheduleMeetingVisual is hidden on mobile, so surface the
-            human escape hatch as a banner below the connect flow. */}
-        <ScheduleMeetingBanner className="md:hidden" />
+        <div className="flex shrink-0 flex-col gap-3 md:mt-8">
+          {/* Right-side ScheduleMeetingVisual is hidden on mobile, so the human
+              escape hatch rides in the footer above the report CTA. */}
+          <ScheduleMeetingBanner className="md:hidden" href={meetingUrl} />
+          <Button
+            type="button"
+            size="xl"
+            className="w-full rounded-2xl text-base font-medium"
+            onClick={onOpenReport}
+            disabled={!reportApp.virtualMcpId}
+          >
+            See full report
+            <ArrowRight size={18} />
+          </Button>
+        </div>
       </div>
     </AuthSplitLayout>
   );

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -12,7 +12,7 @@ export function CompanionCardSkeleton() {
   return (
     <div className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-4">
       <div className="flex items-center gap-2">
-        <div className="size-12 shrink-0 animate-pulse rounded-lg bg-muted/60" />
+        <div className="size-9 shrink-0 animate-pulse rounded-lg bg-muted/60" />
         <div className="h-4 w-32 animate-pulse rounded bg-muted/60" />
         <div className="ml-auto h-8 w-20 animate-pulse rounded-lg bg-muted/60" />
       </div>
@@ -54,9 +54,9 @@ export function CompanionCard({
         <IntegrationIcon
           icon={card.icon}
           name={card.title}
-          size="md"
+          size="sm"
           fit="contain"
-          className="p-2"
+          className="p-1.5"
         />
         <p className="flex-1 text-sm text-foreground">{card.title}</p>
         {card.satisfied ? (

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -62,21 +62,15 @@ export function CompanionMcpsSection({
 
   // Empty: no requirements survive → just the report CTA (section header hidden).
   if (!isLoading && !error && cards.length === 0) {
-    // On mobile the parent gives us a full-height flex column, so pin the CTA to
-    // the bottom; on md+ fall back to the natural grid.
-    return (
-      <div className="flex min-h-0 flex-1 flex-col justify-end gap-10 md:grid md:flex-none">
-        {cta}
-      </div>
-    );
+    return <div className="grid gap-8 md:gap-10">{cta}</div>;
   }
 
   const busy = connectingFieldKey !== null;
 
   return (
-    // On mobile this grows to fill the parent's full-height column (header pinned
-    // top, CTA pinned bottom, cards scroll in between); on md+ it's the compact grid.
-    <div className="flex min-h-0 flex-1 flex-col gap-6 md:grid md:flex-none">
+    // Natural stack — the page scrolls on mobile; on md+ the card list gets its
+    // own capped scroll area (below) while everything else stays put.
+    <div className="grid gap-6">
       <div className="grid gap-1.5">
         <p className="text-2xl font-medium text-foreground">
           Unlock your full diagnostic
@@ -99,15 +93,15 @@ export function CompanionMcpsSection({
           </p>
         </div>
       ) : isLoading ? (
-        <div className="flex min-h-0 flex-1 flex-col gap-4">
+        <div className="grid gap-4">
           {[0, 1, 2].map((i) => (
             <CompanionCardSkeleton key={i} />
           ))}
         </div>
       ) : (
         <ScrollReveal
-          wrapperClassName="flex min-h-0 flex-1 flex-col md:block"
-          className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1 md:max-h-[45vh] md:flex-none"
+          wrapperClassName="block"
+          className="-mx-1 px-1 md:max-h-[45vh] md:overflow-y-auto"
         >
           <div className="grid gap-4">
             {connectError && (

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -1,8 +1,6 @@
 import { ScrollReveal } from "@/web/components/scroll-reveal";
 import { authClient } from "@/web/lib/auth-client";
 import { SELF_MCP_ALIAS_ID, useMCPClient } from "@decocms/mesh-sdk";
-import { Button } from "@deco/ui/components/button.tsx";
-import { ArrowRight } from "@untitledui/icons";
 import { CompanionCard, CompanionCardSkeleton } from "./companion-card.tsx";
 import { useCommerceCompanions } from "./use-commerce-companions.ts";
 import { useConnectCompanion } from "./use-connect-companion.ts";
@@ -15,13 +13,9 @@ interface CompanionOrg {
 export function CompanionMcpsSection({
   org,
   cdConnectionId,
-  reportDisabled,
-  onOpenReport,
 }: {
   org: CompanionOrg;
   cdConnectionId: string;
-  reportDisabled: boolean;
-  onOpenReport: () => void;
 }) {
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id ?? "";
@@ -47,30 +41,19 @@ export function CompanionMcpsSection({
     cdConnectionId,
   });
 
-  const cta = (
-    <Button
-      type="button"
-      size="xl"
-      className="w-full"
-      onClick={onOpenReport}
-      disabled={reportDisabled}
-    >
-      See full report
-      <ArrowRight size={16} />
-    </Button>
-  );
-
-  // Empty: no requirements survive → just the report CTA (section header hidden).
+  // Empty: nothing to connect → render nothing (the parent footer still shows
+  // the report CTA).
   if (!isLoading && !error && cards.length === 0) {
-    return <div className="grid gap-8 md:gap-10">{cta}</div>;
+    return null;
   }
 
   const busy = connectingFieldKey !== null;
 
   return (
-    // Natural stack — the page scrolls on mobile; on md+ the card list gets its
-    // own capped scroll area (below) while everything else stays put.
-    <div className="grid gap-6">
+    // Mobile: fill the parent's remaining height — the header + intro copy stay
+    // pinned while the card list scrolls. md+: natural block with a capped
+    // scroll area so the right panel stays visible.
+    <div className="flex min-h-0 flex-1 flex-col gap-6 md:block md:flex-none">
       <div className="grid gap-1.5">
         <p className="text-2xl font-medium text-foreground">
           Unlock your full diagnostic
@@ -100,8 +83,8 @@ export function CompanionMcpsSection({
         </div>
       ) : (
         <ScrollReveal
-          wrapperClassName="block"
-          className="-mx-1 px-1 md:max-h-[45vh] md:overflow-y-auto"
+          wrapperClassName="flex min-h-0 flex-1 flex-col md:block"
+          className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1 md:max-h-[45vh] md:flex-none"
         >
           <div className="grid gap-4">
             {connectError && (
@@ -121,8 +104,6 @@ export function CompanionMcpsSection({
           </div>
         </ScrollReveal>
       )}
-
-      {cta}
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
@@ -15,10 +15,30 @@ const HEADLINE = "Rather have us walk you through it?";
 const BODY =
   "Book a 20-minute call and we'll run the diagnostic with you, live.";
 
+/**
+ * Build the scheduling link, prefilling the site under diagnosis and the
+ * signed-in user's email as query params so the booking page arrives with
+ * context (both omitted when unknown).
+ */
+export function buildScheduleMeetingUrl({
+  siteUrl,
+  email,
+}: {
+  siteUrl?: string | null;
+  email?: string | null;
+}): string {
+  const url = new URL(SCHEDULE_MEETING_URL);
+  if (siteUrl) url.searchParams.set("siteUrl", siteUrl);
+  if (email) url.searchParams.set("email", email);
+  return url.toString();
+}
+
 function ScheduleMeetingCta({
+  href = SCHEDULE_MEETING_URL,
   size = "lg",
   className,
 }: {
+  href?: string;
   size?: "lg" | "xl";
   className?: string;
 }) {
@@ -29,7 +49,7 @@ function ScheduleMeetingCta({
       size={size}
       className={cn("w-full", className)}
     >
-      <a href={SCHEDULE_MEETING_URL} target="_blank" rel="noreferrer">
+      <a href={href} target="_blank" rel="noreferrer">
         Schedule a meeting
         <ArrowUpRight size={16} />
       </a>
@@ -92,7 +112,7 @@ function ConnectionAnimation() {
  * in the AuthSplitLayout `visual` slot). The "or" to the connect-your-tools
  * flow on the left: a human escape hatch for people who resist granting access.
  */
-export function ScheduleMeetingVisual() {
+export function ScheduleMeetingVisual({ href }: { href?: string }) {
   return (
     <div className="relative flex h-full w-full items-center justify-center p-10">
       <div className="flex w-full max-w-[380px] flex-col gap-6 rounded-3xl border border-border bg-card p-8 card-shadow">
@@ -103,7 +123,7 @@ export function ScheduleMeetingVisual() {
           </h2>
           <p className="text-base leading-6 text-muted-foreground">{BODY}</p>
         </div>
-        <ScheduleMeetingCta size="xl" />
+        <ScheduleMeetingCta href={href} size="xl" />
       </div>
     </div>
   );
@@ -114,10 +134,16 @@ export function ScheduleMeetingVisual() {
  * split disappears, so this is a compact, tappable banner that opens the
  * scheduling flow directly — quieter than the full card, still inviting.
  */
-export function ScheduleMeetingBanner({ className }: { className?: string }) {
+export function ScheduleMeetingBanner({
+  className,
+  href = SCHEDULE_MEETING_URL,
+}: {
+  className?: string;
+  href?: string;
+}) {
   return (
     <a
-      href={SCHEDULE_MEETING_URL}
+      href={href}
       target="_blank"
       rel="noreferrer"
       className={cn(


### PR DESCRIPTION
## What is this contribution about?
On mobile the commerce onboarding connect-tools screen looked awful: the connect flow forced a `100dvh` full-height column while `AuthSplitLayout` vertically centered it inside a `100vh` section, so on iOS Safari everything was pushed down (large top gap) and the "Prefer to talk to a human?" banner was clipped behind the browser toolbar. This adds an `align="top"` option to `AuthSplitLayout` (top-aligned with tighter top padding on mobile, still centered on desktop), replaces the full-height / pinned-CTA / inner-scroll layout with a natural stack that scrolls with the page, and shrinks the per-connection logos (`md` → `sm`). Desktop is unchanged.

## Screenshots/Demonstration
> Mobile: header sits near the top, cards + "See full report" + schedule banner all flow and stay fully visible (no clipping). Desktop: unchanged split screen.

## How to Test
1. Open the commerce onboarding connect-tools screen on a mobile viewport (iOS Safari or device toolbar).
2. Confirm there's no large top gap, the content scrolls naturally, and the "Prefer to talk to a human?" banner is fully visible (not clipped by the browser chrome).
3. Confirm desktop still shows the centered split screen with the schedule-a-meeting panel on the right.

## Migration Notes
> Not applicable.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the connect-tools screen on mobile with an app-shell layout: header stays pinned, cards scroll, and a bottom footer holds the talk-to-human banner and a larger “See full report” CTA. Also pre-fills the schedule link with the site URL and user email. Desktop remains unchanged.

- **New Features**
  - Mobile footer with banner above a larger “See full report” CTA; report CTA moved out of `CompanionMcpsSection`.
  - Prefilled scheduling via `buildScheduleMeetingUrl` (uses `siteUrl` + session email) and passed to both `ScheduleMeetingVisual` and the banner; softened `ScrollReveal` fade (72px height, 1px blur).

- **Bug Fixes**
  - Replaced `align="top"` with `align="fill"` in `AuthSplitLayout`, which now owns the dynamic viewport height on mobile (no calc-based height). Header/footer pin, cards scroll, and the banner isn’t clipped; card list stays capped on md+. Reduced connection logo and skeleton sizes (`md` → `sm`).

<sup>Written for commit 07f125c0497952e1e2c54e987825ab8aa636ba1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

