### PR TITLE
[release]: bump sandbox image to 1.8.3

### DIFF
--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {


### PR DESCRIPTION
## Why

The auto-bump for #4261 (autostash rebase fix) was **missed**: the release bot ran on the merge commit ~10s after merge, before the GitHub API associated the PR with the merge SHA, logged `No merged PR associated … skipping release bump`, and left `packages/sandbox` at **1.8.2**. So no `studio-sandbox:1.8.3` image was published. Re-running the tagging workflow fails now (main advanced → non-fast-forward push).

## What

Bump `packages/sandbox/package.json` → **1.8.3** so `release-studio-sandbox.yaml` builds & pushes `ghcr.io/decocms/studio/studio-sandbox:1.8.3` on merge.

The `[release]:` prefix makes `release-tagging` skip re-bumping this commit (otherwise it would bump 1.8.3 → 1.8.4).

## After merge

- Confirm the `Release Studio Sandbox Image` run publishes `1.8.3`.
- Then un-draft & merge decocms/deco-apps-cd#121 (already pinned to 1.8.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@decocms/sandbox` from 1.8.2 to 1.8.3 to publish the missing `ghcr.io/decocms/studio/studio-sandbox:1.8.3` image. Uses the `[release]` prefix so release-tagging skips re-bumping this commit.

<sup>Written for commit abdcbfbe1c8a8ccd8c8434121310113d19ee07d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

