### PR TITLE
feat(commerce-onboarding): shared-SA connect UI for GA4/GSC (consent-free, step-by-step)

### DIFF
--- a/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   bindCommerceDiscoveryResource,
   fetchCommerceDiscoveryAuth,
+  fetchCommerceDiscoveryConnectionStatus,
   triggerCommerceDiscoveryRun,
 } from "./auth-client";
 
@@ -324,5 +325,58 @@ describe("bindCommerceDiscoveryResource", () => {
     ).rejects.toThrow(
       "COMMERCE_DISCOVERY_INTERNAL_API_KEY is required to set up Commerce Discovery.",
     );
+  });
+});
+
+describe("fetchCommerceDiscoveryConnectionStatus", () => {
+  test("GETs the status for the normalized domain + org and returns providers", async () => {
+    const captured: Array<{ method: string; url: string }> = [];
+
+    const out = await fetchCommerceDiscoveryConnectionStatus(
+      { siteUrl: "https://example.com/loja", orgId: "org_123" },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async (input, init) => {
+          const request = new Request(input, init);
+          captured.push({ method: request.method, url: request.url });
+          return Response.json({
+            url: "example.com",
+            org_id: "org_123",
+            providers: {
+              ga4: { connected: true, via: "sa", resource: "123456789" },
+              gsc: { connected: false, via: null, resource: null },
+              vtex: { connected: true, via: "oauth", resource: null },
+            },
+          });
+        },
+      },
+    );
+
+    expect(out.ga4).toEqual({
+      connected: true,
+      via: "sa",
+      resource: "123456789",
+    });
+    expect(out.gsc?.connected).toBe(false);
+    expect(captured).toEqual([
+      {
+        method: "GET",
+        url: "https://commerce.example.test/api/v2/internal/diagnostics/example.com/connections/status?org_id=org_123",
+      },
+    ]);
+  });
+
+  test("treats a 409 (never upgraded) as everything disconnected, not a throw", async () => {
+    const out = await fetchCommerceDiscoveryConnectionStatus(
+      { siteUrl: "https://example.com", orgId: "org_123" },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () =>
+          Response.json({ error: "not_upgraded" }, { status: 409 }),
+      },
+    );
+    expect(out).toEqual({});
   });
 });

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  bindCommerceDiscoveryResource,
   fetchCommerceDiscoveryAuth,
   triggerCommerceDiscoveryRun,
 } from "./auth-client";
@@ -163,6 +164,156 @@ describe("triggerCommerceDiscoveryRun", () => {
     await expect(
       triggerCommerceDiscoveryRun(
         { siteUrl: "https://example.com", orgId: "org_123" },
+        {
+          settings: {
+            commerceDiscoveryInternalApiUrl: undefined,
+            commerceDiscoveryInternalApiKey: undefined,
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      "COMMERCE_DISCOVERY_INTERNAL_API_KEY is required to set up Commerce Discovery.",
+    );
+  });
+});
+
+describe("bindCommerceDiscoveryResource", () => {
+  test("POSTs /bindings for the normalized domain and returns the verified binding", async () => {
+    const captured: Array<{
+      method: string;
+      pathname: string;
+      authorization: string | null;
+      body: unknown;
+    }> = [];
+
+    const out = await bindCommerceDiscoveryResource(
+      {
+        siteUrl: "https://example.com/loja",
+        orgId: "org_123",
+        provider: "ga4",
+        resourceId: "123456789",
+      },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async (input, init) => {
+          const request = new Request(input, init);
+          const url = new URL(request.url);
+          captured.push({
+            method: request.method,
+            pathname: url.pathname,
+            authorization: request.headers.get("authorization"),
+            body: await request.json(),
+          });
+          return Response.json({
+            url: "example.com",
+            org_id: "org_123",
+            binding: {
+              resource_id: "123456789",
+              evidence: "https://www.example.com",
+            },
+          });
+        },
+      },
+    );
+
+    expect(out).toEqual({
+      ok: true,
+      resourceId: "123456789",
+      evidence: "https://www.example.com",
+    });
+    expect(captured).toEqual([
+      {
+        method: "POST",
+        pathname: "/api/v2/internal/diagnostics/example.com/bindings",
+        authorization: "Bearer master-key",
+        body: { org_id: "org_123", provider: "ga4", resource_id: "123456789" },
+      },
+    ]);
+  });
+
+  test("returns the pt-BR detail on a 422 verification failure (not a throw)", async () => {
+    const out = await bindCommerceDiscoveryResource(
+      {
+        siteUrl: "https://attacker.com.br",
+        orgId: "org_123",
+        provider: "ga4",
+        resourceId: "999",
+      },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () =>
+          Response.json(
+            {
+              error: "verification_failed",
+              reason: "no-match",
+              detail:
+                "nenhum web stream da property 999 aponta para attacker.com.br.",
+            },
+            { status: 422 },
+          ),
+      },
+    );
+
+    expect(out).toEqual({
+      ok: false,
+      reason: "no-match",
+      detail: "nenhum web stream da property 999 aponta para attacker.com.br.",
+    });
+  });
+
+  test("maps a 409 (already bound elsewhere) to an actionable pt-BR detail", async () => {
+    const out = await bindCommerceDiscoveryResource(
+      {
+        siteUrl: "https://example.com",
+        orgId: "org_123",
+        provider: "gsc",
+        resourceId: "sc-domain:example.com",
+      },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () =>
+          Response.json({ error: "resource_already_bound" }, { status: 409 }),
+      },
+    );
+
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.reason).toBe("resource_already_bound");
+      expect(out.detail).toContain("outra loja");
+    }
+  });
+
+  test("throws on an unexpected status", async () => {
+    await expect(
+      bindCommerceDiscoveryResource(
+        {
+          siteUrl: "https://example.com",
+          orgId: "org_123",
+          provider: "ga4",
+          resourceId: "1",
+        },
+        {
+          baseUrl: "https://commerce.example.test",
+          apiKey: "master-key",
+          fetchImpl: async () =>
+            Response.json({ error: "boom" }, { status: 500 }),
+        },
+      ),
+    ).rejects.toThrow("Commerce Discovery auth failed");
+  });
+
+  test("requires an internal API key", async () => {
+    await expect(
+      bindCommerceDiscoveryResource(
+        {
+          siteUrl: "https://example.com",
+          orgId: "org_123",
+          provider: "ga4",
+          resourceId: "1",
+        },
         {
           settings: {
             commerceDiscoveryInternalApiUrl: undefined,

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.ts
@@ -254,3 +254,52 @@ export async function triggerCommerceDiscoveryRun(
   }
   return { triggered: true };
 }
+
+const ConnectionStatusSchema = z.object({
+  providers: z.record(
+    z.string(),
+    z.object({
+      connected: z.boolean(),
+      via: z.enum(["oauth", "sa"]).nullable(),
+      resource: z.string().nullable(),
+    }),
+  ),
+});
+
+export type CommerceDiscoveryConnectionStatus = z.infer<
+  typeof ConnectionStatusSchema
+>["providers"];
+
+/**
+ * Read per-provider connection status for a store — the single source of truth
+ * the studio card renders as "Conectado", unifying both lanes (Studio-vault
+ * OAuth and shared-SA binding). Read-only; soft-tolerant: a diagnostic that was
+ * never upgraded (404/409) reports everything disconnected rather than throwing,
+ * so the onboarding UI degrades cleanly before the first upgrade.
+ */
+export async function fetchCommerceDiscoveryConnectionStatus(
+  input: { siteUrl: string; orgId: string },
+  options: CommerceDiscoveryAuthOptions = {},
+): Promise<CommerceDiscoveryConnectionStatus> {
+  const baseUrl = resolveBaseUrl(options);
+  const apiKey = resolveApiKey(options);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const domain = domainFromSiteUrl(input.siteUrl);
+  const url = `${baseUrl}/api/v2/internal/diagnostics/${encodeURIComponent(
+    domain,
+  )}/connections/status?org_id=${encodeURIComponent(input.orgId)}`;
+
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  if (response.status === 404 || response.status === 409) {
+    return {};
+  }
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response));
+  }
+  const parsed = ConnectionStatusSchema.safeParse(await response.json());
+  return parsed.success ? parsed.data.providers : {};
+}

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.ts
@@ -9,6 +9,14 @@ const UpgradeResponseSchema = z.object({
   token: z.string().min(1),
 });
 
+const BindResponseSchema = z.object({
+  binding: z
+    .object({ resource_id: z.string(), evidence: z.string() })
+    .optional(),
+  reason: z.string().optional(),
+  detail: z.string().optional(),
+});
+
 type FetchImpl = (
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -24,6 +32,22 @@ export interface CommerceDiscoveryAuthInput {
   /** Deep link back to this workspace's report, used in that email. */
   reportUrl?: string;
 }
+
+export type CommerceDiscoveryProvider = "ga4" | "gsc";
+
+export interface CommerceDiscoveryBindInput {
+  siteUrl: string;
+  orgId: string;
+  provider: CommerceDiscoveryProvider;
+  /** ga4: bare numeric property id; gsc: site (sc-domain:… / URL-prefix). */
+  resourceId: string;
+}
+
+/** Verified ⇒ the resource is bound to this store; rejected ⇒ an actionable
+ *  pt-BR reason the form shows inline (wrong domain, SA not granted yet, …). */
+export type CommerceDiscoveryBindResult =
+  | { ok: true; resourceId: string; evidence: string }
+  | { ok: false; reason: string; detail: string };
 
 export interface CommerceDiscoveryAuthOptions {
   baseUrl?: string;
@@ -118,6 +142,80 @@ export async function fetchCommerceDiscoveryAuth(
   }
 
   return { authorizationToken: parsed.data.token };
+}
+
+/**
+ * Bind a GA4 property / GSC site to a store via the shared service account —
+ * the consent-free lane for the unverified-OAuth workaround. The client grants
+ * `deco-reader@…` access to the resource and types its id; Commerce Discovery
+ * VERIFIES the resource belongs to this domain before persisting (ga4: a web
+ * stream's defaultUri points here; gsc: the site id embeds the host). With a
+ * shared SA, knowing an id is never enough — the verification is the auth.
+ *
+ * Soft-tolerant: a verification failure (422) or a resource already bound to
+ * another store (409) is returned as { ok: false, reason, detail } — the detail
+ * is client-safe pt-BR the UI shows inline. Unexpected statuses still throw.
+ */
+export async function bindCommerceDiscoveryResource(
+  input: CommerceDiscoveryBindInput,
+  options: CommerceDiscoveryAuthOptions = {},
+): Promise<CommerceDiscoveryBindResult> {
+  const baseUrl = resolveBaseUrl(options);
+  const apiKey = resolveApiKey(options);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const domain = domainFromSiteUrl(input.siteUrl);
+  const url = `${baseUrl}/api/v2/internal/diagnostics/${encodeURIComponent(
+    domain,
+  )}/bindings`;
+
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      org_id: input.orgId,
+      provider: input.provider,
+      resource_id: input.resourceId,
+    }),
+  });
+
+  if (response.status === 409) {
+    return {
+      ok: false,
+      reason: "resource_already_bound",
+      detail:
+        "Este recurso já está vinculado a outra loja. Se ele é seu, fale com o suporte para revisão manual.",
+    };
+  }
+  if (response.status === 422) {
+    const parsed = BindResponseSchema.safeParse(await response.json());
+    return {
+      ok: false,
+      reason: parsed.success
+        ? (parsed.data.reason ?? "verification_failed")
+        : "verification_failed",
+      detail:
+        (parsed.success ? parsed.data.detail : undefined) ??
+        "Não foi possível verificar o acesso a este recurso.",
+    };
+  }
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response));
+  }
+
+  const parsed = BindResponseSchema.safeParse(await response.json());
+  if (!parsed.success || !parsed.data.binding) {
+    throw new Error(
+      "Commerce Discovery bind response did not include a binding.",
+    );
+  }
+  return {
+    ok: true,
+    resourceId: parsed.data.binding.resource_id,
+    evidence: parsed.data.binding.evidence,
+  };
 }
 
 /**

--- a/apps/mesh/src/tools/commerce-discovery/bind.ts
+++ b/apps/mesh/src/tools/commerce-discovery/bind.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { normalizeCommerceSiteUrl } from "../../commerce-discovery/site-url";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
+import { bindCommerceDiscoveryResource } from "./auth-client";
+
+const CommerceDiscoveryBindInputSchema = z.object({
+  siteUrl: z.string().min(1).describe("Website URL of the store being bound."),
+  provider: z
+    .enum(["ga4", "gsc"])
+    .describe(
+      "Which Google source to bind: ga4 (Analytics) or gsc (Search Console).",
+    ),
+  resourceId: z
+    .string()
+    .min(1)
+    .describe(
+      "The resource id the client typed: GA4 numeric property id, or GSC site (sc-domain:example.com or https://example.com/).",
+    ),
+});
+
+const CommerceDiscoveryBindOutputSchema = z.discriminatedUnion("ok", [
+  z.object({
+    ok: z.literal(true),
+    resourceId: z.string(),
+    evidence: z.string(),
+  }),
+  z.object({
+    ok: z.literal(false),
+    reason: z.string(),
+    detail: z.string(),
+  }),
+]);
+
+export const COMMERCE_DISCOVERY_BIND = defineTool({
+  name: "COMMERCE_DISCOVERY_BIND",
+  description:
+    "Bind a GA4 property or GSC site to the org's store via the shared service account (consent-free lane). The client grants deco-reader@… access to the resource and provides its id; Commerce Discovery verifies the resource belongs to this domain before persisting. Returns ok:false with an actionable pt-BR detail when verification fails or the resource is already bound elsewhere.",
+  annotations: {
+    title: "Bind Commerce Discovery Data Source",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: CommerceDiscoveryBindInputSchema,
+  outputSchema: CommerceDiscoveryBindOutputSchema,
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const organization = requireOrganization(ctx);
+    // Same gate as COMMERCE_DISCOVERY_RUN: the internal API key authorizes the
+    // wire; ctx.access.check enforces which member of the org may bind.
+    await ctx.access.check();
+
+    const normalized = normalizeCommerceSiteUrl(input.siteUrl);
+    if (!normalized.ok) {
+      throw new Error(normalized.error);
+    }
+
+    return bindCommerceDiscoveryResource({
+      siteUrl: normalized.value,
+      orgId: organization.id,
+      provider: input.provider,
+      resourceId: input.resourceId.trim(),
+    });
+  },
+});

--- a/apps/mesh/src/tools/commerce-discovery/index.ts
+++ b/apps/mesh/src/tools/commerce-discovery/index.ts
@@ -1,3 +1,4 @@
 export { COMMERCE_DISCOVERY_BIND } from "./bind";
+export { COMMERCE_DISCOVERY_CONNECTION_STATUS } from "./status";
 export { COMMERCE_DISCOVERY_RUN } from "./run";
 export { COMMERCE_DISCOVERY_SETUP } from "./setup";

--- a/apps/mesh/src/tools/commerce-discovery/index.ts
+++ b/apps/mesh/src/tools/commerce-discovery/index.ts
@@ -1,2 +1,3 @@
+export { COMMERCE_DISCOVERY_BIND } from "./bind";
 export { COMMERCE_DISCOVERY_RUN } from "./run";
 export { COMMERCE_DISCOVERY_SETUP } from "./setup";

--- a/apps/mesh/src/tools/commerce-discovery/status.ts
+++ b/apps/mesh/src/tools/commerce-discovery/status.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { normalizeCommerceSiteUrl } from "../../commerce-discovery/site-url";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
+import { fetchCommerceDiscoveryConnectionStatus } from "./auth-client";
+
+const CommerceDiscoveryStatusInputSchema = z.object({
+  siteUrl: z.string().min(1).describe("Website URL of the store to inspect."),
+});
+
+const CommerceDiscoveryStatusOutputSchema = z.object({
+  providers: z.record(
+    z.string(),
+    z.object({
+      connected: z.boolean(),
+      via: z.enum(["oauth", "sa"]).nullable(),
+      resource: z.string().nullable(),
+    }),
+  ),
+});
+
+export const COMMERCE_DISCOVERY_CONNECTION_STATUS = defineTool({
+  name: "COMMERCE_DISCOVERY_CONNECTION_STATUS",
+  description:
+    "Read per-provider connection status (ga4/gsc/vtex) for the org's store — { connected, via: oauth|sa, resource }. The single source of truth for whether a data source is connected, unifying the OAuth (Studio vault) and shared-SA binding lanes. Read-only.",
+  annotations: {
+    title: "Commerce Discovery Connection Status",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: CommerceDiscoveryStatusInputSchema,
+  outputSchema: CommerceDiscoveryStatusOutputSchema,
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const organization = requireOrganization(ctx);
+    await ctx.access.check();
+
+    const normalized = normalizeCommerceSiteUrl(input.siteUrl);
+    if (!normalized.ok) {
+      throw new Error(normalized.error);
+    }
+
+    const providers = await fetchCommerceDiscoveryConnectionStatus({
+      siteUrl: normalized.value,
+      orgId: organization.id,
+    });
+    return { providers };
+  },
+});

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -79,6 +79,7 @@ export const CORE_TOOLS = [
   ConnectionTools.CONNECTION_TEST,
   CommerceDiscoveryTools.COMMERCE_DISCOVERY_SETUP,
   CommerceDiscoveryTools.COMMERCE_DISCOVERY_RUN,
+  CommerceDiscoveryTools.COMMERCE_DISCOVERY_BIND,
 
   // Virtual MCP collection tools
   VirtualMCPTools.COLLECTION_VIRTUAL_MCP_CREATE,

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -80,6 +80,7 @@ export const CORE_TOOLS = [
   CommerceDiscoveryTools.COMMERCE_DISCOVERY_SETUP,
   CommerceDiscoveryTools.COMMERCE_DISCOVERY_RUN,
   CommerceDiscoveryTools.COMMERCE_DISCOVERY_BIND,
+  CommerceDiscoveryTools.COMMERCE_DISCOVERY_CONNECTION_STATUS,
 
   // Virtual MCP collection tools
   VirtualMCPTools.COLLECTION_VIRTUAL_MCP_CREATE,

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -81,6 +81,7 @@ const ALL_TOOL_NAMES = [
   "COMMERCE_DISCOVERY_SETUP",
   "COMMERCE_DISCOVERY_RUN",
   "COMMERCE_DISCOVERY_BIND",
+  "COMMERCE_DISCOVERY_CONNECTION_STATUS",
   // Virtual MCP tools
   "COLLECTION_VIRTUAL_MCP_CREATE",
   "COLLECTION_VIRTUAL_MCP_LIST",
@@ -442,6 +443,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   {
     name: "COMMERCE_DISCOVERY_BIND",
     description: "Bind Commerce Discovery data source",
+    category: "Connections",
+  },
+  {
+    name: "COMMERCE_DISCOVERY_CONNECTION_STATUS",
+    description: "Read Commerce Discovery connection status",
     category: "Connections",
   },
   {
@@ -1158,6 +1164,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "COMMERCE_DISCOVERY_SETUP",
       "COMMERCE_DISCOVERY_RUN",
       "COMMERCE_DISCOVERY_BIND",
+      "COMMERCE_DISCOVERY_CONNECTION_STATUS",
     ],
     dangerous: true,
   },

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -80,6 +80,7 @@ const ALL_TOOL_NAMES = [
   "CONNECTION_TEST",
   "COMMERCE_DISCOVERY_SETUP",
   "COMMERCE_DISCOVERY_RUN",
+  "COMMERCE_DISCOVERY_BIND",
   // Virtual MCP tools
   "COLLECTION_VIRTUAL_MCP_CREATE",
   "COLLECTION_VIRTUAL_MCP_LIST",
@@ -436,6 +437,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   {
     name: "COMMERCE_DISCOVERY_RUN",
     description: "Run Commerce Discovery",
+    category: "Connections",
+  },
+  {
+    name: "COMMERCE_DISCOVERY_BIND",
+    description: "Bind Commerce Discovery data source",
     category: "Connections",
   },
   {
@@ -1151,6 +1157,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "COLLECTION_CONNECTIONS_DELETE",
       "COMMERCE_DISCOVERY_SETUP",
       "COMMERCE_DISCOVERY_RUN",
+      "COMMERCE_DISCOVERY_BIND",
     ],
     dangerous: true,
   },

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -80,6 +80,10 @@ export const KEYS = {
     ] as const,
   commerceDiscoveryCompanionGscSites: (orgId: string, connectionId: string) =>
     ["commerce-discovery", "companion-gsc-sites", orgId, connectionId] as const,
+  // Per-(org, siteUrl) connection status from commerce-discovery — the single
+  // source of truth for "Conectado" across both lanes (OAuth + shared-SA).
+  commerceDiscoveryConnectionStatus: (orgId: string, siteUrl: string) =>
+    ["commerce-discovery", "connection-status", orgId, siteUrl] as const,
 
   connectionActivity: (
     connectionId: string,

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -23,6 +23,11 @@ import {
   shouldAutoOpenCompanionConfig,
 } from "./companions-core.ts";
 import { COMPANION_CONFIG_FORMS } from "./companion-forms/registry.ts";
+import { SaBindingForm } from "./companion-forms/sa-binding-form.tsx";
+import {
+  type BindProvider,
+  PROVIDER_BY_BINDING_TYPE,
+} from "./companion-forms/sa-binding-copy.ts";
 
 /**
  * Loading placeholder that mirrors {@link CompanionCard}'s box model (square-ish
@@ -67,9 +72,26 @@ export function CompanionCard({
   onAutoOpenConfigHandled: () => void;
 }) {
   const linkedConnectionId = card.linkedConnectionId;
+  // GA4/GSC use the shared-SA lane by default; only fall back to the OAuth gear
+  // when the card was actually satisfied via OAuth (has a companion connection).
+  const saProvider = PROVIDER_BY_BINDING_TYPE[card.bindingType] as
+    | BindProvider
+    | undefined;
+  const useSaFlow = !!saProvider && card.boundVia !== "oauth";
 
   const action =
-    card.satisfied && linkedConnectionId ? (
+    useSaFlow && saProvider ? (
+      <SaConnectAction
+        card={card}
+        provider={saProvider}
+        org={org}
+        selfClient={selfClient}
+        siteUrl={siteUrl}
+        onOAuthInstead={onConnect}
+        disabled={disabled}
+        connecting={connecting}
+      />
+    ) : card.satisfied && linkedConnectionId ? (
       <div className="flex items-center justify-end gap-1 sm:justify-start">
         <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
           <CheckCircle size={16} className="text-success" /> Conectado
@@ -149,6 +171,119 @@ export function CompanionCard({
 
       <div className="shrink-0 sm:mt-auto sm:w-full sm:pt-1">{action}</div>
     </div>
+  );
+}
+
+/** The shared-SA connect/config action for GA4/GSC: a "Conectar" button (or a
+ *  "Conectado" + gear once bound) that opens a dialog with the step-by-step
+ *  binding form. The low-key "authorize via OAuth" link inside the dialog runs
+ *  the legacy OAuth flow for anyone who prefers it. No companion MCP client is
+ *  needed — the binding lives in commerce-discovery, not a Studio connection. */
+function SaConnectAction({
+  card,
+  provider,
+  org,
+  selfClient,
+  siteUrl,
+  onOAuthInstead,
+  disabled,
+  connecting,
+}: {
+  card: CompanionCardModel;
+  provider: BindProvider;
+  org: { id: string; slug: string };
+  selfClient: Client;
+  siteUrl?: string;
+  onOAuthInstead: () => void;
+  disabled: boolean;
+  connecting: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [savePending, setSavePending] = useState(false);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && savePending) return; // don't close mid-verify
+    setOpen(next);
+  };
+
+  return (
+    <>
+      {card.satisfied ? (
+        <div className="flex items-center justify-end gap-1 sm:justify-start">
+          <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <CheckCircle size={16} className="text-success" /> Conectado
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0"
+                onClick={() => setOpen(true)}
+                aria-label={`Configurar ${card.title}`}
+              >
+                <Settings01 size={16} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Editar configuração</TooltipContent>
+          </Tooltip>
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="sm:w-full"
+          disabled={disabled || connecting}
+          onClick={() => setOpen(true)}
+          aria-label={`Conectar ${card.title}`}
+        >
+          {connecting ? (
+            <Loading01 size={16} className="animate-spin" />
+          ) : (
+            "Conectar"
+          )}
+        </Button>
+      )}
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader className="flex-row items-center gap-3 space-y-0 text-left">
+            <IntegrationIcon
+              icon={card.icon}
+              name={card.title}
+              size="md"
+              fit="contain"
+              className="p-1.5"
+            />
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <DialogTitle>{card.title}</DialogTitle>
+              <DialogDescription>
+                Conceda acesso ao nosso leitor e informe o identificador
+              </DialogDescription>
+            </div>
+          </DialogHeader>
+          <SaBindingForm
+            provider={provider}
+            siteUrl={siteUrl}
+            selfClient={selfClient}
+            org={org}
+            initialResourceId={card.boundResource ?? undefined}
+            onDone={() => setOpen(false)}
+            onIsPendingChange={setSavePending}
+            onOAuthInstead={
+              card.satisfied
+                ? undefined
+                : () => {
+                    setOpen(false);
+                    onOAuthInstead();
+                  }
+            }
+          />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/sa-binding-copy.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/sa-binding-copy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BIND_PROVIDER_COPY,
+  PROVIDER_BY_BINDING_TYPE,
+  remediationFor,
+  SA_EMAIL,
+} from "./sa-binding-copy.ts";
+
+describe("PROVIDER_BY_BINDING_TYPE", () => {
+  test("maps only the two Google companions to provider codes", () => {
+    expect(PROVIDER_BY_BINDING_TYPE["google-analytics"]).toBe("ga4");
+    expect(PROVIDER_BY_BINDING_TYPE["google-search-console"]).toBe("gsc");
+    expect(PROVIDER_BY_BINDING_TYPE.vtex).toBeUndefined();
+  });
+});
+
+describe("connect steps always name the shared SA", () => {
+  test("both providers instruct adding the SA email", () => {
+    for (const provider of ["ga4", "gsc"] as const) {
+      const joined = BIND_PROVIDER_COPY[provider].connectSteps.join(" ");
+      expect(joined).toContain(SA_EMAIL);
+    }
+  });
+});
+
+describe("remediationFor", () => {
+  test("no-web-stream (site URL missing on GA) walks through adding a web stream", () => {
+    const r = remediationFor("ga4", "no-web-stream");
+    expect(r.title).toContain("fluxo de dados da Web");
+    expect(r.steps.join(" ")).toContain("Adicionar fluxo");
+  });
+
+  test("no-access is provider-specific (GSC calls out the unusable permission)", () => {
+    expect(remediationFor("ga4", "no-access").steps.join(" ")).toContain(
+      SA_EMAIL,
+    );
+    expect(remediationFor("gsc", "no-access").steps.join(" ")).toContain(
+      "Não verificado",
+    );
+  });
+
+  test("resource_already_bound points to manual review", () => {
+    expect(
+      remediationFor("ga4", "resource_already_bound").steps.join(" "),
+    ).toContain("suporte");
+  });
+
+  test("unknown reason falls back to a safe generic remediation", () => {
+    const r = remediationFor("gsc", "something-new");
+    expect(r.title.length).toBeGreaterThan(0);
+    expect(r.steps.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/sa-binding-copy.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/sa-binding-copy.ts
@@ -1,0 +1,139 @@
+// Copy + step-by-step guidance for the shared-SA binding flow (the consent-free
+// lane). Pure data/functions so the instructions are unit-testable and the form
+// stays presentational. The whole point: tell the user EXACTLY what to do —
+// both to grant access up front and to fix a specific failure (e.g. a GA4
+// property with no web data stream ⇒ no site URL to verify against).
+
+export type BindProvider = "ga4" | "gsc";
+
+/** The shared service account the client grants access to — never a human
+ *  account (no consent screen, no god-login to protect). */
+export const SA_EMAIL = "deco-reader@decocms.iam.gserviceaccount.com";
+
+/** commerce-discovery binding requirement types → provider codes. Only these
+ *  two use the shared-SA lane; VTEX keeps its own credential flow. */
+export const PROVIDER_BY_BINDING_TYPE: Record<string, BindProvider> = {
+  "google-analytics": "ga4",
+  "google-search-console": "gsc",
+};
+
+export interface BindProviderCopy {
+  /** Human label, e.g. "Google Analytics". */
+  label: string;
+  /** Field label for the id the user pastes. */
+  resourceLabel: string;
+  resourcePlaceholder: string;
+  /** Where to find that id. */
+  resourceHint: string;
+  /** Ordered steps to grant the SA access + locate the id. */
+  connectSteps: string[];
+}
+
+export const BIND_PROVIDER_COPY: Record<BindProvider, BindProviderCopy> = {
+  ga4: {
+    label: "Google Analytics",
+    resourceLabel: "ID da propriedade",
+    resourcePlaceholder: "ex: 123456789",
+    resourceHint:
+      "No GA4: Admin → Detalhes da propriedade → ID da propriedade (só números).",
+    connectSteps: [
+      "Abra o Google Analytics (GA4) da sua loja.",
+      "Vá em Admin → Acesso à propriedade (Gerenciamento de acesso).",
+      `Clique em + → Adicionar usuários, cole ${SA_EMAIL} e conceda o papel Leitor.`,
+      "Copie o ID da propriedade (Admin → Detalhes da propriedade) e cole abaixo.",
+    ],
+  },
+  gsc: {
+    label: "Google Search Console",
+    resourceLabel: "Site / propriedade",
+    resourcePlaceholder: "ex: sc-domain:sualoja.com.br",
+    resourceHint:
+      "Use o mesmo formato que aparece no Search Console: sc-domain:sualoja.com.br ou https://www.sualoja.com.br/.",
+    connectSteps: [
+      "Abra o Google Search Console da sua loja.",
+      "Vá em Configurações → Usuários e permissões.",
+      `Clique em Adicionar usuário, cole ${SA_EMAIL} e escolha permissão Completa.`,
+      "Copie o endereço do site como aparece no seletor de propriedades e cole abaixo.",
+    ],
+  },
+};
+
+export interface RemediationCopy {
+  title: string;
+  steps: string[];
+}
+
+/**
+ * Map a bind failure `reason` to concrete, provider-specific next steps. The
+ * backend already returns a one-line pt-BR `detail`; this turns each failure
+ * into an actionable checklist the form renders inline. `no-web-stream` is the
+ * "site URL missing on GA" case — the property has no web data stream to verify
+ * the domain against, so we walk the user through creating one.
+ */
+export function remediationFor(
+  provider: BindProvider,
+  reason: string,
+): RemediationCopy {
+  const label = BIND_PROVIDER_COPY[provider].label;
+  switch (reason) {
+    case "no-access":
+      return {
+        title: `Ainda não conseguimos acessar este recurso no ${label}.`,
+        steps:
+          provider === "ga4"
+            ? [
+                `Confirme que ${SA_EMAIL} foi adicionado em Admin → Acesso à propriedade com o papel Leitor.`,
+                "Confira se o ID da propriedade está correto (só números, sem o prefixo 'properties/').",
+                "A concessão de acesso pode levar alguns segundos — tente novamente.",
+              ]
+            : [
+                `Confirme que ${SA_EMAIL} foi adicionado em Configurações → Usuários e permissões.`,
+                "A permissão precisa ser Completa ou Restrita — 'Não verificado' não funciona.",
+                "Confira se o endereço do site está exatamente como aparece no Search Console.",
+              ],
+      };
+    case "no-web-stream":
+      // GA4-specific: the property measures no website, so there's no defaultUri
+      // (site URL) to check ownership against.
+      return {
+        title:
+          "Esta propriedade do GA4 não tem um fluxo de dados da Web (site) configurado.",
+        steps: [
+          "No GA4, vá em Admin → Fluxos de dados.",
+          "Clique em Adicionar fluxo → Web.",
+          "Informe a URL do site da sua loja e salve o fluxo.",
+          "Volte aqui e tente vincular de novo. (Propriedades só de app precisam de vínculo manual — fale com o suporte.)",
+        ],
+      };
+    case "no-match":
+      return {
+        title: `O recurso informado não corresponde ao domínio desta loja.`,
+        steps:
+          provider === "ga4"
+            ? [
+                "Verifique se digitou o ID da propriedade certa — provavelmente é de outro site.",
+                "No GA4, o site medido aparece em Admin → Fluxos de dados → (seu fluxo Web) → URL do stream.",
+              ]
+            : [
+                "Verifique se selecionou a propriedade do Search Console referente a esta loja.",
+                "O endereço precisa cobrir o mesmo domínio do diagnóstico.",
+              ],
+      };
+    case "resource_already_bound":
+      return {
+        title: "Este recurso já está vinculado a outra loja.",
+        steps: [
+          "Se este recurso é realmente desta loja, fale com o suporte para uma revisão manual.",
+          "Caso tenha digitado o id errado, confira e tente novamente.",
+        ],
+      };
+    default:
+      return {
+        title: "Não foi possível verificar o acesso a este recurso.",
+        steps: [
+          "Revise os passos de acesso acima e tente novamente.",
+          "Se persistir, fale com o suporte.",
+        ],
+      };
+  }
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/sa-binding-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/sa-binding-form.tsx
@@ -1,0 +1,234 @@
+import { KEYS } from "@/web/lib/query-keys";
+import { Button } from "@deco/ui/components/button.tsx";
+import { DialogFooter } from "@deco/ui/components/dialog.tsx";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@deco/ui/components/form.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Copy01 } from "@untitledui/icons";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { unwrapToolResult } from "../companions-core.ts";
+import {
+  type BindProvider,
+  BIND_PROVIDER_COPY,
+  type RemediationCopy,
+  remediationFor,
+  SA_EMAIL,
+} from "./sa-binding-copy.ts";
+
+interface SaFormValues {
+  resourceId: string;
+}
+
+interface SaBindResult {
+  ok: boolean;
+  reason?: string;
+  detail?: string;
+  resourceId?: string;
+}
+
+/**
+ * The consent-free "connect a Google source" form: it tells the user exactly
+ * what to do (grant the shared SA access + where to find the id), sends the id
+ * to COMMERCE_DISCOVERY_BIND (which verifies ownership server-side), and on
+ * failure renders a reason-specific checklist — e.g. a GA4 property with no web
+ * data stream gets the steps to add one. Optionally offers the old OAuth flow
+ * behind a low-key link.
+ */
+export function SaBindingForm({
+  provider,
+  siteUrl,
+  selfClient,
+  org,
+  initialResourceId,
+  onDone,
+  onIsPendingChange,
+  onOAuthInstead,
+}: {
+  provider: BindProvider;
+  siteUrl?: string;
+  selfClient: Client;
+  org: { id: string };
+  initialResourceId?: string;
+  onDone: () => void;
+  onIsPendingChange?: (isPending: boolean) => void;
+  onOAuthInstead?: () => void;
+}) {
+  const copy = BIND_PROVIDER_COPY[provider];
+  const queryClient = useQueryClient();
+  const [remediation, setRemediation] = useState<
+    (RemediationCopy & { detail?: string }) | null
+  >(null);
+
+  const schema = z.object({
+    resourceId: z
+      .string()
+      .trim()
+      .min(1, `Informe o ${copy.resourceLabel.toLowerCase()}`),
+  });
+
+  const form = useForm<SaFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { resourceId: initialResourceId ?? "" },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (values: SaFormValues): Promise<SaBindResult> => {
+      if (!siteUrl) {
+        throw new Error("URL da loja indisponível — recarregue a página.");
+      }
+      const result = await selfClient.callTool({
+        name: "COMMERCE_DISCOVERY_BIND",
+        arguments: { siteUrl, provider, resourceId: values.resourceId },
+      });
+      return unwrapToolResult<SaBindResult>(result);
+    },
+    // Notify the parent dialog directly (no useEffect — banned in this repo).
+    onMutate: () => onIsPendingChange?.(true),
+    onSettled: () => onIsPendingChange?.(false),
+    onSuccess: async (res) => {
+      if (res.ok) {
+        setRemediation(null);
+        toast.success(`${copy.label} conectado`);
+        if (siteUrl) {
+          await queryClient.invalidateQueries({
+            queryKey: KEYS.commerceDiscoveryConnectionStatus(org.id, siteUrl),
+          });
+        }
+        onDone();
+        return;
+      }
+      setRemediation({
+        ...remediationFor(provider, res.reason ?? "unknown"),
+        detail: res.detail,
+      });
+    },
+  });
+
+  const handleSubmit = form.handleSubmit((data) => mutation.mutate(data));
+  const isPending = mutation.isPending;
+
+  const copyEmail = () => {
+    navigator.clipboard?.writeText(SA_EMAIL);
+    toast.success("E-mail copiado");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <ol className="space-y-2 text-sm text-muted-foreground">
+        {copy.connectSteps.map((step, i) => (
+          <li key={step} className="flex gap-2">
+            <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-foreground">
+              {i + 1}
+            </span>
+            <span>{step}</span>
+          </li>
+        ))}
+      </ol>
+
+      <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 p-2">
+        <code className="min-w-0 flex-1 truncate text-xs text-foreground">
+          {SA_EMAIL}
+        </code>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={copyEmail}
+          aria-label="Copiar e-mail do service account"
+        >
+          <Copy01 size={16} />
+        </Button>
+      </div>
+
+      <Form {...form}>
+        <FormField
+          control={form.control}
+          name="resourceId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{copy.resourceLabel}</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  placeholder={copy.resourcePlaceholder}
+                  disabled={isPending}
+                  autoComplete="off"
+                />
+              </FormControl>
+              <FormDescription>{copy.resourceHint}</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </Form>
+
+      {remediation && (
+        <div
+          role="alert"
+          className="space-y-2 rounded-lg border border-destructive/40 bg-destructive/5 p-3"
+        >
+          <p className="text-sm font-medium text-foreground">
+            {remediation.title}
+          </p>
+          <ol className="space-y-1 text-sm text-muted-foreground">
+            {remediation.steps.map((step) => (
+              <li key={step} className="flex gap-2">
+                <span aria-hidden>•</span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+
+      {mutation.isError && (
+        <p role="alert" className="text-sm text-destructive">
+          {mutation.error instanceof Error
+            ? mutation.error.message
+            : "Não foi possível vincular."}
+        </p>
+      )}
+
+      <DialogFooter className="flex-col gap-2 pt-2 sm:flex-row sm:items-center sm:justify-between">
+        {onOAuthInstead ? (
+          <button
+            type="button"
+            onClick={onOAuthInstead}
+            disabled={isPending}
+            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50"
+          >
+            autorizar via login do Google
+          </button>
+        ) : (
+          <span />
+        )}
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onDone}
+            disabled={isPending}
+          >
+            Cancelar
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Verificando..." : "Vincular"}
+          </Button>
+        </div>
+      </DialogFooter>
+    </form>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -129,6 +129,7 @@ function CompanionMcpsSectionContent({
     selfClient,
     org,
     cdConnectionId,
+    siteUrl,
   });
   const {
     connect,

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -334,6 +334,44 @@ describe("buildCompanionCards", () => {
     });
     expect(cards[0]!.icon).toBeNull();
   });
+  it("marks a card connected via the shared-SA binding (boundVia='sa')", () => {
+    const cards = buildCompanionCards({
+      requirements: [{ fieldKey: "GA", bindingType: "google-analytics" }],
+      itemsById: {},
+      itemsByName: {
+        "google-analytics": item("deco/google-analytics", "google-analytics"),
+      },
+      connections: [],
+      configurationState: null,
+      curated,
+      saBindings: { "google-analytics": { resource: "123456789" } },
+    });
+    expect(cards[0]!.satisfied).toBe(true);
+    expect(cards[0]!.boundVia).toBe("sa");
+    expect(cards[0]!.boundResource).toBe("123456789");
+    expect(cards[0]!.linkedConnectionId).toBeNull();
+  });
+  it("OAuth linkage wins over an SA binding (run-time precedence)", () => {
+    const cards = buildCompanionCards({
+      requirements: [{ fieldKey: "GA", bindingType: "google-analytics" }],
+      itemsById: {},
+      itemsByName: {
+        "google-analytics": item("deco/google-analytics", "google-analytics"),
+      },
+      connections: [
+        { id: "c_ga", app_name: "google-analytics", status: "active" },
+      ],
+      configurationState: {
+        GA: { __type: "google-analytics", value: "c_ga" },
+      },
+      curated,
+      saBindings: { "google-analytics": { resource: "123" } },
+    });
+    expect(cards[0]!.satisfied).toBe(true);
+    expect(cards[0]!.boundVia).toBe("oauth");
+    expect(cards[0]!.boundResource).toBeNull();
+    expect(cards[0]!.linkedConnectionId).toBe("c_ga");
+  });
 });
 
 describe("matchGscSite", () => {

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -51,7 +51,18 @@ export interface CompanionCardModel {
   candidateConnectionId: string | null;
   linkedConnectionId: string | null;
   configurationState: Record<string, unknown> | null;
+  /** Which lane satisfied this card: "oauth" (Studio-vault companion connection)
+   *  or "sa" (shared service-account verified binding in commerce-discovery).
+   *  null when not connected. Drives which config/connect UI the card opens. */
+  boundVia: "oauth" | "sa" | null;
+  /** The SA-bound resource (GA4 property id / GSC site) when boundVia === "sa",
+   *  so the card can prefill it for viewing/editing. Null otherwise. */
+  boundResource: string | null;
 }
+
+/** Providers connected through the shared-SA lane, keyed by binding type
+ *  (e.g. "google-analytics"), from the commerce-discovery status endpoint. */
+export type SaBindings = Record<string, { resource: string | null }>;
 
 type ComparisonWhere = { field: string[]; operator: "in"; value: string[] };
 type WhereExpr =
@@ -251,6 +262,8 @@ export function buildCompanionCards(args: {
   connectionReadiness?: Record<string, boolean>;
   configurationState: Record<string, unknown> | null | undefined;
   curated: Record<string, CompanionCopy>;
+  /** Providers connected via the shared-SA lane (from commerce-discovery). */
+  saBindings?: SaBindings;
 }): CompanionCardModel[] {
   const cards: CompanionCardModel[] = [];
   const connectionsById = new Map(args.connections.map((c) => [c.id, c]));
@@ -269,7 +282,18 @@ export function buildCompanionCards(args: {
     const linkedReady = linkedConnectionId
       ? args.connectionReadiness?.[linkedConnectionId] !== false
       : false;
-    const satisfied = !!linkedConnectionId && linkedReady;
+    // OAuth (local configuration_state) takes precedence; else the shared-SA
+    // binding reported by commerce-discovery. Mirrors run-time resolution.
+    const oauthSatisfied = !!linkedConnectionId && linkedReady;
+    const saBinding = oauthSatisfied
+      ? undefined
+      : args.saBindings?.[req.bindingType];
+    const satisfied = oauthSatisfied || !!saBinding;
+    const boundVia: "oauth" | "sa" | null = oauthSatisfied
+      ? "oauth"
+      : saBinding
+        ? "sa"
+        : null;
     cards.push({
       fieldKey: req.fieldKey,
       bindingType: req.bindingType,
@@ -294,6 +318,8 @@ export function buildCompanionCards(args: {
             ),
       linkedConnectionId,
       configurationState: linkedConnection?.configuration_state ?? null,
+      boundVia,
+      boundResource: saBinding?.resource ?? null,
     });
   }
   return cards;

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
@@ -2,12 +2,18 @@ import { KEYS } from "@/web/lib/query-keys";
 import { callRegistryTool } from "@/web/utils/registry-utils";
 import { useMCPClient, WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { useSuspenseQueries, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useQuery,
+  useSuspenseQueries,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { PROVIDER_BY_BINDING_TYPE } from "./companion-forms/sa-binding-copy.ts";
 import { COMMERCE_COMPANION_MCPS } from "./companions.ts";
 import {
   buildCompanionCards,
   buildRegistryWhere,
   parseBindingRequirements,
+  type SaBindings,
   unwrapToolResult,
   type CandidateConnection,
   type CompanionCardModel,
@@ -25,14 +31,27 @@ type ConnectionWhereCondition = {
   value: string[];
 };
 
+interface ConnectionStatusResult {
+  providers?: Record<
+    string,
+    {
+      connected?: boolean;
+      via?: "oauth" | "sa" | null;
+      resource?: string | null;
+    }
+  >;
+}
+
 export function useCommerceCompanions({
   selfClient,
   org,
   cdConnectionId,
+  siteUrl,
 }: {
   selfClient: Client;
   org: CompanionOrg;
   cdConnectionId: string;
+  siteUrl?: string;
 }): { cards: CompanionCardModel[] } {
   // 1) CD's live config schema (on the CD connection's OWN client).
   const cdClient = useMCPClient({
@@ -214,6 +233,29 @@ export function useCommerceCompanions({
     if (item.server?.name) itemsByName[item.server.name] = item;
   }
 
+  // Shared-SA connection status from commerce-discovery — the source of truth
+  // for the SA lane (OAuth is judged locally, above). Non-suspense + soft: while
+  // it loads, or when there's no siteUrl yet, SA-bound cards simply read as not
+  // connected until it resolves. A binding write invalidates this key.
+  const statusQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryConnectionStatus(org.id, siteUrl ?? ""),
+    enabled: !!siteUrl,
+    queryFn: async () => {
+      const result = await selfClient.callTool({
+        name: "COMMERCE_DISCOVERY_CONNECTION_STATUS",
+        arguments: { siteUrl },
+      });
+      return unwrapToolResult<ConnectionStatusResult>(result);
+    },
+  });
+  const saBindings: SaBindings = {};
+  for (const [bindingType, code] of Object.entries(PROVIDER_BY_BINDING_TYPE)) {
+    const p = statusQuery.data?.providers?.[code];
+    if (p?.connected && p.via === "sa") {
+      saBindings[bindingType] = { resource: p.resource ?? null };
+    }
+  }
+
   const cards = buildCompanionCards({
     requirements,
     itemsById,
@@ -222,6 +264,7 @@ export function useCommerceCompanions({
     connectionReadiness,
     configurationState,
     curated: COMMERCE_COMPANION_MCPS,
+    saBindings,
   });
 
   return { cards };


### PR DESCRIPTION
## Contexto

O Google não verificou nosso OAuth app, então o consent do GA4/GSC mostra a tela de "app não verificado" e os clientes não completam a conexão. A lane shared-SA (mergeada no commerce-discovery em [#162](https://github.com/decocms/commerce-discovery/pull/162)) resolve: o cliente dá acesso ao service account compartilhado (`deco-reader@decocms.iam.gserviceaccount.com`) e digita o id — **zero consent screen**. O commerce-discovery verifica que o recurso pertence ao domínio da loja antes de gravar (anti-IDOR).

Este PR entrega a **experiência completa no studio**: a lane SA vira o caminho padrão pro cliente, com OAuth a um clique discreto de distância, e os dois caminhos acendem "Conectado".

## O que entra

**Camada de integração (server→CD):**
- `bindCommerceDiscoveryResource()` + tool `COMMERCE_DISCOVERY_BIND` — envia o id pro endpoint de bind; 422/409 voltam `{ ok:false, reason, detail }` (pt-BR).
- `fetchCommerceDiscoveryConnectionStatus()` + tool `COMMERCE_DISCOVERY_CONNECTION_STATUS` — lê o status por provider (fonte única de verdade).

**UI:**
- **`SaBindingForm`** — o diálogo de conexão sem consent. Diz exatamente o que fazer (conceder acesso ao `deco-reader@…` + onde achar o id, com botão de copiar), manda pro `COMMERCE_DISCOVERY_BIND`, e **em caso de falha renderiza um checklist específico por motivo**. O caso que você pediu — propriedade GA4 sem fluxo de dados da Web (sem site URL pra verificar) — cai no `no-web-stream` e mostra o passo-a-passo pra criar o fluxo. O mapa motivo→passos é puro e testado.
- **Card**: "Conectar" do GA4/GSC abre o diálogo SA por padrão; um link discreto "autorizar via login do Google" roda o fluxo OAuth antigo. Cards conectados por OAuth mantêm o seletor de propriedade/site atual, intocado.
- **Estado unificado**: `buildCompanionCards` marca o card conectado também pela lane SA (`boundVia: "oauth" | "sa"`, OAuth com precedência), alimentado pelo status endpoint — a mesma precedência que o run usa. Um bind bem-sucedido invalida a query de status e o card vira "Conectado".

100% aditivo: a lane OAuth via Studio Vault segue funcionando; a SA é um caminho paralelo.

## Teste

`bun run check` ✓ (todos os workspaces) · `bun test` (onboarding + commerce-discovery) 69 pass/0 fail · `bun run lint` sem erros novos. `bun run fmt` aplicado.

Cobertura unit: o mapa de instruções (incl. `no-web-stream`), a precedência OAuth×SA no builder de cards, e os clients de wire (bind + status). **A fiação React (diálogo/card) é tipada e lintada, mas precisa de QA manual** — não consigo verificar visualmente aqui.

Depende de: commerce-discovery [#167](https://github.com/decocms/commerce-discovery/pull/167) (status endpoint) + [#162](https://github.com/decocms/commerce-discovery/pull/162) (mergeado). Infra: SA `deco-reader` + `GOOGLE_SA_JSON` já provisionados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
