### PR TITLE
feat(sandbox): telemetry on installed deps per sandbox install

### DIFF
--- a/packages/sandbox/daemon/setup/dep-metrics.test.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { isPackageManifest } from "./dep-metrics";
+
+describe("isPackageManifest", () => {
+  it("accepts real package roots (npm/yarn/bun + nested + pnpm)", () => {
+    expect(isPackageManifest("react/package.json")).toBe(true);
+    expect(isPackageManifest("@scope/pkg/package.json")).toBe(true);
+    expect(isPackageManifest("foo/node_modules/bar/package.json")).toBe(true);
+    expect(
+      isPackageManifest(".pnpm/bar@1.0.0/node_modules/bar/package.json"),
+    ).toBe(true);
+    expect(
+      isPackageManifest(
+        ".pnpm/@scope+bar@1.0.0/node_modules/@scope/bar/package.json",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects fixture/sample package.json shipped inside a package", () => {
+    expect(isPackageManifest("foo/test/fixtures/package.json")).toBe(false);
+    expect(isPackageManifest(".cache/foo/package.json")).toBe(false);
+    expect(isPackageManifest("package.json")).toBe(false);
+  });
+});

--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -79,11 +79,14 @@ export interface DepMetricsInput {
  * Prometheus). Best-effort: observability only, never throws.
  */
 export async function emitInstalledDeps(input: DepMetricsInput): Promise<void> {
+  // The install already succeeded by the time we're called, so count it before
+  // the fallible dep scan — otherwise a scan failure (e.g. no node_modules for
+  // a dependency-less manifest) would undercount successful installs.
+  installCounter.add(1, { package_manager: input.packageManager });
   try {
     const deps = await readInstalledDeps(
       join(input.installRoot, "node_modules"),
     );
-    installCounter.add(1, { package_manager: input.packageManager });
     depCountHistogram.record(deps.length, {
       package_manager: input.packageManager,
     });

--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -1,17 +1,5 @@
 import { join } from "node:path";
-import { metrics } from "@opentelemetry/api";
 import type { PackageManager } from "../types";
-
-// Same meter name as entry.ts (getMeter is cached by name) so we don't have to
-// plumb an instrument through the orchestrator.
-const meter = metrics.getMeter("link-daemon");
-const installCounter = meter.createCounter("sandbox_install_total", {
-  description: "Successful sandbox dependency installs",
-});
-const depCountHistogram = meter.createHistogram(
-  "sandbox_install_dependency_count",
-  { description: "Installed dependency count per successful install" },
-);
 
 // Guard against a pathological node_modules blowing up the log line.
 const MAX_DEPS = 10_000;
@@ -72,24 +60,19 @@ export interface DepMetricsInput {
 }
 
 /**
- * After a SUCCESSFUL install, emit the installed dependency set for
- * downstream aggregation (VictoriaLogs) so the team can decide which packages
- * to pre-bake into the sandbox image. Package name/version go ONLY in the JSON
- * log line — never as metric labels (per-package cardinality would wreck
- * Prometheus). Best-effort: observability only, never throws.
+ * After a SUCCESSFUL install, emit the installed dependency set as a single
+ * JSON log line for downstream aggregation (VictoriaLogs) so the team can
+ * decide which packages to pre-bake into the sandbox image. Logs, not metrics:
+ * per-package cardinality would wreck Prometheus, and sandbox pods can't reach
+ * an in-cluster OTLP collector anyway (egress is locked to 53/443), so their
+ * stdout scraped out-of-band is the only channel that leaves the pod.
+ * Best-effort: observability only, never throws.
  */
 export async function emitInstalledDeps(input: DepMetricsInput): Promise<void> {
-  // The install already succeeded by the time we're called, so count it before
-  // the fallible dep scan — otherwise a scan failure (e.g. no node_modules for
-  // a dependency-less manifest) would undercount successful installs.
-  installCounter.add(1, { package_manager: input.packageManager });
   try {
     const deps = await readInstalledDeps(
       join(input.installRoot, "node_modules"),
     );
-    depCountHistogram.record(deps.length, {
-      package_manager: input.packageManager,
-    });
     console.log(
       JSON.stringify({
         msg: "sandbox.install.deps",

--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -1,0 +1,104 @@
+import { join } from "node:path";
+import { metrics } from "@opentelemetry/api";
+import type { PackageManager } from "../types";
+
+// Same meter name as entry.ts (getMeter is cached by name) so we don't have to
+// plumb an instrument through the orchestrator.
+const meter = metrics.getMeter("link-daemon");
+const installCounter = meter.createCounter("sandbox_install_total", {
+  description: "Successful sandbox dependency installs",
+});
+const depCountHistogram = meter.createHistogram(
+  "sandbox_install_dependency_count",
+  { description: "Installed dependency count per successful install" },
+);
+
+// Guard against a pathological node_modules blowing up the log line.
+const MAX_DEPS = 10_000;
+
+/**
+ * True when a `package.json` (path relative to node_modules) is a real package
+ * manifest — its dir sits directly under a `node_modules` or a scope dir. This
+ * rejects fixture/sample `package.json` files shipped deep inside packages.
+ */
+export function isPackageManifest(rel: string): boolean {
+  const d = rel.split("/").slice(0, -1);
+  const n = d.length;
+  if (n === 0) return false;
+  if (n >= 2 && d[n - 2].startsWith("@")) {
+    return n === 2 || d[n - 3] === "node_modules";
+  }
+  return n === 1 || d[n - 2] === "node_modules";
+}
+
+/**
+ * Flattened installed dependency set, read straight from the on-disk
+ * node_modules (PM-agnostic — works for npm/pnpm/yarn/bun without parsing four
+ * lockfile formats). `followSymlinks: false` + `dot: true` picks up pnpm's real
+ * package dirs under `.pnpm/` while skipping its top-level symlinks, so every
+ * PM yields the same flattened `name@version` set (deduped).
+ */
+async function readInstalledDeps(
+  nodeModulesDir: string,
+): Promise<{ name: string; version: string }[]> {
+  const seen = new Map<string, { name: string; version: string }>();
+  const glob = new Bun.Glob("**/package.json");
+  for await (const rel of glob.scan({
+    cwd: nodeModulesDir,
+    followSymlinks: false,
+    dot: true,
+  })) {
+    if (seen.size >= MAX_DEPS) break;
+    if (!isPackageManifest(rel)) continue;
+    try {
+      const raw = await Bun.file(join(nodeModulesDir, rel)).json();
+      const name = raw?.name;
+      const version = raw?.version;
+      if (typeof name !== "string" || typeof version !== "string") continue;
+      seen.set(`${name}@${version}`, { name, version });
+    } catch {
+      // unreadable / partial manifest — skip
+    }
+  }
+  return [...seen.values()];
+}
+
+export interface DepMetricsInput {
+  installRoot: string;
+  packageManager: PackageManager;
+  bootId: string;
+  repoName?: string;
+  branch?: string;
+}
+
+/**
+ * After a SUCCESSFUL install, emit the installed dependency set for
+ * downstream aggregation (VictoriaLogs) so the team can decide which packages
+ * to pre-bake into the sandbox image. Package name/version go ONLY in the JSON
+ * log line — never as metric labels (per-package cardinality would wreck
+ * Prometheus). Best-effort: observability only, never throws.
+ */
+export async function emitInstalledDeps(input: DepMetricsInput): Promise<void> {
+  try {
+    const deps = await readInstalledDeps(
+      join(input.installRoot, "node_modules"),
+    );
+    installCounter.add(1, { package_manager: input.packageManager });
+    depCountHistogram.record(deps.length, {
+      package_manager: input.packageManager,
+    });
+    console.log(
+      JSON.stringify({
+        msg: "sandbox.install.deps",
+        bootId: input.bootId,
+        packageManager: input.packageManager,
+        repoName: input.repoName,
+        branch: input.branch,
+        dependencyCount: deps.length,
+        dependencies: deps,
+      }),
+    );
+  } catch (err) {
+    console.warn("[install] dep metrics emit failed", err);
+  }
+}

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -26,6 +26,7 @@ import { discoverScripts } from "../process/script-discovery";
 import type { Application, Config } from "../types";
 import { autodetectApplication } from "./autodetect";
 import { spawnClone } from "./clone";
+import { emitInstalledDeps } from "./dep-metrics";
 import { configureGitIdentity } from "./identity";
 import { spawnInstall } from "./install";
 import { spawnSetupStep } from "./spawn-step";
@@ -296,7 +297,8 @@ export class SetupOrchestrator {
       this.broadcastDiscoveredScripts(config);
       return true;
     }
-    if (!config.application?.packageManager?.name) {
+    const pm = config.application?.packageManager?.name;
+    if (!pm) {
       // Nothing to install — proceed to start, which will diagnose.
       return true;
     }
@@ -340,6 +342,17 @@ export class SetupOrchestrator {
       return false;
     }
     this.markInstallSucceeded(config);
+    // Report the installed dep set for pre-bake analysis (best-effort, async).
+    void emitInstalledDeps({
+      installRoot: resolvePmRoot(
+        config.repoDir,
+        config.application?.packageManager?.path,
+      ),
+      packageManager: pm,
+      bootId: process.env.DAEMON_BOOT_ID ?? "",
+      repoName: config.git?.repository?.repoName,
+      branch: config.git?.repository?.branch,
+    });
     return true;
   }
 


### PR DESCRIPTION
## Summary

Adds **observability-only** telemetry on *which* dependencies get installed in each sandbox, so the team can decide which packages to pre-bake into the sandbox image. No change to install behavior; no shared cache.

After a **successful** install (`stepInstall`, exit 0), the daemon reads the flattened installed dependency set and emits it. Install behavior, gating, and skip logic are untouched — the emit is a fire-and-forget, best-effort side effect that never throws.

## What it emits

- **One structured JSON log line** per successful install (`msg: "sandbox.install.deps"`) with: `bootId`, `packageManager`, `repoName`, `branch`, `dependencyCount`, and `dependencies: [{ name, version }]`. Aggregated downstream in VictoriaLogs.
- **Low-cardinality metrics** on the existing `link-daemon` meter (no new OTel dep): `sandbox_install_total` counter and `sandbox_install_dependency_count` histogram, labeled only by `package_manager`.
- **Package name/version are NEVER metric labels** — that lives only in the log line, to avoid a Prometheus cardinality explosion.

## How the dep set is read

PM-agnostic: walks the on-disk `node_modules` via `Bun.Glob("**/package.json")` (`followSymlinks: false`, `dot: true`) and collects `{name, version}`, deduped. This covers **npm / pnpm / yarn / bun with one code path** — pnpm's real package dirs under `.pnpm/` are picked up while its top-level symlinks are skipped, so every PM yields the same flattened set. A small filter (`isPackageManifest`, unit-tested) rejects fixture/sample `package.json` files shipped inside packages. Chose reading node_modules over parsing four different lockfile formats: smaller diff, uniform coverage, and it reflects what actually landed on disk.

- **deno** is not covered — it has no install step (auto-fetch), so the emit is never reached for it. All PMs that actually run an install are covered.

## Where it's hooked

`packages/sandbox/daemon/setup/orchestrator.ts` → `stepInstall()`, right after `markInstallSucceeded()` on the exit-0 path. Identifiers come from what's already in that code path: `DAEMON_BOOT_ID` (the daemon's existing log correlation key) + repo name/branch from config. New helper: `packages/sandbox/daemon/setup/dep-metrics.ts`.

## Testing

- `bun run check` (typecheck) clean
- `bun test daemon/setup` — existing orchestrator/clone tests pass; added `dep-metrics.test.ts` for the manifest filter
- `bun run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds observability-only telemetry that records which dependencies were installed after a successful sandbox install. No changes to install behavior or caching.

- **New Features**
  - Emits one JSON log line per successful install (`msg: "sandbox.install.deps"`) with `bootId`, `packageManager`, `repoName`, `branch`, `dependencyCount`, and `dependencies: [{ name, version }]`.
  - PM-agnostic: scans on-disk `node_modules` to build a deduped dep set (works for `npm`/`pnpm`/`yarn`/`bun`); excludes fixture/sample manifests via a small, tested filter.
  - Hooked into `stepInstall()` after a successful install; fire-and-forget and never throws.

- **Bug Fixes**
  - Removed no-op install metrics (counter/histogram); only the stdout JSON log line is emitted.

<sup>Written for commit 363a4f3510ddd471691e0f01bedc1d99c1add367. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

