### PR TITLE
fix(mcp-apps): rebind app bridge when iframe re-navigates

### DIFF
--- a/apps/mesh/src/mcp-apps/use-app-bridge.ts
+++ b/apps/mesh/src/mcp-apps/use-app-bridge.ts
@@ -269,6 +269,38 @@ class BridgeStore {
       this.set({ error: "Failed to load app", isLoading: false });
     };
 
+    // Rebind the bridge when the iframe re-navigates. Relocating an iframe in
+    // the DOM (e.g. the tile board reordering/moving tiles) gives it a fresh
+    // browsing context — a new `contentWindow` — WITHOUT React re-firing this
+    // ref. The existing bridge's transport stays bound to the now-dead window,
+    // so the reloaded app's `ui/initialize` never reaches us and it hangs on
+    // "Connecting to host". The initial load is skipped: the ref-time
+    // connectBridge already listens before the app's `connect()` runs.
+    let sawLoad = false;
+    iframe.onload = () => {
+      if (this.disposed) return;
+      if (!sawLoad) {
+        sawLoad = true;
+        return;
+      }
+      this.set({ height: this.config.minHeight, isLoading: true, error: null });
+      this.connectBridge(iframe);
+    };
+
+    this.connectBridge(iframe);
+  };
+
+  /** Build a fresh AppBridge and connect its transport to the iframe's current
+   *  contentWindow. Closes any prior bridge first (reload rebind). */
+  private connectBridge(iframe: HTMLIFrameElement) {
+    this.clearTimeout();
+    this.unsubTheme?.();
+    this.unsubTheme = null;
+    if (this.bridge) {
+      this.bridge.close();
+      this.bridge = null;
+    }
+
     try {
       const { client, displayMode, maxHeight, toolInfo, orgId } = this.config;
       const hostContext = buildHostContext(
@@ -299,7 +331,7 @@ class BridgeStore {
         isLoading: false,
       });
     }
-  };
+  }
 
   // ---- private handler registration ----
 


### PR DESCRIPTION
## Problem

An MCP app embedded in a home-screen **tile** hangs on "Connecting to host…", while the **same app opened in the full view works**.

## Root cause

Both paths render through the same `MCPAppFrame` → `useAppBridge`. The host `AppBridge` binds its `PostMessageTransport` **once**, to the `iframe.contentWindow` captured in the ref callback (`connectTransport`).

The stuck state is diagnostic: the child's own "Connecting to host…" is visible, which means the host overlay `isLoading` is already `false` (otherwise "Loading app…" would cover an `invisible` iframe). That's only possible if the host completed `ui/initialize` against **one** child document but the visible child is a **different** document the transport isn't listening to.

Relocating an `<iframe>` in the DOM gives it a **fresh browsing context (new `contentWindow`) without React re-firing the ref**. The tile is the only consumer living inside the dnd-kit tile board (long-lived, reorderable, tree swaps between mobile/desktop, drag overlay), so it desyncs; the full view mounts its iframe once and never moves it.

The `@modelcontextprotocol/ext-apps` host already handles a re-initialize (`_oninitialize` responds normally to a second `ui/initialize`) — the only missing piece was pointing the transport at the live window.

## Fix

Rebind the bridge on iframe `load` events **after the first**, reconnecting the transport to the current `contentWindow`. The initial load keeps the ref-time bridge (it's already listening before the app's `connect()` runs, so no first-load race). Harmless to the working same-window reload case; fixes the new-window case.

## Testing

- `bun run fmt` ✅
- typecheck of `use-app-bridge.ts` ✅
- ⚠️ Not yet reproduced/verified live (Chrome extension wasn't connected during authoring). Reviewer/author should confirm against a tile embedding e.g. `decocms/commerce-discovery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP apps embedded in home-screen tiles getting stuck on "Connecting to host" by rebinding the app bridge when the iframe re-navigates. First load behavior is unchanged; subsequent loads rebind to the live `contentWindow`.

- **Bug Fixes**
  - Cause: moving the iframe creates a new browsing context; the transport stayed bound to the old window.
  - Change: rebind `AppBridge` on iframe `load` after the first via `connectBridge()`, which closes the previous bridge, resets loading state, and reconnects to the current `contentWindow`.

<sup>Written for commit 3054b686550cd736c52c438dcdf93cec48b8efec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

