### PR TITLE
test(mesh-sdk): cover selectDefaultModel resolution order and keyId attach

### DIFF
--- a/packages/mesh-sdk/src/lib/default-model.test.ts
+++ b/packages/mesh-sdk/src/lib/default-model.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { selectDefaultModel } from "./default-model";
+import type { AiProviderModel } from "../types/ai-providers";
+
+function model(modelId: string): AiProviderModel {
+  return {
+    providerId: "anthropic",
+    modelId,
+    title: modelId,
+    description: null,
+    logo: null,
+    capabilities: [],
+    limits: null,
+    costs: null,
+  };
+}
+
+describe("selectDefaultModel", () => {
+  it("returns null for an empty model list", () => {
+    expect(selectDefaultModel([], "anthropic")).toBeNull();
+  });
+
+  it("prefers an exact match over a later, higher-priority substring match", () => {
+    const models = [model("claude-sonnet-legacy"), model("claude-sonnet-5")];
+    const result = selectDefaultModel(models, "anthropic");
+    expect(result?.modelId).toBe("claude-sonnet-5");
+  });
+
+  it("falls back to a substring match when no candidate matches exactly", () => {
+    const models = [model("some-claude-sonnet-variant")];
+    const result = selectDefaultModel(models, "anthropic");
+    expect(result?.modelId).toBe("some-claude-sonnet-variant");
+  });
+
+  it("falls back to the first model when no preference matches at all", () => {
+    const models = [model("gpt-5"), model("gemini-3")];
+    const result = selectDefaultModel(models, "anthropic");
+    expect(result?.modelId).toBe("gpt-5");
+  });
+
+  it("returns the first model as-is for a provider with no configured preferences", () => {
+    const models = [model("openai-compatible-model")];
+    const result = selectDefaultModel(models, "openai-compatible");
+    expect(result?.modelId).toBe("openai-compatible-model");
+  });
+
+  it("attaches keyId to the selected model when provided", () => {
+    const models = [model("claude-sonnet-5")];
+    const result = selectDefaultModel(models, "anthropic", "key-123");
+    expect(result?.keyId).toBe("key-123");
+  });
+
+  it("omits keyId when not provided", () => {
+    const models = [model("claude-sonnet-5")];
+    const result = selectDefaultModel(models, "anthropic");
+    expect(result?.keyId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Source
Improvement (Source 3, Option A) — `selectDefaultModel` in `packages/mesh-sdk/src/lib/default-model.ts` had no test coverage despite non-trivial resolution logic (exact match → substring match → first-model fallback, per-provider preference lists, optional `keyId` attach).

## Why
This function picks the default AI model shown across Simple Model Mode and provider key setup — a wrong resolution order regression here would silently steer users to the wrong model with no test to catch it. Locks in the priority order (exact-before-substring across providers) and the `keyId` attach behavior used by `handleModelSelect`.

## Test plan
- `bun test packages/mesh-sdk/src/lib/default-model.test.ts` — 7 new cases: empty list, exact-over-substring priority, substring fallback, first-model fallback (no preferences match), provider with no configured preferences at all, `keyId` attached vs omitted.

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` (mesh-sdk workspace) — clean
- `bun test packages/mesh-sdk/src/lib/default-model.test.ts` — 7 pass

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `selectDefaultModel` in `packages/mesh-sdk` to lock down default model resolution and optional `keyId` attach. Covers exact-over-substring priority, substring and first-model fallbacks, providers without preferences, and presence/absence of `keyId` to prevent regressions.

<sup>Written for commit 071295737253b4ebe64fa68865682f16a7f90090. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

