### PR TITLE
feat(commerce-discovery): trigger diagnostic run on 'See full report'

### DIFF
--- a/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { fetchCommerceDiscoveryAuth } from "./auth-client";
+import {
+  fetchCommerceDiscoveryAuth,
+  triggerCommerceDiscoveryRun,
+} from "./auth-client";
 
 describe("fetchCommerceDiscoveryAuth", () => {
   test("upgrades the normalized domain and returns the generated client token", async () => {
@@ -85,6 +88,75 @@ describe("fetchCommerceDiscoveryAuth", () => {
       ),
     ).rejects.toThrow(
       "Commerce Discovery auth response did not include a token.",
+    );
+  });
+});
+
+describe("triggerCommerceDiscoveryRun", () => {
+  test("POSTs /run for the normalized domain with the org id + bearer", async () => {
+    const captured: Array<{
+      method: string;
+      pathname: string;
+      authorization: string | null;
+      body: unknown;
+    }> = [];
+
+    const out = await triggerCommerceDiscoveryRun(
+      { siteUrl: "https://example.com/path", orgId: "org_123" },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async (input, init) => {
+          const request = new Request(input, init);
+          const url = new URL(request.url);
+          captured.push({
+            method: request.method,
+            pathname: url.pathname,
+            authorization: request.headers.get("authorization"),
+            body: await request.json(),
+          });
+          return Response.json({ url: "example.com", scope: "private", run: {} });
+        },
+      },
+    );
+
+    expect(out).toEqual({ triggered: true });
+    expect(captured).toEqual([
+      {
+        method: "POST",
+        pathname: "/api/v2/internal/diagnostics/example.com/run",
+        authorization: "Bearer master-key",
+        body: { org_id: "org_123" },
+      },
+    ]);
+  });
+
+  test("treats a 409 (not upgraded yet) as a soft skip, not a throw", async () => {
+    const out = await triggerCommerceDiscoveryRun(
+      { siteUrl: "https://example.com", orgId: "org_123" },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () =>
+          Response.json({ error: "not_upgraded_or_not_owner" }, { status: 409 }),
+      },
+    );
+    expect(out).toEqual({ triggered: false, reason: "not_upgraded" });
+  });
+
+  test("requires an internal API key", async () => {
+    await expect(
+      triggerCommerceDiscoveryRun(
+        { siteUrl: "https://example.com", orgId: "org_123" },
+        {
+          settings: {
+            commerceDiscoveryInternalApiUrl: undefined,
+            commerceDiscoveryInternalApiKey: undefined,
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      "COMMERCE_DISCOVERY_INTERNAL_API_KEY is required to set up Commerce Discovery.",
     );
   });
 });

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
@@ -115,7 +115,11 @@ describe("triggerCommerceDiscoveryRun", () => {
             authorization: request.headers.get("authorization"),
             body: await request.json(),
           });
-          return Response.json({ url: "example.com", scope: "private", run: {} });
+          return Response.json({
+            url: "example.com",
+            scope: "private",
+            run: {},
+          });
         },
       },
     );
@@ -138,7 +142,10 @@ describe("triggerCommerceDiscoveryRun", () => {
         baseUrl: "https://commerce.example.test",
         apiKey: "master-key",
         fetchImpl: async () =>
-          Response.json({ error: "not_upgraded_or_not_owner" }, { status: 409 }),
+          Response.json(
+            { error: "not_upgraded_or_not_owner" },
+            { status: 409 },
+          ),
       },
     );
     expect(out).toEqual({ triggered: false, reason: "not_upgraded" });

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.ts
@@ -112,3 +112,40 @@ export async function fetchCommerceDiscoveryAuth(
 
   return { authorizationToken: parsed.data.token };
 }
+
+/**
+ * Trigger the Commerce Discovery diagnostic run for a store — called once the
+ * user has connected their data sources ("See full report"). This is the run
+ * whose private probes resolve creds and whose completion fires the enriched
+ * agent loop. Soft-tolerant: a 409 (diagnostic not upgraded yet) is returned as
+ * { triggered: false } rather than thrown, so the UI can still open the report.
+ */
+export async function triggerCommerceDiscoveryRun(
+  input: { siteUrl: string; orgId: string },
+  options: CommerceDiscoveryAuthOptions = {},
+): Promise<{ triggered: boolean; reason?: string }> {
+  const baseUrl = resolveBaseUrl(options);
+  const apiKey = resolveApiKey(options);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const domain = domainFromSiteUrl(input.siteUrl);
+  const url = `${baseUrl}/api/v2/internal/diagnostics/${encodeURIComponent(
+    domain,
+  )}/run`;
+
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ org_id: input.orgId }),
+  });
+
+  if (response.status === 409) {
+    return { triggered: false, reason: "not_upgraded" };
+  }
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response));
+  }
+  return { triggered: true };
+}

--- a/apps/mesh/src/tools/commerce-discovery/index.ts
+++ b/apps/mesh/src/tools/commerce-discovery/index.ts
@@ -1,1 +1,2 @@
+export { COMMERCE_DISCOVERY_RUN } from "./run";
 export { COMMERCE_DISCOVERY_SETUP } from "./setup";

--- a/apps/mesh/src/tools/commerce-discovery/run.ts
+++ b/apps/mesh/src/tools/commerce-discovery/run.ts
@@ -30,6 +30,10 @@ export const COMMERCE_DISCOVERY_RUN = defineTool({
   handler: async (input, ctx) => {
     requireAuth(ctx);
     const organization = requireOrganization(ctx);
+    // Enforce the caller's role/permission for this tool (connections:manage),
+    // like every other org-scoped tool — the internal API key gates the wire, not
+    // who in the org may trigger a run.
+    await ctx.access.check();
 
     const normalized = normalizeCommerceSiteUrl(input.siteUrl);
     if (!normalized.ok) {

--- a/apps/mesh/src/tools/commerce-discovery/run.ts
+++ b/apps/mesh/src/tools/commerce-discovery/run.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { normalizeCommerceSiteUrl } from "../../commerce-discovery/site-url";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
+import { triggerCommerceDiscoveryRun } from "./auth-client";
+
+const CommerceDiscoveryRunInputSchema = z.object({
+  siteUrl: z.string().min(1).describe("Website URL to run the diagnostic for."),
+});
+
+const CommerceDiscoveryRunOutputSchema = z.object({
+  triggered: z.boolean(),
+  reason: z.string().optional(),
+});
+
+export const COMMERCE_DISCOVERY_RUN = defineTool({
+  name: "COMMERCE_DISCOVERY_RUN",
+  description:
+    "Trigger the Commerce Discovery diagnostic run for the current organization's store. Call once the data sources (GA4/GSC/VTEX) are connected — this run resolves credentials and produces the enriched report.",
+  annotations: {
+    title: "Run Commerce Discovery",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: CommerceDiscoveryRunInputSchema,
+  outputSchema: CommerceDiscoveryRunOutputSchema,
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const organization = requireOrganization(ctx);
+
+    const normalized = normalizeCommerceSiteUrl(input.siteUrl);
+    if (!normalized.ok) {
+      throw new Error(normalized.error);
+    }
+
+    return triggerCommerceDiscoveryRun({
+      siteUrl: normalized.value,
+      orgId: organization.id,
+    });
+  },
+});

--- a/apps/mesh/src/tools/commerce-discovery/setup.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.ts
@@ -147,11 +147,15 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
       });
 
       try {
+        const base = getWellKnownCommerceDiscoveryConnection(
+          organization.id,
+          auth.authorizationToken,
+        );
         connection = await ctx.storage.connections.create({
-          ...getWellKnownCommerceDiscoveryConnection(
-            organization.id,
-            auth.authorizationToken,
-          ),
+          ...base,
+          // Persist the site so a returning session (arriving with no ?siteUrl
+          // param) can still recover it and trigger the run from "See full report".
+          metadata: { ...(base.metadata ?? {}), siteUrl: normalized.value },
           organization_id: organization.id,
           created_by: userId,
         });

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -78,6 +78,7 @@ export const CORE_TOOLS = [
   ConnectionTools.COLLECTION_CONNECTIONS_DELETE,
   ConnectionTools.CONNECTION_TEST,
   CommerceDiscoveryTools.COMMERCE_DISCOVERY_SETUP,
+  CommerceDiscoveryTools.COMMERCE_DISCOVERY_RUN,
 
   // Virtual MCP collection tools
   VirtualMCPTools.COLLECTION_VIRTUAL_MCP_CREATE,

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -79,6 +79,7 @@ const ALL_TOOL_NAMES = [
   "COLLECTION_CONNECTIONS_DELETE",
   "CONNECTION_TEST",
   "COMMERCE_DISCOVERY_SETUP",
+  "COMMERCE_DISCOVERY_RUN",
   // Virtual MCP tools
   "COLLECTION_VIRTUAL_MCP_CREATE",
   "COLLECTION_VIRTUAL_MCP_LIST",
@@ -430,6 +431,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   {
     name: "COMMERCE_DISCOVERY_SETUP",
     description: "Set up Commerce Discovery",
+    category: "Connections",
+  },
+  {
+    name: "COMMERCE_DISCOVERY_RUN",
+    description: "Run Commerce Discovery",
     category: "Connections",
   },
   {
@@ -1144,6 +1150,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "COLLECTION_CONNECTIONS_UPDATE",
       "COLLECTION_CONNECTIONS_DELETE",
       "COMMERCE_DISCOVERY_SETUP",
+      "COMMERCE_DISCOVERY_RUN",
     ],
     dangerous: true,
   },

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -620,13 +620,27 @@ function CommerceSetupContent({
         name: "COMMERCE_DISCOVERY_RUN",
         arguments: { siteUrl },
       });
-      return parseSelfToolResult<{ triggered: boolean; reason?: string }>(result);
+      return parseSelfToolResult<{ triggered: boolean; reason?: string }>(
+        result,
+      );
     },
     retry: false,
   });
 
   const setupReady = !!connectionQuery.data.item && !!virtualMcpQuery.data.item;
-  const currentSiteUrl = initialSiteUrl ?? siteUrlInput;
+  // A returning session may arrive with no ?siteUrl param and an empty form while
+  // the connection already exists (setupReady). Recover the site from the
+  // connection metadata (persisted at setup) so the run can still be triggered.
+  const connectionItem = connectionQuery.data.item as unknown as
+    | { metadata?: Record<string, unknown> | null }
+    | null
+    | undefined;
+  const connectionSiteUrl =
+    typeof connectionItem?.metadata?.siteUrl === "string"
+      ? (connectionItem.metadata.siteUrl as string)
+      : undefined;
+  const currentSiteUrl =
+    initialSiteUrl || siteUrlInput || connectionSiteUrl || "";
   const currentMeetingUrl = buildScheduleMeetingUrl({
     siteUrl: currentSiteUrl,
     email: sessionEmail,

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -611,6 +611,20 @@ function CommerceSetupContent({
     },
   });
 
+  // Triggers the diagnostic run now that the user has connected their data
+  // sources. Fire-and-forget from the "See full report" click — the report view
+  // polls for the enriched deck as it lands.
+  const runMutation = useMutation({
+    mutationFn: async (siteUrl: string) => {
+      const result = await selfClient.callTool({
+        name: "COMMERCE_DISCOVERY_RUN",
+        arguments: { siteUrl },
+      });
+      return parseSelfToolResult<{ triggered: boolean; reason?: string }>(result);
+    },
+    retry: false,
+  });
+
   const setupReady = !!connectionQuery.data.item && !!virtualMcpQuery.data.item;
   const currentSiteUrl = initialSiteUrl ?? siteUrlInput;
   const currentMeetingUrl = buildScheduleMeetingUrl({
@@ -652,6 +666,11 @@ function CommerceSetupContent({
   };
 
   const openReport = () => {
+    // Kick off the enriching run (fire-and-forget) — the user is done connecting.
+    const normalized = normalizeCommerceSiteUrl(currentSiteUrl);
+    if (normalized.ok) {
+      runMutation.mutate(normalized.value);
+    }
     localStorage.setItem(
       LOCALSTORAGE_KEYS.sidebarOpen(),
       JSON.stringify(false),


### PR DESCRIPTION
## Why
The commerce diagnostic run has to happen **after** the user connects their data sources. Today the run is kicked off at setup/upgrade time — before GA4/GSC/VTEX are connected — so it collects nothing private and the enrichment agent has nothing to work with. This moves the trigger to the "See full report" click (the natural "I'm done connecting" signal).

## What
- **`auth-client.triggerCommerceDiscoveryRun()`** → `POST {commerce}/api/v2/internal/diagnostics/:domain/run` with the internal API key + org id. A `409` (diagnostic not upgraded yet) is a soft skip, not a throw.
- **New `COMMERCE_DISCOVERY_RUN` tool** (registered in `tools/index.ts`) wrapping it, scoped to the current org.
- **`commerce-onboarding`**: the **"See full report"** button fires the run (fire-and-forget) before navigating to the report; the report view polls for the enriched deck as it lands.

## Why one deliberate trigger (not per-connection)
Triggering on each connection would race: the first connect starts a run with only that source, and later connects get **deduped** by commerce's single-flight → the run captures a partial source set. Firing once when the user is done avoids this entirely.

## Pairs with
commerce-discovery **#130** — which stops `/upgrade` from running and adds the `/run` endpoint (with org-ownership verification).

## Tests
Added `triggerCommerceDiscoveryRun` unit tests (POST shape + bearer + org id; 409 soft-skip; requires API key). No local node_modules in this checkout (same as #4244) — relying on CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger the Commerce Discovery diagnostic run when the user clicks “See full report” after connecting GA4/GSC/VTEX, capturing private data for enrichment and avoiding partial runs. Enforces access and recovers the `siteUrl` for returning sessions so the run reliably starts.

- **New Features**
  - Added `triggerCommerceDiscoveryRun()` and `COMMERCE_DISCOVERY_RUN` tool → POST `/api/v2/internal/diagnostics/:domain/run` with org id and internal API key; `409` is a soft skip; enforces `ctx.access.check()`; registered in `CORE_TOOLS` and registry/permissions.
  - Updated onboarding/setup: “See full report” fire-and-forget run; persist normalized `siteUrl` in connection metadata and recover it for returning sessions; report view keeps polling for the enriched deck.

<sup>Written for commit afcf50a1f2eaa186e9ab0b7dfcacc2147ac51f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

