### PR TITLE
chore(sandbox-env): bump chart to 0.9.2 to publish the golden cache template

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,11 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.9.2: opt-in golden node_modules reflink cache (depsCache.golden, default
+# off) — sets GOLDEN_CACHE_ENABLED so the daemon reflink-restores a cached
+# node_modules and skips install. Additive; no change unless enabled. (The
+# daemon-side code merged in 0.9.1's window but the chart wasn't bumped, so
+# the publish workflow skipped it — this bump ships the template.)
 # 0.9.1: opt-in node-local deps cache (depsCache.*, default off) —
 # hostPath store keyed per-repo by the daemon. Additive; no change for
 # consumers that leave it disabled.
@@ -22,7 +27,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.1
+version: 0.9.2
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.5.7"
 kubeVersion: ">=1.30.0-0"


### PR DESCRIPTION
## Why

The golden node_modules reflink work (#4357) added `depsCache.golden` → the `GOLDEN_CACHE_ENABLED` env in the `SandboxTemplate`, but merged with `Chart.yaml` still at **0.9.1**. The `release-sandbox-charts` workflow **skips republishing a version that already exists**, and 0.9.1 was already published (pre-golden, depsCache only). So the golden template is on `main` but **not in the published chart** — enabling `depsCache.golden` today would render nothing.

## Change

Bump `sandbox-env` `0.9.1 → 0.9.2` (chart content already on main; this just triggers publish). `helm template` confirmed the golden env renders only when `depsCache.golden=true`.

## Follow-up (deco-apps-cd)

To actually deploy it, bump `targetRevision: 0.9.1 → 0.9.2` for `studio-sandbox-prod` and `studio-sandbox-stg` in the CD root `values.yaml`. **Safe** — golden is off by default; 0.9.2 behaves identically to 0.9.1 until someone sets `depsCache.golden=true` (which still wants the live prod-xfs boot validation first).

No behavior change in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `sandbox-env` chart from 0.9.1 to 0.9.2 to publish the golden `node_modules` reflink cache template (`depsCache.golden` → `GOLDEN_CACHE_ENABLED`). No behavior change unless enabled; golden is off by default.

- **Migration**
  - Update CD to `targetRevision: 0.9.2` for `studio-sandbox-prod` and `studio-sandbox-stg` to pick up the template.

<sup>Written for commit 7f104c42c0524769fb35a9c481ba9a27cd9ab1a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

