### PR TITLE
feat(sections-editor): show global matcher blocks in variant rule picker

### DIFF
--- a/apps/mesh/ct/harness/variant-harnesses.tsx
+++ b/apps/mesh/ct/harness/variant-harnesses.tsx
@@ -9,6 +9,7 @@ import { VariantRenameDialog } from "@/web/components/sections-editor/variant-re
 import {
   MatcherPicker,
   type MatcherEntry,
+  type MatcherGlobalEntry,
 } from "@/web/components/sections-editor/matcher-picker";
 
 /**
@@ -112,11 +113,15 @@ export function VariantRenameDialogHarness({
 export function MatcherPickerHarness({
   currentRt,
   currentLabel,
+  currentGlobalKey,
   matchers,
+  globals,
 }: {
   currentRt: string;
   currentLabel: string;
+  currentGlobalKey?: string;
   matchers: MatcherEntry[];
+  globals?: MatcherGlobalEntry[];
 }) {
   const [events, setEvents] = useState<unknown[]>([]);
   const push = (e: unknown) => setEvents((prev) => [...prev, e]);
@@ -125,8 +130,11 @@ export function MatcherPickerHarness({
       <MatcherPicker
         currentRt={currentRt}
         currentLabel={currentLabel}
+        currentGlobalKey={currentGlobalKey}
         matchers={matchers}
+        globals={globals}
         onSelect={(resolveType) => push({ type: "select", resolveType })}
+        onSelectGlobal={(blockKey) => push({ type: "selectGlobal", blockKey })}
       />
       <EventLog events={events} />
     </div>

--- a/apps/mesh/ct/tests/matcher-picker.ct.tsx
+++ b/apps/mesh/ct/tests/matcher-picker.ct.tsx
@@ -104,3 +104,71 @@ test("typing in the search filters the rule list", async ({ mount, page }) => {
   await expect(page.getByRole("option", { name: /Geolocation/ })).toBeVisible();
   await expect(page.getByRole("option", { name: /Device/ })).toHaveCount(0);
 });
+
+const GLOBALS = [
+  {
+    blockKey: "TestHero",
+    title: "Test Hero",
+    description: "50% of sessions",
+    iconName: "Shuffle01",
+  },
+  {
+    blockKey: "MobileOnly",
+    title: "Mobile Only",
+    description: "Mobile",
+    iconName: "Phone01",
+  },
+];
+
+test("renders saved global rules in a separate group", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <MatcherPickerHarness
+      currentRt=""
+      currentLabel="Always"
+      matchers={MATCHERS}
+      globals={GLOBALS}
+    />,
+  );
+  await component.getByRole("button", { name: "Always" }).click();
+  await expect(page.getByRole("option", { name: /Test Hero/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /Mobile Only/ })).toBeVisible();
+});
+
+test("selecting a global emits its blockKey", async ({ mount, page }) => {
+  const component = await mount(
+    <MatcherPickerHarness
+      currentRt=""
+      currentLabel="Always"
+      matchers={MATCHERS}
+      globals={GLOBALS}
+    />,
+  );
+  await component.getByRole("button", { name: "Always" }).click();
+  await page.getByRole("option", { name: /Test Hero/ }).click();
+  await expect
+    .poll(() => readEvents(component))
+    .toEqual([{ type: "selectGlobal", blockKey: "TestHero" }]);
+});
+
+test("search matches globals by title and description", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <MatcherPickerHarness
+      currentRt=""
+      currentLabel="Always"
+      matchers={MATCHERS}
+      globals={GLOBALS}
+    />,
+  );
+  await component.getByRole("button", { name: "Always" }).click();
+  await page.getByPlaceholder("Search rules...").fill("Hero");
+  await expect(page.getByRole("option", { name: /Test Hero/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /Mobile Only/ })).toHaveCount(
+    0,
+  );
+});

--- a/apps/mesh/ct/tests/number-field.ct.tsx
+++ b/apps/mesh/ct/tests/number-field.ct.tsx
@@ -15,7 +15,10 @@ test("renders an input[type=number] and round-trips an integer value", async ({
 
   const input = component.getByLabel("Count");
   await expect(input).toBeVisible();
-  await expect(input).toHaveAttribute("type", "number");
+  // Uses a text input with a decimal inputMode so leading decimals ("0.4") can
+  // be typed left-to-right without the browser/controlled-value collapsing "0.".
+  await expect(input).toHaveAttribute("type", "text");
+  await expect(input).toHaveAttribute("inputmode", "decimal");
   await input.fill("42");
 
   await expect.poll(() => readFormValue(component)).toEqual({ count: 42 });
@@ -49,7 +52,8 @@ test("integer type behaves the same as number", async ({ mount }) => {
 
   const input = component.getByLabel("Count");
   await expect(input).toBeVisible();
-  await expect(input).toHaveAttribute("type", "number");
+  await expect(input).toHaveAttribute("type", "text");
+  await expect(input).toHaveAttribute("inputmode", "numeric");
   await input.fill("7");
 
   await expect.poll(() => readFormValue(component)).toEqual({ count: 7 });
@@ -66,6 +70,42 @@ test("accepts decimal values", async ({ mount }) => {
   await component.getByLabel("Count").fill("3.14");
 
   await expect.poll(() => readFormValue(component)).toEqual({ count: 3.14 });
+});
+
+test("allows typing a leading decimal left-to-right (0.4)", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    count: { type: "number", title: "Count" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Count");
+  await input.fill(""); // start from empty, as the real matcher-rule form does
+  // pressSequentially replays real keystrokes, unlike fill() which sets the
+  // value atomically — this is what regressed with a controlled type=number.
+  await input.pressSequentially("0.4");
+
+  await expect(input).toHaveValue("0.4");
+  await expect.poll(() => readFormValue(component)).toEqual({ count: 0.4 });
+});
+
+test("ignores non-numeric characters while typing", async ({ mount }) => {
+  const meta = sectionWithProps({
+    count: { type: "number", title: "Count" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  const input = component.getByLabel("Count");
+  await input.fill("");
+  await input.pressSequentially("1a2b");
+
+  await expect(input).toHaveValue("12");
+  await expect.poll(() => readFormValue(component)).toEqual({ count: 12 });
 });
 
 test("clearing the input drops the key (onChange undefined)", async ({

--- a/apps/mesh/src/web/components/sections-editor/fields/number-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/number-field.tsx
@@ -3,8 +3,8 @@ import { Input } from "@deco/ui/components/input.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import type { FieldProps } from "./field-props";
 
-/** Intermediate numeric strings the user can be mid-typing: "", "-", ".", "0.", "1e-". */
-const PARTIAL_NUMBER = /^-?\d*\.?\d*(?:[eE]-?\d*)?$/;
+/** Intermediate numeric strings the user can be mid-typing: "", "-", "+", ".", "0.", "1e-", "1e+5". */
+const PARTIAL_NUMBER = /^[+-]?\d*\.?\d*(?:[eE][+-]?\d*)?$/;
 
 /**
  * Number input that keeps the raw typed string in local state instead of

--- a/apps/mesh/src/web/components/sections-editor/fields/number-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/number-field.tsx
@@ -1,7 +1,19 @@
+import { useState } from "react";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import type { FieldProps } from "./field-props";
 
+/** Intermediate numeric strings the user can be mid-typing: "", "-", ".", "0.", "1e-". */
+const PARTIAL_NUMBER = /^-?\d*\.?\d*(?:[eE]-?\d*)?$/;
+
+/**
+ * Number input that keeps the raw typed string in local state instead of
+ * reflecting the parsed number back into the field. A controlled `type="number"`
+ * bound to `Number(value)` collapses transient states like "0." to "0" on every
+ * keystroke, so a leading decimal ("0.4") can never be typed left-to-right. We
+ * hold the raw text, parse it for the model, and only re-adopt the external
+ * value when it changes to a genuinely different number (e.g. switching variants).
+ */
 export function NumberField({
   schema,
   value,
@@ -9,7 +21,18 @@ export function NumberField({
   path,
   label,
 }: FieldProps) {
-  const numValue = typeof value === "number" ? value : "";
+  const externalStr = typeof value === "number" ? String(value) : "";
+  const [raw, setRaw] = useState(externalStr);
+  const [prevExternal, setPrevExternal] = useState(externalStr);
+
+  if (externalStr !== prevExternal) {
+    setPrevExternal(externalStr);
+    // Don't clobber an in-progress edit ("0.") that already parses to the
+    // incoming value; only adopt a truly different external number.
+    const sameNumber =
+      raw !== "" && externalStr !== "" && Number(raw) === Number(externalStr);
+    if (!sameNumber) setRaw(externalStr);
+  }
 
   return (
     <div className="space-y-2">
@@ -23,11 +46,15 @@ export function NumberField({
       </div>
       <Input
         id={path}
-        type="number"
-        value={numValue}
+        type="text"
+        inputMode={schema.type === "integer" ? "numeric" : "decimal"}
+        value={raw}
         onChange={(e) => {
-          const v = e.target.value;
-          onChange(v === "" ? undefined : Number(v));
+          const next = e.target.value;
+          if (next !== "" && !PARTIAL_NUMBER.test(next)) return;
+          setRaw(next);
+          const parsed = Number(next);
+          onChange(next === "" || Number.isNaN(parsed) ? undefined : parsed);
         }}
         className="h-10"
       />

--- a/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
+++ b/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
@@ -13,12 +13,52 @@ import { resolveBlockSchemaMetadata, type LiveMeta } from "./resolve-schema";
 import { MatcherIcon, resolveMatcherIconName } from "./matcher-icons";
 import { labelFromResolveType } from "./section-types";
 import { getIconComponent } from "../agent-icon";
+import {
+  buildMatcherBlockReference,
+  inlineMatcherRule,
+  listSavedMatcherBlocks,
+} from "./matcher-rules";
+import { globalSectionLabel } from "./page-list";
+import { formatMatcher } from "./format-matcher";
 
 export interface MatcherEntry {
   resolveType: string;
   title: string;
   description?: string;
   iconName: string;
+}
+
+/** A saved matcher block (global rule) shown under the picker's "Saved rules". */
+export interface MatcherGlobalEntry {
+  /** Decofile key referenced as the rule's `__resolveType`. */
+  blockKey: string;
+  title: string;
+  description?: string;
+  iconName: string;
+}
+
+/**
+ * Build the "Saved rules" list from the decofile: every global matcher block,
+ * labelled by its name and described by a human summary of its underlying rule.
+ */
+export function extractMatcherGlobals(
+  meta: LiveMeta,
+  decofile: Record<string, unknown>,
+): MatcherGlobalEntry[] {
+  return listSavedMatcherBlocks(decofile, meta).map((block) => {
+    const raw = (decofile[block.blockKey] ?? {}) as Record<string, unknown>;
+    const inlined = inlineMatcherRule(
+      buildMatcherBlockReference(block.blockKey),
+      decofile,
+      meta,
+    );
+    return {
+      blockKey: block.blockKey,
+      title: globalSectionLabel(block.blockKey, raw),
+      description: formatMatcher(inlined),
+      iconName: resolveMatcherIconName(block.matcherResolveType),
+    };
+  });
 }
 
 const ALWAYS_MATCHER_ICON = "Users03";
@@ -71,20 +111,38 @@ function resolveCurrentMatcherIcon(
 export function MatcherPicker({
   currentRt,
   currentLabel,
+  currentGlobalKey,
   matchers,
+  globals = [],
   onSelect,
+  onSelectGlobal,
 }: {
   currentRt: string;
   currentLabel: string;
+  /** Block key when the current rule references a saved global matcher block. */
+  currentGlobalKey?: string;
   matchers: MatcherEntry[];
+  globals?: MatcherGlobalEntry[];
   onSelect: (resolveType: string) => void;
+  onSelectGlobal?: (blockKey: string) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const currentIconName = resolveCurrentMatcherIcon(currentRt, matchers);
+  // A saved-block reference wins the trigger icon; otherwise fall back to the
+  // built-in matcher module's icon.
+  const currentGlobal = currentGlobalKey
+    ? globals.find((g) => g.blockKey === currentGlobalKey)
+    : undefined;
+  const currentIconName =
+    currentGlobal?.iconName ?? resolveCurrentMatcherIcon(currentRt, matchers);
   const CurrentIcon = getIconComponent(currentIconName);
 
   const handleSelect = (rt: string) => {
     onSelect(rt);
+    setOpen(false);
+  };
+
+  const handleSelectGlobal = (blockKey: string) => {
+    onSelectGlobal?.(blockKey);
     setOpen(false);
   };
 
@@ -116,7 +174,10 @@ export function MatcherPicker({
             <CommandItem
               value="always Target all users"
               onSelect={() => handleSelect("")}
-              className={cn("gap-2.5", !currentRt && "bg-accent/60")}
+              className={cn(
+                "gap-2.5",
+                !currentRt && !currentGlobalKey && "bg-accent/60",
+              )}
             >
               <MatcherIcon iconName={ALWAYS_MATCHER_ICON} size="sm" />
               <div className="flex min-w-0 flex-1 flex-col">
@@ -133,7 +194,9 @@ export function MatcherPicker({
                 onSelect={() => handleSelect(matcher.resolveType)}
                 className={cn(
                   "gap-2.5",
-                  currentRt === matcher.resolveType && "bg-accent/60",
+                  !currentGlobalKey &&
+                    currentRt === matcher.resolveType &&
+                    "bg-accent/60",
                 )}
               >
                 <MatcherIcon iconName={matcher.iconName} size="sm" />
@@ -148,6 +211,31 @@ export function MatcherPicker({
               </CommandItem>
             ))}
           </CommandGroup>
+          {globals.length > 0 && (
+            <CommandGroup heading="Saved rules">
+              {globals.map((global) => (
+                <CommandItem
+                  key={global.blockKey}
+                  value={`${global.title} ${global.blockKey} ${global.description ?? ""}`}
+                  onSelect={() => handleSelectGlobal(global.blockKey)}
+                  className={cn(
+                    "gap-2.5",
+                    currentGlobalKey === global.blockKey && "bg-accent/60",
+                  )}
+                >
+                  <MatcherIcon iconName={global.iconName} size="sm" />
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate text-sm">{global.title}</span>
+                    {global.description && (
+                      <span className="truncate text-xs text-muted-foreground">
+                        {global.description}
+                      </span>
+                    )}
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
         </CommandList>
       </CommandDialog>
     </>

--- a/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
+++ b/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
@@ -45,7 +45,7 @@ export function extractMatcherGlobals(
   meta: LiveMeta,
   decofile: Record<string, unknown>,
 ): MatcherGlobalEntry[] {
-  return listSavedMatcherBlocks(decofile, meta).map((block) => {
+  return listSavedMatcherBlocks(meta, decofile).map((block) => {
     const raw = (decofile[block.blockKey] ?? {}) as Record<string, unknown>;
     const inlined = inlineMatcherRule(
       buildMatcherBlockReference(block.blockKey),

--- a/apps/mesh/src/web/components/sections-editor/matcher-rules.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-rules.test.ts
@@ -31,7 +31,7 @@ describe("matcher-rules", () => {
   };
 
   it("lists only saved matcher blocks (globals), excluding sections and pages", () => {
-    expect(listSavedMatcherBlocks(decofile)).toEqual([
+    expect(listSavedMatcherBlocks(null, decofile)).toEqual([
       {
         blockKey: "MobilePromo",
         matcherResolveType: "website/matchers/device.ts",
@@ -41,11 +41,41 @@ describe("matcher-rules", () => {
   });
 
   it("sorts saved matcher blocks by display name", () => {
-    const result = listSavedMatcherBlocks({
+    const result = listSavedMatcherBlocks(null, {
       Zeta: { __resolveType: "website/matchers/random.ts", name: "Alpha rule" },
       Alpha: { __resolveType: "website/matchers/random.ts", name: "Zeta rule" },
     });
     expect(result.map((b) => b.blockKey)).toEqual(["Zeta", "Alpha"]);
+  });
+
+  it("falls back to blockKey for name and sort when name is absent", () => {
+    const result = listSavedMatcherBlocks(null, {
+      Bravo: { __resolveType: "website/matchers/random.ts" },
+      Alpha: { __resolveType: "website/matchers/random.ts" },
+    });
+    expect(result).toEqual([
+      {
+        blockKey: "Alpha",
+        matcherResolveType: "website/matchers/random.ts",
+        name: undefined,
+      },
+      {
+        blockKey: "Bravo",
+        matcherResolveType: "website/matchers/random.ts",
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("excludes auto-generated preview stubs", () => {
+    expect(
+      listSavedMatcherBlocks(null, {
+        "Preview MobilePromo": {
+          __resolveType: "website/matchers/device.ts",
+          mobile: true,
+        },
+      }),
+    ).toEqual([]);
   });
 
   it("detects saved matcher block references", () => {

--- a/apps/mesh/src/web/components/sections-editor/matcher-rules.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-rules.test.ts
@@ -5,6 +5,7 @@ import {
   getSavedMatcherBlockKey,
   inlineMatcherRule,
   isSavedMatcherBlockReference,
+  listSavedMatcherBlocks,
   readMatcherRuleFormState,
   resolveEffectiveMatcherRule,
   resolveVariantRuleLabel,
@@ -28,6 +29,24 @@ describe("matcher-rules", () => {
       name: "Home",
     },
   };
+
+  it("lists only saved matcher blocks (globals), excluding sections and pages", () => {
+    expect(listSavedMatcherBlocks(decofile)).toEqual([
+      {
+        blockKey: "MobilePromo",
+        matcherResolveType: "website/matchers/device.ts",
+        name: "Mobile Promo",
+      },
+    ]);
+  });
+
+  it("sorts saved matcher blocks by display name", () => {
+    const result = listSavedMatcherBlocks({
+      Zeta: { __resolveType: "website/matchers/random.ts", name: "Alpha rule" },
+      Alpha: { __resolveType: "website/matchers/random.ts", name: "Zeta rule" },
+    });
+    expect(result.map((b) => b.blockKey)).toEqual(["Zeta", "Alpha"]);
+  });
 
   it("detects saved matcher block references", () => {
     expect(

--- a/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
@@ -1,4 +1,5 @@
 import {
+  isAutoPreviewBlockKey,
   isManifestMatcherResolveType,
   isSavedBlockResolveType,
 } from "./block-type-utils";
@@ -52,13 +53,14 @@ export interface SavedMatcherBlock {
  * reference an existing global instead of an inline matcher.
  */
 export function listSavedMatcherBlocks(
+  meta: LiveMeta | null | undefined,
   decofile: Record<string, unknown>,
-  meta?: LiveMeta | null,
 ): SavedMatcherBlock[] {
   const entries: SavedMatcherBlock[] = [];
 
   for (const [key, val] of Object.entries(decofile)) {
     if (key.includes("/") || !isSavedBlockResolveType(key)) continue;
+    if (isAutoPreviewBlockKey(key)) continue;
     if (!val || typeof val !== "object" || Array.isArray(val)) continue;
 
     const obj = val as Record<string, unknown>;

--- a/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
@@ -35,6 +35,47 @@ function isMatcherBlockData(
   return isMatcherModuleResolveType(moduleRt);
 }
 
+/** A saved matcher block (a global rule) stored in the decofile. */
+export interface SavedMatcherBlock {
+  /** Decofile key used as the `__resolveType` reference (e.g. `TestHero`). */
+  blockKey: string;
+  /** The underlying matcher module (e.g. `website/matchers/random.ts`). */
+  matcherResolveType: string;
+  /** Optional display name stored on the block. */
+  name?: string;
+}
+
+/**
+ * List all saved matcher blocks (global rules) in the decofile — decofile
+ * entries keyed by a bare id (no module path) whose body is a matcher block.
+ * These are what the rule picker offers under "Saved rules" so a variant can
+ * reference an existing global instead of an inline matcher.
+ */
+export function listSavedMatcherBlocks(
+  decofile: Record<string, unknown>,
+  meta?: LiveMeta | null,
+): SavedMatcherBlock[] {
+  const entries: SavedMatcherBlock[] = [];
+
+  for (const [key, val] of Object.entries(decofile)) {
+    if (key.includes("/") || !isSavedBlockResolveType(key)) continue;
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+
+    const obj = val as Record<string, unknown>;
+    if (!isMatcherBlockData(obj, meta)) continue;
+
+    entries.push({
+      blockKey: key,
+      matcherResolveType: (obj.__resolveType as string) ?? "",
+      name: typeof obj.name === "string" ? obj.name : undefined,
+    });
+  }
+
+  return entries.sort((a, b) =>
+    (a.name ?? a.blockKey).localeCompare(b.name ?? b.blockKey),
+  );
+}
+
 export function isSavedMatcherBlockReference(
   rule: Record<string, unknown> | undefined,
   decofile: Record<string, unknown>,

--- a/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
@@ -9,6 +9,7 @@ import {
   Copy01,
   DotsGrid,
   DotsHorizontal,
+  Edit03,
   LayoutAlt01,
   Plus,
   Trash01,
@@ -83,12 +84,14 @@ function VariantRowContent({
   label,
   canDelete,
   dragging,
+  onRename,
   onDuplicate,
   onDelete,
 }: {
   label: string;
   canDelete: boolean;
   dragging?: boolean;
+  onRename?: () => void;
   onDuplicate?: () => void;
   onDelete?: () => void;
 }) {
@@ -124,6 +127,17 @@ function VariantRowContent({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            {onRename && (
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRename();
+                }}
+              >
+                <Edit03 size={14} />
+                Rename
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               onClick={(e) => {
                 e.stopPropagation();
@@ -156,6 +170,7 @@ function SortableVariantRow({
   selected,
   canDelete,
   onSelect,
+  onRename,
   onDuplicate,
   onDelete,
 }: {
@@ -163,6 +178,7 @@ function SortableVariantRow({
   selected: boolean;
   canDelete: boolean;
   onSelect: () => void;
+  onRename?: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
 }) {
@@ -199,6 +215,7 @@ function SortableVariantRow({
       <VariantRowContent
         label={entry.label}
         canDelete={canDelete}
+        onRename={onRename}
         onDuplicate={onDuplicate}
         onDelete={onDelete}
       />
@@ -211,6 +228,7 @@ export function SectionVariantList({
   variants,
   selectedIndex,
   onSelect,
+  onRename,
   onDuplicate,
   onDelete,
   onRemoveAll,
@@ -221,6 +239,7 @@ export function SectionVariantList({
   variants: SectionVariantEntry[];
   selectedIndex: number;
   onSelect: (index: number) => void;
+  onRename?: (index: number) => void;
   onDuplicate: (index: number) => void;
   onDelete: (index: number) => void;
   onRemoveAll: () => void;
@@ -368,6 +387,7 @@ export function SectionVariantList({
                 selected={entry.index === selectedIndex}
                 canDelete={canDelete}
                 onSelect={() => handleSelect(entry.index)}
+                onRename={onRename ? () => onRename(entry.index) : undefined}
                 onDuplicate={() => onDuplicate(entry.index)}
                 onDelete={() => onDelete(entry.index)}
               />

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -50,7 +50,11 @@ import { activeSeoResolveType, buildSeoSavePayload } from "./seo-save";
 import { isSeoEnabled, unwrapSeoConfig } from "./seo-lazy-render";
 import { PageSeoForm } from "./page-seo-form";
 import { SeoFormFields } from "./seo-form-fields";
-import { MatcherPicker, extractMatchers } from "./matcher-picker";
+import {
+  MatcherPicker,
+  extractMatcherGlobals,
+  extractMatchers,
+} from "./matcher-picker";
 import { PageVariantTabs, VariantTabIcon } from "./page-variant-tabs";
 import { MakeReusableModal } from "./make-reusable-modal";
 import { AddSectionModal } from "./add-section-modal";
@@ -454,6 +458,9 @@ export function SectionsEditor({
   const [renameVariantIndex, setRenameVariantIndex] = useState<number | null>(
     null,
   );
+  const [renameSectionVariantIndex, setRenameSectionVariantIndex] = useState<
+    number | null
+  >(null);
   const [isVariantRuleOpen, setIsVariantRuleOpen] = useState(true);
   const [addSectionOpen, setAddSectionOpen] = useState(false);
   const [jsonOpen, setJsonOpen] = useState(false);
@@ -1547,6 +1554,8 @@ export function SectionsEditor({
   }
 
   const availableMatchers = meta ? extractMatchers(meta) : [];
+  const availableMatcherGlobals =
+    meta && decofile ? extractMatcherGlobals(meta, decofile) : [];
   const canAddSection =
     !isGlobalBlockMode && !!(previewUrl && meta && decofile);
 
@@ -1669,6 +1678,69 @@ export function SectionsEditor({
     scheduleRuleSave(newRule);
   };
 
+  /**
+   * Point the active page variant at an existing saved matcher block (global
+   * rule). Writes the page with a reference (`{ __resolveType: blockKey }`) and
+   * cleans up the previously-referenced block if it becomes orphaned.
+   */
+  const handlePageVariantSelectGlobal = async (blockKey: string) => {
+    cancelPendingRuleSaves();
+    const {
+      activePageKey: pageKey,
+      decofile: latestDecofile,
+      variantIndex,
+    } = latestRef.current;
+    if (!pageKey) return;
+
+    const fullPageData = latestDecofile[pageKey] as Record<string, unknown>;
+    const current = fullPageData?.sections;
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return;
+    }
+    const mv = current as Record<string, unknown>;
+    if (!Array.isArray(mv.variants)) return;
+
+    const variants = [...(mv.variants as Array<Record<string, unknown>>)];
+    const target = variants[variantIndex];
+    if (!target) return;
+
+    const prevBlockKey = getSavedMatcherBlockKey(
+      target.rule as Record<string, unknown> | undefined,
+      latestDecofile,
+      meta,
+    );
+    const rule = buildMatcherBlockReference(blockKey);
+    variants[variantIndex] = { ...target, rule };
+
+    const projectedDecofile = {
+      ...latestDecofile,
+      [pageKey]: { ...fullPageData, sections: { ...mv, variants } },
+    };
+
+    const { resolveType, formValue } = readMatcherRuleFormState(
+      rule,
+      projectedDecofile,
+      meta ?? undefined,
+    );
+    setRuleResolveType(resolveType);
+    setRuleFormValue(formValue);
+
+    try {
+      await saveBlock.mutateAsync({
+        blockKey: pageKey,
+        data: projectedDecofile[pageKey] as Record<string, unknown>,
+      });
+      if (prevBlockKey && prevBlockKey !== blockKey) {
+        await cleanupOrphanMatcherBlock(prevBlockKey, projectedDecofile);
+      }
+      onSaved?.();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Could not apply saved rule",
+      );
+    }
+  };
+
   const scheduleSectionRuleSave = (newRule: Record<string, unknown>) => {
     if (sectionRuleDebounceRef.current) {
       clearTimeout(sectionRuleDebounceRef.current);
@@ -1696,6 +1768,43 @@ export function SectionsEditor({
 
       const mvObj = getMultivariateSectionObject(rawSection, parsed);
       if (!mvObj) return;
+
+      // When the variant references a saved matcher block (global rule), edits
+      // to the rule form update the shared block, not the inline section rule —
+      // mirrors the page-variant path in scheduleRuleSave.
+      const currentSectionVariants =
+        (mvObj.variants as Array<Record<string, unknown>>) ?? [];
+      const currentSectionRule = currentSectionVariants[
+        targetSectionVariantIndex
+      ]?.rule as Record<string, unknown> | undefined;
+      if (
+        isSavedMatcherBlockReference(currentSectionRule, latestDecofile, meta)
+      ) {
+        const blockKey = (currentSectionRule?.__resolveType as string) ?? "";
+        const existingBlock = latestDecofile[blockKey] as
+          | Record<string, unknown>
+          | undefined;
+        const displayName =
+          typeof existingBlock?.name === "string"
+            ? existingBlock.name
+            : blockKey;
+        const { __resolveType: matcherRt, ...matcherData } = newRule;
+        saveBlock.mutate(
+          {
+            blockKey,
+            data: buildMatcherBlockData(
+              (matcherRt as string) ?? "",
+              matcherData,
+              displayName,
+            ),
+          },
+          {
+            onSuccess: () => onSaved?.(),
+            onError: (err) => toast.error(`Save failed: ${err.message}`),
+          },
+        );
+        return;
+      }
 
       const updatedMvObj = updateMultivariateSectionVariantRule(
         mvObj,
@@ -1744,6 +1853,83 @@ export function SectionsEditor({
       ? { __resolveType: sectionRuleResolveType, ...next }
       : { ...next };
     scheduleSectionRuleSave(newRule);
+  };
+
+  /**
+   * Point the active section variant at an existing saved matcher block (global
+   * rule). Writes the page with a reference and cleans up the previously-
+   * referenced block if it becomes orphaned.
+   */
+  const handleSectionVariantSelectGlobal = async (blockKey: string) => {
+    cancelPendingRuleSaves();
+    const {
+      selectedSectionIndex: targetSectionIndex,
+      sectionVariantIndex: targetSectionVariantIndex,
+      rawSections: latestRawSections,
+      parsedSections: latestParsedSections,
+      decofile: latestDecofile,
+      activePageKey: pageKey,
+      pageVariants: latestVariants,
+      variantIndex: latestVariantIndex,
+    } = latestRef.current;
+    if (targetSectionIndex === null || !pageKey) return;
+
+    const rawSection = latestRawSections[targetSectionIndex];
+    const parsed = latestParsedSections[targetSectionIndex];
+    if (!rawSection || !parsed?.isMultivariate) return;
+
+    const mvObj = getMultivariateSectionObject(rawSection, parsed);
+    if (!mvObj) return;
+
+    const variants = (mvObj.variants as Array<Record<string, unknown>>) ?? [];
+    const prevBlockKey = getSavedMatcherBlockKey(
+      variants[targetSectionVariantIndex]?.rule as
+        | Record<string, unknown>
+        | undefined,
+      latestDecofile,
+      meta,
+    );
+    const rule = buildMatcherBlockReference(blockKey);
+    const updatedMvObj = updateMultivariateSectionVariantRule(
+      mvObj,
+      targetSectionVariantIndex,
+      rule,
+    );
+    const updatedSections = [...latestRawSections];
+    updatedSections[targetSectionIndex] = rebuildSectionWithMultivariate(
+      rawSection,
+      parsed,
+      updatedMvObj,
+    );
+
+    const fullPageData = buildPageDataWithSections(
+      latestDecofile,
+      pageKey,
+      updatedSections,
+      latestVariantIndex,
+      latestVariants,
+    );
+    const projectedDecofile = { ...latestDecofile, [pageKey]: fullPageData };
+
+    const { resolveType, formValue } = readMatcherRuleFormState(
+      rule,
+      projectedDecofile,
+      meta ?? undefined,
+    );
+    setSectionRuleResolveType(resolveType);
+    setSectionRuleFormValue(formValue);
+
+    try {
+      await saveBlock.mutateAsync({ blockKey: pageKey, data: fullPageData });
+      if (prevBlockKey && prevBlockKey !== blockKey) {
+        await cleanupOrphanMatcherBlock(prevBlockKey, projectedDecofile);
+      }
+      onSaved?.();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Could not apply saved rule",
+      );
+    }
   };
 
   if (!isGlobalBlockMode && !activePage) {
@@ -2126,6 +2312,151 @@ export function SectionsEditor({
     }
   };
 
+  /**
+   * Section-variant analogue of handleRenamePageVariant: naming a section
+   * variant promotes its inline matcher to a global block and points the rule
+   * at it; clearing the name inlines the matcher again.
+   */
+  const handleRenameSectionVariant = async (
+    variantIndex: number,
+    nextName: string,
+  ) => {
+    cancelPendingRuleSaves();
+
+    const {
+      selectedSectionIndex: sectionIndex,
+      rawSections: latestRawSections,
+      parsedSections: latestParsedSections,
+      decofile: latestDecofile,
+      activePageKey: pageKey,
+      pageVariants: latestVariants,
+      variantIndex: latestVariantIndex,
+    } = latestRef.current;
+    if (sectionIndex === null || !pageKey) return;
+
+    const rawSection = latestRawSections[sectionIndex];
+    const parsed = latestParsedSections[sectionIndex];
+    if (!rawSection || !parsed?.isMultivariate) return;
+
+    const mvObj = getMultivariateSectionObject(rawSection, parsed);
+    if (!mvObj) return;
+
+    const variants = (mvObj.variants as Array<Record<string, unknown>>) ?? [];
+    const target = variants[variantIndex];
+    if (!target?.rule || typeof target.rule !== "object") {
+      toast.error("This variant has no matcher rule to rename.");
+      return;
+    }
+    const targetRule = target.rule as Record<string, unknown>;
+
+    const trimmed = nextName.trim();
+    setRenameVariantPending(true);
+
+    const persistSectionVariants = async (
+      nextVariants: Array<Record<string, unknown>>,
+    ): Promise<Record<string, unknown>> => {
+      const updatedMvObj = { ...mvObj, variants: nextVariants };
+      const updatedSections = [...latestRawSections];
+      updatedSections[sectionIndex] = rebuildSectionWithMultivariate(
+        rawSection,
+        parsed,
+        updatedMvObj,
+      );
+      const fullPageData = buildPageDataWithSections(
+        latestDecofile,
+        pageKey,
+        updatedSections,
+        latestVariantIndex,
+        latestVariants,
+      );
+      await saveBlock.mutateAsync({ blockKey: pageKey, data: fullPageData });
+      return { ...latestDecofile, [pageKey]: fullPageData };
+    };
+
+    try {
+      if (!trimmed) {
+        if (!isSavedMatcherBlockReference(targetRule, latestDecofile, meta)) {
+          setRenameSectionVariantIndex(null);
+          return;
+        }
+        const blockKey = (targetRule.__resolveType as string) ?? "";
+        const nextVariants = [...variants];
+        nextVariants[variantIndex] = {
+          ...target,
+          rule: inlineMatcherRule(targetRule, latestDecofile, meta),
+        };
+        const projectedDecofile = await persistSectionVariants(nextVariants);
+        await cleanupOrphanMatcherBlock(blockKey, projectedDecofile);
+        setRenameSectionVariantIndex(null);
+        onSaved?.();
+        return;
+      }
+
+      const unwrapped = unwrapMatcherRule(targetRule, latestDecofile, meta);
+      if (!unwrapped) {
+        toast.error("Could not read this variant's matcher rule.");
+        return;
+      }
+
+      if (unwrapped.blockKey) {
+        await saveBlock.mutateAsync({
+          blockKey: unwrapped.blockKey,
+          data: buildMatcherBlockData(
+            unwrapped.resolveType,
+            unwrapped.data,
+            trimmed,
+          ),
+        });
+        setRenameSectionVariantIndex(null);
+        onSaved?.();
+        return;
+      }
+
+      const blockId = suggestBlockId(trimmed);
+      const validationError = validateBlockId(blockId, latestDecofile);
+      if (validationError) {
+        toast.error(validationError);
+        return;
+      }
+
+      const blockData = buildMatcherBlockData(
+        unwrapped.resolveType,
+        unwrapped.data,
+        trimmed,
+      );
+
+      let createdBlockId: string | null = null;
+      try {
+        await saveBlock.mutateAsync({ blockKey: blockId, data: blockData });
+        createdBlockId = blockId;
+        const nextVariants = [...variants];
+        nextVariants[variantIndex] = {
+          ...target,
+          rule: buildMatcherBlockReference(blockId),
+        };
+        await persistSectionVariants(nextVariants);
+        createdBlockId = null;
+      } catch (err) {
+        if (createdBlockId) {
+          await deleteBlock
+            .mutateAsync({ blockKey: createdBlockId })
+            .catch(() => {});
+        }
+        throw err;
+      }
+
+      setRenameSectionVariantIndex(null);
+      toast.success(`Saved matcher as global block "${trimmed}"`);
+      onSaved?.();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to rename variant",
+      );
+    } finally {
+      setRenameVariantPending(false);
+    }
+  };
+
   const exitSectionEditing = () => {
     clearSectionEditing();
   };
@@ -2408,6 +2739,7 @@ export function SectionsEditor({
                 }))}
                 selectedIndex={safeSectionVariantIndex}
                 onSelect={handleSelectSectionVariant}
+                onRename={setRenameSectionVariantIndex}
                 onDuplicate={handleDuplicateSectionVariant}
                 onDelete={handleDeleteSectionVariant}
                 onRemoveAll={handleRemoveAllSectionVariants}
@@ -2421,9 +2753,23 @@ export function SectionsEditor({
                   </span>
                   <MatcherPicker
                     currentRt={sectionRuleResolveType ?? ""}
-                    currentLabel={formatMatcher(activeSectionFlagVariant?.rule)}
+                    currentLabel={resolveVariantRuleLabel(
+                      activeSectionFlagVariant?.rule,
+                      decofile ?? {},
+                      formatMatcher,
+                      meta ?? undefined,
+                    )}
+                    currentGlobalKey={
+                      getSavedMatcherBlockKey(
+                        activeSectionFlagVariant?.rule,
+                        decofile ?? {},
+                        meta ?? undefined,
+                      ) ?? undefined
+                    }
                     matchers={availableMatchers}
+                    globals={availableMatcherGlobals}
                     onSelect={handleSectionMatcherTypeChange}
+                    onSelectGlobal={handleSectionVariantSelectGlobal}
                   />
                   {sectionRuleSchema && sectionRuleFormValue && (
                     <div className="pt-1">
@@ -2513,8 +2859,17 @@ export function SectionsEditor({
                       formatMatcher,
                       meta ?? undefined,
                     )}
+                    currentGlobalKey={
+                      getSavedMatcherBlockKey(
+                        activeVariant?.rule,
+                        decofile ?? {},
+                        meta ?? undefined,
+                      ) ?? undefined
+                    }
                     matchers={availableMatchers}
+                    globals={availableMatcherGlobals}
                     onSelect={handleMatcherTypeChange}
+                    onSelectGlobal={handlePageVariantSelectGlobal}
                   />
                   {ruleSchema && ruleFormValue && (
                     <div className="space-y-3">
@@ -2621,6 +2976,41 @@ export function SectionsEditor({
           }}
           onOpenChange={(open) => {
             if (!open && !renameVariantPending) setRenameVariantIndex(null);
+          }}
+        />
+      )}
+
+      {renameSectionVariantIndex !== null && (
+        <VariantRenameDialog
+          open
+          initialName={
+            isSavedMatcherBlockReference(
+              sectionFlagVariants[renameSectionVariantIndex]?.rule,
+              decofile ?? {},
+              meta ?? undefined,
+            )
+              ? resolveVariantRuleLabel(
+                  sectionFlagVariants[renameSectionVariantIndex]?.rule,
+                  decofile ?? {},
+                  formatMatcher,
+                  meta ?? undefined,
+                )
+              : ""
+          }
+          autoLabel={formatMatcher(
+            resolveEffectiveMatcherRule(
+              sectionFlagVariants[renameSectionVariantIndex]?.rule,
+              decofile ?? {},
+              meta ?? undefined,
+            ),
+          )}
+          isPending={renameVariantPending}
+          onSubmit={async (name) => {
+            await handleRenameSectionVariant(renameSectionVariantIndex, name);
+          }}
+          onOpenChange={(open) => {
+            if (!open && !renameVariantPending)
+              setRenameSectionVariantIndex(null);
           }}
         />
       )}


### PR DESCRIPTION
## Summary

The variant rule picker only listed built-in matcher module types (Always / Never / Device / Date / Cron …). It never surfaced **saved matcher blocks** (global rules) — e.g. a `TestHero` block referenced by `{ "rule": { "__resolveType": "TestHero" } }` — so an existing global couldn't be reused. This PR shows globals in the picker and lets a variant reference or be promoted to one, for **both page and section variants**.

Also fixes a decimal-input bug in the schema form's number field.

## Changes

**Show globals in the picker**
- `listSavedMatcherBlocks(decofile, meta)` in `matcher-rules.ts` — enumerates saved matcher blocks, excluding sections/pages, sorted by name.
- `matcher-picker.tsx`: new `extractMatcherGlobals()` helper + a **"Saved rules"** group. Each global shows its name, a human summary of its underlying rule, and the matching icon. Selecting one points the variant at the block. The active global is highlighted and drives the trigger icon.

**Wired into both editors** (`sections-editor.tsx`)
- Both `MatcherPicker` call sites (page + section variants) pass `globals` / `currentGlobalKey` / `onSelectGlobal`.
- `handlePageVariantSelectGlobal` / `handleSectionVariantSelectGlobal` persist the reference and clean up the previously-referenced block if it becomes orphaned.
- `scheduleSectionRuleSave` is now saved-block-aware (mirrors the page path): editing a referenced global's fields from a section variant updates the shared block.

**Rename → create global for section variants** (was page-only)
- Added a **Rename** action to the section variant list dropdown; `handleRenameSectionVariant` promotes an inline matcher to a global block (with rollback), and clearing the name inlines it back and cleans up the orphan. Reuses the existing `VariantRenameDialog`.

**fix(number-field): decimals**
- `NumberField` was a controlled `type="number"` bound to `Number(value)`, so typing `0.4` left-to-right collapsed `"0."` → `0` every keystroke and the dot never stuck (workaround: type `04`, insert `.`). Now keeps the raw typed string in local state and uses `type="text"` + `inputMode`, parsing to a number for the model. Leading decimals type normally.

## Testing
- `bun run check` (tsc) — passes
- `bun run lint` — 0 errors
- `bun test` sections-editor — 387 pass, + 2 new tests for `listSavedMatcherBlocks`
- `bun run fmt` — applied

## Manual test notes
On an A/B page: open a variant's rule picker → existing globals appear under **Saved rules**; pick one to reference it. Use **Rename** on a page or section variant to promote its matcher to `.deco/blocks/<id>.json`; clearing the name inlines it again. In a number field (e.g. random matcher `traffic`), type `0.4` normally.

## Follow-up
- Component-test (`matcher-picker.ct.tsx`) coverage for the new "Saved rules" group and section rename is not yet added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show global matcher blocks in the variant rule picker so page and section variants can reuse or promote shared rules. Also fixes number inputs so decimals and scientific notation type correctly.

- **New Features**
  - Variant rule picker shows a “Saved rules” group listing global matcher blocks (name, summary, icon); selecting one references the block and uses its icon. Search matches titles and descriptions.
  - Works for both page and section variants; switching to a different global cleans up orphans.
  - Editing a section variant that references a global updates the shared block.
  - Added “Rename” for section variants to promote an inline matcher to a global; clearing the name inlines it back and cleans up the orphan.

- **Bug Fixes**
  - `NumberField`: switched to text input with `inputMode`, keeps raw string so you can type decimals like 0.4 left-to-right, ignores non-numeric chars, and supports “+”/scientific notation (e.g. 1e+5); values are parsed to numbers for the model.
  - `matcher-rules`: `listSavedMatcherBlocks(meta, decofile)` excludes sections/pages and auto-generated preview stubs, and sorts by display name with a block-key fallback.

<sup>Written for commit ea760634a260d3b40ece7ca2cd828af286736008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

