### PR TITLE
feat(preview): persist last visited page (incl. :param values) to localStorage

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/last-preview-page.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/last-preview-page.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { lastPreviewPageKey, parseLastPreviewPage } from "./last-preview-page";
+
+describe("last-preview-page", () => {
+  it("lastPreviewPageKey scopes by org, vm and branch", () => {
+    expect(lastPreviewPageKey("acme", "vm-1", "main")).toBe(
+      "deco:preview:last-page:acme:vm-1:main",
+    );
+  });
+
+  it("parseLastPreviewPage round-trips a valid entry", () => {
+    const entry = {
+      path: "/blog/:slug",
+      pageKey: "pages-Blogpost-abc",
+      params: { slug: "dicas" },
+    };
+    expect(parseLastPreviewPage(JSON.stringify(entry))).toEqual(entry);
+  });
+
+  it("parseLastPreviewPage defaults missing fields", () => {
+    expect(parseLastPreviewPage(JSON.stringify({ path: "/about" }))).toEqual({
+      path: "/about",
+      pageKey: null,
+      params: {},
+    });
+  });
+
+  it("parseLastPreviewPage rejects malformed values", () => {
+    expect(parseLastPreviewPage(null)).toBeNull();
+    expect(parseLastPreviewPage("not json")).toBeNull();
+    expect(parseLastPreviewPage(JSON.stringify("string"))).toBeNull();
+    expect(parseLastPreviewPage(JSON.stringify(["a"]))).toBeNull();
+    expect(parseLastPreviewPage(JSON.stringify({ path: 42 }))).toBeNull();
+    expect(
+      parseLastPreviewPage(JSON.stringify({ path: "no-leading-slash" })),
+    ).toBeNull();
+  });
+
+  it("parseLastPreviewPage drops non-string param values", () => {
+    expect(
+      parseLastPreviewPage(
+        JSON.stringify({ path: "/b/:slug", params: { slug: "ok", n: 1 } }),
+      ),
+    ).toEqual({ path: "/b/:slug", pageKey: null, params: { slug: "ok" } });
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/preview/last-preview-page.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/last-preview-page.ts
@@ -1,0 +1,55 @@
+/** Last page visited in the preview, persisted to localStorage per project+branch. */
+export interface LastPreviewPage {
+  /** Page path, possibly a template (e.g. `/blog/:slug`). */
+  path: string;
+  /** Page block key pinned in the picker; null for plain in-iframe navigation. */
+  pageKey: string | null;
+  /** Values for `:param` tokens in the path template. */
+  params: Record<string, string>;
+}
+
+export function lastPreviewPageKey(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+): string {
+  return `deco:preview:last-page:${orgSlug}:${virtualMcpId}:${branch}`;
+}
+
+/** Validate a raw localStorage value; null for anything malformed. */
+export function parseLastPreviewPage(
+  raw: string | null,
+): LastPreviewPage | null {
+  if (!raw) return null;
+  try {
+    const obj = JSON.parse(raw) as Record<string, unknown>;
+    if (!obj || typeof obj !== "object" || Array.isArray(obj)) return null;
+    if (typeof obj.path !== "string" || !obj.path.startsWith("/")) return null;
+    const pageKey = typeof obj.pageKey === "string" ? obj.pageKey : null;
+    const params: Record<string, string> = {};
+    if (obj.params && typeof obj.params === "object") {
+      for (const [key, value] of Object.entries(obj.params)) {
+        if (typeof value === "string") params[key] = value;
+      }
+    }
+    return { path: obj.path, pageKey, params };
+  } catch {
+    return null;
+  }
+}
+
+export function readLastPreviewPage(key: string): LastPreviewPage | null {
+  try {
+    return parseLastPreviewPage(localStorage.getItem(key));
+  } catch {
+    return null;
+  }
+}
+
+export function writeLastPreviewPage(key: string, page: LastPreviewPage): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(page));
+  } catch {
+    // Quota exceeded / privacy mode — persistence is best-effort.
+  }
+}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -81,6 +81,12 @@ import {
   useSandboxReloadHandler,
 } from "../hooks/use-sandbox-events";
 import { SandboxStateCard } from "./state-card";
+import {
+  lastPreviewPageKey,
+  readLastPreviewPage,
+  writeLastPreviewPage,
+  type LastPreviewPage,
+} from "./last-preview-page";
 import { derivePhaseProgress } from "./derive-phase-progress";
 import { track } from "@/web/lib/posthog-client";
 import { useSandboxRepoDir } from "../hooks/use-sandbox-repo-dir";
@@ -475,7 +481,18 @@ export function PreviewContent() {
         )
       : null;
 
-  // Reset navigation when the VM preview base URL changes (branch switch, etc.)
+  // Last visited page (incl. `:param` values), persisted per project+branch.
+  const previewStorageKey =
+    virtualMcpId && branch
+      ? lastPreviewPageKey(org.slug, virtualMcpId, branch)
+      : null;
+  const persistLastPage = (page: LastPreviewPage) => {
+    if (previewStorageKey) writeLastPreviewPage(previewStorageKey, page);
+  };
+
+  // When the VM preview base URL appears or changes (first boot, branch
+  // switch, etc.), restore the last visited page for this project+branch;
+  // reset navigation to "/" when there's nothing saved.
   const [prevIframeBase, setPrevIframeBase] = useState<string | null>(null);
   if (
     previewState.kind === "iframe" &&
@@ -483,7 +500,21 @@ export function PreviewContent() {
   ) {
     const hadPreviousBase = prevIframeBase !== null;
     setPrevIframeBase(previewState.previewUrl);
-    if (hadPreviousBase) {
+    const saved = previewStorageKey
+      ? readLastPreviewPage(previewStorageKey)
+      : null;
+    if (saved) {
+      // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- expect the restored page's resolved path on the next iframe load
+      intendedPathRef.current = fillPathTemplate(saved.path, saved.params);
+      setCurrentPath(saved.path);
+      setPinnedPageKey(saved.pageKey);
+      setDirectPreviewUrl(null);
+      setActiveGlobalSection(null);
+      if (saved.pageKey && Object.keys(saved.params).length > 0) {
+        const pageKey = saved.pageKey;
+        setPathParamsByPage((prev) => ({ ...prev, [pageKey]: saved.params }));
+      }
+    } else if (hadPreviousBase) {
       // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- clear stale navigation intent on branch switch
       intendedPathRef.current = null;
       setCurrentPath("/");
@@ -749,16 +780,15 @@ export function PreviewContent() {
 
   const navigatePreviewToPage = (page: PageEntry) => {
     // The iframe loads the template with any stored param values filled in.
-    intendedPathRef.current = fillPathTemplate(
-      page.path,
-      pathParamsByPage[page.key] ?? {},
-    );
+    const params = pathParamsByPage[page.key] ?? {};
+    intendedPathRef.current = fillPathTemplate(page.path, params);
     setActiveGlobalSection(null);
     setDirectPreviewUrl(null);
     setPinnedPageKey(page.key);
     setCurrentPath(page.path);
     setCmsSelectedSectionIndex(null);
     setCmsInitialEditSeo(false);
+    persistLastPage({ path: page.path, pageKey: page.key, params });
   };
 
   const setPathParamValue = (name: string, value: string) => {
@@ -768,6 +798,7 @@ export function PreviewContent() {
     // Guard against a stale onLoad from the previous URL resetting currentPath.
     intendedPathRef.current = fillPathTemplate(currentPath, nextValues);
     setPathParamsByPage((prev) => ({ ...prev, [pageKey]: nextValues }));
+    persistLastPage({ path: currentPath, pageKey, params: nextValues });
   };
 
   const navigatePreviewToGlobalSection = (section: GlobalSectionEntry) => {
@@ -1479,6 +1510,11 @@ export function PreviewContent() {
                         return;
                       }
                       setCurrentPath(iframePath);
+                      persistLastPage({
+                        path: iframePath,
+                        pageKey: pinnedPageKey,
+                        params: pathParamValues,
+                      });
                     } catch {
                       // Cross-origin — can't read, keep current value
                     }


### PR DESCRIPTION
> Stacked on #4385 (inline `:param` inputs) — merge that one first; GitHub will retarget this PR to `main` automatically.

## Summary

The preview tab always opened at `/`, losing where you were after a reload. It now remembers the last visited page — including custom `:param` values typed in the URL bar — and restores it when the preview boots.

- **What's saved**: page path template (e.g. `/inspira-novo/blog/:slug`), the pinned page block key, and the `:param` values (e.g. `{ slug: "dicas" }`), in `localStorage` keyed by org + virtual MCP + branch (`deco:preview:last-page:<org>:<vm>:<branch>`).
- **When it saves**: selecting a page in the URL bar dropdown, committing a param value, and in-iframe navigation.
- **When it restores**: when the sandbox preview URL first appears, and on branch switch (each branch restores its own last page). Restoring a template page brings back the editable violet param input with the saved value. With nothing saved, behavior is unchanged (starts at `/`).
- Malformed/legacy entries are ignored (validated parse); writes are best-effort (private mode/quota safe).

## Implementation notes

- New `last-preview-page.ts`: storage key builder, validated `parseLastPreviewPage()`, and thin `read`/`write` wrappers around `localStorage`.
- `preview.tsx`: the existing "reset navigation on base URL change" render block now restores the saved page instead of resetting to `/` when an entry exists; `intendedPathRef` is primed with the resolved path so the iframe onLoad sync accepts the restored navigation.

## Testing

- `bun test` — 5 new unit tests for the parse/key logic; 459 tests across the affected folders pass.
- `bun run lint` 0 errors, `bun run fmt` applied, `tsc --noEmit` clean for `apps/mesh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remember the last visited preview page and restore it on load, including `:param` values, so the preview no longer resets to `/`. State is scoped per org, virtual MCP, and branch using `localStorage`.

- **New Features**
  - Saves path template, pinned page key, and param values to `localStorage` under `deco:preview:last-page:<org>:<vm>:<branch>`.
  - Restores on first sandbox URL load and on branch switch; falls back to `/` if nothing saved.
  - Updates the saved page when selecting a page, committing a param value, or navigating inside the iframe.
  - Validates reads and ignores malformed entries; writes are best-effort.

<sup>Written for commit 3da457478a9ed7c809155c94b2f59eaa63f12807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

