### PR TITLE
test(shared): cover groupConnections grouping and ordering

### DIFF
--- a/apps/mesh/src/shared/utils/group-connections.test.ts
+++ b/apps/mesh/src/shared/utils/group-connections.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import type { ConnectionEntity } from "@decocms/mesh-sdk";
+import { groupConnections } from "./group-connections";
+
+/** Minimal stand-in — grouping only reads app_name/title/icon/connection_url. */
+const conn = (fields: Partial<ConnectionEntity>) =>
+  ({
+    id: "id",
+    title: "Connection",
+    app_name: null,
+    connection_url: null,
+    icon: null,
+    ...fields,
+  }) as unknown as ConnectionEntity;
+
+describe("groupConnections", () => {
+  it("keeps a connection with a unique slug as a single item", () => {
+    const a = conn({ id: "a", app_name: "vtex", title: "VTEX" });
+    expect(groupConnections([a])).toEqual([{ type: "single", connection: a }]);
+  });
+
+  it("groups multiple connections sharing the same app_name", () => {
+    const a = conn({ id: "a", app_name: "vtex", title: "VTEX (1)", icon: "i" });
+    const b = conn({ id: "b", app_name: "vtex", title: "VTEX (2)" });
+    const result = groupConnections([a, b]);
+    expect(result).toEqual([
+      {
+        type: "group",
+        key: "vtex",
+        icon: "i",
+        title: "VTEX",
+        connections: [a, b],
+      },
+    ]);
+  });
+
+  it("does not strip a numeric suffix from the title when app_name is absent", () => {
+    const a = conn({ id: "a", title: "Server (1)" });
+    const b = conn({ id: "b", title: "Server (1)" });
+    const result = groupConnections([a, b]);
+    expect(result).toEqual([
+      {
+        type: "group",
+        key: "server-1",
+        icon: null,
+        title: "Server (1)",
+        connections: [a, b],
+      },
+    ]);
+  });
+
+  it("preserves first-seen order across singles and groups", () => {
+    const a = conn({ id: "a", app_name: "vtex", title: "VTEX (1)" });
+    const b = conn({ id: "b", app_name: "shopify", title: "Shopify" });
+    const c = conn({ id: "c", app_name: "vtex", title: "VTEX (2)" });
+    const result = groupConnections([a, b, c]);
+    expect(
+      result.map((item) =>
+        item.type === "single" ? item.connection.id : item.key,
+      ),
+    ).toEqual(["vtex", "b"]);
+  });
+});


### PR DESCRIPTION
## Source
A small improvement (Source 3, option A): `groupConnections` (`apps/mesh/src/shared/utils/group-connections.ts`) had no test file, despite being pure logic used to render the connections list and the virtual-MCP add-connection dialog.

## Why
This function decides how connections are visually bucketed (single card vs. a grouped card with a trimmed title) — a regression here silently changes what users see in two different UI surfaces. A test locks in the grouping-by-slug behavior, the `(N)` suffix stripping (which only applies when `app_name` is present), and first-seen ordering.

## What's covered
- a connection with a unique slug stays a `single` item
- multiple connections sharing an `app_name` are merged into a `group`, with the numeric `(N)` suffix stripped from the shared title
- the same numeric suffix is preserved verbatim when `app_name` is absent (slug falls back to the title, so two identical titles still group, but the display title isn't rewritten)
- singles and groups keep their first-seen order

## How to verify
```
bun test apps/mesh/src/shared/utils/group-connections.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` (apps/mesh workspace)
- `bun test apps/mesh/src/shared/utils/group-connections.test.ts` (4 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `groupConnections` to verify grouping and ordering used by the connections list and the virtual-MCP add-connection dialog. Covers single vs. group, grouping by `app_name` with numeric "(N)" stripping, preserving the suffix when `app_name` is absent, and first-seen ordering.

<sup>Written for commit fed3b6d30964b7ef63e79cf8acbd0b25709ac3ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

