### PR TITLE
test(decopilot): cover runProjectorWorkflowBody skip paths

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts
@@ -450,6 +450,62 @@ describe("runProjectorWorkflowBody", () => {
     expect(purgeCalls).toHaveLength(0);
   });
 
+  test("missing run row → skip, no runtime calls, projectFn never invoked", async () => {
+    const { rt, calls } = makeRuntime();
+    rt.resolveRun = async () => null;
+    let projectFnCalled = false;
+    const projectFn = makeProjectFn({});
+    await runProjectorWorkflowBody(input, rt, async () => {
+      projectFnCalled = true;
+      return projectFn();
+    });
+
+    expect(projectFnCalled).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("stale fence (runFenceToken differs from input) → skip, no runtime calls", async () => {
+    const { rt, calls } = makeRuntime();
+    rt.resolveRun = async () => ({
+      orgId: "org_1",
+      createdBy: "user_1",
+      version: 2,
+      status: "in_progress",
+      runFenceToken: "fence_newer",
+      title: null,
+    });
+    let projectFnCalled = false;
+    const projectFn = makeProjectFn({});
+    await runProjectorWorkflowBody(input, rt, async () => {
+      projectFnCalled = true;
+      return projectFn();
+    });
+
+    expect(projectFnCalled).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("legacy v1 run (version !== 2) → skip, no runtime calls", async () => {
+    const { rt, calls } = makeRuntime();
+    rt.resolveRun = async () => ({
+      orgId: "org_1",
+      createdBy: "user_1",
+      version: 1,
+      status: "in_progress",
+      runFenceToken: "fence_a",
+      title: null,
+    });
+    let projectFnCalled = false;
+    const projectFn = makeProjectFn({});
+    await runProjectorWorkflowBody(input, rt, async () => {
+      projectFnCalled = true;
+      return projectFn();
+    });
+
+    expect(projectFnCalled).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
   test("forwards input.messageId to projectFn (queue ordering plumb)", async () => {
     // Guards the plumb from thread-gate-workflow → consumeRunProjection →
     // runProjectorWorkflowBody → projectFn. This asserts up to the projectFn


### PR DESCRIPTION
## Source
Improvement found while reading recently-changed `apps/mesh/src/api/routes/decopilot/projector-workflow.ts` (touched in #4391).

## Why
`resolveRunStepWithRuntime` has three skip branches — missing run row, stale/mismatched fence token, and legacy (v1) run — that gate whether `runProjectorWorkflowBody` does anything at all. The existing test file exercises `shouldSkipProjection` in isolation and every non-skip outcome path, but never exercises these three skip branches through the full `runProjectorWorkflowBody` flow, so a regression there (e.g. accidentally calling `markRunFailed`/`purgeRun` on a stale or legacy run) would go unnoticed.

## What changed
Added three tests asserting that when `resolveRun` returns null, a mismatched `runFenceToken`, or `version !== 2`, `runProjectorWorkflowBody` returns early with zero runtime calls and never invokes `projectFn`.

## Verify
```
bun test apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (clean aside from 2 pre-existing unrelated `use-stick-to-bottom` module errors)
- `bun test apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts` — 23 pass

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests covering `runProjectorWorkflowBody` skip paths (missing run, mismatched `runFenceToken`, legacy v1). Ensures it returns early with zero runtime calls and never invokes `projectFn`.

<sup>Written for commit 1e72d1cf3f33e09f39d4493ce917e096ef8c2a49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

