### PR TITLE
fix(commerce-onboarding): truncate companion item labels

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.test.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.test.tsx
@@ -1,0 +1,26 @@
+import { setupComponentTest } from "../../../../test/setup";
+setupComponentTest();
+
+import { describe, expect, it } from "bun:test";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SelectableList } from "./selectable-list.tsx";
+
+describe("SelectableList", () => {
+  it("constrains long option labels so they truncate inside the row", () => {
+    const longLabel =
+      "https://www.example.com/a/very/long/google/search/console/site/url/that/should/not/stretch/the/dialog";
+
+    const { getByRole, getByText } = render(
+      <SelectableList
+        options={[{ value: "site", label: longLabel }]}
+        value="site"
+        onChange={() => {}}
+        ariaLabel="Site verificado"
+      />,
+    );
+
+    expect(getByRole("radio", { name: longLabel })).toHaveClass("min-w-0");
+    expect(getByText(longLabel)).toHaveClass("min-w-0", "flex-1", "truncate");
+  });
+});

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/selectable-list.tsx
@@ -122,7 +122,7 @@ export function SelectableList({
                 onClick={() => onChange(option.value)}
                 onKeyDown={handleKeyDown}
                 className={cn(
-                  "flex w-full items-center justify-between gap-2 rounded-sm px-2 py-2 text-left text-sm",
+                  "flex min-w-0 w-full items-center justify-between gap-2 rounded-sm px-2 py-2 text-left text-sm",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   "disabled:pointer-events-none disabled:opacity-50",
                   selected
@@ -130,7 +130,7 @@ export function SelectableList({
                     : "text-foreground hover:bg-muted/50",
                 )}
               >
-                <span className="truncate">{option.label}</span>
+                <span className="min-w-0 flex-1 truncate">{option.label}</span>
                 {selected ? (
                   <CheckCircle size={16} className="shrink-0 text-primary" />
                 ) : null}


### PR DESCRIPTION
## Summary
- Constrain companion MCP selectable rows so long GA property and GSC site labels truncate inside the dialog.
- Add component coverage for long selectable labels.

## Test Plan
- [x] bun test apps/mesh/src/web/routes/commerce-onboarding

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncates long GA property and GSC site labels in the Commerce onboarding companion list so the dialog doesn’t stretch.

- **Bug Fixes**
  - Constrain row button with min-w-0 to enable truncation.
  - Set label span to min-w-0 flex-1 truncate to keep text inside the row.
  - Add a unit test for long labels in `SelectableList`.

<sup>Written for commit 7f6402c3c4c8a0a4938cb00d451d2d021ca5c1ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

