### PR TITLE
test(sandbox): cover computeBranchDivergence branch/base edge cases

### DIFF
--- a/packages/sandbox/daemon/git/branch-divergence.test.ts
+++ b/packages/sandbox/daemon/git/branch-divergence.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import {
+  computeBranchDivergence,
+  type GitTryRunner,
+} from "./branch-divergence";
+
+function fakeGit(responses: Record<string, string | null>): GitTryRunner {
+  return (args) => {
+    const key = args.join(" ");
+    return key in responses ? responses[key] : null;
+  };
+}
+
+describe("computeBranchDivergence", () => {
+  it("returns early with zero counts when HEAD is detached", () => {
+    const result = computeBranchDivergence(
+      "/repo",
+      fakeGit({
+        "symbolic-ref --short refs/remotes/origin/HEAD": "origin/main",
+        "rev-parse --abbrev-ref HEAD": "HEAD",
+        "rev-parse HEAD": "abc123",
+      }),
+    );
+    expect(result).toEqual({
+      base: "main",
+      aheadOfBase: 0,
+      behindBase: 0,
+      headSha: "abc123",
+      unpushed: 0,
+    });
+  });
+
+  it("falls back to main when origin/HEAD symbolic-ref is unavailable", () => {
+    const result = computeBranchDivergence(
+      "/repo",
+      fakeGit({
+        "rev-parse --abbrev-ref HEAD": "feature/x",
+        "rev-parse --verify --quiet origin/feature/x": null,
+        "rev-parse --verify --quiet origin/main": null,
+        "rev-parse HEAD": "deadbeef",
+      }),
+    );
+    expect(result.base).toBe("main");
+    expect(result.aheadOfBase).toBe(0);
+    expect(result.behindBase).toBe(0);
+  });
+
+  it("treats all local commits ahead as unpushed when the branch was never pushed", () => {
+    const result = computeBranchDivergence(
+      "/repo",
+      fakeGit({
+        "symbolic-ref --short refs/remotes/origin/HEAD": "origin/main",
+        "rev-parse --abbrev-ref HEAD": "feature/x",
+        "rev-parse --verify --quiet origin/feature/x": null,
+        "rev-parse --verify --quiet origin/main": "sha",
+        "rev-list --left-right --count origin/main...HEAD": "0\t3",
+        "rev-parse HEAD": "headsha",
+      }),
+    );
+    expect(result.aheadOfBase).toBe(3);
+    expect(result.behindBase).toBe(0);
+    expect(result.unpushed).toBe(3);
+    expect(result.headSha).toBe("headsha");
+  });
+
+  it("computes unpushed from the remote branch when one exists", () => {
+    const result = computeBranchDivergence(
+      "/repo",
+      fakeGit({
+        "symbolic-ref --short refs/remotes/origin/HEAD": "origin/main",
+        "rev-parse --abbrev-ref HEAD": "feature/x",
+        "rev-parse --verify --quiet origin/feature/x": "sha",
+        "rev-parse --verify --quiet origin/main": "sha",
+        "rev-list --left-right --count origin/main...origin/feature/x": "2\t5",
+        "rev-list --count origin/feature/x..HEAD": "1",
+        "rev-parse origin/feature/x": "remotesha",
+      }),
+    );
+    expect(result.behindBase).toBe(2);
+    expect(result.aheadOfBase).toBe(5);
+    expect(result.unpushed).toBe(1);
+    expect(result.headSha).toBe("remotesha");
+  });
+});


### PR DESCRIPTION
## Source
Improvement (Source 3, missing test): `computeBranchDivergence` (`packages/sandbox/daemon/git/branch-divergence.ts`) is a pure function shared by the `/git/status` HTTP route and `BranchStatusMonitor`, but it had no direct unit test — only indirect, slow coverage via a real-git-repo integration test in `clone.test.ts` that only exercises the happy path.

## Why
Several branches of its logic (detached HEAD, branch never pushed to origin, missing `origin/HEAD` symbolic-ref falling back to `main`, missing `origin/<base>`) were previously untested. The function already takes an injectable `GitTryRunner`, making it trivial to unit-test without spinning up git — this PR just uses that seam.

## What's covered
- Detached HEAD returns zero counts early.
- Falls back to `main` when `origin/HEAD` symbolic-ref is unavailable.
- Branch never pushed to origin: `unpushed` mirrors `aheadOfBase`.
- Branch pushed to origin: `unpushed`/`aheadOfBase`/`behindBase` computed from the remote ref.

## To verify
```
bun test packages/sandbox/daemon/git/branch-divergence.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun run check` (tsc, in `packages/sandbox`)
- `bun test packages/sandbox/daemon/git/branch-divergence.test.ts` — 4 pass

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add direct unit tests for `computeBranchDivergence` to cover branch/base edge cases and validate output fields.

Covers: detached HEAD early return, fallback to `main` when `origin/HEAD` is missing, "never pushed" branches where `unpushed` equals `aheadOfBase`, and remote-ref based `aheadOfBase`/`behindBase`/`unpushed` and `headSha` calculations.

<sup>Written for commit b1a5609550383abcd20759fd70ba9359c9ff838b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

