### PR TITLE
posthog: route browser events through first-party proxy

### DIFF
--- a/apps/mesh/src/api/routes/public-config.test.ts
+++ b/apps/mesh/src/api/routes/public-config.test.ts
@@ -41,7 +41,8 @@ describe("GET /api/config", () => {
     expect(body.success).toBe(true);
     expect(body.config.posthog).toEqual({
       key: "phc_test_key",
-      host: "https://us.i.posthog.com",
+      // First-party reverse proxy default (see public-config.ts).
+      host: "https://ph.studio.decocms.com",
     });
   });
 

--- a/apps/mesh/src/api/routes/public-config.ts
+++ b/apps/mesh/src/api/routes/public-config.ts
@@ -70,7 +70,10 @@ export type PublicConfig = {
   };
 };
 
-const POSTHOG_DEFAULT_HOST = "https://us.i.posthog.com";
+// First-party reverse proxy (Cloudflare Worker, repo decocms/posthog-proxy) so
+// ad blockers don't drop browser events. Server-side posthog-node (src/posthog.ts)
+// is unaffected and keeps talking to PostHog directly. POSTHOG_HOST still overrides.
+const POSTHOG_DEFAULT_HOST = "https://ph.studio.decocms.com";
 
 function buildPosthogConfig(): PublicConfig["posthog"] {
   const key = process.env.POSTHOG_KEY;

--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -58,6 +58,10 @@ export function initPostHog(key: string, host: string) {
   const lpDistinctId = lpBootstrapDistinctId();
   posthog.init(key, {
     api_host: host,
+    // api_host is a first-party reverse proxy so ad blockers (which block
+    // *.posthog.com) don't drop events. ui_host must stay real PostHog so the
+    // toolbar and "open in PostHog" links resolve.
+    ui_host: "https://us.posthog.com",
     ...(lpDistinctId ? { bootstrap: { distinctID: lpDistinctId } } : {}),
     capture_pageview: "history_change",
     capture_pageleave: true,


### PR DESCRIPTION
## Why
Ad blockers ship filter lists that block `*.posthog.com`, so a meaningful share of browser `posthog-js` events never reach PostHog. Serving PostHog through a **first-party** domain sidesteps those lists.

## What
- **Browser `api_host` default → `https://ph.studio.decocms.com`** (`public-config.ts`) — a first-party reverse proxy Worker (repo `decocms/posthog-proxy`, US region, already deployed).
- **Add `ui_host: https://us.posthog.com`** to `posthog.init` (`posthog-client.ts`) so the toolbar and "open in PostHog" links resolve while api_host is a proxy.
- **Server-side `posthog-node` untouched** (`src/posthog.ts`) — server events aren't ad-blocked, so they keep talking to PostHog directly (no reason to add proxy hops).

## ⚠️ Deploy note
Host is `POSTHOG_HOST ?? default`. This PR changes the **default**. If a `POSTHOG_HOST` secret is currently set on the deployment, it overrides this — unset it (or set it to the proxy) for the repoint to take effect.

Proxy verified end-to-end: `/static/array.js` → 200, `/i/v0/e/` capture → `{"status":"Ok"}`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route browser analytics through a first‑party proxy to bypass ad blockers and recover client events. Default `posthog-js` `api_host` now points to https://ph.studio.decocms.com with `ui_host` at https://us.posthog.com; server-side `posthog-node` remains direct, and the public-config test now reflects the new default.

- **Migration**
  - If `POSTHOG_HOST` is set, it overrides the new default. Unset it or set it to https://ph.studio.decocms.com to enable the proxy.

<sup>Written for commit a18be94223959673c07a8b0184fde2b1da3baf63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

