### PR TITLE
fix(visual-editor): frame section manifestKey as resolveType, not a file path

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/visual-editor-prompt.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/visual-editor-prompt.test.ts
@@ -65,7 +65,18 @@ describe("formatVisualEditorMessage", () => {
 
   test("omits manifestKey when null", () => {
     const msg = formatVisualEditorMessage(basePayload, "test");
-    expect(msg).not.toContain("Section source file");
+    expect(msg).not.toContain("Section resolveType");
+  });
+
+  test("frames manifestKey as a resolveType, not a literal path", () => {
+    const payload = {
+      ...basePayload,
+      manifestKey: "site/sections/Landing/Hero.tsx",
+    };
+    const msg = formatVisualEditorMessage(payload, "test");
+    expect(msg).toContain("Section resolveType");
+    expect(msg).toContain("not a literal file path");
+    expect(msg).toContain("src/sections/");
   });
 
   test("includes componentName when present", () => {

--- a/apps/mesh/src/web/components/sandbox/preview/visual-editor-prompt.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/visual-editor-prompt.tsx
@@ -26,7 +26,9 @@ export function formatVisualEditorMessage(
 
   if (payload.manifestKey) {
     lines.push(
-      `**Section source file:** \`${sanitizeMd(payload.manifestKey)}\``,
+      `**Section resolveType:** \`${sanitizeMd(payload.manifestKey)}\``,
+      "",
+      "This is a Deco resolveType, not a literal file path. The leading segment is the app name, not a directory — the actual source file lives under a sections directory whose root varies by site (commonly `sections/`, `src/sections/`, or `site/sections/`). Locate the file by searching for the trailing path (e.g. the component filename), don't assume the resolveType is a valid path on disk.",
       "",
     );
   }


### PR DESCRIPTION
## Summary

The visual editor prompt (`apps/mesh/src/web/components/sandbox/preview/visual-editor-prompt.tsx`) labeled `manifestKey` — e.g. `site/sections/Landing/Hero.tsx` — as **Section source file** and instructed the AI to read it directly.

But `manifestKey` is a Deco **resolveType**, not a filesystem path: the leading segment (`site`) is the *app name*, not a directory. On sites whose sections live under `src/sections/` (or `sections/`), the AI opened a path that doesn't exist and ended up editing the wrong component.

## Changes

- Relabel `**Section source file:**` → `**Section resolveType:**`.
- Add guidance explaining it's a resolveType (leading segment = app name), that the real file lives under a sections directory whose root varies by site (`sections/`, `src/sections/`, `site/sections/`), and to locate it by searching for the trailing path/filename rather than assuming the resolveType is a valid on-disk path.
- Update the null-case test assertion and add a case covering the new framing.

## Testing

- `bun test .../visual-editor-prompt.test.ts` → 16 pass / 0 fail
- `bun run fmt` clean

## Follow-up (not in this PR)

A couple of hardcoded `site/sections/...` assumptions elsewhere would also break on `src/sections` sites:
- `section-catalog.ts:32` excludes `site/sections/Theme/Theme.tsx`
- `blog-data.ts:634` prefix `site/sections/Blog/Post/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the visual editor prompt to treat `manifestKey` as a Deco resolveType, not a filesystem path. Prevents opening nonexistent paths and editing the wrong component on sites using `src/sections` or `sections`.

- **Bug Fixes**
  - Relabeled "Section source file" to "Section resolveType".
  - Added guidance: leading segment is app name; sections root varies (`sections/`, `src/sections/`, `site/sections/`); search by trailing path/filename.
  - Updated tests to omit the label when null and to cover the new resolveType framing.

<sup>Written for commit 117d4a71ce525196263f03d40816efddf524498c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

