### PR TITLE
feat(chat): show sent timestamp on user and assistant messages

### DIFF
--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -13,6 +13,7 @@ import { ToolCallShell } from "./parts/tool-call-part/common.tsx";
 import type { ChatMessage } from "../types.ts";
 import { MessageStatsBar } from "../usage-stats.tsx";
 import { MessageTextPart } from "./parts/text-part.tsx";
+import { MessageTimestamp } from "./timestamp.tsx";
 import {
   GenericToolCallPart,
   GenerateImagePart,
@@ -884,6 +885,7 @@ export function MessageAssistant({
               {isTerminallyDone && <NextActionChip />}
             </>
           )}
+          {!isLoading && <MessageTimestamp message={message!} />}
         </div>
       ) : isLoading ? (
         <ThinkingState startedAt={startedAt} />

--- a/apps/mesh/src/web/components/chat/message/timestamp.tsx
+++ b/apps/mesh/src/web/components/chat/message/timestamp.tsx
@@ -1,0 +1,40 @@
+import type { UIMessage } from "ai";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { toEpochMs } from "../../../lib/format-time.ts";
+
+/**
+ * Small muted label showing when a message was sent. Reads the server-stamped
+ * top-level `created_at` (fallback: `metadata.created_at`) that every persisted
+ * message row carries; renders nothing for optimistic rows not yet stamped.
+ */
+export function MessageTimestamp({
+  message,
+  className,
+}: {
+  message: UIMessage;
+  className?: string;
+}) {
+  const raw =
+    (message as unknown as { created_at?: string | Date | null }).created_at ??
+    (message.metadata as { created_at?: string | Date | null } | undefined)
+      ?.created_at ??
+    null;
+  const ms = toEpochMs(raw);
+  if (ms === null) return null;
+
+  const date = new Date(ms);
+  return (
+    <span
+      title={date.toLocaleString()}
+      className={cn(
+        "text-[11px] text-muted-foreground/60 select-none",
+        className,
+      )}
+    >
+      {date.toLocaleTimeString(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+      })}
+    </span>
+  );
+}

--- a/apps/mesh/src/web/components/chat/message/user.tsx
+++ b/apps/mesh/src/web/components/chat/message/user.tsx
@@ -7,6 +7,7 @@ import { FileNode } from "../tiptap/file/node.tsx";
 import { MentionNode } from "../tiptap/mention/node.tsx";
 import type { Metadata } from "../types.ts";
 import { MessageTextPart } from "./parts/text-part.tsx";
+import { MessageTimestamp } from "./timestamp.tsx";
 import {
   type TriggerEventData,
   TriggerEventPart,
@@ -97,62 +98,65 @@ export function MessageUser<T extends Metadata>({
           className,
         )}
       >
-        <div
-          tabIndex={0}
-          onClick={handleClick}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          className="w-full border border-border/60 min-w-0 shadow-xs rounded-lg text-[14px] wrap-break-word overflow-wrap-anywhere bg-background cursor-pointer transition-colors relative flex outline-none"
-        >
-          <div className="absolute inset-0 bg-muted/75 rounded-lg pointer-events-none" />
+        <div className="w-full min-w-0 flex flex-col">
           <div
-            ref={setContentRef}
-            className={cn(
-              "z-10 px-4 py-2 flex-1 transition-[max-height,opacity] duration-300 ease-out",
-              isFocused
-                ? "max-h-[50vh] overflow-auto opacity-100"
-                : cn(
-                    "max-h-[84px] overflow-hidden opacity-99",
-                    isOverflowing && "mask-b-from-1%",
-                  ),
-            )}
+            tabIndex={0}
+            onClick={handleClick}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            className="w-full border border-border/60 min-w-0 shadow-xs rounded-lg text-[14px] wrap-break-word overflow-wrap-anywhere bg-background cursor-pointer transition-colors relative flex outline-none"
           >
-            <div className="flex flex-col gap-2">
-              {/* Trigger-event cards always render from `parts`, even when the
+            <div className="absolute inset-0 bg-muted/75 rounded-lg pointer-events-none" />
+            <div
+              ref={setContentRef}
+              className={cn(
+                "z-10 px-4 py-2 flex-1 transition-[max-height,opacity] duration-300 ease-out",
+                isFocused
+                  ? "max-h-[50vh] overflow-auto opacity-100"
+                  : cn(
+                      "max-h-[84px] overflow-hidden opacity-99",
+                      isOverflowing && "mask-b-from-1%",
+                    ),
+              )}
+            >
+              <div className="flex flex-col gap-2">
+                {/* Trigger-event cards always render from `parts`, even when the
                   message also carries a tiptapDoc (automation runs do). */}
-              {parts.map((part, index) =>
-                part.type === "data-trigger-event" ? (
-                  <TriggerEventPart
-                    key={`${id}-${index}`}
-                    event={(part as { data: TriggerEventData }).data}
-                  />
-                ) : null,
-              )}
-              {hasTiptapDoc ? (
-                <RichMessageContent tiptapDoc={metadata.tiptapDoc} />
-              ) : (
-                parts.map((part, index) => {
-                  if (part.type === "text") {
-                    // The guard-wrapped event text the model reads sits
-                    // directly after its `data-trigger-event` card — render the
-                    // card, not the raw JSON. The automation's own instruction
-                    // text (no card before it) still renders.
-                    if (parts[index - 1]?.type === "data-trigger-event") {
-                      return null;
+                {parts.map((part, index) =>
+                  part.type === "data-trigger-event" ? (
+                    <TriggerEventPart
+                      key={`${id}-${index}`}
+                      event={(part as { data: TriggerEventData }).data}
+                    />
+                  ) : null,
+                )}
+                {hasTiptapDoc ? (
+                  <RichMessageContent tiptapDoc={metadata.tiptapDoc} />
+                ) : (
+                  parts.map((part, index) => {
+                    if (part.type === "text") {
+                      // The guard-wrapped event text the model reads sits
+                      // directly after its `data-trigger-event` card — render the
+                      // card, not the raw JSON. The automation's own instruction
+                      // text (no card before it) still renders.
+                      if (parts[index - 1]?.type === "data-trigger-event") {
+                        return null;
+                      }
+                      return (
+                        <MessageTextPart
+                          key={`${id}-${index}`}
+                          id={id}
+                          part={part}
+                        />
+                      );
                     }
-                    return (
-                      <MessageTextPart
-                        key={`${id}-${index}`}
-                        id={id}
-                        part={part}
-                      />
-                    );
-                  }
-                  return null;
-                })
-              )}
+                    return null;
+                  })
+                )}
+              </div>
             </div>
           </div>
+          <MessageTimestamp message={message} className="mt-1 mr-1 self-end" />
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
Renders the send time under each chat message (user and assistant).

The timestamp was already on every message — persisted rows carry a top-level `created_at` (fallback `metadata.created_at`), read via the existing `toEpochMs` helper. This PR only adds the render; no new plumbing.

- New `MessageTimestamp` component (`chat/message/timestamp.tsx`) — muted local time label, full datetime on hover, renders nothing for optimistic rows not yet stamped.
- User bubble: shown right-aligned below the bubble.
- Assistant bubble: shown at the bottom of the content column once the turn settles (`!isLoading`).

## Testing
- `bun run --cwd=apps/mesh check` passes
- `bun run fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the sent time under each chat message so users can see when messages were sent. Adds a small timestamp to user and assistant bubbles without changing data flow.

- **New Features**
  - Added `MessageTimestamp` component: shows local time, full datetime on hover; hides for optimistic messages; reads existing `created_at` (fallback `metadata.created_at`) via `toEpochMs`.
  - Placement: right-aligned under user bubble; at the bottom of the assistant content when the turn is settled (`!isLoading`).

<sup>Written for commit 4704731686e813327a6d1d16e21959e444eec6a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

