### PR TITLE
test(registry): cover monitor-utils duration formatting and dedup ordering

### DIFF
--- a/apps/mesh/src/web/lib/registry/monitor-utils.test.ts
+++ b/apps/mesh/src/web/lib/registry/monitor-utils.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import {
+  collapseLatestToolResults,
+  formatMonitorDuration,
+  monitorStatusBadgeClass,
+} from "./monitor-utils";
+import type { MonitorToolResult } from "./types";
+
+describe("monitorStatusBadgeClass", () => {
+  it("returns a class for each known status", () => {
+    expect(monitorStatusBadgeClass("running")).toContain("blue");
+    expect(monitorStatusBadgeClass("completed")).toContain("emerald");
+    expect(monitorStatusBadgeClass("failed")).toContain("red");
+    expect(monitorStatusBadgeClass("cancelled")).toContain("zinc");
+    expect(monitorStatusBadgeClass("pending")).toContain("amber");
+  });
+
+  it("returns empty string for an unknown status", () => {
+    expect(monitorStatusBadgeClass("bogus")).toBe("");
+  });
+});
+
+describe("formatMonitorDuration", () => {
+  it("returns null when not started", () => {
+    expect(formatMonitorDuration(null, null)).toBeNull();
+  });
+
+  it("formats sub-second durations in ms", () => {
+    const start = "2024-01-01T00:00:00.000Z";
+    const end = "2024-01-01T00:00:00.500Z";
+    expect(formatMonitorDuration(start, end)).toBe("500ms");
+  });
+
+  it("formats durations under a minute in seconds with one decimal", () => {
+    const start = "2024-01-01T00:00:00.000Z";
+    const end = "2024-01-01T00:00:01.500Z";
+    expect(formatMonitorDuration(start, end)).toBe("1.5s");
+  });
+
+  it("formats durations over a minute as minutes and seconds", () => {
+    const start = "2024-01-01T00:00:00.000Z";
+    const end = "2024-01-01T00:01:05.000Z";
+    expect(formatMonitorDuration(start, end)).toBe("1m 5s");
+  });
+
+  it("treats the 1000ms boundary as seconds, not ms", () => {
+    const start = "2024-01-01T00:00:00.000Z";
+    const end = "2024-01-01T00:00:01.000Z";
+    expect(formatMonitorDuration(start, end)).toBe("1.0s");
+  });
+});
+
+describe("collapseLatestToolResults", () => {
+  const result = (toolName: string, durationMs: number): MonitorToolResult => ({
+    toolName,
+    success: true,
+    durationMs,
+  });
+
+  it("keeps only the latest result per tool name", () => {
+    const results = [result("a", 1), result("b", 2), result("a", 3)];
+    const collapsed = collapseLatestToolResults(results);
+    expect(collapsed).toHaveLength(2);
+    expect(collapsed.find((r) => r.toolName === "a")?.durationMs).toBe(3);
+  });
+
+  it("moves a repeated tool name to the end, reflecting its latest call order", () => {
+    const results = [result("a", 1), result("b", 2), result("a", 3)];
+    const collapsed = collapseLatestToolResults(results);
+    expect(collapsed.map((r) => r.toolName)).toEqual(["b", "a"]);
+  });
+
+  it("returns an empty array for no results", () => {
+    expect(collapseLatestToolResults([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Source
Improvement — `apps/mesh/src/web/lib/registry/monitor-utils.ts` had no test coverage for any of its three exported pure helpers.

## Why
`formatMonitorDuration` and `collapseLatestToolResults` have non-obvious behavior worth pinning down: the ms/s and s/m boundary formatting, and the fact that a repeated `toolName` in `collapseLatestToolResults` moves to the END of the collapsed array (reflecting its latest call position) rather than staying at its first-seen index. A regression here would silently reorder or misformat monitor run displays.

## What's tested
- `monitorStatusBadgeClass`: known statuses + unknown-status fallback to `""`.
- `formatMonitorDuration`: not-started (`null`), sub-second ms, sub-minute seconds, minute+seconds, and the exact 1000ms boundary.
- `collapseLatestToolResults`: keeps latest duration per tool name, reorders repeated names to the end, and handles an empty input.

## How to verify
`bun test apps/mesh/src/web/lib/registry/monitor-utils.test.ts`

## Checks run locally
- `bun run fmt` (no changes needed)
- `bunx tsc --noEmit` in `apps/mesh` (clean)
- `bun test apps/mesh/src/web/lib/registry/monitor-utils.test.ts` (10 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `apps/mesh/src/web/lib/registry/monitor-utils.ts` to pin down duration formatting and tool-result dedup ordering, preventing regressions in monitor displays. Covers status badge class fallback, ms/second/minute formatting (including the 1000ms boundary), and collapsing that keeps the latest duration and moves repeated tool names to the end.

<sup>Written for commit a9e4e1dcb6ca3d0c0d7129354e87681fbf0d94ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

