### PR TITLE
test(sandbox): cover canHotReloadDaemon branches

### DIFF
--- a/packages/sandbox/server/daemon-spawn.test.ts
+++ b/packages/sandbox/server/daemon-spawn.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildSandboxDaemonSpawnCommand,
+  canHotReloadDaemon,
   deriveNodeModulesDir,
   resolveDaemonStdio,
   sandboxDaemonLogPath,
@@ -54,6 +55,37 @@ describe("sandboxDaemonLogPath", () => {
     expect(sandboxDaemonLogPath(workdir)).toBe(
       "/data/sandboxes/h1/tmp/daemon.log",
     );
+  });
+});
+
+describe("canHotReloadDaemon", () => {
+  it("is false when hotReload is not requested, even if paths match", () => {
+    expect(
+      canHotReloadDaemon({
+        daemonExec: "/repo/packages/sandbox/daemon/entry.ts",
+        sourceDaemonPath: "/repo/packages/sandbox/daemon/entry.ts",
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when hotReload is requested but the daemon is a materialized bundle", () => {
+    expect(
+      canHotReloadDaemon({
+        daemonExec: "/tmp/cache/sandbox-daemon-deadbeef.js",
+        sourceDaemonPath: "/repo/packages/sandbox/daemon/entry.ts",
+        hotReload: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when hotReload is requested and paths resolve to the same file, even with a non-normalized path", () => {
+    expect(
+      canHotReloadDaemon({
+        daemonExec: "/repo/packages/sandbox/daemon/../daemon/entry.ts",
+        sourceDaemonPath: "/repo/packages/sandbox/daemon/entry.ts",
+        hotReload: true,
+      }),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Source
Missing test coverage — improvement, not tied to an issue.

## Why
`canHotReloadDaemon` (packages/sandbox/server/daemon-spawn.ts) decides whether the spawned sandbox daemon gets `bun --hot` — get it wrong and either hot reload silently stops working in dev, or a materialized-bundle production spawn accidentally reloads from a nonexistent source path. It was previously only exercised indirectly through `buildSandboxDaemonSpawnCommand`, so a regression in the resolve/compare logic itself wouldn't have failed any test.

## What changed
Added a `describe("canHotReloadDaemon", ...)` block covering:
- `hotReload` not requested → false even when paths already match
- `hotReload` requested but `daemonExec` is a materialized bundle (paths differ) → false
- `hotReload` requested and paths resolve to the same file after a non-normalized (`../`) path → true

## How to verify
`bun test packages/sandbox/server/daemon-spawn.test.ts`

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` (packages/sandbox)
- `bun test packages/sandbox/server/daemon-spawn.test.ts` — 12 pass, 0 fail

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add direct tests for canHotReloadDaemon to lock down hot reload eligibility and path resolution. Tests assert false when hotReload is not requested, false when daemonExec is a materialized bundle, and true when exec and source resolve to the same file even with non-normalized paths.

<sup>Written for commit 63183fa37261f1c59d289102f9579be423d8e2bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

