### PR TITLE
fix(commerce-onboarding): surface generic error when the run fails to start

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -612,8 +612,9 @@ function CommerceSetupContent({
   });
 
   // Triggers the diagnostic run now that the user has connected their data
-  // sources. Fire-and-forget from the "See full report" click — the report view
-  // polls for the enriched deck as it lands.
+  // sources ("See full report"). We await the TRIGGER so a failure surfaces (a
+  // generic error, no navigation) instead of silently opening an empty report;
+  // the run itself is async — the report view polls for the enriched deck.
   const runMutation = useMutation({
     mutationFn: async (siteUrl: string) => {
       const result = await selfClient.callTool({
@@ -626,6 +627,7 @@ function CommerceSetupContent({
     },
     retry: false,
   });
+  const [runError, setRunError] = useState<string | null>(null);
 
   const setupReady = !!connectionQuery.data.item && !!virtualMcpQuery.data.item;
   // A returning session may arrive with no ?siteUrl param and an empty form while
@@ -679,11 +681,21 @@ function CommerceSetupContent({
     toolName: COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
   };
 
-  const openReport = () => {
-    // Kick off the enriching run (fire-and-forget) — the user is done connecting.
+  const openReport = async () => {
+    setRunError(null);
+    // Trigger the enriching run now that the user is done connecting. Await it so a
+    // failure surfaces (generic message, stay put) instead of silently opening an
+    // empty report. No resolvable site (legacy session) ⇒ nothing to trigger, just open.
     const normalized = normalizeCommerceSiteUrl(currentSiteUrl);
     if (normalized.ok) {
-      runMutation.mutate(normalized.value);
+      try {
+        await runMutation.mutateAsync(normalized.value);
+      } catch {
+        setRunError(
+          "Algo deu errado ao gerar seu relatório. Tente novamente em instantes.",
+        );
+        return;
+      }
     }
     localStorage.setItem(
       LOCALSTORAGE_KEYS.sidebarOpen(),
@@ -706,6 +718,8 @@ function CommerceSetupContent({
         org={org}
         reportApp={reportApp}
         onOpenReport={openReport}
+        isSubmitting={runMutation.isPending}
+        error={runError}
         meetingUrl={currentMeetingUrl}
         meetingVisual={currentMeetingVisual}
         siteUrl={currentSiteUrl}
@@ -836,6 +850,8 @@ function CommerceDiscoveryReady({
   org,
   reportApp,
   onOpenReport,
+  isSubmitting,
+  error,
   meetingUrl,
   meetingVisual,
   siteUrl,
@@ -843,6 +859,8 @@ function CommerceDiscoveryReady({
   org: CommerceOrganization;
   reportApp: CommerceDiscoveryReportApp;
   onOpenReport: () => void;
+  isSubmitting?: boolean;
+  error?: string | null;
   meetingUrl: string;
   meetingVisual: ReactNode;
   siteUrl?: string;
@@ -864,15 +882,22 @@ function CommerceDiscoveryReady({
           {/* Right-side ScheduleMeetingVisual is hidden on mobile, so the human
               escape hatch rides in the footer above the report CTA. */}
           <ScheduleMeetingBanner className="md:hidden" href={meetingUrl} />
+          {error ? <InlineError message={error} /> : null}
           <Button
             type="button"
             size="xl"
             className="w-full rounded-2xl text-base font-medium"
             onClick={onOpenReport}
-            disabled={!reportApp.virtualMcpId}
+            disabled={isSubmitting || !reportApp.virtualMcpId}
           >
-            See full report
-            <ArrowRight size={18} />
+            {isSubmitting ? (
+              <CommerceOnboardingButtonLoading />
+            ) : (
+              <>
+                See full report
+                <ArrowRight size={18} />
+              </>
+            )}
           </Button>
         </div>
       </div>

--- a/packages/e2e/fixtures/commerce-upgrade-mock.ts
+++ b/packages/e2e/fixtures/commerce-upgrade-mock.ts
@@ -11,15 +11,17 @@
  * Uses `node:http` (NOT `Bun.serve`) so it typechecks under the suite's Node
  * types and runs under either node or bun.
  *
- * Mirrors the real contract from
- * `api/v2/internal/diagnostics/:domain/upgrade`:
- *   POST { org_id, name } -> { url, org_id, scope, token, run }
+ * Mirrors the real contract from `api/v2/internal/diagnostics/:domain/*`:
+ *   POST /upgrade { org_id, name } -> { url, org_id, scope, token, run }
+ *   POST /run     { org_id }       -> { url, scope, run }   (triggered on
+ *                                      "See full report"; the flow awaits it)
  */
 
 import { createServer } from "node:http";
 
 const port = Number(process.env.COMMERCE_MOCK_PORT ?? "4100");
 const UPGRADE_RE = /^\/api\/v2\/internal\/diagnostics\/([^/]+)\/upgrade$/;
+const RUN_RE = /^\/api\/v2\/internal\/diagnostics\/([^/]+)\/run$/;
 
 const server = createServer((req, res) => {
   const url = new URL(req.url ?? "/", "http://localhost");
@@ -51,6 +53,23 @@ const server = createServer((req, res) => {
           org_id: orgId,
           scope: "private",
           token: `dgn_e2e_${orgId ?? "unknown"}`,
+          run: { id: "run_e2e", status: "running" },
+        }),
+      );
+    });
+    return;
+  }
+
+  const runMatch = url.pathname.match(RUN_RE);
+  if (req.method === "POST" && runMatch) {
+    const domain = decodeURIComponent(runMatch[1]);
+    req.on("data", () => {}); // drain
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          url: domain,
+          scope: "private",
           run: { id: "run_e2e", status: "running" },
         }),
       );


### PR DESCRIPTION
## Why
"See full report" fired the `COMMERCE_DISCOVERY_RUN` trigger **fire-and-forget** (`runMutation.mutate` wasn't awaited before navigating). So when the trigger failed — e.g. commerce's `/run` returning 404 during a deploy skew — the error was swallowed: the report just opened empty with no signal. That's exactly how a real 404 slipped through unnoticed and the agent loop never started.

## What
- `openReport` now **awaits the trigger**. On failure it shows a **generic** message ("Algo deu errado ao gerar seu relatório. Tente novamente em instantes.") and **stays** on the screen so the user can retry; on success it navigates as before.
- The button shows a loading state while the trigger is in flight.
- No debug details are shown to the user (per request) — just the generic copy; the real error still throws server-side / in logs.
- The run **itself** stays async — we only await the quick trigger POST; the report view still polls for the enriched deck.

Reuses the existing `InlineError` + `CommerceOnboardingButtonLoading` primitives.

No local node_modules in this checkout — format verified with biome 2.2.5 (studio's pinned version); relying on CI for typecheck/lint/test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Await the diagnostic run trigger in commerce onboarding so failures surface with a generic error instead of opening an empty report. Adds a loading state to the “See full report” button.

- **Bug Fixes**
  - Await the trigger using mutateAsync; the run stays async and the report view keeps polling.
  - On failure, show a generic message and keep the user on the page to retry; no debug details to users.
  - Disable the CTA and show a loading state while the trigger runs.
  - Stub POST `/run` in the e2e commerce mock so the flow can await it.

<sup>Written for commit 43d502f35845442d98444f9a969d459756e6c56f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

