### PR TITLE
test(web): cover stripMcpServerPrefix edge cases

### DIFF
--- a/apps/mesh/src/web/lib/tool-namespace.test.ts
+++ b/apps/mesh/src/web/lib/tool-namespace.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { stripMcpServerPrefix } from "./tool-namespace";
+
+describe("stripMcpServerPrefix", () => {
+  it("strips the mcp__<server>__ prefix added by coding agents", () => {
+    expect(stripMcpServerPrefix("mcp__cms__conn-abc_hello_world")).toBe(
+      "conn-abc_hello_world",
+    );
+  });
+
+  it("strips a server name containing hyphens and digits", () => {
+    expect(stripMcpServerPrefix("mcp__my-server-2__do_thing")).toBe("do_thing");
+  });
+
+  it("leaves names without the prefix untouched", () => {
+    expect(stripMcpServerPrefix("conn-abc_hello_world")).toBe(
+      "conn-abc_hello_world",
+    );
+  });
+
+  it("leaves a name that merely contains 'mcp' untouched when it lacks the double-underscore shape", () => {
+    expect(stripMcpServerPrefix("some_mcp_tool")).toBe("some_mcp_tool");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(stripMcpServerPrefix("")).toBe("");
+  });
+});


### PR DESCRIPTION
## Source
Improvement — `stripMcpServerPrefix` (apps/mesh/src/web/lib/tool-namespace.ts) had zero test coverage despite being used in several tool-name-rendering paths: `extract-pending-approvals.ts`, the generic tool-call-part renderer, `use-tool-definition-lookup.ts`, and `project-app-view.tsx`.

## Why
This regex-based prefix strip feeds directly into what users see as the tool's "friendly name" in chat. A regression here (e.g. an anchor or character-class change) would silently mangle tool names across the chat UI with no test to catch it.

## What's covered
- Standard `mcp__<server>__` prefix stripping
- Server names containing hyphens/digits
- Names without the prefix pass through unchanged
- A name that merely contains "mcp" without the double-underscore shape is untouched
- Empty string

## Verify
```
bun test apps/mesh/src/web/lib/tool-namespace.test.ts
```

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit -p .`
- `bun test apps/mesh/src/web/lib/tool-namespace.test.ts` (5/5 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `stripMcpServerPrefix` to cover edge cases and ensure tool friendly names render correctly in chat.
Tests include standard `mcp__<server>__` stripping, hyphen/digit server names, pass-through when no prefix, strings that just contain "mcp", and empty input.

<sup>Written for commit c0bcd94e8b183e53f3d0515a23b04308ded8f11a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

