### PR TITLE
test(sections-editor): cover isValidPagePath backslash rejection and whitespace trimming

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/page-path-utils.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-path-utils.test.ts
@@ -19,6 +19,12 @@ describe("page-path-utils", () => {
     expect(isValidPagePath("//evil.com")).toBe(false);
     expect(isValidPagePath("/../secret")).toBe(false);
     expect(isValidPagePath("about")).toBe(false);
+    expect(isValidPagePath("/foo\\bar")).toBe(false);
+  });
+
+  it("isValidPagePath trims surrounding whitespace before checking", () => {
+    expect(isValidPagePath("  /about  ")).toBe(true);
+    expect(isValidPagePath("  about  ")).toBe(false);
   });
 
   it("validatePagePath returns error messages", () => {


### PR DESCRIPTION
## Summary
- Source: a small improvement found while reading the freshest churn in this run — `page-path-utils.ts` (path template validation used by the sections editor / preview URL bar) already has thorough tests, but two behaviors implemented in `isValidPagePath` had no coverage: rejecting paths containing a backslash, and trimming surrounding whitespace before validating.
- Payoff: these are real branches in the validation logic guarding page path input (a trust boundary — user-typed paths feed into preview/iframe navigation); a future refactor of `isValidPagePath` could silently drop the backslash check or the trim step without any test catching it.

## Test plan
- `bun test apps/mesh/src/web/components/sections-editor/page-path-utils.test.ts` — 12 pass, 0 fail.
- Ran `bun run fmt` locally (no changes needed) and the targeted test file above; full CI will run typecheck/lint across the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for isValidPagePath to ensure paths with backslashes are rejected and surrounding whitespace is trimmed before validation. This protects the sections editor’s page path input and prevents regressions in the preview navigation.

<sup>Written for commit 0330194e59a2b809134afe57edf30115ae8d7ff5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

