### PR TITLE
test(preview): cover resolveSectionCandidates cycle guard and unresolved refs

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/section-candidates.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/section-candidates.test.ts
@@ -117,6 +117,33 @@ describe("resolveSectionCandidates", () => {
     ).toEqual([BANNER, HEADER]);
   });
 
+  it("falls back to the literal key when a saved-block reference is unresolved", () => {
+    expect(
+      resolveSectionCandidates({ __resolveType: "missing-block" }, {}),
+    ).toEqual(["missing-block"]);
+  });
+
+  it("stops resolving a self-referencing saved block instead of looping forever", () => {
+    expect(
+      resolveSectionCandidates(
+        { __resolveType: "self-ref" },
+        { "self-ref": { __resolveType: "self-ref" } },
+      ),
+    ).toEqual(["self-ref"]);
+  });
+
+  it("bounds resolution of a mutually-referencing cycle to 5 hops", () => {
+    expect(
+      resolveSectionCandidates(
+        { __resolveType: "a" },
+        {
+          a: { __resolveType: "b" },
+          b: { __resolveType: "a" },
+        },
+      ),
+    ).toEqual(["b"]);
+  });
+
   it("returns null for a lazy wrapper around a hidden section", () => {
     expect(
       resolveSectionCandidates(


### PR DESCRIPTION
## Source
Small improvement (Source 3, Option A): `resolveSectionCandidates` in `apps/mesh/src/web/components/sandbox/preview/section-candidates.ts` has a saved-block indirection resolver with a hop cap (`i < 5`) and a self-loop guard (`next !== rt`), used to avoid an infinite loop when a decofile has a broken or cyclic `__resolveType` reference chain. None of the existing tests exercised those branches.

## Why
This is the DOM-alignment path for the CMS section overlay — a corrupt or cyclic saved-block reference in a decofile is user-editable data, so the safety guard against infinite resolution is exactly the kind of logic that should have a regression test pinning its behavior.

## What's covered
- Unresolved reference (`decofile` lacks the key) falls back to the literal key instead of throwing/looping.
- A block whose `__resolveType` points at itself breaks immediately instead of looping.
- A mutual two-node cycle (`a -> b -> a`) terminates after the 5-hop cap rather than spinning forever.

## Verify
`bun test apps/mesh/src/web/components/sandbox/preview/section-candidates.test.ts`

## Checks run locally
- `bun run fmt`
- `bun test apps/mesh/src/web/components/sandbox/preview/section-candidates.test.ts` (12 pass)
- Skipped repo-wide `tsc --noEmit` (pre-existing unrelated error on an unresolved `use-stick-to-bottom` module in this checkout); full CI will validate typecheck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added regression tests for resolveSectionCandidates to cover unresolved saved-block references and cyclic __resolveType chains. Confirms fallback to the literal key, immediate stop on self-reference, and a 5-hop cap for mutual cycles to prevent infinite loops in the CMS section overlay.

<sup>Written for commit 76c745045809713c39069b2911d40ca6198f2eed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

