### PR TITLE
test(commerce-onboarding): cover maskConfigValue sensitive-key detection

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { maskConfigValue } from "./companion-card.tsx";
+
+describe("maskConfigValue", () => {
+  it("masks keys ending in token, secret, password, appKey, or key", () => {
+    expect(maskConfigValue("appToken", "abc123")).toBe("••••••••");
+    expect(maskConfigValue("clientSecret", "abc123")).toBe("••••••••");
+    expect(maskConfigValue("password", "abc123")).toBe("••••••••");
+    expect(maskConfigValue("appKey", "abc123")).toBe("••••••••");
+    expect(maskConfigValue("accessKey", "abc123")).toBe("••••••••");
+  });
+
+  it("is case-insensitive", () => {
+    expect(maskConfigValue("ACCESSTOKEN", "abc123")).toBe("••••••••");
+    expect(maskConfigValue("Api_Secret", "abc123")).toBe("••••••••");
+  });
+
+  it("does not mask non-sensitive keys", () => {
+    expect(maskConfigValue("siteUrl", "https://example.com")).toBe(
+      "https://example.com",
+    );
+    expect(maskConfigValue("propertyId", "12345")).toBe("12345");
+    expect(maskConfigValue("accountName", "Acme")).toBe("Acme");
+  });
+
+  it("only matches the sensitive term at the end of the key", () => {
+    expect(maskConfigValue("keyholder", "abc123")).toBe("abc123");
+    expect(maskConfigValue("tokenizer", "abc123")).toBe("abc123");
+  });
+});

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -154,7 +154,7 @@ export function CompanionCard({
   );
 }
 
-function maskConfigValue(key: string, value: string) {
+export function maskConfigValue(key: string, value: string) {
   const isSensitiveKey = /(token|secret|password|appKey|key)$/i.test(key);
   return isSensitiveKey ? "••••••••" : value;
 }


### PR DESCRIPTION
**Source:** small improvement found while reading `companion-card.tsx` — no injected issue matched, and no in-flight PR touches this file.

**Why:** `maskConfigValue` decides whether a saved companion config value (API keys, tokens, site URLs, etc.) is displayed in plaintext or masked in the UI. It's pure regex logic with zero test coverage anywhere in the repo, so a change to the sensitive-key pattern (e.g. an accidental anchor/typo) could silently leak a secret in the settings UI with nothing to catch it.

**What changed:**
- Exported `maskConfigValue` (was module-private) so it's testable in isolation.
- Added `companion-card.test.ts` covering: masking of `token`/`secret`/`password`/`appKey`/`key`-suffixed keys, case-insensitivity, non-sensitive keys left in plaintext, and the end-anchor behavior (`keyholder`/`tokenizer` are *not* masked).

**To confirm:** `bun test apps/mesh/src/web/routes/commerce-onboarding/companion-card.test.ts`

**Checked locally:** `bun run fmt`, `tsc --noEmit` in `apps/mesh`, and the targeted test file above — all green. Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `maskConfigValue` and export it for isolation. Tests verify case-insensitive masking of keys ending with token, secret, password, appKey, or key, leave other keys in plaintext, and do not mask partial matches to avoid leaking secrets in the UI.

<sup>Written for commit 59188f4d8ac7511bb8e7d42aaa3d468786628eeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

