### PR TITLE
fix(sandbox): force checkout in clone orchestrator so stale untracked files don't abort the clone

### DIFF
--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -283,9 +283,16 @@ export async function spawnClone(deps: CloneDeps): Promise<number> {
       deps,
     );
     if (fetchCode !== 0) return fetchCode;
+    // `-f`: the daemon writes files into repoDir before the first clone (that's
+    // why we're on the init+fetch path), and the CMS can leave stale untracked
+    // `.deco/blocks/*.json` there. Those collide with branch-tracked paths and
+    // a plain checkout aborts ("untracked working tree files would be
+    // overwritten"). Force lets the committed branch content win; only files
+    // that collide with tracked paths are overwritten — `.decocms/daemon.json`
+    // (not tracked on the branch) is left in place.
     const checkoutCmd = branchOnRemote
-      ? `${gc} -C ${dir} checkout -B ${branchOnRemote} refs/remotes/origin/${branchOnRemote}`
-      : `${gc} -C ${dir} checkout FETCH_HEAD`;
+      ? `${gc} -C ${dir} checkout -f -B ${branchOnRemote} refs/remotes/origin/${branchOnRemote}`
+      : `${gc} -C ${dir} checkout -f FETCH_HEAD`;
     const checkoutCode = await runStep(checkoutCmd, deps);
     if (checkoutCode !== 0) return checkoutCode;
     if (branchToForkLocally) {


### PR DESCRIPTION
## Problem

A sandbox failed to boot with:

```
error: The following untracked working tree files would be overwritten by checkout:
        .deco/blocks/pages-Home%2520(principal)-287364.json
Please move or remove them before you switch branches.
Aborting
[orchestrator] clone failed (exit 1)
```

The clone orchestrator's **init+fetch path** (`packages/sandbox/daemon/setup/clone.ts`) is taken when `repoDir` is non-empty but has no `.git` — which is the normal case, because the daemon writes `.decocms/daemon.json` into `repoDir` before the first clone. That path did `git init` + `git fetch` + an **unforced** `git checkout -B <branch>`.

When the visual CMS had left a stale untracked file under `.deco/blocks/` that collides with a path tracked on the target branch, git refuses to overwrite it and aborts — taking the whole clone (and thus the dev server) down with it.

## Fix

Force the checkout (`checkout -f`). Only files that collide with branch-tracked paths are overwritten, so the committed branch content wins (the user's edit lives in that commit — no data loss). Untracked files that don't collide — notably `.decocms/daemon.json` — are left in place.

## Testing

- Reproduced on a local kind sandbox: unforced checkout aborted; with `-f` the clone completes and the working tree is populated onto the branch.
- Verified the rebuilt daemon inside the sandbox pod ships the fix.

## Follow-up (separate bug, not addressed here)

The colliding filename `pages-Home%2520(principal)-287364.json` is double-URL-encoded (`"Home (principal)"` → `%20` → `%2520`). The CMS block-file writer is encoding an already-encoded name, producing a shadow file. Worth fixing at the source so it stops colliding in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `git checkout -f` in the sandbox clone orchestrator to prevent aborts when stale untracked files would be overwritten, so clones complete and sandboxes boot reliably.
This overwrites only colliding paths and keeps safe files in place.

- **Bug Fixes**
  - Add `-f` to `git checkout` for both branch and `FETCH_HEAD` paths in `packages/sandbox/daemon/setup/clone.ts`.
  - Preserve non-colliding files (e.g., `.decocms/daemon.json`) while letting committed branch content win.

<sup>Written for commit d8341ea113a6d81b8a2315daf7761c5e2fbbc2bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

