### PR TITLE
fix(automations): stop misparsing every-N-days cron as weeks

### DIFF
--- a/apps/mesh/src/web/lib/cron-utils.test.ts
+++ b/apps/mesh/src/web/lib/cron-utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { buildCronFromInterval, parseCronToInterval } from "./cron-utils.ts";
+
+describe("parseCronToInterval", () => {
+  test("round-trips an every-7-days cron as days, not weeks", () => {
+    const cron = buildCronFromInterval(7, "days");
+    expect(cron).toBe("0 0 */7 * *");
+    expect(parseCronToInterval(cron)).toEqual({ count: 7, unit: "days" });
+  });
+
+  test("round-trips other day-multiples of 7 as days", () => {
+    expect(parseCronToInterval("0 0 */14 * *")).toEqual({
+      count: 14,
+      unit: "days",
+    });
+  });
+
+  test("still parses the literal weekly cron as weeks", () => {
+    expect(parseCronToInterval("0 0 * * 1")).toEqual({
+      count: 1,
+      unit: "weeks",
+    });
+  });
+});

--- a/apps/mesh/src/web/lib/cron-utils.ts
+++ b/apps/mesh/src/web/lib/cron-utils.ts
@@ -92,11 +92,7 @@ export function parseCronToInterval(
   const h = e.match(/^0\s+\*\/(\d+)\s+\*\s+\*\s+\*$/);
   if (h) return { count: parseInt(h[1]!), unit: "hours" };
   const d = e.match(/^0\s+0\s+\*\/(\d+)\s+\*\s+\*$/);
-  if (d) {
-    const n = parseInt(d[1]!);
-    if (n % 7 === 0) return { count: n / 7, unit: "weeks" };
-    return { count: n, unit: "days" };
-  }
+  if (d) return { count: parseInt(d[1]!), unit: "days" };
   return null;
 }
 


### PR DESCRIPTION
## Source
A real bug found by reading `apps/mesh/src/web/lib/cron-utils.ts` (not from an open issue).

## Why a maintainer wants this
The automation schedule editor silently corrupts a user's firing interval: typing "every 7 days" and blurring the field displays "every 1 week" on the next render, and if the user then edits the count again (thinking in weeks), the saved cron gets rebuilt with the wrong unit — changing how often the automation actually fires, with no error or warning.

## Failure scenario
- `buildCronFromInterval(7, "days")` produces `"0 0 */7 * *"`.
- `parseCronToInterval("0 0 */7 * *")` collapsed any `*/N` day-of-month cron where `N % 7 === 0` into `{ count: N/7, unit: "weeks" }` instead of `{ count: N, unit: "days" }`.
- In `TriggerCard` (`apps/mesh/src/web/components/automations/trigger-card.tsx`), `interval` is recomputed via `parseCronToInterval` on every render, but the count `<input>`'s local `count` state is untouched — so right after saving "every 7 days," the UI relabels it "every 7 weeks," and a follow-up count edit calls `buildCronFromInterval(newCount, "weeks")`, rewriting the cron with the wrong unit.
- This isn't an edge case — it triggers for any day count that's a plain multiple of 7 (7, 14, 21, 28…), an entirely ordinary value.

## Fix
Removed the `n % 7 === 0` branch in `parseCronToInterval` so `*/N` day-of-month crons always parse back as `{ count: N, unit: "days" }`, matching how `buildCronFromInterval` actually encodes a days interval. The literal weekly cron (`0 0 * * 1`) is unaffected — it's matched separately as an exact string.

Added `apps/mesh/src/web/lib/cron-utils.test.ts` with a regression test that fails on the old code and passes now:
```ts
const cron = buildCronFromInterval(7, "days"); // "0 0 */7 * *"
expect(parseCronToInterval(cron)).toEqual({ count: 7, unit: "days" }); // was { count: 1, unit: "weeks" }
```

## To confirm
```
bun test apps/mesh/src/web/lib/cron-utils.test.ts
```

## Checks run locally
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — clean
- `bun test apps/mesh/src/web/lib/cron-utils.test.ts` — 3 pass

Full CI will cover the rest (lint, full test suite).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in the automation schedule editor where every-N-days crons (e.g., */7) were parsed as weeks, causing the UI to relabel and save the wrong unit. Parsing now matches how we build crons, so day intervals round-trip correctly; weekly cron remains unaffected.

- **Bug Fixes**
  - `parseCronToInterval` now always parses `0 0 */N * *` as days; `0 0 * * 1` still parses as 1 week.
  - Added regression tests in `apps/mesh/src/web/lib/cron-utils.test.ts` to cover 7/14-day cases and weekly cron; prevents the post-save unit flip and unintended schedule changes.

<sup>Written for commit 480068b0b78a75ca1175508c46cd25b85bb04ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

