### PR TITLE
feat(commerce-onboarding): configure companion connections

### DIFF
--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -49,6 +49,16 @@ export const KEYS = {
   // candidate connections satisfying a binding, and the registry batch).
   commerceDiscoveryCompanionSchema: (orgId: string, connectionId: string) =>
     ["commerce-discovery", "companion-schema", orgId, connectionId] as const,
+  commerceDiscoveryCompanionConnectionSchema: (
+    orgId: string,
+    connectionId: string,
+  ) =>
+    [
+      "commerce-discovery",
+      "companion-connection-schema",
+      orgId,
+      connectionId,
+    ] as const,
   commerceDiscoveryCompanionConnections: (orgId: string) =>
     ["commerce-discovery", "companion-connections", orgId] as const,
   commerceDiscoveryCompanionRegistry: (orgId: string, key: string) =>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -1,7 +1,20 @@
 import { IntegrationIcon } from "@/web/components/integration-icon";
+import { KEYS } from "@/web/lib/query-keys";
 import { Button } from "@deco/ui/components/button.tsx";
-import { CheckCircle, Loading01 } from "@untitledui/icons";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { useMCPClient } from "@decocms/mesh-sdk";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import RjsfForm from "@rjsf/shadcn";
+import type { FieldTemplateProps } from "@rjsf/utils";
+import validator from "@rjsf/validator-ajv8";
+import { CheckCircle, Edit03, Loading01 } from "@untitledui/icons";
+import { useState } from "react";
 import type { CompanionCardModel } from "./companions-core.ts";
+import {
+  getConfigurationSummaryEntries,
+  hasConfigurationValues,
+  unwrapToolResult,
+} from "./companions-core.ts";
 
 /**
  * Loading placeholder that mirrors {@link CompanionCard}'s box model (same
@@ -42,12 +55,24 @@ export function CompanionCard({
   connecting,
   disabled,
   onConnect,
+  org,
+  selfClient,
 }: {
   card: CompanionCardModel;
   connecting: boolean;
   disabled: boolean;
   onConnect: () => void;
+  org: { id: string; slug: string };
+  selfClient: Client;
 }) {
+  const linkedConnectionId = card.linkedConnectionId;
+  const savedConfigEntries = getConfigurationSummaryEntries(
+    card.configurationState,
+  );
+  const [isEditingConfiguration, setIsEditingConfiguration] = useState(
+    card.satisfied && !hasConfigurationValues(card.configurationState),
+  );
+
   return (
     <div className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-4">
       <div className="flex items-center gap-2">
@@ -93,6 +118,252 @@ export function CompanionCard({
             Using your existing {card.title}
           </p>
         )}
+      </div>
+      {card.satisfied && linkedConnectionId && (
+        <CompanionConfiguration
+          card={card}
+          org={org}
+          selfClient={selfClient}
+          connectionId={linkedConnectionId}
+          savedConfigEntries={savedConfigEntries}
+          isEditing={isEditingConfiguration}
+          onEdit={() => setIsEditingConfiguration(true)}
+          onCancel={() => setIsEditingConfiguration(false)}
+          onSaved={() => setIsEditingConfiguration(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+interface CompanionConfigurationProps {
+  card: CompanionCardModel;
+  org: { id: string; slug: string };
+  selfClient: Client;
+  connectionId: string;
+  savedConfigEntries: Array<{ key: string; label: string; value: string }>;
+  isEditing: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSaved: () => void;
+}
+
+function hasSchemaProperties(stateSchema: Record<string, unknown> | undefined) {
+  const properties = stateSchema?.properties;
+  return (
+    !!properties &&
+    typeof properties === "object" &&
+    Object.keys(properties).length > 0
+  );
+}
+
+function isSensitiveConfigKey(key: string) {
+  return /(token|secret|password|appKey|key)$/i.test(key);
+}
+
+function maskConfigValue(key: string, value: string) {
+  return isSensitiveConfigKey(key) ? "••••••••" : value;
+}
+
+function CompactFieldTemplate({
+  id,
+  label,
+  description,
+  children,
+}: FieldTemplateProps) {
+  if (id.includes("__type") || id.includes("__binding")) return null;
+
+  return (
+    <div className="grid gap-1.5">
+      {label && (
+        <label className="text-sm font-medium text-foreground" htmlFor={id}>
+          {label}
+        </label>
+      )}
+      {children}
+      {description && (
+        <div className="text-xs leading-4 text-muted-foreground">
+          {description}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CompanionConfiguration({
+  card,
+  org,
+  selfClient,
+  connectionId,
+  savedConfigEntries,
+  isEditing,
+  onEdit,
+  onCancel,
+  onSaved,
+}: CompanionConfigurationProps) {
+  const queryClient = useQueryClient();
+  const companionClient = useMCPClient({
+    connectionId,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const [formState, setFormState] = useState<Record<string, unknown>>(
+    card.configurationState ?? {},
+  );
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const schemaQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryCompanionConnectionSchema(
+      org.id,
+      connectionId,
+    ),
+    queryFn: async () => {
+      const result = await companionClient.callTool({
+        name: "MCP_CONFIGURATION",
+        arguments: {},
+      });
+      return unwrapToolResult<{ stateSchema?: Record<string, unknown> }>(
+        result,
+      );
+    },
+    retry: false,
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async (state: Record<string, unknown>) => {
+      const result = await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_UPDATE",
+        arguments: {
+          id: connectionId,
+          data: { configuration_state: state },
+        },
+      });
+      return unwrapToolResult<{ item: unknown }>(result);
+    },
+    onSuccess: async () => {
+      setValidationError(null);
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryCompanionConnections(org.id),
+      });
+      onSaved();
+    },
+  });
+
+  const stateSchema = schemaQuery.data?.stateSchema;
+  const shouldRenderConfiguration =
+    hasSchemaProperties(stateSchema) &&
+    (isEditing || savedConfigEntries.length > 0);
+
+  if (schemaQuery.isPending) {
+    return (
+      <div className="flex items-center gap-2 border-t border-border pt-3 text-sm text-muted-foreground">
+        <Loading01 size={14} className="animate-spin" />
+        Loading configuration...
+      </div>
+    );
+  }
+
+  if (schemaQuery.error || !shouldRenderConfiguration || !stateSchema) {
+    return null;
+  }
+
+  if (!isEditing && savedConfigEntries.length > 0) {
+    return (
+      <div className="grid gap-3 border-t border-border pt-3">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-medium text-foreground">Configuration</p>
+          <Button type="button" variant="ghost" size="sm" onClick={onEdit}>
+            <Edit03 size={14} />
+            Edit
+          </Button>
+        </div>
+        <dl className="grid gap-2">
+          {savedConfigEntries.map((entry) => (
+            <div
+              key={entry.key}
+              className="flex items-center justify-between gap-3 text-sm"
+            >
+              <dt className="text-muted-foreground">{entry.label}</dt>
+              <dd className="truncate text-foreground">
+                {maskConfigValue(entry.key, entry.value)}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    );
+  }
+
+  const handleSave = () => {
+    if (!hasConfigurationValues(formState)) {
+      setValidationError("Enter at least one configuration value.");
+      return;
+    }
+    const result = validator.validateFormData(formState, stateSchema);
+    if (result.errors.length > 0) {
+      setValidationError(result.errors[0]?.stack ?? "Invalid configuration.");
+      return;
+    }
+    setValidationError(null);
+    saveMutation.mutate(formState);
+  };
+
+  return (
+    <div className="grid gap-3 border-t border-border pt-3">
+      <p className="text-sm font-medium text-foreground">
+        Configure {card.title}
+      </p>
+      <RjsfForm
+        key={`${connectionId}:configuration`}
+        schema={stateSchema}
+        validator={validator}
+        formData={formState}
+        onChange={(data) => setFormState(data.formData ?? {})}
+        liveValidate={false}
+        showErrorList={false}
+        templates={{ FieldTemplate: CompactFieldTemplate }}
+      >
+        <></>
+      </RjsfForm>
+      {(validationError || saveMutation.error) && (
+        <p role="alert" className="text-sm text-destructive">
+          {validationError ??
+            (saveMutation.error instanceof Error
+              ? saveMutation.error.message
+              : "Could not save configuration.")}
+        </p>
+      )}
+      <div className="flex justify-end gap-2">
+        {savedConfigEntries.length > 0 && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setFormState(card.configurationState ?? {});
+              setValidationError(null);
+              onCancel();
+            }}
+            disabled={saveMutation.isPending}
+          >
+            Cancel
+          </Button>
+        )}
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleSave}
+          disabled={saveMutation.isPending}
+        >
+          {saveMutation.isPending ? (
+            <>
+              <Loading01 size={14} className="animate-spin" />
+              Saving
+            </>
+          ) : (
+            "Save"
+          )}
+        </Button>
       </div>
     </div>
   );

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -121,6 +121,8 @@ export function CompanionMcpsSection({
                 card={card}
                 connecting={connectingFieldKey === card.fieldKey}
                 disabled={busy && connectingFieldKey !== card.fieldKey}
+                org={org}
+                selfClient={selfClient}
                 onConnect={() => void connect(card)}
               />
             ))}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import {
   buildCompanionCards,
   buildRegistryWhere,
+  getConfigurationSummaryEntries,
+  hasConfigurationValues,
   mergeBindingValue,
   parseBindingRequirements,
   resolveCandidate,
@@ -70,6 +72,36 @@ describe("mergeBindingValue", () => {
     expect(mergeBindingValue(null, "VTEX_STORE", "vtex", "c1")).toEqual({
       VTEX_STORE: { __type: "vtex", value: "c1" },
     });
+  });
+});
+
+describe("hasConfigurationValues", () => {
+  it("treats null, empty objects, and empty scalar values as not configured", () => {
+    expect(hasConfigurationValues(null)).toBe(false);
+    expect(hasConfigurationValues({})).toBe(false);
+    expect(hasConfigurationValues({ propertyId: null })).toBe(false);
+    expect(hasConfigurationValues({ accountName: "" })).toBe(false);
+    expect(hasConfigurationValues({ accountName: "   " })).toBe(false);
+  });
+
+  it("detects nested saved values", () => {
+    expect(hasConfigurationValues({ accountName: "electrolux" })).toBe(true);
+    expect(hasConfigurationValues({ nested: { value: "123" } })).toBe(true);
+  });
+});
+
+describe("getConfigurationSummaryEntries", () => {
+  it("returns displayable non-empty config entries and hides internal fields", () => {
+    expect(
+      getConfigurationSummaryEntries({
+        __type: "vtex",
+        accountName: "electrolux",
+        propertyId: null,
+        currency: "",
+      }),
+    ).toEqual([
+      { key: "accountName", label: "Account Name", value: "electrolux" },
+    ]);
   });
 });
 
@@ -195,12 +227,23 @@ describe("buildCompanionCards", () => {
       requirements: [{ fieldKey: "VTEX_STORE", bindingType: "vtex" }],
       itemsById: { "deco/vtex": item("deco/vtex", "VTEX") },
       itemsByName: {},
-      connections: [{ id: "c_vtex", app_name: "vtex", status: "active" }],
+      connections: [
+        {
+          id: "c_vtex",
+          app_name: "vtex",
+          status: "active",
+          configuration_state: { accountName: "electrolux" },
+        },
+      ],
       configurationState: { VTEX_STORE: { __type: "vtex", value: "c_vtex" } },
       curated,
     });
     expect(cards[0]!.satisfied).toBe(true);
     expect(cards[0]!.candidateConnectionId).toBeNull();
+    expect(cards[0]!.linkedConnectionId).toBe("c_vtex");
+    expect(cards[0]!.configurationState).toEqual({
+      accountName: "electrolux",
+    });
   });
   it("treats configuration_state links to missing org connections as connectable", () => {
     const cards = buildCompanionCards({

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -12,6 +12,7 @@ export interface CandidateConnection {
   app_id?: string | null;
   connection_token?: string | null;
   oauth_config?: unknown | null;
+  configuration_state?: Record<string, unknown> | null;
   status?: string | null;
   updated_at?: string | null;
 }
@@ -48,6 +49,8 @@ export interface CompanionCardModel {
   bullets: string[];
   satisfied: boolean;
   candidateConnectionId: string | null;
+  linkedConnectionId: string | null;
+  configurationState: Record<string, unknown> | null;
 }
 
 type ComparisonWhere = { field: string[]; operator: "in"; value: string[] };
@@ -123,6 +126,54 @@ export function mergeBindingValue(
   };
 }
 
+function isMeaningfulConfigValue(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number" || typeof value === "boolean") return true;
+  if (Array.isArray(value)) return value.some(isMeaningfulConfigValue);
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(
+      ([key, entryValue]) =>
+        !key.startsWith("__") && isMeaningfulConfigValue(entryValue),
+    );
+  }
+  return false;
+}
+
+export function hasConfigurationValues(
+  state: Record<string, unknown> | null | undefined,
+): boolean {
+  return isMeaningfulConfigValue(state);
+}
+
+function formatConfigurationKey(key: string): string {
+  return key
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function stringifyConfigurationValue(value: unknown): string | null {
+  if (!isMeaningfulConfigValue(value)) return null;
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+export function getConfigurationSummaryEntries(
+  state: Record<string, unknown> | null | undefined,
+): Array<{ key: string; label: string; value: string }> {
+  if (!state) return [];
+  return Object.entries(state).flatMap(([key, value]) => {
+    if (key.startsWith("__")) return [];
+    const stringValue = stringifyConfigurationValue(value);
+    if (!stringValue) return [];
+    return [{ key, label: formatConfigurationKey(key), value: stringValue }];
+  });
+}
+
 /** Pick an existing org connection satisfying a binding by app identity:
  * app_name === bindingType OR app_id === registryAppId. Prefer active, then most recent. */
 export function resolveCandidate(
@@ -176,7 +227,7 @@ export function buildCompanionCards(args: {
   curated: Record<string, CompanionCopy>;
 }): CompanionCardModel[] {
   const cards: CompanionCardModel[] = [];
-  const connectionsById = new Set(args.connections.map((c) => c.id));
+  const connectionsById = new Map(args.connections.map((c) => [c.id, c]));
   for (const req of args.requirements) {
     const curatedEntry = args.curated[req.bindingType];
     const item = curatedEntry
@@ -186,11 +237,13 @@ export function buildCompanionCards(args: {
     const linked = (
       args.configurationState?.[req.fieldKey] as { value?: string } | undefined
     )?.value;
-    const linkedExists = !!linked && connectionsById.has(linked);
-    const linkedReady = linkedExists
-      ? args.connectionReadiness?.[linked] !== false
+    const linkedConnection = linked ? connectionsById.get(linked) : undefined;
+    const linkedConnectionId: string | null =
+      linked && linkedConnection ? linked : null;
+    const linkedReady = linkedConnectionId
+      ? args.connectionReadiness?.[linkedConnectionId] !== false
       : false;
-    const satisfied = linkedExists && linkedReady;
+    const satisfied = !!linkedConnectionId && linkedReady;
     cards.push({
       fieldKey: req.fieldKey,
       bindingType: req.bindingType,
@@ -206,13 +259,15 @@ export function buildCompanionCards(args: {
       satisfied,
       candidateConnectionId: satisfied
         ? null
-        : linkedExists
-          ? linked
+        : linkedConnectionId
+          ? linkedConnectionId
           : resolveCandidate(
               args.connections,
               req.bindingType,
               curatedEntry?.registryAppId,
             ),
+      linkedConnectionId,
+      configurationState: linkedConnection?.configuration_state ?? null,
     });
   }
   return cards;


### PR DESCRIPTION
## Summary
- Add companion MCP configuration editing for linked commerce onboarding connections.
- Surface saved companion configuration state in cards, masking sensitive-looking values.
- Add core helpers and tests for detecting and summarizing saved configuration state.

## Test Plan
- [x] bun run fmt
- [x] bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
- [x] bun run check
- [x] bun run lint

## Notes
- `bun test` was also attempted, but resilience scenarios expect a running Studio service and timed out at `wait-for-studio-healthy`; the run was stopped after that environment setup failure.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add configuration editing for linked companion connections in commerce onboarding, and show a masked summary of saved values directly in the card. This lets users fetch schema from MCP, edit, validate, and save config without leaving the flow.

- **New Features**
  - Added configuration editor in `CompanionCard` for satisfied links; schema fetched via MCP (`MCP_CONFIGURATION`) and rendered with `@rjsf/shadcn` + `@rjsf/validator-ajv8`.
  - Display a compact summary of saved config (non-empty, non-internal keys) with sensitive values masked; includes Edit/Save/Cancel and basic validation/errors.
  - Save via `COLLECTION_CONNECTIONS_UPDATE` and invalidate `KEYS.commerceDiscoveryCompanionConnections`; added `KEYS.commerceDiscoveryCompanionConnectionSchema` for schema queries.
  - Extended card model with `linkedConnectionId` and `configurationState`; added `hasConfigurationValues` and `getConfigurationSummaryEntries` helpers with tests.

<sup>Written for commit e549132b4d53d9e5e8cf4f83fc0fd25c10ac20f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

