### PR TITLE
test(harness): cover csvField escaping edge cases

### DIFF
--- a/packages/harness/src/decopilot/csv.test.ts
+++ b/packages/harness/src/decopilot/csv.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { csvField } from "./csv";
+
+describe("csvField", () => {
+  it("returns empty string for null, undefined, and empty string", () => {
+    expect(csvField(null)).toBe("");
+    expect(csvField(undefined)).toBe("");
+    expect(csvField("")).toBe("");
+  });
+
+  it("returns plain strings unquoted", () => {
+    expect(csvField("hello")).toBe("hello");
+    expect(csvField("core/slides")).toBe("core/slides");
+  });
+
+  it("quotes and escapes fields containing a comma", () => {
+    expect(csvField("a,b")).toBe('"a,b"');
+  });
+
+  it("quotes and doubles embedded quotes", () => {
+    expect(csvField('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it("quotes fields containing a newline", () => {
+    expect(csvField("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("quotes fields containing a semicolon", () => {
+    expect(csvField("a;b")).toBe('"a;b"');
+  });
+
+  it("quotes a field needing multiple escapes only once, wrapping the whole value", () => {
+    expect(csvField('a,"b"\nc;d')).toBe('"a,""b""\nc;d"');
+  });
+});


### PR DESCRIPTION
## Source
Small improvement (Source 3, missing unit test) — `csvField` in `packages/harness/src/decopilot/csv.ts` is a pure RFC-4180 field-escaping helper used by every system-prompt catalog block (`connections-block.ts`, `skills-block.ts`, `prompts-block.ts`, `agents-block.ts`) but had zero test coverage.

## Why it's useful
This function shapes what gets embedded into the decopilot system prompt, so a quoting/escaping regression (e.g. failing to double an embedded `"`, or not quoting on `;`) would silently corrupt the prompt for every agent. A regression here would be very easy to introduce and hard to notice, since nothing currently exercises the escaping branches.

## Testing
Added `packages/harness/src/decopilot/csv.test.ts` covering: null/undefined/empty input, plain unquoted strings, and quoting/escaping for commas, embedded quotes, newlines, semicolons, and combined multi-escape values.

Reviewer can confirm with:
```
bun test packages/harness/src/decopilot/csv.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/harness` (clean)
- `bun test packages/harness/src/decopilot/csv.test.ts` (7 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `csvField` to ensure correct RFC-4180 escaping and prevent malformed CSV content in decopilot system prompts.

Tests in `packages/harness/src/decopilot/csv.test.ts` cover null/undefined/empty, unquoted plain strings, and values with commas, embedded quotes (doubled), newlines, semicolons, and combined multi-escape cases.

<sup>Written for commit f31b19115b6bc43fe501256e66cbdc81a726ccca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

