### PR TITLE
feat(ai-providers): add LLMAPI as a first-class provider

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/llmapi.ts
+++ b/apps/mesh/src/ai-providers/adapters/llmapi.ts
@@ -1,0 +1,99 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import type { ModelCapability } from "@decocms/mesh-sdk";
+import type { MeshProvider, ModelInfo, ProviderAdapter } from "../types";
+
+const LLMAPI_BASE_URL = "https://api.llmapi.ai/v1";
+const LLMAPI_ICON_URL =
+  "https://llmapi.ai/wp-content/uploads/2026/01/Frame-2085662993.png";
+
+// Shape of an entry in llmapi's OpenRouter-style /v1/models payload. Only the
+// fields we read — the endpoint returns much more (per-provider routing, etc).
+interface LlmapiModel {
+  id: string;
+  name?: string;
+  description?: string;
+  context_length?: number;
+  pricing?: { prompt?: string; completion?: string };
+  architecture?: { input_modalities?: string[]; output_modalities?: string[] };
+  supported_parameters?: string[] | null;
+  reasoning_levels?: unknown[];
+  providers?: { reasoning?: boolean }[];
+}
+
+export const llmapiAdapter: ProviderAdapter = {
+  info: {
+    id: "llmapi",
+    name: "LLMAPI",
+    description: "One API key, 400+ models across every provider",
+    logo: LLMAPI_ICON_URL,
+  },
+
+  supportedMethods: ["api-key"],
+
+  create(apiKey): MeshProvider {
+    const openai = createOpenAI({
+      apiKey: apiKey || "not-needed",
+      baseURL: LLMAPI_BASE_URL,
+      name: "llmapi",
+    });
+
+    // Route languageModel() through /chat/completions (llmapi doesn't serve the
+    // OpenAI Responses API). Same wrapper the openai-compatible adapter uses.
+    const aiSdk: typeof openai = Object.assign(
+      (...args: Parameters<typeof openai>) => openai.chat(...args),
+      openai,
+      { languageModel: openai.chat },
+    );
+
+    return {
+      info: this.info,
+      aiSdk,
+
+      async listModels(): Promise<ModelInfo[]> {
+        const res = await fetch(`${LLMAPI_BASE_URL}/models`, {
+          headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+          signal: AbortSignal.timeout(15_000),
+        });
+        if (!res.ok) {
+          throw new Error(`LLMAPI listModels failed: ${res.status}`);
+        }
+        const { data }: { data: LlmapiModel[] } = await res.json();
+        return data.map((m) => {
+          const arch = m.architecture ?? {};
+          const canReason =
+            !!m.reasoning_levels?.length ||
+            !!m.providers?.some((p) => p.reasoning);
+          return {
+            providerId: "llmapi",
+            modelId: m.id,
+            title: m.name || m.id,
+            description: m.description ?? null,
+            logo: null,
+            capabilities: [
+              ...new Set([
+                // "image" in input means vision (accepts images), not image
+                // generation — remap so it's distinct from output "image".
+                ...(arch.input_modalities ?? []).map((mod) =>
+                  mod === "image" ? "vision" : mod,
+                ),
+                ...(arch.output_modalities ?? []),
+                ...(m.supported_parameters?.includes("tools")
+                  ? (["tools"] as const)
+                  : []),
+                ...(canReason ? (["reasoning"] as const) : []),
+              ]),
+            ] as ModelCapability[],
+            limits: {
+              contextWindow: m.context_length ?? 0,
+              maxOutputTokens: null,
+            },
+            costs: {
+              input: Number(m.pricing?.prompt) || 0,
+              output: Number(m.pricing?.completion) || 0,
+            },
+          };
+        });
+      },
+    };
+  },
+};

--- a/apps/mesh/src/ai-providers/registry.ts
+++ b/apps/mesh/src/ai-providers/registry.ts
@@ -1,5 +1,6 @@
 import { anthropicAdapter } from "./adapters/anthropic";
 import { googleAdapter } from "./adapters/google";
+import { llmapiAdapter } from "./adapters/llmapi";
 import { openaiCompatibleAdapter } from "./adapters/openai-compatible";
 import { openrouterAdapter } from "./adapters/openrouter";
 import type { ProviderId } from "./provider-ids";
@@ -14,6 +15,7 @@ export function getProviders(): Partial<Record<ProviderId, ProviderAdapter>> {
     anthropic: anthropicAdapter,
     google: googleAdapter,
     openrouter: openrouterAdapter,
+    llmapi: llmapiAdapter,
     "openai-compatible": openaiCompatibleAdapter,
   };
 }

--- a/apps/mesh/src/web/views/settings/ai-providers/provider-grid.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/provider-grid.tsx
@@ -70,8 +70,9 @@ export function ProviderGrid({
   const deco = providers.find((p) => p.id === "deco");
   const CLOUD_ORDER: Record<string, number> = {
     openrouter: 0,
-    anthropic: 1,
-    google: 2,
+    llmapi: 1,
+    anthropic: 2,
+    google: 3,
   };
   const cloud = providers
     .filter((p) => p.id !== "deco" && p.id !== "openai-compatible")

--- a/packages/harness/src/decopilot/mesh-provider.ts
+++ b/packages/harness/src/decopilot/mesh-provider.ts
@@ -115,6 +115,7 @@ const THOUGHT_SIGNATURE_ID_PROVIDERS = new Set<string>([
   "openai-compatible",
   "openrouter",
   "deco",
+  "llmapi",
 ]);
 
 /**

--- a/packages/harness/src/decopilot/provider-from-secret.test.ts
+++ b/packages/harness/src/decopilot/provider-from-secret.test.ts
@@ -19,10 +19,15 @@ describe("createProviderFromSecret", () => {
   // wedged on every decopilot run. `languageModel(...)` must construct a model
   // synchronously and return. (A regression would hang this test — a loud,
   // CI-visible failure, since a synchronous infinite loop ignores test timeouts.)
-  for (const providerId of ["openrouter", "deco"] as const) {
+  for (const providerId of [
+    "openrouter",
+    "deco",
+    "llmapi",
+    "openai-compatible",
+  ] as const) {
     it(`${providerId}: languageModel returns a model without self-recursion`, () => {
       const provider = createProviderFromSecret(secret(providerId));
-      const model = provider.aiSdk.languageModel("openrouter/auto");
+      const model = provider.aiSdk.languageModel("some-model");
       expect(model).toBeDefined();
       expect(typeof (model as { modelId?: unknown }).modelId).toBe("string");
     });

--- a/packages/harness/src/decopilot/provider-from-secret.ts
+++ b/packages/harness/src/decopilot/provider-from-secret.ts
@@ -114,14 +114,20 @@ export function createProviderFromSecret(
       );
     }
 
+    case "llmapi":
     case "openai-compatible": {
+      // llmapi is a fixed-endpoint OpenAI-compatible gateway; openai-compatible
+      // is user-configured. Both route languageModel() through chat completions.
       let normalizedBaseUrl = (baseUrl ?? "").replace(/\/+$/, "");
+      if (providerId === "llmapi" && !normalizedBaseUrl) {
+        normalizedBaseUrl = "https://api.llmapi.ai/v1";
+      }
       if (normalizedBaseUrl && !normalizedBaseUrl.endsWith("/v1")) {
         normalizedBaseUrl += "/v1";
       }
       const openai = createOpenAI({
         apiKey: apiKey || "not-needed",
-        name: "openai-compatible",
+        name: providerId,
         ...(normalizedBaseUrl ? { baseURL: normalizedBaseUrl } : {}),
         ...(extraHeaders ? { headers: extraHeaders } : {}),
       });
@@ -137,7 +143,7 @@ export function createProviderFromSecret(
     default:
       throw new Error(
         `decopilot: unsupported modelSource.providerId '${providerId}'. ` +
-          "Supported: anthropic, google, openrouter, deco, openai-compatible.",
+          "Supported: anthropic, google, openrouter, deco, openai-compatible, llmapi.",
       );
   }
 }

--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -26,6 +26,7 @@ export const DEFAULT_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
       "anthropic/claude-haiku",
       "anthropic/claude",
     ],
+    llmapi: ["claude-sonnet-4-6", "claude-sonnet", "gpt-5.1"],
     google: ["gemini-3-flash"],
     "claude-code": [
       "claude-code:sonnet",
@@ -48,6 +49,7 @@ export const FAST_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
     "google/gemini-3-flash",
   ],
   deco: ["qwen/qwen3.5-flash", "anthropic/claude-haiku"],
+  llmapi: ["claude-haiku-4-5", "claude-haiku", "gpt-4o-mini"],
   google: ["gemini-2.5-flash", "gemini-3-flash"],
   "claude-code": ["claude-code:haiku", "claude-code:sonnet"],
   codex: ["codex:gpt-5.4-mini"],
@@ -79,6 +81,7 @@ export const SMART_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
     "anthropic/claude-sonnet",
     "anthropic/claude",
   ],
+  llmapi: ["claude-sonnet-4-6", "claude-sonnet"],
   google: ["gemini-3-pro", "gemini-3-flash"],
   "claude-code": ["claude-code:sonnet"],
   codex: ["codex:gpt-5.4"],
@@ -113,6 +116,7 @@ export const THINKING_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
       // Fable suspended by US government directive (2026-06-13)
       "anthropic/claude-fable",
     ],
+    llmapi: ["claude-opus-4-8", "claude-opus", "claude-sonnet-4-6"],
     google: ["gemini-3-pro"],
     "claude-code": [
       "claude-code:opus-1m",
@@ -129,6 +133,7 @@ export const THINKING_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
 export const IMAGE_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
   openrouter: ["openai/gpt-image-1", "google/gemini-2.0-flash-image"],
   deco: ["openai/gpt-image-1", "google/gemini-2.0-flash-image"],
+  llmapi: ["gemini-2.5-flash-image", "gpt-image-1"],
   google: ["gemini-2.0-flash-image"],
 };
 

--- a/packages/mesh-sdk/src/types/ai-providers.ts
+++ b/packages/mesh-sdk/src/types/ai-providers.ts
@@ -6,6 +6,7 @@ export const PROVIDER_IDS = [
   "deco",
   "anthropic",
   "openrouter",
+  "llmapi",
   "google",
   "claude-code",
   "codex",


### PR DESCRIPTION
## Summary

Adds [LLMAPI](https://llmapi.ai) (`llmapi.ai`) as a first-class AI provider, alongside OpenRouter/Anthropic/Google. LLMAPI is an OpenAI-compatible gateway (~273 models across every provider, `Authorization: Bearer llmapi_…`, base URL `https://api.llmapi.ai/v1`). Its `/v1/models` returns an OpenRouter-shaped payload (pricing/architecture/context_length), so the model catalog comes back with real capabilities, limits, and costs — not just bare ids.

Wired it in exactly like OpenRouter, reusing the existing data-driven registry so no UI changes were needed (the provider card, connect form, model selector, and key storage all populate from the registry).

## Changes

- **New adapter** `apps/mesh/src/ai-providers/adapters/llmapi.ts` — `createOpenAI` at the fixed base URL with the chat-completions wrapper (LLMAPI doesn't serve the Responses API), plus a `/models` mapper → `capabilities` (modalities, `image`→`vision`, tools, reasoning), `limits`, and `costs` (pricing arrives as strings like `"3e-7"`, parsed via `Number(...)`).
- **Registry + union** — registered in `getProviders()` and added `"llmapi"` to `PROVIDER_IDS` (so `AI_PROVIDER_KEY_CREATE`'s `z.enum` accepts it and keys store the raw token).
- **Decopilot runtime** (`provider-from-secret.ts`) — the agent-run model resolution path. Merged with the `openai-compatible` case; LLMAPI gets a fixed default base URL.
- **Thought-signature codec** — added `llmapi` to `THOUGHT_SIGNATURE_ID_PROVIDERS` (OpenAI-wire gateway that can route Gemini; a no-op when no signature is embedded).
- **Defaults & ordering** — per-tier default model preferences (thinking/smart/fast/image) and grid ordering (placed right after OpenRouter).
- **Test** — extended the `createProviderFromSecret` self-recursion regression guard to cover `llmapi` and `openai-compatible`.

## Testing

- `bun run check` (all workspaces), `bun run lint` (0 errors — the 7 warnings are pre-existing in unrelated e2e/sections-editor files), `bun run fmt`.
- `bun test packages/harness/src/decopilot/provider-from-secret.test.ts` — 4 pass.
- **Live end-to-end** against the real API: `listModels()` returned 273 models with correct capabilities and **0 NaN costs**, and a real `generateText` through the AI SDK (`gpt-4o-mini` via `/chat/completions`) returned `"pong"`.

## Follow-ups

- The provider-card logo points at LLMAPI's own favicon URL (`llmapi.ai/wp-content/...`); other providers use deco's CDN (`assets.decocache.com`). Trivial to re-host if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `llmapi` as a first-class AI provider. It plugs in an OpenAI-compatible gateway at `https://api.llmapi.ai/v1` with rich `/v1/models` metadata so users can browse hundreds of models with accurate capabilities, limits, and pricing.

- **New Features**
  - Added `apps/mesh/src/ai-providers/adapters/llmapi.ts` using `@ai-sdk/openai`; routes via `/chat/completions`; maps OpenRouter-shaped `/v1/models` to capabilities, limits, and costs (parses scientific-pricing strings).
  - Registered `llmapi` in the provider registry and `PROVIDER_IDS`; included in thought-signature providers; ordered after OpenRouter in the provider grid; added per-tier default model preferences.
  - Decopilot support: handled in `createProviderFromSecret` with a fixed default base URL and the shared `openai-compatible` path.
  - Tests: extended the self-recursion guard to cover `llmapi` and `openai-compatible`.

<sup>Written for commit 15009cc6bdc0fc4f1fd7e1086e85a49fd1efc429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

