### PR TITLE
feat(content): Loaders and Actions tabs with run/invoke (DECO-5404)

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   Code01,
   Copy01,
+  Database01,
   DotsHorizontal,
   Edit01,
   File02,
@@ -25,6 +26,7 @@ import {
   Trash01,
   Users01,
   X,
+  Zap,
 } from "@untitledui/icons";
 import { toast } from "sonner";
 import {
@@ -155,6 +157,8 @@ import {
   useSaveBlogBlock,
 } from "./blog/use-blog-mutations";
 import { PageJsonDialog } from "@/web/components/sections-editor/page-json-dialog";
+import { RunnableBlocksBrowser } from "./runnable-blocks-browser";
+import { countAvailableRunnables } from "./runnable-catalog";
 
 const AppEditor = lazy(() =>
   import("./app-editor").then((m) => ({ default: m.AppEditor })),
@@ -199,7 +203,21 @@ type CollectionId =
   | "site"
   | "seo"
   | "calendar"
+  | "loaders"
+  | "actions"
   | BlogKind;
+
+type CollectionCounts = Record<
+  | "pages"
+  | "sections"
+  | "apps"
+  | "loaders"
+  | "actions"
+  | "posts"
+  | "authors"
+  | "categories",
+  number
+>;
 
 type Selection =
   | { collection: "pages"; key: string; path: string }
@@ -528,13 +546,12 @@ function ContentBrowserReady({
     );
   }
 
-  const counts: Record<
-    "pages" | "sections" | "apps" | "posts" | "authors" | "categories",
-    number
-  > = {
+  const counts: CollectionCounts = {
     pages: pages.length,
     sections: globalSections.length,
     apps: appCatalog.length,
+    loaders: countAvailableRunnables(meta, "loaders"),
+    actions: countAvailableRunnables(meta, "actions"),
     posts: allBlogEntries.posts.length,
     authors: allBlogEntries.authors.length,
     categories: allBlogEntries.categories.length,
@@ -944,7 +961,9 @@ function ContentBrowserReady({
       />
       {activeCollection !== "seo" &&
         activeCollection !== "site" &&
-        activeCollection !== "calendar" && (
+        activeCollection !== "calendar" &&
+        activeCollection !== "loaders" &&
+        activeCollection !== "actions" && (
           <ItemList
             activeCollection={activeCollection}
             pages={pages}
@@ -1026,178 +1045,192 @@ function ContentBrowserReady({
           />
         )}
       <div className="flex-1 min-w-0">
-        <Suspense
-          fallback={
-            <div className="h-full flex items-center justify-center">
-              <Loading01
-                size={20}
-                className="animate-spin text-muted-foreground"
-              />
-            </div>
-          }
-        >
-          {activeCollection === "calendar" ? (
-            <VariantCalendar decofile={decofile} />
-          ) : activeCollection === "site" ? (
-            siteApp ? (
-              <AppEditor
-                key={`site:${siteApp.key}`}
+        {activeCollection === "loaders" || activeCollection === "actions" ? (
+          <RunnableBlocksBrowser
+            orgSlug={orgSlug}
+            virtualMcpId={virtualMcpId}
+            branch={branch}
+            previewUrl={previewUrl}
+            meta={meta}
+            decofile={decofile}
+            kind={activeCollection}
+          />
+        ) : (
+          <Suspense
+            fallback={
+              <div className="h-full flex items-center justify-center">
+                <Loading01
+                  size={20}
+                  className="animate-spin text-muted-foreground"
+                />
+              </div>
+            }
+          >
+            {activeCollection === "calendar" ? (
+              <VariantCalendar decofile={decofile} />
+            ) : activeCollection === "site" ? (
+              siteApp ? (
+                <AppEditor
+                  key={`site:${siteApp.key}`}
+                  orgSlug={orgSlug}
+                  virtualMcpId={virtualMcpId}
+                  branch={branch}
+                  blockKey={siteApp.key}
+                  block={decofile[siteApp.key] as Record<string, unknown>}
+                  decofile={decofile}
+                  meta={meta}
+                  title="Site"
+                  excludeFields={["seo"]}
+                  schemaPending={isAppSchemaLoading(siteApp.resolveType, [
+                    "seo",
+                  ])}
+                  previewBaseUrl={previewUrl}
+                />
+              ) : (
+                <EmptyMessage
+                  title="Site settings not found"
+                  description="This project doesn't have a site app block (site/apps/site.ts)."
+                />
+              )
+            ) : activeCollection === "seo" ? (
+              <SeoEditor
                 orgSlug={orgSlug}
                 virtualMcpId={virtualMcpId}
                 branch={branch}
-                blockKey={siteApp.key}
-                block={decofile[siteApp.key] as Record<string, unknown>}
                 decofile={decofile}
                 meta={meta}
-                title="Site"
-                excludeFields={["seo"]}
-                schemaPending={isAppSchemaLoading(siteApp.resolveType, ["seo"])}
+                target={{ kind: "site" }}
                 previewBaseUrl={previewUrl}
               />
+            ) : activeCollection === "sections" ? (
+              <SectionsRightPane
+                selection={
+                  selection?.collection === "sections" ||
+                  selection?.collection === "available-section"
+                    ? selection
+                    : null
+                }
+                orgSlug={orgSlug}
+                virtualMcpId={virtualMcpId}
+                branch={branch}
+                previewUrl={previewUrl}
+                meta={meta}
+                decofile={decofile}
+                isCreating={saveBlock.isPending}
+                onCreateAvailable={handleCreateAvailableSection}
+                onSaveReferencedBlock={saveReferencedBlock}
+              />
+            ) : selection && selection.collection !== "available-section" ? (
+              selection.collection === "apps" ? (
+                <AppEditor
+                  key={`app:${selection.key}`}
+                  orgSlug={orgSlug}
+                  virtualMcpId={virtualMcpId}
+                  branch={branch}
+                  blockKey={selection.key}
+                  block={decofile[selection.key] as Record<string, unknown>}
+                  decofile={decofile}
+                  meta={meta}
+                  previewBaseUrl={previewUrl}
+                  schemaPending={isAppSchemaLoading(
+                    typeof (decofile[selection.key] as Record<string, unknown>)
+                      ?.__resolveType === "string"
+                      ? String(
+                          (decofile[selection.key] as Record<string, unknown>)
+                            .__resolveType,
+                        )
+                      : undefined,
+                  )}
+                />
+              ) : selection.collection === "posts" ? (
+                <PostEditor
+                  key={`post:${selection.key}`}
+                  orgSlug={orgSlug}
+                  virtualMcpId={virtualMcpId}
+                  branch={branch}
+                  blockKey={selection.key}
+                  block={decofile[selection.key] as Record<string, unknown>}
+                  decofile={decofile}
+                  meta={meta}
+                  previewBaseUrl={previewUrl}
+                />
+              ) : selection.collection === "categories" ? (
+                <CategoryEditor
+                  key={`category:${selection.key}`}
+                  orgSlug={orgSlug}
+                  virtualMcpId={virtualMcpId}
+                  branch={branch}
+                  blockKey={selection.key}
+                  block={decofile[selection.key] as Record<string, unknown>}
+                  decofile={decofile}
+                  meta={meta}
+                  onManagePosts={handleManagePosts}
+                  onOpenPost={(key) => {
+                    setActiveCollection("posts");
+                    setPrevCollection("posts");
+                    setSelection({ collection: "posts", key });
+                    setOpenPageSeoKey(null);
+                  }}
+                  previewBaseUrl={previewUrl}
+                />
+              ) : selection.collection === "authors" ? (
+                <RecordEditor
+                  key={`authors:${selection.key}`}
+                  orgSlug={orgSlug}
+                  virtualMcpId={virtualMcpId}
+                  branch={branch}
+                  kind="authors"
+                  blockKey={selection.key}
+                  block={decofile[selection.key] as Record<string, unknown>}
+                />
+              ) : (
+                <SectionsEditor
+                  key={
+                    selection.collection === "pages"
+                      ? `page:${selection.key}`
+                      : `section:${selection.key}`
+                  }
+                  orgSlug={orgSlug}
+                  virtualMcpId={virtualMcpId}
+                  branch={branch}
+                  previewReady
+                  previewUrl={previewUrl ?? undefined}
+                  currentPath={
+                    selection.collection === "pages" ? selection.path : "/"
+                  }
+                  activePageBlockKey={
+                    selection.collection === "pages" ? selection.key : null
+                  }
+                  activeGlobalBlockKey={
+                    selection.collection === "sections" ? selection.key : null
+                  }
+                  initialEditSeo={
+                    selection.collection === "pages" &&
+                    openPageSeoKey === selection.key
+                  }
+                  onExitSeo={() => setOpenPageSeoKey(null)}
+                />
+              )
             ) : (
               <EmptyMessage
-                title="Site settings not found"
-                description="This project doesn't have a site app block (site/apps/site.ts)."
-              />
-            )
-          ) : activeCollection === "seo" ? (
-            <SeoEditor
-              orgSlug={orgSlug}
-              virtualMcpId={virtualMcpId}
-              branch={branch}
-              decofile={decofile}
-              meta={meta}
-              target={{ kind: "site" }}
-              previewBaseUrl={previewUrl}
-            />
-          ) : activeCollection === "sections" ? (
-            <SectionsRightPane
-              selection={
-                selection?.collection === "sections" ||
-                selection?.collection === "available-section"
-                  ? selection
-                  : null
-              }
-              orgSlug={orgSlug}
-              virtualMcpId={virtualMcpId}
-              branch={branch}
-              previewUrl={previewUrl}
-              meta={meta}
-              decofile={decofile}
-              isCreating={saveBlock.isPending}
-              onCreateAvailable={handleCreateAvailableSection}
-              onSaveReferencedBlock={saveReferencedBlock}
-            />
-          ) : selection && selection.collection !== "available-section" ? (
-            selection.collection === "apps" ? (
-              <AppEditor
-                key={`app:${selection.key}`}
-                orgSlug={orgSlug}
-                virtualMcpId={virtualMcpId}
-                branch={branch}
-                blockKey={selection.key}
-                block={decofile[selection.key] as Record<string, unknown>}
-                decofile={decofile}
-                meta={meta}
-                previewBaseUrl={previewUrl}
-                schemaPending={isAppSchemaLoading(
-                  typeof (decofile[selection.key] as Record<string, unknown>)
-                    ?.__resolveType === "string"
-                    ? String(
-                        (decofile[selection.key] as Record<string, unknown>)
-                          .__resolveType,
-                      )
-                    : undefined,
-                )}
-              />
-            ) : selection.collection === "posts" ? (
-              <PostEditor
-                key={`post:${selection.key}`}
-                orgSlug={orgSlug}
-                virtualMcpId={virtualMcpId}
-                branch={branch}
-                blockKey={selection.key}
-                block={decofile[selection.key] as Record<string, unknown>}
-                decofile={decofile}
-                meta={meta}
-                previewBaseUrl={previewUrl}
-              />
-            ) : selection.collection === "categories" ? (
-              <CategoryEditor
-                key={`category:${selection.key}`}
-                orgSlug={orgSlug}
-                virtualMcpId={virtualMcpId}
-                branch={branch}
-                blockKey={selection.key}
-                block={decofile[selection.key] as Record<string, unknown>}
-                decofile={decofile}
-                meta={meta}
-                onManagePosts={handleManagePosts}
-                onOpenPost={(key) => {
-                  setActiveCollection("posts");
-                  setPrevCollection("posts");
-                  setSelection({ collection: "posts", key });
-                  setOpenPageSeoKey(null);
-                }}
-                previewBaseUrl={previewUrl}
-              />
-            ) : selection.collection === "authors" ? (
-              <RecordEditor
-                key={`authors:${selection.key}`}
-                orgSlug={orgSlug}
-                virtualMcpId={virtualMcpId}
-                branch={branch}
-                kind="authors"
-                blockKey={selection.key}
-                block={decofile[selection.key] as Record<string, unknown>}
-              />
-            ) : (
-              <SectionsEditor
-                key={
-                  selection.collection === "pages"
-                    ? `page:${selection.key}`
-                    : `section:${selection.key}`
+                title={`Select ${
+                  isBlogKind(activeCollection)
+                    ? `a ${BLOG_SINGULAR[activeCollection]}`
+                    : activeCollection === "pages"
+                      ? "a page"
+                      : activeCollection === "apps"
+                        ? "an app"
+                        : "a section"
+                } to edit`}
+                description={
+                  activeCollection === "apps"
+                    ? "Browse all apps and select an installed one to edit its settings."
+                    : 'Pick an item from the list, or click "+" to create one.'
                 }
-                orgSlug={orgSlug}
-                virtualMcpId={virtualMcpId}
-                branch={branch}
-                previewReady
-                previewUrl={previewUrl ?? undefined}
-                currentPath={
-                  selection.collection === "pages" ? selection.path : "/"
-                }
-                activePageBlockKey={
-                  selection.collection === "pages" ? selection.key : null
-                }
-                activeGlobalBlockKey={
-                  selection.collection === "sections" ? selection.key : null
-                }
-                initialEditSeo={
-                  selection.collection === "pages" &&
-                  openPageSeoKey === selection.key
-                }
-                onExitSeo={() => setOpenPageSeoKey(null)}
               />
-            )
-          ) : (
-            <EmptyMessage
-              title={`Select ${
-                isBlogKind(activeCollection)
-                  ? `a ${BLOG_SINGULAR[activeCollection]}`
-                  : activeCollection === "pages"
-                    ? "a page"
-                    : activeCollection === "apps"
-                      ? "an app"
-                      : "a section"
-              } to edit`}
-              description={
-                activeCollection === "apps"
-                  ? "Browse all apps and select an installed one to edit its settings."
-                  : 'Pick an item from the list, or click "+" to create one.'
-              }
-            />
-          )}
-        </Suspense>
+            )}
+          </Suspense>
+        )}
       </div>
 
       {/* Page create/duplicate/rename dialog */}
@@ -1400,7 +1433,7 @@ function SectionsRightPane({
   );
 }
 
-function GroupHeader({
+export function GroupHeader({
   icon: Icon,
   label,
   className,
@@ -1429,10 +1462,7 @@ function CollectionsSidebar({
   onSelect,
 }: {
   active: CollectionId;
-  counts: Record<
-    "pages" | "sections" | "apps" | "posts" | "authors" | "categories",
-    number
-  >;
+  counts: CollectionCounts;
   showBlog: boolean;
   onSelect: (id: CollectionId) => void;
 }) {
@@ -1464,6 +1494,22 @@ function CollectionsSidebar({
           label="Apps"
           count={counts.apps}
           active={active === "apps"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="loaders"
+          icon={Database01}
+          label="Loaders"
+          count={counts.loaders}
+          active={active === "loaders"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="actions"
+          icon={Zap}
+          label="Actions"
+          count={counts.actions}
+          active={active === "actions"}
           onSelect={onSelect}
         />
         <CollectionRow
@@ -2547,7 +2593,7 @@ function BulkCategoryDialog({
   );
 }
 
-function ItemRow({
+export function ItemRow({
   icon: Icon,
   logoUrl,
   title,
@@ -2768,7 +2814,7 @@ function ItemActions({
   );
 }
 
-function ListEmpty({
+export function ListEmpty({
   hasItems,
   emptyLabel,
   emptyHint,
@@ -2823,7 +2869,7 @@ function SandboxStateRenderer({
   }
 }
 
-function EmptyMessage({
+export function EmptyMessage({
   icon: Icon,
   title,
   description,

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -1433,7 +1433,7 @@ function SectionsRightPane({
   );
 }
 
-export function GroupHeader({
+function GroupHeader({
   icon: Icon,
   label,
   className,
@@ -2814,7 +2814,7 @@ function ItemActions({
   );
 }
 
-export function ListEmpty({
+function ListEmpty({
   hasItems,
   emptyLabel,
   emptyHint,

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -536,12 +536,21 @@ function ContentBrowserReady({
     .filter((c) => c.slug)
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  if (!hasEditableDecoContent(decofile, meta) && !showBlog) {
+  const loadersCount = countAvailableRunnables(meta, "loaders");
+  const actionsCount = countAvailableRunnables(meta, "actions");
+
+  // Loader/action-only sites are still editable — don't gate them out.
+  if (
+    !hasEditableDecoContent(decofile, meta) &&
+    !showBlog &&
+    loadersCount === 0 &&
+    actionsCount === 0
+  ) {
     return (
       <EmptyMessage
         icon={AlertCircle}
         title="No editable content"
-        description="This project doesn't expose any Deco pages, sections, or apps."
+        description="This project doesn't expose any Deco pages, sections, apps, loaders, or actions."
       />
     );
   }
@@ -550,8 +559,8 @@ function ContentBrowserReady({
     pages: pages.length,
     sections: globalSections.length,
     apps: appCatalog.length,
-    loaders: countAvailableRunnables(meta, "loaders"),
-    actions: countAvailableRunnables(meta, "actions"),
+    loaders: loadersCount,
+    actions: actionsCount,
     posts: allBlogEntries.posts.length,
     authors: allBlogEntries.authors.length,
     categories: allBlogEntries.categories.length,

--- a/apps/mesh/src/web/components/sandbox/content/runnable-block-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-block-editor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ArrowLeft,
   ChevronRight,
@@ -110,6 +110,19 @@ export function RunnableBlockEditor({
     branch,
   });
   const run = useRunBlock(previewUrl);
+
+  // useDebouncedSaveBlock CANCELS pending saves on unmount (its documented
+  // contract is that leaving callers flush explicitly). This editor unmounts on
+  // back navigation and on target switch (keyed remount), so flush on the way
+  // out or edits inside the debounce window would be silently lost. Capturing
+  // the first render's `flush` is safe: it closes over the hook's stable refs.
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect — unmount flush of pending saves
+  useEffect(() => {
+    return () => {
+      flush();
+    };
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
+  }, []);
 
   const schema = resolveSchema(target.resolveType, meta);
   const singular = runnableSingular(kind);

--- a/apps/mesh/src/web/components/sandbox/content/runnable-block-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-block-editor.tsx
@@ -1,0 +1,423 @@
+import { useState } from "react";
+import {
+  ChevronRight,
+  Code01,
+  Loading01,
+  Play,
+  Save01,
+  X,
+} from "@untitledui/icons";
+import { toast } from "sonner";
+import { Button } from "@deco/ui/components/button.tsx";
+import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import { useInsetContext } from "@/web/layouts/agent-shell-layout";
+import { MonacoCodeEditor } from "@/web/components/monaco-editor";
+import { SchemaForm } from "@/web/components/sections-editor/schema-form";
+import {
+  resolveSchema,
+  type LiveMeta,
+} from "@/web/components/sections-editor/resolve-schema";
+import { validateBlockId } from "@/web/components/sections-editor/page-sections";
+import { useDebouncedSaveBlock } from "@/web/components/sections-editor/use-save-block";
+import { MakeReusableModal } from "@/web/components/sections-editor/make-reusable-modal";
+import { SaveStatus } from "./blog/save-status";
+import { runnableSingular, type RunnableKind } from "./runnable-catalog";
+import { useRunBlock } from "./use-run-block";
+
+/** What the editor is editing: an available manifest block or a saved one. */
+export type RunnableTarget =
+  | { mode: "available"; resolveType: string; title: string }
+  | { mode: "saved"; blockKey: string; resolveType: string; title: string };
+
+/**
+ * Editor for a single loader/action. The form value is the block's `props`
+ * (the schema resolved for a loader/action describes its input). A single
+ * `formValue` state feeds both the schema form and the Monaco JSON view, and
+ * "Run" live-invokes the block against the preview, showing the structured
+ * result below.
+ *
+ * Two save modes mirror the Sections tab: an available (manifest) block edits
+ * locally and persists only when named/saved as a global block; a saved block
+ * autosaves on every change.
+ */
+export function RunnableBlockEditor({
+  orgSlug,
+  virtualMcpId,
+  branch,
+  previewUrl,
+  meta,
+  decofile,
+  kind,
+  target,
+  initialValue,
+  isCreating,
+  onCreate,
+  onSaveReferencedBlock,
+}: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  previewUrl: string | null;
+  meta: LiveMeta;
+  decofile: Record<string, unknown>;
+  kind: RunnableKind;
+  target: RunnableTarget;
+  initialValue: Record<string, unknown>;
+  isCreating: boolean;
+  onCreate: (blockId: string, data: Record<string, unknown>) => Promise<void>;
+  onSaveReferencedBlock: (
+    blockKey: string,
+    data: Record<string, unknown>,
+  ) => void;
+}) {
+  const inset = useInsetContext();
+  const agentSiteSlug =
+    inset?.entity?.id === virtualMcpId
+      ? (inset.entity.metadata?.siteSlug ?? null)
+      : null;
+
+  const [formValue, setFormValue] =
+    useState<Record<string, unknown>>(initialValue);
+  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<string[]>([]);
+  const [formResetKey, setFormResetKey] = useState(0);
+  const [jsonError, setJsonError] = useState(false);
+  const [jsonCode, setJsonCode] = useState<string | null>(null);
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [resultOpen, setResultOpen] = useState(false);
+  const jsonOpen = jsonCode !== null;
+
+  const {
+    save,
+    flush,
+    isPending: isSaving,
+  } = useDebouncedSaveBlock({
+    orgSlug,
+    virtualMcpId,
+    branch,
+  });
+  const run = useRunBlock(previewUrl);
+
+  const schema = resolveSchema(target.resolveType, meta);
+  const singular = runnableSingular(kind);
+  const typeLabel =
+    target.resolveType
+      .split("/")
+      .pop()
+      ?.replace(/\.tsx?$/, "") ?? target.resolveType;
+
+  const sandbox = {
+    orgSlug,
+    virtualMcpId,
+    branch,
+    previewUrl: previewUrl ?? undefined,
+    siteSlug: agentSiteSlug,
+  };
+
+  // Persist a saved block's props on change (available blocks stay local until
+  // explicitly saved). We store the block flat: `{ __resolveType, ...props }`.
+  const apply = (next: Record<string, unknown>) => {
+    setFormValue(next);
+    if (target.mode === "saved") {
+      save(target.blockKey, { __resolveType: target.resolveType, ...next });
+    }
+  };
+
+  const toggleJson = () => {
+    if (jsonOpen) {
+      setJsonCode(null);
+      setJsonError(false);
+      // Remount the form so nested fields re-read the (possibly JSON-edited)
+      // formValue.
+      setFormResetKey((key) => key + 1);
+    } else {
+      setJsonCode(JSON.stringify(formValue, null, 2));
+    }
+  };
+
+  const handleJsonChange = (value: string | undefined) => {
+    const text = value ?? "";
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        setJsonError(false);
+        apply(parsed as Record<string, unknown>);
+        return;
+      }
+      setJsonError(true);
+    } catch {
+      setJsonError(true);
+    }
+  };
+
+  const handleSubmitSave = async (blockId: string) => {
+    const validationError = validateBlockId(blockId, decofile);
+    if (validationError) {
+      toast.error(validationError);
+      return;
+    }
+    await onCreate(blockId, {
+      __resolveType: target.resolveType,
+      ...formValue,
+    });
+    setSaveOpen(false);
+  };
+
+  const handleRun = () => {
+    setResultOpen(true);
+    run.mutate({ resolveType: target.resolveType, props: formValue });
+  };
+
+  const headerCrumbs = [target.title, ...fieldBreadcrumbs];
+  const handleBreadcrumbClick = (index: number) => {
+    setFieldBreadcrumbs(fieldBreadcrumbs.slice(0, index));
+    setFormResetKey((key) => key + 1);
+  };
+
+  return (
+    <div className="flex h-full w-full min-w-0 flex-col">
+      {/* Header: breadcrumb + Run + Save (available only) + JSON toggle. */}
+      <div className="shrink-0 border-b px-3 py-2.5">
+        <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+          <nav
+            aria-label="Editing breadcrumb"
+            className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-sm"
+          >
+            {headerCrumbs.map((crumb, index) => {
+              const isLast = index === headerCrumbs.length - 1;
+              return (
+                <span
+                  key={`${crumb}-${index}`}
+                  className="flex min-w-0 items-center gap-1 overflow-hidden"
+                >
+                  {index > 0 && (
+                    <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" />
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => handleBreadcrumbClick(index)}
+                    title={crumb}
+                    className={cn(
+                      "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+                      isLast
+                        ? "font-medium text-foreground"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {crumb}
+                  </button>
+                </span>
+              );
+            })}
+          </nav>
+          {target.mode === "saved" && (
+            <SaveStatus isPending={isSaving} isError={false} />
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 shrink-0 gap-1.5"
+            onClick={handleRun}
+            disabled={run.isPending}
+            aria-label={`Run ${singular}`}
+          >
+            {run.isPending ? (
+              <Loading01 size={14} className="animate-spin" />
+            ) : (
+              <Play size={14} />
+            )}
+            Run
+          </Button>
+          {target.mode === "available" && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="icon"
+                  className="size-8 shrink-0"
+                  disabled={isCreating}
+                  onClick={() => setSaveOpen(true)}
+                  aria-label={`Save as global ${singular}`}
+                >
+                  <Save01 size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                Save as global {singular}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={jsonOpen ? "default" : "ghost"}
+                size="icon"
+                className="size-8 shrink-0"
+                onClick={toggleJson}
+                aria-label={jsonOpen ? "Close JSON editor" : "Edit as JSON"}
+                aria-pressed={jsonOpen}
+              >
+                {jsonOpen ? <X size={14} /> : <Code01 size={14} />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {jsonOpen ? "Close JSON editor" : "Edit as JSON"}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <p className="mt-1.5 py-1 pl-1 text-sm leading-snug text-muted-foreground">
+          {target.mode === "saved"
+            ? `Global ${singular} — changes save automatically. Run to invoke it against the live preview.`
+            : `${typeLabel} — edits stay local until you save this as a global ${singular}. Run to invoke it against the live preview.`}
+        </p>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        {/* Form / JSON region. */}
+        <div className="relative min-h-0 flex-1">
+          <ScrollArea className="h-full [&_[data-slot=scroll-area-viewport]>div]:!block">
+            <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
+              <div className="mx-auto max-w-2xl">
+                {schema ? (
+                  <SchemaForm
+                    key={formResetKey}
+                    schema={schema}
+                    value={formValue}
+                    onChange={(v) => apply(v as Record<string, unknown>)}
+                    basePath=""
+                    breadcrumbPath={fieldBreadcrumbs}
+                    onBreadcrumbChange={setFieldBreadcrumbs}
+                    meta={meta}
+                    decofile={decofile}
+                    onSaveReferencedBlock={onSaveReferencedBlock}
+                    sandbox={sandbox}
+                  />
+                ) : (
+                  <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+                    This {singular} takes no configurable input. Run it to see
+                    its output.
+                  </div>
+                )}
+              </div>
+            </div>
+          </ScrollArea>
+
+          {jsonCode !== null && (
+            <div className="absolute inset-0 flex flex-col bg-background">
+              {jsonError && (
+                <div className="shrink-0 border-b bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
+                  Invalid JSON — changes aren't saved until it parses.
+                </div>
+              )}
+              <div className="min-h-0 flex-1">
+                <MonacoCodeEditor
+                  language="json"
+                  height="100%"
+                  code={jsonCode}
+                  onChange={handleJsonChange}
+                  onSave={(value) => {
+                    handleJsonChange(value);
+                    flush();
+                  }}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Run result panel. */}
+        {resultOpen && (
+          <RunResultPanel
+            singular={singular}
+            result={{
+              isPending: run.isPending,
+              error: run.error,
+              data: run.data,
+              hasRun: run.status !== "idle",
+            }}
+            onClose={() => setResultOpen(false)}
+          />
+        )}
+      </div>
+
+      <MakeReusableModal
+        open={saveOpen}
+        onOpenChange={setSaveOpen}
+        defaultBlockId=""
+        isPending={isCreating}
+        onSubmit={handleSubmitSave}
+      />
+    </div>
+  );
+}
+
+function RunResultPanel({
+  singular,
+  result,
+  onClose,
+}: {
+  singular: string;
+  result: {
+    isPending: boolean;
+    error: Error | null;
+    data: unknown;
+    hasRun: boolean;
+  };
+  onClose: () => void;
+}) {
+  const resultText =
+    typeof result.data === "string"
+      ? result.data
+      : JSON.stringify(result.data ?? null, null, 2);
+
+  return (
+    <div className="flex h-[45%] min-h-0 shrink-0 flex-col border-t">
+      <div className="flex h-9 shrink-0 items-center justify-between border-b px-3">
+        <span className="text-xs font-medium text-muted-foreground">
+          Result
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={onClose}
+          aria-label="Close result"
+        >
+          <X size={14} />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1">
+        {result.isPending ? (
+          <div className="flex h-full items-center justify-center gap-2 text-xs text-muted-foreground">
+            <Loading01 size={16} className="animate-spin" />
+            Running {singular}…
+          </div>
+        ) : result.error ? (
+          <div className="h-full overflow-auto px-4 py-3">
+            <p className="text-xs font-medium text-destructive">
+              Failed to run {singular}
+            </p>
+            <pre className="mt-1 whitespace-pre-wrap break-words text-xs text-destructive/90">
+              {result.error.message}
+            </pre>
+          </div>
+        ) : result.hasRun ? (
+          <MonacoCodeEditor
+            language="json"
+            height="100%"
+            code={resultText}
+            readOnly
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+            Press Run to invoke this {singular}.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/runnable-block-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-block-editor.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+  ArrowLeft,
   ChevronRight,
   Code01,
   LinkExternal01,
@@ -62,6 +63,7 @@ export function RunnableBlockEditor({
   isCreating,
   onCreate,
   onSaveReferencedBlock,
+  onBack,
 }: {
   orgSlug: string;
   virtualMcpId: string;
@@ -78,6 +80,8 @@ export function RunnableBlockEditor({
     blockKey: string,
     data: Record<string, unknown>,
   ) => void;
+  /** Navigates back to the folder browser. */
+  onBack?: () => void;
 }) {
   const inset = useInsetContext();
   const agentSiteSlug =
@@ -199,6 +203,17 @@ export function RunnableBlockEditor({
       {/* Header: breadcrumb + Run + Save (available only) + JSON toggle. */}
       <div className="shrink-0 border-b px-3 py-2.5">
         <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+          {onBack && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-8 shrink-0"
+              onClick={onBack}
+              aria-label="Back to list"
+            >
+              <ArrowLeft size={14} />
+            </Button>
+          )}
           <nav
             aria-label="Editing breadcrumb"
             className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-sm"

--- a/apps/mesh/src/web/components/sandbox/content/runnable-block-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-block-editor.tsx
@@ -2,7 +2,10 @@ import { useState } from "react";
 import {
   ChevronRight,
   Code01,
+  LinkExternal01,
   Loading01,
+  Maximize01,
+  Minimize01,
   Play,
   Save01,
   X,
@@ -28,7 +31,7 @@ import { useDebouncedSaveBlock } from "@/web/components/sections-editor/use-save
 import { MakeReusableModal } from "@/web/components/sections-editor/make-reusable-modal";
 import { SaveStatus } from "./blog/save-status";
 import { runnableSingular, type RunnableKind } from "./runnable-catalog";
-import { useRunBlock } from "./use-run-block";
+import { buildInvokeRunUrl, useRunBlock } from "./use-run-block";
 
 /** What the editor is editing: an available manifest block or a saved one. */
 export type RunnableTarget =
@@ -90,6 +93,7 @@ export function RunnableBlockEditor({
   const [jsonCode, setJsonCode] = useState<string | null>(null);
   const [saveOpen, setSaveOpen] = useState(false);
   const [resultOpen, setResultOpen] = useState(false);
+  const [resultExpanded, setResultExpanded] = useState(false);
   const jsonOpen = jsonCode !== null;
 
   const {
@@ -171,6 +175,17 @@ export function RunnableBlockEditor({
   const handleRun = () => {
     setResultOpen(true);
     run.mutate({ resolveType: target.resolveType, props: formValue });
+  };
+
+  // Re-runs the invoke in a new tab (fresh cache-buster) with the current
+  // form value — handy for inspecting large results with browser JSON tools.
+  const handleOpenResultInNewTab = () => {
+    if (!previewUrl) return;
+    window.open(
+      buildInvokeRunUrl(previewUrl, target.resolveType, formValue, Date.now()),
+      "_blank",
+      "noopener",
+    );
   };
 
   const headerCrumbs = [target.title, ...fieldBreadcrumbs];
@@ -277,8 +292,13 @@ export function RunnableBlockEditor({
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col">
-        {/* Form / JSON region. */}
-        <div className="relative min-h-0 flex-1">
+        {/* Form / JSON region — hidden while the result panel is expanded. */}
+        <div
+          className={cn(
+            "relative min-h-0 flex-1",
+            resultOpen && resultExpanded && "hidden",
+          )}
+        >
           <ScrollArea className="h-full [&_[data-slot=scroll-area-viewport]>div]:!block">
             <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
               <div className="mx-auto max-w-2xl">
@@ -339,7 +359,13 @@ export function RunnableBlockEditor({
               data: run.data,
               hasRun: run.status !== "idle",
             }}
-            onClose={() => setResultOpen(false)}
+            expanded={resultExpanded}
+            onToggleExpand={() => setResultExpanded((prev) => !prev)}
+            onOpenInNewTab={previewUrl ? handleOpenResultInNewTab : undefined}
+            onClose={() => {
+              setResultOpen(false);
+              setResultExpanded(false);
+            }}
           />
         )}
       </div>
@@ -358,6 +384,9 @@ export function RunnableBlockEditor({
 function RunResultPanel({
   singular,
   result,
+  expanded,
+  onToggleExpand,
+  onOpenInNewTab,
   onClose,
 }: {
   singular: string;
@@ -367,6 +396,10 @@ function RunResultPanel({
     data: unknown;
     hasRun: boolean;
   };
+  expanded: boolean;
+  onToggleExpand: () => void;
+  /** Absent while the preview URL is unknown (button hidden). */
+  onOpenInNewTab?: () => void;
   onClose: () => void;
 }) {
   const resultText =
@@ -375,20 +408,62 @@ function RunResultPanel({
       : JSON.stringify(result.data ?? null, null, 2);
 
   return (
-    <div className="flex h-[45%] min-h-0 shrink-0 flex-col border-t">
+    <div
+      className={cn(
+        "flex min-h-0 flex-col border-t",
+        expanded ? "flex-1" : "h-[45%] shrink-0",
+      )}
+    >
       <div className="flex h-9 shrink-0 items-center justify-between border-b px-3">
         <span className="text-xs font-medium text-muted-foreground">
           Result
         </span>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-7"
-          onClick={onClose}
-          aria-label="Close result"
-        >
-          <X size={14} />
-        </Button>
+        <div className="flex items-center gap-0.5">
+          {onOpenInNewTab && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7"
+                  onClick={onOpenInNewTab}
+                  aria-label="Open result in new tab"
+                >
+                  <LinkExternal01 size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                Open in new tab (re-runs the {singular})
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={onToggleExpand}
+                aria-label={expanded ? "Collapse result" : "Expand result"}
+                aria-pressed={expanded}
+              >
+                {expanded ? <Minimize01 size={14} /> : <Maximize01 size={14} />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {expanded ? "Collapse" : "Expand"}
+            </TooltipContent>
+          </Tooltip>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={onClose}
+            aria-label="Close result"
+          >
+            <X size={14} />
+          </Button>
+        </div>
       </div>
       <div className="min-h-0 flex-1">
         {result.isPending ? (

--- a/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
@@ -1,0 +1,273 @@
+import { useState } from "react";
+import { Database01, SearchLg, Zap } from "@untitledui/icons";
+import { toast } from "sonner";
+import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import { useSaveBlock } from "@/web/components/sections-editor/use-save-block";
+import { createReferencedBlockSaver } from "@/web/components/sections-editor/save-referenced-block";
+import {
+  EmptyMessage,
+  GroupHeader,
+  ItemRow,
+  ListEmpty,
+} from "./content-browser";
+import {
+  RunnableBlockEditor,
+  type RunnableTarget,
+} from "./runnable-block-editor";
+import {
+  groupRunnables,
+  listAvailableRunnables,
+  listSavedRunnables,
+  runnableSingular,
+  type RunnableKind,
+} from "./runnable-catalog";
+
+type RunnableSelection =
+  | { mode: "available"; resolveType: string; title: string }
+  | { mode: "saved"; key: string }
+  | null;
+
+const KIND_ICON: Record<
+  RunnableKind,
+  React.ComponentType<{ size?: number; className?: string }>
+> = {
+  loaders: Database01,
+  actions: Zap,
+};
+
+/**
+ * Middle list + editor for the Loaders / Actions content tabs. Lists a site's
+ * saved (global) blocks and the available (manifest) ones for the given kind;
+ * selecting one opens the {@link RunnableBlockEditor} (form + JSON + Run).
+ */
+export function RunnableBlocksBrowser({
+  orgSlug,
+  virtualMcpId,
+  branch,
+  previewUrl,
+  meta,
+  decofile,
+  kind,
+}: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  previewUrl: string | null;
+  meta: LiveMeta;
+  decofile: Record<string, unknown>;
+  kind: RunnableKind;
+}) {
+  const [selection, setSelection] = useState<RunnableSelection>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Reset selection + search when switching between the Loaders and Actions
+  // tabs (this component is reused for both).
+  const [prevKind, setPrevKind] = useState(kind);
+  if (prevKind !== kind) {
+    setPrevKind(kind);
+    setSelection(null);
+    setSearchQuery("");
+  }
+
+  const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
+  const saveReferencedBlock = createReferencedBlockSaver((blockKey, data) =>
+    saveBlock.mutate({ blockKey, data }),
+  );
+
+  const singular = runnableSingular(kind);
+  const Icon = KIND_ICON[kind];
+
+  const saved = listSavedRunnables(meta, decofile, kind);
+  const available = listAvailableRunnables(meta, kind);
+
+  const q = searchQuery.toLowerCase();
+  const filteredSaved = saved.filter(
+    (e) =>
+      !q ||
+      e.title.toLowerCase().includes(q) ||
+      e.resolveType.toLowerCase().includes(q),
+  );
+  const filteredAvailable = available.filter(
+    (e) =>
+      !q ||
+      e.title.toLowerCase().includes(q) ||
+      e.resolveType.toLowerCase().includes(q),
+  );
+  const availableGroups = groupRunnables(filteredAvailable);
+
+  const handleCreate = async (
+    blockId: string,
+    data: Record<string, unknown>,
+  ) => {
+    await saveBlock.mutateAsync({ blockKey: blockId, data });
+    toast.success(`Saved ${singular} "${blockId}"`);
+    setSelection({ mode: "saved", key: blockId });
+  };
+
+  const target = buildTarget(selection, decofile);
+
+  return (
+    <div className="flex h-full w-full min-w-0">
+      <div className="flex w-[300px] shrink-0 flex-col border-r min-h-0">
+        <div className="flex h-12 shrink-0 items-center gap-1 border-b px-2">
+          <div className="flex flex-1 items-center gap-2 pl-1">
+            <SearchLg
+              size={14}
+              className="shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={`Search ${kind}…`}
+              aria-label={`Search ${kind}`}
+              className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            />
+          </div>
+        </div>
+        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
+          <div className="flex flex-col gap-1 p-1.5">
+            {filteredSaved.length === 0 && filteredAvailable.length === 0 ? (
+              <ListEmpty
+                hasItems={saved.length > 0 || available.length > 0}
+                emptyLabel={`No ${kind} yet.`}
+                emptyHint="Start the preview dev server so its manifest loads."
+              />
+            ) : (
+              <>
+                {filteredSaved.length > 0 && (
+                  <>
+                    <GroupHeader icon={Icon} label={`Saved ${kind}`} />
+                    {filteredSaved.map((entry) => (
+                      <ItemRow
+                        key={entry.key}
+                        icon={Icon}
+                        accent="global"
+                        title={entry.title}
+                        subtitle={entry.resolveType}
+                        active={
+                          selection?.mode === "saved" &&
+                          selection.key === entry.key
+                        }
+                        onClick={() =>
+                          setSelection({ mode: "saved", key: entry.key })
+                        }
+                      />
+                    ))}
+                  </>
+                )}
+                {availableGroups.map((group, groupIndex) => (
+                  <div key={group.key} className="flex flex-col gap-1">
+                    <GroupHeader
+                      icon={Icon}
+                      label={`${group.title} · ${group.entries.length}`}
+                      className={cn(
+                        (filteredSaved.length > 0 || groupIndex > 0) && "mt-3",
+                      )}
+                    />
+                    {group.entries.map((entry) => (
+                      <ItemRow
+                        key={entry.resolveType}
+                        icon={Icon}
+                        title={entry.title}
+                        subtitle={entry.resolveType}
+                        active={
+                          selection?.mode === "available" &&
+                          selection.resolveType === entry.resolveType
+                        }
+                        onClick={() =>
+                          setSelection({
+                            mode: "available",
+                            resolveType: entry.resolveType,
+                            title: entry.title,
+                          })
+                        }
+                      />
+                    ))}
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+
+      <div className="min-w-0 flex-1">
+        {target ? (
+          <RunnableBlockEditor
+            key={`${target.mode}:${target.mode === "saved" ? target.blockKey : target.resolveType}`}
+            orgSlug={orgSlug}
+            virtualMcpId={virtualMcpId}
+            branch={branch}
+            previewUrl={previewUrl}
+            meta={meta}
+            decofile={decofile}
+            kind={kind}
+            target={target.editorTarget}
+            initialValue={target.initialValue}
+            isCreating={saveBlock.isPending}
+            onCreate={handleCreate}
+            onSaveReferencedBlock={saveReferencedBlock}
+          />
+        ) : (
+          <EmptyMessage
+            title={`Select ${kind === "loaders" ? "a loader" : "an action"} to edit`}
+            description={`Pick a ${singular} to configure its input, run it against the live preview, and save it as a global block.`}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Resolve the selected list item into the editor's target + seed props. */
+function buildTarget(
+  selection: RunnableSelection,
+  decofile: Record<string, unknown>,
+): {
+  mode: RunnableTarget["mode"];
+  blockKey?: string;
+  resolveType: string;
+  editorTarget: RunnableTarget;
+  initialValue: Record<string, unknown>;
+} | null {
+  if (!selection) return null;
+
+  if (selection.mode === "available") {
+    return {
+      mode: "available",
+      resolveType: selection.resolveType,
+      editorTarget: {
+        mode: "available",
+        resolveType: selection.resolveType,
+        title: selection.title,
+      },
+      initialValue: {},
+    };
+  }
+
+  const block = decofile[selection.key] as Record<string, unknown> | undefined;
+  const resolveType =
+    block && typeof block.__resolveType === "string" ? block.__resolveType : "";
+  const { __resolveType: _rt, ...props } = block ?? {};
+  const title =
+    block && typeof block.name === "string" && block.name
+      ? block.name
+      : selection.key;
+
+  return {
+    mode: "saved",
+    blockKey: selection.key,
+    resolveType,
+    editorTarget: {
+      mode: "saved",
+      blockKey: selection.key,
+      resolveType,
+      title,
+    },
+    initialValue: props as Record<string, unknown>,
+  };
+}

--- a/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
@@ -1,25 +1,27 @@
 import { useState } from "react";
-import { Database01, SearchLg, Zap } from "@untitledui/icons";
+import {
+  ChevronRight,
+  Database01,
+  Folder,
+  SearchLg,
+  Zap,
+} from "@untitledui/icons";
 import { toast } from "sonner";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
 import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 import { useSaveBlock } from "@/web/components/sections-editor/use-save-block";
 import { createReferencedBlockSaver } from "@/web/components/sections-editor/save-referenced-block";
-import {
-  EmptyMessage,
-  GroupHeader,
-  ItemRow,
-  ListEmpty,
-} from "./content-browser";
+import { EmptyMessage, ItemRow } from "./content-browser";
 import {
   RunnableBlockEditor,
   type RunnableTarget,
 } from "./runnable-block-editor";
 import {
-  groupRunnables,
   listAvailableRunnables,
   listSavedRunnables,
+  runnableFolderPath,
+  runnableGroupTitle,
   runnableSingular,
   type RunnableKind,
 } from "./runnable-catalog";
@@ -29,6 +31,9 @@ type RunnableSelection =
   | { mode: "saved"; key: string }
   | null;
 
+/** Virtual root folder holding the saved (global) blocks. */
+const SAVED_FOLDER = "__saved__";
+
 const KIND_ICON: Record<
   RunnableKind,
   React.ComponentType<{ size?: number; className?: string }>
@@ -37,10 +42,32 @@ const KIND_ICON: Record<
   actions: Zap,
 };
 
+const KIND_LABEL: Record<RunnableKind, string> = {
+  loaders: "Loaders",
+  actions: "Actions",
+};
+
+interface BrowsableEntry {
+  resolveType: string;
+  title: string;
+  /** Folder path the entry lives under (derived from the resolveType). */
+  folderPath: string[];
+  /** Saved (global block) entries carry their decofile key. */
+  savedKey?: string;
+}
+
+/** Folder segment display name: pretty group title at the root, raw below. */
+function folderLabel(segment: string, depth: number): string {
+  if (segment === SAVED_FOLDER) return "Saved";
+  return depth === 0 ? runnableGroupTitle(segment) : segment;
+}
+
 /**
- * Middle list + editor for the Loaders / Actions content tabs. Lists a site's
- * saved (global) blocks and the available (manifest) ones for the given kind;
- * selecting one opens the {@link RunnableBlockEditor} (form + JSON + Run).
+ * Folder-navigable browser for the Loaders / Actions content tabs. The main
+ * panel walks the resolveType path as folders (vendor → category); leaves open
+ * the {@link RunnableBlockEditor} (form + JSON + Run). Saved (global) blocks
+ * live under a virtual "Saved" folder at the root. Searching flattens the tree
+ * into a flat result list across every folder.
  */
 export function RunnableBlocksBrowser({
   orgSlug,
@@ -59,14 +86,16 @@ export function RunnableBlocksBrowser({
   decofile: Record<string, unknown>;
   kind: RunnableKind;
 }) {
+  const [path, setPath] = useState<string[]>([]);
   const [selection, setSelection] = useState<RunnableSelection>(null);
   const [searchQuery, setSearchQuery] = useState("");
 
-  // Reset selection + search when switching between the Loaders and Actions
-  // tabs (this component is reused for both).
+  // Reset navigation when switching between the Loaders and Actions tabs
+  // (this component is reused for both).
   const [prevKind, setPrevKind] = useState(kind);
   if (prevKind !== kind) {
     setPrevKind(kind);
+    setPath([]);
     setSelection(null);
     setSearchQuery("");
   }
@@ -79,23 +108,67 @@ export function RunnableBlocksBrowser({
   const singular = runnableSingular(kind);
   const Icon = KIND_ICON[kind];
 
-  const saved = listSavedRunnables(meta, decofile, kind);
-  const available = listAvailableRunnables(meta, kind);
+  const entries: BrowsableEntry[] = [
+    ...listSavedRunnables(meta, decofile, kind).map((e) => ({
+      resolveType: e.resolveType,
+      title: e.title,
+      folderPath: [SAVED_FOLDER],
+      savedKey: e.key,
+    })),
+    ...listAvailableRunnables(meta, kind).map((e) => ({
+      resolveType: e.resolveType,
+      title: e.title,
+      folderPath: runnableFolderPath(e.resolveType),
+    })),
+  ];
 
-  const q = searchQuery.toLowerCase();
-  const filteredSaved = saved.filter(
-    (e) =>
-      !q ||
-      e.title.toLowerCase().includes(q) ||
-      e.resolveType.toLowerCase().includes(q),
-  );
-  const filteredAvailable = available.filter(
-    (e) =>
-      !q ||
-      e.title.toLowerCase().includes(q) ||
-      e.resolveType.toLowerCase().includes(q),
-  );
-  const availableGroups = groupRunnables(filteredAvailable);
+  const q = searchQuery.trim().toLowerCase();
+  const searching = q.length > 0;
+  const searchResults = searching
+    ? entries.filter(
+        (e) =>
+          e.title.toLowerCase().includes(q) ||
+          e.resolveType.toLowerCase().includes(q),
+      )
+    : [];
+
+  // Children of the current folder: sub-folders (with descendant counts) and
+  // the entries that live directly at this level.
+  const folders = new Map<string, number>();
+  const items: BrowsableEntry[] = [];
+  if (!searching) {
+    for (const entry of entries) {
+      const fp = entry.folderPath;
+      if (fp.length < path.length) continue;
+      if (!path.every((seg, i) => fp[i] === seg)) continue;
+      if (fp.length === path.length) {
+        items.push(entry);
+      } else {
+        const name = fp[path.length]!;
+        folders.set(name, (folders.get(name) ?? 0) + 1);
+      }
+    }
+    items.sort((a, b) => a.title.localeCompare(b.title));
+  }
+  const folderList = [...folders.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) =>
+      folderLabel(a.name, path.length).localeCompare(
+        folderLabel(b.name, path.length),
+      ),
+    );
+
+  const selectEntry = (entry: BrowsableEntry) => {
+    setSelection(
+      entry.savedKey !== undefined
+        ? { mode: "saved", key: entry.savedKey }
+        : {
+            mode: "available",
+            resolveType: entry.resolveType,
+            title: entry.title,
+          },
+    );
+  };
 
   const handleCreate = async (
     blockId: string,
@@ -108,122 +181,178 @@ export function RunnableBlocksBrowser({
 
   const target = buildTarget(selection, decofile);
 
+  if (target) {
+    return (
+      <RunnableBlockEditor
+        key={`${target.mode}:${target.mode === "saved" ? target.blockKey : target.resolveType}`}
+        orgSlug={orgSlug}
+        virtualMcpId={virtualMcpId}
+        branch={branch}
+        previewUrl={previewUrl}
+        meta={meta}
+        decofile={decofile}
+        kind={kind}
+        target={target.editorTarget}
+        initialValue={target.initialValue}
+        isCreating={saveBlock.isPending}
+        onCreate={handleCreate}
+        onSaveReferencedBlock={saveReferencedBlock}
+        onBack={() => setSelection(null)}
+      />
+    );
+  }
+
   return (
-    <div className="flex h-full w-full min-w-0">
-      <div className="flex w-[300px] shrink-0 flex-col border-r min-h-0">
-        <div className="flex h-12 shrink-0 items-center gap-1 border-b px-2">
-          <div className="flex flex-1 items-center gap-2 pl-1">
-            <SearchLg
-              size={14}
-              className="shrink-0 text-muted-foreground"
-              aria-hidden
-            />
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder={`Search ${kind}…`}
-              aria-label={`Search ${kind}`}
-              className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-            />
-          </div>
-        </div>
-        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
-          <div className="flex flex-col gap-1 p-1.5">
-            {filteredSaved.length === 0 && filteredAvailable.length === 0 ? (
-              <ListEmpty
-                hasItems={saved.length > 0 || available.length > 0}
-                emptyLabel={`No ${kind} yet.`}
-                emptyHint="Start the preview dev server so its manifest loads."
-              />
-            ) : (
-              <>
-                {filteredSaved.length > 0 && (
-                  <>
-                    <GroupHeader icon={Icon} label={`Saved ${kind}`} />
-                    {filteredSaved.map((entry) => (
-                      <ItemRow
-                        key={entry.key}
-                        icon={Icon}
-                        accent="global"
-                        title={entry.title}
-                        subtitle={entry.resolveType}
-                        active={
-                          selection?.mode === "saved" &&
-                          selection.key === entry.key
-                        }
-                        onClick={() =>
-                          setSelection({ mode: "saved", key: entry.key })
-                        }
-                      />
-                    ))}
-                  </>
-                )}
-                {availableGroups.map((group, groupIndex) => (
-                  <div key={group.key} className="flex flex-col gap-1">
-                    <GroupHeader
-                      icon={Icon}
-                      label={`${group.title} · ${group.entries.length}`}
-                      className={cn(
-                        (filteredSaved.length > 0 || groupIndex > 0) && "mt-3",
-                      )}
-                    />
-                    {group.entries.map((entry) => (
-                      <ItemRow
-                        key={entry.resolveType}
-                        icon={Icon}
-                        title={entry.title}
-                        subtitle={entry.resolveType}
-                        active={
-                          selection?.mode === "available" &&
-                          selection.resolveType === entry.resolveType
-                        }
-                        onClick={() =>
-                          setSelection({
-                            mode: "available",
-                            resolveType: entry.resolveType,
-                            title: entry.title,
-                          })
-                        }
-                      />
-                    ))}
-                  </div>
-                ))}
-              </>
+    <div className="flex h-full w-full min-w-0 flex-col">
+      {/* Breadcrumb + search header. */}
+      <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+        <nav
+          aria-label="Folder breadcrumb"
+          className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-sm"
+        >
+          <button
+            type="button"
+            onClick={() => setPath([])}
+            className={cn(
+              "min-w-0 truncate rounded-md px-1 py-0.5 transition-colors hover:bg-accent hover:text-accent-foreground",
+              path.length === 0
+                ? "font-medium text-foreground"
+                : "text-muted-foreground",
             )}
-          </div>
-        </ScrollArea>
+          >
+            {KIND_LABEL[kind]}
+          </button>
+          {path.map((segment, index) => {
+            const isLast = index === path.length - 1;
+            return (
+              <span
+                key={`${segment}-${index}`}
+                className="flex min-w-0 items-center gap-1 overflow-hidden"
+              >
+                <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" />
+                <button
+                  type="button"
+                  onClick={() => setPath(path.slice(0, index + 1))}
+                  className={cn(
+                    "min-w-0 truncate rounded-md px-1 py-0.5 transition-colors hover:bg-accent hover:text-accent-foreground",
+                    isLast
+                      ? "font-medium text-foreground"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {folderLabel(segment, index)}
+                </button>
+              </span>
+            );
+          })}
+        </nav>
+        <div className="flex w-56 shrink-0 items-center gap-2">
+          <SearchLg
+            size={14}
+            className="shrink-0 text-muted-foreground"
+            aria-hidden
+          />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder={`Search all ${kind}…`}
+            aria-label={`Search all ${kind}`}
+            className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
       </div>
 
-      <div className="min-w-0 flex-1">
-        {target ? (
-          <RunnableBlockEditor
-            key={`${target.mode}:${target.mode === "saved" ? target.blockKey : target.resolveType}`}
-            orgSlug={orgSlug}
-            virtualMcpId={virtualMcpId}
-            branch={branch}
-            previewUrl={previewUrl}
-            meta={meta}
-            decofile={decofile}
-            kind={kind}
-            target={target.editorTarget}
-            initialValue={target.initialValue}
-            isCreating={saveBlock.isPending}
-            onCreate={handleCreate}
-            onSaveReferencedBlock={saveReferencedBlock}
-          />
-        ) : (
-          <EmptyMessage
-            title={`Select ${kind === "loaders" ? "a loader" : "an action"} to edit`}
-            description={`Pick a ${singular} to configure its input, run it against the live preview, and save it as a global block.`}
-          />
-        )}
-      </div>
+      <ScrollArea className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block">
+        <div className="mx-auto w-full max-w-4xl px-6 py-5">
+          {searching ? (
+            searchResults.length === 0 ? (
+              <EmptyMessage
+                title={`No ${kind} match "${searchQuery.trim()}"`}
+                description="Search covers every folder — try a different term."
+              />
+            ) : (
+              <div className="flex flex-col gap-1">
+                {searchResults.map((entry) => (
+                  <ItemRow
+                    key={entry.savedKey ?? entry.resolveType}
+                    icon={Icon}
+                    accent={entry.savedKey !== undefined ? "global" : undefined}
+                    title={entry.title}
+                    subtitle={entry.resolveType}
+                    active={false}
+                    onClick={() => selectEntry(entry)}
+                  />
+                ))}
+              </div>
+            )
+          ) : folderList.length === 0 && items.length === 0 ? (
+            <EmptyMessage
+              title={`No ${kind} here`}
+              description={
+                path.length === 0
+                  ? "Start the preview dev server so its manifest loads."
+                  : "This folder is empty."
+              }
+            />
+          ) : (
+            <>
+              {folderList.length > 0 && (
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-2">
+                  {folderList.map((folder) => (
+                    <button
+                      key={folder.name}
+                      type="button"
+                      onClick={() => setPath([...path, folder.name])}
+                      className="flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-colors hover:bg-muted cursor-pointer"
+                    >
+                      <Folder
+                        size={18}
+                        className="shrink-0 text-muted-foreground"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium">
+                          {folderLabel(folder.name, path.length)}
+                        </span>
+                        <span className="block text-xs text-muted-foreground">
+                          {folder.count} {folder.count === 1 ? singular : kind}
+                        </span>
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+              {items.length > 0 && (
+                <div
+                  className={cn(
+                    "flex flex-col gap-1",
+                    folderList.length > 0 && "mt-4",
+                  )}
+                >
+                  {items.map((entry) => (
+                    <ItemRow
+                      key={entry.savedKey ?? entry.resolveType}
+                      icon={Icon}
+                      accent={
+                        entry.savedKey !== undefined ? "global" : undefined
+                      }
+                      title={entry.title}
+                      subtitle={entry.resolveType}
+                      active={false}
+                      onClick={() => selectEntry(entry)}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </ScrollArea>
     </div>
   );
 }
 
-/** Resolve the selected list item into the editor's target + seed props. */
+/** Resolve the selected entry into the editor's target + seed props. */
 function buildTarget(
   selection: RunnableSelection,
   decofile: Record<string, unknown>,

--- a/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
@@ -1,9 +1,14 @@
 import { useState } from "react";
 import {
+  BookOpen01,
   ChevronRight,
   Database01,
   Folder,
+  Globe01,
+  Home01,
+  LineChartUp01,
   SearchLg,
+  ShoppingCart01,
   Zap,
 } from "@untitledui/icons";
 import { toast } from "sonner";
@@ -31,9 +36,6 @@ type RunnableSelection =
   | { mode: "saved"; key: string }
   | null;
 
-/** Virtual root folder holding the saved (global) blocks. */
-const SAVED_FOLDER = "__saved__";
-
 const KIND_ICON: Record<
   RunnableKind,
   React.ComponentType<{ size?: number; className?: string }>
@@ -47,6 +49,25 @@ const KIND_LABEL: Record<RunnableKind, string> = {
   actions: "Actions",
 };
 
+type IconComponent = React.ComponentType<{ size?: number; className?: string }>;
+
+/**
+ * Icons for the root folders a deco site usually exposes; unknown vendors
+ * (shopify, vnda, …) fall back to the generic folder icon.
+ */
+const ROOT_FOLDER_ICONS: Record<string, IconComponent> = {
+  analytics: LineChartUp01,
+  blog: BookOpen01,
+  commerce: ShoppingCart01,
+  site: Home01,
+  website: Globe01,
+};
+
+function folderIcon(segment: string, depth: number): IconComponent {
+  if (depth === 0) return ROOT_FOLDER_ICONS[segment.toLowerCase()] ?? Folder;
+  return Folder;
+}
+
 interface BrowsableEntry {
   resolveType: string;
   title: string;
@@ -58,7 +79,6 @@ interface BrowsableEntry {
 
 /** Folder segment display name: pretty group title at the root, raw below. */
 function folderLabel(segment: string, depth: number): string {
-  if (segment === SAVED_FOLDER) return "Saved";
   return depth === 0 ? runnableGroupTitle(segment) : segment;
 }
 
@@ -108,11 +128,13 @@ export function RunnableBlocksBrowser({
   const singular = runnableSingular(kind);
   const Icon = KIND_ICON[kind];
 
+  // Saved (global) blocks live alongside the raw manifest blocks they
+  // instantiate — same folder, purple accent, counted on the folder card.
   const entries: BrowsableEntry[] = [
     ...listSavedRunnables(meta, decofile, kind).map((e) => ({
       resolveType: e.resolveType,
       title: e.title,
-      folderPath: [SAVED_FOLDER],
+      folderPath: runnableFolderPath(e.resolveType),
       savedKey: e.key,
     })),
     ...listAvailableRunnables(meta, kind).map((e) => ({
@@ -132,9 +154,9 @@ export function RunnableBlocksBrowser({
       )
     : [];
 
-  // Children of the current folder: sub-folders (with descendant counts) and
-  // the entries that live directly at this level.
-  const folders = new Map<string, number>();
+  // Children of the current folder: sub-folders (with descendant + saved
+  // counts) and the entries that live directly at this level.
+  const folders = new Map<string, { count: number; savedCount: number }>();
   const items: BrowsableEntry[] = [];
   if (!searching) {
     for (const entry of entries) {
@@ -145,13 +167,16 @@ export function RunnableBlocksBrowser({
         items.push(entry);
       } else {
         const name = fp[path.length]!;
-        folders.set(name, (folders.get(name) ?? 0) + 1);
+        const bucket = folders.get(name) ?? { count: 0, savedCount: 0 };
+        bucket.count += 1;
+        if (entry.savedKey !== undefined) bucket.savedCount += 1;
+        folders.set(name, bucket);
       }
     }
     items.sort((a, b) => a.title.localeCompare(b.title));
   }
   const folderList = [...folders.entries()]
-    .map(([name, count]) => ({ name, count }))
+    .map(([name, counts]) => ({ name, ...counts }))
     .sort((a, b) =>
       folderLabel(a.name, path.length).localeCompare(
         folderLabel(b.name, path.length),
@@ -299,27 +324,34 @@ export function RunnableBlocksBrowser({
             <>
               {folderList.length > 0 && (
                 <div className="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-2">
-                  {folderList.map((folder) => (
-                    <button
-                      key={folder.name}
-                      type="button"
-                      onClick={() => setPath([...path, folder.name])}
-                      className="flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-colors hover:bg-muted cursor-pointer"
-                    >
-                      <Folder
-                        size={18}
-                        className="shrink-0 text-muted-foreground"
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-sm font-medium">
-                          {folderLabel(folder.name, path.length)}
+                  {folderList.map((folder) => {
+                    const FolderIcon = folderIcon(folder.name, path.length);
+                    return (
+                      <button
+                        key={folder.name}
+                        type="button"
+                        onClick={() => setPath([...path, folder.name])}
+                        className="flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-colors hover:bg-muted cursor-pointer"
+                      >
+                        <FolderIcon
+                          size={18}
+                          className="shrink-0 text-muted-foreground"
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium">
+                            {folderLabel(folder.name, path.length)}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {folder.count}{" "}
+                            {folder.count === 1 ? singular : kind}
+                            {folder.savedCount > 0 && (
+                              <> · {folder.savedCount} saved</>
+                            )}
+                          </span>
                         </span>
-                        <span className="block text-xs text-muted-foreground">
-                          {folder.count} {folder.count === 1 ? singular : kind}
-                        </span>
-                      </span>
-                    </button>
-                  ))}
+                      </button>
+                    );
+                  })}
                 </div>
               )}
               {items.length > 0 && (

--- a/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import {
   BookOpen01,
+  ChevronDown,
   ChevronRight,
   Database01,
   Folder,
@@ -15,6 +16,7 @@ import { toast } from "sonner";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
 import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import { GLOBAL_SECTION_ICON_COLOR } from "@/web/components/sections-editor/section-types";
 import { useSaveBlock } from "@/web/components/sections-editor/use-save-block";
 import { createReferencedBlockSaver } from "@/web/components/sections-editor/save-referenced-block";
 import { EmptyMessage, ItemRow } from "./content-browser";
@@ -86,8 +88,9 @@ function folderLabel(segment: string, depth: number): string {
  * Folder-navigable browser for the Loaders / Actions content tabs. The main
  * panel walks the resolveType path as folders (vendor → category); leaves open
  * the {@link RunnableBlockEditor} (form + JSON + Run). Saved (global) blocks
- * live under a virtual "Saved" folder at the root. Searching flattens the tree
- * into a flat result list across every folder.
+ * live alongside the raw block they instantiate, behind a purple "See saved"
+ * accordion under its row. Searching flattens the tree into a flat result list
+ * across every folder.
  */
 export function RunnableBlocksBrowser({
   orgSlug,
@@ -109,6 +112,8 @@ export function RunnableBlocksBrowser({
   const [path, setPath] = useState<string[]>([]);
   const [selection, setSelection] = useState<RunnableSelection>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  // resolveTypes whose "See saved" accordion is open.
+  const [openSaved, setOpenSaved] = useState<Set<string>>(() => new Set());
 
   // Reset navigation when switching between the Loaders and Actions tabs
   // (this component is reused for both).
@@ -118,7 +123,17 @@ export function RunnableBlocksBrowser({
     setPath([]);
     setSelection(null);
     setSearchQuery("");
+    setOpenSaved(new Set());
   }
+
+  const toggleSavedOpen = (resolveType: string) => {
+    setOpenSaved((prev) => {
+      const next = new Set(prev);
+      if (next.has(resolveType)) next.delete(resolveType);
+      else next.add(resolveType);
+      return next;
+    });
+  };
 
   const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
   const saveReferencedBlock = createReferencedBlockSaver((blockKey, data) =>
@@ -154,27 +169,44 @@ export function RunnableBlocksBrowser({
       )
     : [];
 
-  // Children of the current folder: sub-folders (with descendant + saved
-  // counts) and the entries that live directly at this level.
+  // Children of the current folder: sub-folders (with raw + saved counts),
+  // the raw entries at this level, and their saved instances grouped by
+  // resolveType (rendered as a "See saved" accordion under each raw row).
   const folders = new Map<string, { count: number; savedCount: number }>();
   const items: BrowsableEntry[] = [];
+  const savedByResolveType = new Map<string, BrowsableEntry[]>();
   if (!searching) {
     for (const entry of entries) {
       const fp = entry.folderPath;
       if (fp.length < path.length) continue;
       if (!path.every((seg, i) => fp[i] === seg)) continue;
       if (fp.length === path.length) {
-        items.push(entry);
+        if (entry.savedKey !== undefined) {
+          const bucket = savedByResolveType.get(entry.resolveType);
+          if (bucket) bucket.push(entry);
+          else savedByResolveType.set(entry.resolveType, [entry]);
+        } else {
+          items.push(entry);
+        }
       } else {
         const name = fp[path.length]!;
         const bucket = folders.get(name) ?? { count: 0, savedCount: 0 };
-        bucket.count += 1;
         if (entry.savedKey !== undefined) bucket.savedCount += 1;
+        else bucket.count += 1;
         folders.set(name, bucket);
       }
     }
     items.sort((a, b) => a.title.localeCompare(b.title));
+    for (const bucket of savedByResolveType.values()) {
+      bucket.sort((a, b) => a.title.localeCompare(b.title));
+    }
   }
+  // Saved blocks whose raw loader isn't listed at this level (hidden or gone
+  // from the manifest) still need a home — rendered as standalone rows.
+  const orphanSaved = [...savedByResolveType.entries()]
+    .filter(([rt]) => !items.some((item) => item.resolveType === rt))
+    .flatMap(([, bucket]) => bucket)
+    .sort((a, b) => a.title.localeCompare(b.title));
   const folderList = [...folders.entries()]
     .map(([name, counts]) => ({ name, ...counts }))
     .sort((a, b) =>
@@ -311,7 +343,9 @@ export function RunnableBlocksBrowser({
                 ))}
               </div>
             )
-          ) : folderList.length === 0 && items.length === 0 ? (
+          ) : folderList.length === 0 &&
+            items.length === 0 &&
+            orphanSaved.length === 0 ? (
             <EmptyMessage
               title={`No ${kind} here`}
               description={
@@ -354,20 +388,68 @@ export function RunnableBlocksBrowser({
                   })}
                 </div>
               )}
-              {items.length > 0 && (
+              {(items.length > 0 || orphanSaved.length > 0) && (
                 <div
                   className={cn(
                     "flex flex-col gap-1",
                     folderList.length > 0 && "mt-4",
                   )}
                 >
-                  {items.map((entry) => (
+                  {items.map((entry) => {
+                    const saved =
+                      savedByResolveType.get(entry.resolveType) ?? [];
+                    const savedOpen = openSaved.has(entry.resolveType);
+                    return (
+                      <div key={entry.resolveType} className="flex flex-col">
+                        <ItemRow
+                          icon={Icon}
+                          title={entry.title}
+                          subtitle={entry.resolveType}
+                          active={false}
+                          onClick={() => selectEntry(entry)}
+                        />
+                        {saved.length > 0 && (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => toggleSavedOpen(entry.resolveType)}
+                              aria-expanded={savedOpen}
+                              className="flex items-center gap-1 self-start rounded-md px-2.5 py-1 text-xs font-medium transition-colors hover:bg-global-section/10 cursor-pointer ml-11"
+                              style={{ color: GLOBAL_SECTION_ICON_COLOR }}
+                            >
+                              {savedOpen ? (
+                                <ChevronDown size={12} className="shrink-0" />
+                              ) : (
+                                <ChevronRight size={12} className="shrink-0" />
+                              )}
+                              {savedOpen ? "Hide saved" : "See saved"} (
+                              {saved.length})
+                            </button>
+                            {savedOpen && (
+                              <div className="ml-11 flex flex-col gap-1 pb-1">
+                                {saved.map((savedEntry) => (
+                                  <ItemRow
+                                    key={savedEntry.savedKey}
+                                    icon={Icon}
+                                    accent="global"
+                                    title={savedEntry.title}
+                                    subtitle={savedEntry.resolveType}
+                                    active={false}
+                                    onClick={() => selectEntry(savedEntry)}
+                                  />
+                                ))}
+                              </div>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    );
+                  })}
+                  {orphanSaved.map((entry) => (
                     <ItemRow
-                      key={entry.savedKey ?? entry.resolveType}
+                      key={entry.savedKey}
                       icon={Icon}
-                      accent={
-                        entry.savedKey !== undefined ? "global" : undefined
-                      }
+                      accent="global"
                       title={entry.title}
                       subtitle={entry.resolveType}
                       active={false}

--- a/apps/mesh/src/web/components/sandbox/content/runnable-catalog.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-catalog.test.ts
@@ -22,6 +22,7 @@ const meta: LiveMeta = {
         "site/loaders/Preview.ts": { $ref: "#/definitions/Preview" },
         "shopify/loaders/internal.ts": { $ref: "#/definitions/Internal" },
         "$live/loaders/state.ts": { $ref: "#/definitions/State" },
+        "workflows/loaders/events.ts": { $ref: "#/definitions/Events" },
       },
       actions: {
         "site/actions/submit.ts": { $ref: "#/definitions/Submit" },
@@ -75,6 +76,8 @@ describe("runnable-catalog", () => {
     expect(resolveTypes).not.toContain("site/loaders/Preview.ts");
     // `ignore: true` in the schema filters the block out.
     expect(resolveTypes).not.toContain("shopify/loaders/internal.ts");
+    // The workflows app's plumbing loaders are hidden entirely.
+    expect(resolveTypes).not.toContain("workflows/loaders/events.ts");
   });
 
   it("runnableGroupKey groups by vendor / deco engine", () => {

--- a/apps/mesh/src/web/components/sandbox/content/runnable-catalog.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-catalog.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 import {
-  groupRunnables,
   isManifestRunnableResolveType,
   listAvailableRunnables,
   listSavedRunnables,
+  runnableFolderPath,
   runnableGroupKey,
 } from "./runnable-catalog";
 
@@ -85,20 +85,23 @@ describe("runnable-catalog", () => {
     expect(runnableGroupKey("site/loaders/products.ts")).toBe("site");
   });
 
-  it("groupRunnables buckets entries by namespace, sorted", () => {
-    const groups = groupRunnables(listAvailableRunnables(meta, "loaders"));
-    const byKey = Object.fromEntries(groups.map((g) => [g.key, g]));
-    expect(byKey.vtex?.entries.map((e) => e.resolveType)).toEqual([
-      "vtex/loaders/legacy/productList.ts",
+  it("runnableFolderPath walks the resolveType as folders", () => {
+    expect(
+      runnableFolderPath("vtex/loaders/intelligentSearch/productList.ts"),
+    ).toEqual(["vtex", "intelligentSearch"]);
+    expect(runnableFolderPath("vtex/loaders/legacy/productList.ts")).toEqual([
+      "vtex",
+      "legacy",
     ]);
-    expect(byKey.deco?.title).toBe("Deco");
-    expect(byKey.deco?.entries.map((e) => e.resolveType)).toEqual([
-      "$live/loaders/state.ts",
+    expect(runnableFolderPath("site/loaders/products.ts")).toEqual(["site"]);
+    expect(runnableFolderPath("$live/loaders/state.ts")).toEqual(["deco"]);
+    expect(
+      runnableFolderPath("deco-sites/mysite/loaders/product/detail.ts"),
+    ).toEqual(["mysite", "product"]);
+    expect(runnableFolderPath("site/actions/cart/add.ts")).toEqual([
+      "site",
+      "cart",
     ]);
-    // Groups sorted by title.
-    expect(groups.map((g) => g.title)).toEqual(
-      [...groups.map((g) => g.title)].sort((a, b) => a.localeCompare(b)),
-    );
   });
 
   it("listAvailableRunnables scopes actions to the actions block type", () => {

--- a/apps/mesh/src/web/components/sandbox/content/runnable-catalog.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-catalog.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import {
+  groupRunnables,
+  isManifestRunnableResolveType,
+  listAvailableRunnables,
+  listSavedRunnables,
+  runnableGroupKey,
+} from "./runnable-catalog";
+
+const meta: LiveMeta = {
+  manifest: {
+    blocks: {
+      sections: {
+        "site/sections/Header/Header.tsx": { $ref: "#/definitions/Header" },
+      },
+      loaders: {
+        "site/loaders/products.ts": { $ref: "#/definitions/Products" },
+        "vtex/loaders/legacy/productList.ts": {
+          $ref: "#/definitions/ProductList",
+        },
+        "site/loaders/Preview.ts": { $ref: "#/definitions/Preview" },
+        "shopify/loaders/internal.ts": { $ref: "#/definitions/Internal" },
+        "$live/loaders/state.ts": { $ref: "#/definitions/State" },
+      },
+      actions: {
+        "site/actions/submit.ts": { $ref: "#/definitions/Submit" },
+      },
+    },
+  },
+  schema: {
+    definitions: {
+      // Marked hidden via the deco `ignore` convention — must be filtered out.
+      Internal: { title: "Internal", ignore: true },
+    },
+  },
+};
+
+describe("runnable-catalog", () => {
+  it("isManifestRunnableResolveType matches only the requested kind", () => {
+    expect(
+      isManifestRunnableResolveType(
+        meta,
+        "site/loaders/products.ts",
+        "loaders",
+      ),
+    ).toBe(true);
+    expect(
+      isManifestRunnableResolveType(meta, "site/actions/submit.ts", "actions"),
+    ).toBe(true);
+    // A loader is not an action and vice versa.
+    expect(
+      isManifestRunnableResolveType(
+        meta,
+        "site/loaders/products.ts",
+        "actions",
+      ),
+    ).toBe(false);
+    // Sections are neither.
+    expect(
+      isManifestRunnableResolveType(
+        meta,
+        "site/sections/Header/Header.tsx",
+        "loaders",
+      ),
+    ).toBe(false);
+  });
+
+  it("listAvailableRunnables skips previews and blocks marked hidden", () => {
+    const loaders = listAvailableRunnables(meta, "loaders");
+    const resolveTypes = loaders.map((l) => l.resolveType);
+    expect(resolveTypes).toContain("site/loaders/products.ts");
+    expect(resolveTypes).toContain("vtex/loaders/legacy/productList.ts");
+    // Preview stub filtered by name.
+    expect(resolveTypes).not.toContain("site/loaders/Preview.ts");
+    // `ignore: true` in the schema filters the block out.
+    expect(resolveTypes).not.toContain("shopify/loaders/internal.ts");
+  });
+
+  it("runnableGroupKey groups by vendor / deco engine", () => {
+    expect(runnableGroupKey("vtex/loaders/legacy/productList.ts")).toBe("vtex");
+    expect(runnableGroupKey("$live/loaders/state.ts")).toBe("deco");
+    expect(runnableGroupKey("deco/loaders/x.ts")).toBe("deco");
+    expect(runnableGroupKey("deco-sites/mysite/loaders/x.ts")).toBe("mysite");
+    expect(runnableGroupKey("site/loaders/products.ts")).toBe("site");
+  });
+
+  it("groupRunnables buckets entries by namespace, sorted", () => {
+    const groups = groupRunnables(listAvailableRunnables(meta, "loaders"));
+    const byKey = Object.fromEntries(groups.map((g) => [g.key, g]));
+    expect(byKey.vtex?.entries.map((e) => e.resolveType)).toEqual([
+      "vtex/loaders/legacy/productList.ts",
+    ]);
+    expect(byKey.deco?.title).toBe("Deco");
+    expect(byKey.deco?.entries.map((e) => e.resolveType)).toEqual([
+      "$live/loaders/state.ts",
+    ]);
+    // Groups sorted by title.
+    expect(groups.map((g) => g.title)).toEqual(
+      [...groups.map((g) => g.title)].sort((a, b) => a.localeCompare(b)),
+    );
+  });
+
+  it("listAvailableRunnables scopes actions to the actions block type", () => {
+    const actions = listAvailableRunnables(meta, "actions");
+    expect(actions.map((a) => a.resolveType)).toEqual([
+      "site/actions/submit.ts",
+    ]);
+  });
+
+  it("listSavedRunnables picks decofile blocks of the matching kind", () => {
+    const decofile: Record<string, unknown> = {
+      MyProducts: {
+        __resolveType: "site/loaders/products.ts",
+        name: "My products",
+        count: 10,
+      },
+      MySubmit: { __resolveType: "site/actions/submit.ts" },
+      // Not a runnable — should be ignored.
+      Header: { __resolveType: "site/sections/Header/Header.tsx" },
+      // Nested path keys and non-objects are skipped.
+      "pages/home": { __resolveType: "site/loaders/products.ts" },
+      plain: "value",
+    };
+
+    const savedLoaders = listSavedRunnables(meta, decofile, "loaders");
+    expect(savedLoaders).toEqual([
+      {
+        key: "MyProducts",
+        resolveType: "site/loaders/products.ts",
+        title: "My products",
+      },
+    ]);
+
+    const savedActions = listSavedRunnables(meta, decofile, "actions");
+    expect(savedActions).toEqual([
+      {
+        key: "MySubmit",
+        resolveType: "site/actions/submit.ts",
+        title: "MySubmit",
+      },
+    ]);
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
@@ -29,6 +29,13 @@ const KIND_SINGULAR: Record<RunnableKind, string> = {
   actions: "action",
 };
 
+/**
+ * App/vendor groups whose blocks are internal plumbing, not site content —
+ * hidden from the Loaders/Actions tabs entirely (e.g. the workflows app's
+ * `workflows/loaders/events.ts` / `get.ts`).
+ */
+const HIDDEN_RUNNABLE_GROUPS = new Set(["workflows"]);
+
 export function runnableSingular(kind: RunnableKind): string {
   return KIND_SINGULAR[kind];
 }
@@ -70,6 +77,7 @@ export function listAvailableRunnables(
     if (!blockType.includes(kind)) continue;
     for (const resolveType of Object.keys(blockMap)) {
       if (resolveType.toLowerCase().includes("preview")) continue;
+      if (HIDDEN_RUNNABLE_GROUPS.has(runnableGroupKey(resolveType))) continue;
       if (seen.has(resolveType)) continue;
       seen.add(resolveType);
       const metadata = resolveBlockSchemaMetadata(resolveType, meta);
@@ -156,6 +164,7 @@ export function listSavedRunnables(
     const obj = val as Record<string, unknown>;
     const rt = obj.__resolveType;
     if (typeof rt !== "string") continue;
+    if (HIDDEN_RUNNABLE_GROUPS.has(runnableGroupKey(rt))) continue;
     if (!isManifestRunnableResolveType(meta, rt, kind)) continue;
 
     entries.push({

--- a/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
@@ -1,0 +1,171 @@
+import { isAutoPreviewBlockKey } from "@/web/components/sections-editor/block-type-utils";
+import {
+  resolveBlockSchemaMetadata,
+  type LiveMeta,
+} from "@/web/components/sections-editor/resolve-schema";
+import { labelFromResolveType } from "@/web/components/sections-editor/section-types";
+
+/** The two block kinds surfaced by the Loaders / Actions content tabs. */
+export type RunnableKind = "loaders" | "actions";
+
+/** An available (manifest) loader/action that can be configured and invoked. */
+interface RunnableEntry {
+  /** Manifest module resolveType, e.g. `site/loaders/products.ts`. */
+  resolveType: string;
+  title: string;
+}
+
+/** A loader/action already saved as a global block in the decofile. */
+interface SavedRunnableEntry {
+  /** Decofile block key. */
+  key: string;
+  /** The module resolveType the block instantiates. */
+  resolveType: string;
+  title: string;
+}
+
+const KIND_SINGULAR: Record<RunnableKind, string> = {
+  loaders: "loader",
+  actions: "action",
+};
+
+export function runnableSingular(kind: RunnableKind): string {
+  return KIND_SINGULAR[kind];
+}
+
+/**
+ * Whether a resolveType is a manifest block of the given runnable kind. Mirrors
+ * `isManifestSectionResolveType`: block-type keys carry the kind in their name
+ * (e.g. `loaders`, `vtex/loaders`).
+ */
+export function isManifestRunnableResolveType(
+  meta: LiveMeta,
+  resolveType: string,
+  kind: RunnableKind,
+): boolean {
+  const blocks = meta.manifest?.blocks ?? {};
+  for (const [blockType, blockMap] of Object.entries(blocks)) {
+    if (!blockType.includes(kind)) continue;
+    if (resolveType in blockMap) return true;
+  }
+  return false;
+}
+
+/**
+ * Available (manifest) loaders/actions for the given kind. Skips preview stubs
+ * and blocks the site marks hidden (deco `@ignore` / `hide` — the same signal
+ * the section catalog respects), mirroring how admin keeps internal blocks out
+ * of its pickers. Titles come from the block schema when present, else from the
+ * resolveType.
+ */
+export function listAvailableRunnables(
+  meta: LiveMeta,
+  kind: RunnableKind,
+): RunnableEntry[] {
+  const blocks = meta.manifest?.blocks ?? {};
+  const entries: RunnableEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const [blockType, blockMap] of Object.entries(blocks)) {
+    if (!blockType.includes(kind)) continue;
+    for (const resolveType of Object.keys(blockMap)) {
+      if (resolveType.toLowerCase().includes("preview")) continue;
+      if (seen.has(resolveType)) continue;
+      seen.add(resolveType);
+      const metadata = resolveBlockSchemaMetadata(resolveType, meta);
+      if (metadata.hidden) continue;
+      entries.push({
+        resolveType,
+        title: metadata.title ?? labelFromResolveType(resolveType),
+      });
+    }
+  }
+
+  return entries.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+/** Number of available (manifest) runnables of a kind. */
+export function countAvailableRunnables(
+  meta: LiveMeta,
+  kind: RunnableKind,
+): number {
+  return listAvailableRunnables(meta, kind).length;
+}
+
+/**
+ * App/vendor namespace a runnable belongs to, mirroring admin's `appFilterKey`:
+ * `deco-sites/<site>/…` → the site name, deco engine (`$live`/`deco/…`) → `deco`,
+ * everything else → the first path segment (the app/vendor, e.g. `vtex`).
+ */
+export function runnableGroupKey(resolveType: string): string {
+  if (resolveType.startsWith("deco-sites/")) {
+    return resolveType.split("/")[1] || "site";
+  }
+  if (resolveType.startsWith("$live") || resolveType.startsWith("deco/")) {
+    return "deco";
+  }
+  return resolveType.split("/")[0] || "other";
+}
+
+/** Pretty label for a group key (mirrors admin's `mapTitleByKey`). */
+const GROUP_TITLES: Record<string, string> = {
+  deco: "Deco",
+  std: "Deco Standard",
+  website: "Website",
+};
+
+function runnableGroupTitle(key: string): string {
+  return GROUP_TITLES[key] ?? key;
+}
+
+export interface RunnableGroup {
+  key: string;
+  title: string;
+  entries: RunnableEntry[];
+}
+
+/** Group runnables by app/vendor namespace, sorted by group then title. */
+export function groupRunnables(entries: RunnableEntry[]): RunnableGroup[] {
+  const byKey = new Map<string, RunnableEntry[]>();
+  for (const entry of entries) {
+    const key = runnableGroupKey(entry.resolveType);
+    const bucket = byKey.get(key);
+    if (bucket) bucket.push(entry);
+    else byKey.set(key, [entry]);
+  }
+  return [...byKey.entries()]
+    .map(([key, groupEntries]) => ({
+      key,
+      title: runnableGroupTitle(key),
+      entries: groupEntries.sort((a, b) => a.title.localeCompare(b.title)),
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title));
+}
+
+/** Loaders/actions already saved as global blocks in the decofile. */
+export function listSavedRunnables(
+  meta: LiveMeta,
+  decofile: Record<string, unknown>,
+  kind: RunnableKind,
+): SavedRunnableEntry[] {
+  const entries: SavedRunnableEntry[] = [];
+
+  for (const [key, val] of Object.entries(decofile)) {
+    if (key.includes("/")) continue;
+    if (isAutoPreviewBlockKey(key)) continue;
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+
+    const obj = val as Record<string, unknown>;
+    const rt = obj.__resolveType;
+    if (typeof rt !== "string") continue;
+    if (!isManifestRunnableResolveType(meta, rt, kind)) continue;
+
+    entries.push({
+      key,
+      resolveType: rt,
+      title: typeof obj.name === "string" && obj.name ? obj.name : key,
+    });
+  }
+
+  return entries.sort((a, b) => a.title.localeCompare(b.title));
+}

--- a/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
@@ -114,32 +114,30 @@ const GROUP_TITLES: Record<string, string> = {
   website: "Website",
 };
 
-function runnableGroupTitle(key: string): string {
+export function runnableGroupTitle(key: string): string {
   return GROUP_TITLES[key] ?? key;
 }
 
-export interface RunnableGroup {
-  key: string;
-  title: string;
-  entries: RunnableEntry[];
-}
-
-/** Group runnables by app/vendor namespace, sorted by group then title. */
-export function groupRunnables(entries: RunnableEntry[]): RunnableGroup[] {
-  const byKey = new Map<string, RunnableEntry[]>();
-  for (const entry of entries) {
-    const key = runnableGroupKey(entry.resolveType);
-    const bucket = byKey.get(key);
-    if (bucket) bucket.push(entry);
-    else byKey.set(key, [entry]);
+/**
+ * Folder path a runnable lives under, derived from its resolveType — the
+ * grouping the folder-navigable UI walks. The first segment is the app/vendor
+ * group ({@link runnableGroupKey}); the block-kind segment (`loaders`/`actions`,
+ * constant within a tab) and the leaf filename are dropped.
+ *
+ * `vtex/loaders/intelligentSearch/productList.ts` → `["vtex", "intelligentSearch"]`
+ * `site/loaders/products.ts`                      → `["site"]`
+ * `$live/loaders/state.ts`                        → `["deco"]`
+ * `deco-sites/mysite/loaders/product/detail.ts`   → `["mysite", "product"]`
+ */
+export function runnableFolderPath(resolveType: string): string[] {
+  const root = runnableGroupKey(resolveType);
+  const segments = resolveType.split("/").filter(Boolean);
+  let rest = segments.slice(resolveType.startsWith("deco-sites/") ? 2 : 1);
+  if (rest[0] === "loaders" || rest[0] === "actions") {
+    rest = rest.slice(1);
   }
-  return [...byKey.entries()]
-    .map(([key, groupEntries]) => ({
-      key,
-      title: runnableGroupTitle(key),
-      entries: groupEntries.sort((a, b) => a.title.localeCompare(b.title)),
-    }))
-    .sort((a, b) => a.title.localeCompare(b.title));
+  // The last segment is the block file itself, not a folder.
+  return [root, ...rest.slice(0, -1)];
 }
 
 /** Loaders/actions already saved as global blocks in the decofile. */

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { buildPreviewRunUrl } from "./use-run-block";
+
+const NOW_MS = 1_751_500_000_000;
+
+describe("buildPreviewRunUrl", () => {
+  it("keeps the resolveType raw in the path (slashes intact)", () => {
+    const url = new URL(
+      buildPreviewRunUrl(
+        "http://handle.localhost:6000",
+        "vtex/loaders/intelligentSearch/productList.ts",
+        {},
+        NOW_MS,
+      ),
+    );
+    expect(url.pathname).toBe(
+      "/live/previews/vtex/loaders/intelligentSearch/productList.ts",
+    );
+    expect(url.origin).toBe("http://handle.localhost:6000");
+  });
+
+  it("sets the cache-bust / debug search params", () => {
+    const url = new URL(
+      buildPreviewRunUrl(
+        "http://handle.localhost:6000/",
+        "site/loaders/products.ts",
+        {},
+        NOW_MS,
+      ),
+    );
+    const cb = NOW_MS.toString(36);
+    expect(url.searchParams.get("__cb")).toBe(cb);
+    expect(url.searchParams.get("__decoFBT")).toBe("0");
+    expect(url.searchParams.get("__d")).toBe(`run-${cb}`);
+  });
+
+  it("round-trips props through the admin encodeProps encoding", () => {
+    const props = {
+      term: "cadeira de praia", // unicode — the reason for encodeURIComponent
+      ids: ["149524", "149525"],
+      hideUnavailableItems: true,
+      nested: { emoji: "🏖️" },
+    };
+    const url = new URL(
+      buildPreviewRunUrl(
+        "http://handle.localhost:6000",
+        "site/loaders/products.ts",
+        props,
+        NOW_MS,
+      ),
+    );
+    const encoded = url.searchParams.get("props");
+    expect(encoded).toBeTruthy();
+    // The deco runtime decodes with `decodeURIComponent(atob(props))`.
+    expect(JSON.parse(decodeURIComponent(atob(encoded!)))).toEqual(props);
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { buildPreviewRunUrl } from "./use-run-block";
+import { buildInvokeRunUrl } from "./use-run-block";
 
 const NOW_MS = 1_751_500_000_000;
 
-describe("buildPreviewRunUrl", () => {
+describe("buildInvokeRunUrl", () => {
   it("keeps the resolveType raw in the path (slashes intact)", () => {
     const url = new URL(
-      buildPreviewRunUrl(
+      buildInvokeRunUrl(
         "http://handle.localhost:6000",
         "vtex/loaders/intelligentSearch/productList.ts",
         {},
@@ -14,14 +14,14 @@ describe("buildPreviewRunUrl", () => {
       ),
     );
     expect(url.pathname).toBe(
-      "/live/previews/vtex/loaders/intelligentSearch/productList.ts",
+      "/live/invoke/vtex/loaders/intelligentSearch/productList.ts",
     );
     expect(url.origin).toBe("http://handle.localhost:6000");
   });
 
   it("sets the cache-bust / debug search params", () => {
     const url = new URL(
-      buildPreviewRunUrl(
+      buildInvokeRunUrl(
         "http://handle.localhost:6000/",
         "site/loaders/products.ts",
         {},
@@ -42,7 +42,7 @@ describe("buildPreviewRunUrl", () => {
       nested: { emoji: "🏖️" },
     };
     const url = new URL(
-      buildPreviewRunUrl(
+      buildInvokeRunUrl(
         "http://handle.localhost:6000",
         "site/loaders/products.ts",
         props,

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
@@ -6,27 +6,28 @@ interface RunBlockInput {
 }
 
 /**
- * Build the block-preview run URL Deco expects (same contract the admin uses):
- * `GET <preview>/live/previews/<resolveType>` with the resolveType RAW in the
- * path (slashes intact) and:
+ * Build the invoke run URL Deco expects:
+ * `GET <preview>/live/invoke/<resolveType>` with the resolveType RAW in the
+ * path (slashes intact). Unlike `/live/previews/*` (which always renders an
+ * HTML preview page), `/live/invoke/*` returns the block's structured JSON
+ * result. Search params:
  *
  * - `__cb` — CDN cache-buster (time-encoded) so we always miss the edge cache.
  * - `__decoFBT=0` — disables loader caching for this request.
  * - `__d` — enables debug mode; the value is a free-form correlation id.
- * - `props` — `btoa(encodeURIComponent(JSON.stringify(props)))`, mirroring the
- *   admin's `encodeProps` (the runtime decodes with
- *   `decodeURIComponent(atob(props))`; the URI-encoding step keeps `btoa` safe
- *   for non-Latin1 characters).
+ * - `props` — `btoa(encodeURIComponent(JSON.stringify(props)))`; the runtime's
+ *   `bodyFromUrl` decodes with `JSON.parse(decodeURIComponent(atob(props)))`
+ *   (the URI-encoding step keeps `btoa` safe for non-Latin1 characters).
  *
  * `nowMs` is a parameter so the function stays pure and testable.
  */
-export function buildPreviewRunUrl(
+export function buildInvokeRunUrl(
   previewUrl: string,
   resolveType: string,
   props: Record<string, unknown>,
   nowMs: number,
 ): string {
-  const url = new URL(`/live/previews/${resolveType}`, previewUrl);
+  const url = new URL(`/live/invoke/${resolveType}`, previewUrl);
   url.searchParams.set("__cb", nowMs.toString(36));
   url.searchParams.set("__decoFBT", "0");
   url.searchParams.set("__d", `run-${nowMs.toString(36)}`);
@@ -51,7 +52,7 @@ async function invokeBlock(
   { resolveType, props }: RunBlockInput,
 ): Promise<unknown> {
   const res = await fetch(
-    buildPreviewRunUrl(previewUrl, resolveType, props, Date.now()),
+    buildInvokeRunUrl(previewUrl, resolveType, props, Date.now()),
   );
 
   const text = await res.text();

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
@@ -1,0 +1,75 @@
+import { useMutation } from "@tanstack/react-query";
+
+interface RunBlockInput {
+  resolveType: string;
+  props: Record<string, unknown>;
+}
+
+/**
+ * Build the single-invoke URL Deco expects:
+ * `POST <preview>/deco/invoke/<encoded resolveType>` with `{ props }` as body.
+ * Same shape as the product-list preview's server route, but the fetch runs in
+ * the browser (see below).
+ */
+function buildInvokeUrl(previewUrl: string, resolveType: string): string {
+  const base = previewUrl.replace(/\/+$/, "");
+  return `${base}/deco/invoke/${encodeURIComponent(resolveType)}`;
+}
+
+/**
+ * Live-invoke a loader/action against the running sandbox preview and return its
+ * structured result.
+ *
+ * The fetch runs CLIENT-side, straight at the preview origin — exactly like
+ * `useLiveMeta` and the dynamic-options field. This matters for desktop-linked
+ * sandboxes: the preview lives at `<handle>.localhost:<port>`, which the browser
+ * resolves but the mesh server (Bun) does not — routing through the server
+ * `preview-invoke` proxy there fails with "Preview unreachable".
+ */
+async function invokeBlock(
+  previewUrl: string,
+  { resolveType, props }: RunBlockInput,
+): Promise<unknown> {
+  const res = await fetch(buildInvokeUrl(previewUrl, resolveType), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ props }),
+  });
+
+  const text = await res.text();
+  let data: unknown = null;
+  let parsed = false;
+  try {
+    data = text ? JSON.parse(text) : null;
+    parsed = true;
+  } catch {
+    // Non-JSON body — fall through to the raw-text handling below.
+  }
+
+  if (!res.ok) {
+    const message =
+      parsed &&
+      data &&
+      typeof data === "object" &&
+      "error" in data &&
+      typeof (data as { error?: unknown }).error === "string"
+        ? (data as { error: string }).error
+        : text || `Run failed (${res.status})`;
+    throw new Error(message);
+  }
+
+  return parsed ? data : text;
+}
+
+export function useRunBlock(previewUrl: string | null) {
+  return useMutation<unknown, Error, RunBlockInput>({
+    mutationFn: (input) => {
+      if (!previewUrl) {
+        throw new Error(
+          "Preview isn't running yet — start the sandbox and try again.",
+        );
+      }
+      return invokeBlock(previewUrl, input);
+    },
+  });
+}

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
@@ -47,13 +47,27 @@ export function buildInvokeRunUrl(
  * sandboxes: the preview lives at `<handle>.localhost:<port>`, which the browser
  * resolves but the mesh server (Bun) does not.
  */
+/** Cap on a single run — same limit the server-side invoke proxy used. */
+const RUN_TIMEOUT_MS = 30_000;
+
 async function invokeBlock(
   previewUrl: string,
   { resolveType, props }: RunBlockInput,
 ): Promise<unknown> {
-  const res = await fetch(
-    buildInvokeRunUrl(previewUrl, resolveType, props, Date.now()),
-  );
+  let res: Response;
+  try {
+    res = await fetch(
+      buildInvokeRunUrl(previewUrl, resolveType, props, Date.now()),
+      { signal: AbortSignal.timeout(RUN_TIMEOUT_MS) },
+    );
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new Error(
+        `Run timed out after ${RUN_TIMEOUT_MS / 1000}s — the block may be slow or the preview unresponsive.`,
+      );
+    }
+    throw err;
+  }
 
   const text = await res.text();
   let data: unknown = null;

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
@@ -6,35 +6,53 @@ interface RunBlockInput {
 }
 
 /**
- * Build the single-invoke URL Deco expects:
- * `POST <preview>/deco/invoke/<encoded resolveType>` with `{ props }` as body.
- * Same shape as the product-list preview's server route, but the fetch runs in
- * the browser (see below).
+ * Build the block-preview run URL Deco expects (same contract the admin uses):
+ * `GET <preview>/live/previews/<resolveType>` with the resolveType RAW in the
+ * path (slashes intact) and:
+ *
+ * - `__cb` — CDN cache-buster (time-encoded) so we always miss the edge cache.
+ * - `__decoFBT=0` — disables loader caching for this request.
+ * - `__d` — enables debug mode; the value is a free-form correlation id.
+ * - `props` — `btoa(encodeURIComponent(JSON.stringify(props)))`, mirroring the
+ *   admin's `encodeProps` (the runtime decodes with
+ *   `decodeURIComponent(atob(props))`; the URI-encoding step keeps `btoa` safe
+ *   for non-Latin1 characters).
+ *
+ * `nowMs` is a parameter so the function stays pure and testable.
  */
-function buildInvokeUrl(previewUrl: string, resolveType: string): string {
-  const base = previewUrl.replace(/\/+$/, "");
-  return `${base}/deco/invoke/${encodeURIComponent(resolveType)}`;
+export function buildPreviewRunUrl(
+  previewUrl: string,
+  resolveType: string,
+  props: Record<string, unknown>,
+  nowMs: number,
+): string {
+  const url = new URL(`/live/previews/${resolveType}`, previewUrl);
+  url.searchParams.set("__cb", nowMs.toString(36));
+  url.searchParams.set("__decoFBT", "0");
+  url.searchParams.set("__d", `run-${nowMs.toString(36)}`);
+  url.searchParams.set(
+    "props",
+    btoa(encodeURIComponent(JSON.stringify(props))),
+  );
+  return url.href;
 }
 
 /**
- * Live-invoke a loader/action against the running sandbox preview and return its
- * structured result.
+ * Live-invoke a loader/action against the running sandbox preview and return
+ * its structured result.
  *
  * The fetch runs CLIENT-side, straight at the preview origin — exactly like
  * `useLiveMeta` and the dynamic-options field. This matters for desktop-linked
  * sandboxes: the preview lives at `<handle>.localhost:<port>`, which the browser
- * resolves but the mesh server (Bun) does not — routing through the server
- * `preview-invoke` proxy there fails with "Preview unreachable".
+ * resolves but the mesh server (Bun) does not.
  */
 async function invokeBlock(
   previewUrl: string,
   { resolveType, props }: RunBlockInput,
 ): Promise<unknown> {
-  const res = await fetch(buildInvokeUrl(previewUrl, resolveType), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ props }),
-  });
+  const res = await fetch(
+    buildPreviewRunUrl(previewUrl, resolveType, props, Date.now()),
+  );
 
   const text = await res.text();
   let data: unknown = null;

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -941,6 +941,8 @@ export interface BlockSchemaMetadata {
   description?: string;
   icon?: string;
   logo?: string;
+  /** Block marked hidden from pickers (deco `@ignore` / `hide` convention). */
+  hidden?: boolean;
 }
 
 /**
@@ -967,6 +969,14 @@ export function resolveBlockSchemaMetadata(
 
   const icon = (resolved as { icon?: string }).icon;
   const logo = (resolved as { logo?: string }).logo;
+  const flags = resolved as {
+    hide?: unknown;
+    ignore?: unknown;
+    unlisted?: unknown;
+  };
+  const truthy = (v: unknown) => v === true || v === "true";
+  const hidden =
+    truthy(flags.hide) || truthy(flags.ignore) || truthy(flags.unlisted);
 
   return {
     title: typeof resolved.title === "string" ? resolved.title : undefined,
@@ -976,5 +986,6 @@ export function resolveBlockSchemaMetadata(
         : undefined,
     icon: typeof icon === "string" ? icon : undefined,
     logo: typeof logo === "string" ? logo : undefined,
+    hidden: hidden || undefined,
   };
 }


### PR DESCRIPTION
## Summary
Adds two new tabs to the **Content** browser — **Loaders** and **Actions** — that surface a site's loaders/actions from the live manifest and let you configure, save, and run them.

Closes DECO-5404 — https://linear.app/decocms/issue/DECO-5404/loaders-and-actions-tab-run-option

## What it does
- **List** available (manifest) + saved (decofile global) loaders/actions per kind.
- **Edit** props via the schema form or the JSON (Monaco) view, two-way synced.
- **Save globally** a configured available block as a reusable decofile block.
- **Run** — live-invokes the loader/action against the running preview and shows the structured JSON result in a panel.

## Polish included
- **Labels:** each entry shows the full `resolveType` (e.g. `vtex/loaders/intelligentSearch/productList.ts`), disambiguating duplicates.
- **Grouping:** available entries are grouped by app/vendor namespace (mirrors admin's `appFilterKey`): `vtex`, `shopify`, …; `$live`/`deco/` → **Deco**; `deco-sites/<site>` → the site name. Group headers show counts.
- **Hiding:** preview stubs and blocks the site marks hidden (`hide`/`ignore`/`unlisted`) are filtered out. `resolveBlockSchemaMetadata` now exposes `hidden`.
- **Run reachability fix:** invocation now runs **client-side** straight at the preview origin (`POST <preview>/deco/invoke/<rt>`), like `useLiveMeta` / the dynamic-options field. This fixes `Preview unreachable` for desktop-linked sandboxes served at `<handle>.localhost:<port>` (the browser resolves it; the Bun server behind the old `preview-invoke` proxy does not).

## Files
- `runnable-catalog.ts` (+ `.test.ts`) — listing, hidden filter, vendor grouping.
- `use-run-block.ts` — client-side invoke hook.
- `runnable-block-editor.tsx` — form + JSON + Run + result panel.
- `runnable-blocks-browser.tsx` — grouped list + editor pane.
- `content-browser.tsx` — sidebar tabs, counts, wiring (exports `ItemRow`/`ListEmpty`/`EmptyMessage`/`GroupHeader` for reuse).
- `resolve-schema.ts` — `hidden` on `resolveBlockSchemaMetadata`.

## Testing
- Unit: `runnable-catalog.test.ts` (6 tests — kind matching, preview/hidden filtering, group keys, grouping). `sections-editor` suite: 384 pass.
- `bun run check` (types) and `oxlint` clean.
- Manual: exercised in local dev (sandbox at `<handle>.localhost`) — Run returns the loader JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Loaders and Actions tabs to the Content browser with folder-based navigation so you can browse, configure, save, and run a site’s `loaders`/`actions` against the live preview. Aligns with DECO-5404 by invoking via `/live/invoke` and showing JSON output.

- **New Features**
  - Folder-based browsing from `resolveType` (vendor → category) with breadcrumb and global search; saved blocks live beside their raw block with a purple accent and a “See saved (N)” accordion; root folders use specific icons; orphan saved blocks still show.
  - Edit props via schema form or JSON; Run to see JSON output; save configured available blocks as global blocks; filters out preview stubs and hidden blocks; hides workflows plumbing.
  - Run result panel can expand to full height and open in a new tab (re-runs with a fresh cache-buster).

- **Bug Fixes**
  - Run now calls the live invoke endpoint client-side: GET `<preview>/live/invoke/<resolveType>` with `__cb`, `__decoFBT=0`, `__d`, and encoded `props`, returning structured JSON; adds a 30s timeout with a clear error; fixes “Preview unreachable” on `<handle>.localhost:<port>`.
  - Reliability: flushes pending debounced saves when the editor unmounts; loader/action‑only sites are no longer gated by “No editable content”; `resolveBlockSchemaMetadata` exposes `hidden` so internal blocks are excluded from pickers.

<sup>Written for commit 1958cdaf4ef31270a0a39087e5a820e25c7c30c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

