### PR TITLE
feat(commerce-discovery): pass claiming user's email + report link on /upgrade

### DIFF
--- a/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
@@ -55,7 +55,8 @@ describe("fetchCommerceDiscoveryAuth", () => {
           org_id: "org_123",
           name: "Acme",
           email: "owner@acme.com",
-          report_url: "https://studio.example.test/commerce-onboarding?org=acme",
+          report_url:
+            "https://studio.example.test/commerce-onboarding?org=acme",
         },
       },
     ]);

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
@@ -18,6 +18,8 @@ describe("fetchCommerceDiscoveryAuth", () => {
         siteUrl: "https://example.com/path",
         orgId: "org_123",
         orgName: "Acme",
+        email: "owner@acme.com",
+        reportUrl: "https://studio.example.test/commerce-onboarding?org=acme",
       },
       {
         baseUrl: "https://commerce.example.test",
@@ -49,7 +51,12 @@ describe("fetchCommerceDiscoveryAuth", () => {
         method: "POST",
         pathname: "/api/v2/internal/diagnostics/example.com/upgrade",
         authorization: "Bearer master-key",
-        body: { org_id: "org_123", name: "Acme" },
+        body: {
+          org_id: "org_123",
+          name: "Acme",
+          email: "owner@acme.com",
+          report_url: "https://studio.example.test/commerce-onboarding?org=acme",
+        },
       },
     ]);
   });

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.ts
@@ -18,6 +18,11 @@ export interface CommerceDiscoveryAuthInput {
   siteUrl: string;
   orgId: string;
   orgName?: string;
+  /** Claiming user's email — Commerce Discovery sends the run-completion
+   *  email (the onboarding "generating" screen's promise) to this address. */
+  email?: string;
+  /** Deep link back to this workspace's report, used in that email. */
+  reportUrl?: string;
 }
 
 export interface CommerceDiscoveryAuthOptions {
@@ -96,6 +101,8 @@ export async function fetchCommerceDiscoveryAuth(
     body: JSON.stringify({
       org_id: input.orgId,
       ...(input.orgName ? { name: input.orgName } : {}),
+      ...(input.email ? { email: input.email } : {}),
+      ...(input.reportUrl ? { report_url: input.reportUrl } : {}),
     }),
   });
 

--- a/apps/mesh/src/tools/commerce-discovery/setup.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.ts
@@ -106,6 +106,16 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
     const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(organization.id);
     const virtualMcpId = getCommerceDiscoveryAgentId(organization.id);
 
+    // Claim contact forwarded on /upgrade: Commerce Discovery emails this
+    // address when the run completes (the "generating" screen's promise),
+    // linking back to this workspace's onboarding report.
+    const claimContact = {
+      email: ctx.auth.user?.email,
+      reportUrl: `${ctx.baseUrl}/commerce-onboarding?org=${encodeURIComponent(
+        organization.slug ?? organization.id,
+      )}&siteUrl=${encodeURIComponent(normalized.value)}`,
+    };
+
     let connection = await ctx.storage.connections.findById(
       connectionId,
       organization.id,
@@ -120,6 +130,7 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
         siteUrl: normalized.value,
         orgId: organization.id,
         orgName: organization.name,
+        ...claimContact,
       });
       if (auth.authorizationToken) {
         console.log("[commerce-discovery] repairing missing auth token", {
@@ -138,6 +149,7 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
         siteUrl: normalized.value,
         orgId: organization.id,
         orgName: organization.name,
+        ...claimContact,
       });
 
       console.log("[commerce-discovery] creating connection", {


### PR DESCRIPTION
Commerce Discovery's onboarding "generating" screen promises an email when the diagnostic is ready. The CD side now sends it (decocms/commerce-discovery#145: `submit_findings` at enrichment end, orchestrator tail as fallback, exactly-once per claim) — but it needs a recipient, which only Studio knows. This forwards the session user's email plus a deep link back to `/commerce-onboarding?org=<slug>&siteUrl=<url>` in the `/upgrade` body (`email` / `report_url`, both optional — CD ignores absent fields). Snapshot-at-claim by design: the claimer is exactly who was promised the email, and it avoids a Studio endpoint exposing user emails to a service token. Covered by the extended `auth-client` test; `COMMERCE_DISCOVERY_SETUP` passes the contact on both the create and token-repair paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the claiming user's email and a deep link to the onboarding report in the Commerce Discovery /upgrade request. This lets Commerce Discovery email the claimer when the diagnostic finishes, as promised on the “generating” screen.

- **New Features**
  - Add optional email and report_url to the `fetchCommerceDiscoveryAuth` payload.
  - In `COMMERCE_DISCOVERY_SETUP`, pass the session user’s email and a report link on both create and token-repair paths.
  - Update tests to assert the new fields are sent.

- **Refactors**
  - Apply `biome` formatting (no functional changes).

<sup>Written for commit a1142596a474966f08742c787434e7ba7a2ab150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

