### PR TITLE
test(shared): cover slugify separator collapsing and empty-result edge cases

### DIFF
--- a/apps/mesh/src/shared/utils/slugify.test.ts
+++ b/apps/mesh/src/shared/utils/slugify.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { slugify } from "./slugify";
+
+describe("slugify", () => {
+  it("lowercases and hyphenates spaces", () => {
+    expect(slugify("My Cool Server")).toBe("my-cool-server");
+  });
+
+  it("replaces forward slashes with hyphens", () => {
+    expect(slugify("deco/vtex")).toBe("deco-vtex");
+  });
+
+  it("strips special characters not in the allowed set", () => {
+    expect(slugify("Server @ v1.0!")).toBe("server-v10");
+  });
+
+  it("collapses runs of separators into a single hyphen", () => {
+    expect(slugify("a   b__c--d")).toBe("a-b-c-d");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(slugify("  -Hello World-  ")).toBe("hello-world");
+  });
+
+  it("returns an empty string when input has no sluggable characters", () => {
+    expect(slugify("@@@")).toBe("");
+  });
+});


### PR DESCRIPTION
## Source
Missing unit test — `slugify` (`apps/mesh/src/shared/utils/slugify.ts`) is a pure string-transform used to build user-facing identifiers (e.g. the Cursor/Claude Code MCP install deeplinks in `virtual-mcp-share-modal.tsx`, where the slug feeds directly into a shell command and a URL) but has no test file at all.

## Why
This is genuinely tricky regex logic (collapsing separators, stripping disallowed chars, trimming leading/trailing hyphens) feeding into a shell-command string — a regression here (e.g. a name that slugifies to `""`, or double hyphens leaking through) would silently produce a broken `claude mcp add-json` command or an empty MCP server name. Locking down the behavior with tests makes future edits to this function safe.

## What's covered
- Basic lowercase + space-to-hyphen conversion
- Forward slash replacement (used for names like `deco/vtex`)
- Stripping disallowed special characters
- Collapsing consecutive separators (spaces/underscores/hyphens) into one hyphen
- Trimming leading/trailing hyphens
- All-special-character input producing an empty string

## How to verify
```
bun test apps/mesh/src/shared/utils/slugify.test.ts
```

## Checks run locally
- `bun run fmt` — clean, no changes needed
- `bun x tsc --noEmit` in `apps/mesh` — passes
- `bun test apps/mesh/src/shared/utils/slugify.test.ts` — 6/6 pass

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `apps/mesh/src/shared/utils/slugify.ts` covering separator collapsing, disallowed character stripping, slash replacement, trimming, and empty-output cases. This prevents regressions that could break MCP install deeplinks and shell commands.

<sup>Written for commit 39587367f6106ba1e898c447c04cceaca7278944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

