### PR TITLE
fix(sections-editor): render color picker for format "color"

### DIFF
--- a/apps/mesh/ct/tests/string-field.ct.tsx
+++ b/apps/mesh/ct/tests/string-field.ct.tsx
@@ -164,6 +164,22 @@ test("color-input text input round-trips the hex value", async ({ mount }) => {
     .toEqual({ color: "#ff0000" });
 });
 
+// deco sites (via @decocms/start's `Color` widget alias) emit format: "color".
+test('"color" format renders a color input plus a text input', async ({
+  mount,
+}) => {
+  const meta = sectionWithProps({
+    color: { type: "string", title: "Color", format: "color" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.locator('input[type="color"]')).toBeVisible();
+  const textInput = component.getByLabel("Color");
+  await expect(textInput).toBeVisible();
+});
+
 test("date format renders input[type=date] and converts to an ISO string", async ({
   mount,
 }) => {

--- a/apps/mesh/ct/tests/widget-dispatch.ct.tsx
+++ b/apps/mesh/ct/tests/widget-dispatch.ct.tsx
@@ -162,6 +162,19 @@ test("color-input format → native color input", async ({ mount }) => {
   await expect(component.locator('input[type="color"]')).toBeVisible();
 });
 
+// @decocms/start's schema generator maps the `Color` widget alias to
+// format: "color", so deco sites emit "color" rather than our "color-input".
+test("color format → native color input", async ({ mount }) => {
+  const meta = sectionWithProps({
+    accent: { type: "string", title: "Accent", format: "color" },
+  });
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await expect(component.locator('input[type="color"]')).toBeVisible();
+});
+
 test("date format → native date input", async ({ mount }) => {
   const meta = sectionWithProps({
     publishedAt: { type: "string", title: "Published At", format: "date" },

--- a/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
@@ -221,7 +221,9 @@ export function StringField({
     );
   }
 
-  if (format === "color-input") {
+  // "color" is the format emitted by @decocms/start's schema generator for the
+  // `Color` widget alias; "color-input" is our own alias. Accept both.
+  if (format === "color-input" || format === "color") {
     return (
       <div className="space-y-2">
         <FieldLabel

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -301,7 +301,7 @@ export function renderField(props: FieldProps) {
     case "string": {
       // Format-based widgets
       const fmt = schema.format;
-      if (fmt === "color-input") {
+      if (fmt === "color-input" || fmt === "color") {
         return <StringField key={props.path} {...effectiveProps} />;
       }
       if (fmt === "textarea" || fmt === "rich-text" || fmt === "html") {


### PR DESCRIPTION
## Summary

The section editor only rendered the native color picker for `format: "color-input"`. But `@decocms/start`'s schema generator maps the `Color` widget alias to **`format: "color"`**, so color fields on deco sites (e.g. `baggagio-tanstack`) fell through to a plain text input in the editor — the color swatch never showed.

This accepts **both** `"color"` and `"color-input"` in the string-field widget dispatch and the `renderField` format check.

## Changes

- `sections-editor/fields/string-field.tsx` — color widget dispatch matches `"color-input" || "color"`.
- `sections-editor/schema-form.tsx` — same in `renderField`'s string format check.
- Tests: added `"color"` cases in `ct/tests/widget-dispatch.ct.tsx` and `ct/tests/string-field.ct.tsx`.

## Context

This is the studio/admin half of an end-to-end fix. The other half — the schema generator emitting `type`/`format` for `Color`-typed fields whose alias import can't be resolved by ts-morph — is handled in `@decocms/start` (decocms/blocks#322). Both are needed for the color widget to render on affected sites.

## Testing

- `bun run --cwd=apps/mesh test:ct ... -g color` → **5 passed** (incl. 2 new)
- `bun run lint` → 0 errors
- `bun run fmt` ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the native color picker when a string field uses format "color" (not just "color-input"), fixing plain text inputs on deco sites using `@decocms/start`.

- **Bug Fixes**
  - Accept `"color"` and `"color-input"` in the string-field widget dispatch.
  - Update `renderField` to route both formats to the color widget.
  - Add CT coverage for `"color"` in widget-dispatch and string-field tests.

<sup>Written for commit e4f33ffebe6b6430fff8809631f9f1a64634c0cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

