### PR TITLE
test(connections): cover parseNpxLikeCommand and buildCustomStdioParameters edge cases

### DIFF
--- a/apps/mesh/src/web/utils/connection-form-helpers.test.ts
+++ b/apps/mesh/src/web/utils/connection-form-helpers.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildCustomStdioParameters,
+  parseNpxLikeCommand,
+} from "./connection-form-helpers";
+
+describe("parseNpxLikeCommand", () => {
+  it("extracts the package name from a plain npx/bunx command", () => {
+    expect(parseNpxLikeCommand("npx some-package")).toEqual({
+      packageName: "some-package",
+    });
+    expect(parseNpxLikeCommand("bunx some-package")).toEqual({
+      packageName: "some-package",
+    });
+  });
+
+  it("skips leading flags to find the package name", () => {
+    expect(parseNpxLikeCommand("npx -y some-package")).toEqual({
+      packageName: "some-package",
+    });
+    expect(parseNpxLikeCommand("npx --yes --silent some-package")).toEqual({
+      packageName: "some-package",
+    });
+  });
+
+  it("is case-insensitive on the command but not the package name", () => {
+    expect(parseNpxLikeCommand("NPX some-package")).toEqual({
+      packageName: "some-package",
+    });
+  });
+
+  it("returns null when the command isn't npx/bunx", () => {
+    expect(parseNpxLikeCommand("node some-package")).toBeNull();
+  });
+
+  it("returns null when there's no package name (only a command)", () => {
+    expect(parseNpxLikeCommand("npx")).toBeNull();
+  });
+
+  it("returns null when only flags follow the command", () => {
+    expect(parseNpxLikeCommand("npx -y --silent")).toBeNull();
+  });
+
+  it("returns null for empty or whitespace-only input", () => {
+    expect(parseNpxLikeCommand("")).toBeNull();
+    expect(parseNpxLikeCommand("   ")).toBeNull();
+  });
+});
+
+describe("buildCustomStdioParameters", () => {
+  it("splits the args string on whitespace", () => {
+    expect(
+      buildCustomStdioParameters("my-cli", "run --watch", undefined, []),
+    ).toEqual({ command: "my-cli", args: ["run", "--watch"] });
+  });
+
+  it("omits args when the args string is empty or whitespace-only", () => {
+    expect(buildCustomStdioParameters("my-cli", "", undefined, [])).toEqual({
+      command: "my-cli",
+    });
+    expect(buildCustomStdioParameters("my-cli", "   ", undefined, [])).toEqual({
+      command: "my-cli",
+    });
+  });
+
+  it("trims and includes cwd only when non-blank", () => {
+    expect(buildCustomStdioParameters("my-cli", "", "  /repo  ", [])).toEqual({
+      command: "my-cli",
+      cwd: "/repo",
+    });
+    expect(buildCustomStdioParameters("my-cli", "", "   ", [])).toEqual({
+      command: "my-cli",
+    });
+  });
+
+  it("includes envVars only when at least one has a non-blank key", () => {
+    const withVars = buildCustomStdioParameters("my-cli", "", undefined, [
+      { key: "API_KEY", value: "secret" },
+    ]);
+    expect(withVars.envVars).toEqual({ API_KEY: "secret" });
+
+    const withoutVars = buildCustomStdioParameters("my-cli", "", undefined, [
+      { key: "  ", value: "ignored" },
+    ]);
+    expect(withoutVars.envVars).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Source
Missing unit test coverage — `apps/mesh/src/web/utils/connection-form-helpers.ts` has no test file, despite containing pure, non-trivial parsing/building logic used by the connection form (npx/bunx command parsing, STDIO parameter construction).

## Why
These two functions have real edge-case behavior (flag-skipping, case-insensitivity, whitespace trimming, conditional field inclusion) that was previously unverified by any test — a regression here would silently break connection setup for npx/bunx-based and custom STDIO MCP servers.

## What's covered
- `parseNpxLikeCommand`: plain npx/bunx commands, leading flags (`-y`, `--yes --silent`), command case-insensitivity, non-npx commands, missing package name, flags-only input, empty/whitespace input.
- `buildCustomStdioParameters`: args splitting, omitting empty/whitespace-only args, trimming and conditionally including `cwd`, conditionally including `envVars` based on non-blank keys.

## Verify
```
bun test apps/mesh/src/web/utils/connection-form-helpers.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh`
- `bun test apps/mesh/src/web/utils/connection-form-helpers.test.ts` (11 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `parseNpxLikeCommand` and `buildCustomStdioParameters` to cover edge cases and prevent regressions in connection setup. Tests verify npx/bunx package detection with flags and case-insensitivity, and correct STDIO parameter construction (args splitting, trimmed `cwd`, and only valid `envVars`).

<sup>Written for commit 30df7bd961fc8e24f5dda86965a43ad1a3ad2ed3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

