### PR TITLE
test(runtime): cover Binding().isImplementedBy required/optional/regex matching

### DIFF
--- a/packages/runtime/src/bindings/utils.test.ts
+++ b/packages/runtime/src/bindings/utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import type { ToolBinder } from "../mcp.ts";
+import { Binding } from "./utils.ts";
+
+const REQUIRED_TOOL = {
+  name: "SEND_MESSAGE" as const,
+  inputSchema: z.object({}),
+};
+const OPTIONAL_TOOL = {
+  name: "READ_HISTORY" as const,
+  inputSchema: z.object({}),
+  opt: true as const,
+};
+// `Binding`'s type signature only accepts string-named binders, but its
+// implementation also supports RegExp names at runtime — cast to exercise it.
+const REGEX_TOOL = {
+  name: /^EVENT_.*$/,
+  inputSchema: z.object({}),
+} as unknown as ToolBinder;
+
+describe("Binding().isImplementedBy", () => {
+  it("is true when every required tool is present", () => {
+    const binding = Binding([REQUIRED_TOOL]);
+    expect(binding.isImplementedBy([{ name: "SEND_MESSAGE" }])).toBe(true);
+  });
+
+  it("is false when a required tool is missing", () => {
+    const binding = Binding([REQUIRED_TOOL]);
+    expect(binding.isImplementedBy([{ name: "OTHER_TOOL" }])).toBe(false);
+  });
+
+  it("ignores optional tools that are missing", () => {
+    const binding = Binding([REQUIRED_TOOL, OPTIONAL_TOOL]);
+    expect(binding.isImplementedBy([{ name: "SEND_MESSAGE" }])).toBe(true);
+  });
+
+  it("matches a regex tool name against any implementing tool", () => {
+    const binding = Binding([REGEX_TOOL]);
+    expect(binding.isImplementedBy([{ name: "EVENT_PUBLISH" }])).toBe(true);
+    expect(binding.isImplementedBy([{ name: "SEND_MESSAGE" }])).toBe(false);
+  });
+
+  it("requires an exact match, not a substring, for string tool names", () => {
+    const binding = Binding([REQUIRED_TOOL]);
+    expect(binding.isImplementedBy([{ name: "SEND_MESSAGE_EXTRA" }])).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Source
A small improvement — an untested pure function found while reading `packages/runtime/src/bindings/`.

## Why
`Binding()` (`packages/runtime/src/bindings/utils.ts`) is the runtime's public API for checking whether a set of MCP tools implements a binding contract (required vs. optional tools, string or regex name matching). It's re-exported from the package's public entrypoint (`bindings/index.ts`) but had zero test coverage, so a regression in the matching logic (e.g. breaking the optional-tool skip, or the exact-match regex anchoring) would ship silently.

## What the test covers
- required tool present → `true`
- required tool missing → `false`
- optional (`opt: true`) tool missing → still `true`
- `RegExp` tool names matched against implementing tools
- string tool names require an exact match, not a substring

## Verify
```
bun test packages/runtime/src/bindings/utils.test.ts
```

## Checks run locally
- `bun run fmt`
- `cd packages/runtime && bun x tsc --noEmit`
- `bun test packages/runtime/src/bindings/utils.test.ts` (5 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `Binding().isImplementedBy` covering required vs optional tools, exact string matches, and `RegExp` name matching. Improves runtime bindings coverage in `packages/runtime/src/bindings/utils.test.ts` and guards against regressions in the matching logic.

<sup>Written for commit 05e7dec55f96477f3e8e5dad540669ee778a2184. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

