### PR TITLE
fix(web): align CMS highlight clicks past hidden sections

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/cms-editor-script.ts
@@ -88,21 +88,32 @@ export const CMS_EDITOR_SCRIPT = `(function() {
 
   // Candidate manifest keys per editable section, sent by the editor. Each
   // entry is an array of acceptable DOM keys: [] = wildcard (e.g. multivariate,
-  // whose rendered key we can't predict); a Lazy lists both its loader key and
-  // the inner section's key, since the classic runtime keeps the Lazy wrapper
-  // at top level while TanStack renders the inner section directly.
+  // whose rendered key we can't predict); null = renders NOTHING (hidden
+  // section — multivariate whose variants are all gated by never), so the
+  // alignment must not consume a DOM node for it; a Lazy lists both its loader
+  // key and the inner section's key, since the classic runtime keeps the Lazy
+  // wrapper at top level while TanStack renders the inner section directly.
   var sectionCandidates = [];
 
   // Best in-order assignment of editable sections to DOM sections, maximizing
   // key matches (DP / LCS-style). deco injects framework sections (SEO, Theme,
   // Session, …) that may lead, trail, OR interleave with the editable run; this
-  // skips whichever don't match, on any runtime — no hardcoded list.
+  // skips whichever don't match, on any runtime — no hardcoded list. Hidden
+  // sections (null candidates) have no DOM node: only visible entries are
+  // aligned, then scattered back to their decofile positions (null-filled), so
+  // returned indexes still match the decofile array.
   var computeAlignment = function(tops) {
-    var N = sectionCandidates.length, M = tops.length;
-    if (!N || M < N) return tops.slice();
+    var visible = [], k;
+    for (k = 0; k < sectionCandidates.length; k++) {
+      if (sectionCandidates[k] !== null) visible.push(k);
+    }
+    var N = visible.length, M = tops.length;
+    var res = new Array(sectionCandidates.length).fill(null);
+    if (!N) return res;
+    if (M < N) return tops.slice();
     var domKeys = tops.map(function(s) { return s.getAttribute("data-manifest-key"); });
     var match = function(i, j) {
-      var c = sectionCandidates[i];
+      var c = sectionCandidates[visible[i]];
       if (!c || !c.length) return 1;
       return c.indexOf(domKeys[j]) >= 0 ? 1 : 0;
     };
@@ -116,10 +127,9 @@ export const CMS_EDITOR_SCRIPT = `(function() {
         else { dp[i][j] = assign; bt[i][j] = 1; }
       }
     }
-    var res = new Array(N);
     i = N; j = M;
     while (i > 0) {
-      if (bt[i][j] === 1) { res[i - 1] = tops[j - 1]; i--; j--; }
+      if (bt[i][j] === 1) { res[visible[i - 1]] = tops[j - 1]; i--; j--; }
       else { j--; }
     }
     return res;

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -45,6 +45,7 @@ import {
 import { useDecofile } from "@/web/components/sections-editor/use-decofile";
 import { withVariantMatcherOverride } from "@/web/components/sections-editor/variant-matcher-override";
 import { parseSections } from "@/web/components/sections-editor/parse-sections";
+import { resolveSectionCandidates } from "./section-candidates";
 import { getPageVariantSectionsAt } from "@/web/components/sections-editor/page-variants";
 import { useLiveMeta } from "@/web/components/sections-editor/use-live-meta";
 import {
@@ -133,69 +134,6 @@ const DEVICE_LABELS: Record<PreviewDeviceSize, string> = {
   tablet: "Tablet (768px)",
   desktop: "Desktop",
 };
-
-const LAZY_RESOLVE_TYPE = "website/sections/Rendering/Lazy.tsx";
-
-/**
- * Candidate top-level `data-manifest-key`s a page section can render as, used
- * iframe-side to align the editable run within the DOM. Saved-block refs
- * (globals) resolve to their underlying component. A Lazy returns BOTH its
- * loader key and the inner section's key — the classic runtime keeps the Lazy
- * wrapper at top level, TanStack renders the inner section directly. Multivariate
- * flags render an unpredictable active variant, so they return [] (a wildcard
- * the iframe treats as "matches anything").
- */
-function resolveSectionCandidates(
-  section: { __resolveType?: unknown; section?: unknown; variants?: unknown },
-  decofile: Record<string, unknown>,
-): string[] {
-  let obj: { __resolveType?: unknown; section?: unknown; variants?: unknown } =
-    section;
-  let rt = typeof obj?.__resolveType === "string" ? obj.__resolveType : "";
-  for (let i = 0; rt && i < 5; i++) {
-    const block = decofile[rt];
-    if (block && typeof block === "object" && "__resolveType" in block) {
-      const next = (block as { __resolveType?: unknown }).__resolveType;
-      if (typeof next === "string" && next && next !== rt) {
-        obj = block as typeof obj;
-        rt = next;
-        continue;
-      }
-    }
-    break;
-  }
-  if (!rt) return [];
-  // Multivariate (A/B) renders one of its variants — collect every variant's
-  // possible key so it matches whichever rendered (NOT a blind wildcard, which
-  // could otherwise grab an adjacent framework section).
-  if (rt.includes("flags/multivariate")) {
-    const variants = Array.isArray(obj.variants) ? obj.variants : [];
-    const keys: string[] = [];
-    for (const v of variants) {
-      const value = (v as { value?: unknown })?.value;
-      if (value && typeof value === "object") {
-        for (const k of resolveSectionCandidates(
-          value as { __resolveType?: unknown },
-          decofile,
-        )) {
-          if (!keys.includes(k)) keys.push(k);
-        }
-      }
-    }
-    return keys;
-  }
-  if (rt === LAZY_RESOLVE_TYPE) {
-    const inner =
-      obj.section && typeof obj.section === "object"
-        ? resolveSectionCandidates(
-            obj.section as { __resolveType?: unknown },
-            decofile,
-          )
-        : [];
-    return inner.length ? [rt, ...inner] : [rt];
-  }
-  return [rt];
-}
 
 /**
  * Inline editor for one `:param` token, rendered in place inside the URL

--- a/apps/mesh/src/web/components/sandbox/preview/section-candidates.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/section-candidates.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { resolveSectionCandidates } from "./section-candidates";
+
+const NEVER = "website/matchers/never.ts";
+const SECTION_MULTIVARIATE = "website/flags/multivariate/section.ts";
+const LAZY = "website/sections/Rendering/Lazy.tsx";
+const BANNER = "site/sections/Images/BannersGrid.tsx";
+const HEADER = "site/sections/Header/Header.tsx";
+
+describe("resolveSectionCandidates", () => {
+  it("returns the resolve type for a plain section", () => {
+    expect(resolveSectionCandidates({ __resolveType: BANNER }, {})).toEqual([
+      BANNER,
+    ]);
+  });
+
+  it("returns both loader and inner keys for a lazy section", () => {
+    expect(
+      resolveSectionCandidates(
+        { __resolveType: LAZY, section: { __resolveType: BANNER } },
+        {},
+      ),
+    ).toEqual([LAZY, BANNER]);
+  });
+
+  it("resolves saved-block references through the decofile", () => {
+    expect(
+      resolveSectionCandidates(
+        { __resolveType: "my-saved-header" },
+        { "my-saved-header": { __resolveType: HEADER } },
+      ),
+    ).toEqual([HEADER]);
+  });
+
+  it("collects every variant key of a multivariate section", () => {
+    expect(
+      resolveSectionCandidates(
+        {
+          __resolveType: SECTION_MULTIVARIATE,
+          variants: [
+            { value: { __resolveType: BANNER }, rule: { __resolveType: "x" } },
+            { value: { __resolveType: HEADER }, rule: { __resolveType: "y" } },
+          ],
+        },
+        {},
+      ),
+    ).toEqual([BANNER, HEADER]);
+  });
+
+  it("returns null for a hidden section (single variant gated by never)", () => {
+    expect(
+      resolveSectionCandidates(
+        {
+          __resolveType: SECTION_MULTIVARIATE,
+          variants: [
+            {
+              value: { __resolveType: BANNER },
+              rule: { __resolveType: NEVER },
+            },
+          ],
+        },
+        {},
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when every variant is gated by never", () => {
+    expect(
+      resolveSectionCandidates(
+        {
+          __resolveType: SECTION_MULTIVARIATE,
+          variants: [
+            {
+              value: { __resolveType: BANNER },
+              rule: { __resolveType: NEVER },
+            },
+            {
+              value: { __resolveType: HEADER },
+              rule: { __resolveType: NEVER },
+            },
+          ],
+        },
+        {},
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for a multivariate with no variants", () => {
+    expect(
+      resolveSectionCandidates(
+        { __resolveType: SECTION_MULTIVARIATE, variants: [] },
+        {},
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps never-gated variant keys when another variant can render", () => {
+    // A never variant can still be forced via x-deco-matchers-override, so its
+    // key stays an acceptable DOM match.
+    expect(
+      resolveSectionCandidates(
+        {
+          __resolveType: SECTION_MULTIVARIATE,
+          variants: [
+            {
+              value: { __resolveType: BANNER },
+              rule: { __resolveType: NEVER },
+            },
+            {
+              value: { __resolveType: HEADER },
+              rule: { __resolveType: "website/matchers/always.ts" },
+            },
+          ],
+        },
+        {},
+      ),
+    ).toEqual([BANNER, HEADER]);
+  });
+
+  it("returns null for a lazy wrapper around a hidden section", () => {
+    expect(
+      resolveSectionCandidates(
+        {
+          __resolveType: LAZY,
+          section: {
+            __resolveType: SECTION_MULTIVARIATE,
+            variants: [
+              {
+                value: { __resolveType: BANNER },
+                rule: { __resolveType: NEVER },
+              },
+            ],
+          },
+        },
+        {},
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/preview/section-candidates.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/section-candidates.ts
@@ -1,0 +1,78 @@
+import { NEVER_MATCHER_RESOLVE_TYPE } from "@/web/components/sections-editor/section-types";
+
+const LAZY_RESOLVE_TYPE = "website/sections/Rendering/Lazy.tsx";
+
+/**
+ * Candidate top-level `data-manifest-key`s a page section can render as, used
+ * iframe-side to align the editable run within the DOM. Saved-block refs
+ * (globals) resolve to their underlying component. A Lazy returns BOTH its
+ * loader key and the inner section's key — the classic runtime keeps the Lazy
+ * wrapper at top level, TanStack renders the inner section directly.
+ * Multivariate flags collect every variant's possible key; when NO variant can
+ * ever render (all gated by `never` — the hidden-section shape) the flag
+ * resolves to nothing and produces no DOM node at all, signalled as null so
+ * the iframe alignment doesn't consume a DOM node for it.
+ */
+export function resolveSectionCandidates(
+  section: { __resolveType?: unknown; section?: unknown; variants?: unknown },
+  decofile: Record<string, unknown>,
+): string[] | null {
+  let obj: { __resolveType?: unknown; section?: unknown; variants?: unknown } =
+    section;
+  let rt = typeof obj?.__resolveType === "string" ? obj.__resolveType : "";
+  for (let i = 0; rt && i < 5; i++) {
+    const block = decofile[rt];
+    if (block && typeof block === "object" && "__resolveType" in block) {
+      const next = (block as { __resolveType?: unknown }).__resolveType;
+      if (typeof next === "string" && next && next !== rt) {
+        obj = block as typeof obj;
+        rt = next;
+        continue;
+      }
+    }
+    break;
+  }
+  if (!rt) return [];
+  // Multivariate (A/B) renders one of its variants — collect every variant's
+  // possible key so it matches whichever rendered (NOT a blind wildcard, which
+  // could otherwise grab an adjacent framework section). When EVERY variant is
+  // gated by a `never` matcher (the hidden-section shape) the flag renders
+  // nothing → null. A partially-never multivariate keeps all variants' keys:
+  // a never variant can still render under a matcher override.
+  if (rt.includes("flags/multivariate")) {
+    const variants = Array.isArray(obj.variants) ? obj.variants : [];
+    const allNever =
+      variants.length === 0 ||
+      variants.every((v) => {
+        const rule = (v as { rule?: { __resolveType?: unknown } })?.rule;
+        return rule?.__resolveType === NEVER_MATCHER_RESOLVE_TYPE;
+      });
+    if (allNever) return null;
+    const keys: string[] = [];
+    for (const v of variants) {
+      const value = (v as { value?: unknown })?.value;
+      if (value && typeof value === "object") {
+        for (const k of resolveSectionCandidates(
+          value as { __resolveType?: unknown },
+          decofile,
+        ) ?? []) {
+          if (!keys.includes(k)) keys.push(k);
+        }
+      }
+    }
+    return keys;
+  }
+  // A Lazy whose inner section can never render effectively renders nothing.
+  if (rt === LAZY_RESOLVE_TYPE) {
+    const inner =
+      obj.section && typeof obj.section === "object"
+        ? resolveSectionCandidates(
+            obj.section as { __resolveType?: unknown },
+            decofile,
+          )
+        : [];
+    if (inner === null) return null;
+    return inner.length ? [rt, ...inner] : [rt];
+  }
+  return [rt];
+}


### PR DESCRIPTION
## Summary

When a page has a hidden section — a `website/flags/multivariate/section.ts` whose single variant is gated by `website/matchers/never.ts` (the shape `hideSection` produces) — clicking a section in the CMS preview highlight opened the wrong section.

**Root cause:** a hidden section renders no DOM node, but `resolveSectionCandidates` still sent its variant's manifest key as an alignment candidate. The iframe's DP alignment (`computeAlignment` in `cms-editor-script.ts`) assigns every editable entry exactly one DOM node, so the hidden entry consumed a node belonging to a later section (often a sibling rendering the same component, e.g. another `BannersGrid`), shifting every subsequent index — or, when the DOM ended up with fewer top-level sections than the decofile array, bailed to the fully misaligned fallback.

**Fix (both ends):**
- `resolveSectionCandidates` returns `null` ("renders nothing") when **every** variant of a multivariate is gated by `never` (single-variant hidden shape included), and for a `Lazy` wrapping such a flag. Partially-never multivariates keep all variant keys, since a never variant can still render under an `x-deco-matchers-override` preview.
- `computeAlignment` aligns only the visible (non-null) entries and scatters the result back to decofile positions, so click indexes stay 1:1 with the decofile sections array and the `M < N` fallback counts only sections that actually render.

Hidden sections are `isHidden` (not `isMultivariate`) in the editor, so they can never be forced to render via the variant override flow — the `null` marker is safe there.

Also extracts `resolveSectionCandidates` from `preview.tsx` into `section-candidates.ts` with unit tests.

## Testing

- 9 new unit tests in `section-candidates.test.ts` (hidden with 1/N variants, empty multivariate, mixed never+always, lazy-over-hidden, saved-block refs)
- All 468 existing tests under `sandbox/preview/` + `sections-editor/` pass
- `bun run fmt`, `bun run lint` and `tsc --noEmit` (apps/mesh) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned CMS preview highlights when pages contain hidden sections gated by `website/matchers/never.ts`. Hidden sections no longer consume a DOM slot in alignment, so clicks open the correct decofile section.

- **Bug Fixes**
  - `resolveSectionCandidates` returns null for multivariates where all variants use `never`, and for a `Lazy` wrapping such content; partially-`never` flags still return all variant keys for override preview.
  - `computeAlignment` aligns only non-null entries and scatters results back to original positions, preserving 1:1 indexes and fixing the M < N fallback.

- **Refactors**
  - Extracted `resolveSectionCandidates` to `section-candidates.ts` with unit tests.

<sup>Written for commit f83c4873dbdc25f07c9ffa11c13e534ec259af96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

