### PR TITLE
feat(blog): add Table block editor (DECO-5396)

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-registry.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/block-registry.tsx
@@ -21,6 +21,7 @@ import {
   StepsBlock,
 } from "./list-blocks";
 import { ProductCardBlock, ProductShelfBlock } from "./product-blocks";
+import { TableBlock } from "./table-block";
 import { blockComponentName, isBlogPostBlockResolveType } from "../blog-data";
 import { str } from "./primitives";
 
@@ -163,6 +164,22 @@ export function BlockEditor({
           <ComparisonBlock
             left={str(block.left)}
             right={str(block.right)}
+            onChange={(next) => onChange({ ...block, ...next })}
+          />
+        );
+      case "Table":
+        return (
+          <TableBlock
+            headers={
+              typeof block.headers === "string"
+                ? block.headers
+                : JSON.stringify(block.headers ?? [])
+            }
+            rows={
+              typeof block.rows === "string"
+                ? block.rows
+                : JSON.stringify(block.rows ?? [])
+            }
             onChange={(next) => onChange({ ...block, ...next })}
           />
         );

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/table-block.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/table-block.tsx
@@ -1,0 +1,196 @@
+import { Plus, Trash01 } from "@untitledui/icons";
+import { AddButton, parseJsonArray, str } from "./primitives";
+
+/**
+ * Inline editor for the blog Table block (`blog/sections/blocks/Table.tsx`).
+ * The section stores `headers` as a JSON-encoded `string[]` and `rows` as a
+ * JSON-encoded `string[][]` (body rows × cells), each tolerant of already
+ * being an array. Cells accept inline HTML (the section sanitizes them), but
+ * the editor keeps plain text inputs — authors type text and the grid stays
+ * legible.
+ *
+ * A fresh block (no stored headers/rows) starts from a 2×2 template — two
+ * headers and two rows — so authors see a usable grid immediately. Once data
+ * exists the grid can shrink down to a single column and a single row, so
+ * deleting the second header actually removes it. Header cells left entirely
+ * blank persist as `[]` so the site renders no header row, matching the
+ * section's optional-header semantics — the editor still shows the blank
+ * header inputs so the columns stay labelable after a reload.
+ */
+
+const TEMPLATE_COLS = 2;
+const TEMPLATE_ROWS = 2;
+
+function parseHeaders(value: unknown): string[] {
+  return parseJsonArray<unknown>(value).map(str);
+}
+
+function parseRows(value: unknown): string[][] {
+  return parseJsonArray<unknown>(value).map((row) =>
+    Array.isArray(row) ? row.map(str) : [],
+  );
+}
+
+function emptyRow(cols: number): string[] {
+  return Array.from({ length: cols }, () => "");
+}
+
+export function TableBlock({
+  headers,
+  rows,
+  onChange,
+}: {
+  headers: string;
+  rows: string;
+  onChange: (next: { headers: string; rows: string }) => void;
+}) {
+  const head = parseHeaders(headers);
+  const body = parseRows(rows);
+
+  // A never-edited block has neither headers nor rows — show the starter
+  // template. Any stored data (even a single blank cell) opts out of it, so
+  // the grid can shrink to one column / one row.
+  const isEmpty = head.length === 0 && body.length === 0;
+  const colCount = isEmpty
+    ? TEMPLATE_COLS
+    : Math.max(head.length, ...body.map((row) => row.length), 1);
+
+  // Pad the parsed data out to a rectangular grid so every render has a
+  // consistent column count regardless of ragged stored rows.
+  const displayHead = Array.from({ length: colCount }, (_, c) => head[c] ?? "");
+  const displayBody = isEmpty
+    ? Array.from({ length: TEMPLATE_ROWS }, () => emptyRow(colCount))
+    : body.map((row) =>
+        Array.from({ length: colCount }, (_, c) => row[c] ?? ""),
+      );
+
+  const commit = (nextHead: string[], nextBody: string[][]) =>
+    onChange({
+      // A fully blank header row collapses to [] → no <thead> on the site.
+      headers: JSON.stringify(
+        nextHead.some((cell) => cell.trim() !== "") ? nextHead : [],
+      ),
+      rows: JSON.stringify(nextBody),
+    });
+
+  const setHeader = (c: number, value: string) =>
+    commit(
+      displayHead.map((cell, i) => (i === c ? value : cell)),
+      displayBody,
+    );
+
+  const setCell = (r: number, c: number, value: string) =>
+    commit(
+      displayHead,
+      displayBody.map((row, ri) =>
+        ri === r ? row.map((cell, ci) => (ci === c ? value : cell)) : row,
+      ),
+    );
+
+  const addRow = () =>
+    commit(displayHead, [...displayBody, emptyRow(colCount)]);
+
+  const removeRow = (r: number) =>
+    commit(
+      displayHead,
+      displayBody.filter((_, i) => i !== r),
+    );
+
+  const addColumn = () =>
+    commit(
+      [...displayHead, ""],
+      displayBody.map((row) => [...row, ""]),
+    );
+
+  const removeColumn = (c: number) =>
+    commit(
+      displayHead.filter((_, i) => i !== c),
+      displayBody.map((row) => row.filter((_, i) => i !== c)),
+    );
+
+  return (
+    <div className="space-y-2">
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="bg-muted/40">
+              {displayHead.map((cell, c) => (
+                <th
+                  key={c}
+                  className="group/col relative border-b border-r p-0 last:border-r-0"
+                >
+                  <input
+                    value={cell}
+                    onChange={(e) => setHeader(c, e.target.value)}
+                    placeholder={`Header ${c + 1}`}
+                    className="w-full border-0 bg-transparent py-2 pl-7 pr-3 text-xs font-semibold uppercase tracking-wide outline-none placeholder:text-muted-foreground/40 focus:bg-background focus:ring-0"
+                  />
+                  {colCount > 1 && (
+                    <button
+                      type="button"
+                      aria-label={`Remove column ${c + 1}`}
+                      onClick={() => removeColumn(c)}
+                      className="absolute left-0.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground/50 opacity-0 transition-opacity hover:text-destructive group-hover/col:opacity-100 cursor-pointer"
+                    >
+                      <Trash01 size={12} />
+                    </button>
+                  )}
+                </th>
+              ))}
+              <th className="w-8 border-b" />
+            </tr>
+          </thead>
+          <tbody>
+            {displayBody.map((row, r) => (
+              <tr key={r} className="group/item border-b last:border-b-0">
+                {row.map((cell, c) => (
+                  <td key={c} className="border-r p-0 last:border-r-0">
+                    <input
+                      value={cell}
+                      onChange={(e) => setCell(r, c, e.target.value)}
+                      placeholder="—"
+                      className="w-full border-0 bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground/30 focus:bg-muted/30 focus:ring-0"
+                    />
+                  </td>
+                ))}
+                <td className="w-8 text-center align-middle">
+                  {displayBody.length > 1 && (
+                    <button
+                      type="button"
+                      aria-label={`Remove row ${r + 1}`}
+                      onClick={() => removeRow(r)}
+                      className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition-opacity hover:text-destructive group-hover/item:opacity-100 cursor-pointer"
+                    >
+                      <Trash01 size={13} />
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {displayBody.length === 0 && (
+              <tr>
+                <td
+                  colSpan={colCount + 1}
+                  className="px-3 py-4 text-center text-xs text-muted-foreground"
+                >
+                  No rows yet — add one below.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex gap-2">
+        <AddButton label="Add row" onClick={addRow} />
+        <button
+          type="button"
+          onClick={addColumn}
+          className="flex items-center gap-1.5 rounded-md border border-dashed px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground cursor-pointer"
+        >
+          <Plus size={13} />
+          Add column
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -517,6 +517,11 @@ const KNOWN_BLOG_BLOCK_CATALOG: Record<
     description: "Side-by-side comparison",
     iconName: "Columns03",
   },
+  Table: {
+    title: "Table",
+    description: "Rows and columns of structured data",
+    iconName: "Table",
+  },
   ProductCard: {
     title: "Product card",
     description: "Single product",


### PR DESCRIPTION
## Summary

Adds a bespoke inline editor for the blog **Table** block, so editors can build structured/comparison tables in the post editor without writing HTML.

The section itself was added in [`deco-cx/apps#1634`](https://github.com/deco-cx/apps/pull/1634) (merged); that PR explicitly deferred the Studio side (catalog + dispatcher). This is that follow-up.

## Changes

- **`blocks/table-block.tsx`** (new) — `TableBlock` editor. Matches the section's shape: `headers` as a JSON-encoded `string[]` and `rows` as a JSON-encoded `string[][]`, tolerant of already being arrays.
  - Real `<table>` grid of inline inputs; add/remove rows and columns with hover affordances (same pattern as the other collection blocks).
  - Starts from a **2×2 template** (2 headers + 2 rows) on a fresh block; grid can shrink down to a single column/row.
  - A fully-blank header row is persisted as `[]` so the site renders no `<thead>`, matching the section's optional-header semantics.
- **`blocks/block-registry.tsx`** — imports `TableBlock` and adds `case "Table"` to the dispatcher, tolerating string- or array-valued `headers`/`rows`.
- **`blog-data.ts`** — adds a `Table` entry to `KNOWN_BLOG_BLOCK_CATALOG` (`iconName: "Table"`) so the inserter shows a friendly label + icon.

Works whether the section arrives as an app block (`blog/sections/blocks/Table.tsx`) or as a site block (`site/sections/Blog/Post/Table.tsx`) — `isBlogPostBlockResolveType` accepts both prefixes and `blockComponentName` resolves `"Table"` from either.

## Testing

- `bun run fmt` clean
- `tsc --noEmit` clean
- `bun test` for the blog editor: 76 pass / 0 fail

## Notes

The block only surfaces in the ⊕ picker once the target site's live manifest includes the Table section (i.e. after the site upgrades its `deco-cx/apps` dependency to a release containing #1634).

Refs DECO-5396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an inline editor for the blog Table block so authors can build structured/comparison tables without HTML. Completes DECO-5396 by wiring the Table editor into the dispatcher and inserter for both app and site Table sections.

- **New Features**
  - Real table grid with inline inputs and hover add/remove controls.
  - Starts as 2×2; can shrink to 1×1; add/remove rows and columns.
  - Persists `headers` as JSON `string[]` and `rows` as JSON `string[][]`; accepts string or array; blank header saves as `[]` to hide the table header.

- **Migration**
  - The block appears in the inserter after the site updates to a `deco-cx/apps` release that includes the Table section.

<sup>Written for commit e63de46458f83f3b5512b869484fff725ab1e433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

