### PR TITLE
test(commerce-onboarding): cover matchGscSite empty-list and unparseable-URL fallback

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -315,6 +315,16 @@ describe("matchGscSite", () => {
     const site = matchGscSite(undefined, [{ siteUrl: "https://example.com/" }]);
     expect(site).toBeNull();
   });
+  it("returns null when sites is empty", () => {
+    expect(matchGscSite("example.com", [])).toBeNull();
+  });
+  it("falls back to the raw string instead of throwing on an unparseable siteUrl", () => {
+    const site = matchGscSite("not a valid url", [
+      { siteUrl: "not a valid url" },
+      { siteUrl: "https://example.com/" },
+    ]);
+    expect(site).toBe("not a valid url");
+  });
 });
 
 describe("shouldAutoOpenCompanionConfig", () => {


### PR DESCRIPTION
## Source
Improvement (Source 3, missing test coverage) — `matchGscSite` in `apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts` had no test for its `try/catch` fallback path or for an empty `sites` list, even though the rest of the file is otherwise well covered.

## Why
`matchGscSite` silently swallows `URL` parse errors and falls back to comparing raw strings — that fallback branch was completely untested, so a future refactor could break it (e.g. start throwing, or normalize incorrectly) without any test catching it.

## What's covered
- `matchGscSite` returns `null` when `sites` is empty.
- `matchGscSite` falls back to raw-string comparison instead of throwing when a `siteUrl` isn't a parseable URL.

## Verify
`bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts`

## Checks run locally
- `bun run fmt` (no changes needed)
- `bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts` (36 pass)
Full CI will run typecheck/lint/full suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `matchGscSite` to cover two edge cases: an empty `sites` list and unparseable `siteUrl` values. Confirms it returns null when no sites are provided and falls back to raw-string matching instead of throwing when a URL can’t be parsed.

<sup>Written for commit b3b3f9442a39ac0bb55291af9a40a78924e688a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

