### PR TITLE
test(web): cover getProviderLogo fallback chain

### DIFF
--- a/apps/mesh/src/web/utils/ai-providers-logos.test.ts
+++ b/apps/mesh/src/web/utils/ai-providers-logos.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import {
+  DEFAULT_LOGO,
+  getProviderLogo,
+  PROVIDER_LOGOS,
+} from "./ai-providers-logos.ts";
+
+describe("getProviderLogo", () => {
+  it("returns the providerId's logo when there is a direct match", () => {
+    expect(
+      getProviderLogo({ providerId: "anthropic", modelId: "claude" }),
+    ).toBe(PROVIDER_LOGOS.anthropic);
+  });
+
+  it("prefers the modelId's upstream prefix over providerId", () => {
+    expect(
+      getProviderLogo({ providerId: "openrouter", modelId: "openai/gpt-4o" }),
+    ).toBe(PROVIDER_LOGOS.openai);
+  });
+
+  it("falls back to providerId when the upstream prefix is unknown", () => {
+    expect(getProviderLogo({ providerId: "openai", modelId: "foo/bar" })).toBe(
+      PROVIDER_LOGOS.openai,
+    );
+  });
+
+  it("infers the upstream provider from an unprefixed modelId", () => {
+    expect(
+      getProviderLogo({ providerId: "litellm", modelId: "claude-3-5-sonnet" }),
+    ).toBe(PROVIDER_LOGOS.anthropic);
+    expect(
+      getProviderLogo({ providerId: "litellm", modelId: "gpt-4o-mini" }),
+    ).toBe(PROVIDER_LOGOS.openai);
+  });
+
+  it("returns the default logo when nothing matches", () => {
+    expect(
+      getProviderLogo({
+        providerId: "unknown-provider",
+        modelId: "mystery-model",
+      }),
+    ).toBe(DEFAULT_LOGO);
+  });
+});


### PR DESCRIPTION
**Source:** improvement — `getProviderLogo` (apps/mesh/src/web/utils/ai-providers-logos.ts) had zero test coverage despite real branching logic that decides which provider logo renders in the model selector.

**Why:** the fallback chain (modelId upstream prefix → providerId → inferred-from-modelId-name → default logo) is exactly the kind of layered precedence that's easy to silently break in a refactor (e.g. reordering the checks, or "simplifying" the inference heuristic) and would only surface as a wrong/missing logo in the UI — not a build failure.

**What the test covers:**
- direct `providerId` match
- `modelId` upstream prefix (`"openai/gpt-4o"`) taking precedence over `providerId`
- falling back to `providerId` when the upstream prefix is unknown
- inferring the provider from an unprefixed `modelId` (e.g. `"gpt-4o-mini"`, `"claude-3-5-sonnet"`)
- falling back to `DEFAULT_LOGO` when nothing matches

**To verify:** `bun test apps/mesh/src/web/utils/ai-providers-logos.test.ts`

**Checked locally:** `bun run fmt` and the targeted test file (5/5 passing). Full CI will run typecheck/lint across the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added tests for the `getProviderLogo` fallback chain to lock in logo selection precedence and prevent regressions in the model selector.

Covers direct provider match, upstream prefix override, fallback to providerId when prefix is unknown, inference from unprefixed modelId, and default logo.

<sup>Written for commit ef42d6ac94aaad42123c6db60bd967a20c8dc530. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

