### PR TITLE
test(web): cover getDevAgentIds, getLiveDevAgentMaps, and findDevPartner

### DIFF
--- a/apps/mesh/src/web/lib/agent-capabilities.test.ts
+++ b/apps/mesh/src/web/lib/agent-capabilities.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "bun:test";
+import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
 import type { CurrentLink } from "@/web/hooks/use-current-link";
 import {
   agentHasClonableSource,
   agentHasConnectedGithub,
   agentShowsGithubHeaderActions,
+  findDevPartner,
+  getDevAgentIds,
+  getLiveDevAgentMaps,
   hasLocalCliHarness,
 } from "./agent-capabilities";
+
+const agent = (id: string, liveAgentId?: string): VirtualMCPEntity =>
+  ({
+    id,
+    connections: [],
+    metadata: liveAgentId ? { instructions: null, liveAgentId } : null,
+  }) as any;
 
 describe("agentHasClonableSource", () => {
   it("returns false for null/undefined metadata", () => {
@@ -203,5 +214,63 @@ describe("hasLocalCliHarness", () => {
         link({ online: true, capabilities: ["claude-code", "codex"] }),
       ),
     ).toBe(true);
+  });
+});
+
+describe("getDevAgentIds", () => {
+  it("returns an empty set for null/undefined/empty agents", () => {
+    expect(getDevAgentIds(null).size).toBe(0);
+    expect(getDevAgentIds(undefined).size).toBe(0);
+    expect(getDevAgentIds([]).size).toBe(0);
+  });
+
+  it("only includes agents with a string liveAgentId", () => {
+    const agents = [agent("dev-1", "live-1"), agent("plain-1")];
+    expect(getDevAgentIds(agents)).toEqual(new Set(["dev-1"]));
+  });
+});
+
+describe("getLiveDevAgentMaps", () => {
+  it("returns empty maps for null/undefined/empty agents", () => {
+    const { liveToDev, devToLive } = getLiveDevAgentMaps(null);
+    expect(liveToDev.size).toBe(0);
+    expect(devToLive.size).toBe(0);
+  });
+
+  it("builds both directions from dev agents' liveAgentId", () => {
+    const agents = [agent("dev-1", "live-1"), agent("plain-1")];
+    const { liveToDev, devToLive } = getLiveDevAgentMaps(agents);
+    expect(devToLive.get("dev-1")).toBe("live-1");
+    expect(liveToDev.get("live-1")).toBe("dev-1");
+    expect(devToLive.has("plain-1")).toBe(false);
+  });
+});
+
+describe("findDevPartner", () => {
+  it("returns null for a null/undefined agent", () => {
+    expect(findDevPartner(null, [])).toBeNull();
+    expect(findDevPartner(undefined, [])).toBeNull();
+  });
+
+  it("returns 'dev' mode when the agent itself has a liveAgentId", () => {
+    const dev = agent("dev-1", "live-1");
+    expect(findDevPartner(dev, [dev])).toEqual({
+      mode: "dev",
+      targetId: "live-1",
+    });
+  });
+
+  it("returns 'live' mode when some dev agent points back at this agent", () => {
+    const live = agent("live-1");
+    const dev = agent("dev-1", "live-1");
+    expect(findDevPartner(live, [dev, live])).toEqual({
+      mode: "live",
+      targetId: "dev-1",
+    });
+  });
+
+  it("returns null when the agent has no dev/live pairing", () => {
+    const solo = agent("solo-1");
+    expect(findDevPartner(solo, [solo])).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
`apps/mesh/src/web/lib/agent-capabilities.ts` had zero test coverage for `getDevAgentIds`, `getLiveDevAgentMaps`, and `findDevPartner` — the pure functions backing the Develop/Live agent-pairing toggle. Everything else in the file (`agentHasClonableSource`, `agentHasConnectedGithub`, `agentShowsGithubHeaderActions`, `hasLocalCliHarness`) already had tests; these three were the gap.

Adds tests covering:
- `getDevAgentIds`: empty/null input, filtering to only agents with a string `liveAgentId`
- `getLiveDevAgentMaps`: empty input, both map directions populated from dev agents
- `findDevPartner`: null agent, dev-mode (agent has `liveAgentId`), live-mode (reverse lookup via another agent's `liveAgentId`), and no-pairing case

## Test plan
- [x] `bun test apps/mesh/src/web/lib/agent-capabilities.test.ts` — 24 pass, 0 fail
- [x] `bun run fmt`
- Full CI will run typecheck/lint across the monorepo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for getDevAgentIds, getLiveDevAgentMaps, and findDevPartner to validate the Develop/Live agent-pairing toggle and prevent regressions. Covers null/empty inputs, filtering to dev agents with a string liveAgentId, building both live↔dev maps, resolving dev/live partner, and no-pairing cases.

<sup>Written for commit 7b3d95b5d1590274379acc82385873d89a996ac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

