### PR TITLE
test(github): cover countGitChanges and readGitHeadBranch edge cases

### DIFF
--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from "bun:test";
 import {
   canPublishDirectly,
   combinePublishDiffs,
+  countGitChanges,
   hasGitLocalWork,
   hasLocalWorkToPush,
   hasUnpublishedWork,
   isDecoOnlyDiff,
   PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
+  readGitHeadBranch,
   shouldUseBaseDiff,
   stripGeneratedFilesFromDiff,
   type GitDiffResult,
@@ -201,6 +203,54 @@ describe("hasGitLocalWork", () => {
     expect(hasGitLocalWork({ ...cleanStatus, ahead: 2, unpushed: 2 })).toBe(
       false,
     );
+  });
+});
+
+describe("countGitChanges", () => {
+  test("0 for null", () => {
+    expect(countGitChanges(null)).toBe(0);
+  });
+
+  test("0 for a clean tree", () => {
+    expect(countGitChanges(cleanStatus)).toBe(0);
+  });
+
+  test("sums modified, created, deleted, not_added, and renamed", () => {
+    expect(
+      countGitChanges({
+        ...cleanStatus,
+        modified: ["a.ts"],
+        created: ["b.ts", "c.ts"],
+        deleted: ["d.ts"],
+        not_added: ["e.ts"],
+        renamed: [{ from: "f.ts", to: "g.ts" }],
+      }),
+    ).toBe(6);
+  });
+
+  test("ignores staged and conflicted (already-indexed, not working-tree edits)", () => {
+    expect(
+      countGitChanges({
+        ...cleanStatus,
+        staged: ["a.ts"],
+        conflicted: ["b.ts"],
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("readGitHeadBranch", () => {
+  test("null for null and undefined", () => {
+    expect(readGitHeadBranch(null)).toBeNull();
+    expect(readGitHeadBranch(undefined)).toBeNull();
+  });
+
+  test("returns the current branch name", () => {
+    expect(readGitHeadBranch(cleanStatus)).toBe("feat/foo");
+  });
+
+  test("null on detached HEAD", () => {
+    expect(readGitHeadBranch({ ...cleanStatus, current: null })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Source
Missing unit test (Source 3, Option A). `apps/mesh/src/web/components/thread/github/sandbox-git-api.ts` already has thorough coverage for most of its exported helpers, but `countGitChanges` and `readGitHeadBranch` — both real, used pure functions (`file-explorer.tsx`, `publish-dialog.tsx`) — had zero tests.

## Why
`countGitChanges` deliberately excludes `staged`/`conflicted` from its count (unlike `hasGitLocalWork`, which includes them) — a real, easy-to-regress distinction that had no test locking it in. `readGitHeadBranch`'s null-fallback for a detached HEAD was likewise unverified.

## What's covered
- `countGitChanges`: null status, clean tree, summing across modified/created/deleted/not_added/renamed, and the staged/conflicted exclusion.
- `readGitHeadBranch`: null/undefined status, normal branch name, and detached HEAD (`current: null`).

## Verify
```
bun test apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun test apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts` (40 pass)
- Full-repo `tsc`/lint left to CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `countGitChanges` and `readGitHeadBranch` in `apps/mesh/src/web/components/thread/github/sandbox-git-api.ts` to cover edge cases and prevent regressions. Tests confirm the change count excludes `staged`/`conflicted`, sums modified/created/deleted/not_added/renamed, and that the head branch returns null for detached or nullish status.

<sup>Written for commit 06a0136bc0cd9bb9584a4ed4207efe650a6a6243. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

