### PR TITLE
feat(dbos): expose per-queue backlog depth for external autoscaling

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -796,6 +796,12 @@ import {
   setBackgroundToolRuntime,
 } from "@/harnesses/decopilot/background-tool-workflow";
 import { abortBackgroundJobs } from "@/harnesses/decopilot/background-abort-registry";
+const DBOS_QUEUE_NAMES = new Set([
+  AUTOMATIONS_QUEUE,
+  THREAD_GATE_QUEUE,
+  HOSTED_HARNESS_QUEUE,
+  BACKGROUND_TOOLS_QUEUE,
+]);
 const getHandleOAuthProtectedResourceMetadata = () =>
   oAuthProtectedResourceMetadata(auth);
 const getHandleOAuthDiscoveryMetadata = () => oAuthDiscoveryMetadata(auth);
@@ -1210,6 +1216,22 @@ export async function createApp(options: CreateAppOptions = {}) {
       console.error("Failed to collect metrics:", error);
       return c.text("# Error collecting metrics", 500);
     }
+  });
+
+  // Backlog size (ENQUEUED count) for one DBOS queue, e.g. for a KEDA
+  // metrics-api trigger: `{ "queue_length": <n> }`. Restricted to the
+  // queues we actually register — DBOS.listQueuedWorkflows would happily
+  // query a made-up name and just return an empty list.
+  app.get(`${SYSTEM_PATHS.DBOS_QUEUE_DEPTH_PREFIX}:queueName`, async (c) => {
+    const queueName = c.req.param("queueName");
+    if (!DBOS_QUEUE_NAMES.has(queueName)) {
+      return c.json({ error: `Unknown queue: ${queueName}` }, 404);
+    }
+    const queued = await DBOS.listQueuedWorkflows({
+      queueName,
+      status: "ENQUEUED",
+    });
+    return c.json({ queue_length: queued.length });
   });
 
   // ============================================================================

--- a/apps/mesh/src/api/utils/paths.test.ts
+++ b/apps/mesh/src/api/utils/paths.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { shouldSkipStudioContext, SYSTEM_PATHS } from "./paths";
+
+describe("DBOS queue-depth path", () => {
+  test("skips StudioContext for the queue-depth endpoint", () => {
+    expect(
+      shouldSkipStudioContext(
+        `${SYSTEM_PATHS.DBOS_QUEUE_DEPTH_PREFIX}automations`,
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match unrelated paths", () => {
+    expect(shouldSkipStudioContext("/api/dbos-queue-depth/automations")).toBe(
+      false,
+    );
+    expect(shouldSkipStudioContext("/dbos-queue-depth")).toBe(false);
+  });
+});

--- a/apps/mesh/src/api/utils/paths.ts
+++ b/apps/mesh/src/api/utils/paths.ts
@@ -14,6 +14,10 @@ export const SYSTEM_PATHS = {
   HEALTH_LIVE: "/health/live",
   HEALTH_READY: "/health/ready",
   METRICS: "/metrics",
+  // Cluster-internal only: no Service/Gateway routes to it (worker pods have
+  // neither), so it only answers on the pod's own port — for a KEDA
+  // metrics-api trigger or similar in-cluster poller.
+  DBOS_QUEUE_DEPTH_PREFIX: "/dbos-queue-depth/",
 } as const;
 
 /** Path prefixes for different route types (internal use only) */
@@ -45,7 +49,8 @@ function isSystemPath(path: string): boolean {
     path === SYSTEM_PATHS.HEALTH_LIVE ||
     path === SYSTEM_PATHS.HEALTH_READY ||
     path === SYSTEM_PATHS.METRICS ||
-    path.startsWith(PATH_PREFIXES.WELL_KNOWN)
+    path.startsWith(PATH_PREFIXES.WELL_KNOWN) ||
+    path.startsWith(SYSTEM_PATHS.DBOS_QUEUE_DEPTH_PREFIX)
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds `GET /dbos-queue-depth/:queueName`, returning `{ "queue_length": <ENQUEUED count> }` via `DBOS.listQueuedWorkflows`, for our 4 registered queues (`automations`, `thread-gate`, `decopilot-hosted-harness`, `background-tools`).
- Cluster-internal by construction: worker pods have no `Service` selector or nginx sidecar (see `worker-deployment.yaml` comments), so this route only answers on the pod's own port — same reachability as the existing Prometheus scrape, not through the Gateway/nginx-fronted API deployment.
- Restricted to the 4 known queue names (404 on anything else) rather than passing through arbitrary input to `DBOS.listQueuedWorkflows`.

## Why
Worker autoscaling today is CPU-only (`worker.autoscaling`, target 65%), which is a weak proxy for backlog on I/O-bound, per-partition-concurrency queues (`thread-gate`/`decopilot-hosted-harness` are concurrency-1-per-thread). DBOS's own docs recommend a KEDA `metrics-api` trigger against a queue-depth endpoint for this — but there's no such endpoint built into `@dbos-inc/dbos-sdk`'s admin server (checked the installed `4.21.6` source: it only exposes queue *config*, not depth, plus several unauthenticated destructive endpoints we don't want to turn on). This ships the minimal, safe piece: a read-only depth counter using the SDK's public `DBOS.listQueuedWorkflows` API.

## Out of scope (follow-up, needs a separate call)
- Neither `eks-serverless` (prod) nor `eks-decocms` (stg) currently has KEDA installed — confirmed via `kubectl get crd`. A `ScaledObject` pointed at this endpoint would be a no-op until the KEDA operator is installed cluster-wide, which is an infra decision, not bundled here.
- No k8s Service/ScaledObject changes in this PR — just the app-level endpoint.

## Test plan
- [x] `bun run --cwd=apps/mesh check` (tsc)
- [x] `bunx oxlint` on changed files
- [x] `bun test apps/mesh/src/api/utils/paths.test.ts`
- [ ] Manual: curl the endpoint against a running worker pod for each of the 4 queue names

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cluster‑internal endpoint to report per-queue backlog for autoscaling. Exposes GET /dbos-queue-depth/:queueName that returns the ENQUEUED count via `DBOS.listQueuedWorkflows` for `automations`, `thread-gate`, `decopilot-hosted-harness`, and `background-tools`.

- **New Features**
  - Adds GET `/dbos-queue-depth/:queueName` → `{ "queue_length": number }` using `DBOS.listQueuedWorkflows`.
  - Route is internal-only (served by worker pods; not exposed via Gateway) and whitelists the 4 queues (404 otherwise).
  - Marks the path as a system route and updates tests to ensure StudioContext is skipped.

<sup>Written for commit 5fe76cc5fe6f28f47be399737812e286ba146468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

