### PR TITLE
test(sandbox): cover isSyntheticBranch, buildDevEnv, and pmRunCommand

### DIFF
--- a/packages/sandbox/daemon/constants.test.ts
+++ b/packages/sandbox/daemon/constants.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { buildDevEnv, isSyntheticBranch, pmRunCommand } from "./constants";
+
+describe("isSyntheticBranch", () => {
+  test("matches the ephemeral sentinel", () => {
+    expect(isSyntheticBranch("ephemeral")).toBe(true);
+  });
+
+  test("matches any thread: prefixed branch", () => {
+    expect(isSyntheticBranch("thread:abc123")).toBe(true);
+  });
+
+  test("rejects real git branches", () => {
+    expect(isSyntheticBranch("main")).toBe(false);
+    expect(isSyntheticBranch("feat/thread-stuff")).toBe(false);
+  });
+});
+
+describe("buildDevEnv", () => {
+  test("always sets HOST and HOSTNAME to 0.0.0.0", () => {
+    const env = buildDevEnv({});
+    expect(env.HOST).toBe("0.0.0.0");
+    expect(env.HOSTNAME).toBe("0.0.0.0");
+  });
+
+  test("derives PORT from config.application.port when not overridden", () => {
+    const env = buildDevEnv({ application: { port: 4000 } });
+    expect(env.PORT).toBe("4000");
+  });
+
+  test("an explicit PORT override wins over config.application.port", () => {
+    const env = buildDevEnv({ application: { port: 4000 } }, { PORT: "5000" });
+    expect(env.PORT).toBe("5000");
+  });
+
+  test("omits PORT when no config port is set and no override given", () => {
+    const env = buildDevEnv({});
+    expect(env.PORT).toBeUndefined();
+  });
+
+  test("overrides can also stomp HOST/HOSTNAME", () => {
+    const env = buildDevEnv({}, { HOST: "127.0.0.1" });
+    expect(env.HOST).toBe("127.0.0.1");
+    expect(env.HOSTNAME).toBe("0.0.0.0");
+  });
+});
+
+describe("pmRunCommand", () => {
+  test("builds a cd + run-prefix command and matching label", () => {
+    const { cmd, label } = pmRunCommand("", "/app/repo", "npm run", "dev");
+    expect(cmd).toBe("cd /app/repo && npm run dev");
+    expect(label).toBe("$ cd /app/repo && npm run dev");
+  });
+
+  test("prepends the runtime prefix verbatim", () => {
+    const { cmd } = pmRunCommand(
+      "NODE_ENV=production ",
+      "/app/repo",
+      "pnpm run",
+      "build",
+    );
+    expect(cmd).toBe("NODE_ENV=production cd /app/repo && pnpm run build");
+  });
+});


### PR DESCRIPTION
## Source
No open issue covers this; `packages/sandbox/daemon/constants.ts` had zero test coverage despite exporting three pure functions used across the daemon's clone, exec, and lifecycle-probe paths (`isSyntheticBranch`, `buildDevEnv`, `pmRunCommand`).

## Why
These functions gate real behavior: `isSyntheticBranch` decides whether a "branch" is an ephemeral sandbox key that must never be checked out, and `buildDevEnv`'s override-precedence (explicit `PORT` override vs. `config.application.port`) is exactly the kind of branch that regresses silently without a test.

## What's covered
- `isSyntheticBranch`: the `ephemeral` sentinel, `thread:`-prefixed branches, and real branch names.
- `buildDevEnv`: default `HOST`/`HOSTNAME`, `PORT` derived from config, explicit `PORT` override winning over config, `PORT` omitted when neither is set, and overrides stomping `HOST`/`HOSTNAME`.
- `pmRunCommand`: command/label construction, including a non-empty runtime prefix.

## Verify
```
bun test packages/sandbox/daemon/constants.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/sandbox`
- `bun test packages/sandbox/daemon/constants.test.ts` (10 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `isSyntheticBranch`, `buildDevEnv`, and `pmRunCommand` in `packages/sandbox/daemon/constants.ts`. Locks in behavior for synthetic branch detection, env var precedence (including `PORT` overrides), and command/label construction to prevent regressions in clone, exec, and lifecycle-probe paths.

<sup>Written for commit 373714c74951295fda2418c3e8fc218a8d673d4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

