### PR TITLE
feat(analytics): bootstrap LP distinct_id (ph_did) + commerce_onboarding_viewed

### DIFF
--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -17,10 +17,48 @@ let initialized = false;
 let lastOrgGroupKey: string | null = null;
 let bootstrapTimingSent = false;
 
+const LP_DISTINCT_ID_STASH = "mesh:lp-distinct-id";
+
+/**
+ * Cross-domain identity handoff from the marketing LP: diagnostic-deck CTAs
+ * stamp the visitor's PostHog distinct_id onto the studio URL as `ph_did`.
+ * Bootstrapping init with that id makes this browser continue the LP person,
+ * so the eventual `identify(user.id)` merges the whole anonymous LP journey
+ * (URL submitted → slides viewed → CTA) into the signed-up user.
+ *
+ * Two guards:
+ * - the param is stashed in sessionStorage (survives the auth round-trip)
+ *   and scrubbed from the URL so it can't be copied around;
+ * - it's only honored when PostHog has no persisted state on this domain —
+ *   a returning visitor keeps their own identity even if they open a
+ *   forwarded LP link carrying someone else's id.
+ */
+function lpBootstrapDistinctId(): string | undefined {
+  try {
+    const url = new URL(window.location.href);
+    const fromUrl = url.searchParams.get("ph_did");
+    if (fromUrl) {
+      sessionStorage.setItem(LP_DISTINCT_ID_STASH, fromUrl);
+      url.searchParams.delete("ph_did");
+      window.history.replaceState(window.history.state, "", url.toString());
+    }
+    const candidate = fromUrl ?? sessionStorage.getItem(LP_DISTINCT_ID_STASH);
+    if (!candidate) return undefined;
+    const hasOwnState = Object.keys(window.localStorage).some(
+      (k) => k.startsWith("ph_") && k.endsWith("_posthog"),
+    );
+    return hasOwnState ? undefined : candidate;
+  } catch {
+    return undefined;
+  }
+}
+
 export function initPostHog(key: string, host: string) {
   if (initialized || typeof window === "undefined") return;
+  const lpDistinctId = lpBootstrapDistinctId();
   posthog.init(key, {
     api_host: host,
+    ...(lpDistinctId ? { bootstrap: { distinctID: lpDistinctId } } : {}),
     capture_pageview: "history_change",
     capture_pageleave: true,
     autocapture: true,
@@ -66,6 +104,12 @@ export function resetUser() {
 export function track(event: string, properties?: Record<string, unknown>) {
   if (!initialized) return;
   posthog.capture(event, properties);
+}
+
+/** Whether `initPostHog` has run — for render-time one-shot trackers that
+ *  must not burn their "fired" guard while calls would still be dropped. */
+export function isPostHogInitialized() {
+  return initialized;
 }
 
 /**

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -11,6 +11,7 @@ import {
   useActiveOrganizations,
 } from "@/web/lib/auth-client";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+import { isPostHogInitialized, track } from "@/web/lib/posthog-client";
 import { KEYS } from "@/web/lib/query-keys";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
@@ -188,10 +189,26 @@ function commerceSiteUrlErrorPtBr(error: string): string {
   }
 }
 
+// One-shot per SPA load, render-time (useEffect is banned in this app; same
+// pattern as PostHogIdentitySync). This is the LP→studio funnel seam: the
+// diagnostic deck's CTAs land here, so this event is funnel step "arrived in
+// studio", joinable to the LP journey via the bootstrapped ph_did identity.
+let onboardingViewTracked = false;
+
 function CommerceOnboardingPage() {
   const search = useSearch({ from: "/commerce-onboarding" });
   const { org: requestedOrgSlug, siteUrl } = search;
   const siteHost = siteUrlToHost(siteUrl);
+
+  if (!onboardingViewTracked && isPostHogInitialized()) {
+    onboardingViewTracked = true;
+    track("commerce_onboarding_viewed", {
+      site_url: siteUrl,
+      domain: siteHost ?? undefined,
+      // Person-level copy so the store follows the user across sessions.
+      ...(siteHost ? { $set: { last_scanned_domain: siteHost } } : {}),
+    });
+  }
 
   return (
     <CommerceSiteHostContext.Provider value={siteHost}>


### PR DESCRIPTION
## Why

PostHog audit of the diagnostic funnel (project 394178): **0 of 14 LP diagnostic persons merged with any of 156 studio persons in 30 days**. The LP and studio are separate domains, so the anonymous visitor who scanned their store, viewed the slides, and clicked the CTA becomes a brand-new person the moment they land on studio — the landing→signup funnel can never converge.

## What

1. **`ph_did` bootstrap** (`posthog-client.ts`): LP CTAs stamp the visitor's distinct_id onto the studio URL (companion PR deco-sites/decocms-tanstack#45). `initPostHog` now reads it, stashes it in sessionStorage (survives the auth round-trip), scrubs it from the URL, and passes `bootstrap: { distinctID }` — **only when this browser has no persisted PostHog state**, so returning users keep their own identity even on forwarded links. The existing `identify(user.id)` on login then merges the full LP journey into the user.
2. **`commerce_onboarding_viewed` {site_url, domain}** on the `/commerce-onboarding` route (one-shot, render-time — respecting the useEffect ban), plus `last_scanned_domain` as a person property. This is funnel step 7 ("arrived in studio") between the LP's `diagnostic_cta_clicked` and `user_signed_up`.

## Verification

- `bun run check` (tsc): clean.
- `bun test apps/mesh/src/web/lib/posthog-client.test.ts`: 5 pass.
- Manual: open `/commerce-onboarding?siteUrl=https://x.com.br/&ph_did=test-id` in a fresh profile → event fires, URL scrubbed, `posthog.get_distinct_id() === "test-id"`; sign up → LP person merges.

Part 2/3 of the funnel wiring (LP → studio → engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies LP and studio identities by bootstrapping PostHog `distinct_id` from `ph_did`, so LP→studio journeys merge on signup. Also tracks a one-shot `commerce_onboarding_viewed` to mark “arrived in studio.”

- **New Features**
  - LP identity handoff: read `ph_did`, stash in `sessionStorage`, scrub from URL, and pass `bootstrap: { distinctID }` only if no existing PostHog state. Existing `identify(user.id)` then merges the LP journey.
  - Event: fire `commerce_onboarding_viewed` on `/commerce-onboarding` once per SPA load when PostHog is ready. Includes `site_url` and `domain`, and sets person property `last_scanned_domain`.

<sup>Written for commit 8a978a469a74d8f19bd080633670662531f5af57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

