### PR TITLE
fix(sandbox): rotate clone credential on resume/adopt

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -50,6 +50,7 @@ import {
   applyPreviewPattern,
   buildConfigPayload,
   computeHandle as composeBranchHandle,
+  gitCredentialRefreshPatch,
   withSandboxLock,
 } from "../shared";
 import type { RunnerStateStore, RunnerStateStoreOps } from "../state-store";
@@ -945,7 +946,12 @@ export class AgentSandboxProvider implements SandboxProvider {
       const persisted = await ops.get(id, RUNNER_KIND);
       if (persisted) {
         const rec = await this.rehydrate(id, handle, persisted);
-        if (rec)
+        if (rec) {
+          // Resume reuses the running pod, whose daemon still holds the clone
+          // credential baked in at provision — a ~1h GitHub App token that has
+          // likely expired. Forward the freshly-minted one so authenticated git
+          // keeps working. No-op when unchanged / public clone.
+          await this.refreshDaemonGitCredential(rec, opts);
           return this.finish(
             rec,
             ops,
@@ -953,6 +959,7 @@ export class AgentSandboxProvider implements SandboxProvider {
             /* patchTtl */ true,
             "resume",
           );
+        }
         await ops.delete(id, RUNNER_KIND);
       }
     }
@@ -986,7 +993,10 @@ export class AgentSandboxProvider implements SandboxProvider {
           );
           return null;
         });
-        if (adopted)
+        if (adopted) {
+          // Same as resume: the adopted pod's daemon holds a clone credential
+          // from an earlier provision that may have lapsed. Rotate it.
+          await this.refreshDaemonGitCredential(adopted, opts);
           return this.finish(
             adopted,
             ops,
@@ -994,6 +1004,7 @@ export class AgentSandboxProvider implements SandboxProvider {
             /* patchTtl */ true,
             "adopt",
           );
+        }
         await deleteSandboxClaim(this.kubeConfig, this.namespace, handle).catch(
           () => {},
         );
@@ -1325,6 +1336,31 @@ export class AgentSandboxProvider implements SandboxProvider {
       port: opts?.workload?.devPort ?? DEFAULT_DEV_PORT,
       tenant: opts?.tenant ?? undefined,
     });
+  }
+
+  /**
+   * Forward a freshly-minted clone credential to a resumed/adopted sandbox's
+   * daemon so authenticated git survives the ~1h expiry of the token baked in
+   * at provision. Best-effort: a rotation failure must not fail the resume (the
+   * sandbox is otherwise healthy; worst case git stays stale until next start).
+   * The daemon classifies same-repo + new-token as `git-credential-refresh` and
+   * rotates `origin` in place; identical token / public clone is a no-op.
+   */
+  private async refreshDaemonGitCredential(
+    rec: K8sRecord,
+    opts: EnsureOptions,
+  ): Promise<void> {
+    const patch = gitCredentialRefreshPatch(opts);
+    if (!patch) return;
+    try {
+      await postConfig(rec.daemonUrl, rec.token, patch);
+    } catch (err) {
+      console.warn(
+        `[${LOG_LABEL}] git credential refresh failed for ${rec.handle}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
   }
 
   /**

--- a/packages/sandbox/server/provider/shared/git-credential-refresh.test.ts
+++ b/packages/sandbox/server/provider/shared/git-credential-refresh.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  cloneUrlHasCredentials,
+  gitCredentialRefreshPatch,
+} from "./git-credential-refresh";
+import type { EnsureOptions } from "../types";
+
+const repo = (cloneUrl: string): EnsureOptions => ({
+  repo: { cloneUrl, userName: "u", userEmail: "e" },
+});
+
+describe("cloneUrlHasCredentials", () => {
+  test("true when userinfo is present", () => {
+    expect(
+      cloneUrlHasCredentials(
+        "https://x-access-token:ghs_abc@github.com/o/r.git",
+      ),
+    ).toBe(true);
+  });
+
+  test("false for anonymous clone URL", () => {
+    expect(cloneUrlHasCredentials("https://github.com/o/r.git")).toBe(false);
+  });
+
+  test("false for a non-URL string", () => {
+    expect(cloneUrlHasCredentials("git@github.com:o/r.git")).toBe(false);
+  });
+});
+
+describe("gitCredentialRefreshPatch", () => {
+  test("forwards only the credentialed cloneUrl", () => {
+    expect(
+      gitCredentialRefreshPatch(
+        repo("https://x-access-token:ghs_NEW@github.com/o/r.git"),
+      ),
+    ).toEqual({
+      git: {
+        repository: {
+          cloneUrl: "https://x-access-token:ghs_NEW@github.com/o/r.git",
+        },
+      },
+    });
+  });
+
+  test("null for a public (anonymous) clone — nothing to rotate", () => {
+    expect(gitCredentialRefreshPatch(repo("https://github.com/o/r.git"))).toBe(
+      null,
+    );
+  });
+
+  test("null when no repo is set (tool-only / smoke sandbox)", () => {
+    expect(gitCredentialRefreshPatch({})).toBe(null);
+  });
+});

--- a/packages/sandbox/server/provider/shared/git-credential-refresh.ts
+++ b/packages/sandbox/server/provider/shared/git-credential-refresh.ts
@@ -1,0 +1,35 @@
+import type { ConfigPatch } from "../../daemon-client";
+import type { EnsureOptions } from "../types";
+
+/** True when the clone URL embeds a credential (userinfo), e.g.
+ * `https://x-access-token:TOKEN@github.com/owner/repo.git`. */
+export function cloneUrlHasCredentials(cloneUrl: string): boolean {
+  try {
+    return new URL(cloneUrl).username.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The daemon `/config` patch that rotates the embedded git credential on a
+ * resumed/adopted sandbox, or null when there's nothing to rotate.
+ *
+ * The clone token (`x-access-token:ghs_…`) is a ~1h GitHub App installation
+ * token baked into `cloneUrl` at provision time. On a fresh provision it's
+ * minted moments before use, but resume/adopt reuse the pod that already holds
+ * the *original* (now-expired) token — so authenticated git (clone/fetch/push)
+ * fails once it lapses. Every `SANDBOX_START` re-mints a fresh `opts.repo`
+ * credential, so on resume/adopt we forward JUST the credentialed cloneUrl: the
+ * daemon deep-merges it and classifies same-repo-path + new-token as a
+ * `git-credential-refresh`, rotating `origin` without re-cloning or touching
+ * branch/workload state. Same token → daemon no-ops. Public clone (no
+ * credential) → null, nothing to rotate.
+ */
+export function gitCredentialRefreshPatch(
+  opts: EnsureOptions,
+): ConfigPatch | null {
+  const cloneUrl = opts.repo?.cloneUrl;
+  if (!cloneUrl || !cloneUrlHasCredentials(cloneUrl)) return null;
+  return { git: { repository: { cloneUrl } } };
+}

--- a/packages/sandbox/server/provider/shared/index.ts
+++ b/packages/sandbox/server/provider/shared/index.ts
@@ -3,3 +3,4 @@ export { withSandboxLock } from "./lock";
 export { computeHandle } from "./handle";
 export { applyPreviewPattern } from "./preview-url";
 export { buildConfigPayload } from "./build-config-payload";
+export { gitCredentialRefreshPatch } from "./git-credential-refresh";

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -60,9 +60,11 @@ export interface EnsureOptions {
      * Clone URL. May embed an OAuth credential via userinfo (e.g.
      * `https://x-access-token:TOKEN@github.com/...`) — `git clone` stores
      * the credential on the remote so subsequent fetch/pull/push from
-     * inside the sandbox work without further plumbing. The token is
-     * frozen for the lifetime of the sandbox: to refresh, destroy and
-     * recreate.
+     * inside the sandbox work without further plumbing. The embedded token
+     * is short-lived (~1h GitHub App token); callers should pass a freshly
+     * minted URL on every ensure. Runners that reuse a running pod
+     * (resume/adopt) forward the new credential to the daemon so it rotates
+     * `origin` in place rather than leaving a stale token.
      */
     cloneUrl: string;
     userName: string;


### PR DESCRIPTION
## Symptom

Sandbox clone loops on `Invalid username or token. Password authentication is not supported`, with a `ghs_…` token in the URL. The preview sits on "Server is starting…".

## Root cause (confirmed against prod)

The clone URL bakes a **~1h GitHub App installation token**, minted at provision time. In `agent-sandbox` `ensureLocked`, only the **fresh-provision** path posts config to the daemon. The **resume** and **adopt** branches reuse the already-running pod and `finish()` **without forwarding the freshly-minted credential**. So once the original token expires (~1h), every resume replays a pod whose daemon still holds the dead token — `git clone/fetch` fail, even though the stored downstream token is perfectly fresh.

DB confirmation for the reported sandbox:
- `sandbox_runner_state.state.ensureOpts.repo.cloneUrl` was frozen with the expired token (the exact `ghs_nWaw…` in the failing clone).
- `downstream_tokens` for the child connection was **current** (refreshed after the sandbox started, valid, with a working refresh token). So mint/refresh is healthy — the sandbox just never re-reads it.

This is **not** a token-validation gap (`ls-remote` already is the validation) and **not** a mint failure. It's a frozen credential on the pod.

## Fix

On **resume** and **adopt**, forward just the credentialed `cloneUrl` from `opts.repo` (which `SANDBOX_START` re-mints on every ensure) to the daemon. The daemon already classifies *same repo path + new token* as `git-credential-refresh` and rotates `origin` in place — no re-clone, no branch/workload churn. Best-effort: a rotation failure never fails the resume. Public clone / unchanged token → no-op.

The fix leans entirely on the daemon path that already exists (`config-store/classify.ts` → `syncOriginRemote`), so the end-to-end behavior is covered by existing daemon tests; this PR adds a unit test for the new server-side patch builder.

## Not covered (follow-up)

A sandbox that sits **idle >1h and then does a git op from inside** (push) still has a stale `origin` until the next ensure. Fully closing that needs refresh-on-demand credentials (a `GIT_ASKPASS` callback to mesh) or a periodic credential-refresh push — tracked separately. The reported failure is the boot/clone/resume path, which this covers.

## Testing

- New unit test: `git-credential-refresh.test.ts` (patch builder + credential detection).
- Existing daemon coverage the fix relies on: `classify.test.ts` (credential-only change → `git-credential-refresh`), `store.test.ts` (transition fires), `sync-origin-remote.test.ts` (origin rotation).
- `tsc --noEmit` (sandbox + mesh), `oxlint` (0 errors), `bun run fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox git failures after ~1h by rotating the clone credential on resume and adopt. We now forward the fresh credentialed `cloneUrl` to the daemon so authenticated clone/fetch/push keep working without re-cloning.

- **Bug Fixes**
  - On resume/adopt, post only the credentialed `opts.repo.cloneUrl` to the daemon as a config patch (`git-credential-refresh`), which rotates `origin` in place.
  - No-op for public clones or unchanged tokens; failures are logged and do not block resume/adopt.
  - Added `git-credential-refresh` helper and unit tests; clarified `EnsureOptions.repo.cloneUrl` docs.

<sup>Written for commit fe0cb9bf54ae600b52c83d19192103326316647a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

