### PR TITLE
test(web): cover getStatusConfig default and unknown-status fallback

### DIFF
--- a/apps/mesh/src/web/lib/task-status.test.ts
+++ b/apps/mesh/src/web/lib/task-status.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { getStatusConfig, STATUS_CONFIG } from "./task-status";
+
+describe("getStatusConfig", () => {
+  test("returns the matching config for each known status key", () => {
+    for (const key of Object.keys(STATUS_CONFIG) as Array<
+      keyof typeof STATUS_CONFIG
+    >) {
+      expect(getStatusConfig(key)).toBe(STATUS_CONFIG[key]);
+    }
+  });
+
+  test("defaults to completed when status is undefined", () => {
+    expect(getStatusConfig(undefined)).toBe(STATUS_CONFIG.completed);
+  });
+
+  test("falls back to the unknown config for an unrecognized status", () => {
+    const config = getStatusConfig("bogus_status");
+    expect(config.label).toBe("Unknown");
+    expect(config).not.toBe(STATUS_CONFIG.completed);
+  });
+
+  test("falls back to the unknown config for an empty string", () => {
+    expect(getStatusConfig("").label).toBe("Unknown");
+  });
+});


### PR DESCRIPTION
## Source
Small improvement (Source 3) — `getStatusConfig` in `apps/mesh/src/web/lib/task-status.ts` had no test coverage.

## Why
`getStatusConfig` has non-obvious fallback logic: an `undefined` status silently defaults to `"completed"`, while any unrecognized string falls back to a distinct `UNKNOWN` config. Neither branch was covered, so a future edit to the fallback chain (e.g. changing the default status) could regress silently.

## What's covered
- Every known `StatusKey` maps to its own `STATUS_CONFIG` entry.
- `undefined` → `STATUS_CONFIG.completed`.
- An unrecognized string and an empty string → the `UNKNOWN` config.

## Verify
```
bun test apps/mesh/src/web/lib/task-status.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh`
- `bun test apps/mesh/src/web/lib/task-status.test.ts` (4 pass)

Full CI will run lint/typecheck/tests across the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `getStatusConfig` to cover fallback behavior and status-to-config mapping. Verifies each known status returns its `STATUS_CONFIG`, `undefined` defaults to `completed`, and empty or unrecognized strings use the Unknown config.

<sup>Written for commit fef94d5146a19aec9d289d07924c163fd1c72055. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

