### PR TITLE
fix(sandbox): fetch base branch when resuming an existing branch

### DIFF
--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { computeBranchDivergence } from "../git/branch-divergence";
 import type { Config } from "../types";
-import { spawnClone } from "./clone";
+import { isSafeRefName, spawnClone } from "./clone";
 
 /**
  * Creates a bare "origin" git repo with two branches:
@@ -20,7 +20,12 @@ import { spawnClone } from "./clone";
  *
  * Returned `url` is a `file://` URL safe to use as a clone source.
  */
-function setupBareRepo(): { url: string; root: string; cleanup: () => void } {
+function setupBareRepo(): {
+  url: string;
+  root: string;
+  bare: string;
+  cleanup: () => void;
+} {
   const root = mkdtempSync(join(tmpdir(), "clonetest-"));
   const bare = join(root, "origin.git");
   const seed = join(root, "seed");
@@ -48,6 +53,7 @@ function setupBareRepo(): { url: string; root: string; cleanup: () => void } {
   return {
     url: `file://${bare}`,
     root,
+    bare,
     cleanup: () => rmSync(root, { recursive: true, force: true }),
   };
 }
@@ -56,6 +62,19 @@ function currentBranch(repoDir: string): string {
   return execSync(`git -C ${repoDir} rev-parse --abbrev-ref HEAD`)
     .toString()
     .trim();
+}
+
+/** Run a git command, returning trimmed stdout or null on non-zero exit. */
+function tryGitOut(repoDir: string, args: string): string | null {
+  try {
+    return execSync(`git -C ${repoDir} ${args}`, {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
 }
 
 function makeConfig(
@@ -71,6 +90,42 @@ function makeConfig(
     repoDir,
   } as unknown as Config;
 }
+
+describe("isSafeRefName", () => {
+  it("accepts real branch names", () => {
+    for (const name of [
+      "main",
+      "master",
+      "feature/x",
+      "release/1.0",
+      "feat-2.0_a",
+      "user/fix.bug",
+    ]) {
+      expect(isSafeRefName(name)).toBe(true);
+    }
+  });
+
+  it("rejects shell metacharacters and ref-format edge cases", () => {
+    for (const name of [
+      "x;whoami",
+      "a$(id)b",
+      "a`id`b",
+      "a|b",
+      "a&b",
+      "a>b",
+      "a b",
+      "-x",
+      "/x",
+      "x/",
+      "a..b",
+      "a//b",
+      "x.lock",
+      "",
+    ]) {
+      expect(isSafeRefName(name)).toBe(false);
+    }
+  });
+});
 
 describe("spawnClone", () => {
   it("clones the target branch directly when it exists on remote", async () => {
@@ -102,9 +157,83 @@ describe("spawnClone", () => {
       // Even though only feature/x was cloned, origin/main must be present with
       // origin/HEAD pointing at it — otherwise computeBranchDivergence can't
       // compute ahead/behind vs base and the header falsely shows "Up to date".
+      // Assert the two artifacts fetchBaseBranch produces directly, so a
+      // regression that drops the fetch or the symbolic-ref step is caught
+      // (aheadOfBase alone would survive it via the "main" default fallback).
+      expect(
+        tryGitOut(
+          repoDir,
+          "rev-parse --verify --quiet refs/remotes/origin/main",
+        ),
+      ).toBeTruthy();
+      expect(
+        tryGitOut(repoDir, "symbolic-ref --short refs/remotes/origin/HEAD"),
+      ).toBe("origin/main");
       const div = computeBranchDivergence(repoDir);
       expect(div.base).toBe("main");
+      // feature/x has a commit that main does not — the button gates on
+      // aheadOfBase > 0. (Exact counts are approximate on shallow clones and
+      // not asserted; they aren't surfaced in the UI.)
       expect(div.aheadOfBase).toBeGreaterThan(0);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("does not re-fetch the base when resuming the default branch itself", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      // Resuming `main` (the default) hits the `base === branchOnRemote` skip:
+      // the base is already the cloned branch, so no second fetch is needed.
+      const code = await spawnClone({
+        config: makeConfig(repoDir, url, "main"),
+        onChunk: () => {},
+      });
+      expect(code).toBe(0);
+      expect(currentBranch(repoDir)).toBe("main");
+      const div = computeBranchDivergence(repoDir);
+      expect(div.base).toBe("main");
+      expect(div.aheadOfBase).toBe(0);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("refuses a maliciously named default branch instead of running it", async () => {
+    const { url, root, cleanup, bare } = setupBareRepo();
+    try {
+      // Git permits `;`/`$()`/backticks in ref names; the default branch name
+      // flows into `sh -c` git commands, so an unsafe name must be rejected
+      // before interpolation rather than executed.
+      const evil = "x;whoami";
+      const mainSha = execSync(`git -C ${bare} rev-parse refs/heads/main`)
+        .toString()
+        .trim();
+      execSync(`git -C ${bare} branch '${evil}' ${mainSha}`, {
+        stdio: "ignore",
+      });
+      execSync(`git -C ${bare} symbolic-ref HEAD 'refs/heads/${evil}'`, {
+        stdio: "ignore",
+      });
+
+      const repoDir = join(root, "workspace");
+      const code = await spawnClone({
+        config: makeConfig(repoDir, url, "feature/x"),
+        onChunk: () => {},
+      });
+      // Best-effort: the clone still succeeds; it just skips the unsafe base.
+      expect(code).toBe(0);
+      // origin/HEAD must NOT have been pointed at the malicious ref.
+      expect(
+        tryGitOut(repoDir, "symbolic-ref --short refs/remotes/origin/HEAD"),
+      ).not.toBe(`origin/${evil}`);
+      expect(
+        tryGitOut(
+          repoDir,
+          `rev-parse --verify --quiet 'refs/remotes/origin/${evil}'`,
+        ),
+      ).toBeNull();
     } finally {
       cleanup();
     }

--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { computeBranchDivergence } from "../git/branch-divergence";
 import type { Config } from "../types";
 import { spawnClone } from "./clone";
 
@@ -84,6 +85,26 @@ describe("spawnClone", () => {
       expect(currentBranch(repoDir)).toBe("feature/x");
       // The clone landed on feature/x — the file unique to that branch is present.
       expect(existsSync(join(repoDir, "feature.txt"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("fetches the base branch so divergence vs base is computable (case 2)", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      const code = await spawnClone({
+        config: makeConfig(repoDir, url, "feature/x"),
+        onChunk: () => {},
+      });
+      expect(code).toBe(0);
+      // Even though only feature/x was cloned, origin/main must be present with
+      // origin/HEAD pointing at it — otherwise computeBranchDivergence can't
+      // compute ahead/behind vs base and the header falsely shows "Up to date".
+      const div = computeBranchDivergence(repoDir);
+      expect(div.base).toBe("main");
+      expect(div.aheadOfBase).toBeGreaterThan(0);
     } finally {
       cleanup();
     }

--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -96,6 +96,26 @@ async function runNetworkStep(cmd: string, deps: CloneDeps): Promise<number> {
 // through to a fork-from-default fallback.
 const LS_REMOTE_NO_MATCH = 2;
 
+/**
+ * Conservative ref-name allowlist. `base` below is derived from
+ * remote-controlled `ls-remote` output and interpolated into `sh -c` git
+ * commands; git permits shell metacharacters (`;`, `$(…)`, backticks, `|`, …)
+ * in branch names, so an untrusted remote whose HEAD points at a maliciously
+ * named default branch could inject commands. Restrict to characters that
+ * appear in real branch names and reject the ref-format edge cases.
+ */
+export function isSafeRefName(name: string): boolean {
+  return (
+    /^[A-Za-z0-9._/-]+$/.test(name) &&
+    !name.startsWith("-") &&
+    !name.startsWith("/") &&
+    !name.endsWith("/") &&
+    !name.endsWith(".lock") &&
+    !name.includes("..") &&
+    !name.includes("//")
+  );
+}
+
 /** Like runNetworkStep but also returns the (merged stdout+stderr) output. */
 async function runNetworkStepCapture(
   cmd: string,
@@ -125,6 +145,14 @@ async function runNetworkStepCapture(
  * from the moment the sandbox comes online. Best-effort: a failure here leaves
  * the working tree intact and only delays the base ref to the next fetch, so
  * we warn rather than abort the whole clone.
+ *
+ * The base is fetched at `--depth 1`, so `computeBranchDivergence`'s ahead/
+ * behind counts are only exact when a merge-base is reachable within the
+ * shallow slice; for a branch that diverged long ago the counts are
+ * approximate. That's acceptable because the only consumer that matters —
+ * the header button — reads `aheadOfBase > 0` as a boolean (the numeric
+ * count and `behindBase` are not surfaced in the UI). A later full fetch
+ * (e.g. the PR-diff path) corrects the numbers.
  */
 async function fetchBaseBranch(
   gc: string,
@@ -147,6 +175,17 @@ async function fetchBaseBranch(
   // "ref: refs/heads/main\tHEAD"
   const base = output.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/)?.[1] ?? null;
   if (!base || base === branchOnRemote) return;
+  // `base` comes from remote-controlled ls-remote output and is interpolated
+  // into `sh -c` git commands below — reject anything outside a safe ref-name
+  // charset to close the command-injection vector (git allows `;`, `$(…)`,
+  // backticks, etc. in branch names).
+  if (!isSafeRefName(base)) {
+    deps.onChunk(
+      "setup",
+      `\r\n[clone] warning: refusing unsafe base branch name ${JSON.stringify(base)}; divergence vs base unavailable until next fetch\r\n`,
+    );
+    return;
+  }
 
   const fetchCode = await runNetworkStep(
     `${gc} -C ${dir} fetch --depth 1 origin +refs/heads/${base}:refs/remotes/origin/${base}`,

--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -96,6 +96,75 @@ async function runNetworkStep(cmd: string, deps: CloneDeps): Promise<number> {
 // through to a fork-from-default fallback.
 const LS_REMOTE_NO_MATCH = 2;
 
+/** Like runNetworkStep but also returns the (merged stdout+stderr) output. */
+async function runNetworkStepCapture(
+  cmd: string,
+  deps: CloneDeps,
+): Promise<{ code: number; output: string }> {
+  let output = "";
+  const tee: CloneDeps = {
+    ...deps,
+    onChunk: (src, data) => {
+      output += data;
+      deps.onChunk(src, data);
+    },
+  };
+  const code = await runNetworkStep(cmd, tee);
+  return { code, output };
+}
+
+/**
+ * After a Case-2 clone (`--branch <branch>` for a branch that already exists on
+ * origin), the shallow single-branch clone brings down only
+ * `origin/<branch>` — `origin/<base>` is absent. `computeBranchDivergence`
+ * then can't compute ahead/behind vs base and the header falsely reports
+ * "Up to date" until a background fetch happens to populate the base ref.
+ *
+ * Fetch the remote's default branch (shallow, matching the Case-1 default
+ * clone) and point `origin/HEAD` at it so divergence-vs-base is computable
+ * from the moment the sandbox comes online. Best-effort: a failure here leaves
+ * the working tree intact and only delays the base ref to the next fetch, so
+ * we warn rather than abort the whole clone.
+ */
+async function fetchBaseBranch(
+  gc: string,
+  dir: string,
+  cloneUrl: string,
+  branchOnRemote: string,
+  deps: CloneDeps,
+): Promise<void> {
+  const { code, output } = await runNetworkStepCapture(
+    `${gc} ls-remote --symref ${cloneUrl} HEAD`,
+    deps,
+  );
+  if (code !== 0) {
+    deps.onChunk(
+      "setup",
+      `\r\n[clone] warning: could not resolve remote default branch; divergence vs base unavailable until next fetch\r\n`,
+    );
+    return;
+  }
+  // "ref: refs/heads/main\tHEAD"
+  const base = output.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/)?.[1] ?? null;
+  if (!base || base === branchOnRemote) return;
+
+  const fetchCode = await runNetworkStep(
+    `${gc} -C ${dir} fetch --depth 1 origin +refs/heads/${base}:refs/remotes/origin/${base}`,
+    deps,
+  );
+  if (fetchCode !== 0) {
+    deps.onChunk(
+      "setup",
+      `\r\n[clone] warning: failed to fetch base branch '${base}'; divergence vs base unavailable until next fetch\r\n`,
+    );
+    return;
+  }
+  await runStep(
+    `${gc} -C ${dir} symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/${base}`,
+    deps,
+  );
+}
+
 /** Resolves to exit code (0 on success). Emits chunks via `onChunk`. */
 export async function spawnClone(deps: CloneDeps): Promise<number> {
   const { config } = deps;
@@ -186,6 +255,9 @@ export async function spawnClone(deps: CloneDeps): Promise<number> {
         deps,
       );
     }
+    if (branchOnRemote) {
+      await fetchBaseBranch(gc, dir, cloneUrl, branchOnRemote, deps);
+    }
     return 0;
   }
 
@@ -196,6 +268,9 @@ export async function spawnClone(deps: CloneDeps): Promise<number> {
   if (cloneCode !== 0) return cloneCode;
   if (branchToForkLocally) {
     return runStep(`${gc} -C ${dir} checkout -B ${branchToForkLocally}`, deps);
+  }
+  if (branchOnRemote) {
+    await fetchBaseBranch(gc, dir, cloneUrl, branchOnRemote, deps);
   }
   return 0;
 }


### PR DESCRIPTION
## Summary

Fixes the header action button falsely showing **"Up to date"** instead of **"Submit for review"** after saving changes on a resumed branch.

**Root cause:** when the sandbox resumes an existing remote branch, it clones with `git clone --depth 1 --branch <branch>` — a shallow, single-branch clone that brings down only `origin/<branch>`. `origin/<base>` (e.g. `origin/main`) is never fetched. `computeBranchDivergence` (`branch-divergence.ts:51`) only computes ahead/behind `if refExists("origin/<base>")`, so it returns `aheadOfBase: 0`, and `selectHeaderButton` falls through to "Up to date". The state only self-corrected once an unrelated background fetch happened to populate the base ref.

This is the "resume existing branch" path (Case 2). New branches (Case 1) clone the default branch and fork locally, so `origin/main` is already present — no bug there.

## Change

- New `fetchBaseBranch()` in `clone.ts`: after a Case-2 clone, resolve the remote default via `git ls-remote --symref <url> HEAD`, shallow-fetch it into `refs/remotes/origin/<base>`, and point `origin/HEAD` at it. Wired into both the `git clone --branch` path and the `init + fetch` (non-empty-dir) fallback.
- Best-effort: on failure it warns and defers the base ref to the next fetch — never aborts the clone or touches the working tree.

## Notes / trade-off

The base fetch is `--depth 1` to match the existing Case-1 default-branch clone. This makes `aheadOfBase` detected correctly (`> 0`), which is all the "Submit for review" gate needs. `behindBase` may be approximate until a full-history fetch runs — same shallow trade-off Case 1 already has, and it doesn't affect the button.

Per the request, no "base unknown" guard was added to `panel-state`/`branch-divergence`.

## Testing

- New test in `clone.test.ts`: cloning a non-default existing branch (`feature/x`) leaves `origin/main` present with `origin/HEAD` set, and `computeBranchDivergence` returns `base: "main"` with `aheadOfBase > 0`.
- `bun test packages/sandbox/daemon/setup/clone.test.ts` → 6 pass
- `bun run fmt` + `bun run check` (packages/sandbox) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetches the base branch right after cloning an existing remote branch and validates the remote default branch name to prevent command injection. This ensures divergence vs base is computed so “Submit for review” appears when ahead.

- **Bug Fixes**
  - Implemented fetchBaseBranch in packages/sandbox/daemon/setup/clone.ts to resolve the remote default via git ls-remote --symref HEAD, shallow-fetch origin/<base>, and set origin/HEAD.
  - Invoked after Case-2 clones (git clone --branch <branch>) and the init+fetch fallback; validates the resolved base against a strict allowlist before shell use and, on failure or unsafe names, logs a warning and continues without modifying the working tree.

<sup>Written for commit 7a4f903001418f53f7c8e7f6ca988cfee9e89079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

