### PR TITLE
test(web): cover getPreset lookup and edge cases

### DIFF
--- a/apps/mesh/src/web/utils/openai-compatible-presets.test.ts
+++ b/apps/mesh/src/web/utils/openai-compatible-presets.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getPreset,
+  OPENAI_COMPATIBLE_PRESETS,
+} from "./openai-compatible-presets";
+
+describe("getPreset", () => {
+  it("returns the matching preset by id", () => {
+    expect(getPreset("ollama")?.name).toBe("Ollama");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(getPreset("not-a-real-preset")).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(getPreset(null)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined", () => {
+    expect(getPreset(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(getPreset("")).toBeUndefined();
+  });
+
+  it("is case-sensitive", () => {
+    expect(getPreset("Ollama")).toBeUndefined();
+  });
+
+  it("resolves every declared preset id", () => {
+    for (const preset of OPENAI_COMPATIBLE_PRESETS) {
+      expect(getPreset(preset.id)).toBe(preset);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
`getPreset` in `openai-compatible-presets.ts` (used by the AI provider connection form to resolve a branded preset — logo, name, base-URL placeholder — from a `preset_id`) had no test coverage.

- Improvement, not tied to an issue: a small, pure lookup function with several untested edge cases (unknown id, `null`/`undefined`/empty string, case sensitivity).
- New test asserts: matching id resolves, unknown/nullish/empty inputs return `undefined`, lookup is case-sensitive, and every declared preset resolves by its own id (catches future id typos in `OPENAI_COMPATIBLE_PRESETS`).

## Test plan
- `bun test apps/mesh/src/web/utils/openai-compatible-presets.test.ts` — 7 pass.
- Ran `bun run fmt` locally (no changes needed). Skipped the full `bunx tsc --noEmit` for `apps/mesh` — it currently fails on an unrelated pre-existing missing dependency (`use-stick-to-bottom`, from prior work not touched here); full CI will validate typechecking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `getPreset` to cover lookup and edge cases. Ensures valid ids resolve; unknown, nullish, and empty inputs return undefined; matching is case-sensitive; and every `OPENAI_COMPATIBLE_PRESETS` id resolves (guards against typos).

<sup>Written for commit 0458e47508c1c9ff27558b0bfc41701a1daa240c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

