### PR TITLE
fix(ci): stop release-tagging from racing itself on concurrent merges

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -11,6 +11,16 @@ on:
       # here must cut a release to rebuild that image — it is not a ConfigMap.
       - "deploy/helm/studio/files/**"
 
+# Serialize release-tagging across merges. This job pushes a `[release]:`
+# version-bump commit straight to main; two runs from near-simultaneous
+# merges would otherwise race and one push would be rejected non-fast-forward.
+# cancel-in-progress: false — every merge's bump must run, so queue them
+# rather than cancel. (The push step also rebases-and-retries as a backstop
+# for main advancing via an unrelated merge.)
+concurrency:
+  group: release-tagging-main
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: read
@@ -262,7 +272,25 @@ jobs:
           fi
 
           git commit -F .release-commit-message
-          git push origin main
+          # main can advance between our checkout and this push (a sibling
+          # merge). Rebase our bump onto the latest main and retry instead of
+          # failing non-fast-forward — the bump only touches version manifests,
+          # so it rebases cleanly over unrelated merges. (A concurrent bump of
+          # the *same* manifest is serialized away by the `concurrency` guard
+          # above; if one still conflicts, we fail loudly rather than guess.)
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              echo "pushed version bump (attempt ${attempt})"
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "::error::version-bump push rejected after ${attempt} attempts"
+              exit 1
+            fi
+            echo "push rejected; rebasing onto origin/main and retrying"
+            git fetch origin main
+            git rebase origin/main
+          done
           # No [skip ci], no API dispatch: this push (made with the App token,
           # which re-triggers workflows) is itself what kicks off release-mesh
           # and the package publish workflows for the package.json files that


### PR DESCRIPTION
## Problem

`release-tagging` pushes a `[release]:` version-bump commit directly to `main`. When two PRs merge within seconds of each other, both runs trigger and the second push is rejected:

```
! [rejected]  main -> main (fetch first)
```

(Seen just now: #4357 and #4360 merged back-to-back — [failed run](https://github.com/decocms/studio/actions/runs/28897748133).) **Re-running doesn't help** — the job checks out the *original trigger commit*, which is now behind `main`, so it's a permanent non-fast-forward.

## Fix

- **`concurrency` guard** (`cancel-in-progress: false`) serializes release-tagging runs so bumps queue instead of racing.
- **Rebase-and-retry push** — rebase the bump onto latest `main` and retry (up to 5×) rather than hard-failing. The bump only touches version manifests, so it rebases cleanly over unrelated merges (the actual trigger here: #4360 changed a Helm chart, not `package.json`). A real same-manifest conflict still fails loudly.

actionlint clean; YAML validated.

## Note on the incident it fixes

No damage from that failure — the daemon image build is a separate workflow and published fine (`sha-beee678`); the golden feature is off by default so prod is unaffected. This just stops the red run from recurring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `release-tagging` from racing on back-to-back merges by serializing runs and rebasing before push, so version bumps reliably land on `main`. Stops permanent non-fast-forward failures and the resulting red runs.

- **Bug Fixes**
  - Added `concurrency` group `release-tagging-main` with `cancel-in-progress: false` to queue runs instead of racing.
  - Replaced direct push with a rebase-and-retry loop: push `HEAD:main`, on rejection fetch/rebase onto `origin/main` and retry up to 5 times; fail loudly on real conflicts.

<sup>Written for commit b1c1bdb4edda53858cd27b49af95d9dc5a77cc66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

