### PR TITLE
test(bindings): cover createCollectionBindings tool naming and readOnly filtering

### DIFF
--- a/packages/bindings/test/collections.test.ts
+++ b/packages/bindings/test/collections.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import {
+  BaseCollectionEntitySchema,
+  createCollectionBindings,
+} from "../src/well-known/collections";
+
+const EntitySchema = BaseCollectionEntitySchema.extend({
+  email: z.string(),
+});
+
+describe("createCollectionBindings", () => {
+  it("includes all five CRUD tools by default, uppercased and namespaced", () => {
+    const bindings = createCollectionBindings("users", EntitySchema);
+
+    expect(bindings.map((b) => b.name)).toEqual([
+      "COLLECTION_USERS_LIST",
+      "COLLECTION_USERS_GET",
+      "COLLECTION_USERS_CREATE",
+      "COLLECTION_USERS_UPDATE",
+      "COLLECTION_USERS_DELETE",
+    ]);
+  });
+
+  it("marks mutation tools as optional but not LIST/GET", () => {
+    const bindings = createCollectionBindings("users", EntitySchema);
+    const byName = Object.fromEntries(bindings.map((b) => [b.name, b]));
+
+    expect(byName.COLLECTION_USERS_LIST).not.toHaveProperty("opt");
+    expect(byName.COLLECTION_USERS_GET).not.toHaveProperty("opt");
+    expect(byName.COLLECTION_USERS_CREATE).toHaveProperty("opt", true);
+    expect(byName.COLLECTION_USERS_UPDATE).toHaveProperty("opt", true);
+    expect(byName.COLLECTION_USERS_DELETE).toHaveProperty("opt", true);
+  });
+
+  it("excludes mutation tools when readOnly is set", () => {
+    const bindings = createCollectionBindings("products", EntitySchema, {
+      readOnly: true,
+    });
+
+    expect(bindings.map((b) => b.name)).toEqual([
+      "COLLECTION_PRODUCTS_LIST",
+      "COLLECTION_PRODUCTS_GET",
+    ]);
+  });
+
+  it("uppercases mixed-case collection names in tool names", () => {
+    const bindings = createCollectionBindings("orderItems", EntitySchema);
+    expect(bindings[0].name).toBe("COLLECTION_ORDERITEMS_LIST");
+  });
+});


### PR DESCRIPTION
## Source
Small improvement (Source 3, option A) — `createCollectionBindings` in `packages/bindings/src/well-known/collections.ts` is the core factory every Collection binding (users, products, orders, etc.) is built from, but it had zero direct test coverage: no test asserted the generated tool-name casing, the `readOnly` mutation-exclusion branch, or the `opt: true` flags on CRUD tools.

## Why
This is a widely reused pure factory function with real branching logic (readOnly filtering, name casing) and no regression safety net — a change here would silently break every collection binding's tool names.

## What's tested
- Default (non-readOnly) output includes all 5 CRUD tools with correctly namespaced/uppercased names
- LIST/GET have no `opt` flag; CREATE/UPDATE/DELETE are marked `opt: true`
- `readOnly: true` excludes CREATE/UPDATE/DELETE entirely
- Mixed-case collection names (e.g. `orderItems`) uppercase correctly in tool names

## Verify
```
bun test packages/bindings/test/collections.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/bindings`
- `bun test packages/bindings/test/collections.test.ts` (4 pass)

Full CI will run the whole suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for the `createCollectionBindings` factory in `packages/bindings` to verify tool-name casing, `opt` flags on CRUD tools, and `readOnly` filtering. This guards all collection bindings against regressions by locking in the 5-tool default, mutation opt-in, and correct uppercasing for mixed-case names.

<sup>Written for commit a0d623ed2e44995253b0a6a40ae22d46814a7994. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

