### PR TITLE
fix(sandbox): autostash rebase to survive concurrent generated-file writes

### DIFF
--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -348,7 +348,13 @@ function rebaseOntoBaseInner(
   commitBeforeRebase(repoDir, operator);
 
   try {
-    runGit(repoDir, ["rebase", "-X", "theirs", upstream]);
+    // --autostash: the sandbox dev server keeps regenerating tracked files
+    // (e.g. src/server/cms/blocks.gen.json, .deco/blocks/*.json). It can dirty
+    // the working tree in the window between commitBeforeRebase and the rebase's
+    // internal checkout, which otherwise aborts with "Your local changes would
+    // be overwritten by checkout / could not detach HEAD". Autostash stashes
+    // that churn, runs the rebase, and restores it afterwards.
+    runGit(repoDir, ["rebase", "--autostash", "-X", "theirs", upstream]);
   } catch (err) {
     if (!isRebaseInProgress(repoDir)) {
       throw err;


### PR DESCRIPTION
## Summary

Fixes the `could not detach HEAD` failure hit during the sandbox one-click **Publish** flow (`push → rebase-onto-base`).

The running dev server keeps regenerating git-tracked files (`src/server/cms/blocks.gen.json`, `.deco/blocks/*.json`). It can dirty the working tree in the window between `commitBeforeRebase` and the rebase's internal checkout, so git aborts with:

```
error: Your local changes to the following files would be overwritten by checkout:
  src/server/cms/blocks.gen.json
... could not detach HEAD
```

(Retrying often works purely by timing.) Adding `--autostash` stashes that churn across the rebase and restores it afterward.

## Change

One line in `rebaseOntoBaseInner`:

```diff
-    runGit(repoDir, ["rebase", "-X", "theirs", upstream]);
+    runGit(repoDir, ["rebase", "--autostash", "-X", "theirs", upstream]);
```

## Test

- `bun test packages/sandbox/daemon/git/rebase-onto-base.test.ts` — passes
- `bun run --cwd=apps/mesh check` (tsc) — passes
- `bun run fmt` — clean

## Scope / follow-up (intentionally not here)

Diagnosis of the same publish flow surfaced a **separate, more serious data-loss** mode: under dev-server instability the rebase could end with a HEAD that dropped the branch's real changes, and the unconditional `forcePushRebasedBranch` force-pushed it — moving `origin/<branch>` backwards onto an ancestor of the pushed commit (confirmed on GitHub: branches `rho-hydrae`/`kappa-lyrae` ended at ancestors of commits `eb042f6`/`c3f5ac49c` that never reached main). A guard for that is being deferred to a follow-up because it needs care to avoid false positives in the legitimate "already published, nothing new" case. The deeper trigger (dev server writing tracked files during git ops) also warrants a durable fix (quiesce generation / separate worktree during publish/rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)