### PR TITLE
fix(commerce-onboarding): use brand purple tint for connection animation

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
@@ -72,7 +72,13 @@ function ConnectionNode({ children }: { children: React.ReactNode }) {
  */
 function ConnectionAnimation() {
   return (
-    <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-muted/40 px-7 py-7">
+    <div
+      className="flex items-center justify-between rounded-2xl border border-border/60 px-7 py-7"
+      style={{
+        backgroundColor:
+          "color-mix(in srgb, var(--brand-purple-light) 15%, transparent)",
+      }}
+    >
       <ConnectionNode>
         <User01 size={20} className="text-muted-foreground" />
       </ConnectionNode>


### PR DESCRIPTION
## What is this contribution about?

Replaces the neutral gray background (`bg-muted/40`) on the "you → deco" connection animation inside the schedule-meeting card with a soft purple tint using the design system's `--brand-purple-light` CSS variable at 15% opacity. This brings the card in line with the brand palette and makes it feel more intentional.

## Screenshots/Demonstration

Before: gray (`bg-muted/40`) background on the connection animation box.
After: soft lavender using `color-mix(in srgb, var(--brand-purple-light) 15%, transparent)`.

## How to Test

1. Navigate to the commerce onboarding flow and reach the "Schedule a meeting" step (shown as the right-side panel on `md+` screens).
2. Confirm the connection animation area has a purple tint instead of gray.
3. Check both light and dark modes.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the gray background of the “you → deco” connection animation in the Schedule a meeting card with a soft brand purple tint using `--brand-purple-light` at 15%. This aligns the commerce onboarding UI with the brand and looks better in light and dark modes.

<sup>Written for commit 3a89d24c08a3c13c87bc8b5f279cc56ee5db9d04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

