### PR TITLE
fix(typegen): name the failing tool and never throw a blank error message

### DIFF
--- a/packages/typegen/src/runtime.test.ts
+++ b/packages/typegen/src/runtime.test.ts
@@ -67,6 +67,25 @@ describe("createMeshClient", () => {
     );
   });
 
+  test("throws a message naming the tool even with no text content", async () => {
+    mockCallTool.mockResolvedValueOnce({
+      isError: true,
+      content: [],
+    });
+
+    type Tools = {
+      FAIL_TOOL: { input: Record<string, never>; output: unknown };
+    };
+    const client = createMeshClient<Tools>(
+      { mcpId: "vmc_test", apiKey: "sk" },
+      deps,
+    );
+
+    await expect(client.FAIL_TOOL({})).rejects.toThrow(
+      'Tool "FAIL_TOOL" failed',
+    );
+  });
+
   test("close() closes the underlying client and allows reconnect", async () => {
     type Tools = { TOOL: { input: Record<string, never>; output: unknown } };
     const client = createMeshClient<Tools>(

--- a/packages/typegen/src/runtime.ts
+++ b/packages/typegen/src/runtime.ts
@@ -70,10 +70,15 @@ export function createMeshClient<T extends ToolMap>(
         });
 
         if (result.isError) {
-          const message = Array.isArray(result.content)
-            ? result.content.map((c) => ("text" in c ? c.text : "")).join(" ")
-            : "Tool call failed";
-          throw new Error(message);
+          const text = Array.isArray(result.content)
+            ? result.content
+                .map((c) => ("text" in c ? c.text : ""))
+                .filter(Boolean)
+                .join(" ")
+            : "";
+          throw new Error(
+            `Tool "${toolName}" failed${text ? `: ${text}` : ""}`,
+          );
         }
 
         return result.structuredContent;


### PR DESCRIPTION
## Source
A real bug found by reading code (not an existing issue): `packages/typegen/src/runtime.ts` (the generated Mesh SDK client used by external consumers of `@decocms/typegen`).

## Why a maintainer wants this
On a failed tool call, the generated client throws `new Error(message)` where `message` is built by joining the `text` parts of `result.content`. If `content` is empty (a valid MCP error shape) or has no text parts, this silently throws `Error("")` — a completely blank error with zero diagnostic value — and even in the normal case the thrown error never names which tool failed, which matters for consumers calling several tools through the generated client.

## Failure scenario + regression test
Given `result = { isError: true, content: [] }`, the current code throws `new Error("")`. The new test `throws a message naming the tool even with no text content` in `packages/typegen/src/runtime.test.ts` reproduces this (fails on current `main`, passes after the fix) and asserts the thrown error is `Tool "FAIL_TOOL" failed`.

## Fix
Filter out empty text parts before joining, and always prefix the thrown message with the failing tool's name, only appending `: <details>` when there is actual text content.

## To verify
```
bun test packages/typegen/src/runtime.test.ts
```

## Checks run locally
- `bun run fmt`
- `cd packages/typegen && bunx tsc --noEmit`
- `bun test packages/typegen/src/runtime.test.ts` (6 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids blank error messages and always names the failing tool when a tool call fails in the generated Mesh client from `@decocms/typegen`.

- **Bug Fixes**
  - On `isError`, throw `Tool "<name>" failed[: <details>]`, filtering out empty/non-text parts.
  - Added a test to assert empty content produces `Tool "FAIL_TOOL" failed`.

<sup>Written for commit 19821788080c2ea9eac30c6a096752dc9ac8a28a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

