### PR TITLE
fix(decopilot): heartbeat desktop runs from the projector chunk tap

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/progress-bump.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/progress-bump.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { ProgressBumpThrottle } from "./progress-bump";
+import { ProgressBumpThrottle, tapProgressStream } from "./progress-bump";
 
 describe("ProgressBumpThrottle", () => {
   it("allows the first bump, then throttles within the interval", () => {
@@ -39,5 +39,130 @@ describe("ProgressBumpThrottle", () => {
     expect(t.shouldBump("task1", 1_000)).toBe(true);
     // now - last === interval → not < interval → allowed
     expect(t.shouldBump("task1", 4_000)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tapProgressStream — the desktop-run liveness heartbeat tap. `chunkStream`
+// in project-chunks.ts is a `ReadableStream<UIMessageChunk>` (not an
+// AsyncIterable), so the tap is a pass-through TransformStream, mirroring
+// dispatch-run.ts's `tapProgress`.
+// ---------------------------------------------------------------------------
+
+async function collect<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const out: T[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out.push(value as T);
+  }
+  return out;
+}
+
+function streamFrom<T>(items: T[]): ReadableStream<T> {
+  return new ReadableStream<T>({
+    start(controller) {
+      for (const item of items) controller.enqueue(item);
+      controller.close();
+    },
+  });
+}
+
+describe("tapProgressStream", () => {
+  it("yields every chunk unchanged, in order", async () => {
+    const throttle = new ProgressBumpThrottle(3_000);
+    const tapped = tapProgressStream(
+      streamFrom([1, 2, 3, 4]),
+      "task1",
+      throttle,
+      () => {},
+    );
+    expect(await collect(tapped)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("calls onBump once per throttle window across many items", async () => {
+    // Window far longer than the test's own runtime, so every item after the
+    // first is deterministically inside the same window.
+    const throttle = new ProgressBumpThrottle(60_000);
+    let bumps = 0;
+    const out = await collect(
+      tapProgressStream(
+        streamFrom(["a", "b", "c", "d", "e"]),
+        "task1",
+        throttle,
+        () => {
+          bumps += 1;
+        },
+      ),
+    );
+    expect(out).toEqual(["a", "b", "c", "d", "e"]);
+    expect(bumps).toBe(1);
+  });
+
+  it("does not call onBump when the throttle denies (window not elapsed)", async () => {
+    const throttle = new ProgressBumpThrottle(60_000);
+    throttle.shouldBump("task1"); // consumes the window (real Date.now())
+    let bumps = 0;
+    await collect(
+      tapProgressStream(streamFrom([1]), "task1", throttle, () => {
+        bumps += 1;
+      }),
+    );
+    expect(bumps).toBe(0);
+  });
+
+  it("forgets throttle state once the stream completes", async () => {
+    const throttle = new ProgressBumpThrottle(60_000);
+    await collect(
+      tapProgressStream(streamFrom([1]), "task1", throttle, () => {}),
+    );
+    // State was cleared on completion, so the next bump for the SAME task is
+    // allowed immediately — even though the 60s window hasn't elapsed.
+    expect(throttle.shouldBump("task1")).toBe(true);
+  });
+
+  it("is independent per task — a busy task's window doesn't block another task's first bump", async () => {
+    const throttle = new ProgressBumpThrottle(60_000);
+    throttle.shouldBump("task1"); // task1 now inside its window
+    let bumps = 0;
+    await collect(
+      tapProgressStream(streamFrom([1]), "task2", throttle, () => {
+        bumps += 1;
+      }),
+    );
+    expect(bumps).toBe(1);
+  });
+});
+
+describe("tapProgressStream error propagation", () => {
+  it("propagates a source error to the consumer instead of swallowing it", async () => {
+    const boom = new Error("source exploded");
+    const source = new ReadableStream<number>({
+      start(controller) {
+        controller.enqueue(1);
+        controller.error(boom);
+      },
+    });
+    const throttle = new ProgressBumpThrottle(60_000);
+    const reader = tapProgressStream(
+      source,
+      "task1",
+      throttle,
+      () => {},
+    ).getReader();
+    // Drain until the rejection surfaces; the error must reach the consumer
+    // unchanged — a tap that swallowed it would end the stream cleanly and
+    // silently truncate the run.
+    let caught: unknown;
+    try {
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBe(boom);
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/progress-bump.ts
+++ b/apps/mesh/src/api/routes/decopilot/progress-bump.ts
@@ -42,3 +42,37 @@ export class ProgressBumpThrottle {
     this.lastBumpMs.delete(taskId);
   }
 }
+
+/**
+ * Tap a chunk stream so each chunk drives a THROTTLED `onBump()` call. Pure
+ * pass-through: every chunk is forwarded unchanged; `onBump` is a
+ * fire-and-forget side effect that must never block or fail the stream —
+ * callers should swallow their own errors (see projector-workflow.ts and
+ * dispatch-run.ts's `tapProgress`, which this mirrors for the
+ * `ReadableStream`-shaped `chunkStream` used by project-chunks.ts).
+ *
+ * This is the desktop-run liveness heartbeat: desktop chunks go daemon → NATS
+ * directly, so the projector's live chunk consumption is the only mesh
+ * component that ever sees them — see the reaper's `RUN_IDLE_TIMEOUT_MS` in
+ * run-registry.ts.
+ */
+export function tapProgressStream<T>(
+  stream: ReadableStream<T>,
+  taskId: string,
+  throttle: ProgressBumpThrottle,
+  onBump: () => void,
+): ReadableStream<T> {
+  return stream.pipeThrough(
+    new TransformStream<T, T>({
+      transform(chunk, controller) {
+        if (throttle.shouldBump(taskId)) onBump();
+        controller.enqueue(chunk);
+      },
+      flush() {
+        // Stream ended — drop this task's throttle state so the map can't
+        // grow unbounded across many short-lived runs.
+        throttle.clear(taskId);
+      },
+    }),
+  );
+}

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
@@ -5,6 +5,7 @@ import { projectChunks } from "./project-chunks";
 import { createProjectorChunkStream } from "./projector-chunk-stream";
 import { createRunPersistence } from "./run-persistence";
 import { recordPoison } from "./projector-metrics";
+import { ProgressBumpThrottle, tapProgressStream } from "./progress-bump";
 import { resolveThreadStatus } from "./status";
 import { synthesizedErrorMessageId } from "./message-ids";
 import { foldedToUIMessage } from "./projector-seed";
@@ -102,6 +103,24 @@ export function getProjectorWorkflowRuntime(): ProjectorWorkflowRuntime {
   return requireRuntime();
 }
 
+/**
+ * Process-wide progress-bump throttle for the projector's live chunk
+ * consumption (Task 9, A1/A2) — the desktop-run liveness heartbeat. Desktop
+ * chunks go daemon → NATS directly (no mesh HTTP hop), so this tap on the
+ * JetStream-sourced chunkStream is the ONLY place a desktop run's progress
+ * gets recorded; without it the reaper's `RUN_IDLE_TIMEOUT_MS` (run-registry.ts)
+ * force-fails any run running longer than ~10 minutes. Module scope (not
+ * per-call) so the per-task last-bump map survives across the multiple
+ * `projectFromJetStreamStep` invocations a thread's runs may see — mirrors
+ * dispatch-run.ts's `progressThrottle`.
+ *
+ * Hosted runs already heartbeat via dispatch-run.ts's own `tapProgress` on
+ * the hosted uiStream; they now ALSO bump here (the projector consumes every
+ * run's chunks, hosted included). Harmless — same `last_progress_at` column,
+ * both throttled independently, so it's at most one extra write per ~3s.
+ */
+const progressThrottle = new ProgressBumpThrottle();
+
 export async function projectFromJetStreamStep(
   input: ProjectorWorkflowInput,
   orgId: string,
@@ -114,11 +133,22 @@ export async function projectFromJetStreamStep(
     await rt.messageParts.loadWindow(input.runId, { limit: 500 })
   ).messages.map(foldedToUIMessage);
   const result = await projectChunks({
-    chunkStream: await createProjectorChunkStream({
-      js,
-      runId: input.runId,
-      fenceToken: input.fenceToken,
-    }),
+    chunkStream: tapProgressStream(
+      await createProjectorChunkStream({
+        js,
+        runId: input.runId,
+        fenceToken: input.fenceToken,
+      }),
+      input.runId,
+      progressThrottle,
+      () => {
+        // Fire-and-forget: never awaited in the chunk path (a slow DB write
+        // must not backpressure projection) and never allowed to fail the
+        // stream (a missed bump is a missed heartbeat, not a projection
+        // error — the reaper simply relies on an older timestamp).
+        void rt.bumpProgress({ runId: input.runId, orgId }).catch(() => {});
+      },
+    ),
     persistence: await createRunPersistence({
       messageParts: rt.messageParts,
       orgId,


### PR DESCRIPTION
## Summary

User-desktop runs longer than ~10 minutes are force-failed mid-stream by the progress reaper (#4355) while the daemon keeps streaming — the thread shows **failed** over a live, healthy stream (verified on stg: thread flipped failed at 12:19:48Z with its codex process pid-verified alive minutes later).

Root cause: #4355's heartbeat (`tapProgress`) only taps the **hosted** uiStream. Desktop chunks go daemon → NATS directly; the only mesh component that sees them live is the projector (`consumeRunProjection` live-tails the subject from dispatch) — and the projector's `bumpProgress` runtime hook was **declared (projector-workflow.ts) and implemented (app.ts) but never called**.

## Fix

`tapProgressStream` — a pass-through `TransformStream` tap (co-located with `ProgressBumpThrottle`) wired around the projector's chunk stream in `projectFromJetStreamStep`. Each observed chunk drives a throttled (≤1/3s), fire-and-forget `rt.bumpProgress({runId, orgId})` that can never backpressure or fail projection.

- Hosted runs now bump from both tapProgress and the projector replay — intentional, throttled, same column, commented.
- No workflow step changes: edit is inside an existing step body; workflow-source-guard unaffected (verified — neither file is registered workflow source).
- Known shared limitation with the hosted precedent: throttle-map entry leaks on error/cancel paths (flush-only cleanup) — parity with `tapProgress`, bounded by run cardinality.

## Testing

- 11 unit tests on the throttle + tap (order preservation, throttle windows, per-task isolation, cleanup, error propagation added post-review).
- Full decopilot dir: 461/476, the 15 failures are the known Postgres-less local integration set, verified identical on unmodified main.
- `bun run check`, lint, knip, biome all clean. Independent review: approved (2 minors: the error-propagation test — added; throttle-leak parity — documented).

Note: this is the tactical fix under the current architecture. The control-plane unification (gate live-tails for hosted too; errors-as-stream-events; executor heartbeats on the subject) is being specced separately and will subsume `tapProgress` entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents long-running desktop runs from being force-failed by the progress reaper by adding a throttled heartbeat in the projector chunk path. Desktop runs now reliably update progress while streaming.

- **Bug Fixes**
  - Added `tapProgressStream`, a pass-through TransformStream that bumps progress from the projector’s chunk stream (desktop path), throttled to ~1 per 3s and never blocking the stream.
  - Wired the tap into `projectFromJetStreamStep` with a module-scope `ProgressBumpThrottle`; calls `rt.bumpProgress` fire-and-forget.
  - Hosted runs also bump via the projector now; safe due to throttling and same target column.

<sup>Written for commit 2129c45cf4ce8d5ac719ba7ad385cf7e268945f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

