### PR TITLE
test(web): cover formatBytes unit boundaries and rounding

### DIFF
--- a/apps/mesh/src/web/lib/format-bytes.test.ts
+++ b/apps/mesh/src/web/lib/format-bytes.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { formatBytes } from "./format-bytes.ts";
+
+describe("formatBytes", () => {
+  test("formats sub-KB sizes as bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+  });
+
+  test("formats KB with one decimal below 10 KB", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  test("formats KB rounded above 10 KB", () => {
+    expect(formatBytes(10 * 1024)).toBe("10 KB");
+    expect(formatBytes(500 * 1024)).toBe("500 KB");
+  });
+
+  test("formats MB with one decimal below 10 MB", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MB");
+    expect(formatBytes(5.5 * 1024 * 1024)).toBe("5.5 MB");
+  });
+
+  test("formats MB rounded above 10 MB", () => {
+    expect(formatBytes(10 * 1024 * 1024)).toBe("10 MB");
+    expect(formatBytes(250 * 1024 * 1024)).toBe("250 MB");
+  });
+});


### PR DESCRIPTION
## Source
No open issue covers this — `formatBytes` (`apps/mesh/src/web/lib/format-bytes.ts`) had zero test coverage despite being used to render byte sizes in the chat tool-output panel and the monitoring log detail view (truncated payload sizes).

## Why
It's a small pure function but has several silent unit/rounding boundaries (B→KB at 1024, KB→MB at 1024², and the "< 10" switch from one-decimal to rounded display within each unit). A future edit to the thresholds could silently mis-render sizes with nothing to catch it.

## What
Added `format-bytes.test.ts` covering:
- sub-KB values (including 0)
- KB with one decimal below the 10 KB cutoff
- KB rounded at/above 10 KB
- MB with one decimal below the 10 MB cutoff
- MB rounded at/above 10 MB

## Verify
```
bun test apps/mesh/src/web/lib/format-bytes.test.ts
```

## Checks run locally
- `bun run fmt` — clean, no changes
- `apps/mesh` `tsc --noEmit` — no errors
- `bun test apps/mesh/src/web/lib/format-bytes.test.ts` — 5 pass

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `formatBytes` covering B/KB/MB thresholds and the <10 one-decimal vs >=10 rounded rules. This prevents regressions in byte size display in the chat tool-output panel and monitoring log detail view.

<sup>Written for commit f47a6d14b87567e922fedfdfc03039146463f4e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

