### PR TITLE
test(sandbox): cover discard's restore-vs-delete branch in git routes

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -1,4 +1,11 @@
-import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "bun:test";
@@ -426,6 +433,39 @@ describe("git routes", () => {
     expect(await res.json()).toEqual({
       error: "Invalid path: ../outside-secret.txt",
     });
+  });
+
+  it("discard restores a modified tracked file to its HEAD content", async () => {
+    const { appRoot, repoDir } = initRepo();
+    writeFileSync(join(repoDir, "README.md"), "changed\n");
+
+    const handler = makeGitDiscardHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/discard", {
+        method: "POST",
+        body: JSON.stringify({ filepaths: ["README.md"] }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(readFileSync(join(repoDir, "README.md"), "utf8")).toBe("hello\n");
+  });
+
+  it("discard deletes an untracked file instead of restoring it", async () => {
+    const { appRoot, repoDir } = initRepo();
+    const untracked = join(repoDir, "scratch.txt");
+    writeFileSync(untracked, "temp\n");
+
+    const handler = makeGitDiscardHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/discard", {
+        method: "POST",
+        body: JSON.stringify({ filepaths: ["scratch.txt"] }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(existsSync(untracked)).toBe(false);
   });
 
   it("rebase rejects invalid base branch names", async () => {


### PR DESCRIPTION
## Source
A small improvement seen while reading `packages/sandbox/daemon/routes/git.ts` — the `discard()` function's core branching (restore a tracked file vs. delete an untracked one) had zero test coverage. The existing `git.test.ts` only exercised the path-traversal error case for the discard handler, never the two normal outcomes.

## Why
This is the main logic that decides whether "discard changes" runs `git checkout` (tracked file) or `unlinkSync` (new/untracked file) — the two behave very differently for the user, and a regression here would silently corrupt or delete the wrong thing. Worth a maintainer's five minutes to lock it in.

## What's covered
- `discard restores a modified tracked file to its HEAD content` — modifies README.md, discards it, asserts the working tree reverts to the committed content.
- `discard deletes an untracked file instead of restoring it` — writes a new untracked file, discards it, asserts it's removed from disk.

## Verify
```
bun test packages/sandbox/daemon/routes/git.test.ts
```

## Checks run locally
- `bun run fmt` (clean, no changes)
- `bun x tsc --noEmit` in `packages/sandbox` (passes)
- `bun test packages/sandbox/daemon/routes/git.test.ts` — 20 pass, 0 fail

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests covering `discard()` in sandbox git routes to exercise the restore-vs-delete logic. Verifies that modified tracked files revert to HEAD content and untracked files are deleted.

<sup>Written for commit 59387befcf0320d7a28a75079d759b5e29a86fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

