### PR TITLE
feat(branch-name): generate branch names from creator slug + timestamp

### DIFF
--- a/apps/mesh/src/shared/branch-name.test.ts
+++ b/apps/mesh/src/shared/branch-name.test.ts
@@ -3,23 +3,30 @@ import { describe, expect, test } from "bun:test";
 import { generateBranchName } from "./branch-name";
 
 describe("generateBranchName", () => {
-  test("returns a hyphenated two-word Bayer-style name", () => {
-    const name = generateBranchName();
-    const parts = name.split("-");
-    expect(parts.length).toBe(2);
-    expect(parts[0]!.length).toBeGreaterThan(0);
-    expect(parts[1]!.length).toBeGreaterThan(0);
+  test("returns <user-slug>-<base36-timestamp>", () => {
+    const name = generateBranchName("Tavano");
+    expect(name).toMatch(/^tavano-[0-9a-z]+$/);
+  });
+
+  test("slugifies the label: lowercases, strips accents, collapses separators", () => {
+    const name = generateBranchName("João Silva");
+    expect(name).toMatch(/^joao-silva-[0-9a-z]+$/);
+  });
+
+  test("falls back to 'user' when the label has no usable characters", () => {
+    expect(generateBranchName("")).toMatch(/^user-[0-9a-z]+$/);
+    expect(generateBranchName(null)).toMatch(/^user-[0-9a-z]+$/);
+    expect(generateBranchName("!!!")).toMatch(/^user-[0-9a-z]+$/);
   });
 
   test("does not include a namespace prefix", () => {
-    const name = generateBranchName();
-    expect(name.includes("/")).toBe(false);
+    expect(generateBranchName("Tavano").includes("/")).toBe(false);
   });
 
-  test("is valid for git ref syntax", () => {
+  test("is valid git ref syntax and never starts with a hyphen", () => {
     const pattern = /^[A-Za-z0-9._/-]+$/;
-    for (let i = 0; i < 10; i++) {
-      const name = generateBranchName();
+    for (const label of ["Tavano", "José", "a.b_c", "  spaced  "]) {
+      const name = generateBranchName(label);
       expect(pattern.test(name)).toBe(true);
       expect(name.startsWith("-")).toBe(false);
     }

--- a/apps/mesh/src/shared/branch-name.ts
+++ b/apps/mesh/src/shared/branch-name.ts
@@ -1,125 +1,46 @@
 /**
  * Branch-name generator used as a fallback when SANDBOX_START is invoked without
- * an explicit branch. The word lists were lifted out of daemon.ts so the
- * orchestrator — not the sandbox — decides the branch name and can persist
+ * an explicit branch. Lives in shared/ because it runs on both sides: the web
+ * "New branch" button calls it in the browser, while the orchestrator calls it
+ * server-side so it — not the sandbox — decides the branch name and can persist
  * it to sandboxMap before the daemon ever sees it.
  *
- * Format: `<greek-letter>-<constellation-genitive>` — mirrors real Bayer
- * designations for stars (e.g. α Centauri → `alpha-centauri`, β Pictoris →
- * `beta-pictoris`). Only single-word constellation genitives are used so the
- * result is always a clean two-token, hyphen-joined git ref.
+ * Format: `<user-slug>-<base36-timestamp>` (e.g. `joao-silva-mabc1x9z`). The
+ * slug attributes the branch to whoever created it; the base36-encoded
+ * `Date.now()` is a monotonic clock, so a given user only collides if two
+ * branches are minted within the same millisecond. The suffix is always a valid
+ * git ref token (lowercase alphanumeric).
  */
 
-const GREEK_LETTERS: readonly string[] = [
-  "alpha",
-  "beta",
-  "gamma",
-  "delta",
-  "epsilon",
-  "zeta",
-  "eta",
-  "theta",
-  "iota",
-  "kappa",
-  "lambda",
-  "mu",
-  "nu",
-  "xi",
-  "omicron",
-  "pi",
-  "rho",
-  "sigma",
-  "tau",
-  "upsilon",
-  "phi",
-  "chi",
-  "psi",
-  "omega",
-];
+/**
+ * Slugify an arbitrary label (display name, email local-part, …) into a git-ref
+ * safe token: strip diacritics, lowercase, collapse every run of non
+ * alphanumeric characters to a single hyphen, and trim leading/trailing
+ * hyphens. Returns "user" when nothing usable remains.
+ */
+function slugify(label: string | null | undefined): string {
+  const slug = (label ?? "")
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "user";
+}
 
-const CONSTELLATIONS: readonly string[] = [
-  "andromedae",
-  "antliae",
-  "apodis",
-  "aquarii",
-  "aquilae",
-  "arae",
-  "arietis",
-  "aurigae",
-  "bootis",
-  "caeli",
-  "camelopardalis",
-  "cancri",
-  "capricorni",
-  "carinae",
-  "cassiopeiae",
-  "centauri",
-  "cephei",
-  "ceti",
-  "chamaeleontis",
-  "circini",
-  "columbae",
-  "corvi",
-  "crateris",
-  "crucis",
-  "cygni",
-  "delphini",
-  "doradus",
-  "draconis",
-  "equulei",
-  "eridani",
-  "fornacis",
-  "geminorum",
-  "gruis",
-  "herculis",
-  "horologii",
-  "hydrae",
-  "hydri",
-  "indi",
-  "lacertae",
-  "leonis",
-  "leporis",
-  "librae",
-  "lupi",
-  "lyncis",
-  "lyrae",
-  "mensae",
-  "microscopii",
-  "monocerotis",
-  "muscae",
-  "normae",
-  "octantis",
-  "ophiuchi",
-  "orionis",
-  "pavonis",
-  "pegasi",
-  "persei",
-  "phoenicis",
-  "pictoris",
-  "piscium",
-  "puppis",
-  "pyxidis",
-  "reticuli",
-  "sagittae",
-  "sagittarii",
-  "scorpii",
-  "sculptoris",
-  "scuti",
-  "serpentis",
-  "sextantis",
-  "tauri",
-  "telescopii",
-  "trianguli",
-  "tucanae",
-  "velorum",
-  "virginis",
-  "volantis",
-  "vulpeculae",
-];
-
-export function generateBranchName(): string {
-  const greek = GREEK_LETTERS[Math.floor(Math.random() * GREEK_LETTERS.length)];
-  const constellation =
-    CONSTELLATIONS[Math.floor(Math.random() * CONSTELLATIONS.length)];
-  return `${greek}-${constellation}`;
+/**
+ * Build a branch name for `userLabel` (the creator's display name, or their
+ * email local-part as a fallback). Callers should pass the most human-readable
+ * identity they have; slugification handles the rest.
+ */
+export function generateBranchName(userLabel?: string | null): string {
+  const slug = slugify(userLabel);
+  // base36(Date.now()) is a clock: its high-order (leading) digits change
+  // slowly, so branches minted the same day share a prefix like "mrch3…".
+  // Reverse the digits so the fast-changing low-order digit leads and the
+  // suffix looks distinct at a glance. Reversal is a bijection, so this keeps
+  // the exact same uniqueness guarantee (two branches only collide if minted
+  // within the same millisecond).
+  const stamp = Date.now().toString(36).split("").reverse().join("");
+  return `${slug}-${stamp}`;
 }

--- a/apps/mesh/src/tools/sandbox/start.test.ts
+++ b/apps/mesh/src/tools/sandbox/start.test.ts
@@ -479,15 +479,15 @@ describe("SANDBOX_START", () => {
     expect(result.isNewVm).toBe(false);
   });
 
-  it("generates a Bayer-style branch when input.branch is omitted and threads it into the ref", async () => {
+  it("generates a <creator-slug>-<timestamp> branch when input.branch is omitted and threads it into the ref", async () => {
     const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
     const updateSpy = mock(async () => {});
     const ctx = makeCtx({ virtualMcp, updateSpy });
 
     const result = await SANDBOX_START.handler({ virtualMcpId: VMCP_ID }, ctx);
 
-    // <greek-letter>-<constellation>, no namespace prefix.
-    expect(result.branch).toMatch(/^[a-z]+-[a-z]+$/);
+    // <creator-slug>-<base36-timestamp>, no namespace prefix. Test user is "Test".
+    expect(result.branch).toMatch(/^test-[0-9a-z]+$/);
     expect(result.branch.includes("/")).toBe(false);
     const [id] = mockEnsure.mock.calls[0]! as [SandboxId];
     expect(id.projectRef).toBe(

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -104,7 +104,11 @@ export const SANDBOX_START = defineTool({
     requireAuth(ctx);
     const organization = requireOrganization(ctx);
     await ctx.access.check();
-    const resolvedBranch = input.branch ?? generateBranchName();
+    const resolvedBranch =
+      input.branch ??
+      generateBranchName(
+        ctx.auth.user?.name ?? ctx.auth.user?.email?.split("@")[0],
+      );
 
     // Resolve kind after loading metadata so recorded sandboxMap entries can
     // pin the provider when the caller did not pass an explicit kind.

--- a/apps/mesh/src/tools/thread/create.integration.test.ts
+++ b/apps/mesh/src/tools/thread/create.integration.test.ts
@@ -38,7 +38,8 @@ describe("COLLECTION_THREADS_CREATE", () => {
       env.ctx,
     );
 
-    expect(result.item.branch).toMatch(/^[a-z]+-[a-z]+$/);
+    // <creator-slug>-<base36-timestamp>; the test user's name is "T".
+    expect(result.item.branch).toMatch(/^t-[0-9a-z]+$/);
     expect(result.item.virtual_mcp_id).toBe(vmcp.id);
   });
 

--- a/apps/mesh/src/tools/thread/create.ts
+++ b/apps/mesh/src/tools/thread/create.ts
@@ -127,7 +127,9 @@ export const COLLECTION_THREADS_CREATE = defineTool({
       branch =
         data.branch ??
         pickWarmBranchFromSandboxMap(metadata?.sandboxMap, userId) ??
-        generateBranchName();
+        generateBranchName(
+          ctx.auth.user?.name ?? ctx.auth.user?.email?.split("@")[0],
+        );
     }
 
     const result = await ctx.storage.threads.create({

--- a/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
+++ b/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
@@ -12,6 +12,7 @@ interface Props {
   orgId: string;
   orgSlug: string;
   userId: string;
+  userLabel: string | null | undefined;
   virtualMcpId: string;
   connectionId: string | null;
   owner: string;

--- a/apps/mesh/src/web/components/chat/pills/chat-mode-row.test.tsx
+++ b/apps/mesh/src/web/components/chat/pills/chat-mode-row.test.tsx
@@ -68,6 +68,7 @@ const BRANCH_PILL_PROPS = {
   orgId: "org-1",
   orgSlug: "my-org",
   userId: "user-1",
+  userLabel: "Test User",
   virtualMcpId: "vmcp-1",
   connectionId: "conn-1",
   owner: "acme",

--- a/apps/mesh/src/web/components/chat/pills/chat-mode-row.tsx
+++ b/apps/mesh/src/web/components/chat/pills/chat-mode-row.tsx
@@ -61,6 +61,7 @@ export function ChatModeRow({ virtualMcp, currentBranch }: SmartProps) {
 
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id ?? "";
+  const userLabel = session?.user?.name ?? session?.user?.email?.split("@")[0];
   const { org } = useProjectContext();
 
   const branchPill =
@@ -69,6 +70,7 @@ export function ChatModeRow({ virtualMcp, currentBranch }: SmartProps) {
         orgId={org.id}
         orgSlug={org.slug}
         userId={userId}
+        userLabel={userLabel}
         virtualMcpId={virtualMcp?.id ?? ""}
         connectionId={connectionId}
         owner={githubRepo.owner}

--- a/apps/mesh/src/web/components/thread/github/branch-picker.tsx
+++ b/apps/mesh/src/web/components/thread/github/branch-picker.tsx
@@ -29,6 +29,9 @@ interface Props {
   orgId: string;
   orgSlug: string;
   userId: string;
+  /** Human-readable creator label (display name, else email local-part) used to
+   *  seed generated branch names. */
+  userLabel: string | null | undefined;
   virtualMcpId: string;
   connectionId: string | null;
   owner: string;
@@ -51,6 +54,7 @@ export function BranchPicker({
   orgId,
   orgSlug,
   userId,
+  userLabel,
   // virtualMcpId is consumed by callers via Props (e.g. BranchPill);
   // BranchPicker itself doesn't use it directly. Kept on the Props
   // contract so the pill container can pass it down uniformly.
@@ -194,7 +198,7 @@ export function BranchPicker({
               variant="outline"
               size="sm"
               className="h-7 shrink-0"
-              onClick={() => pick(generateBranchName())}
+              onClick={() => pick(generateBranchName(userLabel))}
             >
               New
             </Button>

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -229,7 +229,9 @@ export function HeaderActions({ virtualMcpId }: Props) {
   };
 
   const switchToFreshBranch = async () => {
-    const nextBranch = generateBranchName();
+    const nextBranch = generateBranchName(
+      session?.user?.name ?? session?.user?.email?.split("@")[0],
+    );
     await setCurrentTaskBranch(nextBranch);
   };
 

--- a/packages/e2e/tests/chat-locked-thread.spec.ts
+++ b/packages/e2e/tests/chat-locked-thread.spec.ts
@@ -112,7 +112,7 @@ async function createAgentAndThread(
   // (`pickWarmBranchFromSandboxMap` → `generateBranchName()`), which
   // would beat the body's "main" in the route handler's
   // `existingThread?.branch ?? input.branch` resolution and pin the row
-  // to a synthetic name like "deco/keen-forge". Seed the row at "main"
+  // to a synthetic name like "jane-doe-mabc1x9z". Seed the row at "main"
   // so the lock assertions can check against a stable value.
   const thread = await callSelfMcpTool<{ item: { id: string } }>(
     api,


### PR DESCRIPTION
## Summary

Changes the auto-generated branch-name scheme (used by the chat **New branch** button and the sandbox/thread orchestrator) from the random Bayer-style codename (`alpha-centauri`, `tau-ceti`) to **`<creator-slug>-<base36-timestamp>`**, e.g. `guilhermetavano-pma3hcrm`.

Motivation: generated branches now say *who* created them, and stay unique via the timestamp instead of relying on an unchecked random draw.

### What changed
- **`shared/branch-name.ts`** — `generateBranchName(userLabel)` now:
  - slugifies the creator's display name (NFKD accent-strip → lowercase → non-alphanumeric collapsed to `-`), falling back to the email local-part, then `"user"`.
  - appends a **reversed** base36 `Date.now()`. Reversing puts the fast-changing low-order digit first so branches minted the same day differ at a glance (`mrch3amp` → `pma3hcrm`); reversal is a bijection so the uniqueness guarantee is unchanged — two branches only collide if created within the same millisecond.
- **Creator label threaded through all 4 call sites:**
  - `tools/thread/create.ts` & `tools/sandbox/start.ts` — from `ctx.auth.user`.
  - `branch-picker.tsx` (chat "New" button) — new `userLabel` prop, forwarded via `branch-pill.tsx` from `chat-mode-row.tsx` (`session.user`).
  - `header-actions.tsx` (post-merge fresh branch) — from `session.user`.

### Testing
- `bun test src/shared/branch-name.test.ts` + `chat-mode-row.test.tsx` — pass (rewrote the branch-name tests for the new contract: slug, accent-stripping, fallback, git-ref validity).
- `bun run --cwd=apps/mesh check` (tsc) — clean.
- `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch auto-generated branch names to `<creator-slug>-<base36-timestamp>` so branches show who created them and stay unique. Applies to chat “New” branch, sandbox/thread orchestration, and post-merge fresh-branch.

- **New Features**
  - `generateBranchName(userLabel)` slugifies the creator’s name (accent-strip, lowercase, collapse separators), falling back to email local-part, then “user”.
  - Appends a reversed base36 `Date.now()` suffix for uniqueness and easy visual diff between close-in-time branches.
  - Passes `userLabel` through all call sites: thread create, sandbox start, chat branch picker, and header actions.
  - Updates tests and assertions (including sandbox-start and thread-create) to expect `<creator-slug>-<base36-timestamp>` and validate git-ref safety.

<sup>Written for commit 1ca6cb9d47ac73d4afb06c3dcbfd37e5a9060762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

