### PR TITLE
fix(sandbox): unwedge daemon lifecycle after a dev-script failure

### DIFF
--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -388,6 +388,9 @@ const execH = makeExecHandler({
   repoDir,
   store,
   taskManager,
+  lifecycle,
+  getStatus: () => currentStatus,
+  setStatus,
 });
 
 const tasksListH = makeTasksListHandler({ taskManager });

--- a/packages/sandbox/daemon/routes/exec.test.ts
+++ b/packages/sandbox/daemon/routes/exec.test.ts
@@ -4,8 +4,39 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { TenantConfigStore } from "../config-store";
 import { Broadcaster } from "../events/broadcast";
+import type { DaemonStatus, LifecycleState } from "../events/types";
+import type { LifecycleManager } from "../lifecycle/manager";
 import { TaskManager } from "../process/task-manager";
 import { makeExecHandler } from "./exec";
+
+/** Minimal hand-rolled fake — mirrors the real LifecycleManager's surface
+ * (`current`/`transition`) without pulling in its Broadcaster dependency. */
+function fakeLifecycle(initial: LifecycleState) {
+  let state = initial;
+  const calls: LifecycleState[] = [];
+  const manager = {
+    current: () => state,
+    transition: (next: LifecycleState) => {
+      calls.push(next);
+      state = next;
+    },
+  } as unknown as LifecycleManager;
+  return { manager, calls };
+}
+
+/** Minimal hand-rolled fake for the daemon's status getter/setter pair. */
+function fakeStatus(initial: DaemonStatus) {
+  let status = initial;
+  const calls: DaemonStatus[] = [];
+  return {
+    getStatus: () => status,
+    setStatus: (next: DaemonStatus) => {
+      calls.push(next);
+      status = next;
+    },
+    calls,
+  };
+}
 
 function req(name: string, body?: object): Request {
   const init: RequestInit = {
@@ -96,5 +127,109 @@ describe("exec handler", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { taskId: string };
     expect(typeof body.taskId).toBe("string");
+  });
+});
+
+describe("exec handler — dev-starter lifecycle reconciliation", () => {
+  // Regression: a failed dev script wedges status=error / lifecycle=
+  // start-failed, and the probe refuses to promote lifecycle out of a
+  // terminal phase (anti-resurrection guard). Manually running the dev
+  // starter from the studio terminal drawer is explicit user intent and must
+  // unwedge both, or the daemon can never report healthy again.
+  let appRoot: string;
+  let logsDir: string;
+  let taskManager: TaskManager;
+  let store: TenantConfigStore;
+
+  beforeEach(async () => {
+    appRoot = mkdtempSync(join(tmpdir(), "exec-root-"));
+    logsDir = mkdtempSync(join(tmpdir(), "exec-logs-"));
+    taskManager = new TaskManager({
+      logsDir,
+      ttlMs: 60_000,
+      reapIntervalMs: 60_000,
+    });
+    store = new TenantConfigStore();
+    writeFileSync(
+      join(appRoot, "package.json"),
+      JSON.stringify({
+        scripts: { dev: "echo dev", start: "echo start", build: "echo build" },
+      }),
+    );
+    await store.apply({
+      application: {
+        packageManager: { name: "npm" },
+        runtime: "node",
+      },
+    });
+  });
+
+  afterEach(() => {
+    taskManager.shutdown();
+    rmSync(appRoot, { recursive: true, force: true });
+    rmSync(logsDir, { recursive: true, force: true });
+  });
+
+  it("exec of a WELL_KNOWN_STARTERS script clears error status and enters starting from start-failed", async () => {
+    const lifecycle = fakeLifecycle({ phase: "start-failed", error: "boom" });
+    const status = fakeStatus({ state: "error", reason: "boom" });
+    const h = makeExecHandler({
+      repoDir: appRoot,
+      store,
+      taskManager,
+      lifecycle: lifecycle.manager,
+      getStatus: status.getStatus,
+      setStatus: status.setStatus,
+    });
+
+    const res = await h(req("dev"));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { taskId: string };
+    expect(typeof body.taskId).toBe("string"); // spawn still happens
+    expect(status.calls).toEqual([{ state: "running" }]);
+    expect(lifecycle.calls).toEqual([{ phase: "starting" }]);
+  });
+
+  it("exec of a WELL_KNOWN_STARTERS script leaves a live running lifecycle and non-error status untouched", async () => {
+    const lifecycle = fakeLifecycle({
+      phase: "running",
+      port: 3000,
+      htmlSupport: true,
+    });
+    const status = fakeStatus({ state: "running" });
+    const h = makeExecHandler({
+      repoDir: appRoot,
+      store,
+      taskManager,
+      lifecycle: lifecycle.manager,
+      getStatus: status.getStatus,
+      setStatus: status.setStatus,
+    });
+
+    const res = await h(req("dev"));
+
+    expect(res.status).toBe(200);
+    expect(status.calls).toEqual([]);
+    expect(lifecycle.calls).toEqual([]);
+  });
+
+  it("exec of a non-starter script never touches status or lifecycle, even from error/start-failed", async () => {
+    const lifecycle = fakeLifecycle({ phase: "start-failed", error: "boom" });
+    const status = fakeStatus({ state: "error", reason: "boom" });
+    const h = makeExecHandler({
+      repoDir: appRoot,
+      store,
+      taskManager,
+      lifecycle: lifecycle.manager,
+      getStatus: status.getStatus,
+      setStatus: status.setStatus,
+    });
+
+    const res = await h(req("build"));
+
+    expect(res.status).toBe(200);
+    expect(status.calls).toEqual([]);
+    expect(lifecycle.calls).toEqual([]);
   });
 });

--- a/packages/sandbox/daemon/routes/exec.ts
+++ b/packages/sandbox/daemon/routes/exec.ts
@@ -1,9 +1,12 @@
 import type { TenantConfigStore } from "../config-store";
 import {
   PACKAGE_MANAGER_DAEMON_CONFIG,
+  WELL_KNOWN_STARTERS,
   buildDevEnv,
   pmRunCommand,
 } from "../constants";
+import type { DaemonStatus } from "../events/types";
+import type { LifecycleManager } from "../lifecycle/manager";
 import type { TaskManager } from "../process/task-manager";
 import { discoverScripts } from "../process/script-discovery";
 import { jsonResponse, parseJsonBody } from "./body-parser";
@@ -16,6 +19,10 @@ export interface ExecDeps {
   repoDir: string;
   store: TenantConfigStore;
   taskManager: TaskManager;
+  /** Lifecycle/status reconciliation when the exec'd script is a dev starter. */
+  lifecycle: LifecycleManager;
+  getStatus: () => DaemonStatus;
+  setStatus: (next: DaemonStatus) => void;
 }
 
 interface ExecBody {
@@ -97,6 +104,28 @@ export function makeExecHandler(deps: ExecDeps) {
       pmConf.runPrefix,
       name,
     );
+
+    // Manually running a dev starter is explicit intent to (re)start the dev
+    // server — the same WELL_KNOWN_STARTERS list whose non-zero exit wedges
+    // status=error / lifecycle=start-failed must also unwedge them, or the
+    // daemon can never report healthy again (the probe refuses to promote
+    // from terminal phases, and stepStart skips while status=error). Only
+    // failure-ish states are touched: a mid-pipeline phase (cloning/
+    // installing/starting) or a live `running` is left alone, and `paused`
+    // (user stop) is respected.
+    if ((WELL_KNOWN_STARTERS as readonly string[]).includes(name)) {
+      if (deps.getStatus().state === "error") {
+        deps.setStatus({ state: "running" });
+      }
+      const phase = deps.lifecycle.current().phase;
+      // Deliberately narrower than stepStart's reconciliation (which also
+      // covers clone-failed/install-failed): a manual dev exec can't repair a
+      // broken clone/install — those wedges have their own resumeFrom retry
+      // endpoints, and pretending `starting` there would lie to the probe.
+      if (phase === "idle" || phase === "start-failed" || phase === "crashed") {
+        deps.lifecycle.transition({ phase: "starting" });
+      }
+    }
 
     const task = await deps.taskManager.spawn({
       command: cmd,

--- a/packages/sandbox/daemon/setup/orchestrator.test.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.test.ts
@@ -466,3 +466,264 @@ describe("SetupOrchestrator status transitions", () => {
     }
   });
 });
+
+describe("SetupOrchestrator lifecycle wedge fixes", () => {
+  // Regression: once a dev script exits non-zero, status flips to `error`
+  // and lifecycle to `start-failed` (see "flips status to error" above). With
+  // nothing to clear `error`, stepStart's status gate silently skips every
+  // future `start` step forever — the daemon can never report healthy again.
+  // These two entry points are the only ways out: an explicit studio retry
+  // (resumeFrom) and the orchestrator itself confirming the exact dev
+  // command+cwd is already running (stepStart's already-running branch).
+
+  it("resumeFrom clears an error status before the step enqueues", () => {
+    const { dir, cleanup } = tempRoot();
+    try {
+      const broadcaster = new Broadcaster(1024);
+      const { lifecycle } = makeLifecycleSpy(broadcaster);
+      let status: { state: string; reason?: string } = {
+        state: "error",
+        reason: "dev script exited with code 1",
+      };
+      const statusCalls: Array<{ state: string }> = [];
+
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir: join(dir, "repo") },
+        store: {
+          read: () => null,
+          hydrate: () => {},
+          applyInternal: async () => ({
+            kind: "applied",
+            before: null,
+            after: {},
+            transition: { kind: "no-op" },
+          }),
+        } as never,
+        taskManager: {
+          spawn: async () => ({ id: "t1" }),
+          killByLogName: () => 0,
+          waitForLogNamesIdle: async () => {},
+          onTaskExit: () => () => {},
+        } as never,
+        setStatus: (next) => {
+          statusCalls.push(next);
+          status = next;
+        },
+        getStatus: () => status,
+        broadcaster,
+        installState: { isInstalledFor: () => false } as never,
+        logsDir: dir,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
+      });
+
+      orchestrator.resumeFrom("start");
+
+      // resumeFrom clears status synchronously, before enqueueStep's
+      // fire-and-forget drain ever gets a chance to read it.
+      expect(statusCalls).toEqual([{ state: "running" }]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("resumeFrom leaves a paused status untouched (not a failure)", () => {
+    const { dir, cleanup } = tempRoot();
+    try {
+      const broadcaster = new Broadcaster(1024);
+      const { lifecycle } = makeLifecycleSpy(broadcaster);
+      const statusCalls: Array<{ state: string }> = [];
+
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir: join(dir, "repo") },
+        store: {
+          read: () => null,
+          hydrate: () => {},
+          applyInternal: async () => ({
+            kind: "applied",
+            before: null,
+            after: {},
+            transition: { kind: "no-op" },
+          }),
+        } as never,
+        taskManager: {
+          spawn: async () => ({ id: "t1" }),
+          killByLogName: () => 0,
+          waitForLogNamesIdle: async () => {},
+          onTaskExit: () => () => {},
+        } as never,
+        setStatus: (next) => statusCalls.push(next),
+        getStatus: () => ({ state: "paused" as const }),
+        broadcaster,
+        installState: { isInstalledFor: () => false } as never,
+        logsDir: dir,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
+      });
+
+      orchestrator.resumeFrom("start");
+
+      expect(statusCalls).toHaveLength(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  async function drain(o: {
+    isRunning: () => boolean;
+    pendingCount: () => number;
+  }) {
+    const deadline = Date.now() + 5_000;
+    while (o.isRunning() || o.pendingCount() > 0) {
+      if (Date.now() > deadline) throw new Error("orchestrator hung");
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  }
+
+  it("stepStart's already-running branch reconciles a start-failed lifecycle to starting", async () => {
+    const { dir, cleanup } = tempRoot();
+    try {
+      const repoDir = join(dir, "repo");
+      mkdirSync(repoDir);
+      writeFileSync(
+        join(repoDir, "deno.json"),
+        JSON.stringify({ tasks: { dev: "echo hi" } }),
+      );
+      const broadcaster = new Broadcaster(1024);
+      const { lifecycle, states } = makeLifecycleSpy(broadcaster);
+
+      const spawns: Array<{ command: string; cwd: string }> = [];
+      let running: { command: string; cwd: string } | null = null;
+
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir },
+        store: {
+          read: () => ({
+            application: { packageManager: { name: "deno" }, runtime: "deno" },
+          }),
+          hydrate: () => {},
+          applyInternal: async () => ({
+            kind: "applied",
+            before: null,
+            after: {},
+            transition: { kind: "no-op" },
+          }),
+        } as never,
+        taskManager: {
+          spawn: async (s: { command: string; cwd: string }) => {
+            spawns.push({ command: s.command, cwd: s.cwd });
+            return { id: `t${spawns.length}` };
+          },
+          killByLogName: () => 0,
+          waitForLogNamesIdle: async () => {},
+          runningCommandByLogName: () => running,
+          onTaskExit: () => () => {},
+        } as never,
+        setStatus: () => {},
+        getStatus: () => ({ state: "running" as const }),
+        broadcaster,
+        installState: { isInstalledFor: () => true } as never,
+        logsDir: dir,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
+      });
+
+      // 1st start: nothing running → spawns once via the normal path
+      // (lifecycle → starting there too, but that's not what's under test).
+      orchestrator.handle({ kind: "port-change", from: undefined, to: 3000 });
+      await drain(orchestrator);
+      expect(spawns).toHaveLength(1);
+
+      // Simulate the wedge: the dev script crashed (the real onTaskExit
+      // handler would do this), leaving lifecycle at a terminal failure
+      // phase the probe refuses to promote from.
+      lifecycle.transition({ phase: "start-failed", error: "boom" });
+
+      // But the exact same dev command+cwd is (for whatever reason — a
+      // race, a warm-pool reattach) still reported as running by
+      // TaskManager. A 2nd start step must reconcile lifecycle instead of
+      // silently returning.
+      running = spawns[0];
+      orchestrator.handle({ kind: "port-change", from: 3000, to: 8000 });
+      await drain(orchestrator);
+
+      expect(spawns).toHaveLength(1); // still no respawn
+      expect(states.at(-1)).toEqual({ phase: "starting" });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("stepStart's already-running branch is a no-op when lifecycle already reflects running", async () => {
+    const { dir, cleanup } = tempRoot();
+    try {
+      const repoDir = join(dir, "repo");
+      mkdirSync(repoDir);
+      writeFileSync(
+        join(repoDir, "deno.json"),
+        JSON.stringify({ tasks: { dev: "echo hi" } }),
+      );
+      const broadcaster = new Broadcaster(1024);
+      const { lifecycle, states } = makeLifecycleSpy(broadcaster);
+
+      const spawns: Array<{ command: string; cwd: string }> = [];
+      let running: { command: string; cwd: string } | null = null;
+
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir },
+        store: {
+          read: () => ({
+            application: { packageManager: { name: "deno" }, runtime: "deno" },
+          }),
+          hydrate: () => {},
+          applyInternal: async () => ({
+            kind: "applied",
+            before: null,
+            after: {},
+            transition: { kind: "no-op" },
+          }),
+        } as never,
+        taskManager: {
+          spawn: async (s: { command: string; cwd: string }) => {
+            spawns.push({ command: s.command, cwd: s.cwd });
+            return { id: `t${spawns.length}` };
+          },
+          killByLogName: () => 0,
+          waitForLogNamesIdle: async () => {},
+          runningCommandByLogName: () => running,
+          onTaskExit: () => () => {},
+        } as never,
+        setStatus: () => {},
+        getStatus: () => ({ state: "running" as const }),
+        broadcaster,
+        installState: { isInstalledFor: () => true } as never,
+        logsDir: dir,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
+      });
+
+      // 1st start: nothing running → spawns once.
+      orchestrator.handle({ kind: "port-change", from: undefined, to: 3000 });
+      await drain(orchestrator);
+      expect(spawns).toHaveLength(1);
+
+      // Probe already confirmed the dev server is live.
+      lifecycle.transition({
+        phase: "running",
+        port: 3000,
+        htmlSupport: false,
+      });
+      const statesBefore = states.length;
+
+      running = spawns[0];
+      orchestrator.handle({ kind: "port-change", from: 3000, to: 8000 });
+      await drain(orchestrator);
+
+      expect(spawns).toHaveLength(1); // still no respawn
+      // No new transition beyond the `running` we forced above.
+      expect(states.length).toBe(statesBefore);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -105,6 +105,12 @@ export class SetupOrchestrator {
 
   /** Studio retry endpoint → resume from a named step. Fire-and-forget. */
   resumeFrom(step: Step): void {
+    // A retry is explicit intent: clear a dev-script-failure `error` so the
+    // enqueued step isn't silently skipped by stepStart's status gate. `paused`
+    // is deliberately left alone — that's a user stop, not a failure.
+    if (this.deps.getStatus().state === "error") {
+      this.deps.setStatus({ state: "running" });
+    }
     this.enqueueStep(step);
   }
 
@@ -464,6 +470,16 @@ export class SetupOrchestrator {
       this.chunk(
         `[orchestrator] dev already running (${command.source}) — skipping restart\r\n`,
       );
+      // The dev task we would have spawned is already up (same command+cwd),
+      // but a prior failure may have left lifecycle at a terminal phase the
+      // probe refuses to promote from. Reconcile: enter `starting` so the
+      // probe can confirm `running` on its next healthy response. No-op when
+      // the lifecycle already reflects a live server.
+      // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
+      const cur = this.deps.lifecycle.current().phase;
+      if (cur !== "running" && cur !== "starting") {
+        this.deps.lifecycle.transition({ phase: "starting" });
+      }
       return;
     }
     await this.stopDevTask();


### PR DESCRIPTION
## Summary

After a dev script exits non-zero once, the sandbox daemon can never report healthy again — even when the dev server is later restarted and serving fine. The wedge permanently hides the studio's Content tab / Sections editor, which gate on `lifecycle.phase === "running"` (the preview iframe keeps working since it doesn't consult the lifecycle, making the failure look like a UI bug).

Root cause (verified live on a wedged stg sandbox): four interlocking early-returns —
1. dev-script failure sets `status=error` + `lifecycle=start-failed` (correct);
2. the terminal drawer's Run/Restart (`/exec/dev`) spawns a plain task, never touching lifecycle/status;
3. the health probe deliberately refuses to promote `start-failed → running` (anti-resurrection guard — untouched here);
4. the studio retry (`setup/start`) is silently skipped while `status=error`, and **nothing ever resets `status=error`**.

## Changes

- `resumeFrom` (studio retry) clears `status: error → running` before enqueueing — a retry is explicit intent; `paused` (user stop) is left alone.
- `stepStart`'s "dev already running — skipping restart" branch now reconciles the lifecycle to `starting` (probe confirms `running` on the next healthy response) instead of bare-returning.
- `POST /exec/<name>` where `<name>` ∈ `WELL_KNOWN_STARTERS` — the same list whose failure wedges the state — clears `error` and enters `starting`, from `idle`/`start-failed`/`crashed` only (deliberately narrower than stepStart: a manual dev exec can't repair a clone/install wedge, and those have their own retry endpoints).

The probe's anti-resurrection guard is unchanged; mid-pipeline phases and a live `running` are never stomped.

## Testing

- New unit tests (hand-rolled fakes, repo style): 3 exec-path cases + 4 orchestrator cases; positive cases verified to fail pre-fix.
- Full `packages/sandbox/daemon` suite: 458/458 pass (incl. daemon-binary e2e specs); `bun run check`, lint, and biome clean.
- Known pre-existing edge tracked as follow-up (not introduced here): stale port-sniffer on re-entering `starting` from a terminal phase — affects the existing retry path equally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a wedge where a failed dev script left the sandbox daemon stuck in `status=error` and `lifecycle=start-failed`, hiding the Studio Content tab. Explicit retries and terminal-run restarts now clear the error and move lifecycle back to `starting` so the probe can confirm `running`.

- **Bug Fixes**
  - `resumeFrom` clears `status: error → running` before enqueuing; leaves `paused` unchanged.
  - `stepStart` reconciles lifecycle to `starting` when the dev task is already running; no-ops if already `running`/`starting`.
  - `POST /exec/<name>` for `WELL_KNOWN_STARTERS` clears error status and sets lifecycle to `starting` from `idle`/`start-failed`/`crashed`; non-starter scripts are untouched.
  - Added targeted unit tests for `exec` and `orchestrator`; full daemon suite passes.

<sup>Written for commit 69a1419c833e17a3eac6f691f89e1aff220caa11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

