### PR TITLE
fix(sandbox): emit one log line per installed dep, not a 16KB array

### DIFF
--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -60,28 +60,45 @@ export interface DepMetricsInput {
 }
 
 /**
- * After a SUCCESSFUL install, emit the installed dependency set as a single
- * JSON log line for downstream aggregation (VictoriaLogs) so the team can
- * decide which packages to pre-bake into the sandbox image. Logs, not metrics:
- * per-package cardinality would wreck Prometheus, and sandbox pods can't reach
- * an in-cluster OTLP collector anyway (egress is locked to 53/443), so their
+ * After a SUCCESSFUL install, emit the installed dependency set as JSON log
+ * lines for downstream aggregation (VictoriaLogs) so the team can decide which
+ * packages to pre-bake into the sandbox image. Logs, not metrics: per-package
+ * cardinality would wreck Prometheus, and sandbox pods can't reach an
+ * in-cluster OTLP collector anyway (egress is locked to 53/443), so their
  * stdout scraped out-of-band is the only channel that leaves the pod.
- * Best-effort: observability only, never throws.
+ *
+ * One line PER dependency, not one array line: the pipeline truncates log
+ * lines at 16KB, so a big monorepo's array gets cut mid-JSON and becomes
+ * unparseable — and per-line rows are what let `stats by (name) count()`
+ * aggregate without unrolling a nested array. A trailing summary line carries
+ * the install-level totals. Best-effort: observability only, never throws.
  */
 export async function emitInstalledDeps(input: DepMetricsInput): Promise<void> {
   try {
     const deps = await readInstalledDeps(
       join(input.installRoot, "node_modules"),
     );
+    const base = {
+      bootId: input.bootId,
+      packageManager: input.packageManager,
+      repoName: input.repoName,
+      branch: input.branch,
+    };
+    for (const d of deps) {
+      console.log(
+        JSON.stringify({
+          msg: "sandbox.dep.installed",
+          name: d.name,
+          version: d.version,
+          ...base,
+        }),
+      );
+    }
     console.log(
       JSON.stringify({
         msg: "sandbox.install.deps",
-        bootId: input.bootId,
-        packageManager: input.packageManager,
-        repoName: input.repoName,
-        branch: input.branch,
         dependencyCount: deps.length,
-        dependencies: deps,
+        ...base,
       }),
     );
   } catch (err) {


### PR DESCRIPTION
## Problem
The merged dep-install telemetry (#4269) emitted the whole `dependencies` array in a single `sandbox.install.deps` JSON log line. The log pipeline truncates lines at **16KB**, so a large monorepo (e.g. a 391-dep install) gets cut mid-JSON → the line is unparseable → VictoriaLogs `unpack_json` extracts nothing → the top-deps aggregation collapses to `name=""`. Confirmed live: `_msg` length was exactly 16384 bytes.

## Fix
Emit **one small line per dependency** (`sandbox.dep.installed` with `name`, `version`, + pm/repo/branch/bootId), each well under the cap, plus a trailing `sandbox.install.deps` **summary** line with install-level totals (`dependencyCount`). Per-line rows are also what let VictoriaLogs `stats by (name) count()` aggregate directly — no nested-array unroll.

## Trade-off
More lines per install (one per dep, capped at the existing `MAX_DEPS=10000`). Tiny lines, infrequent (per sandbox boot), well within VL capacity — and the correct shape for per-package aggregation, which is the whole point.

## Testing
`bun test daemon/setup/dep-metrics.test.ts` passes; `bun run fmt` clean. Dashboard panel queries updated to the per-dep line format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch dep-install telemetry to emit one log line per installed dependency (`sandbox.dep.installed`: name, version, context) plus a small summary line (`sandbox.install.deps`: dependencyCount). This prevents 16KB log truncation and restores accurate per-package aggregation in VictoriaLogs.

<sup>Written for commit a46b67e6ffd46bd5b41fc65d10cdd001ba78a96d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

