### PR TITLE
test(github): cover resolveSandboxBranchFromMap and resolveEffectiveBranch edge cases

### DIFF
--- a/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts
+++ b/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts
@@ -45,6 +45,47 @@ describe("resolveSandboxBranchFromMap", () => {
       "deco/other",
     );
   });
+
+  test("returns prefer as-is when userId is missing", () => {
+    expect(
+      resolveSandboxBranchFromMap(sandboxMapFixture, undefined, "deco/pref"),
+    ).toBe("deco/pref");
+  });
+
+  test("returns null when userId is missing and no prefer given", () => {
+    expect(
+      resolveSandboxBranchFromMap(sandboxMapFixture, undefined),
+    ).toBeNull();
+  });
+
+  test("returns prefer as-is when user has no sandbox map entry", () => {
+    expect(
+      resolveSandboxBranchFromMap(
+        sandboxMapFixture,
+        "unknown-user",
+        "deco/pref",
+      ),
+    ).toBe("deco/pref");
+  });
+
+  test("skips branches with no sandbox kinds when scanning for a fallback", () => {
+    const mapWithEmptyEntry = {
+      user1: {
+        "deco/empty": {},
+        "deco/other": {
+          "agent-sandbox": {
+            sandboxHandle: "h2",
+            previewUrl: "http://localhost:2",
+            sandboxProviderKind: "agent-sandbox" as const,
+          },
+        },
+      },
+    } satisfies SandboxMap;
+
+    expect(resolveSandboxBranchFromMap(mapWithEmptyEntry, "user1", null)).toBe(
+      "deco/other",
+    );
+  });
 });
 
 describe("resolveEffectiveBranch", () => {
@@ -68,5 +109,27 @@ describe("resolveEffectiveBranch", () => {
         gitCurrentBranch: "git-branch",
       }),
     ).toBe("map-branch");
+  });
+
+  test("prefers sandbox branch over map and git branches", () => {
+    expect(
+      resolveEffectiveBranch({
+        chatBranch: null,
+        sandboxBranch: "sse-branch",
+        sandboxMapBranch: "map-branch",
+        gitCurrentBranch: "git-branch",
+      }),
+    ).toBe("sse-branch");
+  });
+
+  test("returns null when every source is null", () => {
+    expect(
+      resolveEffectiveBranch({
+        chatBranch: null,
+        sandboxBranch: null,
+        sandboxMapBranch: null,
+        gitCurrentBranch: null,
+      }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Source: small test-coverage improvement found while reading `apps/mesh/src/web/components/thread/github/header-actions.tsx` (a recently-churned file) and its helper `resolve-sandbox-branch.ts`.
- Payoff: `resolveSandboxBranchFromMap` and `resolveEffectiveBranch` drive which branch the GitHub header actions target, but the existing test file only covered the happy paths. Missing branches (no `userId`, unknown user, empty-`kinds` entries skipped during fallback scan, and `resolveEffectiveBranch`'s null-fallthrough / sandbox-branch precedence) were unverified.
- No behavior changes — pure test additions.

## Test plan
- `bun test apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts` — 10 pass (was 4).

## Local checks run
- `bun run fmt`
- `bun test apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts`

Full CI will run typecheck/lint/full suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for edge cases in resolveSandboxBranchFromMap and resolveEffectiveBranch. Verifies branch resolution for GitHub header actions, including missing/unknown user, empty sandbox kinds in fallback, sandbox precedence over map and git, and all-null fallthrough, with no behavior changes.

<sup>Written for commit d79bb6c5c9a41d3c295ccf338dac86ebc05eea11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

