### PR TITLE
fix(threads): stop treating excluded thread_id as a scope filter

### DIFF
--- a/apps/mesh/src/tools/thread/list-messages.test.ts
+++ b/apps/mesh/src/tools/thread/list-messages.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import type { WhereExpression } from "@decocms/bindings/collections";
+import { extractThreadIdFromWhere } from "./list-messages";
+
+describe("extractThreadIdFromWhere", () => {
+  it("returns null when there is no where clause", () => {
+    expect(extractThreadIdFromWhere(undefined)).toBeNull();
+  });
+
+  it("extracts thread_id from a direct eq comparison", () => {
+    const where: WhereExpression = {
+      field: ["thread_id"],
+      operator: "eq",
+      value: "thread-A",
+    };
+    expect(extractThreadIdFromWhere(where)).toBe("thread-A");
+  });
+
+  it("extracts thread_id nested under an 'and' group", () => {
+    const where: WhereExpression = {
+      operator: "and",
+      conditions: [{ field: ["thread_id"], operator: "eq", value: "thread-A" }],
+    };
+    expect(extractThreadIdFromWhere(where)).toBe("thread-A");
+  });
+
+  it("extracts thread_id nested under an 'or' group", () => {
+    const where: WhereExpression = {
+      operator: "or",
+      conditions: [{ field: ["thread_id"], operator: "eq", value: "thread-A" }],
+    };
+    expect(extractThreadIdFromWhere(where)).toBe("thread-A");
+  });
+
+  it("does NOT extract thread_id nested under a 'not' group (exclusion, not scoping)", () => {
+    const where: WhereExpression = {
+      operator: "not",
+      conditions: [{ field: ["thread_id"], operator: "eq", value: "thread-A" }],
+    };
+    // Excluding thread-A must never resolve to scoping the query to thread-A.
+    expect(extractThreadIdFromWhere(where)).toBeNull();
+  });
+});

--- a/apps/mesh/src/tools/thread/list-messages.ts
+++ b/apps/mesh/src/tools/thread/list-messages.ts
@@ -17,7 +17,7 @@ import { ThreadMessageEntitySchema } from "./schema";
 /**
  * Extract threadId from where clause (backward compat)
  */
-function extractThreadIdFromWhere(
+export function extractThreadIdFromWhere(
   where: WhereExpression | undefined,
 ): string | null {
   if (!where) return null;
@@ -28,7 +28,10 @@ function extractThreadIdFromWhere(
   ) {
     return String(where.value);
   }
-  if ("conditions" in where) {
+  if (
+    "conditions" in where &&
+    (where.operator === "and" || where.operator === "or")
+  ) {
     for (const condition of where.conditions) {
       const found = extractThreadIdFromWhere(condition);
       if (found) return found;


### PR DESCRIPTION
## Source
A bug found while completing an existing (uncommitted) test file for `extractThreadIdFromWhere` in `apps/mesh/src/tools/thread/list-messages.ts` — the helper wasn't exported so the test couldn't even import it. Exporting it revealed the test for the `not` case actually failed against current logic.

## Why this matters
`COLLECTION_THREAD_MESSAGES_LIST` falls back to `extractThreadIdFromWhere(input.where)` to scope a query to a single thread when `thread_id` isn't passed directly. The helper recursed into `conditions` for **any** grouping operator, including `not`. So a where clause meaning "exclude thread_id = X" (`{ operator: "not", conditions: [{ field: ["thread_id"], operator: "eq", value: "X" }] }`) was misread as "scope to thread_id = X" — the opposite of what the caller asked for, returning messages from the very thread the caller wanted excluded.

## Failure scenario + regression test
Given a `not` where clause excluding `thread-A`, `extractThreadIdFromWhere` returned `"thread-A"` instead of `null`. Fixed by only descending into `conditions` when the operator is `and` or `or`. Test: `apps/mesh/src/tools/thread/list-messages.test.ts` (`does NOT extract thread_id nested under a 'not' group`), which failed before the fix and passes after.

## Verify
```
bun test apps/mesh/src/tools/thread/list-messages.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` in `apps/mesh` (clean)
- `bun test apps/mesh/src/tools/thread/list-messages.test.ts` (5/5 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating excluded thread_id as a scope filter when listing thread messages. This fixes cases where a `not` where clause returned messages from the excluded thread.

- **Bug Fixes**
  - `extractThreadIdFromWhere` now recurses only into `and`/`or` groups; `not` groups never yield a thread_id.
  - Exported the helper and added a regression test for the `not` case.

<sup>Written for commit b0cc682393a6a87685f6c2767ee1484e6ba87ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

