### PR TITLE
fix(github): skip PR open when rebase leaves branch even with base

### DIFF
--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -346,6 +346,27 @@ function PublishDialogBody({
         );
       }
 
+      // The rebase onto base drops commits whose changes already landed on
+      // base (git drops empty commits). If that leaves the branch even with
+      // base, GitHub would reject the PR with 422 "No commits between …".
+      // Treat an in-sync branch as already published instead of surfacing a
+      // raw GitHub error.
+      const statusAfterRebase = await fetchGitStatus(
+        orgSlug,
+        virtualMcpId,
+        branch,
+      );
+      if ((statusAfterRebase.aheadOfBase ?? 0) === 0) {
+        toast.success(`Already up to date with ${baseBranch}`);
+        handleOpenChange(false);
+        setGitDiff(null);
+        setPublishTitle("");
+        setPublishBody("");
+        await onPullRequestChanged?.();
+        await onPublished?.();
+        return;
+      }
+
       try {
         openedPr = await openPullRequestForBranch(githubClient, {
           owner,


### PR DESCRIPTION
## Summary

Fixes the production `create_pull_request` failure `422 Validation Failed — No commits between <base> and <branch>` seen in the one-click **Publish** flow.

The Publish orchestration in `handlePublish` (`apps/mesh/src/web/components/thread/github/publish-dialog.tsx`) ran a fixed sequence — **push → rebase onto base → open PR → squash-merge** — with **no status re-check between the rebase and opening the PR**.

`rebaseOntoBase` does `git rebase -X theirs origin/<base>`. When the branch's commit(s) reproduce changes that already landed on base, the replayed commits become empty and git drops them (`--empty=drop`), leaving the branch **even with base** (`aheadOfBase` goes `1 → 0`). The `openPullRequestForBranch` that followed then fired unconditionally against an empty branch → GitHub 422.

This happens in practice because the one-click flow also squash-merges to base, so a prior run (or a retry after a sandbox hiccup) can leave the change already on `main`; the next Publish rebases the now-redundant commit away and 422s.

## Change

After the rebase, re-fetch git status and short-circuit when `aheadOfBase === 0`: show an "Already up to date" toast, close the dialog, refresh PR state — instead of surfacing a raw GitHub error. This aligns with the existing `panel-state` "Up to date" state for `aheadOfBase === 0`.

## Testing

- `bun run fmt` — clean
- `bun run --cwd=apps/mesh check` (tsc) — passes

No unit test added: `handlePublish` depends on network calls (git status/rebase + GitHub client), which per `TESTING.md` belongs to the e2e tier rather than a mock-based unit test.

## Follow-up (not in this PR)

Secondary bug observed in the same HAR: `suggest-commit` (`apps/mesh/src/lib/suggest-commit-message.ts`) leaked a `</think>` reasoning tag as the PR title. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix one-click Publish failing with GitHub 422 when a rebase drops empty commits. We now check status after rebase and skip opening a PR if the branch is even with base.

- **Bug Fixes**
  - After `rebaseOntoBase`, re-fetch git status and short-circuit when `aheadOfBase === 0`.
  - Show “Already up to date” toast, close the dialog, clear draft fields, and refresh PR state to match the panel’s “Up to date” UI.

<sup>Written for commit 1b26bc8afd668069f796af27d302aa0dd0ea504a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

