### PR TITLE
fix(automations): record failure reason on failed automation runs

### DIFF
--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -383,10 +383,14 @@ async function buildDispatchRequestStep(
   return { ok: true, request: serializableRequest };
 }
 
-async function markRunFailedStep(taskId: string): Promise<void> {
+async function markRunFailedStep(
+  taskId: string,
+  reason?: string,
+  kind?: string,
+): Promise<void> {
   const rt = requireRuntime();
   try {
-    await rt.storage.markRunFailed(taskId);
+    await rt.storage.markRunFailed(taskId, reason, kind);
   } catch {
     // best-effort
   }
@@ -444,7 +448,7 @@ async function fireAutomationWorkflowFn(
     { name: "buildDispatchRequest" },
   );
   if (!built.ok) {
-    await DBOS.runStep(() => markRunFailedStep(taskId), {
+    await DBOS.runStep(() => markRunFailedStep(taskId, built.reason, "setup"), {
       name: "markRunFailed",
     });
     return { taskId, error: built.reason };
@@ -467,16 +471,17 @@ async function fireAutomationWorkflowFn(
       await DBOS.runStep(() => deactivateAutomationStep(prep.automation.id), {
         name: "deactivateAutomation",
       });
-      await DBOS.runStep(() => markRunFailedStep(taskId), {
-        name: "markRunFailed",
-      });
+      await DBOS.runStep(
+        () => markRunFailedStep(taskId, runError, "permanent"),
+        { name: "markRunFailed" },
+      );
       return { taskId, error: runError };
     }
     console.error(
       `[fireAutomationWorkflow] ERROR "${prep.automation.name}" taskId=${taskId}:`,
       runError,
     );
-    await DBOS.runStep(() => markRunFailedStep(taskId), {
+    await DBOS.runStep(() => markRunFailedStep(taskId, runError, "error"), {
       name: "markRunFailed",
     });
     return { taskId, error: runError };

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "8aa255710fe562a3a0a86373ba60c9bfb53b34a9b17539083a22866e734fdede",
-  "automations/dbos-workflow.ts": "c00ba679036dcbd3818c704d0263501b3608561b3b79e323cd5ab11dee574a85",
-  "dispatch-queue/hosted-harness-workflow.ts": "95dd5d43674e17e87b9c0f03087f3e08b98692e578630cdccbe6a0a1b0541165",
+  "automations/dbos-workflow.ts": "b18986ee38512806b636e5c386b7ec24bf2e8f9d219c838d3b40b6c681c12b67",
+  "dispatch-queue/hosted-harness-workflow.ts": "e930e3914aed1a55845ebff94eda6df48a702f197eb36b1780b818c3633d1edd",
   "dispatch-queue/thread-gate-workflow.ts": "ea44994c388639356b281cfca82c06a781a7cc210c18bfbfc834d81002a04f98",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
   "harnesses/decopilot/background-tool-workflow.ts": "b75384d08b2293a101da50f0dfc63c23fc27f4b5636d2a9ada3cc22d2f61202b",

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
@@ -69,6 +69,19 @@ export type StudioContextFactory = (
 export const HOSTED_HARNESS_PARTITION_CONCURRENCY = 1;
 
 /**
+ * Human-readable reason for a run aborted by the opt-in timeout. Passed to
+ * `AbortController.abort(reason)` so the surfaced error (and the thread's
+ * recorded `failure_reason`) says WHY the run ended instead of a bare abort.
+ */
+function formatTimeoutReason(timeoutMs: number): string {
+  const human =
+    timeoutMs >= 60_000
+      ? `${Math.round(timeoutMs / 60_000)}m`
+      : `${Math.round(timeoutMs / 1_000)}s`;
+  return `Run exceeded its ${human} time limit and was aborted`;
+}
+
+/**
  * Serializable input to a hosted harness run. Everything needed to (re)run the
  * in-process agent loop from a DBOS-replayed workflow journal — the
  * non-serializable `abortSignal` is excluded (the run constructs its own from
@@ -173,7 +186,13 @@ async function runHostedHarness(
   const abortController = new AbortController();
   const timeoutHandle =
     timeoutMs != null
-      ? setTimeout(() => abortController.abort(), timeoutMs)
+      ? setTimeout(
+          // Pass a descriptive reason so a timeout surfaces as a legible error
+          // (recorded in the thread's failure_reason) instead of a bare abort.
+          () =>
+            abortController.abort(new Error(formatTimeoutReason(timeoutMs))),
+          timeoutMs,
+        )
       : null;
 
   try {

--- a/apps/mesh/src/storage/automations.ts
+++ b/apps/mesh/src/storage/automations.ts
@@ -103,7 +103,7 @@ export interface AutomationsStorage {
     automation: Automation,
     triggerId: string | null,
   ): Promise<string>;
-  markRunFailed(taskId: string): Promise<void>;
+  markRunFailed(taskId: string, reason?: string, kind?: string): Promise<void>;
   markRunCompleted(taskId: string): Promise<void>;
   updateTriggerLastRunAt(triggerId: string, lastRunAt: string): Promise<void>;
   deactivateAutomation(id: string): Promise<void>;
@@ -611,10 +611,22 @@ class KyselyAutomationsStorage implements AutomationsStorage {
     return taskId;
   }
 
-  async markRunFailed(taskId: string): Promise<void> {
+  async markRunFailed(
+    taskId: string,
+    reason?: string,
+    kind?: string,
+  ): Promise<void> {
     await this.db
       .updateTable("threads")
-      .set({ status: "failed", updated_at: new Date().toISOString() })
+      .set({
+        status: "failed",
+        updated_at: new Date().toISOString(),
+        // Record WHY the fire failed so the thread doesn't show a reason-less
+        // "errored" (e.g. a 5-min timeout abort). Only overwrite when we
+        // actually have a reason — never clobber an existing one with null.
+        ...(reason != null ? { failure_reason: reason } : {}),
+        ...(kind != null ? { failure_kind: kind } : {}),
+      })
       .where("id", "=", taskId)
       .where("status", "=", "in_progress")
       .execute();


### PR DESCRIPTION
## Problem

Automation runs that fail — including the **5-minute timeout abort** — were marked `status = 'failed'` with `failure_reason` and `failure_kind` left **NULL**. The UI then shows a reason-less "errored" with no explanation.

Found while investigating a real prod thread (`thrd_J5cKVKyrKLyEHM-Dc3wT7`, Deco org): an automation fire ran for **exactly 5:00** and was aborted by `AUTOMATIONS_RUN_TIMEOUT_MS` mid-run (task 1 of a 17-task commerce-discovery workflow). The DBOS `hostedHarnessWorkflow` recorded `SUCCESS` (a timeout abort is a clean cancellation), but the thread showed a bare "failed" with no reason.

## Root cause

- `AutomationsStorage.markRunFailed(taskId)` (`storage/automations.ts`) set only `status: 'failed'` — never `failure_reason`/`failure_kind` (the columns exist and are used elsewhere).
- `fireAutomationWorkflow` already computes the error message (`runError`) and even classifies permanent vs transient — but **discarded** it when calling `markRunFailedStep(taskId)`.

## Changes (small, contained)

- `markRunFailed(taskId, reason?, kind?)` now persists `failure_reason`/`failure_kind` when provided. It only sets them when non-null, so it never clobbers an existing reason.
- `fireAutomationWorkflow` passes the reason + a `kind` at all three failure sites:
  - build/setup failure → `kind: "setup"` (reason = `built.reason`)
  - permanent dispatch error → `kind: "permanent"` (reason = `runError`)
  - transient error → `kind: "error"` (reason = `runError`)
- The opt-in run timeout now calls `abortController.abort(new Error("Run exceeded its 5m time limit and was aborted"))` instead of a bare `abort()`, so a timeout surfaces as a **legible** error that flows into `failure_reason` (and logs), rather than a generic abort.

Net effect: a timed-out or otherwise-failed automation now shows *why* it failed instead of a mystery error.

## Testing

- `tsc --noEmit` clean for the changed files; `bun run fmt` clean.
- (oxlint wasn't runnable in my local shell this session — CI lint will cover it. Changes are plain server-side edits with no lint-sensitive patterns.)
- No automated test added: the `markRunFailed` change is DB I/O (e2e tier per `TESTING.md`, not unit). The behavior is a straightforward column write; happy to add an e2e assertion on `failure_reason` if you'd like.

## Notes / possible follow-ups

- This fixes the **automation** failure path (where the reason is dropped today). Interactive (non-automation) hosted runs don't set a timeout, so they're unaffected.
- A separate, larger option we discussed — making the 5-minute cap **configurable per-automation** — is intentionally *not* in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record and surface `failure_reason` and `failure_kind` for failed automation runs, including timeout aborts, so the UI shows a clear failure reason instead of a blank "errored".

- **Bug Fixes**
  - `markRunFailed(taskId, reason?, kind?)` now persists `failure_reason`/`failure_kind` when provided (never overwrites with null).
  - `fireAutomationWorkflow` passes reason/kind for all failure paths: setup ("setup"), permanent ("permanent"), transient ("error").
  - Hosted harness run-timeout aborts with a human-friendly error (e.g., "Run exceeded its 5m time limit and was aborted") so timeouts populate `failure_reason`.

<sup>Written for commit 616c4dd1fbb66d8aae32c4485e288cc513abb966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

