### PR TITLE
fix(commerce-onboarding): isolate companion section suspense

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -30,7 +30,10 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowRight } from "@untitledui/icons";
 import { createContext, Suspense, useContext, useRef, useState } from "react";
 import type { FormEvent, ReactNode } from "react";
-import { CompanionMcpsSection } from "./commerce-onboarding/companion-mcps-section.tsx";
+import {
+  CompanionMcpsSection,
+  CompanionMcpsSectionSkeleton,
+} from "./commerce-onboarding/companion-mcps-section.tsx";
 import {
   buildScheduleMeetingUrl,
   ScheduleMeetingBanner,
@@ -819,10 +822,18 @@ function CommerceDiscoveryReady({
           On md+ it collapses back to a natural block (right panel has the card). */}
       <div className="flex min-h-0 flex-1 flex-col gap-6 md:grid md:gap-4">
         <CommerceHeader />
-        <CompanionMcpsSection
-          org={org}
-          cdConnectionId={reportApp.connectionId}
-        />
+        {/* Own Suspense boundary: the section's cdClient (useMCPClient) suspends
+            on first mount while its MCP connection is established. Without this
+            boundary that suspense bubbles to the page-level <Suspense> in
+            CommerceSetup, unmounting the header + title + report CTA and
+            flashing the full-page connect indicator. The fallback mirrors the
+            section's own loading UI so the title stays stable in place. */}
+        <Suspense fallback={<CompanionMcpsSectionSkeleton />}>
+          <CompanionMcpsSection
+            org={org}
+            cdConnectionId={reportApp.connectionId}
+          />
+        </Suspense>
         <div className="flex shrink-0 flex-col gap-3 md:mt-8">
           {/* Right-side ScheduleMeetingVisual is hidden on mobile, so the human
               escape hatch rides in the footer above the report CTA. */}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -10,6 +10,51 @@ interface CompanionOrg {
   slug: string;
 }
 
+// Shared between the live section and its Suspense fallback so the layout can't
+// drift between the two — see CompanionMcpsSectionSkeleton.
+const SECTION_CONTAINER_CLASS =
+  "flex min-h-0 flex-1 flex-col gap-6 md:grid md:flex-none md:gap-4";
+
+function SectionIntro() {
+  return (
+    <div className="grid gap-1.5">
+      <p className="text-2xl font-medium text-foreground">
+        Unlock your full diagnostic
+      </p>
+      <p className="text-base text-muted-foreground">
+        Connect your tools to unlock 100+ checks across your funnel.
+      </p>
+    </div>
+  );
+}
+
+function CompanionCardSkeletons() {
+  return (
+    <div className="grid gap-4">
+      {[0, 1, 2].map((i) => (
+        <CompanionCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Suspense fallback for CompanionMcpsSection. The section's `cdClient`
+ * (useMCPClient → useSuspenseQuery) suspends on first mount while its MCP
+ * connection is established; wrapping the section in its own boundary keeps that
+ * suspense from bubbling to the page-level boundary and unmounting the header +
+ * title + report CTA. This fallback mirrors the section's internal `isLoading`
+ * UI (intro + card skeletons) so the title stays put across both phases.
+ */
+export function CompanionMcpsSectionSkeleton() {
+  return (
+    <div className={SECTION_CONTAINER_CLASS}>
+      <SectionIntro />
+      <CompanionCardSkeletons />
+    </div>
+  );
+}
+
 export function CompanionMcpsSection({
   org,
   cdConnectionId,
@@ -53,15 +98,8 @@ export function CompanionMcpsSection({
     // Mobile: fill the parent's remaining height — the header + intro copy stay
     // pinned while the card list scrolls. md+: natural block with a capped
     // scroll area so the right panel stays visible.
-    <div className="flex min-h-0 flex-1 flex-col gap-6 md:grid md:flex-none md:gap-4">
-      <div className="grid gap-1.5">
-        <p className="text-2xl font-medium text-foreground">
-          Unlock your full diagnostic
-        </p>
-        <p className="text-base text-muted-foreground">
-          Connect your tools to unlock 100+ checks across your funnel.
-        </p>
-      </div>
+    <div className={SECTION_CONTAINER_CLASS}>
+      <SectionIntro />
 
       {error ? (
         <div
@@ -76,11 +114,7 @@ export function CompanionMcpsSection({
           </p>
         </div>
       ) : isLoading ? (
-        <div className="grid gap-4">
-          {[0, 1, 2].map((i) => (
-            <CompanionCardSkeleton key={i} />
-          ))}
-        </div>
+        <CompanionCardSkeletons />
       ) : (
         <ScrollReveal
           wrapperClassName="flex min-h-0 flex-1 flex-col md:block"


### PR DESCRIPTION
Isolates the companion section in suspense to improve loading behavior and prevent layout shifts during onboarding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wraps the commerce MCP companion section in its own Suspense boundary with a matching skeleton to stop full-page flashes and layout shifts during onboarding. The header, title, and report CTA now stay mounted while the MCP connection initializes.

- **Bug Fixes**
  - Added a local Suspense boundary with `CompanionMcpsSectionSkeleton` (intro + card skeletons) to mirror the section’s loading UI.
  - Prevented suspense from bubbling to the page-level boundary in `CommerceSetup`, so the header, title, and “See full report” remain stable.
  - Light refactor: shared container class and small components (`SectionIntro`, `CompanionCardSkeletons`) to keep live and fallback layouts identical.

<sup>Written for commit 37fdf05e6f521ecf5388aff79e2af8953bc3889a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

