### PR TITLE
docs(sandbox): correct deps-cache isolation comment — per-repo key is load-bearing

### DIFF
--- a/packages/sandbox/daemon/setup/install.ts
+++ b/packages/sandbox/daemon/setup/install.ts
@@ -10,13 +10,23 @@ import { spawnSetupStep } from "./spawn-step";
  * Per-repo package-cache env, derived from the pod-level DEPS_CACHE_ROOT
  * (the chart's node-local hostPath mount — see depsCache in
  * deploy/helm/sandbox-env/values.yaml). Keyed by the credential-stripped
- * cloneUrl so sandboxes of different repos never share cache entries: a
- * cache shared across repos would let one repo's untrusted code poison
- * another repo's store. Sandboxes of the *same* cloneUrl still share it,
- * which is intended for private repos (sandbox access implies repo
- * write) but is cross-tenant for repos reachable at different privilege
- * levels (public/template). Tampered cache entries are caught by bun's
- * lockfile integrity check on install, not by this key.
+ * cloneUrl so sandboxes of different repos never share cache entries.
+ *
+ * This key is the ONLY cross-repo isolation boundary — load-bearing, not
+ * belt-and-suspenders. bun does NOT re-verify a cache entry's integrity on
+ * install: tamper a cached file, reinstall, and the tampered bytes land in
+ * node_modules unchecked (verified empirically). The cache dir is writable
+ * by the sandbox uid, so a cache shared across repos would let one repo's
+ * untrusted code overwrite a package that every other repo then installs —
+ * a cross-tenant RCE. Neither copyfile nor hardlink helps; the shared
+ * *writable* store is the hole. Do NOT widen this to a shared cache unless
+ * it is made read-only to tenant pods and populated out-of-band by a
+ * trusted process.
+ *
+ * Same-cloneUrl sandboxes still share a cache. For private repos that's one
+ * trust domain (sandbox access implies repo write). For a repo reachable by
+ * multiple orgs at different privilege levels (public/template) it is
+ * cross-tenant — a known residual gap; key by org too if it matters.
  *
  * Only bun consumes BUN_INSTALL_CACHE_DIR; npm/pnpm/yarn/deno ignore it.
  */


### PR DESCRIPTION
## What

Corrects a **false and dangerous** comment in `depsCacheEnv` (shipped in #4352).

The comment claimed:
> Tampered cache entries are caught by bun's lockfile integrity check on install, not by this key.

**This is false.** Verified empirically: populate a bun cache, tamper a cached file, `rm node_modules`, reinstall — the tampered bytes land in `node_modules` unchecked. bun does *not* re-verify cached content on install; it trusts its cache.

```
>>> TAMPERING cache file (append `globalThis.PWNED=true`)
$ bun install
+ is-odd@3.0.1
2 packages installed
node_modules/is-odd/index.js  ← contains PWNED
```

## Why it matters

The cache dir is writable by the sandbox uid (`1000`). Combined with "bun doesn't re-verify," the per-repo cache key (`sha256(cloneUrl)`) is the **only** thing stopping one repo's untrusted sandbox code from overwriting a package that every *other* repo would then install — a cross-tenant RCE. The old wording framed the key as redundant, which would invite widening it to a shared cache "for better hit rate." That change would be a security hole, not an optimization. (I went looking for exactly that shared-cache win; this is why it's not being shipped.)

Neither `--backend=copyfile` nor hardlink closes it — the shared *writable* store is the hole.

## Change

Comment only, no behavior change. Rewrites the doc to:
- State the key is the sole cross-repo isolation boundary (load-bearing).
- Record the "bun doesn't re-verify" finding so nobody re-derives it the hard way.
- Warn that a shared cache is only safe if made read-only to tenants + populated out-of-band by a trusted process.
- Keep the honest note that same-URL public/template repos remain a residual cross-tenant gap (key by org if it matters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a misleading comment in `packages/sandbox/daemon/setup/install.ts` to clarify that the per-repo deps-cache key is load-bearing for cross-repo isolation. Documents that bun does not re-verify cached content on install, so a shared writable cache could enable cross-tenant package poisoning; docs only, no behavior change.

<sup>Written for commit 5db90e8c885be4b6fe77b186935ceb13cce7d590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

