### PR TITLE
test(sections-editor): cover extractPages fallback name derivation

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/page-list.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-list.test.ts
@@ -27,6 +27,50 @@ describe("page-list", () => {
     ]);
   });
 
+  it("extractPages derives a name from the key, stripping uuid and hex suffixes", () => {
+    const decofile = {
+      "pages-home-11111111-1111-4111-8111-111111111111": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/",
+      },
+      "pages-about-c4bcbfb771e9": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/about",
+      },
+    };
+
+    expect(extractPages(decofile)).toEqual([
+      {
+        key: "pages-home-11111111-1111-4111-8111-111111111111",
+        name: "home",
+        path: "/",
+      },
+      { key: "pages-about-c4bcbfb771e9", name: "about", path: "/about" },
+    ]);
+  });
+
+  it("extractPages URL-decodes derived names and falls back to raw text on malformed encoding", () => {
+    const decofile = {
+      "pages-Category%20Page-c4bcbfb771e9": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/category",
+      },
+      "pages-bad-%E0%A4%A": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/bad",
+      },
+    };
+
+    expect(extractPages(decofile)).toEqual([
+      {
+        key: "pages-Category%20Page-c4bcbfb771e9",
+        name: "Category Page",
+        path: "/category",
+      },
+      { key: "pages-bad-%E0%A4%A", name: "bad-%E0%A4%A", path: "/bad" },
+    ]);
+  });
+
   it("findPageForPath prefers an explicit block key when paths collide", () => {
     const pages = [
       {


### PR DESCRIPTION
## Source
Missing test coverage (Source 3, Option A) — no open PR or issue covers this file.

## Why
`extractPages`' fallback name derivation (`parsePageName` in `page-list.tsx`) strips a uuid/hex suffix from a page's block key and URL-decodes it when the block has no explicit `name` field. Every existing test used a key with no suffix, so the uuid-stripping, percent-decoding, and — notably — the `decodeURIComponent` failure fallback (malformed `%`-encoding silently falling back to the raw string) were entirely untested. A future refactor of that regex/try-catch could silently break page name display and nothing would catch it.

## What's tested
- `pages-home-11111111-1111-4111-8111-111111111111` → `home` (uuid suffix stripped)
- `pages-about-c4bcbfb771e9` → `about` (legacy hex suffix stripped)
- `pages-Category%20Page-c4bcbfb771e9` → `Category Page` (percent-decoding)
- `pages-bad-%E0%A4%A` → `bad-%E0%A4%A` (malformed encoding falls back to raw text instead of throwing)

## Verify
```
bun test apps/mesh/src/web/components/sections-editor/page-list.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun test apps/mesh/src/web/components/sections-editor/page-list.test.ts` (14 pass)
- `tsc --noEmit` in `apps/mesh` shows only pre-existing, unrelated errors (missing `use-stick-to-bottom` module types, untouched by this change)

Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added tests for `extractPages` fallback page name derivation when a block has no explicit `name`. Covers UUID/hex suffix stripping, percent-decoding, and safe fallback to raw text on malformed encodings to prevent page name regressions.

<sup>Written for commit ff1beb9381fa27a6a499c8164f512a2c725cb183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

