### PR TITLE
feat(sections-editor): add Duplicate action to array field rows

### DIFF
--- a/apps/mesh/ct/tests/array-field.ct.tsx
+++ b/apps/mesh/ct/tests/array-field.ct.tsx
@@ -121,11 +121,45 @@ test("delete removes the targeted item from the list", async ({
     .toEqual({ tags: ["a", "b"] });
 
   // The per-row actions trigger is in the DOM (opacity-0 until hover) and clickable.
-  await component.getByRole("button", { name: "Open actions for a" }).click();
+  // `exact` disambiguates the button from the sortable row (whose accessible
+  // name embeds the button label).
+  await component
+    .getByRole("button", { name: "Open actions for a", exact: true })
+    .click();
   // The DropdownMenu content is portaled onto document.body — query via page.
   await page.getByRole("menuitem", { name: "Delete" }).click();
 
   await expect.poll(() => readFormValue(component)).toEqual({ tags: ["b"] });
+});
+
+test("duplicate inserts a copy right after the targeted item", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    tags: { type: "array", title: "Tags", items: { type: "string" } },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ tags: ["a", "b"] }}
+    />,
+  );
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ tags: ["a", "b"] });
+
+  await component
+    .getByRole("button", { name: "Open actions for a", exact: true })
+    .click();
+  // The DropdownMenu content is portaled onto document.body — query via page.
+  await page.getByRole("menuitem", { name: "Duplicate" }).click();
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ tags: ["a", "a", "b"] });
 });
 
 test("add a number item appends the default 0", async ({ mount }) => {

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -18,7 +18,13 @@ import {
   arrayMove,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { DotsGrid, DotsHorizontal, Plus, Trash01 } from "@untitledui/icons";
+import {
+  Copy01,
+  DotsGrid,
+  DotsHorizontal,
+  Plus,
+  Trash01,
+} from "@untitledui/icons";
 import { toast } from "sonner";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
@@ -156,12 +162,14 @@ function SortableArrayRow({
   labelText,
   imageSrc,
   onOpen,
+  onDuplicate,
   onRemove,
 }: {
   sortableId: string;
   labelText: string;
   imageSrc?: string;
   onOpen: () => void;
+  onDuplicate: () => void;
   onRemove: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
@@ -223,6 +231,10 @@ function SortableArrayRow({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={onDuplicate}>
+            <Copy01 size={14} />
+            Duplicate
+          </DropdownMenuItem>
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
             onClick={onRemove}
@@ -348,6 +360,20 @@ export function ArrayField({
       return;
     }
     addItem();
+  };
+
+  const duplicateItem = (index: number) => {
+    const original = items[index];
+    const copy =
+      typeof structuredClone === "function"
+        ? structuredClone(original)
+        : JSON.parse(JSON.stringify(original ?? null));
+    const next = [
+      ...items.slice(0, index + 1),
+      copy,
+      ...items.slice(index + 1),
+    ];
+    onChange(next);
   };
 
   const removeItem = (index: number) => {
@@ -549,6 +575,7 @@ export function ArrayField({
                       labelText={labelText}
                       imageSrc={imageSrc}
                       onOpen={() => openItem(entry.index)}
+                      onDuplicate={() => duplicateItem(entry.index)}
                       onRemove={() => removeItem(entry.index)}
                     />
                   );


### PR DESCRIPTION
## Summary

Adds a **Duplicate** option to the per-row dropdown menu in the array field editor (the "Shelves" list in ProductShelfGroup and every other array field use this generic editor). Previously the row menu only offered **Delete**.

- New `Duplicate` item (with `Copy01` icon) above `Delete` in `SortableArrayRow`.
- `duplicateItem(index)` deep-clones the item (`structuredClone`, with a `JSON` fallback) and inserts the copy **right after** the source item so list order stays intuitive.
- Threads a new `onDuplicate` prop through `SortableArrayRow`.

## Testing

- Added a component test: `["a","b"]` → duplicate `a` → `["a","a","b"]`.
- Fixed the adjacent **delete** component test, which was already failing on `main` with a Playwright strict-mode violation (the row `<div role="button">` and the trigger `<button>` shared a substring accessible name); both now use `{ name: ..., exact: true }`.
- `bun run test:ct array-field` → **8 passed**.
- `bun run --cwd=apps/mesh check` → no type errors; `bun run fmt` clean.

## Notes

Duplicating deep-clones the item as an independent copy — editing the duplicate won't affect the original. If duplicates of *referenced* blocks should instead keep pointing at the same shared block, that would need a follow-up special case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Duplicate action to array field rows in the sections editor, affecting all arrays (e.g., Shelves lists). It deep-clones the item and inserts the copy right after the source to keep order intuitive.

- **New Features**
  - Adds “Duplicate” above “Delete” in the per-row menu (uses `Copy01` icon).
  - Deep-clones via `structuredClone` with JSON fallback and inserts after the source.
  - Threads `onDuplicate` through `SortableArrayRow` and wires it in `ArrayField`.

- **Bug Fixes**
  - Fixes strict-mode locator conflict in the delete test by using exact accessible names.
  - Adds a component test for duplicate behavior.

<sup>Written for commit 312d6e89f3caaed06b1410b593a54ecaadb210c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

