### PR TITLE
test(web): cover readLastLocation edge cases and storage failure handling

### DIFF
--- a/apps/mesh/src/web/lib/last-location.test.ts
+++ b/apps/mesh/src/web/lib/last-location.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  clearLastLocation,
+  readLastLocation,
+  saveLastLocation,
+} from "./last-location";
+
+/** Minimal localStorage stub — Bun's test runtime has no DOM/localStorage. */
+function stubLocalStorage(seed: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...seed };
+  return {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+  };
+}
+
+describe("last-location", () => {
+  beforeEach(() => {
+    (globalThis as { localStorage?: unknown }).localStorage =
+      stubLocalStorage();
+  });
+  afterEach(() => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  test("round-trips a full location", () => {
+    saveLastLocation({ org: "acme", taskId: "t1", virtualmcpid: "v1" });
+    expect(readLastLocation()).toEqual({
+      org: "acme",
+      taskId: "t1",
+      virtualmcpid: "v1",
+    });
+  });
+
+  test("returns null when nothing is stored", () => {
+    expect(readLastLocation()).toBeNull();
+  });
+
+  test("returns null for corrupt JSON", () => {
+    (globalThis.localStorage as Storage).setItem(
+      "mesh:last-location",
+      "not json",
+    );
+    expect(readLastLocation()).toBeNull();
+  });
+
+  test("returns null when org is missing or not a string", () => {
+    (globalThis.localStorage as Storage).setItem(
+      "mesh:last-location",
+      JSON.stringify({ taskId: "t1" }),
+    );
+    expect(readLastLocation()).toBeNull();
+  });
+
+  test("drops non-string taskId/virtualmcpid but keeps org", () => {
+    (globalThis.localStorage as Storage).setItem(
+      "mesh:last-location",
+      JSON.stringify({ org: "acme", taskId: 42, virtualmcpid: null }),
+    );
+    expect(readLastLocation()).toEqual({ org: "acme" });
+  });
+
+  test("clearLastLocation removes the stored value", () => {
+    saveLastLocation({ org: "acme" });
+    clearLastLocation();
+    expect(readLastLocation()).toBeNull();
+  });
+
+  test("save/read/clear swallow localStorage failures", () => {
+    (globalThis as { localStorage?: unknown }).localStorage = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    };
+    expect(() => saveLastLocation({ org: "acme" })).not.toThrow();
+    expect(readLastLocation()).toBeNull();
+    expect(() => clearLastLocation()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Source
Missing unit test — `apps/mesh/src/web/lib/last-location.ts` is a pure helper (save/read/clear the "where the user last was" localStorage record used to restore cold-start navigation) with no test coverage at all.

## Why
`readLastLocation` has several silent-failure branches (corrupt JSON, missing/non-string `org`, non-string `taskId`/`virtualmcpid`, a throwing `localStorage`) that are easy to regress without anyone noticing, since a broken restore just silently sends users to the org home instead of throwing.

## What's covered
- round-trip save/read of a full location
- `null` when nothing is stored
- `null` on corrupt JSON
- `null` when `org` is missing or not a string
- non-string `taskId`/`virtualmcpid` dropped while `org` is kept
- `clearLastLocation` removes the stored value
- save/read/clear all swallow a throwing `localStorage` (quota/privacy-mode)

## Verify
```
bun test apps/mesh/src/web/lib/last-location.test.ts
```

## Checks run locally
- `bun run fmt` (no changes)
- `bunx tsc --noEmit` in `apps/mesh` (clean)
- `bun test apps/mesh/src/web/lib/last-location.test.ts` (7 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `readLastLocation`, `saveLastLocation`, and `clearLastLocation` to cover edge cases and `localStorage` failures, keeping cold-start navigation restore safe. Tests check round-trip, null on empty/corrupt JSON or invalid/missing `org`, dropping non-string `taskId`/`virtualmcpid` while keeping `org`, clear removes the record, and all operations swallow storage exceptions.

<sup>Written for commit c2fbf95b09bc514b7120f726018e8eb533dfb781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

