### PR TITLE
test(sandbox): cover installProtectedBranchHook install + block/allow behavior

### DIFF
--- a/packages/sandbox/daemon/git/protect-branch.test.ts
+++ b/packages/sandbox/daemon/git/protect-branch.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installProtectedBranchHook } from "./protect-branch";
+
+function runHook(
+  hookPath: string,
+  remoteRef: string,
+): { status: number; stderr: string } {
+  try {
+    execFileSync(hookPath, {
+      input: `refs/heads/x local-sha ${remoteRef} remote-sha\n`,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { status: 0, stderr: "" };
+  } catch (err) {
+    const e = err as { status: number; stderr: Buffer };
+    return { status: e.status, stderr: e.stderr.toString() };
+  }
+}
+
+describe("installProtectedBranchHook", () => {
+  it("installs an executable pre-push hook", () => {
+    const repoDir = mkdtempSync(join(tmpdir(), "protect-branch-"));
+    try {
+      installProtectedBranchHook(repoDir);
+      const hookPath = join(repoDir, ".git", "hooks", "pre-push");
+      expect(statSync(hookPath).mode & 0o777).toBe(0o755);
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks pushes to main/master and allows other branches", () => {
+    const repoDir = mkdtempSync(join(tmpdir(), "protect-branch-"));
+    try {
+      installProtectedBranchHook(repoDir);
+      const hookPath = join(repoDir, ".git", "hooks", "pre-push");
+
+      const main = runHook(hookPath, "refs/heads/main");
+      expect(main.status).not.toBe(0);
+      expect(main.stderr).toContain("not allowed from a sandbox");
+
+      const master = runHook(hookPath, "refs/heads/master");
+      expect(master.status).not.toBe(0);
+
+      const feature = runHook(hookPath, "refs/heads/feature/x");
+      expect(feature.status).toBe(0);
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
**Source:** improvement — `packages/sandbox/daemon/git/protect-branch.ts` had zero test coverage for the actual pre-push hook logic it generates.

**Why:** `installProtectedBranchHook` writes an executable shell script that is the sandbox's last line of defense against a rogue push to `main`/`master`. Nothing verified the file is actually installed executable, or that the generated hook logic really blocks `main`/`master` and lets other branches through — a shell-quoting typo in the heredoc would silently defeat the protection.

**What the test does:** installs the hook into a real temp git dir, asserts the file mode is `0o755`, then executes the hook directly with pre-push's stdin protocol (`local_ref local_sha remote_ref remote_sha`) to confirm it exits non-zero with the expected message for `refs/heads/main` and `refs/heads/master`, and exits 0 for a feature branch.

**Reviewer command:**
```
bun test packages/sandbox/daemon/git/protect-branch.test.ts
```

**Checks run locally:** `bun run fmt`, `bun x tsc --noEmit` (in `packages/sandbox`), and the targeted test file above — all green. Full CI will cover the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add end-to-end tests for the sandbox pre-push protection hook generated by `installProtectedBranchHook`. Verifies the script is installed executable (0o755), rejects pushes to `refs/heads/main` and `refs/heads/master` with the expected message, and allows other branches.

<sup>Written for commit aae6e1d401863cebd41951a970b128811de9d7ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

