### PR TITLE
fix(nginx): raise large_client_header_buffers to avoid cookie 400s

### DIFF
--- a/deploy/helm/studio/files/api-nginx.conf
+++ b/deploy/helm/studio/files/api-nginx.conf
@@ -34,6 +34,11 @@ server {
   keepalive_requests 1000;
   send_timeout 60s;
 
+  # Cookies concatenate into one Cookie: header line; the default 8k buffer is
+  # exceeded by normal domain-wide accumulation (Better Auth session + PostHog +
+  # siblings), yielding a 400 "Request Header Or Cookie Too Large".
+  large_client_header_buffers 4 32k;
+
   location / {
     proxy_pass http://studio_api;
     proxy_http_version 1.1;
@@ -68,6 +73,10 @@ server {
   keepalive_timeout 65s;
   keepalive_requests 1000;
   send_timeout 60s;
+
+  # See the preview server above: raise from the 8k default so accumulated
+  # cookies in one Cookie: header line don't 400 with "Cookie Too Large".
+  large_client_header_buffers 4 32k;
 
   location = /healthz {
     access_log off;


### PR DESCRIPTION
## Summary

Fixes intermittent **`400 Bad Request — Request Header Or Cookie Too Large`** from the in-pod SPA/API nginx (`nginxinc/nginx-unprivileged:1.27`, reports as `nginx/1.27.5`).

### Root cause
nginx's default `large_client_header_buffers 4 8k` was never overridden in `api-nginx.conf`. The `Cookie:` request header is a *single* line holding all cookies concatenated; normal domain-wide accumulation (Better Auth `session_token` + PostHog `ph_*` + any siblings on the registrable domain) crosses 8k and nginx rejects the request. Intermittent because it depends on each browser's accumulated cookie set.

### Not the cause (ruled out)
- Better Auth **cookie cache** (`session_data`, which would serialize the full user incl. base64 `image`) is **never enabled** — no `session.cookieCache`/`customSession`; mesh always passes a `database`, so the fork's no-DB auto-enable is skipped.
- JWT payload already trimmed to `{id,email,name,role}`; org logos are hoisted to `/files/` URLs. No single fat cookie is written by the app — all app-set cookies (`org_sso_state`, fs unlock tokens) are path-scoped and transient.

So there is no single oversized cookie to shrink; the right fix is raising the buffer.

### Change
`large_client_header_buffers 4 32k` in both `server` blocks of `deploy/helm/studio/files/api-nginx.conf`.

## Testing
Config-only change; nginx directive is valid in `server` context. No app code touched.

## Follow-up
Confirm no deployed `auth-config`/branch has manually set `session.cookieCache.enabled: true` — that would reintroduce full-user (incl. base64 image) serialization into a single `session_data` cookie.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise `nginx` header buffers to prevent intermittent 400s caused by large combined Cookie headers. This stops "Request Header Or Cookie Too Large" errors from the in-pod reverse proxy.

- **Bug Fixes**
  - Set `large_client_header_buffers 4 32k` in both `server` blocks of `deploy/helm/studio/files/api-nginx.conf`.
  - Prevents rejections in in-pod `nginx` (`nginx/1.27` from `nginxinc/nginx-unprivileged:1.27`) when browsers send >8k `Cookie` headers.

<sup>Written for commit e718dec679af7debc3f843b0c7781910d0b32334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

