### PR TITLE
feat(sections-editor): stack page variants vertically

### DIFF
--- a/apps/mesh/ct/tests/page-variant-tabs.ct.tsx
+++ b/apps/mesh/ct/tests/page-variant-tabs.ct.tsx
@@ -4,26 +4,27 @@ import { readEvents } from "../harness/ct-utils";
 import type { PageVariant } from "@/web/components/sections-editor/page-variants";
 
 /**
- * PageVariantTabs — the horizontal page-variant tab strip. Add a variant,
- * select a tab, or open a tab's actions menu to rename / duplicate / delete.
- * Delete is disabled when only one variant remains. The DropdownMenu is
- * portaled → queried via `page`.
+ * PageVariantTabs — the vertical page-variant list. Add a variant, select a
+ * row, or open a row's actions menu to rename / duplicate / delete. Delete is
+ * disabled when only one variant remains. The DropdownMenu is portaled →
+ * queried via `page`.
+ *
+ * Rows are `<div role="button">` (dnd-kit spreads `{...attributes}`) whose
+ * accessible name is computed from content, so it includes the nested
+ * "Actions for X" trigger label. Select rows via `getByText(label)` and query
+ * the actions trigger with `exact: true` to avoid matching the row.
  */
 const TWO: PageVariant[] = [
   { label: "Default", sections: [] },
   { label: "Mobile", sections: [], rule: { __resolveType: "x/matchers/A.ts" } },
 ];
 
-test("renders a tab per variant plus an add button", async ({ mount }) => {
+test("renders a row per variant plus an add button", async ({ mount }) => {
   const component = await mount(
     <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
   );
-  await expect(
-    component.getByRole("button", { name: "Default", exact: true }),
-  ).toBeVisible();
-  await expect(
-    component.getByRole("button", { name: "Mobile", exact: true }),
-  ).toBeVisible();
+  await expect(component.getByText("Default", { exact: true })).toBeVisible();
+  await expect(component.getByText("Mobile", { exact: true })).toBeVisible();
   await expect(
     component.getByRole("button", { name: "Add variant" }),
   ).toBeVisible();
@@ -37,11 +38,11 @@ test("clicking the add button fires onAdd", async ({ mount }) => {
   await expect.poll(() => readEvents(component)).toEqual([{ type: "add" }]);
 });
 
-test("clicking a tab fires onSelect with its index", async ({ mount }) => {
+test("clicking a row fires onSelect with its index", async ({ mount }) => {
   const component = await mount(
     <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
   );
-  await component.getByRole("button", { name: "Mobile", exact: true }).click();
+  await component.getByText("Mobile", { exact: true }).click();
   await expect
     .poll(() => readEvents(component))
     .toEqual([{ type: "select", index: 1 }]);
@@ -51,7 +52,9 @@ test("rename from the tab menu fires onRename", async ({ mount, page }) => {
   const component = await mount(
     <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
   );
-  await component.getByRole("button", { name: "Actions for Mobile" }).click();
+  await component
+    .getByRole("button", { name: "Actions for Mobile", exact: true })
+    .click();
   await page.getByRole("menuitem", { name: "Rename" }).click();
   await expect
     .poll(() => readEvents(component))
@@ -65,7 +68,9 @@ test("duplicate from the tab menu fires onDuplicate", async ({
   const component = await mount(
     <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
   );
-  await component.getByRole("button", { name: "Actions for Mobile" }).click();
+  await component
+    .getByRole("button", { name: "Actions for Mobile", exact: true })
+    .click();
   await page.getByRole("menuitem", { name: "Duplicate" }).click();
   await expect
     .poll(() => readEvents(component))
@@ -79,7 +84,9 @@ test("delete from the tab menu fires onDelete (multiple variants)", async ({
   const component = await mount(
     <PageVariantTabsHarness variants={TWO} activeIndex={0} />,
   );
-  await component.getByRole("button", { name: "Actions for Default" }).click();
+  await component
+    .getByRole("button", { name: "Actions for Default", exact: true })
+    .click();
   await page.getByRole("menuitem", { name: "Delete" }).click();
   await expect
     .poll(() => readEvents(component))
@@ -96,6 +103,8 @@ test("delete is disabled when only one variant remains", async ({
       activeIndex={0}
     />,
   );
-  await component.getByRole("button", { name: "Actions for Solo" }).click();
+  await component
+    .getByRole("button", { name: "Actions for Solo", exact: true })
+    .click();
   await expect(page.getByRole("menuitem", { name: "Delete" })).toBeDisabled();
 });

--- a/apps/mesh/src/web/components/sections-editor/page-variant-tabs.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-variant-tabs.tsx
@@ -27,9 +27,9 @@ import {
 import {
   SortableContext,
   arrayMove,
-  horizontalListSortingStrategy,
   sortableKeyboardCoordinates,
   useSortable,
+  verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import {
@@ -45,9 +45,10 @@ import { resolveMatcherIconName } from "./matcher-icons";
 import type { PageVariant } from "./page-variants";
 import type { LiveMeta } from "./resolve-schema";
 
-const VARIANT_GREEN_TEXT = "oklch(0.65 0.15 160)";
-const VARIANT_TAB_ACTIVE_CLASS =
-  "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.22)]";
+const VARIANT_ROW_CLASS =
+  "text-[oklch(0.45_0.15_160)] hover:bg-[oklch(0.65_0.15_160/0.12)] dark:text-[oklch(0.78_0.15_160)] dark:hover:bg-[oklch(0.65_0.15_160/0.15)]";
+const VARIANT_SELECTED_ROW_CLASS =
+  "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.2)]";
 
 export function VariantTabIcon({
   rule,
@@ -94,7 +95,86 @@ function remapEntryIndices(entries: VariantTabEntry[]): VariantTabEntry[] {
   }));
 }
 
-function SortablePageVariantTab({
+function PageVariantRowContent({
+  label,
+  effectiveRule,
+  matchers,
+  canDelete,
+  dragging,
+  onRename,
+  onDuplicate,
+  onDelete,
+}: {
+  label: string;
+  effectiveRule: Record<string, unknown> | undefined;
+  matchers: Array<{ resolveType: string; iconName: string }>;
+  canDelete: boolean;
+  dragging?: boolean;
+  onRename?: () => void;
+  onDuplicate?: () => void;
+  onDelete?: () => void;
+}) {
+  return (
+    <>
+      <VariantTabIcon rule={effectiveRule} matchers={matchers} />
+      <span className="min-w-0 flex-1 truncate text-sm font-medium">
+        {label}
+      </span>
+
+      {!dragging && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={`Actions for ${label}`}
+              className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100"
+              onClick={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              <DotsHorizontal size={14} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-36">
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onRename?.();
+              }}
+            >
+              <Edit01 size={14} />
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onDuplicate?.();
+              }}
+            >
+              <Copy01 size={14} />
+              Duplicate
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              variant="destructive"
+              disabled={!canDelete}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete?.();
+              }}
+            >
+              <Trash01 size={14} />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </>
+  );
+}
+
+function SortablePageVariantRow({
   entry,
   sortableId,
   isActive,
@@ -127,7 +207,7 @@ function SortablePageVariantTab({
 
   const style = {
     transform: CSS.Transform.toString(
-      transform ? { ...transform, y: 0 } : null,
+      transform ? { ...transform, x: 0 } : null,
     ),
     opacity: isDragging ? 0 : undefined,
   };
@@ -142,65 +222,38 @@ function SortablePageVariantTab({
     <div
       ref={setNodeRef}
       style={style}
+      {...attributes}
+      {...listeners}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
       className={cn(
-        "group shrink-0 inline-flex items-center rounded-md transition-colors touch-none",
-        isActive
-          ? VARIANT_TAB_ACTIVE_CLASS
-          : "text-muted-foreground hover:bg-muted hover:text-foreground",
-        isDragging ? "cursor-grabbing" : "cursor-grab",
+        "group flex select-none items-center gap-2 rounded-md px-2 py-2.5 transition-colors touch-none",
+        isDragging
+          ? "cursor-grabbing"
+          : "cursor-pointer active:cursor-grabbing",
+        isActive ? VARIANT_SELECTED_ROW_CLASS : VARIANT_ROW_CLASS,
       )}
     >
-      <button
-        type="button"
-        {...attributes}
-        {...listeners}
-        onClick={onSelect}
-        className="inline-flex items-center gap-1.5 h-8 pl-3 pr-1.5 text-sm font-medium cursor-[inherit]"
-      >
-        <VariantTabIcon rule={effectiveRule} matchers={matchers} />
-        <span className="truncate">{entry.variant.label}</span>
-      </button>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label={`Actions for ${entry.variant.label}`}
-            onClick={(e) => e.stopPropagation()}
-            onPointerDown={(e) => e.stopPropagation()}
-            className={cn(
-              "inline-flex h-8 w-6 items-center justify-center pr-1 cursor-pointer transition-opacity",
-              "opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100",
-              isActive && "opacity-100",
-            )}
-          >
-            <DotsHorizontal size={12} />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-36">
-          <DropdownMenuItem onClick={onRename}>
-            <Edit01 size={14} />
-            Rename
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={onDuplicate}>
-            <Copy01 size={14} />
-            Duplicate
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            variant="destructive"
-            disabled={!canDelete}
-            onClick={onDelete}
-          >
-            <Trash01 size={14} />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <PageVariantRowContent
+        label={entry.variant.label}
+        effectiveRule={effectiveRule}
+        matchers={matchers}
+        canDelete={canDelete}
+        onRename={onRename}
+        onDuplicate={onDuplicate}
+        onDelete={onDelete}
+      />
     </div>
   );
 }
 
-function PageVariantTabPreview({
+function PageVariantRowPreview({
   variant,
   decofile,
   meta,
@@ -220,12 +273,17 @@ function PageVariantTabPreview({
   return (
     <div
       className={cn(
-        "inline-flex items-center gap-1.5 h-8 pl-3 pr-3 text-sm font-medium rounded-md shadow-lg ring-1 ring-border/60 cursor-grabbing",
-        VARIANT_TAB_ACTIVE_CLASS,
+        "flex items-center gap-2 rounded-md px-2 py-2.5 shadow-lg ring-1 ring-border/60 cursor-grabbing",
+        VARIANT_SELECTED_ROW_CLASS,
       )}
     >
-      <VariantTabIcon rule={effectiveRule} matchers={matchers} />
-      <span className="truncate">{variant.label}</span>
+      <PageVariantRowContent
+        label={variant.label}
+        effectiveRule={effectiveRule}
+        matchers={matchers}
+        canDelete={false}
+        dragging
+      />
     </div>
   );
 }
@@ -338,26 +396,41 @@ export function PageVariantTabs({
   };
 
   return (
-    <div className="flex items-center border-b shrink-0">
-      <div
-        className={cn(
-          "flex flex-1 min-w-0 items-center gap-1.5 pl-3 pr-2 py-2 overflow-x-auto",
-          activeEntry && "cursor-grabbing",
-        )}
+    <div className="space-y-1 border-b p-2 shrink-0">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">
+          Variants
+        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Add variant"
+              className="size-6"
+              onClick={onAdd}
+            >
+              <Plus size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Add variant</TooltipContent>
+        </Tooltip>
+      </div>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
       >
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
-          onDragCancel={handleDragCancel}
+        <SortableContext
+          items={entryIds}
+          strategy={verticalListSortingStrategy}
         >
-          <SortableContext
-            items={entryIds}
-            strategy={horizontalListSortingStrategy}
-          >
+          <div className="space-y-0.5">
             {entries.map((entry) => (
-              <SortablePageVariantTab
+              <SortablePageVariantRow
                 key={entry.id}
                 sortableId={entry.id}
                 entry={entry}
@@ -372,38 +445,20 @@ export function PageVariantTabs({
                 onDelete={() => onDelete(entry.index)}
               />
             ))}
-          </SortableContext>
+          </div>
+        </SortableContext>
 
-          <DragOverlay dropAnimation={null}>
-            {activeEntry ? (
-              <PageVariantTabPreview
-                variant={activeEntry.variant}
-                decofile={decofile}
-                meta={meta}
-                matchers={matchers}
-              />
-            ) : null}
-          </DragOverlay>
-        </DndContext>
-      </div>
-      <div className="shrink-0 pr-3 pl-1 py-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label="Add variant"
-              className="size-8 shrink-0 cursor-pointer"
-              style={{ color: VARIANT_GREEN_TEXT }}
-              onClick={onAdd}
-            >
-              <Plus size={14} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Add variant</TooltipContent>
-        </Tooltip>
-      </div>
+        <DragOverlay dropAnimation={null}>
+          {activeEntry ? (
+            <PageVariantRowPreview
+              variant={activeEntry.variant}
+              decofile={decofile}
+              meta={meta}
+              matchers={matchers}
+            />
+          ) : null}
+        </DragOverlay>
+      </DndContext>
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sections-editor/page-variant-tabs.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-variant-tabs.tsx
@@ -396,7 +396,7 @@ export function PageVariantTabs({
   };
 
   return (
-    <div className="space-y-1 border-b p-2 shrink-0">
+    <div className="space-y-1 border-b p-2">
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-muted-foreground">
           Variants

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -2680,24 +2680,6 @@ export function SectionsEditor({
         )}
       </div>
 
-      {/* Variant selector (when page sections are multivariate) */}
-      {hasMultipleVariants && !isEditing && !editingSeo && activePageKey && (
-        <PageVariantTabs
-          listKey={activePageKey}
-          variants={pageVariants}
-          activeIndex={safeVariantIndex}
-          decofile={decofile ?? {}}
-          meta={meta}
-          matchers={availableMatchers}
-          onSelect={selectPageVariant}
-          onReorder={handleReorderPageVariants}
-          onRename={setRenameVariantIndex}
-          onDuplicate={handleDuplicatePageVariant}
-          onDelete={handleDeletePageVariant}
-          onAdd={handleAddPageVariant}
-        />
-      )}
-
       {/* Drill-down: SEO form, section form, or section list */}
       {editingSeo ? (
         <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
@@ -2821,6 +2803,23 @@ export function SectionsEditor({
         </ScrollArea>
       ) : (
         <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
+          {/* Variant selector (when page sections are multivariate) */}
+          {hasMultipleVariants && activePageKey && (
+            <PageVariantTabs
+              listKey={activePageKey}
+              variants={pageVariants}
+              activeIndex={safeVariantIndex}
+              decofile={decofile ?? {}}
+              meta={meta}
+              matchers={availableMatchers}
+              onSelect={selectPageVariant}
+              onReorder={handleReorderPageVariants}
+              onRename={setRenameVariantIndex}
+              onDuplicate={handleDuplicatePageVariant}
+              onDelete={handleDeletePageVariant}
+              onAdd={handleAddPageVariant}
+            />
+          )}
           {/* Variant rule editor (collapsible so users can reclaim space) */}
           {hasMultipleVariants && ruleResolveType !== null && (
             <div


### PR DESCRIPTION
## Summary
Reworks the page-level variant switcher in the sections editor to match the section-variant list, based on design feedback (the horizontal chip layout wasn't landing).

- **Vertical layout** — page variants now render as a vertical list (a "Variants" header + Add button and full-width reorderable rows), mirroring `SectionVariantList`, instead of a horizontal chip strip.
- **No drag-handle icon** — removed the `DotsGrid` handle that caused hover flicker; the row itself is the drag source.
- **Cursor fix** — plain pointer at rest, `grabbing` only on mouse-down/drag (was a persistent grab hand).
- **Scrolls with content** — moved `PageVariantTabs` inside the main `ScrollArea` (above the "Variant rule" editor) so the variant list scrolls together with the section list instead of staying pinned at the top.

## Affected areas
- `apps/mesh/src/web/components/sections-editor/page-variant-tabs.tsx`
- `apps/mesh/src/web/components/sections-editor/sections-editor.tsx`

`PageVariantTabs` only renders in the main section-list branch (in global-block mode `pageVariants` is empty, so `hasMultipleVariants` is false), so relocating it into that branch loses no cases.

## Testing
- `bun run fmt` ✅
- `bun run --cwd apps/mesh check` (tsc) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stacks the page variant switcher vertically to match the section-variant list. Improves drag UX and makes the variant list scroll with the editor content.

- **New Features**
  - Page variants now display as a vertical list with a "Variants" header and Add button; rows are full-width and reorderable.
  - Drag-and-drop uses `verticalListSortingStrategy` from `@dnd-kit/sortable`; the whole row is the drag handle (removed the icon).
  - Cursor shows as a normal pointer at rest; switches to grabbing only during drag.
  - Moved `PageVariantTabs` inside the main `ScrollArea` so variants scroll with the section list.

- **Refactors**
  - Updated CTs to target rows via `getByText(label)` and the actions trigger with `{ exact: true }` (rows are `role="button"` with computed names); removed a vestigial `shrink-0` now that the component lives inside the `ScrollArea`.

<sup>Written for commit 7443087b09f9f2a37d1d265566d8cb6ab65c0af7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

