### PR TITLE
feat(sections-editor): hide/show toggle for array items

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/array-item-display.ts
+++ b/apps/mesh/src/web/components/sections-editor/array-item-display.ts
@@ -1,3 +1,4 @@
+import { arrayItemDisplayValue } from "./array-item-hidden";
 import { lazyWrappedInner } from "./block-ref-field-utils";
 import { extractUrl } from "./fields/extract-url";
 import type { SchemaProperty } from "./resolve-schema";
@@ -113,7 +114,9 @@ export function getArrayItemLabel(
     return String(item);
   }
   if (item && typeof item === "object" && !Array.isArray(item)) {
-    let obj = item as Record<string, unknown>;
+    // Hidden items (`{ __resolveType: ".../multivariate.ts", variants: [{ value, rule: never }] }`)
+    // should be labelled by the value they hide, not "Multivariate".
+    let obj = arrayItemDisplayValue(item) as Record<string, unknown>;
     // Lazy-wrapped section items (`{ __resolveType: ".../Lazy.tsx", section: {...} }`)
     // should be labelled by the inner section, not "Lazy".
     const inner = lazyWrappedInner(obj);

--- a/apps/mesh/src/web/components/sections-editor/array-item-hidden.ts
+++ b/apps/mesh/src/web/components/sections-editor/array-item-hidden.ts
@@ -1,0 +1,55 @@
+import {
+  NEVER_MATCHER_RESOLVE_TYPE,
+  PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
+} from "./section-types";
+
+/**
+ * Hiding an array item mirrors how a page section is hidden: wrap the item value
+ * in a generic multivariate flag whose single variant is gated by a `never`
+ * matcher, so the deco resolver resolves it to nothing on the live site.
+ *
+ * Unlike sections we use the value-generic `website/flags/multivariate.ts`
+ * (`PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE`) instead of the section-specific flag,
+ * since array items are plain values (banners, links, …), not sections.
+ */
+interface HiddenItemWrap {
+  __resolveType: string;
+  variants: Array<{ value?: unknown; rule?: { __resolveType?: string } }>;
+}
+
+function asWrap(item: unknown): HiddenItemWrap | null {
+  if (!item || typeof item !== "object" || Array.isArray(item)) return null;
+  const obj = item as Record<string, unknown>;
+  if (!Array.isArray(obj.variants)) return null;
+  return obj as unknown as HiddenItemWrap;
+}
+
+/** True when the item is wrapped in a multivariate + `never` matcher. */
+export function isArrayItemHidden(item: unknown): boolean {
+  const wrap = asWrap(item);
+  const first = wrap?.variants?.[0];
+  return first?.rule?.__resolveType === NEVER_MATCHER_RESOLVE_TYPE;
+}
+
+/** Wrap an item value so it never renders on the live site. */
+export function hideArrayItem(value: unknown): HiddenItemWrap {
+  return {
+    __resolveType: PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
+    variants: [{ value, rule: { __resolveType: NEVER_MATCHER_RESOLVE_TYPE } }],
+  };
+}
+
+/** Unwrap a hidden item back to the underlying value it was hiding. */
+export function showArrayItem(item: unknown): unknown {
+  if (!isArrayItemHidden(item)) return item;
+  return asWrap(item)?.variants?.[0]?.value;
+}
+
+/**
+ * The value to display / edit for an array item: the inner value when hidden,
+ * the item itself otherwise. Keeps labels, images and the drill-in editor
+ * working for hidden items.
+ */
+export function arrayItemDisplayValue(item: unknown): unknown {
+  return isArrayItemHidden(item) ? showArrayItem(item) : item;
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -22,6 +22,8 @@ import {
   Copy01,
   DotsGrid,
   DotsHorizontal,
+  Eye,
+  EyeOff,
   Plus,
   Trash01,
 } from "@untitledui/icons";
@@ -33,8 +35,19 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { getArrayItemImageSrc, getArrayItemLabel } from "../array-item-display";
+import {
+  arrayItemDisplayValue,
+  hideArrayItem,
+  isArrayItemHidden,
+  showArrayItem,
+} from "../array-item-hidden";
 import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import {
   buildArrayDrillDownBreadcrumb,
@@ -161,6 +174,8 @@ function SortableArrayRow({
   sortableId,
   labelText,
   imageSrc,
+  hidden,
+  onToggleHidden,
   onOpen,
   onDuplicate,
   onRemove,
@@ -168,6 +183,8 @@ function SortableArrayRow({
   sortableId: string;
   labelText: string;
   imageSrc?: string;
+  hidden?: boolean;
+  onToggleHidden?: () => void;
   onOpen: () => void;
   onDuplicate: () => void;
   onRemove: () => void;
@@ -215,7 +232,42 @@ function SortableArrayRow({
           className="h-12 max-w-[100px] shrink-0 rounded object-cover"
         />
       )}
-      <span className="min-w-0 flex-1 truncate text-sm">{labelText}</span>
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-sm",
+          hidden && "line-through opacity-50",
+        )}
+      >
+        {labelText}
+      </span>
+      {onToggleHidden && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={hidden ? "Show item" : "Hide item"}
+              className={cn(
+                "size-6 shrink-0",
+                hidden
+                  ? "opacity-100"
+                  : "opacity-0 transition-opacity group-hover:opacity-100",
+              )}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleHidden();
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              {hidden ? <EyeOff size={14} /> : <Eye size={14} />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {hidden ? "Show item" : "Hide item"}
+          </TooltipContent>
+        </Tooltip>
+      )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
@@ -269,6 +321,9 @@ export function ArrayField({
   const itemSchema = schema.items;
   const arrayFieldKey = arrayFieldKeyFromPath(path);
   const usesSectionPicker = isSectionArrayField(schema, arrayFieldKey);
+  // Only plain object arrays (banners, links, …) get the hide toggle. Section
+  // pickers have their own hide flow, and primitive arrays can't be wrapped.
+  const canHideItems = !usesSectionPicker && itemSchema?.type === "object";
   const selection = resolveArrayItemSelection(
     label,
     breadcrumbPath,
@@ -295,7 +350,7 @@ export function ArrayField({
   }
 
   const itemLabel = (item: unknown, index: number) =>
-    getArrayItemLabel(item, index, itemSchema);
+    getArrayItemLabel(arrayItemDisplayValue(item), index, itemSchema);
 
   const openItem = (index: number) => {
     if (suppressClickRef.current) return;
@@ -376,6 +431,15 @@ export function ArrayField({
     onChange(next);
   };
 
+  const toggleItemHidden = (index: number) => {
+    const item = items[index];
+    const next = [...items];
+    next[index] = isArrayItemHidden(item)
+      ? showArrayItem(item)
+      : hideArrayItem(item);
+    onChange(next);
+  };
+
   const removeItem = (index: number) => {
     onChange(items.filter((_, i) => i !== index));
     if (selectedIndex === index) {
@@ -389,7 +453,8 @@ export function ArrayField({
 
   const updateItem = (index: number, val: unknown) => {
     const next = [...items];
-    next[index] = val;
+    // Preserve the hidden wrapper when editing a hidden item's inner value.
+    next[index] = isArrayItemHidden(items[index]) ? hideArrayItem(val) : val;
     onChange(next);
 
     // When editing the currently selected item, the display label may change
@@ -455,11 +520,11 @@ export function ArrayField({
       : null;
   const activeImage =
     activeEntry != null && activeItem !== undefined
-      ? getArrayItemImageSrc(activeItem, itemSchema)
+      ? getArrayItemImageSrc(arrayItemDisplayValue(activeItem), itemSchema)
       : undefined;
 
   if (selectedIndex !== null && selectedIndex < items.length) {
-    const item = items[selectedIndex];
+    const item = arrayItemDisplayValue(items[selectedIndex]);
     const editorSchema = itemEditorSchema(
       item,
       itemSchema,
@@ -567,13 +632,22 @@ export function ArrayField({
                   const item = items[entry.index];
                   if (item === undefined) return null;
                   const labelText = itemLabel(item, entry.index);
-                  const imageSrc = getArrayItemImageSrc(item, itemSchema);
+                  const imageSrc = getArrayItemImageSrc(
+                    arrayItemDisplayValue(item),
+                    itemSchema,
+                  );
                   return (
                     <SortableArrayRow
                       key={entry.id}
                       sortableId={entry.id}
                       labelText={labelText}
                       imageSrc={imageSrc}
+                      hidden={isArrayItemHidden(item)}
+                      onToggleHidden={
+                        canHideItems
+                          ? () => toggleItemHidden(entry.index)
+                          : undefined
+                      }
                       onOpen={() => openItem(entry.index)}
                       onDuplicate={() => duplicateItem(entry.index)}
                       onRemove={() => removeItem(entry.index)}


### PR DESCRIPTION
## Summary

Adds a **hide/show eye toggle to individual array items** in the schema-form editor — the same UX page sections already have, now for object arrays (e.g. the Carousel's **Banners** list).

Hiding reuses the exact platform mechanism sections use: the item value is wrapped in a multivariate flag gated by a `never` matcher, so the deco resolver resolves it to nothing on the live site. The only difference from sections is the flag type — array items use the value-generic `website/flags/multivariate.ts` instead of the section-specific one, since array items are plain values (banners, links, …), not sections.

This avoids modeling a per-site `hide?: boolean` on every component + filtering it manually: the toggle works for any object array in any site.

## Changes

- **`array-item-hidden.ts`** (new) — `hideArrayItem` / `showArrayItem` / `isArrayItemHidden` / `arrayItemDisplayValue`, mirroring `hideSection`.
- **`fields/array-field.tsx`** — `Eye`/`EyeOff` toggle + strikethrough on array rows (appears on hover, stays visible when hidden). Gated to object arrays only (`itemSchema.type === "object"`), excluding section-pickers and primitive arrays. Label, image, drag-overlay and the drill-in editor operate on the unwrapped value; edits preserve the wrapper.
- **`array-item-display.ts`** — `getArrayItemLabel` unwraps the hidden wrapper so breadcrumb matching (and thus editing a hidden item) keeps working.

## Testing notes

- `bun run fmt`, `bun run check`, `bun run lint` all pass.
- **Open question to validate in a real site (farmrio Carousel):** whether the deco resolver strips null-resolved items from a props array.
  - If it **strips** → a hidden banner disappears cleanly (no empty slide / extra dot) and no component change is ever needed. 🎉
  - If it **doesn't** → the array keeps a `null` hole and the consuming component needs `.filter(Boolean)` (or we fall back to a `hide` boolean). This PR is the admin-side half needed to run that test.

## Screenshots

_Sections already have the eye toggle; this brings the same to array items — pending UI screenshot from the running editor._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hide/show eye toggle for individual items in object arrays (e.g., Carousel Banners) in the sections editor, matching the page sections UX. Hidden items are wrapped in `website/flags/multivariate.ts` with a `never` matcher so they resolve to nothing on the live site, avoiding `hide` props in components.

- New Features
  - Eye/EyeOff button on object-array rows; strikethrough when hidden; shows on hover and stays visible when hidden.
  - Applies only to plain object arrays; excluded section pickers and primitive arrays.
  - Labels, images, breadcrumbs, and the drill-in editor operate on the unwrapped value; edits preserve the hidden wrapper.
  - Helpers added: `hideArrayItem`, `showArrayItem`, `isArrayItemHidden`, `arrayItemDisplayValue`.

<sup>Written for commit f97db28faae0224b8018a92d4efd08a43401cbed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

