### PR TITLE
fix(decopilot): stop purging the run stream on RUN_FAILED — the consume step still projects it

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1013,7 +1013,6 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   const cancelReactorDeps: RunReactorDeps = {
     storage: threadStorage,
-    streamBuffer,
     sseHub,
   };
 

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -10,8 +10,11 @@
  * - Per-subject message limit (500K msgs/subject) prevents one thread
  *   from starving others.
  * - Per-thread publish error tracking with sampled logging.
- * - `purge()` is called on terminal events from the run reactor to drop
- *   completed runs early; the 24h `max_age` is the upper bound.
+ * - `purge()` is owned by the projector: `runProjectorWorkflowBody` purges a
+ *   run's subject after a terminal projection, and `dispatchRun` purges the
+ *   previous turn's remnants at turn start. Nothing may purge a subject the
+ *   consume step hasn't projected yet (it needs the contiguous seq 1..N log);
+ *   the 24h `max_age` is the backstop for never-projected runs.
  */
 
 import {

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -10,11 +10,17 @@
  * broken. See TESTING.md: don't mock your own code.
  *
  * So here `storage` is a real SqlThreadStorage against real Postgres, and we
- * assert the actual row state after each event. The two remaining deps —
- * `sseHub` and `streamBuffer` — are output side-channels (fire-and-forget,
- * the reactor never branches on their return), so we capture their emissions
- * to assert on, the same way an e2e spec reads the DB to assert. That is
- * observing output, not faking an input contract.
+ * assert the actual row state after each event. The remaining dep — `sseHub` —
+ * is an output side-channel (fire-and-forget, the reactor never branches on its
+ * return), so we capture its emissions to assert on, the same way an e2e spec
+ * reads the DB to assert. That is observing output, not faking an input
+ * contract.
+ *
+ * The reactor performs NO JetStream purge on any event: the consume step
+ * projects every dispatched run (its entry guard ignores terminal status) and
+ * needs the contiguous seq 1..N log, so purge ownership lives in the projector
+ * workflow. `RunReactorDeps` has no stream buffer — the guarantee is
+ * structural.
  */
 
 import {
@@ -37,7 +43,6 @@ import { SqlThreadStorage } from "@/storage/threads";
 import type { Thread } from "@/storage/types";
 import { reactAll, type RunReactorDeps } from "./run-reactor";
 import type { RunEvent } from "./run-state";
-import type { StreamBuffer } from "./stream-buffer";
 
 const ORG = "org_1";
 const USER = "user_1";
@@ -64,16 +69,14 @@ beforeEach(async () => {
 // ---------------------------------------------------------------------------
 
 /**
- * Capturing reactor: real storage, plus in-memory capture of the two output
- * side-channels. Returns the deps to pass to reactAll and the captured output.
+ * Capturing reactor: real storage, plus in-memory capture of the SSE output
+ * side-channel. Returns the deps to pass to reactAll and the captured output.
  */
 function makeReactor(): {
   deps: RunReactorDeps;
   sseEvents: Array<{ orgId: string; event: SSEEvent }>;
-  purged: string[];
 } {
   const sseEvents: Array<{ orgId: string; event: SSEEvent }> = [];
-  const purged: string[] = [];
   const deps: RunReactorDeps = {
     storage,
     sseHub: {
@@ -81,14 +84,8 @@ function makeReactor(): {
         sseEvents.push({ orgId, event });
       },
     },
-    // Only purge() is exercised by the reactor; capture it.
-    streamBuffer: {
-      purge(taskId: string) {
-        purged.push(taskId);
-      },
-    } as unknown as StreamBuffer,
   };
-  return { deps, sseEvents, purged };
+  return { deps, sseEvents };
 }
 
 const react = (event: RunEvent, deps: RunReactorDeps) =>
@@ -123,7 +120,7 @@ function statusData(event: SSEEvent): Record<string, unknown> {
 describe("reactAll (real Postgres)", () => {
   describe("RUN_STARTED", () => {
     it("flips the row to in_progress and emits 1 status event", async () => {
-      const { deps, sseEvents, purged } = makeReactor();
+      const { deps, sseEvents } = makeReactor();
       const thread = await createThread(); // default status "completed"
       await database.db
         .updateTable("threads")
@@ -154,7 +151,6 @@ describe("reactAll (real Postgres)", () => {
       expect(row?.run_started_at).not.toBeNull();
       expect(rawRow.last_progress_at).toBeNull();
       expect(sseEvents).toHaveLength(1);
-      expect(purged).toHaveLength(0);
     });
 
     it("emitted status event reflects the real row (title, branch, created_at, updated_at)", async () => {
@@ -189,7 +185,7 @@ describe("reactAll (real Postgres)", () => {
 
   describe("RUN_RESUMED", () => {
     it("sets run_started_at WITHOUT touching status; emits 1 event", async () => {
-      const { deps, sseEvents, purged } = makeReactor();
+      const { deps, sseEvents } = makeReactor();
       const thread = await createThread(); // status "completed"
 
       await react(
@@ -209,13 +205,12 @@ describe("reactAll (real Postgres)", () => {
       // Proof the status column was never written: it stays "completed".
       expect(row?.status).toBe("completed");
       expect(sseEvents).toHaveLength(1);
-      expect(purged).toHaveLength(0);
     });
   });
 
   describe("STEP_COMPLETED", () => {
     it("emits 1 step event and performs no DB write", async () => {
-      const { deps, sseEvents, purged } = makeReactor();
+      const { deps, sseEvents } = makeReactor();
       const thread = await createThread();
       const before = await storage.get(thread.id, ORG);
 
@@ -228,13 +223,12 @@ describe("reactAll (real Postgres)", () => {
       expect(after?.updated_at).toBe(before?.updated_at); // untouched
       expect(after?.status).toBe(before?.status);
       expect(sseEvents).toHaveLength(1);
-      expect(purged).toHaveLength(0);
     });
   });
 
   describe("RUN_COMPLETED", () => {
-    it("does NOT write status to DB (consume step owns it), does NOT purge, emits 2 SSE events", async () => {
-      const { deps, sseEvents, purged } = makeReactor();
+    it("does NOT write status to DB (consume step owns it), emits 2 SSE events", async () => {
+      const { deps, sseEvents } = makeReactor();
       const thread = await createThread();
       await setInProgress(thread.id);
 
@@ -251,16 +245,14 @@ describe("reactAll (real Postgres)", () => {
       // run_* columns are also untouched — the consume step clears them.
       expect(row?.run_config).not.toBeNull();
       expect(row?.run_started_at).not.toBeNull();
-      // Purge ownership is the projector workflow's job (cleanupRunStep).
-      expect(purged).toHaveLength(0);
       // SSE is still emitted for instant UX.
       expect(sseEvents).toHaveLength(2);
     });
   });
 
   describe("RUN_REQUIRES_ACTION", () => {
-    it("does NOT write status to DB (consume step owns it), does NOT purge, emits 2 SSE events", async () => {
-      const { deps, sseEvents, purged } = makeReactor();
+    it("does NOT write status to DB (consume step owns it), emits 2 SSE events", async () => {
+      const { deps, sseEvents } = makeReactor();
       const thread = await createThread();
       await setInProgress(thread.id);
 
@@ -281,17 +273,15 @@ describe("reactAll (real Postgres)", () => {
       // run_* columns also stay — the consume step clears them.
       expect(row?.run_config).not.toBeNull();
       expect(row?.run_started_at).not.toBeNull();
-      // Purge is the projector workflow's job.
-      expect(purged).toHaveLength(0);
       // SSE is still emitted for instant UX.
       expect(sseEvents).toHaveLength(2);
     });
   });
 
   describe("RUN_FAILED", () => {
-    it("error/cancelled/reaped: sets status=failed, clears run_* columns, purges, 2 events", async () => {
+    it("error/cancelled/reaped: sets status=failed, clears run_* columns, 2 events", async () => {
       for (const reason of ["error", "cancelled", "reaped"] as const) {
-        const { deps, sseEvents, purged } = makeReactor();
+        const { deps, sseEvents } = makeReactor();
         const thread = await createThread();
         await setInProgress(thread.id);
 
@@ -305,13 +295,12 @@ describe("reactAll (real Postgres)", () => {
         expect(row?.run_owner_pod).toBeNull();
         expect(row?.run_config).toBeNull();
         expect(row?.run_started_at).toBeNull();
-        expect(purged).toEqual([thread.id]);
         expect(sseEvents).toHaveLength(2);
       }
     });
 
-    it("ghost: flips an in_progress row to failed (forceFailIfInProgress), clears run_*, purges, 2 events", async () => {
-      const { deps, sseEvents, purged } = makeReactor();
+    it("ghost: flips an in_progress row to failed (forceFailIfInProgress), clears run_*, 2 events", async () => {
+      const { deps, sseEvents } = makeReactor();
       const thread = await createThread();
       await setInProgress(thread.id);
 
@@ -325,12 +314,11 @@ describe("reactAll (real Postgres)", () => {
       expect(row?.run_owner_pod).toBeNull();
       expect(row?.run_config).toBeNull();
       expect(row?.run_started_at).toBeNull();
-      expect(purged).toEqual([thread.id]);
       expect(sseEvents).toHaveLength(2);
     });
 
     it("ghost: no-op when the row is NOT in_progress (real forceFailIfInProgress short-circuit)", async () => {
-      const { deps, sseEvents, purged } = makeReactor();
+      const { deps, sseEvents } = makeReactor();
       const thread = await createThread(); // status "completed", not in_progress
 
       await react(
@@ -340,14 +328,13 @@ describe("reactAll (real Postgres)", () => {
 
       const row = await storage.get(thread.id, ORG);
       expect(row?.status).toBe("completed"); // unchanged
-      expect(purged).toHaveLength(0);
       expect(sseEvents).toHaveLength(0);
     });
   });
 
   describe("PREVIOUS_RUN_ABORTED", () => {
-    it("is a no-op: no DB change, no purge, no SSE", async () => {
-      const { deps, sseEvents, purged } = makeReactor();
+    it("is a no-op: no DB change, no SSE", async () => {
+      const { deps, sseEvents } = makeReactor();
       const thread = await createThread();
       await setInProgress(thread.id);
       const before = await storage.get(thread.id, ORG);
@@ -359,7 +346,6 @@ describe("reactAll (real Postgres)", () => {
 
       const after = await storage.get(thread.id, ORG);
       expect(after).toEqual(before); // byte-for-byte unchanged
-      expect(purged).toHaveLength(0);
       expect(sseEvents).toHaveLength(0);
     });
   });

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { ThreadStoragePort } from "@/storage/ports";
 import { reactAll, type RunReactorDeps } from "./run-reactor";
-import type { StreamBuffer } from "./stream-buffer";
 
 describe("run reactor", () => {
-  test("RUN_FAILED purges the abandoned run's stream buffer", async () => {
-    const purged: string[] = [];
+  test("RUN_FAILED writes the terminal status + emits SSE, and does NOT purge the stream", async () => {
     const updates: unknown[] = [];
     const emitted: unknown[] = [];
     const deps: RunReactorDeps = {
@@ -22,11 +20,6 @@ describe("run reactor", () => {
         }),
         forceFailIfInProgress: async () => true,
       } as unknown as ThreadStoragePort,
-      streamBuffer: {
-        purge: (runId: string) => {
-          purged.push(runId);
-        },
-      } as unknown as StreamBuffer,
       sseHub: {
         emit: (_orgId, event) => {
           emitted.push(event);
@@ -52,10 +45,11 @@ describe("run reactor", () => {
     );
 
     expect(updates).toHaveLength(1);
-    // Failed runs are NOT projected, so the durable projector never runs its
-    // cleanup step for them — the reactor purges the abandoned stream buffer
-    // here as explicit cleanup (see run-reactor.ts RUN_FAILED handling).
-    expect(purged).toEqual(["run_1"]);
+    // Regression guard: the reactor must NOT purge the run's JetStream
+    // subject on RUN_FAILED. The consume step still projects force-failed
+    // runs and needs the contiguous seq 1..N log — a mid-run purge beheads
+    // it and the projector poisons the thread with "missing seq N".
+    // Structural since RunReactorDeps no longer accepts a stream buffer.
     expect(emitted).toHaveLength(2);
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -1,9 +1,9 @@
 /**
  * Run Reactor — impure shell of the run lifecycle pipeline
  *
- * Every DB write, SSE emit, and stream buffer purge triggered by a run
- * state transition lives here. This is the only layer in the pipeline
- * that performs I/O; decide() and project() are kept pure.
+ * Every DB write and SSE emit triggered by a run state transition lives
+ * here. This is the only layer in the pipeline that performs I/O;
+ * decide() and project() are kept pure.
  *
  * Consumed via RunRegistry — callers should not use reactAll directly:
  *   registry.execute(command)          — dispatch + react (common case)
@@ -17,7 +17,6 @@ import {
   createDecopilotStepEvent,
   createDecopilotThreadStatusEvent,
 } from "@decocms/mesh-sdk";
-import type { StreamBuffer } from "./stream-buffer";
 import type { RunEvent, RunTransition } from "./run-state";
 
 // ============================================================================
@@ -30,7 +29,6 @@ import type { RunEvent, RunTransition } from "./run-state";
 
 export interface RunReactorDeps {
   storage: ThreadStoragePort;
-  streamBuffer: StreamBuffer;
   sseHub: { emit(orgId: string, event: SSEEvent): void };
 }
 
@@ -71,7 +69,7 @@ async function handleTerminalStatus(
 // ============================================================================
 
 async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
-  const { storage, streamBuffer, sseHub } = deps;
+  const { storage, sseHub } = deps;
 
   switch (event.type) {
     case "RUN_STARTED": {
@@ -160,7 +158,14 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
           run_started_at: null,
         });
       }
-      streamBuffer.purge(event.taskId);
+      // Deliberately NO JetStream purge here. The consume step projects every
+      // dispatched run (its entry guard ignores terminal status) and requires
+      // the contiguous seq 1..N log; purging on a force-fail beheads a log the
+      // producer may still be appending to (reaped-but-alive run, or an
+      // in-band failure racing the consume step's read), and the projector
+      // then poisons the thread with a persisted "missing seq N" error part.
+      // Terminal purge is owned by the projector (runProjectorWorkflowBody);
+      // dispatch-start clears the previous turn; max_age bounds the rest.
       const failedThread = await storage.get(event.taskId, event.orgId);
       sseHub.emit(
         event.orgId,

--- a/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.integration.test.ts
@@ -36,7 +36,6 @@ import { SqlThreadStorage } from "@/storage/threads";
 import type { Thread } from "@/storage/types";
 import { RunRegistry } from "./run-registry";
 import type { RunReactorDeps } from "./run-reactor";
-import type { StreamBuffer } from "./stream-buffer";
 
 const ORG = "org_1";
 const USER = "user_1";
@@ -72,7 +71,6 @@ afterEach(() => {
 
 function makeRegistry(opts: { clock?: () => Date } = {}) {
   const sseEvents: Array<{ orgId: string; event: SSEEvent }> = [];
-  const purged: string[] = [];
   const deps: RunReactorDeps = {
     storage,
     sseHub: {
@@ -80,17 +78,12 @@ function makeRegistry(opts: { clock?: () => Date } = {}) {
         sseEvents.push({ orgId, event });
       },
     },
-    streamBuffer: {
-      purge(taskId: string) {
-        purged.push(taskId);
-      },
-    } as unknown as StreamBuffer,
   };
   const registry = opts.clock
     ? new RunRegistry(deps, opts.clock)
     : new RunRegistry(deps);
   createdRegistries.push(registry);
-  return { registry, sseEvents, purged };
+  return { registry, sseEvents };
 }
 
 function startThread(registry: RunRegistry, taskId: string, orgId = ORG) {
@@ -159,9 +152,9 @@ describe("RunRegistry storage orchestration (real Postgres)", () => {
   });
 
   describe("reapStaleRuns (terminal side effects)", () => {
-    it("reaps a stuck run: real terminal DB write (failed, run_* cleared) + purge", async () => {
+    it("reaps a stuck run: real terminal DB write (failed, run_* cleared)", async () => {
       let now = new Date("2024-01-01T00:00:00Z");
-      const { registry, purged } = makeRegistry({ clock: () => now });
+      const { registry } = makeRegistry({ clock: () => now });
       const thread = await seedRunningThread();
       startThread(registry, thread.id); // in-memory running, startedAt = now
 
@@ -181,19 +174,16 @@ describe("RunRegistry storage orchestration (real Postgres)", () => {
       expect(signal.aborted).toBe(true);
       expect(registry.isRunning(thread.id)).toBe(false);
 
-      // The terminal write + purge are fire-and-forget inside the reaper, and
-      // the reactor calls streamBuffer.purge() on the line *after* the status
-      // write commits. Poll until BOTH the row and the purge are observable —
-      // asserting purge the instant status flips to "failed" is a race (it
-      // passed locally and in CI for #3579, then flaked here).
+      // The terminal write is fire-and-forget inside the reaper — poll until
+      // the row is observable. (No JetStream purge on force-fail: the consume
+      // step still projects the run and needs the contiguous seq 1..N log.)
       await waitFor(async () => {
         const r = await storage.get(thread.id, ORG);
         return (
           r?.status === "failed" &&
           r.run_owner_pod === null &&
           r.run_config === null &&
-          r.run_started_at === null &&
-          purged.includes(thread.id)
+          r.run_started_at === null
         );
       });
       const row = await storage.get(thread.id, ORG);
@@ -201,7 +191,6 @@ describe("RunRegistry storage orchestration (real Postgres)", () => {
       expect(row?.run_owner_pod).toBeNull();
       expect(row?.run_config).toBeNull();
       expect(row?.run_started_at).toBeNull();
-      expect(purged).toContain(thread.id);
     });
 
     it("does not reap a fresh run when last_progress_at belongs to a previous turn", async () => {

--- a/apps/mesh/src/api/routes/decopilot/run-registry.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { RunRegistry } from "./run-registry";
-import type { StreamBuffer } from "./stream-buffer";
 import type { RunReactorDeps } from "./run-reactor";
 
 // ---------------------------------------------------------------------------
@@ -38,7 +37,6 @@ function inertDeps(): RunReactorDeps {
       // which is exactly the timing these pure tests exercise.
       getProgress: async () => null,
     } as unknown as RunReactorDeps["storage"],
-    streamBuffer: { purge() {} } as unknown as StreamBuffer,
     sseHub: { emit() {} },
   };
 }


### PR DESCRIPTION
## Summary

Self-host report (b2g): a slide-generation run "executed for a very long time"; after F5 the thread showed **`Error: missing seq 1`** as the assistant's reply.

### Root cause

`run-reactor.ts` purged `decopilot.stream.<runId>` on every `RUN_FAILED`. That purge is a leftover from the pre-#4179 architecture — its own comment/test said *"failed runs are NOT projected, so the reactor purges as explicit cleanup"*. Since the unified consume step (#4179), **every dispatched run is projected** (`consumeRunProjection`'s entry guard deliberately ignores terminal status), and projection asserts a contiguous `seq 1..N` log.

The purge beheads that log in two live ways:

1. **Reaper mid-run** (the reported incident): the hung slide tool stops chunk flow → no progress bumps for 10 min (`RUN_IDLE_TIMEOUT_MS`) → reaper `FORCE_FAIL` → reactor purges `seq 1..K` **while the producer is still alive** (abort isn't forwarded to the hung tool). When the tool finally returns, chunks resume at `seq K+1`; dispatch completes; the consume step reads the beheaded log → `missing seq 1` → `markRunFailed` + the raw error persisted as a visible error part.
2. **In-band failure race**: a hosted run that fails in-band fires `RUN_FAILED` right before the gate workflow's consume step reads the subject; the purge is fire-and-forget, so it races the `DeliverPolicy.All` read and can produce the same poisoned projection on an otherwise ordinary failure.

### Fix

Remove the purge from the reactor and drop `streamBuffer` from `RunReactorDeps` entirely, so "the reactor never purges" is structural. Purge ownership is now single-owner, matching the projection design:

- `runProjectorWorkflowBody` purges after a **terminal projection** (already the case),
- `dispatchRun` clears the **previous turn's remnants** at turn start (already the case),
- the stream's 24h `max_age` bounds never-projected runs (the documented backstop).

With this, the incident scenario projects the run's real content once the producer finishes (thread status stays `failed` from the reaper — `completeRunIfNotCompleted` only flips from `in_progress`), instead of destroying the log and fabricating `missing seq 1`.

### Known separate edges (not this PR)

- Genuine retention eviction (>24h / 4GB / 500K-msg caps) can still behead a log; rare, documented SLA.
- Internal projection errors (`missing seq N`, idle-timeout) are still persisted verbatim as user-visible error parts when they do happen — sanitizing that is a separable change in `consume-harness-stream`.

## Testing

- `bun test apps/mesh/src/api/routes/decopilot/ apps/mesh/src/dispatch-queue/` — unit suites pass (458 pass; the only failures are the `(real Postgres)` integration specs when no local PG is up).
- Integration suites (`run-reactor.integration.test.ts`, `run-registry.integration.test.ts`) pass against a disposable `postgres:16` + migrations: **13 pass / 0 fail**.
- `bun run check` clean; `bun run lint` 0 errors (7 pre-existing warnings, none in touched files); `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop purging the run’s JetStream subject on RUN_FAILED in Decopilot. This prevents beheading the stream and fixes “missing seq 1” projections from reaped or raced failures.

- **Bug Fixes**
  - Do not purge on RUN_FAILED. The consume step projects every run and needs a contiguous seq 1..N log.
  - Prevents “missing seq 1” when the reaper force-fails a still-running producer or when failure races the consume read.

- **Refactors**
  - Moved purge ownership to the projector (after terminal projection) and `dispatchRun` (previous turn cleanup). The 24h `max_age` remains the backstop.
  - Removed `streamBuffer` from `RunReactorDeps` and related wiring/tests. Updated comments to reflect the new ownership.

<sup>Written for commit bca072434f2563f51b9dd2af06a35a054febf04a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

