### PR TITLE
fix(content): address cubic review on blog category cascade

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
@@ -382,6 +382,20 @@ describe("renameCategoryOnPost", () => {
     expect(next.categories).toEqual([{ name: "Fresh", slug: "fresh" }]);
   });
 
+  test("refreshes the denormalized name when the new slug precedes the old", () => {
+    const payload = {
+      categories: [
+        { name: "Stale", slug: "fresh" },
+        { name: "Old", slug: "old" },
+      ],
+    };
+    const next = renameCategoryOnPost(payload, "old", {
+      name: "Fresh",
+      slug: "fresh",
+    });
+    expect(next.categories).toEqual([{ name: "Fresh", slug: "fresh" }]);
+  });
+
   test("is a no-op (same reference) when the old slug is absent", () => {
     const payload = { categories: [{ name: "News", slug: "news" }] };
     expect(

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -304,11 +304,16 @@ export function renameCategoryOnPost(
   if (!categories.some((c) => categorySlugOf(c) === oldSlug)) {
     return payload;
   }
-  const mapped = categories.map((c) =>
-    categorySlugOf(c) === oldSlug
+  // Rewrite BOTH the old slug and any pre-existing new-slug entry to the fresh
+  // `{ name, slug }`. Refreshing the pre-existing one matters when it sits
+  // before the old slug: the dedupe below keeps the first occurrence, so
+  // without this the stale denormalized name would win over the rename.
+  const mapped = categories.map((c) => {
+    const slug = categorySlugOf(c);
+    return slug === oldSlug || slug === category.slug
       ? { name: category.name, slug: category.slug }
-      : c,
-  );
+      : c;
+  });
   // A post that listed both the old and the new slug would now name the new
   // slug twice — keep the first occurrence. Only dedupe real slugs so we never
   // silently drop malformed (slug-less) entries.

--- a/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
@@ -64,7 +64,7 @@ export function CategoryEditor({
   const save = useSaveBlogBlock({ orgSlug, virtualMcpId, branch });
   const initial = getBlogPayload(block, "categories");
 
-  const [category, setCategory] = useAutosave(initial, (next) => {
+  const [category, setCategory, syncCategory] = useAutosave(initial, (next) => {
     save.mutate({
       blockKey,
       data: buildBlogBlock(blockKey, "categories", next),
@@ -118,8 +118,20 @@ export function CategoryEditor({
         });
         changed += 1;
       }
-      // Sync the draft + persist the category block with its new slug.
-      commitSlug(newSlug);
+      // Persist the category block with its new slug and AWAIT it before
+      // reporting success — routing this through the debounced autosave would
+      // let the toast fire (and the user navigate away) before the write is
+      // even dispatched, leaving posts renamed but the category slug possibly
+      // never persisted. `nextCategory` carries the full current draft, so the
+      // write captures any name/description edits made before the rename.
+      const nextCategory = { ...category, slug: newSlug };
+      await save.mutateAsync({
+        blockKey,
+        data: buildBlogBlock(blockKey, "categories", nextCategory),
+      });
+      // Draft-only catch-up (no extra write): keeps future name/description
+      // edits on the new slug instead of spreading the stale one back in.
+      syncCategory(nextCategory);
       toast.success(
         changed > 0
           ? `Renamed slug and updated ${changed} ${changed === 1 ? "post" : "posts"}`

--- a/apps/mesh/src/web/components/sandbox/content/blog/use-autosave.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-autosave.ts
@@ -16,7 +16,7 @@ export function useAutosave<T>(
   initial: T,
   save: (value: T) => void,
   delay = AUTOSAVE_DELAY,
-): readonly [T, (next: T) => void] {
+): readonly [T, (next: T) => void, (next: T) => void] {
   const [draft, setDraft] = useState<T>(initial);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -26,5 +26,16 @@ export function useAutosave<T>(
     timer.current = setTimeout(() => save(next), delay);
   };
 
-  return [draft, update] as const;
+  // Update the draft WITHOUT scheduling a save, cancelling any pending one.
+  // For callers that already persisted the value through another path (e.g.
+  // an awaited `mutateAsync`) and only need the local draft to catch up — a
+  // plain `update` here would fire a redundant write, and a stale pending
+  // timer could clobber the just-persisted value.
+  const sync = (next: T) => {
+    setDraft(next);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = null;
+  };
+
+  return [draft, update, sync] as const;
 }

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -910,7 +910,14 @@ function ContentBrowserReady({
   };
 
   // ------------------ Render ------------------
-  const isDeleting = deleteBlock.isPending || deleteBlogBlock.isPending;
+  // `saveBlogBlock.isPending` covers the category-delete cascade (posts are
+  // rewritten via saveBlogBlock BEFORE the category block is unlinked), so the
+  // confirm dialog stays locked for the whole operation instead of only its
+  // final unlink — otherwise it could be re-clicked or dismissed mid-cascade.
+  const isDeleting =
+    deleteBlock.isPending ||
+    deleteBlogBlock.isPending ||
+    saveBlogBlock.isPending;
   const deleteNoun =
     deleteTarget?.kind === "blog"
       ? BLOG_SINGULAR[deleteTarget.blogKind]


### PR DESCRIPTION
Follow-up to #4247 (already merged) addressing three cubic review points on the blog category slug cascade.

## 1. Rename toast fired before the category slug was persisted

`runRename` awaited each post rewrite, but committed the category's own new slug through the **debounced, fire-and-forget** autosave (`700ms`). The success toast fired before that write was even dispatched — so if the user navigated away within the window (or the autosave failed silently, since its error handler only rolls back the optimistic cache), posts ended up renamed while the category slug was potentially never persisted: an inconsistent state the user was told was done.

**Fix:** persist the category block with `await save.mutateAsync(...)` before the toast. To sync the local draft afterward without firing a *redundant* write (or leaving a stale autosave timer that could clobber the just-persisted value), `useAutosave` now returns a third `sync(next)` setter that updates the draft and cancels any pending save. `nextCategory` carries the full current draft, so name/description edits made before the rename are captured in the same write.

## 2. Delete dialog clickable during the cascade

`isDeleting` only tracked `deleteBlock`/`deleteBlogBlock`. The category-delete cascade rewrites posts via `saveBlogBlock.mutateAsync` **before** the block unlink starts, so `isDeleting` stayed `false` throughout it — the confirm dialog could be re-clicked or dismissed mid-cascade (duplicate runs / closing while in progress).

**Fix:** include `saveBlogBlock.isPending` in `isDeleting`, locking the dialog for the whole operation.

## 3. Stale denormalized name on rename dedupe

When a post already carried the new slug **before** the old slug, `renameCategoryOnPost` rewrote only the old-slug entry, then the duplicate-collapse kept the *first* occurrence — the pre-existing entry with its (possibly stale) name — and dropped the freshly-named rewrite. Net result: old slug removed, but a stale category name left on the new slug.

**Fix:** rewrite both the old-slug and any pre-existing new-slug entry to the fresh `{ name, slug }` before deduping, so whichever position wins carries the current name. Added a regression test.

## Testing
- `bun test blog-data.test.ts` — 34 pass (1 new regression case for #3).
- `tsc --noEmit` clean; `bun run fmt:check` clean; `bun run lint` 0 errors on changed files.
- The `sync` addition to `useAutosave` is additive (third tuple element) — existing `[draft, update]` destructures are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three issues in the blog category slug cascade to ensure consistent saves and safer deletes. Improves rename flow, delete dialog locking, and category name consistency on posts.

- **Bug Fixes**
  - Renaming a category now awaits persisting the category block via `mutateAsync` before the success toast; adds `sync` to `useAutosave` to update the draft without a redundant autosave.
  - Delete confirmation stays locked through the entire cascade by including `saveBlogBlock.isPending` in `isDeleting`.
  - `renameCategoryOnPost` rewrites both old- and new-slug entries before deduping to refresh the denormalized name; adds a regression test.

<sup>Written for commit 5b832127dbc2b220356b6b506db7f3b94dc85bbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

