### PR TITLE
fix(sandbox): recognize Windows absolute paths in clone repoDir check

### DIFF
--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -282,6 +282,16 @@ describe("spawnClone", () => {
     }
   }, 30_000);
 
+  it("rejects a relative repoDir instead of cloning into it", async () => {
+    const chunks: string[] = [];
+    const { code } = await spawnClone({
+      config: makeConfig("relative/workspace", "file:///irrelevant.git"),
+      onChunk: (_source, data) => chunks.push(data),
+    });
+    expect(code).toBe(1);
+    expect(chunks.join("")).toContain("not an absolute path");
+  });
+
   it("fails with a non-zero exit when ls-remote cannot reach the remote", async () => {
     const { root, cleanup } = setupBareRepo();
     try {

--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -1,5 +1,6 @@
 import { sleep } from "@decocms/std";
 import { existsSync, readdirSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import { isSyntheticBranch } from "../constants";
 import type { Config } from "../types";
 import { spawnSetupStep } from "./spawn-step";
@@ -235,7 +236,7 @@ export async function spawnClone(deps: CloneDeps): Promise<CloneResult> {
   if (!cloneUrl) {
     return { code: 1 };
   }
-  if (!config.repoDir || !config.repoDir.startsWith("/")) {
+  if (!config.repoDir || !isAbsolute(config.repoDir)) {
     deps.onChunk(
       "setup",
       `\r\n[clone] repoDir is not an absolute path (got: ${String(config.repoDir)}) — aborting clone to prevent relative-path mishap\r\n`,


### PR DESCRIPTION
## Summary
Follow-up to #4376. After that fix, the daemon boots on Windows but the `clone` orchestrator step aborts with:

```
[clone] repoDir is not an absolute path (got: C:\Users\...\deco\sandboxes\<handle>\repo) — aborting clone to prevent relative-path mishap
```

`spawnClone` hand-rolled its absolute-path check as `config.repoDir.startsWith("/")` (`packages/sandbox/daemon/setup/clone.ts`), the same class of POSIX-only assumption as the previous node-pty bug. `repoDir` is a legitimate, correctly-constructed Windows absolute path (`path.join` was used upstream) — the guard just couldn't recognize it. Swapped for `node:path`'s `isAbsolute`, which dispatches to the platform-correct implementation.

## Test plan
- [x] Added a unit test asserting a relative `repoDir` is still rejected (guard still functions)
- [x] `bun test packages/sandbox/daemon/setup/clone.test.ts`
- [x] `bun run fmt`
- [x] `tsc --noEmit` on `packages/sandbox`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows absolute path recognition in the sandbox clone step so valid `repoDir` paths on Windows no longer abort the clone.

- **Bug Fixes**
  - Replace manual absolute-path check with `node:path.isAbsolute` in `packages/sandbox/daemon/setup/clone.ts`.
  - Add a unit test to ensure relative `repoDir` is still rejected in `packages/sandbox/daemon/setup/clone.test.ts`.

<sup>Written for commit 5780c7d32e391c82abf2ba52235d0edc3c02e7d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

