### PR TITLE
fix(sandbox): debounce dev-server crash detection in daemon probe

### DIFF
--- a/packages/sandbox/daemon/constants.ts
+++ b/packages/sandbox/daemon/constants.ts
@@ -22,6 +22,14 @@ export const DECO_GID = 1000;
 export const PROBE_FAST_MS = 1000;
 export const PROBE_SLOW_MS = 30_000;
 export const PROBE_HEAD_TIMEOUT_MS = 5_000;
+// Consecutive HEAD misses required to flip an *online* server to offline
+// ("crashed"). A single slow probe is expected: a busy dev server (e.g. Vite
+// re-transforming a large edited file, or a heavy SSR of `/`) can block past
+// PROBE_HEAD_TIMEOUT_MS while still very much alive. Without this debounce one
+// slow response marks the sandbox crashed, which the UI surfaces as "the dev
+// server died". After the first miss the probe polls at PROBE_FAST_MS, so a
+// genuine crash is still caught within ~PROBE_FAILURE_THRESHOLD seconds.
+export const PROBE_FAILURE_THRESHOLD = 3;
 
 /**
  * Synthetic branches are sandbox isolation keys, not real git refs.

--- a/packages/sandbox/daemon/probe.test.ts
+++ b/packages/sandbox/daemon/probe.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { cadence, reduce, type ProbeState } from "./probe";
-import { PROBE_FAST_MS, PROBE_SLOW_MS } from "./constants";
+import {
+  cadence,
+  reduce,
+  shouldEscalateFailure,
+  type ProbeState,
+} from "./probe";
+import {
+  PROBE_FAILURE_THRESHOLD,
+  PROBE_FAST_MS,
+  PROBE_SLOW_MS,
+} from "./constants";
 
 const initial: ProbeState = {
   status: "booting",
@@ -173,6 +182,27 @@ describe("reduce", () => {
       expect(r.next).toEqual(state);
       expect(r.log).toBeUndefined();
     });
+  });
+});
+
+describe("shouldEscalateFailure", () => {
+  test("online is held below the threshold", () => {
+    expect(shouldEscalateFailure("online", 1)).toBe(false);
+    expect(shouldEscalateFailure("online", PROBE_FAILURE_THRESHOLD - 1)).toBe(
+      false,
+    );
+  });
+
+  test("online escalates at the threshold", () => {
+    expect(shouldEscalateFailure("online", PROBE_FAILURE_THRESHOLD)).toBe(true);
+    expect(shouldEscalateFailure("online", PROBE_FAILURE_THRESHOLD + 1)).toBe(
+      true,
+    );
+  });
+
+  test("booting/offline escalate immediately (no debounce)", () => {
+    expect(shouldEscalateFailure("booting", 1)).toBe(true);
+    expect(shouldEscalateFailure("offline", 1)).toBe(true);
   });
 });
 

--- a/packages/sandbox/daemon/probe.ts
+++ b/packages/sandbox/daemon/probe.ts
@@ -4,6 +4,7 @@
  * timeout. Treats any HTTP response (incl. 404) as "up".
  */
 import {
+  PROBE_FAILURE_THRESHOLD,
   PROBE_FAST_MS,
   PROBE_HEAD_TIMEOUT_MS,
   PROBE_SLOW_MS,
@@ -77,6 +78,21 @@ export function cadence(state: ProbeState): number {
   return state.status === "online" ? PROBE_SLOW_MS : PROBE_FAST_MS;
 }
 
+/**
+ * Whether a HEAD miss should escalate to a `head-failure` event (→ offline) or
+ * be absorbed as a transient blip. Only an *online* server is debounced —
+ * `booting`/`offline` pass straight through (reduce ignores head-failure for
+ * them anyway). An online server is held until `PROBE_FAILURE_THRESHOLD`
+ * consecutive misses so a single slow probe (heavy dev-server work) doesn't
+ * report a live server as crashed.
+ */
+export function shouldEscalateFailure(
+  status: UpstreamStatus,
+  consecutiveFailures: number,
+): boolean {
+  return status !== "online" || consecutiveFailures >= PROBE_FAILURE_THRESHOLD;
+}
+
 interface HeadResult {
   status: number;
   isHtml: boolean;
@@ -118,6 +134,9 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
   };
   let inFlight = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  // Consecutive HEAD misses. Reset on any response; drives the debounce so a
+  // busy-but-alive dev server isn't flipped to "crashed" on one slow probe.
+  let consecutiveFailures = 0;
 
   function applyEvent(event: ProbeEvent) {
     const result = reduce(state, event);
@@ -165,20 +184,30 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
     }
 
     if (result !== null) {
+      consecutiveFailures = 0;
       applyEvent({
         kind: "head-response",
         status: result.status,
         isHtml: result.isHtml,
       });
     } else {
-      applyEvent({ kind: "head-failure" });
+      consecutiveFailures++;
+      // Debounce: hold an online server through transient slow probes; only
+      // escalate to offline once we've missed PROBE_FAILURE_THRESHOLD in a row.
+      if (shouldEscalateFailure(state.status, consecutiveFailures)) {
+        applyEvent({ kind: "head-failure" });
+      }
     }
     schedule();
   }
 
   function schedule() {
     if (timer) clearTimeout(timer);
-    timer = setTimeout(() => void tick(), cadence(state));
+    // While a miss is pending on an online server, re-probe fast so a real
+    // crash is confirmed within ~PROBE_FAILURE_THRESHOLD seconds instead of
+    // waiting a full slow interval.
+    const delay = consecutiveFailures > 0 ? PROBE_FAST_MS : cadence(state);
+    timer = setTimeout(() => void tick(), delay);
   }
 
   schedule();


### PR DESCRIPTION
## Problem

Using the visual CMS on a real site (deco-sites/casaevideo-tanstack), a burst of section edits makes the preview report **"the dev server died."** Investigated on a local kind sandbox by reproducing the exact trigger — a burst of `.deco/blocks/*.json` writes — while watching the pod.

Findings from the repro:
- **The dev-server process never dies** — `workerd` PID stayed constant across the whole storm, thread count flat.
- **Not an OOM** — `memory.events oom_kill=0`; pod sat ~2.1 GB against a 3 Gi limit.
- What actually flips is the daemon's **liveness probe**: `[probe] server stopped responding on port 3000` → `[lifecycle] running → crashed`.

Root cause: each block-file write makes **Vite (the dev server on :3000) re-transform** — during the storm the node/Vite process ran 25–60% CPU while `/` was unanswered for several seconds. `packages/sandbox/daemon/probe.ts` HEADs `/` with a 5 s timeout (`PROBE_HEAD_TIMEOUT_MS`) and a **single** miss while `online` flips straight to `offline` (→ `crashed`). So a busy-but-alive dev server is reported as crashed, and the UI shows it as dead. `/` is also the most expensive possible probe target (full dev pipeline).

## Fix

Debounce the crash detection. An `online` server is held through transient slow probes and only escalated to `offline` after `PROBE_FAILURE_THRESHOLD` (3) **consecutive** misses. After the first miss the probe polls at `PROBE_FAST_MS` instead of the 30 s idle cadence, so a *genuine* crash is still confirmed within a few seconds.

- `reduce()` stays pure and unchanged.
- The debounce decision is a pure, unit-tested helper `shouldEscalateFailure(status, consecutiveFailures)`.
- The consecutive-miss counter lives in the probe driver; `booting`/`offline` are unaffected (they already fast-poll and `reduce` ignores `head-failure` for them).

## Testing

- `bun test packages/sandbox/daemon/probe.test.ts` — 17 pass (added coverage for the debounce helper: held below threshold, escalates at threshold, no debounce for booting/offline).
- Rebuilt the daemon + image, loaded into the kind sandbox cluster, and confirmed the debounce symbols are present in the deployed `daemon.js`.

## Not addressed here (deeper root cause, external)

The underlying cost is in the deco framework's dev server (`@decocms/start`, in the site's node_modules): every `.deco/blocks/*.json` write invalidates/re-transforms a ~1 MB JSON through Vite. Coalescing/debouncing block-file changes there (or not routing block JSON through Vite's module graph) would remove the editor lag itself. This PR only stops the daemon from mislabeling that busy window as a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debounces dev-server crash detection in the sandbox daemon so transient slow probes don’t mark a live server as crashed. Online servers now flip to offline only after 3 consecutive HEAD timeouts, with fast re-probing to confirm real crashes quickly.

- **Bug Fixes**
  - Added `PROBE_FAILURE_THRESHOLD = 3` and fast polling after a miss using `PROBE_FAST_MS`.
  - Introduced `shouldEscalateFailure()` and a consecutive-miss counter in the probe driver; `reduce()` unchanged.
  - No debounce for `booting`/`offline`; any response resets the miss counter. Updated tests to cover the new logic.

<sup>Written for commit 8cf6188f102cdf64debca6cc717f6753cc0f53b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

