### PR TITLE
test(commerce-onboarding): cover SelectableList click and keyboard navigation

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.test.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.test.tsx
@@ -1,0 +1,91 @@
+import { setupComponentTest } from "../../../../test/setup";
+setupComponentTest();
+import { describe, expect, it, mock } from "bun:test";
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SelectableList } from "./selectable-list";
+
+const OPTIONS = [
+  { value: "a", label: "Alpha" },
+  { value: "b", label: "Beta" },
+  { value: "c", label: "Gamma" },
+];
+
+describe("SelectableList", () => {
+  it("calls onChange when an option is clicked", () => {
+    const onChange = mock(() => {});
+    const { getByRole } = render(
+      <SelectableList
+        options={OPTIONS}
+        value="a"
+        onChange={onChange}
+        ariaLabel="Options"
+      />,
+    );
+    fireEvent.click(getByRole("radio", { name: "Beta" }));
+    expect(onChange).toHaveBeenCalledWith("b");
+  });
+
+  it("wraps to the first option on ArrowDown from the last", () => {
+    const onChange = mock(() => {});
+    const { getByRole } = render(
+      <SelectableList
+        options={OPTIONS}
+        value="c"
+        onChange={onChange}
+        ariaLabel="Options"
+      />,
+    );
+    fireEvent.keyDown(getByRole("radio", { name: "Gamma" }), {
+      key: "ArrowDown",
+    });
+    expect(onChange).toHaveBeenCalledWith("a");
+  });
+
+  it("wraps to the last option on ArrowUp from the first", () => {
+    const onChange = mock(() => {});
+    const { getByRole } = render(
+      <SelectableList
+        options={OPTIONS}
+        value="a"
+        onChange={onChange}
+        ariaLabel="Options"
+      />,
+    );
+    fireEvent.keyDown(getByRole("radio", { name: "Alpha" }), {
+      key: "ArrowUp",
+    });
+    expect(onChange).toHaveBeenCalledWith("c");
+  });
+
+  it("jumps to the last option on End", () => {
+    const onChange = mock(() => {});
+    const { getByRole } = render(
+      <SelectableList
+        options={OPTIONS}
+        value="a"
+        onChange={onChange}
+        ariaLabel="Options"
+      />,
+    );
+    fireEvent.keyDown(getByRole("radio", { name: "Alpha" }), { key: "End" });
+    expect(onChange).toHaveBeenCalledWith("c");
+  });
+
+  it("ignores arrow keys when disabled", () => {
+    const onChange = mock(() => {});
+    const { getByRole } = render(
+      <SelectableList
+        options={OPTIONS}
+        value="a"
+        onChange={onChange}
+        disabled
+        ariaLabel="Options"
+      />,
+    );
+    fireEvent.keyDown(getByRole("radio", { name: "Alpha" }), {
+      key: "ArrowDown",
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Source
Missing unit test (Source 3, Option A) — `SelectableList` (`apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx`) had no test file at all, despite containing real logic: click-to-select, and arrow-key/Home/End radiogroup navigation with wraparound.

## Why
This component drives the picker used in the GA/GSC/VTEX companion config forms in commerce onboarding. The keyboard-navigation math (`(currentIndex + 1) % len`, `(currentIndex - 1 + len) % len`) is exactly the kind of off-by-one-prone logic that benefits from a regression test, and it had zero coverage.

## What's covered
- Clicking a radio option calls `onChange` with its value
- ArrowDown wraps from the last option to the first
- ArrowUp wraps from the first option to the last
- End jumps to the last option
- Arrow keys are ignored when the list is `disabled`

(Free-text search filtering was intentionally left untested — this harness's happy-dom setup doesn't propagate `fireEvent.input`/`fireEvent.change` into React 19's controlled-input `onChange`, so a search test would be unreliable here; the keyboard/click paths don't depend on that and are reliably testable.)

## Verify
```
bun test apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.test.tsx
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` (apps/mesh workspace)
- `bun test apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.test.tsx` (5 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `SelectableList` to verify click-to-select and keyboard navigation: ArrowUp/ArrowDown wraparound, End jumps to last, and arrows ignored when disabled. This improves regression coverage for the commerce onboarding companion forms (GA/GSC/VTEX).

<sup>Written for commit 5703ae22b1041be3142e2ea148373e1f8a5bd38a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

