### PR TITLE
fix(sandbox): chunk dep-install log lines to survive the log pipeline

### DIFF
--- a/packages/sandbox/daemon/setup/dep-metrics.test.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.test.ts
@@ -56,11 +56,9 @@ describe("buildDepLines", () => {
     return seen;
   };
 
-  it("chunks a big install into parseable lines under the 16KB pipeline cap", () => {
+  it("emits a typical install intact under the 16KB pipeline cap", () => {
     const deps = Array.from({ length: 391 }, (_, i) => dep(i));
-    const lines = buildDepLines(deps, input);
-    expect(lines.length).toBeGreaterThan(1);
-    const seen = assertIntact(lines, deps);
+    const seen = assertIntact(buildDepLines(deps, input), deps);
     expect(seen[0]).toBe("@scope/package-name-0@10.0.0");
   });
 
@@ -74,6 +72,19 @@ describe("buildDepLines", () => {
     }));
     const lines = buildDepLines(deps, input);
     expect(lines.length).toBeGreaterThan(2);
+    assertIntact(lines, deps);
+  });
+
+  // Regression for the escaping undercount: deps stored as a string get their
+  // quotes escaped in the final line (+2 bytes each). Many short deps must
+  // still yield lines under 16KB, not just few-and-long ones.
+  it("keeps lines under cap with thousands of short deps (escaping counted)", () => {
+    const deps = Array.from({ length: 4000 }, (_, i) => ({
+      name: `p${i}`,
+      version: "1.0.0",
+    }));
+    const lines = buildDepLines(deps, input);
+    expect(lines.length).toBeGreaterThan(1);
     assertIntact(lines, deps);
   });
 

--- a/packages/sandbox/daemon/setup/dep-metrics.test.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.test.ts
@@ -35,23 +35,46 @@ describe("buildDepLines", () => {
     version: `10.${i}.${i}`,
   });
 
-  it("chunks a big install into parseable lines under the 16KB pipeline cap", () => {
-    const deps = Array.from({ length: 391 }, (_, i) => dep(i));
-    const lines = buildDepLines(deps, input);
-    expect(lines.length).toBe(2);
+  // Every emitted line must round-trip and stay under the pipeline's 16KB
+  // byte cap; the full dep set must survive across chunks exactly once.
+  const assertIntact = (
+    lines: string[],
+    deps: { name: string; version: string }[],
+  ) => {
     const seen: string[] = [];
     for (const line of lines) {
-      expect(line.length).toBeLessThan(16_000);
+      expect(Buffer.byteLength(line)).toBeLessThan(16_000);
       const o = JSON.parse(line);
       expect(o.msg).toBe("sandbox.deps");
-      expect(o.chunks).toBe(2);
-      expect(o.dependencyCount).toBe(391);
+      expect(o.chunks).toBe(lines.length);
+      expect(o.dependencyCount).toBe(deps.length);
       expect(typeof o.deps).toBe("string");
       seen.push(...JSON.parse(o.deps));
     }
-    expect(seen.length).toBe(391);
-    expect(new Set(seen).size).toBe(391);
+    expect(seen.length).toBe(deps.length);
+    expect(new Set(seen).size).toBe(deps.length);
+    return seen;
+  };
+
+  it("chunks a big install into parseable lines under the 16KB pipeline cap", () => {
+    const deps = Array.from({ length: 391 }, (_, i) => dep(i));
+    const lines = buildDepLines(deps, input);
+    expect(lines.length).toBeGreaterThan(1);
+    const seen = assertIntact(lines, deps);
     expect(seen[0]).toBe("@scope/package-name-0@10.0.0");
+  });
+
+  // The bug this fix closes: count-based chunking (200/line) would emit a
+  // ~40KB line here and get it truncated. Byte-based chunking must not.
+  it("keeps lines under cap even with pathologically long package names", () => {
+    const longName = `@${"o".repeat(100)}/${"p".repeat(100)}`; // ~203 chars
+    const deps = Array.from({ length: 200 }, (_, i) => ({
+      name: longName,
+      version: `1.0.${i}`,
+    }));
+    const lines = buildDepLines(deps, input);
+    expect(lines.length).toBeGreaterThan(2);
+    assertIntact(lines, deps);
   });
 
   it("emits a single countable line for a zero-dep install", () => {

--- a/packages/sandbox/daemon/setup/dep-metrics.test.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { isPackageManifest } from "./dep-metrics";
+import { buildDepLines, isPackageManifest } from "./dep-metrics";
 
 describe("isPackageManifest", () => {
   it("accepts real package roots (npm/yarn/bun + nested + pnpm)", () => {
@@ -20,5 +20,45 @@ describe("isPackageManifest", () => {
     expect(isPackageManifest("foo/test/fixtures/package.json")).toBe(false);
     expect(isPackageManifest(".cache/foo/package.json")).toBe(false);
     expect(isPackageManifest("package.json")).toBe(false);
+  });
+});
+
+describe("buildDepLines", () => {
+  const input = {
+    bootId: "boot-1",
+    packageManager: "bun" as const,
+    repoName: "org/repo",
+    branch: "main",
+  };
+  const dep = (i: number) => ({
+    name: `@scope/package-name-${i}`,
+    version: `10.${i}.${i}`,
+  });
+
+  it("chunks a big install into parseable lines under the 16KB pipeline cap", () => {
+    const deps = Array.from({ length: 391 }, (_, i) => dep(i));
+    const lines = buildDepLines(deps, input);
+    expect(lines.length).toBe(2);
+    const seen: string[] = [];
+    for (const line of lines) {
+      expect(line.length).toBeLessThan(16_000);
+      const o = JSON.parse(line);
+      expect(o.msg).toBe("sandbox.deps");
+      expect(o.chunks).toBe(2);
+      expect(o.dependencyCount).toBe(391);
+      expect(typeof o.deps).toBe("string");
+      seen.push(...JSON.parse(o.deps));
+    }
+    expect(seen.length).toBe(391);
+    expect(new Set(seen).size).toBe(391);
+    expect(seen[0]).toBe("@scope/package-name-0@10.0.0");
+  });
+
+  it("emits a single countable line for a zero-dep install", () => {
+    const lines = buildDepLines([], input);
+    expect(lines.length).toBe(1);
+    const o = JSON.parse(lines[0]);
+    expect(o.dependencyCount).toBe(0);
+    expect(JSON.parse(o.deps)).toEqual([]);
   });
 });

--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -59,26 +59,28 @@ export interface DepMetricsInput {
   branch?: string;
 }
 
-// Cap the serialized `deps` array per line, leaving ~2KB of the pipeline's
-// 16KB line budget for the JSON envelope. Chunk by BYTES, not dep count:
-// count-based chunking can't bound the line when package names run long
-// (npm allows names up to 214 chars), which would re-introduce the 16KB
-// truncation this whole format exists to avoid.
-const MAX_DEPS_BYTES = 14_000;
+// Cap the whole serialized line well under the pipeline's 16KB (16384)
+// truncation. We budget the FINAL line, not the raw array: `deps` is stored
+// as a string, so the outer JSON.stringify escapes every element's quotes
+// (`"x"` → `\"x\"`, +2 bytes each) — ignoring that undercounts short-dep-heavy
+// lines by ~2 bytes/dep and would let them cross 16KB.
+const MAX_LINE_BYTES = 15_500;
 
-/** Greedily pack `name@version` strings into groups whose serialized
- * JSON array stays under MAX_DEPS_BYTES. A single over-long dep still gets
- * its own group (a lone specifier is ~230 bytes worst case, far under cap). */
-function chunkByBytes(flat: string[]): string[][] {
+/** Greedily pack `name@version` strings into groups so each rendered line
+ * (envelope + double-encoded deps) stays under MAX_LINE_BYTES. `envelopeBytes`
+ * is the measured line size minus deps content; per element we add its escaped
+ * cost: `\"<dep>\"` = byteLength+4, plus a comma. A single over-long dep still
+ * gets its own group (a lone specifier is ~230 bytes, far under cap). */
+function chunkByBytes(flat: string[], envelopeBytes: number): string[][] {
   const groups: string[][] = [];
   let cur: string[] = [];
-  let bytes = 2; // the enclosing []
+  let bytes = envelopeBytes + 2; // + the enclosing []
   for (const dep of flat) {
-    const entry = Buffer.byteLength(JSON.stringify(dep)) + 1; // element + comma
-    if (cur.length && bytes + entry > MAX_DEPS_BYTES) {
+    const entry = Buffer.byteLength(dep) + 5; // \"…\" (4) + comma (1)
+    if (cur.length && bytes + entry > MAX_LINE_BYTES) {
       groups.push(cur);
       cur = [];
-      bytes = 2;
+      bytes = envelopeBytes + 2;
     }
     cur.push(dep);
     bytes += entry;
@@ -109,7 +111,22 @@ export function buildDepLines(
   input: Omit<DepMetricsInput, "installRoot">,
 ): string[] {
   const flat = deps.map((d) => `${d.name}@${d.version}`);
-  const groups = chunkByBytes(flat);
+  // Measure the line minus dep content once (deps="", 3-digit chunk counts as
+  // headroom) so the chunker can keep the FINAL line under the cap.
+  const envelopeBytes = Buffer.byteLength(
+    JSON.stringify({
+      msg: "sandbox.deps",
+      chunk: 999,
+      chunks: 999,
+      dependencyCount: deps.length,
+      deps: "",
+      bootId: input.bootId,
+      packageManager: input.packageManager,
+      repoName: input.repoName,
+      branch: input.branch,
+    }),
+  );
+  const groups = chunkByBytes(flat, envelopeBytes);
   if (groups.length === 0) groups.push([]); // zero-dep install still emits one countable line
   return groups.map((group, i) =>
     JSON.stringify({

--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -59,9 +59,33 @@ export interface DepMetricsInput {
   branch?: string;
 }
 
-// ~200 name@version strings ≈ 7KB/line: under the pipeline's 16KB line
-// truncation, and 1-3 lines per install stays under its burst sampler.
-const DEPS_PER_LINE = 200;
+// Cap the serialized `deps` array per line, leaving ~2KB of the pipeline's
+// 16KB line budget for the JSON envelope. Chunk by BYTES, not dep count:
+// count-based chunking can't bound the line when package names run long
+// (npm allows names up to 214 chars), which would re-introduce the 16KB
+// truncation this whole format exists to avoid.
+const MAX_DEPS_BYTES = 14_000;
+
+/** Greedily pack `name@version` strings into groups whose serialized
+ * JSON array stays under MAX_DEPS_BYTES. A single over-long dep still gets
+ * its own group (a lone specifier is ~230 bytes worst case, far under cap). */
+function chunkByBytes(flat: string[]): string[][] {
+  const groups: string[][] = [];
+  let cur: string[] = [];
+  let bytes = 2; // the enclosing []
+  for (const dep of flat) {
+    const entry = Buffer.byteLength(JSON.stringify(dep)) + 1; // element + comma
+    if (cur.length && bytes + entry > MAX_DEPS_BYTES) {
+      groups.push(cur);
+      cur = [];
+      bytes = 2;
+    }
+    cur.push(dep);
+    bytes += entry;
+  }
+  if (cur.length) groups.push(cur);
+  return groups;
+}
 
 /**
  * After a SUCCESSFUL install, emit the installed dependency set as JSON log
@@ -71,7 +95,7 @@ const DEPS_PER_LINE = 200;
  * in-cluster OTLP collector anyway (egress is locked to 53/443), so their
  * stdout scraped out-of-band is the only channel that leaves the pod.
  *
- * Format is CHUNKED lines of ~200 deps because both simpler shapes fail in
+ * Format is byte-bounded CHUNKED lines because both simpler shapes fail in
  * the pipeline (observed in prod, not hypothetical):
  *  - one line with the whole array → truncated at 16KB → unparseable JSON;
  *  - one line per dep → ~350-line burst per install → the collector's rate
@@ -85,16 +109,15 @@ export function buildDepLines(
   input: Omit<DepMetricsInput, "installRoot">,
 ): string[] {
   const flat = deps.map((d) => `${d.name}@${d.version}`);
-  const chunks = Math.max(1, Math.ceil(flat.length / DEPS_PER_LINE));
-  return Array.from({ length: chunks }, (_, i) =>
+  const groups = chunkByBytes(flat);
+  if (groups.length === 0) groups.push([]); // zero-dep install still emits one countable line
+  return groups.map((group, i) =>
     JSON.stringify({
       msg: "sandbox.deps",
       chunk: i + 1,
-      chunks,
+      chunks: groups.length,
       dependencyCount: deps.length,
-      deps: JSON.stringify(
-        flat.slice(i * DEPS_PER_LINE, (i + 1) * DEPS_PER_LINE),
-      ),
+      deps: JSON.stringify(group),
       bootId: input.bootId,
       packageManager: input.packageManager,
       repoName: input.repoName,

--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -59,6 +59,10 @@ export interface DepMetricsInput {
   branch?: string;
 }
 
+// ~200 name@version strings ≈ 7KB/line: under the pipeline's 16KB line
+// truncation, and 1-3 lines per install stays under its burst sampler.
+const DEPS_PER_LINE = 200;
+
 /**
  * After a SUCCESSFUL install, emit the installed dependency set as JSON log
  * lines for downstream aggregation (VictoriaLogs) so the team can decide which
@@ -67,40 +71,44 @@ export interface DepMetricsInput {
  * in-cluster OTLP collector anyway (egress is locked to 53/443), so their
  * stdout scraped out-of-band is the only channel that leaves the pod.
  *
- * One line PER dependency, not one array line: the pipeline truncates log
- * lines at 16KB, so a big monorepo's array gets cut mid-JSON and becomes
- * unparseable — and per-line rows are what let `stats by (name) count()`
- * aggregate without unrolling a nested array. A trailing summary line carries
- * the install-level totals. Best-effort: observability only, never throws.
+ * Format is CHUNKED lines of ~200 deps because both simpler shapes fail in
+ * the pipeline (observed in prod, not hypothetical):
+ *  - one line with the whole array → truncated at 16KB → unparseable JSON;
+ *  - one line per dep → ~350-line burst per install → the collector's rate
+ *    sampler drops ~99% (survivors arrive tagged sample_rate=100).
+ * `deps` is a pre-JSON-encoded string (not a real array) so no pipeline stage
+ * can flatten or re-shape it; VictoriaLogs `unroll (deps)` parses it back
+ * into per-dep rows for `stats by (deps) count()`. Best-effort: never throws.
  */
+export function buildDepLines(
+  deps: { name: string; version: string }[],
+  input: Omit<DepMetricsInput, "installRoot">,
+): string[] {
+  const flat = deps.map((d) => `${d.name}@${d.version}`);
+  const chunks = Math.max(1, Math.ceil(flat.length / DEPS_PER_LINE));
+  return Array.from({ length: chunks }, (_, i) =>
+    JSON.stringify({
+      msg: "sandbox.deps",
+      chunk: i + 1,
+      chunks,
+      dependencyCount: deps.length,
+      deps: JSON.stringify(
+        flat.slice(i * DEPS_PER_LINE, (i + 1) * DEPS_PER_LINE),
+      ),
+      bootId: input.bootId,
+      packageManager: input.packageManager,
+      repoName: input.repoName,
+      branch: input.branch,
+    }),
+  );
+}
+
 export async function emitInstalledDeps(input: DepMetricsInput): Promise<void> {
   try {
     const deps = await readInstalledDeps(
       join(input.installRoot, "node_modules"),
     );
-    const base = {
-      bootId: input.bootId,
-      packageManager: input.packageManager,
-      repoName: input.repoName,
-      branch: input.branch,
-    };
-    for (const d of deps) {
-      console.log(
-        JSON.stringify({
-          msg: "sandbox.dep.installed",
-          name: d.name,
-          version: d.version,
-          ...base,
-        }),
-      );
-    }
-    console.log(
-      JSON.stringify({
-        msg: "sandbox.install.deps",
-        dependencyCount: deps.length,
-        ...base,
-      }),
-    );
+    for (const line of buildDepLines(deps, input)) console.log(line);
   } catch (err) {
     console.warn("[install] dep metrics emit failed", err);
   }


### PR DESCRIPTION
## Problem — both prior formats are destroyed by the log pipeline (observed in prod)
1. **#4269 (one array line):** truncated at exactly **16KB** → unparseable JSON → VictoriaLogs extracts nothing. A 391-dep install's line was cut mid-array.
2. **#4271 (one line per dep):** ~350 lines burst per install → the collector's **rate sampler drops ~99%** (survivors arrive tagged `sample_rate=100`). Real installs surfaced as 2-4 random transitive deps — noise, not a ranking.

## Fix — chunked lines that dodge both walls
Emit `msg: "sandbox.deps"` lines of **~200 `name@version` strings each** (~7KB → under truncation; 1-3 lines/install → under the burst sampler), each carrying `chunk`/`chunks`/`dependencyCount` + install context. The `deps` field is a **pre-JSON-encoded string**, not a real array, so no pipeline stage can flatten or re-shape it.

## Verified against live infra, not theory
Inserted a probe line in this exact format into the VictoriaLogs datasource and ran the panel query:
```
_msg:~"sandbox.deps" | unpack_json | unroll (deps) | deps:!"" | stats by (deps) count() installs | sort by (installs desc)
```
→ returns one row per package (`react@19.1.0`, `vite@6.1.0`, `zod@3.24.1`). The Grafana panel is wired to this query and will populate as sandboxes install after this rolls (image release + deco-apps-cd bump are automatic since #4272).

## Testing
- New pure unit tests for the chunking (`buildDepLines`): 391 deps → 2 lines, each <16KB, all deps present exactly once, parseable; zero-dep install still emits 1 countable line.
- `bun test daemon/setup/dep-metrics.test.ts`: 4 pass. `bun run fmt` clean; no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Chunk dependency-install telemetry into byte-bounded JSON log lines and cap the final serialized line at 15.5KB (including deps-string escaping) to survive the log pipeline and restore reliable dependency metrics in VictoriaLogs/Grafana. Replaces the broken single-array and per-dep formats.

- **Bug Fixes**
  - Emit chunked `sandbox.deps` lines with final bytes ≤15.5KB to avoid 16KB truncation and burst sampling; greedily pack `name@version` entries by `Buffer.byteLength`.
  - Encode the deps array as a JSON string so the pipeline can’t reshape it; VictoriaLogs can unroll it back into per-dep rows.
  - Added `buildDepLines` and tests for long-name deps, thousands of short deps (quote-escaping accounted), large installs, and zero-dep installs.

<sup>Written for commit 6d7d0f643d99b4d8eba2dd9be4a40851c4a78f94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

