### PR TITLE
feat(mesh): mobile UI consistency and drawer improvements

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -503,7 +503,7 @@ export function ChatInput({
                       <button
                         type="button"
                         onClick={handleVoiceCancel}
-                        className="flex items-center justify-center size-8 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                        className="flex items-center justify-center size-10 md:size-8 [&_svg]:size-[18px] md:[&_svg]:size-4 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                         aria-label="Cancel recording"
                       >
                         <X size={16} />
@@ -511,7 +511,7 @@ export function ChatInput({
                       <button
                         type="button"
                         onClick={handleVoiceConfirm}
-                        className="flex items-center justify-center size-8 rounded-lg bg-foreground text-background hover:opacity-80 transition-opacity"
+                        className="flex items-center justify-center size-10 md:size-8 [&_svg]:size-[18px] md:[&_svg]:size-4 rounded-lg bg-foreground text-background hover:opacity-80 transition-opacity"
                         aria-label="Use transcription"
                       >
                         <Check size={16} />
@@ -553,7 +553,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group min-w-0 shrink animate-in fade-in duration-200"
                         >
                           <BookOpen01 size={14} className="shrink-0" />
-                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[320px]/chat-bottom:max-w-32 @[320px]/chat-bottom:opacity-100">
+                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[460px]/chat-bottom:max-w-32 @[460px]/chat-bottom:opacity-100">
                             Plan mode
                           </span>
                           <X
@@ -580,7 +580,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group min-w-0 shrink animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Image01 size={14} className="shrink-0" />
-                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[320px]/chat-bottom:max-w-[120px] @[320px]/chat-bottom:opacity-100">
+                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[460px]/chat-bottom:max-w-[120px] @[460px]/chat-bottom:opacity-100">
                             Create image
                           </span>
                           <X
@@ -607,7 +607,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group min-w-0 shrink animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Globe02 size={14} className="shrink-0" />
-                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[320px]/chat-bottom:max-w-[120px] @[320px]/chat-bottom:opacity-100">
+                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[460px]/chat-bottom:max-w-[120px] @[460px]/chat-bottom:opacity-100">
                             Web search
                           </span>
                           <X
@@ -634,7 +634,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group min-w-0 shrink animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Telescope size={14} className="shrink-0" />
-                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[320px]/chat-bottom:max-w-[120px] @[320px]/chat-bottom:opacity-100">
+                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[460px]/chat-bottom:max-w-[120px] @[460px]/chat-bottom:opacity-100">
                             Deep research
                           </span>
                           <X
@@ -674,7 +674,7 @@ export function ChatInput({
                           variant="ghost"
                           size="icon"
                           className={cn(
-                            "size-8 rounded-lg transition-colors",
+                            "size-10 md:size-8 rounded-lg transition-colors",
                             voice.status === "permission-denied"
                               ? "text-destructive hover:text-destructive hover:bg-destructive/10"
                               : "text-muted-foreground hover:text-foreground",
@@ -685,7 +685,7 @@ export function ChatInput({
                               : "Voice input"
                           }
                         >
-                          <Microphone01 size={18} />
+                          <Microphone01 className="size-[18px]" />
                         </Button>
                       )}
 
@@ -705,7 +705,7 @@ export function ChatInput({
                         size="icon"
                         disabled={!canSubmit && !showStopOrCancel}
                         className={cn(
-                          "size-8 rounded-lg transition-all",
+                          "size-10 md:size-8 rounded-lg transition-all",
                           !canSubmit &&
                             !showStopOrCancel &&
                             "bg-muted text-muted-foreground hover:bg-muted hover:text-muted-foreground cursor-not-allowed",
@@ -719,9 +719,9 @@ export function ChatInput({
                         }
                       >
                         {showStopOrCancel ? (
-                          <Stop size={20} />
+                          <Stop className="size-[18px]" />
                         ) : (
-                          <ArrowUp size={20} />
+                          <ArrowUp className="size-[18px]" />
                         )}
                       </Button>
                     </div>

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -271,6 +271,7 @@ export function ChatInput({
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
+  const navigate = useNavigate();
   const { org, locator } = useProjectContext();
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
   const fullVm = useVirtualMCP(selectedVirtualMcp?.id ?? decopilotId);
@@ -553,7 +554,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group min-w-0 shrink animate-in fade-in duration-200"
                         >
                           <BookOpen01 size={14} className="shrink-0" />
-                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[460px]/chat-bottom:max-w-32 @[460px]/chat-bottom:opacity-100">
+                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[380px]/chat-bottom:max-w-32 @[380px]/chat-bottom:opacity-100">
                             Plan mode
                           </span>
                           <X
@@ -580,7 +581,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group min-w-0 shrink animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Image01 size={14} className="shrink-0" />
-                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[460px]/chat-bottom:max-w-[120px] @[460px]/chat-bottom:opacity-100">
+                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[380px]/chat-bottom:max-w-[120px] @[380px]/chat-bottom:opacity-100">
                             Create image
                           </span>
                           <X
@@ -607,7 +608,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group min-w-0 shrink animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Globe02 size={14} className="shrink-0" />
-                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[460px]/chat-bottom:max-w-[120px] @[460px]/chat-bottom:opacity-100">
+                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[380px]/chat-bottom:max-w-[120px] @[380px]/chat-bottom:opacity-100">
                             Web search
                           </span>
                           <X
@@ -634,7 +635,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group min-w-0 shrink animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Telescope size={14} className="shrink-0" />
-                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[460px]/chat-bottom:max-w-[120px] @[460px]/chat-bottom:opacity-100">
+                          <span className="min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[380px]/chat-bottom:max-w-[120px] @[380px]/chat-bottom:opacity-100">
                             Deep research
                           </span>
                           <X
@@ -661,7 +662,14 @@ export function ChatInput({
                           currentBranch={taskCtx?.currentBranch ?? null}
                         />
                       )}
-                      <TierTrigger />
+                      <TierTrigger
+                        onSettingsClick={() =>
+                          navigate({
+                            to: "/$org/settings/ai-providers",
+                            params: { org: org.slug },
+                          })
+                        }
+                      />
 
                       {/* Microphone button — kept mounted (and disabled)
                           during streaming/run to avoid layout shift when

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
@@ -10,7 +10,14 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@deco/ui/components/drawer.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { Check, ChevronDown, Cloud01, Monitor01 } from "@untitledui/icons";
 import {
   getWellKnownDecopilotVirtualMCP,
@@ -202,6 +209,7 @@ export function ModePickerPure({
   onSelect,
 }: PureProps) {
   const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
   const { icon, text } = locked
     ? harnessPillLabel(mode)
     : editablePillLabel(mode);
@@ -219,48 +227,107 @@ export function ModePickerPure({
     setOpen(false);
   };
 
+  const triggerButton = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="default"
+      aria-label={
+        showHarnessLabel && harnessLabel
+          ? `This chat is using ${harnessLabel} on ${runtimeLabel(mode)}. Start a new chat to use a different runtime.`
+          : labelWithRuntime
+      }
+      disabled={locked}
+      data-testid={locked ? "mode-picker-locked" : "mode-picker"}
+      className={cn(
+        baseClasses,
+        isLocal && localPreviewClasses,
+        "shrink min-w-0",
+        locked ? "gap-0" : "gap-0 @[460px]/chat-bottom:gap-1.5",
+        "h-10 md:h-8",
+      )}
+    >
+      {icon}
+      <span
+        className={cn(
+          "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
+          !locked &&
+            "@[460px]/chat-bottom:max-w-32 @[460px]/chat-bottom:opacity-100",
+        )}
+      >
+        {text}
+      </span>
+      {!locked && (
+        <ChevronDown
+          size={12}
+          className="opacity-60 hidden @[460px]/chat-bottom:inline-block"
+        />
+      )}
+    </Button>
+  );
+
+  const drawerRows = (
+    <div className="px-2 pt-2 pb-6 flex flex-col gap-0.5">
+      {cloudRows.length > 0 && <Section title="Cloud" />}
+      {cloudRows.map((row) => (
+        <Row
+          key={row.mode}
+          row={row}
+          active={mode === row.mode}
+          onSelect={handleSelect}
+          large
+        />
+      ))}
+      {localRows.length > 0 && (
+        <Section
+          title="Local"
+          variant="success"
+          icon={
+            <Monitor01 size={12} data-testid="local-section-desktop-icon" />
+          }
+          testId="local-section-header"
+        />
+      )}
+      {localRows.map((row) => {
+        const available = row.isAvailable(availability);
+        return (
+          <Row
+            key={row.mode}
+            row={row}
+            active={mode === row.mode}
+            onSelect={handleSelect}
+            large
+            unavailableHint={
+              available
+                ? undefined
+                : availability.userDesktop
+                  ? "Not detected on your desktop"
+                  : "Desktop not detected"
+            }
+          />
+        );
+      })}
+    </div>
+  );
+
+  if (isMobile && !locked) {
+    return (
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
+        <DrawerContent className="p-0">
+          <DrawerTitle className="sr-only">Select mode</DrawerTitle>
+          {drawerRows}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
   return (
     <Popover open={open} onOpenChange={locked ? undefined : setOpen}>
       <Tooltip>
         <TooltipTrigger asChild>
           <span className="inline-flex min-w-0 shrink">
-            <PopoverTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="default"
-                aria-label={
-                  showHarnessLabel && harnessLabel
-                    ? `This chat is using ${harnessLabel} on ${runtimeLabel(mode)}. Start a new chat to use a different runtime.`
-                    : labelWithRuntime
-                }
-                disabled={locked}
-                data-testid={locked ? "mode-picker-locked" : "mode-picker"}
-                className={cn(
-                  baseClasses,
-                  isLocal && localPreviewClasses,
-                  "shrink min-w-0",
-                  locked ? "gap-0" : "gap-0 @[320px]/chat-bottom:gap-1.5",
-                )}
-              >
-                {icon}
-                <span
-                  className={cn(
-                    "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
-                    !locked &&
-                      "@[320px]/chat-bottom:max-w-32 @[320px]/chat-bottom:opacity-100",
-                  )}
-                >
-                  {text}
-                </span>
-                {!locked && (
-                  <ChevronDown
-                    size={12}
-                    className="opacity-60 hidden @[320px]/chat-bottom:inline-block"
-                  />
-                )}
-              </Button>
-            </PopoverTrigger>
+            <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
           </span>
         </TooltipTrigger>
         <TooltipContent>
@@ -346,11 +413,13 @@ function Row({
   active,
   onSelect,
   unavailableHint,
+  large,
 }: {
   row: ModeRow;
   active: boolean;
   onSelect: (mode: AgentMode) => void;
   unavailableHint?: string;
+  large?: boolean;
 }) {
   return (
     <button
@@ -358,8 +427,8 @@ function Row({
       role="menuitem"
       onClick={() => onSelect(row.mode)}
       className={cn(
-        "flex items-start gap-2 px-2 py-1.5 rounded-md text-left",
-        "hover:bg-muted",
+        "flex items-start gap-2 rounded-md text-left hover:bg-muted transition-colors",
+        large ? "px-4 py-3 rounded-lg gap-3" : "px-2 py-1.5",
       )}
     >
       <span className="shrink-0 text-muted-foreground mt-0.5">{row.icon}</span>

--- a/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
+++ b/apps/mesh/src/web/components/chat/pills/mode-picker.tsx
@@ -243,7 +243,7 @@ export function ModePickerPure({
         baseClasses,
         isLocal && localPreviewClasses,
         "shrink min-w-0",
-        locked ? "gap-0" : "gap-0 @[460px]/chat-bottom:gap-1.5",
+        locked ? "gap-0" : "gap-0 @[380px]/chat-bottom:gap-1.5",
         "h-10 md:h-8",
       )}
     >
@@ -252,22 +252,17 @@ export function ModePickerPure({
         className={cn(
           "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
           !locked &&
-            "@[460px]/chat-bottom:max-w-32 @[460px]/chat-bottom:opacity-100",
+            "@[380px]/chat-bottom:max-w-32 @[380px]/chat-bottom:opacity-100",
         )}
       >
         {text}
       </span>
-      {!locked && (
-        <ChevronDown
-          size={12}
-          className="opacity-60 hidden @[460px]/chat-bottom:inline-block"
-        />
-      )}
+      {!locked && <ChevronDown size={12} className="opacity-60" />}
     </Button>
   );
 
   const drawerRows = (
-    <div className="px-2 pt-2 pb-6 flex flex-col gap-0.5">
+    <div role="menu" className="px-2 pt-2 pb-6 flex flex-col gap-0.5">
       {cloudRows.length > 0 && <Section title="Cloud" />}
       {cloudRows.map((row) => (
         <Row
@@ -310,9 +305,12 @@ export function ModePickerPure({
     </div>
   );
 
-  if (isMobile && !locked) {
+  if (isMobile) {
     return (
-      <Drawer open={open} onOpenChange={setOpen}>
+      <Drawer
+        open={locked ? false : open}
+        onOpenChange={locked ? undefined : setOpen}
+      >
         <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
         <DrawerContent className="p-0">
           <DrawerTitle className="sr-only">Select mode</DrawerTitle>

--- a/apps/mesh/src/web/components/chat/tier-trigger.tsx
+++ b/apps/mesh/src/web/components/chat/tier-trigger.tsx
@@ -27,8 +27,6 @@ import {
   Stars01,
 } from "@untitledui/icons";
 import type { ChatTier } from "@/tools/organization/schema";
-import { useNavigate } from "@tanstack/react-router";
-import { useProjectContext } from "@decocms/mesh-sdk";
 import { useSimpleMode } from "@/web/hooks/use-organization-settings";
 import {
   resolveTierSubtitle,
@@ -88,7 +86,7 @@ export function TierTriggerPure({
       aria-label={TIER_LABELS[tier]}
       className={cn(
         "text-muted-foreground hover:text-foreground transition-[gap] duration-200 shrink min-w-0",
-        "gap-0 @[460px]/chat-bottom:gap-1.5",
+        "gap-0 @[380px]/chat-bottom:gap-1.5",
         "h-10 md:h-8",
       )}
     >
@@ -96,20 +94,17 @@ export function TierTriggerPure({
       <span
         className={cn(
           "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
-          "@[460px]/chat-bottom:max-w-24 @[460px]/chat-bottom:opacity-100",
+          "@[380px]/chat-bottom:max-w-24 @[380px]/chat-bottom:opacity-100",
         )}
       >
         {TIER_LABELS[tier]}
       </span>
-      <ChevronDown
-        size={12}
-        className="opacity-60 hidden @[460px]/chat-bottom:inline-block"
-      />
+      <ChevronDown size={12} className="opacity-60" />
     </Button>
   );
 
   const drawerRows = (
-    <div className="px-2 pt-2 pb-6 flex flex-col gap-0.5">
+    <div role="menu" className="px-2 pt-2 pb-6 flex flex-col gap-0.5">
       {TIER_ORDER.map((t) => {
         const subtitle = subtitleFor(t);
         const modelLabel = modelLabelFor?.(t);
@@ -119,6 +114,8 @@ export function TierTriggerPure({
           <button
             key={t}
             type="button"
+            role="menuitem"
+            aria-label={TIER_LABELS[t]}
             onClick={() => handleSelect(t)}
             className="flex items-start gap-3 px-4 py-3 rounded-lg text-left hover:bg-muted transition-colors"
           >
@@ -278,12 +275,14 @@ function tierIconFor(tier: ChatTier): ReactNode {
  * Smart wrapper used by `Chat.Input`. Reads current tier + mode, builds
  * the per-tier subtitle resolver, and writes through `useSetChatTier`.
  */
-export function TierTrigger() {
+export function TierTrigger({
+  onSettingsClick,
+}: {
+  onSettingsClick?: () => void;
+}) {
   const tier = useChatTier();
   const setTier = useSetChatTier();
   const mode = useAgentMode();
-  const navigate = useNavigate();
-  const { org } = useProjectContext();
   const simpleMode = useSimpleMode();
 
   const subtitleFor = (t: ChatTier): string | null =>
@@ -298,10 +297,6 @@ export function TierTrigger() {
       }
     : undefined;
 
-  const handleSettingsClick = () => {
-    navigate({ to: "/$org/settings/ai-providers", params: { org: org.slug } });
-  };
-
   return (
     <TierTriggerPure
       tier={tier}
@@ -309,7 +304,7 @@ export function TierTrigger() {
       iconFor={tierIconFor}
       onSelect={setTier}
       modelLabelFor={modelLabelFor}
-      onSettingsClick={handleSettingsClick}
+      onSettingsClick={onSettingsClick}
     />
   );
 }

--- a/apps/mesh/src/web/components/chat/tier-trigger.tsx
+++ b/apps/mesh/src/web/components/chat/tier-trigger.tsx
@@ -10,15 +10,26 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@deco/ui/components/drawer.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import {
   Atom01,
   ChevronDown,
   Check,
   Lightning01,
+  LinkExternal01,
   Stars01,
 } from "@untitledui/icons";
 import type { ChatTier } from "@/tools/organization/schema";
+import { useNavigate } from "@tanstack/react-router";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useSimpleMode } from "@/web/hooks/use-organization-settings";
 import {
   resolveTierSubtitle,
   useAgentMode,
@@ -40,6 +51,10 @@ interface PureProps {
    *  popover row. Omit for a label-only treatment. */
   iconFor?: (tier: ChatTier) => ReactNode;
   onSelect: (tier: ChatTier) => void;
+  /** Optional actual model name for each tier (e.g. "claude-sonnet-4-5"). */
+  modelLabelFor?: (tier: ChatTier) => string | null;
+  /** If provided, renders a settings link at the bottom of the popover. */
+  onSettingsClick?: () => void;
 }
 
 /**
@@ -54,44 +69,122 @@ export function TierTriggerPure({
   subtitleFor,
   iconFor,
   onSelect,
+  modelLabelFor,
+  onSettingsClick,
 }: PureProps) {
   const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+
   const handleSelect = (t: ChatTier) => {
     onSelect(t);
     setOpen(false);
   };
+
+  const triggerButton = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="default"
+      aria-label={TIER_LABELS[tier]}
+      className={cn(
+        "text-muted-foreground hover:text-foreground transition-[gap] duration-200 shrink min-w-0",
+        "gap-0 @[460px]/chat-bottom:gap-1.5",
+        "h-10 md:h-8",
+      )}
+    >
+      {iconFor?.(tier)}
+      <span
+        className={cn(
+          "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
+          "@[460px]/chat-bottom:max-w-24 @[460px]/chat-bottom:opacity-100",
+        )}
+      >
+        {TIER_LABELS[tier]}
+      </span>
+      <ChevronDown
+        size={12}
+        className="opacity-60 hidden @[460px]/chat-bottom:inline-block"
+      />
+    </Button>
+  );
+
+  const drawerRows = (
+    <div className="px-2 pt-2 pb-6 flex flex-col gap-0.5">
+      {TIER_ORDER.map((t) => {
+        const subtitle = subtitleFor(t);
+        const modelLabel = modelLabelFor?.(t);
+        const icon = iconFor?.(t);
+        const active = t === tier;
+        return (
+          <button
+            key={t}
+            type="button"
+            onClick={() => handleSelect(t)}
+            className="flex items-start gap-3 px-4 py-3 rounded-lg text-left hover:bg-muted transition-colors"
+          >
+            {icon && (
+              <span className="shrink-0 text-muted-foreground mt-0.5">
+                {icon}
+              </span>
+            )}
+            <div className="flex-1">
+              <div className="text-sm font-medium">{TIER_LABELS[t]}</div>
+              {subtitle && (
+                <div className="text-xs text-muted-foreground">{subtitle}</div>
+              )}
+              {modelLabel && (
+                <div className="text-xs text-muted-foreground/60 font-mono mt-0.5">
+                  {modelLabel}
+                </div>
+              )}
+            </div>
+            {active && (
+              <Check size={16} className="text-foreground mt-0.5 shrink-0" />
+            )}
+          </button>
+        );
+      })}
+      {onSettingsClick && (
+        <button
+          type="button"
+          onClick={() => {
+            onSettingsClick();
+            setOpen(false);
+          }}
+          className="flex items-start gap-3 px-4 py-3 rounded-lg text-left hover:bg-muted transition-colors border-t border-border/40 mt-1"
+        >
+          <span className="shrink-0 text-muted-foreground mt-0.5">
+            <LinkExternal01 size={18} />
+          </span>
+          <div className="flex-1">
+            <div className="text-sm">Model settings</div>
+            <div className="text-xs text-muted-foreground">
+              Configure which model runs each tier
+            </div>
+          </div>
+        </button>
+      )}
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
+        <DrawerContent className="p-0">
+          <DrawerTitle className="sr-only">Select tier</DrawerTitle>
+          {drawerRows}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Tooltip>
         <TooltipTrigger asChild>
           <span className="inline-flex min-w-0 shrink">
-            <PopoverTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="default"
-                aria-label={TIER_LABELS[tier]}
-                className={cn(
-                  "text-muted-foreground hover:text-foreground transition-[gap] duration-200 shrink min-w-0",
-                  "gap-0 @[320px]/chat-bottom:gap-1.5",
-                )}
-              >
-                {iconFor?.(tier)}
-                <span
-                  className={cn(
-                    "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
-                    "@[320px]/chat-bottom:max-w-24 @[320px]/chat-bottom:opacity-100",
-                  )}
-                >
-                  {TIER_LABELS[tier]}
-                </span>
-                <ChevronDown
-                  size={12}
-                  className="opacity-60 hidden @[320px]/chat-bottom:inline-block"
-                />
-              </Button>
-            </PopoverTrigger>
+            <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
           </span>
         </TooltipTrigger>
         <TooltipContent>{TIER_LABELS[tier]}</TooltipContent>
@@ -100,6 +193,7 @@ export function TierTriggerPure({
         <div role="menu" className="flex flex-col">
           {TIER_ORDER.map((t) => {
             const subtitle = subtitleFor(t);
+            const modelLabel = modelLabelFor?.(t);
             const icon = iconFor?.(t);
             const active = t === tier;
             return (
@@ -126,6 +220,11 @@ export function TierTriggerPure({
                       {subtitle}
                     </div>
                   )}
+                  {modelLabel && (
+                    <div className="text-xs text-muted-foreground/60 font-mono mt-0.5">
+                      {modelLabel}
+                    </div>
+                  )}
                 </div>
                 {active && (
                   <Check size={14} className="text-foreground mt-0.5" />
@@ -133,6 +232,29 @@ export function TierTriggerPure({
               </button>
             );
           })}
+          {onSettingsClick && (
+            <button
+              type="button"
+              onClick={() => {
+                onSettingsClick();
+                setOpen(false);
+              }}
+              className={cn(
+                "flex items-start gap-2 px-2 py-1.5 rounded-md text-left",
+                "hover:bg-muted border-t border-border/40 mt-0.5",
+              )}
+            >
+              <span className="shrink-0 text-muted-foreground mt-0.5">
+                <LinkExternal01 size={16} />
+              </span>
+              <div className="flex-1">
+                <div className="text-sm">Model settings</div>
+                <div className="text-xs text-muted-foreground">
+                  Configure which model runs each tier
+                </div>
+              </div>
+            </button>
+          )}
         </div>
       </PopoverContent>
     </Popover>
@@ -147,9 +269,9 @@ export function TierTriggerPure({
  * it without depending on the chat AgentMode concept.
  */
 function tierIconFor(tier: ChatTier): ReactNode {
-  if (tier === "fast") return <Lightning01 size={16} />;
-  if (tier === "thinking") return <Atom01 size={16} />;
-  return <Stars01 size={16} />;
+  if (tier === "fast") return <Lightning01 className="size-[18px] md:size-4" />;
+  if (tier === "thinking") return <Atom01 className="size-[18px] md:size-4" />;
+  return <Stars01 className="size-[18px] md:size-4" />;
 }
 
 /**
@@ -160,9 +282,25 @@ export function TierTrigger() {
   const tier = useChatTier();
   const setTier = useSetChatTier();
   const mode = useAgentMode();
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+  const simpleMode = useSimpleMode();
 
   const subtitleFor = (t: ChatTier): string | null =>
     resolveTierSubtitle(mode, t);
+
+  const isDecopilot = mode === "cloud-decopilot" || mode === "local-decopilot";
+
+  const modelLabelFor = isDecopilot
+    ? (t: ChatTier): string | null => {
+        const slot = simpleMode.tiers[t];
+        return slot?.title ?? slot?.modelId ?? null;
+      }
+    : undefined;
+
+  const handleSettingsClick = () => {
+    navigate({ to: "/$org/settings/ai-providers", params: { org: org.slug } });
+  };
 
   return (
     <TierTriggerPure
@@ -170,6 +308,8 @@ export function TierTrigger() {
       subtitleFor={subtitleFor}
       iconFor={tierIconFor}
       onSelect={setTier}
+      modelLabelFor={modelLabelFor}
+      onSettingsClick={handleSettingsClick}
     />
   );
 }

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -26,12 +26,21 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@deco/ui/components/drawer.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { useQuery } from "@tanstack/react-query";
 import { useCurrentEditor } from "@tiptap/react";
 import {
+  ArrowLeft,
   BookOpen01,
+  ChevronRight,
   Globe02,
   Image01,
   Link01,
@@ -113,6 +122,10 @@ export function ToolsPopover({
   const { editor } = useCurrentEditor();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const supportsFiles = modelSupportsFiles(selectedModel);
+  const isMobile = useIsMobile();
+  const [drawerView, setDrawerView] = useState<"main" | "prompts" | "approval">(
+    "main",
+  );
 
   const handleAddFileClick = () => {
     if (!supportsFiles || isStreaming) return;
@@ -172,7 +185,6 @@ export function ToolsPopover({
     const matched = APPROVAL_LEVEL_OPTIONS.find((opt) => opt.value === next);
     if (!matched) return;
     if (matched.value === preferences.toolApprovalLevel) {
-      // No-op: same level re-selected, just close the popover.
       setOpen(false);
       return;
     }
@@ -292,6 +304,35 @@ export function ToolsPopover({
   const isWebSearchActive = chatMode === "web-search";
   const isDeepResearchActive = chatMode === "deep-research";
 
+  const triggerButton = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="default"
+      disabled={disabled}
+      title="Tools"
+      aria-label="Tools"
+      className={cn(
+        "text-muted-foreground hover:text-foreground transition-[gap] duration-200 shrink min-w-0",
+        "gap-0 @[460px]/chat-bottom:gap-1.5",
+        "h-10 md:h-8",
+      )}
+    >
+      <Settings04 className="size-[18px] md:size-3.5" />
+      <span
+        className={cn(
+          "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
+          "@[460px]/chat-bottom:max-w-24 @[460px]/chat-bottom:opacity-100",
+        )}
+      >
+        Tools
+      </span>
+    </Button>
+  );
+
+  const itemCls =
+    "flex items-center gap-3 w-full px-4 py-3 text-sm rounded-lg transition-colors hover:bg-muted text-left";
+
   return (
     <>
       <input
@@ -304,209 +345,436 @@ export function ToolsPopover({
         disabled={isStreaming}
       />
 
-      <DropdownMenu
-        open={open}
-        onOpenChange={(next) => {
-          if (next && !open) {
-            track("chat_tools_popover_opened", {
-              chat_mode: chatMode,
-            });
-          }
-          setOpen(next);
-        }}
-      >
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="default"
-            disabled={disabled}
-            title="Tools"
-            aria-label="Tools"
-            className={cn(
-              "text-muted-foreground hover:text-foreground transition-[gap] duration-200 shrink min-w-0",
-              "gap-0 @[320px]/chat-bottom:gap-1.5",
-            )}
-          >
-            <Settings04 size={14} />
-            <span
-              className={cn(
-                "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
-                "@[320px]/chat-bottom:max-w-24 @[320px]/chat-bottom:opacity-100",
-              )}
-            >
-              Tools
-            </span>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-52 p-1.5 space-y-1">
-          {!supportsFiles ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuItem
-                  aria-disabled="true"
-                  className="opacity-50 cursor-not-allowed"
-                  onSelect={(e) => e.preventDefault()}
-                >
-                  <Plus size={16} />
-                  <span className="flex-1">Add file</span>
-                </DropdownMenuItem>
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                The selected model does not support reading files or images.
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <DropdownMenuItem
-              onClick={handleAddFileClick}
-              disabled={isStreaming}
-            >
-              <Plus size={16} />
-              <span className="flex-1">Add file</span>
-            </DropdownMenuItem>
-          )}
+      {isMobile ? (
+        <Drawer
+          open={open}
+          onOpenChange={(next) => {
+            if (!next) setDrawerView("main");
+            if (next && !open) {
+              track("chat_tools_popover_opened", { chat_mode: chatMode });
+            }
+            setOpen(next);
+          }}
+        >
+          <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
+          <DrawerContent className="p-0">
+            <DrawerTitle className="sr-only">Tools</DrawerTitle>
 
-          <DropdownMenuItem
-            onClick={handleTogglePlanMode}
-            className={cn(isPlanMode && "text-violet-600 dark:text-violet-400")}
-          >
-            <BookOpen01
-              size={16}
-              className={cn(isPlanMode && "text-violet-500")}
-            />
-            <span className="flex-1">Plan mode</span>
-            <span
-              className={cn(
-                "text-xs text-muted-foreground",
-                isPlanMode && "text-violet-500 font-medium",
-              )}
-            >
-              {PLAN_MODE_SHORTCUT}
-            </span>
-          </DropdownMenuItem>
-
-          {/* Create image */}
-          <DropdownMenuItem
-            onClick={handleForceImageGeneration}
-            className={cn(isImageActive && "text-pink-600 dark:text-pink-400")}
-          >
-            <Image01
-              size={16}
-              className={cn(isImageActive && "text-pink-500")}
-            />
-            <span className="flex-1">Create image</span>
-            {isImageActive && (
-              <span className="text-xs text-pink-500 font-medium">On</span>
-            )}
-          </DropdownMenuItem>
-
-          {/* Web search */}
-          <DropdownMenuItem
-            onClick={handleForceWebSearch}
-            className={cn(
-              isWebSearchActive && "text-blue-600 dark:text-blue-400",
-            )}
-          >
-            <Globe02
-              size={16}
-              className={cn(isWebSearchActive && "text-blue-500")}
-            />
-            <span className="flex-1">Web search</span>
-            {isWebSearchActive && (
-              <span className="text-xs text-blue-500 font-medium">On</span>
-            )}
-          </DropdownMenuItem>
-
-          {/* Deep research */}
-          <DropdownMenuItem
-            onClick={handleForceDeepResearch}
-            className={cn(
-              isDeepResearchActive && "text-blue-600 dark:text-blue-400",
-            )}
-          >
-            <Telescope
-              size={16}
-              className={cn(isDeepResearchActive && "text-blue-500")}
-            />
-            <span className="flex-1">Deep research</span>
-            {isDeepResearchActive && (
-              <span className="text-xs text-blue-500 font-medium">On</span>
-            )}
-          </DropdownMenuItem>
-
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger className="gap-2">
-              <span className="flex size-4 items-center justify-center text-base font-medium text-muted-foreground">
-                /
-              </span>
-              <span className="flex-1">Prompts</span>
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="w-80 max-h-72 overflow-y-auto p-1.5">
-              {isPromptsLoading ? (
-                <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground">
-                  <Loading01 size={14} className="animate-spin" />
-                  Loading prompts…
-                </div>
-              ) : prompts.length === 0 ? (
-                <div className="px-2 py-3 text-sm text-muted-foreground">
-                  No prompts available
-                </div>
-              ) : (
-                prompts.map((prompt) => (
-                  <DropdownMenuItem
-                    key={prompt.name}
-                    onClick={() => handlePromptSelect(prompt)}
-                    className="flex flex-col items-start gap-0.5"
-                  >
-                    <span className="font-medium text-sm capitalize">
-                      {prompt.title ||
-                        displayToolName(
-                          prompt.name,
-                          getGatewayClientId(prompt._meta),
-                        )}
+            {/* Main view */}
+            {drawerView === "main" && (
+              <div className="overflow-y-auto px-2 pt-2 pb-6 flex flex-col gap-0.5">
+                {!supportsFiles ? (
+                  <div className={cn(itemCls, "opacity-50 cursor-not-allowed")}>
+                    <Plus size={18} />
+                    <span className="flex-1">Add file</span>
+                    <span className="text-xs text-muted-foreground">
+                      Model unsupported
                     </span>
-                    {prompt.description && (
-                      <span className="text-xs text-muted-foreground line-clamp-2">
-                        {prompt.description}
-                      </span>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className={itemCls}
+                    disabled={isStreaming}
+                    onClick={handleAddFileClick}
+                  >
+                    <Plus size={18} />
+                    <span className="flex-1">Add file</span>
+                  </button>
+                )}
+
+                <button
+                  type="button"
+                  className={cn(
+                    itemCls,
+                    isPlanMode && "text-violet-600 dark:text-violet-400",
+                  )}
+                  onClick={handleTogglePlanMode}
+                >
+                  <BookOpen01
+                    size={18}
+                    className={cn(isPlanMode && "text-violet-500")}
+                  />
+                  <span className="flex-1">Plan mode</span>
+                  <span
+                    className={cn(
+                      "text-xs text-muted-foreground",
+                      isPlanMode && "text-violet-500 font-medium",
                     )}
+                  >
+                    {PLAN_MODE_SHORTCUT}
+                  </span>
+                </button>
+
+                <button
+                  type="button"
+                  className={cn(
+                    itemCls,
+                    isImageActive && "text-pink-600 dark:text-pink-400",
+                  )}
+                  onClick={handleForceImageGeneration}
+                >
+                  <Image01
+                    size={18}
+                    className={cn(isImageActive && "text-pink-500")}
+                  />
+                  <span className="flex-1">Create image</span>
+                  {isImageActive && (
+                    <span className="text-xs text-pink-500 font-medium">
+                      On
+                    </span>
+                  )}
+                </button>
+
+                <button
+                  type="button"
+                  className={cn(
+                    itemCls,
+                    isWebSearchActive && "text-blue-600 dark:text-blue-400",
+                  )}
+                  onClick={handleForceWebSearch}
+                >
+                  <Globe02
+                    size={18}
+                    className={cn(isWebSearchActive && "text-blue-500")}
+                  />
+                  <span className="flex-1">Web search</span>
+                  {isWebSearchActive && (
+                    <span className="text-xs text-blue-500 font-medium">
+                      On
+                    </span>
+                  )}
+                </button>
+
+                <button
+                  type="button"
+                  className={cn(
+                    itemCls,
+                    isDeepResearchActive && "text-blue-600 dark:text-blue-400",
+                  )}
+                  onClick={handleForceDeepResearch}
+                >
+                  <Telescope
+                    size={18}
+                    className={cn(isDeepResearchActive && "text-blue-500")}
+                  />
+                  <span className="flex-1">Deep research</span>
+                  {isDeepResearchActive && (
+                    <span className="text-xs text-blue-500 font-medium">
+                      On
+                    </span>
+                  )}
+                </button>
+
+                <button
+                  type="button"
+                  className={itemCls}
+                  onClick={() => setDrawerView("prompts")}
+                >
+                  <span className="flex size-[18px] items-center justify-center text-base font-medium text-muted-foreground">
+                    /
+                  </span>
+                  <span className="flex-1">Prompts</span>
+                  <ChevronRight size={16} className="text-muted-foreground" />
+                </button>
+
+                <button
+                  type="button"
+                  className={itemCls}
+                  onClick={() => setDrawerView("approval")}
+                >
+                  <ShieldTick size={18} />
+                  <span className="flex-1">Approval</span>
+                  <span className="text-xs text-muted-foreground mr-1">
+                    {currentApprovalShort}
+                  </span>
+                  <ChevronRight size={16} className="text-muted-foreground" />
+                </button>
+
+                <button
+                  type="button"
+                  className={itemCls}
+                  onClick={handleConnections}
+                >
+                  <Link01 size={18} />
+                  <span className="flex-1">Connections</span>
+                  <Suspense>
+                    <ConnectionIcons />
+                  </Suspense>
+                </button>
+              </div>
+            )}
+
+            {/* Prompts sub-view */}
+            {drawerView === "prompts" && (
+              <div className="flex flex-col overflow-hidden">
+                <button
+                  type="button"
+                  className="flex items-center gap-2 px-4 py-3 text-sm font-medium hover:bg-muted transition-colors"
+                  onClick={() => setDrawerView("main")}
+                >
+                  <ArrowLeft size={16} />
+                  Prompts
+                </button>
+                <div className="overflow-y-auto px-2 pb-6 flex flex-col gap-0.5">
+                  {isPromptsLoading ? (
+                    <div className="flex items-center gap-2 px-4 py-3 text-sm text-muted-foreground">
+                      <Loading01 size={14} className="animate-spin" />
+                      Loading prompts…
+                    </div>
+                  ) : prompts.length === 0 ? (
+                    <div className="px-4 py-3 text-sm text-muted-foreground">
+                      No prompts available
+                    </div>
+                  ) : (
+                    prompts.map((prompt) => (
+                      <button
+                        key={prompt.name}
+                        type="button"
+                        className={cn(itemCls, "flex-col items-start gap-0.5")}
+                        onClick={() => handlePromptSelect(prompt)}
+                      >
+                        <span className="font-medium text-sm capitalize">
+                          {prompt.title ||
+                            displayToolName(
+                              prompt.name,
+                              getGatewayClientId(prompt._meta),
+                            )}
+                        </span>
+                        {prompt.description && (
+                          <span className="text-xs text-muted-foreground line-clamp-2">
+                            {prompt.description}
+                          </span>
+                        )}
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Approval sub-view */}
+            {drawerView === "approval" && (
+              <div className="flex flex-col overflow-hidden">
+                <button
+                  type="button"
+                  className="flex items-center gap-2 px-4 py-3 text-sm font-medium hover:bg-muted transition-colors"
+                  onClick={() => setDrawerView("main")}
+                >
+                  <ArrowLeft size={16} />
+                  Approval
+                </button>
+                <div className="overflow-y-auto px-2 pb-6 flex flex-col gap-0.5">
+                  {APPROVAL_LEVEL_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      className={cn(
+                        itemCls,
+                        opt.value === preferences.toolApprovalLevel &&
+                          "font-medium",
+                      )}
+                      onClick={() => handleApprovalLevelChange(opt.value)}
+                    >
+                      <span className="flex size-4 items-center justify-center shrink-0">
+                        {opt.value === preferences.toolApprovalLevel && (
+                          <span className="size-2 rounded-full bg-foreground" />
+                        )}
+                      </span>
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </DrawerContent>
+        </Drawer>
+      ) : (
+        <DropdownMenu
+          open={open}
+          onOpenChange={(next) => {
+            if (next && !open) {
+              track("chat_tools_popover_opened", {
+                chat_mode: chatMode,
+              });
+            }
+            setOpen(next);
+          }}
+        >
+          <DropdownMenuTrigger asChild>{triggerButton}</DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-52 p-1.5 space-y-1">
+            {!supportsFiles ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuItem
+                    aria-disabled="true"
+                    className="opacity-50 cursor-not-allowed"
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    <Plus size={16} />
+                    <span className="flex-1">Add file</span>
                   </DropdownMenuItem>
-                ))
-              )}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger className="gap-2">
-              <ShieldTick size={16} />
-              <span className="flex-1">Approval</span>
-              <span className="text-xs text-muted-foreground">
-                {currentApprovalShort}
-              </span>
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="w-48 p-1.5">
-              <DropdownMenuRadioGroup
-                value={preferences.toolApprovalLevel}
-                onValueChange={handleApprovalLevelChange}
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  The selected model does not support reading files or images.
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <DropdownMenuItem
+                onClick={handleAddFileClick}
+                disabled={isStreaming}
               >
-                {APPROVAL_LEVEL_OPTIONS.map((opt) => (
-                  <DropdownMenuRadioItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
+                <Plus size={16} />
+                <span className="flex-1">Add file</span>
+              </DropdownMenuItem>
+            )}
 
-          <DropdownMenuItem onClick={handleConnections}>
-            <Link01 size={16} />
-            <span className="flex-1">Connections</span>
-            <Suspense>
-              <ConnectionIcons />
-            </Suspense>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+            <DropdownMenuItem
+              onClick={handleTogglePlanMode}
+              className={cn(
+                isPlanMode && "text-violet-600 dark:text-violet-400",
+              )}
+            >
+              <BookOpen01
+                size={16}
+                className={cn(isPlanMode && "text-violet-500")}
+              />
+              <span className="flex-1">Plan mode</span>
+              <span
+                className={cn(
+                  "text-xs text-muted-foreground",
+                  isPlanMode && "text-violet-500 font-medium",
+                )}
+              >
+                {PLAN_MODE_SHORTCUT}
+              </span>
+            </DropdownMenuItem>
+
+            {/* Create image */}
+            <DropdownMenuItem
+              onClick={handleForceImageGeneration}
+              className={cn(
+                isImageActive && "text-pink-600 dark:text-pink-400",
+              )}
+            >
+              <Image01
+                size={16}
+                className={cn(isImageActive && "text-pink-500")}
+              />
+              <span className="flex-1">Create image</span>
+              {isImageActive && (
+                <span className="text-xs text-pink-500 font-medium">On</span>
+              )}
+            </DropdownMenuItem>
+
+            {/* Web search */}
+            <DropdownMenuItem
+              onClick={handleForceWebSearch}
+              className={cn(
+                isWebSearchActive && "text-blue-600 dark:text-blue-400",
+              )}
+            >
+              <Globe02
+                size={16}
+                className={cn(isWebSearchActive && "text-blue-500")}
+              />
+              <span className="flex-1">Web search</span>
+              {isWebSearchActive && (
+                <span className="text-xs text-blue-500 font-medium">On</span>
+              )}
+            </DropdownMenuItem>
+
+            {/* Deep research */}
+            <DropdownMenuItem
+              onClick={handleForceDeepResearch}
+              className={cn(
+                isDeepResearchActive && "text-blue-600 dark:text-blue-400",
+              )}
+            >
+              <Telescope
+                size={16}
+                className={cn(isDeepResearchActive && "text-blue-500")}
+              />
+              <span className="flex-1">Deep research</span>
+              {isDeepResearchActive && (
+                <span className="text-xs text-blue-500 font-medium">On</span>
+              )}
+            </DropdownMenuItem>
+
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="gap-2">
+                <span className="flex size-4 items-center justify-center text-base font-medium text-muted-foreground">
+                  /
+                </span>
+                <span className="flex-1">Prompts</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-80 max-h-72 overflow-y-auto p-1.5">
+                {isPromptsLoading ? (
+                  <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground">
+                    <Loading01 size={14} className="animate-spin" />
+                    Loading prompts…
+                  </div>
+                ) : prompts.length === 0 ? (
+                  <div className="px-2 py-3 text-sm text-muted-foreground">
+                    No prompts available
+                  </div>
+                ) : (
+                  prompts.map((prompt) => (
+                    <DropdownMenuItem
+                      key={prompt.name}
+                      onClick={() => handlePromptSelect(prompt)}
+                      className="flex flex-col items-start gap-0.5"
+                    >
+                      <span className="font-medium text-sm capitalize">
+                        {prompt.title ||
+                          displayToolName(
+                            prompt.name,
+                            getGatewayClientId(prompt._meta),
+                          )}
+                      </span>
+                      {prompt.description && (
+                        <span className="text-xs text-muted-foreground line-clamp-2">
+                          {prompt.description}
+                        </span>
+                      )}
+                    </DropdownMenuItem>
+                  ))
+                )}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="gap-2">
+                <ShieldTick size={16} />
+                <span className="flex-1">Approval</span>
+                <span className="text-xs text-muted-foreground">
+                  {currentApprovalShort}
+                </span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-48 p-1.5">
+                <DropdownMenuRadioGroup
+                  value={preferences.toolApprovalLevel}
+                  onValueChange={handleApprovalLevelChange}
+                >
+                  {APPROVAL_LEVEL_OPTIONS.map((opt) => (
+                    <DropdownMenuRadioItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            <DropdownMenuItem onClick={handleConnections}>
+              <Link01 size={16} />
+              <span className="flex-1">Connections</span>
+              <Suspense>
+                <ConnectionIcons />
+              </Suspense>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
 
       <PromptArgsDialog
         prompt={activePrompt}

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -314,7 +314,7 @@ export function ToolsPopover({
       aria-label="Tools"
       className={cn(
         "text-muted-foreground hover:text-foreground transition-[gap] duration-200 shrink min-w-0",
-        "gap-0 @[460px]/chat-bottom:gap-1.5",
+        "gap-0 @[380px]/chat-bottom:gap-1.5",
         "h-10 md:h-8",
       )}
     >
@@ -322,7 +322,7 @@ export function ToolsPopover({
       <span
         className={cn(
           "min-w-0 truncate transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0",
-          "@[460px]/chat-bottom:max-w-24 @[460px]/chat-bottom:opacity-100",
+          "@[380px]/chat-bottom:max-w-24 @[380px]/chat-bottom:opacity-100",
         )}
       >
         Tools
@@ -349,7 +349,10 @@ export function ToolsPopover({
         <Drawer
           open={open}
           onOpenChange={(next) => {
-            if (!next) setDrawerView("main");
+            if (!next) {
+              setDrawerView("main");
+              setActivePrompt(null);
+            }
             if (next && !open) {
               track("chat_tools_popover_opened", { chat_mode: chatMode });
             }
@@ -574,7 +577,25 @@ export function ToolsPopover({
                         opt.value === preferences.toolApprovalLevel &&
                           "font-medium",
                       )}
-                      onClick={() => handleApprovalLevelChange(opt.value)}
+                      onClick={() => {
+                        const matched = APPROVAL_LEVEL_OPTIONS.find(
+                          (o) => o.value === opt.value,
+                        );
+                        if (!matched) return;
+                        if (matched.value !== preferences.toolApprovalLevel) {
+                          playSwitchSound();
+                          track("chat_approval_level_changed", {
+                            from_level: preferences.toolApprovalLevel,
+                            to_level: matched.value,
+                            source: "tools_popover",
+                          });
+                          setPreferences({
+                            ...preferences,
+                            toolApprovalLevel: matched.value,
+                          });
+                        }
+                        setDrawerView("main");
+                      }}
                     >
                       <span className="flex size-4 items-center justify-center shrink-0">
                         {opt.value === preferences.toolApprovalLevel && (

--- a/apps/mesh/src/web/components/sidebar/navigation-mobile.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation-mobile.tsx
@@ -9,6 +9,7 @@ import {
 } from "@deco/ui/components/sidebar.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { type ReactNode, Suspense } from "react";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { SidebarCollapsibleGroup } from "./sidebar-group";
 import { SidebarLogoHeader } from "./sidebar-logo-header";
 import type { NavigationSidebarItem, SidebarSection } from "./types";
@@ -104,13 +105,15 @@ export function MobileNavigationSidebar({
   footer,
   additionalContent,
 }: MobileNavigationSidebarProps) {
+  const { org } = useProjectContext();
+
   return (
     <div
       className="bg-sidebar flex h-full w-full flex-col"
       data-sidebar="sidebar"
     >
       <Suspense fallback={<div className="h-12 shrink-0" />}>
-        <SidebarLogoHeader onToggle={onClose} />
+        <SidebarLogoHeader onToggle={onClose} orgSlug={org.slug} />
       </Suspense>
       <SidebarContent className="flex flex-col flex-1 px-2 py-2 gap-0">
         {sections.map((section, index) => (

--- a/apps/mesh/src/web/components/sidebar/sidebar-logo-header.tsx
+++ b/apps/mesh/src/web/components/sidebar/sidebar-logo-header.tsx
@@ -4,11 +4,13 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { LayoutLeft } from "@untitledui/icons";
 import { LinkedDesktopIndicator } from "@/web/components/header/linked-desktop-indicator";
 import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
+import { Link, useParams } from "@tanstack/react-router";
 
 interface SidebarLogoHeaderProps {
   /** Collapse / close the sidebar. */
   onToggle: () => void;
   className?: string;
+  hideDesktopIndicator?: boolean;
 }
 
 /**
@@ -29,16 +31,18 @@ interface SidebarLogoHeaderProps {
 export function SidebarLogoHeader({
   onToggle,
   className,
+  hideDesktopIndicator,
 }: SidebarLogoHeaderProps) {
   const config = usePublicConfig();
   const logo = config.logo ?? DEFAULT_LOGO;
   const lightSrc = typeof logo === "string" ? logo : logo.light;
   const darkSrc = typeof logo === "string" ? logo : logo.dark;
+  const { org } = useParams({ from: "/shell/$org" });
 
   return (
     <SidebarHeader
       className={cn(
-        "flex flex-row items-center gap-2 md:gap-0.5 shrink-0 h-12 pl-1 pr-2 pt-0.25 pb-0",
+        "flex flex-row items-center gap-1 md:gap-0.5 shrink-0 h-12 pl-1 pr-2 pt-0.25 pb-0",
         // The desktop sidebar collapses to a narrow icon rail where a logo +
         // toggle row can't fit; hide it there (the toolbar trigger reopens it).
         // The mobile drawer is always expanded, so it stays visible.
@@ -46,7 +50,12 @@ export function SidebarLogoHeader({
         className,
       )}
     >
-      <span className="flex items-center shrink-0 pl-1">
+      <Link
+        to="/$org"
+        params={{ org }}
+        aria-label="Back to home"
+        className="flex items-center shrink-0 pl-1"
+      >
         <span className="flex items-center shrink-0 px-2">
           <img
             src={lightSrc}
@@ -59,11 +68,11 @@ export function SidebarLogoHeader({
             className="size-6 object-contain hidden dark:block"
           />
         </span>
-      </span>
+      </Link>
       <ToolbarIconButton onClick={onToggle} aria-label="Toggle sidebar">
         <LayoutLeft size={16} />
       </ToolbarIconButton>
-      <LinkedDesktopIndicator />
+      {!hideDesktopIndicator && <LinkedDesktopIndicator />}
     </SidebarHeader>
   );
 }

--- a/apps/mesh/src/web/components/sidebar/sidebar-logo-header.tsx
+++ b/apps/mesh/src/web/components/sidebar/sidebar-logo-header.tsx
@@ -4,13 +4,16 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { LayoutLeft } from "@untitledui/icons";
 import { LinkedDesktopIndicator } from "@/web/components/header/linked-desktop-indicator";
 import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
-import { Link, useParams } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 
 interface SidebarLogoHeaderProps {
   /** Collapse / close the sidebar. */
   onToggle: () => void;
   className?: string;
-  hideDesktopIndicator?: boolean;
+  /** Whether to show the linked-desktop indicator. Defaults to true. */
+  showDesktopIndicator?: boolean;
+  /** When provided, wraps the logo in a link back to the org home. */
+  orgSlug?: string;
 }
 
 /**
@@ -31,13 +34,28 @@ interface SidebarLogoHeaderProps {
 export function SidebarLogoHeader({
   onToggle,
   className,
-  hideDesktopIndicator,
+  showDesktopIndicator = true,
+  orgSlug,
 }: SidebarLogoHeaderProps) {
   const config = usePublicConfig();
   const logo = config.logo ?? DEFAULT_LOGO;
   const lightSrc = typeof logo === "string" ? logo : logo.light;
   const darkSrc = typeof logo === "string" ? logo : logo.dark;
-  const { org } = useParams({ from: "/shell/$org" });
+
+  const logoImages = (
+    <span className="flex items-center shrink-0 px-2">
+      <img
+        src={lightSrc}
+        alt="Logo"
+        className="size-6 object-contain dark:hidden"
+      />
+      <img
+        src={darkSrc}
+        alt="Logo"
+        className="size-6 object-contain hidden dark:block"
+      />
+    </span>
+  );
 
   return (
     <SidebarHeader
@@ -50,29 +68,22 @@ export function SidebarLogoHeader({
         className,
       )}
     >
-      <Link
-        to="/$org"
-        params={{ org }}
-        aria-label="Back to home"
-        className="flex items-center shrink-0 pl-1"
-      >
-        <span className="flex items-center shrink-0 px-2">
-          <img
-            src={lightSrc}
-            alt="Logo"
-            className="size-6 object-contain dark:hidden"
-          />
-          <img
-            src={darkSrc}
-            alt="Logo"
-            className="size-6 object-contain hidden dark:block"
-          />
-        </span>
-      </Link>
+      {orgSlug ? (
+        <Link
+          to="/$org"
+          params={{ org: orgSlug }}
+          aria-label="Back to home"
+          className="flex items-center shrink-0 pl-1"
+        >
+          {logoImages}
+        </Link>
+      ) : (
+        <span className="flex items-center shrink-0 pl-1">{logoImages}</span>
+      )}
       <ToolbarIconButton onClick={onToggle} aria-label="Toggle sidebar">
         <LayoutLeft size={16} />
       </ToolbarIconButton>
-      {!hideDesktopIndicator && <LinkedDesktopIndicator />}
+      {showDesktopIndicator && <LinkedDesktopIndicator />}
     </SidebarHeader>
   );
 }

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -335,10 +335,11 @@ export function TaskGroupsList({
       <SyncSidebarAgentGroupsEmpty
         value={groupBy === "agent" && groups.length === 0}
       />
-      <div className="shrink-0 px-1 h-10 md:h-7 mb-2 flex items-center justify-between">
+      <div className="shrink-0 h-10 md:h-7 mb-2 flex items-center justify-between">
         <div className="flex items-center gap-0.5">
           <ToolbarIconButton
             aria-label="Search threads"
+            className="justify-start pl-2 md:pl-1.5"
             onClick={() => {
               track("tasks_panel_search_opened");
               setSearchEverOpened(true);
@@ -350,6 +351,7 @@ export function TaskGroupsList({
           <ToolbarIconButton
             aria-label={`Group by ${GROUP_BY_LABELS[groupBy === "agent" ? "status" : "agent"].toLowerCase()}`}
             title={`Grouped by ${GROUP_BY_LABELS[groupBy].toLowerCase()}`}
+            className="justify-start pl-2 md:pl-1.5"
             onClick={() => {
               const next: GroupBy = groupBy === "agent" ? "status" : "agent";
               track("tasks_panel_group_by_changed", { to_value: next });
@@ -364,7 +366,10 @@ export function TaskGroupsList({
           </ToolbarIconButton>
           <Popover>
             <PopoverTrigger asChild>
-              <ToolbarIconButton aria-label="Filter tasks">
+              <ToolbarIconButton
+                aria-label="Filter tasks"
+                className="justify-start pl-2 md:pl-1.5"
+              >
                 <FilterLines size={16} />
                 {filtersActive && (
                   <span className="absolute top-0.5 right-0.5 size-2 rounded-full bg-red-500 ring-1 ring-sidebar pointer-events-none" />

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -336,10 +336,9 @@ export function TaskGroupsList({
         value={groupBy === "agent" && groups.length === 0}
       />
       <div className="shrink-0 h-10 md:h-7 mb-2 flex items-center justify-between">
-        <div className="flex items-center gap-0.5">
+        <div className="flex items-center gap-0.5 pl-0.5 md:pl-0">
           <ToolbarIconButton
             aria-label="Search threads"
-            className="justify-start pl-2 md:pl-1.5"
             onClick={() => {
               track("tasks_panel_search_opened");
               setSearchEverOpened(true);
@@ -351,7 +350,6 @@ export function TaskGroupsList({
           <ToolbarIconButton
             aria-label={`Group by ${GROUP_BY_LABELS[groupBy === "agent" ? "status" : "agent"].toLowerCase()}`}
             title={`Grouped by ${GROUP_BY_LABELS[groupBy].toLowerCase()}`}
-            className="justify-start pl-2 md:pl-1.5"
             onClick={() => {
               const next: GroupBy = groupBy === "agent" ? "status" : "agent";
               track("tasks_panel_group_by_changed", { to_value: next });
@@ -366,10 +364,7 @@ export function TaskGroupsList({
           </ToolbarIconButton>
           <Popover>
             <PopoverTrigger asChild>
-              <ToolbarIconButton
-                aria-label="Filter tasks"
-                className="justify-start pl-2 md:pl-1.5"
-              >
+              <ToolbarIconButton aria-label="Filter tasks">
                 <FilterLines size={16} />
                 {filtersActive && (
                   <span className="absolute top-0.5 right-0.5 size-2 rounded-full bg-red-500 ring-1 ring-sidebar pointer-events-none" />

--- a/apps/mesh/src/web/components/toolbar-icon-button.tsx
+++ b/apps/mesh/src/web/components/toolbar-icon-button.tsx
@@ -19,7 +19,7 @@ export function ToolbarIconButton({
       type={type}
       className={cn(
         "relative flex size-10 md:size-7 shrink-0 items-center justify-center rounded-md transition-colors",
-        "max-md:[&_svg]:size-5",
+        "max-md:[&_svg]:size-[18px]",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         active
           ? "bg-sidebar-accent text-sidebar-foreground"

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -60,10 +60,12 @@ export default function OrgShellLayout() {
             <div className="app-shell-root flex flex-col h-dvh overflow-hidden">
               {isMobile ? (
                 <Toolbar.Header className="grid-cols-1 px-1 pr-1">
-                  <div className="grid w-full grid-cols-[auto_auto_auto_1fr_auto_auto_auto] items-center gap-2">
-                    <Toolbar.LogoLink />
-                    <SidebarTriggerButton />
-                    <LinkedDesktopIndicator />
+                  <div className="grid w-full grid-cols-[auto_1fr_auto_auto_auto] items-center gap-1">
+                    <div className="flex items-center gap-1">
+                      <Toolbar.LogoLink />
+                      <SidebarTriggerButton />
+                      <LinkedDesktopIndicator />
+                    </div>
                     <div aria-hidden className="min-w-0" />
                     <Toolbar.TogglesSlot />
                     <Toolbar.TabsSlot className="min-w-0 justify-self-end" />

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -342,7 +342,7 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
   return (
     <div className="flex flex-col h-full bg-sidebar" data-sidebar="sidebar">
       <SidebarLogoHeader onToggle={onClose} hideDesktopIndicator />
-      <SidebarContent className="flex flex-col flex-1 px-2 py-2 gap-0">
+      <SidebarContent className="flex flex-col flex-1 px-2 py-2 gap-0 overflow-y-auto">
         {groups.map((group, i) => (
           <SidebarGroup
             key={`${group.label}-${i}`}

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -62,6 +62,7 @@ import {
   MobileSidebarSheet,
   SidebarTriggerButton,
 } from "@/web/layouts/shell-controls";
+import { SidebarLogoHeader } from "@/web/components/sidebar/sidebar-logo-header";
 
 interface SettingsNavItem {
   key: string;
@@ -340,6 +341,7 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
 
   return (
     <div className="flex flex-col h-full bg-sidebar">
+      <SidebarLogoHeader onToggle={onClose} hideDesktopIndicator />
       <div className="flex flex-col flex-1 overflow-y-auto px-2 py-2 gap-0.5">
         {groups.map((group, i) => (
           <div key={`${group.label}-${i}`} className="flex flex-col gap-0.5">

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -340,64 +340,68 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <div className="flex flex-col h-full bg-sidebar">
+    <div className="flex flex-col h-full bg-sidebar" data-sidebar="sidebar">
       <SidebarLogoHeader onToggle={onClose} hideDesktopIndicator />
-      <div className="flex flex-col flex-1 overflow-y-auto px-2 py-2 gap-0.5">
+      <SidebarContent className="flex flex-col flex-1 px-2 py-2 gap-0">
         {groups.map((group, i) => (
-          <div key={`${group.label}-${i}`} className="flex flex-col gap-0.5">
+          <SidebarGroup
+            key={`${group.label}-${i}`}
+            className="pt-0 pr-0 pb-0 pl-0"
+          >
             {group.label && (
               <p
                 className={cn(
-                  "px-2 pt-1.5 pb-0.5 text-xs font-medium text-muted-foreground/60",
+                  "px-1 pt-1.5 pb-0.5 text-xs font-medium text-sidebar-foreground/70",
                   i > 0 && "mt-3",
                 )}
               >
                 {group.label}
               </p>
             )}
-            {group.items.map((item) => (
-              <Link
-                key={item.key}
-                to={item.to}
-                params={{ org }}
-                onClick={onClose}
-                className={cn(
-                  "flex items-center gap-2 w-full px-2 h-10 rounded-md transition-colors text-sm",
-                  isActive(item.to)
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium"
-                    : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
-                )}
-              >
-                <span className="relative [&>svg]:size-5 shrink-0">
-                  {item.icon}
-                  {item.badge ? (
-                    <span className="absolute -right-1 -top-1 size-2 rounded-full bg-red-500 pointer-events-none" />
-                  ) : null}
-                </span>
-                <span className="truncate">{item.label}</span>
-              </Link>
-            ))}
-          </div>
+            <SidebarGroupContent>
+              <SidebarMenu className="gap-1.5">
+                {group.items.map((item) => (
+                  <SidebarMenuItem key={item.key}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={isActive(item.to)}
+                      className="h-10! text-sm!"
+                    >
+                      <Link to={item.to} params={{ org }} onClick={onClose}>
+                        <span className="relative [&>svg]:size-5 shrink-0">
+                          {item.icon}
+                          {item.badge ? (
+                            <span className="absolute -right-1 -top-1 size-2 rounded-full bg-red-500 pointer-events-none" />
+                          ) : null}
+                        </span>
+                        <span>{item.label}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
         ))}
 
-        {/* Sign Out */}
-        <div className="flex flex-col gap-0.5">
-          <div className="h-px bg-border/50 my-2" />
-          <button
-            type="button"
-            onClick={() => {
-              clearPersistedQueryCache();
-              authClient.signOut();
-            }}
-            className="flex items-center gap-2 w-full px-2 h-10 rounded-md transition-colors text-sm text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
-          >
-            <span className="[&>svg]:size-5 shrink-0">
-              <LogOut01 size={20} />
-            </span>
-            <span className="truncate">Sign Out</span>
-          </button>
-        </div>
-      </div>
+        <SidebarGroup className="pt-0 pr-0 pb-0 pl-0 mt-auto">
+          <div className="h-px bg-sidebar-border my-2" />
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                className="h-10! text-sm!"
+                onClick={() => {
+                  clearPersistedQueryCache();
+                  authClient.signOut();
+                }}
+              >
+                <LogOut01 size={16} />
+                <span>Sign Out</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
+      </SidebarContent>
 
       {/* Version */}
       <div className="px-4 pb-3 pt-1 border-t border-border/50">

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -341,7 +341,11 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
 
   return (
     <div className="flex flex-col h-full bg-sidebar" data-sidebar="sidebar">
-      <SidebarLogoHeader onToggle={onClose} hideDesktopIndicator />
+      <SidebarLogoHeader
+        onToggle={onClose}
+        showDesktopIndicator={false}
+        orgSlug={org}
+      />
       <SidebarContent className="flex flex-col flex-1 px-2 py-2 gap-0 overflow-y-auto">
         {groups.map((group, i) => (
           <SidebarGroup
@@ -391,6 +395,7 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
               <SidebarMenuButton
                 className="h-10! text-sm!"
                 onClick={() => {
+                  track("signed_out", { source: "settings_sidebar" });
                   clearPersistedQueryCache();
                   authClient.signOut();
                 }}

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -348,7 +348,7 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
             {group.label && (
               <p
                 className={cn(
-                  "px-3 pt-1.5 pb-0.5 text-xs font-medium text-muted-foreground/60",
+                  "px-2 pt-1.5 pb-0.5 text-xs font-medium text-muted-foreground/60",
                   i > 0 && "mt-3",
                 )}
               >
@@ -362,13 +362,13 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
                 params={{ org }}
                 onClick={onClose}
                 className={cn(
-                  "flex items-center gap-3 w-full px-3 py-2.5 rounded-lg transition-colors text-sm",
+                  "flex items-center gap-2 w-full px-2 h-10 rounded-md transition-colors text-sm",
                   isActive(item.to)
                     ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium"
                     : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
                 )}
               >
-                <span className="relative shrink-0">
+                <span className="relative [&>svg]:size-5 shrink-0">
                   {item.icon}
                   {item.badge ? (
                     <span className="absolute -right-1 -top-1 size-2 rounded-full bg-red-500 pointer-events-none" />
@@ -389,10 +389,10 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
               clearPersistedQueryCache();
               authClient.signOut();
             }}
-            className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg transition-colors text-sm text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
+            className="flex items-center gap-2 w-full px-2 h-10 rounded-md transition-colors text-sm text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
           >
-            <span className="shrink-0">
-              <LogOut01 size={14} />
+            <span className="[&>svg]:size-5 shrink-0">
+              <LogOut01 size={20} />
             </span>
             <span className="truncate">Sign Out</span>
           </button>

--- a/apps/mesh/src/web/views/settings/ai-providers/simple-mode-section.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/simple-mode-section.tsx
@@ -303,7 +303,18 @@ export function SimpleModeSection() {
       },
       { keepDirty: true },
     );
-  }, [form, allKeys, models0, models1, models2, key0?.id, key1?.id, key2?.id]);
+    scheduleAutosave();
+  }, [
+    form,
+    allKeys,
+    models0,
+    models1,
+    models2,
+    key0?.id,
+    key1?.id,
+    key2?.id,
+    scheduleAutosave,
+  ]);
 
   return (
     <SettingsSection title="Default models" headerClassName="pl-0">


### PR DESCRIPTION
## Summary

- **Input bar responsiveness**: raise label breakpoint from 320px → 460px to prevent truncated labels; unify button heights (40px) and icon sizes (18px) on mobile
- **Top bar consistency**: `gap-1` between logo/sidebar-toggle/desktop-indicator; same gap in `SidebarLogoHeader` so spacing is identical whether sidebar is open or closed
- **Sidebar alignment**: task-group control icons (search/group-by/filter) now align with Home/Library nav icons via `justify-start pl-2`
- **Settings mobile sidebar**: added logo + toggle header (logo links home); desktop indicator hidden there
- **Mobile drawers**: `ToolsPopover`, `TierTrigger`, and `ModePicker` all open as bottom drawers on mobile instead of floating dropdowns. Prompts and Approval in the tools drawer use sub-view navigation (back button replaces the list)
- **Simple mode autosave bug**: Effect 2 auto-filled tier slots but never called `scheduleAutosave()`, so models showed in settings UI but were never persisted — fixed
- **Tier label**: removed "not configured" fallback (returned `null` instead) so the label row only renders when an actual model name is available

## Test plan

- [ ] Open chat on mobile — input bottom bar labels show/hide correctly at wider breakpoints
- [ ] Open tools (⚙) drawer on mobile — all items accessible, Prompts/Approval sub-views navigate back correctly
- [ ] Open tier picker and mode picker on mobile — bottom drawers open with correct items
- [ ] Open settings page on mobile — sidebar sheet shows logo header; tapping logo navigates home
- [ ] Add an AI provider key and visit AI Providers settings — tier slots auto-fill and show "Saved" indicator
- [ ] Open tier picker after configuring models — model names appear (no "not configured")
- [ ] Desktop behavior unchanged throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies mobile UI by converting chat popovers to bottom drawers, tightening spacing, and aligning the mobile Settings sidebar with Home. Adds a model-aware tier picker with a link to Model settings and improves input ergonomics.

- **New Features**
  - Mobile: `ToolsPopover`, `TierTrigger`, and `ModePicker` open as bottom drawers; Tools includes Prompts/Approval sub-views with a back button (Approval returns to main view).
  - Tier picker: shows the actual model per tier (when available) and adds a “Model settings” link to AI Providers.
  - Chat input (mobile): 40px button height, 18px icon size; labels show from 380px.
  - Spacing/layout: gap-1 between logo, sidebar toggle, and desktop indicator; task-group controls align with nav icons; top bar gap reduced to gap-1.
  - Settings (mobile): header adds a logo that links home and hides the desktop indicator; sidebar uses `SidebarMenuItem`/`SidebarMenuButton` styling to match Home and restores scrolling.

- **Bug Fixes**
  - Simple mode: autosave now runs after tier slots auto-fill, so models persist.
  - Tier label: removed “not configured” fallback so the row only renders when a real model is set.
  - Tools drawer: clears stale prompt dialog on close.
  - Mode picker: locked state handled correctly on mobile; caret remains visible at small sizes.
  - Accessibility/UX: added ARIA roles to drawer rows; fixed `ToolbarIconButton` tap target; added tracking on mobile sign-out.
  - No desktop behavior changes.

<sup>Written for commit 6675c9263bdeb198b09aa4041db5cd9511db0879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

