### PR TITLE
ci: run apps/mesh/migrations unit tests (were never globbed)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
             echo "::group::$f"
             bun test "$f"
             echo "::endgroup::"
-          done < <(find apps/mesh/src packages \
+          done < <(find apps/mesh/src apps/mesh/migrations packages \
             \( -name '*.test.ts' -o -name '*.test.tsx' \) \
             ! -name '*.integration.test.ts' \
             ! -name '*.e2e.test.ts')


### PR DESCRIPTION
## Why

The unit-test job in `test.yml` globbed only `apps/mesh/src` + `packages` for `*.test.ts`, so the three test files under `apps/mesh/migrations/` **never ran in CI**:

- `index.test.ts` — the guardrail that a migration file is registered in `index.ts`
- `122-split-web-research-tier.test.ts`
- `077-tier-only-model-selection.test.ts`

This is why #4179 shipped `123-drop-thread-projected-seq` unregistered (so it never ran) with the guardrail sitting red, and nobody was alerted. A dead guardrail is worse than none.

## What

Add `apps/mesh/migrations` to the `find` roots. All three tests pass locally. Integration/e2e are still excluded by the existing name filters.

## Context

Follow-up to #4370. That PR's branch was auto-deleted on squash-merge and this commit got stranded on the deleted branch by a bad push; this is the same one-line change re-landed cleanly on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI test discovery to run migration unit tests. We now include apps/mesh/migrations in the test search, so the three migration tests (including the index.test.ts guardrail) run in CI; integration and e2e tests remain excluded.

<sup>Written for commit 1efe3950621830673ad396402c272f72d69e1e87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

