### PR TITLE
fix(sandbox): strip generated files from suggest-commit diff

### DIFF
--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -5,6 +5,7 @@ import {
   hasUnpublishedWork,
   isDecoOnlyDiff,
   mergeBranchMetaWithGitStatus,
+  stripGeneratedFilesFromDiff,
   type GitDiffResult,
   type GitStatus,
 } from "./sandbox-git-api.ts";
@@ -208,5 +209,34 @@ describe("isDecoOnlyDiff", () => {
   test("false for empty diff", () => {
     expect(isDecoOnlyDiff({ diffs: {} })).toBe(false);
     expect(isDecoOnlyDiff(null)).toBe(false);
+  });
+});
+
+describe("stripGeneratedFilesFromDiff", () => {
+  test("drops blocks.gen.json and tailwind css, keeps source", () => {
+    const diff: GitDiffResult = {
+      mergeBaseSha: "abc",
+      diffs: {
+        "routes/index.tsx": { from: "a", to: "b" },
+        "src/server/cms/blocks.gen.json": { from: "{}", to: '{"foo":{}}' },
+        "static/tailwind.css": { from: ".a{}", to: ".a{}.b{}" },
+        "src/static/tailwind.css": { from: "x", to: "y" },
+        ".deco/blocks/home.json": { from: "{}", to: "{}" },
+      },
+    };
+    const stripped = stripGeneratedFilesFromDiff(diff);
+    expect(Object.keys(stripped.diffs).sort()).toEqual([
+      ".deco/blocks/home.json",
+      "routes/index.tsx",
+    ]);
+    expect(stripped.mergeBaseSha).toBe("abc");
+  });
+
+  test("does not mutate the input diff", () => {
+    const diff: GitDiffResult = {
+      diffs: { "blocks.gen.json": { from: "{}", to: '{"a":{}}' } },
+    };
+    stripGeneratedFilesFromDiff(diff);
+    expect(Object.keys(diff.diffs)).toEqual(["blocks.gen.json"]);
   });
 });

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -130,18 +130,43 @@ export async function fetchGitDiff(
   return parseJson<GitDiffResult>(res);
 }
 
+/**
+ * Drop auto-generated files (Tailwind CSS output, `blocks.gen.json`) from a
+ * diff before sending it to `suggest-commit`. Their full-content `from`/`to`
+ * bodies can be megabytes on their own and blew past the endpoint's 512KB body
+ * limit (413). They carry no signal for an LLM commit message either — the
+ * server backfills the diff from the daemon when the client omits it, so a
+ * fully-stripped diff still yields a suggestion.
+ */
+export function stripGeneratedFilesFromDiff(
+  diff: GitDiffResult,
+): GitDiffResult {
+  const diffs: Record<string, GitDiffEntry> = {};
+  for (const [path, entry] of Object.entries(diff.diffs)) {
+    if (isBlocksGenJsonPath(path) || isTailwindCssPath(path)) continue;
+    diffs[path] = entry;
+  }
+  return { ...diff, diffs };
+}
+
 export async function fetchSuggestCommitMessage(
   orgSlug: string,
   virtualMcpId: string,
   branch: string,
   payload?: { status: GitStatus; diff: GitDiffResult },
 ): Promise<CommitSuggestion> {
+  const body = payload
+    ? {
+        status: payload.status,
+        diff: stripGeneratedFilesFromDiff(payload.diff),
+      }
+    : {};
   const res = await sandboxFetch(
     buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "suggest-commit"),
     {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(payload ?? {}),
+      body: JSON.stringify(body),
     },
   );
   return parseJson<CommitSuggestion>(res);


### PR DESCRIPTION
## Summary

The publish dialog was POSTing the **full working-tree diff** (every changed file's complete old/new content) to `git/suggest-commit`, whose body limit is **512KB** (`sandbox-proxy.ts`). Auto-generated `tailwind.css` and `blocks.gen.json` can each be megabytes on their own, so a 2.1MB diff blew past the limit and returned **413 Payload too large**.

This strips those generated files from the diff before sending. They carry no signal for an LLM-generated commit message anyway — the server already filters `static/*.css` in `changedPaths`, and when the client omits the diff the server backfills it from the daemon directly (no proxy body limit on that path), so a suggestion is still produced.

## Changes

- **`sandbox-git-api.ts`**: added `stripGeneratedFilesFromDiff(diff)` (reuses existing `isBlocksGenJsonPath` / `isTailwindCssPath` helpers); `fetchSuggestCommitMessage` strips generated files before serializing.
- Returns a new object — does **not** mutate the caller's `gitDiff` state, so the diff shown in the publish dialog is unaffected. Only the suggest-commit request is trimmed.

## Testing

- Added `stripGeneratedFilesFromDiff` unit tests (strips at root + nested paths, keeps source + `.deco` JSON, preserves `mergeBaseSha`, no input mutation).
- `bun test sandbox-git-api.test.ts` → 21 pass.

> [!NOTE]
> This targets the two generated files behind the reported 413. A branch with >512KB of legitimate *source* diff could still 413 — not the reported case, but a fallback (omit the diff entirely when the stripped payload is still over the limit, letting the server backfill) could be added if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip auto-generated `tailwind.css` and `blocks.gen.json` from the diff sent to `git/suggest-commit` to avoid 413 errors from the 512KB body limit. The publish dialog’s shown diff is unchanged, and the server backfills when needed.

- **Bug Fixes**
  - Use `stripGeneratedFilesFromDiff` to drop those files before POSTing the request.
  - Keep the input diff immutable; only the request body is trimmed.
  - Add unit tests for path coverage and immutability.

<sup>Written for commit 8e80b25f7d98dad3c5147ceaa9630a76aa46cbc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

