### PR TITLE
revert(studio): switch to fresh branch after publish (reverts #4347)

### DIFF
--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 import { authClient } from "@/web/lib/auth-client.ts";
 import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
 import { resolveGithubAttachment } from "@/web/lib/github-repo.ts";
+import { generateBranchName } from "@/shared/branch-name";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import { useChatTask } from "../../chat/index";
 import { squashMergePullRequest } from "./github-pr-api.ts";
@@ -60,7 +61,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const { org } = useProjectContext();
   const { data: session } = authClient.useSession();
   const vm = useVirtualMCP(virtualMcpId);
-  const { currentBranch: branch } = useChatTask();
+  const { currentBranch: branch, setCurrentTaskBranch } = useChatTask();
   const chat = useChatStream();
   const [publishOpen, setPublishOpen] = useState(false);
   const [publishDialogIntent, setPublishDialogIntent] = useState<
@@ -227,6 +228,11 @@ export function HeaderActions({ virtualMcpId }: Props) {
     ]);
   };
 
+  const switchToFreshBranch = async () => {
+    const nextBranch = generateBranchName();
+    await setCurrentTaskBranch(nextBranch);
+  };
+
   const handleSquashMerge = async (pullNumber: number) => {
     if (!githubRepo?.connectionId || githubActionPending) return;
     setGithubActionPending(true);
@@ -239,10 +245,8 @@ export function HeaderActions({ virtualMcpId }: Props) {
         coAuthor,
       });
       toast.success(`Published PR #${pullNumber}`);
-      // Stay on the same chat + sandbox; refreshing PR state flips the header
-      // to the terminal "Published" pill (panel-state) instead of navigating
-      // the user onto a fresh branch.
       await refreshPrState();
+      await switchToFreshBranch();
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : "Failed to merge pull request",
@@ -336,6 +340,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
           }
           openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}
+          onPublished={switchToFreshBranch}
         />
       )}
     </>

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -89,6 +89,8 @@ export interface PublishDialogProps {
   openPullRequest?: PrSummary | null;
   /** Called after commit/push or PR open/merge so the header can refresh. */
   onPullRequestChanged?: () => void | Promise<void>;
+  /** Called after a successful publish (squash-merge to base). */
+  onPublished?: () => void | Promise<void>;
 }
 
 export function PublishDialog(props: PublishDialogProps) {
@@ -127,6 +129,7 @@ function PublishDialogBody({
   headSha = null,
   openPullRequest = null,
   onPullRequestChanged,
+  onPublished,
 }: PublishDialogProps) {
   const githubClient = useMCPClient({
     connectionId: githubConnectionId,
@@ -387,6 +390,7 @@ function PublishDialogBody({
       setPublishTitle("");
       setPublishBody("");
       await onPullRequestChanged?.();
+      await onPublished?.();
     } catch (error) {
       if (
         error instanceof PublishFlowError &&


### PR DESCRIPTION
## Summary

Reverts #4347. That PR made **Publish to production** stay on the same chat + sandbox after a squash-merge. We're rolling that back: after publishing, navigate the user onto a **freshly generated branch** again — starting a new chat + sandbox based on the just-published state of the default branch.

## Why

Team decision to restore the previous behavior: publish should kick off a clean new working branch, not leave you sitting on the merged one.

## How the fresh branch is based on latest `main`

The flow is ordered so the new branch always includes the publication:

1. `squashMergePullRequest(...)` squash-merges the PR into the default branch (main).
2. `refreshPrState()` refreshes PR state.
3. `switchToFreshBranch()` generates a new name (`generateBranchName()`) and calls `setCurrentTaskBranch`.
4. The sandbox provisions for the new (nonexistent-on-remote) branch, so the daemon forks it from a fresh fetch of the default branch (`checkout-branch.ts` "absent everywhere" path: `git fetch origin <default>` → `git checkout -B <branch> origin/<default>`) — which now contains the squash-merge.

Because `switchToFreshBranch()` runs only after `await squashMergePullRequest(...)` resolves, there's no race between provisioning and the merge landing.

## Changes

- `header-actions.tsx`: restored the `generateBranchName` import, the `setCurrentTaskBranch` destructure, the `switchToFreshBranch` helper, its call in `handleSquashMerge`, and the `onPublished` prop on `PublishDialog`.
- `publish-dialog.tsx`: restored the `onPublished` prop and its `await onPublished?.()` call in the publish flow.

Applied manually rather than via `git revert` because `main` diverged (the repo helper import moved from `getActiveGithubRepo` to `resolveGithubAttachment`), so an automatic revert would conflict.

## Testing

- `bun run --cwd=apps/mesh check` (tsc) passes.
- `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts #4347 to restore the behavior: after publishing (squash-merge), switch to a freshly generated branch and start a new chat + sandbox based on the updated default branch. Ensures the new workspace includes the merged changes instead of leaving users on the merged branch.

<sup>Written for commit 9dd69c7d19e95e430f50640ceafd4a5619f542fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

