### PR TITLE
fix(web): reduce desktop-link status poll frequency

### DIFF
--- a/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
@@ -59,7 +59,7 @@ export function ConnectDesktopDialog({
   open,
   onOpenChange,
 }: ConnectDesktopDialogProps) {
-  const link = useCurrentLink();
+  const link = useCurrentLink({ fast: open });
   const [copied, setCopied] = useState(false);
   const desktopName = link.hostname ?? link.machineId ?? "Your desktop";
 

--- a/apps/mesh/src/web/hooks/use-current-link.ts
+++ b/apps/mesh/src/web/hooks/use-current-link.ts
@@ -20,9 +20,19 @@ export interface CurrentLink {
 
 const OFFLINE: CurrentLink = { online: false, capabilities: [], ready: false };
 
-export function useCurrentLink(): CurrentLink {
+export interface UseCurrentLinkOptions {
+  /**
+   * Poll faster while something is actively watching for a state change
+   * (e.g. the "waiting for desktop" connect dialog). Everyone else gets the
+   * slow, passive-display cadence.
+   */
+  fast?: boolean;
+}
+
+export function useCurrentLink(options?: UseCurrentLinkOptions): CurrentLink {
   const { org } = useProjectContext();
   const studio = useStudioTools();
+  const fast = options?.fast ?? false;
 
   const { data } = useQuery<CurrentLink>({
     queryKey: KEYS.currentLink(org.id),
@@ -33,8 +43,8 @@ export function useCurrentLink(): CurrentLink {
       > | null;
       return link ? { ...link, ready: true } : { ...OFFLINE, ready: true };
     },
-    staleTime: 4_000,
-    refetchInterval: 5_000,
+    staleTime: fast ? 1_000 : 10_000,
+    refetchInterval: fast ? 2_000 : 15_000,
     refetchOnWindowFocus: true,
   });
 


### PR DESCRIPTION
## Summary
- `useCurrentLink` polled `LINK_CURRENT_GET` every 5s from every mounted consumer (header indicator, offline banner, connect dialog, availability checks, empty states, home layout). Each poll is a real NATS tunnel round-trip to the user's desktop `deco link` daemon, not a cheap cache read.
- Most consumers are passive UI (advisory status, not gating anything) and don't need 5s freshness. Backed those off to a 15s interval / 10s staleTime.
- The one place freshness actually matters — `ConnectDesktopDialog`'s "waiting for desktop…" spinner, shown right after the user runs `bunx decocms@latest link` and is actively watching — keeps fast polling (2s) only while that dialog is open.

## Why not remove polling entirely
Scoped this to the cheap, low-risk fix. A push-based (SSE) redesign is possible since this repo already has a proven SSE hub for decopilot streaming, but reliable disconnect detection would need either NATS system-account events or a new heartbeat/TTL mechanism (JetStream KV is installed but unused today) — real new infra and failure surface, not justified without evidence of actual load/latency pain.

## Test plan
- [x] `bun run fmt`
- [x] `bun run check` (tsc, no errors)
- [x] `bun run lint` (0 errors; pre-existing unrelated warnings only)
- [ ] Manual: open the connect-desktop dialog, run `deco link`, confirm it still detects the connection promptly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce `LINK_CURRENT_GET` polling to cut NATS round-trips without hurting UX. Passive UI now polls every 15s with 10s staleTime; `ConnectDesktopDialog` keeps a 2s interval by calling `useCurrentLink({ fast: open })`.

<sup>Written for commit b0f5d6a719a57da42f4e22b9f6577585497063be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

