### PR TITLE
chore(web): use canonical exponentialBackoffWithJitter instead of hand-rolled formulas

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-git-status.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-git-status.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { exponentialBackoffWithJitter } from "@decocms/std";
 import {
   fetchGitStatus,
   isSandboxUnreachable,
@@ -25,7 +26,13 @@ export function useSandboxGitStatus(args: {
     refetchInterval: (query) => {
       if (!isSandboxUnreachable(query.state.error)) return BASE_INTERVAL_MS;
       const failures = query.state.fetchFailureCount;
-      return Math.min(BASE_INTERVAL_MS * 2 ** failures, MAX_INTERVAL_MS);
+      return exponentialBackoffWithJitter(
+        MAX_INTERVAL_MS,
+        BASE_INTERVAL_MS,
+        failures,
+        2,
+        0,
+      );
     },
     retry: (_count, error) => !isSandboxUnreachable(error),
     staleTime: 1000,

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { exponentialBackoffWithJitter } from "@decocms/std";
 import { KEYS } from "@/web/lib/query-keys";
 import { buildDecofileFetchUrl } from "./preview-fetch-url";
 
@@ -37,6 +38,7 @@ export function useDecofile(
     // a known-down endpoint and spams 5xx logs.
     retry: (failureCount, error) =>
       (error as { status?: number }).status !== 502 && failureCount < 2,
-    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 5000),
+    retryDelay: (attempt) =>
+      exponentialBackoffWithJitter(5000, 1000, attempt, 2, 0),
   });
 }

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -1,4 +1,5 @@
 import { type Query, useQuery } from "@tanstack/react-query";
+import { exponentialBackoffWithJitter } from "@decocms/std";
 import { KEYS } from "@/web/lib/query-keys";
 import type { LiveMeta } from "./resolve-schema";
 
@@ -45,6 +46,7 @@ export function useLiveMeta(
     // a known-down endpoint and spams 5xx logs.
     retry: (failureCount, error) =>
       (error as { status?: number }).status !== 502 && failureCount < 3,
-    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 5000),
+    retryDelay: (attempt) =>
+      exponentialBackoffWithJitter(5000, 1000, attempt, 2, 0),
   });
 }


### PR DESCRIPTION
## Source
Improvement found by reading code (Source 3 — no matching small/clear open issue; Source 2 code-bug hunt found nothing that met the anti-slop bar).

## Why a maintainer wants this
`packages/std/src/backoff.ts` is explicitly documented as "the canonical exponential-backoff-with-jitter calculator for this repo... consolidated from ~9 ad-hoc copies," with an explicit instruction not to hand-roll `Math.min(base * 2 ** attempt, cap)` again. Three React Query hooks in `apps/mesh/src/web` still did exactly that, so this closes a couple of the stragglers and keeps the formula in one place as call sites keep growing.

## What changed
- `apps/mesh/src/web/components/sections-editor/use-decofile.ts`
- `apps/mesh/src/web/components/sections-editor/use-live-meta.ts`
- `apps/mesh/src/web/components/sandbox/hooks/use-sandbox-git-status.ts`

Each replaces its inline `Math.min(base * 2 ** attempt, cap)` with `exponentialBackoffWithJitter(cap, base, attempt, 2, 0)` from `@decocms/std`. `jitter = 0` reproduces the exact prior numeric output (verified by inspecting the helper's implementation: `Math.min(cap, base * multiplier ** attempt) * (1 - jitter * Math.random())`, which is identity when `jitter = 0`), so this is a pure refactor with no behavior change.

## How to confirm
- `bunx tsc --noEmit` in `apps/mesh` (clean)
- The helper itself is already covered by `packages/std/src/backoff.test.ts`; no new test needed since the values are provably identical to the old formula.

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` — passed, no errors
- Did not run the full test suite / lint / e2e (need infra not available here) — full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced inline exponential backoff formulas in three web hooks with the canonical `exponentialBackoffWithJitter` from `@decocms/std`. This centralizes retry timing and keeps behavior identical (jitter=0).

- **Refactors**
  - Swapped `Math.min(base * 2 ** attempt, cap)` for `exponentialBackoffWithJitter(cap, base, attempt, 2, 0)` in `use-sandbox-git-status`, `use-decofile`, and `use-live-meta`.
  - No functional changes; retry delays remain the same.

<sup>Written for commit 977f7b1499ff06164169973a9f9f41fad231f1ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

