### PR TITLE
test(web): cover provision-repo-scoped-github-connection helpers

### DIFF
--- a/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.test.ts
+++ b/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isHttpTokenEndpoint,
+  nonEmptyString,
+  normalizeRepositoryId,
+} from "./provision-repo-scoped-github-connection.ts";
+
+describe("nonEmptyString", () => {
+  test("trims and accepts a non-empty string", () => {
+    expect(nonEmptyString("  hello  ")).toBe("hello");
+  });
+
+  test("rejects whitespace-only strings", () => {
+    expect(nonEmptyString("   ")).toBeNull();
+  });
+
+  test("rejects non-string values", () => {
+    expect(nonEmptyString(undefined)).toBeNull();
+    expect(nonEmptyString(123)).toBeNull();
+  });
+});
+
+describe("isHttpTokenEndpoint", () => {
+  test("accepts plain https/http URLs", () => {
+    expect(isHttpTokenEndpoint("https://github.com/token")).toBe(true);
+    expect(isHttpTokenEndpoint("http://github.com/token")).toBe(true);
+  });
+
+  test("rejects non-http(s) protocols", () => {
+    expect(isHttpTokenEndpoint("javascript:alert(1)")).toBe(false);
+    expect(isHttpTokenEndpoint("ftp://github.com/token")).toBe(false);
+  });
+
+  test("rejects URLs carrying embedded credentials", () => {
+    expect(isHttpTokenEndpoint("https://user:pass@github.com/token")).toBe(
+      false,
+    );
+  });
+
+  test("rejects malformed URLs", () => {
+    expect(isHttpTokenEndpoint("not a url")).toBe(false);
+  });
+});
+
+describe("normalizeRepositoryId", () => {
+  test("accepts positive integers", () => {
+    expect(normalizeRepositoryId(42)).toBe(42);
+  });
+
+  test("rejects non-integers, non-positive numbers, and non-numbers", () => {
+    expect(normalizeRepositoryId(1.5)).toBeUndefined();
+    expect(normalizeRepositoryId(0)).toBeUndefined();
+    expect(normalizeRepositoryId(-1)).toBeUndefined();
+    expect(normalizeRepositoryId(Number.NaN)).toBeUndefined();
+    expect(normalizeRepositoryId("42")).toBeUndefined();
+  });
+});

--- a/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
+++ b/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
@@ -9,7 +9,7 @@ type McpCallTool = (req: {
 const REFRESH_GRANT_METADATA_ERROR =
   "GitHub MCP did not return refreshable repo grant metadata";
 
-function nonEmptyString(value: unknown): string | null {
+export function nonEmptyString(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
   }
@@ -17,7 +17,7 @@ function nonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function isHttpTokenEndpoint(value: string): boolean {
+export function isHttpTokenEndpoint(value: string): boolean {
   try {
     const url = new URL(value);
     return (
@@ -30,7 +30,7 @@ function isHttpTokenEndpoint(value: string): boolean {
   }
 }
 
-function normalizeRepositoryId(value: unknown): number | undefined {
+export function normalizeRepositoryId(value: unknown): number | undefined {
   return typeof value === "number" &&
     Number.isFinite(value) &&
     Number.isInteger(value) &&


### PR DESCRIPTION
## Source
Missing unit test coverage (Source 3) — `apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts` had three pure validation helpers with zero tests, discovered while scanning recently-changed files for uncovered logic.

## Why this is worth merging
`isHttpTokenEndpoint` is a real trust-boundary check: it decides whether a `tokenEndpoint` returned by the GitHub MCP is safe to persist and later use for token refresh (rejecting non-http(s) protocols and URLs carrying embedded credentials like `https://user:pass@evil.com`). That kind of validation logic deserves a pinned regression test, not just eyeballing.

## What changed
- Exported the three previously-private helpers (`nonEmptyString`, `isHttpTokenEndpoint`, `normalizeRepositoryId`) so they're testable in isolation.
- Added `provision-repo-scoped-github-connection.test.ts` covering: string trimming/emptiness, accepted vs. rejected URL protocols, embedded-credential rejection, malformed URLs, and repository-id normalization edge cases (non-integer, zero, negative, NaN, string).

## How to verify
```
bun test apps/mesh/src/web/lib/provision-repo-scoped-github-connection.test.ts
```

## Checks run locally
- `bun run fmt` — clean
- `bun test apps/mesh/src/web/lib/provision-repo-scoped-github-connection.test.ts` — 9 pass, 0 fail

Full typecheck/lint/e2e will run in CI (this laptop has no Docker/Postgres/NATS, and a pre-existing unrelated missing dep — `use-stick-to-bottom` — blocks a full `tsc --noEmit` locally regardless of this change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for the GitHub repo-scope provisioning helpers and export them for isolated testing. Pins validation for safe HTTP(S) token endpoints (no credentials, no non-http protocols) and strict repo ID normalization.

<sup>Written for commit 80e3b913cd64b21623b08fe0ad7574bc4d7e96b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

