### PR TITLE
fix(sandbox): preserve incoming Host in daemon preview proxy

### DIFF
--- a/packages/sandbox/daemon/proxy.ts
+++ b/packages/sandbox/daemon/proxy.ts
@@ -33,7 +33,12 @@ export function makeProxyHandler({ broadcaster, getDevPort }: ProxyDeps) {
     log("proxy", req.method, url.pathname);
     const outHeaders = new Headers(req.headers);
     outHeaders.delete("accept-encoding");
-    outHeaders.delete("host");
+    // Preserve the browser's Host so the upstream dev server sees the external
+    // preview origin (e.g. `<handle>.localhost:5174`) rather than the loopback
+    // socket. Bun's fetch honors an explicit Host header (unlike the WHATWG
+    // "forbidden header" rule), so keeping it here propagates through Vite
+    // (changeOrigin:false) to the app server — which lets mesh advertise the
+    // correct OAuth protected-resource URL instead of `https://[::1]:<port>`.
     outHeaders.delete("transfer-encoding");
     outHeaders.delete("content-length");
     outHeaders.delete("authorization");


### PR DESCRIPTION
## Summary

The sandbox daemon preview proxy (`packages/sandbox/daemon/proxy.ts`) stripped the browser `Host` header before forwarding to the sandboxed dev server. The upstream then saw the loopback socket (`[::1]:<port>`) instead of the external preview origin.

For the mesh app this broke MCP **OAuth**: it derives its OAuth *protected-resource metadata* `resource` from the request origin, so it advertised `https://[::1]:<port>/…`, and the MCP OAuth client rejected it:

> Authentication failed: Protected resource `https://[::1]:<port>/…/mcp/<id>` does not match expected `http://<handle>.localhost:5174/…/mcp/<id>`

This preserves the `Host` header so the upstream (and any app deriving public URLs from the request) sees the real preview origin. Bun's `fetch` forwards an explicit `Host` (it does not enforce the WHATWG forbidden-header rule), so keeping it on `outHeaders` propagates through Vite (`changeOrigin:false`) to the app server.

## ⚠️ Reviewer note — blast radius

This proxy fronts **every** sandbox preview, not just mesh. Forwarding the external Host means upstream dev servers now see it, which interacts with dev-server host allowlists:

- **Vite `server.allowedHosts`** rejects unknown hosts. `*.localhost` is allowed (dev works), but **production preview hostnames are real domains** — an app that hasn't allowlisted its preview host could start returning `Blocked request`. Please confirm the prod preview host is acceptable to upstream dev servers (or gate this to `.localhost`) before merging.
- Frameworks derive redirects / cookie `Domain` / HMR websocket URLs / CSRF-Origin checks from `Host`; forwarding the external host changes those.

An alternative that avoids the app-facing `Host` change is to forward `X-Forwarded-Host`/`X-Forwarded-Proto` and have consumers honor them. Opening this as the minimal change per request; happy to switch approaches.

## Testing

- `bun test packages/sandbox/daemon/proxy.test.ts` → 3 pass (no host assertions in the suite).
- Needs a daemon rebuild + restart to verify the live preview/OAuth flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the incoming Host header in the sandbox preview proxy so upstream dev servers see the external preview origin instead of `[::1]:<port>`. Fixes mesh MCP OAuth failures caused by mismatched protected-resource URLs.

- **Migration**
  - Ensure dev-server host allowlists permit preview domains (e.g., add production preview hosts to `vite.server.allowedHosts`).
  - Recheck redirects, cookie Domain, HMR URLs, and CSRF/Origin checks with the external host.

<sup>Written for commit 2acb6a8c0e7c9846bdf9579eb689dd61e343096a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

