### PR TITLE
test(web): cover lpBootstrapDistinctId URL param, stash, and returning-visitor guard

### DIFF
--- a/apps/mesh/src/web/lib/posthog-client.test.ts
+++ b/apps/mesh/src/web/lib/posthog-client.test.ts
@@ -182,3 +182,93 @@ describe("posthog-client.identifyUser LP merge", () => {
     expect(aliasCalls).toHaveLength(0);
   });
 });
+
+/** Unlike `stubLocalStorage`, exposes stored keys as own enumerable
+ * properties — required because `lpBootstrapDistinctId` reads
+ * `Object.keys(window.localStorage)` directly (real Storage objects do
+ * this natively; our plain get/set/removeItem stub above does not). */
+function stubLocalStorageExposingKeys(seed: Record<string, string> = {}) {
+  const stub: Record<string, unknown> = { ...seed };
+  stub.getItem = (k: string) => (k in stub ? (stub[k] as string) : null);
+  stub.setItem = (k: string, v: string) => {
+    stub[k] = v;
+  };
+  stub.removeItem = (k: string) => {
+    delete stub[k];
+  };
+  (globalThis.window as { localStorage?: unknown }).localStorage = stub;
+  return stub;
+}
+
+function stubLocationAndHistory(href: string) {
+  const win = globalThis.window as { location?: unknown; history?: unknown };
+  win.location = { href };
+  const replaceStateCalls: unknown[][] = [];
+  win.history = {
+    state: null,
+    replaceState: (...args: unknown[]) => {
+      replaceStateCalls.push(args);
+      (win.location as { href: string }).href = args[2] as string;
+    },
+  };
+  return { replaceStateCalls };
+}
+
+describe("posthog-client.initPostHog LP bootstrap", () => {
+  beforeEach(() => {
+    initCalls.length = 0;
+    __resetForTest();
+    delete (globalThis.window as { location?: unknown }).location;
+    delete (globalThis.window as { history?: unknown }).history;
+    delete (globalThis.window as { localStorage?: unknown }).localStorage;
+  });
+
+  test("bootstraps from a ph_did URL param, stashes it, and strips it from the URL", () => {
+    stubLocalStorageExposingKeys();
+    const { replaceStateCalls } = stubLocationAndHistory(
+      "https://app.deco.cx/orgs/acme?ph_did=lp-anon-9&keep=1",
+    );
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    expect(initCalls[0]![1]).toMatchObject({
+      bootstrap: { distinctID: "lp-anon-9" },
+    });
+    expect(replaceStateCalls).toHaveLength(1);
+    const strippedUrl = replaceStateCalls[0]![2] as string;
+    expect(strippedUrl).not.toContain("ph_did");
+    expect(strippedUrl).toContain("keep=1");
+  });
+
+  test("bootstraps from a previously stashed id when no URL param is present", () => {
+    stubLocalStorageExposingKeys({
+      "mesh:lp-distinct-id": JSON.stringify({
+        id: "lp-anon-1",
+        ts: Date.now(),
+      }),
+    });
+    stubLocationAndHistory("https://app.deco.cx/orgs/acme");
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    expect(initCalls[0]![1]).toMatchObject({
+      bootstrap: { distinctID: "lp-anon-1" },
+    });
+  });
+
+  test("skips bootstrap for a returning visitor who already has PostHog state", () => {
+    stubLocalStorageExposingKeys({
+      "mesh:lp-distinct-id": JSON.stringify({
+        id: "lp-anon-1",
+        ts: Date.now(),
+      }),
+      ph_phc_test_posthog: JSON.stringify({ distinct_id: "existing-user" }),
+    });
+    stubLocationAndHistory("https://app.deco.cx/orgs/acme");
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    expect(initCalls[0]![1]).not.toHaveProperty("bootstrap");
+  });
+
+  test("omits bootstrap entirely when there is no URL param or stash", () => {
+    stubLocalStorageExposingKeys();
+    stubLocationAndHistory("https://app.deco.cx/orgs/acme");
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    expect(initCalls[0]![1]).not.toHaveProperty("bootstrap");
+  });
+});


### PR DESCRIPTION
## Source
Improvement (Source 3, Option A) — `lpBootstrapDistinctId` in `apps/mesh/src/web/lib/posthog-client.ts` had no test coverage at all. It's real branching logic (URL query-param extraction + stash write + URL scrubbing + a returning-visitor guard checked against `Object.keys(window.localStorage)`) that silently gates the cross-subdomain LP→signup identity merge — a regression here wouldn't fail loudly, it would just quietly stop merging marketing-site journeys into signed-up users.

## What this covers
Exercises `lpBootstrapDistinctId` indirectly through `initPostHog`'s `bootstrap` option, since it isn't exported directly:
- bootstraps from a `ph_did` URL param, stashes it in localStorage, and strips the param from the URL (via `history.replaceState`) while preserving other query params
- falls back to a previously stashed id when there's no URL param
- skips the bootstrap for a returning visitor who already has PostHog state on this domain (any `ph_..._posthog` localStorage key)
- omits the `bootstrap` option entirely when there's no candidate id

No production code changed — test-only addition.

## Verify
```
bun run fmt
cd apps/mesh && bun x tsc --noEmit
bun test apps/mesh/src/web/lib/posthog-client.test.ts
```

Ran locally: `bun run fmt` (clean), `tsc --noEmit` in `apps/mesh` (clean), and the single test file above (13 pass, 0 fail). Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds test coverage for the LP identity bootstrap (`lpBootstrapDistinctId`) through `initPostHog`’s `bootstrap` option to safeguard cross-subdomain LP→signup identity merging.
Covers extracting `ph_did` from the URL, stashing to `localStorage`, scrubbing the param while preserving others, falling back to a stashed id, skipping bootstrap when any `ph_*_posthog` key exists, and omitting `bootstrap` when no candidate id is present.

<sup>Written for commit 0238445f98b922f78a2525248c7cea03b25d4f3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

