### PR TITLE
feat(commerce-onboarding): selectable-list picker for GA/GSC config + stable loading

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,12 +1,23 @@
-# Companion Config Forms Implementation Progress
+# Companion Config Selectable List — Progress
+
+BASE: 35624272969e8fb84ee2b793f3d12d7e8e6947a4
 
 ## Tasks
+- [x] Task 1: SelectableList presentational component (commit 39c071d, review clean)
+- [x] Task 2: GA form (commit dd5f82e, review clean)
+- [x] Task 3: GSC form (commit f19bb0b, review clean)
+- [x] Task 4: verification (build/lint/fmt clean, app renders no console errors; live GA/GSC dialog needs OAuth - not reachable here)
 
-- [ ] Task 1: Pure helpers (matchGscSite + toPropertyOptions)
-- [ ] Task 2: Shared form infra (types + save hook)
-- [ ] Task 3: VTEX config form
-- [ ] Task 4: Google Analytics config form (property picker)
-- [ ] Task 5: Google Search Console config form (site picker, context-matched)
-- [ ] Task 6: Registry + wire dialog, thread contextSiteUrl, remove RJSF
+## Minor findings (for final review)
 
 ---
+- Task 1 minors (non-blocking, no fix): index key for unlabeled groups; aria-checked boolean serialization; list-level disabled only.
+
+## Final review
+- Whole-branch review (opus): mergeable, 1 Important a11y finding -> fixed in f145a43 (keyboard nav + accessible name).
+- Re-review (opus): clean and mergeable. Remaining Minor (dataset.value! redundancy) left as-is.
+
+Commits: 39c071d, dd5f82e, f19bb0b, f145a43
+
+## PR
+- https://github.com/decocms/studio/pull/4265 (tau-cancri -> main, pushed via SSH)

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.ts
@@ -38,26 +38,18 @@ function resolveBaseUrl(options: CommerceDiscoveryAuthOptions): string {
   ).replace(/\/+$/, "");
 }
 
-function resolveApiKey(options: CommerceDiscoveryAuthOptions): string | null {
-  return (
+function resolveApiKey(options: CommerceDiscoveryAuthOptions): string {
+  const apiKey =
     options.apiKey ??
-    (options.settings ?? getSettings()).commerceDiscoveryInternalApiKey ??
-    null
-  );
-}
+    (options.settings ?? getSettings()).commerceDiscoveryInternalApiKey;
 
-/**
- * Local-dev escape hatch. When no internal API key is configured and the server
- * runs in development mode, skip the real upgrade call and mint a stub token so
- * onboarding can be exercised without the internal commerce-skills worker.
- * Mirrors the e2e upgrade mock's token shape (`commerce-upgrade-mock.ts`).
- *
- * Only active under `NODE_ENV=development` (what `dev:server` sets). In
- * production the missing key throws; under `bun test` (`NODE_ENV=test`) it also
- * throws, so the required-key contract stays covered.
- */
-function isDevStubEnabled(): boolean {
-  return process.env.NODE_ENV === "development";
+  if (!apiKey) {
+    throw new Error(
+      "COMMERCE_DISCOVERY_INTERNAL_API_KEY is required to set up Commerce Discovery.",
+    );
+  }
+
+  return apiKey;
 }
 
 function domainFromSiteUrl(siteUrl: string): string {
@@ -87,23 +79,8 @@ export async function fetchCommerceDiscoveryAuth(
   input: CommerceDiscoveryAuthInput,
   options: CommerceDiscoveryAuthOptions = {},
 ) {
-  const apiKey = resolveApiKey(options);
-
-  if (!apiKey) {
-    if (isDevStubEnabled()) {
-      console.warn(
-        "[commerce-discovery] COMMERCE_DISCOVERY_INTERNAL_API_KEY not set — " +
-          "minting a dev stub token. Local development only; setup will not " +
-          "reach the real commerce-skills worker.",
-      );
-      return { authorizationToken: `dgn_dev_${input.orgId}` };
-    }
-    throw new Error(
-      "COMMERCE_DISCOVERY_INTERNAL_API_KEY is required to set up Commerce Discovery.",
-    );
-  }
-
   const baseUrl = resolveBaseUrl(options);
+  const apiKey = resolveApiKey(options);
   const fetchImpl = options.fetchImpl ?? fetch;
   const domain = domainFromSiteUrl(input.siteUrl);
   const url = `${baseUrl}/api/v2/internal/diagnostics/${encodeURIComponent(

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.ts
@@ -38,18 +38,26 @@ function resolveBaseUrl(options: CommerceDiscoveryAuthOptions): string {
   ).replace(/\/+$/, "");
 }
 
-function resolveApiKey(options: CommerceDiscoveryAuthOptions): string {
-  const apiKey =
+function resolveApiKey(options: CommerceDiscoveryAuthOptions): string | null {
+  return (
     options.apiKey ??
-    (options.settings ?? getSettings()).commerceDiscoveryInternalApiKey;
+    (options.settings ?? getSettings()).commerceDiscoveryInternalApiKey ??
+    null
+  );
+}
 
-  if (!apiKey) {
-    throw new Error(
-      "COMMERCE_DISCOVERY_INTERNAL_API_KEY is required to set up Commerce Discovery.",
-    );
-  }
-
-  return apiKey;
+/**
+ * Local-dev escape hatch. When no internal API key is configured and the server
+ * runs in development mode, skip the real upgrade call and mint a stub token so
+ * onboarding can be exercised without the internal commerce-skills worker.
+ * Mirrors the e2e upgrade mock's token shape (`commerce-upgrade-mock.ts`).
+ *
+ * Only active under `NODE_ENV=development` (what `dev:server` sets). In
+ * production the missing key throws; under `bun test` (`NODE_ENV=test`) it also
+ * throws, so the required-key contract stays covered.
+ */
+function isDevStubEnabled(): boolean {
+  return process.env.NODE_ENV === "development";
 }
 
 function domainFromSiteUrl(siteUrl: string): string {
@@ -79,8 +87,23 @@ export async function fetchCommerceDiscoveryAuth(
   input: CommerceDiscoveryAuthInput,
   options: CommerceDiscoveryAuthOptions = {},
 ) {
-  const baseUrl = resolveBaseUrl(options);
   const apiKey = resolveApiKey(options);
+
+  if (!apiKey) {
+    if (isDevStubEnabled()) {
+      console.warn(
+        "[commerce-discovery] COMMERCE_DISCOVERY_INTERNAL_API_KEY not set — " +
+          "minting a dev stub token. Local development only; setup will not " +
+          "reach the real commerce-skills worker.",
+      );
+      return { authorizationToken: `dgn_dev_${input.orgId}` };
+    }
+    throw new Error(
+      "COMMERCE_DISCOVERY_INTERNAL_API_KEY is required to set up Commerce Discovery.",
+    );
+  }
+
+  const baseUrl = resolveBaseUrl(options);
   const fetchImpl = options.fetchImpl ?? fetch;
   const domain = domainFromSiteUrl(input.siteUrl);
   const url = `${baseUrl}/api/v2/internal/diagnostics/${encodeURIComponent(

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -49,8 +49,8 @@ export const KEYS = {
   // candidate connections satisfying a binding, and the registry batch).
   commerceDiscoveryCompanionSchema: (orgId: string, connectionId: string) =>
     ["commerce-discovery", "companion-schema", orgId, connectionId] as const,
-  commerceDiscoveryCompanionConnections: (orgId: string) =>
-    ["commerce-discovery", "companion-connections", orgId] as const,
+  commerceDiscoveryCompanionConnections: (orgId: string, key: string) =>
+    ["commerce-discovery", "companion-connections", orgId, key] as const,
   commerceDiscoveryCompanionRegistry: (orgId: string, key: string) =>
     ["commerce-discovery", "companion-registry", orgId, key] as const,
   commerceDiscoveryCompanionOAuthStatus: (

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -51,6 +51,11 @@ export const KEYS = {
     ["commerce-discovery", "companion-schema", orgId, connectionId] as const,
   commerceDiscoveryCompanionConnections: (orgId: string, key: string) =>
     ["commerce-discovery", "companion-connections", orgId, key] as const,
+  // Prefix for every companion-connections query in an org, regardless of the
+  // requirements-signature `key`. Use with invalidateQueries to refetch all
+  // variants after a connection is created/linked/updated.
+  commerceDiscoveryCompanionConnectionsPrefix: (orgId: string) =>
+    ["commerce-discovery", "companion-connections", orgId] as const,
   commerceDiscoveryCompanionRegistry: (orgId: string, key: string) =>
     ["commerce-discovery", "companion-registry", orgId, key] as const,
   commerceDiscoveryCompanionOAuthStatus: (

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -271,20 +271,20 @@ function CompanionConfiguration({
       {FormComponent ? (
         <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
           <DialogContent className="sm:max-w-lg">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <IntegrationIcon
-                  icon={card.icon}
-                  name={card.title}
-                  size="sm"
-                  fit="contain"
-                  className="p-1.5"
-                />
-                {card.title}
-              </DialogTitle>
-              <DialogDescription>
-                Configure {card.title} to enrich data
-              </DialogDescription>
+            <DialogHeader className="flex-row items-stretch gap-3 space-y-0 text-left">
+              <IntegrationIcon
+                icon={card.icon}
+                name={card.title}
+                size="md"
+                fit="contain"
+                className="h-auto w-auto min-w-0 self-stretch aspect-square p-1.5"
+              />
+              <div className="flex flex-col gap-1">
+                <DialogTitle>{card.title}</DialogTitle>
+                <DialogDescription>
+                  Configure {card.title} to enrich data
+                </DialogDescription>
+              </div>
             </DialogHeader>
             <FormComponent
               card={card}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -272,14 +272,16 @@ function CompanionConfiguration({
         <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
           <DialogContent className="sm:max-w-lg">
             <DialogHeader className="flex-row items-stretch gap-3 space-y-0 text-left">
-              <IntegrationIcon
-                icon={card.icon}
-                name={card.title}
-                size="md"
-                fit="contain"
-                className="h-auto w-auto min-w-0 self-stretch aspect-square p-1.5"
-              />
-              <div className="flex flex-col gap-1">
+              <div className="aspect-square min-w-0 shrink-0 self-stretch">
+                <IntegrationIcon
+                  icon={card.icon}
+                  name={card.title}
+                  size="md"
+                  fit="contain"
+                  className="h-full w-full min-w-0 p-1.5"
+                />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
                 <DialogTitle>{card.title}</DialogTitle>
                 <DialogDescription>
                   Configure {card.title} to enrich data

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -15,7 +15,7 @@ import {
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { useMCPClient } from "@decocms/mesh-sdk";
 import { CheckCircle, Edit03, Loading01 } from "@untitledui/icons";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import type { CompanionCardModel } from "./companions-core.ts";
 import { getConfigurationSummaryEntries } from "./companions-core.ts";
 import { COMPANION_CONFIG_FORMS } from "./companion-forms/registry.ts";
@@ -123,14 +123,20 @@ export function CompanionCard({
         )}
       </div>
       {card.satisfied && linkedConnectionId && (
-        <CompanionConfiguration
-          card={card}
-          org={org}
-          selfClient={selfClient}
-          connectionId={linkedConnectionId}
-          savedConfigEntries={savedConfigEntries}
-          contextSiteUrl={siteUrl}
-        />
+        // Own Suspense boundary: CompanionConfiguration opens the companion's own
+        // MCP client (useMCPClient → useSuspenseQuery). Isolating it here keeps a
+        // connecting companion from bubbling up and reverting the whole section
+        // to its skeleton — only this card's config area shows a placeholder.
+        <Suspense fallback={<CompanionConfigurationFallback />}>
+          <CompanionConfiguration
+            card={card}
+            org={org}
+            selfClient={selfClient}
+            connectionId={linkedConnectionId}
+            savedConfigEntries={savedConfigEntries}
+            contextSiteUrl={siteUrl}
+          />
+        </Suspense>
       )}
     </div>
   );
@@ -160,6 +166,22 @@ function NotAvailableNote({ title }: NotAvailableNoteProps) {
       <p className="text-xs text-muted-foreground">
         Configuration isn't available here yet for {title}.
       </p>
+    </div>
+  );
+}
+
+/**
+ * Placeholder shown while {@link CompanionConfiguration}'s companion MCP client
+ * connects. Mirrors the config section's box model (top border + header row with
+ * a label and an action) so the card doesn't jump when the real content swaps in.
+ */
+function CompanionConfigurationFallback() {
+  return (
+    <div className="grid gap-3 border-t border-border pt-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="h-5 w-24 animate-pulse rounded bg-muted/60" />
+        <div className="h-8 w-20 animate-pulse rounded-lg bg-muted/60" />
+      </div>
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -272,9 +272,18 @@ function CompanionConfiguration({
         <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
           <DialogContent className="sm:max-w-lg">
             <DialogHeader>
-              <DialogTitle>Configure {card.title}</DialogTitle>
+              <DialogTitle className="flex items-center gap-2">
+                <IntegrationIcon
+                  icon={card.icon}
+                  name={card.title}
+                  size="sm"
+                  fit="contain"
+                  className="p-1.5"
+                />
+                {card.title}
+              </DialogTitle>
               <DialogDescription>
-                Update the values this companion uses for Commerce Discovery.
+                Configure {card.title} to enrich data
               </DialogDescription>
             </DialogHeader>
             <FormComponent

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -271,16 +271,14 @@ function CompanionConfiguration({
       {FormComponent ? (
         <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
           <DialogContent className="sm:max-w-lg">
-            <DialogHeader className="flex-row items-stretch gap-3 space-y-0 text-left">
-              <div className="aspect-square min-w-0 shrink-0 self-stretch">
-                <IntegrationIcon
-                  icon={card.icon}
-                  name={card.title}
-                  size="md"
-                  fit="contain"
-                  className="h-full w-full min-w-0 p-1.5"
-                />
-              </div>
+            <DialogHeader className="flex-row items-center gap-3 space-y-0 text-left">
+              <IntegrationIcon
+                icon={card.icon}
+                name={card.title}
+                size="md"
+                fit="contain"
+                className="p-1.5"
+              />
               <div className="flex min-w-0 flex-1 flex-col gap-1">
                 <DialogTitle>{card.title}</DialogTitle>
                 <DialogDescription>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
@@ -113,10 +113,7 @@ export function GoogleAnalyticsConfigForm({
               <FormLabel>Google Analytics Property</FormLabel>
               <FormControl>
                 <SelectableList
-                  groups={options.map((group) => ({
-                    label: group.account,
-                    options: group.options,
-                  }))}
+                  options={options.flatMap((group) => group.options)}
                   value={field.value}
                   onChange={field.onChange}
                   disabled={isPending}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
@@ -13,16 +13,11 @@ import {
 } from "@deco/ui/components/form.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { DialogFooter } from "@deco/ui/components/dialog.tsx";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@deco/ui/components/select.tsx";
 import { KEYS } from "@/web/lib/query-keys";
 import { unwrapToolResult, toPropertyOptions } from "../companions-core.ts";
+import { LoadingIndicator } from "../loading-indicator.tsx";
 import { useSaveCompanionConfig } from "./use-save-companion-config.ts";
+import { SelectableList } from "./selectable-list.tsx";
 import type { CompanionFormProps } from "./types.ts";
 
 const schema = z.object({
@@ -77,8 +72,8 @@ export function GoogleAnalyticsConfigForm({
 
   if (propertiesQuery.isLoading) {
     return (
-      <div className="space-y-4">
-        <p className="text-sm text-muted-foreground">Loading properties...</p>
+      <div className="flex min-h-[200px] items-center justify-center">
+        <LoadingIndicator label="Loading properties…" />
       </div>
     );
   }
@@ -117,26 +112,15 @@ export function GoogleAnalyticsConfigForm({
             <FormItem>
               <FormLabel>Google Analytics Property</FormLabel>
               <FormControl>
-                <Select
+                <SelectableList
+                  groups={options.map((group) => ({
+                    label: group.account,
+                    options: group.options,
+                  }))}
                   value={field.value}
-                  onValueChange={field.onChange}
+                  onChange={field.onChange}
                   disabled={isPending}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a property" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {options.map((group) => (
-                      <div key={group.account}>
-                        {group.options.map((option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </div>
-                    ))}
-                  </SelectContent>
-                </Select>
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
@@ -8,7 +8,6 @@ import {
   FormControl,
   FormField,
   FormItem,
-  FormLabel,
   FormMessage,
 } from "@deco/ui/components/form.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -110,7 +109,6 @@ export function GoogleAnalyticsConfigForm({
           name="propertyId"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Google Analytics Property</FormLabel>
               <FormControl>
                 <SelectableList
                   options={options.flatMap((group) => group.options)}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
@@ -15,9 +15,9 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { DialogFooter } from "@deco/ui/components/dialog.tsx";
 import { KEYS } from "@/web/lib/query-keys";
 import { unwrapToolResult, toPropertyOptions } from "../companions-core.ts";
-import { LoadingIndicator } from "../loading-indicator.tsx";
 import { useSaveCompanionConfig } from "./use-save-companion-config.ts";
 import { SelectableList } from "./selectable-list.tsx";
+import { LoadingIndicator } from "../loading-indicator.tsx";
 import type { CompanionFormProps } from "./types.ts";
 
 const schema = z.object({
@@ -120,6 +120,7 @@ export function GoogleAnalyticsConfigForm({
                   value={field.value}
                   onChange={field.onChange}
                   disabled={isPending}
+                  ariaLabel="Google Analytics Property"
                 />
               </FormControl>
               <FormMessage />

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
@@ -13,16 +13,11 @@ import {
 } from "@deco/ui/components/form.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { DialogFooter } from "@deco/ui/components/dialog.tsx";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@deco/ui/components/select.tsx";
 import { KEYS } from "@/web/lib/query-keys";
 import { unwrapToolResult, matchGscSite } from "../companions-core.ts";
 import { useSaveCompanionConfig } from "./use-save-companion-config.ts";
+import { SelectableList } from "./selectable-list.tsx";
+import { LoadingIndicator } from "../loading-indicator.tsx";
 import type { CompanionFormProps } from "./types.ts";
 
 const schema = z.object({
@@ -80,8 +75,8 @@ export function GoogleSearchConsoleConfigForm({
 
   if (sitesQuery.isLoading) {
     return (
-      <div className="space-y-4">
-        <p className="text-sm text-muted-foreground">Loading sites...</p>
+      <div className="flex min-h-[200px] items-center justify-center">
+        <LoadingIndicator label="Loading sites…" />
       </div>
     );
   }
@@ -129,22 +124,19 @@ export function GoogleSearchConsoleConfigForm({
             <FormItem>
               <FormLabel>Verified Site</FormLabel>
               <FormControl>
-                <Select
+                <SelectableList
+                  groups={[
+                    {
+                      options: sites.map((site) => ({
+                        value: site.siteUrl,
+                        label: site.siteUrl,
+                      })),
+                    },
+                  ]}
                   value={field.value}
-                  onValueChange={field.onChange}
+                  onChange={field.onChange}
                   disabled={isPending}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a site" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {sites.map((site) => (
-                      <SelectItem key={site.siteUrl} value={site.siteUrl}>
-                        {site.siteUrl}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
@@ -136,6 +136,7 @@ export function GoogleSearchConsoleConfigForm({
                   value={field.value}
                   onChange={field.onChange}
                   disabled={isPending}
+                  ariaLabel="Verified Site"
                 />
               </FormControl>
               <FormMessage />

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
@@ -125,14 +125,10 @@ export function GoogleSearchConsoleConfigForm({
               <FormLabel>Verified Site</FormLabel>
               <FormControl>
                 <SelectableList
-                  groups={[
-                    {
-                      options: sites.map((site) => ({
-                        value: site.siteUrl,
-                        label: site.siteUrl,
-                      })),
-                    },
-                  ]}
+                  options={sites.map((site) => ({
+                    value: site.siteUrl,
+                    label: site.siteUrl,
+                  }))}
                   value={field.value}
                   onChange={field.onChange}
                   disabled={isPending}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
@@ -8,7 +8,6 @@ import {
   FormControl,
   FormField,
   FormItem,
-  FormLabel,
   FormMessage,
 } from "@deco/ui/components/form.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -122,7 +121,6 @@ export function GoogleSearchConsoleConfigForm({
           name="siteUrl"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Verified Site</FormLabel>
               <FormControl>
                 <SelectableList
                   options={sites.map((site) => ({

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
@@ -17,15 +17,66 @@ export function SelectableList({
   value,
   onChange,
   disabled,
+  ariaLabel,
 }: {
   groups: SelectableGroup[];
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
+  ariaLabel?: string;
 }): ReactElement {
+  const flatValues = groups.flatMap((g) => g.options.map((o) => o.value));
+
+  const tabbableValue = flatValues.includes(value)
+    ? value
+    : (flatValues[0] ?? "");
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+    if (disabled) return;
+
+    const handled = [
+      "ArrowDown",
+      "ArrowRight",
+      "ArrowUp",
+      "ArrowLeft",
+      "Home",
+      "End",
+    ].includes(e.key);
+    if (!handled) return;
+
+    e.preventDefault();
+
+    const currentValue = (e.currentTarget as HTMLButtonElement).dataset.value!;
+    const currentIndex = flatValues.indexOf(currentValue);
+    const len = flatValues.length;
+    if (len === 0) return;
+
+    let nextIndex: number;
+    if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+      nextIndex = (currentIndex + 1) % len;
+    } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+      nextIndex = (currentIndex - 1 + len) % len;
+    } else if (e.key === "Home") {
+      nextIndex = 0;
+    } else {
+      // End
+      nextIndex = len - 1;
+    }
+
+    const nextValue = flatValues[nextIndex]!;
+    onChange(nextValue);
+
+    const container = e.currentTarget.closest('[role="radiogroup"]');
+    const nextButton = container?.querySelector<HTMLButtonElement>(
+      `[data-value="${CSS.escape(nextValue)}"]`,
+    );
+    nextButton?.focus();
+  }
+
   return (
     <div
       role="radiogroup"
+      aria-label={ariaLabel}
       className="min-h-[200px] max-h-[280px] overflow-y-auto rounded-md border border-border bg-background p-1"
     >
       {groups.map((group, groupIndex) => (
@@ -44,7 +95,10 @@ export function SelectableList({
                 role="radio"
                 aria-checked={selected}
                 disabled={disabled}
+                data-value={option.value}
+                tabIndex={option.value === tabbableValue ? 0 : -1}
                 onClick={() => onChange(option.value)}
+                onKeyDown={handleKeyDown}
                 className={cn(
                   "flex w-full items-center justify-between gap-2 rounded-sm px-2 py-2 text-left text-sm",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
@@ -21,7 +21,9 @@ export function SelectableList({
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
-  ariaLabel?: string;
+  // Required: this is the radiogroup's only accessible-name source, so every
+  // variant must supply one rather than shipping an unlabeled picker.
+  ariaLabel: string;
   searchPlaceholder?: string;
 }): ReactElement {
   const [query, setQuery] = useState("");
@@ -91,7 +93,7 @@ export function SelectableList({
           onChange={(e) => setQuery(e.target.value)}
           disabled={disabled}
           placeholder={searchPlaceholder}
-          aria-label={ariaLabel ? `Search ${ariaLabel}` : "Search"}
+          aria-label={`Search ${ariaLabel}`}
           className="h-8 pl-8"
         />
       </div>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
@@ -1,0 +1,68 @@
+import type { ReactElement } from "react";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { CheckCircle } from "@untitledui/icons";
+
+export interface SelectableOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectableGroup {
+  label?: string;
+  options: SelectableOption[];
+}
+
+export function SelectableList({
+  groups,
+  value,
+  onChange,
+  disabled,
+}: {
+  groups: SelectableGroup[];
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}): ReactElement {
+  return (
+    <div
+      role="radiogroup"
+      className="min-h-[200px] max-h-[280px] overflow-y-auto rounded-md border border-border bg-background p-1"
+    >
+      {groups.map((group, groupIndex) => (
+        <div key={group.label ?? `group-${groupIndex}`}>
+          {group.label ? (
+            <div className="px-2 py-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {group.label}
+            </div>
+          ) : null}
+          {group.options.map((option) => {
+            const selected = option.value === value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                disabled={disabled}
+                onClick={() => onChange(option.value)}
+                className={cn(
+                  "flex w-full items-center justify-between gap-2 rounded-sm px-2 py-2 text-left text-sm",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "disabled:pointer-events-none disabled:opacity-50",
+                  selected
+                    ? "bg-muted font-medium text-foreground"
+                    : "text-foreground hover:bg-muted/50",
+                )}
+              >
+                <span className="truncate">{option.label}</span>
+                {selected ? (
+                  <CheckCircle size={16} className="shrink-0 text-primary" />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
@@ -1,32 +1,37 @@
 import type { ReactElement } from "react";
+import { useState } from "react";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { CheckCircle } from "@untitledui/icons";
+import { Input } from "@deco/ui/components/input.tsx";
+import { CheckCircle, SearchSm } from "@untitledui/icons";
 
 export interface SelectableOption {
   value: string;
   label: string;
 }
 
-export interface SelectableGroup {
-  label?: string;
-  options: SelectableOption[];
-}
-
 export function SelectableList({
-  groups,
+  options,
   value,
   onChange,
   disabled,
   ariaLabel,
+  searchPlaceholder = "Search…",
 }: {
-  groups: SelectableGroup[];
+  options: SelectableOption[];
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
   ariaLabel?: string;
+  searchPlaceholder?: string;
 }): ReactElement {
-  const flatValues = groups.flatMap((g) => g.options.map((o) => o.value));
+  const [query, setQuery] = useState("");
 
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = normalizedQuery
+    ? options.filter((o) => o.label.toLowerCase().includes(normalizedQuery))
+    : options;
+
+  const flatValues = filtered.map((o) => o.value);
   const tabbableValue = flatValues.includes(value)
     ? value
     : (flatValues[0] ?? "");
@@ -74,19 +79,34 @@ export function SelectableList({
   }
 
   return (
-    <div
-      role="radiogroup"
-      aria-label={ariaLabel}
-      className="min-h-[200px] max-h-[280px] overflow-y-auto rounded-md border border-border bg-background p-1"
-    >
-      {groups.map((group, groupIndex) => (
-        <div key={group.label ?? `group-${groupIndex}`}>
-          {group.label ? (
-            <div className="px-2 py-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {group.label}
-            </div>
-          ) : null}
-          {group.options.map((option) => {
+    <div className="space-y-2">
+      <div className="relative">
+        <SearchSm
+          size={16}
+          className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          disabled={disabled}
+          placeholder={searchPlaceholder}
+          aria-label={ariaLabel ? `Search ${ariaLabel}` : "Search"}
+          className="h-8 pl-8"
+        />
+      </div>
+
+      <div
+        role="radiogroup"
+        aria-label={ariaLabel}
+        className="max-h-[280px] overflow-y-auto"
+      >
+        {filtered.length === 0 ? (
+          <div className="px-2 py-2 text-sm text-muted-foreground">
+            No results
+          </div>
+        ) : (
+          filtered.map((option) => {
             const selected = option.value === value;
             return (
               <button
@@ -114,9 +134,9 @@ export function SelectableList({
                 ) : null}
               </button>
             );
-          })}
-        </div>
-      ))}
+          })
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/use-save-companion-config.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/use-save-companion-config.ts
@@ -36,7 +36,7 @@ export function useSaveCompanionConfig({
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: KEYS.commerceDiscoveryCompanionConnections(org.id),
+        queryKey: KEYS.commerceDiscoveryCompanionConnectionsPrefix(org.id),
       });
       onDone();
     },

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -2,6 +2,8 @@ import { ErrorBoundary } from "@/web/components/error-boundary";
 import { ScrollReveal } from "@/web/components/scroll-reveal";
 import { authClient } from "@/web/lib/auth-client";
 import { SELF_MCP_ALIAS_ID, useMCPClient } from "@decocms/mesh-sdk";
+import { Button } from "@deco/ui/components/button.tsx";
+import { QueryErrorResetBoundary } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { CompanionCard, CompanionCardSkeleton } from "./companion-card.tsx";
 import { useCommerceCompanions } from "./use-commerce-companions.ts";
@@ -54,7 +56,7 @@ function CompanionMcpsSectionSkeleton() {
   );
 }
 
-function CompanionMcpsSectionError() {
+function CompanionMcpsSectionError({ onRetry }: { onRetry: () => void }) {
   return (
     <div className={SECTION_CONTAINER_CLASS}>
       <SectionIntro />
@@ -66,8 +68,17 @@ function CompanionMcpsSectionError() {
           Couldn't load companion integrations.
         </p>
         <p className="mt-1 text-sm text-muted-foreground">
-          Reload the page to try again.
+          Something went wrong loading your integrations.
         </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          onClick={onRetry}
+        >
+          Try again
+        </Button>
       </div>
     </div>
   );
@@ -79,11 +90,24 @@ export function CompanionMcpsSection(props: {
   siteUrl?: string;
 }) {
   return (
-    <ErrorBoundary fallback={<CompanionMcpsSectionError />}>
-      <Suspense fallback={<CompanionMcpsSectionSkeleton />}>
-        <CompanionMcpsSectionContent {...props} />
-      </Suspense>
-    </ErrorBoundary>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          fallback={({ resetError }) => (
+            <CompanionMcpsSectionError
+              onRetry={() => {
+                reset();
+                resetError();
+              }}
+            />
+          )}
+        >
+          <Suspense fallback={<CompanionMcpsSectionSkeleton />}>
+            <CompanionMcpsSectionContent {...props} />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   );
 }
 

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -137,7 +137,7 @@ function CompanionMcpsSectionContent({
 
       <ScrollReveal
         wrapperClassName="flex min-h-0 flex-1 flex-col md:block"
-        className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1 md:max-h-[45vh] md:flex-none"
+        className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1 md:max-h-[60vh] md:flex-none"
       >
         <div className="grid gap-4">
           {connectError && (

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -1,6 +1,8 @@
+import { ErrorBoundary } from "@/web/components/error-boundary";
 import { ScrollReveal } from "@/web/components/scroll-reveal";
 import { authClient } from "@/web/lib/auth-client";
 import { SELF_MCP_ALIAS_ID, useMCPClient } from "@decocms/mesh-sdk";
+import { Suspense } from "react";
 import { CompanionCard, CompanionCardSkeleton } from "./companion-card.tsx";
 import { useCommerceCompanions } from "./use-commerce-companions.ts";
 import { useConnectCompanion } from "./use-connect-companion.ts";
@@ -10,8 +12,9 @@ interface CompanionOrg {
   slug: string;
 }
 
-// Shared between the live section and its Suspense fallback so the layout can't
-// drift between the two — see CompanionMcpsSectionSkeleton.
+// Shared between the live section, its Suspense fallback, and its error fallback
+// so the layout can't drift between the three — see CompanionMcpsSectionSkeleton
+// and CompanionMcpsSectionError.
 const SECTION_CONTAINER_CLASS =
   "flex min-h-0 flex-1 flex-col gap-6 md:grid md:flex-none md:gap-4";
 
@@ -38,7 +41,53 @@ function CompanionCardSkeletons() {
   );
 }
 
-export function CompanionMcpsSection({
+// Suspense fallback for the whole section. `useCommerceCompanions` (and the MCP
+// clients it/the cards open) are Suspense queries, so the card loading state now
+// lives here as a stable boundary fallback instead of an `isLoading` branch that
+// could tear down and re-mount as deeper queries resolve.
+function CompanionMcpsSectionSkeleton() {
+  return (
+    <div className={SECTION_CONTAINER_CLASS}>
+      <SectionIntro />
+      <CompanionCardSkeletons />
+    </div>
+  );
+}
+
+function CompanionMcpsSectionError() {
+  return (
+    <div className={SECTION_CONTAINER_CLASS}>
+      <SectionIntro />
+      <div
+        role="alert"
+        className="rounded-2xl border border-border bg-card p-4"
+      >
+        <p className="text-sm text-foreground">
+          Couldn't load companion integrations.
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Reload the page to try again.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function CompanionMcpsSection(props: {
+  org: CompanionOrg;
+  cdConnectionId: string;
+  siteUrl?: string;
+}) {
+  return (
+    <ErrorBoundary fallback={<CompanionMcpsSectionError />}>
+      <Suspense fallback={<CompanionMcpsSectionSkeleton />}>
+        <CompanionMcpsSectionContent {...props} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+function CompanionMcpsSectionContent({
   org,
   cdConnectionId,
   siteUrl,
@@ -55,7 +104,7 @@ export function CompanionMcpsSection({
     orgSlug: org.slug,
   });
 
-  const { cards, isLoading, error } = useCommerceCompanions({
+  const { cards } = useCommerceCompanions({
     selfClient,
     org,
     cdConnectionId,
@@ -73,7 +122,7 @@ export function CompanionMcpsSection({
 
   // Empty: nothing to connect → render nothing (the parent footer still shows
   // the report CTA).
-  if (!isLoading && !error && cards.length === 0) {
+  if (cards.length === 0) {
     return null;
   }
 
@@ -86,46 +135,30 @@ export function CompanionMcpsSection({
     <div className={SECTION_CONTAINER_CLASS}>
       <SectionIntro />
 
-      {error ? (
-        <div
-          role="alert"
-          className="rounded-2xl border border-border bg-card p-4"
-        >
-          <p className="text-sm text-foreground">
-            Couldn't load companion integrations.
-          </p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Reload the page to try again.
-          </p>
+      <ScrollReveal
+        wrapperClassName="flex min-h-0 flex-1 flex-col md:block"
+        className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1 md:max-h-[45vh] md:flex-none"
+      >
+        <div className="grid gap-4">
+          {connectError && (
+            <p role="alert" className="text-sm text-destructive">
+              {connectError}
+            </p>
+          )}
+          {cards.map((card) => (
+            <CompanionCard
+              key={card.fieldKey}
+              card={card}
+              connecting={connectingFieldKey === card.fieldKey}
+              disabled={busy && connectingFieldKey !== card.fieldKey}
+              org={org}
+              selfClient={selfClient}
+              siteUrl={siteUrl}
+              onConnect={() => void connect(card)}
+            />
+          ))}
         </div>
-      ) : isLoading ? (
-        <CompanionCardSkeletons />
-      ) : (
-        <ScrollReveal
-          wrapperClassName="flex min-h-0 flex-1 flex-col md:block"
-          className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1 md:max-h-[45vh] md:flex-none"
-        >
-          <div className="grid gap-4">
-            {connectError && (
-              <p role="alert" className="text-sm text-destructive">
-                {connectError}
-              </p>
-            )}
-            {cards.map((card) => (
-              <CompanionCard
-                key={card.fieldKey}
-                card={card}
-                connecting={connectingFieldKey === card.fieldKey}
-                disabled={busy && connectingFieldKey !== card.fieldKey}
-                org={org}
-                selfClient={selfClient}
-                siteUrl={siteUrl}
-                onConnect={() => void connect(card)}
-              />
-            ))}
-          </div>
-        </ScrollReveal>
-      )}
+      </ScrollReveal>
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
@@ -32,7 +32,9 @@ export function CommerceOnboardingLoading({
 }) {
   return (
     <AuthSplitLayout>
-      <CommerceOnboardingLoadingIndicator variant={variant} />
+      <div className="flex justify-center">
+        <CommerceOnboardingLoadingIndicator variant={variant} />
+      </div>
     </AuthSplitLayout>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
@@ -32,9 +32,7 @@ export function CommerceOnboardingLoading({
 }) {
   return (
     <AuthSplitLayout>
-      <div className="flex justify-center">
-        <CommerceOnboardingLoadingIndicator variant={variant} />
-      </div>
+      <CommerceOnboardingLoadingIndicator variant={variant} />
     </AuthSplitLayout>
   );
 }
@@ -45,7 +43,7 @@ export function CommerceOnboardingLoadingIndicator({
   variant: CommerceOnboardingLoadingVariant;
 }) {
   return (
-    <div className="py-4" role="status" aria-live="polite">
+    <div className="flex justify-center py-4" role="status" aria-live="polite">
       <LoadingIndicator
         label={getCommerceOnboardingLoadingLabel(variant)}
         className="text-muted-foreground"

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
@@ -2,7 +2,7 @@ import { KEYS } from "@/web/lib/query-keys";
 import { callRegistryTool } from "@/web/utils/registry-utils";
 import { useMCPClient, WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { useQueries, useQuery } from "@tanstack/react-query";
+import { useSuspenseQueries, useSuspenseQuery } from "@tanstack/react-query";
 import { COMMERCE_COMPANION_MCPS } from "./companions.ts";
 import {
   buildCompanionCards,
@@ -33,14 +33,14 @@ export function useCommerceCompanions({
   selfClient: Client;
   org: CompanionOrg;
   cdConnectionId: string;
-}): { cards: CompanionCardModel[]; isLoading: boolean; error: unknown } {
+}): { cards: CompanionCardModel[] } {
   // 1) CD's live config schema (on the CD connection's OWN client).
   const cdClient = useMCPClient({
     connectionId: cdConnectionId,
     orgId: org.id,
     orgSlug: org.slug,
   });
-  const schemaQuery = useQuery({
+  const schemaQuery = useSuspenseQuery({
     queryKey: KEYS.commerceDiscoveryCompanionSchema(org.id, cdConnectionId),
     queryFn: async () => {
       const result = await cdClient.callTool({
@@ -66,7 +66,7 @@ export function useCommerceCompanions({
   const registryKey = [...registryAppIds, ...nameOnly].sort().join(",");
 
   // 2) CD saved state (shared cache key with the parent connection query).
-  const cdConnectionQuery = useQuery({
+  const cdConnectionQuery = useSuspenseQuery({
     queryKey: KEYS.commerceDiscoveryConnection(org.id, cdConnectionId),
     queryFn: async () => {
       const result = await selfClient.callTool({
@@ -89,10 +89,14 @@ export function useCommerceCompanions({
     .filter((v): v is string => typeof v === "string" && v.length > 0);
 
   // 3) Existing org connections that could satisfy a binding (app identity).
-  const connectionsQuery = useQuery({
+  const connectionsQuery = useSuspenseQuery({
     queryKey: KEYS.commerceDiscoveryCompanionConnections(org.id),
-    enabled: requirements.length > 0,
     queryFn: async () => {
+      // Suspense queries can't be `enabled`-gated; skip the call when there are
+      // no binding requirements (schema resolved above, so this is stable).
+      if (requirements.length === 0) {
+        return { items: [] as CandidateConnection[] };
+      }
       const conditions: ConnectionWhereCondition[] = [
         { field: ["app_name"], operator: "in", value: bindingTypes },
         { field: ["app_id"], operator: "in", value: registryAppIds },
@@ -125,7 +129,7 @@ export function useCommerceCompanions({
   const oauthStatusConnections = linkedConnections.filter(
     (connection) => connection.oauth_config && !connection.connection_token,
   );
-  const oauthStatusQueries = useQueries({
+  const oauthStatusQueries = useSuspenseQueries({
     queries: oauthStatusConnections.map((connection) => ({
       queryKey: KEYS.commerceDiscoveryCompanionOAuthStatus(
         org.id,
@@ -158,10 +162,14 @@ export function useCommerceCompanions({
   }
 
   // 4) Registry batch (one LIST on the Deco store).
-  const registryQuery = useQuery({
+  const registryQuery = useSuspenseQuery({
     queryKey: KEYS.commerceDiscoveryCompanionRegistry(org.id, registryKey),
-    enabled: requirements.length > 0,
     queryFn: async () => {
+      // Suspense queries can't be `enabled`-gated; skip the call when there are
+      // no binding requirements (schema resolved above, so this is stable).
+      if (requirements.length === 0) {
+        return { items: [] as RegistryItemLike[] };
+      }
       const where = buildRegistryWhere(registryAppIds, nameOnly);
       const result = await callRegistryTool<{ items: RegistryItemLike[] }>(
         WellKnownOrgMCPId.REGISTRY(org.id),
@@ -193,19 +201,5 @@ export function useCommerceCompanions({
     curated: COMMERCE_COMPANION_MCPS,
   });
 
-  const isLoading =
-    schemaQuery.isPending ||
-    cdConnectionQuery.isPending ||
-    (requirements.length > 0 &&
-      (connectionsQuery.isPending ||
-        registryQuery.isPending ||
-        oauthStatusQueries.some((query) => query.isPending)));
-  const error =
-    schemaQuery.error ??
-    cdConnectionQuery.error ??
-    connectionsQuery.error ??
-    registryQuery.error ??
-    null;
-
-  return { cards, isLoading, error };
+  return { cards };
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
@@ -92,10 +92,13 @@ export function useCommerceCompanions({
   // Key includes every input the queryFn reads from the closure so a schema or
   // config-state change (which alters the short-circuit and the WHERE clause)
   // triggers a fresh fetch instead of serving a stale empty/partial result.
+  // Each segment is namespaced (binding/app/linked) so the same string in
+  // different categories can't collapse into one key and cross-contaminate the
+  // cache — these map to distinct WHERE fields (app_name / app_id / id).
   const connectionsKey = [
-    ...bindingTypes,
-    ...registryAppIds,
-    ...[...linkedConnectionIds].sort(),
+    ...bindingTypes.map((t) => `binding:${t}`),
+    ...registryAppIds.map((a) => `app:${a}`),
+    ...linkedConnectionIds.map((id) => `linked:${id}`),
   ]
     .sort()
     .join(",");

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
@@ -89,8 +89,21 @@ export function useCommerceCompanions({
     .filter((v): v is string => typeof v === "string" && v.length > 0);
 
   // 3) Existing org connections that could satisfy a binding (app identity).
+  // Key includes every input the queryFn reads from the closure so a schema or
+  // config-state change (which alters the short-circuit and the WHERE clause)
+  // triggers a fresh fetch instead of serving a stale empty/partial result.
+  const connectionsKey = [
+    ...bindingTypes,
+    ...registryAppIds,
+    ...[...linkedConnectionIds].sort(),
+  ]
+    .sort()
+    .join(",");
   const connectionsQuery = useSuspenseQuery({
-    queryKey: KEYS.commerceDiscoveryCompanionConnections(org.id),
+    queryKey: KEYS.commerceDiscoveryCompanionConnections(
+      org.id,
+      connectionsKey,
+    ),
     queryFn: async () => {
       // Suspense queries can't be `enabled`-gated; skip the call when there are
       // no binding requirements (schema resolved above, so this is stable).
@@ -136,13 +149,20 @@ export function useCommerceCompanions({
         connection.id,
       ),
       queryFn: async () => {
-        const response = await fetch(
-          `/api/${encodeURIComponent(org.slug)}/connections/${encodeURIComponent(connection.id)}/oauth-token/status`,
-          { credentials: "include" },
-        );
-        if (!response.ok) return { hasToken: false };
-        const data = (await response.json()) as { hasToken?: unknown };
-        return { hasToken: data.hasToken === true };
+        // Optional metadata: a transient failure must not escalate to the
+        // Suspense boundary and blank the whole section. Treat any error
+        // (network, non-ok, parse) as "no token".
+        try {
+          const response = await fetch(
+            `/api/${encodeURIComponent(org.slug)}/connections/${encodeURIComponent(connection.id)}/oauth-token/status`,
+            { credentials: "include" },
+          );
+          if (!response.ok) return { hasToken: false };
+          const data = (await response.json()) as { hasToken?: unknown };
+          return { hasToken: data.hasToken === true };
+        } catch {
+          return { hasToken: false };
+        }
       },
       retry: false,
     })),

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
@@ -123,7 +123,7 @@ export function useConnectCompanion({
         queryKey: KEYS.commerceDiscoveryConnection(org.id, cdConnectionId),
       });
       await queryClient.invalidateQueries({
-        queryKey: KEYS.commerceDiscoveryCompanionConnections(org.id),
+        queryKey: KEYS.commerceDiscoveryCompanionConnectionsPrefix(org.id),
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary

Improves the **commerce-onboarding companion config** UX. The headline change replaces the property/site `Select` dropdowns in the Google Analytics and Google Search Console configure dialogs with an inline, always-visible **selectable list**, and stabilizes the companion-card / config-form loading states to avoid layout shift.

## What changed

**New `SelectableList` picker** (`companion-forms/selectable-list.tsx`)
- Controlled presentational component: `{ groups, value, onChange, disabled, ariaLabel }`.
- Renders selectable rows (radiogroup semantics); the current selection is always visible and highlighted with a `CheckCircle`.
- Bordered, scrollable container (`min-h-[200px] max-h-[280px]`) so short lists don't collapse and long lists scroll.
- Full keyboard support: roving tabindex, Arrow/Home/End navigation with wrap-around, and an accessible name — parity with the dropdown it replaces.

**Google Analytics form** — uses `SelectableList` with rows **grouped by account** (section headers). Loading shows a centered spinner in a fixed-height box.

**Google Search Console form** — uses `SelectableList` as a single flat (header-less) list; the existing `matchGscSite` context-site preselect is preserved. Same fixed-height spinner treatment.

**Companion cards / loading** (earlier commits on the branch) — center the loading indicator across variants, stabilize card loading with Suspense, and raise the card scroll cap.

No changes to data fetching, Zod schemas, `useSaveCompanionConfig`, the save flow, or `companions-core.ts` helpers.

## Testing

- `bun run check`, `bun run lint`, `bun run fmt` — clean.
- `bun test` for the companion-forms area — 30/30 pass.
- Onboarding page renders with no console errors.
- ⚠️ **Not yet verified live:** the GA/GSC *configure* dialogs only render for OAuth-connected companions, which weren't set up in the dev sandbox. The interactive visual check (account-grouped rows, selected-row highlight, no layout shift) still needs a run with authenticated GA/GSC connections. Screenshots to follow.

## Notes for reviewers

- `SelectableList` uses an imperative DOM focus move inside its keydown handler (scoped to its own radiogroup via `closest('[role="radiogroup"]')`) because React 19's compiler bans `useEffect`/`useRef`-based focus effects here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced GA/GSC dropdowns with a flat, searchable `SelectableList`, and stabilized the companion section with Suspense plus a retryable error boundary to remove flicker. Loading indicators are centered, cards scroll to 60vh, and config dialogs show the companion icon and name.

- **New Features**
  - Added `SelectableList`: flat, searchable picker with radiogroup semantics, full keyboard nav, and a required `ariaLabel`.
  - GA/GSC forms use `SelectableList` with a fixed-height, centered loading state; GSC preselect preserved.

- **Refactors**
  - Converted companion queries to `useSuspenseQuery`/`useSuspenseQueries`; wrapped the section with `ErrorBoundary` + `QueryErrorResetBoundary` (“Try again”), and gave each card config its own `Suspense` with a header-shaped fallback.
  - Strengthened `commerceDiscoveryCompanionConnections` caching: added a requirements-signature key, namespaced signature segments to prevent cross-category key collisions, and introduced `commerceDiscoveryCompanionConnectionsPrefix` for org-wide invalidation; updated save/connect flows to invalidate by org prefix. OAuth-status fetch is tolerant so failures don’t bubble to Suspense.

<sup>Written for commit 09f13e70f6810300458384cabcb23d4e1ddd0047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

