### PR TITLE
feat(web): remove Shopify Headless Store button from browse agents menu

### DIFF
--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -40,8 +40,6 @@ import {
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import {
-  HYDROGEN_TEMPLATE,
-  SHOPIFY_HYDROGEN_ICON,
   WEBSITE_TEMPLATE,
   useCreateAgentFromTemplate,
 } from "@/web/hooks/use-create-website-agent";
@@ -259,31 +257,6 @@ function PinAgentPopoverContent({
             </div>
             <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
               Start Website
-            </span>
-          </button>
-
-          <button
-            type="button"
-            disabled={isCreatingFromTemplate}
-            onClick={async () => {
-              track("agent_create_clicked", {
-                source: "browse_popover",
-                method: "hydrogen",
-              });
-              await createFromTemplate(HYDROGEN_TEMPLATE);
-              onClose();
-            }}
-            className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <div className="w-12 h-12 rounded-xl border-2 border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-              <img
-                src={SHOPIFY_HYDROGEN_ICON}
-                alt=""
-                className="size-5 object-contain"
-              />
-            </div>
-            <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
-              Shopify Headless Store
             </span>
           </button>
 


### PR DESCRIPTION
## Summary
Removes the fixed **"Shopify Headless Store"** button from the Browse Agents menu (the popover on desktop / drawer on mobile in `agents-section.tsx`), along with the now-unused `HYDROGEN_TEMPLATE` and `SHOPIFY_HYDROGEN_ICON` imports.

The remaining fixed buttons in the menu: **Create new**, **Start Website**, **Import GitHub**, and **Import deco.cx** (deco users only).

## Notes
- The equivalent "Create Shopify Headless Store" item in the `agents-list` route dropdown (`create-agent-dropdown.tsx`) was left intact, since the request targeted the browse-agents menu card.

## Testing
- `bun run fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the fixed "Shopify Headless Store" button from the Browse Agents menu (desktop popover and mobile drawer) to simplify the options. Cleaned up unused `HYDROGEN_TEMPLATE` and `SHOPIFY_HYDROGEN_ICON` imports.

<sup>Written for commit 44ddfea81197dc2b9e6e7c34c0335b22ee22e77c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

