### PR TITLE
feat(sandbox): golden node_modules cache via reflink (skip install on hit)

### DIFF
--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -214,6 +214,14 @@ spec:
             # per-repo BUN_INSTALL_CACHE_DIR under it (see setup/install.ts).
             - name: DEPS_CACHE_ROOT
               value: "/deps-cache"
+            {{- if .Values.depsCache.golden }}
+            # Golden node_modules reflink cache (opt-in, off by default — it
+            # touches the boot install path). Requires a reflink-capable
+            # filesystem shared between the cache and the workdir; falls back
+            # to a normal install otherwise. See setup/golden-cache.ts.
+            - name: GOLDEN_CACHE_ENABLED
+              value: "1"
+            {{- end }}
             {{- end }}
             - name: DAEMON_PORT
               value: "9000"

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -237,18 +237,20 @@ readOnlyRootFilesystem: true
 # Only bun reads BUN_INSTALL_CACHE_DIR — npm/pnpm/yarn/deno installs are
 # unaffected.
 #
-# No hardlinking here: the hostPath cache and the pod's /app emptyDir are
-# separate mounts, so bun's link() into node_modules fails EXDEV and it
-# falls back to copyfile on every install. The win is the saved
-# download + extract, not a zero-copy link. Near-instant install needs a
-# prebaked read-only node_modules overlay — a separate design.
+# bun links into node_modules with its default backend: on a reflink- or
+# hardlink-capable filesystem that node_modules shares with the cache the
+# install is near-instant; otherwise (e.g. a hostPath on a different mount
+# than /app) it falls back to copyfile — still saving the download + extract.
 #
 # The daemon keys the cache per-repo under this root (DEPS_CACHE_ROOT →
-# BUN_INSTALL_CACHE_DIR=<root>/bun/<repo-hash>), so sandboxes of
-# different repos never share cache entries. Within one repo the shared
-# cache is still cross-tenant when the same cloneUrl is reachable at
-# different privilege levels (public/template repos): tampered entries
-# are caught by bun's lockfile integrity check, not by this isolation.
+# BUN_INSTALL_CACHE_DIR=<root>/bun/<repo-hash>), so different repos never
+# share cache entries — the sole cross-repo isolation boundary, since bun
+# does NOT re-verify cache content on install (a tampered cached file is
+# installed as-is). Same-cloneUrl sandboxes share a cache: one trust domain
+# for private repos (sandbox access implies repo write); still cross-tenant
+# for a repo reachable by multiple orgs (public/template) — key by org if
+# that matters. Do NOT widen to a shared cache without making it read-only
+# to tenant pods.
 depsCache:
   enabled: false
   # Node path backing the cache. Created root-owned by kubelet
@@ -259,6 +261,16 @@ depsCache:
   # Growth is currently unreaped; only enable on nodes you're willing to
   # let accrue package cache until the node is recycled.
   hostPath: /var/cache/studio-sandbox-deps
+  # Golden node_modules reflink cache (opt-in, off by default). On a hit,
+  # `cp --reflink=always` a per-(repo,lockfile) golden into the repo — a CoW
+  # clone that's near-instant and skips `bun install` entirely; on a miss,
+  # install then publish the result. Requires the golden dir and /app to
+  # share a reflink-capable filesystem (true on the prod instance-store xfs;
+  # NOT on kind's overlay bind-mounts, where it falls back to a normal
+  # install). Separate switch from `enabled` because it touches the boot
+  # install path — leave off until validated on the target nodes. Adds the
+  # same unreaped-growth caveat as above (a golden ≈ a full node_modules).
+  golden: false
 
 # ── sentinel token ─────────────────────────────────────────────────────
 sentinel:

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -277,6 +277,11 @@ const lastProbe = startUpstreamProbe({
         htmlSupport: s.htmlSupport,
       });
       if (wasDown) broadcaster.emit("reload", {});
+      // Dev server is confirmed healthy — safe to publish this boot's fresh
+      // install as the golden node_modules (no-op unless one is pending). Only
+      // publishing from a boot that actually came up keeps a broken install
+      // from becoming a sticky, reused golden. Best-effort, fire-and-forget.
+      if (wasDown) void orchestrator.publishPendingGolden();
       if (!baselineTimer) {
         baselineTimer = setTimeout(() => {
           baselineTimer = null;

--- a/packages/sandbox/daemon/setup/golden-cache.test.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  goldenEnabled,
   goldenNodeModulesPath,
   lockfileHash,
   sameFilesystem,
@@ -88,6 +89,33 @@ describe("lockfileHash", () => {
     expect(lockfileHash(dir, "npm")).toBeTruthy();
     // bun ignores an npm lockfile
     expect(lockfileHash(dir, "bun")).toBeNull();
+  });
+});
+
+describe("goldenEnabled (kill switch)", () => {
+  const orig = process.env.GOLDEN_CACHE_ENABLED;
+  afterEach(() => {
+    if (orig === undefined) delete process.env.GOLDEN_CACHE_ENABLED;
+    else process.env.GOLDEN_CACHE_ENABLED = orig;
+  });
+
+  it("is off by default (unset)", () => {
+    delete process.env.GOLDEN_CACHE_ENABLED;
+    expect(goldenEnabled()).toBe(false);
+  });
+
+  it('is on for "1" and "true" only', () => {
+    process.env.GOLDEN_CACHE_ENABLED = "1";
+    expect(goldenEnabled()).toBe(true);
+    process.env.GOLDEN_CACHE_ENABLED = "true";
+    expect(goldenEnabled()).toBe(true);
+  });
+
+  it("stays off for other values", () => {
+    for (const v of ["0", "false", "yes", "", "on"]) {
+      process.env.GOLDEN_CACHE_ENABLED = v;
+      expect(goldenEnabled()).toBe(false);
+    }
   });
 });
 

--- a/packages/sandbox/daemon/setup/golden-cache.test.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  goldenNodeModulesPath,
+  lockfileHash,
+  sameFilesystem,
+} from "./golden-cache";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "golden-test-"));
+}
+
+describe("goldenNodeModulesPath", () => {
+  const base = {
+    cacheRoot: "/deps-cache",
+    cloneUrl: "https://github.com/o/n.git",
+    pm: "bun",
+    lockHash: "abc123",
+  };
+
+  it("is null without cacheRoot / cloneUrl / lockHash", () => {
+    expect(goldenNodeModulesPath({ ...base, cacheRoot: undefined })).toBeNull();
+    expect(goldenNodeModulesPath({ ...base, cloneUrl: undefined })).toBeNull();
+    expect(goldenNodeModulesPath({ ...base, lockHash: null })).toBeNull();
+  });
+
+  it("composes <root>/golden/<repo>/<pm>-<lockhash>/node_modules", () => {
+    const p = goldenNodeModulesPath(base);
+    expect(p).toMatch(
+      /^\/deps-cache\/golden\/[0-9a-f]{16}\/bun-abc123\/node_modules$/,
+    );
+  });
+
+  it("keys by repo — different repos get different golden dirs", () => {
+    const a = goldenNodeModulesPath(base);
+    const b = goldenNodeModulesPath({
+      ...base,
+      cloneUrl: "https://github.com/o/other.git",
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("is stable across git-token refresh (credential-stripped key)", () => {
+    const url = (t: string) => `https://x-access-token:${t}@github.com/o/n.git`;
+    const a = goldenNodeModulesPath({ ...base, cloneUrl: url("tok1") });
+    const b = goldenNodeModulesPath({ ...base, cloneUrl: url("tok2") });
+    const bare = goldenNodeModulesPath(base);
+    expect(a).toBe(b);
+    expect(a).toBe(bare);
+  });
+
+  it("separates package managers for the same lockfile hash", () => {
+    const bun = goldenNodeModulesPath({ ...base, pm: "bun" });
+    const pnpm = goldenNodeModulesPath({ ...base, pm: "pnpm" });
+    expect(bun).not.toBe(pnpm);
+  });
+});
+
+describe("lockfileHash", () => {
+  it("returns null when no lockfile is present", () => {
+    expect(lockfileHash(tmp(), "bun")).toBeNull();
+  });
+
+  it("returns null for a package manager with no known lockfile", () => {
+    const dir = tmp();
+    writeFileSync(join(dir, "bun.lock"), "x");
+    expect(lockfileHash(dir, "deno")).toBeNull();
+  });
+
+  it("hashes lockfile content — same bytes, same hash; different bytes differ", () => {
+    const a = tmp();
+    const b = tmp();
+    const c = tmp();
+    writeFileSync(join(a, "bun.lock"), "lockfile-A");
+    writeFileSync(join(b, "bun.lock"), "lockfile-A");
+    writeFileSync(join(c, "bun.lock"), "lockfile-B");
+    const ha = lockfileHash(a, "bun");
+    expect(ha).toBeTruthy();
+    expect(lockfileHash(b, "bun")).toBe(ha);
+    expect(lockfileHash(c, "bun")).not.toBe(ha);
+  });
+
+  it("picks the pm's lockfile (npm uses package-lock.json)", () => {
+    const dir = tmp();
+    writeFileSync(join(dir, "package-lock.json"), "{}");
+    expect(lockfileHash(dir, "npm")).toBeTruthy();
+    // bun ignores an npm lockfile
+    expect(lockfileHash(dir, "bun")).toBeNull();
+  });
+});
+
+describe("sameFilesystem", () => {
+  it("true for a path against itself", () => {
+    const dir = tmp();
+    expect(sameFilesystem(dir, dir)).toBe(true);
+  });
+
+  it("false when a path does not exist", () => {
+    expect(sameFilesystem("/nonexistent/xyz", tmp())).toBe(false);
+  });
+});

--- a/packages/sandbox/daemon/setup/golden-cache.test.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.test.ts
@@ -1,11 +1,18 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   goldenEnabled,
   goldenNodeModulesPath,
   lockfileHash,
+  pruneGoldens,
   sameFilesystem,
 } from "./golden-cache";
 
@@ -127,5 +134,68 @@ describe("sameFilesystem", () => {
 
   it("false when a path does not exist", () => {
     expect(sameFilesystem("/nonexistent/xyz", tmp())).toBe(false);
+  });
+});
+
+describe("pruneGoldens", () => {
+  // Make a golden dir <root>/golden/<repo>/<name> with a given mtime (ms).
+  function mkGolden(root: string, repo: string, name: string, mtimeMs: number) {
+    const dir = join(root, "golden", repo, name);
+    mkdirSync(dir, { recursive: true });
+    const t = new Date(mtimeMs);
+    utimesSync(dir, t, t);
+    return dir;
+  }
+
+  it("no-ops on a missing cache root / empty store", () => {
+    expect(() => pruneGoldens(undefined)).not.toThrow();
+    expect(() => pruneGoldens(tmp())).not.toThrow();
+  });
+
+  it("drops goldens older than the TTL, keeps fresh ones", () => {
+    const root = tmp();
+    const now = 1_000_000_000_000;
+    const fresh = mkGolden(root, "repoA", "bun-fresh", now - 1000);
+    const stale = mkGolden(root, "repoA", "bun-stale", now - 10 * 86_400_000);
+    pruneGoldens(root, { now, ttlMs: 7 * 86_400_000, maxPerRepo: 99 });
+    expect(existsSync(fresh)).toBe(true);
+    expect(existsSync(stale)).toBe(false);
+  });
+
+  it("caps to the newest maxPerRepo per repo", () => {
+    const root = tmp();
+    const now = 1_000_000_000_000;
+    const dirs = [0, 1, 2, 3].map((i) =>
+      mkGolden(root, "repoB", `bun-${i}`, now - i * 1000),
+    );
+    pruneGoldens(root, { now, ttlMs: 999 * 86_400_000, maxPerRepo: 2 });
+    // Newest two (i=0,1) survive; older two (i=2,3) are pruned.
+    expect(existsSync(dirs[0])).toBe(true);
+    expect(existsSync(dirs[1])).toBe(true);
+    expect(existsSync(dirs[2])).toBe(false);
+    expect(existsSync(dirs[3])).toBe(false);
+  });
+
+  it("never reaps in-flight .tmp. publishes", () => {
+    const root = tmp();
+    const now = 1_000_000_000_000;
+    const tmpPublish = mkGolden(
+      root,
+      "repoC",
+      ".tmp.123.node_modules",
+      now - 999 * 86_400_000, // ancient, but must be skipped
+    );
+    pruneGoldens(root, { now, ttlMs: 1, maxPerRepo: 0 });
+    expect(existsSync(tmpPublish)).toBe(true);
+  });
+
+  it("prunes each repo independently", () => {
+    const root = tmp();
+    const now = 1_000_000_000_000;
+    const a = mkGolden(root, "repoA", "bun-1", now);
+    const b = mkGolden(root, "repoB", "bun-1", now);
+    pruneGoldens(root, { now, ttlMs: 999 * 86_400_000, maxPerRepo: 5 });
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(true);
   });
 });

--- a/packages/sandbox/daemon/setup/golden-cache.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.ts
@@ -1,0 +1,236 @@
+/**
+ * Golden node_modules cache — the reflink "last mile" on top of the bun
+ * download cache (see depsCacheEnv in install.ts).
+ *
+ * A fresh sandbox pod has an empty node_modules and pays a full `bun install`
+ * (download + materialize). This keeps a per-`(repo, packageManager,
+ * lockfile)` "golden" node_modules on the shared node-local hostPath
+ * (DEPS_CACHE_ROOT). On a hit we `cp --reflink=always` it into the repo — a
+ * CoW clone that's near-instant regardless of tree size (measured ~1s for
+ * 700MB on prod xfs) and skips `bun install` entirely. On a miss we run the
+ * normal install, then publish its result as the golden for next time.
+ *
+ * Safety mirrors depsCacheEnv's per-repo key (the only cross-repo isolation
+ * boundary — bun does not re-verify cache content): a golden is keyed by the
+ * credential-stripped cloneUrl, so repos never share one. Within a repo,
+ * sharing is the same trust domain (sandbox access implies repo write).
+ * reflink is copy-on-write, so a pod mutating its own node_modules never
+ * writes through to the shared golden — verified: writing a cloned file
+ * leaves the source intact.
+ *
+ * Only used when the golden dir and the repo's node_modules live on the same
+ * filesystem (reflink requires it — `st_dev` must match). On any other setup
+ * (e.g. a hostPath on a different mount than the pod's workdir) golden is
+ * skipped and the normal install path runs. Best-effort throughout: any
+ * failure falls back to `bun install`, never blocks the boot.
+ */
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import type { Config } from "../types";
+
+/**
+ * Lockfiles that fully pin a package manager's resolution, so an identical
+ * lockfile yields an identical node_modules. No lockfile → no golden (we
+ * can't guarantee the tree is reproducible, so caching it is unsafe).
+ */
+const LOCKFILES: Record<string, readonly string[]> = {
+  bun: ["bun.lock", "bun.lockb"],
+  npm: ["package-lock.json", "npm-shrinkwrap.json"],
+  pnpm: ["pnpm-lock.yaml"],
+  yarn: ["yarn.lock"],
+};
+
+/** 16 hex chars of sha256, credential-stripped — matches depsCacheEnv's key. */
+function repoHash(cloneUrl: string): string {
+  let key = cloneUrl;
+  try {
+    const u = new URL(cloneUrl);
+    u.username = "";
+    u.password = "";
+    key = u.toString();
+  } catch {
+    // non-URL cloneUrl (ssh shorthand) — hash it as-is
+  }
+  return createHash("sha256").update(key).digest("hex").slice(0, 16);
+}
+
+/**
+ * Content hash of the first present lockfile for `pm` under `installRoot`.
+ * Null when no lockfile exists (→ golden disabled for this install).
+ */
+export function lockfileHash(installRoot: string, pm: string): string | null {
+  const names = LOCKFILES[pm];
+  if (!names) return null;
+  for (const name of names) {
+    const path = join(installRoot, name);
+    try {
+      const buf = readFileSync(path);
+      return createHash("sha256").update(buf).digest("hex").slice(0, 32);
+    } catch {
+      // not this one — try the next
+    }
+  }
+  return null;
+}
+
+/**
+ * Absolute golden node_modules path for a `(repo, pm, lockfile)` triple, or
+ * null when golden can't apply: no cache root, no cloneUrl, or no lockfile.
+ * Pure given the lockHash — the fs read lives in `lockfileHash`.
+ */
+export function goldenNodeModulesPath(opts: {
+  cacheRoot: string | undefined;
+  cloneUrl: string | undefined;
+  pm: string;
+  lockHash: string | null;
+}): string | null {
+  const { cacheRoot, cloneUrl, pm, lockHash } = opts;
+  if (!cacheRoot || !cloneUrl || !lockHash) return null;
+  return join(
+    cacheRoot,
+    "golden",
+    repoHash(cloneUrl),
+    `${pm}-${lockHash}`,
+    "node_modules",
+  );
+}
+
+/** True when both paths resolve to the same filesystem (reflink prerequisite). */
+export function sameFilesystem(a: string, b: string): boolean {
+  try {
+    return statSync(a).dev === statSync(b).dev;
+  } catch {
+    return false;
+  }
+}
+
+type Log = (msg: string) => void;
+
+/** reflink-clone `src` → `dst` via coreutils cp. Resolves to the exit code. */
+function reflinkClone(src: string, dst: string): Promise<number> {
+  // --reflink=always (not auto): fail loudly rather than silently degrade to a
+  // slow full copy that would block the boot — the caller falls back to a
+  // normal install on non-zero. -a preserves the tree faithfully. Args array
+  // (no shell) keeps paths from being reinterpreted.
+  return new Promise((resolve) => {
+    const child = spawn("cp", ["-a", "--reflink=always", src, dst], {
+      stdio: "ignore",
+    });
+    child.on("error", () => resolve(1));
+    child.on("close", (code) => resolve(code ?? 1));
+  });
+}
+
+interface GoldenOpts {
+  config: Config;
+  installRoot: string;
+  pm: string;
+  cacheRoot?: string;
+  log?: Log;
+}
+
+function resolveGolden(opts: GoldenOpts): {
+  golden: string;
+  targetNodeModules: string;
+} | null {
+  const cacheRoot = opts.cacheRoot ?? process.env.DEPS_CACHE_ROOT;
+  const golden = goldenNodeModulesPath({
+    cacheRoot,
+    cloneUrl: opts.config.git?.repository?.cloneUrl,
+    pm: opts.pm,
+    lockHash: lockfileHash(opts.installRoot, opts.pm),
+  });
+  if (!golden) return null;
+  return { golden, targetNodeModules: join(opts.installRoot, "node_modules") };
+}
+
+/**
+ * Reflink an existing golden into the repo's node_modules, skipping install.
+ * Returns true only when node_modules is now populated from the golden.
+ */
+export async function tryRestoreGolden(opts: GoldenOpts): Promise<boolean> {
+  const log = opts.log ?? (() => {});
+  const paths = resolveGolden(opts);
+  if (!paths) return false;
+  const { golden, targetNodeModules } = paths;
+  if (!existsSync(golden)) return false;
+  // reflink needs golden and the destination parent on one filesystem.
+  if (!sameFilesystem(golden, opts.installRoot)) {
+    log("[golden] cache and workdir on different filesystems — skipping");
+    return false;
+  }
+  try {
+    // A partial node_modules (interrupted prior boot) would make cp nest the
+    // clone inside it; start clean.
+    rmSync(targetNodeModules, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+  const code = await reflinkClone(golden, targetNodeModules);
+  if (code !== 0) {
+    log(`[golden] restore failed (cp exit ${code}) — falling back to install`);
+    rmSync(targetNodeModules, { recursive: true, force: true });
+    return false;
+  }
+  log("[golden] restored node_modules from cache (skipped install)");
+  return true;
+}
+
+/**
+ * Snapshot a freshly-installed node_modules as the golden for its lockfile.
+ * Best-effort and idempotent: no-op if a golden already exists, atomic
+ * publish (reflink to a temp dir, then rename) so a concurrent publisher or a
+ * crash mid-copy never leaves a half-written golden in place. Never throws.
+ */
+export async function publishGolden(opts: GoldenOpts): Promise<void> {
+  const log = opts.log ?? (() => {});
+  try {
+    const paths = resolveGolden(opts);
+    if (!paths) return;
+    const { golden, targetNodeModules } = paths;
+    if (!existsSync(targetNodeModules)) return;
+    if (existsSync(golden)) return; // already published for this lockfile
+
+    const goldenDir = dirname(golden);
+    mkdirSync(goldenDir, { recursive: true });
+    // Now that goldenDir exists, confirm it shares a filesystem with the
+    // source (reflink prerequisite) — skip the doomed cp otherwise. (Checked
+    // here, not before mkdir, since statSync on a not-yet-created dir fails.)
+    if (!sameFilesystem(opts.installRoot, goldenDir)) {
+      log(
+        "[golden] cache and workdir on different filesystems — not publishing",
+      );
+      return;
+    }
+    // Unique temp within the same dir (→ same fs → atomic rename). PID keeps
+    // concurrent publishers on one node from colliding.
+    const tmp = join(goldenDir, `.tmp.${process.pid}.node_modules`);
+    rmSync(tmp, { recursive: true, force: true });
+    const code = await reflinkClone(targetNodeModules, tmp);
+    if (code !== 0) {
+      rmSync(tmp, { recursive: true, force: true });
+      log(`[golden] publish reflink failed (cp exit ${code})`);
+      return;
+    }
+    try {
+      renameSync(tmp, golden);
+      log("[golden] published node_modules to cache");
+    } catch {
+      // Lost the race (another publisher renamed first) or golden appeared —
+      // both fine; drop our temp.
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  } catch (e) {
+    log(`[golden] publish skipped: ${(e as Error).message}`);
+  }
+}

--- a/packages/sandbox/daemon/setup/golden-cache.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.ts
@@ -105,7 +105,14 @@ export function goldenNodeModulesPath(opts: {
   );
 }
 
-/** True when both paths resolve to the same filesystem (reflink prerequisite). */
+/**
+ * True when both paths report the same `st_dev` — a cheap NEGATIVE filter for
+ * reflink (different dev ⇒ reflink can't work, skip the doomed cp). It is NOT
+ * sufficient: two bind-mounts of one underlying fs can share a dev number yet
+ * still EXDEV on reflink (observed on kind: /deps-cache hostPath + /app
+ * emptyDir both dev fe01, cp --reflink=always fails). The `cp` exit code is
+ * the authoritative test; callers must handle its failure regardless.
+ */
 export function sameFilesystem(a: string, b: string): boolean {
   try {
     return statSync(a).dev === statSync(b).dev;

--- a/packages/sandbox/daemon/setup/golden-cache.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.ts
@@ -123,6 +123,17 @@ export function sameFilesystem(a: string, b: string): boolean {
 
 type Log = (msg: string) => void;
 
+/**
+ * Independent kill switch. Golden touches the boot's install path, so it stays
+ * OFF unless explicitly enabled — separate from depsCache (which only mounts
+ * the cache + biases bun's backend). Ships dormant; flip GOLDEN_CACHE_ENABLED
+ * to turn it on, unset to disable without redeploying the daemon image.
+ */
+export function goldenEnabled(): boolean {
+  const v = process.env.GOLDEN_CACHE_ENABLED;
+  return v === "1" || v === "true";
+}
+
 /** reflink-clone `src` → `dst` via coreutils cp. Resolves to the exit code. */
 function reflinkClone(src: string, dst: string): Promise<number> {
   // --reflink=always (not auto): fail loudly rather than silently degrade to a
@@ -150,6 +161,7 @@ function resolveGolden(opts: GoldenOpts): {
   golden: string;
   targetNodeModules: string;
 } | null {
+  if (!goldenEnabled()) return null;
   const cacheRoot = opts.cacheRoot ?? process.env.DEPS_CACHE_ROOT;
   const golden = goldenNodeModulesPath({
     cacheRoot,

--- a/packages/sandbox/daemon/setup/golden-cache.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.ts
@@ -30,13 +30,28 @@ import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
   statSync,
+  utimesSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 import type { Config } from "../types";
+
+/**
+ * GC bounds for the golden store (a golden ≈ a full node_modules on the node
+ * hostPath, so unbounded growth would fill the disk). Pruned opportunistically
+ * after each publish: drop goldens untouched for longer than the TTL, then cap
+ * the number kept per repo (newest by mtime win). Restore touches a golden's
+ * mtime, so an actively-used lockfile never ages out.
+ */
+const GOLDEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const GOLDEN_MAX_PER_REPO = 5;
+
+/** Pod-local runtime caches that must not travel in a shared golden. */
+const RUNTIME_CACHE_DIRS = [".vite", ".cache"];
 
 /**
  * Lockfiles that fully pin a package manager's resolution, so an identical
@@ -201,15 +216,27 @@ export async function tryRestoreGolden(opts: GoldenOpts): Promise<boolean> {
     rmSync(targetNodeModules, { recursive: true, force: true });
     return false;
   }
+  // Mark recently-used so GC's TTL doesn't reap an actively-restored lockfile.
+  try {
+    const now = new Date();
+    utimesSync(golden, now, now);
+  } catch {
+    // best-effort
+  }
   log("[golden] restored node_modules from cache (skipped install)");
   return true;
 }
 
 /**
- * Snapshot a freshly-installed node_modules as the golden for its lockfile.
- * Best-effort and idempotent: no-op if a golden already exists, atomic
- * publish (reflink to a temp dir, then rename) so a concurrent publisher or a
- * crash mid-copy never leaves a half-written golden in place. Never throws.
+ * Snapshot a node_modules as the golden for its lockfile. Publish only ever
+ * runs for a boot whose dev server came up healthy (the orchestrator defers
+ * it to the `running` transition) — a broken install therefore never becomes
+ * a golden, which is what keeps a bad golden from getting stuck and reused.
+ *
+ * Best-effort and idempotent: no-op if a golden already exists; reflink to a
+ * temp dir, strip pod-local runtime caches (.vite/.cache — they churn and are
+ * per-pod), then atomically rename so a concurrent publisher or a crash
+ * mid-copy never leaves a half-written golden in place. Never throws.
  */
 export async function publishGolden(opts: GoldenOpts): Promise<void> {
   const log = opts.log ?? (() => {});
@@ -241,6 +268,11 @@ export async function publishGolden(opts: GoldenOpts): Promise<void> {
       log(`[golden] publish reflink failed (cp exit ${code})`);
       return;
     }
+    // Strip pod-local runtime caches from the snapshot (cheap — reflink is
+    // CoW, so these were near-free to clone and near-free to drop).
+    for (const d of RUNTIME_CACHE_DIRS) {
+      rmSync(join(tmp, d), { recursive: true, force: true });
+    }
     try {
       renameSync(tmp, golden);
       log("[golden] published node_modules to cache");
@@ -251,5 +283,52 @@ export async function publishGolden(opts: GoldenOpts): Promise<void> {
     }
   } catch (e) {
     log(`[golden] publish skipped: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Bound golden-store growth on the node. For each repo: drop goldens whose
+ * mtime is older than the TTL, then keep only the newest GOLDEN_MAX_PER_REPO.
+ * Opportunistic (called after a publish), best-effort, never throws. Safe to
+ * race a concurrent restore: an in-flight reflink from a golden we delete just
+ * fails → that pod falls back to install, and already-completed CoW clones are
+ * independent of the source.
+ */
+export function pruneGoldens(
+  cacheRoot: string | undefined = process.env.DEPS_CACHE_ROOT,
+  opts: { ttlMs?: number; maxPerRepo?: number; now?: number } = {},
+): void {
+  if (!cacheRoot) return;
+  const ttlMs = opts.ttlMs ?? GOLDEN_TTL_MS;
+  const maxPerRepo = opts.maxPerRepo ?? GOLDEN_MAX_PER_REPO;
+  const now = opts.now ?? Date.now();
+  const root = join(cacheRoot, "golden");
+  let repos: string[];
+  try {
+    repos = readdirSync(root);
+  } catch {
+    return; // no golden store yet
+  }
+  for (const repo of repos) {
+    const repoDir = join(root, repo);
+    let entries: { path: string; mtime: number }[];
+    try {
+      entries = readdirSync(repoDir)
+        .filter((name) => !name.startsWith(".tmp.")) // skip in-flight publishes
+        .map((name) => {
+          const path = join(repoDir, name);
+          return { path, mtime: statSync(path).mtimeMs };
+        });
+    } catch {
+      continue;
+    }
+    // Newest first; anything past the cap or older than the TTL is pruned.
+    entries.sort((a, b) => b.mtime - a.mtime);
+    for (let i = 0; i < entries.length; i++) {
+      const e = entries[i];
+      if (i >= maxPerRepo || now - e.mtime > ttlMs) {
+        rmSync(e.path, { recursive: true, force: true });
+      }
+    }
   }
 }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -27,7 +27,7 @@ import type { Application, Config } from "../types";
 import { autodetectApplication } from "./autodetect";
 import { type CloneResult, spawnClone } from "./clone";
 import { emitInstalledDeps } from "./dep-metrics";
-import { publishGolden, tryRestoreGolden } from "./golden-cache";
+import { publishGolden, pruneGoldens, tryRestoreGolden } from "./golden-cache";
 import { configureGitIdentity } from "./identity";
 import { spawnInstall } from "./install";
 import { spawnSetupStep } from "./spawn-step";
@@ -69,6 +69,10 @@ export class SetupOrchestrator {
   private running = false;
   private currentBranchHead: string | undefined;
   private latestScripts: string[] | null = null;
+  // A fresh install that hasn't been published as a golden yet — published by
+  // publishPendingGolden() once the dev server is confirmed healthy. Null when
+  // the boot restored an existing golden (nothing new to publish).
+  private pendingGolden: { installRoot: string; pm: string } | null = null;
 
   constructor(private readonly deps: SetupOrchestratorDeps) {
     this.deps.taskManager.onTaskExit((summary) => {
@@ -118,6 +122,29 @@ export class SetupOrchestrator {
   /** True while a step is being applied. Surfaced on /health. */
   isRunning(): boolean {
     return this.running;
+  }
+
+  /**
+   * Publish the golden for this boot's fresh install — but only now that the
+   * dev server is confirmed healthy (called from the probe's `running`
+   * transition). Deferring here is what stops a broken install from becoming
+   * a reused golden. No-op when nothing is pending (golden-restore boot, or a
+   * boot with no fresh install), and self-guards against the `running`
+   * transition re-firing. Fire-and-forget; best-effort.
+   */
+  async publishPendingGolden(): Promise<void> {
+    const pending = this.pendingGolden;
+    if (!pending) return;
+    this.pendingGolden = null;
+    const config = this.currentConfig();
+    if (!config) return;
+    await publishGolden({
+      config,
+      installRoot: pending.installRoot,
+      pm: pending.pm,
+      log: (m) => this.rawChunk(`${m}\r\n`),
+    });
+    pruneGoldens();
   }
 
   pendingCount(): number {
@@ -337,6 +364,8 @@ export class SetupOrchestrator {
         log: (m) => this.chunk(`${m}\r\n`),
       })
     ) {
+      // Restored from an existing golden — nothing to publish.
+      this.pendingGolden = null;
       this.markInstallSucceeded(config);
       return true;
     }
@@ -379,19 +408,12 @@ export class SetupOrchestrator {
       return false;
     }
     this.markInstallSucceeded(config);
-    // Publish this fresh node_modules as the golden for its lockfile so the
-    // next branch on this node reflink-restores it instead of reinstalling.
-    // Awaited (not fire-and-forget) so the reflink snapshot is taken now,
-    // while node_modules is quiescent — the dev server (stepStart, next)
-    // writes node_modules/.vite, which would otherwise race the snapshot and
-    // capture an inconsistent tree. Best-effort: never throws (see
-    // golden-cache.ts). Miss-path only (~1s), so it doesn't slow warm boots.
-    await publishGolden({
-      config,
-      installRoot,
-      pm,
-      log: (m) => this.rawChunk(`${m}\r\n`),
-    });
+    // Don't publish the golden yet — defer to publishPendingGolden(), which
+    // the probe's `running` transition calls once the dev server is confirmed
+    // healthy. Publishing only from a boot that actually came up prevents a
+    // broken-but-exit-0 install from becoming a golden that every later branch
+    // then reuses (the "sticky bad golden" failure mode).
+    this.pendingGolden = { installRoot, pm };
     // Report the installed dep set for pre-bake analysis (best-effort, async).
     void emitInstalledDeps({
       installRoot,

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -27,6 +27,7 @@ import type { Application, Config } from "../types";
 import { autodetectApplication } from "./autodetect";
 import { type CloneResult, spawnClone } from "./clone";
 import { emitInstalledDeps } from "./dep-metrics";
+import { publishGolden, tryRestoreGolden } from "./golden-cache";
 import { configureGitIdentity } from "./identity";
 import { spawnInstall } from "./install";
 import { spawnSetupStep } from "./spawn-step";
@@ -320,6 +321,26 @@ export class SetupOrchestrator {
     }
 
     this.deps.lifecycle.transition({ phase: "installing" });
+
+    // Golden fast path: reflink a cached node_modules for this exact lockfile
+    // and skip `bun install` entirely (see golden-cache.ts). Best-effort — a
+    // miss or any failure falls through to the normal install below.
+    const installRoot = resolvePmRoot(
+      config.repoDir,
+      config.application?.packageManager?.path,
+    );
+    if (
+      await tryRestoreGolden({
+        config,
+        installRoot,
+        pm,
+        log: (m) => this.chunk(`${m}\r\n`),
+      })
+    ) {
+      this.markInstallSucceeded(config);
+      return true;
+    }
+
     this.chunk(`[orchestrator] installing dependencies\r\n`);
 
     const installLogPath = appLogPath(this.deps.logsDir, "install");
@@ -358,12 +379,18 @@ export class SetupOrchestrator {
       return false;
     }
     this.markInstallSucceeded(config);
+    // Publish this fresh node_modules as the golden for its lockfile so the
+    // next branch on this node reflink-restores it instead of reinstalling
+    // (best-effort, async — see golden-cache.ts).
+    void publishGolden({
+      config,
+      installRoot,
+      pm,
+      log: (m) => this.rawChunk(`${m}\r\n`),
+    });
     // Report the installed dep set for pre-bake analysis (best-effort, async).
     void emitInstalledDeps({
-      installRoot: resolvePmRoot(
-        config.repoDir,
-        config.application?.packageManager?.path,
-      ),
+      installRoot,
       packageManager: pm,
       bootId: process.env.DAEMON_BOOT_ID ?? "",
       repoName: config.git?.repository?.repoName,

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -380,9 +380,13 @@ export class SetupOrchestrator {
     }
     this.markInstallSucceeded(config);
     // Publish this fresh node_modules as the golden for its lockfile so the
-    // next branch on this node reflink-restores it instead of reinstalling
-    // (best-effort, async — see golden-cache.ts).
-    void publishGolden({
+    // next branch on this node reflink-restores it instead of reinstalling.
+    // Awaited (not fire-and-forget) so the reflink snapshot is taken now,
+    // while node_modules is quiescent — the dev server (stepStart, next)
+    // writes node_modules/.vite, which would otherwise race the snapshot and
+    // capture an inconsistent tree. Best-effort: never throws (see
+    // golden-cache.ts). Miss-path only (~1s), so it doesn't slow warm boots.
+    await publishGolden({
       config,
       installRoot,
       pm,


### PR DESCRIPTION
## What

The reflink "last mile" on top of the deps cache (#4352): a per-`(repo, packageManager, lockfile)` **golden node_modules** on the shared node-local hostPath. On a hit, `cp -a --reflink=always` clones it into the repo — a copy-on-write clone that's near-instant regardless of tree size and **skips `bun install` entirely**. On a miss, the normal install runs and publishes its result as the golden for next time.

Proven on prod xfs earlier this session: reflink clone of a 686MB `node_modules` took **~1s**, and it's write-safe (writing the clone left the source intact — CoW).

## Why reflink, not hardlink

Hardlinking from a shared cache would hit the same ~1s but is **unsafe** here: shared inodes + uid-1000 pods running untrusted code + bun-doesn't-re-verify (see #4356) = one repo can poison another's packages. reflink is copy-on-write, so a pod's writes never reach the shared golden. It's the fast *and* safe option.

## Safety

- **Per-repo key** (credential-stripped cloneUrl) — the same cross-repo isolation boundary the deps cache uses; repos never share a golden. Within a repo it's one trust domain (sandbox access implies repo write).
- **Same-filesystem gate** (`st_dev` match) before any reflink — else skip and install normally.
- **CoW isolation** — verified.
- **Fail-safe everywhere** — a partial/failed restore `rm`s and falls back to `bun install`; publish is background, idempotent, atomic (temp + rename). Worst case: a no-op, never a broken boot.

## Changes

- `setup/golden-cache.ts` — keying (`lockfileHash`, `goldenNodeModulesPath`), `sameFilesystem`, `tryRestoreGolden`, `publishGolden`. Uses `child_process.spawn("cp", [...])` (args array, no shell). Independent of `install.ts` so it doesn't conflict with #4356.
- `orchestrator.stepInstall` — restore before install (hit → skip + mark succeeded), publish after a successful miss (async, best-effort).

## Testing / validation status

- 11 unit tests (keying, lockfile hashing, per-PM separation, token-refresh stability, same-fs). Orchestrator suite green, typecheck clean, daemon bundle builds.
- ⚠️ **The daemon lifecycle wiring is not yet exercised end-to-end in a pod.** The reflink *mechanism* is proven on prod xfs, but the hit→skip→publish cycle in a live boot is not. **kind can't test the fast path** (ext4 → reflink fails → fallback); validating the fallback on kind and the hit path on a prod-xfs pod is the pre-merge gate. Do not merge before that.

Follow-up (not in this PR): golden GC (stale lockfile dirs accrue until node recycle, same as the deps cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a golden `node_modules` cache using reflink to skip installs on cache hits. Publishing is now gated on a healthy dev server and the cache is pruned to prevent disk growth.

- New Features
  - Per-(repo, package manager, lockfile) golden path under `DEPS_CACHE_ROOT/golden/...` keyed by a credential‑stripped repo URL.
  - Restore before install via `cp -a --reflink=always` when cache and workdir share a filesystem; on hit, skip `bun install`. `cp` exit code is authoritative; any failure falls back to a normal install.
  - Publish only after the dev server is healthy; the snapshot strips `.vite`/`.cache`, uses atomic temp+rename, and is best‑effort. After each publish, `pruneGoldens()` drops entries older than 7d and keeps the newest 5 per repo; restore touches mtime to keep active ones fresh.
  - Kill switch: off by default; enable with `GOLDEN_CACHE_ENABLED=1|true` (Helm `depsCache.golden: true`). Requires a reflink‑capable filesystem shared with `/app`; otherwise it falls back to a normal install.

<sup>Written for commit 0c69ccc24ccdfedfb24fa7ee17d85c5c7fe209e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

