### PR TITLE
test(harness): cover resolveModeConfig branches for all chat modes

### DIFF
--- a/packages/harness/src/decopilot/mode-config.test.ts
+++ b/packages/harness/src/decopilot/mode-config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { resolveModeConfig } from "./mode-config";
+
+describe("resolveModeConfig", () => {
+  it("default mode forces nothing and injects no prompts", () => {
+    const config = resolveModeConfig("default", { isCliAgent: false });
+    expect(config).toEqual({
+      isPlanMode: false,
+      forcedFirstStepTool: null,
+      planPrompt: null,
+      webSearchInstructionPrompt: null,
+    });
+  });
+
+  it("plan mode sets isPlanMode and builds a planPrompt, no tool forcing", () => {
+    const config = resolveModeConfig("plan", { isCliAgent: false });
+    expect(config.isPlanMode).toBe(true);
+    expect(config.forcedFirstStepTool).toBeNull();
+    expect(config.webSearchInstructionPrompt).toBeNull();
+    expect(config.planPrompt).toContain("propose_plan");
+  });
+
+  it("plan mode drops the propose_plan requirement for CLI agents", () => {
+    const config = resolveModeConfig("plan", { isCliAgent: true });
+    expect(config.planPrompt).not.toContain("propose_plan");
+    expect(config.planPrompt).toContain("plan mode");
+  });
+
+  it("web-search mode forces web_search and injects the search instruction prompt", () => {
+    const config = resolveModeConfig("web-search", { isCliAgent: false });
+    expect(config.isPlanMode).toBe(false);
+    expect(config.forcedFirstStepTool).toBe("web_search");
+    expect(config.planPrompt).toBeNull();
+    expect(config.webSearchInstructionPrompt).toContain("web_search");
+  });
+
+  it("deep-research mode forces deep_research and shares the search instruction prompt", () => {
+    const config = resolveModeConfig("deep-research", { isCliAgent: false });
+    expect(config.forcedFirstStepTool).toBe("deep_research");
+    expect(config.webSearchInstructionPrompt).toContain("deep_research");
+  });
+
+  it("gen-image mode forces generate_image with no instruction prompt", () => {
+    const config = resolveModeConfig("gen-image", { isCliAgent: false });
+    expect(config.forcedFirstStepTool).toBe("generate_image");
+    expect(config.webSearchInstructionPrompt).toBeNull();
+    expect(config.planPrompt).toBeNull();
+  });
+});


### PR DESCRIPTION
## Source
Improvement (Source 3, Option A) — `resolveModeConfig` in `packages/harness/src/decopilot/mode-config.ts` had no test coverage at all despite branching over 5 chat modes and a CLI-agent flag that changes the generated plan prompt.

## Why
This function decides tool-forcing and prompt injection for every decopilot chat turn (default/plan/web-search/deep-research/gen-image). A regression here (e.g. wrong mode → wrong forced tool, or losing the CLI-agent branch in `buildPlanPrompt`) would silently misroute tool calls with no test to catch it.

## What's covered
- `default`: no forcing, no prompts
- `plan`: `isPlanMode` true, `propose_plan` required in the prompt for non-CLI agents, omitted for CLI agents
- `web-search` / `deep-research`: correct forced tool + shared web-search instruction prompt
- `gen-image`: forces `generate_image`, no instruction prompt

## Verify
`bun test packages/harness/src/decopilot/mode-config.test.ts`

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/harness` (clean)
- `bun test packages/harness/src/decopilot/mode-config.test.ts` (6 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added tests for `resolveModeConfig` in `packages/harness` covering all chat modes (default, plan, web-search, deep-research, gen-image) and the CLI-agent branch. Ensures correct tool forcing and prompt injection don’t regress.

<sup>Written for commit ef8b507c40b3e20544a185fa02e6ce6d1ba45310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

