### PR TITLE
test(store): cover getRegistryItemAppName fallback chain

### DIFF
--- a/apps/mesh/src/web/utils/extract-connection-data.test.ts
+++ b/apps/mesh/src/web/utils/extract-connection-data.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { getRegistryItemAppName } from "./extract-connection-data";
+
+describe("getRegistryItemAppName", () => {
+  it("prefers the mcp.mesh appName over the server name", () => {
+    expect(
+      getRegistryItemAppName({
+        _meta: { "mcp.mesh": { id: "x", appName: "my-app" } },
+        server: { name: "server-name" },
+      }),
+    ).toBe("my-app");
+  });
+
+  it("falls back to server.name when appName is absent", () => {
+    expect(
+      getRegistryItemAppName({
+        _meta: { "mcp.mesh": { id: "x" } },
+        server: { name: "server-name" },
+      }),
+    ).toBe("server-name");
+  });
+
+  it("falls back to server.name when appName is an empty string", () => {
+    expect(
+      getRegistryItemAppName({
+        _meta: { "mcp.mesh": { id: "x", appName: "" } },
+        server: { name: "server-name" },
+      }),
+    ).toBe("server-name");
+  });
+
+  it("returns null when neither appName nor server.name is set", () => {
+    expect(getRegistryItemAppName({ server: { name: "" } })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Source
Improvement (Source 3, option A) — `getRegistryItemAppName` in `extract-connection-data.ts` is an exported pure function with zero test coverage, despite the file's own doc comment noting it "must stay in sync with the app_name field set in extractConnectionData" (the field used to match catalog items to installed connections).

## Why
Locks in the appName → server.name → null fallback chain that connection-matching logic depends on, so a future refactor of the metadata shape can't silently break app-identity matching without a failing test.

## What this covers
- `_meta["mcp.mesh"].appName` takes precedence over `server.name`
- falls back to `server.name` when `appName` is absent
- falls back to `server.name` when `appName` is an empty string
- returns `null` when neither is set

## Verification
- `cd apps/mesh && bun test src/web/utils/extract-connection-data.test.ts` — 4 pass
- `bun x tsc --noEmit` (apps/mesh workspace) — no errors
- `bun run fmt` — clean

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `getRegistryItemAppName` to lock the appName → server.name → null fallback chain. This protects connection matching from regressions if the metadata shape changes.

<sup>Written for commit dda412b58db3ab9521bff02f9da62d1ab92b3353. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

