### PR TITLE
fix(schema): resolve #/root block-registry refs for Multi matcher rendering

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -1115,3 +1115,113 @@ describe("resolveSchema – allOf is an intersection, never an inline-union", ()
     });
   });
 });
+
+describe("resolveSchema – #/root block-registry refs (recursive matchers)", () => {
+  // Mirrors the /live/_meta shape for the Multi matcher: its `matchers: Matcher[]`
+  // field chains $ref → [Matcher] → Matcher → matchers → #/root/matchers, the
+  // union of every matcher implementation plus saved matcher blocks. Before the
+  // fix, resolveRef only understood #/definitions/… so #/root/matchers resolved
+  // to {} and each array item rendered as an empty object (blank "Item 1").
+  function matcherMeta(): LiveMeta {
+    return {
+      manifest: {
+        blocks: {
+          matchers: {
+            "website/matchers/multi.ts": { $ref: "#/definitions/MultiDef" },
+          },
+        },
+      },
+      schema: {
+        definitions: {
+          MultiDef: {
+            title: "Multi",
+            allOf: [{ $ref: "#/definitions/MultiProps" }],
+            properties: {
+              __resolveType: { enum: ["website/matchers/multi.ts"] },
+            },
+          },
+          MultiProps: {
+            type: "object",
+            required: ["op", "matchers"],
+            properties: {
+              op: { type: "string" },
+              matchers: { $ref: "#/definitions/MatcherArr", title: "Matchers" },
+            },
+          },
+          MatcherArr: {
+            type: "array",
+            items: { $ref: "#/definitions/MatcherRef" },
+            title: "[Matcher]",
+          },
+          MatcherRef: { $ref: "#/definitions/MatcherUnion", title: "Matcher" },
+          MatcherUnion: { $ref: "#/root/matchers", title: "matchers" },
+          Cookie: {
+            title: "Cookie",
+            properties: {
+              __resolveType: { enum: ["website/matchers/cookie.ts"] },
+              name: { type: "string", title: "Name" },
+            },
+          },
+          Resolvable: {},
+        },
+        root: {
+          matchers: {
+            title: "matchers",
+            anyOf: [
+              // fallback saved-block ref, carries no __resolveType — skipped
+              { $ref: "#/definitions/Resolvable" },
+              // built-in module matcher, referenced by $ref
+              { $ref: "#/definitions/Cookie" },
+              // recursion: Multi can nest itself — must not loop forever
+              { $ref: "#/definitions/MultiDef" },
+              // saved matcher block, inlined with a __resolveType enum
+              {
+                title: "#website/matchers/device.ts@Desktop",
+                properties: { __resolveType: { enum: ["Desktop"] } },
+              },
+            ],
+          },
+        },
+      },
+    };
+  }
+
+  test("resolves the nested Matcher array item into a block-ref picker", () => {
+    const items = resolveSchema("website/matchers/multi.ts", matcherMeta())
+      ?.properties?.matchers?.items;
+
+    expect(items?.type).toBe("block-ref");
+    const rts = items?.anyOfRefs?.map((r) => r.resolveType) ?? [];
+    // inline saved block + built-in module matcher + recursive self, in one union
+    expect(rts).toContain("Desktop");
+    expect(rts).toContain("website/matchers/cookie.ts");
+    expect(rts).toContain("website/matchers/multi.ts");
+    // the bare Resolvable fallback (no __resolveType) is not offered as an option
+    expect(rts).not.toContain("Resolvable");
+  });
+
+  test("Resolvable placeholder ($ref branch with no __resolveType enum) is excluded from the picker", () => {
+    // deco-start emits root.matchers as all-$ref branches: Resolvable first,
+    // then concrete matchers. Resolvable has no __resolveType.enum so its `rt`
+    // falls back to the bare ref key ("Resolvable", no "/") — it must be skipped.
+    const it = resolveSchema("website/matchers/multi.ts", matcherMeta())
+      ?.properties?.matchers?.items;
+    const rts = it?.anyOfRefs?.map((r) => r.resolveType) ?? [];
+    expect(rts).not.toContain("Resolvable");
+    expect(rts.length).toBeGreaterThan(0);
+  });
+
+  test("without #/root handling the item would resolve empty (regression guard)", () => {
+    // A #/root ref that does not exist must degrade to {} (empty object), never
+    // throw — matching the old missing-key behavior for unknown registries.
+    const meta = matcherMeta();
+    (meta.schema.root as Record<string, unknown>).matchers = {
+      $ref: "#/root/doesNotExist",
+      title: "matchers",
+    };
+    const items = resolveSchema("website/matchers/multi.ts", meta)?.properties
+      ?.matchers?.items;
+    expect(items?.type).toBe("object");
+    expect(items?.anyOfRefs ?? []).toHaveLength(0);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -268,7 +268,19 @@ export function resolveSchema(
     unknown
   >;
 
+  // deco "block registry" unions live under `#/root/<blockType>` (matchers,
+  // sections, loaders, …) — the anyOf of every implementation plus saved
+  // blocks. These are siblings of `definitions`, so the last-segment lookup
+  // below misses them (`#/root/matchers` → `matchers`, absent from defs → {}).
+  // Recursive block-ref fields (e.g. Multi's `matchers: Matcher[]`) chain into
+  // one of these, so without this branch they resolve to an empty object and
+  // the field renders blank.
+  const root = (globalSchema.root ?? {}) as Record<string, unknown>;
   const resolveRef = (ref: string): RawSchema => {
+    if (ref.startsWith("#/root/")) {
+      const rootKey = ref.slice("#/root/".length);
+      return (root[rootKey] as RawSchema | undefined) ?? {};
+    }
     const key = ref.split("/").pop() ?? "";
     return (defs[key] as RawSchema | undefined) ?? {};
   };
@@ -573,7 +585,7 @@ export function resolveSchema(
         }
 
         if (loaderBranches.length > 0) {
-          const anyOfRefs = loaderBranches.map((branch) => {
+          const loaderRefs = loaderBranches.map((branch) => {
             const rtSchema = (branch.properties as RawSchema | undefined)
               ?.__resolveType as RawSchema | undefined;
             const rtEnum = (rtSchema?.enum ?? []) as unknown[];
@@ -591,6 +603,59 @@ export function resolveSchema(
               schema: eagerBranchSchema(branch, depth + 1, nonNull.length),
             };
           });
+
+          // Block-registry unions (`#/root/matchers`, etc.) mix inline loader
+          // branches (saved blocks) with `$ref` branches (the built-in module
+          // types). Fold those `$ref` branches in too, otherwise selecting a
+          // Multi matcher only offers saved matchers, not `cookie`/`device`/…
+          // The `Resolvable` fallback ref (no `__resolveType`) is skipped.
+          const refBranchRefs: SchemaAnyOfRef[] = [];
+          for (const branch of nonNull) {
+            if (loaderBranches.includes(branch)) continue;
+            if (typeof branch.$ref !== "string") continue;
+            const def = resolveRef(branch.$ref);
+            let rt: string | undefined;
+            const rtProp = (def.properties as RawSchema | undefined)
+              ?.__resolveType as RawSchema | undefined;
+            if (
+              Array.isArray(rtProp?.enum) &&
+              typeof rtProp.enum[0] === "string"
+            ) {
+              rt = rtProp.enum[0];
+            }
+            if (!rt && Array.isArray(def.allOf)) {
+              for (const part of def.allOf as RawSchema[]) {
+                const e = (
+                  (part.properties as RawSchema | undefined)?.__resolveType as
+                    | RawSchema
+                    | undefined
+                )?.enum;
+                if (Array.isArray(e) && typeof e[0] === "string") {
+                  rt = e[0];
+                  break;
+                }
+              }
+            }
+            if (!rt) continue;
+            refBranchRefs.push({
+              resolveType: rt,
+              title:
+                typeof def.title === "string" && !def.title.startsWith("#")
+                  ? def.title
+                  : labelFromResolveType(rt),
+              description:
+                typeof def.description === "string"
+                  ? def.description
+                  : undefined,
+              schema: eagerBranchSchema(def, depth + 1, nonNull.length),
+            });
+          }
+
+          const seenRt = new Set(loaderRefs.map((r) => r.resolveType));
+          const anyOfRefs = [
+            ...loaderRefs,
+            ...refBranchRefs.filter((r) => !seenRt.has(r.resolveType)),
+          ];
 
           // Preserve the non-loader (plain data) branch so multivariate
           // field rendering can use it instead of the circular block-ref.
@@ -709,6 +774,10 @@ export function resolveSchema(
               rt = (branch.$ref as string).split("/").pop() ?? "";
             }
             const discriminatorValue = typeDiscriminatorFromBranch(branch);
+            // Skip the `Resolvable` placeholder: it has no `__resolveType.enum`
+            // so `rt` degrades to the bare ref key (no `/`). All real module
+            // blocks (matchers, loaders, sections) contain `/` in their path.
+            if (!discriminatorValue && !rt.includes("/")) continue;
             anyOfRefs.push({
               resolveType: discriminatorValue ?? rt,
               title:


### PR DESCRIPTION
## Summary

- **Root cause**: `resolveRef` inside `resolveSchema` only handled `#/definitions/…` refs. The `Multi` matcher's `matchers: Matcher[]` field chains through `$ref` hops ending at `#/root/matchers` — deco's runtime union of all matcher implementations — which lives as a sibling of `definitions`, not inside it. This made every array item resolve to `{}` → blank "Item 1" in the form.
- **Three fixes** in `resolve-schema.ts`:
  1. Teach `resolveRef` about `#/root/<blockType>` (reads from `schema.root`)
  2. In the loader-branch union path, fold in `$ref` branches too — block registries mix inline saved-block branches (inline `__resolveType.enum`) with `$ref` module branches; previously only inline ones were collected
  3. In the `allRefs` path, skip the `Resolvable` placeholder (its `__resolveType` has no `enum`, so `rt` falls back to `"Resolvable"` with no `/` — all real module blocks contain `/`)

## Test plan
- [ ] Open a page variant, select **Multi** as the rule type, add an item to **Matchers** — the item should now show a full matcher picker (cookie, device, pathname, etc.) instead of blank
- [ ] Nested: add a Multi matcher inside another Multi matcher — recursion is cycle-guarded, should not hang
- [ ] Negate matcher: its single `matcher` field should also show the picker
- [ ] Tested against two live sites: `iota-normae` (mixed inline+$ref union) and `delta-hydrae` (all-$ref union via deco-start) — both produce the correct picker
- [ ] `bun test apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts` → 33 pass
- [ ] `bun run check` clean, `bun run lint` 0 errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schema resolution for `#/root` block registries so the Multi matcher shows the correct matcher picker (including nested and negated cases) instead of blank items.

- **Bug Fixes**
  - Added `#/root/<blockType>` support in `resolveRef` to read from `schema.root`.
  - Merged `$ref` branches into block-ref unions (not just inline loader branches) and deduped by `resolveType`.
  - Skipped the `Resolvable` placeholder (no `__resolveType.enum`) to avoid bogus options in the picker.

<sup>Written for commit d4e041ac2665778b3e460037afd47750f3f8f887. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

