### PR TITLE
fix(commerce-onboarding): disambiguate same-named GA properties across accounts

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -386,10 +386,34 @@ describe("toPropertyOptions", () => {
     expect(options[0]!.options).toHaveLength(2);
     expect(options[0]!.options[0]).toEqual({
       value: "properties/456",
-      label: "Property A",
+      label: "Property A (Account One)",
     });
     expect(options[1]!.account).toBe("accounts/999");
     expect(options[1]!.options).toHaveLength(1);
+  });
+  it("disambiguates same-named properties across different accounts", () => {
+    const options = toPropertyOptions({
+      response: {
+        accountSummaries: [
+          {
+            account: "accounts/123",
+            displayName: "Client A",
+            propertySummaries: [
+              { property: "properties/456", displayName: "example.com" },
+            ],
+          },
+          {
+            account: "accounts/999",
+            displayName: "Client B",
+            propertySummaries: [
+              { property: "properties/789", displayName: "example.com" },
+            ],
+          },
+        ],
+      },
+    });
+    const labels = options.flatMap((g) => g.options).map((o) => o.label);
+    expect(new Set(labels).size).toBe(labels.length);
   });
   it("handles missing or empty propertySummaries", () => {
     const options = toPropertyOptions({

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -359,9 +359,13 @@ export function toPropertyOptions(response: unknown): PropertyOptionGroup[] {
   const summaries = data?.response?.accountSummaries ?? [];
   return summaries.map((acc) => ({
     account: acc.account,
+    // Property names aren't unique across GA accounts (e.g. an agency managing
+    // several client sites, each with a property named after the same domain);
+    // the account name disambiguates them once the caller flattens groups into
+    // a single picker list (SelectableList has no grouped-header rendering).
     options: (acc.propertySummaries ?? []).map((prop) => ({
       value: prop.property,
-      label: prop.displayName,
+      label: `${prop.displayName} (${acc.displayName})`,
     })),
   }));
 }


### PR DESCRIPTION
## Source
A bug found while reading `apps/mesh/src/web/routes/commerce-onboarding/` (this run's hottest-churn area) — not tied to an existing issue.

## Why
`toPropertyOptions` (`companions-core.ts`) groups Google Analytics properties by account, but the Google Analytics config form immediately flattens all groups into one `SelectableList` (which has no grouped-header rendering) using only `prop.displayName` as the label. GA property display names are not unique across accounts — an agency operator managing several client stores routinely has multiple accounts each with a property named after the same domain (e.g. `example.com`). Those properties then render as identical, indistinguishable rows, so a user can pick the wrong property and silently wire analytics data from/to the wrong store.

## Fix
Bake the account's display name into each option's label (`"example.com (Client A)"` vs `"example.com (Client B)"`) so the picker stays disambiguated even after flattening — no changes needed to the picker component itself.

## Failure scenario + regression test
Given two GA accounts that each expose a property named `example.com`, `toPropertyOptions` previously produced two options with the identical label `"example.com"`. Added `companions-core.test.ts` → `toPropertyOptions > disambiguates same-named properties across different accounts`, which fails on `main` (duplicate labels) and passes after the fix.

## Verify
```
cd apps/mesh && bun test src/web/routes/commerce-onboarding/companions-core.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` in `apps/mesh` (clean — the one pre-existing error reported, in an unrelated untracked file, predates this branch)
- `bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts` (34 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disambiguates Google Analytics property options in commerce onboarding by appending the account name to each property's label, preventing identical choices across accounts. Adds a regression test to ensure same-named properties from different accounts render as unique options.

<sup>Written for commit 01d2a444c5a39fd8c3bb84676aa4f9de9dc34f7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

