### PR TITLE
test(web): cover generateSlug edge cases

### DIFF
--- a/apps/mesh/src/web/lib/slug.test.ts
+++ b/apps/mesh/src/web/lib/slug.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { generateSlug } from "./slug";
+
+describe("generateSlug", () => {
+  it("lowercases and hyphenates spaces", () => {
+    expect(generateSlug("My Cool Site")).toBe("my-cool-site");
+  });
+
+  it("strips special characters", () => {
+    expect(generateSlug("Acme, Inc.!")).toBe("acme-inc");
+  });
+
+  it("collapses runs of whitespace and hyphens into one", () => {
+    expect(generateSlug("Foo   --  Bar")).toBe("foo-bar");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(generateSlug("  -Foo Bar-  ")).toBe("foo-bar");
+  });
+
+  it("preserves existing numbers", () => {
+    expect(generateSlug("Site 2026")).toBe("site-2026");
+  });
+
+  it("returns an empty string when nothing survives", () => {
+    expect(generateSlug("!!!")).toBe("");
+  });
+});


### PR DESCRIPTION
## Source
Missing unit test (Source 3) — `generateSlug` in `apps/mesh/src/web/lib/slug.ts` had no test file. It's used by `import-from-deco-dialog.tsx` to derive a project slug from an imported site's display name.

## Why
Nails down the transform behavior (lowercasing, special-character stripping, whitespace/hyphen collapsing, leading/trailing trim, empty-result case) so a future edit to this regex chain can't silently break slug generation for real site names (e.g. names with punctuation or accents).

## Test plan
Run `bun test apps/mesh/src/web/lib/slug.test.ts` — 6 new tests, all passing.

## Checks run locally
- `bun run fmt`
- `bun test apps/mesh/src/web/lib/slug.test.ts` (6 pass)

Full CI will run typecheck/lint/the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for generateSlug to prevent regressions in how we create project slugs from imported site names in import-from-deco-dialog. Covers lowercasing, special-character stripping, whitespace/hyphen collapsing, leading/trailing trim, number preservation, and empty-result handling (6 tests).

<sup>Written for commit 2b1c549081096900b9b540b5ab7b99b069a2e7c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

