### PR TITLE
feat(sandbox): extend the deps cache to deno (per-repo DENO_DIR)

### DIFF
--- a/packages/sandbox/daemon/setup/install.test.ts
+++ b/packages/sandbox/daemon/setup/install.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { depsCacheEnv } from "./install";
+import { denoCacheEnv, depsCacheEnv } from "./install";
 import type { Config } from "../types";
 
-function configWith(cloneUrl?: string): Config {
+function configWith(cloneUrl?: string, pm?: string): Config {
   return {
     git: cloneUrl ? { repository: { cloneUrl } } : undefined,
+    application: pm ? { packageManager: { name: pm } } : undefined,
   } as Config;
 }
 
@@ -66,5 +67,56 @@ describe("depsCacheEnv", () => {
     expect(env?.BUN_INSTALL_CACHE_DIR).toMatch(
       /^\/deps-cache\/bun\/[0-9a-f]{16}$/,
     );
+  });
+});
+
+describe("denoCacheEnv", () => {
+  it("returns null for non-deno package managers", () => {
+    expect(
+      denoCacheEnv(configWith("https://x.com/a/b", "bun"), "/deps-cache"),
+    ).toBeNull();
+    expect(
+      denoCacheEnv(configWith("https://x.com/a/b"), "/deps-cache"),
+    ).toBeNull();
+  });
+
+  it("returns null without a cache root or cloneUrl", () => {
+    expect(
+      denoCacheEnv(configWith("https://x.com/a/b", "deno"), undefined),
+    ).toBeNull();
+    expect(
+      denoCacheEnv(configWith(undefined, "deno"), "/deps-cache"),
+    ).toBeNull();
+  });
+
+  it("sets DENO_DIR under <root>/deno/<repo-hash> for deno", () => {
+    const env = denoCacheEnv(
+      configWith("https://x.com/a/b", "deno"),
+      "/deps-cache",
+    );
+    expect(env?.DENO_DIR).toMatch(/^\/deps-cache\/deno\/[0-9a-f]{16}$/);
+  });
+
+  it("shares the per-repo key with the bun cache (same repo → same hash)", () => {
+    const deno = denoCacheEnv(
+      configWith("https://x.com/a/b", "deno"),
+      "/deps-cache",
+    );
+    const bun = depsCacheEnv(configWith("https://x.com/a/b"), "/deps-cache");
+    const denoHash = deno?.DENO_DIR?.split("/").pop();
+    const bunHash = bun?.BUN_INSTALL_CACHE_DIR?.split("/").pop();
+    expect(denoHash).toBe(bunHash);
+  });
+
+  it("is stable across git-token refresh (credential-stripped)", () => {
+    const a = denoCacheEnv(
+      configWith("https://x-access-token:t1@github.com/o/n.git", "deno"),
+      "/deps-cache",
+    );
+    const b = denoCacheEnv(
+      configWith("https://x-access-token:t2@github.com/o/n.git", "deno"),
+      "/deps-cache",
+    );
+    expect(a?.DENO_DIR).toBe(b?.DENO_DIR);
   });
 });

--- a/packages/sandbox/daemon/setup/install.ts
+++ b/packages/sandbox/daemon/setup/install.ts
@@ -28,15 +28,17 @@ import { spawnSetupStep } from "./spawn-step";
  * multiple orgs at different privilege levels (public/template) it is
  * cross-tenant — a known residual gap; key by org too if it matters.
  *
- * Only bun consumes BUN_INSTALL_CACHE_DIR; npm/pnpm/yarn/deno ignore it.
+ * bun (install-time) reads BUN_INSTALL_CACHE_DIR; deno (dev-run-time) reads
+ * DENO_DIR — see `denoCacheEnv`. npm/pnpm/yarn are unaffected by both.
  */
-export function depsCacheEnv(
-  config: Config,
-  cacheRoot: string | undefined = process.env.DEPS_CACHE_ROOT,
-): Record<string, string> | null {
-  if (!cacheRoot) return null;
-  const cloneUrl = config.git?.repository?.cloneUrl;
-  if (!cloneUrl) return null;
+
+/**
+ * 16 hex chars of sha256 over the credential-stripped cloneUrl — the per-repo
+ * cache-partition key shared by every cache flavor (bun, deno, golden). Stable
+ * across git-token refresh because the token lives in the URL userinfo, which
+ * is stripped before hashing.
+ */
+export function repoCacheKey(cloneUrl: string): string {
   let key = cloneUrl;
   try {
     const u = new URL(cloneUrl);
@@ -46,8 +48,45 @@ export function depsCacheEnv(
   } catch {
     // non-URL cloneUrl (ssh shorthand) — hash it as-is
   }
-  const hash = createHash("sha256").update(key).digest("hex").slice(0, 16);
-  return { BUN_INSTALL_CACHE_DIR: join(cacheRoot, "bun", hash) };
+  return createHash("sha256").update(key).digest("hex").slice(0, 16);
+}
+
+export function depsCacheEnv(
+  config: Config,
+  cacheRoot: string | undefined = process.env.DEPS_CACHE_ROOT,
+): Record<string, string> | null {
+  if (!cacheRoot) return null;
+  const cloneUrl = config.git?.repository?.cloneUrl;
+  if (!cloneUrl) return null;
+  return {
+    BUN_INSTALL_CACHE_DIR: join(cacheRoot, "bun", repoCacheKey(cloneUrl)),
+  };
+}
+
+/**
+ * Per-repo DENO_DIR for deno projects. Deno has no install step — it fetches
+ * jsr/npm/https deps lazily into DENO_DIR at `deno task dev` time — so unlike
+ * bun's cache this must be injected into the dev-server (start) env, not the
+ * install env (see orchestrator.stepStart). Returns null for non-deno package
+ * managers so bun/npm/pnpm/yarn dev servers are untouched.
+ *
+ * Kept per-repo like the bun cache. Deno DOES re-verify cached module content
+ * against deno.lock integrity hashes on load — so a shared deno cache would be
+ * materially less dangerous than a shared bun one (poison → error, not silent
+ * RCE). But that only covers lockfile-pinned modules; a repo with no/partial
+ * deno.lock has no expected hash to check, so "less dangerous" is not "safe".
+ * Stay per-repo — it costs nothing and doesn't depend on every tenant keeping
+ * a complete lockfile.
+ */
+export function denoCacheEnv(
+  config: Config,
+  cacheRoot: string | undefined = process.env.DEPS_CACHE_ROOT,
+): Record<string, string> | null {
+  if (!cacheRoot) return null;
+  if (config.application?.packageManager?.name !== "deno") return null;
+  const cloneUrl = config.git?.repository?.cloneUrl;
+  if (!cloneUrl) return null;
+  return { DENO_DIR: join(cacheRoot, "deno", repoCacheKey(cloneUrl)) };
 }
 
 export interface InstallDeps {

--- a/packages/sandbox/daemon/setup/install.ts
+++ b/packages/sandbox/daemon/setup/install.ts
@@ -38,7 +38,7 @@ import { spawnSetupStep } from "./spawn-step";
  * across git-token refresh because the token lives in the URL userinfo, which
  * is stripped before hashing.
  */
-export function repoCacheKey(cloneUrl: string): string {
+function repoCacheKey(cloneUrl: string): string {
   let key = cloneUrl;
   try {
     const u = new URL(cloneUrl);

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -29,7 +29,7 @@ import { type CloneResult, spawnClone } from "./clone";
 import { emitInstalledDeps } from "./dep-metrics";
 import { publishGolden, pruneGoldens, tryRestoreGolden } from "./golden-cache";
 import { configureGitIdentity } from "./identity";
-import { spawnInstall } from "./install";
+import { denoCacheEnv, spawnInstall } from "./install";
 import { spawnSetupStep } from "./spawn-step";
 import { installProtectedBranchHook } from "../git/protect-branch";
 
@@ -471,7 +471,10 @@ export class SetupOrchestrator {
     await this.deps.taskManager.spawn({
       command: command.cmd,
       cwd: command.cwd,
-      env: buildDevEnv(config, config.env),
+      // denoCacheEnv points DENO_DIR at the per-repo node-local cache for deno
+      // dev servers (no-op for other PMs); layered under config.env so a
+      // user-supplied DENO_DIR still wins.
+      env: buildDevEnv(config, { ...denoCacheEnv(config), ...config.env }),
       label: command.label,
       mode: "pty",
       logName: command.source,


### PR DESCRIPTION
## What

The node-local deps cache (#4352) was **bun-only**. `depsCacheEnv` emits only `BUN_INSTALL_CACHE_DIR`, and it's applied inside `spawnInstall` — which deno never reaches (deno has no install step; it fetches jsr/npm/https deps lazily at `deno task dev` time). So deno-native sandboxes paid a full cold module fetch on every boot with no caching.

This adds `denoCacheEnv` → `DENO_DIR=<DEPS_CACHE_ROOT>/deno/<repo-hash>`, injected into the **dev-server (start) env** in `orchestrator.stepStart` (the deno cost is at run-time, not install-time). Layered under `config.env` so a user-supplied `DENO_DIR` still wins. Returns `null` for non-deno PMs, so bun/npm/pnpm/yarn dev servers are untouched.

**No chart change** — `DEPS_CACHE_ROOT` is already mounted (and gated by `depsCache.enabled`).

## Isolation

Keyed per-repo like the bun cache (extracted a shared `repoCacheKey` helper). Deno *does* re-verify cached module content against `deno.lock` integrity hashes on load (unlike bun, which doesn't re-verify) — so a shared deno cache would be materially *less* dangerous. But that only covers lockfile-pinned modules; a repo with no/partial `deno.lock` has no expected hash to check, so "less dangerous" ≠ "safe". Stays per-repo — costs nothing and doesn't depend on every tenant keeping a complete lockfile. Full rationale in the code comment.

## Not included

Golden node_modules stays bun/npm-only — deno-native projects don't materialize `node_modules` (they run from `DENO_DIR`), so DENO_DIR sharing is the whole caching story for them. A `nodeModulesDir`-opt-in deno project is a niche follow-up.

## Testing

- `install.test.ts`: 12 pass — added deno cases (non-deno → null, per-repo hash, shares the key with the bun cache, token-refresh stable).
- typecheck clean; daemon bundle builds.
- ⚠️ Not yet exercised end-to-end (a real `deno task dev` honoring DENO_DIR under the pod) — worth a stg smoke test before relying on the hit-rate, same as the bun cache rollout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-repo Deno dependency caching by setting `DENO_DIR=<DEPS_CACHE_ROOT>/deno/<repo-hash>` and injecting it into the dev-server env. This removes cold fetches on every Deno sandbox boot; bun/npm/pnpm/yarn behavior is unchanged.

- **Refactors**
  - Extracted a shared, internal `repoCacheKey` used by both the bun install cache and the new Deno cache.

<sup>Written for commit 9f5bd6c97736db4dd885507415344a84f872dafe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

