### PR TITLE
fix(sandbox): emit small dep-metrics lines (pipeline drops large ones)

### DIFF
--- a/packages/sandbox/daemon/setup/dep-metrics.test.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.test.ts
@@ -91,6 +91,18 @@ describe("buildDepLines", () => {
     assertIntact(lines, deps);
   });
 
+  // A pathologically long branch/repo name must not inflate the envelope past
+  // the small line cap (which would drop the whole install's data).
+  it("keeps lines small even with a very long branch/repo name", () => {
+    const deps = Array.from({ length: 100 }, (_, i) => dep(i));
+    const lines = buildDepLines(deps, {
+      ...input,
+      repoName: "org/".concat("r".repeat(500)),
+      branch: "feature/".concat("b".repeat(500)),
+    });
+    assertIntact(lines, deps);
+  });
+
   it("emits a single countable line for a zero-dep install", () => {
     const lines = buildDepLines([], input);
     expect(lines.length).toBe(1);

--- a/packages/sandbox/daemon/setup/dep-metrics.test.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.test.ts
@@ -35,15 +35,17 @@ describe("buildDepLines", () => {
     version: `10.${i}.${i}`,
   });
 
-  // Every emitted line must round-trip and stay under the pipeline's 16KB
-  // byte cap; the full dep set must survive across chunks exactly once.
+  // Every emitted line must round-trip and stay SMALL (the pipeline drops
+  // large lines — see MAX_LINE_BYTES); the full dep set must survive across
+  // chunks exactly once. 700 = MAX_LINE_BYTES (600) + headroom for the last
+  // element that fits under the running estimate.
   const assertIntact = (
     lines: string[],
     deps: { name: string; version: string }[],
   ) => {
     const seen: string[] = [];
     for (const line of lines) {
-      expect(Buffer.byteLength(line)).toBeLessThan(16_000);
+      expect(Buffer.byteLength(line)).toBeLessThan(700);
       const o = JSON.parse(line);
       expect(o.msg).toBe("sandbox.deps");
       expect(o.chunks).toBe(lines.length);
@@ -56,35 +58,36 @@ describe("buildDepLines", () => {
     return seen;
   };
 
-  it("emits a typical install intact under the 16KB pipeline cap", () => {
+  it("splits a typical install into many small lines, intact", () => {
     const deps = Array.from({ length: 391 }, (_, i) => dep(i));
-    const seen = assertIntact(buildDepLines(deps, input), deps);
+    const lines = buildDepLines(deps, input);
+    expect(lines.length).toBeGreaterThan(10);
+    const seen = assertIntact(lines, deps);
     expect(seen[0]).toBe("@scope/package-name-0@10.0.0");
   });
 
-  // The bug this fix closes: count-based chunking (200/line) would emit a
-  // ~40KB line here and get it truncated. Byte-based chunking must not.
-  it("keeps lines under cap even with pathologically long package names", () => {
+  // Long names (npm allows up to 214 chars) must still yield only small lines,
+  // never an oversized one — the byte budget accounts for them.
+  it("keeps lines small even with pathologically long package names", () => {
     const longName = `@${"o".repeat(100)}/${"p".repeat(100)}`; // ~203 chars
-    const deps = Array.from({ length: 200 }, (_, i) => ({
+    const deps = Array.from({ length: 50 }, (_, i) => ({
       name: longName,
       version: `1.0.${i}`,
     }));
     const lines = buildDepLines(deps, input);
-    expect(lines.length).toBeGreaterThan(2);
+    expect(lines.length).toBeGreaterThan(10);
     assertIntact(lines, deps);
   });
 
-  // Regression for the escaping undercount: deps stored as a string get their
-  // quotes escaped in the final line (+2 bytes each). Many short deps must
-  // still yield lines under 16KB, not just few-and-long ones.
-  it("keeps lines under cap with thousands of short deps (escaping counted)", () => {
+  // deps stored as a string get quotes escaped in the final line (+2 bytes
+  // each); many short deps must still yield only small lines.
+  it("keeps lines small with thousands of short deps (escaping counted)", () => {
     const deps = Array.from({ length: 4000 }, (_, i) => ({
       name: `p${i}`,
       version: "1.0.0",
     }));
     const lines = buildDepLines(deps, input);
-    expect(lines.length).toBeGreaterThan(1);
+    expect(lines.length).toBeGreaterThan(100);
     assertIntact(lines, deps);
   });
 

--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -59,12 +59,17 @@ export interface DepMetricsInput {
   branch?: string;
 }
 
-// Cap the whole serialized line well under the pipeline's 16KB (16384)
-// truncation. We budget the FINAL line, not the raw array: `deps` is stored
-// as a string, so the outer JSON.stringify escapes every element's quotes
-// (`"x"` → `\"x\"`, +2 bytes each) — ignoring that undercounts short-dep-heavy
-// lines by ~2 bytes/dep and would let them cross 16KB.
-const MAX_LINE_BYTES = 15_500;
+// Cap each emitted line SMALL. Measured in prod: the log pipeline stores only
+// small lines from sandbox pods (observed max ~765 bytes across namespaces;
+// the earlier ~15KB single-line format was rejected outright with
+// "missing _msg field"). ~250-byte lines (the earlier per-dep format) survived
+// reliably, so we keep lines well inside that proven range. This means many
+// small lines per big install, which the collector may burst-sample — the
+// panel sums `sample_rate` to correct for that (unsampled → sample_rate=1).
+// We budget the FINAL line, not the raw array: `deps` is stored as a string,
+// so the outer JSON.stringify escapes every element's quotes (`"x"` → `\"x\"`,
+// +2 bytes each), which the per-element cost below accounts for.
+const MAX_LINE_BYTES = 600;
 
 /** Greedily pack `name@version` strings into groups so each rendered line
  * (envelope + double-encoded deps) stays under MAX_LINE_BYTES. `envelopeBytes`

--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -71,6 +71,14 @@ export interface DepMetricsInput {
 // +2 bytes each), which the per-element cost below accounts for.
 const MAX_LINE_BYTES = 600;
 
+// Bound the context fields so an unusually long branch/repo name can't inflate
+// the per-line envelope past the small cap — that would push even a single-dep
+// line over the limit and get the whole install's data dropped. 80 chars is
+// plenty to identify a repo/branch; the full value is never needed here.
+const MAX_META_BYTES = 80;
+const clipMeta = (s: string | undefined): string | undefined =>
+  s !== undefined && s.length > MAX_META_BYTES ? s.slice(0, MAX_META_BYTES) : s;
+
 /** Greedily pack `name@version` strings into groups so each rendered line
  * (envelope + double-encoded deps) stays under MAX_LINE_BYTES. `envelopeBytes`
  * is the measured line size minus deps content; per element we add its escaped
@@ -116,8 +124,11 @@ export function buildDepLines(
   input: Omit<DepMetricsInput, "installRoot">,
 ): string[] {
   const flat = deps.map((d) => `${d.name}@${d.version}`);
+  const repoName = clipMeta(input.repoName);
+  const branch = clipMeta(input.branch);
   // Measure the line minus dep content once (deps="", 3-digit chunk counts as
-  // headroom) so the chunker can keep the FINAL line under the cap.
+  // headroom) so the chunker can keep the FINAL line under the cap. Uses the
+  // clipped meta so the budget matches what's actually emitted.
   const envelopeBytes = Buffer.byteLength(
     JSON.stringify({
       msg: "sandbox.deps",
@@ -127,8 +138,8 @@ export function buildDepLines(
       deps: "",
       bootId: input.bootId,
       packageManager: input.packageManager,
-      repoName: input.repoName,
-      branch: input.branch,
+      repoName,
+      branch,
     }),
   );
   const groups = chunkByBytes(flat, envelopeBytes);
@@ -142,8 +153,8 @@ export function buildDepLines(
       deps: JSON.stringify(group),
       bootId: input.bootId,
       packageManager: input.packageManager,
-      repoName: input.repoName,
-      branch: input.branch,
+      repoName,
+      branch,
     }),
   );
 }


### PR DESCRIPTION
## Root cause (measured in prod, not inferred)
The previous chunked format emitted ~15KB `sandbox.deps` lines. The log pipeline **rejects large lines from sandbox pods** — confirmed:
- `sandbox.deps` appears **nowhere** in VictoriaLogs (0 hits, any form), while VL logs 53 `missing _msg field` ingestion rejections, one from a 1.9.2 pod.
- Across 1500 lines in all namespaces, **max surviving `_msg` = 765 bytes; nothing >2KB exists**.
- The earlier ~250B per-dep lines (1.9.1) survived reliably.

So the 16KB truncation we saw earlier was the *generous* end; in practice only small lines land. My chunked cap (15.5KB) was ~20× too big → every line dropped → panel empty.

## Fix
`MAX_LINE_BYTES` 15500 → **600**. Each line stays well inside the proven-surviving range (~13 deps/line → ~27 lines for a big install, vs the 350 one-per-dep lines that got burst-sampled). Small enough to survive ingestion, few enough to cut sampling.

Residual burst-sampling is handled in the **panel**: `stats by (deps) sum(sample_rate)` (unsampled → sample_rate=1 → sum=count; sampled → reversed to an estimate).

## Tests
Updated to assert the small cap: every emitted line `< 700` bytes and the full set intact exactly once, across typical (391), long-name (~203-char), and 4000-short-dep inputs. 6 pass, typecheck clean.

## Honest caveat
I've had three wrong iterations on this chasing undocumented pipeline limits (16KB truncation → burst sampling → large-line drop). This cap is grounded in the measured 765B ceiling + proven 250B survival, but I can only fully confirm end-to-end once it deploys and a sandbox installs. I'll verify against real `sandbox.deps` lines after roll before calling it done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit small `sandbox.deps` log lines (~600B) and clip long repo/branch metadata so they survive ingestion; previous ~15KB lines were dropped, leaving the panel with no data.

- **Bug Fixes**
  - Capped each emitted line at 600 bytes and grouped deps to stay under the ~765B observed ceiling.
  - Bounded `repoName` and `branch` to 80 chars so long metadata can’t oversize lines; chunking budgets against the clipped values.
  - Correctly budgets JSON escaping and long package names; works for large installs and thousands of short deps.
  - Updated tests to assert <700B per line and exact reconstruction, including long-name, large-count, and long repo/branch cases.
  - Panel compensates for burst sampling by summing `sample_rate`.

<sup>Written for commit 4ef12d1910a0da710c0034acd591c65ad9541def. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

