### PR TITLE
fix(sidebar): drop ghost agent groups for deleted agents

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -169,7 +169,7 @@ export function TaskGroupsList({
   // to home). Their thread groups are folded into the live counterpart's group
   // (rendered as a "Develop" sub-section) so dev sessions stay navigable under
   // one entry instead of a confusing standalone group.
-  const groups = useSidebarGroupOrder(
+  const orderedGroups = useSidebarGroupOrder(
     orderScope,
     foldDevGroupsIntoLive(
       groupThreadsByVirtualMcp(sortedThreads, decopilotId),
@@ -178,6 +178,21 @@ export function TaskGroupsList({
     decopilotId,
     orgPinnedIds,
     orderRevision,
+  );
+
+  // Groups are built from threads, whose virtual_mcp_id has no FK cascade — so a
+  // deleted agent leaves its threads orphaned and would render a ghost "Agent"
+  // group. Drop groups whose agent no longer exists in the (delete-invalidated)
+  // list. Decopilot (synthetic well-known) and the tool-call-runs bucket are
+  // never backed by a listed agent, so they're always kept.
+  const knownAgentIds = new Set(
+    agents.map((a) => a.id).filter((id): id is string => Boolean(id)),
+  );
+  const groups = orderedGroups.filter(
+    (g) =>
+      g.virtualMcpId === decopilotId ||
+      g.virtualMcpId === TOOL_CALL_RUNS_GROUP_KEY ||
+      knownAgentIds.has(g.virtualMcpId),
   );
 
   const memberFiltered = (threads: Task[]) =>


### PR DESCRIPTION
## Summary

When a user deletes an agent, it wasn't leaving the sidebar — it stayed there rendered with the fallback name **"Agent"**.

**Root cause:** the sidebar builds its agent groups from **threads** (`groupThreadsByVirtualMcp`), not from the agent list. `threads.virtual_mcp_id` is a plain text column with no FK cascade (migration `057`), so `COLLECTION_VIRTUAL_MCP_DELETE` removes the agent but leaves its threads orphaned. Those orphaned threads keep forming a group, and since the agent no longer exists, `useVirtualMCP(id)` returns `null` → the label falls back to `?? "Agent"` (`task-group.tsx:257`). The delete already invalidates the collection cache correctly; the group just never got removed because it's driven by the leftover threads.

## Fix

After ordering the groups in `task-groups-list.tsx`, filter out any group whose agent no longer exists in the (delete-invalidated) agent list, while preserving the synthetic **Decopilot** and **Automation runs** (tool-call-runs) groups, which are never backed by a listed agent.

Since the delete mutation already calls `invalidateCollection()` (invalidates both the item and the `VIRTUAL_MCP` list queries), the list refetches without the deleted agent and the group disappears from the sidebar. Covers both the expanded and collapsed sidebar views (same `groups`) and the empty state.

## Notes / follow-up

This is a frontend-only fix — the orphaned threads remain in the DB (they're just no longer surfaced). If we'd rather have the agent deletion also delete/hide its threads server-side (cascade in `COLLECTION_VIRTUAL_MCP_DELETE`), that can be a follow-up.

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/mesh check` (tsc) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar bug where deleted agents stayed visible as a ghost “Agent” group. We now drop groups whose agent no longer exists while keeping the synthetic Decopilot and Automation runs groups.

- **Bug Fixes**
  - After `useSidebarGroupOrder`, filter groups to only those with IDs present in the `agents` list, plus `decopilotId` and `TOOL_CALL_RUNS_GROUP_KEY`.
  - Addresses orphaned threads from `virtual_mcp_id` (no FK cascade) so deletes stop rendering ghost groups.
  - Works in both expanded and collapsed views; delete already invalidates the list, so the group disappears immediately.

<sup>Written for commit 3e49497bca7437ee767e089921f7bf8ab26f36e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

