### PR TITLE
feat(decopilot)!: unified run control plane — executors publish, the projector consumes

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -873,10 +873,12 @@ export async function createApp(options: CreateAppOptions = {}) {
       init: async () => {},
       // Test/no-NATS stub: drain the stream so `createUIMessageStream`'s
       // `execute` actually runs to completion. Nothing is buffered;
-      // `createTailStream` returns null so /stream surfaces a 204 / 503
-      // to the client when NATS isn't available.
+      // `createTailStream` returns null so `dispatchRunAndWait` never takes
+      // the tail-wait branch that calls `pump()` — this stub only exists to
+      // satisfy the `StreamBuffer` interface (`disableNats` mode has no
+      // durable subject to race, so there's nothing to propagate here).
       pump: (stream: ReadableStream) => {
-        void (async () => {
+        return (async () => {
           const reader = stream.getReader();
           try {
             while (true) {

--- a/apps/mesh/src/api/routes/decopilot/consume-run-projection.ts
+++ b/apps/mesh/src/api/routes/decopilot/consume-run-projection.ts
@@ -20,6 +20,22 @@ export interface ConsumeRunProjectionOptions {
  * it resolves the active fence, opens the run's JetStream subject from seq 1
  * inside `projectFromJetStreamStep`, streams those chunks through the AI SDK
  * fold, persists step/final parts, and writes the terminal status.
+ *
+ * unified-control-plane T3: for the hosted topology, the thread gate now
+ * calls this step immediately after STARTING (not awaiting) the hosted child
+ * — so this consumer is routinely opened BEFORE the child has published its
+ * first chunk. This is safe and not new: it is exactly the timing the
+ * desktop topology has always used (the gate returns as soon as the work item
+ * is durably published to the tunnel, well before the remote daemon streams
+ * anything back). `projectFromJetStreamStep` → `createProjectorChunkStream`
+ * opens the JetStream consumer with `deliver_policy: DeliverPolicy.All`
+ * (`projector-chunk-stream.ts`) — "deliver everything retained on the
+ * subject, then keep delivering as new messages arrive" — and
+ * `natsChunkSource`'s pull loop (`nats-chunk-source.ts`) simply `await`s the
+ * next message when nothing is available yet, live-tailing rather than
+ * assuming a complete/retained stream. There is no hosted-only branch
+ * anywhere in this path that assumed the producer had already finished; both
+ * topologies always went through the same `createProjectorChunkStream` call.
  */
 export async function consumeRunProjection(
   opts: ConsumeRunProjectionOptions,

--- a/apps/mesh/src/api/routes/decopilot/consume-run-projection.ts
+++ b/apps/mesh/src/api/routes/decopilot/consume-run-projection.ts
@@ -4,10 +4,17 @@ import {
   runProjectorWorkflowBody,
   shouldSkipProjection,
 } from "./projector-workflow";
+import { RUN_IDLE_TIMEOUT_MS } from "./run-registry";
 
 export interface ConsumeRunProjectionOptions {
   runId: string;
   fenceToken?: string;
+  /** Idle window enforced on the live subject tail — a silent subject (no
+   *  events of any kind) for this long ends the consume with a synthesized
+   *  liveness terminal instead of hanging. Defaults to `RUN_IDLE_TIMEOUT_MS`
+   *  (the SAME constant the progress-based reaper reads — see run-registry.ts)
+   *  so both enforcement points agree on one window; override only for tests
+   *  that need a shortened, deterministic timeout. unified-control-plane T4. */
   idleTimeoutMs?: number;
   signal?: AbortSignal;
   /** The turn's request message id — forwarded to the projector so the
@@ -36,6 +43,16 @@ export interface ConsumeRunProjectionOptions {
  * assuming a complete/retained stream. There is no hosted-only branch
  * anywhere in this path that assumed the producer had already finished; both
  * topologies always went through the same `createProjectorChunkStream` call.
+ *
+ * unified-control-plane T4: with no child await anywhere (T3), subject
+ * silence is the only signal an executor died before/without publishing.
+ * `idleTimeoutMs` (defaulted here to `RUN_IDLE_TIMEOUT_MS`) is threaded all
+ * the way to `natsChunkSource`, which errors the stream with
+ * `StreamIdleTimeoutError` after that much silence. `runProjectorWorkflowBody`'s
+ * catch tells that apart from a genuine projection error and records a
+ * `markRunFailed(kind: "liveness")` terminal instead of `"projection"`. The
+ * progress-based reaper (`run-registry.ts`) stays as an out-of-process
+ * backstop for the same window — both read `RUN_IDLE_TIMEOUT_MS`.
  */
 export async function consumeRunProjection(
   opts: ConsumeRunProjectionOptions,
@@ -69,7 +86,12 @@ export async function consumeRunProjection(
   if (!js) throw new Error("JetStream unavailable for consume step");
 
   await runProjectorWorkflowBody(
-    { runId, fenceToken, messageId: opts.messageId },
+    {
+      runId,
+      fenceToken,
+      messageId: opts.messageId,
+      idleTimeoutMs: opts.idleTimeoutMs ?? RUN_IDLE_TIMEOUT_MS,
+    },
     rt,
     projectFromJetStreamStep,
   );

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -103,6 +103,7 @@ import type {
   HarnessStreamTitleOptions,
 } from "./consume-harness-stream";
 import { ingestRun } from "./ingest-run";
+import { withLivenessHeartbeat } from "./with-liveness-heartbeat";
 import {
   checkModelPermission,
   fetchModelPermissions,
@@ -1563,7 +1564,12 @@ async function prepareRun(
             publishRawChunk: async () => false,
             publishDone: async () => false,
           },
-          chunks: dispatchHarnessChunks(),
+          // Heartbeat wraps the RAW harness source, before ingestRun's
+          // seq-wrapper (unified-control-plane T5) — a `data-liveness`
+          // chunk injected during a silent model/tool wait gets a real seq
+          // through the exact same publish path as every other chunk (see
+          // with-liveness-heartbeat.ts's module doc for the full contract).
+          chunks: withLivenessHeartbeat(dispatchHarnessChunks()),
           // Deterministic per turn (runId + fence) so a synthesized error
           // message dedupes across the live write + projector retries while
           // distinct turns of the same thread never collide. See message-ids.ts.

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -13,15 +13,22 @@
  *     completes but its chunks are dropped.
  *
  * Architecture: dispatch-run owns the shared infrastructure (run-registry
- * lifecycle, memory load, JetStream buffering, registry FINISH dispatch,
- * posthog events). The actual streamText loop + tool assembly +
- * system-prompt construction is delegated to a Harness via
- * `localDispatch(harnessId, harnessInput, ctx)`. The three in-tree harnesses
- * (`decopilot`, `claude-code`, `codex`) each produce `UIMessageChunk`
- * streams consumed by the harness kernel (`consumeHarnessStream`) — the
- * ONLY consume-side stream layer. dispatch-run feeds the kernel a lazy
- * chunk source and run-lifecycle hooks (registry STEP_DONE/FINISH, thread
- * status, posthog); the kernel's output stream is the run's uiStream.
+ * liveness bookkeeping, memory load, JetStream buffering, registry
+ * STEP_DONE/FINISH dispatch). Terminal-status DB writes and the
+ * `chat_message_completed` / `chat_message_failed` / usage posthog events are
+ * OWNED BY THE PROJECTOR (`runProjectorWorkflowBody`'s `recordCompleted` /
+ * `recordFailed`), fired once from the run's fenced JetStream log — the same
+ * mechanism for hosted and desktop. This module's `chat_message_started`
+ * (pre-stream) and `chat_message_aborted` (user cancel) posthog events are
+ * the only ones still emitted from here, since neither has a projector
+ * equivalent. The actual streamText loop + tool assembly + system-prompt
+ * construction is delegated to a Harness via `localDispatch(harnessId,
+ * harnessInput, ctx)`. The three in-tree harnesses (`decopilot`,
+ * `claude-code`, `codex`) each produce `UIMessageChunk` streams published to
+ * JetStream via `ingestRun` (see `buildAgentSandboxUiStream`) — the ONLY
+ * consume-side stream layer for the hosted live path. dispatch-run feeds it a
+ * lazy chunk source and run-lifecycle hooks (registry STEP_DONE/FINISH
+ * liveness bookkeeping, thread status SSE).
  */
 
 import type { StudioContext } from "@/core/studio-context";
@@ -69,10 +76,7 @@ import type {
 } from "@decocms/harness/types";
 import { WORKSPACE_CWD_REPO } from "@decocms/harness/workspace-cwd";
 import { createProviderFromSecret } from "@decocms/harness/decopilot/provider-from-secret";
-import {
-  classifyStreamError,
-  stringifyError,
-} from "@decocms/harness/stream-error";
+import { stringifyError } from "@decocms/harness/stream-error";
 import { isCliHarness } from "@decocms/harness/cli-harness";
 import { DEFAULT_WINDOW_SIZE, generateMessageId } from "./constants";
 import { mintRunFenceToken } from "./dispatch-fence";
@@ -248,12 +252,16 @@ export interface AgentSandboxUiStreamInput {
  *
  * The raw harness chunks are wrapped as `(seq, chunk)` (monotonic counter) and
  * fed through the shared `ingestRun` unit, which publishes each chunk to
- * JetStream with a seq-keyed `Nats-Msg-Id` and drives the live hooks (usage /
- * posthog completion / SSE finish) + title-chunk injection. `ingestRun`
- * neutralizes title/message persistence so the durable projector is the sole
- * writer of parts + status + title. The returned stream yields NOTHING (raw
- * chunks are the NATS source); the pump that drains it still publishes the
- * `{done}` sentinel so tails close.
+ * JetStream with a seq-keyed `Nats-Msg-Id` and drives the live hooks
+ * (run-registry STEP_DONE/FINISH liveness bookkeeping, the abort-only
+ * `chat_message_aborted` posthog event) + title-chunk injection. Completion
+ * / failure analytics and usage recording are NOT driven from here — the
+ * durable projector is the sole source (`recordCompleted`/`recordFailed`),
+ * same as it's the sole writer of parts + status + title. The returned
+ * stream yields NOTHING (raw chunks are the NATS source); the pump that
+ * drains it still publishes the `{done}` sentinel so tails close, and now
+ * propagates a mid-stream `ingestRun` failure to its caller instead of
+ * swallowing it (see `NatsStreamBuffer.pump`).
  */
 export function buildAgentSandboxUiStream(
   input: AgentSandboxUiStreamInput,
@@ -705,7 +713,17 @@ export async function dispatchRunAndWait(
         : null;
 
       if (buffer && tail) {
-        buffer.pump(uiStream, taskId, registrySignal, input.organizationId);
+        const pumpDone = buffer.pump(
+          uiStream,
+          taskId,
+          registrySignal,
+          input.organizationId,
+        );
+        // Pre-arm: if the tail-read loop below throws before we reach the
+        // await, pumpDone's rejection must not become an unhandled
+        // rejection — the pre-armed no-op catch marks it handled while
+        // `await pumpDone` below still rejects for the normal path.
+        void pumpDone.catch(() => {});
         const reader = tail.getReader();
         try {
           while (true) {
@@ -715,6 +733,17 @@ export async function dispatchRunAndWait(
         } finally {
           reader.releaseLock();
         }
+        // The tail closes on ANY `{done}` marker — including the legacy
+        // UNFENCED sentinel `pump()` publishes in its `finally` even after a
+        // mid-stream failure (so a live tail never hangs). That marker alone
+        // would make this function return as if the run finished cleanly.
+        // `pumpDone` is what actually carries the failure (pump() re-throws
+        // whatever it caught from `uiStream`, i.e. `ingestRun`'s propagated
+        // error) — by the time the tail sees a done marker, `pump()`'s own
+        // try/catch/finally has already run (publishing that very marker is
+        // downstream of it), so this await settles immediately and surfaces
+        // a mid-stream ingest failure the tail's close alone would swallow.
+        await pumpDone;
       } else {
         // Fallback: no JetStream tail available — drain uiStream directly.
         // This still executes the hosted producer path; when the streamBuffer
@@ -1671,25 +1700,14 @@ async function prepareRun(
                 return;
               }
               console.error("[decopilot] stream error:", stringifyError(error));
-              posthog.capture({
-                distinctId: input.userId,
-                event: "chat_message_failed",
-                groups: { organization: input.organizationId },
-                properties: {
-                  organization_id: input.organizationId,
-                  thread_id: mem.thread.id,
-                  agent_id: input.agent.id,
-                  model_id: models.thinking.id,
-                  mode: input.mode,
-                  duration_ms: Date.now() - streamStartAt,
-                  error_category: classifyStreamError(error),
-                  error_message:
-                    error instanceof Error
-                      ? error.message
-                      : stringifyError(error),
-                  is_resume: input.isResume ?? false,
-                },
-              });
+              // Failure analytics (`chat_message_failed`) are emitted by the
+              // projector's `recordFailed`, same as the completion event above —
+              // this hook used to double-capture it here. The projector fires
+              // once the run's fenced terminal (in-band error chunk +
+              // `{done}`) is durably materialized, which happens for every
+              // caught failure now that `dispatchRunAndWait` propagates a
+              // mid-stream ingest error instead of swallowing it (see
+              // `hosted-harness-workflow.ts`'s catch).
 
               runRegistry
                 .execute({

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -84,7 +84,6 @@ import { synthesizedErrorMessageId } from "./message-ids";
 import { loadDecopilotContext } from "@/harnesses/decopilot/context-loader";
 import { PartEmitter } from "./part-emitter";
 import { foldedToUIMessage } from "./projector-seed";
-import { ProgressBumpThrottle } from "./progress-bump";
 import { uploadFileParts, resolveStorageRefs } from "./file-materializer";
 import type { ToolApprovalLevel } from "./helpers";
 import { type ChatMode } from "./mode-config";
@@ -141,46 +140,6 @@ const finishDurationHistogram = meter.createHistogram(
 const FINISH_TRACE = process.env.DECOPILOT_FINISH_TRACE === "1";
 
 /**
- * Process-wide progress-bump throttle (Task 9, A1/A2). One instance shared by
- * every run on this pod — it dedupes `last_progress_at` writes to ≤1 per ~3s
- * per task. Lives at module scope (not per-run) so its per-task last-bump map
- * survives across the multiple `prepareRun` invocations a thread may see.
- */
-const progressThrottle = new ProgressBumpThrottle();
-
-/**
- * Tap a UI stream so each chunk drives a THROTTLED `last_progress_at` bump.
- * Pure pass-through: every chunk is forwarded unchanged; the bump is a
- * fire-and-forget side effect that never blocks or fails the stream. This is
- * the run's liveness heartbeat — the reaper reads `last_progress_at` to decide
- * whether a run is stuck.
- */
-function tapProgress(
-  stream: ReadableStream<unknown>,
-  ctx: StudioContext,
-  taskId: string,
-): ReadableStream<unknown> {
-  return stream.pipeThrough(
-    new TransformStream<unknown, unknown>({
-      transform(chunk, controller) {
-        if (progressThrottle.shouldBump(taskId)) {
-          ctx.storage.threads.bumpProgress(taskId).catch(() => {
-            // Heartbeat is best-effort; a failed bump just means the reaper
-            // may rely on an older timestamp. Never surface to the stream.
-          });
-        }
-        controller.enqueue(chunk);
-      },
-      flush() {
-        // Run ended — drop this task's throttle state so the map can't grow
-        // unbounded across many short-lived threads.
-        progressThrottle.clear(taskId);
-      },
-    }),
-  );
-}
-
-/**
  * Defer stream construction until the first consumer pull.
  *
  * `prepareRun` must NOT start any harness work unless its `uiStream` is
@@ -195,10 +154,10 @@ function tapProgress(
  * factory.
  *
  * `highWaterMark: 0` is load-bearing: with the default (1) the stream calls
- * `pull` at construction to pre-fill its queue, defeating the laziness.
- * For the same reason the factory must contain any `pipeThrough` wrapping
- * (e.g. `tapProgress`) — piping into a transform with the default writable
- * high-water mark eagerly pulls one chunk even with no downstream consumer.
+ * `pull` at construction to pre-fill its queue, defeating the laziness. For
+ * the same reason, any future `pipeThrough` wrapping must live INSIDE the
+ * factory — piping into a transform with the default writable high-water
+ * mark eagerly pulls one chunk even with no downstream consumer.
  */
 function lazyStream<T>(factory: () => ReadableStream<T>): ReadableStream<T> {
   let reader: ReadableStreamDefaultReader<T> | null = null;
@@ -1551,185 +1510,182 @@ async function prepareRun(
     // `whenComplete` resolves, so awaiting it from there would deadlock. The
     // ordering that matters now is that the same lazy kernel path publishes
     // the JetStream chunks before invoking the finish hook.
-    // The progress tap (the run's liveness heartbeat) lives INSIDE the lazy
-    // factory: `pipeThrough` at the return site would eagerly pull one chunk
-    // through the lazy stream even with no consumer (transform writable
-    // high-water mark), starting the harness for never-consumed link runs.
+    //
+    // No progress tap wraps this stream: `buildAgentSandboxUiStream`'s
+    // returned `ReadableStream` never enqueues a value (it only
+    // closes/errors — raw chunks go to JetStream via `ingestRun`
+    // internally), so a chunk-driven tap here would never fire. The
+    // projector's `tapProgressStream` (progress-bump.ts, driven from the
+    // JetStream-sourced chunkStream in projector-workflow.ts) is the single
+    // liveness heartbeat for both hosted and desktop runs.
     const uiStream = lazyStream(() =>
-      tapProgress(
-        buildAgentSandboxUiStream({
-          runId: mem.thread.id,
-          fenceToken: runFenceToken,
-          streamBuffer: streamBuffer ?? {
-            publishRawChunk: async () => false,
-            publishDone: async () => false,
+      buildAgentSandboxUiStream({
+        runId: mem.thread.id,
+        fenceToken: runFenceToken,
+        streamBuffer: streamBuffer ?? {
+          publishRawChunk: async () => false,
+          publishDone: async () => false,
+        },
+        // Heartbeat wraps the RAW harness source, before ingestRun's
+        // seq-wrapper (unified-control-plane T5) — a `data-liveness`
+        // chunk injected during a silent model/tool wait gets a real seq
+        // through the exact same publish path as every other chunk (see
+        // with-liveness-heartbeat.ts's module doc for the full contract).
+        chunks: withLivenessHeartbeat(dispatchHarnessChunks()),
+        // Deterministic per turn (runId + fence) so a synthesized error
+        // message dedupes across the live write + projector retries while
+        // distinct turns of the same thread never collide. See message-ids.ts.
+        errorMessageId: synthesizedErrorMessageId(mem.thread.id, runFenceToken),
+        // Seed the hook reassembly with the trailing persisted message so a
+        // tool-approval CONTINUATION reconciles its tool-output against the
+        // proposal (and adopts its id) instead of throwing. Mirrors the
+        // projector's `loadWindow` seed. Lazy + only `.at(-1)` is used, so a
+        // single-row window is enough; V1 threads (no part storage) skip it.
+        loadOriginalMessages: partEmitter
+          ? async () =>
+              (
+                await ctx.storage.threads
+                  .messageParts()
+                  .loadWindow(mem.thread.id, { limit: 1 })
+              ).messages.map(foldedToUIMessage)
+          : undefined,
+        title: {
+          currentThreadTitle: mem.thread.title,
+          threadId: mem.thread.id,
+          // Projector owns the title write — `ingestRun` neutralizes this
+          // persistence callback. The projector is the sole sidebar-SSE
+          // source for both hosted and desktop now.
+          persistTitle: async (threadId, title) => {
+            await ctx.storage.threads.update(threadId, { title });
           },
-          // Heartbeat wraps the RAW harness source, before ingestRun's
-          // seq-wrapper (unified-control-plane T5) — a `data-liveness`
-          // chunk injected during a silent model/tool wait gets a real seq
-          // through the exact same publish path as every other chunk (see
-          // with-liveness-heartbeat.ts's module doc for the full contract).
-          chunks: withLivenessHeartbeat(dispatchHarnessChunks()),
-          // Deterministic per turn (runId + fence) so a synthesized error
-          // message dedupes across the live write + projector retries while
-          // distinct turns of the same thread never collide. See message-ids.ts.
-          errorMessageId: synthesizedErrorMessageId(
-            mem.thread.id,
-            runFenceToken,
-          ),
-          // Seed the hook reassembly with the trailing persisted message so a
-          // tool-approval CONTINUATION reconciles its tool-output against the
-          // proposal (and adopts its id) instead of throwing. Mirrors the
-          // projector's `loadWindow` seed. Lazy + only `.at(-1)` is used, so a
-          // single-row window is enough; V1 threads (no part storage) skip it.
-          loadOriginalMessages: partEmitter
-            ? async () =>
-                (
-                  await ctx.storage.threads
-                    .messageParts()
-                    .loadWindow(mem.thread.id, { limit: 1 })
-                ).messages.map(foldedToUIMessage)
-            : undefined,
-          title: {
-            currentThreadTitle: mem.thread.title,
-            threadId: mem.thread.id,
-            // Projector owns the title write — `ingestRun` neutralizes this
-            // persistence callback. The projector is the sole sidebar-SSE
-            // source for both hosted and desktop now.
-            persistTitle: async (threadId, title) => {
-              await ctx.storage.threads.update(threadId, { title });
-            },
+        },
+        hooks: {
+          onStep: () => {
+            const transitions = runRegistry.dispatch({
+              type: "STEP_DONE",
+              taskId: mem.thread.id,
+            });
+            pendingOps.push(
+              runRegistry.react(transitions).catch((e) => {
+                console.error(
+                  "[decopilot:stream] onStepFinish reactor failed",
+                  e,
+                );
+              }),
+            );
           },
-          hooks: {
-            onStep: () => {
-              const transitions = runRegistry.dispatch({
-                type: "STEP_DONE",
-                taskId: mem.thread.id,
-              });
-              pendingOps.push(
-                runRegistry.react(transitions).catch((e) => {
-                  console.error(
-                    "[decopilot:stream] onStepFinish reactor failed",
-                    e,
-                  );
+          onFinish: async (responseMessage, finishReason) => {
+            const pendingCount = pendingOps.length;
+
+            // Phase 1 (settle): await the dispatch-level side-effect ops
+            // accumulated during the run (step reactors). The kernel already
+            // settled its own pending before invoking this hook, so this
+            // segment isolates the dispatch-side flush cost.
+            const settleStart = performance.now();
+            await Promise.allSettled(pendingOps);
+            finishDurationHistogram.record(performance.now() - settleStart, {
+              phase: "settle",
+            });
+
+            if (registrySignal.aborted) return;
+
+            // Yield a macrotask before the synchronous finish bookkeeping so
+            // the settle-burst of pending-op continuations and the FINISH
+            // reactor's DB write don't run in one tick — lets queued I/O
+            // (health probes) get a turn and caps the worst onFinish
+            // event-loop stalls.
+            await sleep(0);
+
+            const heapBefore = FINISH_TRACE ? safeMemoryUsage() : null;
+            const saveStart = performance.now();
+
+            const threadStatus = resolveThreadStatus(
+              finishReason,
+              responseMessage?.parts as {
+                type: string;
+                state?: string;
+                text?: string;
+              }[],
+            );
+
+            await runRegistry.execute({
+              type: "FINISH",
+              taskId: mem.thread.id,
+              threadStatus,
+            });
+
+            const saveMs = performance.now() - saveStart;
+            finishDurationHistogram.record(saveMs, { phase: "save" });
+
+            if (FINISH_TRACE && heapBefore) {
+              const heapAfter = safeMemoryUsage() ?? heapBefore;
+              let messageBytes = -1;
+              try {
+                messageBytes = JSON.stringify(responseMessage)?.length ?? -1;
+              } catch {
+                // circular/oversized — leave -1
+              }
+              console.warn(
+                JSON.stringify({
+                  msg: "decopilot-finish-trace",
+                  threadId: mem.thread.id,
+                  pendingOps: pendingCount,
+                  saveMs: Math.round(saveMs),
+                  parts: responseMessage?.parts?.length ?? 0,
+                  messageBytes,
+                  rssDelta: heapAfter.rss - heapBefore.rss,
+                  heapUsedDelta: heapAfter.heapUsed - heapBefore.heapUsed,
+                  externalDelta: heapAfter.external - heapBefore.external,
                 }),
               );
-            },
-            onFinish: async (responseMessage, finishReason) => {
-              const pendingCount = pendingOps.length;
+            }
 
-              // Phase 1 (settle): await the dispatch-level side-effect ops
-              // accumulated during the run (step reactors). The kernel already
-              // settled its own pending before invoking this hook, so this
-              // segment isolates the dispatch-side flush cost.
-              const settleStart = performance.now();
-              await Promise.allSettled(pendingOps);
-              finishDurationHistogram.record(performance.now() - settleStart, {
-                phase: "settle",
+            // Completion analytics are emitted by the projector after the
+            // same fenced JetStream log is durably materialized.
+          },
+          onError: (error) => {
+            if (registrySignal.aborted) {
+              // User cancelled (frontend stop button), tab closed mid-stream,
+              // or run was force-failed. Frontend chat_message_stopped covers
+              // the first case; this server event also covers the other two.
+              posthog.capture({
+                distinctId: input.userId,
+                event: "chat_message_aborted",
+                groups: { organization: input.organizationId },
+                properties: {
+                  organization_id: input.organizationId,
+                  thread_id: mem.thread.id,
+                  agent_id: input.agent.id,
+                  model_id: models.thinking.id,
+                  mode: input.mode,
+                  duration_ms: Date.now() - streamStartAt,
+                  is_resume: input.isResume ?? false,
+                },
               });
+              return;
+            }
+            console.error("[decopilot] stream error:", stringifyError(error));
+            // Failure analytics (`chat_message_failed`) are emitted by the
+            // projector's `recordFailed`, same as the completion event above —
+            // this hook used to double-capture it here. The projector fires
+            // once the run's fenced terminal (in-band error chunk +
+            // `{done}`) is durably materialized, which happens for every
+            // caught failure now that `dispatchRunAndWait` propagates a
+            // mid-stream ingest error instead of swallowing it (see
+            // `hosted-harness-workflow.ts`'s catch).
 
-              if (registrySignal.aborted) return;
-
-              // Yield a macrotask before the synchronous finish bookkeeping so
-              // the settle-burst of pending-op continuations and the FINISH
-              // reactor's DB write don't run in one tick — lets queued I/O
-              // (health probes) get a turn and caps the worst onFinish
-              // event-loop stalls.
-              await sleep(0);
-
-              const heapBefore = FINISH_TRACE ? safeMemoryUsage() : null;
-              const saveStart = performance.now();
-
-              const threadStatus = resolveThreadStatus(
-                finishReason,
-                responseMessage?.parts as {
-                  type: string;
-                  state?: string;
-                  text?: string;
-                }[],
-              );
-
-              await runRegistry.execute({
+            runRegistry
+              .execute({
                 type: "FINISH",
                 taskId: mem.thread.id,
-                threadStatus,
+                threadStatus: "failed",
+              })
+              .catch((e) => {
+                console.error("[decopilot:stream] onError reactor failed", e);
               });
-
-              const saveMs = performance.now() - saveStart;
-              finishDurationHistogram.record(saveMs, { phase: "save" });
-
-              if (FINISH_TRACE && heapBefore) {
-                const heapAfter = safeMemoryUsage() ?? heapBefore;
-                let messageBytes = -1;
-                try {
-                  messageBytes = JSON.stringify(responseMessage)?.length ?? -1;
-                } catch {
-                  // circular/oversized — leave -1
-                }
-                console.warn(
-                  JSON.stringify({
-                    msg: "decopilot-finish-trace",
-                    threadId: mem.thread.id,
-                    pendingOps: pendingCount,
-                    saveMs: Math.round(saveMs),
-                    parts: responseMessage?.parts?.length ?? 0,
-                    messageBytes,
-                    rssDelta: heapAfter.rss - heapBefore.rss,
-                    heapUsedDelta: heapAfter.heapUsed - heapBefore.heapUsed,
-                    externalDelta: heapAfter.external - heapBefore.external,
-                  }),
-                );
-              }
-
-              // Completion analytics are emitted by the projector after the
-              // same fenced JetStream log is durably materialized.
-            },
-            onError: (error) => {
-              if (registrySignal.aborted) {
-                // User cancelled (frontend stop button), tab closed mid-stream,
-                // or run was force-failed. Frontend chat_message_stopped covers
-                // the first case; this server event also covers the other two.
-                posthog.capture({
-                  distinctId: input.userId,
-                  event: "chat_message_aborted",
-                  groups: { organization: input.organizationId },
-                  properties: {
-                    organization_id: input.organizationId,
-                    thread_id: mem.thread.id,
-                    agent_id: input.agent.id,
-                    model_id: models.thinking.id,
-                    mode: input.mode,
-                    duration_ms: Date.now() - streamStartAt,
-                    is_resume: input.isResume ?? false,
-                  },
-                });
-                return;
-              }
-              console.error("[decopilot] stream error:", stringifyError(error));
-              // Failure analytics (`chat_message_failed`) are emitted by the
-              // projector's `recordFailed`, same as the completion event above —
-              // this hook used to double-capture it here. The projector fires
-              // once the run's fenced terminal (in-band error chunk +
-              // `{done}`) is durably materialized, which happens for every
-              // caught failure now that `dispatchRunAndWait` propagates a
-              // mid-stream ingest error instead of swallowing it (see
-              // `hosted-harness-workflow.ts`'s catch).
-
-              runRegistry
-                .execute({
-                  type: "FINISH",
-                  taskId: mem.thread.id,
-                  threadStatus: "failed",
-                })
-                .catch((e) => {
-                  console.error("[decopilot:stream] onError reactor failed", e);
-                });
-            },
           },
-        }),
-        ctx,
-        mem.thread.id,
-      ),
+        },
+      }),
     );
 
     // Setup complete — hand the uiStream back to `dispatchRunAndWait`,
@@ -1737,12 +1693,9 @@ async function prepareRun(
     // finishes. The harness does not start until that first pull (see
     // `lazyStream`). When a streamBuffer is configured the run also pumps
     // into JetStream so `/stream` tails see chunks live across runs and tabs.
-    //
-    // The stream is wrapped (inside the lazy factory) with a throttled
-    // progress tap (Task 9): every chunk that flows out is "progress",
-    // collapsed to ≤1 `last_progress_at` write per ~3s per run. The single
-    // consumer downstream (pump or direct drain) pulls through this tap, so
-    // the heartbeat fires regardless of which consumption path runs.
+    // The run's liveness heartbeat is driven by the projector's own tap on
+    // its JetStream-sourced chunk consumption (see progress-bump.ts), not
+    // this stream.
     return {
       taskId: mem.thread.id,
       uiStream,

--- a/apps/mesh/src/api/routes/decopilot/ingest-run.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/ingest-run.test.ts
@@ -383,4 +383,73 @@ describe("ingestRun done marker", () => {
     expect(done).toEqual([]);
     expect(finishCount).toBe(0);
   });
+
+  test("stamps the highest contiguous published seq onto a mid-stream source throw", async () => {
+    // A caller that must publish its OWN fence-scoped terminal after catching
+    // this (hosted-harness-workflow.ts's publishHostedHarnessFailure) needs to
+    // know how far the log already got so its terminal continues the seq
+    // counter instead of colliding with already-published content chunks.
+    const d = deps();
+    async function* broken() {
+      yield { seq: 1, chunk: { type: "start" } as UIMessageChunk };
+      yield {
+        seq: 2,
+        chunk: { type: "text-start", id: "t" } as UIMessageChunk,
+      };
+      throw new Error("source failed mid-stream");
+    }
+
+    let caught: unknown;
+    try {
+      await ingestRun(
+        { runId: "run_1", fenceToken: "fence_a", chunks: broken() },
+        d.deps,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error & { lastAckSeq?: number }).lastAckSeq).toBe(2);
+    // The two chunks that DID publish before the throw are still on the log —
+    // only the {done} marker is withheld.
+    expect(d.published.map((p) => p.msgId)).toEqual([
+      "run_1:fence_a:1",
+      "run_1:fence_a:2",
+    ]);
+    expect(d.done).toEqual([]);
+  });
+
+  test("stamps lastAckSeq=0 when the very first chunk's publish fails (nothing ever confirmed)", async () => {
+    let caught: unknown;
+    try {
+      await ingestRun(
+        {
+          runId: "run_1",
+          fenceToken: "fence_a",
+          chunks: chunks({
+            seq: 1,
+            chunk: { type: "start" } as UIMessageChunk,
+          }),
+        },
+        {
+          streamBuffer: {
+            publishRawChunk: async () => false,
+            publishDone: async () => true,
+          },
+          hooks: {},
+          title: {
+            currentThreadTitle: null,
+            threadId: "run_1",
+            persistTitle: async () => {},
+          },
+        },
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error & { lastAckSeq?: number }).lastAckSeq).toBe(0);
+  });
 });

--- a/apps/mesh/src/api/routes/decopilot/ingest-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/ingest-run.ts
@@ -69,6 +69,25 @@ export interface IngestRunInput {
   originalMessages?: UIMessage[];
 }
 
+/**
+ * Duck-typed shape a caller can read off a caught `ingestRun` failure (see
+ * `ingestRun`'s `sourceError` handling below). `lastAckSeq` is the highest
+ * CONTIGUOUS published seq at the moment of failure (0 if no chunk was ever
+ * confirmed) — a caller that must publish its own fence-scoped terminal after
+ * catching this (see `hosted-harness-workflow.ts`'s `publishHostedHarnessFailure`)
+ * needs it to pick a seq that keeps the run's JetStream log contiguous instead
+ * of colliding with (or leaving a gap before) already-published content chunks.
+ *
+ * Plain own-enumerable property, not a class/`instanceof` check — DBOS
+ * serializes a step's thrown error through `serialize-error` for its durable
+ * journal and reconstructs a plain `Error` on replay (losing any subclass),
+ * but own-enumerable properties survive that round trip. Same idiom as
+ * `PermanentRunError.permanent` (see `core/dispatch-errors.ts`).
+ */
+export interface WithLastAckSeq {
+  lastAckSeq?: number;
+}
+
 export interface IngestRunDeps {
   streamBuffer: Pick<StreamBuffer, "publishRawChunk" | "publishDone">;
   /** usage / onFinish / onError → posthog / SSE; the caller wires them. */
@@ -182,8 +201,16 @@ export async function ingestRun(
   await whenComplete;
 
   // A source/publish throw poisons the run: re-raise so the caller fails and we
-  // never stamp a {done} marker on a partial run.
-  if (sourceError !== undefined) throw sourceError;
+  // never stamp a {done} marker on a partial run. Stamp the highest contiguous
+  // published seq onto the error first (see `WithLastAckSeq`) so a caller that
+  // must publish its own terminal after this (the hosted-harness child's catch)
+  // can continue the run's seq counter instead of colliding with seq 1..ackSeq.
+  if (sourceError !== undefined) {
+    if (sourceError instanceof Error) {
+      (sourceError as Error & WithLastAckSeq).lastAckSeq = ackSeq;
+    }
+    throw sourceError;
+  }
 
   // Authoritative terminal sentinel: published ONLY after a clean run (no throw
   // from the source stream or the kernel), fence-scoped so the projector keys

--- a/apps/mesh/src/api/routes/decopilot/nats-chunk-source.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-chunk-source.ts
@@ -3,7 +3,23 @@ import type { UIMessageChunk } from "ai";
 import { sleep } from "@decocms/std";
 import type { DecodedEvent, RawMsg } from "@decocms/harness/run-stream-codec";
 
-export const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60_000;
+/**
+ * Thrown by `natsChunkSource` when a pull produces no message within
+ * `idleTimeoutMs` — the subject went silent. Distinguishable via `instanceof`
+ * from any other error a downstream stage (decode/fence/dedup, persistence)
+ * might throw, so a caller can tell a TRUE liveness breach (nothing published
+ * at all) apart from a genuine projection failure (unified-control-plane T4:
+ * see `runProjectorWorkflowBody`'s catch in `projector-workflow.ts`, which
+ * maps this to `markRunFailed(kind: "liveness")` instead of `"projection"`).
+ * Carries the window that elapsed so the caller can render it (e.g. "no
+ * stream events for 10m") without threading the value through twice.
+ */
+export class StreamIdleTimeoutError extends Error {
+  constructor(public readonly idleTimeoutMs: number) {
+    super("producer produced no output before timeout");
+    this.name = "StreamIdleTimeoutError";
+  }
+}
 
 export function fenceFilter(
   runId: string,
@@ -115,9 +131,18 @@ function iteratorFor<T>(
 /**
  * Shared NATS source: turns an iterable of raw run-stream messages into a
  * pull-based `ReadableStream<RawMsg>`. `idleTimeoutMs` (projector only) errors
- * the stream when a pull produces no message within the window; omit it for the
- * live tail, which stays open across silent gaps. `onCancel` (e.g. `sub.stop`)
- * fires once on cancel.
+ * the stream with `StreamIdleTimeoutError` when a pull produces no message
+ * within the window; omit it for the live tail, which stays open across
+ * silent gaps. `onCancel` (e.g. `sub.stop`) fires once on cancel.
+ *
+ * The idle window is per-PULL, not a single deadline for the whole stream:
+ * each `pull()` call below races a fresh `iterator.next()` against a fresh
+ * `sleep(idleTimeoutMs)`, and any message — a UI chunk, a status chunk, a
+ * future `data-liveness` heartbeat, literally anything the ReadableStream
+ * machinery hands back from `iterator.next()` — resolves that race and the
+ * NEXT `pull()` starts a brand-new window. So "no events of any kind for
+ * idleTimeoutMs" is exactly what trips this, not "no events since stream
+ * start" (unified-control-plane T4).
  */
 export function natsChunkSource(opts: {
   messages: AsyncIterable<RawMsg> | Iterable<RawMsg>;
@@ -154,9 +179,7 @@ export function natsChunkSource(opts: {
         .catch(() => "cancelled" as const);
       const result = await Promise.race([next, idle]);
       if (result === "idle") {
-        controller.error(
-          new Error("producer produced no output before timeout"),
-        );
+        controller.error(new StreamIdleTimeoutError(idleTimeoutMs));
         return;
       }
       if (result === "cancelled") return; // idle lost the race; loop again on next pull

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -448,6 +448,84 @@ describe("NatsStreamBuffer", () => {
     });
   });
 
+  describe("pump", () => {
+    function bufferForPump() {
+      const published: Array<{ subj: string; data: Uint8Array }> = [];
+      const mockJs = {
+        publish: mockOf((subj: string, data: Uint8Array) => {
+          published.push({ subj, data });
+          return Promise.resolve({ seq: published.length });
+        }),
+      };
+      const buffer = new NatsStreamBuffer({
+        getConnection: () => ({}) as never,
+        getJetStream: () => mockJs as never,
+      });
+      (buffer as unknown as { js: unknown }).js = mockJs;
+      return { buffer, published };
+    }
+
+    function doneBody(data: Uint8Array): unknown {
+      return JSON.parse(new TextDecoder().decode(data));
+    }
+
+    it("resolves after a clean drain and publishes the unfenced done sentinel", async () => {
+      const { buffer, published } = bufferForPump();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+
+      await expect(
+        buffer.pump(stream, "task-1", new AbortController().signal),
+      ).resolves.toBeUndefined();
+
+      expect(published).toHaveLength(1);
+      expect(doneBody(published[0]!.data)).toEqual({ done: true });
+    });
+
+    it("REJECTS with the stream's error on a mid-stream failure — the old contract silently swallowed this", async () => {
+      // Regression for the "pump-swallow gap" (unified-control-plane T2):
+      // a mid-stream `ingestRun` failure (healthy JetStream) used to vanish
+      // here, so `dispatchRunAndWait` returned as if the run had finished
+      // cleanly and no fenced terminal ever reached the stream.
+      const { buffer, published } = bufferForPump();
+      const boom = new Error("ingest failed mid-stream");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.error(boom);
+        },
+      });
+
+      await expect(
+        buffer.pump(stream, "task-1", new AbortController().signal),
+      ).rejects.toBe(boom);
+
+      // The safety-net unfenced done sentinel STILL goes out (finally block)
+      // so a live tail closes instead of hanging — only the caller-facing
+      // promise changed, not the wire behavior.
+      expect(published).toHaveLength(1);
+      expect(doneBody(published[0]!.data)).toEqual({ done: true });
+    });
+
+    it("resolves (not rejects) when JetStream is unavailable — nothing to drain", async () => {
+      const buffer = new NatsStreamBuffer({
+        getConnection: () => null,
+        getJetStream: () => null,
+      });
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+
+      await expect(
+        buffer.pump(stream, "task-1", new AbortController().signal),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe("publishRawChunk", () => {
     function bufferWithPublish() {
       const published: Array<{ subj: string; data: Uint8Array }> = [];

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -277,7 +277,7 @@ export class NatsStreamBuffer implements StreamBuffer {
     taskId: string,
     registrySignal: AbortSignal,
     orgId?: string,
-  ): void {
+  ): Promise<void> {
     const js = this.js;
     if (!js) {
       // No JetStream client — every chunk for this run is silently dropped
@@ -286,7 +286,7 @@ export class NatsStreamBuffer implements StreamBuffer {
       console.warn(
         `[Decopilot] pump: JetStream client unavailable for thread ${taskId}; chunks NOT published to NATS`,
       );
-      return;
+      return Promise.resolve();
     }
 
     const tracker = createPublishTracker(taskId, orgId);
@@ -343,10 +343,18 @@ export class NatsStreamBuffer implements StreamBuffer {
       }
     };
 
-    void (async () => {
+    return (async () => {
       const reader = stream.getReader();
       let sinceYield = 0;
       let publishedChunks = 0;
+      // Captured, not swallowed: a mid-stream failure (e.g. the
+      // `buildAgentSandboxUiStream` vessel erroring because `ingestRun` threw)
+      // still publishes the legacy unfenced `{done}` below so any tail
+      // consumer closes cleanly, but the caller (`dispatchRunAndWait`) needs
+      // to learn about the failure too — awaiting the promise this function
+      // now returns surfaces it instead of the caller reading a false
+      // "the tail saw {done}, so the run finished cleanly" signal.
+      let caught: unknown;
       try {
         while (true) {
           const { done, value } = await reader.read();
@@ -364,6 +372,7 @@ export class NatsStreamBuffer implements StreamBuffer {
           }
         }
       } catch (err) {
+        caught = err;
         console.warn(
           `[Decopilot] stream pump error for thread ${taskId}:`,
           (err as Error)?.message ?? err,
@@ -383,6 +392,7 @@ export class NatsStreamBuffer implements StreamBuffer {
           );
         }
       }
+      if (caught !== undefined) throw caught;
     })();
   }
 

--- a/apps/mesh/src/api/routes/decopilot/progress-bump.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/progress-bump.test.ts
@@ -43,10 +43,10 @@ describe("ProgressBumpThrottle", () => {
 });
 
 // ---------------------------------------------------------------------------
-// tapProgressStream — the desktop-run liveness heartbeat tap. `chunkStream`
-// in project-chunks.ts is a `ReadableStream<UIMessageChunk>` (not an
-// AsyncIterable), so the tap is a pass-through TransformStream, mirroring
-// dispatch-run.ts's `tapProgress`.
+// tapProgressStream — the run liveness heartbeat tap (sole heartbeat for
+// both hosted and desktop runs). `chunkStream` in project-chunks.ts is a
+// `ReadableStream<UIMessageChunk>` (not an AsyncIterable), so the tap is a
+// pass-through TransformStream.
 // ---------------------------------------------------------------------------
 
 async function collect<T>(stream: ReadableStream<T>): Promise<T[]> {

--- a/apps/mesh/src/api/routes/decopilot/progress-bump.ts
+++ b/apps/mesh/src/api/routes/decopilot/progress-bump.ts
@@ -47,14 +47,15 @@ export class ProgressBumpThrottle {
  * Tap a chunk stream so each chunk drives a THROTTLED `onBump()` call. Pure
  * pass-through: every chunk is forwarded unchanged; `onBump` is a
  * fire-and-forget side effect that must never block or fail the stream —
- * callers should swallow their own errors (see projector-workflow.ts and
- * dispatch-run.ts's `tapProgress`, which this mirrors for the
- * `ReadableStream`-shaped `chunkStream` used by project-chunks.ts).
+ * callers should swallow their own errors (see projector-workflow.ts, which
+ * drives this for the `ReadableStream`-shaped `chunkStream` used by
+ * project-chunks.ts).
  *
- * This is the desktop-run liveness heartbeat: desktop chunks go daemon → NATS
- * directly, so the projector's live chunk consumption is the only mesh
- * component that ever sees them — see the reaper's `RUN_IDLE_TIMEOUT_MS` in
- * run-registry.ts.
+ * This is the run's liveness heartbeat for BOTH topologies: desktop chunks
+ * go daemon → NATS directly, so the projector's live chunk consumption is
+ * the only mesh component that ever sees them; hosted runs are also
+ * live-tailed by the projector post-unification, so this one tap covers
+ * both — see the reaper's `RUN_IDLE_TIMEOUT_MS` in run-registry.ts.
  */
 export function tapProgressStream<T>(
   stream: ReadableStream<T>,

--- a/apps/mesh/src/api/routes/decopilot/projector-chunk-stream.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-chunk-stream.test.ts
@@ -1,6 +1,8 @@
 import type { UIMessageChunk } from "ai";
 import { describe, expect, test } from "bun:test";
+import { sleep } from "@decocms/std";
 import { createProjectorChunkStreamFromMessages } from "./projector-chunk-stream";
+import { StreamIdleTimeoutError } from "./nats-chunk-source";
 
 const enc = new TextEncoder();
 
@@ -148,5 +150,87 @@ describe("createProjectorChunkStreamFromMessages", () => {
     expect(await readAll(stream)).toEqual([
       { type: "text-delta", id: "t", delta: "hello" },
     ]);
+  });
+
+  // unified-control-plane T4: silence on the subject (no events of ANY kind —
+  // not just "no done/finish") is the only signal an executor died before/
+  // without publishing, now that nothing awaits the child directly (T1-T3).
+  // These characterize the liveness-breach signal this module produces and
+  // confirm it is a rolling per-message window, not a single stream-wide
+  // deadline — the mechanism `runProjectorWorkflowBody` (projector-workflow.ts)
+  // relies on to tell a true liveness breach apart from a real projection bug.
+  describe("liveness: idle-timeout as a first-class silence terminal", () => {
+    test("a fully silent source trips StreamIdleTimeoutError after idleTimeoutMs", async () => {
+      async function* silent(): AsyncIterable<Msg> {
+        await new Promise<never>(() => {}); // mimics a dead executor: never yields
+      }
+      const stream = createProjectorChunkStreamFromMessages({
+        messages: silent(),
+        runId: "run_1",
+        fenceToken: "fence_a",
+        idleTimeoutMs: 15,
+      });
+
+      let caught: unknown;
+      try {
+        await readAll(stream);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(StreamIdleTimeoutError);
+      expect((caught as StreamIdleTimeoutError).idleTimeoutMs).toBe(15);
+      expect((caught as Error).message).toContain(
+        "producer produced no output before timeout",
+      );
+    });
+
+    test("any event resets the idle window — gaps under idleTimeoutMs never trip it, even though the total elapsed time exceeds it", async () => {
+      // 3 gaps of 20ms (60ms total) against a 50ms idle window: a single
+      // stream-wide deadline would have errored at 50ms; a per-message
+      // rolling window (the actual implementation) never sees a gap wider
+      // than 20ms and completes cleanly. The middle chunk stands in for a
+      // future T5/T6 `data-liveness` heartbeat — any chunk type resets the
+      // window identically, there is no special-casing by type.
+      async function* trickle(): AsyncIterable<Msg> {
+        await sleep(20);
+        yield msg("run_1:fence_a:1", { p: { type: "start" } });
+        await sleep(20);
+        yield msg("run_1:fence_a:2", {
+          p: { type: "data-liveness", data: {} },
+        });
+        await sleep(20);
+        yield msg("run_1:fence_a:3", { p: { type: "finish" } });
+      }
+      const stream = createProjectorChunkStreamFromMessages({
+        messages: trickle(),
+        runId: "run_1",
+        fenceToken: "fence_a",
+        idleTimeoutMs: 50,
+      });
+
+      const out = await readAll(stream);
+      expect(out.map((c) => c.type)).toEqual([
+        "start",
+        "data-liveness",
+        "finish",
+      ]);
+    });
+
+    test("omitting idleTimeoutMs disables idle enforcement (live-tail semantics)", async () => {
+      // No idle timer at all when idleTimeoutMs is omitted — the UI live-tail
+      // (nats-stream-buffer.ts) relies on exactly this to stay open across
+      // silent gaps that span whole runs.
+      async function* delayedFinish(): AsyncIterable<Msg> {
+        await sleep(30);
+        yield msg("run_1:fence_a:1", { p: { type: "finish" } });
+      }
+      const stream = createProjectorChunkStreamFromMessages({
+        messages: delayedFinish(),
+        runId: "run_1",
+        fenceToken: "fence_a",
+      });
+
+      expect((await readAll(stream)).map((c) => c.type)).toEqual(["finish"]);
+    });
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/projector-chunk-stream.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-chunk-stream.ts
@@ -3,7 +3,6 @@ import { DeliverPolicy, type JetStreamClient } from "@nats-io/jetstream";
 import { DECOPILOT_STREAM_NAME } from "./projector-stream-messages";
 import {
   assertContiguousAndDedup,
-  DEFAULT_IDLE_TIMEOUT_MS,
   fenceFilter,
   natsChunkSource,
   projectorChunkStream,
@@ -24,6 +23,11 @@ export interface ProjectorChunkStreamOptions {
     | Iterable<ProjectorStreamMessage>;
   runId: string;
   fenceToken: string;
+  /** Omit for no idle enforcement (live tail). The projector's production
+   *  caller always supplies `RUN_IDLE_TIMEOUT_MS` (defaulted in
+   *  `consume-run-projection.ts` — see that file's `ConsumeRunProjectionOptions`
+   *  doc) — this module stays agnostic of that constant so it can also back
+   *  the unbounded UI live-tail (`nats-stream-buffer.ts`). */
   idleTimeoutMs?: number;
   /**
    * Cleanup callback wired as the source's `onCancel`. Fires once when the
@@ -49,7 +53,7 @@ export function createProjectorChunkStreamFromMessages(
 ): ReadableStream<UIMessageChunk> {
   const source = natsChunkSource({
     messages: options.messages,
-    idleTimeoutMs: options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS,
+    idleTimeoutMs: options.idleTimeoutMs,
     onCancel: options.onDone,
   });
   const events = source

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { ProjectChunksResult } from "./project-chunks";
 import {
+  livenessFailureReason,
   runProjectorWorkflowBody,
   shouldSkipProjection,
 } from "./projector-workflow";
@@ -8,6 +9,7 @@ import type {
   ProjectorWorkflowRuntime,
   ProjectorWorkflowInput,
 } from "./projector-workflow";
+import { StreamIdleTimeoutError } from "./nats-chunk-source";
 
 describe("projector workflow helpers", () => {
   test("does not skip terminal runs for the same fence", () => {
@@ -298,6 +300,41 @@ describe("runProjectorWorkflowBody", () => {
     expect(failCall.reason).toBeTruthy();
     const recordFailCall = calls.find((c) => c.kind === "record-fail");
     expect(recordFailCall?.failKind).toBe("projection");
+    expect(recordFailCall?.reason).toBe(failCall.reason);
+    expect(recordFailCall?.runId).toBe("run_1");
+    expect(recordFailCall?.orgId).toBe("org_1");
+    expect(recordFailCall?.distinctId).toBe("user_1");
+  });
+
+  // unified-control-plane T4: a StreamIdleTimeoutError (thrown by
+  // natsChunkSource — nats-chunk-source.ts — when the subject goes silent for
+  // idleTimeoutMs) is a LIVENESS breach, not a projection bug, and must be
+  // recorded distinctly so `failure_reason` reads as a liveness terminal
+  // instead of the generic (and misleading) "projection" catch-all every
+  // other thrown error still gets — see the "projection throw" test above for
+  // the unchanged-baseline comparison.
+  test("silence (StreamIdleTimeoutError) throw → markRunFailed(kind='liveness') with a liveness reason, and workflow re-throws", async () => {
+    const { rt, calls } = makeRuntime();
+    const idleTimeoutMs = 10 * 60_000; // RUN_IDLE_TIMEOUT_MS (10m)
+    const projectFn = async () => {
+      throw new StreamIdleTimeoutError(idleTimeoutMs);
+    };
+
+    await expect(
+      runProjectorWorkflowBody(input, rt, projectFn),
+    ).rejects.toBeInstanceOf(StreamIdleTimeoutError);
+
+    const failCalls = calls.filter((c) => c.kind === "fail");
+    const completeCalls = calls.filter((c) => c.kind === "complete");
+
+    expect(completeCalls).toHaveLength(0);
+    expect(failCalls).toHaveLength(1);
+    const failCall = failCalls[0]!;
+    expect(failCall.failKind).toBe("liveness");
+    expect(failCall.reason).toBe(livenessFailureReason(idleTimeoutMs));
+    expect(failCall.reason).toBe("liveness: no stream events for 10m");
+    const recordFailCall = calls.find((c) => c.kind === "record-fail");
+    expect(recordFailCall?.failKind).toBe("liveness");
     expect(recordFailCall?.reason).toBe(failCall.reason);
     expect(recordFailCall?.runId).toBe("run_1");
     expect(recordFailCall?.orgId).toBe("org_1");

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts
@@ -387,6 +387,53 @@ describe("runProjectorWorkflowBody", () => {
     expect(calls.filter((c) => c.kind === "requires-action")).toHaveLength(0);
   });
 
+  test("EXACTLY ONCE: a no-op flip (run already terminal) does NOT re-fire recordCompleted", async () => {
+    // Simulates a retried/re-entrant projection of an already-completed run
+    // (e.g. a redelivered consume step, or a run the hosted live path already
+    // finalized before the projector backstop ran). The conditional DB flip
+    // (`WHERE status = 'in_progress'`) returns null/falsy on a no-op — the
+    // side-effect (posthog `chat_message_completed`) must not fire again.
+    const { rt, calls } = makeRuntime();
+    rt.completeRunIfNotCompleted = async (runId, orgId) => {
+      calls.push({ kind: "complete", runId, orgId });
+      return null; // no-op: already terminal
+    };
+    const projectFn = makeProjectFn({
+      outcome: {
+        failed: false,
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+        finalParts: [],
+      },
+    });
+
+    await runProjectorWorkflowBody(input, rt, projectFn);
+
+    expect(calls.filter((c) => c.kind === "complete")).toHaveLength(1);
+    expect(calls.filter((c) => c.kind === "record-complete")).toHaveLength(0);
+  });
+
+  test("EXACTLY ONCE: a no-op flip (run already terminal) does NOT re-fire recordFailed", async () => {
+    const { rt, calls } = makeRuntime();
+    rt.markRunFailed = async (runId, orgId, reason, kind) => {
+      calls.push({ kind: "fail", runId, orgId, reason, failKind: kind });
+      return null; // no-op: already terminal
+    };
+    const projectFn = makeProjectFn({
+      outcome: {
+        failed: true,
+        finishReason: undefined,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        finalParts: [],
+      },
+    });
+
+    await runProjectorWorkflowBody(input, rt, projectFn);
+
+    expect(calls.filter((c) => c.kind === "fail")).toHaveLength(1);
+    expect(calls.filter((c) => c.kind === "record-fail")).toHaveLength(0);
+  });
+
   test("purge (cleanup) runs on ALL terminal paths (completed, harness-failed, requires_action)", async () => {
     // completed path
     const { rt: rt1, calls: calls1 } = makeRuntime();

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
@@ -3,12 +3,24 @@ import type { SqlThreadMessagePartStorage } from "@/storage/thread-message-parts
 import type { ProjectChunksResult } from "./project-chunks";
 import { projectChunks } from "./project-chunks";
 import { createProjectorChunkStream } from "./projector-chunk-stream";
+import { StreamIdleTimeoutError } from "./nats-chunk-source";
 import { createRunPersistence } from "./run-persistence";
 import { recordPoison } from "./projector-metrics";
 import { ProgressBumpThrottle, tapProgressStream } from "./progress-bump";
 import { resolveThreadStatus } from "./status";
 import { synthesizedErrorMessageId } from "./message-ids";
 import { foldedToUIMessage } from "./projector-seed";
+
+/**
+ * Reason string persisted to `failure_reason` when the run's subject went
+ * silent for the idle window — the wording distinguishes a liveness breach
+ * (nothing published at all) from an actual projection error in the UI and
+ * analytics (`kind: "liveness"` vs `"projection"`). unified-control-plane T4.
+ */
+export function livenessFailureReason(idleTimeoutMs: number): string {
+  const minutes = Math.round(idleTimeoutMs / 60_000);
+  return `liveness: no stream events for ${minutes}m`;
+}
 
 export function shouldSkipProjection(input: {
   status: string;
@@ -31,6 +43,11 @@ export interface ProjectorWorkflowInput {
   /** The turn's request message id — anchors the projected reply's created_at
    *  right after its own user message (queue ordering). */
   messageId?: string;
+  /** Idle window enforced on the live subject tail (unified-control-plane T4).
+   *  Threaded from `ConsumeRunProjectionOptions.idleTimeoutMs` (defaulted
+   *  there to `RUN_IDLE_TIMEOUT_MS`) down to `createProjectorChunkStream`.
+   *  Omitted → no idle enforcement (matches the pre-T4 unbounded behavior). */
+  idleTimeoutMs?: number;
 }
 
 export interface ProjectorRunRow {
@@ -57,7 +74,7 @@ export interface ProjectorWorkflowRuntime {
     runId: string,
     orgId: string,
     reason: string,
-    kind: "harness" | "transport" | "projection",
+    kind: "harness" | "transport" | "projection" | "liveness",
   ): Promise<unknown>;
   persistTitle(runId: string, orgId: string, title: string): Promise<unknown>;
   onTitleUpdated(input: {
@@ -77,7 +94,7 @@ export interface ProjectorWorkflowRuntime {
     orgId: string;
     distinctId: string;
     reason: string;
-    kind: "harness" | "projection";
+    kind: "harness" | "projection" | "liveness";
   }): Promise<void>;
   purgeRun(runId: string, fenceToken: string): Promise<void>;
 }
@@ -133,11 +150,17 @@ export async function projectFromJetStreamStep(
     await rt.messageParts.loadWindow(input.runId, { limit: 500 })
   ).messages.map(foldedToUIMessage);
   const result = await projectChunks({
+    // BOTH liveness enforcement points feed from this one stream: the tap
+    // bumps `last_progress_at` (DB reaper backstop) on every subject event,
+    // and the source's idleTimeoutMs (typed StreamIdleTimeoutError) is the
+    // in-process terminal — so executor heartbeats (data-liveness chunks)
+    // reset both automatically.
     chunkStream: tapProgressStream(
       await createProjectorChunkStream({
         js,
         runId: input.runId,
         fenceToken: input.fenceToken,
+        idleTimeoutMs: input.idleTimeoutMs,
       }),
       input.runId,
       progressThrottle,
@@ -271,25 +294,42 @@ export async function runProjectorWorkflowBody(
     // purging is safe.
     await rt.purgeRun(input.runId, input.fenceToken);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    // A silent subject (StreamIdleTimeoutError, thrown by natsChunkSource —
+    // see nats-chunk-source.ts) is a LIVENESS breach, not a projection bug:
+    // the executor died (or never started) before publishing anything, so
+    // there was nothing to project. Distinguishing it here (unified-control-
+    // plane T4) gives the thread a legible `failure_reason` instead of the
+    // generic (and misleading) "projection" catch-all every other thrown
+    // error still gets.
+    const isLivenessBreach = error instanceof StreamIdleTimeoutError;
+    const reason = isLivenessBreach
+      ? livenessFailureReason((error as StreamIdleTimeoutError).idleTimeoutMs)
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    const kind = isLivenessBreach ? "liveness" : "projection";
     recordPoison(input.runId, orgId);
     const flippedOnError = await rt.markRunFailed(
       input.runId,
       orgId,
-      message,
-      "projection",
+      reason,
+      kind,
     );
     if (flippedOnError) {
       await rt.recordFailed({
         runId: input.runId,
         orgId,
         distinctId,
-        reason: message,
-        kind: "projection",
+        reason,
+        kind,
       });
     }
     // Re-throw so DBOS records the workflow failure (poison run — projection
-    // itself threw after exhausting retries; NOT a harness-error run).
+    // itself threw after exhausting retries; NOT a harness-error run). This
+    // holds for the liveness case too: the consume step genuinely failed to
+    // produce a projection, so DBOS's retry/redelivery bookkeeping still
+    // applies — the ONLY thing T4 changes is the recorded reason/kind, not
+    // the step's success/failure verdict.
     // Do NOT purge here: the DBOS workflow has failed so a potential
     // re-delivery or operator inspection of the JetStream subject is still
     // meaningful.

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
@@ -122,19 +122,17 @@ export function getProjectorWorkflowRuntime(): ProjectorWorkflowRuntime {
 
 /**
  * Process-wide progress-bump throttle for the projector's live chunk
- * consumption (Task 9, A1/A2) — the desktop-run liveness heartbeat. Desktop
- * chunks go daemon → NATS directly (no mesh HTTP hop), so this tap on the
- * JetStream-sourced chunkStream is the ONLY place a desktop run's progress
- * gets recorded; without it the reaper's `RUN_IDLE_TIMEOUT_MS` (run-registry.ts)
- * force-fails any run running longer than ~10 minutes. Module scope (not
- * per-call) so the per-task last-bump map survives across the multiple
- * `projectFromJetStreamStep` invocations a thread's runs may see — mirrors
- * dispatch-run.ts's `progressThrottle`.
- *
- * Hosted runs already heartbeat via dispatch-run.ts's own `tapProgress` on
- * the hosted uiStream; they now ALSO bump here (the projector consumes every
- * run's chunks, hosted included). Harmless — same `last_progress_at` column,
- * both throttled independently, so it's at most one extra write per ~3s.
+ * consumption (Task 9, A1/A2) — the SOLE liveness heartbeat for both
+ * topologies (unified-control-plane). Desktop chunks go daemon → NATS
+ * directly (no mesh HTTP hop), so this tap on the JetStream-sourced
+ * chunkStream is the only place a desktop run's progress gets recorded.
+ * Hosted runs are live-tailed the same way post-unification (dispatch-run.ts
+ * no longer has its own tap — its wrapped stream never enqueued a chunk, so
+ * it never fired; removed). Without this tap the reaper's
+ * `RUN_IDLE_TIMEOUT_MS` (run-registry.ts) force-fails any run running longer
+ * than ~10 minutes. Module scope (not per-call) so the per-task last-bump
+ * map survives across the multiple `projectFromJetStreamStep` invocations a
+ * thread's runs may see.
  */
 const progressThrottle = new ProgressBumpThrottle();
 

--- a/apps/mesh/src/api/routes/decopilot/routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.test.ts
@@ -10,6 +10,8 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   applyThreadLock,
   computeIdempotencyKey,
@@ -352,5 +354,80 @@ describe("applyThreadLock", () => {
     expect(result.harnessId).toBe("claude-code");
     expect(result.sandboxProviderKind).toBe("agent-sandbox");
     expect(result.branch).toBe("feature-x");
+  });
+});
+
+// unified-control-plane T7: Stop must also tear down the detached hosted
+// child (see hosted-harness-workflow.ts's `startHostedHarness` doc comment —
+// since T3, the gate starts the child and does NOT await it, so a Stop that
+// only cancelled the gate head left the child running as a wasted-but-inert
+// background burn). `cancelActiveThreadRun` is a route-layer closure over
+// live StudioContext/DBOS/NATS dependencies (DB reads, `DBOS.cancelWorkflow`
+// via `cancelHostedHarness`, cross-pod broadcast) — exercising it end-to-end
+// needs a launched DBOS + Postgres instance (repo policy: no mock fortress),
+// so — same technique as thread-gate-workflow.test.ts's step-ordering
+// regressions and hosted-harness-workflow.test.ts's `hostedChildWorkflowId`
+// regression — this reads the real function body directly instead of a
+// stand-in.
+describe("cancelActiveThreadRun (T7: stop cancels the detached hosted child)", () => {
+  const src = readFileSync(join(import.meta.dir, "routes.ts"), "utf8");
+  const fnStart = src.indexOf("async function cancelActiveThreadRun(args: {");
+  const fnEnd = src.indexOf(
+    '\n  app.post("/:org/decopilot/cancel/:threadId"',
+    fnStart,
+  );
+  const body = src.slice(fnStart, fnEnd === -1 ? undefined : fnEnd);
+
+  test("locates the function", () => {
+    expect(fnStart).toBeGreaterThan(-1);
+    expect(fnEnd).toBeGreaterThan(fnStart);
+  });
+
+  test("imports cancelHostedHarness through the dispatch-queue barrel — the same single source of truth startHostedHarness uses, not a reconstructed id", () => {
+    expect(src).toContain(
+      'import { cancelHostedHarness, enqueueThreadRun } from "@/dispatch-queue";',
+    );
+  });
+
+  test("reads the thread's CURRENT fence before cancelling the child (not a stale/cached one)", () => {
+    const fenceReadIdx = body.indexOf(
+      "await ctx.storage.threads.getRunFence(taskId)",
+    );
+    expect(fenceReadIdx).toBeGreaterThan(-1);
+  });
+
+  test("only cancels the child when a live fence exists — desktop runs (no hosted child) and threads that never dispatched are a no-op", () => {
+    const fenceReadIdx = body.indexOf(
+      "const fenceToken = await ctx.storage.threads.getRunFence(taskId);",
+    );
+    const guardIdx = body.indexOf("if (fenceToken) {", fenceReadIdx);
+    const cancelCallIdx = body.indexOf(
+      "await cancelHostedHarness(taskId, fenceToken);",
+      guardIdx,
+    );
+    expect(fenceReadIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeGreaterThan(fenceReadIdx);
+    expect(cancelCallIdx).toBeGreaterThan(guardIdx);
+  });
+
+  test("best-effort: the DBOS cancel is wrapped in try/catch so an unknown/already-terminal child (or any DBOS hiccup) can never fail the user-facing Stop", () => {
+    const fenceReadIdx = body.indexOf(
+      "const fenceToken = await ctx.storage.threads.getRunFence(taskId);",
+    );
+    const tryIdx = body.lastIndexOf("try {", fenceReadIdx);
+    const catchIdx = body.indexOf("} catch (err) {", fenceReadIdx);
+    expect(tryIdx).toBeGreaterThan(-1);
+    expect(catchIdx).toBeGreaterThan(fenceReadIdx);
+    // The catch logs (not rethrows) — grep the slice for a rethrow between
+    // the catch and its close to make sure it stays a swallow-and-log.
+    const catchBody = body.slice(catchIdx, body.indexOf("\n    }", catchIdx));
+    expect(catchBody).not.toContain("throw ");
+  });
+
+  test("the hosted-child cancel runs AFTER the gate-head cancel (freeing the DBOS queue partition before touching the child)", () => {
+    const gateHeadCancelIdx = body.indexOf("await cancelThreadGateHead(");
+    const hostedCancelIdx = body.indexOf("await cancelHostedHarness(");
+    expect(gateHeadCancelIdx).toBeGreaterThan(-1);
+    expect(hostedCancelIdx).toBeGreaterThan(gateHeadCancelIdx);
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -834,13 +834,33 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       });
     });
 
-    // Tear down the hosted-harness child workflow (Task 7b). The in-memory cancel
-    // below (cancelBroadcast + run-registry CANCEL → AbortController) already
-    // stops the running harness loop; this additionally tells DBOS to stop
-    // recovering / retrying the child on pod recycles. Keyed by
-    // `decopilot-hosted:<runId>:<fenceToken>` — read the current fence from the
-    // thread row. Best-effort: cancelling an already-finished/unknown workflow
-    // (e.g. desktop runs, which have no hosted child) must not fail the cancel.
+    // Tear down the hosted-harness child workflow (Task 7b / unified-control-
+    // plane T7). Division of labor vs. the in-memory cancel below
+    // (cancelBroadcast + run-registry CANCEL → AbortController):
+    //   - RUNNING child (already dequeued, `runHostedHarness` step executing):
+    //     `DBOS.cancelWorkflow` (called by `cancelHostedHarness`) is a pure DB
+    //     status flip to CANCELLED — DBOS only checks that flag BEFORE a step
+    //     starts / when recording a step's result, never mid-step (verified
+    //     against @dbos-inc/dbos-sdk 4.21.6's `callStepFunction` — no
+    //     AbortSignal is threaded into an in-flight non-timeout step call). So
+    //     for an already-running child this call does NOT stop the agent loop
+    //     in real time; the run-registry's `abortController.abort()` below
+    //     (wired into the harness kernel call via `registrySignal` in
+    //     dispatch-run.ts) is what actually interrupts it. What this call DOES
+    //     guarantee for a running child: it can never later report SUCCESS,
+    //     and — because the child has `maxRecoveryAttempts: 1000` for
+    //     multi-hour survivability — a pod crash right after Stop can't have
+    //     DBOS's recovery executor resurrect/re-run it on a new pod.
+    //   - ENQUEUED child (started but not yet dequeued by the concurrency=1
+    //     hosted-harness queue partition — no in-memory run/AbortController
+    //     exists yet for the registry cancel to reach): this call flips it
+    //     straight to CANCELLED and clears its queue slot, so it is NEVER
+    //     dequeued/executed — a full, real cancel for that narrow window.
+    // Keyed by `decopilot-hosted:<runId>:<fenceToken>` (`hostedChildWorkflowId`,
+    // the same single source of truth `startHostedHarness` uses) — read the
+    // current fence from the thread row. Best-effort: cancelling an
+    // already-finished/unknown workflow (e.g. desktop runs, which have no
+    // hosted child) must not fail the cancel.
     try {
       const fenceToken = await ctx.storage.threads.getRunFence(taskId);
       if (fenceToken) {

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -52,7 +52,12 @@ async function handleTerminalStatus(
   // DB status write intentionally removed: the consume step (consume-run-projection.ts)
   // is now the sole writer for completed/requires_action. The live reactor only emits
   // SSE for instant UX — the durable projector workflow owns the terminal DB transition.
-  // (RUN_FAILED is exempt: failed runs skip the projector path and keep their write below.)
+  // (RUN_FAILED below still writes directly, but the projector path now runs
+  // unconditionally for both topologies too — so for stream-driven failures that write
+  // RACES the projector's `markRunFailed` on the same terminal state. The write here
+  // remains the sole DB terminal only for desktop pre-publish setup failures
+  // (`failPreparedRun`) and for reaped/cancelled/ghost force-fails, which never reach
+  // the projector. See the T3 report's follow-up for the race.)
   sseHub.emit(
     orgId,
     createDecopilotThreadStatusEvent(taskId, status, {

--- a/apps/mesh/src/api/routes/decopilot/run-registry.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.ts
@@ -31,8 +31,17 @@ const REAP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
  * replaces the old absolute 30-min age cap so legitimate hours-long runs that
  * keep streaming are never killed (A1), while a flapping run that resumes but
  * makes no real progress still trips (A2).
+ *
+ * Exported (unified-control-plane T4): also the ONE idle window the gate-side
+ * consume path (`consume-run-projection.ts` → `natsChunkSource`) enforces on
+ * the live subject tail. The reaper watches `last_progress_at` (DB-level,
+ * cross-pod); the consume-side timer watches the subject directly
+ * (in-process, per-attempt) — two different enforcement points, but they must
+ * agree on the SAME window so neither fires meaningfully earlier/later than
+ * the other for the same stall. See `livenessFailureReason` in
+ * `projector-workflow.ts` for the consume-side terminal this produces.
  */
-const RUN_IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+export const RUN_IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
 /** Events that mark a new inflight run. */
 const INFLIGHT_START_EVENTS = new Set(["RUN_STARTED", "RUN_RESUMED"]);

--- a/apps/mesh/src/api/routes/decopilot/run-registry.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.ts
@@ -40,8 +40,23 @@ const REAP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
  * agree on the SAME window so neither fires meaningfully earlier/later than
  * the other for the same stall. See `livenessFailureReason` in
  * `projector-workflow.ts` for the consume-side terminal this produces.
+ *
+ * unified-control-plane T9: env-overridable so CI can prove the
+ * liveness-terminal path (executor dies mid-run → thread reaches `failed`
+ * with a "liveness" reason) without an e2e test waiting 10 real minutes.
+ * Read ONCE at module load — this is a fixed, process-wide knob, never a
+ * per-request parameter (same idiom as this directory's other module-level
+ * `process.env` trace flags, e.g. `dispatch-run.ts`'s `FINISH_TRACE`). Unset
+ * (every non-e2e environment, including production) keeps the 10-minute
+ * default unchanged. `packages/e2e/playwright.config.ts` sets
+ * `RUN_IDLE_TIMEOUT_MS` on the e2e webServer process only.
  */
-export const RUN_IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const RUN_IDLE_TIMEOUT_MS_OVERRIDE = Number(process.env.RUN_IDLE_TIMEOUT_MS);
+export const RUN_IDLE_TIMEOUT_MS =
+  Number.isFinite(RUN_IDLE_TIMEOUT_MS_OVERRIDE) &&
+  RUN_IDLE_TIMEOUT_MS_OVERRIDE > 0
+    ? RUN_IDLE_TIMEOUT_MS_OVERRIDE
+    : 10 * 60 * 1000; // 10 minutes
 
 /** Events that mark a new inflight run. */
 const INFLIGHT_START_EVENTS = new Set(["RUN_STARTED", "RUN_RESUMED"]);

--- a/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
@@ -19,14 +19,24 @@ export interface StreamBuffer {
   init(): Promise<void>;
 
   /**
-   * Detached pump from `stream` into the per-task subject. Fire-and-forget:
-   * returns synchronously, then drains `stream` in the background, publishing
-   * each chunk as a JetStream message. When `stream` ends (or `registrySignal`
-   * aborts), publishes a `{done: true}` sentinel so tail consumers can close.
+   * Drains `stream` into the per-task subject, publishing each chunk as a
+   * JetStream message. When `stream` ends (or `registrySignal` aborts),
+   * publishes a `{done: true}` sentinel so tail consumers can close — even on
+   * a mid-stream failure, so a live `/stream` tail always sees SOME done
+   * marker instead of hanging.
    *
    * The pump is the sole consumer of `stream`; do not also `pipeThrough` or
    * `tee` it for the HTTP response. Tail consumers read from JetStream via
    * `createTailStream`.
+   *
+   * Returns a promise: the caller need not await it to let draining start
+   * (it begins synchronously, same as the old fire-and-forget contract), but
+   * AWAITING it surfaces a mid-stream `stream` error as a rejection — the
+   * `{done}` sentinel above is published regardless, so a rejection here
+   * means "the tail closed, but the run did not finish cleanly," not "the
+   * tail never closed." `dispatchRunAndWait` awaits this after its own
+   * tail-wait loop so a mid-stream ingest failure (with healthy JetStream)
+   * propagates instead of looking like a clean completion.
    *
    * `orgId` is optional but recommended — it tags the `decopilot.stream.publish_errors`
    * OTEL counter so per-org alerting is possible.
@@ -36,7 +46,7 @@ export interface StreamBuffer {
     taskId: string,
     registrySignal: AbortSignal,
     orgId?: string,
-  ): void;
+  ): Promise<void>;
 
   /**
    * Publish ONE raw chunk to the per-task subject and AWAIT the publish ack.

--- a/apps/mesh/src/api/routes/decopilot/with-liveness-heartbeat.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/with-liveness-heartbeat.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { sleep } from "@decocms/std";
+// Margins are deliberately generous (intervals in the tens of ms, mostly
+// one-sided lower-bound assertions): under a full parallel `bun test` run a
+// tight window + tight bound flakes on scheduler jitter alone, not a real
+// bug — this bit us once during development with a 10ms interval.
+import type { UIMessageChunk } from "ai";
+import {
+  buildLivenessChunk,
+  withLivenessHeartbeat,
+} from "./with-liveness-heartbeat";
+
+async function collect(
+  iter: AsyncGenerator<UIMessageChunk>,
+): Promise<UIMessageChunk[]> {
+  const out: UIMessageChunk[] = [];
+  for await (const chunk of iter) out.push(chunk);
+  return out;
+}
+
+describe("buildLivenessChunk", () => {
+  test("shape: data-liveness, transient, carries a timestamp", () => {
+    const chunk = buildLivenessChunk(() => 12345);
+    expect(chunk).toEqual({
+      type: "data-liveness",
+      data: { t: 12345 },
+      transient: true,
+    });
+  });
+});
+
+describe("withLivenessHeartbeat", () => {
+  test("no heartbeats when the source is faster than the interval", async () => {
+    async function* fast(): AsyncGenerator<UIMessageChunk> {
+      yield { type: "text-start", id: "1" };
+      await sleep(5);
+      yield { type: "text-delta", id: "1", delta: "hi" };
+    }
+    const out = await collect(
+      withLivenessHeartbeat(fast(), { intervalMs: 30 }),
+    );
+    expect(out.map((c) => c.type)).toEqual(["text-start", "text-delta"]);
+  });
+
+  test("injects a data-liveness chunk after intervalMs of silence, then resumes the source", async () => {
+    async function* slowThenFast(): AsyncGenerator<UIMessageChunk> {
+      yield { type: "text-start", id: "1" };
+      await sleep(80); // spans ~3 heartbeat windows at intervalMs=25
+      yield { type: "text-delta", id: "1", delta: "done waiting" };
+    }
+    const out = await collect(
+      withLivenessHeartbeat(slowThenFast(), { intervalMs: 25 }),
+    );
+    const types = out.map((c) => c.type);
+    expect(types[0]).toBe("text-start");
+    expect(types.at(-1)).toBe("text-delta");
+    const heartbeats = types.filter((t) => t === "data-liveness");
+    expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+    // Every heartbeat is between the two real chunks, not before/after.
+    expect(types.slice(1, -1).every((t) => t === "data-liveness")).toBe(true);
+  });
+
+  test("a real chunk resets the window (disarmed) — no heartbeat right after one arrives", async () => {
+    async function* steadyDrip(): AsyncGenerator<UIMessageChunk> {
+      // 4 chunks, each 8ms apart, well under the 60ms interval (7.5x
+      // margin) — the window should never elapse because every chunk
+      // re-arms it.
+      for (let i = 0; i < 4; i++) {
+        await sleep(8);
+        yield { type: "text-delta", id: "1", delta: String(i) };
+      }
+    }
+    const out = await collect(
+      withLivenessHeartbeat(steadyDrip(), { intervalMs: 60 }),
+    );
+    expect(out.every((c) => c.type === "text-delta")).toBe(true);
+    expect(out).toHaveLength(4);
+  });
+
+  test("stops cleanly on source completion — never emits after the stream ends", async () => {
+    async function* short(): AsyncGenerator<UIMessageChunk> {
+      yield { type: "text-start", id: "1" };
+    }
+    const out = await collect(
+      withLivenessHeartbeat(short(), { intervalMs: 10 }),
+    );
+    expect(out).toEqual([{ type: "text-start", id: "1" }]);
+    // Give a would-be dangling timer a chance to misfire; collect() already
+    // awaited the generator to natural completion, so nothing further can
+    // be yielded regardless — this just documents the intent.
+    await sleep(30);
+  });
+
+  test("propagates a source error and stops emitting heartbeats", async () => {
+    async function* boom(): AsyncGenerator<UIMessageChunk> {
+      yield { type: "text-start", id: "1" };
+      await sleep(5);
+      throw new Error("harness exploded");
+    }
+    let caught: unknown;
+    const out: UIMessageChunk[] = [];
+    try {
+      for await (const chunk of withLivenessHeartbeat(boom(), {
+        intervalMs: 10,
+      })) {
+        out.push(chunk);
+      }
+    } catch (err) {
+      caught = err;
+    }
+    expect(out).toEqual([{ type: "text-start", id: "1" }]);
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("harness exploded");
+  });
+
+  test("an early consumer break stops the underlying source and the heartbeat timer", async () => {
+    let sourceCleanedUp = false;
+    async function* infinite(): AsyncGenerator<UIMessageChunk> {
+      try {
+        let i = 0;
+        while (true) {
+          await sleep(5);
+          yield { type: "text-delta", id: "1", delta: String(i++) };
+        }
+      } finally {
+        sourceCleanedUp = true;
+      }
+    }
+    let count = 0;
+    for await (const _chunk of withLivenessHeartbeat(infinite(), {
+      intervalMs: 10,
+    })) {
+      count++;
+      if (count === 2) break;
+    }
+    expect(count).toBe(2);
+    expect(sourceCleanedUp).toBe(true);
+  });
+
+  test("a long silence yields multiple heartbeats, not just one", async () => {
+    async function* longSilence(): AsyncGenerator<UIMessageChunk> {
+      await sleep(145); // ~5.8 windows at intervalMs=25
+      yield { type: "finish" };
+    }
+    const out = await collect(
+      withLivenessHeartbeat(longSilence(), { intervalMs: 25 }),
+    );
+    const heartbeats = out.filter((c) => c.type === "data-liveness");
+    expect(heartbeats.length).toBeGreaterThanOrEqual(4);
+    expect(out.at(-1)?.type).toBe("finish");
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/with-liveness-heartbeat.ts
+++ b/apps/mesh/src/api/routes/decopilot/with-liveness-heartbeat.ts
@@ -57,6 +57,7 @@ import type { UIMessageChunk } from "ai";
 import {
   HeartbeatEmitter,
   type HeartbeatEmitterOptions,
+  buildLivenessChunk as buildSharedLivenessChunk,
 } from "@decocms/harness/liveness-heartbeat";
 
 export type DataLivenessChunk = Extract<
@@ -68,15 +69,14 @@ export type DataLivenessChunk = Extract<
   transient: true;
 };
 
-/** Builds one `data-liveness` chunk. `now` is injectable for tests. */
+/** Builds one `data-liveness` chunk. `now` is injectable for tests.
+ * Delegates to the shared wire-shape source of truth so the hosted and
+ * desktop emitters can never drift; this wrapper only re-asserts the
+ * stronger `ai`-typed shape (see LivenessDataChunk's doc in the helper). */
 export function buildLivenessChunk(
   now: () => number = Date.now,
 ): DataLivenessChunk {
-  return {
-    type: "data-liveness",
-    data: { t: now() },
-    transient: true,
-  } as DataLivenessChunk;
+  return buildSharedLivenessChunk(now) as DataLivenessChunk;
 }
 
 export interface WithLivenessHeartbeatOptions {

--- a/apps/mesh/src/api/routes/decopilot/with-liveness-heartbeat.ts
+++ b/apps/mesh/src/api/routes/decopilot/with-liveness-heartbeat.ts
@@ -1,0 +1,134 @@
+/**
+ * Hosted-executor liveness heartbeat (unified-control-plane T5).
+ *
+ * Wraps the hosted harness's raw `AsyncIterable<UIMessageChunk>` (the source
+ * `buildAgentSandboxUiStream` in `dispatch-run.ts` feeds into `ingestRun` via
+ * its seq-wrapper) so a `data-liveness` chunk is injected whenever
+ * `LIVENESS_HEARTBEAT_INTERVAL_MS` (30s) elapses with no real chunk from the
+ * harness — the agent loop awaiting a model response, or a long tool call
+ * with no incremental output.
+ *
+ * MUST wrap the source BEFORE `buildAgentSandboxUiStream`'s `seqChunks()`
+ * wrapper (this is why the call site passes `withLivenessHeartbeat(...)` as
+ * the `chunks` input, not something layered after `ingestRun`): the
+ * heartbeat needs to flow through the exact same pipeline every other chunk
+ * does (`seqChunks` → `ingestRun`'s dedup/publish → JetStream) so it
+ * consumes a REAL seq. That's what makes it participate in the dedup
+ * contract (`${runId}:${fenceToken}:${seq}` `Nats-Msg-Id`) and — critically —
+ * what resets `natsChunkSource`'s per-pull idle race on the projector's
+ * consume side (unified-control-plane T4): ANY message arriving at that
+ * layer restarts the idle window, and this heartbeat is just another message
+ * on the subject from that layer's point of view.
+ *
+ * Wire representation: `{ type: "data-liveness", data: { t }, transient: true }`.
+ * `transient: true` is a first-class AI SDK `UIMessageChunk` field (see the
+ * installed `ai` package's `DataUIMessageChunk` type) that the SDK's OWN
+ * shared stream reducer (`processUIMessageStream`, used identically by the
+ * CLIENT's `readUIMessageStream` — see `store/thread-connection.ts` — AND
+ * the SERVER's `consumeHarnessStream`/`project-chunks.ts`, both server-side
+ * consumers built on `createUIMessageStream`) honors by calling the
+ * consumer's `onData` hook (unused here) and explicitly NOT pushing the
+ * chunk into the accumulated `UIMessage.parts` array. Concretely, verified
+ * against the installed `ai@6.0.208` package source
+ * (`node_modules/ai/dist/index.js`, the `isDataUIMessageChunk` branch):
+ *   - CLIENT fold: never renders it — `state.message.parts` never gets a
+ *     `data-liveness` entry, so the chat UI has no bubble to suppress. (Two
+ *     redundant defenses ALSO already exist independently of `transient` —
+ *     `message/use-filter-parts.ts`'s `p.type.startsWith("data-")` skip and
+ *     `message/assistant.tsx`'s `MessagePart` default-case
+ *     `fallback.type.startsWith("data-") → return null` — so even a
+ *     hypothetical non-transient data chunk would render nothing.)
+ *   - PROJECTOR fold: `project-chunks.ts`'s `consumeHarnessStream` call uses
+ *     the SAME reducer, so `responseMessage.parts` passed to
+ *     `persistence.emitStepParts`/`emitFinal` (the durable `PartEmitter`
+ *     write path, `run-persistence.ts`) never contains a `data-liveness`
+ *     entry either — no DB row is written per heartbeat. This holds without
+ *     needing an explicit `isRunStatusControlChunk`-style filter (that
+ *     existing filter is required for `data-run-status`, which is NOT
+ *     transient); `transient: true` alone is sufficient here and is the
+ *     more precise tool for a chunk that must never become a message part.
+ *   - The raw chunk is still `controller.enqueue`d by the reducer regardless
+ *     of `transient` (only the accumulated-parts push is skipped), so it
+ *     still reaches JetStream / the live tail / the idle-window reset above
+ *     — only the "becomes a persisted or rendered message part" step is
+ *     suppressed.
+ */
+import type { UIMessageChunk } from "ai";
+import {
+  HeartbeatEmitter,
+  type HeartbeatEmitterOptions,
+} from "@decocms/harness/liveness-heartbeat";
+
+export type DataLivenessChunk = Extract<
+  UIMessageChunk,
+  { type: `data-${string}` }
+> & {
+  type: "data-liveness";
+  data: { t: number };
+  transient: true;
+};
+
+/** Builds one `data-liveness` chunk. `now` is injectable for tests. */
+export function buildLivenessChunk(
+  now: () => number = Date.now,
+): DataLivenessChunk {
+  return {
+    type: "data-liveness",
+    data: { t: now() },
+    transient: true,
+  } as DataLivenessChunk;
+}
+
+export interface WithLivenessHeartbeatOptions {
+  intervalMs?: number;
+  sleepFn?: HeartbeatEmitterOptions["sleepFn"];
+  now?: () => number;
+}
+
+/**
+ * See module doc above. A real chunk from `source` resets the silence
+ * window (re-arms the emitter); the emitter self-reschedules after every
+ * heartbeat, so a single long-silent tool call yields several heartbeats,
+ * not just one. Stops cleanly — no dangling timer, no late emit — when the
+ * source completes, throws, or the consumer stops pulling early (`.return()`
+ * on this generator, e.g. from a `for await` `break` upstream).
+ */
+export async function* withLivenessHeartbeat(
+  source: AsyncIterable<UIMessageChunk>,
+  opts: WithLivenessHeartbeatOptions = {},
+): AsyncGenerator<UIMessageChunk> {
+  const buildHeartbeat = () => buildLivenessChunk(opts.now);
+  let resolveHeartbeat: (() => void) | null = null;
+  const emitter = new HeartbeatEmitter({
+    intervalMs: opts.intervalMs,
+    sleepFn: opts.sleepFn,
+    emit: () => resolveHeartbeat?.(),
+  });
+  const iterator = source[Symbol.asyncIterator]();
+  let nextChunk = iterator.next();
+  try {
+    emitter.arm();
+    while (true) {
+      const heartbeat = new Promise<"heartbeat">((resolve) => {
+        resolveHeartbeat = () => resolve("heartbeat");
+      });
+      const winner = await Promise.race([
+        nextChunk.then((r) => ({ kind: "chunk" as const, r })),
+        heartbeat.then((kind) => ({ kind })),
+      ]);
+      resolveHeartbeat = null;
+      if (winner.kind === "heartbeat") {
+        yield buildHeartbeat();
+        continue; // keep racing the SAME pending nextChunk
+      }
+      // Real chunk arrived: push the next heartbeat window out from now.
+      emitter.arm();
+      if (winner.r.done) return;
+      yield winner.r.value;
+      nextChunk = iterator.next();
+    }
+  } finally {
+    emitter.stop();
+    await iterator.return?.(undefined).catch(() => {});
+  }
+}

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,8 +1,8 @@
 {
   "auth/install-studio-pack-workflow.ts": "8aa255710fe562a3a0a86373ba60c9bfb53b34a9b17539083a22866e734fdede",
   "automations/dbos-workflow.ts": "76f03ce0e787209aacbe2ac128cb50c6d12eb513b7e0c7ae463401544de43127",
-  "dispatch-queue/hosted-harness-workflow.ts": "e085caea252a9ec10066251d7d1758d858d231c4fab9b8f39e4b4daa37db9a35",
-  "dispatch-queue/thread-gate-workflow.ts": "5a46512167c1115f0c8db902e5fd85d1c90721fef795b76c6a3cccf4816ba39c",
+  "dispatch-queue/hosted-harness-workflow.ts": "a7736a9f349ad7d865485ff9a26c8eaabd20fc76b3b9d95c92ae87018b42a774",
+  "dispatch-queue/thread-gate-workflow.ts": "06f56f3be803319d20d27ccbc758e1af177f626693f7e6c53c087b4f5515b185",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
   "harnesses/decopilot/background-tool-workflow.ts": "b75384d08b2293a101da50f0dfc63c23fc27f4b5636d2a9ada3cc22d2f61202b",
   "monitoring/dbos-retention-workflow.ts": "b43e3596b386b53faf372b140d9137a12252565987543640d17f7798504b8dbb"

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,8 +1,8 @@
 {
   "auth/install-studio-pack-workflow.ts": "8aa255710fe562a3a0a86373ba60c9bfb53b34a9b17539083a22866e734fdede",
   "automations/dbos-workflow.ts": "76f03ce0e787209aacbe2ac128cb50c6d12eb513b7e0c7ae463401544de43127",
-  "dispatch-queue/hosted-harness-workflow.ts": "a7736a9f349ad7d865485ff9a26c8eaabd20fc76b3b9d95c92ae87018b42a774",
-  "dispatch-queue/thread-gate-workflow.ts": "06f56f3be803319d20d27ccbc758e1af177f626693f7e6c53c087b4f5515b185",
+  "dispatch-queue/hosted-harness-workflow.ts": "0b394f56423c5efe4cf3ec8ff95fc78ffb51ab266b5dde0272bca6347af3f390",
+  "dispatch-queue/thread-gate-workflow.ts": "2e63fcff27fb5109f2264d31d455dbbfb1b3f18ce46c0eb3075ca6b0266fe379",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
   "harnesses/decopilot/background-tool-workflow.ts": "b75384d08b2293a101da50f0dfc63c23fc27f4b5636d2a9ada3cc22d2f61202b",
   "monitoring/dbos-retention-workflow.ts": "b43e3596b386b53faf372b140d9137a12252565987543640d17f7798504b8dbb"

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "8aa255710fe562a3a0a86373ba60c9bfb53b34a9b17539083a22866e734fdede",
   "automations/dbos-workflow.ts": "76f03ce0e787209aacbe2ac128cb50c6d12eb513b7e0c7ae463401544de43127",
-  "dispatch-queue/hosted-harness-workflow.ts": "23666d60acd156404d9a40735d7518888ec691885c3104cc10ac54bad416779c",
+  "dispatch-queue/hosted-harness-workflow.ts": "e085caea252a9ec10066251d7d1758d858d231c4fab9b8f39e4b4daa37db9a35",
   "dispatch-queue/thread-gate-workflow.ts": "5a46512167c1115f0c8db902e5fd85d1c90721fef795b76c6a3cccf4816ba39c",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
   "harnesses/decopilot/background-tool-workflow.ts": "b75384d08b2293a101da50f0dfc63c23fc27f4b5636d2a9ada3cc22d2f61202b",

--- a/apps/mesh/src/dbos/workflow-version.test.ts
+++ b/apps/mesh/src/dbos/workflow-version.test.ts
@@ -8,6 +8,6 @@ describe("DBOS_WORKFLOW_VERSION", () => {
   });
 
   it("is the current pinned version", () => {
-    expect(DBOS_WORKFLOW_VERSION).toBe("3");
+    expect(DBOS_WORKFLOW_VERSION).toBe("4");
   });
 });

--- a/apps/mesh/src/dbos/workflow-version.ts
+++ b/apps/mesh/src/dbos/workflow-version.ts
@@ -27,5 +27,32 @@
  *
  * Bumping deliberately strands whatever is mid-flight on the prior version (a
  * one-time cost) — correct, because those instances ARE incompatible.
+ *
+ * EXEMPLAR — "3" -> "4" (unified-control-plane T3, `threadGateWorkflow`):
+ * the gate's hosted-dispatch branch used to `await enqueueHostedHarness(...)`
+ * — start the hosted child AND block until `handle.getResult()` resolved —
+ * before proceeding to its `consumeRunProjection` step. That became
+ * `startHostedHarness(...)`: start the child, do NOT await its result, fall
+ * straight through to `consumeRunProjection`. Two things make this
+ * version-bump-worthy rather than recovery-compatible:
+ *   1. Dropping the `getResult()` wait removes a whole recorded parent-
+ *      workflow operation from `threadGateWorkflow`'s journal — an in-flight
+ *      v3 instance recovered against v4 code would replay dispatch, then look
+ *      for a recorded "await the child" operation that the new code path
+ *      never issues, and diverge.
+ *   2. The step immediately after — `consumeRunProjection` — now runs at a
+ *      structurally different point in time for the hosted topology: before,
+ *      it always ran AFTER the child (and everything it published) had
+ *      already finished; now it runs concurrently with the child, live-
+ *      tailing the stream exactly like the desktop topology already did (see
+ *      `consume-run-projection.ts`'s T3 comment). That's a genuine step-
+ *      sequence/timing contract change on a durably-recorded step, not an
+ *      edit confined to logic inside one step.
+ * Deploy consequence: any v3 gate workflow still mid-flight at deploy time
+ * (a message queued or a run in progress when the new pods roll out) strands
+ * — no v4 executor can recover it, by design (see "Bumping deliberately
+ * strands..." above). The existing Stop-button cancel path
+ * (`cancelThreadGateHead` + `cancelHostedHarness`, `routes.ts`) is the
+ * user-facing recovery: cancel the stranded gate/child and re-send.
  */
-export const DBOS_WORKFLOW_VERSION = "3";
+export const DBOS_WORKFLOW_VERSION = "4";

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { synthesizedErrorMessageId } from "@/api/routes/decopilot/message-ids";
+import { buildTerminalErrorChunks } from "./hosted-harness-workflow";
+
+describe("buildTerminalErrorChunks", () => {
+  test("carries the REAL err.message verbatim — never a masked/generic string", () => {
+    const result = buildTerminalErrorChunks(
+      "thread-1",
+      "fence-a",
+      new Error("tool call exploded: ECONNRESET talking to upstream MCP"),
+    );
+
+    expect(result.errorChunk).toEqual({
+      type: "error",
+      errorText: "tool call exploded: ECONNRESET talking to upstream MCP",
+    });
+  });
+
+  test("stringifies a non-Error thrown value", () => {
+    const result = buildTerminalErrorChunks("thread-1", "fence-a", "boom");
+
+    expect(result.errorChunk).toEqual({ type: "error", errorText: "boom" });
+  });
+
+  test("uses the SAME deterministic id the projector computes for its own synthesized error", () => {
+    const result = buildTerminalErrorChunks(
+      "thread-1",
+      "fence-a",
+      new Error("x"),
+    );
+
+    // The durable projector independently calls synthesizedErrorMessageId with
+    // the same (runId, fenceToken) when IT synthesizes an error message from
+    // this same chunk (see projector-workflow.ts) — so a projector retry's
+    // emitError collapses onto this SAME row (ON CONFLICT DO NOTHING) instead
+    // of duplicating it.
+    expect(result.messageId).toBe(
+      synthesizedErrorMessageId("thread-1", "fence-a"),
+    );
+  });
+
+  test("defaults the error chunk and paired {done} sentinel to seq 1", () => {
+    const result = buildTerminalErrorChunks(
+      "thread-1",
+      "fence-a",
+      new Error("x"),
+    );
+
+    expect(result.seq).toBe(1);
+    expect(result.finalSeq).toBe(1);
+  });
+
+  test("continues the run's seq counter from an explicit startSeq", () => {
+    const result = buildTerminalErrorChunks(
+      "thread-1",
+      "fence-a",
+      new Error("x"),
+      7,
+    );
+
+    expect(result.seq).toBe(7);
+    expect(result.finalSeq).toBe(7);
+  });
+
+  test("distinct turns of the same thread never collide", () => {
+    const turnOne = buildTerminalErrorChunks(
+      "thread-1",
+      "fence-a",
+      new Error("x"),
+    );
+    const turnTwo = buildTerminalErrorChunks(
+      "thread-1",
+      "fence-b",
+      new Error("x"),
+    );
+
+    expect(turnOne.messageId).not.toBe(turnTwo.messageId);
+  });
+});

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
@@ -238,8 +238,11 @@ describe("hostedChildWorkflowId", () => {
     // Source-text assertion: both call sites must read through this helper
     // rather than reconstructing the `decopilot-hosted:` string independently
     // (the exact drift this export exists to prevent — see the module doc
-    // comment; unified-control-plane T7 will add a third call site for
-    // stop-cancellation).
+    // comment). unified-control-plane T7 (stop cancels the live hosted
+    // child) reuses `cancelHostedHarness` from `cancelActiveThreadRun`
+    // (routes.ts's stop path) instead of adding a third direct call site —
+    // see routes.test.ts's "cancelActiveThreadRun (T7...)" describe block
+    // for that regression coverage.
     const src = readFileSync(
       join(import.meta.dir, "hosted-harness-workflow.ts"),
       "utf8",

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
@@ -221,6 +221,120 @@ describe("hostedHarnessWorkflowFn's try/catch contract (Finding 1)", () => {
   });
 });
 
+// unified-control-plane T9 proof obligation 1 (carried from T1's review): the
+// "half-terminal" invariant — `{done}` must NEVER be published when the
+// error-chunk publish itself failed (returned false OR threw), and the
+// child's outer catch must swallow that failure rather than rethrow (per
+// `hostedHarnessWorkflowFn`'s guarantee: it always returns normally). This is
+// best proved as a unit test on `publishHostedHarnessFailure`'s ordering
+// rather than forced into e2e (there is no black-box way to make JetStream's
+// publish call fail on demand from Playwright).
+describe("half-terminal invariant (T9 proof obligation 1): done is never published when the error-terminal publish itself failed", () => {
+  const request = {
+    organizationId: "org-1",
+    userId: "user-1",
+  } as SerializableDispatchRunInput;
+
+  const input: HostedHarnessInput = {
+    runId: "run-half-terminal",
+    fenceToken: "fence-half-terminal",
+    threadId: "thread-half-terminal",
+    request,
+  };
+
+  test("publishRawChunk returns false → publishDone is NOT called, and publishHostedHarnessFailure itself resolves without throwing", async () => {
+    const streamBuffer = {
+      publishRawChunk: mock(() => Promise.resolve(false)),
+      publishDone: mock(() => Promise.resolve(true)),
+    } as unknown as NonNullable<HostedHarnessRuntime["deps"]["streamBuffer"]>;
+    setHostedHarnessRuntime({
+      dispatchRunFn: mock(() => Promise.resolve({ taskId: "t" })),
+      meshContextFactory: async () => null,
+      deps: {
+        runRegistry: {} as HostedHarnessRuntime["deps"]["runRegistry"],
+        cancelBroadcast: {} as HostedHarnessRuntime["deps"]["cancelBroadcast"],
+        streamBuffer,
+      },
+    });
+
+    await expect(
+      publishHostedHarnessFailure(input, new Error("harness exploded")),
+    ).resolves.toBeUndefined();
+
+    expect(streamBuffer.publishRawChunk).toHaveBeenCalledTimes(1);
+    expect(streamBuffer.publishDone).not.toHaveBeenCalled();
+  });
+
+  test("publishRawChunk throws → publishDone is NOT called (the rejection propagates out of publishHostedHarnessFailure itself, unswallowed at this layer)", async () => {
+    const publishErr = new Error("JetStream unavailable");
+    const streamBuffer = {
+      publishRawChunk: mock(() => Promise.reject(publishErr)),
+      publishDone: mock(() => Promise.resolve(true)),
+    } as unknown as NonNullable<HostedHarnessRuntime["deps"]["streamBuffer"]>;
+    setHostedHarnessRuntime({
+      dispatchRunFn: mock(() => Promise.resolve({ taskId: "t" })),
+      meshContextFactory: async () => null,
+      deps: {
+        runRegistry: {} as HostedHarnessRuntime["deps"]["runRegistry"],
+        cancelBroadcast: {} as HostedHarnessRuntime["deps"]["cancelBroadcast"],
+        streamBuffer,
+      },
+    });
+
+    await expect(
+      publishHostedHarnessFailure(input, new Error("harness exploded")),
+    ).rejects.toBe(publishErr);
+
+    expect(streamBuffer.publishRawChunk).toHaveBeenCalledTimes(1);
+    expect(streamBuffer.publishDone).not.toHaveBeenCalled();
+  });
+
+  test("end-to-end: dispatchRunFn throws AND the error-terminal publish itself throws → the reconstructed workflow body (mirroring hostedHarnessWorkflowFn's outer .catch) still returns normally, never rethrows", async () => {
+    const dispatchErr = new Error("harness exploded mid-stream");
+    const publishErr = new Error("JetStream unavailable");
+    const streamBuffer = {
+      publishRawChunk: mock(() => Promise.reject(publishErr)),
+      publishDone: mock(() => Promise.resolve(true)),
+    } as unknown as NonNullable<HostedHarnessRuntime["deps"]["streamBuffer"]>;
+    setHostedHarnessRuntime({
+      dispatchRunFn: mock(() => Promise.reject(dispatchErr)),
+      meshContextFactory: async () => null,
+      deps: {
+        runRegistry: {} as HostedHarnessRuntime["deps"]["runRegistry"],
+        cancelBroadcast: {} as HostedHarnessRuntime["deps"]["cancelBroadcast"],
+        streamBuffer,
+      },
+    });
+
+    // Reconstruct hostedHarnessWorkflowFn's full try/catch — including the
+    // OUTER `.catch` wrapped around the `publishHostedHarnessFailure` step —
+    // the same technique the "Finding 1" describe block above uses, since
+    // this test tier can't launch a real DBOS.runStep. See that block's
+    // comment for why.
+    let escaped: unknown;
+    try {
+      try {
+        await runHostedHarness(input, {} as StudioContext);
+      } catch (err) {
+        await publishHostedHarnessFailure(input, err).catch(() => {
+          // mirrors hostedHarnessWorkflowFn's console.error-and-swallow —
+          // "there's nothing more this workflow can durably do" per its
+          // comment.
+        });
+      }
+    } catch (err) {
+      escaped = err;
+    }
+
+    // The child catch swallows, never rethrows: nothing escapes the
+    // reconstructed workflow body.
+    expect(escaped).toBeUndefined();
+    // done was never published — the half-terminal invariant.
+    expect(streamBuffer.publishRawChunk).toHaveBeenCalledTimes(1);
+    expect(streamBuffer.publishDone).not.toHaveBeenCalled();
+  });
+});
+
 describe("hostedChildWorkflowId", () => {
   test("derives the deterministic child workflow id from (runId, fenceToken)", () => {
     expect(hostedChildWorkflowId("run-1", "fence-a")).toBe(

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { synthesizedErrorMessageId } from "@/api/routes/decopilot/message-ids";
-import { buildTerminalErrorChunks } from "./hosted-harness-workflow";
+import type { WithLastAckSeq } from "@/api/routes/decopilot/ingest-run";
+import type { StudioContext } from "@/core/studio-context";
+import {
+  buildTerminalErrorChunks,
+  type HostedHarnessInput,
+  type HostedHarnessRuntime,
+  publishHostedHarnessFailure,
+  runHostedHarness,
+  type SerializableDispatchRunInput,
+  setHostedHarnessRuntime,
+  terminalErrorStartSeq,
+} from "./hosted-harness-workflow";
 
 describe("buildTerminalErrorChunks", () => {
   test("carries the REAL err.message verbatim — never a masked/generic string", () => {
@@ -75,5 +88,134 @@ describe("buildTerminalErrorChunks", () => {
     );
 
     expect(turnOne.messageId).not.toBe(turnTwo.messageId);
+  });
+});
+
+describe("terminalErrorStartSeq", () => {
+  test("returns undefined for a non-Error thrown value", () => {
+    expect(terminalErrorStartSeq("boom")).toBeUndefined();
+  });
+
+  test("returns undefined when the error carries no lastAckSeq (setup failure, no chunk ever published)", () => {
+    expect(terminalErrorStartSeq(new Error("user membership lost"))).toBe(
+      undefined,
+    );
+  });
+
+  test("returns lastAckSeq + 1 when ingestRun stamped a mid-stream failure", () => {
+    const err = new Error("source failed mid-stream") as Error & WithLastAckSeq;
+    err.lastAckSeq = 2;
+    expect(terminalErrorStartSeq(err)).toBe(3);
+  });
+
+  test("returns 1 (via lastAckSeq=0) when the very first publish failed — nothing was ever confirmed", () => {
+    const err = new Error("publishRawChunk failed") as Error & WithLastAckSeq;
+    err.lastAckSeq = 0;
+    expect(terminalErrorStartSeq(err)).toBe(1);
+  });
+
+  test("end-to-end: feeds buildTerminalErrorChunks to continue the run's seq counter", () => {
+    const err = new Error("source failed mid-stream") as Error & WithLastAckSeq;
+    err.lastAckSeq = 5;
+    const result = buildTerminalErrorChunks(
+      "thread-1",
+      "fence-a",
+      err,
+      terminalErrorStartSeq(err),
+    );
+    expect(result.seq).toBe(6);
+    expect(result.finalSeq).toBe(6);
+  });
+});
+
+// Finding 1 regression: a mid-stream `dispatchRunFn` failure used to run with
+// `retriesAllowed: true` on the `runHostedHarness` DBOS step, so a real
+// application-level throw (which, post-T2's pump-swallow fix, now propagates
+// instead of being swallowed) re-executed the ENTIRE agent loop up to 3 more
+// times — real LLM cost, a delayed terminal, and a risk of the projector
+// splicing two divergent generations into one message (the fence is stable
+// across attempts while the pump's seq counter restarts at 0 each attempt).
+// Fixed by setting `retriesAllowed: false`: an application-level throw is a
+// DELIBERATE terminal that should flow straight to `hostedHarnessWorkflowFn`'s
+// catch, exactly once.
+describe("hostedHarnessWorkflowFn's try/catch contract (Finding 1)", () => {
+  // `hostedHarnessWorkflowFn` itself isn't exported and calls `DBOS.runStep`,
+  // which throws immediately outside a launched DBOS instance
+  // (`ensureDBOSIsLaunched`) — this unit-test tier doesn't stand one up (repo
+  // policy: no DBOS mocks). So this test calls `runHostedHarness` /
+  // `publishHostedHarnessFailure` directly to reconstruct the try/catch body
+  // verbatim, minus the `DBOS.runStep` wrapping. That documents INTENT — "the
+  // dispatch fn runs exactly once, and a caught failure publishes exactly one
+  // fenced terminal" — rather than exercising DBOS's actual retry/recovery
+  // machinery. The "no retry" half of the fix (the actual `retriesAllowed`
+  // config DBOS enforces) is separately verified below by reading the real
+  // registration call site.
+
+  const request = {
+    organizationId: "org-1",
+    userId: "user-1",
+  } as SerializableDispatchRunInput;
+
+  const input: HostedHarnessInput = {
+    runId: "run-1",
+    fenceToken: "fence-1",
+    threadId: "thread-1",
+    request,
+  };
+
+  function runtimeWithDispatchFn(
+    dispatchRunFn: HostedHarnessRuntime["dispatchRunFn"],
+  ) {
+    const streamBuffer = {
+      publishRawChunk: mock(() => Promise.resolve(true)),
+      publishDone: mock(() => Promise.resolve(true)),
+    } as unknown as NonNullable<HostedHarnessRuntime["deps"]["streamBuffer"]>;
+    const rt: HostedHarnessRuntime = {
+      dispatchRunFn,
+      meshContextFactory: async () => null,
+      deps: {
+        runRegistry: {} as HostedHarnessRuntime["deps"]["runRegistry"],
+        cancelBroadcast: {} as HostedHarnessRuntime["deps"]["cancelBroadcast"],
+        streamBuffer,
+      },
+    };
+    setHostedHarnessRuntime(rt);
+    return { streamBuffer };
+  }
+
+  test("a dispatchRunFn that throws mid-run: the catch publishes the fenced terminal, and the dispatch fn ran EXACTLY ONCE", async () => {
+    const boom = new Error("harness exploded mid-stream");
+    const dispatchRunFn = mock(() => Promise.reject(boom));
+    const { streamBuffer } = runtimeWithDispatchFn(dispatchRunFn);
+    const fakeCtx = {} as StudioContext;
+
+    let caught: unknown;
+    try {
+      await runHostedHarness(input, fakeCtx);
+    } catch (err) {
+      caught = err;
+      await publishHostedHarnessFailure(input, err);
+    }
+
+    expect(caught).toBe(boom);
+    expect(dispatchRunFn).toHaveBeenCalledTimes(1);
+    expect(streamBuffer.publishRawChunk).toHaveBeenCalledTimes(1);
+    expect(streamBuffer.publishDone).toHaveBeenCalledTimes(1);
+  });
+
+  test("registers the runHostedHarness step with retriesAllowed: false", () => {
+    // Source-text assertion (same technique as
+    // dbos/workflow-source-guard.test.ts) — DBOS's actual retry-on-throw
+    // behavior can't be exercised without a launched DBOS instance, so this
+    // reads the real registration call site instead of a stand-in.
+    const src = readFileSync(
+      join(import.meta.dir, "hosted-harness-workflow.ts"),
+      "utf8",
+    );
+    const marker = 'name: "runHostedHarness"';
+    const idx = src.indexOf(marker);
+    expect(idx).toBeGreaterThan(-1);
+    const stepConfig = src.slice(idx, idx + 100);
+    expect(stepConfig).toContain("retriesAllowed: false");
   });
 });

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
@@ -6,6 +6,7 @@ import type { WithLastAckSeq } from "@/api/routes/decopilot/ingest-run";
 import type { StudioContext } from "@/core/studio-context";
 import {
   buildTerminalErrorChunks,
+  hostedChildWorkflowId,
   type HostedHarnessInput,
   type HostedHarnessRuntime,
   publishHostedHarnessFailure,
@@ -217,5 +218,59 @@ describe("hostedHarnessWorkflowFn's try/catch contract (Finding 1)", () => {
     expect(idx).toBeGreaterThan(-1);
     const stepConfig = src.slice(idx, idx + 100);
     expect(stepConfig).toContain("retriesAllowed: false");
+  });
+});
+
+describe("hostedChildWorkflowId", () => {
+  test("derives the deterministic child workflow id from (runId, fenceToken)", () => {
+    expect(hostedChildWorkflowId("run-1", "fence-a")).toBe(
+      "decopilot-hosted:run-1:fence-a",
+    );
+  });
+
+  test("distinct fence tokens on the same run produce distinct ids (no cross-turn collision)", () => {
+    expect(hostedChildWorkflowId("run-1", "fence-a")).not.toBe(
+      hostedChildWorkflowId("run-1", "fence-b"),
+    );
+  });
+
+  test("is the SAME id both cancelHostedHarness and startHostedHarness derive — single source of truth", () => {
+    // Source-text assertion: both call sites must read through this helper
+    // rather than reconstructing the `decopilot-hosted:` string independently
+    // (the exact drift this export exists to prevent — see the module doc
+    // comment; unified-control-plane T7 will add a third call site for
+    // stop-cancellation).
+    const src = readFileSync(
+      join(import.meta.dir, "hosted-harness-workflow.ts"),
+      "utf8",
+    );
+    const startMatches = src.match(
+      /startWorkflow\(hostedHarnessWorkflow, \{\s*workflowID: hostedChildWorkflowId\(/,
+    );
+    const cancelMatches = src.match(/cancelWorkflow\(hostedChildWorkflowId\(/);
+    expect(startMatches).not.toBeNull();
+    expect(cancelMatches).not.toBeNull();
+  });
+});
+
+// T3 regression: `startHostedHarness` must NOT await the child's result — the
+// gate no longer blocks on the hosted agent loop before proceeding to its
+// consume step (that coupling is what this task removes). Exercising the
+// real `DBOS.startWorkflow` call requires a launched DBOS instance (repo
+// policy: no DBOS mocks), so — same technique as the `retriesAllowed: false`
+// regression above — this reads the real function body directly.
+describe("startHostedHarness (T3: start-only, no getResult await)", () => {
+  test("does not call handle.getResult()", () => {
+    const src = readFileSync(
+      join(import.meta.dir, "hosted-harness-workflow.ts"),
+      "utf8",
+    );
+    const marker = "export async function startHostedHarness(";
+    const idx = src.indexOf(marker);
+    expect(idx).toBeGreaterThan(-1);
+    const nextFnStart = src.indexOf("\nexport async function", idx + 1);
+    const body = src.slice(idx, nextFnStart === -1 ? undefined : nextFnStart);
+    expect(body).toContain("DBOS.startWorkflow(hostedHarnessWorkflow");
+    expect(body).not.toContain("getResult()");
   });
 });

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
@@ -22,12 +22,28 @@
  * ## Guarantee: the child publishes its own fence-scoped terminal for every
  * CAUGHT failure (and `{done}` on success)
  *
- * NOT yet covered: a mid-stream harness failure with healthy JetStream is
- * swallowed inside `dispatch-run.ts`'s pump (unfenced `{done}` only, which
- * the consume step ignores) and never reaches this wrapper — closing that
- * class is the unified-control-plane T2 (hosted ingest becomes a thin
- * publisher whose throws propagate). Until then that class terminates via
- * the liveness reaper with a generic reason.
+ * Closed (unified-control-plane T2): a mid-stream harness failure with
+ * healthy JetStream used to be swallowed inside `dispatch-run.ts`'s pump
+ * (`NatsStreamBuffer.pump` caught the `uiStream` error, logged it, and only
+ * published the legacy UNFENCED `{done}` sentinel — which the consume step
+ * deliberately ignores — so `dispatchRunAndWait` returned as if the run had
+ * finished cleanly). `pump()` now returns a promise that REJECTS with the
+ * same error after publishing that sentinel; `dispatchRunAndWait` awaits it
+ * (after its own tail-wait loop) so the error propagates out of
+ * `rt.dispatchRunFn` here, straight into THIS wrapper's existing catch below
+ * — no new call site needed, since `runHostedHarness` is a thin wrapper
+ * around `dispatchRunFn` with no try/catch of its own. The degraded
+ * fallback branch (`dispatchRunAndWait` with no JetStream tail) already
+ * propagated correctly before this change; the fix makes the healthy-
+ * JetStream branch behave the SAME way instead of a special-cased swallow.
+ *
+ * The seq the failure-terminal publishes at is also threaded through now:
+ * `ingestRun` stamps the highest contiguous published seq onto the thrown
+ * error as `.lastAckSeq` (own-enumerable, survives the DBOS step boundary —
+ * see `ingest-run.ts`'s `WithLastAckSeq`) before re-throwing; the catch below
+ * reads it via `terminalErrorStartSeq` and passes `lastAckSeq + 1` as
+ * `buildTerminalErrorChunks`'s `startSeq`, so a mid-stream failure after
+ * content chunks 1..K continues the log at K+1 instead of colliding with it.
  *
  * A started hosted child either publishes `{done}` after a clean completion
  * (already true via `ingestRun`'s `publishDone` inside `runHostedHarness`), or
@@ -57,6 +73,7 @@ import type {
   DurableDispatchRunInput,
 } from "@/api/routes/decopilot/dispatch-run";
 import { synthesizedErrorMessageId } from "@/api/routes/decopilot/message-ids";
+import type { WithLastAckSeq } from "@/api/routes/decopilot/ingest-run";
 import type { StudioContext } from "@/core/studio-context";
 
 export { HOSTED_HARNESS_QUEUE } from "./queue-names";
@@ -152,8 +169,12 @@ function requireRuntime(): HostedHarnessRuntime {
  * No DB terminal-status writes here — the consume / projector step owns
  * terminal status. The NATS streaming + `{done}` publish happen inside
  * `dispatchRunAndWait` (via `ingestRun` / the stream buffer pump).
+ *
+ * Exported (only) for `hosted-harness-workflow.test.ts`, which calls this
+ * directly to reconstruct `hostedHarnessWorkflowFn`'s try/catch without the
+ * `DBOS.runStep` wrapping — see that test file's comment for why.
  */
-async function runHostedHarness(
+export async function runHostedHarness(
   input: HostedHarnessInput,
   ctx?: StudioContext,
 ): Promise<void> {
@@ -203,20 +224,13 @@ async function runHostedHarness(
  *
  * `startSeq` (default 1) is the seq to publish the error chunk at; the paired
  * `{done}` sentinel's `finalSeq` is the same value (this is the run's only
- * chunk in the caller's common case). Defaulting to 1 is deliberate: every
- * failure this helper is invoked for today (StudioContext resolution,
- * `HostedHarnessRuntime` not wired) throws BEFORE `dispatchRunFn` publishes
- * any content chunk, so seq 1 is genuinely free. The one known gap:
- * `dispatchRunAndWait` can publish real content chunks (via `ingestRun`'s
- * internal `ackSeq` counter) before rejecting — in the degraded
- * no-JetStream-tail fallback branch, and also in the healthy branch when
- * the tail-subscription read itself errors mid-run (NATS drop) after
- * seqs 1..K published — and that counter isn't threaded back through
- * `DispatchRunAndWaitFn`'s `{ taskId }` result — so in that rare case a caller
- * MUST pass the true next seq once that plumbing exists; until then the
- * projector's contiguity check (`assertContiguousAndDedup`) surfaces a
- * "missing seq" error for that run instead of a clean `failed` status, which
- * is still strictly better than today's silent unfenced-done stall.
+ * chunk in the common case: a failure before any content chunk published —
+ * StudioContext resolution, `HostedHarnessRuntime` not wired — so seq 1 is
+ * genuinely free). `publishHostedHarnessFailure` below no longer always
+ * defaults it: when the caught error carries `ingestRun`'s `.lastAckSeq` (a
+ * mid-stream failure AFTER content chunks 1..K were already confirmed —
+ * `terminalErrorStartSeq` reads it), it passes `K + 1` so the error chunk
+ * continues the run's contiguous log instead of colliding with it.
  *
  * The message id is `synthesizedErrorMessageId(runId, fenceToken)` — the SAME
  * pure function the durable projector calls when ITS OWN re-projection of
@@ -250,14 +264,32 @@ export function buildTerminalErrorChunks(
 }
 
 /**
+ * Reads `ingestRun`'s `.lastAckSeq` (see `ingest-run.ts`'s `WithLastAckSeq`)
+ * off a caught failure and returns the seq the terminal error chunk must
+ * publish at to stay contiguous with it — `lastAckSeq + 1`. `undefined` when
+ * the caught value isn't an `Error` or carries no seq info (a setup failure
+ * before any chunk was ever published), in which case
+ * `buildTerminalErrorChunks` falls back to its own `startSeq = 1` default.
+ * Pure (no I/O) so it's unit-testable without a DBOS/NATS harness.
+ */
+export function terminalErrorStartSeq(err: unknown): number | undefined {
+  if (!(err instanceof Error)) return undefined;
+  const lastAckSeq = (err as Error & WithLastAckSeq).lastAckSeq;
+  return typeof lastAckSeq === "number" ? lastAckSeq + 1 : undefined;
+}
+
+/**
  * Publish the caught failure's terminal (error chunk + `{done}`) to the run's
  * subject, via the SAME `StreamBuffer` surface `ingestRun` uses on the clean
  * path (`publishRawChunk` + `publishDone`). Returns without throwing when the
  * error-chunk publish itself reports failure (JetStream unavailable) — there
  * is nothing more this function can durably do; the caller logs and moves on
  * (see `hostedHarnessWorkflowFn`'s catch).
+ *
+ * Exported (only) for `hosted-harness-workflow.test.ts` — see `runHostedHarness`'s
+ * doc comment above for why.
  */
-async function publishHostedHarnessFailure(
+export async function publishHostedHarnessFailure(
   input: HostedHarnessInput,
   err: unknown,
 ): Promise<void> {
@@ -267,6 +299,7 @@ async function publishHostedHarnessFailure(
     input.runId,
     input.fenceToken,
     err,
+    terminalErrorStartSeq(err),
   );
   if (!streamBuffer) {
     // No JetStream buffer wired (test mode / NATS down) — mirrors
@@ -298,13 +331,25 @@ async function hostedHarnessWorkflowFn(
 ): Promise<void> {
   try {
     // ONE step (happy path): run the agent loop to completion, streaming to
-    // NATS + publishing {done}. Retriable — hosted/in-process runs have no
-    // external daemon to race, so DBOS can recover them (the queue's
-    // concurrency=1 per threadId still guarantees a single in-flight hosted
-    // run per thread).
+    // NATS + publishing {done}. NOT retriable: an application-level throw
+    // here is a DELIBERATE terminal (T2's pump-swallow fix means mid-stream
+    // `ingestRun` failures now propagate instead of being swallowed), so it
+    // should flow straight to the catch below, which publishes the
+    // fence-scoped error terminal exactly once — no re-run, no splice, no 3×
+    // billing. A DBOS-driven retry-on-throw would instead re-execute the
+    // ENTIRE agent loop up to 3 more times (real LLM cost, delayed
+    // terminal); worse, the fence stays stable across attempts while
+    // `buildAgentSandboxUiStream` restarts its seq counter at 0 each
+    // attempt, so a later attempt's low seqs can collide with the first
+    // attempt's inside JetStream's dedup window (dropped) while the rest
+    // land — splicing two possibly-divergent generations into one projected
+    // message. Pod-crash recovery (the process dying mid-step, not the step
+    // throwing) is a separate concern already covered by the workflow's own
+    // `maxRecoveryAttempts` below — that mechanism doesn't need
+    // `retriesAllowed` here; the two were conflated by the previous comment.
     await DBOS.runStep(() => runHostedHarness(input), {
       name: "runHostedHarness",
-      retriesAllowed: true,
+      retriesAllowed: false,
     });
   } catch (err) {
     // Second step, only reached on failure: publish the fence-scoped error +
@@ -321,11 +366,15 @@ async function hostedHarnessWorkflowFn(
     // Interim note (until Task 3 lands): the gate's `runDispatchSteps` still
     // awaits this child via `enqueueHostedHarness`'s `getResult()`. Before
     // this change, a caught failure rejected the child workflow, so the
-    // gate's `trackMessageFailed` catch (thread-gate-workflow.ts ~544-555)
-    // fired for it. After this change, `getResult()` resolves instead, so
-    // that catch no longer fires for hosted-child failures — `chat_message_
-    // failed` posthog analytics undercounts them until T3 rewires the gate to
-    // read status from the projector fold instead of the child's outcome.
+    // gate's `trackMessageFailed` catch (thread-gate-workflow.ts) fired for
+    // it (mislabeled `error_category: "setup"` even for in-flight failures).
+    // After this change, `getResult()` resolves instead, so that catch no
+    // longer fires for hosted-child failures. The `chat_message_failed`
+    // signal is NOT lost, though: `runProjectorWorkflowBody`'s `recordFailed`
+    // (unified-control-plane T2) is now the sole source, firing once the
+    // consume step folds the in-band error chunk this catch publishes below
+    // — correctly categorized (`kind: "harness"`) and, unlike the old gate
+    // catch, consistent with the desktop topology's failure analytics too.
     await DBOS.runStep(() => publishHostedHarnessFailure(input, err), {
       name: "publishHostedHarnessFailure",
       retriesAllowed: true,

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
@@ -19,6 +19,28 @@
  * terminal-status writes happen here — the durable projector / consume step
  * owns terminal status.
  *
+ * ## Guarantee: the child publishes its own fence-scoped terminal for every
+ * CAUGHT failure (and `{done}` on success)
+ *
+ * NOT yet covered: a mid-stream harness failure with healthy JetStream is
+ * swallowed inside `dispatch-run.ts`'s pump (unfenced `{done}` only, which
+ * the consume step ignores) and never reaches this wrapper — closing that
+ * class is the unified-control-plane T2 (hosted ingest becomes a thin
+ * publisher whose throws propagate). Until then that class terminates via
+ * the liveness reaper with a generic reason.
+ *
+ * A started hosted child either publishes `{done}` after a clean completion
+ * (already true via `ingestRun`'s `publishDone` inside `runHostedHarness`), or
+ * — on ANY caught failure — a synthesized in-band `{type:"error"}` chunk
+ * followed by `{done}` (see `buildTerminalErrorChunks` /
+ * `hostedHarnessWorkflowFn`'s catch below). The durable projector treats an
+ * in-band error chunk with no following `{type:"finish"}` as the run's failed
+ * verdict (`project-chunks.ts`'s `failed` flag), so the thread reaches a
+ * terminal status purely from what's on the stream — the workflow's own DBOS
+ * status is deliberately NOT the signal (see the catch's comment for why).
+ * This is the foundation the gate (Task 3) builds on to stop awaiting the
+ * child and treat the projector's live-tail as the sole terminal authority.
+ *
  * Runtime dependencies (the dispatch fn, the studio-context factory, the
  * dispatch deps) are looked up via a module-level registry, mirroring
  * `thread-gate-workflow.ts`. App boot wires them via `setHostedHarnessRuntime`
@@ -27,12 +49,14 @@
  */
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
+import type { UIMessageChunk } from "ai";
 import type {
   DispatchRunDeps,
   DispatchRunRuntimeInput,
   DispatchRunInput,
   DurableDispatchRunInput,
 } from "@/api/routes/decopilot/dispatch-run";
+import { synthesizedErrorMessageId } from "@/api/routes/decopilot/message-ids";
 import type { StudioContext } from "@/core/studio-context";
 
 export { HOSTED_HARNESS_QUEUE } from "./queue-names";
@@ -164,22 +188,170 @@ async function runHostedHarness(
   );
 }
 
+/**
+ * Deterministic error-terminal payload for a caught hosted-harness failure.
+ * Pure (no I/O) so it's unit-testable without a DBOS/NATS harness.
+ *
+ * Returns an in-band `{type:"error"}` `UIMessageChunk` — NOT a thrown
+ * exception — because the harness kernel's AI-SDK reader treats an in-band
+ * error chunk with no following `{type:"finish"}` as the run's terminal
+ * failure verdict (see `project-chunks.ts`'s `failed` flag); no `start`/
+ * `finish` wrapper is needed. `errorText` is the REAL `err.message` — the
+ * wire/client may mask it later for display, but the subject must carry the
+ * truth (a masked subject is what turned a recent prod incident into an
+ * archaeology dig — every layer had already thrown away the real message).
+ *
+ * `startSeq` (default 1) is the seq to publish the error chunk at; the paired
+ * `{done}` sentinel's `finalSeq` is the same value (this is the run's only
+ * chunk in the caller's common case). Defaulting to 1 is deliberate: every
+ * failure this helper is invoked for today (StudioContext resolution,
+ * `HostedHarnessRuntime` not wired) throws BEFORE `dispatchRunFn` publishes
+ * any content chunk, so seq 1 is genuinely free. The one known gap:
+ * `dispatchRunAndWait` can publish real content chunks (via `ingestRun`'s
+ * internal `ackSeq` counter) before rejecting — in the degraded
+ * no-JetStream-tail fallback branch, and also in the healthy branch when
+ * the tail-subscription read itself errors mid-run (NATS drop) after
+ * seqs 1..K published — and that counter isn't threaded back through
+ * `DispatchRunAndWaitFn`'s `{ taskId }` result — so in that rare case a caller
+ * MUST pass the true next seq once that plumbing exists; until then the
+ * projector's contiguity check (`assertContiguousAndDedup`) surfaces a
+ * "missing seq" error for that run instead of a clean `failed` status, which
+ * is still strictly better than today's silent unfenced-done stall.
+ *
+ * The message id is `synthesizedErrorMessageId(runId, fenceToken)` — the SAME
+ * pure function the durable projector calls when ITS OWN re-projection of
+ * this chunk synthesizes the persisted error row (see
+ * `projector-workflow.ts`). The AI-SDK `error` chunk shape carries no id
+ * field, so it isn't stamped onto the wire chunk itself; returning it here
+ * documents (and lets tests assert) the convergence — whichever writer needs
+ * a stable row id for this failure computes the exact same one, so retries
+ * collapse via `ON CONFLICT DO NOTHING` instead of duplicating.
+ */
+export interface HostedHarnessTerminalError {
+  messageId: string;
+  errorChunk: UIMessageChunk;
+  seq: number;
+  finalSeq: number;
+}
+
+export function buildTerminalErrorChunks(
+  runId: string,
+  fenceToken: string,
+  err: unknown,
+  startSeq = 1,
+): HostedHarnessTerminalError {
+  const errorText = err instanceof Error ? err.message : String(err);
+  return {
+    messageId: synthesizedErrorMessageId(runId, fenceToken),
+    errorChunk: { type: "error", errorText },
+    seq: startSeq,
+    finalSeq: startSeq,
+  };
+}
+
+/**
+ * Publish the caught failure's terminal (error chunk + `{done}`) to the run's
+ * subject, via the SAME `StreamBuffer` surface `ingestRun` uses on the clean
+ * path (`publishRawChunk` + `publishDone`). Returns without throwing when the
+ * error-chunk publish itself reports failure (JetStream unavailable) — there
+ * is nothing more this function can durably do; the caller logs and moves on
+ * (see `hostedHarnessWorkflowFn`'s catch).
+ */
+async function publishHostedHarnessFailure(
+  input: HostedHarnessInput,
+  err: unknown,
+): Promise<void> {
+  const rt = requireRuntime();
+  const { streamBuffer } = rt.deps;
+  const { messageId, errorChunk, seq, finalSeq } = buildTerminalErrorChunks(
+    input.runId,
+    input.fenceToken,
+    err,
+  );
+  if (!streamBuffer) {
+    // No JetStream buffer wired (test mode / NATS down) — mirrors
+    // `dispatchRunAndWait`'s own degraded fallback: nothing durable to do.
+    console.error(
+      `[hostedHarness] no streamBuffer configured; dropping terminal error for run=${input.runId} fence=${input.fenceToken} messageId=${messageId}`,
+    );
+    return;
+  }
+  const published = await streamBuffer.publishRawChunk(
+    input.runId,
+    errorChunk,
+    {
+      fenceToken: input.fenceToken,
+      seq,
+    },
+  );
+  if (!published) {
+    console.error(
+      `[hostedHarness] failed to publish terminal error chunk for run=${input.runId} fence=${input.fenceToken} messageId=${messageId}`,
+    );
+    return;
+  }
+  await streamBuffer.publishDone(input.runId, input.fenceToken, finalSeq);
+}
+
 async function hostedHarnessWorkflowFn(
   input: HostedHarnessInput,
 ): Promise<void> {
-  // ONE step: run the agent loop to completion, streaming to NATS + publishing
-  // {done}. Retriable — hosted/in-process runs have no external daemon to race,
-  // so DBOS can recover them (the queue's concurrency=1 per threadId still
-  // guarantees a single in-flight hosted run per thread).
-  await DBOS.runStep(() => runHostedHarness(input), {
-    name: "runHostedHarness",
-    retriesAllowed: true,
-  });
+  try {
+    // ONE step (happy path): run the agent loop to completion, streaming to
+    // NATS + publishing {done}. Retriable — hosted/in-process runs have no
+    // external daemon to race, so DBOS can recover them (the queue's
+    // concurrency=1 per threadId still guarantees a single in-flight hosted
+    // run per thread).
+    await DBOS.runStep(() => runHostedHarness(input), {
+      name: "runHostedHarness",
+      retriesAllowed: true,
+    });
+  } catch (err) {
+    // Second step, only reached on failure: publish the fence-scoped error +
+    // {done} terminal, then RETURN NORMALLY — do not rethrow. The child's
+    // DBOS status becoming SUCCESS here is intentional: run OUTCOME lives on
+    // the thread via the projector's fold of what's on the stream (an in-band
+    // error chunk with no following finish → failed), not on this workflow's
+    // DBOS status. Appending a step only on this (previously-terminal, never
+    // replayed) failure branch doesn't retroactively change any ALREADY
+    // recorded step for an in-flight workflow being recovered, so this is
+    // recovery-compatible — no DBOS_WORKFLOW_VERSION bump needed (only a
+    // workflow-source-guard snapshot re-baseline).
+    //
+    // Interim note (until Task 3 lands): the gate's `runDispatchSteps` still
+    // awaits this child via `enqueueHostedHarness`'s `getResult()`. Before
+    // this change, a caught failure rejected the child workflow, so the
+    // gate's `trackMessageFailed` catch (thread-gate-workflow.ts ~544-555)
+    // fired for it. After this change, `getResult()` resolves instead, so
+    // that catch no longer fires for hosted-child failures — `chat_message_
+    // failed` posthog analytics undercounts them until T3 rewires the gate to
+    // read status from the projector fold instead of the child's outcome.
+    await DBOS.runStep(() => publishHostedHarnessFailure(input, err), {
+      name: "publishHostedHarnessFailure",
+      retriesAllowed: true,
+    }).catch((publishErr) => {
+      // Best-effort: if we can't even publish the failure terminal (e.g.
+      // JetStream itself is down), there's nothing more this workflow can
+      // durably do — swallow so it still returns normally per the guarantee
+      // above. A thread stuck with NO fence-scoped terminal at all needs a
+      // different safety net (idle reaper / manual unbrick), out of scope
+      // here.
+      console.error(
+        `[hostedHarness] could not publish terminal error for run=${input.runId} fence=${input.fenceToken}`,
+        publishErr,
+      );
+    });
+  }
 }
 
 // ⚠️ Durable DBOS workflow. Changing its STEP SEQUENCE (add/remove/reorder a
 // step, or change a step's recorded I/O) requires bumping DBOS_WORKFLOW_VERSION
-// — see apps/mesh/src/dbos/workflow-version.ts.
+// — see apps/mesh/src/dbos/workflow-version.ts. Exception (used by the
+// failure-terminal step below): appending a step on a branch where the OLD
+// code recorded nothing further (a previously-rethrowing failure path) is
+// recovery-compatible — old in-flight instances never reach the new step's
+// function id, so no replay mismatch. Re-baseline the source-guard snapshot
+// only.
 const hostedHarnessWorkflow = DBOS.registerWorkflow(hostedHarnessWorkflowFn, {
   name: "hostedHarnessWorkflow",
   // A hosted run now spans a whole agent loop with no fixed cap, so a

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
@@ -5,13 +5,19 @@
  * thread-gate's `!useLink` branch into a single callable `runHostedHarness`
  * and wrapped in its own DBOS child workflow (`hostedHarnessWorkflow`).
  *
- * Task 7b wiring: the thread gate's `dispatchRunAndWaitStep` now enqueues this
- * child fire-and-forget onto `HOSTED_HARNESS_QUEUE` (partitioned by threadId,
- * concurrency 1 — one active hosted run per thread) instead of running inline.
- * The parent gate immediately proceeds to its consume step, which drains the
- * run's JetStream consumer, projects final parts/title, and writes terminal
- * status — providing unified terminal-status writes for both hosted and desktop
- * topologies.
+ * unified-control-plane T3: the thread gate's `runDispatchSteps` now STARTS
+ * this child on `HOSTED_HARNESS_QUEUE` (partitioned by threadId, concurrency 1
+ * — one active hosted run per thread) and does NOT await its result —
+ * `startHostedHarness` below returns as soon as the start itself is durably
+ * recorded. The parent gate immediately proceeds to its consume step, which
+ * live-tails the run's JetStream subject, projects final parts/title, and
+ * writes terminal status — providing unified terminal-status writes for both
+ * hosted and desktop topologies, with the SAME timing shape: the consume step
+ * is opened before the producer (child workflow / desktop daemon) has
+ * necessarily published anything yet. (Before T3, the gate `await`ed the
+ * child's `getResult()` in full before starting the consume step — a
+ * carried-over interim behavior from before the child published its own
+ * terminal; see the "Guarantee" section below.)
  *
  * The hosted execution body is exactly what `dispatchRunAndWait` does: claim
  * the run, drive the agent loop via the harness kernel, stream chunks to
@@ -54,8 +60,9 @@
  * verdict (`project-chunks.ts`'s `failed` flag), so the thread reaches a
  * terminal status purely from what's on the stream — the workflow's own DBOS
  * status is deliberately NOT the signal (see the catch's comment for why).
- * This is the foundation the gate (Task 3) builds on to stop awaiting the
- * child and treat the projector's live-tail as the sole terminal authority.
+ * This is the foundation T3 builds on: the gate no longer awaits the child at
+ * all (`startHostedHarness` below) — the projector's live-tail is now the
+ * SOLE terminal authority, for both a clean finish and every caught failure.
  *
  * Runtime dependencies (the dispatch fn, the studio-context factory, the
  * dispatch deps) are looked up via a module-level registry, mirroring
@@ -363,18 +370,16 @@ async function hostedHarnessWorkflowFn(
     // recovery-compatible — no DBOS_WORKFLOW_VERSION bump needed (only a
     // workflow-source-guard snapshot re-baseline).
     //
-    // Interim note (until Task 3 lands): the gate's `runDispatchSteps` still
-    // awaits this child via `enqueueHostedHarness`'s `getResult()`. Before
-    // this change, a caught failure rejected the child workflow, so the
-    // gate's `trackMessageFailed` catch (thread-gate-workflow.ts) fired for
-    // it (mislabeled `error_category: "setup"` even for in-flight failures).
-    // After this change, `getResult()` resolves instead, so that catch no
-    // longer fires for hosted-child failures. The `chat_message_failed`
-    // signal is NOT lost, though: `runProjectorWorkflowBody`'s `recordFailed`
-    // (unified-control-plane T2) is now the sole source, firing once the
-    // consume step folds the in-band error chunk this catch publishes below
-    // — correctly categorized (`kind: "harness"`) and, unlike the old gate
-    // catch, consistent with the desktop topology's failure analytics too.
+    // T3 update: the gate's `runDispatchSteps` no longer awaits this child at
+    // all (`startHostedHarness` below returns right after the start is
+    // recorded) — so there is no `getResult()` rejection for a gate-level
+    // catch to observe in the first place, for EITHER a clean finish or a
+    // caught failure. The `chat_message_failed` signal is NOT lost:
+    // `runProjectorWorkflowBody`'s `recordFailed` (unified-control-plane T2)
+    // is the sole source, firing once the consume step's live tail folds the
+    // in-band error chunk this catch publishes below — correctly categorized
+    // (`kind: "harness"`) and consistent with the desktop topology's failure
+    // analytics.
     await DBOS.runStep(() => publishHostedHarnessFailure(input, err), {
       name: "publishHostedHarnessFailure",
       retriesAllowed: true,
@@ -410,35 +415,68 @@ const hostedHarnessWorkflow = DBOS.registerWorkflow(hostedHarnessWorkflowFn, {
 });
 
 /**
- * Enqueue a hosted harness run on the partitioned hosted-harness queue. The
- * partition key is the threadId, so per-thread concurrency=1 serializes hosted
- * runs on the same thread (mirroring the thread gate). The workflow ID is keyed
- * by `(runId, fenceToken)` so a redelivered enqueue collapses onto the existing
- * workflow handle instead of duplicating the run.
- *
- * Returns after the hosted harness child workflow completes. The thread-gate
- * workflow calls this before its projector step; projecting before the hosted
- * child has produced any retained JetStream messages can race an empty consumer
- * and leave the thread stuck in_progress.
+ * Deterministic hosted-child workflow ID, keyed by `(runId, fenceToken)` — a
+ * redelivered start (a DBOS replay of the parent gate workflow) collapses
+ * onto the SAME child instead of spawning a second agent loop for the same
+ * attempt. Exported: this is the single source of truth for the id — both
+ * `startHostedHarness` and `cancelHostedHarness` below derive it from here,
+ * and unified-control-plane T7 (stop cancels the live child, not just the
+ * in-memory run registry) will too, rather than reconstructing the
+ * `decopilot-hosted:<runId>:<fenceToken>` string independently.
  */
-function hostedHarnessWorkflowId(runId: string, fenceToken: string): string {
+export function hostedChildWorkflowId(
+  runId: string,
+  fenceToken: string,
+): string {
   return `decopilot-hosted:${runId}:${fenceToken}`;
 }
 
-export async function enqueueHostedHarness(
+/**
+ * Start (do NOT await) a hosted harness run on the partitioned hosted-harness
+ * queue. The partition key is the threadId, so per-thread concurrency=1
+ * serializes hosted runs on the same thread (mirroring the thread gate). The
+ * workflow ID is `hostedChildWorkflowId(runId, fenceToken)`, so a redelivered
+ * start collapses onto the existing workflow handle instead of duplicating
+ * the run.
+ *
+ * unified-control-plane T3: this used to be `enqueueHostedHarness`, which
+ * additionally `await`ed `handle.getResult()` — the thread-gate workflow
+ * blocked on the ENTIRE child agent loop before proceeding to its consume
+ * step (a carried-over interim shape from before T1 gave the child its own
+ * terminal-publishing guarantee). That coupling is gone: the caller now
+ * starts the child and moves straight to `consumeRunProjection`, which
+ * live-tails the run's JetStream subject exactly like the desktop topology
+ * already does — the child publishes chunks as it runs; the consume step's
+ * `DeliverPolicy.All` consumer, opened BEFORE chunk 1 is necessarily
+ * published, simply waits for it (see `projector-chunk-stream.ts` /
+ * `nats-chunk-source.ts`'s live-tail pull semantics). The child is a fully
+ * detached, pure executor per T1's contract: whatever it does (clean finish
+ * or a caught failure), it publishes its own fence-scoped terminal to the
+ * stream — the projector's live tail is now the ONLY thing the gate's
+ * completion depends on, for BOTH topologies.
+ *
+ * Only the START call is durably recorded here (DBOS forbids
+ * `DBOS.startWorkflow` from within a step/transaction, so this must run from
+ * workflow body context — same restriction as before). Dropping the
+ * `getResult()` wait removes a whole recorded parent-workflow operation from
+ * `threadGateWorkflow`'s journal, which is why this change requires the
+ * `DBOS_WORKFLOW_VERSION` bump (see workflow-version.ts) — an in-flight v3
+ * gate replayed against v4 code would replay dispatch, hit the missing
+ * recorded `getResult`, and diverge.
+ */
+export async function startHostedHarness(
   input: HostedHarnessInput,
 ): Promise<{ workflowID: string }> {
   const handle = await DBOS.startWorkflow(hostedHarnessWorkflow, {
-    workflowID: hostedHarnessWorkflowId(input.runId, input.fenceToken),
+    workflowID: hostedChildWorkflowId(input.runId, input.fenceToken),
     queueName: HOSTED_HARNESS_QUEUE,
     enqueueOptions: { queuePartitionKey: input.threadId },
   })(input);
-  await handle.getResult();
   return { workflowID: handle.workflowID };
 }
 
 /**
- * Best-effort cancel of a hosted-harness child workflow (Task 7b). The in-memory
+ * Best-effort cancel of a hosted-harness child workflow. The in-memory
  * cancel path (`cancelBroadcast` + run-registry CANCEL → AbortController) already
  * stops the running harness loop; this additionally tells DBOS to stop
  * recovering / retrying the child workflow on pod recycles. Cancelling an
@@ -449,5 +487,5 @@ export async function cancelHostedHarness(
   runId: string,
   fenceToken: string,
 ): Promise<void> {
-  await DBOS.cancelWorkflow(hostedHarnessWorkflowId(runId, fenceToken));
+  await DBOS.cancelWorkflow(hostedChildWorkflowId(runId, fenceToken));
 }

--- a/apps/mesh/src/dispatch-queue/index.ts
+++ b/apps/mesh/src/dispatch-queue/index.ts
@@ -17,3 +17,12 @@ export {
   type HostedHarnessInput,
   type HostedHarnessRuntime,
 } from "./hosted-harness-workflow";
+// `hostedChildWorkflowId` is intentionally NOT re-exported here yet — no
+// caller outside this module needs it today (`startHostedHarness` and
+// `cancelHostedHarness`, both already barrel-exported above, are the only
+// current consumers). Knip flags an unconsumed barrel re-export as dead
+// code, and per repo policy that's fixed by not adding the export, not by
+// suppressing the warning. unified-control-plane T7 (stop cancels the live
+// hosted child by id, not just via `cancelHostedHarness`) should add
+// `hostedChildWorkflowId` to this re-export list — it's already exported
+// from `./hosted-harness-workflow` directly — when it lands the consumer.

--- a/apps/mesh/src/dispatch-queue/index.ts
+++ b/apps/mesh/src/dispatch-queue/index.ts
@@ -17,12 +17,12 @@ export {
   type HostedHarnessInput,
   type HostedHarnessRuntime,
 } from "./hosted-harness-workflow";
-// `hostedChildWorkflowId` is intentionally NOT re-exported here yet — no
-// caller outside this module needs it today (`startHostedHarness` and
+// `hostedChildWorkflowId` is intentionally NOT re-exported here — no caller
+// outside this module needs it (`startHostedHarness` and
 // `cancelHostedHarness`, both already barrel-exported above, are the only
-// current consumers). Knip flags an unconsumed barrel re-export as dead
-// code, and per repo policy that's fixed by not adding the export, not by
-// suppressing the warning. unified-control-plane T7 (stop cancels the live
-// hosted child by id, not just via `cancelHostedHarness`) should add
-// `hostedChildWorkflowId` to this re-export list — it's already exported
-// from `./hosted-harness-workflow` directly — when it lands the consumer.
+// consumers). Knip flags an unconsumed barrel re-export as dead code, and per
+// repo policy that's fixed by not adding the export, not by suppressing the
+// warning. unified-control-plane T7 (stop cancels the live hosted child, not
+// just the in-memory run registry) landed by reusing `cancelHostedHarness`
+// from `cancelActiveThreadRun` (routes.ts) rather than importing
+// `hostedChildWorkflowId` directly — so this stayed internal-only.

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   claimRunFenceForDispatch,
   resolveHarnessExecutionSite,
@@ -152,3 +154,72 @@ describe("resolveHarnessExecutionSite (topology tuple → site)", () => {
     ).toBe("cluster");
   });
 });
+
+// `runDispatchSteps` itself calls `DBOS.runStep`, which requires a launched
+// DBOS instance (repo policy: no DBOS mocks) — so, same technique as
+// hosted-harness-workflow.test.ts's `retriesAllowed: false` / `getResult()`
+// regressions, this reads the real function body to pin the fix-round-1
+// restructuring: the hosted child's START call must sit INSIDE the dispatch
+// try/catch (a failure to even START the child is a setup failure like any
+// other dispatch throw — it must fire trackMessageFailed + rethrow, fail the
+// gate attempt, and let DBOS recovery re-run it, not be swallowed into a
+// 30-minute idle-timeout misfire), and the gate must never again await the
+// child's result before consuming.
+describe("runDispatchSteps step ordering (hosted child start shares the dispatch try/catch; only its RESULT is fire-and-forget)", () => {
+  const src = readFileSync(
+    join(import.meta.dir, "thread-gate-workflow.ts"),
+    "utf8",
+  );
+  const fnStart = src.indexOf("export async function runDispatchSteps(");
+  const fnEnd = src.indexOf("\nasync function threadGateWorkflowFn", fnStart);
+  const body = src.slice(fnStart, fnEnd === -1 ? undefined : fnEnd);
+
+  it("locates the function", () => {
+    expect(fnStart).toBeGreaterThan(-1);
+    expect(fnEnd).toBeGreaterThan(fnStart);
+  });
+
+  it("starts the hosted child INSIDE the dispatch try block (after the dispatch step, before the catch), and consumes AFTER the try/catch closes", () => {
+    const tryIdx = body.indexOf("try {");
+    const dispatchStepIdx = body.indexOf('name: "dispatchRunAndWait",');
+    const startCallIdx = body.indexOf("await startHostedHarness(");
+    const catchIdx = body.indexOf("} catch (err) {");
+    const rethrowIdx = body.indexOf("throw err;", catchIdx);
+    const consumeCallIdx = body.indexOf("consumeRunProjection({");
+
+    expect(tryIdx).toBeGreaterThan(-1);
+    expect(dispatchStepIdx).toBeGreaterThan(tryIdx);
+    // The hosted-start call is textually AFTER the dispatch step resolves,
+    // but still INSIDE the same try block — a throw here reaches the exact
+    // same catch as a `dispatchRunAndWaitStep` throw.
+    expect(startCallIdx).toBeGreaterThan(dispatchStepIdx);
+    expect(catchIdx).toBeGreaterThan(startCallIdx);
+    expect(rethrowIdx).toBeGreaterThan(catchIdx);
+    // The consume step is unconditional and comes after the try/catch closes.
+    expect(consumeCallIdx).toBeGreaterThan(rethrowIdx);
+  });
+
+  it("does NOT await the child's result (no getResult call in the function body)", () => {
+    expect(body).not.toContain("getResult()");
+  });
+
+  it("a hosted-start throw reaches the SAME catch as a dispatch throw — no separate swallow-and-log wrapper", () => {
+    const firstCatchIdx = body.indexOf("} catch (err) {");
+    const secondCatchIdx = body.indexOf("} catch (err) {", firstCatchIdx + 1);
+    // Exactly one catch block in the whole function — the hosted-start call
+    // no longer has its own try/catch; that swallow-and-log wrapper is gone.
+    expect(firstCatchIdx).toBeGreaterThan(-1);
+    expect(secondCatchIdx).toBe(-1);
+    expect(body).not.toContain("falling through to consume");
+    expect(body).not.toContain("console.error");
+    // The shared catch still fires trackMessageFailed + rethrows.
+    const catchBody = body.slice(firstCatchIdx, rethrowIdxOf(body));
+    expect(catchBody).toContain("trackMessageFailedStep");
+  });
+});
+
+function rethrowIdxOf(body: string): number {
+  const catchIdx = body.indexOf("} catch (err) {");
+  const idx = body.indexOf("throw err;", catchIdx);
+  return idx === -1 ? body.length : idx + "throw err;".length;
+}

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -464,12 +464,16 @@ async function trackMessageStartedStep(ctx: ThreadGateContext): Promise<void> {
 /**
  * Balances `chat_message_started` when the dispatch step throws *before*
  * `streamText` is set up (model-permission failure, agent not found,
- * thread-ownership check, etc. — see `prepareRun`). In-flight stream
- * errors are already emitted by `streamText.onError` inside `dispatchRunAndWait`,
- * so this only covers the pre-stream gap.
+ * thread-ownership check, etc. — see `prepareRun`). In-flight stream errors
+ * (once `streamText` is running) are NOT emitted here — the durable projector's
+ * `recordFailed` is the sole `chat_message_failed` source for those, fired
+ * once the run's fenced terminal is materialized on the stream (both hosted
+ * and desktop). This step only covers the pre-stream gap: a `dispatchRunAndWait`
+ * throw here means setup failed before any run/stream existed for the
+ * projector to fold, so nothing else will ever emit the balancing event.
  *
- * `error_category: "setup"` keeps these distinguishable from stream-time
- * failures (which use `classifyStreamError`).
+ * `error_category: "setup"` keeps these distinguishable from the projector's
+ * `kind: "harness" | "projection"` categorization of stream-time failures.
  */
 async function trackMessageFailedStep(
   ctx: ThreadGateContext,

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -46,7 +46,7 @@ import { consumeRunProjection } from "@/api/routes/decopilot/consume-run-project
 
 export { THREAD_GATE_QUEUE } from "./queue-names";
 import { THREAD_GATE_QUEUE } from "./queue-names";
-import { enqueueHostedHarness } from "./hosted-harness-workflow";
+import { startHostedHarness } from "./hosted-harness-workflow";
 
 /**
  * Per-thread concurrent run cap (partition cap on the gate queue).
@@ -211,17 +211,17 @@ function requireRuntime(): ThreadGateRuntime {
 
 /**
  * Descriptor returned by `dispatchRunAndWaitStep` when the hosted path is
- * taken. The workflow BODY calls `enqueueHostedHarness` using this descriptor
+ * taken. The workflow BODY calls `startHostedHarness` using this descriptor
  * — DBOS forbids `DBOS.startWorkflow` from within a step/transaction, so the
- * enqueue must happen in workflow context. The descriptor is serializable and
+ * start must happen in workflow context. The descriptor is serializable and
  * replay-stable (keyed by runId+fenceToken, both stable across replays).
  */
-type HostedEnqueueDescriptor = Parameters<typeof enqueueHostedHarness>[0];
+type HostedEnqueueDescriptor = Parameters<typeof startHostedHarness>[0];
 
 /**
  * Result of `dispatchRunAndWaitStep`.
  * - `{ hostedEnqueue: ... }`: hosted path taken; workflow body must call
- *   `enqueueHostedHarness` with this descriptor (DBOS step restriction).
+ *   `startHostedHarness` with this descriptor (DBOS step restriction).
  * - `null`: desktop path taken (work item published) — no hosted enqueue needed.
  */
 type DispatchStepResult = {
@@ -317,14 +317,16 @@ async function dispatchRunAndWaitStep(
     //    path below.) ──
     // RETURN a descriptor to the workflow BODY instead of enqueuing here.
     // DBOS forbids `DBOS.startWorkflow` from within a step or transaction —
-    // the actual `enqueueHostedHarness` call happens in `runDispatchSteps`
+    // the actual `startHostedHarness` call happens in `runDispatchSteps`
     // (workflow body context) using this descriptor. The descriptor is
     // serializable and replay-stable (keyed by runId+fenceToken, both stable
     // across DBOS replays). The child workflow runs the in-process agent loop
-    // (streaming to NATS + publishing {done}); the gate no longer blocks on the
-    // loop — completion flows through the consume step in `runDispatchSteps`.
-    // The submit-time fence keys the child workflow ID
-    // (`decopilot-hosted:<runId>:<fenceToken>`) so a redelivery collapses onto
+    // (streaming to NATS + publishing {done}); the gate does not await it at
+    // all (T3) — completion flows exclusively through the consume step in
+    // `runDispatchSteps`, which live-tails the same stream the child writes
+    // to. The submit-time fence keys the child workflow ID
+    // (`hostedChildWorkflowId(runId, fenceToken)`,
+    // `decopilot-hosted:<runId>:<fenceToken>`) so a redelivery collapses onto
     // the existing child rather than spawning a second loop.
     return {
       runFenceToken,
@@ -536,36 +538,84 @@ export async function runDispatchSteps(
       name: "dispatchRunAndWait",
       retriesAllowed: retriable,
     });
-    // Hosted: start and await the child workflow from the WORKFLOW BODY (DBOS
-    // forbids DBOS.startWorkflow from within a step). The descriptor is the
-    // memoized step return — serializable, replay-stable. The body call is
-    // legal workflow context. Idempotent on replay — the child workflow ID is
-    // keyed by (runId, fenceToken). Awaiting it prevents the projector step
-    // below from racing an empty retained stream.
+
+    // Hosted: START (do NOT await) the child workflow from the WORKFLOW BODY
+    // (DBOS forbids `DBOS.startWorkflow` from within a step) — this call sits
+    // directly in workflow-body context, not inside a `DBOS.runStep`, even
+    // though it is textually part of this try block. The descriptor is the
+    // memoized step return — serializable, replay-stable — and the child
+    // workflow ID it produces (`hostedChildWorkflowId(runId, fenceToken)`) is
+    // itself replay-stable, so redelivery collapses onto the same child.
+    //
+    // This is fire-and-forget ONLY with respect to the child's RESULT: it is
+    // never awaited to completion — the child is a fully detached,
+    // self-terminating executor (T1's contract: it publishes its own
+    // fence-scoped terminal for a clean finish AND for every caught failure),
+    // and the consume step below remains the sole completion authority for
+    // BOTH topologies once the child has actually started.
+    //
+    // The START itself failing, though, is a setup failure like any other
+    // throw in this try block — NOT swallowed. A `DBOS.startWorkflow` fault
+    // here (queue/PG unavailable) means the child never came into existence,
+    // so there is nothing for the consume step's live tail to ever pick up:
+    // swallowing it (as this used to) left the run tailing an empty subject
+    // for the full 30-minute idle timeout and dying mislabeled as
+    // `failed(kind:"projection")` with no setup analytics — and a merely
+    // transient fault could even race into a stuck spurious `failed` (the
+    // idle-timeout's `markRunFailed` landing before recovery's successful
+    // re-run). Falling into the catch below instead restores the same
+    // semantics a `dispatchRunAndWaitStep` throw already has: fire the setup
+    // analytics, rethrow, and fail the gate attempt so DBOS recovery
+    // (`maxRecoveryAttempts: 1000`) re-runs it — transient enqueue faults
+    // self-heal (the deterministic child workflow ID dedupes any child that
+    // did actually start, on replay), persistent faults fail fast with
+    // correct categorization instead of being swallowed.
     if (dispatchResult.hostedEnqueue) {
-      await enqueueHostedHarness(dispatchResult.hostedEnqueue);
+      await startHostedHarness(dispatchResult.hostedEnqueue);
     }
   } catch (err) {
-    // Setup errors (prepareRun) propagate out of `dispatchRunAndWait`; in-flight
-    // stream errors are handled inside `streamText.onError` and don't
-    // reach here. So a thrown step at this point means setup failed —
-    // emit the balancing failed event for analytics integrity. Wrapped
-    // in its own DBOS step so replay doesn't double-emit.
+    // Setup errors (prepareRun / link-work preparation, or — as of this fix —
+    // a hosted child failing to even START just above) propagate out BEFORE
+    // any run/child/stream exists — there is nothing for the consume step to
+    // fold, so trackMessageFailed + rethrow is complete: it balances the
+    // started-analytics event and lets DBOS record the workflow failure. A
+    // hosted start-throw happens AFTER `dispatchRunAndWaitStep` already
+    // claimed and persisted the fence, but that doesn't change this: for the
+    // hosted path the fence only marks intent to run a child, and here the
+    // child itself never existed, so no chunks were ever published and
+    // nothing downstream assumes a fence-less state. In-flight stream errors
+    // (once a run has actually started) are handled inside
+    // `streamText.onError` / the hosted child's own catch (T1) and don't
+    // reach here. Wrapped in its own DBOS step so replay doesn't double-emit.
     const msg = err instanceof Error ? err.message : String(err);
     await DBOS.runStep(() => trackMessageFailedStep(ctx, msg), {
       name: "trackMessageFailed",
     });
     throw err;
   }
-  // Note: consume step is intentionally skipped on setup failure; the catch above
-  // re-throws, so nothing to consume for a run that never started.
 
-  // Consume step (Task 7b): the sole terminal-status writer for BOTH topologies.
-  // `dispatchRunAndWait` above only STARTS the run (hosted: returns descriptor →
-  // workflow body runs the child loop; desktop: publish the work item). The actual
-  // completion — draining the run's durable JetStream consumer, projecting the
-  // final parts/title, and writing terminal status — happens here. Both
-  // topologies funnel through `runDispatchSteps`, so wiring it once covers both.
+  // Consume step: the sole terminal-status writer for BOTH topologies, and —
+  // as of T3 — the sole COMPLETION authority too (the gate no longer awaits
+  // the hosted child above). `dispatchRunAndWaitStep` above only STARTS the
+  // run (hosted: returns a descriptor, started just above; desktop: publishes
+  // the work item to the daemon over the tunnel). The actual completion —
+  // live-tailing the run's durable JetStream consumer, projecting the final
+  // parts/title, and writing terminal status — happens here, for both
+  // topologies via one code path.
+  //
+  // Live-tail timing is now IDENTICAL for hosted and desktop: this step opens
+  // `createProjectorChunkStream`'s `DeliverPolicy.All` consumer immediately
+  // after dispatch, with no guarantee the producer (hosted child / desktop
+  // daemon) has published chunk 1 yet — desktop has ALWAYS worked this way
+  // (`dispatchRunAndWaitStep`'s sandbox branch returns as soon as the work
+  // item is durably published, well before the remote daemon streams
+  // anything back), so this is a pattern already proven in production, not a
+  // new race introduced here. See `nats-chunk-source.ts`'s `natsChunkSource`:
+  // a pull with nothing yet retained simply awaits the next published message
+  // (or the idle timeout, as a backstop) — there is no "stream must already
+  // be complete/retained" assumption anywhere in this path for either
+  // topology.
+  //
   // Recovery-safe: `consumeRunProjection` has an entry guard that returns early
   // on a terminal status (the run already finished).
   const runId = ctx.request.taskId ?? ctx.threadId;

--- a/apps/mesh/src/link-daemon/chunk-relay.test.ts
+++ b/apps/mesh/src/link-daemon/chunk-relay.test.ts
@@ -297,6 +297,63 @@ describe("relayDispatchSSEAsChunkStream", () => {
     ]);
   }, 2000);
 
+  it("injects a seq-numbered data-liveness relay line during a silent dispatch gap (T6 liveness heartbeat)", async () => {
+    // Unlike the newline keepalive above, this heartbeat is a REAL relay
+    // line: it must consume the relay's own seq counter (the same one every
+    // ui-message-chunk/error/done event uses) so it rides the identical
+    // dedup/outbox contract and can reset the projector's idle window.
+    const sse = pushableSSEBody();
+    const heartbeatSeen = Promise.withResolvers<RelayLine>();
+    const lines: RelayLine[] = [];
+
+    const relayPromise = relayDispatchSSEAsChunkStream({
+      dispatchBody: sse.body,
+      runId: "run_hb_live",
+      // Tiny interval so the idle gap below trips a liveness heartbeat
+      // deterministically without waiting the real 30s production default.
+      livenessHeartbeatMs: 5,
+      post: async (body): Promise<RelayPostResult> => {
+        if (typeof body === "string") throw new Error("expected a stream");
+        for await (const line of ndjsonLines(body)) {
+          lines.push(line);
+          const chunk =
+            line.event.type === "ui-message-chunk"
+              ? (line.event.chunk as { type?: string } | undefined)
+              : undefined;
+          if (chunk?.type === "data-liveness") heartbeatSeen.resolve(line);
+        }
+        return { ok: true, lastSeq: lines.at(-1)?.seq ?? 0 };
+      },
+    });
+
+    // One real chunk, then stay idle so the pump's silence trips a
+    // liveness heartbeat.
+    sse.push(CHUNK_A);
+    const heartbeatLine = await heartbeatSeen.promise;
+    // The heartbeat consumed the NEXT real seq after CHUNK_A (seq 1) — not a
+    // side channel and not seq 1 again.
+    expect(heartbeatLine.seq).toBe(2);
+    expect(heartbeatLine.event).toEqual({
+      type: "ui-message-chunk",
+      chunk: {
+        type: "data-liveness",
+        data: { t: expect.any(Number) },
+        transient: true,
+      },
+    });
+
+    sse.push(DONE);
+    sse.close();
+    await relayPromise;
+
+    // Seqs are strictly increasing and the pump stops heartbeating once the
+    // dispatch ends: `done` is the terminal line, not followed by more
+    // heartbeats.
+    const seqs = lines.map((l) => l.seq);
+    expect(seqs).toEqual(seqs.map((_, i) => i + 1));
+    expect(lines.at(-1)!.event).toEqual(DONE);
+  }, 2000);
+
   it("reconnects after a dropped POST and resends the full buffered prefix", async () => {
     const sse = pushableSSEBody();
     const attempts: { fromSeq: number; lines: RelayLine[] }[] = [];

--- a/apps/mesh/src/link-daemon/chunk-relay.ts
+++ b/apps/mesh/src/link-daemon/chunk-relay.ts
@@ -36,8 +36,31 @@
  * - Aborting `signal` tears everything down: the sandbox SSE source is
  *   cancelled, in-flight/queued POST attempts stop, and the relay rejects
  *   with the abort reason.
+ *
+ * LIVENESS HEARTBEATS (unified-control-plane T6, mirrors T5's hosted-executor
+ * wrapper `apps/mesh/src/api/routes/decopilot/with-liveness-heartbeat.ts`):
+ * while the pump below is actively pulling from the sandbox SSE, a
+ * `HeartbeatEmitter` (`@decocms/harness/liveness-heartbeat` — the SAME
+ * scheduler class T5 uses) injects a synthetic `data-liveness` relay line
+ * through `pushLine` whenever `livenessHeartbeatMs` (default 30s) elapses
+ * with no real `DispatchSSEEvent` — a long tool call or model wait on the
+ * desktop harness with no incremental output. Because it goes through
+ * `pushLine`, it consumes a REAL seq and is appended to the durable outbox
+ * exactly like any other line, so it rides the same
+ * dedup/resend/rolling-truncation contract and — critically — resets the
+ * projector's per-pull idle window on the consume side
+ * (`natsChunkSource`, unified-control-plane T4) just like any other message
+ * on the run subject. See the `pumpPromise` wiring below for arm/stop
+ * semantics. Version-skew note: an already-deployed daemon predating this
+ * change never emits these — the cluster's `RUN_IDLE_TIMEOUT_MS` (10
+ * minutes) is UNCHANGED here; this task only adds emission, not a threshold
+ * change (see `packages/harness/src/liveness-heartbeat.ts` module doc).
  */
 import { retry, RetryError, sleep } from "@decocms/std";
+import {
+  buildLivenessChunk,
+  HeartbeatEmitter,
+} from "@decocms/harness/liveness-heartbeat";
 import { parseDispatchSSEEvents } from "../harnesses/parse-dispatch-sse";
 import type { DispatchSSEEvent } from "../links/protocol";
 import type { RelayLine } from "../links/protocol/relay";
@@ -126,6 +149,18 @@ export interface RelayDispatchSSEAsChunkStreamInput {
    * tests override with a tiny value.
    */
   heartbeatMs?: number;
+  /**
+   * Liveness heartbeat interval (ms) — UNRELATED to `heartbeatMs` above
+   * (that one is a transport-level blank-line keepalive that never becomes a
+   * relay line). This one controls the `HeartbeatEmitter` silence window
+   * (see the module doc's "LIVENESS HEARTBEATS" section): when the SANDBOX
+   * SSE source itself goes silent this long, a REAL seq-numbered
+   * `data-liveness` relay line is injected. Defaults to
+   * `LIVENESS_HEARTBEAT_INTERVAL_MS` (30s, from
+   * `@decocms/harness/liveness-heartbeat`); tests override with a tiny value
+   * the same way the existing `heartbeatMs` tests do.
+   */
+  livenessHeartbeatMs?: number;
 }
 
 const encoder = new TextEncoder();
@@ -203,17 +238,44 @@ export async function relayDispatchSSEAsChunkStream(
   // ── Pump: sandbox SSE → buffered relay lines ─────────────────────────────
   // Runs independently of POST health so the buffer keeps absorbing the
   // sandbox stream while the cluster connection is down.
+  //
+  // Liveness heartbeat (see module doc "LIVENESS HEARTBEATS"): armed before
+  // the loop starts (silence before the very first chunk counts too),
+  // re-armed on every real event (a chunk/error/done arriving resets the
+  // silence window), and stopped in `finally` on EVERY pump exit — normal
+  // completion, a thrown error, or cancellation via `internal.signal` — so
+  // it can never fire once the dispatch is no longer live. A heartbeat
+  // firing calls `pushLine`, which assigns it the next real wire seq exactly
+  // like any other event.
+  // Failure-mode note: if a heartbeat's pushLine throws (e.g. the outbox's
+  // MAX_OUTBOX_BYTES overflow cap), the emitter swallows it and permanently
+  // stops for this run — liveness heartbeats silently end, but REAL content
+  // hitting the same cap still fails the pump loudly, so the swallow can
+  // never mask a genuine overflow. Bounded, accepted (heartbeat lines are
+  // tiny relative to content).
+  const heartbeat = new HeartbeatEmitter({
+    intervalMs: input.livenessHeartbeatMs,
+    emit: () => {
+      pushLine({ type: "ui-message-chunk", chunk: buildLivenessChunk() });
+    },
+  });
   const pumpPromise = (async () => {
     let sawDone = false;
-    for await (const event of parseDispatchSSEEvents(input.dispatchBody, {
-      signal: internal.signal,
-    })) {
-      pushLine(event);
-      if (event.type === "done") sawDone = true;
+    try {
+      heartbeat.arm();
+      for await (const event of parseDispatchSSEEvents(input.dispatchBody, {
+        signal: internal.signal,
+      })) {
+        pushLine(event);
+        if (event.type === "done") sawDone = true;
+        heartbeat.arm();
+      }
+      if (!sawDone) pushLine({ type: "done" });
+      pumpDone = true;
+      signalChange();
+    } finally {
+      heartbeat.stop();
     }
-    if (!sawDone) pushLine({ type: "done" });
-    pumpDone = true;
-    signalChange();
   })().catch((err: unknown) => {
     pumpError =
       err ?? new Error(`[chunk-relay] runId=${input.runId}: chunk pump failed`);

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -993,7 +993,10 @@ export interface ThreadTable {
    */
   failure_reason: string | null;
   /**
-   * Coarse failure category. One of "harness" | "projection" | "transport".
+   * Coarse failure category. One of "harness" | "projection" | "transport" |
+   * "liveness" | "stall" (the last written only by the progress-based reaper,
+   * `run-registry.ts`; "liveness" is the consume-side subject-silence
+   * terminal — see `projector-workflow.ts`'s `livenessFailureReason`).
    * Null for pre-migration rows or runs failed without kind information.
    */
   failure_kind: string | null;

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "3.111.0",
+      "version": "3.112.1",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -235,6 +235,7 @@
         "@ai-sdk/openai": "^3.0.73",
         "@ai-sdk/provider": "^3.0.10",
         "@decocms/mesh-sdk": "workspace:*",
+        "@decocms/std": "workspace:*",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@openrouter/ai-sdk-provider": "^2.9.1",
         "@opentelemetry/api": "^1.9.0",
@@ -356,7 +357,7 @@
     },
     "packages/ui": {
       "name": "@deco/ui",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -16,7 +16,21 @@ const commerceMockKey = "e2e-commerce-key";
 // but defaults off under NODE_ENV=development (which `dev:server` sets), so opt
 // it back in here. Without this, cache-dependent specs (e.g. proxy roundtrip's
 // no-re-handshake assertion) fail against the dev server.
-const webServerCommand = `MCP_CACHE_ENABLED=true COMMERCE_DISCOVERY_INTERNAL_API_URL=${commerceMockOrigin} COMMERCE_DISCOVERY_INTERNAL_API_KEY=${commerceMockKey} BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run dev:servers`;
+//
+// RUN_IDLE_TIMEOUT_MS shortens the unified-control-plane liveness window
+// (production default: 10 minutes — see run-registry.ts) so
+// decopilot-unified-control-plane.spec.ts's "executor dies mid-run" proof can
+// observe the liveness terminal without a real 10-minute wait. Read ONCE at
+// server boot (run-registry.ts module load), so this applies to the whole e2e
+// run, not per-test. Chosen with headroom above every OTHER spec's
+// held-open-turn windows in this suite (the widest being
+// decopilot-thread-queue.spec.ts's `nextWorkItem(..., { timeoutMs: 35_000 })`
+// waits for a queued turn to reach the fake daemon — the consume step's idle
+// timer is already ticking during that wait, since dispatch marks the run
+// in_progress and opens the live tail before the daemon ever receives
+// anything) so no other spec's legitimately-slow-but-alive turn is
+// misclassified as dead.
+const webServerCommand = `MCP_CACHE_ENABLED=true COMMERCE_DISCOVERY_INTERNAL_API_URL=${commerceMockOrigin} COMMERCE_DISCOVERY_INTERNAL_API_KEY=${commerceMockKey} BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 bun run dev:servers`;
 
 export default defineConfig({
   testDir: "./tests",

--- a/packages/e2e/tests/decopilot-unified-control-plane.spec.ts
+++ b/packages/e2e/tests/decopilot-unified-control-plane.spec.ts
@@ -1,0 +1,393 @@
+/**
+ * E2E: unified-control-plane proof suite (T9).
+ *
+ * Two proofs from `docs/superpowers/specs/2026-07-09-unified-control-plane-design.md`
+ * that need a real dispatched run (not a bare-seed/unit test):
+ *
+ *   1. **Hosted setup-failure surfaces as a stream event.** T1 made the
+ *      hosted child a pure executor: it catches ALL its own failures and
+ *      publishes an in-band `{type:"error"}` chunk + `{done}` to the run's
+ *      subject, carrying the REAL `err.message` (never a masked generic).
+ *      This test proves that end-to-end through a real POST → gate v4 →
+ *      hostedHarnessWorkflow → consumeRunProjection round trip.
+ *
+ *   2. **Executor death mid-run → liveness terminal.** T4 replaced the old
+ *      unbounded/30-min idle heuristic with a first-class liveness rule:
+ *      the consume step's live subject tail goes silent for
+ *      `RUN_IDLE_TIMEOUT_MS` ⇒ the projector synthesizes a `failed` terminal
+ *      with `failure_kind: "liveness"`. This test proves that with a real
+ *      desktop-topology dispatch whose fake daemon publishes a few chunks
+ *      then never publishes again (no `{done}`) — the black-box equivalent
+ *      of the daemon process dying mid-stream: the consume step only ever
+ *      observes the JetStream subject, never the daemon's process liveness
+ *      directly, so "publishes then goes silent" and "daemon crashed" are
+ *      indistinguishable from the mesh's point of view.
+ *
+ * ## Environment facts this suite depends on
+ *
+ * - **e2e orgs have NO AI provider by default.** POSTing a hosted
+ *   (`sandboxProviderKind: "agent-sandbox"`) message with no tier resolution
+ *   path 400s with `TierUnavailableError` at POST time — before the gate
+ *   ever dispatches (see `resolvePerRequestModels` → `resolveTier` in
+ *   `apps/mesh/src/api/routes/decopilot/routes.ts`). The workaround (same
+ *   one the thread-message-queue project used, and the one
+ *   `tests/multi-pod/lib/setup.ts`'s `wireMockProvider` uses for the
+ *   multi-pod cluster): create a real `ai_provider_keys` row via
+ *   `AI_PROVIDER_KEY_CREATE` and pin it to the "smart" tier via
+ *   `ORGANIZATION_SETTINGS_UPDATE` BEFORE posting. `resolveTier`'s fast path
+ *   (`slot && keys.some(k => k.id === slot.keyId)`) then resolves
+ *   successfully WITHOUT ever calling the provider — the credential only
+ *   needs to exist, not work. POST returns 202, the gate dispatches, and the
+ *   hosted child only discovers the endpoint is unusable when it actually
+ *   tries to stream a completion — exactly the "unusable provider config
+ *   that throws in the child post-start" scenario the brief asks for.
+ *
+ * - **`RUN_IDLE_TIMEOUT_MS` is env-shortened for this webServer.**
+ *   `packages/e2e/playwright.config.ts` sets it to 120s (production default:
+ *   10 minutes) specifically so proof 2 doesn't block CI for 10 real
+ *   minutes. See `run-registry.ts`'s doc comment on the override.
+ */
+
+import { expect, test } from "../fixtures/test";
+import { connectDevDb } from "../fixtures/db";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import {
+  createTunnelLinkDaemon,
+  type TunnelLinkDaemon,
+} from "../fixtures/links-presence";
+import { publishRelayManual } from "../fixtures/relay-nats";
+import { DEFAULT_THREAD_TITLE } from "@decocms/harness/decopilot/prompt-constants";
+import type { APIRequestContext } from "@playwright/test";
+
+type Db = Awaited<ReturnType<typeof connectDevDb>>;
+
+async function orgIdForSlug(db: Db, slug: string): Promise<string> {
+  const { rows } = await db.query<{ id: string }>(
+    `SELECT id FROM "organization" WHERE slug = $1`,
+    [slug],
+  );
+  const id = rows[0]?.id;
+  if (!id) throw new Error(`no organization row for slug ${slug}`);
+  return id;
+}
+
+async function fetchThreadRow(
+  db: Db,
+  threadId: string,
+): Promise<{
+  status: string | null;
+  failureReason: string | null;
+  failureKind: string | null;
+}> {
+  const { rows } = await db.query<{
+    status: string;
+    failure_reason: string | null;
+    failure_kind: string | null;
+  }>(`SELECT status, failure_reason, failure_kind FROM threads WHERE id = $1`, [
+    threadId,
+  ]);
+  return {
+    status: rows[0]?.status ?? null,
+    failureReason: rows[0]?.failure_reason ?? null,
+    failureKind: rows[0]?.failure_kind ?? null,
+  };
+}
+
+async function fetchErrorPartTexts(
+  db: Db,
+  threadId: string,
+): Promise<string[]> {
+  const { rows } = await db.query<{ payload: unknown }>(
+    `SELECT payload FROM thread_message_parts WHERE thread_id = $1 AND kind = 'error' ORDER BY seq`,
+    [threadId],
+  );
+  return rows.map((r) => {
+    const payload = r.payload as { text?: unknown } | null;
+    return typeof payload?.text === "string" ? payload.text : "";
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Proof 1: hosted setup-failure surfaces as a stream event
+// ---------------------------------------------------------------------------
+
+test.describe("decopilot hosted — setup-failure surfaces as a stream event", () => {
+  test("an unreachable provider endpoint fails the hosted run with the REAL error text, not a masked generic — no hang", async ({
+    authedPage,
+  }) => {
+    test.setTimeout(90_000);
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+    const db = await connectDevDb();
+    try {
+      const orgId = await orgIdForSlug(db, orgSlug);
+
+      // ── Dummy provider key: exists (so resolveTier's fast path resolves
+      // without ever calling the provider) but points at a closed local
+      // port, so the FIRST real model call the hosted child makes fails
+      // fast and deterministically with a genuine network error — no
+      // external network dependency, no flakiness.
+      const key = await callSelfMcpTool<{ id: string }>(
+        api,
+        orgSlug,
+        "AI_PROVIDER_KEY_CREATE",
+        {
+          providerId: "openai-compatible",
+          label: `e2e-unreachable-${Date.now()}`,
+          apiKey: JSON.stringify({
+            baseUrl: "http://127.0.0.1:1/v1",
+            apiKey: "unused",
+          }),
+        },
+      );
+      await callSelfMcpTool(api, orgSlug, "ORGANIZATION_SETTINGS_UPDATE", {
+        organizationId: orgId,
+        simple_mode: {
+          tiers: {
+            fast: null,
+            smart: { keyId: key.id, modelId: "mock-model" },
+            thinking: null,
+            image: null,
+            web_search: null,
+            deep_research: null,
+          },
+        },
+      });
+
+      const agent = await callSelfMcpTool<{ item: { id: string } }>(
+        api,
+        orgSlug,
+        "COLLECTION_VIRTUAL_MCP_CREATE",
+        {
+          data: {
+            title: "Hosted setup-failure e2e agent",
+            connections: [],
+            status: "active",
+            pinned: false,
+          },
+        },
+      );
+      const thread = await callSelfMcpTool<{ item: { id: string } }>(
+        api,
+        orgSlug,
+        "COLLECTION_THREADS_CREATE",
+        { data: { virtual_mcp_id: agent.item.id } },
+      );
+      const threadId = thread.item.id;
+
+      // ── The load-bearing assertion at POST time: the dummy key makes the
+      // tier check pass (202), NOT the 400 TierUnavailableError an e2e org
+      // gets by default. If this regresses to 400, the rest of the test is
+      // vacuous (the gate never dispatches) — so pin it explicitly.
+      const runResp = await api.post(
+        `/api/${orgSlug}/decopilot/threads/${threadId}/messages`,
+        {
+          data: {
+            messages: [
+              { role: "user", parts: [{ type: "text", text: "hello" }] },
+            ],
+            agent: { id: agent.item.id },
+            branch: "ephemeral",
+            temperature: 0,
+            sandboxProviderKind: "agent-sandbox",
+            harnessId: "decopilot",
+          },
+          headers: { "content-type": "application/json" },
+        },
+      );
+      expect(runResp.status()).toBe(202);
+      const { taskId: runId } = (await runResp.json()) as { taskId: string };
+      expect(typeof runId).toBe("string");
+
+      // ── The contract: the thread reaches `failed` — not a hang, not a
+      // 10-minute-later reaper force-fail — because the hosted child's own
+      // catch (T1) publishes a fenced error terminal the instant the model
+      // call fails, and the projector (live-tailing, T3) folds it
+      // immediately. Bounded well under RUN_IDLE_TIMEOUT_MS.
+      await expect(async () => {
+        const row = await fetchThreadRow(db, threadId);
+        expect(row.status).toBe("failed");
+      }).toPass({ timeout: 60_000, intervals: [500, 1000, 2000, 5000] });
+
+      const row = await fetchThreadRow(db, threadId);
+      // Not the liveness path — this must resolve fast, well inside the
+      // idle window, via the harness's own error-catch.
+      expect(row.failureKind).not.toBe("liveness");
+
+      // ── THE REAL-REASON ASSERTION: the persisted error part carries the
+      // genuine underlying failure (a connection error against
+      // 127.0.0.1:1), never a masked placeholder like "An error occurred".
+      const errorTexts = await fetchErrorPartTexts(db, threadId);
+      expect(errorTexts.length).toBeGreaterThan(0);
+      const combined = errorTexts.join(" ");
+      expect(combined).not.toBe("");
+      expect(combined).not.toContain("An error occurred");
+      expect(combined.toLowerCase()).toContain("connect");
+    } finally {
+      await db.end();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proof 2: executor death mid-run → liveness terminal
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an agent (virtual MCP) + a v2 thread pinned to a user-desktop /
+ * claude-code target, mirroring `decopilot-fence-queueing.spec.ts` /
+ * `decopilot-thread-queue.spec.ts`'s helper of the same name (each spec
+ * owns its own copy by existing repo convention — see those files' Task 9
+ * DRY notes for why this isn't factored into a shared fixture).
+ */
+async function createPullThread(
+  api: APIRequestContext,
+  db: Db,
+  orgSlug: string,
+  orgId: string,
+): Promise<{ agentId: string; threadId: string }> {
+  const agent = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_VIRTUAL_MCP_CREATE",
+    {
+      data: {
+        title: "Liveness e2e agent",
+        connections: [],
+        status: "active",
+        pinned: false,
+      },
+    },
+  );
+  const agentId = agent.item.id;
+
+  const thread = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_THREADS_CREATE",
+    { data: { virtual_mcp_id: agentId } },
+  );
+  const threadId = thread.item.id;
+
+  await db.query(
+    `UPDATE threads
+     SET message_storage_version = 2,
+         harness_id              = 'claude-code',
+         sandbox_provider_kind   = 'user-desktop',
+         title                   = $3
+     WHERE id = $1
+       AND organization_id = $2`,
+    [threadId, orgId, DEFAULT_THREAD_TITLE],
+  );
+
+  return { agentId, threadId };
+}
+
+function postMessage(
+  api: APIRequestContext,
+  orgSlug: string,
+  agentId: string,
+  threadId: string,
+  messageText: string,
+) {
+  return api.post(`/api/${orgSlug}/decopilot/threads/${threadId}/messages`, {
+    data: {
+      messages: [
+        { role: "user", parts: [{ type: "text", text: messageText }] },
+      ],
+      agent: { id: agentId },
+      branch: "ephemeral",
+      temperature: 0.5,
+      harnessId: "claude-code",
+      sandboxProviderKind: "user-desktop",
+    },
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test.describe("decopilot desktop — executor death mid-run reaches a liveness terminal", () => {
+  test("a daemon that publishes a few chunks then goes silent (never {done}) fails the thread with a liveness reason, bounded by the shortened RUN_IDLE_TIMEOUT_MS", async ({
+    authedPage,
+  }) => {
+    // Bounded above the shortened RUN_IDLE_TIMEOUT_MS (120s, see
+    // playwright.config.ts) with headroom for the poll's own interval +
+    // dispatch/claim round trip.
+    test.setTimeout(200_000);
+    const { page, orgSlug, user } = authedPage;
+    const api = page.context().request;
+    const db = await connectDevDb();
+    let daemon: TunnelLinkDaemon | null = null;
+    try {
+      daemon = await createTunnelLinkDaemon(api, user.userId, ["claude-code"]);
+      const orgId = await orgIdForSlug(db, orgSlug);
+      const { agentId, threadId } = await createPullThread(
+        api,
+        db,
+        orgSlug,
+        orgId,
+      );
+
+      const dispatchRes = await postMessage(
+        api,
+        orgSlug,
+        agentId,
+        threadId,
+        "Executor will die after a couple of chunks.",
+      );
+      expect(dispatchRes.status()).toBe(202);
+      const { taskId: runId } = (await dispatchRes.json()) as {
+        taskId: string;
+      };
+      expect(runId).toBeTruthy();
+
+      const workItem = await daemon.nextWorkItem(runId);
+      expect(workItem.runId).toBe(runId);
+      expect(workItem.threadId).toBe(threadId);
+      expect(typeof workItem.runFenceToken).toBe("string");
+
+      // ── Publish a FEW chunks (proves the run genuinely started and was
+      // making progress), then go silent forever — no `{done}`, no error
+      // event, nothing. The consume step only ever watches the JetStream
+      // subject, not the daemon's process itself, so this is the faithful
+      // black-box equivalent of "the desktop daemon process dies mid-run":
+      // from the mesh's point of view the two are indistinguishable —
+      // both are "no more events on the subject."
+      const assistantMessageId = `msg_liveness_${Date.now()}`;
+      const textId = `${assistantMessageId}-text-0`;
+      await publishRelayManual({
+        runId: workItem.runId,
+        fenceToken: workItem.runFenceToken,
+        chunks: [
+          { seq: 1, chunk: { type: "start", messageId: assistantMessageId } },
+          { seq: 2, chunk: { type: "start-step" } },
+          { seq: 3, chunk: { type: "text-start", id: textId } },
+          {
+            seq: 4,
+            chunk: {
+              type: "text-delta",
+              id: textId,
+              delta: "partial reply before the executor dies",
+            },
+          },
+        ],
+        // No doneFinalSeq — the daemon goes silent right here.
+      });
+
+      // ── The contract: the thread eventually reaches `failed` with
+      // `failure_kind: "liveness"` and a `failure_reason` mentioning
+      // "liveness" — not stuck `in_progress` forever, not the old opaque
+      // "projection" reason. The poll window comfortably exceeds the
+      // shortened RUN_IDLE_TIMEOUT_MS (120s) so this is observing the real
+      // liveness enforcement, not a lucky early poll.
+      await expect(async () => {
+        const row = await fetchThreadRow(db, threadId);
+        expect(row.status).toBe("failed");
+        expect(row.failureKind).toBe("liveness");
+        expect(row.failureReason ?? "").toContain("liveness");
+      }).toPass({ timeout: 170_000, intervals: [2_000, 5_000, 10_000] });
+    } finally {
+      await daemon?.close();
+      await db.end();
+    }
+  });
+});

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -31,6 +31,7 @@
     "@ai-sdk/openai": "^3.0.73",
     "@ai-sdk/provider": "^3.0.10",
     "@decocms/mesh-sdk": "workspace:*",
+    "@decocms/std": "workspace:*",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@openrouter/ai-sdk-provider": "^2.9.1",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/harness/src/liveness-heartbeat.test.ts
+++ b/packages/harness/src/liveness-heartbeat.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { sleep } from "@decocms/std";
+import {
+  HeartbeatEmitter,
+  LIVENESS_HEARTBEAT_INTERVAL_MS,
+} from "./liveness-heartbeat";
+
+// Small real intervals (matches this repo's established idle-timeout test
+// style — see nats-chunk-source.test.ts — rather than mocking the clock).
+// Margins are deliberately generous (intervals in the tens of ms, assertions
+// mostly one-sided lower bounds): under a full parallel `bun test` run
+// (hundreds of files/timers contending for the event loop) a tight window
+// with a tight bound flakes on scheduler jitter alone, not a real bug — this
+// bit us once during development with a 10ms interval / exact-count bound.
+
+describe("LIVENESS_HEARTBEAT_INTERVAL_MS", () => {
+  test("is 30s, comfortably under the 10-minute liveness window", () => {
+    expect(LIVENESS_HEARTBEAT_INTERVAL_MS).toBe(30_000);
+    expect(LIVENESS_HEARTBEAT_INTERVAL_MS).toBeLessThan(10 * 60 * 1000);
+  });
+});
+
+describe("HeartbeatEmitter", () => {
+  test("emits every intervalMs while armed", async () => {
+    let emits = 0;
+    const emitter = new HeartbeatEmitter({
+      intervalMs: 25,
+      emit: () => {
+        emits++;
+      },
+    });
+    emitter.arm();
+    // ~3.8 windows of headroom: expect at least 3 emits.
+    await sleep(25 * 3 + 20);
+    emitter.stop();
+    expect(emits).toBeGreaterThanOrEqual(3);
+  });
+
+  test("a call to arm() before the window elapses resets it (disarmed on real chunk)", async () => {
+    let emits = 0;
+    const emitter = new HeartbeatEmitter({
+      intervalMs: 60,
+      emit: () => {
+        emits++;
+      },
+    });
+    emitter.arm();
+    // Simulate 3 real chunks arriving well inside the window (7.5x margin)
+    // — each resets the silence clock, so the window never actually elapses.
+    await sleep(8);
+    emitter.arm();
+    await sleep(8);
+    emitter.arm();
+    await sleep(8);
+    emitter.arm();
+    expect(emits).toBe(0);
+    // Now let a full window elapse with no further reset.
+    await sleep(80);
+    emitter.stop();
+    expect(emits).toBe(1);
+  });
+
+  test("never emits after stop()", async () => {
+    let emits = 0;
+    const emitter = new HeartbeatEmitter({
+      intervalMs: 10,
+      emit: () => {
+        emits++;
+      },
+    });
+    emitter.arm();
+    emitter.stop();
+    await sleep(40);
+    expect(emits).toBe(0);
+  });
+
+  test("stop() during an in-flight window suppresses that pending emit", async () => {
+    let emits = 0;
+    const emitter = new HeartbeatEmitter({
+      intervalMs: 60,
+      emit: () => {
+        emits++;
+      },
+    });
+    emitter.arm();
+    await sleep(5); // well inside the window (12x margin)
+    emitter.stop();
+    await sleep(80); // past when the (now-cancelled) window would have fired
+    expect(emits).toBe(0);
+  });
+
+  test("stop() is idempotent and arm() after stop() is a no-op", async () => {
+    let emits = 0;
+    const emitter = new HeartbeatEmitter({
+      intervalMs: 10,
+      emit: () => {
+        emits++;
+      },
+    });
+    emitter.stop();
+    emitter.stop(); // idempotent — must not throw
+    emitter.arm(); // stopped — must stay a no-op
+    await sleep(30);
+    expect(emits).toBe(0);
+  });
+
+  test("self-reschedules: a long silence yields multiple heartbeats without re-arming", async () => {
+    let emits = 0;
+    const emitter = new HeartbeatEmitter({
+      intervalMs: 25,
+      emit: () => {
+        emits++;
+      },
+    });
+    emitter.arm();
+    await sleep(25 * 5 + 20); // ~5.8 windows, no external arm() calls at all
+    emitter.stop();
+    expect(emits).toBeGreaterThanOrEqual(4);
+  });
+
+  test("a rejecting emit stops the scheduler instead of looping forever", async () => {
+    let emits = 0;
+    const emitter = new HeartbeatEmitter({
+      intervalMs: 20,
+      emit: () => {
+        emits++;
+        throw new Error("publish failed");
+      },
+    });
+    emitter.arm();
+    await sleep(20 * 4);
+    // Exactly one emit: the throw stops the scheduler, so it never reschedules.
+    expect(emits).toBe(1);
+  });
+
+  test("uses the default LIVENESS_HEARTBEAT_INTERVAL_MS when intervalMs is omitted", () => {
+    let capturedMs: number | undefined;
+    const emitter = new HeartbeatEmitter({
+      emit: () => {},
+      sleepFn: (ms, opts) => {
+        capturedMs = ms;
+        // Resolve only on abort so the test doesn't actually wait 30s.
+        return new Promise((_resolve, reject) => {
+          opts.signal.addEventListener("abort", () =>
+            reject(opts.signal.reason),
+          );
+        });
+      },
+    });
+    emitter.arm();
+    emitter.stop();
+    expect(capturedMs).toBe(LIVENESS_HEARTBEAT_INTERVAL_MS);
+  });
+});

--- a/packages/harness/src/liveness-heartbeat.test.ts
+++ b/packages/harness/src/liveness-heartbeat.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { sleep } from "@decocms/std";
 import {
+  buildLivenessChunk,
   HeartbeatEmitter,
   LIVENESS_HEARTBEAT_INTERVAL_MS,
 } from "./liveness-heartbeat";
@@ -150,5 +151,24 @@ describe("HeartbeatEmitter", () => {
     emitter.arm();
     emitter.stop();
     expect(capturedMs).toBe(LIVENESS_HEARTBEAT_INTERVAL_MS);
+  });
+});
+
+describe("buildLivenessChunk", () => {
+  test("shape: data-liveness, transient, carries a timestamp — the single wire-format source of truth for T5 (hosted) and T6 (desktop daemon)", () => {
+    const chunk = buildLivenessChunk(() => 12345);
+    expect(chunk).toEqual({
+      type: "data-liveness",
+      data: { t: 12345 },
+      transient: true,
+    });
+  });
+
+  test("defaults `now` to Date.now", () => {
+    const before = Date.now();
+    const chunk = buildLivenessChunk();
+    const after = Date.now();
+    expect(chunk.data.t).toBeGreaterThanOrEqual(before);
+    expect(chunk.data.t).toBeLessThanOrEqual(after);
   });
 });

--- a/packages/harness/src/liveness-heartbeat.ts
+++ b/packages/harness/src/liveness-heartbeat.ts
@@ -1,0 +1,125 @@
+/**
+ * Liveness heartbeat scheduler (unified-control-plane T5/T6).
+ *
+ * Shared between the hosted executor (apps/mesh's decopilot dispatch, T5)
+ * and the desktop daemon's relay pump (packages/sandbox, T6) — both need the
+ * exact same "call `emit` after N ms of silence, reset the window on every
+ * real chunk, never emit again after `stop()`" scheduler; only the wiring
+ * (what `emit` actually publishes) differs per executor. Lives here because
+ * both `apps/mesh` and `packages/sandbox` already depend on `@decocms/harness`
+ * (see `packages/sandbox/package.json`), so this is reachable from both
+ * without a reverse dependency.
+ *
+ * Pure: no NATS/DBOS/StudioContext/relay-transport knowledge — just a timer.
+ * Uses `@decocms/std`'s `sleep(ms, { signal })` for the wait, never a
+ * hand-rolled `setTimeout` loop (see the repo's async-primitives rule in
+ * AGENTS.md/CLAUDE.md — `@decocms/std` is the one canonical home for this).
+ */
+import { sleep } from "@decocms/std";
+
+/**
+ * Silence window before a heartbeat fires. MUST stay well under the
+ * liveness enforcer's own idle window — `RUN_IDLE_TIMEOUT_MS` (10 minutes,
+ * `apps/mesh/src/api/routes/decopilot/run-registry.ts`), which both the
+ * projector's in-process consume-side timeout (`natsChunkSource`) and the
+ * per-pod reaper backstop enforce. 30s gives ~20 heartbeats of margin inside
+ * that 10-minute window, so a single dropped publish or a slow tick never
+ * risks a false-positive liveness kill. Not imported from run-registry.ts on
+ * purpose: `packages/harness` has no dependency on `apps/mesh` (that would be
+ * the wrong direction) — the relationship is documented here, not enforced
+ * by import.
+ */
+export const LIVENESS_HEARTBEAT_INTERVAL_MS = 30_000;
+
+/** Injectable wait primitive — defaults to `@decocms/std`'s `sleep`. Tests
+ *  inject a small `intervalMs` (matching this repo's existing idle-timeout
+ *  test style, e.g. `nats-chunk-source.test.ts`) rather than mocking this. */
+export type HeartbeatSleepFn = (
+  ms: number,
+  opts: { signal: AbortSignal },
+) => Promise<void>;
+
+export interface HeartbeatEmitterOptions {
+  /** Called each time the silence window elapses without a reset. May be
+   *  async; a throw/rejection stops the scheduler (treated like `stop()`)
+   *  rather than looping forever on a broken emit (e.g. a publish failure). */
+  emit: () => void | Promise<void>;
+  /** Silence window before firing. Defaults to `LIVENESS_HEARTBEAT_INTERVAL_MS`. */
+  intervalMs?: number;
+  /** Injected clock — see `HeartbeatSleepFn`. Defaults to `@decocms/std`'s `sleep`. */
+  sleepFn?: HeartbeatSleepFn;
+}
+
+/**
+ * Pure timer scheduler: emits on a fixed interval while ARMED, resets on
+ * every call to `arm()` (a real chunk/relay line arrived), and never emits
+ * again once `stop()`ped.
+ *
+ * Usage: call `arm()` once to start watching for silence, then call `arm()`
+ * again on every real chunk (this cancels the pending heartbeat and starts a
+ * fresh window — it does NOT disable the scheduler, just resets it). The
+ * scheduler self-reschedules after every successful emit, so multiple
+ * heartbeats fire during one long silent gap (a 5-minute tool call yields
+ * ~10 heartbeats at the default interval). Call `stop()` once the underlying
+ * stream ends or errors — idempotent, safe to call multiple times.
+ */
+export class HeartbeatEmitter {
+  private readonly intervalMs: number;
+  private readonly emitFn: () => void | Promise<void>;
+  private readonly sleepFn: HeartbeatSleepFn;
+  private controller: AbortController | null = null;
+  private stopped = false;
+
+  constructor(options: HeartbeatEmitterOptions) {
+    this.intervalMs = options.intervalMs ?? LIVENESS_HEARTBEAT_INTERVAL_MS;
+    this.emitFn = options.emit;
+    this.sleepFn = options.sleepFn ?? sleep;
+  }
+
+  /**
+   * (Re)start the silence window from now. Idempotent-safe to call
+   * repeatedly (e.g. once per real chunk) — each call cancels the
+   * previously-pending wait (via its `AbortSignal`) and starts a fresh one.
+   * No-op once `stop()`ped.
+   */
+  arm(): void {
+    if (this.stopped) return;
+    this.controller?.abort();
+    const controller = new AbortController();
+    this.controller = controller;
+    void this.wait(controller.signal);
+  }
+
+  private async wait(signal: AbortSignal): Promise<void> {
+    try {
+      await this.sleepFn(this.intervalMs, { signal });
+    } catch {
+      // Aborted by a re-arm (real chunk arrived) or by stop() — not a real
+      // timeout. Swallow: the caller either already started a fresh window
+      // (re-arm) or wants no more emits (stop).
+      return;
+    }
+    if (this.stopped || signal.aborted) return;
+    try {
+      await this.emitFn();
+    } catch {
+      // A broken emit (e.g. the publish call itself failed) must not spin
+      // the scheduler forever on a stream that can no longer make progress
+      // anyway — stop like the underlying stream errored.
+      this.stop();
+      return;
+    }
+    // Self-reschedule: one heartbeat fired, arm the next window unless
+    // something stopped us (or re-armed us — a real chunk racing the emit)
+    // while `emitFn` was in flight.
+    if (!this.stopped && !signal.aborted) this.arm();
+  }
+
+  /** Permanently stop. No further emits, even if a wait is in flight. Idempotent. */
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.controller?.abort();
+    this.controller = null;
+  }
+}

--- a/packages/harness/src/liveness-heartbeat.ts
+++ b/packages/harness/src/liveness-heartbeat.ts
@@ -2,18 +2,30 @@
  * Liveness heartbeat scheduler (unified-control-plane T5/T6).
  *
  * Shared between the hosted executor (apps/mesh's decopilot dispatch, T5)
- * and the desktop daemon's relay pump (packages/sandbox, T6) — both need the
- * exact same "call `emit` after N ms of silence, reset the window on every
- * real chunk, never emit again after `stop()`" scheduler; only the wiring
- * (what `emit` actually publishes) differs per executor. Lives here because
- * both `apps/mesh` and `packages/sandbox` already depend on `@decocms/harness`
- * (see `packages/sandbox/package.json`), so this is reachable from both
- * without a reverse dependency.
+ * and the desktop daemon's relay pump (T6 — wired into
+ * `apps/mesh/src/link-daemon/chunk-relay.ts`, which is the file that
+ * actually pumps a sandbox's raw SSE into seq-numbered relay lines; that
+ * file lives in the `apps/mesh` workspace, which already depends on
+ * `@decocms/harness`, same as `packages/sandbox`) — both need the exact same
+ * "call `emit` after N ms of silence, reset the window on every real chunk,
+ * never emit again after `stop()`" scheduler; only the wiring (what `emit`
+ * actually publishes) differs per executor. Lives here so this is reachable
+ * from both without a reverse dependency (packages/harness has no
+ * dependency on apps/mesh in either direction).
  *
- * Pure: no NATS/DBOS/StudioContext/relay-transport knowledge — just a timer.
- * Uses `@decocms/std`'s `sleep(ms, { signal })` for the wait, never a
- * hand-rolled `setTimeout` loop (see the repo's async-primitives rule in
+ * Pure: no NATS/DBOS/StudioContext/relay-transport knowledge — just a timer
+ * plus the shared `data-liveness` wire-shape builder below. Uses
+ * `@decocms/std`'s `sleep(ms, { signal })` for the wait, never a hand-rolled
+ * `setTimeout` loop (see the repo's async-primitives rule in
  * AGENTS.md/CLAUDE.md — `@decocms/std` is the one canonical home for this).
+ *
+ * Version-skew note (both T5 and T6): only executors built with this change
+ * ever emit `data-liveness` chunks. An old, already-deployed hosted pod or
+ * desktop daemon simply never emits them — the projector's own idle-window
+ * enforcement (`RUN_IDLE_TIMEOUT_MS`, 10 minutes) is UNCHANGED by either
+ * task; it stays where it was until fleet adoption of the emitting build is
+ * complete. This module only ever ADDS emission, never changes the
+ * threshold that consumes it.
  */
 import { sleep } from "@decocms/std";
 
@@ -122,4 +134,32 @@ export class HeartbeatEmitter {
     this.controller?.abort();
     this.controller = null;
   }
+}
+
+// --- Wire shape -------------------------------------------------------------
+
+/**
+ * Shape of the transient `data-liveness` chunk BOTH executors emit — single
+ * source of truth for the wire format, so the desktop daemon's relay pump
+ * (T6, `apps/mesh/src/link-daemon/chunk-relay.ts`) can't drift from the
+ * hosted executor's wrapper (T5,
+ * `apps/mesh/src/api/routes/decopilot/with-liveness-heartbeat.ts`).
+ * Deliberately NOT typed against `ai`'s `UIMessageChunk`: this package pins
+ * no `ai` version, and the desktop path only needs a plain object matching
+ * `DispatchSSEEvent`'s `chunk: z.unknown()` field
+ * (`packages/sandbox/dispatch/schemas.ts`). The hosted wrapper has a hard
+ * `ai` dependency already and re-asserts the stronger `ai`-typed shape
+ * locally — both MUST stay byte-for-byte identical on the wire.
+ */
+export interface LivenessDataChunk {
+  type: "data-liveness";
+  data: { t: number };
+  transient: true;
+}
+
+/** Builds one `data-liveness` chunk. `now` is injectable for tests. */
+export function buildLivenessChunk(
+  now: () => number = Date.now,
+): LivenessDataChunk {
+  return { type: "data-liveness", data: { t: now() }, transient: true };
 }

--- a/tests/multi-pod/lib/db.ts
+++ b/tests/multi-pod/lib/db.ts
@@ -85,3 +85,32 @@ export async function getThreadRunOwnerPod(
   );
   return rows[0]?.run_owner_pod ?? null;
 }
+
+/** Single-quote escape for inlining ids into SQL (ids are uuid-ish, but
+ *  belt-and-suspenders — shared by scenarios that need it beyond the
+ *  string-literal ids `dbQuery`'s callers already build inline). */
+function sqlLit(v: string): string {
+  return v.replace(/'/g, "''");
+}
+
+/** The persisted `threads.status` for a thread, or null if absent. */
+export async function getThreadStatus(
+  threadId: string,
+): Promise<string | null> {
+  const rows = await dbQuery<{ status: string | null }>(
+    `SELECT status FROM threads WHERE id = '${sqlLit(threadId)}'`,
+  );
+  return rows[0]?.status ?? null;
+}
+
+/** Count of persisted `thread_message_parts` rows for a thread. `COUNT(*)`
+ *  is a stable scalar, safe for this module's naive (comma-splitting) CSV
+ *  parser. */
+export async function countThreadMessageParts(
+  threadId: string,
+): Promise<number> {
+  const rows = await dbQuery<{ n: string }>(
+    `SELECT COUNT(*) AS n FROM thread_message_parts WHERE thread_id = '${sqlLit(threadId)}'`,
+  );
+  return Number(rows[0]?.n ?? "0");
+}

--- a/tests/multi-pod/scenarios/attach-cross-pod.test.ts
+++ b/tests/multi-pod/scenarios/attach-cross-pod.test.ts
@@ -32,12 +32,32 @@
  * pre-fix too. If pod-1 (or any non-attached pod) is the owner, the
  * test exercises the actual cross-pod path. Over a few CI runs we get
  * coverage of all three.
+ *
+ * ── unified-control-plane T9 extension ────────────────────────────────
+ * This cluster's `docker-compose.yml` pins every mesh pod to
+ * `STUDIO_SANDBOX_PROVIDER=agent-sandbox` (see that file's comment on the
+ * `mesh-1` service), so `resolveDispatchTarget` short-circuits every
+ * dispatch in this suite to HOSTED execution — this test already drives a
+ * hosted streaming turn through the (now v4) gate: dispatch →
+ * `hostedHarnessWorkflow` (detached, not awaited) → `consumeRunProjection`
+ * live-tailing the subject, identically to desktop. That makes this the
+ * multi-pod suite's existing streaming-turn scenario the T9 proof
+ * obligations ask to extend, rather than write a parallel one: chunks
+ * observed on `/stream` while `in_progress` (below, right after chunk-1 is
+ * confirmed on both survivor pods — the run cannot have reached a terminal
+ * status yet, since mock-ai hasn't sent chunks 2-5 or its `stop` frame),
+ * terminal `completed`, and parts persisted exactly once (a part count
+ * that's stable across two reads taken a beat apart — the exact count mock-ai's
+ * chunk-to-part folding produces isn't a stable contract to pin at this
+ * granularity; see `projector-parity.test.ts` for that level of detail).
  */
 
 import { describe, expect, test } from "bun:test";
 import { postJson, sse } from "../lib/client";
+import { countThreadMessageParts, getThreadStatus } from "../lib/db";
 import { registerTestHooks } from "../lib/hooks";
 import { PODS } from "../lib/pods";
+import { pollUntil } from "../lib/poll-until";
 import {
   bootstrapSession,
   createTestAgent,
@@ -167,5 +187,36 @@ describe("cross-pod /attach", () => {
 
     expect(pod2Joined).toContain("chunk-1");
     expect(pod3Joined).toContain("chunk-1");
-  }, 30_000);
+
+    // ── unified-control-plane T9: chunks observed on /stream while the run
+    // is still `in_progress`. Both survivor pods have only just confirmed
+    // chunk-1 — mock-ai's remaining 4 chunks + `stop` frame (500ms apart)
+    // haven't been sent yet, so the projector cannot have written a
+    // terminal status yet.
+    expect(await getThreadStatus(threadId)).toBe("in_progress");
+
+    // ── Terminal: the hosted run reaches `completed` once mock-ai finishes
+    // streaming (~2.5s total for MOCK_HINT's 5 chunks).
+    await pollUntil(
+      async () => (await getThreadStatus(threadId)) === "completed",
+      {
+        timeoutMs: 15_000,
+        intervalMs: 250,
+        label: "hosted-turn-completed",
+      },
+    );
+
+    // ── Parts persisted EXACTLY ONCE: the count is stable across two reads
+    // taken a beat apart. A double-projection bug (e.g. the v4 gate's
+    // live-tail somehow re-consuming the same run) would show up as the
+    // count still climbing after the terminal write, not as a fixed wrong
+    // number.
+    const countAfterTerminal = await countThreadMessageParts(threadId);
+    expect(countAfterTerminal).toBeGreaterThan(0);
+    await Bun.sleep(1_000);
+    expect(await countThreadMessageParts(threadId)).toBe(countAfterTerminal);
+    // Extended from 30s (the pre-T9 upper bound for the chunk-1 cross-pod
+    // race alone) to cover the added completed-terminal poll + stability
+    // sleep above.
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary

Unifies the hosted and desktop run control planes into one flow: **executors publish to the run's NATS subject; the gate live-tails it via the projector, which is the sole completion authority.** No more topology fork in the gate, no more child-await, one liveness rule for everything.

Spec: three user-settled pillars — (1) errors-as-stream-events (the hosted child catches its own failures and publishes an error terminal, exactly like the desktop daemon), (2) executors heartbeat on the subject (transient `data-liveness` chunks; one rule: no subject events for `RUN_IDLE_TIMEOUT_MS` = 10 min ⇒ liveness terminal with a real `failure_reason`), (3) hard cut with a `DBOS_WORKFLOW_VERSION` 3→4 bump.

## ⚠️ Deploy runbook (why automerge is OFF)

The gate's recorded step sequence changed → version pin bumped **"3" → "4"** (the branch's one deliberate bump, commit `feat(decopilot)!: unified gate control plane…`). At rollout, **in-flight v3 gate workflows strand** (version-scoped recovery — by design). Recovery is user-actionable: a stranded thread's **Stop button** cancels the zombie gate head and frees the thread; the user re-sends. Recommended: deploy stg first and dogfood a few streaming turns (hosted + desktop), then prod at low traffic. Merge timing is a human call.

## Changes (9 commits, one per task)

1. **Hosted child self-terminal** — catches all failures → publishes fenced error chunk + `{done}` (real error text on the subject; masking stays a wire concern). Deterministic error-message id converges with the projector's synthesized-error dedup.
2. **Projector = single side-effect site** — usage/posthog/SSE fire once, from the projector, both topologies. Closed the pump-swallow gap (mid-stream hosted failures now produce a fenced terminal with the true next seq via `.lastAckSeq` error-stamping). `retriesAllowed: false` on the agent-loop step (review-caught: rejection would otherwise re-run the whole loop 3× and could splice divergent generations into one message).
3. **Gate v4** — hosted child started, never awaited (`hostedChildWorkflowId` extracted as single source of truth); consume runs unconditionally for both topologies; start-failure keeps fast-fail semantics (analytics + rethrow → DBOS recovery; review-caught regression fixed).
4. **Liveness terminal** — typed `StreamIdleTimeoutError` → `kind:"liveness"` with honest reason; `RUN_IDLE_TIMEOUT_MS` is the one constant (the divergent 30-min default was provably dead — the per-pod reaper already enforced 10 min).
5. **Hosted heartbeats** — `data-liveness` every 30s of silence, injected pre-seq-wrapper (real seqs, dedup contract); verified ignored by both the client fold and the projector's persisting fold (ai@6.0.208 transient-chunk semantics, source-verified).
6. **Daemon heartbeats** — same shared emitter + wire shape (single source of truth), wired in the relay pump's seq/outbox path; transport keepalives deliberately do NOT reset the liveness window. Version-skew note: old daemons don't emit — the 10-min window doesn't tighten until fleet adoption.
7. **Stop cancels the detached child** — wiring pre-existed (#4179); SDK-verified semantics documented (workflow-cancel = boundary-checked DB flip → covers the enqueued window + blocks recovery resurrection; the NATS broadcast remains the real-time abort) + mutation-verified regression tests.
8. **Deleted** the dead hosted `tapProgress` (provably never fired), the gate's topology fork, and ingestRun's duplicate hooks.
9. **Proofs** — half-terminal invariant units; e2e: hosted setup-failure surfaces the *real* reason (dummy-provider-key pattern), executor-death → liveness terminal (env-shortened window, e2e-only); multi-pod hosted v4 streaming assertions; fence/queue suites byte-identical.

## Verification

- Every task independently reviewed (opus on the high-stakes ones); 2 Important findings caught and fixed pre-merge (retry-splice, swallowed start-failure); all claims verified against installed SDK sources where load-bearing.
- check / lint / knip / fmt / snapshot-guard clean. Full unit scope: 3908 pass / 244 env-dependent fails vs main's 3846 / 245 on the identical scope (branch strictly better; the fail class is the known no-local-PG/NATS set).
- **T9's e2e/multi-pod proofs execute for the first time in THIS PR's CI** — treat that job as part of review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies hosted and desktop run control into one path: executors publish to each run’s NATS subject, and the projector live-tails it as the single completion authority. Adds liveness heartbeats and a stream-silence terminal, and bumps the DBOS workflow version to "4".

- **New Features**
  - Projector is authoritative for completion and side effects (usage, `chat_message_*`, SSE) across both topologies.
  - Hosted child catches its own failures and publishes fenced `{type:"error"}` + `{done}` with the real error message; Stop also cancels the detached hosted child.
  - Liveness: a silent subject for `RUN_IDLE_TIMEOUT_MS` (10m) yields `failure_kind: "liveness"` via a `StreamIdleTimeoutError`; same window used by the reaper and the consume path.
  - Heartbeats: inject `data-liveness` every 30s during silent phases in both hosted (`with-liveness-heartbeat`) and desktop relay (`chunk-relay`) paths; they consume real seqs, reset the idle window, and are transient (not persisted or rendered).
  - Reliability: `NatsStreamBuffer.pump()` returns a promise (propagates mid-stream errors after still publishing a done sentinel); `ingestRun` surfaces `lastAckSeq` on failure for correct terminal sequencing; removed the dead hosted `tapProgress`.
  - Tests: new unit and e2e proofs (hosted setup failure surfaces on-stream; executor death → liveness terminal; multi-pod streaming assertions). `RUN_IDLE_TIMEOUT_MS` is env-overridable for CI; `packages/e2e/playwright.config.ts` sets a shorter window.

- **Migration**
  - DBOS workflow version pinned to "4". Any in-flight v3 gate workflows will strand at rollout; recover by using Stop to cancel the gate and hosted child, then re-send. Deploy to staging first, then roll out to production.

<sup>Written for commit e746eaa7b4f5281effafecc21ccce2ecd84ab3f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

