### PR TITLE
feat(mesh): service-scoped vault lease for trusted internal services

### DIFF
--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -38,7 +38,10 @@ export const resolveOrgFromPath: MiddlewareHandler<{
   const org = await db
     .selectFrom("organization")
     .select(["id", "slug", "name", "metadata"])
-    .where("slug", "=", slug)
+    // Accept either the human slug or the raw org id in the path. Machine callers
+    // (e.g. the vault service lease) hold the org id, not the slug; random 32-char
+    // ids never collide with slugs, so matching both is unambiguous in practice.
+    .where((eb) => eb.or([eb("slug", "=", slug), eb("id", "=", slug)]))
     .executeTakeFirst();
 
   if (!org) {

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -35,13 +35,22 @@ export const resolveOrgFromPath: MiddlewareHandler<{
   }
   const db = ctx.db;
 
+  // Only the vault service-lease resolves the org by id — its machine caller
+  // (commerce-discovery) holds the org id, not the slug. Every other route stays
+  // slug-only so a slug that happens to equal another org's id can never cause
+  // cross-org resolution on an unauthenticated route.
+  const isVaultServicePath =
+    /\/vault\/connections\/[^/]+\/(access-token|configuration)$/.test(
+      c.req.path,
+    );
   const org = await db
     .selectFrom("organization")
     .select(["id", "slug", "name", "metadata"])
-    // Accept either the human slug or the raw org id in the path. Machine callers
-    // (e.g. the vault service lease) hold the org id, not the slug; random 32-char
-    // ids never collide with slugs, so matching both is unambiguous in practice.
-    .where((eb) => eb.or([eb("slug", "=", slug), eb("id", "=", slug)]))
+    .where((eb) =>
+      isVaultServicePath
+        ? eb.or([eb("slug", "=", slug), eb("id", "=", slug)])
+        : eb("slug", "=", slug),
+    )
     .executeTakeFirst();
 
   if (!org) {

--- a/apps/mesh/src/api/routes/credential-vault.test.ts
+++ b/apps/mesh/src/api/routes/credential-vault.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { isVaultServiceToken, safeEqual } from "./credential-vault";
+
+describe("safeEqual", () => {
+  it("matches equal strings and rejects different ones (incl. different lengths — no throw)", () => {
+    expect(safeEqual("abc", "abc")).toBe(true);
+    expect(safeEqual("abc", "abd")).toBe(false);
+    expect(safeEqual("abc", "abcd")).toBe(false); // length guard, timingSafeEqual would throw otherwise
+    expect(safeEqual("", "")).toBe(true);
+  });
+});
+
+describe("isVaultServiceToken", () => {
+  const prev = process.env.VAULT_SERVICE_TOKEN;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.VAULT_SERVICE_TOKEN;
+    else process.env.VAULT_SERVICE_TOKEN = prev;
+  });
+
+  it("is off when the env var is unset", () => {
+    delete process.env.VAULT_SERVICE_TOKEN;
+    expect(isVaultServiceToken("anything")).toBe(false);
+  });
+
+  it("accepts the configured token, rejects others", () => {
+    process.env.VAULT_SERVICE_TOKEN = "svc-secret";
+    expect(isVaultServiceToken("svc-secret")).toBe(true);
+    expect(isVaultServiceToken("wrong")).toBe(false);
+    expect(isVaultServiceToken("")).toBe(false);
+  });
+});

--- a/apps/mesh/src/api/routes/credential-vault.ts
+++ b/apps/mesh/src/api/routes/credential-vault.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { Hono, type Context } from "hono";
 import type { StudioContext } from "@/core/studio-context";
 import { getValidDownstreamAccessToken } from "@/oauth/token-refresh";
@@ -15,6 +16,25 @@ function bearerToken(value: string | undefined): string | null {
   const match = value?.match(/^Bearer\s+(.+)$/i);
   const token = match?.[1]?.trim();
   return token ? token : null;
+}
+
+/** Constant-time string compare (for the service token). */
+export function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  return ab.length === bb.length && timingSafeEqual(ab, bb);
+}
+
+/**
+ * A trusted internal service (e.g. commerce-discovery's credential resolver)
+ * presenting this shared token may lease ANY connection in the org resolved from
+ * the path — bypassing the per-connection grant. It's the service-scoped
+ * equivalent of a workload token; the org in the URL still bounds it. Rotate via
+ * env. Absent ⇒ feature off (only workload-token + grant is accepted).
+ */
+export function isVaultServiceToken(token: string): boolean {
+  const svc = process.env.VAULT_SERVICE_TOKEN;
+  return !!svc && safeEqual(token, svc);
 }
 
 function serializeExpiresAt(value: Date | string | null): string | null {
@@ -58,6 +78,13 @@ async function authorizeVaultRequest(
       ok: false,
       response: c.json({ error: "Organization context required" }, 403),
     };
+  }
+
+  // Trusted internal service: skip workload-token + per-connection grant. Still
+  // bounded to the org resolved from the path (the target lookups below filter
+  // by organizationId), so it can't reach another org's connections.
+  if (isVaultServiceToken(token)) {
+    return { ok: true, ctx, organizationId };
   }
 
   const workloadToken =


### PR DESCRIPTION
## What
Adds `VAULT_SERVICE_TOKEN` — a shared token a **trusted internal service** (commerce-discovery's credential resolver) can present to the vault to lease **any connection's** config + access-token **in the org resolved from the URL path**, bypassing the per-connection grant.

## Why
commerce-discovery resolves a tenant's GA4/GSC/VTEX credentials on every private diagnostic run. Today that requires a **per-connection grant token** stored on the commerce side (an onChange-synced mirror of the studio connection). We're dropping that mirror and moving to **direct, per-`(org,url)` credential resolution** — for which commerce needs to lease any connection in a tenant's org with a single service credential. This is that capability.

## How (`credential-vault.ts`, ~27 LOC)
- `authorizeVaultRequest`: after the org is resolved from the path, if the bearer equals `VAULT_SERVICE_TOKEN`, short-circuit — skip `authenticateWorkloadToken` + `hasGrant`.
- Still **bounded to the path org**: the `access-token`/`configuration` handlers look up the target connection `where organization_id = <path org>`, so the service token can't reach another org's connections.
- Constant-time compare (`timingSafeEqual` + length guard). **Off when the env var is unset** (only workload-token + grant accepted) — zero behavior change for existing callers.

## Notes
- Reaches the handler fine for a non-member service caller: `resolveOrgFromPath` only enforces membership when a user session is present (same path the workload-token flow already uses).
- Unit test covers the compare + env gating. Couldn't run the monorepo `bun install`/`tsc`/biome locally — **please let CI validate**. No workflow-registering files touched (no DBOS source-guard rebaseline).
- Broad-by-design: one token leases across orgs. Rotate via env; keep it to the internal service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a service-scoped vault lease via `VAULT_SERVICE_TOKEN` so trusted internal services can fetch a connection’s configuration and access token for the org in the URL path without per-connection grants. Also accepts the org slug or id in the path for these vault endpoints only.

- **New Features**
  - Accepts a `VAULT_SERVICE_TOKEN` bearer to bypass workload-token + grant; still scoped to the path org (lookups filter by organizationId). Constant-time compare with a length guard; feature is off when the env is unset.
  - Resolves `:org` by slug OR id only on `/vault/connections/:org/(access-token|configuration)`, so machine callers can pass `organization.id` directly without risking cross-org resolution on other routes.

<sup>Written for commit 45ff33b87aebcb6a93871e0b9de2e378ccf4ad8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

