### PR TITLE
feat(library): global file search, drop All files, richer Recently added

### DIFF
--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -56,6 +56,7 @@ import {
   buildPublicOrgFs,
   getPublicSets,
   isPublicVolume,
+  publicVolumeForSet,
 } from "@/file-storage/public-sets";
 import { buildSkillCatalog } from "@/file-storage/skill-catalog";
 import { detectContentType } from "@/object-storage/key-utils";
@@ -420,8 +421,8 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   });
 
   // Most recently written files across every volume, newest first — the
-  // Library page's "Recently added"/"All files" feed. Volume-less by design,
-  // so it lives above the `/:volume/*` routes.
+  // Library page's "Recently added" feed. Volume-less by design, so it
+  // lives above the `/:volume/*` routes.
   app.get("/recent", async (c) => {
     const ctx = c.get("meshContext");
     if (!ctx.auth?.user?.id) {
@@ -443,6 +444,55 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       return c.json({
         entries: await ctx.orgFs.recentWithEffectivePublic(limit),
       });
+    } catch (err) {
+      return fsErrorResponse(c, err);
+    }
+  });
+
+  // Path search (case-insensitive substring) across every volume, newest
+  // first — the Library's search box. Volume-less by design, so it lives
+  // above the `/:volume/*` routes.
+  app.get("/search", async (c) => {
+    const ctx = c.get("meshContext");
+    if (!ctx.auth?.user?.id) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    if (!ctx.organization?.id) {
+      return c.json({ error: "Organization required" }, 400);
+    }
+    const denied = await checkPermission(c, ctx, "ORG_FS_READ");
+    if (denied) return denied;
+    if (!ctx.orgFs) {
+      return c.json({ error: "Object storage not configured" }, 503);
+    }
+    const q = (c.req.query("q") ?? "").trim();
+    if (!q) return c.json({ entries: [] });
+    const limit = Math.min(
+      Math.max(Number(c.req.query("limit")) || DEFAULT_RECENT_LIMIT, 1),
+      MAX_RECENT_LIMIT,
+    );
+    try {
+      // Two manifests: the org's own volumes plus the deployment's shared
+      // public sets (pseudo-org, gated to the configured set volumes like
+      // the browse routes). `seq` is one global sequence, so interleaving
+      // by seq desc preserves write order across both.
+      const publicVolumes = getPublicSets().map((s) =>
+        publicVolumeForSet(s.set),
+      );
+      const [own, pub] = await Promise.all([
+        ctx.orgFs.searchWithEffectivePublic(q, limit),
+        publicVolumes.length > 0
+          ? buildPublicOrgFs(ctx).searchWithEffectivePublic(
+              q,
+              limit,
+              publicVolumes,
+            )
+          : [],
+      ]);
+      const entries = [...own, ...pub]
+        .sort((a, b) => Number(BigInt(b.seq) - BigInt(a.seq)))
+        .slice(0, limit);
+      return c.json({ entries });
     } catch (err) {
       return fsErrorResponse(c, err);
     }

--- a/apps/mesh/src/file-storage/org-fs.integration.test.ts
+++ b/apps/mesh/src/file-storage/org-fs.integration.test.ts
@@ -132,6 +132,38 @@ describe("OrgFs service (integration)", () => {
     expect(capped.map((e) => e.path)).toEqual(["old.txt", "newest.md"]);
   });
 
+  it("searchWithEffectivePublic matches path substrings, escapes LIKE metacharacters, resolves inherited public", async () => {
+    await fs.write("skills", "reports/Q1-Sales.md", "1", { actor: ACTOR });
+    await fs.write("outputs", "thread-1/sales_deck.html", "2", {
+      actor: ACTOR,
+    });
+    await fs.write("skills", "notes.txt", "3", { actor: ACTOR });
+    await fs.write("skills", "gone-sales.txt", "x", { actor: ACTOR });
+    await fs.delete("skills", "gone-sales.txt", { actor: ACTOR });
+    await fs.setReadPublic("skills", "reports", true, { actor: ACTOR });
+
+    // Case-insensitive, newest first, no tombstones; folder publish inherits.
+    const hits = await fs.searchWithEffectivePublic("sales", 10);
+    expect(hits.map((e) => [e.volume, e.path, e.effectivePublic])).toEqual([
+      ["outputs", "thread-1/sales_deck.html", false],
+      ["skills", "reports/Q1-Sales.md", true],
+    ]);
+
+    // `_` is a literal, not a single-char wildcard ("Sales." must not match).
+    expect(
+      (await fs.searchWithEffectivePublic("sales_", 10)).map((e) => e.path),
+    ).toEqual(["thread-1/sales_deck.html"]);
+    expect(await fs.searchWithEffectivePublic("%", 10)).toEqual([]);
+
+    // Volume narrowing (the public-sets pseudo-org passes its set volumes).
+    expect(
+      (await fs.searchWithEffectivePublic("sales", 10, ["outputs"])).map(
+        (e) => e.path,
+      ),
+    ).toEqual(["thread-1/sales_deck.html"]);
+    expect(await fs.searchWithEffectivePublic("sales", 10, [])).toEqual([]);
+  });
+
   it("filesExist batch-probes live files only", async () => {
     await fs.write("skills", "seo/SKILL.md", "skill", { actor: ACTOR });
     await fs.mkdir("skills", "plain", { actor: ACTOR });

--- a/apps/mesh/src/file-storage/org-fs.ts
+++ b/apps/mesh/src/file-storage/org-fs.ts
@@ -275,13 +275,43 @@ export class OrgFs {
 
   /**
    * `recent()` with `effectivePublic` per entry (own flag OR a published
-   * ancestor dir). Batches the ancestor lookup to one query per volume so the
-   * cross-volume feed stays cheap.
+   * ancestor dir).
    */
   async recentWithEffectivePublic(
     limit: number,
   ): Promise<Array<OrgFsEntry & { effectivePublic: boolean }>> {
-    const entries = await this.recent(limit);
+    return this.withEffectivePublic(await this.recent(limit));
+  }
+
+  /**
+   * Path search (case-insensitive substring) with `effectivePublic` per
+   * entry — the Library's search box. Searches every volume unless
+   * `volumes` narrows it (the public-sets pseudo-org passes its configured
+   * set volumes).
+   */
+  async searchWithEffectivePublic(
+    query: string,
+    limit: number,
+    volumes?: string[],
+  ): Promise<Array<OrgFsEntry & { effectivePublic: boolean }>> {
+    return this.withEffectivePublic(
+      await this.manifest.searchFiles({
+        organizationId: this.organizationId,
+        query,
+        limit,
+        volumes,
+      }),
+    );
+  }
+
+  /**
+   * Resolve `effectivePublic` (own flag OR a published ancestor dir) for a
+   * cross-volume entry list. Batches the ancestor lookup to one query per
+   * volume so the feeds stay cheap.
+   */
+  private async withEffectivePublic(
+    entries: OrgFsEntry[],
+  ): Promise<Array<OrgFsEntry & { effectivePublic: boolean }>> {
     const ancestorsByVolume = new Map<string, Set<string>>();
     for (const e of entries) {
       let set = ancestorsByVolume.get(e.volume);
@@ -561,7 +591,7 @@ export class OrgFs {
 
   /**
    * Most recently written live files across every volume, newest first.
-   * Powers the Library page's "Recently added"/"All files" feed.
+   * Powers the Library page's "Recently added" feed.
    */
   async recent(limit: number): Promise<OrgFsEntry[]> {
     return this.manifest.recentFiles({

--- a/apps/mesh/src/storage/org-fs.ts
+++ b/apps/mesh/src/storage/org-fs.ts
@@ -566,6 +566,35 @@ export class OrgFsEntryStorage {
   }
 
   /**
+   * Live files whose path matches `query` (case-insensitive substring, so
+   * folder names in the path match too), newest first across every volume.
+   */
+  async searchFiles(params: {
+    organizationId: string;
+    query: string;
+    limit: number;
+    /** Restrict to these volumes (unset = all of the org's volumes). */
+    volumes?: string[];
+  }): Promise<OrgFsEntry[]> {
+    if (params.volumes && params.volumes.length === 0) return [];
+    // Escape LIKE metacharacters so the query is a literal substring.
+    const escaped = params.query.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+    let qb = this.db
+      .selectFrom("org_fs_entry")
+      .where("organization_id", "=", params.organizationId)
+      .where("kind", "=", "file")
+      .where("deleted_at", "is", null)
+      .where("path", "ilike", `%${escaped}%`);
+    if (params.volumes) qb = qb.where("volume", "in", params.volumes);
+    const rows = await qb
+      .select(COLUMNS)
+      .orderBy("seq", "desc")
+      .limit(params.limit)
+      .execute();
+    return rows.map((r) => rowToEntry(r as OrgFsEntryRow));
+  }
+
+  /**
    * Change feed: entries (including tombstones) with `seq` greater than the
    * cursor, oldest first. Consumers invalidate/delete locally and advance the
    * cursor to the last `seq` returned.

--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -161,6 +161,26 @@ export function useOrgFsRecent(limit = 60, opts?: { enabled?: boolean }) {
   });
 }
 
+/**
+ * Path search (case-insensitive substring) across every volume, newest
+ * first — the Library's search box. Only runs for non-empty queries;
+ * previous results stay on screen while a new query loads.
+ */
+export function useOrgFsSearch(query: string, limit = 50) {
+  const { org } = useProjectContext();
+  return useQuery({
+    queryKey: KEYS.orgFsSearch(org.id, query),
+    enabled: query.length > 0,
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const res = await fsFetch(
+        `/api/${encodeURIComponent(org.slug)}/fs/search?q=${encodeURIComponent(query)}&limit=${limit}`,
+      );
+      return ((await res.json()) as { entries: OrgFsRecentEntry[] }).entries;
+    },
+  });
+}
+
 /** A skill folder (dir containing SKILL.md) in the org filesystem. */
 export interface OrgFsSkill {
   volume: string;
@@ -301,11 +321,12 @@ export function useOrgFsSetShareMode(volume: string) {
       queryClient.invalidateQueries({
         queryKey: KEYS.orgFsStat(org.id, volume, input.path),
       });
-      // Refresh the browser listings + recent feed so public badges re-render.
+      // Refresh the browser listings + feeds so public badges re-render.
       queryClient.invalidateQueries({
         queryKey: KEYS.orgFsVolume(org.id, volume),
       });
       queryClient.invalidateQueries({ queryKey: KEYS.orgFsRecent(org.id) });
+      queryClient.invalidateQueries({ queryKey: KEYS.orgFsSearchRoot(org.id) });
     },
   });
 }
@@ -319,6 +340,7 @@ export function useOrgFsMutations(volume: string) {
       queryKey: KEYS.orgFsVolume(org.id, volume),
     });
     queryClient.invalidateQueries({ queryKey: KEYS.orgFsRecent(org.id) });
+    queryClient.invalidateQueries({ queryKey: KEYS.orgFsSearchRoot(org.id) });
   };
 
   const upload = useMutation({

--- a/apps/mesh/src/web/layouts/library/cards.tsx
+++ b/apps/mesh/src/web/layouts/library/cards.tsx
@@ -231,7 +231,12 @@ function CardHeader({
           )}
         </div>
         {subtitle && (
-          <span className="text-xs text-muted-foreground">{subtitle}</span>
+          <span
+            className="truncate text-xs text-muted-foreground"
+            title={subtitle}
+          >
+            {subtitle}
+          </span>
         )}
       </div>
       {actions}
@@ -315,6 +320,7 @@ export function FileCard({
   filename,
   updatedAt,
   downloadUrl,
+  subtitle,
   publicState,
   onOpen,
   onShare,
@@ -323,6 +329,8 @@ export function FileCard({
   filename: string;
   updatedAt: string;
   downloadUrl: string;
+  /** Overrides the file-type description (e.g. the containing folder). */
+  subtitle?: string;
   publicState?: PublicState;
   onOpen: () => void;
   onShare?: () => void;
@@ -336,7 +344,7 @@ export function FileCard({
         }
         name={filename}
         meta={timeAgo(updatedAt)}
-        subtitle={describeFileType(filename)}
+        subtitle={subtitle ?? describeFileType(filename)}
         publicState={publicState}
         actions={
           <FileActions
@@ -705,6 +713,8 @@ export function RecentFileCard(props: {
   updatedAt: string;
   size: number;
   downloadUrl: string;
+  /** Overrides the file-type description (e.g. the containing folder). */
+  subtitle?: string;
   publicState?: PublicState;
   onOpen: () => void;
   onShare?: () => void;
@@ -721,7 +731,7 @@ export function RecentFileCard(props: {
         }
         name={props.filename}
         meta={timeAgo(props.updatedAt)}
-        subtitle={describeFileType(props.filename)}
+        subtitle={props.subtitle ?? describeFileType(props.filename)}
         publicState={props.publicState}
         actions={
           <FileActions

--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -2,11 +2,12 @@
  * Library (/$org/files) — the org filesystem as a Drive-like home (Figma
  * qFc7wr91 node 7870-5644). Replaces the settings → Files table browser.
  *
- * Root: "Recently added" (cross-volume `/fs/recent` feed) + Folders
- * (volumes and public sets) + "All files". Browsing into a folder swaps to
- * a breadcrumbed listing of that directory in the same card language.
- * Browse location lives in `?path=` and the open preview in `?preview=`,
- * so both are linkable and survive reload.
+ * A global search box (cross-volume `/fs/search`) sits above every view;
+ * typing swaps the active listing for its results. Root: "Recently added"
+ * (cross-volume `/fs/recent` feed) + Folders (volumes and public sets).
+ * Browsing into a folder swaps to a breadcrumbed listing of that directory
+ * in the same card language. Browse location lives in `?path=` and the open
+ * preview in `?preview=`, so both are linkable and survive reload.
  */
 
 import { useRef, useState } from "react";
@@ -23,11 +24,14 @@ import {
   Palette,
   Plus,
   RefreshCw01,
+  SearchLg,
   Stars01,
   Upload01,
+  XClose,
   Zap,
 } from "@untitledui/icons";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   AlertDialog,
@@ -55,6 +59,7 @@ import { FileTypeIcon } from "@/web/components/file-type-icon";
 import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
 import { HeaderTabButton } from "@/web/layouts/main-panel-tabs/header-tab-button";
 import { KEYS } from "@/web/lib/query-keys";
+import { useDebouncedValue } from "@/web/hooks/use-debounced-value.ts";
 import {
   type OrgFsEntry,
   type ShareMode,
@@ -63,6 +68,7 @@ import {
   useOrgFsMutations,
   useOrgFsPublicSets,
   useOrgFsRecent,
+  useOrgFsSearch,
   useOrgFsUsage,
 } from "@/web/hooks/use-org-fs";
 import {
@@ -77,8 +83,10 @@ import {
 import {
   basename,
   browsePathFor,
+  browsePathForEntry,
   type LibraryLocation,
   parseLibraryPath,
+  publicSetOf,
 } from "./location";
 import {
   ResizableHandle,
@@ -119,7 +127,20 @@ const VOLUMES = [
   { id: "outputs", description: "Agent run outputs", glyph: Stars01 },
 ] as const;
 
-const RECENTLY_ADDED_COUNT = 3;
+const RECENTLY_ADDED_COUNT = 6;
+
+/** "volume/dir" a cross-volume entry lives in — home shows the org slug,
+ *  `public-<set>` volumes show as `public/<set>`. */
+function locationOf(volume: string, path: string, orgSlug: string): string {
+  const dir = path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : "";
+  const set = publicSetOf(volume);
+  const volLabel = set
+    ? `public/${set}`
+    : volume === "home"
+      ? homeDisplayName(orgSlug)
+      : volume;
+  return dir ? `${volLabel}/${dir}` : volLabel;
+}
 
 interface PendingDelete {
   volume: string;
@@ -226,7 +247,83 @@ function Breadcrumbs({
   );
 }
 
-/** Root view: Recently added + Folders (volumes/public) + All files. */
+/**
+ * Global search results — cross-volume, shown in place of whatever listing
+ * is active (root or folder) while the search box has a query.
+ */
+function SearchResultsView({
+  query,
+  stale,
+  onOpenFile,
+  onShare,
+  onDelete,
+}: {
+  query: string;
+  /** The input is ahead of `query` (still inside the debounce window). */
+  stale: boolean;
+  onOpenFile: (previewPath: string) => void;
+  onShare: (target: ShareTarget) => void;
+  onDelete: (pending: PendingDelete) => void;
+}) {
+  const { org } = useProjectContext();
+  const fileUrl = useOrgFsFileUrl();
+  const search = useOrgFsSearch(query);
+
+  const shareFile = (e: OrgFsEntry & { volume: string }) =>
+    onShare({
+      volume: e.volume,
+      path: e.path,
+      kind: "file",
+      shareMode: e.shareMode ?? "private",
+      effectivePublic: e.effectivePublic ?? false,
+      url: publicFileUrl(fileUrl(e.volume, e.path)),
+    });
+
+  if (search.isPending) return <GridSkeleton rows={2} />;
+  const results = search.data ?? [];
+  if (results.length === 0) {
+    return <EmptyNote>No files match “{query}”.</EmptyNote>;
+  }
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3",
+        // Dim while showing results for a previous query.
+        (stale || search.isPlaceholderData) && "opacity-50",
+      )}
+    >
+      <SectionLabel>
+        {results.length} {results.length === 1 ? "result" : "results"}
+      </SectionLabel>
+      <CardsGrid>
+        {results.map((e) => {
+          // Hits from the shared public sets are read-only: no share/delete.
+          const readOnly = publicSetOf(e.volume) !== null;
+          return (
+            <FileCard
+              key={`${e.volume}/${e.path}`}
+              filename={basename(e.path)}
+              updatedAt={e.updatedAt}
+              downloadUrl={fileUrl(e.volume, e.path)}
+              subtitle={locationOf(e.volume, e.path, org.slug)}
+              publicState={publicStateOf(e)}
+              onOpen={() => onOpenFile(browsePathForEntry(e.volume, e.path))}
+              onShare={readOnly ? undefined : () => shareFile(e)}
+              onDelete={
+                readOnly
+                  ? undefined
+                  : () =>
+                      onDelete({ volume: e.volume, path: e.path, kind: "file" })
+              }
+            />
+          );
+        })}
+      </CardsGrid>
+    </div>
+  );
+}
+
+/** Root view: Recently added + Folders (volumes/public). */
 function RootView({
   onOpenDir,
   onOpenFile,
@@ -253,9 +350,7 @@ function RootView({
       url: publicFileUrl(fileUrl(e.volume, e.path)),
     });
 
-  const entries = recent.data ?? [];
-  const recentlyAdded = entries.slice(0, RECENTLY_ADDED_COUNT);
-  const allFiles = entries.slice(RECENTLY_ADDED_COUNT);
+  const recentlyAdded = (recent.data ?? []).slice(0, RECENTLY_ADDED_COUNT);
 
   return (
     <>
@@ -275,6 +370,7 @@ function RootView({
                 updatedAt={e.updatedAt}
                 size={e.size}
                 downloadUrl={fileUrl(e.volume, e.path)}
+                subtitle={locationOf(e.volume, e.path, org.slug)}
                 publicState={publicStateOf(e)}
                 onOpen={() => onOpenFile(`${e.volume}/${e.path}`)}
                 onShare={() => shareFile(e)}
@@ -322,28 +418,6 @@ function RootView({
           )}
         </CardsGrid>
       </div>
-
-      {allFiles.length > 0 && (
-        <div className="flex flex-col gap-3">
-          <SectionLabel>All files</SectionLabel>
-          <CardsGrid>
-            {allFiles.map((e) => (
-              <FileCard
-                key={`${e.volume}/${e.path}`}
-                filename={basename(e.path)}
-                updatedAt={e.updatedAt}
-                downloadUrl={fileUrl(e.volume, e.path)}
-                publicState={publicStateOf(e)}
-                onOpen={() => onOpenFile(`${e.volume}/${e.path}`)}
-                onShare={() => shareFile(e)}
-                onDelete={() =>
-                  onDelete({ volume: e.volume, path: e.path, kind: "file" })
-                }
-              />
-            ))}
-          </CardsGrid>
-        </div>
-      )}
     </>
   );
 }
@@ -575,6 +649,11 @@ function LibraryPage() {
   const onOpenSkill = (skillPath: string) => openPreview("skill", skillPath);
   const onOpenBrand = (brandPath: string) => openPreview("brand", brandPath);
 
+  // Global file search — cross-volume, so it lives above the browse
+  // location and stays visible while inside any folder.
+  const [searchText, setSearchText] = useState("");
+  const searchQuery = useDebouncedValue(searchText.trim(), 300);
+
   const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(
     null,
   );
@@ -688,6 +767,7 @@ function LibraryPage() {
       });
     }
     queryClient.invalidateQueries({ queryKey: KEYS.orgFsRecent(org.id) });
+    queryClient.invalidateQueries({ queryKey: KEYS.orgFsSearchRoot(org.id) });
     queryClient.invalidateQueries({ queryKey: KEYS.orgFsPublicSets(org.id) });
   }
 
@@ -765,7 +845,42 @@ function LibraryPage() {
             </div>
           </div>
 
-          {isRoot ? (
+          <div className="relative">
+            <SearchLg
+              size={16}
+              className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setSearchText("");
+              }}
+              placeholder="Search all files…"
+              className="h-10 rounded-xl pr-9 pl-9"
+            />
+            {searchText && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute top-1/2 right-1.5 size-7 -translate-y-1/2"
+                onClick={() => setSearchText("")}
+                aria-label="Clear search"
+              >
+                <XClose size={14} />
+              </Button>
+            )}
+          </div>
+
+          {searchQuery ? (
+            <SearchResultsView
+              query={searchQuery}
+              stale={searchText.trim() !== searchQuery}
+              onOpenFile={onOpenFile}
+              onShare={setShareTarget}
+              onDelete={setPendingDelete}
+            />
+          ) : isRoot ? (
             <RootView
               onOpenDir={onOpenDir}
               onOpenFile={onOpenFile}

--- a/apps/mesh/src/web/layouts/library/location.ts
+++ b/apps/mesh/src/web/layouts/library/location.ts
@@ -55,6 +55,22 @@ export function browsePathFor(
   return location.volume ? `${location.volume}/${entryPath}` : entryPath;
 }
 
+const PUBLIC_VOLUME_PREFIX = "public-";
+
+/** Set name for a `public-<set>` volume (a shared read-only set), else null. */
+export function publicSetOf(volume: string): string | null {
+  return volume.startsWith(PUBLIC_VOLUME_PREFIX)
+    ? volume.slice(PUBLIC_VOLUME_PREFIX.length)
+    : null;
+}
+
+/** Browse path for a cross-volume feed entry (search/recent): `public-<set>`
+ *  volumes map back to the `public/<set>` browse namespace. */
+export function browsePathForEntry(volume: string, entryPath: string): string {
+  const set = publicSetOf(volume);
+  return set ? `public/${set}/${entryPath}` : `${volume}/${entryPath}`;
+}
+
 export function basename(path: string): string {
   const i = path.lastIndexOf("/");
   return i === -1 ? path : path.slice(i + 1);

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -379,6 +379,11 @@ export const KEYS = {
   // volume named like the segment can never collide; mutations invalidate it
   // explicitly alongside the volume prefix.
   orgFsRecent: (orgId: string) => ["org-fs-recent", orgId] as const,
+  // Cross-volume path search (Library search box). The root key is the
+  // prefix mutations invalidate; per-query keys nest under it.
+  orgFsSearchRoot: (orgId: string) => ["org-fs-search", orgId] as const,
+  orgFsSearch: (orgId: string, query: string) =>
+    ["org-fs-search", orgId, query] as const,
   // Skill folders (dirs with SKILL.md) across home + public sets — the
   // attachable-skill set for agent knowledge.
   orgFsSkills: (orgId: string) => ["org-fs-skills", orgId] as const,


### PR DESCRIPTION
## What is this contribution about?
Reworks the Library root per design feedback: the "All files" section (an unordered remainder of the recent feed) is removed, "Recently added" grows to 6 cards and shows each file's containing folder as the card subtitle (truncated, full path on hover), and a global search box is added above every Library view. Search is backed by a new `GET /api/:org/fs/search` endpoint — case-insensitive path-substring search over the `org_fs_entry` manifest (LIKE metacharacters escaped, newest first), covering all of the org's volumes **plus** the deployment's public skill sets (pseudo-org, gated to the configured sets, interleaved by the global `seq` write order). Public-set hits render as `public/<set>/…` and are read-only (no share/delete); results reuse the existing file cards with preview/share/download/delete wired, dim while a newer query loads, and clear via Esc or an X button.

## Screenshots/Demonstration
Search replaces the active listing (root or inside any folder) while a query is typed; clearing it returns to where you were.

## How to Test
1. `bun run dev`, open the Library (`/$org/files`) and upload a few files into different folders/volumes.
2. Check "Recently added": 6 cards, subtitle shows the containing folder (e.g. `uploads/decks`), long paths truncate with a tooltip.
3. Type in the search box (root or inside a folder): cross-volume results appear with their location; `SKILL.md` also surfaces hits from the shared `public/<set>` sets, which offer no share/delete.
4. Esc or the X clears back to the previous view; deleting/sharing a result refreshes the listing.

## Migration Notes
None — no schema changes; one new read-only org-scoped route.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global, cross‑volume file search to the Library and simplify the root view. This removes "All files", expands "Recently added" to 6 cards with folder subtitles, and adds read‑only results from public sets.

- **New Features**
  - New `GET /api/:org/fs/search`: case‑insensitive path substring search over live files, LIKE metacharacters escaped, newest first by global `seq`, merged with configured public sets; supports optional volume narrowing.
  - Search box above every Library view; typing replaces the current listing with results, Esc or the X clears, and results dim while a newer query loads.
  - Public‑set results render as `public/<set>/…` and are read‑only (no share/delete).
  - Home updates: "Recently added" shows 6 cards and uses the containing folder as the card subtitle (truncated with tooltip); removed "All files".

- **Migration**
  - No schema changes or migrations. One new read‑only org‑scoped route (`/api/:org/fs/search`).

<sup>Written for commit 2ae32b05e6e420ef126ea24c4c5e2361c3088c6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

