### PR TITLE
fix(sandbox): integrate remote branch commits before publish push

### DIFF
--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -145,7 +145,145 @@ function setupDivergedSameBranchRepo(): {
   };
 }
 
+/**
+ * The real sandbox topology (setup/clone.ts, new-workspace path): shallow
+ * single-branch clone of the default branch (`clone --depth 1`), workspace
+ * branch forked locally with `checkout -B`, first save pushed with `-u`.
+ * The clone's fetch refspec covers only `main`, so a plain
+ * `fetch origin <branch>` never materializes refs/remotes/origin/<branch> —
+ * the regression behind the "publish rejected as non-fast-forward" bug.
+ */
+function setupSandboxLikeDivergedRepo(): {
+  repoDir: string;
+  bare: string;
+  seed: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "integrate-sandbox-like-"));
+  const bare = join(root, "origin.git");
+  const seed = join(root, "seed");
+  const gitOpts = { stdio: "ignore" as const };
+  const gitcfg = `-c init.defaultBranch=main -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+  const decoPath = ".deco/blocks/campaign-timer.json";
+
+  execSync(`git ${gitcfg} init --bare ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} init ${seed}`, gitOpts);
+  mkdirSync(join(seed, ".deco/blocks"), { recursive: true });
+  writeFileSync(
+    join(seed, decoPath),
+    JSON.stringify({ copy: "deliver complete experiences" }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m initial`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} branch -M main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} remote add origin ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push -u origin main`, gitOpts);
+
+  // Sandbox clone: shallow + single-branch. file:// is required — plain local
+  // paths ignore --depth and fall back to a full-refspec clone.
+  const repoDir = join(root, "workspace");
+  execSync(`git ${gitcfg} clone --depth 1 file://${bare} ${repoDir}`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${repoDir} config user.email test@example.com`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${repoDir} config user.name test`, gitOpts);
+  // New workspace branch forked locally, first save published with -u.
+  execSync(
+    `git ${gitcfg} -C ${repoDir} checkout -B deco/new-workspace`,
+    gitOpts,
+  );
+  writeFileSync(
+    join(repoDir, decoPath),
+    JSON.stringify({ copy: "first save from studio" }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${repoDir} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${repoDir} commit -m "first save"`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${repoDir} push -u origin deco/new-workspace`,
+    gitOpts,
+  );
+
+  // Another environment commits to the same branch behind the sandbox's back.
+  execSync(`git ${gitcfg} -C ${seed} fetch origin deco/new-workspace`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${seed} checkout -b deco/new-workspace origin/deco/new-workspace`,
+    gitOpts,
+  );
+  writeFileSync(join(seed, "outside.txt"), "committed outside the studio\n");
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m "outside change"`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push origin deco/new-workspace`, gitOpts);
+
+  // Sandbox commits its next save, unaware of the outside commit.
+  writeFileSync(
+    join(repoDir, decoPath),
+    JSON.stringify({ copy: "second save from studio" }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${repoDir} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${repoDir} commit -m "second save"`, gitOpts);
+
+  return {
+    repoDir,
+    bare,
+    seed,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
 describe("integrateRemoteBranch", () => {
+  it("integrates outside commits in a shallow single-branch sandbox clone", () => {
+    const { repoDir, bare, cleanup } = setupSandboxLikeDivergedRepo();
+    try {
+      // Precondition of the regression: the clone's refspec only covers main,
+      // so the workspace branch has no remote-tracking ref to compare against.
+      const trackingRef = () => {
+        try {
+          return execSync(
+            `git -C ${repoDir} rev-parse --verify refs/remotes/origin/deco/new-workspace`,
+            { stdio: "pipe" },
+          )
+            .toString()
+            .trim();
+        } catch {
+          return null;
+        }
+      };
+      expect(trackingRef()).toBeNull();
+
+      const { rebased } = integrateRemoteBranch(repoDir, "deco/new-workspace", {
+        asUser: false,
+      });
+      expect(rebased).toBe(true);
+
+      // Push must now fast-forward, with both saves and the outside commit.
+      execSync(`git -C ${repoDir} push origin deco/new-workspace`, {
+        stdio: "ignore",
+      });
+      const remoteHead = execSync(
+        `git -C ${bare} rev-parse refs/heads/deco/new-workspace`,
+      )
+        .toString()
+        .trim();
+      const localHead = execSync(`git -C ${repoDir} rev-parse HEAD`)
+        .toString()
+        .trim();
+      expect(remoteHead).toBe(localHead);
+      const files = execSync(`git -C ${repoDir} ls-files`).toString();
+      expect(files).toContain("outside.txt");
+      const content = readFileSync(
+        join(repoDir, ".deco/blocks/campaign-timer.json"),
+        "utf-8",
+      );
+      expect(JSON.parse(content)).toEqual({ copy: "second save from studio" });
+    } finally {
+      cleanup();
+    }
+  });
+
   it("replays local commits on top of remote commits so push fast-forwards", () => {
     const { repoDir, bare, cleanup } = setupDivergedSameBranchRepo();
     try {

--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { rebaseOntoBase } from "./rebase-onto-base";
+import { integrateRemoteBranch, rebaseOntoBase } from "./rebase-onto-base";
 
 function setupConflictingRepo(): {
   repoDir: string;
@@ -79,6 +79,194 @@ function setupConflictingRepo(): {
     cleanup: () => rmSync(root, { recursive: true, force: true }),
   };
 }
+
+/**
+ * origin/feat/shipping gains a commit the workspace doesn't have (another
+ * session published), while the workspace commits its own change — the exact
+ * state that makes a blind `git push` fail as non-fast-forward.
+ */
+function setupDivergedSameBranchRepo(): {
+  repoDir: string;
+  bare: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "integrate-remote-branch-"));
+  const bare = join(root, "origin.git");
+  const seed = join(root, "seed");
+  const gitOpts = { stdio: "ignore" as const };
+  const gitcfg = `-c init.defaultBranch=main -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+  const decoPath = ".deco/blocks/shipping.json";
+
+  execSync(`git ${gitcfg} init --bare ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} init ${seed}`, gitOpts);
+
+  mkdirSync(join(seed, ".deco/blocks"), { recursive: true });
+  writeFileSync(
+    join(seed, decoPath),
+    JSON.stringify({ threshold: 200 }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m initial`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} branch -M feat/shipping`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} remote add origin ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push -u origin feat/shipping`, gitOpts);
+
+  const repoDir = join(root, "workspace");
+  execSync(
+    `git ${gitcfg} clone --branch feat/shipping ${bare} ${repoDir}`,
+    gitOpts,
+  );
+  execSync(
+    `git ${gitcfg} -C ${repoDir} config user.email test@example.com`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${repoDir} config user.name test`, gitOpts);
+
+  // Another session pushes to the same branch behind the workspace's back.
+  writeFileSync(join(seed, "other-session.txt"), "from another session\n");
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m "other session"`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push origin feat/shipping`, gitOpts);
+
+  // Workspace commits its own change, unaware of the remote commit.
+  writeFileSync(
+    join(repoDir, decoPath),
+    JSON.stringify({ threshold: 300 }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${repoDir} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${repoDir} commit -m "local save"`, gitOpts);
+
+  return {
+    repoDir,
+    bare,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+describe("integrateRemoteBranch", () => {
+  it("replays local commits on top of remote commits so push fast-forwards", () => {
+    const { repoDir, bare, cleanup } = setupDivergedSameBranchRepo();
+    try {
+      const { rebased } = integrateRemoteBranch(repoDir, "feat/shipping", {
+        asUser: false,
+      });
+      expect(rebased).toBe(true);
+
+      // Remote branch is now an ancestor of HEAD → plain push succeeds.
+      execSync(`git -C ${repoDir} push origin feat/shipping`, {
+        stdio: "ignore",
+      });
+
+      // Both sides survived: the other session's file and the local save.
+      const remoteHead = execSync(
+        `git -C ${bare} rev-parse refs/heads/feat/shipping`,
+      )
+        .toString()
+        .trim();
+      const localHead = execSync(`git -C ${repoDir} rev-parse HEAD`)
+        .toString()
+        .trim();
+      expect(remoteHead).toBe(localHead);
+      const content = readFileSync(
+        join(repoDir, ".deco/blocks/shipping.json"),
+        "utf-8",
+      );
+      expect(JSON.parse(content)).toEqual({ threshold: 300 });
+      const files = execSync(`git -C ${repoDir} ls-files`).toString();
+      expect(files).toContain("other-session.txt");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("prefers the local save when both sides edited the same file", () => {
+    const { repoDir, bare, cleanup } = setupDivergedSameBranchRepo();
+    try {
+      // Make the remote's extra commit conflict with the local one.
+      const seed = join(repoDir, "..", "seed");
+      writeFileSync(
+        join(seed, ".deco/blocks/shipping.json"),
+        JSON.stringify({ threshold: 999 }, null, 2),
+        "utf-8",
+      );
+      execSync(`git -C ${seed} add .`, { stdio: "ignore" });
+      execSync(
+        `git -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false -C ${seed} commit -m "conflicting remote edit"`,
+        { stdio: "ignore" },
+      );
+      execSync(`git -C ${seed} push origin feat/shipping`, { stdio: "ignore" });
+
+      const { rebased } = integrateRemoteBranch(repoDir, "feat/shipping", {
+        asUser: false,
+      });
+      expect(rebased).toBe(true);
+
+      const content = readFileSync(
+        join(repoDir, ".deco/blocks/shipping.json"),
+        "utf-8",
+      );
+      expect(JSON.parse(content)).toEqual({ threshold: 300 });
+
+      execSync(`git -C ${repoDir} push origin feat/shipping`, {
+        stdio: "ignore",
+      });
+      const remoteHead = execSync(
+        `git -C ${bare} rev-parse refs/heads/feat/shipping`,
+      )
+        .toString()
+        .trim();
+      const localHead = execSync(`git -C ${repoDir} rev-parse HEAD`)
+        .toString()
+        .trim();
+      expect(remoteHead).toBe(localHead);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("is a no-op when the remote branch has nothing new", () => {
+    const { repoDir, cleanup } = setupDivergedSameBranchRepo();
+    try {
+      execSync(`git -C ${repoDir} fetch origin feat/shipping`, {
+        stdio: "ignore",
+      });
+      execSync(`git -C ${repoDir} rebase origin/feat/shipping`, {
+        stdio: "ignore",
+      });
+      const before = execSync(`git -C ${repoDir} rev-parse HEAD`)
+        .toString()
+        .trim();
+
+      const { rebased } = integrateRemoteBranch(repoDir, "feat/shipping", {
+        asUser: false,
+      });
+      expect(rebased).toBe(false);
+      const after = execSync(`git -C ${repoDir} rev-parse HEAD`)
+        .toString()
+        .trim();
+      expect(after).toBe(before);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("is a no-op when the branch does not exist on origin", () => {
+    const { repoDir, cleanup } = setupDivergedSameBranchRepo();
+    try {
+      execSync(`git -C ${repoDir} checkout -b brand-new-branch`, {
+        stdio: "ignore",
+      });
+      const { rebased } = integrateRemoteBranch(repoDir, "brand-new-branch", {
+        asUser: false,
+      });
+      expect(rebased).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+});
 
 describe("rebaseOntoBase", () => {
   it("rebases with -X theirs and resolves conflicts from branch changes", () => {

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -280,7 +280,11 @@ function forcePushRebasedBranch(
         throw err;
       }
 
-      runGit(repoDir, ["fetch", "origin", branch]);
+      runGit(repoDir, [
+        "fetch",
+        "origin",
+        `+refs/heads/${branch}:refs/remotes/origin/${branch}`,
+      ]);
       const refreshed = remoteBranchSha(repoDir, branch);
       if (refreshed) {
         runGit(repoDir, [
@@ -328,7 +332,16 @@ function rebaseOntoBaseInner(
     throw new Error("Cannot rebase from a detached HEAD");
   }
 
-  runGit(repoDir, ["fetch", "-p", "origin", base, branch]);
+  // Explicit refspecs for the same reason as integrateRemoteBranch below:
+  // shallow single-branch clones don't map plain command-line refnames onto
+  // refs/remotes/origin/*, which would leave the force-push lease stale.
+  runGit(repoDir, [
+    "fetch",
+    "-p",
+    "origin",
+    `+refs/heads/${base}:refs/remotes/origin/${base}`,
+    `+refs/heads/${branch}:refs/remotes/origin/${branch}`,
+  ]);
   const leaseSha = remoteBranchSha(repoDir, branch);
 
   tryGit(repoDir, [
@@ -406,7 +419,20 @@ function integrateRemoteBranchInner(
 ): { rebased: boolean } {
   assertValidRemoteBranchName(branch);
 
-  if (tryGit(repoDir, ["fetch", "origin", branch]) === null) {
+  // Explicit refspec, not `fetch origin <branch>`: sandbox clones are shallow
+  // single-branch (setup/clone.ts), so their fetch refspec only covers the
+  // branch they were cloned on. For a workspace branch forked locally that's
+  // the *default* branch — a plain fetch would only write FETCH_HEAD, leave
+  // refs/remotes/origin/<branch> missing/stale, and the divergence check below
+  // would report a false "up to date" (the exact non-fast-forward publish
+  // failure this function exists to prevent). Fails when the branch isn't on
+  // origin yet (first publish) — that's the no-op path.
+  const fetched = tryGit(repoDir, [
+    "fetch",
+    "origin",
+    `+refs/heads/${branch}:refs/remotes/origin/${branch}`,
+  ]);
+  if (fetched === null) {
     return { rebased: false };
   }
   const remoteSha = remoteBranchSha(repoDir, branch);

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -346,15 +346,21 @@ function rebaseOntoBaseInner(
   }
 
   commitBeforeRebase(repoDir, operator);
+  performRebase(repoDir, upstream);
 
+  forcePushRebasedBranch(repoDir, branch, leaseSha);
+  return { rebased: true };
+}
+
+function performRebase(repoDir: string, upstreamRef: string): void {
   try {
     // --autostash: the sandbox dev server keeps regenerating tracked files
     // (e.g. src/server/cms/blocks.gen.json, .deco/blocks/*.json). It can dirty
-    // the working tree in the window between commitBeforeRebase and the rebase's
-    // internal checkout, which otherwise aborts with "Your local changes would
-    // be overwritten by checkout / could not detach HEAD". Autostash stashes
-    // that churn, runs the rebase, and restores it afterwards.
-    runGit(repoDir, ["rebase", "--autostash", "-X", "theirs", upstream]);
+    // the working tree in the window between the pre-rebase commit and the
+    // rebase's internal checkout, which otherwise aborts with "Your local
+    // changes would be overwritten by checkout / could not detach HEAD".
+    // Autostash stashes that churn, runs the rebase, and restores it afterwards.
+    runGit(repoDir, ["rebase", "--autostash", "-X", "theirs", upstreamRef]);
   } catch (err) {
     if (!isRebaseInProgress(repoDir)) {
       throw err;
@@ -366,7 +372,55 @@ function rebaseOntoBaseInner(
     abortRebase(repoDir);
     throw new Error("Rebase did not complete");
   }
+}
 
-  forcePushRebasedBranch(repoDir, branch, leaseSha);
+/**
+ * Integrate commits already on `origin/{branch}` into the local branch by
+ * replaying local commits on top — same conflict strategy as rebaseOntoBase
+ * (`-X theirs` + auto-resolution, so the latest local save wins). Used by
+ * publish() before pushing: when another session pushed to the same branch,
+ * a blind push is rejected as non-fast-forward and the save fails.
+ *
+ * No-op when the remote branch is missing (first publish) or already an
+ * ancestor of HEAD. A failed fetch is also a no-op — the subsequent push
+ * surfaces the real error.
+ */
+export function integrateRemoteBranch(
+  repoDir: string,
+  branch: string,
+  options?: RebaseOntoBaseOptions,
+): { rebased: boolean } {
+  const previousAsUser = rebaseGitAsUser;
+  rebaseGitAsUser = options?.asUser ?? true;
+  try {
+    return integrateRemoteBranchInner(repoDir, branch, options?.operator);
+  } finally {
+    rebaseGitAsUser = previousAsUser;
+  }
+}
+
+function integrateRemoteBranchInner(
+  repoDir: string,
+  branch: string,
+  operator?: OperatorIdentity,
+): { rebased: boolean } {
+  assertValidRemoteBranchName(branch);
+
+  if (tryGit(repoDir, ["fetch", "origin", branch]) === null) {
+    return { rebased: false };
+  }
+  const remoteSha = remoteBranchSha(repoDir, branch);
+  if (!remoteSha) {
+    return { rebased: false };
+  }
+  const upToDate =
+    tryGit(repoDir, ["merge-base", "--is-ancestor", remoteSha, "HEAD"]) !==
+    null;
+  if (upToDate) {
+    return { rebased: false };
+  }
+
+  commitBeforeRebase(repoDir, operator);
+  performRebase(repoDir, `origin/${branch}`);
   return { rebased: true };
 }

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { appendCoAuthorTrailer } from "../../git-co-author";
 import { computeBranchDivergence } from "../git/branch-divergence";
 import { parsePorcelainFiles } from "../git/porcelain";
-import { rebaseOntoBase } from "../git/rebase-onto-base";
+import { integrateRemoteBranch, rebaseOntoBase } from "../git/rebase-onto-base";
 import {
   cloneUrlHasCredentials,
   syncOriginRemote,
@@ -535,6 +535,14 @@ export function publish(deps: GitDeps, message: string): { pushed: boolean } {
       );
     }
   }
+
+  // Another session may have pushed to origin/<branch> since this sandbox
+  // last synced (two tabs, agent + human, a redeployed sandbox); a blind push
+  // is then rejected as non-fast-forward and the save fails. Replay local
+  // commits on top of the remote branch so the push is a fast-forward.
+  integrateRemoteBranch(repoDir, branch, {
+    operator: deps.getOperator?.() ?? undefined,
+  });
 
   pushBranch(repoDir, branch);
   return { pushed: true };


### PR DESCRIPTION
## Summary

"Save changes" in the Studio failed with a raw git error whenever `origin/<branch>` had commits the sandbox didn't have (another tab/machine/agent pushing to the same workspace branch, or commits made outside the Studio):

```
! [rejected] omicron-hydrae → omicron-hydrae (fetch first)
error: failed to push some refs ... hint: Updates were rejected because the remote contains work that you do not have locally.
```

`publish()` committed and pushed blind, without ever syncing with the remote branch.

### Changes

- **`integrateRemoteBranch()`** (`packages/sandbox/daemon/git/rebase-onto-base.ts`): fetches `origin/<branch>` and, when the remote has commits the sandbox lacks, replays local commits on top using the same conflict strategy as `rebaseOntoBase` (`-X theirs` + auto-resolution — the publisher's save wins conflicting hunks, non-conflicting remote changes survive). No-op when the branch isn't on origin yet (first publish) or is already up to date; a failed fetch is also a no-op so the push surfaces the real error.
- **`publish()`** (`packages/sandbox/daemon/routes/git.ts`) calls it right before `pushBranch`, so the push is always a fast-forward.
- **Explicit fetch refspecs** (`+refs/heads/<branch>:refs/remotes/origin/<branch>`): sandbox clones are shallow single-branch (`clone --depth 1`, see `setup/clone.ts`), so their fetch refspec only covers the branch they were cloned on — for a workspace branch forked locally that's the *default* branch. A plain `git fetch origin <branch>` only writes `FETCH_HEAD` and never materializes `refs/remotes/origin/<branch>`, which made the divergence check a false "up to date" (caught in manual testing). Applied to `integrateRemoteBranch` and to `rebaseOntoBase`'s force-push lease fetches, which had the same latent staleness.
- Extracted the shared rebase core (`performRebase`) so `rebaseOntoBase` and `integrateRemoteBranch` don't duplicate the autostash/conflict-resolution/abort logic.

## Testing

- New unit tests in `rebase-onto-base.test.ts`: divergence without conflict (both commits survive), same-file conflict (local save wins), up-to-date no-op, branch-missing-on-origin no-op, and a regression test replicating the exact sandbox clone topology (shallow single-branch `file://` clone + locally forked branch). The regression test fails without the refspec fix.
- Manually verified in a local Studio: create workspace → save via Studio → commit to the same branch outside the Studio → save again → publishes cleanly (previously reproduced the screenshot error).
- `bun test` on `packages/sandbox/daemon/{git,routes}`: 138 pass, 0 fail. `bun run fmt`, `bun run lint`, and workspace typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes publish failures when another session pushed to the same branch. We now fetch and replay local commits on top of `origin/<branch>` before pushing, so pushes fast-forward and saves don’t error.

- **Bug Fixes**
  - Added integrateRemoteBranch to fetch with `+refs/heads/<branch>:refs/remotes/origin/<branch>` and rebase local commits on `origin/<branch>` using `-X theirs` with autostash; no-op if branch is missing or already up to date; called by publish before push.
  - Updated fetches in rebaseOntoBase and force-push lease to use explicit refspecs so shallow single-branch clones get fresh remote-tracking refs and accurate divergence checks.

- **Refactors**
  - Extracted performRebase to share autostash/conflict/abort logic across rebase paths.

<sup>Written for commit 4762b7ecdfd6c5c651d6970e8e1c9a6d2bc69332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

