### PR TITLE
fix(file-picker): keep asset search input at 32px height

### DIFF
--- a/apps/mesh/src/web/components/file-picker/file-picker-dialog.tsx
+++ b/apps/mesh/src/web/components/file-picker/file-picker-dialog.tsx
@@ -324,6 +324,7 @@ function BucketPanel({
           onChange={setSearch}
           isSearching={isSearching}
           placeholder={mode === "image" ? "Search images…" : "Search files…"}
+          className="shrink-0"
         />
       ) : null}
 


### PR DESCRIPTION
## Summary
The search input in the asset (file/image) picker was rendering shorter than its intended 32px height.

**Cause:** the `SearchInput` sits inside a flex-column container (`flex flex-col ... h-full min-h-0` in `file-picker-dialog.tsx`). It has a fixed `h-8` (32px) but no `shrink-0`, so when the upload drop-zone and the scrollable list competed for vertical space, flexbox shrank the search field below 32px.

**Fix:** add `className="shrink-0"` to the `SearchInput` usage in the file picker so it always keeps its 32px height.

Scoped the change to this usage instead of the shared `SearchInput` component to avoid affecting the ~9 other places that use it in different layouts.

## Testing
- `bun run fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the asset picker search field getting squashed in the flex layout so it always stays 32px tall. Prevents the input from shrinking when the upload area and list compete for space.

- **Bug Fixes**
  - Added `className="shrink-0"` to `SearchInput` in `file-picker-dialog.tsx` to preserve its `h-8` (32px) height, scoped to this usage only.

<sup>Written for commit 03e054dbd885f2b77a00f367787fceaa2afc14ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

