### PR TITLE
test(web): cover entryMarker contentHash fallback behavior

### DIFF
--- a/apps/mesh/src/web/hooks/use-org-fs.test.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { entryMarker } from "./use-org-fs";
+
+describe("entryMarker", () => {
+  test("prefers contentHash when present", () => {
+    expect(
+      entryMarker({
+        size: 10,
+        updatedAt: "2026-01-01T00:00:00Z",
+        contentHash: "abc123",
+      }),
+    ).toBe("abc123");
+  });
+
+  test("falls back to size-updatedAt when contentHash is null", () => {
+    expect(
+      entryMarker({
+        size: 10,
+        updatedAt: "2026-01-01T00:00:00Z",
+        contentHash: null,
+      }),
+    ).toBe("10-2026-01-01T00:00:00Z");
+  });
+
+  test("falls back to size-updatedAt when contentHash is undefined", () => {
+    expect(
+      entryMarker({
+        size: 5,
+        updatedAt: "2026-02-02T00:00:00Z",
+      }),
+    ).toBe("5-2026-02-02T00:00:00Z");
+  });
+});


### PR DESCRIPTION
## Summary
- `entryMarker` (apps/mesh/src/web/hooks/use-org-fs.ts) is the cache-busting key used to detect content changes in the Library/org-fs preview UI, but had no test coverage of its contentHash vs. size+updatedAt fallback logic.
- Added unit tests covering: contentHash present, contentHash `null`, and contentHash `undefined` — the three states the function actually branches on.

A maintainer touching this fallback (e.g. changing the separator or preferring a different key) now gets immediate feedback if the contract breaks, instead of a silent stale-preview regression.

## Test plan
- `bun test apps/mesh/src/web/hooks/use-org-fs.test.ts` — 3 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added unit tests for `entryMarker` to ensure it prefers contentHash and falls back to size-updatedAt, protecting the Library/org-fs preview cache-busting behavior. Covers contentHash present, null, and undefined.

<sup>Written for commit 945c1e6a9670dcf9d8fcfd02769fabb6c1e6afca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

