### PR TITLE
perf(sandbox): skip git fetch on PR diff when refs resolve locally

### DIFF
--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -300,44 +300,75 @@ export async function computeDiffAgainstBase(
   }
   assertValidRemoteBranchName(branch);
 
-  // Shallow clones often miss one side of the fork — fetch both tips with depth.
-  // This is a NETWORK call and by far the slowest step; keep it async so a slow
-  // fetch never freezes the daemon (and trips crash detection).
-  try {
-    await runGitAsync(repoDir, [
-      "fetch",
-      "--depth",
-      "100",
-      "origin",
-      base,
-      branch,
-    ]);
-  } catch {
-    // Local-only fixtures / offline sandboxes may already have the refs we need.
-  }
-  if (headSha && /^[0-9a-f]{40}$/i.test(headSha)) {
-    await tryGitAsync(repoDir, ["fetch", "--depth", "100", "origin", headSha]);
-  }
-
   const upstream = `origin/${base}`;
-  if (!tryGit(repoDir, ["rev-parse", "--verify", upstream])) {
-    throw new Error(`Base branch '${base}' not found on origin`);
-  }
-
   const remoteHead = `origin/${branch}`;
-  let headRef = "HEAD";
-  if (
-    headSha &&
-    tryGit(repoDir, ["rev-parse", "--verify", `${headSha}^{commit}`]) !== null
-  ) {
-    headRef = headSha;
-  } else if (tryGit(repoDir, ["rev-parse", "--verify", remoteHead])) {
-    headRef = remoteHead;
+  const hasValidHeadSha = !!headSha && /^[0-9a-f]{40}$/i.test(headSha);
+
+  const resolveLocally = (ref: string): boolean =>
+    tryGit(repoDir, ["rev-parse", "--verify", ref]) !== null;
+
+  // Fast path: skip the network fetch when we can already compute the diff from
+  // local refs. Shallow clones miss one side of the fork on the FIRST request,
+  // so that one must fetch — but once the base tip, the exact requested head
+  // commit, and their fork point (merge-base) are all present locally, every
+  // later request (modal reopen, 30s refetch) can compute offline. We only take
+  // this path with an explicit headSha that resolves locally: that pins the
+  // exact commit the client asked for, so there's no staleness risk. Without a
+  // headSha we fall through and fetch to be sure origin/<branch> is current.
+  let headRef: string | null = null;
+  const canSkipFetch =
+    hasValidHeadSha &&
+    resolveLocally(upstream) &&
+    resolveLocally(`${headSha}^{commit}`) &&
+    tryGit(repoDir, ["merge-base", upstream, headSha!]) !== null;
+  if (canSkipFetch) {
+    headRef = headSha!;
+  } else {
+    // Shallow clones often miss one side of the fork — fetch both tips with
+    // depth. This is a NETWORK call and by far the slowest step; keep it async
+    // so a slow fetch never freezes the daemon (and trips crash detection).
+    try {
+      await runGitAsync(repoDir, [
+        "fetch",
+        "--depth",
+        "100",
+        "origin",
+        base,
+        branch,
+      ]);
+    } catch {
+      // Local-only fixtures / offline sandboxes may already have the refs.
+    }
+    if (hasValidHeadSha) {
+      await tryGitAsync(repoDir, [
+        "fetch",
+        "--depth",
+        "100",
+        "origin",
+        headSha!,
+      ]);
+    }
+
+    if (!resolveLocally(upstream)) {
+      throw new Error(`Base branch '${base}' not found on origin`);
+    }
+
+    if (hasValidHeadSha && resolveLocally(`${headSha}^{commit}`)) {
+      headRef = headSha!;
+    } else if (resolveLocally(remoteHead)) {
+      headRef = remoteHead;
+    } else {
+      headRef = "HEAD";
+    }
   }
 
   let paths = listThreeDotDiffPaths(repoDir, upstream, headRef);
 
-  if (paths.length === 0) {
+  // An empty diff after a shallow fetch may just mean the fork point is still
+  // beyond our history — deepen and retry. Skip this on the fast path: we
+  // already have a valid merge-base there, so an empty result is a real empty
+  // diff and a deepen fetch would only add a pointless network round-trip.
+  if (paths.length === 0 && !canSkipFetch) {
     try {
       await runGitAsync(repoDir, [
         "fetch",


### PR DESCRIPTION
## Summary

The **changes modal** (sandbox PR diff viewer) was slow because every request to `computeDiffAgainstBase` ran a network `git fetch --depth 100 origin <base> <branch>` in the daemon — and sometimes a second `--deepen 500`. The fetch is a network round-trip and, per the code's own comment, "by far the slowest step." Since the query has `staleTime: 10s` + `refetchInterval: 30s`, reopening the modal (or just leaving it open) re-ran this pipeline constantly.

This adds a **fast path**: before fetching, check whether the diff can be computed entirely from local refs. When
1. an explicit `headSha` (40-hex) is provided,
2. `origin/{base}` resolves locally,
3. the `headSha` commit resolves locally, and
4. `git merge-base origin/{base} headSha` resolves locally,

we compute the three-dot diff offline and **skip the fetch entirely**. Only the first request on a shallow clone (or a request without `headSha`) still fetches. The empty-diff `--deepen` fallback is also skipped on the fast path, where the merge-base is already known valid.

## Why it's correct

- **New head commits** → caller passes a new `headSha` → cache miss → local miss → falls through to fetch. New PR work always refreshes.
- **Working-tree diffs** go through `computeDiff`, which is untouched.
- **Shallow clones** on first load still hit the fetch path.
- Three-dot PR-diff semantics use the merge-base (fork point), which is stable as the base branch advances forward.

## Known tradeoff

If the **base branch is force-pushed / history-rewritten**, the stale local `origin/{base}` could yield a fork point that differs from the true one until a real fetch happens. This is rare, and the old `--depth 100` fetch didn't reliably cover it on a shallow clone either.

## Testing

- `bun test packages/sandbox/daemon/routes/git.test.ts` → 18 pass (the "honors headSha when set" test now exercises the offline fast path)
- `tsc --noEmit` clean for `packages/sandbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the sandbox changes modal by skipping network `git fetch` for PR diffs when local refs already resolve. `computeDiffAgainstBase` now computes the three-dot diff offline when an explicit `headSha`, `origin/<base>`, and their merge-base are present; only first loads or requests without `headSha` still fetch.

- **Refactors**
  - Skips the empty-diff `--deepen` retry on the offline path.
  - Falls back to the existing fetch logic for shallow clones or when refs are missing; preserves `origin/<base>` validation and `headRef` selection (`headSha` → `origin/<branch>` → `HEAD`).
  - Working-tree diffs are unchanged.

<sup>Written for commit 778484ce644449b5cc54b8ff805c2dc726f00545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

