### PR TITLE
test(automations): cover humanReadableCron and isValidCron branches

### DIFF
--- a/apps/mesh/src/web/lib/cron-utils.test.ts
+++ b/apps/mesh/src/web/lib/cron-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { buildCronFromInterval, parseCronToInterval } from "./cron-utils.ts";
+import {
+  buildCronFromInterval,
+  humanReadableCron,
+  isValidCron,
+  parseCronToInterval,
+} from "./cron-utils.ts";
 
 describe("parseCronToInterval", () => {
   test("round-trips an every-7-days cron as days, not weeks", () => {
@@ -20,5 +25,59 @@ describe("parseCronToInterval", () => {
       count: 1,
       unit: "weeks",
     });
+  });
+});
+
+describe("humanReadableCron", () => {
+  test("formats exact-match schedules", () => {
+    expect(humanReadableCron("* * * * *")).toBe("Every minute");
+    expect(humanReadableCron("0 * * * *")).toBe("Every hour");
+    expect(humanReadableCron("0 0 * * *")).toBe("Every day");
+    expect(humanReadableCron("0 0 * * 1")).toBe("Every week");
+  });
+
+  test("formats every-N interval schedules", () => {
+    expect(humanReadableCron("*/15 * * * *")).toBe("Every 15 minutes");
+    expect(humanReadableCron("0 */3 * * *")).toBe("Every 3 hours");
+    expect(humanReadableCron("0 0 */3 * *")).toBe("Every 3 days");
+  });
+
+  test("collapses every-N-days into weeks when N is a multiple of 7", () => {
+    expect(humanReadableCron("0 0 */14 * *")).toBe("Every 2 weeks");
+  });
+
+  test("formats a specific daily time with zero-padding", () => {
+    expect(humanReadableCron("5 9 * * *")).toBe("Every day at 09:05 UTC");
+  });
+
+  test("formats a specific weekly time with day name", () => {
+    expect(humanReadableCron("30 14 * * 3")).toBe(
+      "Every Wednesday at 14:30 UTC",
+    );
+  });
+
+  test("falls back to the raw expression for unrecognized patterns", () => {
+    expect(humanReadableCron("*/5 */2 * * *")).toBe("*/5 */2 * * *");
+  });
+
+  test("falls back to a placeholder for empty input", () => {
+    expect(humanReadableCron("")).toBe("Unknown schedule");
+  });
+});
+
+describe("isValidCron", () => {
+  test("accepts well-formed 5-field expressions", () => {
+    expect(isValidCron("* * * * *")).toBe(true);
+    expect(isValidCron("*/5 0 1,15 * 1-5")).toBe(true);
+  });
+
+  test("rejects expressions without exactly 5 fields", () => {
+    expect(isValidCron("* * * *")).toBe(false);
+    expect(isValidCron("* * * * * *")).toBe(false);
+  });
+
+  test("rejects fields with invalid characters", () => {
+    expect(isValidCron("a * * * *")).toBe(false);
+    expect(isValidCron("* * * * MON")).toBe(false);
   });
 });


### PR DESCRIPTION
## Source
Small improvement found while reading recently-changed files. `apps/mesh/src/web/lib/cron-utils.ts` was just patched in #4276 for a days/weeks parsing bug, but only `parseCronToInterval` has test coverage — `humanReadableCron` (7 branches: exact matches, every-N-minutes/hours/days, the days→weeks collapse, daily/weekly time formatting, and the raw-string fallback) and `isValidCron` (used as the save-gate for cron input in `trigger-card.tsx` and `automation-detail.tsx`) have none.

## Why
These are pure, branch-heavy functions sitting on a user-facing input path (the automation trigger schedule editor). A regression in any branch (e.g. wrong zero-padding, broken day-name lookup, or a validation regex that stops rejecting malformed input) would ship silently today.

## What changed
Added `bun:test` cases for every branch of `humanReadableCron` and the accept/reject paths of `isValidCron`. No production code changed.

## Verify
```
bun test apps/mesh/src/web/lib/cron-utils.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` (apps/mesh workspace)
- `bun test apps/mesh/src/web/lib/cron-utils.test.ts` — 13 pass

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add comprehensive tests for `humanReadableCron` and `isValidCron` in `apps/mesh/src/web/lib/cron-utils.ts` to close coverage gaps in the automation schedule editor. Covers exact schedules, every-N intervals, days→weeks collapse, daily/weekly time formatting, fallbacks, and valid/invalid inputs; no production code changes.

<sup>Written for commit 048c03157cd42e4dbd1b42401e7e74e26f608735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

