### PR TITLE
test(sandbox-proxy): cover loader-invoke resolveType validation and payload parsing

### DIFF
--- a/apps/mesh/src/lib/loader-invoke.test.ts
+++ b/apps/mesh/src/lib/loader-invoke.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildLoaderInvokeUrl,
+  isValidLoaderResolveType,
+  parseLoaderInvokeRequest,
+} from "./loader-invoke";
+
+describe("isValidLoaderResolveType", () => {
+  it("accepts typical resolveType paths", () => {
+    expect(isValidLoaderResolveType("apps/my-app/loaders/products.ts")).toBe(
+      true,
+    );
+    expect(isValidLoaderResolveType("./loaders/foo.ts")).toBe(true);
+  });
+
+  it("rejects empty strings", () => {
+    expect(isValidLoaderResolveType("")).toBe(false);
+  });
+
+  it("rejects path traversal attempts", () => {
+    expect(isValidLoaderResolveType("../../etc/passwd")).toBe(false);
+    expect(isValidLoaderResolveType("loaders/../../secrets.ts")).toBe(false);
+  });
+
+  it("rejects characters outside the allowed set", () => {
+    expect(isValidLoaderResolveType("loaders/foo bar.ts")).toBe(false);
+    expect(isValidLoaderResolveType("loaders/foo?bar")).toBe(false);
+  });
+});
+
+describe("parseLoaderInvokeRequest", () => {
+  it("returns null when __resolveType is missing", () => {
+    expect(parseLoaderInvokeRequest({})).toBeNull();
+  });
+
+  it("returns null when __resolveType is invalid", () => {
+    expect(
+      parseLoaderInvokeRequest({ __resolveType: "../../etc/passwd" }),
+    ).toBeNull();
+  });
+
+  it("wraps a props object under a payload.props key", () => {
+    const result = parseLoaderInvokeRequest({
+      __resolveType: "loaders/foo.ts",
+      props: { id: "1" },
+    });
+    expect(result).toEqual({
+      resolveType: "loaders/foo.ts",
+      payload: { props: { id: "1" } },
+    });
+  });
+
+  it("falls back to the remaining top-level fields when props isn't an object", () => {
+    const result = parseLoaderInvokeRequest({
+      __resolveType: "loaders/foo.ts",
+      id: "1",
+      qty: 2,
+    });
+    expect(result).toEqual({
+      resolveType: "loaders/foo.ts",
+      payload: { id: "1", qty: 2 },
+    });
+  });
+
+  it("does not treat an array 'props' field as the props object", () => {
+    const result = parseLoaderInvokeRequest({
+      __resolveType: "loaders/foo.ts",
+      props: ["not", "an", "object"],
+    });
+    expect(result).toEqual({
+      resolveType: "loaders/foo.ts",
+      payload: { props: ["not", "an", "object"] },
+    });
+  });
+});
+
+describe("buildLoaderInvokeUrl", () => {
+  it("joins base url and resolveType", () => {
+    expect(
+      buildLoaderInvokeUrl("https://preview.example.com", "loaders/foo.ts"),
+    ).toBe("https://preview.example.com/deco/invoke/loaders%2Ffoo.ts");
+  });
+
+  it("strips trailing slashes from the base url", () => {
+    expect(
+      buildLoaderInvokeUrl("https://preview.example.com///", "loaders/foo.ts"),
+    ).toBe("https://preview.example.com/deco/invoke/loaders%2Ffoo.ts");
+  });
+});


### PR DESCRIPTION
## Source
No open issue covers this. `apps/mesh/src/lib/loader-invoke.ts` had zero test coverage despite `isValidLoaderResolveType` being the sole guard against path traversal for `parseLoaderInvokeRequest`, which parses an **untrusted** request body in `apps/mesh/src/api/routes/sandbox-proxy.ts` (`sandbox-proxy.ts:833`) before building the upstream invoke URL.

## Why
This is a trust-boundary validator with no regression protection — a future edit to the regex or the `..` check could silently reopen a path-traversal hole in the loader-invoke proxy route, and nothing would fail.

## What's covered
- `isValidLoaderResolveType`: valid paths, empty string, `..` traversal attempts, disallowed characters.
- `parseLoaderInvokeRequest`: missing/invalid `__resolveType`, `props`-object wrapping, fallback to remaining top-level fields, array `props` not mistaken for an object.
- `buildLoaderInvokeUrl`: URL join + trailing-slash stripping.

## Verify
```
bun test apps/mesh/src/lib/loader-invoke.test.ts
```

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit`
- `bun test apps/mesh/src/lib/loader-invoke.test.ts` (11 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for loader-invoke validation and payload parsing used by the sandbox proxy. Covers resolveType path checks (traversal and disallowed chars), props handling and fallbacks, and URL building to prevent regressions.

<sup>Written for commit dfcc2cebd4f38c11a56a9d281929cb7ffa0135b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

