### PR TITLE
feat(commerce): improve onboarding companion flow

### DIFF
--- a/apps/mesh/src/web/components/auth-entry.tsx
+++ b/apps/mesh/src/web/components/auth-entry.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { retry, RetryError } from "@decocms/std";
 import { SplashScreen } from "@/web/components/splash-screen";
 import { UnifiedAuthForm } from "@/web/components/unified-auth-form";
+import type { UnifiedAuthFormCopy } from "@/web/components/unified-auth-form";
 import { authClient } from "@/web/lib/auth-client";
 import { useAuthConfig } from "@/web/providers/auth-config-provider";
 
@@ -16,6 +17,8 @@ export interface AuthEntryProps {
   subtitle?: string | null;
   /** Brand element rendered above the auth form header. */
   brand?: ReactNode;
+  /** Optional localized copy for the auth form. */
+  copy?: Partial<UnifiedAuthFormCopy>;
 }
 
 class RetriableAutoLoginResponse {
@@ -134,6 +137,7 @@ export function AuthEntry({
   title,
   subtitle,
   brand,
+  copy,
 }: AuthEntryProps) {
   const {
     sso,
@@ -168,6 +172,7 @@ export function AuthEntry({
         title={title}
         subtitle={subtitle}
         brand={brand}
+        copy={copy}
       />
     );
   }

--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -35,9 +35,110 @@ interface UnifiedAuthFormProps {
    * Brand element rendered above the header. Defaults to the deco logo.
    */
   brand?: React.ReactNode;
+  /** Optional localized copy for this auth surface. */
+  copy?: Partial<UnifiedAuthFormCopy>;
 }
 
 type FormView = "signIn" | "signUp" | "forgotPassword" | "emailOtp";
+
+export interface UnifiedAuthFormCopy {
+  signUpFailed: string;
+  signInFailed: string;
+  authenticationFailed: string;
+  resetEmailFailed: string;
+  otpSendFailed: string;
+  invalidCode: string;
+  invalidEmail: string;
+  invalidEmailOrPassword: string;
+  accountExists: string;
+  networkError: string;
+  tooManyAttempts: string;
+  invalidOrExpiredCode: string;
+  genericError: string;
+  resetPasswordTitle: string;
+  verificationCodeTitle: string;
+  welcomeTitle: string;
+  resetPasswordSubtitle: string;
+  codeSentTo: (email: string) => string;
+  defaultSubtitle: string;
+  resetEmailSent: string;
+  continueWith: (provider: string) => string;
+  divider: string;
+  emailLabel: string;
+  emailPlaceholder: string;
+  sending: string;
+  sendCode: string;
+  verificationCodeLabel: string;
+  enterCodePlaceholder: string;
+  verifying: string;
+  verify: string;
+  useDifferentEmail: string;
+  sendResetLink: string;
+  nameLabel: string;
+  namePlaceholder: string;
+  passwordLabel: string;
+  forgotPassword: string;
+  creatingAccount: string;
+  signingIn: string;
+  continue: string;
+  backToSignIn: string;
+  signInWithPassword: string;
+  alreadyHaveAccount: string;
+  dontHaveAccount: string;
+  signIn: string;
+  signUp: string;
+  signInWithEmailCode: string;
+}
+
+const DEFAULT_AUTH_FORM_COPY: UnifiedAuthFormCopy = {
+  signUpFailed: "Sign up failed",
+  signInFailed: "Sign in failed",
+  authenticationFailed: "Authentication failed",
+  resetEmailFailed: "Failed to send reset email",
+  otpSendFailed: "Failed to send code",
+  invalidCode: "Invalid code",
+  invalidEmail: "Invalid email address",
+  invalidEmailOrPassword: "Invalid email or password. Please try again.",
+  accountExists:
+    "An account with this email already exists. Try signing in instead.",
+  networkError: "Network error. Please check your connection and try again.",
+  tooManyAttempts: "Too many attempts. Please wait a moment and try again.",
+  invalidOrExpiredCode: "Invalid or expired code. Please try again.",
+  genericError: "An error occurred. Please try again.",
+  resetPasswordTitle: "Reset your password",
+  verificationCodeTitle: "Enter verification code",
+  welcomeTitle: "Welcome to deco",
+  resetPasswordSubtitle: "We'll send you a reset link",
+  codeSentTo: (email) => `Code sent to ${email}`,
+  defaultSubtitle: "Sign in or create a new account",
+  resetEmailSent: "Check your email for a password reset link.",
+  continueWith: (provider) => `Continue with ${provider}`,
+  divider: "or",
+  emailLabel: "Email",
+  emailPlaceholder: "Email address",
+  sending: "Sending...",
+  sendCode: "Send code",
+  verificationCodeLabel: "Verification code",
+  enterCodePlaceholder: "Enter code",
+  verifying: "Verifying...",
+  verify: "Verify",
+  useDifferentEmail: "Use a different email",
+  sendResetLink: "Send reset link",
+  nameLabel: "Name",
+  namePlaceholder: "Your name",
+  passwordLabel: "Password",
+  forgotPassword: "Forgot password?",
+  creatingAccount: "Creating account...",
+  signingIn: "Signing in...",
+  continue: "Continue",
+  backToSignIn: "Back to sign in",
+  signInWithPassword: "Sign in with password instead",
+  alreadyHaveAccount: "Already have an account? ",
+  dontHaveAccount: "Don't have an account? ",
+  signIn: "Sign in",
+  signUp: "Sign up",
+  signInWithEmailCode: "Sign in with email code",
+};
 
 export function UnifiedAuthForm({
   redirectUrl,
@@ -45,6 +146,7 @@ export function UnifiedAuthForm({
   title,
   subtitle,
   brand,
+  copy: copyOverrides,
 }: UnifiedAuthFormProps) {
   const { emailAndPassword, resetPassword, emailOtp, socialProviders } =
     useAuthConfig();
@@ -62,6 +164,7 @@ export function UnifiedAuthForm({
   });
   const [emailError, setEmailError] = useState("");
   const [resetEmailSent, setResetEmailSent] = useState(false);
+  const copy = { ...DEFAULT_AUTH_FORM_COPY, ...copyOverrides };
 
   const isSignUp = view === "signUp";
   const isForgotPassword = view === "forgotPassword";
@@ -85,18 +188,18 @@ export function UnifiedAuthForm({
             name: name || "",
           });
           if (result.error) {
-            throw new Error(result.error.message || "Sign up failed");
+            throw new Error(result.error.message || copy.signUpFailed);
           }
           return result;
         } else {
           const result = await authClient.signIn.email({ email, password });
           if (result.error) {
-            throw new Error(result.error.message || "Sign in failed");
+            throw new Error(result.error.message || copy.signInFailed);
           }
           return result;
         }
       } catch (err) {
-        throw err instanceof Error ? err : new Error("Authentication failed");
+        throw err instanceof Error ? err : new Error(copy.authenticationFailed);
       }
     },
     onSuccess: () => {
@@ -117,7 +220,7 @@ export function UnifiedAuthForm({
         redirectTo: "/reset-password",
       });
       if (result.error) {
-        throw new Error(result.error.message || "Failed to send reset email");
+        throw new Error(result.error.message || copy.resetEmailFailed);
       }
       return result;
     },
@@ -139,7 +242,7 @@ export function UnifiedAuthForm({
         type: "sign-in",
       });
       if (result.error) {
-        throw new Error(result.error.message || "Failed to send code");
+        throw new Error(result.error.message || copy.otpSendFailed);
       }
       return result;
     },
@@ -161,7 +264,7 @@ export function UnifiedAuthForm({
         otp,
       });
       if (result.error) {
-        throw new Error(result.error.message || "Invalid code");
+        throw new Error(result.error.message || copy.invalidCode);
       }
       return result;
     },
@@ -183,7 +286,7 @@ export function UnifiedAuthForm({
 
   const handleEmailBlur = () => {
     if (email.trim() && !validateEmail(email)) {
-      setEmailError("Invalid email address");
+      setEmailError(copy.invalidEmail);
     }
   };
 
@@ -191,7 +294,7 @@ export function UnifiedAuthForm({
     e.preventDefault();
 
     if (!validateEmail(email)) {
-      setEmailError("Invalid email address");
+      setEmailError(copy.invalidEmail);
       return;
     }
 
@@ -202,7 +305,7 @@ export function UnifiedAuthForm({
     e.preventDefault();
 
     if (!validateEmail(email)) {
-      setEmailError("Invalid email address");
+      setEmailError(copy.invalidEmail);
       return;
     }
 
@@ -213,7 +316,7 @@ export function UnifiedAuthForm({
     e.preventDefault();
 
     if (!validateEmail(email)) {
-      setEmailError("Invalid email address");
+      setEmailError(copy.invalidEmail);
       return;
     }
 
@@ -282,45 +385,45 @@ export function UnifiedAuthForm({
     const errorMessage = error.message.toLowerCase();
 
     if (errorMessage.includes("unauthorized") || errorMessage.includes("401")) {
-      return "Invalid email or password. Please try again.";
+      return copy.invalidEmailOrPassword;
     }
 
     if (
       errorMessage.includes("already exists") ||
       errorMessage.includes("409")
     ) {
-      return "An account with this email already exists. Try signing in instead.";
+      return copy.accountExists;
     }
 
     if (errorMessage.includes("network") || errorMessage.includes("fetch")) {
-      return "Network error. Please check your connection and try again.";
+      return copy.networkError;
     }
 
     if (errorMessage.includes("rate limit") || errorMessage.includes("429")) {
-      return "Too many attempts. Please wait a moment and try again.";
+      return copy.tooManyAttempts;
     }
 
     if (errorMessage.includes("invalid") && errorMessage.includes("otp")) {
-      return "Invalid or expired code. Please try again.";
+      return copy.invalidOrExpiredCode;
     }
 
-    return error.message || "An error occurred. Please try again.";
+    return error.message || copy.genericError;
   };
 
   const displayError = error || forgotPasswordError || otpError;
 
   const headerTitle = isForgotPassword
-    ? "Reset your password"
+    ? copy.resetPasswordTitle
     : isEmailOtp && otpSent
-      ? "Enter verification code"
-      : (title ?? "Welcome to deco");
+      ? copy.verificationCodeTitle
+      : (title ?? copy.welcomeTitle);
 
   const headerSubtitle = isForgotPassword
-    ? "We'll send you a reset link"
+    ? copy.resetPasswordSubtitle
     : isEmailOtp && otpSent
-      ? `Code sent to ${email}`
+      ? copy.codeSentTo(email)
       : subtitle === undefined
-        ? "Sign in or create a new account"
+        ? copy.defaultSubtitle
         : subtitle;
 
   return (
@@ -361,7 +464,7 @@ export function UnifiedAuthForm({
       {/* Success message for forgot password */}
       {resetEmailSent && (
         <div className="rounded-xl bg-emerald-500/10 p-3 text-sm text-emerald-600 dark:text-emerald-400 text-center">
-          Check your email for a password reset link.
+          {copy.resetEmailSent}
         </div>
       )}
 
@@ -394,8 +497,10 @@ export function UnifiedAuthForm({
                     aria-hidden="true"
                   />
                 )}
-                Continue with{" "}
-                {provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}
+                {copy.continueWith(
+                  provider.name.charAt(0).toUpperCase() +
+                    provider.name.slice(1),
+                )}
               </button>
             ))}
           </div>
@@ -408,7 +513,9 @@ export function UnifiedAuthForm({
         (emailAndPassword.enabled || emailOtp.enabled) && (
           <div className="flex items-center gap-2.5 -my-4">
             <div className="h-px flex-1 bg-border" />
-            <span className="text-base text-muted-foreground">or</span>
+            <span className="text-base text-muted-foreground">
+              {copy.divider}
+            </span>
             <div className="h-px flex-1 bg-border" />
           </div>
         )}
@@ -420,11 +527,11 @@ export function UnifiedAuthForm({
             <form onSubmit={handleSendOtp} className="grid gap-2">
               <div className="grid gap-2">
                 <label className="text-sm font-medium text-foreground">
-                  Email
+                  {copy.emailLabel}
                 </label>
                 <Input
                   type="email"
-                  placeholder="Email address"
+                  placeholder={copy.emailPlaceholder}
                   value={email}
                   onChange={handleInputChange(setEmail)}
                   onBlur={handleEmailBlur}
@@ -443,18 +550,18 @@ export function UnifiedAuthForm({
                 disabled={isLoading || !canSubmit}
                 className="flex h-12 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80 disabled:opacity-50 disabled:pointer-events-none"
               >
-                {isLoading ? "Sending..." : "Send code"}
+                {isLoading ? copy.sending : copy.sendCode}
               </button>
             </form>
           ) : (
             <form onSubmit={handleVerifyOtp} className="grid gap-2">
               <div className="grid gap-2">
                 <label className="text-sm font-medium text-foreground">
-                  Verification code
+                  {copy.verificationCodeLabel}
                 </label>
                 <Input
                   type="text"
-                  placeholder="Enter code"
+                  placeholder={copy.enterCodePlaceholder}
                   value={otp}
                   onChange={handleInputChange(setOtp)}
                   required
@@ -471,7 +578,7 @@ export function UnifiedAuthForm({
                 disabled={isLoading || !canSubmit}
                 className="flex h-12 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80 disabled:opacity-50 disabled:pointer-events-none"
               >
-                {isLoading ? "Verifying..." : "Verify"}
+                {isLoading ? copy.verifying : copy.verify}
               </button>
 
               <button
@@ -485,7 +592,7 @@ export function UnifiedAuthForm({
                 disabled={isLoading}
                 className="mt-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
-                Use a different email
+                {copy.useDifferentEmail}
               </button>
             </form>
           )}
@@ -497,7 +604,7 @@ export function UnifiedAuthForm({
         <form onSubmit={handleForgotPassword} className="grid gap-4">
           <div>
             <label className="block text-sm font-medium text-foreground mb-2">
-              Email
+              {copy.emailLabel}
             </label>
             <Input
               type="email"
@@ -521,7 +628,7 @@ export function UnifiedAuthForm({
             className="w-full font-semibold"
             size="xl"
           >
-            {isLoading ? "Sending..." : "Send reset link"}
+            {isLoading ? copy.sending : copy.sendResetLink}
           </Button>
         </form>
       )}
@@ -532,11 +639,11 @@ export function UnifiedAuthForm({
           {isSignUp && (
             <div>
               <label className="block text-sm font-medium text-foreground mb-2">
-                Name
+                {copy.nameLabel}
               </label>
               <Input
                 type="text"
-                placeholder="Your name"
+                placeholder={copy.namePlaceholder}
                 value={name}
                 onChange={handleInputChange(setName)}
                 required
@@ -547,7 +654,7 @@ export function UnifiedAuthForm({
           )}
           <div>
             <label className="block text-sm font-medium text-foreground mb-2">
-              Email
+              {copy.emailLabel}
             </label>
             <Input
               type="email"
@@ -567,7 +674,7 @@ export function UnifiedAuthForm({
           <div>
             <div className="flex items-center justify-between mb-2">
               <label className="block text-sm font-medium text-foreground">
-                Password
+                {copy.passwordLabel}
               </label>
               {!isSignUp && resetPassword.enabled && (
                 <button
@@ -575,7 +682,7 @@ export function UnifiedAuthForm({
                   onClick={() => switchView("forgotPassword")}
                   className="text-xs text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  Forgot password?
+                  {copy.forgotPassword}
                 </button>
               )}
             </div>
@@ -608,9 +715,9 @@ export function UnifiedAuthForm({
               >
                 {isLoading
                   ? isSignUp
-                    ? "Creating account..."
-                    : "Signing in..."
-                  : "Continue"}
+                    ? copy.creatingAccount
+                    : copy.signingIn
+                  : copy.continue}
               </Button>
             </div>
           </div>
@@ -626,7 +733,7 @@ export function UnifiedAuthForm({
             disabled={isLoading}
             className="font-medium text-[#8CAA25] hover:underline disabled:opacity-50"
           >
-            Back to sign in
+            {copy.backToSignIn}
           </button>
         ) : isEmailOtp && emailAndPassword.enabled ? (
           <button
@@ -635,18 +742,18 @@ export function UnifiedAuthForm({
             disabled={isLoading}
             className="font-medium text-[#8CAA25] hover:underline disabled:opacity-50"
           >
-            Sign in with password instead
+            {copy.signInWithPassword}
           </button>
         ) : !isEmailOtp && emailAndPassword.enabled ? (
           <>
-            {isSignUp ? "Already have an account? " : "Don't have an account? "}
+            {isSignUp ? copy.alreadyHaveAccount : copy.dontHaveAccount}
             <button
               type="button"
               onClick={() => switchView(isSignUp ? "signIn" : "signUp")}
               disabled={isLoading}
               className="font-medium text-[#8CAA25] hover:underline disabled:opacity-50"
             >
-              {isSignUp ? "Sign in" : "Sign up"}
+              {isSignUp ? copy.signIn : copy.signUp}
             </button>
             {emailOtp.enabled && (
               <>
@@ -657,7 +764,7 @@ export function UnifiedAuthForm({
                   disabled={isLoading}
                   className="font-medium text-[#8CAA25] hover:underline disabled:opacity-50"
                 >
-                  Sign in with email code
+                  {copy.signInWithEmailCode}
                 </button>
               </>
             )}

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -119,10 +119,73 @@ function CommerceOnboardingLayout({
   );
 }
 
+const COMMERCE_AUTH_COPY = {
+  signUpFailed: "Falha ao criar conta",
+  signInFailed: "Falha ao entrar",
+  authenticationFailed: "Falha na autenticação",
+  resetEmailFailed: "Não foi possível enviar o e-mail de redefinição",
+  otpSendFailed: "Não foi possível enviar o código",
+  invalidCode: "Código inválido",
+  invalidEmail: "E-mail inválido",
+  invalidEmailOrPassword: "E-mail ou senha inválidos. Tente novamente.",
+  accountExists:
+    "Já existe uma conta com este e-mail. Tente entrar em vez de criar uma nova conta.",
+  networkError: "Erro de rede. Verifique sua conexão e tente novamente.",
+  tooManyAttempts: "Muitas tentativas. Aguarde um momento e tente novamente.",
+  invalidOrExpiredCode: "Código inválido ou expirado. Tente novamente.",
+  genericError: "Algo deu errado. Tente novamente.",
+  resetPasswordTitle: "Redefinir sua senha",
+  verificationCodeTitle: "Informe o código de verificação",
+  welcomeTitle: "Bem-vindo à deco",
+  resetPasswordSubtitle: "Enviaremos um link de redefinição",
+  codeSentTo: (email: string) => `Código enviado para ${email}`,
+  defaultSubtitle: "Entre ou crie uma nova conta",
+  resetEmailSent: "Verifique seu e-mail para redefinir a senha.",
+  continueWith: (provider: string) => `Continuar com ${provider}`,
+  divider: "ou",
+  emailLabel: "E-mail",
+  emailPlaceholder: "Endereço de e-mail",
+  sending: "Enviando...",
+  sendCode: "Enviar código",
+  verificationCodeLabel: "Código de verificação",
+  enterCodePlaceholder: "Informe o código",
+  verifying: "Verificando...",
+  verify: "Verificar",
+  useDifferentEmail: "Usar outro e-mail",
+  sendResetLink: "Enviar link de redefinição",
+  nameLabel: "Nome",
+  namePlaceholder: "Seu nome",
+  passwordLabel: "Senha",
+  forgotPassword: "Esqueceu a senha?",
+  creatingAccount: "Criando conta...",
+  signingIn: "Entrando...",
+  continue: "Continuar",
+  backToSignIn: "Voltar para entrar",
+  signInWithPassword: "Entrar com senha",
+  alreadyHaveAccount: "Já tem uma conta? ",
+  dontHaveAccount: "Não tem uma conta? ",
+  signIn: "Entrar",
+  signUp: "Criar conta",
+  signInWithEmailCode: "Entrar com código por e-mail",
+};
+
 function siteUrlToHost(siteUrl?: string): string | null {
   if (!siteUrl) return null;
   const normalized = normalizeCommerceSiteUrl(siteUrl);
   return normalized.ok ? new URL(normalized.value).hostname : null;
+}
+
+function commerceSiteUrlErrorPtBr(error: string): string {
+  switch (error) {
+    case "Enter a website URL.":
+      return "Informe a URL de um site.";
+    case "Use an HTTP or HTTPS website URL.":
+      return "Use uma URL de site HTTP ou HTTPS.";
+    case "Enter a valid website URL.":
+      return "Informe uma URL de site válida.";
+    default:
+      return error;
+  }
 }
 
 function CommerceOnboardingPage() {
@@ -169,9 +232,10 @@ function CommerceOnboardingScreens({
         <AuthEntry
           callbackUrl={callbackUrl}
           allowAutoLogin={false}
-          title="Unlock your full diagnostic"
+          title="Desbloqueie seu diagnóstico completo"
           subtitle={null}
           brand={siteHost ? <SiteBadge host={siteHost} /> : undefined}
+          copy={COMMERCE_AUTH_COPY}
         />
       </CommerceOnboardingLayout>
     );
@@ -244,9 +308,9 @@ function CommerceOnboardingContent({
   if (organizationsQuery.error) {
     return (
       <CommerceErrorState
-        title="We could not load your organizations"
-        description="Retry to continue commerce setup from this page."
-        actionLabel="Retry"
+        title="Não foi possível carregar suas organizações"
+        description="Tente novamente para continuar a configuração de commerce nesta página."
+        actionLabel="Tentar novamente"
         onRetry={() => organizationsQuery.refetch()}
       />
     );
@@ -263,9 +327,9 @@ function CommerceOnboardingContent({
   if (requestedOrgSlug) {
     return (
       <CommerceErrorState
-        title="Organization not found"
-        description="We could not find that organization for your account."
-        actionLabel="Retry"
+        title="Organização não encontrada"
+        description="Não conseguimos encontrar essa organização na sua conta."
+        actionLabel="Tentar novamente"
         onRetry={() => organizationsQuery.refetch()}
       />
     );
@@ -286,13 +350,13 @@ function CommerceOnboardingContent({
       <CommerceOnboardingLayout>
         <div className="grid gap-10">
           <CommerceHeader
-            title="Choose an organization"
-            description="Select where commerce diagnostics should continue."
+            title="Escolha uma organização"
+            description="Selecione onde o diagnóstico de commerce deve continuar."
           />
           <ScrollReveal className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
             <OrganizationChoice
               organizations={activeOrganizations}
-              selectLabel="Continue"
+              selectLabel="Continuar"
               onSelected={(organization) => setSelectedOrg(organization)}
             />
           </ScrollReveal>
@@ -336,8 +400,8 @@ function CommerceOnboardingContent({
       <CommerceOnboardingLayout>
         <div className="grid gap-10">
           <CommerceHeader
-            title="Choose an organization"
-            description="Your email can access more than one organization. Choose where commerce setup should continue."
+            title="Escolha uma organização"
+            description="Seu e-mail pode acessar mais de uma organização. Escolha onde a configuração de commerce deve continuar."
           />
           <ScrollReveal className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
             <OrganizationChoice
@@ -360,12 +424,12 @@ function CommerceOnboardingContent({
 
   return (
     <CommerceErrorState
-      title="Commerce onboarding needs support"
+      title="O onboarding de commerce precisa de suporte"
       description={
         ensureResult?.error ??
-        "We could not determine a commerce organization for this account."
+        "Não conseguimos determinar uma organização de commerce para esta conta."
       }
-      actionLabel="Try again"
+      actionLabel="Tentar novamente"
       onRetry={() => {
         setSettledEnsureResult(null);
         ensureOrganizationMutation.reset();
@@ -394,9 +458,9 @@ function EnsureOrganizationRecovery({
   if (mutation.error) {
     return (
       <CommerceErrorState
-        title="Commerce onboarding is unavailable"
-        description="We could not prepare an organization for commerce setup. Retry from this page or contact support."
-        actionLabel="Retry"
+        title="Onboarding de commerce indisponível"
+        description="Não foi possível preparar uma organização para a configuração de commerce. Tente novamente por esta página ou fale com o suporte."
+        actionLabel="Tentar novamente"
         onRetry={onRetry}
       />
     );
@@ -477,7 +541,7 @@ function CommerceErrorState({
 function getToolErrorMessage(result: SelfToolResult): string {
   return (
     result.content?.find((item) => item.text)?.text ??
-    "Commerce Discovery setup failed."
+    "A configuração do Commerce Discovery falhou."
   );
 }
 
@@ -514,7 +578,7 @@ function CommerceSetup({
                 message={
                   error instanceof Error
                     ? error.message
-                    : "We could not check Commerce Discovery setup."
+                    : "Não foi possível verificar a configuração do Commerce Discovery."
                 }
                 onRetry={() => {
                   reset();
@@ -563,12 +627,12 @@ function CommerceSetupErrorState({
   return (
     <div className="grid gap-10">
       <CommerceHeader
-        title="Commerce diagnostics"
-        description={`Commerce setup will continue for ${orgName}.`}
+        title="Diagnóstico de commerce"
+        description={`A configuração de commerce continuará em ${orgName}.`}
       />
       <InlineError message={message} />
       <Button type="button" size="xl" className="w-full" onClick={onRetry}>
-        Retry
+        Tentar novamente
       </Button>
     </div>
   );
@@ -641,7 +705,7 @@ function CommerceSetupContent({
       setInlineError(
         error instanceof Error
           ? error.message
-          : "Commerce Discovery setup failed.",
+          : "A configuração do Commerce Discovery falhou.",
       );
     },
   });
@@ -689,7 +753,7 @@ function CommerceSetupContent({
   const runSetup = (rawSiteUrl: string) => {
     const normalized = normalizeCommerceSiteUrl(rawSiteUrl);
     if (!normalized.ok) {
-      setInlineError(normalized.error);
+      setInlineError(commerceSiteUrlErrorPtBr(normalized.error));
       return;
     }
     setInlineError(null);
@@ -774,10 +838,10 @@ function CommerceSetupContent({
         <CommerceOnboardingLayout visual={currentMeetingVisual}>
           <div className="grid gap-10">
             <CommerceHeader
-              title="Commerce diagnostics"
-              description={`Commerce setup will continue for ${org.name}.`}
+              title="Diagnóstico de commerce"
+              description={`A configuração de commerce continuará em ${org.name}.`}
             />
-            <InlineError message={normalized.error} />
+            <InlineError message={commerceSiteUrlErrorPtBr(normalized.error)} />
             <SiteUrlForm
               siteUrl={siteUrlInput}
               error={inlineError}
@@ -794,8 +858,8 @@ function CommerceSetupContent({
       <CommerceOnboardingLayout visual={currentMeetingVisual}>
         <div ref={triggerInitialSetup} className="grid gap-10">
           <CommerceHeader
-            title="Commerce diagnostics"
-            description={`Commerce Discovery is being prepared for ${normalized.value}.`}
+            title="Diagnóstico de commerce"
+            description={`O Commerce Discovery está sendo preparado para ${normalized.value}.`}
           />
           {inlineError ? (
             <>
@@ -820,8 +884,8 @@ function CommerceSetupContent({
     <CommerceOnboardingLayout visual={currentMeetingVisual}>
       <div className="grid gap-10">
         <CommerceHeader
-          title="Commerce diagnostics"
-          description={`Commerce setup will continue for ${org.name}.`}
+          title="Diagnóstico de commerce"
+          description={`A configuração de commerce continuará em ${org.name}.`}
         />
         <SiteUrlForm
           siteUrl={siteUrlInput}
@@ -852,7 +916,7 @@ function SiteUrlForm({
     <form className="grid gap-4" onSubmit={onSubmit}>
       <div className="grid gap-2">
         <label className="text-sm font-medium" htmlFor="commerce-site-url">
-          Website URL
+          URL do site
         </label>
         <Input
           id="commerce-site-url"
@@ -872,7 +936,7 @@ function SiteUrlForm({
         className="w-full"
         disabled={isSubmitting}
       >
-        Continue
+        Continuar
         <ArrowRight size={16} />
       </Button>
     </form>
@@ -923,7 +987,7 @@ function CommerceDiscoveryReady({
             onClick={onOpenReport}
             disabled={isSubmitting || !reportApp.virtualMcpId}
           >
-            {isSubmitting ? "Opening report..." : "See full report"}
+            {isSubmitting ? "Abrindo relatório..." : "Ver relatório completo"}
             {!isSubmitting ? <ArrowRight size={18} /> : null}
           </Button>
         </div>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -96,7 +96,7 @@ export function CompanionCard({
         <p className="flex-1 text-sm text-foreground">{card.title}</p>
         {card.satisfied ? (
           <div className="flex h-8 items-center gap-2 px-3 text-sm text-muted-foreground">
-            <CheckCircle size={16} /> Connected
+            <CheckCircle size={16} /> Conectado
           </div>
         ) : (
           <Button
@@ -105,19 +105,19 @@ export function CompanionCard({
             size="sm"
             disabled={disabled || connecting}
             onClick={onConnect}
-            aria-label={`Connect ${card.title}`}
+            aria-label={`Conectar ${card.title}`}
           >
             {connecting ? (
               <Loading01 size={16} className="animate-spin" />
             ) : (
-              "Connect"
+              "Conectar"
             )}
           </Button>
         )}
       </div>
       <div className="flex flex-col gap-1 px-1 py-2">
         {card.checks !== null && (
-          <UnlockLine>+ {card.checks} checks</UnlockLine>
+          <UnlockLine>+ {card.checks} verificações</UnlockLine>
         )}
         {card.headline && <UnlockLine>{card.headline}</UnlockLine>}
         {card.bullets.map((b) => (
@@ -125,7 +125,7 @@ export function CompanionCard({
         ))}
         {!card.satisfied && card.candidateConnectionId && (
           <p className="px-1 text-xs text-muted-foreground">
-            Using your existing {card.title}
+            Usando sua conexão existente de {card.title}
           </p>
         )}
       </div>
@@ -178,7 +178,7 @@ function NotAvailableNote({ title }: NotAvailableNoteProps) {
   return (
     <div className="grid gap-3 border-t border-border pt-3">
       <p className="text-xs text-muted-foreground">
-        Configuration isn't available here yet for {title}.
+        A configuração ainda não está disponível aqui para {title}.
       </p>
     </div>
   );
@@ -243,10 +243,10 @@ function CompanionConfiguration({
       <div className="grid gap-3 border-t border-border pt-3">
         <div className="flex items-center justify-between gap-3">
           <div className="grid gap-1">
-            <p className="text-sm font-medium text-foreground">Configuration</p>
+            <p className="text-sm font-medium text-foreground">Configuração</p>
             {savedConfigEntries.length === 0 && (
               <p className="text-xs text-muted-foreground">
-                No configuration values saved yet.
+                Nenhum valor de configuração foi salvo ainda.
               </p>
             )}
           </div>
@@ -258,13 +258,13 @@ function CompanionConfiguration({
                   variant="ghost"
                   size="icon-sm"
                   onClick={() => setDialogOpen(true)}
-                  aria-label={`Edit ${card.title} configuration`}
+                  aria-label={`Editar configuração de ${card.title}`}
                   disabled={!FormComponent}
                 >
                   <Edit03 size={14} />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Edit configuration</TooltipContent>
+              <TooltipContent>Editar configuração</TooltipContent>
             </Tooltip>
           ) : (
             <Button
@@ -274,7 +274,7 @@ function CompanionConfiguration({
               onClick={() => setDialogOpen(true)}
               disabled={!FormComponent}
             >
-              Configure
+              Configurar
             </Button>
           )}
         </div>
@@ -309,7 +309,7 @@ function CompanionConfiguration({
               <div className="flex min-w-0 flex-1 flex-col gap-1">
                 <DialogTitle>{card.title}</DialogTitle>
                 <DialogDescription>
-                  Configure {card.title} to enrich data
+                  Configure o {card.title} para enriquecer os dados
                 </DialogDescription>
               </div>
             </DialogHeader>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
@@ -20,7 +20,7 @@ import { LoadingIndicator } from "../loading-indicator.tsx";
 import type { CompanionFormProps } from "./types.ts";
 
 const schema = z.object({
-  propertyId: z.string().min(1, "Property is required"),
+  propertyId: z.string().min(1, "Selecione uma propriedade"),
 });
 
 type FormData = z.infer<typeof schema>;
@@ -72,7 +72,7 @@ export function GoogleAnalyticsConfigForm({
   if (propertiesQuery.isLoading) {
     return (
       <div className="flex min-h-[200px] items-center justify-center">
-        <LoadingIndicator label="Loading properties…" />
+        <LoadingIndicator label="Carregando propriedades..." />
       </div>
     );
   }
@@ -81,7 +81,7 @@ export function GoogleAnalyticsConfigForm({
     return (
       <div className="space-y-4">
         <p className="text-sm text-destructive">
-          Failed to load Google Analytics properties.
+          Não foi possível carregar as propriedades do Google Analytics.
         </p>
       </div>
     );
@@ -94,8 +94,8 @@ export function GoogleAnalyticsConfigForm({
     return (
       <div className="space-y-4">
         <p className="text-sm text-muted-foreground">
-          No Google Analytics properties found. Please connect a Google
-          Analytics account with properties.
+          Nenhuma propriedade do Google Analytics foi encontrada. Conecte uma
+          conta do Google Analytics com propriedades.
         </p>
       </div>
     );
@@ -115,7 +115,7 @@ export function GoogleAnalyticsConfigForm({
                   value={field.value}
                   onChange={field.onChange}
                   disabled={isPending}
-                  ariaLabel="Google Analytics Property"
+                  ariaLabel="Propriedade do Google Analytics"
                 />
               </FormControl>
               <FormMessage />
@@ -128,7 +128,7 @@ export function GoogleAnalyticsConfigForm({
         <p role="alert" className="text-sm text-destructive">
           {error instanceof Error
             ? error.message
-            : "Failed to save configuration"}
+            : "Não foi possível salvar a configuração"}
         </p>
       )}
 
@@ -139,10 +139,10 @@ export function GoogleAnalyticsConfigForm({
           onClick={onDone}
           disabled={isPending}
         >
-          Cancel
+          Cancelar
         </Button>
         <Button type="submit" disabled={isPending}>
-          {isPending ? "Saving..." : "Save"}
+          {isPending ? "Salvando..." : "Salvar"}
         </Button>
       </DialogFooter>
     </form>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
@@ -20,7 +20,7 @@ import { LoadingIndicator } from "../loading-indicator.tsx";
 import type { CompanionFormProps } from "./types.ts";
 
 const schema = z.object({
-  siteUrl: z.string().min(1, "Site is required"),
+  siteUrl: z.string().min(1, "Selecione um site"),
 });
 
 type FormData = z.infer<typeof schema>;
@@ -75,7 +75,7 @@ export function GoogleSearchConsoleConfigForm({
   if (sitesQuery.isLoading) {
     return (
       <div className="flex min-h-[200px] items-center justify-center">
-        <LoadingIndicator label="Loading sites…" />
+        <LoadingIndicator label="Carregando sites..." />
       </div>
     );
   }
@@ -84,7 +84,7 @@ export function GoogleSearchConsoleConfigForm({
     return (
       <div className="space-y-4">
         <p className="text-sm text-destructive">
-          Failed to load Google Search Console sites.
+          Não foi possível carregar os sites do Google Search Console.
         </p>
       </div>
     );
@@ -96,8 +96,8 @@ export function GoogleSearchConsoleConfigForm({
     return (
       <div className="space-y-4">
         <p className="text-sm text-muted-foreground">
-          No verified sites found. Please verify a site in Google Search
-          Console.
+          Nenhum site verificado foi encontrado. Verifique um site no Google
+          Search Console.
         </p>
       </div>
     );
@@ -130,7 +130,7 @@ export function GoogleSearchConsoleConfigForm({
                   value={field.value}
                   onChange={field.onChange}
                   disabled={isPending}
-                  ariaLabel="Verified Site"
+                  ariaLabel="Site verificado"
                 />
               </FormControl>
               <FormMessage />
@@ -143,7 +143,7 @@ export function GoogleSearchConsoleConfigForm({
         <p role="alert" className="text-sm text-destructive">
           {error instanceof Error
             ? error.message
-            : "Failed to save configuration"}
+            : "Não foi possível salvar a configuração"}
         </p>
       )}
 
@@ -154,10 +154,10 @@ export function GoogleSearchConsoleConfigForm({
           onClick={onDone}
           disabled={isPending}
         >
-          Cancel
+          Cancelar
         </Button>
         <Button type="submit" disabled={isPending}>
-          {isPending ? "Saving..." : "Save"}
+          {isPending ? "Salvando..." : "Salvar"}
         </Button>
       </DialogFooter>
     </form>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
@@ -15,7 +15,7 @@ export function SelectableList({
   onChange,
   disabled,
   ariaLabel,
-  searchPlaceholder = "Search…",
+  searchPlaceholder = "Buscar...",
 }: {
   options: SelectableOption[];
   value: string;
@@ -93,7 +93,7 @@ export function SelectableList({
           onChange={(e) => setQuery(e.target.value)}
           disabled={disabled}
           placeholder={searchPlaceholder}
-          aria-label={`Search ${ariaLabel}`}
+          aria-label={`Buscar ${ariaLabel}`}
           className="h-8 pl-8"
         />
       </div>
@@ -105,7 +105,7 @@ export function SelectableList({
       >
         {filtered.length === 0 ? (
           <div className="px-2 py-2 text-sm text-muted-foreground">
-            No results
+            Nenhum resultado
           </div>
         ) : (
           filtered.map((option) => {

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/vtex-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/vtex-config-form.tsx
@@ -18,7 +18,7 @@ import { useSaveCompanionConfig } from "./use-save-companion-config.ts";
 import type { CompanionFormProps } from "./types.ts";
 
 const schema = z.object({
-  accountName: z.string().min(1, "Account name is required"),
+  accountName: z.string().min(1, "Informe o nome da conta"),
   appKey: z.string().optional(),
   appToken: z.string().optional(),
 });
@@ -75,10 +75,10 @@ export function VtexConfigForm({
           name="accountName"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Account Name</FormLabel>
+              <FormLabel>Nome da conta</FormLabel>
               <FormControl>
                 <Input
-                  placeholder="Your VTEX account name"
+                  placeholder="Nome da sua conta VTEX"
                   {...field}
                   disabled={isPending}
                 />
@@ -93,10 +93,10 @@ export function VtexConfigForm({
           name="appKey"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>App Key (optional)</FormLabel>
+              <FormLabel>App Key (opcional)</FormLabel>
               <FormControl>
                 <PasswordInput
-                  placeholder="VTEX app key"
+                  placeholder="App Key da VTEX"
                   {...field}
                   disabled={isPending}
                 />
@@ -111,10 +111,10 @@ export function VtexConfigForm({
           name="appToken"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>App Token (optional)</FormLabel>
+              <FormLabel>App Token (opcional)</FormLabel>
               <FormControl>
                 <PasswordInput
-                  placeholder="VTEX app token"
+                  placeholder="App Token da VTEX"
                   {...field}
                   disabled={isPending}
                 />
@@ -129,7 +129,7 @@ export function VtexConfigForm({
         <p role="alert" className="text-sm text-destructive">
           {error instanceof Error
             ? error.message
-            : "Failed to save configuration"}
+            : "Não foi possível salvar a configuração"}
         </p>
       )}
 
@@ -140,10 +140,10 @@ export function VtexConfigForm({
           onClick={onDone}
           disabled={isPending}
         >
-          Cancel
+          Cancelar
         </Button>
         <Button type="submit" disabled={isPending}>
-          {isPending ? "Saving..." : "Save"}
+          {isPending ? "Salvando..." : "Salvar"}
         </Button>
       </DialogFooter>
     </form>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -24,10 +24,11 @@ function SectionIntro() {
   return (
     <div className="grid gap-1.5">
       <p className="text-2xl font-medium text-foreground">
-        Unlock your full diagnostic
+        Desbloqueie seu diagnóstico completo
       </p>
       <p className="text-base text-muted-foreground">
-        Connect your tools to unlock 100+ checks across your funnel.
+        Conecte suas ferramentas para liberar mais de 100 verificações no seu
+        funil.
       </p>
     </div>
   );
@@ -65,10 +66,10 @@ function CompanionMcpsSectionError({ onRetry }: { onRetry: () => void }) {
         className="rounded-2xl border border-border bg-card p-4"
       >
         <p className="text-sm text-foreground">
-          Couldn't load companion integrations.
+          Não foi possível carregar as integrações complementares.
         </p>
         <p className="mt-1 text-sm text-muted-foreground">
-          Something went wrong loading your integrations.
+          Algo deu errado ao carregar suas integrações.
         </p>
         <Button
           type="button"
@@ -77,7 +78,7 @@ function CompanionMcpsSectionError({ onRetry }: { onRetry: () => void }) {
           className="mt-3"
           onClick={onRetry}
         >
-          Try again
+          Tentar novamente
         </Button>
       </div>
     </div>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -103,7 +103,7 @@ describe("getConfigurationSummaryEntries", () => {
         currency: "",
       }),
     ).toEqual([
-      { key: "accountName", label: "Account Name", value: "electrolux" },
+      { key: "accountName", label: "Nome da conta", value: "electrolux" },
     ]);
   });
 });

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -147,6 +147,15 @@ export function hasConfigurationValues(
 }
 
 function formatConfigurationKey(key: string): string {
+  const labels: Record<string, string> = {
+    accountName: "Nome da conta",
+    appKey: "App Key",
+    appToken: "App Token",
+    propertyId: "Propriedade",
+    siteUrl: "Site",
+  };
+  if (labels[key]) return labels[key];
+
   return key
     .replace(/[_-]+/g, " ")
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions.ts
@@ -14,16 +14,19 @@ export const COMMERCE_COMPANION_MCPS: Record<string, CompanionCopy> = {
   vtex: {
     registryAppId: "deco/vtex",
     checks: 49,
-    headline: "Out-of-stock, thin PDPs & attribute gaps across every SKU",
+    headline:
+      "Rupturas, PDPs incompletas e lacunas de atributos em todos os SKUs",
   },
   "google-analytics": {
     registryAppId: "deco/google-analytics",
     checks: 49,
-    headline: "Where revenue leaks between product view and checkout",
+    headline:
+      "Onde a receita vaza entre a visualização do produto e o checkout",
   },
   "google-search-console": {
     registryAppId: "deco/google-search-console",
     checks: 49,
-    headline: "Search visibility & indexing gaps across your catalog",
+    headline:
+      "Lacunas de visibilidade na busca e indexação em todo o seu catálogo",
   },
 };

--- a/apps/mesh/src/web/routes/commerce-onboarding/loading-state.test.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/loading-state.test.tsx
@@ -13,11 +13,9 @@ import { CompanionMcpsSectionSkeleton } from "./companion-mcps-section";
 describe("commerce onboarding loading state", () => {
   test("centralizes copy for full-page loading variants", () => {
     expect(getCommerceOnboardingLoadingLabel("workspace")).toBe(
-      "Preparing your commerce workspace...",
+      "Preparando seu workspace de commerce...",
     );
-    expect(getCommerceOnboardingLoadingLabel("generic")).toBe(
-      "Preparing workspace...",
-    );
+    expect(getCommerceOnboardingLoadingLabel("generic")).toBe("Preparando...");
   });
 
   test("renders the full-page loading shell", () => {
@@ -27,16 +25,20 @@ describe("commerce onboarding loading state", () => {
 
     expect(getByRole("status")).toBeInTheDocument();
     expect(
-      getByText("Preparing your commerce workspace..."),
+      getByText("Preparando seu workspace de commerce..."),
     ).toBeInTheDocument();
   });
 
   test("renders the diagnostic card skeleton loading state", () => {
     const { getByText, container } = render(<CompanionMcpsSectionSkeleton />);
 
-    expect(getByText("Unlock your full diagnostic")).toBeInTheDocument();
     expect(
-      getByText("Connect your tools to unlock 100+ checks across your funnel."),
+      getByText("Desbloqueie seu diagnóstico completo"),
+    ).toBeInTheDocument();
+    expect(
+      getByText(
+        "Conecte suas ferramentas para liberar mais de 100 verificações no seu funil.",
+      ),
     ).toBeInTheDocument();
     expect(container.querySelectorAll(".animate-pulse")).toHaveLength(15);
   });

--- a/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
@@ -7,8 +7,8 @@ const COMMERCE_ONBOARDING_LOADING_LABELS: Record<
   CommerceOnboardingLoadingVariant,
   string
 > = {
-  workspace: "Preparing your commerce workspace...",
-  generic: "Preparing workspace...",
+  workspace: "Preparando seu workspace de commerce...",
+  generic: "Preparando...",
 };
 
 export function getCommerceOnboardingLoadingLabel(

--- a/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
@@ -11,9 +11,9 @@ import { ArrowUpRight, User01 } from "@untitledui/icons";
 const SCHEDULE_MEETING_URL =
   "https://decocms-tanstack.deco-cx.workers.dev/agendar";
 
-const HEADLINE = "Rather have us walk you through it?";
+const HEADLINE = "Prefere que a gente acompanhe você?";
 const BODY =
-  "Book a 20-minute call and we'll run the diagnostic with you, live.";
+  "Agende uma chamada de 20 minutos e rodamos o diagnóstico com você, ao vivo.";
 
 /**
  * Build the scheduling link, prefilling the site under diagnosis and the
@@ -50,7 +50,7 @@ function ScheduleMeetingCta({
       className={cn("w-full", className)}
     >
       <a href={href} target="_blank" rel="noreferrer">
-        Schedule a meeting
+        Agendar uma reunião
         <ArrowUpRight size={16} />
       </a>
     </Button>
@@ -156,10 +156,10 @@ export function ScheduleMeetingBanner({
       </span>
       <span className="flex flex-1 flex-col gap-0.5">
         <span className="text-base font-medium leading-5 text-foreground">
-          Prefer to talk to a human?
+          Prefere falar com uma pessoa?
         </span>
         <span className="text-sm leading-5 text-muted-foreground">
-          Book a call and we'll run the diagnostic with you.
+          Agende uma chamada e rodamos o diagnóstico com você.
         </span>
       </span>
       <ArrowUpRight size={18} className="shrink-0 text-muted-foreground" />

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -50,20 +50,20 @@ function commerceDiscoveryVirtualMcpId(orgId: string) {
 }
 
 async function signUpOnCurrentLoginPage(page: Page, email: string) {
-  const nameField = page.getByPlaceholder("Your name");
+  const nameField = page.getByPlaceholder("Seu nome");
   const inSignupMode = await nameField
     .waitFor({ state: "visible", timeout: 2000 })
     .then(() => true)
     .catch(() => false);
   if (!inSignupMode) {
-    await page.getByRole("button", { name: "Sign up" }).click();
+    await page.getByRole("button", { name: /^(Sign up|Criar conta)$/ }).click();
     await nameField.waitFor({ state: "visible" });
   }
 
   await nameField.fill(`Commerce ${Date.now()}`);
   await page.getByPlaceholder("you@example.com").fill(email);
   await page.getByPlaceholder("••••••••").fill(PASSWORD);
-  await page.getByRole("button", { name: "Continue" }).click();
+  await page.getByRole("button", { name: "Continuar" }).click();
 }
 
 async function waitForConnection(db: Client, id: string) {
@@ -245,7 +245,7 @@ test.describe("Commerce onboarding route isolation", () => {
     await expect(page.getByPlaceholder("you@example.com")).toBeVisible();
     await expect(
       page.getByRole("heading", {
-        name: "Rather have us walk you through it?",
+        name: "Prefere que a gente acompanhe você?",
       }),
     ).toBeVisible();
 
@@ -255,7 +255,7 @@ test.describe("Commerce onboarding route isolation", () => {
       timeout: 15_000,
     });
     await expect(
-      page.getByRole("button", { name: "See full report" }),
+      page.getByRole("button", { name: "Ver relatório completo" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -278,7 +278,7 @@ test.describe("Commerce onboarding route isolation", () => {
     await page.goto("/commerce-onboarding?siteUrl=https://example.com/path");
 
     await expect(
-      page.getByRole("button", { name: "See full report" }),
+      page.getByRole("button", { name: "Ver relatório completo" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -337,23 +337,23 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding?siteUrl=example.com");
     await expect(
-      page.getByRole("button", { name: "See full report" }),
+      page.getByRole("button", { name: "Ver relatório completo" }),
     ).toBeVisible({
       timeout: 20_000,
     });
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("Website URL")).toHaveCount(0);
+    await expect(page.getByLabel("URL do site")).toHaveCount(0);
     await expect(
-      page.getByRole("button", { name: "See full report" }),
+      page.getByRole("button", { name: "Ver relatório completo" }),
     ).toBeVisible({
       timeout: 20_000,
     });
     // The old "Companion MCPs" placeholder was replaced by the companion
     // section, whose header is hidden when no companion requirements resolve
     // (the case in this e2e env). The ready view is already asserted via the
-    // "See full report" CTA above; here we only guard against leaking raw
+    // "Ver relatório completo" CTA above; here we only guard against leaking raw
     // connection titles into the onboarding view.
     await expect(page.getByText("Commerce Discovery MCP")).toHaveCount(0);
     await expect(page.getByText("Commerce Discovery agent")).toHaveCount(0);
@@ -378,9 +378,9 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding?siteUrl=example.com");
 
-    const loading = page.getByText("Unlock your full diagnostic");
+    const loading = page.getByText("Desbloqueie seu diagnóstico completo");
     const meetingHeading = page.getByRole("heading", {
-      name: "Rather have us walk you through it?",
+      name: "Prefere que a gente acompanhe você?",
     });
 
     await expect(loading).toBeVisible();
@@ -391,7 +391,7 @@ test.describe("Commerce onboarding route isolation", () => {
       timeout: 1_000,
     });
     await expect(
-      page.getByRole("button", { name: "See full report" }),
+      page.getByRole("button", { name: "Ver relatório completo" }),
     ).toBeVisible({ timeout: 20_000 });
   });
 
@@ -406,17 +406,17 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("Website URL")).toBeVisible();
-    await page.getByLabel("Website URL").fill("ftp://example.com");
-    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByLabel("URL do site")).toBeVisible();
+    await page.getByLabel("URL do site").fill("ftp://example.com");
+    await page.getByRole("button", { name: "Continuar" }).click();
     await expect(
-      page.getByText("Use an HTTP or HTTPS website URL."),
+      page.getByText("Use uma URL de site HTTP ou HTTPS."),
     ).toBeVisible();
 
-    await page.getByLabel("Website URL").fill("example.com");
-    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByLabel("URL do site").fill("example.com");
+    await page.getByRole("button", { name: "Continuar" }).click();
     await expect(
-      page.getByRole("button", { name: "See full report" }),
+      page.getByRole("button", { name: "Ver relatório completo" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -434,7 +434,7 @@ test.describe("Commerce onboarding route isolation", () => {
     const virtualMcpId = commerceDiscoveryVirtualMcpId(orgId);
 
     await page.goto("/commerce-onboarding?siteUrl=example.com");
-    await page.getByRole("button", { name: "See full report" }).click();
+    await page.getByRole("button", { name: "Ver relatório completo" }).click();
 
     await page.waitForURL(
       (url) =>
@@ -481,7 +481,7 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("Website URL")).toBeVisible();
+    await expect(page.getByLabel("URL do site")).toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/commerce-onboarding");
 
     const orgId = await orgIdForSlug(db, expectedSlug);
@@ -527,7 +527,7 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("Website URL")).toBeVisible();
+    await expect(page.getByLabel("URL do site")).toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/commerce-onboarding");
 
     const memberRow = await db.query<{ id: string }>(
@@ -597,7 +597,7 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("Website URL")).toBeVisible();
+    await expect(page.getByLabel("URL do site")).toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/commerce-onboarding");
 
     const createdOrgId = await orgIdForSlug(db, expectedSlug);
@@ -658,7 +658,7 @@ test.describe("Commerce onboarding route isolation", () => {
     await page.goto("/onboarding");
 
     await expect(page).toHaveURL((url) => url.pathname === "/onboarding");
-    await expect(page.getByLabel("Website URL")).toHaveCount(0);
+    await expect(page.getByLabel("URL do site")).toHaveCount(0);
     await expect(page.getByText("Commerce Discovery")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
- Improve commerce onboarding companion flow and auth entry behavior
- Update companion configuration forms and loading states
- Refresh commerce onboarding e2e coverage

## Verification
- bun run fmt (exit 0; Biome reported timeout/RPC diagnostics for files outside repo root under ../org, no fixes applied)
- bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts apps/mesh/src/web/routes/commerce-onboarding/loading-state.test.tsx (36 pass, 0 fail)
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a flexible copy system to `UnifiedAuthForm` and localizes the entire commerce onboarding experience to pt‑BR across auth, companion setup, URL validation, loading states, and Commerce Discovery messages.

- **New Features**
  - `UnifiedAuthForm` accepts a `copy` prop via `UnifiedAuthFormCopy` (with defaults); `AuthEntry` forwards it; the route supplies pt‑BR strings.
  - Localizes onboarding UI: headers, errors, loading labels, schedule‑meeting CTA, and “Ver relatório completo”; GA, GSC, and VTEX forms; companion cards/config dialogs/select lists; saved configuration key labels.
  - Maps website URL validation and tool errors to pt‑BR and standardizes auth/OTP errors via the copy system.
  - Updates unit and e2e tests to the new pt‑BR strings and selectors.

<sup>Written for commit 6bdd6d3a04afc5d1ecdb614b34fb9c08cfc358e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

