### PR TITLE
perf(sandbox): defer base-branch fetch off the clone critical path

### DIFF
--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -132,7 +132,7 @@ describe("spawnClone", () => {
     const { url, root, cleanup } = setupBareRepo();
     try {
       const repoDir = join(root, "workspace");
-      const code = await spawnClone({
+      const { code } = await spawnClone({
         config: makeConfig(repoDir, url, "feature/x"),
         onChunk: () => {},
       });
@@ -149,11 +149,16 @@ describe("spawnClone", () => {
     const { url, root, cleanup } = setupBareRepo();
     try {
       const repoDir = join(root, "workspace");
-      const code = await spawnClone({
+      const { code, fetchBase } = await spawnClone({
         config: makeConfig(repoDir, url, "feature/x"),
         onChunk: () => {},
       });
       expect(code).toBe(0);
+      // The base fetch is deferred off the clone critical path; the
+      // orchestrator runs the returned thunk in the background. Drive it here
+      // to assert the same side effects.
+      expect(fetchBase).toBeDefined();
+      await fetchBase?.(() => {});
       // Even though only feature/x was cloned, origin/main must be present with
       // origin/HEAD pointing at it — otherwise computeBranchDivergence can't
       // compute ahead/behind vs base and the header falsely shows "Up to date".
@@ -185,12 +190,14 @@ describe("spawnClone", () => {
     try {
       const repoDir = join(root, "workspace");
       // Resuming `main` (the default) hits the `base === branchOnRemote` skip:
-      // the base is already the cloned branch, so no second fetch is needed.
-      const code = await spawnClone({
+      // the base is already the cloned branch, so the deferred fetch is a
+      // no-op (it early-returns without a second network fetch).
+      const { code, fetchBase } = await spawnClone({
         config: makeConfig(repoDir, url, "main"),
         onChunk: () => {},
       });
       expect(code).toBe(0);
+      await fetchBase?.(() => {});
       expect(currentBranch(repoDir)).toBe("main");
       const div = computeBranchDivergence(repoDir);
       expect(div.base).toBe("main");
@@ -218,12 +225,14 @@ describe("spawnClone", () => {
       });
 
       const repoDir = join(root, "workspace");
-      const code = await spawnClone({
+      const { code, fetchBase } = await spawnClone({
         config: makeConfig(repoDir, url, "feature/x"),
         onChunk: () => {},
       });
       // Best-effort: the clone still succeeds; it just skips the unsafe base.
       expect(code).toBe(0);
+      // The unsafe-ref rejection lives in the deferred base fetch — drive it.
+      await fetchBase?.(() => {});
       // origin/HEAD must NOT have been pointed at the malicious ref.
       expect(
         tryGitOut(repoDir, "symbolic-ref --short refs/remotes/origin/HEAD"),
@@ -243,7 +252,7 @@ describe("spawnClone", () => {
     const { url, root, cleanup } = setupBareRepo();
     try {
       const repoDir = join(root, "workspace");
-      const code = await spawnClone({
+      const { code } = await spawnClone({
         config: makeConfig(repoDir, url, "feature/new"),
         onChunk: () => {},
       });
@@ -262,7 +271,7 @@ describe("spawnClone", () => {
     const { url, root, cleanup } = setupBareRepo();
     try {
       const repoDir = join(root, "workspace");
-      const code = await spawnClone({
+      const { code } = await spawnClone({
         config: makeConfig(repoDir, url),
         onChunk: () => {},
       });
@@ -280,7 +289,7 @@ describe("spawnClone", () => {
       // file:// URL pointing at a path that doesn't exist — ls-remote returns
       // a fatal error (not exit 2), so spawnClone must surface a non-zero
       // exit code instead of silently falling through to a local fork.
-      const code = await spawnClone({
+      const { code } = await spawnClone({
         config: makeConfig(
           repoDir,
           "file:///nonexistent/path/to/repo.git",
@@ -304,7 +313,7 @@ describe("spawnClone", () => {
       // written before the first clone. spawnClone must fall back to
       // init + fetch + checkout instead of `git clone`.
       writeFileSync(join(repoDir, "marker.txt"), "preexisting\n");
-      const code = await spawnClone({
+      const { code } = await spawnClone({
         config: makeConfig(repoDir, url, "feature/x"),
         onChunk: () => {},
       });

--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -204,19 +204,43 @@ async function fetchBaseBranch(
   );
 }
 
-/** Resolves to exit code (0 on success). Emits chunks via `onChunk`. */
-export async function spawnClone(deps: CloneDeps): Promise<number> {
+export interface CloneResult {
+  /** Exit code — 0 on success. */
+  code: number;
+  /**
+   * Deferred, best-effort fetch of the remote's default branch (+ the
+   * origin/HEAD pointer) so `computeBranchDivergence` can report ahead/behind
+   * vs base. Split off the clone critical path: it's 1-2 network round trips
+   * (`ls-remote --symref` + `fetch`) that only feed the divergence header, so
+   * the orchestrator runs it in the background once the working tree is ready
+   * rather than blocking install+start behind it (the header just shows its
+   * "unavailable until next fetch" state for a beat). Absent when no base
+   * fetch is warranted (target branch absent on remote → local fork; or the
+   * target IS the default branch). `onChunk` is injected by the caller because
+   * the clone's own log tee is closed by the time this runs.
+   */
+  fetchBase?: (
+    onChunk: (source: "setup", data: string) => void,
+  ) => Promise<void>;
+}
+
+/**
+ * Acquires the repo working tree (0 on success). Emits progress via `onChunk`.
+ * The returned `fetchBase` thunk (when present) does the off-critical-path
+ * base-branch fetch — see CloneResult.
+ */
+export async function spawnClone(deps: CloneDeps): Promise<CloneResult> {
   const { config } = deps;
   const cloneUrl = config.git?.repository?.cloneUrl;
   if (!cloneUrl) {
-    return 1;
+    return { code: 1 };
   }
   if (!config.repoDir || !config.repoDir.startsWith("/")) {
     deps.onChunk(
       "setup",
       `\r\n[clone] repoDir is not an absolute path (got: ${String(config.repoDir)}) — aborting clone to prevent relative-path mishap\r\n`,
     );
-    return 1;
+    return { code: 1 };
   }
 
   // GIT_TERMINAL_PROMPT=0 + GIT_ASKPASS=true: refuse to ever prompt for
@@ -258,9 +282,19 @@ export async function spawnClone(deps: CloneDeps): Promise<number> {
         "setup",
         `\r\n[clone] ls-remote failed (exit ${probe}); aborting clone\r\n`,
       );
-      return probe;
+      return { code: probe };
     }
   }
+
+  // Built once branchOnRemote is known; both acquisition paths return it so
+  // the orchestrator can run the base fetch after the dev server is up.
+  const deferBaseFetch =
+    (branchOnRemoteForFetch: string) =>
+    (onChunk: (source: "setup", data: string) => void) =>
+      fetchBaseBranch(gc, dir, cloneUrl, branchOnRemoteForFetch, {
+        ...deps,
+        onChunk,
+      });
 
   // When repoDir already has files (e.g. .decocms/daemon.json written before
   // the first clone) but no .git, `git clone` would fail with "already exists
@@ -273,7 +307,7 @@ export async function spawnClone(deps: CloneDeps): Promise<number> {
     ];
     for (const step of localSteps) {
       const code = await runStep(step, deps);
-      if (code !== 0) return code;
+      if (code !== 0) return { code };
     }
     const fetchRef = branchOnRemote
       ? `+refs/heads/${branchOnRemote}:refs/remotes/origin/${branchOnRemote}`
@@ -282,7 +316,7 @@ export async function spawnClone(deps: CloneDeps): Promise<number> {
       `${gc} -C ${dir} fetch --depth 1 origin ${fetchRef}`,
       deps,
     );
-    if (fetchCode !== 0) return fetchCode;
+    if (fetchCode !== 0) return { code: fetchCode };
     // `-f`: the daemon writes files into repoDir before the first clone (that's
     // why we're on the init+fetch path), and the CMS can leave stale untracked
     // `.deco/blocks/*.json` there. Those collide with branch-tracked paths and
@@ -294,29 +328,36 @@ export async function spawnClone(deps: CloneDeps): Promise<number> {
       ? `${gc} -C ${dir} checkout -f -B ${branchOnRemote} refs/remotes/origin/${branchOnRemote}`
       : `${gc} -C ${dir} checkout -f FETCH_HEAD`;
     const checkoutCode = await runStep(checkoutCmd, deps);
-    if (checkoutCode !== 0) return checkoutCode;
+    if (checkoutCode !== 0) return { code: checkoutCode };
     if (branchToForkLocally) {
-      return runStep(
-        `${gc} -C ${dir} checkout -B ${branchToForkLocally}`,
-        deps,
-      );
+      return {
+        code: await runStep(
+          `${gc} -C ${dir} checkout -B ${branchToForkLocally}`,
+          deps,
+        ),
+      };
     }
-    if (branchOnRemote) {
-      await fetchBaseBranch(gc, dir, cloneUrl, branchOnRemote, deps);
-    }
-    return 0;
+    return {
+      code: 0,
+      ...(branchOnRemote ? { fetchBase: deferBaseFetch(branchOnRemote) } : {}),
+    };
   }
 
   const cloneCmd = branchOnRemote
     ? `${gc} clone --depth 1 --branch ${branchOnRemote} ${cloneUrl} ${dir}`
     : `${gc} clone --depth 1 ${cloneUrl} ${dir}`;
   const cloneCode = await runNetworkStep(cloneCmd, deps);
-  if (cloneCode !== 0) return cloneCode;
+  if (cloneCode !== 0) return { code: cloneCode };
   if (branchToForkLocally) {
-    return runStep(`${gc} -C ${dir} checkout -B ${branchToForkLocally}`, deps);
+    return {
+      code: await runStep(
+        `${gc} -C ${dir} checkout -B ${branchToForkLocally}`,
+        deps,
+      ),
+    };
   }
-  if (branchOnRemote) {
-    await fetchBaseBranch(gc, dir, cloneUrl, branchOnRemote, deps);
-  }
-  return 0;
+  return {
+    code: 0,
+    ...(branchOnRemote ? { fetchBase: deferBaseFetch(branchOnRemote) } : {}),
+  };
 }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -25,7 +25,7 @@ import { appLogPath, hasGitRepo, resolvePmRoot } from "../paths";
 import { discoverScripts } from "../process/script-discovery";
 import type { Application, Config } from "../types";
 import { autodetectApplication } from "./autodetect";
-import { spawnClone } from "./clone";
+import { type CloneResult, spawnClone } from "./clone";
 import { emitInstalledDeps } from "./dep-metrics";
 import { configureGitIdentity } from "./identity";
 import { spawnInstall } from "./install";
@@ -235,9 +235,9 @@ export class SetupOrchestrator {
         /* not present */
       }
       const cloneTee = new LogTee(cloneLogPath, INSTALL_LOG_MAX_BYTES);
-      let code: number;
+      let result: CloneResult;
       try {
-        code = await spawnClone({
+        result = await spawnClone({
           config,
           onChunk: (_src, data) => {
             this.rawChunk(data);
@@ -252,11 +252,27 @@ export class SetupOrchestrator {
         return false;
       }
       cloneTee.close();
-      if (code !== 0) {
-        const error = `exit ${code}`;
+      if (result.code !== 0) {
+        const error = `exit ${result.code}`;
         this.chunk(`\r\n[orchestrator] clone failed (${error})\r\n`);
         this.deps.lifecycle.transition({ phase: "clone-failed", error });
         return false;
+      }
+      // Base-branch fetch is off the critical path: fire it detached so
+      // install+start don't wait on 1-2 network round trips that only feed
+      // the divergence header. Logs via rawChunk (the clone tee is closed);
+      // refreshes branch status when it lands so the header updates without
+      // waiting for the next poll. Best-effort — a failure just leaves the
+      // header in its "unavailable until next fetch" state.
+      if (result.fetchBase) {
+        void result
+          .fetchBase((_src, data) => this.rawChunk(data))
+          .then(() => this.deps.branchStatus.refresh())
+          .catch((e) =>
+            this.rawChunk(
+              `\r\n[clone] deferred base fetch failed: ${(e as Error).message}\r\n`,
+            ),
+          );
       }
     } else if (cloneUrl) {
       // Repo exists. If a different branch is configured, treat that as a


### PR DESCRIPTION
## Summary

The clone step fetched the remote's default branch inline — `ls-remote --symref <url> HEAD` to resolve the default branch, then a second shallow `fetch` of it — **before install could start**. Those 1-2 network round trips exist only to populate `origin/<base>` + the `origin/HEAD` pointer so the branch-divergence header can report "ahead of base" from t=0. They don't touch the working tree, so blocking install/start on them is pure critical-path waste.

`spawnClone` now returns that work as a deferred `fetchBase` thunk instead of awaiting it. The orchestrator fires it **detached** once the working tree is ready, so it overlaps install + dev-server start (fully hidden behind the ~6-22s install) instead of blocking them, then refreshes branch status when it lands so the header updates without waiting for the next poll.

Best-effort, exactly as before: on failure the divergence header just shows its "unavailable until next fetch" state.

## Why

Measured new-branch boot phases (prod): clone ~2-4s, install ~17-22s, dev-server start ~21s. The base fetch is part of that clone window and is the one piece of it that doesn't need to be on the critical path — it feeds a header, not the tree or the dev server.

## Changes

- **`setup/clone.ts`**: `spawnClone` returns `{ code, fetchBase? }`. `fetchBase` is present only when a base fetch is warranted (target branch exists on remote and isn't itself the default); absent for the fork-from-default and resume-default cases. The unsafe-ref-name rejection and shallow-fetch semantics are unchanged — just relocated behind the thunk.
- **`setup/orchestrator.ts`**: captures `fetchBase` and runs it detached with a background-safe logger (the clone's log tee is already closed by then), chaining a `branchStatus.refresh()` on completion.

## Testing

- `clone.test.ts` updated to drive the deferred thunk where base-fetch side effects are asserted (origin/main ref, origin/HEAD pointer, unsafe-ref rejection). 10 pass.
- Orchestrator tests: 7 pass. Full sandbox-package typecheck clean. Daemon bundle builds.

## Scope

Independent of #4352 (deps cache) — branches off `main`. Small win (~1-2s) on its own; stacks with the CPU-limit change that addresses the dominant install/Vite throttling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers the remote base-branch fetch off the clone critical path to shave ~1–2s from new-branch boot. The fetch now runs in the background after the working tree is ready, and the divergence header updates when it completes.

- **Refactors**
  - `spawnClone` returns `{ code, fetchBase? }`; `fetchBase` updates the default branch and `origin/HEAD` best-effort.
  - Orchestrator runs `fetchBase` detached, logs via `rawChunk`, then calls `branchStatus.refresh()`.
  - Preserves behavior: unsafe-ref rejection and shallow-fetch semantics moved behind the thunk. Tests updated.

<sup>Written for commit 6532399e7c026c34855c64aa814ba7632b69006b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

