### PR TITLE
feat(studio): keep same chat + sandbox after publish, show merged state

### DIFF
--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -17,7 +17,6 @@ import { toast } from "sonner";
 import { authClient } from "@/web/lib/auth-client.ts";
 import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
 import { getActiveGithubRepo } from "@/web/lib/github-repo.ts";
-import { generateBranchName } from "@/shared/branch-name";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import { useChatTask } from "../../chat/index";
 import { useSandboxGitStatus } from "@/web/components/sandbox/hooks/use-sandbox-git-status.ts";
@@ -65,7 +64,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const { org } = useProjectContext();
   const { data: session } = authClient.useSession();
   const vm = useVirtualMCP(virtualMcpId);
-  const { currentBranch: branch, setCurrentTaskBranch } = useChatTask();
+  const { currentBranch: branch } = useChatTask();
   const chat = useChatStream();
   const [publishOpen, setPublishOpen] = useState(false);
   const [publishDialogIntent, setPublishDialogIntent] = useState<
@@ -232,11 +231,6 @@ export function HeaderActions({ virtualMcpId }: Props) {
     ]);
   };
 
-  const switchToFreshBranch = async () => {
-    const nextBranch = generateBranchName();
-    await setCurrentTaskBranch(nextBranch);
-  };
-
   const handleSquashMerge = async (pullNumber: number) => {
     if (!githubRepo?.connectionId || githubActionPending) return;
     setGithubActionPending(true);
@@ -249,8 +243,10 @@ export function HeaderActions({ virtualMcpId }: Props) {
         coAuthor,
       });
       toast.success(`Published PR #${pullNumber}`);
+      // Stay on the same chat + sandbox; refreshing PR state flips the header
+      // to the terminal "Published" pill (panel-state) instead of navigating
+      // the user onto a fresh branch.
       await refreshPrState();
-      await switchToFreshBranch();
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : "Failed to merge pull request",
@@ -344,7 +340,6 @@ export function HeaderActions({ virtualMcpId }: Props) {
           }
           openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}
-          onPublished={switchToFreshBranch}
         />
       )}
     </>

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -89,8 +89,6 @@ export interface PublishDialogProps {
   openPullRequest?: PrSummary | null;
   /** Called after commit/push or PR open/merge so the header can refresh. */
   onPullRequestChanged?: () => void | Promise<void>;
-  /** Called after a successful publish (squash-merge to base). */
-  onPublished?: () => void | Promise<void>;
 }
 
 export function PublishDialog(props: PublishDialogProps) {
@@ -129,7 +127,6 @@ function PublishDialogBody({
   headSha = null,
   openPullRequest = null,
   onPullRequestChanged,
-  onPublished,
 }: PublishDialogProps) {
   const githubClient = useMCPClient({
     connectionId: githubConnectionId,
@@ -390,7 +387,6 @@ function PublishDialogBody({
       setPublishTitle("");
       setPublishBody("");
       await onPullRequestChanged?.();
-      await onPublished?.();
     } catch (error) {
       if (
         error instanceof PublishFlowError &&


### PR DESCRIPTION
## Summary

Reworked the post-publish behavior based on team feedback.

**Before:** clicking **Publish to production** (or merging an open PR) squash-merged to `base` and then navigated the user onto a freshly generated branch. That left you on the *old chat* but a *brand-new sandbox* — a jarring mismatch, and not Conductor-like (the UI jumps).

**Now:** after merge, **stay on the same chat and the same sandbox**. Nothing jumps. Refreshing PR state flips the header to the terminal **"Published"** pill — this merged state is already handled by `panel-state.ts` when `pr.merged` is true — so the merged status is visible in place.

## Changes

- `header-actions.tsx`: removed `switchToFreshBranch`; `handleSquashMerge` now just refreshes PR state and stays put. Dropped the now-unused `generateBranchName` import and `setCurrentTaskBranch` destructure.
- `publish-dialog.tsx`: removed the now-unused `onPublished` hook (prop + call). `onPullRequestChanged` (→ `refreshPrState`) already drives the merged UI.

Applies to both publish paths: the publish dialog and the direct squash-merge of an already-open PR.

## Testing

- `bun run --cwd=apps/mesh check` (tsc) passes.
- `bun test apps/mesh/src/web/components/thread/github/` — 107 pass, 0 fail.
- `bun run lint` — 0 errors (pre-existing unrelated warnings only); `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)