### PR TITLE
feat(web): prompt refresh when a newer server version is deployed

### DIFF
--- a/apps/mesh/src/api/routes/public-config.ts
+++ b/apps/mesh/src/api/routes/public-config.ts
@@ -11,6 +11,7 @@ import { isLocalMode } from "@/auth/local-mode";
 import { getInternalUrl } from "@/core/server-constants";
 import { getSettings } from "@/settings";
 import { buildAuthConfig, type AuthConfig } from "@/api/routes/auth";
+import pkg from "../../../package.json" with { type: "json" };
 
 const app = new Hono();
 
@@ -18,6 +19,11 @@ const app = new Hono();
  * Public configuration exposed to the UI
  */
 export type PublicConfig = {
+  /**
+   * Deployed server version (apps/mesh/package.json). Compared against the
+   * client's build-time `__MESH_VERSION__` to detect a stale bundle.
+   */
+  version: string;
   /**
    * Theme customization for light and dark modes.
    * Contains CSS variable overrides that will be injected into the document.
@@ -94,6 +100,7 @@ function buildPosthogConfig(): PublicConfig["posthog"] {
  */
 app.get("/", (c) => {
   const config: PublicConfig = {
+    version: pkg.version,
     theme: getThemeConfig(),
     ...(getConfig().logo && { logo: getConfig().logo }),
     // Only expose internalUrl in local mode — production uses the public URL directly

--- a/apps/mesh/src/web/components/version-check-dialog.tsx
+++ b/apps/mesh/src/web/components/version-check-dialog.tsx
@@ -1,0 +1,54 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
+import { useQuery } from "@tanstack/react-query";
+import type { PublicConfig } from "@/api/routes/public-config";
+import { KEYS } from "@/web/lib/query-keys";
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Polls /api/config on its own (short-lived, unlike the Infinity-staleTime
+ * publicConfig query used for boot) and prompts a refresh once the deployed
+ * server version drifts from this bundle's build-time __MESH_VERSION__.
+ */
+export function VersionCheckDialog() {
+  const { data: serverVersion } = useQuery({
+    queryKey: KEYS.appVersionCheck(),
+    queryFn: async () => {
+      const response = await fetch("/api/config");
+      const { config }: { config: PublicConfig } = await response.json();
+      return config.version;
+    },
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    staleTime: 0,
+  });
+
+  const isStale = !!serverVersion && serverVersion !== __MESH_VERSION__;
+
+  return (
+    <AlertDialog open={isStale}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>A new version is available</AlertDialogTitle>
+          <AlertDialogDescription>
+            You're viewing an outdated version of this page. Refresh to get the
+            latest updates.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction onClick={() => window.location.reload()}>
+            Refresh
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -3,6 +3,7 @@ import { OrgAccessGate } from "@/web/components/org-access-gate";
 import { SplashScreen } from "@/web/components/splash-screen";
 import { SidebarReleaseCard } from "@/web/components/release-channel/sidebar-release-card";
 import { KeyboardShortcutsDialog } from "@/web/components/keyboard-shortcuts-dialog";
+import { VersionCheckDialog } from "@/web/components/version-check-dialog";
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
 import RequiredAuthLayout from "@/web/layouts/required-auth-layout";
 import { authClient } from "@/web/lib/auth-client";
@@ -361,6 +362,8 @@ function ShellLayoutContent() {
         open={shortcutsDialogOpen}
         onOpenChange={setShortcutsDialogOpen}
       />
+
+      <VersionCheckDialog />
     </ShellProjectProvider>
   );
 }

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -11,6 +11,10 @@ export const KEYS = {
   // Public config (no auth required)
   publicConfig: () => ["publicConfig"] as const,
 
+  // Polled separately from publicConfig (which is cached forever) to detect
+  // a deployed version newer than the client's own build.
+  appVersionCheck: () => ["appVersionCheck"] as const,
+
   // Auth-related queries
   session: () => ["session"] as const,
 


### PR DESCRIPTION
## Summary
- `/api/config` (`apps/mesh/src/api/routes/public-config.ts`) now returns a `version` field sourced from `apps/mesh/package.json`.
- New `VersionCheckDialog` (`apps/mesh/src/web/components/version-check-dialog.tsx`) polls that endpoint every 5 minutes via its own `useQuery` (separate from the existing `publicConfig` suspense query, which is cached with `staleTime: Infinity` for boot performance and shouldn't be touched by this).
- If the polled server version differs from the client bundle's build-time `__MESH_VERSION__`, a non-dismissible alert dialog prompts the user to refresh.
- Mounted globally in `ShellLayout` alongside the existing `KeyboardShortcutsDialog`/`SidebarReleaseCard`.

Motivated by a user report of occasionally seeing an old app version on load — that specific report turned out to be a Chrome background-prerender artifact (not a real staleness bug, confirmed via Incognito), but the underlying gap is real: nothing today tells a user their tab is running a stale bundle after a real deploy, e.g. on a long-lived tab left open across releases.

## Testing notes
- `bun run --cwd=apps/mesh check` — clean except two pre-existing, unrelated `use-stick-to-bottom` module errors (present on `main` too, not touched by this change).
- `bun run lint` — 0 errors (7 pre-existing warnings elsewhere, unrelated to these files).
- `bun run fmt` run.
- Not manually verified in a running browser — would need to fake a version mismatch (e.g. temporarily edit the served config) to see the dialog trigger.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prompt users to refresh when a newer server version is deployed, preventing stale bundles on long‑lived tabs. The server now exposes a version, and the client polls every 5 minutes to detect drift.

- **New Features**
  - `/api/config` adds a `version` from `apps/mesh/package.json`.
  - New `VersionCheckDialog` polls every 5 minutes via `@tanstack/react-query`, compares to build-time `__MESH_VERSION__`, and shows a non-dismissible refresh dialog on mismatch.
  - Mounted globally in `ShellLayout`; adds `KEYS.appVersionCheck()` separate from the infinity-stale `publicConfig` cache.

<sup>Written for commit bd15af6be9c9664f75f6cb45aa5600444658c39d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

