### PR TITLE
fix(chat): restore sticky user message; add jump-to-latest pill

### DIFF
--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -1,4 +1,6 @@
+import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { ArrowDown } from "@untitledui/icons";
 import {
   useEffect,
   useRef,
@@ -186,36 +188,44 @@ function ChatMessages() {
 
   return (
     <SubtaskRunsProvider messages={messages}>
-      <div
-        ref={setScrollerEl}
-        data-chat-scroller
-        // CONSTRAINT: this element's COMPUTED `overflow` shorthand must stay
-        // in {auto, scroll} or use-stick-to-bottom's wheel-escape dies. The
-        // lib's wheel handler walks ancestors testing
-        // `["scroll","auto"].includes(getComputedStyle(el).overflow)` — the
-        // SHORTHAND, not overflow-y alone. `overflow-y-auto` with an unset
-        // overflow-x computes (CSS visible→auto coercion, since the two
-        // longhands differ) to a single `"auto"` shorthand, which passes.
-        // Adding `overflow-x-hidden` HERE would make it `"hidden auto"` and
-        // fail the test, killing wheel-up escape on the primary chat
-        // scroller. That's why horizontal clipping lives on the contentRef
-        // wrapper below instead, not here.
-        className="w-full min-w-0 max-w-full overflow-y-auto h-full [container-type:size]"
-        style={{ paddingBottom }}
-      >
-        {/*
+      {/* Positioning context for the jump-to-latest pill. Height-neutral:
+          the scroller's h-full now resolves against this wrapper, which
+          takes the exact box the scroller had. */}
+      <div className="relative h-full w-full min-w-0">
+        <div
+          ref={setScrollerEl}
+          data-chat-scroller
+          // CONSTRAINT: this element's COMPUTED `overflow` shorthand must stay
+          // in {auto, scroll} or use-stick-to-bottom's wheel-escape dies. The
+          // lib's wheel handler walks ancestors testing
+          // `["scroll","auto"].includes(getComputedStyle(el).overflow)` — the
+          // SHORTHAND, not overflow-y alone. `overflow-y-auto` with an unset
+          // overflow-x computes (CSS visible→auto coercion, since the two
+          // longhands differ) to a single `"auto"` shorthand, which passes.
+          // Adding `overflow-x-hidden` HERE would make it `"hidden auto"` and
+          // fail the test, killing wheel-up escape on the primary chat
+          // scroller. That's why horizontal clipping lives on the contentRef
+          // wrapper below instead, not here.
+          className="w-full min-w-0 max-w-full overflow-y-auto h-full [container-type:size]"
+          style={{ paddingBottom }}
+        >
+          {/*
           Single wrapper around ALL scrollable content so the lib's
           ResizeObserver (on contentRef) sees growth from both the older
           pairs AND the streaming last pair. Height is left auto/content-
           driven (plain block) so it grows/shrinks with content — required
           for the ResizeObserver to fire on every size change.
 
-          `overflow-x-hidden` carries the horizontal-clipping defense moved
-          off the scroller above (see its comment): this wrapper never
-          scrolls vertically (its height is unconstrained, so content never
-          exceeds it), so its own computed shorthand ("hidden auto") is
-          harmless — it's invisible to the lib's wheel-escape ancestor walk
-          either way.
+          `overflow-x-clip` carries the horizontal-clipping defense moved
+          off the scroller above (see its comment). It MUST be `clip`, not
+          `hidden`: any overflow value other than visible/clip makes this
+          wrapper a scroll container, and `position: sticky` latches onto
+          its NEAREST scroll-container ancestor — with `hidden` here, the
+          sticky user bubble (pair.tsx) sticks to this never-scrolling
+          wrapper instead of the real scroller and stops pinning entirely.
+          `clip` clips identically without creating a scroll container, and
+          stays invisible to the lib's wheel-escape ancestor walk (computed
+          shorthand is not "auto"/"scroll").
 
           `[container-type:size]` above (on the scroller) + `min-h-[100cqh]`
           below (on the last-pair wrapper) replace the old `min-h-full`:
@@ -231,34 +241,61 @@ function ChatMessages() {
           single-level min-h-full, with or without the highlight-stack's
           inline paddingBottom on the scroller.
         */}
-        <div ref={stick.contentRef} className="overflow-x-hidden">
-          <div className="flex flex-col min-w-0 max-w-2xl mx-auto w-full">
-            <div ref={sentinelRef} aria-hidden className="h-px" />
-            {isFetchingOlder && (
-              <div className="flex items-center justify-center py-3 text-xs text-muted-foreground">
-                Loading older messages…
+          <div ref={stick.contentRef} className="overflow-x-clip">
+            <div className="flex flex-col min-w-0 max-w-2xl mx-auto w-full">
+              <div ref={sentinelRef} aria-hidden className="h-px" />
+              {isFetchingOlder && (
+                <div className="flex items-center justify-center py-3 text-xs text-muted-foreground">
+                  Loading older messages…
+                </div>
+              )}
+              {messagePairs.slice(0, -1).map((pair, index) => (
+                <MessagePair
+                  key={`pair-${pair.user?.id ?? pair.assistant?.id}`}
+                  pair={pair}
+                  isLastPair={false}
+                  status={
+                    index === messagePairs.length - 1 ? status : undefined
+                  }
+                />
+              ))}
+            </div>
+            {lastMessagePair && (
+              <div className="min-h-[100cqh] min-w-0 max-w-2xl mx-auto w-full">
+                <MessagePair
+                  key={`pair-${lastMessagePair.user?.id ?? lastMessagePair.assistant?.id}`}
+                  pair={lastMessagePair}
+                  isLastPair={true}
+                  status={status}
+                />
               </div>
             )}
-            {messagePairs.slice(0, -1).map((pair, index) => (
-              <MessagePair
-                key={`pair-${pair.user?.id ?? pair.assistant?.id}`}
-                pair={pair}
-                isLastPair={false}
-                status={index === messagePairs.length - 1 ? status : undefined}
-              />
-            ))}
           </div>
-          {lastMessagePair && (
-            <div className="min-h-[100cqh] min-w-0 max-w-2xl mx-auto w-full">
-              <MessagePair
-                key={`pair-${lastMessagePair.user?.id ?? lastMessagePair.assistant?.id}`}
-                pair={lastMessagePair}
-                isLastPair={true}
-                status={status}
-              />
-            </div>
-          )}
         </div>
+        {/* Jump-to-latest pill — the standard affordance while detached from
+          the bottom (isAtBottom is false once the user escapes the follow or
+          scrolls up through history; it already treats "within 70px" as at
+          bottom, so it never flickers at rest). scrollToBottom() both
+          scrolls and re-arms the library's stickiness. Sits `bottom` above
+          the highlight-stack reservation so collapsed highlight cards never
+          cover it (paddingBottom already includes the 16px baseline). */}
+        {!stick.isAtBottom && (
+          <Button
+            type="button"
+            // Outline look, but with the translucent dark-mode background
+            // (dark:bg-input/30) overridden to a SOLID theme surface — the
+            // default translucency makes it unreadable over streaming text,
+            // while bg-primary reads as a white blob in dark mode.
+            variant="outline"
+            size="icon-sm"
+            aria-label="Jump to latest"
+            className="absolute left-1/2 z-50 -translate-x-1/2 rounded-full shadow-md animate-in fade-in duration-200 dark:bg-background dark:hover:bg-accent"
+            style={{ bottom: paddingBottom + 8 }}
+            onClick={() => void stick.scrollToBottom()}
+          >
+            <ArrowDown size={14} />
+          </Button>
+        )}
       </div>
     </SubtaskRunsProvider>
   );


### PR DESCRIPTION
## Summary

Two chat-scroll follow-ups to #4388:

**1. Sticky user message regression (fix).** #4388 moved horizontal clipping onto the stick-to-bottom content wrapper as `overflow-x-hidden`. Any `overflow` value other than `visible`/`clip` makes an element a scroll container — and `position: sticky` pins against its *nearest scroll-container ancestor* — so the user bubble silently started "sticking" to a wrapper that never scrolls, i.e. stopped pinning under the header entirely. Fixed with `overflow-x-clip`: identical clipping, no scroll container (sticky re-latches onto the real scroller), still invisible to the library's wheel-escape ancestor walk, same browser floor as the `cqh` units we already require. Constraint documented at the wrapper so neither property gets silently swapped back.

**2. Jump-to-latest pill (the standard detached affordance).** A floating `↓` pill, bottom-center above the highlight-stack reservation, shown whenever `isAtBottom` is false (escaped mid-stream or scrolled up through history; the library's 70px near-bottom window keeps it from flickering at rest). Clicking glides down with the library's spring and re-arms the follow. Outline style with the translucent `dark:bg-input/30` overridden to a solid theme surface so it reads over streaming text in both modes.

## Testing

- `bun run check` / lint / biome green.
- Manual QA on live dev server: sticky bubble pins again during long streams; wheel-escape still instant (the #4388 fix is preserved); pill appears when detached, hides near bottom, click re-engages; verified in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the sticky user message in chat and adds a bottom-center “jump to latest” pill for quick return to new messages. Fixes a regression from #4388 where `overflow-x-hidden` created a scroll container and broke sticky pinning.

- **Bug Fixes**
  - Switched content wrapper from `overflow-x-hidden` to `overflow-x-clip` so `position: sticky` pins to the real scroller.
  - Keeps the scroller’s computed `overflow` in `auto` to preserve wheel-escape behavior.
  - Documents the constraint inline to prevent future regressions.

- **New Features**
  - Adds a floating “↓” pill when detached from bottom; click smoothly scrolls to latest and re-arms follow.
  - Bottom-center placement above the highlight-stack reservation; offset aligns with dynamic `paddingBottom`.
  - Outline style with a solid dark-mode background for readability over streaming text.

<sup>Written for commit 7e1987ae36f0432ac6d87545b739c55a5ca95ebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

