### PR TITLE
fix(commerce-discovery): completo email deep-links to report app view

### DIFF
--- a/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   bindCommerceDiscoveryResource,
+  CommerceDiscoveryClaimError,
+  commerceDiscoveryClaimMessagePtBr,
   fetchCommerceDiscoveryAuth,
   fetchCommerceDiscoveryConnectionStatus,
   triggerCommerceDiscoveryRun,
@@ -83,6 +85,74 @@ describe("fetchCommerceDiscoveryAuth", () => {
     );
   });
 
+  async function captureClaimError(
+    fetchImpl: () => Promise<Response>,
+    input: Partial<{ siteUrl: string; email: string }> = {},
+  ): Promise<CommerceDiscoveryClaimError> {
+    try {
+      await fetchCommerceDiscoveryAuth(
+        {
+          siteUrl: input.siteUrl ?? "https://example.com",
+          orgId: "org_123",
+          ...(input.email ? { email: input.email } : {}),
+        },
+        {
+          baseUrl: "https://commerce.example.test",
+          apiKey: "master-key",
+          fetchImpl,
+        },
+      );
+    } catch (error) {
+      if (error instanceof CommerceDiscoveryClaimError) return error;
+      throw error;
+    }
+    throw new Error("expected fetchCommerceDiscoveryAuth to reject");
+  }
+
+  test("maps a 403 ownership_unverified to a friendly pt-BR message with email + domain", async () => {
+    const error = await captureClaimError(
+      async () =>
+        Response.json(
+          { error: "ownership_unverified", reason: "domain_mismatch" },
+          { status: 403 },
+        ),
+      { siteUrl: "https://loja.com.br/path", email: "someone@gmail.com" },
+    );
+
+    expect(error.code).toBe("ownership_unverified");
+    expect(error.message).toContain("someone@gmail.com");
+    expect(error.message).toContain("loja.com.br");
+    expect(error.message).toContain("permissão para reivindicar");
+  });
+
+  test("maps a 409 already_claimed_by_other_org to a distinct support message", async () => {
+    const error = await captureClaimError(
+      async () =>
+        Response.json(
+          { error: "already_claimed_by_other_org" },
+          { status: 409 },
+        ),
+      { email: "owner@example.com" },
+    );
+
+    expect(error.code).toBe("already_claimed_by_other_org");
+    expect(error.message).toContain("outra organização");
+    expect(error.message).toContain("suporte");
+    // Must NOT tell the user to just retry.
+    expect(error.message).not.toContain("Tente novamente");
+  });
+
+  test("maps an unrecognized/generic upgrade failure to the generic fallback", async () => {
+    const error = await captureClaimError(async () =>
+      Response.json({ error: "missing_org_id" }, { status: 400 }),
+    );
+
+    expect(error.code).toBe("unknown");
+    expect(error.message).toContain(
+      "Não foi possível configurar o Commerce Discovery",
+    );
+  });
+
   test("rejects upgrade responses without a token", async () => {
     await expect(
       fetchCommerceDiscoveryAuth(
@@ -99,6 +169,48 @@ describe("fetchCommerceDiscoveryAuth", () => {
     ).rejects.toThrow(
       "Commerce Discovery auth response did not include a token.",
     );
+  });
+});
+
+describe("commerceDiscoveryClaimMessagePtBr", () => {
+  test("ownership_unverified interpolates email + domain and guides to a different email / domain alias", () => {
+    const message = commerceDiscoveryClaimMessagePtBr("ownership_unverified", {
+      email: "someone@gmail.com",
+      domain: "loja.com.br",
+    });
+    expect(message).toContain("someone@gmail.com");
+    expect(message).toContain("loja.com.br");
+    expect(message).toContain("e-mail do domínio do site");
+    expect(message).toContain("autorizar seu domínio");
+  });
+
+  test("ownership_unverified degrades gracefully without email/domain", () => {
+    const message = commerceDiscoveryClaimMessagePtBr("ownership_unverified");
+    expect(message).toContain("Este e-mail");
+    expect(message).toContain("este site");
+  });
+
+  test("already_claimed_by_other_org points to support and does NOT suggest retrying", () => {
+    const message = commerceDiscoveryClaimMessagePtBr(
+      "already_claimed_by_other_org",
+    );
+    expect(message).toContain("outra organização");
+    expect(message).toContain("suporte");
+    expect(message).not.toContain("Tente novamente");
+  });
+
+  test("the two main codes produce genuinely different messages", () => {
+    expect(commerceDiscoveryClaimMessagePtBr("ownership_unverified")).not.toBe(
+      commerceDiscoveryClaimMessagePtBr("already_claimed_by_other_org"),
+    );
+  });
+
+  test("unknown falls back to a generic friendly message", () => {
+    const message = commerceDiscoveryClaimMessagePtBr("unknown");
+    expect(message).toContain(
+      "Não foi possível configurar o Commerce Discovery",
+    );
+    expect(message).toContain("Tente novamente");
   });
 });
 

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.ts
@@ -85,6 +85,96 @@ function domainFromSiteUrl(siteUrl: string): string {
   return new URL(siteUrl).hostname;
 }
 
+/**
+ * Structured claim-failure codes returned by Commerce Discovery's
+ * `/upgrade` endpoint. `unknown` is our catch-all for any other error string
+ * (missing_org_id, invalid_domain, …) or a non-structured/network failure.
+ */
+export type CommerceDiscoveryClaimCode =
+  | "ownership_unverified"
+  | "already_claimed_by_other_org"
+  | "unknown";
+
+function isClaimCode(value: unknown): value is CommerceDiscoveryClaimCode {
+  return (
+    value === "ownership_unverified" || value === "already_claimed_by_other_org"
+  );
+}
+
+/**
+ * Context available for interpolating friendly claim-failure messages.
+ * `email` is the logged-in user's email (who tried to claim); `domain` is the
+ * site being claimed. Both may be absent, so the mapper degrades gracefully.
+ */
+export interface CommerceDiscoveryClaimContext {
+  email?: string;
+  domain?: string;
+}
+
+/**
+ * Map a structured claim-failure code to a user-facing pt-BR message with the
+ * RIGHT guidance per failure. Interpolates the email + domain when available.
+ *
+ * This lives at the studio boundary (not the UI) because only the thrown
+ * Error's `.message` string survives the MCP self-tool-call boundary — the
+ * structured `code` does not reach the web app (see `parseSelfToolResult` /
+ * `getToolErrorMessage` in commerce-onboarding.tsx, which only read
+ * `result.content[].text`). Building the friendly string here makes
+ * `error.message` already user-ready in the onboarding banner.
+ */
+export function commerceDiscoveryClaimMessagePtBr(
+  code: CommerceDiscoveryClaimCode,
+  context: CommerceDiscoveryClaimContext = {},
+): string {
+  switch (code) {
+    case "ownership_unverified": {
+      const who = context.email ? `O e-mail ${context.email}` : "Este e-mail";
+      const site = context.domain ? ` ${context.domain}` : " este site";
+      return `${who} não tem permissão para reivindicar${site}. Use um e-mail do domínio do site ou peça ao suporte para autorizar seu domínio.`;
+    }
+    case "already_claimed_by_other_org":
+      return "Este site já pertence a outra organização. Fale com o suporte para transferir o acesso.";
+    case "unknown":
+      return "Não foi possível configurar o Commerce Discovery. Tente novamente ou fale com o suporte.";
+    default: {
+      const _exhaustive: never = code;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * A claim (`/upgrade`) failure carrying the structured `code` parsed from the
+ * response JSON's `error` field. Its `.message` is already the friendly pt-BR
+ * text — the seam chosen because the code cannot cross the MCP tool boundary.
+ */
+export class CommerceDiscoveryClaimError extends Error {
+  readonly code: CommerceDiscoveryClaimCode;
+
+  constructor(
+    code: CommerceDiscoveryClaimCode,
+    context: CommerceDiscoveryClaimContext = {},
+  ) {
+    super(commerceDiscoveryClaimMessagePtBr(code, context));
+    this.name = "CommerceDiscoveryClaimError";
+    this.code = code;
+  }
+}
+
+/** Parse the `error` code from an `/upgrade` failure response body. */
+async function parseClaimErrorCode(
+  response: Response,
+): Promise<CommerceDiscoveryClaimCode> {
+  const text = await response.text().catch(() => "");
+  if (!text) return "unknown";
+  try {
+    const parsed = JSON.parse(text) as { error?: unknown };
+    return isClaimCode(parsed.error) ? parsed.error : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
 async function responseErrorMessage(response: Response): Promise<string> {
   const fallback = `Commerce Discovery auth failed with status ${response.status}.`;
   const text = await response.text().catch(() => "");
@@ -131,7 +221,16 @@ export async function fetchCommerceDiscoveryAuth(
   });
 
   if (!response.ok) {
-    throw new Error(await responseErrorMessage(response));
+    // Claim (/upgrade) failures carry a structured `error` code. Because that
+    // code cannot cross the MCP self-tool-call boundary (only the message
+    // string does), we build the friendly pt-BR message HERE, interpolating
+    // the email + domain the client already holds, so the onboarding banner
+    // shows correct per-code guidance verbatim.
+    const code = await parseClaimErrorCode(response);
+    throw new CommerceDiscoveryClaimError(code, {
+      email: input.email,
+      domain,
+    });
   }
 
   const parsed = UpgradeResponseSchema.safeParse(await response.json());

--- a/apps/mesh/src/tools/commerce-discovery/setup.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.test.ts
@@ -109,6 +109,18 @@ describe("COMMERCE_DISCOVERY_SETUP", () => {
     expect(claimArg.siteUrl).toBe("https://new-site.com");
     expect(claimArg.orgId).toBe(ORG_ID);
 
+    // The completion-email CTA ("diagnóstico completo") must deep-link to the
+    // report APP VIEW, not the /commerce-onboarding page: /$org/$taskId with the
+    // vMCP selected and its report view pinned open (chat closed).
+    const reportUrl = (
+      claimArg as unknown as { reportUrl?: string }
+    ).reportUrl!;
+    expect(reportUrl).toContain("https://mesh.example.com/test-org/");
+    expect(reportUrl).toContain("virtualmcpid=commerce-discovery_");
+    expect(reportUrl).toContain("main=app"); // "app:<connId>:<toolName>" pinned view
+    expect(reportUrl).toContain("chat=0");
+    expect(reportUrl).not.toContain("commerce-onboarding");
+
     // The connection must be updated with the fresh token and the new siteUrl.
     expect(updates).toHaveLength(1);
     const update = updates[0]!;

--- a/apps/mesh/src/tools/commerce-discovery/setup.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { StudioContext } from "../../core/studio-context";
+
+const USER_ID = "user_1";
+const ORG_ID = "org_1";
+
+// setup.ts imports fetchCommerceDiscoveryAuth at module top with no injection
+// seam, so we stub the module before importing the tool. This lets us assert
+// that SETUP always calls the per-site claim (/upgrade) even when a per-org
+// connection already exists with a token.
+const fetchAuthMock = mock(
+  async (_input: unknown): Promise<{ authorizationToken: string }> => ({
+    authorizationToken: "dgn_fresh_token",
+  }),
+);
+
+mock.module("./auth-client", () => ({
+  fetchCommerceDiscoveryAuth: fetchAuthMock,
+}));
+
+const { COMMERCE_DISCOVERY_SETUP } = await import("./setup");
+
+interface StubConnection {
+  id: string;
+  connection_token?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+interface StubVirtualMcp {
+  id: string;
+  pinned?: boolean;
+}
+
+function makeCtx(opts: {
+  existingConnection?: StubConnection;
+  existingVirtualMcp?: StubVirtualMcp;
+  connectionUpdate: (id: string, data: Record<string, unknown>) => void;
+}): StudioContext {
+  let connection = opts.existingConnection ?? null;
+  const virtualMcp = opts.existingVirtualMcp ?? { id: "vmcp_1", pinned: true };
+
+  return {
+    auth: {
+      user: {
+        id: USER_ID,
+        email: "owner@example.com",
+        name: "Owner",
+        role: "user",
+      },
+    },
+    access: {
+      granted: () => true,
+      check: async () => {},
+      grant: () => {},
+      setToolName: () => {},
+    },
+    organization: { id: ORG_ID, slug: "test-org", name: "Test Org" },
+    baseUrl: "https://mesh.example.com",
+    storage: {
+      connections: {
+        findById: async () => connection,
+        update: async (id: string, data: Record<string, unknown>) => {
+          opts.connectionUpdate(id, data);
+          connection = { ...(connection ?? { id }), ...data } as StubConnection;
+          return connection;
+        },
+        create: async (data: Record<string, unknown>) => {
+          connection = { id: "conn_1", ...data } as StubConnection;
+          return connection;
+        },
+      },
+      virtualMcps: {
+        findById: async () => virtualMcp,
+        create: async () => virtualMcp,
+        update: async () => virtualMcp,
+      },
+    },
+    metadata: { requestId: "req_1", timestamp: new Date() },
+  } as unknown as StudioContext;
+}
+
+describe("COMMERCE_DISCOVERY_SETUP", () => {
+  test("claims the site and syncs token + metadata even when a connection with a token already exists", async () => {
+    fetchAuthMock.mockClear();
+    const updates: Array<{ id: string; data: Record<string, unknown> }> = [];
+
+    const ctx = makeCtx({
+      // Existing per-org connection that already has a (stale) token — the bug
+      // was that this path skipped /upgrade entirely for a newly onboarded site.
+      existingConnection: {
+        id: "conn_1",
+        connection_token: "dgn_stale_token",
+        metadata: { siteUrl: "https://old-site.com" },
+      },
+      connectionUpdate: (id, data) => updates.push({ id, data }),
+    });
+
+    await COMMERCE_DISCOVERY_SETUP.handler(
+      { siteUrl: "https://new-site.com" },
+      ctx,
+    );
+
+    // The per-site claim (/upgrade) must be called for the current site.
+    expect(fetchAuthMock).toHaveBeenCalledTimes(1);
+    const claimArg = fetchAuthMock.mock.calls[0]?.[0] as {
+      siteUrl: string;
+      orgId: string;
+    };
+    expect(claimArg.siteUrl).toBe("https://new-site.com");
+    expect(claimArg.orgId).toBe(ORG_ID);
+
+    // The connection must be updated with the fresh token and the new siteUrl.
+    expect(updates).toHaveLength(1);
+    const update = updates[0]!;
+    expect(update.id).toBe("conn_1");
+    expect(update.data.connection_token).toBe("dgn_fresh_token");
+    expect((update.data.metadata as Record<string, unknown>).siteUrl).toBe(
+      "https://new-site.com",
+    );
+  });
+});

--- a/apps/mesh/src/tools/commerce-discovery/setup.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.ts
@@ -103,13 +103,25 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
     const virtualMcpId = getCommerceDiscoveryAgentId(organization.id);
 
     // Claim contact forwarded on /upgrade: Commerce Discovery emails this
-    // address when the run completes (the "generating" screen's promise),
-    // linking back to this workspace's onboarding report.
+    // address when the run completes (the "generating" screen's promise). The
+    // "diagnóstico completo" CTA must land on the report app view — NOT the
+    // /commerce-onboarding page. Build the exact URL the onboarding "open report"
+    // button navigates to (commerce-onboarding.tsx): /$org/$taskId with the vMCP
+    // selected and its report view pinned open. connectionId + virtualMcpId are
+    // deterministic per org, so the URL is fully known here at /upgrade time.
+    //   main="app:<connectionId>:<toolName>" — pinned-view tab grammar
+    //   (web/layouts/main-panel-tabs/tab-id.ts:formatPinnedViewTabId).
+    //   chat=0 keeps the chat panel closed (report-first), matching the button.
+    const reportSearch = new URLSearchParams({
+      virtualmcpid: virtualMcpId,
+      main: `app:${connectionId}:${REPORT_TOOL_NAME}`,
+      chat: "0",
+    });
     const claimContact = {
       email: ctx.auth.user?.email,
-      reportUrl: `${ctx.baseUrl}/commerce-onboarding?org=${encodeURIComponent(
+      reportUrl: `${ctx.baseUrl}/${encodeURIComponent(
         organization.slug ?? organization.id,
-      )}&siteUrl=${encodeURIComponent(normalized.value)}`,
+      )}/${crypto.randomUUID()}?${reportSearch.toString()}`,
     };
 
     let connection = await ctx.storage.connections.findById(

--- a/apps/mesh/src/tools/commerce-discovery/setup.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.ts
@@ -41,10 +41,6 @@ const CommerceDiscoverySetupOutputSchema = z.object({
   }),
 });
 
-function isMissingToken(connection: ConnectionEntity): boolean {
-  return !connection.connection_token;
-}
-
 async function rereadConnectionOrThrow(
   ctx: StudioContext,
   connectionId: string,
@@ -125,33 +121,44 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
       virtualMcp: false,
     };
 
-    if (connection && isMissingToken(connection)) {
-      const auth = await fetchCommerceDiscoveryAuth({
-        siteUrl: normalized.value,
-        orgId: organization.id,
-        orgName: organization.name,
-        ...claimContact,
-      });
-      if (auth.authorizationToken) {
-        console.log("[commerce-discovery] repairing missing auth token", {
-          orgId: organization.id,
-          siteUrl: normalized.value,
-          connectionId,
-        });
-        connection = await ctx.storage.connections.update(connection.id, {
-          connection_token: auth.authorizationToken,
-        });
-      }
-    }
+    // Claim the CURRENT site for this org, unconditionally, on every setup.
+    //
+    // The claim is Commerce Discovery's master-gated per-(org, site) upgrade —
+    // POST /api/v2/internal/diagnostics/:domain/upgrade — which sets the
+    // diagnostic to private, links the org, and mints a fresh report token.
+    // But the studio-side connection is keyed per ORG
+    // (WellKnownOrgMCPId.COMMERCE_DISCOVERY(organization.id)), not per site.
+    //
+    // Previously the /upgrade was only called when the connection was missing
+    // (or missing its token). So selecting an EXISTING org whose connection
+    // already had a token skipped /upgrade entirely for the new site: the site
+    // was never claimed, and the subsequent /run returned 409 not_upgraded (no
+    // private run ever started). Decouple the two lifecycles: always claim the
+    // site here (upgrade is idempotent per (org, site)), then persist the
+    // freshly-minted token + siteUrl onto the per-org connection so it follows
+    // the site currently being onboarded and always holds the newest token.
+    //
+    // This also keeps us consistent with commerce-discovery#184, which revokes
+    // prior report tokens for the URL on each /upgrade — because we persist the
+    // token returned by THIS upgrade, the connection never holds a revoked one.
+    const auth = await fetchCommerceDiscoveryAuth({
+      siteUrl: normalized.value,
+      orgId: organization.id,
+      orgName: organization.name,
+      ...claimContact,
+    });
 
-    if (!connection) {
-      const auth = await fetchCommerceDiscoveryAuth({
-        siteUrl: normalized.value,
+    if (connection) {
+      console.log("[commerce-discovery] syncing connection to claimed site", {
         orgId: organization.id,
-        orgName: organization.name,
-        ...claimContact,
+        siteUrl: normalized.value,
+        connectionId,
       });
-
+      connection = await ctx.storage.connections.update(connection.id, {
+        connection_token: auth.authorizationToken,
+        metadata: { ...(connection.metadata ?? {}), siteUrl: normalized.value },
+      });
+    } else {
       console.log("[commerce-discovery] creating connection", {
         orgId: organization.id,
         siteUrl: normalized.value,


### PR DESCRIPTION
## Summary

The "diagnóstico completo" completion email was sending users to the **/commerce-onboarding** page instead of the actual diagnostic report.

The claim contact's `reportUrl` (forwarded to Commerce Discovery on `/upgrade`, used as the email CTA) was built as `/commerce-onboarding?org=&siteUrl=`. This changes it to the exact URL the onboarding "open report" button navigates to:

```
{baseUrl}/{org.slug}/{taskId}?virtualmcpid=commerce-discovery_...&main=app:{connId}:get_my_diagnostic&chat=0
```

`connectionId` + `virtualMcpId` are deterministic per org, so the full URL is known at `/upgrade` time — no extra round-trip.

The public (initial) email is unrelated and unchanged (still the `decocms.com/site` LP).

## Also in this branch

- `always claim the current site on setup` — earlier onboarding fix
- `friendly pt-BR claim-failure messages` — earlier onboarding fix

## Test plan

- [x] `setup.test.ts` asserts the CTA deep-links to the report view (contains `virtualmcpid=commerce-discovery_`, `main=app`, `chat=0`) and NOT `commerce-onboarding`
- [x] `bun test` passes, `tsc --noEmit` clean

Pairs with commerce-discovery#194 (fallback safety net when `report_url` is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “diagnóstico completo” email to open the actual report view, always claims the current site during setup, and shows clearer pt-BR messages when a claim fails. Users land in the report directly, runs start reliably, and errors are easier to act on.

- **Bug Fixes**
  - Email CTA now deep-links to the report app view: /{org}/{taskId}?virtualmcpid=commerce-discovery_...&main=app:{connectionId}:get_my_diagnostic&chat=0 (no more /commerce-onboarding).
  - Setup always claims the current site (calls `/upgrade`) and syncs the fresh token + `metadata.siteUrl` on the per-org connection, preventing 409 not_upgraded.
  - Maps `/upgrade` failures to friendly pt-BR messages with `CommerceDiscoveryClaimError`:
    - `ownership_unverified` and `already_claimed_by_other_org` with specific guidance (interpolates email/domain when available).
    - `unknown` falls back to a generic message.

<sup>Written for commit 31eacfa974501a1d58e29e35c5a3b5fd1e9fbabe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

