### PR TITLE
fix(sandbox): republish daemon as 1.9.7 to force sandbox rollout

### DIFF
--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {


### PR DESCRIPTION
## Summary

The daemon fix in #4345 (git/diff no longer blocks the daemon nor mis-flags the sandbox as crashed) never actually reached the deployed sandbox pods.

`release-tagging` ran for #4345's merge commit but **skipped the version bump** — its "Find the merged pull request" step returned empty (commit→PR association race; the run finished 11s after the push), so `packages/sandbox/package.json` stayed at `1.9.6`. Consequences:

- `release-studio-sandbox` re-built and **re-pushed the mutable `1.9.6` tag** with the fix baked in.
- The `image-bump` dispatch to `deco-apps-cd` was `1.9.6 → 1.9.6` — a no-op. `deco-apps-cd` `main` was already pinned to `1.9.6`, so **ArgoCD saw no tag change and never rolled** the fixed daemon onto sandbox pods.

## Fix

Bump `packages/sandbox/package.json` to **1.9.7**. On merge this:
1. publishes a fresh, immutable `studio-sandbox:1.9.7` (containing #4345);
2. auto-dispatches `image-bump` to `deco-apps-cd` as a real `1.9.6 → 1.9.7` tag change, so new sandbox claims land on the fixed daemon.

## Testing notes

- One-line version bump, no code change.
- Verify after merge: `release-studio-sandbox` builds `1.9.7` (not a skipped/exists run) and the `deco-apps-cd` `image-bump` lands a `1.9.6 → 1.9.7` commit on both `apps/studio-sandbox-stg/values.yaml` and `apps/studio-sandbox-prod/values.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@decocms/sandbox` from 1.9.6 to 1.9.7 to force a sandbox rollout and publish an immutable image with the daemon fix from #4345. This triggers a real tag change (1.9.6 → 1.9.7) in `deco-apps-cd`, prompting ArgoCD to roll the fixed daemon to sandbox pods.

<sup>Written for commit 4b001ded47537b821e2cac926cad30ac0b8aed98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

