### PR TITLE
feat(content): move bulk post category update from modal to right pane

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/bulk-category-panel.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/bulk-category-panel.tsx
@@ -1,0 +1,226 @@
+import { useState } from "react";
+import { File02, Loading01, X } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@deco/ui/components/radio-group.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { type CategoryRef, type PostMeta } from "./blog-data";
+
+/**
+ * Right-pane panel for the bulk "Update category" action, shown while the
+ * posts list is in selection mode (replaces the old modal). Pick a category,
+ * then choose whether to add it (keeping existing categories) or replace all
+ * categories with it (a one-step migration). Holds its own selection/mode
+ * state so the parent only deals with the final apply.
+ */
+export function BulkCategoryPanel({
+  posts,
+  categories,
+  initialSlug,
+  isPending,
+  onApply,
+  onClose,
+}: {
+  posts: PostMeta[];
+  categories: CategoryRef[];
+  /** Pre-selected category (set when arriving from the category editor). */
+  initialSlug?: string | null;
+  isPending: boolean;
+  onApply: (mode: "add" | "replace", category: CategoryRef) => void;
+  onClose: () => void;
+}) {
+  const [slug, setSlug] = useState<string>(
+    initialSlug && categories.some((c) => c.slug === initialSlug)
+      ? initialSlug
+      : (categories[0]?.slug ?? ""),
+  );
+  const [mode, setMode] = useState<"add" | "replace">("add");
+  const selected = categories.find((c) => c.slug === slug);
+  const count = posts.length;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b px-6">
+        <span className="truncate text-sm font-medium">
+          {count} {count === 1 ? "post" : "posts"} selected
+        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              disabled={isPending}
+              onClick={onClose}
+              aria-label="Exit selection"
+            >
+              <X size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Exit selection</TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="min-w-0 flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-2xl px-8 py-8">
+          <h2 className="text-2xl font-bold text-foreground">
+            Update category
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {count === 0
+              ? "Select posts from the list to choose what this update applies to."
+              : `Choose a category to apply to ${count} ${
+                  count === 1 ? "post" : "posts"
+                }.`}
+          </p>
+
+          <div className="mt-6 space-y-4">
+            <div className="space-y-2">
+              <Label>Category</Label>
+              {categories.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No categories yet — create one in the Categories collection.
+                </p>
+              ) : (
+                <Select value={slug} onValueChange={setSlug}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select a category" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {categories.map((c) => (
+                      <SelectItem key={c.slug} value={c.slug}>
+                        <span className="truncate">{c.name}</span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+
+            <RadioGroup
+              value={mode}
+              onValueChange={(v) => setMode(v as "add" | "replace")}
+              className="gap-2"
+            >
+              <Label
+                htmlFor="cat-mode-add"
+                className="flex cursor-pointer items-start gap-2.5 rounded-lg border p-3"
+              >
+                <RadioGroupItem
+                  value="add"
+                  id="cat-mode-add"
+                  className="mt-0.5"
+                />
+                <span className="space-y-0.5">
+                  <span className="block text-sm font-medium">
+                    Add category
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    Keep existing categories and add this one.
+                  </span>
+                </span>
+              </Label>
+              <Label
+                htmlFor="cat-mode-replace"
+                className="flex cursor-pointer items-start gap-2.5 rounded-lg border p-3"
+              >
+                <RadioGroupItem
+                  value="replace"
+                  id="cat-mode-replace"
+                  className="mt-0.5"
+                />
+                <span className="space-y-0.5">
+                  <span className="block text-sm font-medium">
+                    Replace category
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    Remove all current categories and set only this one.
+                  </span>
+                </span>
+              </Label>
+            </RadioGroup>
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                disabled={!selected || isPending || count === 0}
+                onClick={() =>
+                  selected &&
+                  onApply(mode, { name: selected.name, slug: selected.slug })
+                }
+              >
+                {isPending ? (
+                  <>
+                    <Loading01 size={14} className="animate-spin" />
+                    Updating…
+                  </>
+                ) : (
+                  "Apply"
+                )}
+              </Button>
+            </div>
+          </div>
+
+          {/* Selected posts, so the action's scope is visible at a glance */}
+          <div className="mt-8 overflow-hidden rounded-lg border bg-muted/30">
+            <div className="flex items-center gap-2 px-4 py-3">
+              <File02 size={16} className="shrink-0 text-muted-foreground" />
+              <span className="text-sm">
+                {count} selected {count === 1 ? "post" : "posts"}
+              </span>
+            </div>
+            {count === 0 ? (
+              <p className="border-t bg-background px-4 py-3 text-sm text-muted-foreground">
+                No posts selected yet — pick them from the list on the left.
+              </p>
+            ) : (
+              <ul className="divide-y border-t bg-background">
+                {posts.map((p) => (
+                  <li
+                    key={p.key}
+                    className="flex items-center gap-2.5 px-4 py-2.5"
+                  >
+                    <File02
+                      size={14}
+                      className="shrink-0 text-muted-foreground"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm">{p.title}</span>
+                      {p.slug && (
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {p.slug}
+                        </span>
+                      )}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
@@ -69,6 +69,10 @@ export function CategoryEditor({
   block: Record<string, unknown> | undefined;
   decofile: Record<string, unknown>;
   meta: LiveMeta;
+  /**
+   * Jump to the posts list with the bulk "Update category" panel open for
+   * this category.
+   */
   onManagePosts: (slug: string) => void;
   onOpenPost: (key: string) => void;
   previewBaseUrl?: string | null;
@@ -277,16 +281,12 @@ export function CategoryEditor({
                   disabled={!committedSlug}
                   title={
                     !committedSlug
-                      ? "Set a slug to manage this category's posts"
-                      : postCount === 0
-                        ? "Go to the posts list to add posts to this category"
-                        : "Jump to the posts list filtered by this category"
+                      ? "Set a slug to add posts to this category"
+                      : "Pick posts to add to this category"
                   }
-                  onClick={() =>
-                    onManagePosts(postCount === 0 ? "" : committedSlug)
-                  }
+                  onClick={() => onManagePosts(committedSlug)}
                 >
-                  {postCount === 0 ? "Add posts" : "Manage posts"}
+                  Add posts
                   <ArrowRight size={14} />
                 </Button>
               </div>

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -42,14 +42,6 @@ import {
 import { Button } from "@deco/ui/components/button.tsx";
 import { Checkbox } from "@deco/ui/components/checkbox.tsx";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -59,18 +51,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
-import {
-  RadioGroup,
-  RadioGroupItem,
-} from "@deco/ui/components/radio-group.tsx";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@deco/ui/components/select.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import {
   Tooltip,
@@ -174,6 +154,12 @@ const RecordEditor = lazy(() =>
 
 const CategoryEditor = lazy(() =>
   import("./blog/category-editor").then((m) => ({ default: m.CategoryEditor })),
+);
+
+const BulkCategoryPanel = lazy(() =>
+  import("./blog/bulk-category-panel").then((m) => ({
+    default: m.BulkCategoryPanel,
+  })),
 );
 
 const SectionsEditor = lazy(() =>
@@ -408,9 +394,17 @@ function ContentBrowserReady({
   const [selectedPostKeys, setSelectedPostKeys] = useState<Set<string>>(
     () => new Set(),
   );
+  // Category slug that pre-opens the bulk "Update category" panel (set when
+  // arriving from a category's "Add posts" / "Manage posts" action). While
+  // non-null the panel stays open even with zero posts selected.
+  const [bulkCategorySeed, setBulkCategorySeed] = useState<string | null>(null);
   // Multi-select is implicit: selecting the first post (via the hover-revealed
-  // checkbox) enters "selection mode" — clearing the selection leaves it.
-  const clearSelection = () => setSelectedPostKeys(new Set());
+  // checkbox) enters "selection mode". Closing the panel (or applying) leaves
+  // it and drops the seed.
+  const clearSelection = () => {
+    setSelectedPostKeys(new Set());
+    setBulkCategorySeed(null);
+  };
   // Reset search + post filters/selection when switching collections
   // (derived-state sync pattern).
   const [prevCollection, setPrevCollection] = useState(activeCollection);
@@ -421,6 +415,7 @@ function ContentBrowserReady({
     setPostAuthorFilter(null);
     setPostSort("date-desc");
     setSelectedPostKeys(new Set());
+    setBulkCategorySeed(null);
   }
 
   const {
@@ -490,10 +485,6 @@ function ContentBrowserReady({
   const [renameSectionKey, setRenameSectionKey] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget>(null);
   const [jsonPageKey, setJsonPageKey] = useState<string | null>(null);
-  // "Update category" bulk dialog — holds the count of posts it will act on.
-  const [categoryDialog, setCategoryDialog] = useState<{
-    count: number;
-  } | null>(null);
 
   if (decofileLoading || metaLoading) {
     return (
@@ -523,8 +514,8 @@ function ContentBrowserReady({
     ? allBlogEntries[activeCollection]
     : [];
 
-  // Category choices for the bulk "Update category" dialog (parent scope, since
-  // the dialog renders here rather than inside ItemList).
+  // Category choices for the bulk "Update category" panel (parent scope, since
+  // the panel renders in the right pane rather than inside ItemList).
   const bulkCategoryChoices: CategoryRef[] = (
     showBlog ? listBlogPayloads(decofile, "categories") : []
   )
@@ -535,6 +526,17 @@ function ContentBrowserReady({
     })
     .filter((c) => c.slug)
     .sort((a, b) => a.name.localeCompare(b.name));
+
+  // The bulk "Update category" panel shows while posts are selected, or while
+  // a category seed forces it open (arriving from the category editor).
+  const bulkPanelOpen =
+    activeCollection === "posts" &&
+    (selectedPostKeys.size > 0 || bulkCategorySeed !== null);
+  // Posts the panel will act on (selection order is irrelevant — list order
+  // mirrors the decofile scan, same as the list pane).
+  const selectedPostsMeta = bulkPanelOpen
+    ? listPostsWithMeta(decofile).filter((p) => selectedPostKeys.has(p.key))
+    : [];
 
   const loadersCount = countAvailableRunnables(meta, "loaders");
   const actionsCount = countAvailableRunnables(meta, "actions");
@@ -820,21 +822,22 @@ function ContentBrowserReady({
     });
   };
 
-  // Land on the posts list, optionally pre-filtered by a category (from the
-  // category editor). An empty slug lands on the unfiltered list (all
-  // categories) — used by the "Add posts" action for empty categories. Sync
-  // `prevCollection` here so the collection-change reset above doesn't
-  // immediately clear the filter we're setting.
+  // Land on the unfiltered posts list with the bulk "Update category" panel
+  // already open and the clicked category pre-selected (from the category
+  // editor's "Add posts" / "Manage posts" actions). Sync `prevCollection` here
+  // so the collection-change reset above doesn't immediately clear what we're
+  // setting.
   const handleManagePosts = (slug: string) => {
     setActiveCollection("posts");
     setPrevCollection("posts");
     setSelection(null);
     setOpenPageSeoKey(null);
     setSearchQuery("");
-    setPostCategoryFilter(slug || null);
+    setPostCategoryFilter(null);
     setPostAuthorFilter(null);
     setPostSort("date-desc");
     setSelectedPostKeys(new Set());
+    setBulkCategorySeed(slug || null);
   };
 
   // Apply a pure category mutation to every selected post and persist
@@ -865,8 +868,8 @@ function ContentBrowserReady({
     return changed;
   };
 
-  // Driven by the "Update category" dialog: applies the chosen mode, reports
-  // the outcome, then closes the dialog and clears the selection.
+  // Driven by the "Update category" panel: applies the chosen mode, reports
+  // the outcome, then clears the selection (which closes the panel).
   const runBulkCategoryUpdate = async (
     mode: "add" | "replace",
     category: CategoryRef,
@@ -881,7 +884,6 @@ function ContentBrowserReady({
           (unchanged > 0 ? ` (${unchanged} already set)` : ""),
       );
       clearSelection();
-      setCategoryDialog(null);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Bulk update failed");
     }
@@ -1011,12 +1013,11 @@ function ContentBrowserReady({
             }}
             onPostSortChange={setPostSort}
             selectedPostKeys={selectedPostKeys}
+            postBulkPanelOpen={bulkPanelOpen}
             onTogglePostSelect={togglePostSelection}
             onSelectAllPosts={(keys) => setSelectedPostKeys(new Set(keys))}
             onClearPostSelection={() => setSelectedPostKeys(new Set())}
-            onBulkUpdateCategory={() =>
-              setCategoryDialog({ count: selectedPostKeys.size })
-            }
+            onExitPostSelection={clearSelection}
             onBulkDeletePosts={() =>
               setDeleteTarget({
                 kind: "blog-bulk",
@@ -1142,6 +1143,22 @@ function ContentBrowserReady({
                 isCreating={saveBlock.isPending}
                 onCreateAvailable={handleCreateAvailableSection}
                 onSaveReferencedBlock={saveReferencedBlock}
+              />
+            ) : bulkPanelOpen ? (
+              // Posts selection mode: the bulk "Update category" panel takes
+              // over the right pane (rows toggle selection, not the editor).
+              // Keyed by seed so arriving from a category remounts the panel
+              // with that category pre-selected.
+              <BulkCategoryPanel
+                key={bulkCategorySeed ?? "selection"}
+                posts={selectedPostsMeta}
+                categories={bulkCategoryChoices}
+                initialSlug={bulkCategorySeed}
+                isPending={saveBlogBlock.isPending}
+                onApply={(mode, category) =>
+                  void runBulkCategoryUpdate(mode, category)
+                }
+                onClose={clearSelection}
               />
             ) : selection && selection.collection !== "available-section" ? (
               selection.collection === "apps" ? (
@@ -1303,21 +1320,6 @@ function ContentBrowserReady({
           }}
           pageKey={jsonPageKey}
           decofile={decofile}
-        />
-      )}
-
-      {/* Bulk "Update category" dialog */}
-      {categoryDialog && (
-        <BulkCategoryDialog
-          count={categoryDialog.count}
-          categories={bulkCategoryChoices}
-          isPending={saveBlogBlock.isPending}
-          onApply={(mode, category) =>
-            void runBulkCategoryUpdate(mode, category)
-          }
-          onOpenChange={(open) => {
-            if (!open && !saveBlogBlock.isPending) setCategoryDialog(null);
-          }}
         />
       )}
 
@@ -1654,10 +1656,11 @@ function ItemList({
   onPostAuthorFilterChange,
   onPostSortChange,
   selectedPostKeys,
+  postBulkPanelOpen,
   onTogglePostSelect,
   onSelectAllPosts,
   onClearPostSelection,
-  onBulkUpdateCategory,
+  onExitPostSelection,
   onBulkDeletePosts,
   selection,
   onSelect,
@@ -1691,10 +1694,14 @@ function ItemList({
   onPostAuthorFilterChange: (email: string | null) => void;
   onPostSortChange: (sort: PostSort) => void;
   selectedPostKeys: Set<string>;
+  /** The right-pane bulk panel is open (forces selection mode in the list). */
+  postBulkPanelOpen: boolean;
   onTogglePostSelect: (key: string) => void;
   onSelectAllPosts: (keys: string[]) => void;
+  /** Deselect all posts, staying in selection mode if the panel is open. */
   onClearPostSelection: () => void;
-  onBulkUpdateCategory: () => void;
+  /** Leave selection mode entirely (also closes the bulk panel). */
+  onExitPostSelection: () => void;
   onBulkDeletePosts: () => void;
   selection: Selection;
   onSelect: (next: Selection) => void;
@@ -1819,8 +1826,9 @@ function ItemList({
     visiblePostKeys.length > 0 &&
     visiblePostKeys.every((k) => selectedPostKeys.has(k));
   // Selecting the first post enters "selection mode": the toolbar replaces the
-  // filter bar and every row's checkbox becomes visible.
-  const selectionActive = selectionCount > 0;
+  // filter bar and every row's checkbox becomes visible. The open bulk panel
+  // forces it too, so posts can be picked right after landing from a category.
+  const selectionActive = selectionCount > 0 || postBulkPanelOpen;
   const toggleSelectAll = () => {
     if (allVisibleSelected) {
       onClearPostSelection();
@@ -1877,9 +1885,8 @@ function ItemList({
             count={selectionCount}
             allSelected={allVisibleSelected}
             onToggleSelectAll={toggleSelectAll}
-            onUpdateCategory={onBulkUpdateCategory}
             onDelete={onBulkDeletePosts}
-            onExit={onClearPostSelection}
+            onExit={onExitPostSelection}
           />
         ) : (
           <PostFilterBar
@@ -2417,14 +2424,12 @@ function PostSelectionToolbar({
   count,
   allSelected,
   onToggleSelectAll,
-  onUpdateCategory,
   onDelete,
   onExit,
 }: {
   count: number;
   allSelected: boolean;
   onToggleSelectAll: () => void;
-  onUpdateCategory: () => void;
   onDelete: () => void;
   onExit: () => void;
 }) {
@@ -2437,27 +2442,10 @@ function PostSelectionToolbar({
           <TooltipTrigger asChild>
             <Button
               type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1 px-2 text-xs"
-              onClick={onUpdateCategory}
-              aria-label="Set the category for the selected posts"
-            >
-              <Tag01 size={14} />
-              Set category
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            Set the category for the selected posts
-          </TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
               variant="ghost"
               size="icon"
               className="h-7 w-7 text-destructive hover:text-destructive"
+              disabled={count === 0}
               onClick={onDelete}
               aria-label="Delete selected posts"
             >
@@ -2483,137 +2471,6 @@ function PostSelectionToolbar({
         </Tooltip>
       </div>
     </div>
-  );
-}
-
-/**
- * Dialog for the bulk "Update category" action: pick a category, then choose
- * whether to add it (keeping existing categories) or replace all categories
- * with it (a one-step migration). Holds its own selection/mode state so the
- * parent only deals with the final apply.
- */
-function BulkCategoryDialog({
-  count,
-  categories,
-  isPending,
-  onApply,
-  onOpenChange,
-}: {
-  count: number;
-  categories: CategoryRef[];
-  isPending: boolean;
-  onApply: (mode: "add" | "replace", category: CategoryRef) => void;
-  onOpenChange: (open: boolean) => void;
-}) {
-  const [slug, setSlug] = useState<string>(categories[0]?.slug ?? "");
-  const [mode, setMode] = useState<"add" | "replace">("add");
-  const selected = categories.find((c) => c.slug === slug);
-
-  return (
-    <Dialog open onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Update category</DialogTitle>
-          <DialogDescription>
-            Choose a category to apply to {count}{" "}
-            {count === 1 ? "post" : "posts"}.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-4 py-2">
-          <div className="space-y-2">
-            <Label>Category</Label>
-            {categories.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No categories yet — create one in the Categories collection.
-              </p>
-            ) : (
-              <Select value={slug} onValueChange={setSlug}>
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Select a category" />
-                </SelectTrigger>
-                <SelectContent>
-                  {categories.map((c) => (
-                    <SelectItem key={c.slug} value={c.slug}>
-                      <span className="truncate">{c.name}</span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          </div>
-
-          <RadioGroup
-            value={mode}
-            onValueChange={(v) => setMode(v as "add" | "replace")}
-            className="gap-2"
-          >
-            <Label
-              htmlFor="cat-mode-add"
-              className="flex cursor-pointer items-start gap-2.5 rounded-lg border p-3"
-            >
-              <RadioGroupItem
-                value="add"
-                id="cat-mode-add"
-                className="mt-0.5"
-              />
-              <span className="space-y-0.5">
-                <span className="block text-sm font-medium">Add category</span>
-                <span className="block text-xs text-muted-foreground">
-                  Keep existing categories and add this one.
-                </span>
-              </span>
-            </Label>
-            <Label
-              htmlFor="cat-mode-replace"
-              className="flex cursor-pointer items-start gap-2.5 rounded-lg border p-3"
-            >
-              <RadioGroupItem
-                value="replace"
-                id="cat-mode-replace"
-                className="mt-0.5"
-              />
-              <span className="space-y-0.5">
-                <span className="block text-sm font-medium">
-                  Replace category
-                </span>
-                <span className="block text-xs text-muted-foreground">
-                  Remove all current categories and set only this one.
-                </span>
-              </span>
-            </Label>
-          </RadioGroup>
-        </div>
-
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={isPending}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            disabled={!selected || isPending}
-            onClick={() =>
-              selected &&
-              onApply(mode, { name: selected.name, slug: selected.slug })
-            }
-          >
-            {isPending ? (
-              <>
-                <Loading01 size={14} className="animate-spin" />
-                Updating…
-              </>
-            ) : (
-              "Apply"
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }
 


### PR DESCRIPTION
## Summary

Revamps the bulk "Set category" flow for blog posts. The old flow opened a small modal from a toolbar button; now the **"Update category" panel opens in the right pane** (where the post editor normally renders) as soon as posts are selected.

- **New `BulkCategoryPanel`** (right pane, replaces the `BulkCategoryDialog` modal): category picker, add/replace modes, apply/cancel, plus a list of the selected posts (with count) so the action's scope is visible before applying.
- **Selection mode**: the panel opens automatically on the first selected post; the redundant "Set category" toolbar button was removed (toolbar keeps select-all, count, delete, exit). Deselect-all keeps the panel open; the X / Cancel close it.
- **Category editor integration**: the "Add posts" action (label now always "Add posts", previously "Manage posts" when the category had posts) jumps to the **unfiltered** posts list with the panel pre-opened and that category pre-selected, ready to pick posts.
- With zero posts selected (arriving from a category), the list enters selection mode with visible checkboxes, and Apply/Delete stay disabled until something is picked.

## Testing

- `tsc --noEmit` on apps/mesh: clean
- `bun run lint`: 0 errors (7 pre-existing warnings in unrelated files)
- `bun test` on the content components folder: 141 pass
- `bun run fmt` applied

Affected area: Content tab → Blog posts list + category editor (apps/mesh web UI only, no server/API changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved bulk post category updates from a modal to a right-pane panel that opens when you select posts. The category editor’s “Add posts” now jumps to the unfiltered posts list with the panel open and the category pre-selected.

- **New Features**
  - Added right-pane `BulkCategoryPanel` with category picker, add/replace modes, Apply/Cancel, and a visible list of selected posts.
  - Selection opens the panel automatically; removed the toolbar “Set category” button (toolbar keeps select-all, count, delete, exit).
  - From a category, “Add posts” lands on posts with the panel pre-opened and that category pre-selected; panel can stay open with zero selected until closed.
  - Removed the old modal (`BulkCategoryDialog`) and wired the bulk apply flow to clear selection and show toasts. No server/API changes.

<sup>Written for commit d22e3d217bed5dff4e553899270ab7fcb484438b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

