### PR TITLE
test(shared): cover getConnectionSlug fallback chain and URL parsing

### DIFF
--- a/apps/mesh/src/shared/utils/connection-slug.test.ts
+++ b/apps/mesh/src/shared/utils/connection-slug.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { getConnectionSlug } from "./connection-slug";
+
+describe("getConnectionSlug", () => {
+  it("prefers app_name over everything else", () => {
+    expect(
+      getConnectionSlug({
+        app_name: "vtex",
+        connection_url: "https://example.com",
+        title: "VTEX Store",
+        id: "conn_1",
+      }),
+    ).toBe("vtex");
+  });
+
+  it("derives a slug from host + path when connection_url has no port", () => {
+    expect(
+      getConnectionSlug({ connection_url: "https://Example.com/Foo/Bar/" }),
+    ).toBe("examplecom-foo-bar");
+  });
+
+  it("includes the port in the derived slug when present", () => {
+    expect(
+      getConnectionSlug({ connection_url: "http://localhost:4000/mcp" }),
+    ).toBe("localhost-4000-mcp");
+  });
+
+  it("falls back to slugifying the raw url when it fails to parse", () => {
+    expect(getConnectionSlug({ connection_url: "not a url" })).toBe(
+      "not-a-url",
+    );
+  });
+
+  it("falls back to the slugified title when there is no app_name/connection_url", () => {
+    expect(getConnectionSlug({ title: "My Connection" })).toBe("my-connection");
+  });
+
+  it("falls back to the raw id when there is no app_name/connection_url/title", () => {
+    expect(getConnectionSlug({ id: "conn_1" })).toBe("conn_1");
+  });
+
+  it("falls back to 'unknown' when nothing is present", () => {
+    expect(getConnectionSlug({})).toBe("unknown");
+  });
+});


### PR DESCRIPTION
## Source
No open issue fits; this is Source 3 (missing unit test) — `getConnectionSlug` (`apps/mesh/src/shared/utils/connection-slug.ts`) is a pure, exported function with zero test coverage, despite being used by `groupConnections` to bucket connections in the UI.

## Why
It has a 4-branch fallback chain (`app_name` → `connection_url` host+path → `title` → `id`/`"unknown"`) plus a try/catch around `new URL(...)` for malformed URLs — exactly the kind of branchy pure logic that silently regresses without a test.

## What's covered
- `app_name` takes priority over url/title/id
- URL-derived slug with and without a port
- malformed `connection_url` falls back to slugifying the raw string instead of throwing
- fallback to `title`, then `id`, then `"unknown"`

## Verify
`bun test apps/mesh/src/shared/utils/connection-slug.test.ts`

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` (apps/mesh workspace) — no errors
- `bun test apps/mesh/src/shared/utils/connection-slug.test.ts` — 7 pass

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for getConnectionSlug to cover the full fallback chain and URL parsing, including malformed URLs. This prevents regressions and keeps connection bucketing in the UI consistent.

Verifies priority of app_name, URL-derived slug with/without port, and fallback to title, id, then "unknown".

<sup>Written for commit a0d5a8631f8b264182cd901867308d20f8bf2a60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

