### PR TITLE
ci(sandbox): auto-bump deco-apps-cd on studio-sandbox image release

### DIFF
--- a/.github/workflows/release-studio-sandbox.yaml
+++ b/.github/workflows/release-studio-sandbox.yaml
@@ -20,6 +20,11 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      # "true" when the tag was already in GHCR (build skipped) — the bump job
+      # uses this to skip docs/test-only pushes that reuse the existing tag.
+      image-exists: ${{ steps.tag-check.outputs.exists }}
 
     steps:
       - name: Checkout code
@@ -122,3 +127,40 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+  # ---------------------------------------------------------------------------
+  # GitOps: tell deco-apps-cd to bump the sandbox image tag. We fire the generic
+  # `image-bump` repository_dispatch (receiver: deco-apps-cd's bump-image.yml,
+  # which surgically rewrites the `tag:` under the matching `repository:` line
+  # and self-commits with its own GITHUB_TOKEN). No cross-repo write credential
+  # lives here — only a token to trigger the dispatch. Bumps both stg and prod
+  # sandbox values; both are ArgoCD auto-sync, but a SandboxTemplate tag bump
+  # only changes what NEW sandbox claims get — it doesn't disturb running pods.
+  # ---------------------------------------------------------------------------
+  bump-deco-apps-cd:
+    name: Trigger deco-apps-cd bump
+    needs: [build-push]
+    # Only when a NEW image was actually pushed (skip docs/test-only changes to
+    # packages/sandbox that reuse the existing tag).
+    if: needs.build-push.result == 'success' && needs.build-push.outputs.image-exists != 'true'
+    runs-on: ubuntu-latest
+    # Reuses DEPLOY_REPO_TOKEN — the decobot machine-user PAT (admin on
+    # decocms/deco-apps-cd), same token release-mesh uses. The bump is a
+    # convenience and must never red the release: absent token → no-op, job passes.
+    env:
+      DISPATCH_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
+    steps:
+      - name: Skip notice (dispatch token not configured)
+        if: env.DISPATCH_TOKEN == ''
+        run: echo "::notice::DEPLOY_REPO_TOKEN not set — skipping the deco-apps-cd bump."
+      - name: Dispatch image-bump to deco-apps-cd
+        if: env.DISPATCH_TOKEN != ''
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DEPLOY_REPO_TOKEN }}
+          repository: decocms/deco-apps-cd
+          event-type: image-bump
+          client-payload: '{"version": "${{ needs.build-push.outputs.version }}", "repository": "decocms/studio/studio-sandbox", "files": ["apps/studio-sandbox-stg/values.yaml", "apps/studio-sandbox-prod/values.yaml"]}'
+      - name: Summary
+        if: env.DISPATCH_TOKEN != ''
+        run: echo "Dispatched \`image-bump\` (studio-sandbox ${{ needs.build-push.outputs.version }}) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem
Merging any change to `packages/sandbox/**` on main builds + pushes a new `studio-sandbox` image (`release-studio-sandbox.yaml`), but nothing bumps the tag in **deco-apps-cd**, so the release never rolls out without a manual values edit. (Chart default is `1.6.1`; deco-apps-cd is hand-bumped to `1.9.0` — the drift is the symptom.)

## Fix
Add a `bump-deco-apps-cd` job that fires the **generic `image-bump` repository_dispatch** already implemented in deco-apps-cd (`bump-image.yml`), which surgically rewrites the `tag:` under the matching `repository:` line and self-commits. Payload:
```json
{ "version": "<packages/sandbox/package.json version>",
  "repository": "decocms/studio/studio-sandbox",
  "files": ["apps/studio-sandbox-stg/values.yaml", "apps/studio-sandbox-prod/values.yaml"] }
```
Mirrors `release-mesh.yaml`'s dispatch pattern — same `DEPLOY_REPO_TOKEN` (decobot), no cross-repo write credential in this repo.

## Behavior / safety
- Fires **only when a new image was actually pushed** (skips docs/test-only `packages/sandbox` changes that reuse the existing tag), via a new `image-exists` job output.
- No-ops (job still green) if `DEPLOY_REPO_TOKEN` isn't set — the bump never reds a release.
- Bumps **both stg and prod**. Both sandbox apps are ArgoCD auto-sync, but a SandboxTemplate tag bump only changes what **new** sandbox claims get — running pods aren't disturbed. (Confirmed the desired behavior.)

## Testing
YAML parses; job graph `build-push → bump-deco-apps-cd`. The dispatch itself only exercises on a real main merge (needs the org secret). Anchor + files verified against the current deco-apps-cd `studio-sandbox-{stg,prod}/values.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates rollout of new `studio-sandbox` images by auto-bumping the tag in `deco-apps-cd` after a successful image release. This removes manual values edits and keeps staging and prod aligned.

- **New Features**
  - Adds `bump-deco-apps-cd` job in `release-studio-sandbox.yaml` to dispatch `image-bump` to `decocms/deco-apps-cd` with the new version and stg/prod values files.
  - Runs only when a new image was actually pushed; no-ops (green) if `DEPLOY_REPO_TOKEN` is not set.
  - Updates both environments; ArgoCD sync affects new sandbox claims only, not running pods.

<sup>Written for commit 5a2a7f5ffb28023bdb2be52ef4c4bb43f71b5f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

