### PR TITLE
fix(sandbox): bound daemon fs ops with a deadline + forward the run abort signal

### DIFF
--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/index.ts
@@ -44,19 +44,25 @@ export function createVmTools(params: VmToolsParams) {
 
   // Proxy an arbitrary `/_sandbox/*` route through the fs hooks' retry layer.
   // Used by the tools whose daemon surface the typed flat ops don't model
-  // (image-read, html-buffer write/edit).
+  // (image-read, html-buffer write/edit). `signal` is the run's abort signal
+  // (ToolCallOptions.abortSignal) so cancelling the run aborts the daemon call.
   const call = (
     daemonPath: string,
     input: Record<string, unknown>,
+    signal?: AbortSignal,
     method: "POST" | "PUT" = "POST",
-  ): Promise<unknown> => fs.onProxy(daemonPath, input, method);
+  ): Promise<unknown> => fs.onProxy(daemonPath, input, method, signal);
 
   const read = tool({
     needsApproval: approvalFor(TOOL_APPROVAL.read),
     description: READ_DESCRIPTION,
     inputSchema: zodSchema(ReadInputSchema),
-    execute: async (input) => {
-      const result = (await call("/_sandbox/read", input)) as
+    execute: async (input, options) => {
+      const result = (await call(
+        "/_sandbox/read",
+        input,
+        options.abortSignal,
+      )) as
         | { kind: "text"; content: string; lineCount: number }
         | {
             kind: "image";
@@ -89,8 +95,12 @@ export function createVmTools(params: VmToolsParams) {
     needsApproval: approvalFor(TOOL_APPROVAL.write),
     description: WRITE_DESCRIPTION,
     inputSchema: zodSchema(WriteInputSchema),
-    execute: async (input) => {
-      const daemonResult = await call("/_sandbox/write", input);
+    execute: async (input, options) => {
+      const daemonResult = await call(
+        "/_sandbox/write",
+        input,
+        options.abortSignal,
+      );
       // Fast path: mirror `org/home/{decks,pages}/*.html` content into
       // org-fs server-side at step end (skips the mount's slow vfs write-back)
       // so the live-preview watcher sees the bytes in the same step.
@@ -103,8 +113,12 @@ export function createVmTools(params: VmToolsParams) {
     needsApproval: approvalFor(TOOL_APPROVAL.edit),
     description: EDIT_DESCRIPTION,
     inputSchema: zodSchema(EditInputSchema),
-    execute: async (input) => {
-      const daemonResult = (await call("/_sandbox/edit", input)) as {
+    execute: async (input, options) => {
+      const daemonResult = (await call(
+        "/_sandbox/edit",
+        input,
+        options.abortSignal,
+      )) as {
         ok: boolean;
         replacements: number;
         content?: string;
@@ -121,8 +135,8 @@ export function createVmTools(params: VmToolsParams) {
     needsApproval: approvalFor(TOOL_APPROVAL.grep),
     description: GREP_DESCRIPTION,
     inputSchema: zodSchema(GrepInputSchema),
-    execute: async (input) => {
-      const result = await call("/_sandbox/grep", input);
+    execute: async (input, options) => {
+      const result = await call("/_sandbox/grep", input, options.abortSignal);
       return maybeTruncate(result, toolOutputMap);
     },
   });
@@ -131,8 +145,8 @@ export function createVmTools(params: VmToolsParams) {
     needsApproval: approvalFor(TOOL_APPROVAL.glob),
     description: GLOB_DESCRIPTION,
     inputSchema: zodSchema(GlobInputSchema),
-    execute: async (input) => {
-      const result = await call("/_sandbox/glob", input);
+    execute: async (input, options) => {
+      const result = await call("/_sandbox/glob", input, options.abortSignal);
       return maybeTruncate(result, toolOutputMap);
     },
   });
@@ -141,8 +155,8 @@ export function createVmTools(params: VmToolsParams) {
     needsApproval: approvalFor(TOOL_APPROVAL.bash),
     description: BASH_DESCRIPTION,
     inputSchema: zodSchema(BashInputSchema),
-    execute: async (input) => {
-      const result = await call("/_sandbox/bash", input);
+    execute: async (input, options) => {
+      const result = await call("/_sandbox/bash", input, options.abortSignal);
       return maybeTruncate(result, toolOutputMap);
     },
   });
@@ -154,7 +168,7 @@ export function createVmTools(params: VmToolsParams) {
     needsApproval: approvalFor(TOOL_APPROVAL.skill),
     description: SKILL_DESCRIPTION,
     inputSchema: zodSchema(SkillInputSchema),
-    execute: async ({ id }) => {
+    execute: async ({ id }, options) => {
       const path = resolveSkillPath(id);
       if (!path) {
         return {
@@ -162,7 +176,11 @@ export function createVmTools(params: VmToolsParams) {
         };
       }
       try {
-        const result = await call("/_sandbox/read", { path });
+        const result = await call(
+          "/_sandbox/read",
+          { path },
+          options.abortSignal,
+        );
         return maybeTruncate(result, toolOutputMap);
       } catch {
         return {

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types.ts
@@ -62,10 +62,14 @@ export interface SandboxFsHooks {
    * retry layer. Used by the richer LLM-visible tools to cover daemon surfaces
    * the typed flat ops intentionally don't model (image reads, html-buffer
    * preview shapes, copy_to_sandbox/share_with_user transfer routes).
+   *
+   * `signal` is the run's abort signal (AI-SDK `ToolCallOptions.abortSignal`):
+   * cancelling the run aborts the in-flight daemon request.
    */
   onProxy(
     path: string,
     body: Record<string, unknown>,
     method?: "POST" | "PUT",
+    signal?: AbortSignal,
   ): Promise<unknown>;
 }

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
@@ -132,6 +132,66 @@ describe("createSandboxFsHooks", () => {
     ]);
   });
 
+  test("a daemon op that never responds fails at the op deadline — without reaping the sandbox", async () => {
+    // The silent-hang regression: a wedged daemon (stalled org-fs mount) left
+    // the harness awaiting forever with no chunks, so the 10-min liveness
+    // reaper killed an otherwise healthy run. The op deadline converts the
+    // wedge into a tool error the model can react to. It must NOT be treated
+    // as daemon-unreachable — that path reaps + re-provisions the sandbox.
+    let invalidated = 0;
+    const provider = {
+      kind: "agent-sandbox",
+      proxyDaemonRequest: () => new Promise<Response>(() => {}), // never settles
+    } as unknown as SandboxProvider;
+    const hooks = createSandboxFsHooks(provider, {
+      ensureHandle: async () => "h",
+      invalidateHandle: async () => {
+        invalidated++;
+      },
+      canAutoRestart: true,
+      opTimeoutMs: 30,
+    });
+    await expect(hooks.onRead("/app/x.ts")).rejects.toThrow(/timed out after/);
+    expect(invalidated).toBe(0);
+  });
+
+  test("cancelling the run aborts the in-flight op — no timeout wait, no restart retry", async () => {
+    let invalidated = 0;
+    let sawSignal: AbortSignal | undefined;
+    const provider = {
+      kind: "agent-sandbox",
+      proxyDaemonRequest: (
+        _handle: string,
+        _path: string,
+        init: { signal?: AbortSignal },
+      ) => {
+        sawSignal = init.signal;
+        return new Promise<Response>(() => {}); // never settles on its own
+      },
+    } as unknown as SandboxProvider;
+    const hooks = createSandboxFsHooks(provider, {
+      ensureHandle: async () => "h",
+      invalidateHandle: async () => {
+        invalidated++;
+      },
+      canAutoRestart: true,
+      opTimeoutMs: 60_000,
+    });
+    const runAbort = new AbortController();
+    const pending = hooks.onProxy(
+      "/_sandbox/bash",
+      { command: "sleep 999" },
+      "POST",
+      runAbort.signal,
+    );
+    runAbort.abort(new Error("run cancelled"));
+    await expect(pending).rejects.toThrow("run cancelled");
+    expect(invalidated).toBe(0);
+    // The composed signal reaches the transport so honoring providers can
+    // tear down the underlying request too.
+    expect(sawSignal?.aborted).toBe(true);
+  });
+
   test("retries once on daemon-unreachable when canAutoRestart is true", async () => {
     let attempts = 0;
     let invalidated = 0;

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { SandboxProvider } from "./types";
-import { createSandboxFsHooks } from "./sandbox-fs-hooks";
+import { createSandboxFsHooks, opDeadlineMs } from "./sandbox-fs-hooks";
 
 /**
  * A minimal fake `SandboxProvider` that only implements `proxyDaemonRequest`
@@ -153,6 +153,17 @@ describe("createSandboxFsHooks", () => {
     });
     await expect(hooks.onRead("/app/x.ts")).rejects.toThrow(/timed out after/);
     expect(invalidated).toBe(0);
+  });
+
+  test("op deadline follows the op's own budget: 45s default, budget+grace, clamped at the daemon cap", () => {
+    // No budget (read/write/edit/grep/glob): daemon default 30s + 15s grace.
+    expect(opDeadlineMs({ path: "/x" })).toBe(45_000);
+    // Bash with an explicit budget: budget + grace.
+    expect(opDeadlineMs({ command: "x", timeout: 60_000 })).toBe(75_000);
+    // Budget above the daemon's 120s clamp doesn't inflate the deadline; the
+    // deadline stays ABOVE the cap so a command the daemon kills at 120s still
+    // delivers its stdout/stderr instead of losing the race to the client abort.
+    expect(opDeadlineMs({ command: "x", timeout: 999_000 })).toBe(135_000);
   });
 
   test("cancelling the run aborts the in-flight op — no timeout wait, no restart retry", async () => {

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.ts
@@ -73,11 +73,16 @@ export interface SandboxFsHooks {
    * routes behind `copy_to_sandbox`/`share_with_user`). New harness code should
    * prefer the typed flat ops; this exists only to cover the daemon surfaces
    * those ops don't model.
+   *
+   * `signal` is the run's abort signal (AI-SDK `ToolCallOptions.abortSignal`):
+   * cancelling the run aborts the in-flight daemon request instead of leaving
+   * it running detached.
    */
   onProxy(
     path: string,
     body: Record<string, unknown>,
     method?: "POST" | "PUT",
+    signal?: AbortSignal,
   ): Promise<unknown>;
 }
 
@@ -101,6 +106,41 @@ export interface SandboxFsHooksLifecycle {
    * paused the sandbox intentionally.
    */
   canAutoRestart: boolean;
+  /**
+   * Per-op deadline (default DAEMON_OP_TIMEOUT_MS). Tests override with a tiny
+   * value; production callers should not need to.
+   */
+  opTimeoutMs?: number;
+}
+
+/**
+ * Deadline for one daemon op, enforced HERE (transport-agnostic) — the daemon's
+ * own bash timeout (30s default / 120s max) only protects when the daemon is
+ * healthy enough to respond. Without this bound, a wedged daemon or stalled
+ * org-fs mount left the harness awaiting silently past the 10-min liveness
+ * reaper, which then killed an otherwise healthy run. Must stay ABOVE the
+ * daemon's 120s bash cap so a legitimately slow command fails daemon-side
+ * (with its stdout/stderr) rather than here.
+ */
+const DAEMON_OP_TIMEOUT_MS = 180_000;
+
+/** Reject when `signal` fires, even if `promise` (a transport that ignores
+ *  signals) never settles. The orphaned promise is swallowed. */
+function abortable<T>(signal: AbortSignal, promise: Promise<T>): Promise<T> {
+  if (signal.aborted) {
+    promise.catch(() => {});
+    return Promise.reject(signal.reason ?? new Error("aborted"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      promise.catch(() => {});
+      reject(signal.reason ?? new Error("aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", onAbort);
+    });
+  });
 }
 
 /**
@@ -125,28 +165,54 @@ async function daemonRequest(
   path: string,
   body: Record<string, unknown> | null,
   method: "GET" | "POST" | "PUT" = "POST",
+  opts?: { signal?: AbortSignal; timeoutMs?: number },
 ): Promise<unknown> {
+  const timeoutMs = opts?.timeoutMs ?? DAEMON_OP_TIMEOUT_MS;
+  const timeout = AbortSignal.timeout(timeoutMs);
+  const reqSignal = opts?.signal
+    ? AbortSignal.any([opts.signal, timeout])
+    : timeout;
   let res: Response;
+  let rawText: string;
   try {
     const init: {
       method: string;
       headers: Headers;
       body: string | null;
+      signal: AbortSignal;
     } = {
       method,
       headers: new Headers({ "content-type": "application/json" }),
       body: null,
+      signal: reqSignal,
     };
     // GET/HEAD must not carry a body; the runners' proxy strips it anyway,
     // but constructing it is wasteful and obscures intent.
     if (method !== "GET" && body !== null) {
       init.body = JSON.stringify(body);
     }
-    res = await runner.proxyDaemonRequest(handle, path, init);
+    // `abortable` (not just init.signal) so a transport that ignores the
+    // signal — or a body read that stalls — still respects the deadline.
+    ({ res, rawText } = await abortable(
+      reqSignal,
+      (async () => {
+        const r = await runner.proxyDaemonRequest(handle, path, init);
+        return { res: r, rawText: await r.text() };
+      })(),
+    ));
   } catch (cause) {
+    // Run cancelled: propagate as-is. Neither a timeout nor a cancel may become
+    // DaemonUnreachableError — that would trigger the auto-restart retry, which
+    // reaps and re-provisions the sandbox (wrong for a cancelled run, and too
+    // destructive for a busy-but-alive daemon that merely missed one deadline).
+    if (opts?.signal?.aborted) throw cause;
+    if (timeout.aborted) {
+      throw new Error(
+        `Sandbox ${method} ${path} timed out after ${Math.round(timeoutMs / 1000)}s — the sandbox may be overloaded or its filesystem stalled. Retry, or use a smaller operation.`,
+      );
+    }
     throw new DaemonUnreachableError(cause);
   }
-  const rawText = await res.text();
   let json: unknown;
   try {
     json = JSON.parse(rawText);
@@ -231,9 +297,13 @@ export function createSandboxFsHooks(
     daemonPath: string,
     input: Record<string, unknown>,
     method: "POST" | "PUT" = "POST",
+    signal?: AbortSignal,
   ): Promise<unknown> => {
     const tryOnce = async (handle: string) =>
-      daemonRequest(provider, handle, daemonPath, input, method);
+      daemonRequest(provider, handle, daemonPath, input, method, {
+        signal,
+        timeoutMs: lifecycle.opTimeoutMs,
+      });
     const firstHandle = await ensureHandle();
     try {
       return await tryOnce(firstHandle);
@@ -282,7 +352,7 @@ export function createSandboxFsHooks(
   };
 
   return {
-    onProxy: (path, body, method) => call(path, body, method),
+    onProxy: (path, body, method, signal) => call(path, body, method, signal),
     onRead: async (path) => {
       const r = (await call("/_sandbox/read", { path })) as { content: string };
       return r.content;

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.ts
@@ -107,22 +107,38 @@ export interface SandboxFsHooksLifecycle {
    */
   canAutoRestart: boolean;
   /**
-   * Per-op deadline (default DAEMON_OP_TIMEOUT_MS). Tests override with a tiny
-   * value; production callers should not need to.
+   * Fixed per-op deadline override. Default derives from the op's own budget
+   * (`opDeadlineMs`); tests override with a tiny value. Production callers
+   * should not need to.
    */
   opTimeoutMs?: number;
 }
 
 /**
- * Deadline for one daemon op, enforced HERE (transport-agnostic) — the daemon's
- * own bash timeout (30s default / 120s max) only protects when the daemon is
- * healthy enough to respond. Without this bound, a wedged daemon or stalled
- * org-fs mount left the harness awaiting silently past the 10-min liveness
- * reaper, which then killed an otherwise healthy run. Must stay ABOVE the
- * daemon's 120s bash cap so a legitimately slow command fails daemon-side
- * (with its stdout/stderr) rather than here.
+ * HTTP deadline for one daemon op, enforced HERE (transport-agnostic) — the
+ * daemon's own bash timeout (30s default / 120s max) only protects when the
+ * daemon is healthy enough to respond. Without this bound, a wedged daemon or
+ * stalled org-fs mount left the harness awaiting silently past the 10-min
+ * liveness reaper, which then killed an otherwise healthy run.
+ *
+ * The deadline follows the op's own declared budget: `input.timeout` when the
+ * body carries one (bash; clamped to the daemon's 120s cap), else the daemon's
+ * 30s default — plus a grace window so a command the daemon kills at its cap
+ * still delivers its stdout/stderr here instead of losing the race to the
+ * client-side abort. Ops without a budget (read/write/edit/grep/glob) fail at
+ * 45s.
  */
-const DAEMON_OP_TIMEOUT_MS = 180_000;
+const DAEMON_BASH_MAX_TIMEOUT_MS = 120_000; // daemon clamp (daemon/routes/bash.ts)
+const DAEMON_DEFAULT_TIMEOUT_MS = 30_000; // daemon default (daemon/routes/bash.ts)
+const OP_GRACE_MS = 15_000;
+
+export function opDeadlineMs(input: Record<string, unknown>): number {
+  const budget =
+    typeof input.timeout === "number" && input.timeout > 0
+      ? Math.min(input.timeout, DAEMON_BASH_MAX_TIMEOUT_MS)
+      : DAEMON_DEFAULT_TIMEOUT_MS;
+  return budget + OP_GRACE_MS;
+}
 
 /** Reject when `signal` fires, even if `promise` (a transport that ignores
  *  signals) never settles. The orphaned promise is swallowed. */
@@ -167,7 +183,7 @@ async function daemonRequest(
   method: "GET" | "POST" | "PUT" = "POST",
   opts?: { signal?: AbortSignal; timeoutMs?: number },
 ): Promise<unknown> {
-  const timeoutMs = opts?.timeoutMs ?? DAEMON_OP_TIMEOUT_MS;
+  const timeoutMs = opts?.timeoutMs ?? opDeadlineMs(body ?? {});
   const timeout = AbortSignal.timeout(timeoutMs);
   const reqSignal = opts?.signal
     ? AbortSignal.any([opts.signal, timeout])


### PR DESCRIPTION
## Summary

Investigation of the self-host (b2g) "slides generation runs forever" hang — the trigger behind the `missing seq 1` incident that #4337 made non-destructive. This PR fixes the hang class itself.

### Root cause

Every decopilot vm-tool (`read`/`write`/`edit`/`grep`/`glob`/`bash`/`skill`) funnels through one choke point: `sandbox-fs-hooks.ts daemonRequest → provider.proxyDaemonRequest` — an HTTP call with **no timeout and no AbortSignal**.

Layer-by-layer findings:
- The daemon **does** enforce a bash timeout (30s default, 120s max, SIGKILL) — but only when the daemon is healthy enough to respond. A wedged daemon, a stalled connection, or a blocked org-fs mount leaves the harness `await` hanging forever. Slides is the worst-hit flow: deck writes target `org/home/decks/` through the sandbox's org-fs mount, the known-slow vfs write-back path (the `htmlArtifactBuffer` fast-path exists precisely because of it).
- While a tool call is in flight the run stream is **silent** (no incremental output in await mode), and nothing bumps `last_progress_at` during tool execution — so a silent hang crosses the 10-min liveness reaper (`RUN_IDLE_TIMEOUT_MS`) and the healthy-but-stuck run is force-failed.
- The run's abort signal was never forwarded into the daemon call: cancel/reap left the op running detached (the documented 198-minute `generate_image` class; `generateImageCore` has since been fixed — the vm-tools had not).

Chain: wedged fs op → silent ≥10 min → reaper kill → (pre-#4337: purge → `missing seq 1` poison; post-#4337: failed thread) → detached op keeps running "forever".

### Fix (single choke point)

1. **Per-op deadline** in `daemonRequest`, derived from the op's own budget: `input.timeout` when the body carries one (bash; clamped to the daemon's 120s cap), else the daemon's 30s default — plus a 15s grace so a command the daemon kills at its cap still delivers its stdout/stderr instead of losing the race to the client-side abort. Budget-less ops (read/write/edit/grep/glob) fail at 45s; worst case (explicit 120s bash) is 135s. Enforced with a transport-agnostic race (`abortable`), so a transport that ignores `init.signal` (desktop tunnel) is also unstuck. A timeout surfaces as a **plain tool error** the model can react to (retry / report) — deliberately NOT `DaemonUnreachableError`, whose auto-restart path reaps + re-provisions the sandbox (wrong medicine for a busy-but-alive daemon; see the user-desktop-provider lesson).
2. **Abort forwarding**: `ToolCallOptions.abortSignal` now flows from all seven vm-tool `execute`s → `onProxy` → `daemonRequest` → transport fetch (`ProxyRequestInit.signal` was already plumbed end-to-end in the agent-sandbox transport — just never fed). An external abort propagates as-is: no auto-restart retry on a cancelled run.
3. `SandboxFsHooksLifecycle.opTimeoutMs` — fixed override for tests; production uses the derived deadline.

Net effect: a wedged sandbox op now fails in ≤45s (135s worst case) with an in-band error while chunks keep flowing — the run stays alive and the reaper never fires; cancel/reap kills in-flight ops instead of leaving zombies.

### Not in this PR

- Progress heartbeats during tool execution (unnecessary once every op is bounded below the reaper window).
- Model-call timeout in the harness (abort is already forwarded there; a provider stall is terminated by the reaper, now non-destructively per #4337).
- Why the b2g mount stalled specifically (needs their sandbox logs; this PR makes any such stall self-healing).

## Testing

- Two new regression tests in `sandbox-fs-hooks.test.ts`: never-responding op fails at the deadline **without** `invalidateHandle` (no sandbox reap), and cancelling the run rejects immediately, reaches the transport signal, and skips the restart retry.
- `bun test packages/sandbox packages/harness`: 812 pass / 43 fail — identical 43 on a clean checkout (daemon e2e specs that spawn the built daemon binary; environmental).
- `bun run check` clean across workspaces; `bun run lint` 0 errors; `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound sandbox daemon FS ops to a budget-derived deadline (45s default, 135s worst case) and forwarded run abort signals end-to-end to stop silent hangs and detached ops. Stuck vm-tool calls now fail as tool errors while the run stays alive (no sandbox reap).

- **Bug Fixes**
  - Added a per-op timeout in `daemonRequest` derived from the op's own budget (`input.timeout` clamped to the daemon's 120s cap, else 30s default, + 15s grace; via `AbortSignal.timeout`), raced transport-agnostically; timeouts surface as normal tool errors, not `DaemonUnreachableError`.
  - Forwarded `ToolCallOptions.abortSignal` through all vm-tools (`read`, `write`, `edit`, `grep`, `glob`, `bash`, `skill`) → `onProxy` → `daemonRequest` → transport; cancel/reap now aborts in-flight daemon requests and skips auto-restart.
  - Introduced `SandboxFsHooksLifecycle.opTimeoutMs` as a fixed test override (production uses the derived deadline); added regression tests for deadline without reaping and cancel propagation.

<sup>Written for commit 503f7db5ffa9eab9fb79975c3413c852047a943f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


