### PR TITLE
feat(web): inline editor for `*` catch-all in preview path templates

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -198,8 +198,8 @@ function resolveSectionCandidates(
 }
 
 /**
- * Inline editor for one `:param` token, rendered in place inside the URL
- * label. Grows with its content and commits on Enter/blur.
+ * Inline editor for one `:param` or `*` (catch-all) token, rendered in place
+ * inside the URL label. Grows with its content and commits on Enter/blur.
  */
 function PathParamInput({
   name,
@@ -213,7 +213,8 @@ function PathParamInput({
   const [draft, setDraft] = useState(value);
   const [focused, setFocused] = useState(false);
   const cancelledRef = useRef(false);
-  const sizer = draft || `:${name}`;
+  const label = name === "*" ? "*" : `:${name}`;
+  const sizer = draft || label;
   return (
     <>
       <span className="relative inline-flex max-w-64 shrink-0 items-center overflow-hidden">
@@ -228,8 +229,8 @@ function PathParamInput({
         <input
           type="text"
           value={draft}
-          placeholder={`:${name}`}
-          title={`Value for :${name}`}
+          placeholder={label}
+          title={`Value for ${label}`}
           spellCheck={false}
           className="absolute inset-0 rounded-sm bg-violet-500/15 px-1 text-[12px] text-violet-600 outline-none placeholder:text-violet-500/60 focus:bg-violet-500/25 dark:text-violet-400"
           onClick={(e) => e.stopPropagation()}
@@ -758,8 +759,8 @@ export function PreviewContent() {
   })();
 
   // URL-label tokens for path-template pages: host + static path text stay
-  // plain text; each `:param` renders in place as an inline input. Null when
-  // the current path has no params (plain `previewLabel` is used instead).
+  // plain text; each `:param`/`*` renders in place as an inline input. Null
+  // when the current path has no params (plain `previewLabel` is used instead).
   const previewLabelTokens = (() => {
     if (!previewUrl || activeGlobalSection || !currentPageKey) return null;
     if (pathParams.length === 0) return null;

--- a/apps/mesh/src/web/components/sections-editor/page-path-utils.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-path-utils.test.ts
@@ -43,6 +43,12 @@ describe("page-path-utils", () => {
     expect(extractPathParams("/v/:123")).toEqual(["123"]);
   });
 
+  it("extractPathParams treats `*` as a catch-all param", () => {
+    expect(extractPathParams("/*")).toEqual(["*"]);
+    expect(extractPathParams("/c/:category/*")).toEqual(["category", "*"]);
+    expect(extractPathParams("/*/x/*")).toEqual(["*"]);
+  });
+
   it("splitPathTemplate interleaves text and param tokens", () => {
     expect(splitPathTemplate("/inspira-novo/blog/:slug")).toEqual([
       { type: "text", text: "/inspira-novo/blog/" },
@@ -57,6 +63,19 @@ describe("page-path-utils", () => {
     ]);
     expect(splitPathTemplate("/about")).toEqual([
       { type: "text", text: "/about" },
+    ]);
+  });
+
+  it("splitPathTemplate emits a param token for `*`", () => {
+    expect(splitPathTemplate("/*")).toEqual([
+      { type: "text", text: "/" },
+      { type: "param", name: "*" },
+    ]);
+    expect(splitPathTemplate("/c/:category/*")).toEqual([
+      { type: "text", text: "/c/" },
+      { type: "param", name: "category" },
+      { type: "text", text: "/" },
+      { type: "param", name: "*" },
     ]);
   });
 
@@ -78,5 +97,23 @@ describe("page-path-utils", () => {
     expect(fillPathTemplate("/:org/:repo", { org: "deco" })).toBe(
       "/deco/:repo",
     );
+  });
+
+  it("fillPathTemplate fills `*` keeping `/` separators, encoding segments", () => {
+    expect(fillPathTemplate("/*", { "*": "category/shoes" })).toBe(
+      "/category/shoes",
+    );
+    expect(fillPathTemplate("/*", { "*": "sapatos femininos" })).toBe(
+      "/sapatos%20femininos",
+    );
+    // Leading/doubled slashes in the typed value are dropped.
+    expect(fillPathTemplate("/*", { "*": "/category//shoes/" })).toBe(
+      "/category/shoes",
+    );
+    expect(fillPathTemplate("/*", { "*": "/" })).toBe("/*");
+    expect(fillPathTemplate("/*", {})).toBe("/*");
+    expect(
+      fillPathTemplate("/c/:category/*", { category: "roupas", "*": "a/b" }),
+    ).toBe("/c/roupas/a/b");
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/page-path-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-path-utils.ts
@@ -22,14 +22,18 @@ export function validatePagePath(path: string): string | null {
   return null;
 }
 
-/** Matches `:param` tokens in page path templates (e.g. `/blog/:slug`, `/:my-cat`). */
-const PATH_PARAM_RE = /:([A-Za-z0-9_-]+)/g;
+/**
+ * Matches dynamic tokens in page path templates: `:param` (e.g. `/blog/:slug`,
+ * `/:my-cat`) and the `*` catch-all (e.g. `/*` for PLPs). The catch-all is
+ * reported under the name `"*"`.
+ */
+const PATH_PARAM_RE = /:([A-Za-z0-9_-]+)|\*/g;
 
-/** Param names (`:slug`) in a page path template, deduped, in order. */
+/** Param names (`:slug`, `*`) in a page path template, deduped, in order. */
 export function extractPathParams(path: string): string[] {
   const names: string[] = [];
   for (const match of path.matchAll(PATH_PARAM_RE)) {
-    const name = match[1]!;
+    const name = match[1] ?? "*";
     if (!names.includes(name)) names.push(name);
   }
   return names;
@@ -39,7 +43,7 @@ export type PathToken =
   | { type: "text"; text: string }
   | { type: "param"; name: string };
 
-/** Split a path template into static text and `:param` tokens, in order. */
+/** Split a path template into static text and `:param`/`*` tokens, in order. */
 export function splitPathTemplate(path: string): PathToken[] {
   const tokens: PathToken[] = [];
   let last = 0;
@@ -47,7 +51,7 @@ export function splitPathTemplate(path: string): PathToken[] {
     if (match.index > last) {
       tokens.push({ type: "text", text: path.slice(last, match.index) });
     }
-    tokens.push({ type: "param", name: match[1]! });
+    tokens.push({ type: "param", name: match[1] ?? "*" });
     last = match.index + match[0].length;
   }
   if (last < path.length) {
@@ -56,13 +60,23 @@ export function splitPathTemplate(path: string): PathToken[] {
   return tokens;
 }
 
-/** Replace `:param` tokens with URL-encoded values; unset/empty values keep the token. */
+/** Replace `:param`/`*` tokens with URL-encoded values; unset/empty values keep the token. */
 export function fillPathTemplate(
   path: string,
   values: Record<string, string>,
 ): string {
-  return path.replace(PATH_PARAM_RE, (token, name: string) => {
-    const value = values[name]?.trim();
-    return value ? encodeURIComponent(value) : token;
+  return path.replace(PATH_PARAM_RE, (token, name?: string) => {
+    const value = values[name ?? "*"]?.trim();
+    if (!value) return token;
+    if (name !== undefined) return encodeURIComponent(value);
+    // The `*` catch-all may span multiple segments (e.g. `category/shoes`):
+    // keep `/` separators, encode each segment, drop empty ones (leading or
+    // doubled slashes in the typed value).
+    const filled = value
+      .split("/")
+      .filter(Boolean)
+      .map(encodeURIComponent)
+      .join("/");
+    return filled || token;
   });
 }


### PR DESCRIPTION
## Summary

Pages with a `*` catch-all in their path (e.g. PLPs at `/*`) now get the same inline URL-bar editor that `:param` templates already have in the preview: the `*` renders in place as an editable input, and the typed value is filled into the iframe navigation.

- `page-path-utils.ts`: the path-template tokenizer (`PATH_PARAM_RE`) now also matches `*`, reported as a param named `"*"`. This propagates to `extractPathParams`, `splitPathTemplate` and `fillPathTemplate` — all consumed only by the preview (other importers use just `normalizePagePath`/`validatePagePath`).
- Fill behavior: `:param` values stay fully URL-encoded (unchanged, including `/`); the `*` value may span multiple segments — `category/shoes` fills to `/category/shoes` (each segment encoded individually, `/` separators kept, leading/doubled slashes in the typed value dropped).
- `preview.tsx`: `PathParamInput` shows `*` as placeholder/label instead of `:*`. Everything else (per-page+branch value persistence, Enter/Escape, keeping the template as `currentPath` so the page stays matched) reuses the existing `:param` infrastructure unchanged.

## Testing

- New unit tests in `page-path-utils.test.ts` covering `/*`, multi-segment values, encoding, empty/unset values, and mixed `/c/:category/*` templates — `bun test` passes (16 tests).
- `bun run fmt`, `bun run lint` (no errors in changed files) and `apps/mesh` typecheck all pass.

Known parity note: navigating via links inside the iframe on a catch-all page sets `currentPath` to the literal path, losing the `/*` page match — same pre-existing behavior as `:param` pages, intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inline editor support for `*` catch-all tokens in preview path templates, so pages like `/*` render `*` as an editable input in the URL bar. Values can span multiple segments; slashes are preserved and segments are URL-encoded.

- **New Features**
  - Path utilities now parse `*` alongside `:param` and propagate through `extractPathParams`, `splitPathTemplate`, and `fillPathTemplate`.
  - Preview URL bar renders `*` as an inline input (placeholder/label `*`), reusing existing `:param` behavior.
  - Fill rules: `:param` remains fully URL-encoded (including `/`); `*` keeps `/` separators, encodes each segment, and drops extra leading/double slashes. Tests cover `/*`, mixed templates, encoding, and empty values.

<sup>Written for commit 9c95c5835ef350eea2e159ed4115cd0efc838194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

