### PR TITLE
test(web): cover invalidateVirtualMcpQueries predicate branches

### DIFF
--- a/apps/mesh/src/web/lib/query-keys.test.ts
+++ b/apps/mesh/src/web/lib/query-keys.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { invalidateVirtualMcpQueries } from "./query-keys.ts";
+
+function capturePredicate(orgId?: string) {
+  let predicate: (query: { queryKey: readonly unknown[] }) => boolean = () =>
+    false;
+  const queryClient = {
+    invalidateQueries: (opts: {
+      predicate: (query: { queryKey: readonly unknown[] }) => boolean;
+    }) => {
+      predicate = opts.predicate;
+    },
+    // biome-ignore lint: minimal fake matching the subset used by the function under test
+  } as any;
+  invalidateVirtualMcpQueries(queryClient, orgId);
+  return predicate;
+}
+
+describe("invalidateVirtualMcpQueries", () => {
+  test("matches a VIRTUAL_MCP collection key for the given org", () => {
+    const predicate = capturePredicate("org_1");
+    expect(
+      predicate({
+        queryKey: ["prefix", "org_1", "scope", "collection", "VIRTUAL_MCP"],
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects a key for a different org when orgId is provided", () => {
+    const predicate = capturePredicate("org_1");
+    expect(
+      predicate({
+        queryKey: ["prefix", "org_2", "scope", "collection", "VIRTUAL_MCP"],
+      }),
+    ).toBe(false);
+  });
+
+  test("matches any org when orgId is omitted", () => {
+    const predicate = capturePredicate(undefined);
+    expect(
+      predicate({
+        queryKey: ["prefix", "org_2", "scope", "collection", "VIRTUAL_MCP"],
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects non-collection or non-VIRTUAL_MCP keys", () => {
+    const predicate = capturePredicate("org_1");
+    expect(
+      predicate({
+        queryKey: ["prefix", "org_1", "scope", "not-collection", "VIRTUAL_MCP"],
+      }),
+    ).toBe(false);
+    expect(
+      predicate({
+        queryKey: ["prefix", "org_1", "scope", "collection", "OTHER"],
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Source: Source 3 (missing unit test) — `apps/mesh/src/web/lib/query-keys.ts` had 505 lines and zero test coverage, including `invalidateVirtualMcpQueries`, whose invalidation `predicate` has real branching logic (org match, key-shape match) that silently determines which cached queries get evicted.
- Adds `apps/mesh/src/web/lib/query-keys.test.ts`, covering: org-scoped match, org mismatch rejection, org-omitted wildcard match, and rejection of non-collection/non-VIRTUAL_MCP keys.

## Why this matters
A regression in this predicate (e.g. a shifted key index) would silently stop invalidating Virtual MCP caches after mutations — no crash, just stale UI — so it's worth locking the branches down with a test.

## Test plan
- `bun test apps/mesh/src/web/lib/query-keys.test.ts` — 4 pass.
- `bunx tsc --noEmit` in `apps/mesh` — no new errors.
- Full CI will run lint/typecheck/full suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests for invalidateVirtualMcpQueries to lock down its predicate logic and prevent regressions that break Virtual MCP cache invalidation. Covers org match, org mismatch, wildcard org (omitted), and rejection of non-collection or non-VIRTUAL_MCP keys.

<sup>Written for commit 680c23cd2641e74c3fec85a9b55bbcea08f5288d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

