### PR TITLE
test(mcp-utils): cover sharedJsonSchemaValidator validation and cache-key stability

### DIFF
--- a/packages/mcp-utils/src/shared-schema-validator.test.ts
+++ b/packages/mcp-utils/src/shared-schema-validator.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { sharedJsonSchemaValidator } from "./shared-schema-validator";
+
+describe("sharedJsonSchemaValidator", () => {
+  it("returns valid:true with the input as data on a matching schema", () => {
+    const validator = sharedJsonSchemaValidator.getValidator<{ name: string }>({
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    });
+
+    const result = validator({ name: "deco" });
+    expect(result.valid).toBe(true);
+    expect(result.data).toEqual({ name: "deco" });
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("returns valid:false with a non-empty errorMessage on a schema mismatch", () => {
+    const validator = sharedJsonSchemaValidator.getValidator({
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    });
+
+    const result = validator({ name: 42 });
+    expect(result.valid).toBe(false);
+    expect(result.data).toBeUndefined();
+    expect(typeof result.errorMessage).toBe("string");
+    expect(result.errorMessage?.length).toBeGreaterThan(0);
+  });
+
+  it("validates structurally-identical schemas with different key order and different object identity the same way", () => {
+    const a = sharedJsonSchemaValidator.getValidator<{ a: number; b: string }>({
+      type: "object",
+      properties: { a: { type: "number" }, b: { type: "string" } },
+      required: ["a", "b"],
+    });
+    const b = sharedJsonSchemaValidator.getValidator<{ a: number; b: string }>({
+      required: ["a", "b"],
+      properties: { b: { type: "string" }, a: { type: "number" } },
+      type: "object",
+    });
+
+    expect(a({ a: 1, b: "x" }).valid).toBe(true);
+    expect(b({ a: 1, b: "x" }).valid).toBe(true);
+    expect(a({ a: "not a number", b: "x" }).valid).toBe(false);
+    expect(b({ a: "not a number", b: "x" }).valid).toBe(false);
+  });
+
+  it("returns a stable validator function per schema object reference", () => {
+    const schema = { type: "string" };
+    const first = sharedJsonSchemaValidator.getValidator(schema);
+    const second = sharedJsonSchemaValidator.getValidator(schema);
+    expect(first).toBe(second);
+  });
+});


### PR DESCRIPTION
## Source
Improvement (Source 3, Option A) — `packages/mcp-utils/src/shared-schema-validator.ts` had zero test coverage despite being non-trivial, process-wide-singleton logic (memoized Ajv compilation, content-keyed caching) described at length in its own comments as the fix for a multi-hour production memory leak.

## Why
This validator is injected into every MCP `Client`/`Server` in the mesh. Its correctness (valid/invalid results, error message surfacing, and — critically — that structurally-identical schemas with different key order or object identity still validate consistently via the stable-stringify cache key) has no regression protection today. A future refactor of the caching logic could silently break validation with no test to catch it.

## What's covered
- `valid:true` result shape on a matching schema
- `valid:false` with a non-empty `errorMessage` on a schema mismatch
- structurally-identical schemas (different key order, different object references) validate the same inputs the same way — the behavior the file's own comments call out as the reason `stableStringify` exists
- `getValidator` returns a stable validator function per schema object reference (the `WeakMap` fast path)

## Verify
```
bun test packages/mcp-utils/src/shared-schema-validator.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/mcp-utils`
- `bun test packages/mcp-utils/src/shared-schema-validator.test.ts` (4 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add test coverage for `packages/mcp-utils/src/shared-schema-validator.ts` to ensure correct validation results and cache-key stability. Tests verify valid/invalid outputs with error messages, consistent behavior across structurally identical schemas (key order/object identity), and reuse of the same validator function for the same schema object.

<sup>Written for commit 7e6c331a9ef7d6600359c4e8529cbe88bf475cbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

