### PR TITLE
ci(release): cut a release when the baked nginx conf changes

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -7,6 +7,9 @@ on:
     paths:
       - "apps/mesh/**"
       - "packages/**"
+      # Baked into the nginx image at build time (Dockerfile.nginx), so a change
+      # here must cut a release to rebuild that image — it is not a ConfigMap.
+      - "deploy/helm/studio/files/**"
 
 permissions:
   contents: write

--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -116,6 +116,14 @@ jobs:
               continue;
             }
 
+            // The nginx conf is baked into the studio-nginx image, tagged with
+            // apps/mesh's version — so a change here must bump that version to
+            // force a rebuild (there is no ConfigMap to reload).
+            if (file.startsWith("deploy/helm/studio/files/")) {
+              manifests.add("apps/mesh/package.json");
+              continue;
+            }
+
             const match = file.match(/^packages\/([^/]+)\//);
             if (match) {
               manifests.add(`packages/${match[1]}/package.json`);

--- a/deploy/helm/studio/files/api-nginx.conf
+++ b/deploy/helm/studio/files/api-nginx.conf
@@ -1,3 +1,7 @@
+# This file is baked into the nginx image (Dockerfile.nginx), not mounted as a
+# ConfigMap — edits only take effect after a release rebuilds the image and the
+# deployed tag is bumped. release-tagging watches this dir so that happens.
+
 map $http_upgrade $connection_upgrade {
   default upgrade;
   ''      "";


### PR DESCRIPTION
## Summary

Follow-up to #4330. That PR merged but **no release was cut**, so the `large_client_header_buffers` fix never reached the running pods.

### Why #4330 didn't ship
`release-tagging.yaml` only triggers on `apps/mesh/**` and `packages/**`. #4330 changed `deploy/helm/studio/files/api-nginx.conf`, which is **baked into the nginx image** at build time (`Dockerfile.nginx` → `COPY … /etc/nginx/conf.d/default.conf`), *not* mounted as a ConfigMap. So: no version bump → no `release-mesh` run → nginx image never rebuilt. A manual `release-mesh` dispatch also short-circuits (`nginx-image-exists` is true for the current version, so `build-nginx-docker` is skipped).

### Fix
Add `deploy/helm/studio/files/**` to the `release-tagging` path filter so edits to the baked nginx conf cut a release automatically.

**This PR also ships #4330's fix:** on `push`, GitHub evaluates `paths` against the workflow file *as it exists in the pushed commit*. The merge commit both adds the new path **and** touches `api-nginx.conf` (a comment documenting the bake-vs-ConfigMap gotcha), so it trips its own new filter → release-tagging fires → version bumps → nginx image rebuilds with the buffer fix.

## Testing
CI-config change + a comment. No app code, no nginx behavior change beyond what #4330 already merged.

## After merge
Once the release cuts a new tag, bump `image.tag` + `nginx.image.tag` in `deco-studio` **and** `deco-studio-stg` (deco-apps-cd) to that tag — that's what rolls the fix onto prod/stg pods.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger releases when the baked nginx config changes so the nginx image rebuilds and ships config updates automatically.

- **Bug Fixes**
  - Watch `deploy/helm/studio/files/**` in `release-tagging.yaml` and bump `apps/mesh/package.json` when it changes to force the nginx image rebuild.
  - Add a note in `api-nginx.conf` clarifying it’s baked, not a ConfigMap.

<sup>Written for commit 40ee823a5ff8dcfee4d3da7e4f5c217c2f2ab6d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

