### PR TITLE
fix(sandbox): resolve cloneUrl from repo remote so the deps cache isn't silently disabled

### DIFF
--- a/packages/sandbox/daemon/setup/golden-cache.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.ts
@@ -39,6 +39,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import type { Config } from "../types";
+import { resolveCloneUrl } from "./install";
 
 /**
  * GC bounds for the golden store (a golden ≈ a full node_modules on the node
@@ -180,7 +181,7 @@ function resolveGolden(opts: GoldenOpts): {
   const cacheRoot = opts.cacheRoot ?? process.env.DEPS_CACHE_ROOT;
   const golden = goldenNodeModulesPath({
     cacheRoot,
-    cloneUrl: opts.config.git?.repository?.cloneUrl,
+    cloneUrl: resolveCloneUrl(opts.config),
     pm: opts.pm,
     lockHash: lockfileHash(opts.installRoot, opts.pm),
   });

--- a/packages/sandbox/daemon/setup/install.test.ts
+++ b/packages/sandbox/daemon/setup/install.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "bun:test";
-import { denoCacheEnv, depsCacheEnv } from "./install";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "bun:test";
+import { denoCacheEnv, depsCacheEnv, resolveCloneUrl } from "./install";
 import type { Config } from "../types";
 
 function configWith(cloneUrl?: string, pm?: string): Config {
@@ -8,6 +12,60 @@ function configWith(cloneUrl?: string, pm?: string): Config {
     application: pm ? { packageManager: { name: pm } } : undefined,
   } as Config;
 }
+
+/** A real on-disk git repo with an `origin` remote, for the fallback path. */
+function repoWithOrigin(originUrl: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "deps-cache-test-"));
+  const run = (args: string[]) => spawnSync("git", args, { cwd: dir });
+  run(["init", "-q"]);
+  run(["remote", "add", "origin", originUrl]);
+  return dir;
+}
+
+describe("resolveCloneUrl", () => {
+  const tmpDirs: string[] = [];
+  afterAll(() => {
+    for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+  });
+
+  it("prefers the cloneUrl in the config", () => {
+    expect(resolveCloneUrl(configWith("https://x.com/a/b"))).toBe(
+      "https://x.com/a/b",
+    );
+  });
+
+  it("falls back to the cloned repo's origin remote when config has none", () => {
+    // Regression: on warm-pool adopt/resurrect the runtime config arrives
+    // without git.repository, so keying off config alone leaves DENO_DIR unset
+    // and every boot re-fetches cold.
+    const dir = repoWithOrigin("https://github.com/o/n.git");
+    tmpDirs.push(dir);
+    const config = { repoDir: dir } as Config;
+    expect(resolveCloneUrl(config)).toBe("https://github.com/o/n.git");
+    // and the cache env now keys off it instead of returning null
+    expect(depsCacheEnv(config, "/deps-cache")?.BUN_INSTALL_CACHE_DIR).toMatch(
+      /^\/deps-cache\/bun\/[0-9a-f]{16}$/,
+    );
+  });
+
+  it("fallback key matches the same repo passed via config (token-stripped)", () => {
+    const dir = repoWithOrigin("https://x-access-token:tok@github.com/o/n.git");
+    tmpDirs.push(dir);
+    const viaRemote = depsCacheEnv({ repoDir: dir } as Config, "/deps-cache");
+    const viaConfig = depsCacheEnv(
+      configWith("https://github.com/o/n.git"),
+      "/deps-cache",
+    );
+    expect(viaRemote).toEqual(viaConfig);
+  });
+
+  it("returns undefined with neither config cloneUrl nor a git repo", () => {
+    expect(resolveCloneUrl({} as Config)).toBeUndefined();
+    const empty = mkdtempSync(join(tmpdir(), "deps-cache-test-"));
+    tmpDirs.push(empty);
+    expect(resolveCloneUrl({ repoDir: empty } as Config)).toBeUndefined();
+  });
+});
 
 describe("depsCacheEnv", () => {
   it("returns null without a cache root", () => {

--- a/packages/sandbox/daemon/setup/install.ts
+++ b/packages/sandbox/daemon/setup/install.ts
@@ -2,7 +2,8 @@ import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { PACKAGE_MANAGER_DAEMON_CONFIG } from "../constants";
-import { resolvePmRoot } from "../paths";
+import { gitSync } from "../git/git-sync";
+import { hasGitRepo, resolvePmRoot } from "../paths";
 import type { Config } from "../types";
 import { spawnSetupStep } from "./spawn-step";
 
@@ -51,12 +52,36 @@ function repoCacheKey(cloneUrl: string): string {
   return createHash("sha256").update(key).digest("hex").slice(0, 16);
 }
 
+/**
+ * The repo's cloneUrl for cache-key derivation. Prefer the daemon config, but
+ * fall back to the cloned repo's `origin` remote: on warm-pool adopt/resurrect
+ * paths the runtime config often arrives without `git.repository`, so keying
+ * off the config alone silently disables every cache (DENO_DIR, bun, golden)
+ * and each boot re-fetches from cold. The repo is always cloned by the time
+ * any cache is consulted (install/start), so its origin remote is a reliable
+ * fallback. repoCacheKey strips credentials, so the token in the remote URL
+ * doesn't perturb the key.
+ */
+export function resolveCloneUrl(config: Config): string | undefined {
+  const fromConfig = config.git?.repository?.cloneUrl;
+  if (fromConfig) return fromConfig;
+  const repoDir = config.repoDir;
+  if (!repoDir || !hasGitRepo(repoDir)) return undefined;
+  try {
+    return (
+      gitSync(["remote", "get-url", "origin"], { cwd: repoDir }) || undefined
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 export function depsCacheEnv(
   config: Config,
   cacheRoot: string | undefined = process.env.DEPS_CACHE_ROOT,
 ): Record<string, string> | null {
   if (!cacheRoot) return null;
-  const cloneUrl = config.git?.repository?.cloneUrl;
+  const cloneUrl = resolveCloneUrl(config);
   if (!cloneUrl) return null;
   return {
     BUN_INSTALL_CACHE_DIR: join(cacheRoot, "bun", repoCacheKey(cloneUrl)),
@@ -84,7 +109,7 @@ export function denoCacheEnv(
 ): Record<string, string> | null {
   if (!cacheRoot) return null;
   if (config.application?.packageManager?.name !== "deno") return null;
-  const cloneUrl = config.git?.repository?.cloneUrl;
+  const cloneUrl = resolveCloneUrl(config);
   if (!cloneUrl) return null;
   return { DENO_DIR: join(cacheRoot, "deno", repoCacheKey(cloneUrl)) };
 }


### PR DESCRIPTION
## What

Follow-up to #4362 / #4357. The bun (`BUN_INSTALL_CACHE_DIR`), deno (`DENO_DIR`), and golden `node_modules` caches all key off `config.git.repository.cloneUrl`. On **warm-pool adopt / rehydrate** paths that field is often absent from the daemon's runtime config, so `depsCacheEnv` / `denoCacheEnv` / the golden cache all silently return `null` → **DENO_DIR is never set**, deno falls back to pod-local `~/.cache/deno` (dies with the pod), and **every boot re-fetches all modules from cold**.

## Evidence (prod, `agent-sandbox-system`, deco-sites/farmrio)

- Warm-pool pod (`role=claimed`), image `1.10.2`, running `deno task dev`:
  - live dev process: **`DENO_DIR` unset**
  - node hostPath `/deps-cache/deno`: **does not exist** (only `bun/`)
  - but `git -C /app/repo remote get-url origin` → `https://***@github.com/deco-sites/farmrio.git`
- A cold-start pod on the same image **did** have `DENO_DIR` set and a populated 210M cache — so the bug is intermittent, correlated with the adopt/rehydrate path, not the image.
- Cache correctness itself is fine: same `DENO_DIR`, boot 1 = 1934 downloads, boot 2 = **0**. The problem is purely that the dir is never assigned.

## Root cause

The config-store merges additively and treats git identity as immutable, so it retains `git.repository` **only if the server ever sends it**. The normal ensure path sends it (with `opts.repo`); rebind/rehydrate/back-compat paths send `repo: null`, and the pod may already have the repo cloned from a prior adoption. Result: repo present on disk, but no `cloneUrl` in the runtime config → cache keyed off nothing → disabled.

## Fix

`resolveCloneUrl(config)`: prefer the config value, else read the cloned repo's `origin` remote. The repo is always cloned by the time any cache is consulted (install/start run after clone), so the remote is a reliable fallback. `repoCacheKey` already strips credentials, so token refresh doesn't move the key. Wired into all three cache flavors (one edit covers golden — both restore and publish route through `resolveGolden`).

## Why not a server-side "always send cloneUrl"

Investigated and rejected: on an empty rehydrated pod the only recoverable URL is the credential-free annotation, which would **break `git clone` for private repos**; the credentialed URL isn't recoverable without re-minting the git token. The daemon self-resolving from its own clone is the correct boundary — it always has the repo when it needs the key.

## Testing

- `install.test.ts`: 16 pass — added `resolveCloneUrl` cases (config wins; falls back to origin remote; fallback key == config key, token-stripped; undefined with no repo).
- typecheck clean; daemon bundle builds (no stray `// @bun` pragma).
- ⚠️ Not yet exercised end-to-end on a real warm-pool adopt in stg — worth confirming `DENO_DIR` is set + `/deps-cache/deno` populated on an adopted pod before relying on the hit-rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dependency caches being silently disabled on warm-pool adopt/rehydrate by resolving the repo URL from the cloned repo’s `origin` remote when `config.git.repository.cloneUrl` is missing. Ensures `DENO_DIR`, `BUN_INSTALL_CACHE_DIR`, and golden `node_modules` are set and reused across boots.

- **Bug Fixes**
  - Added `resolveCloneUrl(config)`: prefer config value, else read `git remote get-url origin` (credentials stripped for keys).
  - Wired into `depsCacheEnv`, `denoCacheEnv`, and golden cache resolution.
  - Added tests covering config precedence, remote fallback, token stripping, and no-repo cases.

<sup>Written for commit 988092cecfb78b4f77cb2e2fca8f8953344461a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

