### PR TITLE
fix(analytics): merge LP identity on login for returning browsers

### DIFF
--- a/apps/mesh/src/web/lib/posthog-client.test.ts
+++ b/apps/mesh/src/web/lib/posthog-client.test.ts
@@ -132,7 +132,10 @@ describe("posthog-client.identifyUser LP merge", () => {
 
   test("aliases the stashed LP distinct_id after identify, then clears it", () => {
     const store = stubLocalStorage({
-      "mesh:lp-distinct-id": JSON.stringify({ id: "lp-anon-1", ts: Date.now() }),
+      "mesh:lp-distinct-id": JSON.stringify({
+        id: "lp-anon-1",
+        ts: Date.now(),
+      }),
     });
     initPostHog("phc_test", "https://us.i.posthog.com");
     identifyUser("user_42", { email: "x@y.com" });
@@ -143,7 +146,10 @@ describe("posthog-client.identifyUser LP merge", () => {
 
   test("second login does not re-alias (stash consumed)", () => {
     stubLocalStorage({
-      "mesh:lp-distinct-id": JSON.stringify({ id: "lp-anon-1", ts: Date.now() }),
+      "mesh:lp-distinct-id": JSON.stringify({
+        id: "lp-anon-1",
+        ts: Date.now(),
+      }),
     });
     initPostHog("phc_test", "https://us.i.posthog.com");
     identifyUser("user_42");

--- a/apps/mesh/src/web/lib/posthog-client.test.ts
+++ b/apps/mesh/src/web/lib/posthog-client.test.ts
@@ -22,6 +22,9 @@ afterAll(() => {
   }
 });
 
+const identifyCalls: unknown[][] = [];
+const aliasCalls: unknown[][] = [];
+
 mock.module("posthog-js", () => ({
   default: {
     init: (...args: unknown[]) => {
@@ -33,14 +36,40 @@ mock.module("posthog-js", () => ({
     reset: () => {
       resetCount += 1;
     },
-    identify: () => {},
+    identify: (...args: unknown[]) => {
+      identifyCalls.push(args);
+    },
+    alias: (...args: unknown[]) => {
+      aliasCalls.push(args);
+    },
     capture: () => {},
     captureException: () => {},
   },
 }));
 
-const { initPostHog, setOrganizationGroup, resetUser, __resetForTest } =
-  await import("./posthog-client");
+const {
+  initPostHog,
+  identifyUser,
+  setOrganizationGroup,
+  resetUser,
+  __resetForTest,
+} = await import("./posthog-client");
+
+/** Minimal localStorage stub — enough for the LP-stash read/write/remove. */
+function stubLocalStorage(seed: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...seed };
+  const stub = {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+  };
+  (globalThis.window as { localStorage?: unknown }).localStorage = stub;
+  return store;
+}
 
 describe("posthog-client.setOrganizationGroup", () => {
   beforeEach(() => {
@@ -90,5 +119,60 @@ describe("posthog-client.setOrganizationGroup", () => {
 
     setOrganizationGroup("org_1", { name: "Acme", slug: "acme" });
     expect(groupCalls).toHaveLength(2);
+  });
+});
+
+describe("posthog-client.identifyUser LP merge", () => {
+  beforeEach(() => {
+    identifyCalls.length = 0;
+    aliasCalls.length = 0;
+    __resetForTest();
+    delete (globalThis.window as { localStorage?: unknown }).localStorage;
+  });
+
+  test("aliases the stashed LP distinct_id after identify, then clears it", () => {
+    const store = stubLocalStorage({
+      "mesh:lp-distinct-id": JSON.stringify({ id: "lp-anon-1", ts: Date.now() }),
+    });
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    identifyUser("user_42", { email: "x@y.com" });
+    expect(identifyCalls).toHaveLength(1);
+    expect(aliasCalls).toEqual([["lp-anon-1"]]);
+    expect(store["mesh:lp-distinct-id"]).toBeUndefined(); // one-shot
+  });
+
+  test("second login does not re-alias (stash consumed)", () => {
+    stubLocalStorage({
+      "mesh:lp-distinct-id": JSON.stringify({ id: "lp-anon-1", ts: Date.now() }),
+    });
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    identifyUser("user_42");
+    identifyUser("user_42");
+    expect(aliasCalls).toHaveLength(1);
+  });
+
+  test("ignores an expired stash", () => {
+    stubLocalStorage({
+      "mesh:lp-distinct-id": JSON.stringify({
+        id: "lp-anon-1",
+        ts: Date.now() - 25 * 60 * 60 * 1000,
+      }),
+    });
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    identifyUser("user_42");
+    expect(aliasCalls).toHaveLength(0);
+  });
+
+  test("ignores a corrupt stash and no localStorage at all", () => {
+    stubLocalStorage({ "mesh:lp-distinct-id": "not-json" });
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    identifyUser("user_42");
+    expect(aliasCalls).toHaveLength(0);
+
+    __resetForTest();
+    delete (globalThis.window as { localStorage?: unknown }).localStorage;
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    identifyUser("user_42");
+    expect(aliasCalls).toHaveLength(0);
   });
 });

--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -18,6 +18,32 @@ let lastOrgGroupKey: string | null = null;
 let bootstrapTimingSent = false;
 
 const LP_DISTINCT_ID_STASH = "mesh:lp-distinct-id";
+// How long a stashed LP id stays mergeable. Long enough for "clicked the CTA
+// this morning, signed up tonight"; short enough that a shared machine can't
+// attach someone's week-old LP browsing to an unrelated login.
+const LP_STASH_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** The stashed LP distinct_id, or undefined when absent/expired/corrupt. */
+function readLpStash(): string | undefined {
+  try {
+    const raw = window.localStorage.getItem(LP_DISTINCT_ID_STASH);
+    if (!raw) return undefined;
+    const { id, ts } = JSON.parse(raw) as { id?: unknown; ts?: unknown };
+    if (typeof id !== "string" || !id || typeof ts !== "number")
+      return undefined;
+    return Date.now() - ts <= LP_STASH_TTL_MS ? id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function clearLpStash() {
+  try {
+    window.localStorage.removeItem(LP_DISTINCT_ID_STASH);
+  } catch {
+    // ignore — worst case the next login re-attempts a no-op merge
+  }
+}
 
 /**
  * Cross-domain identity handoff from the marketing LP: diagnostic-deck CTAs
@@ -27,22 +53,26 @@ const LP_DISTINCT_ID_STASH = "mesh:lp-distinct-id";
  * (URL submitted → slides viewed → CTA) into the signed-up user.
  *
  * Two guards:
- * - the param is stashed in sessionStorage (survives the auth round-trip)
- *   and scrubbed from the URL so it can't be copied around;
- * - it's only honored when PostHog has no persisted state on this domain —
- *   a returning visitor keeps their own identity even if they open a
- *   forwarded LP link carrying someone else's id.
+ * - the param is stashed in localStorage (survives the auth round-trip and
+ *   tab changes, expires after LP_STASH_TTL_MS) and scrubbed from the URL so
+ *   it can't be copied around;
+ * - the BOOTSTRAP is only honored when PostHog has no persisted state on this
+ *   domain — a returning visitor keeps their own identity. For that returning
+ *   case the merge happens at login instead: see mergeLpPersonOnLogin.
  */
 function lpBootstrapDistinctId(): string | undefined {
   try {
     const url = new URL(window.location.href);
     const fromUrl = url.searchParams.get("ph_did");
     if (fromUrl) {
-      sessionStorage.setItem(LP_DISTINCT_ID_STASH, fromUrl);
+      window.localStorage.setItem(
+        LP_DISTINCT_ID_STASH,
+        JSON.stringify({ id: fromUrl, ts: Date.now() }),
+      );
       url.searchParams.delete("ph_did");
       window.history.replaceState(window.history.state, "", url.toString());
     }
-    const candidate = fromUrl ?? sessionStorage.getItem(LP_DISTINCT_ID_STASH);
+    const candidate = fromUrl ?? readLpStash();
     if (!candidate) return undefined;
     const hasOwnState = Object.keys(window.localStorage).some(
       (k) => k.startsWith("ph_") && k.endsWith("_posthog"),
@@ -50,6 +80,28 @@ function lpBootstrapDistinctId(): string | undefined {
     return hasOwnState ? undefined : candidate;
   } catch {
     return undefined;
+  }
+}
+
+/**
+ * Merge the LP journey into the just-identified user even when the bootstrap
+ * was skipped — the RETURNING-browser case (any prior studio visit leaves
+ * persisted PostHog state), which is most logins. `$create_alias` merges the
+ * still-anonymous LP person into the current identified person; PostHog
+ * refuses identified↔identified merges, so a stale or forwarded id can never
+ * pull another ACCOUNT's history — only anonymous LP browsing. One-shot: the
+ * stash is cleared after the attempt. When the bootstrap DID run, the alias
+ * is a no-op (both ids already point at the same person).
+ */
+function mergeLpPersonOnLogin(userId: string) {
+  const lpDistinctId = readLpStash();
+  if (!lpDistinctId) return;
+  clearLpStash();
+  if (lpDistinctId === userId) return;
+  try {
+    posthog.alias(lpDistinctId);
+  } catch {
+    // analytics must never break login
   }
 }
 
@@ -93,6 +145,7 @@ export function identifyUser(
 ) {
   if (!initialized) return;
   posthog.identify(userId, props);
+  mergeLpPersonOnLogin(userId);
 }
 
 export function resetUser() {


### PR DESCRIPTION
## Why

Follow-up to #4303. The `ph_did` bootstrap only applies to browsers with **no persisted PostHog state** on studio — a deliberate guard, but it means every returning visitor (i.e. almost everyone in the current funnel) skips it and their LP journey never merges. Live data confirms the gap: **6 of the 14 LP diagnostic persons (30d) share an IP with an identified studio user** — they logged in, but stayed "(anonymous)" on the LP side of the funnel.

## What

- The `ph_did` stash moves from sessionStorage to **localStorage with a 24h TTL** (survives tab changes and delayed signups).
- **`identifyUser()` now aliases the stashed LP id after `identify()`**: `$create_alias` merges the still-anonymous LP person into the identified user. Safe by construction — PostHog refuses identified↔identified merges, so a stale/forwarded id can only ever attach anonymous LP browsing, never another account's history. One-shot (stash cleared after the attempt); no-op when the bootstrap already ran.

This covers all three arrival cases: fresh browser (bootstrap), returning known browser (alias on login), already-logged-in browser clicking the LP CTA (alias fires immediately on the session identify).

## Verification

- `bun test posthog-client.test.ts`: 9 pass (4 new: alias fires + one-shot, expired stash ignored, corrupt stash ignored).
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the identity merge gap for returning browsers by aliasing the LP anonymous `distinct_id` on login so LP journeys attach to the signed-in user. Stashes `ph_did` in `localStorage` for 24h and aliases it immediately after `identify()`.

- **Bug Fixes**
  - Stash LP `distinct_id` in `localStorage` (24h TTL); scrub it from the URL.
  - On `identifyUser()`, call `posthog.alias` after `posthog.identify`, then clear the stash (one-shot).
  - Safe by PostHog rules: identified↔identified merges are rejected; no-op if the bootstrap already merged.
  - Bootstrap still only runs on fresh browsers; this covers returners.
  - Tests added for aliasing order, one-shot behavior, and expired/corrupt/missing `localStorage`.

<sup>Written for commit ec35d6cd50d1913fc3e4b75e40964d480518fbf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

