### PR TITLE
fix(org-fs): temp allow-same-origin in preview sandbox CSP (demo, revert)

### DIFF
--- a/apps/mesh/src/api/routes/files.ts
+++ b/apps/mesh/src/api/routes/files.ts
@@ -53,9 +53,10 @@ function applyContentPolicy(headers: Headers, contentType: string): void {
     contentType.startsWith("text/html") ||
     contentType.startsWith("image/svg")
   ) {
+    // TEMP(demo 2026-07-08, REVERT): allow-same-origin — see org-fs.ts.
     headers.set(
       "Content-Security-Policy",
-      "sandbox allow-scripts allow-modals",
+      "sandbox allow-scripts allow-modals allow-same-origin",
     );
   }
 }

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -107,7 +107,11 @@ function byteResponse(
       : "private, max-age=0",
   };
   if (contentType.startsWith("text/html")) {
-    headers["Content-Security-Policy"] = "sandbox allow-scripts allow-modals";
+    // TEMP(demo 2026-07-08, REVERT): allow-same-origin gives previews a real
+    // origin so nested frame-ancestors checks pass — but re-enables
+    // credentialed same-origin API calls from member HTML.
+    headers["Content-Security-Policy"] =
+      "sandbox allow-scripts allow-modals allow-same-origin";
   }
   return c.body(Buffer.from(bytes), 200, headers);
 }


### PR DESCRIPTION
## What is this contribution about?
TEMPORARY (revert 2026-07-09, after the demo). The CSP `sandbox` on member-authored HTML previews (`org-fs` read route and `/files/*`) gives the document an opaque origin, which fails every `frame-ancestors` check on nested iframes — so pages embedding `www.decocms.com/site/<domain>` were blocked even though `studio.decocms.com` is in that site's allowlist. Adding `allow-same-origin` gives previews a real origin so those embeds load; the tradeoff is that while this is live, member-authored HTML runs with the studio origin and can make credentialed `/api/:org/...` calls as the viewer — which is why this must be reverted (both spots are marked `TEMP(demo 2026-07-08, REVERT)`). Verified with a minimal Chrome repro: sandboxed intermediate frame → nested iframe blocked despite allowlist; with `allow-same-origin` → loads with no console errors.

## How to Test
1. Open a studio page preview that embeds an iframe of a site enforcing `frame-ancestors` (e.g. `www.decocms.com/site/...`).
2. Before: console shows `Framing 'https://www.decocms.com/' violates ... frame-ancestors` and the iframe is blank.
3. After: the embedded site renders, no CSP errors.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily add allow-same-origin to the CSP sandbox for HTML previews so nested iframes that enforce frame-ancestors load in the studio. This unblocks demo embeds and will be reverted after the demo due to the security tradeoff.

- **Bug Fixes**
  - Add allow-same-origin to CSP for HTML in the `org-fs` read route and `/files/*` previews, giving previews a real origin so nested frame-ancestors checks pass.
  - Note: While live, member-authored HTML runs with the studio origin and can make credentialed `/api/:org/...` calls; revert scheduled for 2026-07-09.

<sup>Written for commit aad02989a4873e3065c6ef3df1faf0f3fbc8bb11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

