### PR TITLE
fix(deploy): gracefully quit nginx on preStop instead of sleeping

### DIFF
--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -91,8 +91,17 @@ spec:
             periodSeconds: 5
           lifecycle:
             preStop:
+              # `nginx -s quit` closes the listen socket and drains open
+              # keep-alive connections immediately, so a pod mid-rollout stops
+              # serving its (stale) baked SPA build right away instead of
+              # continuing to answer normally for the whole grace window. The
+              # sleep after gives that drain time to finish before kubelet's
+              # SIGTERM lands and force-kills it mid-shutdown.
               exec:
-                command: ["sleep", "{{ .Values.nginx.preStopSleepSeconds | default 15 }}"]
+                command:
+                  - /bin/sh
+                  - -c
+                  - "nginx -s quit; sleep {{ .Values.nginx.preStopSleepSeconds | default 15 }}"
           {{- with .Values.nginx.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## Summary
- The nginx sidecar's `preStop` hook was just `sleep 15` — during that window a terminating pod keeps answering requests completely normally, still serving its old baked SPA build (old JS bundle / `__MESH_VERSION__`), instead of actually stopping.
- Fix: `nginx -s quit` closes the listen socket and drains existing keep-alive connections immediately when the pod starts terminating, instead of continuing to serve as if healthy for the full grace window.

Note: this was originally written while chasing a user-reported "sometimes I open the app and see an old version" bug. That symptom turned out to be unrelated — it was Chrome prerendering the page in the background from history/most-visited shortcuts and showing a stale snapshot on tab-open (confirmed via Incognito, which has no history to prerender from and loaded current immediately). This PR stands on its own merits regardless: a terminating pod shouldn't keep serving its stale build for 15s just because nothing told it to stop.

## Testing notes
- `helm template deploy/helm/studio --set database.url=... --show-only templates/deployment.yaml` renders the new `preStop.exec.command` correctly.
- `bun run fmt` run, no changes needed beyond the template edit.
- Not tested against a live rollout (would need a staging deploy to observe the actual connection-drain behavior end-to-end).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully stop the nginx sidecar during pod termination to prevent serving stale SPA assets during rollouts. Replaces the preStop sleep with `nginx -s quit` so the pod closes its listen socket and drains keep-alives immediately, removing the 15s stale window behind the L4 NLB.

- **Bug Fixes**
  - Update `preStop` to: `/bin/sh -c "nginx -s quit; sleep {{ .Values.nginx.preStopSleepSeconds | default 15 }}"`
  - Stops terminating pods from serving old bundles; allows clean drain before kill without other app changes

<sup>Written for commit b8fb2250f3055c37f038ec4e696f7b5e8ac90f12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
