### PR TITLE
fix(sandbox): resolve node-pty node_modules dir on Windows

### DIFF
--- a/packages/sandbox/server/daemon-spawn.test.ts
+++ b/packages/sandbox/server/daemon-spawn.test.ts
@@ -1,9 +1,34 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildSandboxDaemonSpawnCommand,
+  deriveNodeModulesDir,
   resolveDaemonStdio,
   sandboxDaemonLogPath,
 } from "./daemon-spawn";
+
+describe("deriveNodeModulesDir", () => {
+  it("derives the node_modules dir from a POSIX node-pty resolution", () => {
+    expect(
+      deriveNodeModulesDir(
+        "/Users/me/project/node_modules/node-pty/lib/index.js",
+      ),
+    ).toBe("/Users/me/project/node_modules");
+  });
+
+  it("derives the node_modules dir from a Windows node-pty resolution", () => {
+    expect(
+      deriveNodeModulesDir(
+        "C:\\Users\\me\\AppData\\Local\\Temp\\bunx-123\\node_modules\\node-pty\\lib\\index.js",
+      ),
+    ).toBe("C:\\Users\\me\\AppData\\Local\\Temp\\bunx-123\\node_modules");
+  });
+
+  it("throws when the path has no node_modules segment", () => {
+    expect(() =>
+      deriveNodeModulesDir("/Users/me/project/lib/index.js"),
+    ).toThrow("could not derive node_modules path from node-pty resolution");
+  });
+});
 
 describe("resolveDaemonStdio", () => {
   it("inherits the parent fds when no log fd is given", () => {

--- a/packages/sandbox/server/daemon-spawn.ts
+++ b/packages/sandbox/server/daemon-spawn.ts
@@ -23,7 +23,7 @@
 import { createHash } from "node:crypto";
 import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { mkdir, rename, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export interface DaemonProcess {
@@ -47,16 +47,23 @@ export function resolveSourceDaemonPath(): string {
   return resolve(fileURLToPath(new URL("../daemon/entry.ts", import.meta.url)));
 }
 
-export function resolveNodePtyNodeModulesDir(): string {
-  const ptyEntry = Bun.resolveSync("node-pty", import.meta.dir);
-  const marker = "/node_modules/";
-  const idx = ptyEntry.lastIndexOf(marker);
-  if (idx < 0) {
+/**
+ * Matches on `/` or `\` regardless of host OS: Bun.resolveSync returns
+ * native separators (backslashes on Windows), but we also want this
+ * derivation to be unit-testable with Windows-style paths from any host.
+ */
+export function deriveNodeModulesDir(entryPath: string): string {
+  const match = /^(.*[/\\]node_modules)[/\\]/.exec(entryPath);
+  if (!match) {
     throw new Error(
-      `could not derive node_modules path from node-pty resolution: ${ptyEntry}`,
+      `could not derive node_modules path from node-pty resolution: ${entryPath}`,
     );
   }
-  return ptyEntry.slice(0, idx + marker.length - 1);
+  return match[1];
+}
+
+export function resolveNodePtyNodeModulesDir(): string {
+  return deriveNodeModulesDir(Bun.resolveSync("node-pty", import.meta.dir));
 }
 
 export async function materializeDaemonBundle(
@@ -141,7 +148,7 @@ export function createDefaultDaemonSpawn(
     const ptyNodeModulesDir = resolveNodePtyNodeModulesDir();
     const existingNodePath = process.env.NODE_PATH;
     const nodePath = existingNodePath
-      ? `${ptyNodeModulesDir}:${existingNodePath}`
+      ? `${ptyNodeModulesDir}${delimiter}${existingNodePath}`
       : ptyNodeModulesDir;
     // Per-sandbox log: open `<workdir>/tmp/daemon.log` (truncate every spawn)
     // and point this sandbox daemon's stdout/stderr at it, so each sandbox's

--- a/packages/sandbox/server/daemon-spawn.ts
+++ b/packages/sandbox/server/daemon-spawn.ts
@@ -53,13 +53,13 @@ export function resolveSourceDaemonPath(): string {
  * derivation to be unit-testable with Windows-style paths from any host.
  */
 export function deriveNodeModulesDir(entryPath: string): string {
-  const match = /^(.*[/\\]node_modules)[/\\]/.exec(entryPath);
-  if (!match) {
+  const dir = /^(.*[/\\]node_modules)[/\\]/.exec(entryPath)?.[1];
+  if (!dir) {
     throw new Error(
       `could not derive node_modules path from node-pty resolution: ${entryPath}`,
     );
   }
-  return match[1];
+  return dir;
 }
 
 export function resolveNodePtyNodeModulesDir(): string {


### PR DESCRIPTION
## Summary
- `resolveNodePtyNodeModulesDir` sliced node-pty's resolved path on the hardcoded POSIX marker `/node_modules/`. On Windows, `Bun.resolveSync` returns backslash paths, so the marker never matched and bring-up always threw `could not derive node_modules path from node-pty resolution: ...` — this is the exact error a Windows user hit running the local sandbox daemon link.
- Extracted the derivation into `deriveNodeModulesDir`, matching `/` or `\` so it works on any host OS.
- Also fixed `NODE_PATH` being joined with a hardcoded `:` instead of `path.delimiter` (`;` on Windows) — a second latent bug in the same function that would have broken silently once the first was fixed.

## Test plan
- [x] `bun test packages/sandbox/server/daemon-spawn.test.ts` — added POSIX/Windows/no-match cases for `deriveNodeModulesDir`
- [x] `bun run fmt`
- [x] `tsc --noEmit` on `packages/sandbox`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows path handling so the sandbox daemon can start on Windows by correctly resolving the `node-pty` `node_modules` directory and using the platform `NODE_PATH` delimiter.

- **Bug Fixes**
  - Added `deriveNodeModulesDir` to parse the `node_modules` dir from a `node-pty` path using `/` or `\`; added POSIX/Windows/no-match tests.
  - Built `NODE_PATH` with `path.delimiter` instead of `:`.
  - Guarded the regex capture group in `deriveNodeModulesDir` to satisfy `noUncheckedIndexedAccess` and avoid undefined access.

<sup>Written for commit c8f63d5a699a57c0130228fc86ea3fade698e146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

