### PR TITLE
chore(sandbox-env): bump chart to 0.9.1 to publish deps cache

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,9 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.9.1: opt-in node-local deps cache (depsCache.*, default off) —
+# hostPath store keyed per-repo by the daemon. Additive; no change for
+# consumers that leave it disabled.
 # 0.9.0: org-fs is mandatory — removed the `orgFs.enabled` + `hostUsers`
 # toggles (sidecar always deployed, hostUsers fixed true). Minor bump:
 # behavior change for consumers that ran with org-fs disabled / userns
@@ -19,7 +22,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.0
+version: 0.9.1
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.5.7"
 kubeVersion: ">=1.30.0-0"


### PR DESCRIPTION
#4352 merged the `depsCache` template + values into `sandbox-env` but left `version: 0.9.0` unchanged. The chart publish workflow **skips versions that already exist**, so the deployed 0.9.0 chart would never pick up the new template — the deps cache is unshippable until the version moves.

Patch bump to **0.9.1**: purely additive, opt-in, default off. No behavior change for consumers that leave `depsCache.enabled: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `sandbox-env` Helm chart to 0.9.1 to publish the new deps cache (`depsCache.*`) template and values, which 0.9.0 could not pick up because that version already existed. This is additive and opt-in (disabled by default); no behavior change for users who keep `depsCache.enabled: false`.

<sup>Written for commit d3ca678130075161b9c8a603f899e904bf599067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

