### PR TITLE
fix(runtime): load persisted trigger state before enabling a new trigger type

### DIFF
--- a/packages/runtime/src/triggers.test.ts
+++ b/packages/runtime/src/triggers.test.ts
@@ -370,6 +370,49 @@ describe("createTriggers with storage", () => {
     fetchSpy.mockRestore();
   });
 
+  it("enable after restart preserves other persisted trigger types", async () => {
+    const storage = createMockStorage();
+
+    // Simulate prior session: "github.push" was already active
+    storage.data.set("conn-enable-restart", {
+      credentials: {
+        callbackUrl: "https://mesh.example.com/api/trigger-callback",
+        callbackToken: "prior-token",
+      },
+      activeTriggerTypes: ["github.push"],
+    });
+
+    // New instance (simulates restart) — in-memory cache is empty
+    const t = createTriggers({
+      definitions: [
+        ...defs,
+        {
+          type: "github.pull_request.opened" as const,
+          description: "PR opened",
+          params: z.object({ repo: z.string().describe("Repo") }),
+        },
+      ],
+      storage,
+    });
+    const configureTool = t.tools()[1];
+
+    // Enable a second trigger type without redeclaring credentials
+    await configureTool.execute({
+      context: {
+        type: "github.pull_request.opened",
+        params: {},
+        enabled: true,
+      },
+      runtimeContext: mockCtx("conn-enable-restart"),
+    });
+
+    const stored = storage.data.get("conn-enable-restart") as any;
+    expect(stored.activeTriggerTypes.sort()).toEqual([
+      "github.pull_request.opened",
+      "github.push",
+    ]);
+  });
+
   it("disable after restart clears persisted credentials from storage", async () => {
     const storage = createMockStorage();
 

--- a/packages/runtime/src/triggers.ts
+++ b/packages/runtime/src/triggers.ts
@@ -92,6 +92,9 @@ class TriggerStateManager {
     triggerType: string,
     newCredentials?: CallbackCredentials,
   ): Promise<void> {
+    // Ensure state is loaded (may be empty after restart)
+    await this.loadFromStorage(connectionId);
+
     if (newCredentials) {
       this.credentials.set(connectionId, newCredentials);
     }


### PR DESCRIPTION
## Source

A real bug found by reading `packages/runtime/src/triggers.ts` (the `@decocms/runtime` trigger SDK used by any MCP that supports persistent triggers across restarts).

## Why a maintainer wants it

Without this fix, enabling a second trigger type after a process restart silently drops any previously configured trigger types from persisted storage — an MCP developer following the documented `TRIGGER_CONFIGURE` API loses trigger subscriptions with no error or warning.

## The bug

`TriggerStateManager.disable()` calls `await this.loadFromStorage(connectionId)` first, with a comment noting "state may be empty after restart" — but `enable()` (the sibling method, right above it) was missing that same call.

**Failure scenario:** a connection has `activeTriggerTypes: ["github.push"]` persisted in storage. The process restarts (fresh in-memory `Map`s). A client calls `TRIGGER_CONFIGURE` to enable `"github.pull_request.opened"` on the same connection, without credentials (since they were already stored). Because `enable()` never loads existing state, it starts from an empty `Set`, adds only `"github.pull_request.opened"`, and persists that — permanently overwriting storage and losing the `"github.push"` subscription, even though it was never explicitly disabled.

## Fix

Added the same `await this.loadFromStorage(connectionId)` call at the top of `enable()` that `disable()` already has (`packages/runtime/src/triggers.ts`).

## Regression test

Added `"enable after restart preserves other persisted trigger types"` in `packages/runtime/src/triggers.test.ts`, mirroring the existing `"disable after restart clears persisted credentials from storage"` test: seeds storage with a prior `github.push` trigger, creates a fresh `createTriggers()` instance (simulating restart), enables `github.pull_request.opened`, and asserts storage still contains both trigger types.

Confirmed the test fails on unfixed code (storage ends up with only `["github.pull_request.opened"]`) and passes after the fix.

## How to verify

```
bun test packages/runtime/src/triggers.test.ts
```

## Checks run locally

- `bun run fmt`
- `bun x tsc --noEmit` in `packages/runtime`
- `bun test packages/runtime/src/triggers.test.ts` (14/14 pass)

Full CI will run the broader suite/lint/typecheck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a state-loss bug in `@decocms/runtime` triggers: enabling a new trigger type after a restart now preserves previously persisted trigger types. Prevents silent overwrites when using `TRIGGER_CONFIGURE`.

- **Bug Fixes**
  - In `packages/runtime/src/triggers.ts`, `TriggerStateManager.enable()` now calls `loadFromStorage(connectionId)` before updating state, matching `disable()`.
  - Added regression test “enable after restart preserves other persisted trigger types” in `packages/runtime/src/triggers.test.ts`.

<sup>Written for commit 5206760ef0fad0bcf1848b31d1ec338a643bbf40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

