### PR TITLE
fix(commerce-discovery): completo email deep-links to report app view

### DIFF
--- a/apps/mesh/src/tools/commerce-discovery/setup.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.test.ts
@@ -109,6 +109,17 @@ describe("COMMERCE_DISCOVERY_SETUP", () => {
     expect(claimArg.siteUrl).toBe("https://new-site.com");
     expect(claimArg.orgId).toBe(ORG_ID);
 
+    // The completion-email CTA ("diagnóstico completo") must deep-link to the
+    // report APP VIEW, not the /commerce-onboarding page: /$org/$taskId with the
+    // vMCP selected and its report view pinned open (chat closed).
+    const reportUrl = (claimArg as unknown as { reportUrl?: string })
+      .reportUrl!;
+    expect(reportUrl).toContain("https://mesh.example.com/test-org/");
+    expect(reportUrl).toContain("virtualmcpid=commerce-discovery_");
+    expect(reportUrl).toContain("main=app"); // "app:<connId>:<toolName>" pinned view
+    expect(reportUrl).toContain("chat=0");
+    expect(reportUrl).not.toContain("commerce-onboarding");
+
     // The connection must be updated with the fresh token and the new siteUrl.
     expect(updates).toHaveLength(1);
     const update = updates[0]!;

--- a/apps/mesh/src/tools/commerce-discovery/setup.ts
+++ b/apps/mesh/src/tools/commerce-discovery/setup.ts
@@ -103,13 +103,25 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
     const virtualMcpId = getCommerceDiscoveryAgentId(organization.id);
 
     // Claim contact forwarded on /upgrade: Commerce Discovery emails this
-    // address when the run completes (the "generating" screen's promise),
-    // linking back to this workspace's onboarding report.
+    // address when the run completes (the "generating" screen's promise). The
+    // "diagnóstico completo" CTA must land on the report app view — NOT the
+    // /commerce-onboarding page. Build the exact URL the onboarding "open report"
+    // button navigates to (commerce-onboarding.tsx): /$org/$taskId with the vMCP
+    // selected and its report view pinned open. connectionId + virtualMcpId are
+    // deterministic per org, so the URL is fully known here at /upgrade time.
+    //   main="app:<connectionId>:<toolName>" — pinned-view tab grammar
+    //   (web/layouts/main-panel-tabs/tab-id.ts:formatPinnedViewTabId).
+    //   chat=0 keeps the chat panel closed (report-first), matching the button.
+    const reportSearch = new URLSearchParams({
+      virtualmcpid: virtualMcpId,
+      main: `app:${connectionId}:${REPORT_TOOL_NAME}`,
+      chat: "0",
+    });
     const claimContact = {
       email: ctx.auth.user?.email,
-      reportUrl: `${ctx.baseUrl}/commerce-onboarding?org=${encodeURIComponent(
+      reportUrl: `${ctx.baseUrl}/${encodeURIComponent(
         organization.slug ?? organization.id,
-      )}&siteUrl=${encodeURIComponent(normalized.value)}`,
+      )}/${crypto.randomUUID()}?${reportSearch.toString()}`,
     };
 
     let connection = await ctx.storage.connections.findById(


### PR DESCRIPTION
## Summary

The "diagnóstico completo" completion email was sending users to the **/commerce-onboarding** page instead of the actual diagnostic report.

The claim contact's `reportUrl` (forwarded to Commerce Discovery on `/upgrade`, used as the email CTA) was built as `/commerce-onboarding?org=&siteUrl=`. This changes it to the exact URL the onboarding "open report" button navigates to:

```
{baseUrl}/{org.slug}/{taskId}?virtualmcpid=commerce-discovery_...&main=app:{connId}:get_my_diagnostic&chat=0
```

`connectionId` + `virtualMcpId` are deterministic per org, so the full URL is known at `/upgrade` time — no extra round-trip.

The public (initial) email is unrelated and unchanged (still the `decocms.com/site` LP).

## Test plan

- [x] `setup.test.ts` asserts the CTA deep-links to the report view (contains `virtualmcpid=commerce-discovery_`, `main=app`, `chat=0`) and NOT `commerce-onboarding`
- [x] `bun test` passes, `tsc --noEmit` clean

Pairs with commerce-discovery#194 (fallback safety net when `report_url` is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “diagnóstico completo” email CTA to open the diagnostic report app view instead of the onboarding page. Users land directly on the report with the correct vMCP selected and chat closed.

- **Bug Fixes**
  - Build `reportUrl` as `/{org}/{taskId}?virtualmcpid=...&main=app:<connectionId>:<tool>&chat=0` at `/upgrade` (values are deterministic; no extra round-trip).
  - Tests confirm the deep link targets the report view (and not `/commerce-onboarding`). Public initial email remains unchanged.

<sup>Written for commit c56d9380579a7c6a0795e6f4440274561776eaba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

