### PR TITLE
fix(typegen): retry connecting after a failed connect instead of caching the rejection forever

### DIFF
--- a/packages/typegen/src/runtime.test.ts
+++ b/packages/typegen/src/runtime.test.ts
@@ -103,6 +103,26 @@ describe("createMeshClient", () => {
     expect(mockConnect).toHaveBeenCalledTimes(2);
   });
 
+  test("retries connecting after a failed connect instead of caching the rejection forever", async () => {
+    mockConnect.mockRejectedValueOnce(new Error("network blip"));
+
+    type Tools = { TOOL: { input: Record<string, never>; output: unknown } };
+    const client = createMeshClient<Tools>(
+      { mcpId: "vmc_test", apiKey: "sk" },
+      deps,
+    );
+
+    await expect(client.TOOL({})).rejects.toThrow("network blip");
+
+    // Transient failure resolved — a later call should retry, not replay the
+    // same cached rejection forever.
+    await expect(client.TOOL({})).resolves.toEqual({
+      tool: "TOOL",
+      args: {},
+    });
+    expect(mockConnect).toHaveBeenCalledTimes(2);
+  });
+
   test("builds URL with correct mcpId and baseUrl", async () => {
     type Tools = { TOOL: { input: Record<string, never>; output: unknown } };
 

--- a/packages/typegen/src/runtime.ts
+++ b/packages/typegen/src/runtime.ts
@@ -47,6 +47,12 @@ export function createMeshClient<T extends ToolMap>(
       return client;
     })();
 
+    // A failed connect must not be cached forever — clear it so the next
+    // call retries instead of replaying the same rejection indefinitely.
+    connectPromise.catch(() => {
+      connectPromise = null;
+    });
+
     return connectPromise;
   }
 


### PR DESCRIPTION
## Source
A real bug found while reading `packages/typegen/src/runtime.ts` (hot file — a related fix landed there in #4281).

## Why a maintainer wants this
`createMeshClient()` generates the client used by every consumer of `@decocms/typegen`. Today a single transient connect failure (a network blip, a cold-start timeout) permanently bricks that client instance for its whole lifetime — with no way to recover except constructing a new one, which most callers won't think to do.

## The bug
`getClient()` caches `connectPromise` on first call but never clears it if `client.connect()` rejects. Every later tool call awaits the *same* rejected promise and replays the identical stale error forever. Worse, `close()` also awaits that same rejected promise, so it throws instead of resetting `connectPromise` — there's no way to recover the client at all short of discarding it.

**Failure scenario:** connect fails once (e.g. transient network error) → `client.SOME_TOOL(...)` rejects with "network blip" → network recovers → `client.SOME_TOOL(...)` again → still rejects with "network blip", forever.

## Fix
Attach a `.catch()` to the cached `connectPromise` that clears it back to `null` on rejection, so the next call retries a fresh connection instead of replaying the cached failure.

## Regression test
Added `retries connecting after a failed connect instead of caching the rejection forever` in `packages/typegen/src/runtime.test.ts`. It fails on current `main` (second call still rejects with the first error) and passes after the fix.

## Verify
```
bun test packages/typegen/src/runtime.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/typegen`
- `bun test packages/typegen/src/runtime.test.ts` (7/7 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `createMeshClient()` from getting stuck after a transient connect failure by clearing the cached rejection so later calls retry. This improves resilience for all consumers of `@decocms/typegen`.

- **Bug Fixes**
  - In `packages/typegen/src/runtime.ts`, attach `.catch()` to `connectPromise` to reset it to `null` on rejection, allowing a fresh connection on the next call.
  - Added a regression test in `packages/typegen/src/runtime.test.ts` to verify retries after an initial failed connect.

<sup>Written for commit 6cda66a4fab3658dbd222cf19a4b76a086e0dc1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

