### PR TITLE
feat(thread/github): split Submit for review and Publish into separate header actions

### DIFF
--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -48,9 +48,10 @@ const LOADING_BRANCH_BUTTON: HeaderButton = {
 };
 
 /**
- * HeaderActions renders a single next-action button for the current branch +
- * PR state. Save changes opens the publish dialog; open-PR and squash-merge
- * call GitHub MCP tools directly. Other actions still send chat prompts.
+ * HeaderActions renders the next-action button for the current branch + PR
+ * state, plus a persistent green "Publish" button beside it while there is
+ * local work not yet merged. Submit-for-review and squash-merge call GitHub
+ * MCP tools directly (via the publish dialog); other actions send chat prompts.
  *
  * Mounted for `attached` and `detached` repos (see resolveGithubAttachment).
  * When attached the button always renders — disabled status pills (Loading…,
@@ -65,8 +66,8 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const chat = useChatStream();
   const [publishOpen, setPublishOpen] = useState(false);
   const [publishDialogIntent, setPublishDialogIntent] = useState<
-    "publish" | "open-pr" | "publish-only"
-  >("publish");
+    "open-pr" | "publish-only"
+  >("open-pr");
   const [githubActionPending, setGithubActionPending] = useState(false);
   const debugKeyRef = useRef("");
 
@@ -261,10 +262,6 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const onActivate = (action: HeaderButton["action"]) => {
     if (!action || !githubHeadBranch) return;
     switch (action) {
-      case "commit-and-push":
-        setPublishDialogIntent("publish");
-        setPublishOpen(true);
-        return;
       case "create-pr":
         setPublishDialogIntent("open-pr");
         setPublishOpen(true);
@@ -305,15 +302,11 @@ export function HeaderActions({ virtualMcpId }: Props) {
     setPublishOpen(true);
   };
 
-  // A persistent green "Publish" button sits next to the primary button
-  // whenever there's local work not yet in a PR — i.e. the primary button is
-  // "Save changes" (commit-and-push) or "Submit for review" (create-pr). It
-  // opens the publish dialog in publish-only mode (single green button, gated
-  // by isDecoOnlyDiff so code changes still require review). Suppressed once
-  // the primary button IS the publish action (merge-split) to avoid two
-  // publish affordances at once.
-  const showPublishSide =
-    button.action === "commit-and-push" || button.action === "create-pr";
+  // The persistent green "Publish" button (publish-only dialog, single green
+  // button gated by isDecoOnlyDiff so code changes still require review) is
+  // owned by the panel-state descriptor — set on states with local work not
+  // yet merged, and never on merge-split (where the primary button IS publish).
+  const showPublishSide = button.showPublishSide ?? false;
 
   const actionBusy = githubActionPending || isStreaming;
 
@@ -388,7 +381,6 @@ function HeaderButtonRenderer(props: {
   const chatBlocksAction =
     actionBusy &&
     button.action !== "create-pr" &&
-    button.action !== "commit-and-push" &&
     button.action !== "merge-split";
   const disabled =
     Boolean(button.disabled) ||
@@ -435,7 +427,7 @@ function HeaderButtonRenderer(props: {
         </Button>
       </WithTooltip>
       {props.showPublishSide ? (
-        <WithTooltip label="Publish directly to production">
+        <WithTooltip label="Publish directly, skipping review">
           <Button
             size="sm"
             variant="success"

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -65,7 +65,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const chat = useChatStream();
   const [publishOpen, setPublishOpen] = useState(false);
   const [publishDialogIntent, setPublishDialogIntent] = useState<
-    "publish" | "open-pr"
+    "publish" | "open-pr" | "publish-only"
   >("publish");
   const [githubActionPending, setGithubActionPending] = useState(false);
   const debugKeyRef = useRef("");
@@ -300,6 +300,21 @@ export function HeaderActions({ virtualMcpId }: Props) {
     }
   };
 
+  const onPublishSide = () => {
+    setPublishDialogIntent("publish-only");
+    setPublishOpen(true);
+  };
+
+  // A persistent green "Publish" button sits next to the primary button
+  // whenever there's local work not yet in a PR — i.e. the primary button is
+  // "Save changes" (commit-and-push) or "Submit for review" (create-pr). It
+  // opens the publish dialog in publish-only mode (single green button, gated
+  // by isDecoOnlyDiff so code changes still require review). Suppressed once
+  // the primary button IS the publish action (merge-split) to avoid two
+  // publish affordances at once.
+  const showPublishSide =
+    button.action === "commit-and-push" || button.action === "create-pr";
+
   const actionBusy = githubActionPending || isStreaming;
 
   return (
@@ -309,6 +324,8 @@ export function HeaderActions({ virtualMcpId }: Props) {
         actionBusy={actionBusy}
         githubActionPending={githubActionPending}
         onActivate={onActivate}
+        showPublishSide={showPublishSide}
+        onPublishSide={onPublishSide}
         prNumber={pr?.number}
         prBase={pr?.base}
         onSquashMerge={handleSquashMerge}
@@ -340,7 +357,13 @@ export function HeaderActions({ virtualMcpId }: Props) {
               ? effectiveBranchMeta.headSha
               : null
           }
-          openPullRequest={pr?.state === "open" ? pr : null}
+          openPullRequest={
+            publishDialogIntent === "publish-only"
+              ? null
+              : pr?.state === "open"
+                ? pr
+                : null
+          }
           onPullRequestChanged={refreshPrState}
           onPublished={switchToFreshBranch}
         />
@@ -354,6 +377,8 @@ function HeaderButtonRenderer(props: {
   actionBusy: boolean;
   githubActionPending: boolean;
   onActivate: (action: HeaderButton["action"]) => void;
+  showPublishSide: boolean;
+  onPublishSide: () => void;
   prNumber?: number;
   prBase?: string;
   onSquashMerge: (pullNumber: number) => void | Promise<void>;
@@ -395,19 +420,33 @@ function HeaderButtonRenderer(props: {
   }
 
   return (
-    <WithTooltip label={tooltipLabel}>
-      <Button
-        size="sm"
-        variant={button.variant}
-        disabled={disabled}
-        onClick={() => {
-          if (button.action) props.onActivate(button.action);
-        }}
-      >
-        {loading ? <Spinner size="xs" variant="default" /> : null}
-        {button.label}
-      </Button>
-    </WithTooltip>
+    <div className="flex items-center gap-2">
+      <WithTooltip label={tooltipLabel}>
+        <Button
+          size="sm"
+          variant={button.variant}
+          disabled={disabled}
+          onClick={() => {
+            if (button.action) props.onActivate(button.action);
+          }}
+        >
+          {loading ? <Spinner size="xs" variant="default" /> : null}
+          {button.label}
+        </Button>
+      </WithTooltip>
+      {props.showPublishSide ? (
+        <WithTooltip label="Publish directly to production">
+          <Button
+            size="sm"
+            variant="success"
+            disabled={props.githubActionPending}
+            onClick={props.onPublishSide}
+          >
+            Publish
+          </Button>
+        </WithTooltip>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -221,14 +221,14 @@ describe("selectHeaderButton", () => {
   // the user can commit fixes or push a hotfix even when the dev server
   // can't run.
 
-  test("lifecycle.installing + dirty branch → Save changes (fall-through)", () => {
+  test("lifecycle.installing + dirty branch → Submit for review (fall-through)", () => {
     const r = selectHeaderButton(
       happyInput({
         lifecycle: { phase: "installing" },
         branch: ready({ workingTreeDirty: true }),
       }),
     );
-    expect(r.label).toBe("Save changes");
+    expect(r.label).toBe("Submit for review");
   });
 
   test("lifecycle.starting + clean ready branch → Up to date (fall-through)", () => {
@@ -238,14 +238,14 @@ describe("selectHeaderButton", () => {
     expect(r.label).toBe("Up to date");
   });
 
-  test("lifecycle.install-failed + dirty branch → Save changes (commit fixes)", () => {
+  test("lifecycle.install-failed + dirty branch → Submit for review (commit fixes)", () => {
     const r = selectHeaderButton(
       happyInput({
         lifecycle: { phase: "install-failed", error: "ENOENT package.json" },
         branch: ready({ workingTreeDirty: true }),
       }),
     );
-    expect(r.label).toBe("Save changes");
+    expect(r.label).toBe("Submit for review");
   });
 
   test("lifecycle.start-failed + ahead-of-base → Submit for review", () => {
@@ -258,14 +258,14 @@ describe("selectHeaderButton", () => {
     expect(r.label).toBe("Submit for review");
   });
 
-  test("lifecycle.crashed + dirty branch → Save changes (push hotfix)", () => {
+  test("lifecycle.crashed + dirty branch → Submit for review (push hotfix)", () => {
     const r = selectHeaderButton(
       happyInput({
         lifecycle: { phase: "crashed" },
         branch: ready({ workingTreeDirty: true }),
       }),
     );
-    expect(r.label).toBe("Save changes");
+    expect(r.label).toBe("Submit for review");
   });
 
   test("post-clone with branch still unknown → Loading branch… (defensive)", () => {
@@ -288,12 +288,12 @@ describe("selectHeaderButton", () => {
     expect(r.variant).toBe("outline");
   });
 
-  test("dirty working tree → Save changes", () => {
+  test("dirty working tree → Submit for review", () => {
     const r = selectHeaderButton(
       happyInput({ branch: ready({ workingTreeDirty: true }) }),
     );
-    expect(r.label).toBe("Save changes");
-    expect(r.action).toBe("commit-and-push");
+    expect(r.label).toBe("Submit for review");
+    expect(r.action).toBe("create-pr");
     expect(r.disabled).toBeFalsy();
   });
 
@@ -313,15 +313,15 @@ describe("selectHeaderButton", () => {
     expect(r.action).toBe("create-pr");
   });
 
-  test("unpushed commits with open PR (different head) → Save changes", () => {
+  test("unpushed commits with open PR (different head) → Submit for review", () => {
     const r = selectHeaderButton(
       happyInput({
         branch: ready({ unpushed: 2, aheadOfBase: 2, headSha: "local999" }),
         pr: pr({ headSha: "remote888" }),
       }),
     );
-    expect(r.label).toBe("Save changes");
-    expect(r.action).toBe("commit-and-push");
+    expect(r.label).toBe("Submit for review");
+    expect(r.action).toBe("create-pr");
   });
 
   test("false-positive unpushed (headSha matches PR) → falls through to merge", () => {
@@ -515,7 +515,7 @@ describe("selectHeaderButton", () => {
         reviews: reviews({ mergeableState: "dirty" }),
       }),
     );
-    expect(r.label).toBe("Save changes");
+    expect(r.label).toBe("Submit for review");
   });
 
   test("priority inside PR open: conflicts beat failed checks", () => {

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -288,13 +288,14 @@ describe("selectHeaderButton", () => {
     expect(r.variant).toBe("outline");
   });
 
-  test("dirty working tree → Submit for review", () => {
+  test("dirty working tree → Submit for review + side Publish", () => {
     const r = selectHeaderButton(
       happyInput({ branch: ready({ workingTreeDirty: true }) }),
     );
     expect(r.label).toBe("Submit for review");
     expect(r.action).toBe("create-pr");
     expect(r.disabled).toBeFalsy();
+    expect(r.showPublishSide).toBe(true);
   });
 
   test("unpushed commits ahead of base with no PR → Submit for review", () => {
@@ -303,6 +304,7 @@ describe("selectHeaderButton", () => {
     );
     expect(r.label).toBe("Submit for review");
     expect(r.action).toBe("create-pr");
+    expect(r.showPublishSide).toBe(true);
   });
 
   test("unpushed commits without base divergence and no PR → Submit for review", () => {
@@ -478,6 +480,8 @@ describe("selectHeaderButton", () => {
     expect(r.label).toBe("Publish to production");
     expect(r.action).toBe("merge-split");
     expect(r.variant).toBe("success");
+    // merge-split IS the publish action — no redundant side Publish button.
+    expect(r.showPublishSide).toBeFalsy();
   });
 
   test("PR open + reviews still loading → Publish to production (main base)", () => {

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -171,10 +171,10 @@ export function selectHeaderButton(
 
   if (ready.workingTreeDirty) {
     return {
-      label: "Save changes",
-      action: "commit-and-push",
+      label: "Submit for review",
+      action: "create-pr",
       variant: "default",
-      tooltip: "Commit and push local changes",
+      tooltip: `Push and open a PR for ${ready.branch} → ${ready.base}`,
     };
   }
 
@@ -196,10 +196,10 @@ export function selectHeaderButton(
       };
     }
     return {
-      label: "Save changes",
-      action: "commit-and-push",
+      label: "Submit for review",
+      action: "create-pr",
       variant: "default",
-      tooltip: "Push local commits",
+      tooltip: `Push local commits to PR #${pr.number}`,
     };
   }
 

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -35,7 +35,6 @@ function idleClaimCopy(kind: ClaimPhase["kind"]): string | undefined {
 export type HeaderButton = {
   label: string;
   action?:
-    | "commit-and-push"
     | "create-pr"
     | "reopen"
     | "rebase"
@@ -47,6 +46,13 @@ export type HeaderButton = {
   loading?: boolean;
   variant: "default" | "outline" | "success" | "special";
   tooltip?: string;
+  /**
+   * When true, the header renders a persistent green "Publish" button beside
+   * the primary button (direct publish-to-base for deco-only changes). Set on
+   * the states with local work not yet merged, so the state machine — not the
+   * renderer — owns this affordance.
+   */
+  showPublishSide?: boolean;
   meta?: {
     failingChecks?: string[];
   };
@@ -175,6 +181,7 @@ export function selectHeaderButton(
       action: "create-pr",
       variant: "default",
       tooltip: `Push and open a PR for ${ready.branch} → ${ready.base}`,
+      showPublishSide: true,
     };
   }
 
@@ -193,6 +200,7 @@ export function selectHeaderButton(
         action: "create-pr",
         variant: "default",
         tooltip: `Push and open a PR for ${ready.branch} → ${ready.base}`,
+        showPublishSide: true,
       };
     }
     return {
@@ -200,10 +208,11 @@ export function selectHeaderButton(
       action: "create-pr",
       variant: "default",
       tooltip: `Push local commits to PR #${pr.number}`,
+      showPublishSide: true,
     };
   }
 
-  // Fall-through debug: why not Save changes?
+  // Fall-through debug: why no local work to submit?
   saveChangesDebug("no local work — checking PR/sync state", {
     workingTreeDirty: ready.workingTreeDirty,
     unpushed: ready.unpushed,
@@ -230,6 +239,7 @@ export function selectHeaderButton(
         action: "create-pr",
         variant: "special",
         tooltip: "Open a new PR with the latest commits",
+        showPublishSide: true,
       };
     }
     return {
@@ -255,6 +265,7 @@ export function selectHeaderButton(
         action: "create-pr",
         variant: "default",
         tooltip: `Open a PR for ${ready.branch} → ${ready.base}`,
+        showPublishSide: true,
       };
     }
 

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -41,6 +41,7 @@ import {
   fetchGitDiff,
   fetchGitStatus,
   fetchSuggestCommitMessage,
+  hasGitLocalWork,
   hasLocalWorkToPush,
   hasUnpublishedWork,
   isDecoOnlyDiff,
@@ -64,7 +65,7 @@ class PublishFlowError extends Error {
   }
 }
 
-export type PublishDialogIntent = "publish" | "open-pr";
+export type PublishDialogIntent = "publish" | "open-pr" | "publish-only";
 
 export interface PublishDialogProps {
   open: boolean;
@@ -81,6 +82,7 @@ export interface PublishDialogProps {
   /**
    * `open-pr` — commits are already on the branch; open a PR from them.
    * `publish` — commit/push local changes (default).
+   * `publish-only` — direct publish to base; single green Publish button.
    */
   dialogIntent?: PublishDialogIntent;
   /** Branch HEAD for base…head diff when `dialogIntent` is `open-pr`. */
@@ -150,6 +152,8 @@ function PublishDialogBody({
   /** Header "Save changes" — commit/push only, no new PR / merge. */
   const isSaveChangesFlow = dialogIntent === "publish";
   const openPrFromCommits = dialogIntent === "open-pr" && !commitToOpenPr;
+  /** Side "Publish" button — direct publish to base, single green button. */
+  const isPublishOnly = dialogIntent === "publish-only";
 
   const [gitStatus, setGitStatus] = useState<GitStatus | null>(null);
   const [gitDiff, setGitDiff] = useState<GitDiffResult | null>(null);
@@ -171,8 +175,13 @@ function PublishDialogBody({
 
   const loadGitState = async () => {
     const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
+    // Uncommitted working-tree edits aren't in a commit yet, so a base…head
+    // diff would come back empty. Show the working-tree diff whenever there's
+    // local uncommitted work; fall back to base…head only for a clean tree
+    // whose commits are already ahead of base (open-pr / publish from commits).
     const needsBaseDiff =
-      openPrFromCommits || (!commitToOpenPr && (status.aheadOfBase ?? 0) > 0);
+      !hasGitLocalWork(status) &&
+      (openPrFromCommits || (!commitToOpenPr && (status.aheadOfBase ?? 0) > 0));
     const diffOpts = needsBaseDiff
       ? {
           base: baseBranch,
@@ -668,14 +677,22 @@ function PublishDialogBody({
                             : "Commits and pushes to the branch without opening a pull request."}
                         </span>
                       </>
+                    ) : isPublishOnly ? (
+                      <>
+                        {" → "}
+                        <span className="font-mono">{baseBranch}</span>
+                        {" · "}
+                        <span className="text-foreground/80">
+                          {publishLabel} squash-merges into {baseBranch}.
+                        </span>
+                      </>
                     ) : (
                       <>
                         {" → "}
                         <span className="font-mono">{baseBranch}</span>
                         {" · "}
                         <span className="text-foreground/80">
-                          Submit for review keeps changes on the branch;{" "}
-                          {publishLabel} squash-merges into {baseBranch}.
+                          Opens a pull request into {baseBranch} for review.
                         </span>
                       </>
                     )}
@@ -775,41 +792,41 @@ function PublishDialogBody({
                 </p>
               )}
             </>
-          ) : (
+          ) : isPublishOnly ? (
             <>
               <div className="flex items-center gap-3">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="flex-1"
-                  onClick={handleSubmitForReview}
-                  disabled={
-                    !canSubmitForReview || isSubmittingForReview || isPublishing
-                  }
-                >
-                  {isSubmittingForReview ? (
-                    <Loading01 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <GitBranch01 className="h-4 w-4" />
-                  )}
-                  Submit for review
-                </Button>
                 <PublishButton
                   label={publishLabel}
                   canPublish={canPublish}
                   disabledReason={publishDisabledReason}
                   isPublishing={isPublishing}
-                  isSubmittingForReview={isSubmittingForReview}
+                  isSubmittingForReview={false}
                   onPublish={handlePublish}
                 />
               </div>
+              {publishError && (
+                <p className="mt-2 text-xs text-destructive">{publishError}</p>
+              )}
+            </>
+          ) : (
+            <>
+              <Button
+                type="button"
+                className="w-full"
+                onClick={handleSubmitForReview}
+                disabled={!canSubmitForReview || isSubmittingForReview}
+              >
+                {isSubmittingForReview ? (
+                  <Loading01 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <GitBranch01 className="h-4 w-4" />
+                )}
+                Submit for review
+              </Button>
               {submitForReviewError && (
                 <p className="mt-2 text-xs text-destructive">
                   {submitForReviewError}
                 </p>
-              )}
-              {publishError && (
-                <p className="mt-2 text-xs text-destructive">{publishError}</p>
               )}
             </>
           )}

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -37,11 +37,13 @@ import { useSandboxStart } from "@/web/components/sandbox/hooks/use-sandbox-star
 import { publishToBaseLabel } from "./publish-label.ts";
 import {
   canPublishDirectly,
+  combinePublishDiffs,
   countGitChanges,
   discardGitFiles,
   fetchGitDiff,
   fetchGitStatus,
   fetchSuggestCommitMessage,
+  hasGitLocalWork,
   hasLocalWorkToPush,
   hasUnpublishedWork,
   isSandboxUnreachable,
@@ -167,19 +169,38 @@ function PublishDialogBody({
   const loadStartedRef = useRef(false);
   const reprovisionAttemptedRef = useRef(false);
 
+  const baseDiffOpts = {
+    base: baseBranch,
+    ...(headSha ? { headSha } : {}),
+  };
+
+  // Direct publish squash-merges base…HEAD PLUS the working tree, so show and
+  // gate the union of both — a single daemon diff only returns one. For every
+  // other flow a single diff is the whole story (working tree when dirty, else
+  // base…head), picked by shouldUseBaseDiff.
+  const loadPublishDiff = async (status: GitStatus): Promise<GitDiffResult> => {
+    const baseDiff =
+      (status.aheadOfBase ?? 0) > 0
+        ? await fetchGitDiff(orgSlug, virtualMcpId, branch, baseDiffOpts)
+        : null;
+    const workingDiff = hasGitLocalWork(status)
+      ? await fetchGitDiff(orgSlug, virtualMcpId, branch)
+      : null;
+    return combinePublishDiffs(baseDiff, workingDiff);
+  };
+
   const loadGitState = async () => {
     const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
-    const needsBaseDiff = shouldUseBaseDiff(status, {
-      openPrFromCommits,
-      commitToOpenPr,
-    });
-    const diffOpts = needsBaseDiff
-      ? {
-          base: baseBranch,
-          ...(headSha ? { headSha } : {}),
-        }
-      : undefined;
-    const diff = await fetchGitDiff(orgSlug, virtualMcpId, branch, diffOpts);
+    const diff = isPublishOnly
+      ? await loadPublishDiff(status)
+      : await fetchGitDiff(
+          orgSlug,
+          virtualMcpId,
+          branch,
+          shouldUseBaseDiff(status, { openPrFromCommits, commitToOpenPr })
+            ? baseDiffOpts
+            : undefined,
+        );
     setGitStatus(status);
     setGitDiff(diff);
     setPublishTitle(`Changes from ${status.current ?? branch}`);
@@ -268,7 +289,7 @@ function PublishDialogBody({
     : hasUnpublishedWork(gitStatus, gitDiff);
   const canSubmit =
     !isLoadingGitDiff && (hasLocalUnpublished || openPrFromCommits);
-  const publishGate = canPublishDirectly(gitStatus, gitDiff);
+  const publishGate = canPublishDirectly(gitDiff);
   const canPublish = canSubmit && publishGate.allowed;
   const publishDisabledReason = canSubmit ? publishGate.reason : null;
 

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -36,20 +36,19 @@ import type { PrSummary } from "./use-pr-data.ts";
 import { useSandboxStart } from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { publishToBaseLabel } from "./publish-label.ts";
 import {
+  canPublishDirectly,
   countGitChanges,
   discardGitFiles,
   fetchGitDiff,
   fetchGitStatus,
   fetchSuggestCommitMessage,
-  hasGitLocalWork,
   hasLocalWorkToPush,
   hasUnpublishedWork,
-  isDecoOnlyDiff,
   isSandboxUnreachable,
   publishGitChanges,
-  PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
   readGitHeadBranch,
   rebaseGitBranch,
+  shouldUseBaseDiff,
   type GitDiffResult,
   type GitStatus,
 } from "./sandbox-git-api.ts";
@@ -65,7 +64,7 @@ class PublishFlowError extends Error {
   }
 }
 
-export type PublishDialogIntent = "publish" | "open-pr" | "publish-only";
+export type PublishDialogIntent = "open-pr" | "publish-only";
 
 export interface PublishDialogProps {
   open: boolean;
@@ -80,8 +79,7 @@ export interface PublishDialogProps {
   repo: string;
   previewUrl?: string | null;
   /**
-   * `open-pr` — commits are already on the branch; open a PR from them.
-   * `publish` — commit/push local changes (default).
+   * `open-pr` — push local work and open a PR for review (default).
    * `publish-only` — direct publish to base; single green Publish button.
    */
   dialogIntent?: PublishDialogIntent;
@@ -127,7 +125,7 @@ function PublishDialogBody({
   owner,
   repo,
   previewUrl,
-  dialogIntent = "publish",
+  dialogIntent = "open-pr",
   headSha = null,
   openPullRequest = null,
   onPullRequestChanged,
@@ -149,8 +147,6 @@ function PublishDialogBody({
   const coAuthor = coAuthorFromSessionUser(session?.user);
 
   const commitToOpenPr = openPullRequest?.state === "open";
-  /** Header "Save changes" — commit/push only, no new PR / merge. */
-  const isSaveChangesFlow = dialogIntent === "publish";
   const openPrFromCommits = dialogIntent === "open-pr" && !commitToOpenPr;
   /** Side "Publish" button — direct publish to base, single green button. */
   const isPublishOnly = dialogIntent === "publish-only";
@@ -163,9 +159,7 @@ function PublishDialogBody({
   const [publishBody, setPublishBody] = useState("");
   const [publishError, setPublishError] = useState<string>();
   const [isSubmittingForReview, setIsSubmittingForReview] = useState(false);
-  const [isSavingChanges, setIsSavingChanges] = useState(false);
   const [submitForReviewError, setSubmitForReviewError] = useState<string>();
-  const [saveChangesError, setSaveChangesError] = useState<string>();
   const [discardAllConfirm, setDiscardAllConfirm] = useState(false);
   const [isDiscardingAll, setIsDiscardingAll] = useState(false);
   const [isGeneratingSuggestion, setIsGeneratingSuggestion] = useState(false);
@@ -175,13 +169,10 @@ function PublishDialogBody({
 
   const loadGitState = async () => {
     const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
-    // Uncommitted working-tree edits aren't in a commit yet, so a base…head
-    // diff would come back empty. Show the working-tree diff whenever there's
-    // local uncommitted work; fall back to base…head only for a clean tree
-    // whose commits are already ahead of base (open-pr / publish from commits).
-    const needsBaseDiff =
-      !hasGitLocalWork(status) &&
-      (openPrFromCommits || (!commitToOpenPr && (status.aheadOfBase ?? 0) > 0));
+    const needsBaseDiff = shouldUseBaseDiff(status, {
+      openPrFromCommits,
+      commitToOpenPr,
+    });
     const diffOpts = needsBaseDiff
       ? {
           base: baseBranch,
@@ -219,7 +210,6 @@ function PublishDialogBody({
       setPublishTitle("");
       setPublishBody("");
       setSubmitForReviewError(undefined);
-      setSaveChangesError(undefined);
       try {
         await loadGitState();
       } catch (error) {
@@ -277,17 +267,12 @@ function PublishDialogBody({
     ? hasLocalWorkToPush(gitStatus)
     : hasUnpublishedWork(gitStatus, gitDiff);
   const canSubmit =
-    !isLoadingGitDiff &&
-    (isSaveChangesFlow
-      ? hasLocalUnpublished
-      : hasLocalUnpublished || openPrFromCommits);
-  const canPublish = canSubmit && isDecoOnlyDiff(gitDiff);
-  const publishDisabledReason =
-    canSubmit && !isDecoOnlyDiff(gitDiff)
-      ? PUBLISH_REQUIRES_SUBMIT_TOOLTIP
-      : null;
+    !isLoadingGitDiff && (hasLocalUnpublished || openPrFromCommits);
+  const publishGate = canPublishDirectly(gitStatus, gitDiff);
+  const canPublish = canSubmit && publishGate.allowed;
+  const publishDisabledReason = canSubmit ? publishGate.reason : null;
 
-  /** Push + open PR — open-pr dialog, or save dialog with commits vs base. */
+  /** There is committed or uncommitted local work that can be pushed + PR'd. */
   const showSubmitForReviewButton =
     openPrFromCommits || (!commitToOpenPr && (gitStatus?.aheadOfBase ?? 0) > 0);
   const canSubmitForReview =
@@ -299,33 +284,8 @@ function PublishDialogBody({
     [publishTitle.trim(), publishBody.trim()].filter(Boolean).join("\n\n");
 
   const handleOpenChange = (nextOpen: boolean) => {
-    if (isPublishing || isSubmittingForReview || isSavingChanges) return;
+    if (isPublishing || isSubmittingForReview) return;
     onOpenChange(nextOpen);
-  };
-
-  const handleSaveChanges = async () => {
-    setIsSavingChanges(true);
-    setSaveChangesError(undefined);
-    try {
-      const message =
-        commitMessage() ||
-        publishTitle.trim() ||
-        `Changes from ${githubHeadBranch}`;
-      await publishGitChanges(orgSlug, virtualMcpId, branch, message);
-      toast.success(
-        openPullRequest
-          ? `Saved changes to PR #${openPullRequest.number}`
-          : "Changes saved",
-      );
-      handleOpenChange(false);
-      await onPullRequestChanged?.();
-    } catch (error) {
-      setSaveChangesError(
-        error instanceof Error ? error.message : "Failed to save changes",
-      );
-    } finally {
-      setIsSavingChanges(false);
-    }
   };
 
   const handlePublish = async () => {
@@ -513,20 +473,12 @@ function PublishDialogBody({
         <div className="shrink-0 space-y-3 px-6 pt-5 pb-4">
           <div className="space-y-1">
             <p className="text-xs font-medium text-muted-foreground">
-              {isSaveChangesFlow
-                ? "Save changes"
-                : openPrFromCommits
-                  ? "Submit for review"
-                  : publishLabel}
+              {openPrFromCommits ? "Submit for review" : publishLabel}
             </p>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-green-500" />
               {diffCount} {diffCount === 1 ? "change" : "changes"}{" "}
-              {isSaveChangesFlow
-                ? "to save"
-                : openPrFromCommits
-                  ? "in this PR"
-                  : "to publish"}
+              {openPrFromCommits ? "in this PR" : "to publish"}
             </div>
           </div>
           {discardAllConfirm ? (
@@ -573,7 +525,7 @@ function PublishDialogBody({
                   type="button"
                   className="text-xs text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
                   onClick={() => setDiscardAllConfirm(true)}
-                  disabled={isPublishing || isDiscardingAll || isSavingChanges}
+                  disabled={isPublishing || isDiscardingAll}
                 >
                   Discard all
                 </button>
@@ -604,8 +556,7 @@ function PublishDialogBody({
                       disabled={
                         isGeneratingSuggestion ||
                         isPublishing ||
-                        isSubmittingForReview ||
-                        isSavingChanges
+                        isSubmittingForReview
                       }
                       onClick={regenerateSuggestion}
                     >
@@ -634,7 +585,6 @@ function PublishDialogBody({
                       disabled={
                         isPublishing ||
                         isSubmittingForReview ||
-                        isSavingChanges ||
                         isGeneratingSuggestion
                       }
                       className="text-sm"
@@ -659,7 +609,6 @@ function PublishDialogBody({
                       disabled={
                         isPublishing ||
                         isSubmittingForReview ||
-                        isSavingChanges ||
                         isGeneratingSuggestion
                       }
                       rows={5}
@@ -668,34 +617,14 @@ function PublishDialogBody({
                   </div>
                   <p className="text-xs text-muted-foreground">
                     Branch: <span className="font-mono">{branch}</span>
-                    {isSaveChangesFlow ? (
-                      <>
-                        {" · "}
-                        <span className="text-foreground/80">
-                          {commitToOpenPr
-                            ? `Commits and pushes to update open PR #${openPullRequest.number}.`
-                            : "Commits and pushes to the branch without opening a pull request."}
-                        </span>
-                      </>
-                    ) : isPublishOnly ? (
-                      <>
-                        {" → "}
-                        <span className="font-mono">{baseBranch}</span>
-                        {" · "}
-                        <span className="text-foreground/80">
-                          {publishLabel} squash-merges into {baseBranch}.
-                        </span>
-                      </>
-                    ) : (
-                      <>
-                        {" → "}
-                        <span className="font-mono">{baseBranch}</span>
-                        {" · "}
-                        <span className="text-foreground/80">
-                          Opens a pull request into {baseBranch} for review.
-                        </span>
-                      </>
-                    )}
+                    {" → "}
+                    <span className="font-mono">{baseBranch}</span>
+                    {" · "}
+                    <span className="text-foreground/80">
+                      {isPublishOnly
+                        ? `${publishLabel} squash-merges into ${baseBranch}.`
+                        : `Opens a pull request into ${baseBranch} for review.`}
+                    </span>
                   </p>
                 </div>
               </TabsContent>
@@ -727,83 +656,15 @@ function PublishDialogBody({
         </div>
 
         <div className="shrink-0 border-t px-6 py-3">
-          {isSaveChangesFlow && !showSubmitForReviewButton ? (
+          {isPublishOnly ? (
             <>
-              <Button
-                type="button"
-                className="w-full"
-                onClick={handleSaveChanges}
-                disabled={!canSubmit || isSavingChanges}
-              >
-                {isSavingChanges ? (
-                  <Loading01 className="h-4 w-4 animate-spin" />
-                ) : null}
-                Save changes
-              </Button>
-              {saveChangesError && (
-                <p className="mt-2 text-xs text-destructive">
-                  {saveChangesError}
-                </p>
-              )}
-            </>
-          ) : isSaveChangesFlow ? (
-            <>
-              <div className="flex items-center gap-3">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="flex-1"
-                  onClick={handleSaveChanges}
-                  disabled={
-                    !canSubmit || isSavingChanges || isSubmittingForReview
-                  }
-                >
-                  {isSavingChanges ? (
-                    <Loading01 className="h-4 w-4 animate-spin" />
-                  ) : null}
-                  Save changes
-                </Button>
-                <Button
-                  type="button"
-                  className="flex-1"
-                  onClick={handleSubmitForReview}
-                  disabled={
-                    !canSubmitForReview ||
-                    isSubmittingForReview ||
-                    isSavingChanges
-                  }
-                >
-                  {isSubmittingForReview ? (
-                    <Loading01 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <GitBranch01 className="h-4 w-4" />
-                  )}
-                  Submit for review
-                </Button>
-              </div>
-              {saveChangesError && (
-                <p className="mt-2 text-xs text-destructive">
-                  {saveChangesError}
-                </p>
-              )}
-              {submitForReviewError && (
-                <p className="mt-2 text-xs text-destructive">
-                  {submitForReviewError}
-                </p>
-              )}
-            </>
-          ) : isPublishOnly ? (
-            <>
-              <div className="flex items-center gap-3">
-                <PublishButton
-                  label={publishLabel}
-                  canPublish={canPublish}
-                  disabledReason={publishDisabledReason}
-                  isPublishing={isPublishing}
-                  isSubmittingForReview={false}
-                  onPublish={handlePublish}
-                />
-              </div>
+              <PublishButton
+                label={publishLabel}
+                canPublish={canPublish}
+                disabledReason={publishDisabledReason}
+                isPublishing={isPublishing}
+                onPublish={handlePublish}
+              />
               {publishError && (
                 <p className="mt-2 text-xs text-destructive">{publishError}</p>
               )}
@@ -841,23 +702,21 @@ function PublishButton({
   canPublish,
   disabledReason,
   isPublishing,
-  isSubmittingForReview,
   onPublish,
 }: {
   label: string;
   canPublish: boolean;
   disabledReason: string | null;
   isPublishing: boolean;
-  isSubmittingForReview: boolean;
   onPublish: () => void;
 }) {
   const button = (
     <Button
       type="button"
       variant="success"
-      className="flex-1"
+      className="w-full"
       onClick={onPublish}
-      disabled={!canPublish || isPublishing || isSubmittingForReview}
+      disabled={!canPublish || isPublishing}
     >
       {isPublishing ? <Loading01 className="h-4 w-4 animate-spin" /> : null}
       {label}
@@ -870,7 +729,7 @@ function PublishButton({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="flex flex-1">{button}</span>
+          <span className="flex w-full">{button}</span>
         </TooltipTrigger>
         <TooltipContent>{disabledReason}</TooltipContent>
       </Tooltip>

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+  canPublishDirectly,
+  hasGitLocalWork,
   hasLocalWorkToPush,
   hasUnpublishedWork,
   isDecoOnlyDiff,
+  PUBLISH_MIXED_WORK_TOOLTIP,
+  PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
+  shouldUseBaseDiff,
   stripGeneratedFilesFromDiff,
   type GitDiffResult,
   type GitStatus,
@@ -169,5 +174,124 @@ describe("stripGeneratedFilesFromDiff", () => {
     };
     stripGeneratedFilesFromDiff(diff);
     expect(Object.keys(diff.diffs)).toEqual(["blocks.gen.json"]);
+  });
+});
+
+describe("hasGitLocalWork", () => {
+  test("false for null and a clean tree", () => {
+    expect(hasGitLocalWork(null)).toBe(false);
+    expect(hasGitLocalWork(cleanStatus)).toBe(false);
+  });
+
+  test("true for modified working-tree files", () => {
+    expect(hasGitLocalWork({ ...cleanStatus, modified: ["a.ts"] })).toBe(true);
+  });
+
+  test("true for staged files", () => {
+    expect(hasGitLocalWork({ ...cleanStatus, staged: ["a.ts"] })).toBe(true);
+  });
+
+  test("true for conflicted files", () => {
+    expect(hasGitLocalWork({ ...cleanStatus, conflicted: ["a.ts"] })).toBe(
+      true,
+    );
+  });
+
+  test("false when only ahead/unpushed (committed, clean tree)", () => {
+    expect(hasGitLocalWork({ ...cleanStatus, ahead: 2, unpushed: 2 })).toBe(
+      false,
+    );
+  });
+});
+
+describe("shouldUseBaseDiff", () => {
+  const opts = { openPrFromCommits: false, commitToOpenPr: false };
+
+  test("false when the working tree is dirty (show working-tree diff)", () => {
+    expect(
+      shouldUseBaseDiff(
+        { ...cleanStatus, modified: ["a.ts"], aheadOfBase: 3 },
+        opts,
+      ),
+    ).toBe(false);
+  });
+
+  test("true for a clean tree with commits ahead of base", () => {
+    expect(shouldUseBaseDiff({ ...cleanStatus, aheadOfBase: 2 }, opts)).toBe(
+      true,
+    );
+  });
+
+  test("true when opening a PR from existing commits", () => {
+    expect(
+      shouldUseBaseDiff(cleanStatus, {
+        openPrFromCommits: true,
+        commitToOpenPr: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("false when committing to an already-open PR", () => {
+    expect(
+      shouldUseBaseDiff(
+        { ...cleanStatus, aheadOfBase: 2 },
+        { openPrFromCommits: false, commitToOpenPr: true },
+      ),
+    ).toBe(false);
+  });
+
+  test("false for a clean tree with nothing ahead of base", () => {
+    expect(shouldUseBaseDiff(cleanStatus, opts)).toBe(false);
+  });
+});
+
+describe("canPublishDirectly", () => {
+  const decoDiff: GitDiffResult = {
+    diffs: { ".deco/blocks/home.json": { from: "{}", to: "{}" } },
+  };
+  const codeDiff: GitDiffResult = {
+    diffs: { "routes/index.tsx": { from: "a", to: "b" } },
+  };
+
+  test("allows a deco-only working-tree diff with no commits ahead", () => {
+    const gate = canPublishDirectly(
+      { ...cleanStatus, modified: [".deco/blocks/home.json"] },
+      decoDiff,
+    );
+    expect(gate.allowed).toBe(true);
+    expect(gate.reason).toBeNull();
+  });
+
+  test("allows deco-only committed work on a clean tree", () => {
+    const gate = canPublishDirectly(
+      { ...cleanStatus, aheadOfBase: 1 },
+      decoDiff,
+    );
+    expect(gate.allowed).toBe(true);
+  });
+
+  test("blocks code changes with the submit-for-review reason", () => {
+    const gate = canPublishDirectly(
+      { ...cleanStatus, modified: ["routes/index.tsx"] },
+      codeDiff,
+    );
+    expect(gate.allowed).toBe(false);
+    expect(gate.reason).toBe(PUBLISH_REQUIRES_SUBMIT_TOOLTIP);
+  });
+
+  // The safety regression this guards: a deco-only working-tree diff on top of
+  // an unreviewed code commit ahead of base must NOT publish directly — the
+  // gate can't see the committed code, so it must refuse the mixed payload.
+  test("blocks a deco working-tree edit sitting on a commit ahead of base", () => {
+    const gate = canPublishDirectly(
+      { ...cleanStatus, modified: [".deco/blocks/home.json"], aheadOfBase: 1 },
+      decoDiff,
+    );
+    expect(gate.allowed).toBe(false);
+    expect(gate.reason).toBe(PUBLISH_MIXED_WORK_TOOLTIP);
+  });
+
+  test("blocks an empty diff", () => {
+    expect(canPublishDirectly(cleanStatus, { diffs: {} }).allowed).toBe(false);
   });
 });

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   canPublishDirectly,
+  combinePublishDiffs,
   hasGitLocalWork,
   hasLocalWorkToPush,
   hasUnpublishedWork,
   isDecoOnlyDiff,
-  PUBLISH_MIXED_WORK_TOOLTIP,
   PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
   shouldUseBaseDiff,
   stripGeneratedFilesFromDiff,
@@ -253,45 +253,64 @@ describe("canPublishDirectly", () => {
     diffs: { "routes/index.tsx": { from: "a", to: "b" } },
   };
 
-  test("allows a deco-only working-tree diff with no commits ahead", () => {
-    const gate = canPublishDirectly(
-      { ...cleanStatus, modified: [".deco/blocks/home.json"] },
-      decoDiff,
-    );
+  test("allows a deco-only payload", () => {
+    const gate = canPublishDirectly(decoDiff);
     expect(gate.allowed).toBe(true);
     expect(gate.reason).toBeNull();
   });
 
-  test("allows deco-only committed work on a clean tree", () => {
-    const gate = canPublishDirectly(
-      { ...cleanStatus, aheadOfBase: 1 },
-      decoDiff,
-    );
-    expect(gate.allowed).toBe(true);
-  });
-
-  test("blocks code changes with the submit-for-review reason", () => {
-    const gate = canPublishDirectly(
-      { ...cleanStatus, modified: ["routes/index.tsx"] },
-      codeDiff,
-    );
+  test("blocks a payload containing code", () => {
+    const gate = canPublishDirectly(codeDiff);
     expect(gate.allowed).toBe(false);
     expect(gate.reason).toBe(PUBLISH_REQUIRES_SUBMIT_TOOLTIP);
   });
 
-  // The safety regression this guards: a deco-only working-tree diff on top of
-  // an unreviewed code commit ahead of base must NOT publish directly — the
-  // gate can't see the committed code, so it must refuse the mixed payload.
-  test("blocks a deco working-tree edit sitting on a commit ahead of base", () => {
-    const gate = canPublishDirectly(
-      { ...cleanStatus, modified: [".deco/blocks/home.json"], aheadOfBase: 1 },
-      decoDiff,
-    );
-    expect(gate.allowed).toBe(false);
-    expect(gate.reason).toBe(PUBLISH_MIXED_WORK_TOOLTIP);
+  test("blocks an empty diff", () => {
+    expect(canPublishDirectly({ diffs: {} }).allowed).toBe(false);
+  });
+});
+
+describe("combinePublishDiffs (full publish payload = committed ∪ working)", () => {
+  const committedDeco: GitDiffResult = {
+    mergeBaseSha: "abc",
+    diffs: { ".deco/a.json": { from: "{}", to: "{}" } },
+  };
+  const workingDeco: GitDiffResult = {
+    diffs: { ".deco/b.json": { from: null, to: "{}" } },
+  };
+
+  test("unions committed and working-tree paths, keeps mergeBaseSha", () => {
+    const combined = combinePublishDiffs(committedDeco, workingDeco);
+    expect(Object.keys(combined.diffs).sort()).toEqual([
+      ".deco/a.json",
+      ".deco/b.json",
+    ]);
+    expect(combined.mergeBaseSha).toBe("abc");
   });
 
-  test("blocks an empty diff", () => {
-    expect(canPublishDirectly(cleanStatus, { diffs: {} }).allowed).toBe(false);
+  test("handles null inputs", () => {
+    expect(combinePublishDiffs(null, null).diffs).toEqual({});
+  });
+
+  // The case users hit: an uncommitted deco edit on top of a committed deco
+  // change publishes directly, because the whole payload is deco-only.
+  test("allows deco committed + deco uncommitted", () => {
+    const gate = canPublishDirectly(
+      combinePublishDiffs(committedDeco, workingDeco),
+    );
+    expect(gate.allowed).toBe(true);
+  });
+
+  // The safety case: an uncommitted deco edit on top of a committed CODE change
+  // must still be blocked — the combined payload exposes the committed code.
+  test("blocks deco uncommitted sitting on committed code", () => {
+    const committedCode: GitDiffResult = {
+      diffs: { "routes/x.tsx": { from: "a", to: "b" } },
+    };
+    const gate = canPublishDirectly(
+      combinePublishDiffs(committedCode, workingDeco),
+    );
+    expect(gate.allowed).toBe(false);
+    expect(gate.reason).toBe(PUBLISH_REQUIRES_SUBMIT_TOOLTIP);
   });
 });

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -280,7 +280,7 @@ export function countGitChanges(status: GitStatus | null): number {
 }
 
 /** True when the working tree or index has uncommitted work. */
-function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
+export function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
   if (!status) return false;
   return (
     countGitChanges(status) > 0 ||

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -235,6 +235,9 @@ export function isDecoOnlyDiff(
 export const PUBLISH_REQUIRES_SUBMIT_TOOLTIP =
   "Code changes can't be published directly — use Submit for review";
 
+export const PUBLISH_MIXED_WORK_TOOLTIP =
+  "Commit your changes first, or use Submit for review — a mix of committed and uncommitted work can't be published directly";
+
 export async function discardGitFiles(
   orgSlug: string,
   virtualMcpId: string,
@@ -319,4 +322,50 @@ export function hasUnpublishedWork(
     hasLocalWorkToPush(status) ||
     (diff != null && Object.keys(diff.diffs).length > 0)
   );
+}
+
+/**
+ * Which diff the publish dialog should show/gate. Uncommitted working-tree
+ * edits aren't in a commit yet, so a base…head diff would come back empty —
+ * show the working-tree diff whenever there's local uncommitted work, and fall
+ * back to base…head only for a clean tree whose commits are already ahead of
+ * base (open-pr-from-commits or direct publish of committed work).
+ */
+export function shouldUseBaseDiff(
+  status: GitStatus | null | undefined,
+  opts: { openPrFromCommits: boolean; commitToOpenPr: boolean },
+): boolean {
+  if (hasGitLocalWork(status)) return false;
+  return (
+    opts.openPrFromCommits ||
+    (!opts.commitToOpenPr && (status?.aheadOfBase ?? 0) > 0)
+  );
+}
+
+export interface PublishGate {
+  allowed: boolean;
+  reason: string | null;
+}
+
+/**
+ * Whether the current changes may be squash-merged straight to base, bypassing
+ * review. Publish ships the whole base…HEAD range PLUS the working tree, but a
+ * single diff can only represent one of those — so:
+ *  - if there are BOTH commits ahead of base AND uncommitted work, the gate
+ *    can't see the full payload and code could slip through → refuse;
+ *  - otherwise the (single) diff must be deco-only.
+ */
+export function canPublishDirectly(
+  status: GitStatus | null | undefined,
+  diff: GitDiffResult | null | undefined,
+): PublishGate {
+  const mixedPayload =
+    (status?.aheadOfBase ?? 0) > 0 && hasGitLocalWork(status);
+  if (mixedPayload) {
+    return { allowed: false, reason: PUBLISH_MIXED_WORK_TOOLTIP };
+  }
+  if (!isDecoOnlyDiff(diff)) {
+    return { allowed: false, reason: PUBLISH_REQUIRES_SUBMIT_TOOLTIP };
+  }
+  return { allowed: true, reason: null };
 }

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -235,9 +235,6 @@ export function isDecoOnlyDiff(
 export const PUBLISH_REQUIRES_SUBMIT_TOOLTIP =
   "Code changes can't be published directly — use Submit for review";
 
-export const PUBLISH_MIXED_WORK_TOOLTIP =
-  "Commit your changes first, or use Submit for review — a mix of committed and uncommitted work can't be published directly";
-
 export async function discardGitFiles(
   orgSlug: string,
   virtualMcpId: string,
@@ -348,24 +345,33 @@ export interface PublishGate {
 }
 
 /**
- * Whether the current changes may be squash-merged straight to base, bypassing
- * review. Publish ships the whole base…HEAD range PLUS the working tree, but a
- * single diff can only represent one of those — so:
- *  - if there are BOTH commits ahead of base AND uncommitted work, the gate
- *    can't see the full payload and code could slip through → refuse;
- *  - otherwise the (single) diff must be deco-only.
+ * Union of the committed base…head diff and the uncommitted working-tree diff —
+ * the full set of changes a direct publish squash-merges into base. Publish
+ * commits the working tree, then squash-merges base…HEAD, so the payload is
+ * both; the daemon can only return one diff at a time, so callers fetch both
+ * and combine here. Working-tree entries win for paths present in both (they
+ * hold the latest, about-to-be-committed content).
+ */
+export function combinePublishDiffs(
+  baseDiff: GitDiffResult | null | undefined,
+  workingDiff: GitDiffResult | null | undefined,
+): GitDiffResult {
+  return {
+    diffs: { ...(baseDiff?.diffs ?? {}), ...(workingDiff?.diffs ?? {}) },
+    ...(baseDiff?.mergeBaseSha ? { mergeBaseSha: baseDiff.mergeBaseSha } : {}),
+  };
+}
+
+/**
+ * Whether the changes may be squash-merged straight to base, bypassing review.
+ * `diff` must be the full publish payload (see `combinePublishDiffs`) so the
+ * gate sees every file — committed and uncommitted. Only deco-only payloads
+ * publish directly; anything with code must go through Submit for review.
  */
 export function canPublishDirectly(
-  status: GitStatus | null | undefined,
   diff: GitDiffResult | null | undefined,
 ): PublishGate {
-  const mixedPayload =
-    (status?.aheadOfBase ?? 0) > 0 && hasGitLocalWork(status);
-  if (mixedPayload) {
-    return { allowed: false, reason: PUBLISH_MIXED_WORK_TOOLTIP };
-  }
-  if (!isDecoOnlyDiff(diff)) {
-    return { allowed: false, reason: PUBLISH_REQUIRES_SUBMIT_TOOLTIP };
-  }
-  return { allowed: true, reason: null };
+  return isDecoOnlyDiff(diff)
+    ? { allowed: true, reason: null }
+    : { allowed: false, reason: PUBLISH_REQUIRES_SUBMIT_TOOLTIP };
 }


### PR DESCRIPTION
## Summary

Reworks the sandbox git header so the review/publish actions are two distinct buttons instead of one state-driven "Save changes" button.

- **Primary button** always reads **Submit for review** whenever there is local work (dirty tree or unpushed commits). Opens a dialog with a single **Submit for review** action (push + open PR).
- **Dedicated green `Publish` button** sits alongside it. Opens the dialog in a new **publish-only** mode showing a single green **Publish to production** button. Still gated by `isDecoOnlyDiff` — code changes stay disabled with the "use Submit for review" tooltip; only `.deco/` (CMS) diffs can publish directly.

Each header button now maps to a modal with exactly one action, instead of the old modal that showed Submit + Publish together.

## Changes

- `panel-state.ts` — dirty-tree and unpushed-with-open-PR states now return `Submit for review` (`create-pr`) rather than `Save changes` (`commit-and-push`).
- `header-actions.tsx` — persistent side `Publish` button; opens dialog with `publish-only` intent and passes `openPullRequest={null}` in that mode so the diff resolves against base/working tree correctly.
- `publish-dialog.tsx` — new `publish-only` intent (single green button); Submit-for-review footer trimmed to just the Submit button; description copy split per mode; **show the working-tree diff when there are uncommitted changes** so the diff isn't empty for a freshly-edited tree.
- `sandbox-git-api.ts` — export `hasGitLocalWork` for the diff-selection logic.
- `panel-state.test.ts` — updated the 6 cases that asserted the old `Save changes` / `commit-and-push` behavior.

## Testing

- `bun run --cwd=apps/mesh check` — passes
- `bun test apps/mesh/src/web/components/thread/github/` — 101 pass / 0 fail
- `bun run fmt` + `bun run lint` — clean (0 errors)

Not exercised end-to-end in the real app (requires an attached GitHub repo + running sandbox).

## Notes

The old `Save changes` machinery (`commit-and-push` action, `isSaveChangesFlow` footer branches, `handleSaveChanges`) is now unreachable but left in place; can be removed in a follow-up cleanup once the new UX is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the header into two actions: a primary Submit for review for local work and a green Publish for CMS-only publishes. Publish-only now gates on a combined base…HEAD + working-tree diff, allowing direct publish for `.deco/`-only payloads (even when mixed) and blocking any code changes.

- **New Features**
  - Separate header buttons: primary always shows “Submit for review”; a green “Publish” appears with local work.
  - New `publish-only` dialog intent with a single “Publish to production”, gated by `canPublishDirectly` over a combined diff via `combinePublishDiffs` (allows `.deco/`-only; blocks any code).
  - Submit-for-review dialog shows a single “Submit for review”.
  - Diff selection: `shouldUseBaseDiff` shows the working-tree diff when dirty; otherwise uses base…head. Publish-only fetches both and unions them for gating.
  - Panel state: dirty/unpushed-with-open-PR now map to “Submit for review” (`create-pr`); `showPublishSide` is owned by panel-state.
  - Helpers/tests: export `hasGitLocalWork`; add `combinePublishDiffs`; test `hasGitLocalWork`, `shouldUseBaseDiff`, `canPublishDirectly`, and `combinePublishDiffs`; remove unreachable “Save changes” flow; update unit tests and labels.

<sup>Written for commit 10fc2001c7ef4f7daa511fae2ee0f1596bf23276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

