### PR TITLE
fix(commerce-onboarding): isolate companion section suspense

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -30,7 +30,10 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowRight } from "@untitledui/icons";
 import { createContext, Suspense, useContext, useRef, useState } from "react";
 import type { FormEvent, ReactNode } from "react";
-import { CompanionMcpsSection } from "./commerce-onboarding/companion-mcps-section.tsx";
+import {
+  CompanionMcpsSection,
+  CompanionMcpsSectionSkeleton,
+} from "./commerce-onboarding/companion-mcps-section.tsx";
 import {
   buildScheduleMeetingUrl,
   ScheduleMeetingBanner,
@@ -819,10 +822,18 @@ function CommerceDiscoveryReady({
           On md+ it collapses back to a natural block (right panel has the card). */}
       <div className="flex min-h-0 flex-1 flex-col gap-6 md:grid md:gap-4">
         <CommerceHeader />
-        <CompanionMcpsSection
-          org={org}
-          cdConnectionId={reportApp.connectionId}
-        />
+        {/* Own Suspense boundary: the section's cdClient (useMCPClient) suspends
+            on first mount while its MCP connection is established. Without this
+            boundary that suspense bubbles to the page-level <Suspense> in
+            CommerceSetup, unmounting the header + title + report CTA and
+            flashing the full-page connect indicator. The fallback mirrors the
+            section's own loading UI so the title stays stable in place. */}
+        <Suspense fallback={<CompanionMcpsSectionSkeleton />}>
+          <CompanionMcpsSection
+            org={org}
+            cdConnectionId={reportApp.connectionId}
+          />
+        </Suspense>
         <div className="flex shrink-0 flex-col gap-3 md:mt-8">
           {/* Right-side ScheduleMeetingVisual is hidden on mobile, so the human
               escape hatch rides in the footer above the report CTA. */}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -10,6 +10,51 @@ interface CompanionOrg {
   slug: string;
 }
 
+// Shared between the live section and its Suspense fallback so the layout can't
+// drift between the two — see CompanionMcpsSectionSkeleton.
+const SECTION_CONTAINER_CLASS =
+  "flex min-h-0 flex-1 flex-col gap-6 md:grid md:flex-none md:gap-4";
+
+function SectionIntro() {
+  return (
+    <div className="grid gap-1.5">
+      <p className="text-2xl font-medium text-foreground">
+        Unlock your full diagnostic
+      </p>
+      <p className="text-base text-muted-foreground">
+        Connect your tools to unlock 100+ checks across your funnel.
+      </p>
+    </div>
+  );
+}
+
+function CompanionCardSkeletons() {
+  return (
+    <div className="grid gap-4">
+      {[0, 1, 2].map((i) => (
+        <CompanionCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Suspense fallback for CompanionMcpsSection. The section's `cdClient`
+ * (useMCPClient → useSuspenseQuery) suspends on first mount while its MCP
+ * connection is established; wrapping the section in its own boundary keeps that
+ * suspense from bubbling to the page-level boundary and unmounting the header +
+ * title + report CTA. This fallback mirrors the section's internal `isLoading`
+ * UI (intro + card skeletons) so the title stays put across both phases.
+ */
+export function CompanionMcpsSectionSkeleton() {
+  return (
+    <div className={SECTION_CONTAINER_CLASS}>
+      <SectionIntro />
+      <CompanionCardSkeletons />
+    </div>
+  );
+}
+
 export function CompanionMcpsSection({
   org,
   cdConnectionId,
@@ -53,15 +98,8 @@ export function CompanionMcpsSection({
     // Mobile: fill the parent's remaining height — the header + intro copy stay
     // pinned while the card list scrolls. md+: natural block with a capped
     // scroll area so the right panel stays visible.
-    <div className="flex min-h-0 flex-1 flex-col gap-6 md:grid md:flex-none md:gap-4">
-      <div className="grid gap-1.5">
-        <p className="text-2xl font-medium text-foreground">
-          Unlock your full diagnostic
-        </p>
-        <p className="text-base text-muted-foreground">
-          Connect your tools to unlock 100+ checks across your funnel.
-        </p>
-      </div>
+    <div className={SECTION_CONTAINER_CLASS}>
+      <SectionIntro />
 
       {error ? (
         <div
@@ -76,11 +114,7 @@ export function CompanionMcpsSection({
           </p>
         </div>
       ) : isLoading ? (
-        <div className="grid gap-4">
-          {[0, 1, 2].map((i) => (
-            <CompanionCardSkeleton key={i} />
-          ))}
-        </div>
+        <CompanionCardSkeletons />
       ) : (
         <ScrollReveal
           wrapperClassName="flex min-h-0 flex-1 flex-col md:block"


### PR DESCRIPTION
## Summary

Fixes a flicker on the commerce onboarding "diagnostic ready" screen: while the companion MCP cards load, the header, the **Unlock your full diagnostic** title, and the **See full report** button briefly disappear and then re-render.

### Root cause
`CompanionMcpsSection` opens a *second, distinct* MCP client for the Commerce Discovery connection via `useCommerceCompanions` → `useMCPClient({ connectionId: cdConnectionId })`. `useMCPClient` is built on `useSuspenseQuery`, so on first mount it **suspends** while that connection is established. With no local boundary, the suspense bubbled up to the page-level `<Suspense>` in `CommerceSetup`, which swapped the *entire* `CommerceDiscoveryReady` subtree (header + title + report CTA) for the full-page connect indicator and then remounted it — the observed flash. The section's own `isLoading` skeleton never even got to render.

### Fix
- Wrap `CompanionMcpsSection` in its **own** `<Suspense>` with a `CompanionMcpsSectionSkeleton` fallback. The header and "See full report" button live outside the section (and outside this boundary), so they stay mounted.
- The fallback mirrors the section's internal `isLoading` UI (intro + card skeletons) and shares a `SECTION_CONTAINER_CLASS` constant, so the title stays pinned in place across both phases: MCP-connect suspense → internal data-loading skeletons (seamless handoff, no flash).
- Empty-state behavior preserved: after loading, if there are no companions, the section still returns `null`.

## Testing
- `bun run fmt` — clean
- `bun run check` — exits 0
- `bun run lint` — 0 errors

Not yet verified visually on staging (deploy lag — same as the previous gap fix); the change is a structural suspense-boundary fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated suspense for the companion MCP section to stop the flicker on the commerce onboarding “diagnostic ready” screen. The header, title, and “See full report” stay mounted while companion cards load.

- **Bug Fixes**
  - Root cause: `useMCPClient` for Commerce Discovery suspended on first mount and bubbled to the page `<Suspense>`, unmounting the whole subtree.
  - Fix: Wrapped `CompanionMcpsSection` in its own `<Suspense>` with `CompanionMcpsSectionSkeleton` (intro + card skeletons) and a shared `SECTION_CONTAINER_CLASS` to keep layout stable; empty-state behavior unchanged.

<sup>Written for commit 37fdf05e6f521ecf5388aff79e2af8953bc3889a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

