### PR TITLE
feat(sandbox): page template selection when creating a page

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -637,14 +637,16 @@ function ContentBrowserReady({
     try {
       if (mode === "create") {
         // A template clones an existing page's content; only name/path change.
-        const template = values.templateKey
-          ? (decofile[values.templateKey] as
-              | Record<string, unknown>
-              | undefined)
-          : undefined;
-        const data = template
-          ? { ...template, name: values.name, path: values.path }
-          : buildEmptyPage(values.name, values.path);
+        let data: Record<string, unknown>;
+        if (values.templateKey) {
+          const template = decofile[values.templateKey] as
+            | Record<string, unknown>
+            | undefined;
+          if (!template) throw new Error("Selected template no longer exists.");
+          data = { ...template, name: values.name, path: values.path };
+        } else {
+          data = buildEmptyPage(values.name, values.path);
+        }
         const key = generateUniquePageBlockKey(decofile, values.name);
         await saveBlock.mutateAsync({ blockKey: key, data });
         toast.success(`Created "${values.name}"`);

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -627,12 +627,24 @@ function ContentBrowserReady({
     });
   };
 
-  const submitPageDialog = async (values: { name: string; path: string }) => {
+  const submitPageDialog = async (values: {
+    name: string;
+    path: string;
+    templateKey: string | null;
+  }) => {
     if (!pageDialog) return;
     const { mode, sourceKey } = pageDialog;
     try {
       if (mode === "create") {
-        const data = buildEmptyPage(values.name, values.path);
+        // A template clones an existing page's content; only name/path change.
+        const template = values.templateKey
+          ? (decofile[values.templateKey] as
+              | Record<string, unknown>
+              | undefined)
+          : undefined;
+        const data = template
+          ? { ...template, name: values.name, path: values.path }
+          : buildEmptyPage(values.name, values.path);
         const key = generateUniquePageBlockKey(decofile, values.name);
         await saveBlock.mutateAsync({ blockKey: key, data });
         toast.success(`Created "${values.name}"`);
@@ -1251,6 +1263,7 @@ function ContentBrowserReady({
           initialPath={pageDialog.initialPath}
           isPending={saveBlock.isPending}
           error={pageDialogError}
+          templates={pages}
           validate={validatePageValues}
           onSubmit={submitPageDialog}
           onOpenChange={(next) => {

--- a/apps/mesh/src/web/components/sandbox/content/page-form-dialog.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/page-form-dialog.tsx
@@ -10,8 +10,15 @@ import {
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { validatePagePath } from "@/web/components/sections-editor/page-path-utils";
+import {
+  BLANK_TEMPLATE,
+  PageTemplateSelect,
+  type PageTemplateOption,
+} from "@/web/components/sections-editor/page-template-select";
 
 export type PageFormMode = "create" | "duplicate" | "rename";
+
+export type { PageTemplateOption };
 
 const TITLES: Record<PageFormMode, string> = {
   create: "Create new page",
@@ -39,6 +46,12 @@ export function PageFormDialog({
   isPending = false,
   error,
   /**
+   * Existing pages offered as content templates in "create" mode. Picking
+   * one clones its content; only the name and path come from the form.
+   * Ignored for other modes.
+   */
+  templates,
+  /**
    * Returns a validation error to display (e.g. "path already in use"),
    * or null when the values pass. Called on submit; lets the host
    * de-dupe against the latest decofile snapshot.
@@ -53,12 +66,18 @@ export function PageFormDialog({
   initialPath: string;
   isPending?: boolean;
   error?: string;
+  templates?: PageTemplateOption[];
   validate?: (values: { name: string; path: string }) => string | null;
-  onSubmit: (values: { name: string; path: string }) => void | Promise<void>;
+  onSubmit: (values: {
+    name: string;
+    path: string;
+    templateKey: string | null;
+  }) => void | Promise<void>;
   onOpenChange: (open: boolean) => void;
 }) {
   const [name, setName] = useState(initialName);
   const [path, setPath] = useState(initialPath);
+  const [templateKey, setTemplateKey] = useState(BLANK_TEMPLATE);
   const [localError, setLocalError] = useState<string | null>(null);
   const [prevOpen, setPrevOpen] = useState(open);
 
@@ -67,9 +86,12 @@ export function PageFormDialog({
     if (open) {
       setName(initialName);
       setPath(initialPath);
+      setTemplateKey(BLANK_TEMPLATE);
       setLocalError(null);
     }
   }
+
+  const showTemplates = mode === "create" && !!templates?.length;
 
   const handleOpenChange = (next: boolean) => {
     if (!next && !isPending) {
@@ -94,7 +116,12 @@ export function PageFormDialog({
       return;
     }
     setLocalError(null);
-    await onSubmit({ name: trimmedName, path: trimmedPath });
+    await onSubmit({
+      name: trimmedName,
+      path: trimmedPath,
+      templateKey:
+        showTemplates && templateKey !== BLANK_TEMPLATE ? templateKey : null,
+    });
   };
 
   const displayError = localError ?? error;
@@ -108,6 +135,23 @@ export function PageFormDialog({
           </DialogHeader>
 
           <div className="space-y-4 py-4">
+            {showTemplates && (
+              <div className="space-y-1.5">
+                <label
+                  htmlFor="page-form-template"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Template
+                </label>
+                <PageTemplateSelect
+                  id="page-form-template"
+                  value={templateKey}
+                  onChange={setTemplateKey}
+                  templates={templates ?? []}
+                  disabled={isPending}
+                />
+              </div>
+            )}
             <div className="space-y-1.5">
               <label
                 htmlFor="page-form-name"

--- a/apps/mesh/src/web/components/sandbox/content/page-form-dialog.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/page-form-dialog.tsx
@@ -13,12 +13,10 @@ import { validatePagePath } from "@/web/components/sections-editor/page-path-uti
 import {
   BLANK_TEMPLATE,
   PageTemplateSelect,
-  type PageTemplateOption,
 } from "@/web/components/sections-editor/page-template-select";
+import type { PageEntry } from "@/web/components/sections-editor/page-list";
 
 export type PageFormMode = "create" | "duplicate" | "rename";
-
-export type { PageTemplateOption };
 
 const TITLES: Record<PageFormMode, string> = {
   create: "Create new page",
@@ -66,7 +64,7 @@ export function PageFormDialog({
   initialPath: string;
   isPending?: boolean;
   error?: string;
-  templates?: PageTemplateOption[];
+  templates?: PageEntry[];
   validate?: (values: { name: string; path: string }) => string | null;
   onSubmit: (values: {
     name: string;

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -687,12 +687,16 @@ export function PreviewContent() {
       setCreatePageError(`A page with path "${trimmedPath}" already exists.`);
       return;
     }
+    let template: Record<string, unknown> | undefined;
+    if (templateKey) {
+      template = decofile?.[templateKey] as Record<string, unknown> | undefined;
+      if (!template) {
+        setCreatePageError("Selected template no longer exists.");
+        return;
+      }
+    }
     setCreatePageError(undefined);
     try {
-      const template =
-        templateKey && decofile
-          ? (decofile[templateKey] as Record<string, unknown> | undefined)
-          : undefined;
       const result = await createPage.mutateAsync({
         name,
         path: trimmedPath,

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -668,9 +668,11 @@ export function PreviewContent() {
   const handleCreatePage = async ({
     name,
     path,
+    templateKey,
   }: {
     name: string;
     path: string;
+    templateKey: string | null;
   }) => {
     if (!virtualMcpId || !branch) return;
     const pathError = validatePagePath(path);
@@ -687,9 +689,14 @@ export function PreviewContent() {
     }
     setCreatePageError(undefined);
     try {
+      const template =
+        templateKey && decofile
+          ? (decofile[templateKey] as Record<string, unknown> | undefined)
+          : undefined;
       const result = await createPage.mutateAsync({
         name,
         path: trimmedPath,
+        template,
       });
       setCreatePageDialogOpen(false);
       toast.success(`Page "${name}" created`);
@@ -1321,6 +1328,7 @@ export function PreviewContent() {
         onOpenChange={setCreatePageDialogOpen}
         isPending={createPage.isPending}
         error={createPageError}
+        templates={pages}
         onSubmit={handleCreatePage}
       />
 

--- a/apps/mesh/src/web/components/sections-editor/create-page-modal.tsx
+++ b/apps/mesh/src/web/components/sections-editor/create-page-modal.tsx
@@ -10,13 +10,8 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Loading01 } from "@untitledui/icons";
 import { validatePagePath } from "./page-path-utils";
-import {
-  BLANK_TEMPLATE,
-  PageTemplateSelect,
-  type PageTemplateOption,
-} from "./page-template-select";
-
-export type { PageTemplateOption };
+import { BLANK_TEMPLATE, PageTemplateSelect } from "./page-template-select";
+import type { PageEntry } from "./page-list";
 
 export function CreatePageModal({
   open,
@@ -34,7 +29,7 @@ export function CreatePageModal({
    * Existing pages offered as content templates. Picking one clones its
    * content; only the name and path come from the form.
    */
-  templates?: PageTemplateOption[];
+  templates?: PageEntry[];
   onSubmit: (values: {
     name: string;
     path: string;

--- a/apps/mesh/src/web/components/sections-editor/create-page-modal.tsx
+++ b/apps/mesh/src/web/components/sections-editor/create-page-modal.tsx
@@ -10,22 +10,40 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Loading01 } from "@untitledui/icons";
 import { validatePagePath } from "./page-path-utils";
+import {
+  BLANK_TEMPLATE,
+  PageTemplateSelect,
+  type PageTemplateOption,
+} from "./page-template-select";
+
+export type { PageTemplateOption };
 
 export function CreatePageModal({
   open,
   onOpenChange,
   isPending = false,
   error,
+  templates,
   onSubmit,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   isPending?: boolean;
   error?: string;
-  onSubmit: (values: { name: string; path: string }) => void | Promise<void>;
+  /**
+   * Existing pages offered as content templates. Picking one clones its
+   * content; only the name and path come from the form.
+   */
+  templates?: PageTemplateOption[];
+  onSubmit: (values: {
+    name: string;
+    path: string;
+    templateKey: string | null;
+  }) => void | Promise<void>;
 }) {
   const [name, setName] = useState("My New Page");
   const [path, setPath] = useState("/example-path");
+  const [templateKey, setTemplateKey] = useState(BLANK_TEMPLATE);
   const [localError, setLocalError] = useState<string | null>(null);
   const [prevOpen, setPrevOpen] = useState(open);
 
@@ -34,9 +52,12 @@ export function CreatePageModal({
     if (open) {
       setName("My New Page");
       setPath("/example-path");
+      setTemplateKey(BLANK_TEMPLATE);
       setLocalError(null);
     }
   }
+
+  const showTemplates = !!templates?.length;
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen && !isPending) {
@@ -56,7 +77,12 @@ export function CreatePageModal({
       return;
     }
     setLocalError(null);
-    await onSubmit({ name: trimmedName, path: trimmedPath });
+    await onSubmit({
+      name: trimmedName,
+      path: trimmedPath,
+      templateKey:
+        showTemplates && templateKey !== BLANK_TEMPLATE ? templateKey : null,
+    });
   };
 
   const displayError = localError ?? error;
@@ -101,6 +127,23 @@ export function CreatePageModal({
                 disabled={isPending}
               />
             </div>
+            {showTemplates && (
+              <div className="space-y-1.5">
+                <label
+                  htmlFor="new-page-template"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Template
+                </label>
+                <PageTemplateSelect
+                  id="new-page-template"
+                  value={templateKey}
+                  onChange={setTemplateKey}
+                  templates={templates ?? []}
+                  disabled={isPending}
+                />
+              </div>
+            )}
             {displayError && (
               <p className="text-xs text-destructive">{displayError}</p>
             )}

--- a/apps/mesh/src/web/components/sections-editor/page-template-select.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-template-select.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronSelectorVertical } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@deco/ui/components/command.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+
+/** A page that can seed a new page's content. */
+export type PageTemplateOption = { key: string; name: string; path: string };
+
+/** Sentinel value for "start from a blank page". */
+export const BLANK_TEMPLATE = "__blank__";
+
+/**
+ * Searchable template picker for the create-page dialogs. Shows each page's
+ * name and path, and filters by either as you type. The "Blank page" entry is
+ * always first and is the default.
+ */
+export function PageTemplateSelect({
+  id,
+  value,
+  onChange,
+  templates,
+  disabled,
+}: {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  templates: PageTemplateOption[];
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = templates.find((t) => t.key === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-between font-normal"
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate">{selected?.name ?? "Blank page"}</span>
+            {selected?.path ? (
+              <span className="truncate text-muted-foreground">
+                {selected.path}
+              </span>
+            ) : null}
+          </span>
+          <ChevronSelectorVertical className="shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="p-0"
+        style={{ width: "var(--radix-popover-trigger-width)" }}
+      >
+        <Command>
+          <CommandInput placeholder="Search pages…" className="h-9" />
+          <CommandList
+            // The popover is portalled outside the Dialog, so Radix's
+            // react-remove-scroll blocks wheel events over it (scrollbar drag
+            // still works). Scroll the list ourselves to restore the wheel.
+            onWheel={(e) => {
+              e.currentTarget.scrollTop += e.deltaY;
+            }}
+          >
+            <CommandEmpty>No pages found.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="Blank page"
+                onSelect={() => {
+                  onChange(BLANK_TEMPLATE);
+                  setOpen(false);
+                }}
+              >
+                Blank page
+                <Check
+                  className={cn(
+                    "ml-auto",
+                    value === BLANK_TEMPLATE ? "opacity-100" : "opacity-0",
+                  )}
+                />
+              </CommandItem>
+              {templates.map((t) => (
+                <CommandItem
+                  key={t.key}
+                  value={t.key}
+                  keywords={[t.name, t.path]}
+                  onSelect={() => {
+                    onChange(t.key);
+                    setOpen(false);
+                  }}
+                >
+                  <div className="flex min-w-0 flex-col">
+                    <span className="truncate">{t.name}</span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {t.path}
+                    </span>
+                  </div>
+                  <Check
+                    className={cn(
+                      "ml-auto",
+                      value === t.key ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/page-template-select.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-template-select.tsx
@@ -17,9 +17,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@deco/ui/components/popover.tsx";
-
-/** A page that can seed a new page's content. */
-export type PageTemplateOption = { key: string; name: string; path: string };
+import type { PageEntry } from "./page-list";
 
 /** Sentinel value for "start from a blank page". */
 export const BLANK_TEMPLATE = "__blank__";
@@ -39,7 +37,7 @@ export function PageTemplateSelect({
   id?: string;
   value: string;
   onChange: (value: string) => void;
-  templates: PageTemplateOption[];
+  templates: PageEntry[];
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
@@ -78,8 +76,10 @@ export function PageTemplateSelect({
             // The popover is portalled outside the Dialog, so Radix's
             // react-remove-scroll blocks wheel events over it (scrollbar drag
             // still works). Scroll the list ourselves to restore the wheel.
+            // deltaMode 1 is line-based (Firefox); scale to approx pixels.
             onWheel={(e) => {
-              e.currentTarget.scrollTop += e.deltaY;
+              const factor = e.deltaMode === 1 ? 16 : 1;
+              e.currentTarget.scrollTop += e.deltaY * factor;
             }}
           >
             <CommandEmpty>No pages found.</CommandEmpty>
@@ -101,9 +101,11 @@ export function PageTemplateSelect({
               </CommandItem>
               {templates.map((t) => (
                 <CommandItem
+                  // Search on human text, not the `pages-<uuid>` key (whose
+                  // prefix + hex would create spurious matches). Selection
+                  // uses t.key directly, so the display value is free to differ.
                   key={t.key}
-                  value={t.key}
-                  keywords={[t.name, t.path]}
+                  value={`${t.name} ${t.path}`}
                   onSelect={() => {
                     onChange(t.key);
                     setOpen(false);

--- a/apps/mesh/src/web/components/sections-editor/use-create-page.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-create-page.ts
@@ -26,15 +26,23 @@ export function useCreatePage(params: UseCreatePageParams | null) {
     mutationFn: async ({
       name,
       path,
+      template,
     }: {
       name: string;
       path: string;
+      /**
+       * Source page block to clone. When provided, its content is copied
+       * and only name/path are overridden; otherwise an empty page is built.
+       */
+      template?: Record<string, unknown> | null;
     }): Promise<CreatePageResult> => {
       if (!params?.virtualMcpId || !params.branch) {
         throw new Error("Sandbox not ready");
       }
       const blockKey = generatePageBlockKey(name);
-      const data = createEmptyPageBlock(name, path);
+      const data = template
+        ? { ...template, name, path }
+        : createEmptyPageBlock(name, path);
       await saveBlock.mutateAsync({ blockKey, data });
       return { key: blockKey, name, path };
     },


### PR DESCRIPTION
## Summary
Adds a **Template** option to the "Create new page" dialogs. Picking a template starts the new page from an existing page's content (sections, SEO, etc.) — only the **Name** and **Path** from the form are applied on create. Defaults to **Blank page**.

## Changes
- **New `PageTemplateSelect`** (`sections-editor/page-template-select.tsx`) — a searchable combobox (Popover + cmdk Command) that shows each page's **name and path** and filters by either as you type. First option is always "Blank page".
- Wired into **both** create-page dialogs:
  - `page-form-dialog.tsx` (Content browser)
  - `create-page-modal.tsx` (Preview tab)
- `useCreatePage` / `submitPageDialog` accept an optional template block; when present the content is cloned and only `name`/`path` are overridden.
- Restored **mouse-wheel scrolling** in the dropdown — the popover is portalled outside the Dialog, so `react-remove-scroll` blocks wheel events; the list now scrolls programmatically on `onWheel`.

## Testing
- `bun run fmt` ✅
- `bun run check` (tsc) ✅
- `bun run lint` ✅ (0 errors)

## Screenshots
Template select shows name + path and is searchable; creation logic clones the chosen page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Template option to the “Create new page” dialogs so users can start from an existing page’s content. Only the Name and Path change; default is Blank page.

- **New Features**
  - Searchable Template picker in both create-page dialogs (Content Browser and Preview). Lists pages by name and path; filter by either. Default is “Blank page”.
  - Creation clones the selected page’s content (sections, SEO, etc.) and overrides only name/path.

- **Bug Fixes**
  - Restored mouse-wheel scrolling in the portalled dropdown list and show an error if the selected template no longer exists.

<sup>Written for commit 94b2de204e2acd9029014c35099c07267ed31dee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

