### PR TITLE
test(commerce-onboarding): cover buildCompanionCards icon fallback branches

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -307,6 +307,33 @@ describe("buildCompanionCards", () => {
     expect(cards[0]!.satisfied).toBe(false);
     expect(cards[0]!.candidateConnectionId).toBe("c_vtex");
   });
+  it("falls back to a GitHub avatar when the registry item has no icons", () => {
+    const cards = buildCompanionCards({
+      requirements: [{ fieldKey: "SHOP", bindingType: "shopify" }],
+      itemsById: {},
+      itemsByName: {
+        shopify: {
+          id: "deco/shopify",
+          server: { repository: "https://github.com/deco-cx/shopify" },
+        },
+      },
+      connections: [],
+      configurationState: null,
+      curated,
+    });
+    expect(cards[0]!.icon).toContain("images.weserv.nl");
+  });
+  it("has a null icon when the registry item has neither icons nor a repository", () => {
+    const cards = buildCompanionCards({
+      requirements: [{ fieldKey: "SHOP", bindingType: "shopify" }],
+      itemsById: {},
+      itemsByName: { shopify: { id: "deco/shopify" } },
+      connections: [],
+      configurationState: null,
+      curated,
+    });
+    expect(cards[0]!.icon).toBeNull();
+  });
 });
 
 describe("matchGscSite", () => {


### PR DESCRIPTION
## Source
A missing-test gap found while reading recently-changed commerce-onboarding files (no open issue covers this).

## Why
`buildCompanionCards` in `companions-core.ts` picks a card's icon via a private `cardIcon` helper that falls back from `server.icons[0].src` to a GitHub-avatar proxy URL derived from `server.repository`, and finally to `null`. Every existing test fixture supplies `icons`, so the fallback-to-repository and fallback-to-null branches were completely unexercised — a regression there (e.g. breaking the repository-URL fallback) would ship silently.

## What changed
Added two cases to the existing `buildCompanionCards` describe block:
- registry item with no `icons` but a `server.repository` → icon resolves through `getGitHubAvatarUrl`
- registry item with neither `icons` nor `repository` → icon is `null`

## Verify
```
bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts` (40 pass, 0 fail)

Full CI will run typecheck/lint/full suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to cover buildCompanionCards icon fallback. Verifies the GitHub avatar proxy is used when a registry item has no icons, and null is returned when neither icons nor repository are provided.

<sup>Written for commit 4fcb509b60e6afd0f164f19b9e97620da4895784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

