### PR TITLE
fix(commerce-onboarding): centralize loading states

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -31,13 +31,17 @@ import { ArrowRight } from "@untitledui/icons";
 import { createContext, Suspense, useContext, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { CompanionMcpsSection } from "./commerce-onboarding/companion-mcps-section.tsx";
-import { LoadingIndicator } from "./commerce-onboarding/loading-indicator.tsx";
 import {
   buildScheduleMeetingUrl,
   ScheduleMeetingBanner,
   ScheduleMeetingVisual,
 } from "./commerce-onboarding/schedule-meeting.tsx";
 import { SiteBadge } from "./commerce-onboarding/site-badge.tsx";
+import {
+  CommerceOnboardingButtonLoading,
+  CommerceOnboardingLoading,
+  CommerceOnboardingLoadingIndicator,
+} from "./commerce-onboarding/loading-state.tsx";
 
 interface CommerceOrganization {
   id: string;
@@ -127,11 +131,7 @@ function CommerceOnboardingScreens({
   const siteHost = useCommerceSiteHost();
 
   if (sessionLoading) {
-    return (
-      <AuthSplitLayout>
-        <LoadingState label="Preparing commerce onboarding..." />
-      </AuthSplitLayout>
-    );
+    return <CommerceOnboardingLoading variant="route" />;
   }
 
   if (!session) {
@@ -210,11 +210,7 @@ function CommerceOnboardingContent({
   });
 
   if (organizationsQuery.isPending) {
-    return (
-      <AuthSplitLayout>
-        <LoadingState label="Preparing commerce onboarding..." />
-      </AuthSplitLayout>
-    );
+    return <CommerceOnboardingLoading variant="route" />;
   }
 
   if (organizationsQuery.error) {
@@ -381,7 +377,7 @@ function EnsureOrganizationRecovery({
   return (
     <AuthSplitLayout>
       <div ref={triggerRecovery}>
-        <LoadingState label="Preparing your commerce workspace..." />
+        <CommerceOnboardingLoadingIndicator variant="workspace" />
       </div>
     </AuthSplitLayout>
   );
@@ -423,14 +419,6 @@ function CommerceHeader({
           )}
         </div>
       )}
-    </div>
-  );
-}
-
-function LoadingState({ label }: { label: string }) {
-  return (
-    <div className="py-4" role="status" aria-live="polite">
-      <LoadingIndicator label={label} className="text-muted-foreground" />
     </div>
   );
 }
@@ -501,13 +489,7 @@ function CommerceSetup({
             </AuthSplitLayout>
           )}
         >
-          <Suspense
-            fallback={
-              <AuthSplitLayout>
-                <LoadingState label="Connecting workspace..." />
-              </AuthSplitLayout>
-            }
-          >
+          <Suspense fallback={<CommerceOnboardingLoading variant="connect" />}>
             <CommerceSetupContent
               key={`${org.id}:${initialSiteUrl ?? ""}`}
               org={org}
@@ -715,7 +697,7 @@ function CommerceSetupContent({
               />
             </>
           ) : (
-            <LoadingState label="Setting up Commerce Discovery..." />
+            <CommerceOnboardingLoadingIndicator variant="setup" />
           )}
         </div>
       </AuthSplitLayout>
@@ -779,7 +761,7 @@ function SiteUrlForm({
         disabled={isSubmitting}
       >
         {isSubmitting ? (
-          <LoadingIndicator label="Setting up" />
+          <CommerceOnboardingButtonLoading />
         ) : (
           <>
             Continue

--- a/apps/mesh/src/web/routes/commerce-onboarding/loading-state.test.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/loading-state.test.tsx
@@ -1,0 +1,37 @@
+import { setupComponentTest } from "../../../test/setup";
+setupComponentTest();
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, test } from "bun:test";
+import {
+  CommerceOnboardingLoading,
+  getCommerceOnboardingLoadingLabel,
+} from "./loading-state";
+
+describe("commerce onboarding loading state", () => {
+  test("centralizes copy for every loading variant", () => {
+    expect(getCommerceOnboardingLoadingLabel("route")).toBe(
+      "Preparing commerce onboarding...",
+    );
+    expect(getCommerceOnboardingLoadingLabel("workspace")).toBe(
+      "Preparing your commerce workspace...",
+    );
+    expect(getCommerceOnboardingLoadingLabel("connect")).toBe(
+      "Connecting workspace...",
+    );
+    expect(getCommerceOnboardingLoadingLabel("setup")).toBe(
+      "Setting up Commerce Discovery...",
+    );
+    expect(getCommerceOnboardingLoadingLabel("button")).toBe("Setting up");
+  });
+
+  test("renders the full-page loading shell", () => {
+    const { getByRole, getByText } = render(
+      <CommerceOnboardingLoading variant="connect" />,
+    );
+
+    expect(getByRole("status")).toBeInTheDocument();
+    expect(getByText("Connecting workspace...")).toBeInTheDocument();
+  });
+});

--- a/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
@@ -1,0 +1,59 @@
+import { AuthSplitLayout } from "@/web/components/auth-split-layout";
+import { LoadingIndicator } from "./loading-indicator.tsx";
+
+export type CommerceOnboardingLoadingVariant =
+  | "route"
+  | "workspace"
+  | "connect"
+  | "setup"
+  | "button";
+
+const COMMERCE_ONBOARDING_LOADING_LABELS: Record<
+  CommerceOnboardingLoadingVariant,
+  string
+> = {
+  route: "Preparing commerce onboarding...",
+  workspace: "Preparing your commerce workspace...",
+  connect: "Connecting workspace...",
+  setup: "Setting up Commerce Discovery...",
+  button: "Setting up",
+};
+
+export function getCommerceOnboardingLoadingLabel(
+  variant: CommerceOnboardingLoadingVariant,
+): string {
+  return COMMERCE_ONBOARDING_LOADING_LABELS[variant];
+}
+
+export function CommerceOnboardingLoading({
+  variant,
+}: {
+  variant: CommerceOnboardingLoadingVariant;
+}) {
+  return (
+    <AuthSplitLayout>
+      <CommerceOnboardingLoadingIndicator variant={variant} />
+    </AuthSplitLayout>
+  );
+}
+
+export function CommerceOnboardingLoadingIndicator({
+  variant,
+}: {
+  variant: CommerceOnboardingLoadingVariant;
+}) {
+  return (
+    <div className="py-4" role="status" aria-live="polite">
+      <LoadingIndicator
+        label={getCommerceOnboardingLoadingLabel(variant)}
+        className="text-muted-foreground"
+      />
+    </div>
+  );
+}
+
+export function CommerceOnboardingButtonLoading() {
+  return (
+    <LoadingIndicator label={getCommerceOnboardingLoadingLabel("button")} />
+  );
+}


### PR DESCRIPTION
## Summary
- Add a shared commerce onboarding loading-state module with named variants for route, workspace, connect, setup, and button loading.
- Replace scattered loading labels/rendering in `/commerce-onboarding` with the shared components.
- Add focused component coverage for the centralized loading copy and full-page shell.

## Test Plan
- [x] bun test apps/mesh/src/web/routes/commerce-onboarding/loading-state.test.tsx
- [x] bun run --cwd=apps/mesh check
- [x] bunx oxlint apps/mesh/src/web/routes/commerce-onboarding.tsx apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx apps/mesh/src/web/routes/commerce-onboarding/loading-state.test.tsx
- [x] git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes commerce onboarding loading states in a shared module with simple, named variants. This removes duplicate UI, aligns copy, and simplifies Suspense fallbacks.

- **Refactors**
  - Added `loading-state.tsx` with variants: route, workspace, connect, setup, button.
  - Replaced inline loading UI in `apps/mesh/src/web/routes/commerce-onboarding.tsx` with `CommerceOnboardingLoading`, `CommerceOnboardingLoadingIndicator`, and `CommerceOnboardingButtonLoading`.
  - Centralized copy via `getCommerceOnboardingLoadingLabel`.
  - Added unit tests for labels and the full-page loading shell.

<sup>Written for commit f1cfa80a3abf35a02a54897241082526c558e7e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

