### PR TITLE
fix(sandbox): app-editor form clipped by drawer bar (add min-h-0)

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/app-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/app-editor.tsx
@@ -190,7 +190,7 @@ export function AppEditor({
         )}
         <SaveStatus isPending={isPending} isError={false} />
       </div>
-      <ScrollArea className="min-w-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block">
+      <ScrollArea className="min-h-0 min-w-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block">
         <div className="px-6 py-6">
           <div className="mx-auto max-w-xl">
             {hasEditableFields ? (


### PR DESCRIPTION
## Problema

Ao editar a config de um app (ex: `site/apps/local/app-tags.ts`), formulários altos têm o **último campo cortado pela barra do terminal (sandbox/dev/Stop)**. No caso reportado, o toggle `showFlag` ("Ativar a Flag Desconto na Terceira Compra") de um item de `flagDiscountThirdFor` renderiza, mas fica **atrás da barra de baixo** e inacessível mesmo rolando.

## Causa

O `ScrollArea` do `app-editor.tsx` era `flex-1` **sem `min-h-0`**. Num pai flex-column, o `min-height: auto` padrão do item flex faz o root do Radix ScrollArea crescer até a altura do conteúdo e ultrapassar a área disponível — estendendo-se **atrás da drawer bar**. Dá pra rolar, mas o fundo do viewport (o último campo) fica embaixo da barra.

Não é bug de schema nem de renderização — confirmei via component test que o toggle renderiza corretamente; era puramente clipping de layout.

## Correção

Adiciona `min-h-0` ao `ScrollArea`, alinhando com o `available-section-editor.tsx` (que já usa `min-h-0 flex-1 …` e funciona). O padding `px-6 py-6` do conteúdo já mantém o último campo longe da borda.

```diff
-<ScrollArea className="min-w-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block">
+<ScrollArea className="min-h-0 min-w-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block">
```

## Teste

- Editar um app config alto (ex: item de flag do app-tags) → rolar até o fim → o último campo (toggle) agora fica acessível acima da barra.
- `available-section-editor.tsx` já provava o padrão correto; agora o app-editor bate com ele.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix clipping in the app config editor where the last field was hidden behind the sandbox terminal drawer. Tall forms now scroll to the end and the final field is accessible.

- **Bug Fixes**
  - Cause: `ScrollArea` used `flex-1` without `min-h-0`, so the Radix root expanded beyond the available height.
  - Fix: Add `min-h-0` to the `ScrollArea` class to bound the viewport, matching `available-section-editor.tsx`.

<sup>Written for commit 7b6b8a38e232180eba3fc66915f51eade77a2562. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

