### PR TITLE
fix(sandbox): stop git/diff from blocking the daemon and mis-flagging the sandbox as crashed

### DIFF
--- a/packages/sandbox/daemon/git/git-async.ts
+++ b/packages/sandbox/daemon/git/git-async.ts
@@ -1,0 +1,66 @@
+import { spawn, type SpawnOptions } from "node:child_process";
+import { DECO_UID, DECO_GID } from "../constants";
+import type { GitError, GitSyncOpts } from "./git-sync";
+
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Async twin of {@link gitSync}. Same semantics (drops to deco:1000 unless
+ * `asUser: false`, 30 s default timeout, throws {@link GitError} on non-zero
+ * exit) but backed by `child_process.spawn` so it NEVER blocks the daemon's
+ * single Bun event loop.
+ *
+ * This matters on the hot read paths (git/diff, git/status): `spawnSync` freezes
+ * the whole daemon for the duration of the child — a slow `git fetch` (PR-diff
+ * deepening on a repo with large blobs) can block for ~10 s, during which the
+ * upstream HEAD probe can't run and the sandbox gets mis-flagged as crashed
+ * (surfaced as a 502 on the very next status poll). Streaming stdout also
+ * sidesteps `spawnSync`'s maxBuffer truncation on large `git show` output.
+ */
+export function gitAsync(args: string[], opts: GitSyncOpts): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const asUser = opts.asUser !== false;
+    const spawnOpts: SpawnOptions = {
+      cwd: opts.cwd,
+      env: opts.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: opts.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
+    };
+    if (asUser) {
+      spawnOpts.uid = DECO_UID;
+      spawnOpts.gid = DECO_GID;
+    }
+
+    const child = spawn("git", args, spawnOpts);
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout?.on("data", (d: Buffer) => out.push(d));
+    child.stderr?.on("data", (d: Buffer) => err.push(d));
+
+    child.on("error", (e: Error) => {
+      const gitErr = new Error(
+        `git ${args.join(" ")}: ${e.message}`,
+      ) as GitError;
+      gitErr.stderr = Buffer.concat(err).toString("utf-8");
+      gitErr.status = -1;
+      reject(gitErr);
+    });
+
+    child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      const stderr = Buffer.concat(err).toString("utf-8");
+      if (code === 0) {
+        resolve(Buffer.concat(out).toString("utf-8").trim());
+        return;
+      }
+      const reason = signal ? ` (killed by ${signal})` : "";
+      const gitErr = new Error(
+        `git ${args.join(" ")} exited ${code}${reason}${
+          stderr ? `: ${stderr.trim()}` : ""
+        }`,
+      ) as GitError;
+      gitErr.stderr = stderr;
+      gitErr.status = code ?? -1;
+      reject(gitErr);
+    });
+  });
+}

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -65,6 +65,63 @@ describe("git routes", () => {
     });
   });
 
+  it("publish returns 409 notReady before the repo is cloned", async () => {
+    const appRoot = mkdtempSync(join(tmpdir(), "git-route-root-"));
+    const repoDir = join(appRoot, "app");
+    mkdirSync(repoDir, { recursive: true });
+    const handler = makeGitPublishHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/publish", {
+        method: "POST",
+        body: JSON.stringify({ message: "test" }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "repository not initialized",
+      notReady: true,
+    });
+  });
+
+  it("discard returns 409 notReady before the repo is cloned", async () => {
+    const appRoot = mkdtempSync(join(tmpdir(), "git-route-root-"));
+    const repoDir = join(appRoot, "app");
+    mkdirSync(repoDir, { recursive: true });
+    const handler = makeGitDiscardHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/discard", {
+        method: "POST",
+        body: JSON.stringify({ filepaths: ["README.md"] }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "repository not initialized",
+      notReady: true,
+    });
+  });
+
+  it("rebase returns 409 notReady before the repo is cloned", async () => {
+    const appRoot = mkdtempSync(join(tmpdir(), "git-route-root-"));
+    const repoDir = join(appRoot, "app");
+    mkdirSync(repoDir, { recursive: true });
+    const handler = makeGitRebaseHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/rebase", {
+        method: "POST",
+        body: JSON.stringify({ base: "main" }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "repository not initialized",
+      notReady: true,
+    });
+  });
+
   it("status reports unpushed when feature branch has no remote ref", async () => {
     const { appRoot, repoDir } = initRepo();
     gitSync(["checkout", "-b", "deco/thin-crane"], {
@@ -173,7 +230,7 @@ describe("git routes", () => {
       asUser: false,
     });
 
-    const prDiff = computeDiffAgainstBase(repoDir, "main");
+    const prDiff = await computeDiffAgainstBase(repoDir, "main");
     expect(Object.keys(prDiff.diffs)).toContain("feature.txt");
     expect(prDiff.diffs["feature.txt"]?.from).toBeNull();
     expect(prDiff.diffs["feature.txt"]?.to).toContain("on branch");
@@ -224,7 +281,7 @@ describe("git routes", () => {
       asUser: false,
     });
 
-    const pinned = computeDiffAgainstBase(repoDir, "main", firstSha);
+    const pinned = await computeDiffAgainstBase(repoDir, "main", firstSha);
     expect(pinned.diffs["feature.txt"]?.to).toContain("v1");
     expect(pinned.diffs["feature.txt"]?.to).not.toContain("v2");
   });

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -16,6 +16,7 @@ import {
 import { safePath } from "../paths";
 import type { OperatorIdentity } from "../types";
 import { git } from "../setup/git";
+import { gitAsync } from "../git/git-async";
 import { jsonResponse, parseJsonBody } from "./body-parser";
 
 export interface GitDeps {
@@ -60,11 +61,50 @@ function tryGit(repoDir: string, args: string[]): string | null {
   }
 }
 
+// Async twins of runGit/tryGit for the git/diff hot path. The expensive steps
+// there — network `git fetch` and reading large blobs via `git show` — must not
+// block the daemon's single event loop (see git-async.ts). Cheap metadata
+// probes (rev-parse, merge-base) stay synchronous; they return in single-digit
+// ms and converting them buys nothing.
+async function runGitAsync(
+  repoDir: string,
+  args: string[],
+  opts?: { env?: Record<string, string> },
+): Promise<string> {
+  return gitAsync(["-c", "safe.directory=*", ...args], {
+    cwd: repoDir,
+    env: { ...gitEnv(repoDir), ...opts?.env },
+  });
+}
+
+async function tryGitAsync(
+  repoDir: string,
+  args: string[],
+): Promise<string | null> {
+  try {
+    return await runGitAsync(repoDir, args);
+  } catch {
+    return null;
+  }
+}
+
 // repoDir is pre-created empty on boot; the clone only runs after config
 // arrives. Status/diff probes that race the clone would otherwise exit 128
 // ("not a git repository") and surface as a 500.
 function isGitRepo(repoDir: string): boolean {
   return tryGit(repoDir, ["rev-parse", "--git-dir"]) !== null;
+}
+
+/**
+ * Uniform 409 for mutating/reading git endpoints invoked before (or racing) the
+ * clone. Without it the raw `git ... rev-parse` 128 ("not a git repository")
+ * leaks to the client as a scary 500. `notReady` lets the UI retry.
+ */
+function repoNotReadyResponse(): Response {
+  return jsonResponse(
+    { error: "repository not initialized", notReady: true },
+    409,
+  );
 }
 
 export interface GitStatusFile {
@@ -187,15 +227,6 @@ function computeStatus(repoDir: string): GitStatusResult {
   return { ...working, ...divergence };
 }
 
-function readWorkingFile(repoDir: string, filePath: string): string | null {
-  const abs = path.join(repoDir, filePath);
-  try {
-    return fs.readFileSync(abs, "utf8");
-  } catch {
-    return null;
-  }
-}
-
 function readRefFile(
   repoDir: string,
   ref: string,
@@ -204,39 +235,63 @@ function readRefFile(
   return tryGit(repoDir, ["show", `${ref}:${filePath}`]);
 }
 
-function computeDiff(repoDir: string): GitDiffResult {
+async function readWorkingFileAsync(
+  repoDir: string,
+  filePath: string,
+): Promise<string | null> {
+  try {
+    return await fs.promises.readFile(path.join(repoDir, filePath), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function readRefFileAsync(
+  repoDir: string,
+  ref: string,
+  filePath: string,
+): Promise<string | null> {
+  return tryGitAsync(repoDir, ["show", `${ref}:${filePath}`]);
+}
+
+async function computeDiff(repoDir: string): Promise<GitDiffResult> {
   const status = computeWorkingTreeStatus(repoDir);
   const paths = [
     ...new Set(status.files.map((f) => f.path).filter((p) => p.length > 0)),
   ];
 
   const diffs: Record<string, GitDiffEntry> = {};
-  for (const filePath of paths) {
-    const file = status.files.find((f) => f.path === filePath);
-    const index = file?.index ?? " ";
-    const working = file?.working_dir ?? " ";
-    const isDeleted = index === "D" || working === "D";
-    const isNew =
-      (index === "?" && working === "?") ||
-      index === "A" ||
-      working === "A" ||
-      (!readRefFile(repoDir, "HEAD", filePath) && !isDeleted);
+  // Read every file's before/after off the event loop and in parallel — the
+  // per-file `git show` + working-tree read is what dominates a big diff.
+  await Promise.all(
+    paths.map(async (filePath) => {
+      const file = status.files.find((f) => f.path === filePath);
+      const index = file?.index ?? " ";
+      const working = file?.working_dir ?? " ";
+      const isDeleted = index === "D" || working === "D";
+      const head = await readRefFileAsync(repoDir, "HEAD", filePath);
+      const isNew =
+        (index === "?" && working === "?") ||
+        index === "A" ||
+        working === "A" ||
+        (!head && !isDeleted);
 
-    diffs[filePath] = {
-      from: isNew ? null : readRefFile(repoDir, "HEAD", filePath),
-      to: isDeleted ? null : readWorkingFile(repoDir, filePath),
-    };
-  }
+      diffs[filePath] = {
+        from: isNew ? null : head,
+        to: isDeleted ? null : await readWorkingFileAsync(repoDir, filePath),
+      };
+    }),
+  );
 
   return { diffs };
 }
 
 /** Committed changes on HEAD since branching from `origin/{base}` (PR scope). */
-export function computeDiffAgainstBase(
+export async function computeDiffAgainstBase(
   repoDir: string,
   base: string,
   headSha?: string,
-): GitDiffResult {
+): Promise<GitDiffResult> {
   assertValidRemoteBranchName(base);
 
   const branch = tryGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
@@ -246,13 +301,22 @@ export function computeDiffAgainstBase(
   assertValidRemoteBranchName(branch);
 
   // Shallow clones often miss one side of the fork — fetch both tips with depth.
+  // This is a NETWORK call and by far the slowest step; keep it async so a slow
+  // fetch never freezes the daemon (and trips crash detection).
   try {
-    runGit(repoDir, ["fetch", "--depth", "100", "origin", base, branch]);
+    await runGitAsync(repoDir, [
+      "fetch",
+      "--depth",
+      "100",
+      "origin",
+      base,
+      branch,
+    ]);
   } catch {
     // Local-only fixtures / offline sandboxes may already have the refs we need.
   }
   if (headSha && /^[0-9a-f]{40}$/i.test(headSha)) {
-    tryGit(repoDir, ["fetch", "--depth", "100", "origin", headSha]);
+    await tryGitAsync(repoDir, ["fetch", "--depth", "100", "origin", headSha]);
   }
 
   const upstream = `origin/${base}`;
@@ -275,7 +339,14 @@ export function computeDiffAgainstBase(
 
   if (paths.length === 0) {
     try {
-      runGit(repoDir, ["fetch", "--deepen", "500", "origin", base, branch]);
+      await runGitAsync(repoDir, [
+        "fetch",
+        "--deepen",
+        "500",
+        "origin",
+        base,
+        branch,
+      ]);
     } catch {
       /* see fetch note above */
     }
@@ -286,12 +357,16 @@ export function computeDiffAgainstBase(
     tryGit(repoDir, ["merge-base", upstream, headRef]) ?? upstream;
 
   const diffs: Record<string, GitDiffEntry> = {};
-  for (const filePath of paths) {
-    diffs[filePath] = {
-      from: readRefFile(repoDir, mergeBase, filePath),
-      to: readRefFile(repoDir, headRef, filePath),
-    };
-  }
+  // Read both sides of every changed file off the event loop, in parallel.
+  await Promise.all(
+    paths.map(async (filePath) => {
+      const [from, to] = await Promise.all([
+        readRefFileAsync(repoDir, mergeBase, filePath),
+        readRefFileAsync(repoDir, headRef, filePath),
+      ]);
+      diffs[filePath] = { from, to };
+    }),
+  );
 
   return { diffs, mergeBaseSha: mergeBase.trim() };
 }
@@ -466,10 +541,7 @@ function discard(deps: GitDeps, filepaths: string[]): void {
 export function makeGitStatusHandler(deps: GitDeps) {
   return async (_req: Request): Promise<Response> => {
     if (!isGitRepo(deps.repoDir)) {
-      return jsonResponse(
-        { error: "repository not initialized", notReady: true },
-        409,
-      );
+      return repoNotReadyResponse();
     }
     try {
       return jsonResponse(computeStatus(deps.repoDir));
@@ -485,10 +557,7 @@ export function makeGitStatusHandler(deps: GitDeps) {
 export function makeGitDiffHandler(deps: GitDeps) {
   return async (req: Request): Promise<Response> => {
     if (!isGitRepo(deps.repoDir)) {
-      return jsonResponse(
-        { error: "repository not initialized", notReady: true },
-        409,
-      );
+      return repoNotReadyResponse();
     }
     try {
       let base: string | undefined;
@@ -510,8 +579,8 @@ export function makeGitDiffHandler(deps: GitDeps) {
       }
 
       const result = base
-        ? computeDiffAgainstBase(deps.repoDir, base, headSha)
-        : computeDiff(deps.repoDir);
+        ? await computeDiffAgainstBase(deps.repoDir, base, headSha)
+        : await computeDiff(deps.repoDir);
       return jsonResponse(result);
     } catch (err) {
       if (err instanceof InvalidRemoteBranchNameError) {
@@ -527,6 +596,9 @@ export function makeGitDiffHandler(deps: GitDeps) {
 
 export function makeGitPublishHandler(deps: GitDeps) {
   return async (req: Request): Promise<Response> => {
+    if (!isGitRepo(deps.repoDir)) {
+      return repoNotReadyResponse();
+    }
     let body: { message?: string };
     try {
       body = (await parseJsonBody(req)) as { message?: string };
@@ -545,6 +617,9 @@ export function makeGitPublishHandler(deps: GitDeps) {
 
 export function makeGitDiscardHandler(deps: GitDeps) {
   return async (req: Request): Promise<Response> => {
+    if (!isGitRepo(deps.repoDir)) {
+      return repoNotReadyResponse();
+    }
     let body: { filepaths?: string[] };
     try {
       body = (await parseJsonBody(req)) as { filepaths?: string[] };
@@ -569,6 +644,9 @@ export function makeGitDiscardHandler(deps: GitDeps) {
 
 export function makeGitRebaseHandler(deps: GitDeps) {
   return async (req: Request): Promise<Response> => {
+    if (!isGitRepo(deps.repoDir)) {
+      return repoNotReadyResponse();
+    }
     let body: { base?: string };
     try {
       body = (await parseJsonBody(req)) as { base?: string };


### PR DESCRIPTION
## Summary

Opening the **changes / PR modal** could take the whole sandbox down. This fixes the root cause: `git/diff` was blocking the daemon's single event loop.

The modal calls `git/diff` with a `base`, which hits `computeDiffAgainstBase()` → runs `git fetch --depth 100` **synchronously** (`spawnSync`). The daemon serves every route on one Bun event loop, so a slow fetch (PR-diff deepening on a repo with large blobs) **freezes the entire daemon for ~10s**. During that window the upstream HEAD probe and `git/status` can't respond → the proxy returns **502** → the sandbox is mis-flagged as crashed → re-initializes (**409 notReady**) → recovers. The dev server never actually died — the daemon was just blocked.

### Evidence (from a captured HAR of the bug happening)

| Request | Result |
|---|---|
| `POST git/diff` `{base:"main",headSha:…}` | 200, but **10.8s** (9.4s server-side), **2.1MB** response — only 2 files, one ~2MB block JSON |
| `GET git/status` (+11ms) | **502 Bad Gateway** (daemon blocked) |
| `GET git/status` (+3s) | **409 `repository not initialized`** (sandbox re-init) |
| later | recovers to 200 |
| `POST git/suggest-commit` (2.1MB) | 413 Payload too large *(separate, see below)* |

## Changes

- **New `git-async.ts`** — `gitAsync()`, an async twin of `gitSync` (same uid/gid drop, timeout, `GitError`) backed by `child_process.spawn`. Never blocks the event loop, and streams stdout so it also sidesteps `spawnSync`'s `maxBuffer` truncation on large `git show` output.
- **`routes/git.ts` — git/diff hot path is now async.** The network `git fetch` (the ~9s culprit) and per-file content reads (`git show` + working-tree read) run off the event loop and in parallel. Cheap metadata probes (`rev-parse`, `merge-base`, `diff --name-only`) stay synchronous. **Behaviour-preserving** — identical output, just non-blocking.
- **Guard `publish`/`discard`/`rebase`** with the same `isGitRepo` → `409 notReady` check that `status`/`diff` already had, so racing the clone returns a clean 409 instead of a raw `git … rev-parse` 128 surfaced as a 500 (the original "not a git repository" error that started this investigation).

## Testing

- `bun test packages/sandbox/daemon/routes/git.test.ts` → **18 pass** (added 409-notReady tests for publish/discard/rebase).
- Built the daemon bundle and ran the black-box **git e2e** suite against the real binary → **15 pass / 0 fail**, including `POST /git/diff`.
- `bun run fmt` + typecheck clean.

## Follow-ups (not in this PR)

- **413 on `suggest-commit`**: the client posts the full ~2.1MB diff; the route caps at 512KB. Worth capping/summarizing client-side or raising that route's limit.
- **`publish()` push is still synchronous** — same latent "daemon blocked during a network git op" risk. Can migrate it to `gitAsync` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made `git/diff` async so network `git fetch` and file reads no longer block the daemon, preventing false crash flags and 502s in the UI. Added consistent 409 notReady handling for mutating git routes; behavior stays the same, just stable and responsive.

- **Bug Fixes**
  - Introduced `git-async.ts` with `gitAsync()` (spawn-based, non-blocking, streams stdout; same uid/gid, timeout, and `GitError` semantics as sync).
  - Switched `git/diff` hot path to async: `fetch` and per-file reads (`git show` + working tree) run off the event loop and in parallel; metadata probes remain sync; output unchanged.
  - Guarded `publish`/`discard`/`rebase` with 409 `notReady` when the repo isn’t initialized, instead of surfacing raw git errors as 500s.

<sup>Written for commit 90ef5144ec7621c1cdf32c5094263f064552b808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

