### PR TITLE
test(harness): cover resolveAgentTier tier mapping and decopilot fallback

### DIFF
--- a/packages/harness/src/claude-code/model/agent-tiers.test.ts
+++ b/packages/harness/src/claude-code/model/agent-tiers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { resolveAgentTier } from "./agent-tiers";
+
+describe("resolveAgentTier", () => {
+  it("resolves claude-code tiers", () => {
+    expect(resolveAgentTier("claude-code", "fast")).toEqual({
+      modelId: "claude-code:haiku",
+      label: "Haiku 4.5",
+    });
+    expect(resolveAgentTier("claude-code", "smart")).toEqual({
+      modelId: "claude-code:sonnet",
+      label: "Sonnet 5",
+    });
+    expect(resolveAgentTier("claude-code", "thinking")).toEqual({
+      modelId: "claude-code:opus-1m",
+      label: "Opus 4.8 1M",
+    });
+  });
+
+  it("resolves codex tiers", () => {
+    expect(resolveAgentTier("codex", "fast")).toEqual({
+      modelId: "codex:gpt-5.4-mini",
+      label: "GPT-5.4 Mini",
+    });
+    expect(resolveAgentTier("codex", "smart")).toEqual({
+      modelId: "codex:gpt-5.4",
+      label: "GPT-5.4",
+    });
+  });
+
+  it("returns null for decopilot — it uses the AI provider path instead", () => {
+    expect(resolveAgentTier("decopilot", "fast")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Source
Untested pure function found while scanning recently-churned areas (`packages/harness/src/claude-code/model/agent-tiers.ts`) — no existing test file covered it.

## Why
`resolveAgentTier` drives which model the desktop CLI harness (Claude Code / Codex) dispatches per chat tier, and is the kind of small lookup table that silently drifts when a model ID/label is renamed. A test locks the fast/smart/thinking mapping for both harnesses and the `decopilot` → `null` fallback (which signals "use the AI provider path instead").

## Testing
`bun test packages/harness/src/claude-code/model/agent-tiers.test.ts`

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` (in `packages/harness`)
- `bun test packages/harness/src/claude-code/model/agent-tiers.test.ts` (3 pass)

Full CI will run the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `resolveAgentTier` to lock the tier-to-model mapping and the `decopilot` null fallback. Verifies `claude-code` and `codex` tiers resolve to the expected model IDs and labels so the CLI harness picks the right model.

<sup>Written for commit 0ddbc32dc76585a9184a2e1e5f4e8d989ec256a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

