### PR TITLE
fix(cli): unfreeze link TUI during sandbox removal

### DIFF
--- a/apps/mesh/src/cli/link-app.tsx
+++ b/apps/mesh/src/cli/link-app.tsx
@@ -12,7 +12,11 @@ import {
   subscribeLinkState,
 } from "./link-store";
 
-function statusCell(row: SandboxRow): { color: string; text: string } {
+function statusCell(
+  row: SandboxRow,
+  removing: boolean,
+): { color: string; text: string } {
+  if (removing) return { color: "yellow", text: "◌ Removing…" };
   if (row.status === "ready") return { color: "green", text: "● Live" };
   if (row.status === "spawning")
     return { color: "yellow", text: "◌ Starting…" };
@@ -113,7 +117,7 @@ export function LinkApp() {
             </Box>
           </Box>
           {rows.map((row) => {
-            const s = statusCell(row);
+            const s = statusCell(row, state.removingHandles.has(row.handle));
             const isSelected = row.handle === selected;
             return (
               <Box key={row.handle}>

--- a/apps/mesh/src/cli/link-dispatch.test.ts
+++ b/apps/mesh/src/cli/link-dispatch.test.ts
@@ -113,7 +113,31 @@ describe("dispatchIntent", () => {
     expect([...getLinkState().sandboxes.keys()]).toEqual(["b"]);
   });
 
-  it("confirmYes surfaces the error on failure", async () => {
+  it("confirmYes marks the row as removing while the action is in flight", async () => {
+    rows();
+    setSelectedHandle("a");
+    let resolve: (r: { ok: true }) => void = () => {};
+    setLinkActions(
+      fakeActions({
+        removeSandbox: () =>
+          new Promise<{ ok: true }>((r) => {
+            resolve = r;
+          }),
+      }),
+    );
+    dispatchIntent({ type: "delete" });
+    dispatchIntent({ type: "confirmYes" });
+    // Still in flight: row present and flagged as removing.
+    expect(getLinkState().removingHandles.has("a")).toBe(true);
+    expect([...getLinkState().sandboxes.keys()]).toEqual(["a", "b"]);
+    resolve({ ok: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getLinkState().removingHandles.has("a")).toBe(false);
+    expect([...getLinkState().sandboxes.keys()]).toEqual(["b"]);
+  });
+
+  it("confirmYes surfaces the error and clears removing on failure", async () => {
     rows();
     setSelectedHandle("a");
     setLinkActions(
@@ -126,6 +150,7 @@ describe("dispatchIntent", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(getLinkState().actionError).toBe("nope");
+    expect(getLinkState().removingHandles.has("a")).toBe(false);
     expect([...getLinkState().sandboxes.keys()]).toEqual(["a", "b"]);
   });
 

--- a/apps/mesh/src/cli/link-dispatch.ts
+++ b/apps/mesh/src/cli/link-dispatch.ts
@@ -11,6 +11,7 @@ import {
   removeSandboxRow,
   setActionError,
   setPendingConfirm,
+  setRemoving,
   setSelectedHandle,
 } from "./link-store";
 import { openPreviewUrl } from "./open-url";
@@ -66,9 +67,14 @@ export function dispatchIntent(
       const confirm = state.pendingConfirm;
       setPendingConfirm(null);
       if (confirm === null || !actions) return;
+      setRemoving(confirm.handle, true);
       void actions.removeSandbox(confirm.handle).then((res) => {
-        if (res.ok) removeSandboxRow(confirm.handle);
-        else setActionError(res.error);
+        if (res.ok) {
+          removeSandboxRow(confirm.handle);
+        } else {
+          setRemoving(confirm.handle, false);
+          setActionError(res.error);
+        }
       });
       return;
     }

--- a/apps/mesh/src/cli/link-store.ts
+++ b/apps/mesh/src/cli/link-store.ts
@@ -57,6 +57,8 @@ interface LinkState {
   selectedHandle: string | null;
   /** Non-null while a delete confirmation is awaiting y/n. */
   pendingConfirm: PendingConfirm | null;
+  /** Handles whose removal is in flight (rendered as "Removing…"). */
+  removingHandles: Set<string>;
   /** Transient error from the last interactive action (shown in the footer). */
   actionError: string | null;
   /** Daemon actions the TUI invokes; null until the daemon has started. */
@@ -118,6 +120,7 @@ function initialState(): LinkState {
     logPath: null,
     selectedHandle: null,
     pendingConfirm: null,
+    removingHandles: new Set(),
     actionError: null,
     actions: null,
   };
@@ -185,6 +188,15 @@ export function setActionError(message: string | null) {
   emit();
 }
 
+export function setRemoving(handle: string, removing: boolean) {
+  if (state.removingHandles.has(handle) === removing) return;
+  const removingHandles = new Set(state.removingHandles);
+  if (removing) removingHandles.add(handle);
+  else removingHandles.delete(handle);
+  state = { ...state, removingHandles };
+  emit();
+}
+
 export function setLinkActions(actions: LinkActions) {
   state = { ...state, actions };
   emit();
@@ -199,7 +211,15 @@ export function removeSandboxRow(handle: string) {
   );
   const sandboxes = new Map(state.sandboxes);
   sandboxes.delete(handle);
-  state = { ...state, sandboxes, selectedHandle, pendingConfirm: null };
+  const removingHandles = new Set(state.removingHandles);
+  removingHandles.delete(handle);
+  state = {
+    ...state,
+    sandboxes,
+    selectedHandle,
+    pendingConfirm: null,
+    removingHandles,
+  };
   emit();
 }
 

--- a/apps/mesh/src/link-daemon/purge-sandbox.test.ts
+++ b/apps/mesh/src/link-daemon/purge-sandbox.test.ts
@@ -13,14 +13,16 @@ function sandboxWithVolumes(volumes: string[]): string {
 }
 
 describe("purgeSandboxFiles", () => {
-  it("detaches each direct child of org/ before removing the sandbox", () => {
+  it("detaches each direct child of org/ before removing the sandbox", async () => {
     const root = sandboxWithVolumes(["vol-a", "vol-b"]);
     const detached: string[] = [];
     const removed: string[] = [];
 
-    purgeSandboxFiles(root, {
+    await purgeSandboxFiles(root, {
       detach: (p) => detached.push(p),
-      rm: (p) => removed.push(p),
+      rm: (p) => {
+        removed.push(p);
+      },
     });
 
     expect(detached.sort()).toEqual(
@@ -29,14 +31,16 @@ describe("purgeSandboxFiles", () => {
     expect(removed).toEqual([root]);
   });
 
-  it("removes the sandbox even when there is no org/ dir", () => {
+  it("removes the sandbox even when there is no org/ dir", async () => {
     const root = mkdtempSync(join(tmpdir(), "deco-purge-"));
     const detached: string[] = [];
     const removed: string[] = [];
 
-    purgeSandboxFiles(root, {
+    await purgeSandboxFiles(root, {
       detach: (p) => detached.push(p),
-      rm: (p) => removed.push(p),
+      rm: (p) => {
+        removed.push(p);
+      },
     });
 
     expect(detached).toEqual([]);

--- a/apps/mesh/src/link-daemon/purge-sandbox.ts
+++ b/apps/mesh/src/link-daemon/purge-sandbox.ts
@@ -3,7 +3,8 @@
  * first so `rm` can't hang on a live (or ghost) NFS/FUSE mount nested at
  * `<sandboxPath>/org/<volume>`. All steps are injectable for tests.
  */
-import { existsSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
+import { rm as rmAsync } from "node:fs/promises";
 import { join } from "node:path";
 import { detachMount } from "@decocms/sandbox/org-fs/detach-mount";
 
@@ -11,21 +12,21 @@ export interface PurgeSandboxDeps {
   detach?: (mountPath: string) => void;
   exists?: (path: string) => boolean;
   readdir?: (dir: string) => string[];
-  rm?: (path: string) => void;
+  rm?: (path: string) => void | Promise<void>;
 }
 
 const defaultDetach = (mountPath: string): void =>
   detachMount(mountPath, process.platform === "darwin");
 
-export function purgeSandboxFiles(
+export async function purgeSandboxFiles(
   sandboxPath: string,
   deps: PurgeSandboxDeps = {},
-): void {
+): Promise<void> {
   const detach = deps.detach ?? defaultDetach;
   const exists = deps.exists ?? existsSync;
   const readdir = deps.readdir ?? ((dir) => readdirSync(dir));
   const rm =
-    deps.rm ?? ((path) => rmSync(path, { recursive: true, force: true }));
+    deps.rm ?? ((path) => rmAsync(path, { recursive: true, force: true }));
 
   const orgDir = join(sandboxPath, "org");
   if (exists(orgDir)) {
@@ -33,5 +34,5 @@ export function purgeSandboxFiles(
       detach(join(orgDir, child));
     }
   }
-  rm(sandboxPath);
+  await rm(sandboxPath);
 }

--- a/apps/mesh/src/link-daemon/sandbox-actions.test.ts
+++ b/apps/mesh/src/link-daemon/sandbox-actions.test.ts
@@ -30,7 +30,9 @@ describe("createSandboxActions.removeSandbox", () => {
       provider,
       registry: reg,
       dataDir: "/data",
-      purge: (p) => purged.push(p),
+      purge: (p) => {
+        purged.push(p);
+      },
     });
 
     const res = await actions.removeSandbox("h1");
@@ -50,13 +52,59 @@ describe("createSandboxActions.removeSandbox", () => {
       provider,
       registry: reg,
       dataDir: "/data",
-      purge: (p) => purged.push(p),
+      purge: (p) => {
+        purged.push(p);
+      },
     });
 
     const res = await actions.removeSandbox("h1");
 
     expect(res).toEqual({ ok: false, error: "Can't delete — run in progress" });
     expect(purged).toEqual([]);
+    expect(reg.list().map((r) => r.handle)).toEqual(["h1"]);
+  });
+
+  it("retries once when the first purge fails transiently, then succeeds", async () => {
+    const provider = fakeProvider({ hasHandleAfterDelete: false });
+    const reg = memRegistryWithRow("h1", "/data/sandboxes/h1");
+    let attempts = 0;
+
+    const actions = createSandboxActions({
+      provider,
+      registry: reg,
+      dataDir: "/data",
+      purge: () => {
+        attempts++;
+        if (attempts === 1) throw new Error("resource busy");
+      },
+    });
+
+    const res = await actions.removeSandbox("h1");
+
+    expect(res).toEqual({ ok: true });
+    expect(attempts).toBe(2);
+    expect(reg.list()).toEqual([]);
+  });
+
+  it("bails with the last error after two failed attempts", async () => {
+    const provider = fakeProvider({ hasHandleAfterDelete: false });
+    const reg = memRegistryWithRow("h1", "/data/sandboxes/h1");
+    let attempts = 0;
+
+    const actions = createSandboxActions({
+      provider,
+      registry: reg,
+      dataDir: "/data",
+      purge: () => {
+        attempts++;
+        throw new Error("still busy");
+      },
+    });
+
+    const res = await actions.removeSandbox("h1");
+
+    expect(res).toEqual({ ok: false, error: "still busy" });
+    expect(attempts).toBe(2);
     expect(reg.list().map((r) => r.handle)).toEqual(["h1"]);
   });
 
@@ -69,7 +117,9 @@ describe("createSandboxActions.removeSandbox", () => {
       provider,
       registry: reg,
       dataDir: "/data",
-      purge: (p) => purged.push(p),
+      purge: (p) => {
+        purged.push(p);
+      },
     });
 
     const res = await actions.removeSandbox("ghost");

--- a/apps/mesh/src/link-daemon/sandbox-actions.ts
+++ b/apps/mesh/src/link-daemon/sandbox-actions.ts
@@ -5,6 +5,7 @@
  * refuse), then unmount + rm the branch's files and drop the registry row.
  */
 import { join } from "node:path";
+import { RetryError, retry } from "@decocms/std";
 import type {
   LinkSandboxRegistry,
   SandboxInspection,
@@ -17,7 +18,7 @@ export interface SandboxActionsDeps {
   registry: Pick<LinkSandboxRegistry, "inspect" | "delete">;
   dataDir: string;
   /** Injectable for tests. Defaults to the real unmount-then-rm. */
-  purge?: (sandboxPath: string) => void;
+  purge?: (sandboxPath: string) => void | Promise<void>;
 }
 
 export interface SandboxActions {
@@ -39,22 +40,32 @@ export function createSandboxActions(deps: SandboxActionsDeps): SandboxActions {
       return deps.registry.inspect(handle);
     },
     async removeSandbox(handle) {
-      await deps.provider.deleteSandbox(handle);
-      // On refusal (active dispatch) the provider keeps tracking the handle.
-      if (deps.provider.hasHandle(handle)) {
-        return { ok: false, error: "Can't delete — run in progress" };
-      }
       try {
-        const rec = deps.registry.inspect(handle);
-        const sandboxPath =
-          rec?.sandboxPath ?? join(deps.dataDir, "sandboxes", handle);
-        purge(sandboxPath);
+        // The first attempt often fails transiently — the process may still be
+        // mid-shutdown (provider keeps the handle) or a just-unmounted volume is
+        // briefly busy. Retry the whole stop → verify → purge sequence once
+        // before bailing so the common case self-heals.
+        await retry(
+          async () => {
+            await deps.provider.deleteSandbox(handle);
+            // On refusal (active dispatch) the provider keeps tracking the handle.
+            if (deps.provider.hasHandle(handle)) {
+              throw new Error("Can't delete — run in progress");
+            }
+            const rec = deps.registry.inspect(handle);
+            const sandboxPath =
+              rec?.sandboxPath ?? join(deps.dataDir, "sandboxes", handle);
+            await purge(sandboxPath);
+          },
+          { maxAttempts: 2, minTimeout: 250, jitter: 0 },
+        );
         deps.registry.delete(handle);
         return { ok: true };
       } catch (err) {
+        const cause = err instanceof RetryError ? err.cause : err;
         return {
           ok: false,
-          error: err instanceof Error ? err.message : String(err),
+          error: cause instanceof Error ? cause.message : String(cause),
         };
       }
     },


### PR DESCRIPTION
## Summary
Deleting a sandbox in the `deco link` TUI ran a **synchronous** `rmSync(..., { recursive: true })` over the worktree (git history + `node_modules`), blocking the Node event loop. Ink renders on that same loop, so the whole TUI froze for the duration of the delete.

## Changes
- **`purge-sandbox.ts`** — swap `rmSync` (`node:fs`) for the async `rm` (`node:fs/promises`) and `await` it, so `purgeSandboxFiles` yields the event loop back to Ink. Now `async`; the only caller (`removeSandbox`) already awaited it.
- **Link TUI** — render a transient **`◌ Removing…`** row status while the delete is in flight, via a `removingHandles` set in the store (`link-store.ts`), set on `confirmYes` and cleared on success (row drops) or failure (`link-dispatch.ts`, `link-app.tsx`).
- **`sandbox-actions.ts`** — retry the whole **stop → verify-stopped → purge** sequence once (`@decocms/std` `retry`, `maxAttempts: 2`, per the repo's no-hand-rolled-retry rule). This lets the common transient first failure self-heal — the process may still be mid-shutdown (provider keeps the handle) or a just-unmounted volume is briefly busy. After two failures it bails and surfaces the last error.

## Testing
- `bun test` on the four affected suites — **27 pass**. New coverage: async purge is awaited; retry succeeds on the 2nd attempt / bails after two; the row is flagged `removing` in flight and cleared on failure.
- `bun run fmt`, typecheck, and `oxlint` clean on the touched files.

## Trade-off
A genuine failure (e.g. a real "run in progress") now takes up to one ~250ms backoff before reporting — the persistent "Removing…" indicator covers that gap so the user sees progress rather than a silent stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the link TUI from freezing during sandbox deletion by making file removal async and yielding the event loop. Shows a transient "◌ Removing…" status while deletion runs, and retries once to smooth out transient failures.

- **Bug Fixes**
  - Replaced `rmSync` with awaited async `rm` from `node:fs/promises` in `purge-sandbox.ts`.
  - Link TUI marks rows as removing via `removingHandles` in the store; status shown during delete and cleared on success/failure.
  - Wrapped stop → verify → purge in `@decocms/std` `retry` with `maxAttempts: 2` and a short backoff; errors surface with the last failure message.

<sup>Written for commit 85c664a00003eb56dee43b057806d0536d82132a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

