### PR TITLE
fix(commerce-onboarding): add disconnect option to GA companion config

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -1,4 +1,5 @@
 import { IntegrationIcon } from "@/web/components/integration-icon";
+import { KEYS } from "@/web/lib/query-keys";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
@@ -15,8 +16,10 @@ import {
 } from "@deco/ui/components/tooltip.tsx";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { useMCPClient } from "@decocms/mesh-sdk";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle, Loading01, Settings01 } from "@untitledui/icons";
 import { Suspense, useState } from "react";
+import { toast } from "sonner";
 import type { CompanionCardModel } from "./companions-core.ts";
 import {
   getConfigurationSummaryEntries,
@@ -321,6 +324,7 @@ function CompanionConfiguration({
   });
   const [dialogOpen, setDialogOpen] = useState(autoOpen);
   const [isSavePending, setIsSavePending] = useState(false);
+  const queryClient = useQueryClient();
 
   const FormComponent = COMPANION_CONFIG_FORMS[card.bindingType];
   const savedConfigEntries = getConfigurationSummaryEntries(
@@ -344,6 +348,25 @@ function CompanionConfiguration({
     }
     setDialogOpen(true);
   };
+
+  const disconnectMutation = useMutation({
+    mutationFn: async () => {
+      await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_DELETE",
+        arguments: { id: connectionId, force: true },
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryCompanionConnectionsPrefix(org.id),
+      });
+      toast.success(`${card.title} desconectado`);
+      closeDialog();
+    },
+    onError: () => {
+      toast.error("Não foi possível desconectar. Tente novamente.");
+    },
+  });
 
   // No config form for this binding → nothing to open; skip the gear entirely.
   if (!FormComponent) {
@@ -395,6 +418,7 @@ function CompanionConfiguration({
             org={org}
             contextSiteUrl={contextSiteUrl}
             onDone={closeDialog}
+            onDisconnect={() => disconnectMutation.mutate()}
             onIsPendingChange={setIsSavePending}
           />
         </DialogContent>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-analytics-config-form.tsx
@@ -32,6 +32,7 @@ export function GoogleAnalyticsConfigForm({
   selfClient,
   org,
   onDone,
+  onDisconnect,
   onIsPendingChange,
 }: CompanionFormProps) {
   const propertiesQuery = useQuery({
@@ -97,6 +98,22 @@ export function GoogleAnalyticsConfigForm({
           Nenhuma propriedade do Google Analytics foi encontrada. Conecte uma
           conta do Google Analytics com propriedades.
         </p>
+        <DialogFooter className="flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          {onDisconnect ? (
+            <button
+              type="button"
+              onClick={onDisconnect}
+              className="text-xs text-muted-foreground underline underline-offset-2 hover:text-destructive"
+            >
+              Desconectar conta
+            </button>
+          ) : (
+            <span />
+          )}
+          <Button type="button" variant="outline" onClick={onDone}>
+            Fechar
+          </Button>
+        </DialogFooter>
       </div>
     );
   }
@@ -132,18 +149,32 @@ export function GoogleAnalyticsConfigForm({
         </p>
       )}
 
-      <DialogFooter className="pt-4">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onDone}
-          disabled={isPending}
-        >
-          Cancelar
-        </Button>
-        <Button type="submit" disabled={isPending}>
-          {isPending ? "Salvando..." : "Salvar"}
-        </Button>
+      <DialogFooter className="flex-col gap-2 pt-4 sm:flex-row sm:items-center sm:justify-between">
+        {onDisconnect ? (
+          <button
+            type="button"
+            onClick={onDisconnect}
+            disabled={isPending}
+            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-destructive disabled:opacity-50"
+          >
+            Desconectar conta
+          </button>
+        ) : (
+          <span />
+        )}
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onDone}
+            disabled={isPending}
+          >
+            Cancelar
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Salvando..." : "Salvar"}
+          </Button>
+        </div>
       </DialogFooter>
     </form>
   );

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/types.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/types.ts
@@ -14,6 +14,7 @@ export interface CompanionFormProps {
   org: CompanionOrg;
   contextSiteUrl?: string;
   onDone: () => void;
+  onDisconnect?: () => void;
   onIsPendingChange?: (isPending: boolean) => void;
 }
 


### PR DESCRIPTION
## What is this contribution about?

When a Google Analytics OAuth connection has no visible properties, the config dialog showed only an error message with no way to disconnect. This adds a "Desconectar conta" link in both the empty-state and the normal form footer, wired to `COLLECTION_CONNECTIONS_DELETE` (with `force: true`) and query cache invalidation so the card returns to disconnected state on success.

## Screenshots/Demonstration

Before: dialog showed "Nenhuma propriedade do Google Analytics foi encontrada" with only a close (×) button — no way to disconnect.

After: a "Desconectar conta" underline link appears at the bottom-left of the dialog in both the empty-state and the normal property-selection footer.

## How to Test

1. Connect a Google Analytics account via OAuth whose authorized account has no GA4 properties.
2. Click the settings gear on the "Conectado" card.
3. Confirm "Desconectar conta" appears and clicking it removes the connection and returns the card to the unconnected state.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GA config dialog by adding a way to disconnect when no properties are found. On success, the connection is removed and the card returns to the disconnected state.

- Bug Fixes
  - Show "Desconectar conta" link in both the empty state and the normal footer.
  - Call `COLLECTION_CONNECTIONS_DELETE` with `force: true`.
  - Invalidate `KEYS.commerceDiscoveryCompanionConnectionsPrefix(org.id)` and show success/error toasts.

<sup>Written for commit c9bfc17d2a35cbd9062810c87f9637dadb34e527. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

