### PR TITLE
fix(library): use container queries for responsive card grid

### DIFF
--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -133,8 +133,10 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 
 function CardsGrid({ children }: { children: React.ReactNode }) {
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {children}
+    <div className="@container">
+      <div className="grid grid-cols-1 gap-3 @[440px]:grid-cols-2 @[660px]:grid-cols-3">
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What is this contribution about?

The Library page card grid used viewport-based Tailwind breakpoints (`sm:grid-cols-2 lg:grid-cols-3`). Because the Library lives inside a resizable panel (~55% of the viewport), the 3-column layout would apply at `lg` (1024px viewport) even though the panel itself was only ~550px wide — squishing folder card text into broken multi-line wraps.

Replaced with CSS container queries (`@[440px]:grid-cols-2 @[660px]:grid-cols-3`) so the column count responds to the panel's actual width rather than the viewport.

## Screenshots/Demonstration

Before: 3 narrow columns at 1024px+ viewport causing text overflow in folder cards.  
After: 2 columns in the ~550px panel, 3 only when the panel is genuinely wide enough.

## How to Test

1. Open the Library page (`/$org/files`) on a desktop viewport ≥ 1024px wide.
2. Confirm the Folders section shows 2 columns (not 3) when the preview panel is closed.
3. Open a file preview — the library panel narrows; confirm it stays at 2 columns or drops to 1 without text overflow.
4. Widen the library panel past ~660px and confirm it expands to 3 columns cleanly.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Library card grid to CSS container queries so columns follow the panel width, fixing squished folder text in narrow panels. Now it shows 2 columns in ~550px panels and only jumps to 3 when the panel is truly wide enough.

- **Bug Fixes**
  - Wrapped the grid in `@container` and replaced viewport breakpoints with `@[440px]:grid-cols-2` and `@[660px]:grid-cols-3`.
  - Column count is now based on container width: 1 by default, 2 at ≥440px, 3 at ≥660px.

<sup>Written for commit 247473560fe45b7244eb7539ba301bf38cba8be3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

