### PR TITLE
fix(automations): replace fixed timeout with progress-based stall detection

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -295,6 +295,25 @@ describe("reactAll (real Postgres)", () => {
         expect(row?.run_owner_pod).toBeNull();
         expect(row?.run_config).toBeNull();
         expect(row?.run_started_at).toBeNull();
+        // `Thread` (storage.get()'s return type) doesn't surface
+        // failure_reason/failure_kind — only ThreadUpdateData carries them for
+        // writes. Read the raw column directly so this still exercises the
+        // real SQL write path (the update() whitelist forwarding) rather than
+        // the read-side mapper.
+        const dbRow = await database.db
+          .selectFrom("threads")
+          .select(["failure_reason", "failure_kind"])
+          .where("id", "=", thread.id)
+          .executeTakeFirstOrThrow();
+        if (reason === "reaped") {
+          expect(dbRow.failure_reason).toBe(
+            "Run stalled — no progress within the idle timeout window",
+          );
+          expect(dbRow.failure_kind).toBe("stall");
+        } else {
+          expect(dbRow.failure_reason).toBeNull();
+          expect(dbRow.failure_kind).toBeNull();
+        }
         expect(sseEvents).toHaveLength(2);
       }
     });

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.test.ts
@@ -139,4 +139,49 @@ describe("run reactor", () => {
     expect(updates[0]!.failure_reason).toBeUndefined();
     expect(updates[0]!.failure_kind).toBeUndefined();
   });
+
+  test("RUN_STARTED clears any stale failure_reason/failure_kind from a prior run", async () => {
+    const updates: Record<string, unknown>[] = [];
+    const deps: RunReactorDeps = {
+      storage: {
+        update: async (
+          _id: string,
+          _orgId: string,
+          data: Record<string, unknown>,
+        ) => {
+          updates.push(data);
+          return null;
+        },
+        get: async () => ({
+          id: "run_1",
+          organization_id: "org_1",
+          created_by: "user_1",
+          status: "in_progress",
+        }),
+      } as unknown as ThreadStoragePort,
+      sseHub: { emit: () => {} },
+    };
+
+    await reactAll(
+      [
+        {
+          event: {
+            type: "RUN_STARTED",
+            taskId: "run_1",
+            orgId: "org_1",
+            userId: "user_1",
+            abortController: new AbortController(),
+            podId: "pod_1",
+          },
+          state: undefined,
+        },
+      ],
+      deps,
+    );
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.status).toBe("in_progress");
+    expect(updates[0]!.failure_reason).toBeNull();
+    expect(updates[0]!.failure_kind).toBeNull();
+  });
 });

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.test.ts
@@ -52,4 +52,91 @@ describe("run reactor", () => {
     // Structural since RunReactorDeps no longer accepts a stream buffer.
     expect(emitted).toHaveLength(2);
   });
+
+  test("RUN_FAILED reason 'reaped' records a stall failure_reason/kind", async () => {
+    const updates: Record<string, unknown>[] = [];
+    const deps: RunReactorDeps = {
+      storage: {
+        update: async (
+          _id: string,
+          _orgId: string,
+          data: Record<string, unknown>,
+        ) => {
+          updates.push(data);
+          return null;
+        },
+        get: async () => ({
+          id: "run_1",
+          organization_id: "org_1",
+          created_by: "user_1",
+          status: "failed",
+        }),
+        forceFailIfInProgress: async () => true,
+      } as unknown as ThreadStoragePort,
+      sseHub: { emit: () => {} },
+    };
+
+    await reactAll(
+      [
+        {
+          event: {
+            type: "RUN_FAILED",
+            taskId: "run_1",
+            orgId: "org_1",
+            reason: "reaped",
+          },
+          state: undefined,
+        },
+      ],
+      deps,
+    );
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.status).toBe("failed");
+    expect(updates[0]!.failure_reason).toBe(
+      "Run stalled — no progress within the idle timeout window",
+    );
+    expect(updates[0]!.failure_kind).toBe("stall");
+  });
+
+  test("RUN_FAILED reason 'error' does NOT set failure_reason (unchanged)", async () => {
+    const updates: Record<string, unknown>[] = [];
+    const deps: RunReactorDeps = {
+      storage: {
+        update: async (
+          _id: string,
+          _orgId: string,
+          data: Record<string, unknown>,
+        ) => {
+          updates.push(data);
+          return null;
+        },
+        get: async () => ({
+          id: "run_1",
+          organization_id: "org_1",
+          status: "failed",
+        }),
+        forceFailIfInProgress: async () => true,
+      } as unknown as ThreadStoragePort,
+      sseHub: { emit: () => {} },
+    };
+
+    await reactAll(
+      [
+        {
+          event: {
+            type: "RUN_FAILED",
+            taskId: "run_1",
+            orgId: "org_1",
+            reason: "error",
+          },
+          state: undefined,
+        },
+      ],
+      deps,
+    );
+
+    expect(updates[0]!.failure_reason).toBeUndefined();
+    expect(updates[0]!.failure_kind).toBeUndefined();
+  });
 });

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -19,6 +19,10 @@ import {
 } from "@decocms/mesh-sdk";
 import type { RunEvent, RunTransition } from "./run-state";
 
+/** Recorded on a run the idle reaper force-fails for lack of progress. */
+const STALL_FAILURE_REASON =
+  "Run stalled — no progress within the idle timeout window";
+
 // ============================================================================
 // Errors
 // ============================================================================
@@ -156,6 +160,12 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
           status: "failed",
           run_config: null,
           run_started_at: null,
+          // A reaped run stalled (no progress within the idle window); record a
+          // legible reason. Other reasons ("error"/"cancelled") keep their bare
+          // terminal write — their reason is surfaced elsewhere.
+          ...(event.reason === "reaped"
+            ? { failure_reason: STALL_FAILURE_REASON, failure_kind: "stall" }
+            : {}),
         });
       }
       // Deliberately NO JetStream purge here. The consume step projects every

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -85,6 +85,10 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
         run_config: event.runConfig ?? null,
         run_started_at: new Date().toISOString(),
         last_progress_at: null,
+        // Clear any prior run's recorded failure as this new run starts, so a
+        // re-run of a previously-stalled thread doesn't carry a stale reason.
+        failure_reason: null,
+        failure_kind: null,
       });
       const startedThread = await storage.get(event.taskId, event.orgId);
       sseHub.emit(

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -89,7 +89,6 @@ export const AUTOMATIONS_PARTITION_CONCURRENCY = 10;
 export const AUTOMATIONS_POLL_INTERVAL_MS = 5_000;
 /** Prefix of the retired per-org queues — kept only for migration cleanup. */
 const AUTOMATIONS_ORG_QUEUE_PREFIX = "automations-org-";
-const AUTOMATIONS_RUN_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * MIGRATION (remove once no `automations-org-*` rows remain): delete the
@@ -125,7 +124,6 @@ export async function cleanupOrphanedOrgQueues(pool: Pool): Promise<void> {
 export interface AutomationRuntime {
   storage: AutomationsStorage;
   meshContextFactory: StudioContextFactory;
-  runTimeoutMs?: number;
 }
 
 let runtime: AutomationRuntime | null = null;
@@ -454,12 +452,10 @@ async function fireAutomationWorkflowFn(
     return { taskId, error: built.reason };
   }
 
-  const rt = requireRuntime();
   try {
     await runDispatchSteps({
       threadId: taskId,
       request: built.request,
-      timeoutMs: rt.runTimeoutMs ?? AUTOMATIONS_RUN_TIMEOUT_MS,
       source: "automation",
     });
   } catch (err) {

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,8 +1,8 @@
 {
   "auth/install-studio-pack-workflow.ts": "8aa255710fe562a3a0a86373ba60c9bfb53b34a9b17539083a22866e734fdede",
-  "automations/dbos-workflow.ts": "b18986ee38512806b636e5c386b7ec24bf2e8f9d219c838d3b40b6c681c12b67",
-  "dispatch-queue/hosted-harness-workflow.ts": "e930e3914aed1a55845ebff94eda6df48a702f197eb36b1780b818c3633d1edd",
-  "dispatch-queue/thread-gate-workflow.ts": "ea44994c388639356b281cfca82c06a781a7cc210c18bfbfc834d81002a04f98",
+  "automations/dbos-workflow.ts": "76f03ce0e787209aacbe2ac128cb50c6d12eb513b7e0c7ae463401544de43127",
+  "dispatch-queue/hosted-harness-workflow.ts": "23666d60acd156404d9a40735d7518888ec691885c3104cc10ac54bad416779c",
+  "dispatch-queue/thread-gate-workflow.ts": "201ed970948c64b35685a4cd7768dda0aafb4e5312b4e5156381d66d918f20b9",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
   "harnesses/decopilot/background-tool-workflow.ts": "b75384d08b2293a101da50f0dfc63c23fc27f4b5636d2a9ada3cc22d2f61202b",
   "monitoring/dbos-retention-workflow.ts": "b43e3596b386b53faf372b140d9137a12252565987543640d17f7798504b8dbb"

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
@@ -69,19 +69,6 @@ export type StudioContextFactory = (
 export const HOSTED_HARNESS_PARTITION_CONCURRENCY = 1;
 
 /**
- * Human-readable reason for a run aborted by the opt-in timeout. Passed to
- * `AbortController.abort(reason)` so the surfaced error (and the thread's
- * recorded `failure_reason`) says WHY the run ended instead of a bare abort.
- */
-function formatTimeoutReason(timeoutMs: number): string {
-  const human =
-    timeoutMs >= 60_000
-      ? `${Math.round(timeoutMs / 60_000)}m`
-      : `${Math.round(timeoutMs / 1_000)}s`;
-  return `Run exceeded its ${human} time limit and was aborted`;
-}
-
-/**
  * Serializable input to a hosted harness run. Everything needed to (re)run the
  * in-process agent loop from a DBOS-replayed workflow journal — the
  * non-serializable `abortSignal` is excluded (the run constructs its own from
@@ -97,13 +84,6 @@ export interface HostedHarnessInput {
   threadId: string;
   /** Dispatch input minus the non-serializable abort signal. */
   request: SerializableDispatchRunInput;
-  /**
-   * Optional per-run timeout (ms). When set, the run aborts after this
-   * duration. Automations pass an explicit value; user messages leave it unset
-   * (tool-using agent loops routinely outlast any fixed cap). Falls back to the
-   * runtime's `runTimeoutMs` when omitted.
-   */
-  timeoutMs?: number;
 }
 
 export interface HostedHarnessRuntime {
@@ -115,12 +95,6 @@ export interface HostedHarnessRuntime {
     DispatchRunDeps,
     "runRegistry" | "cancelBroadcast" | "streamBuffer" | "sseHub"
   >;
-  /**
-   * Default per-run timeout (ms). Overridable per-call via
-   * `HostedHarnessInput.timeoutMs`. When neither is set, no abort timer is
-   * installed.
-   */
-  runTimeoutMs?: number;
 }
 
 let runtime: HostedHarnessRuntime | null = null;
@@ -177,33 +151,17 @@ async function runHostedHarness(
     meshCtx.metadata.runMetadata = request.runMetadata;
   }
 
-  // Abort timer is opt-in. Automations supply a cap so a runaway cron can't
-  // pin a thread slot forever; user messages leave it unset because tool-using
-  // agent loops (Claude Code, deep research, multi-step assistants) routinely
-  // outlast any fixed cap, and were not bounded by the legacy fire-and-forget
-  // HTTP path.
-  const timeoutMs = input.timeoutMs ?? rt.runTimeoutMs;
+  // No wall-clock cap: a hosted run lives as long as it makes progress. The
+  // RunRegistry idle reaper aborts + fails a run that goes RUN_IDLE_TIMEOUT_MS
+  // with no progress (see run-registry.ts). The AbortController is retained for
+  // explicit cancellation and the reaper's force-fail.
   const abortController = new AbortController();
-  const timeoutHandle =
-    timeoutMs != null
-      ? setTimeout(
-          // Pass a descriptive reason so a timeout surfaces as a legible error
-          // (recorded in the thread's failure_reason) instead of a bare abort.
-          () =>
-            abortController.abort(new Error(formatTimeoutReason(timeoutMs))),
-          timeoutMs,
-        )
-      : null;
 
-  try {
-    await rt.dispatchRunFn(
-      { ...request, abortSignal: abortController.signal },
-      meshCtx,
-      rt.deps,
-    );
-  } finally {
-    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
-  }
+  await rt.dispatchRunFn(
+    { ...request, abortSignal: abortController.signal },
+    meshCtx,
+    rt.deps,
+  );
 }
 
 async function hostedHarnessWorkflowFn(

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -331,7 +331,6 @@ async function dispatchRunAndWaitStep(
         fenceToken: runFenceToken,
         threadId: ctx.threadId,
         request: claimedRequest,
-        ...(ctx.timeoutMs != null ? { timeoutMs: ctx.timeoutMs } : {}),
       },
     };
   }

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -40,6 +40,10 @@ export type ThreadUpdateData = Partial<Thread> & {
    * active.
    */
   last_progress_at?: string | null;
+  /** Human-readable reason a run ended in "failed" (e.g. a stall). */
+  failure_reason?: string | null;
+  /** Coarse failure category (e.g. "stall"). */
+  failure_kind?: string | null;
 };
 
 export interface ThreadStoragePort {

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -371,6 +371,12 @@ export class SqlThreadStorage implements ThreadStoragePort {
     if (data.last_progress_at !== undefined) {
       updateData.last_progress_at = data.last_progress_at;
     }
+    if (data.failure_reason !== undefined) {
+      updateData.failure_reason = data.failure_reason;
+    }
+    if (data.failure_kind !== undefined) {
+      updateData.failure_kind = data.failure_kind;
+    }
     if (data.metadata !== undefined) {
       updateData.metadata = JSON.stringify(data.metadata);
     }


### PR DESCRIPTION
## Summary

Automation runs were being killed after a fixed **5-minute wall-clock timeout** regardless of progress — a legitimately long, actively-streaming run (e.g. the 17-task commerce-discovery audit) died mid-work, on task 1 of 17. This replaces the crude cap with the **progress-based idle reaper that already governs interactive runs**, unifying both under one mechanism.

Observed on prod thread `thrd_J5cKVKyrKLyEHM-Dc3wT7`: ran exactly 5:00, aborted while streaming tool calls with a null `failure_reason`.

## What changed

1. **Record a real stall reason** — when the RunRegistry idle reaper force-fails a stalled run (`RUN_FAILED` / `reason: "reaped"`), it now writes `failure_reason: "Run stalled — no progress within the idle timeout window"` and `failure_kind: "stall"` instead of a bare `status: "failed"`. Reuses the columns added in #4343. Applied **only** to `"reaped"`; `"error"`/`"cancelled"`/`"ghost"` are unchanged.
2. **Remove the fixed wall-clock cap** on the hosted automation path (`AUTOMATIONS_RUN_TIMEOUT_MS`, the `runHostedHarness` `setTimeout`, `formatTimeoutReason`, and the `timeoutMs` plumbing). Automations now fall under the existing **10-min progress-based idle reaper** (`RUN_IDLE_TIMEOUT_MS`) — a run lives as long as it keeps streaming, and is aborted only after 10 min of no progress. **No absolute cap** (per design); blast radius is bounded by per-org queue concurrency (10). The `AbortController` stays for cancellation + the reaper's force-fail.
3. **Clear stale stall columns on `RUN_STARTED`** so a re-run of a previously-stalled thread doesn't carry a stale reason.

## Design decisions (see spec)

- **Stall-only, no absolute cap**; **10-min idle window** for both automations and interactive (interactive was already 10 min — unchanged); **reuse the existing reaper** rather than build a parallel watchdog.
- The heartbeat that feeds the reaper (`tapProgress` → `last_progress_at`) is already wired on the hosted path, so a progressing automation run is protected.

## Scope

Hosted (cluster) path only. The sandbox/link (user-desktop CLI) timeout branch in `thread-gate-workflow.ts` is intentionally left untouched.

## DBOS / recovery

Recovery-compatible workflow-source change — logic inside the existing `runHostedHarness` step + removal of an unused workflow-input field that replayed journals simply ignore. **No `DBOS_WORKFLOW_VERSION` bump**; the workflow-source-guard snapshot was re-baselined instead.

## Testing

- New reactor unit tests: reaped → stall `failure_reason`/`failure_kind`; `error`/`cancelled` unchanged; `RUN_STARTED` clears the columns.
- DB-tier assertions added to the reaped path in `run-reactor.integration.test.ts` (verifies the `update()` whitelist actually persists the fields, via a raw column read).
- `bun run check`, `fmt:check`, `lint` (0 errors) green; workflow-source-guard 5/5.

## Follow-ups (out of scope)

- Surface `failure_reason`/`failure_kind` on the `Thread` read model / API so a consumer can display the stall reason (currently write-only through the storage layer — a pre-existing gap since #4343; no consumer today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the 5‑minute wall‑clock timeout for automations with progress-based stall detection shared with interactive runs. Runs keep going while streaming and only fail after 10 minutes of no progress; stalled runs record a clear reason.

- **Bug Fixes**
  - Removed the hosted automation cap; rely on the 10‑minute idle reaper (`RUN_IDLE_TIMEOUT_MS`).
  - On reaped runs, write `failure_reason: "Run stalled — no progress within the idle timeout window"` and `failure_kind: "stall"`; other reasons unchanged.
  - Clear `failure_reason`/`failure_kind` on `RUN_STARTED` to avoid stale data on re-runs.
  - Kept `AbortController` for cancellation; removed timeout plumbing and `timeoutMs` from the hosted harness, thread gate, and automations workflow.
  - Added unit and real-Postgres tests and whitelisted the new fields in storage updates; hosted path only (CLI path unchanged).

<sup>Written for commit 692d202689bfc92f37d11c23c6b2db28a842d400. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

