### PR TITLE
test(web): cover registry-utils pure helpers

### DIFF
--- a/apps/mesh/src/web/utils/registry-utils.test.ts
+++ b/apps/mesh/src/web/utils/registry-utils.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
+import {
+  extractItemsFromResponse,
+  flattenPaginatedItems,
+  getConnectionTypeLabel,
+  inferRegistryListToolName,
+} from "./registry-utils";
+
+describe("inferRegistryListToolName", () => {
+  it("uses the collection list tool for well-known registries", () => {
+    const orgId = "org_1";
+    expect(
+      inferRegistryListToolName(WellKnownOrgMCPId.REGISTRY(orgId), orgId),
+    ).toBe("COLLECTION_REGISTRY_APP_LIST");
+    expect(
+      inferRegistryListToolName(
+        WellKnownOrgMCPId.COMMUNITY_REGISTRY(orgId),
+        orgId,
+      ),
+    ).toBe("COLLECTION_REGISTRY_APP_LIST");
+  });
+
+  it("uses the private registry item tool for anything else", () => {
+    expect(inferRegistryListToolName("conn_abc123", "org_1")).toBe(
+      "REGISTRY_ITEM_LIST",
+    );
+  });
+
+  it("does not match a well-known id from a different org", () => {
+    expect(
+      inferRegistryListToolName(WellKnownOrgMCPId.REGISTRY("org_1"), "org_2"),
+    ).toBe("REGISTRY_ITEM_LIST");
+  });
+});
+
+describe("flattenPaginatedItems", () => {
+  it("returns an empty array when no pages are given", () => {
+    expect(flattenPaginatedItems(undefined)).toEqual([]);
+  });
+
+  it("flattens pages that are plain arrays", () => {
+    expect(flattenPaginatedItems([[1, 2], [3]])).toEqual([1, 2, 3]);
+  });
+
+  it("flattens pages shaped as objects with a nested array field", () => {
+    expect(flattenPaginatedItems([{ items: [1, 2] }, { items: [3] }])).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("skips pages with no array field", () => {
+    expect(flattenPaginatedItems([{ items: [1] }, { total: 5 }])).toEqual([1]);
+  });
+});
+
+describe("getConnectionTypeLabel", () => {
+  it("returns null when no type is given", () => {
+    expect(getConnectionTypeLabel(undefined)).toBeNull();
+  });
+
+  it("maps known types to human-readable labels", () => {
+    expect(getConnectionTypeLabel("streamable-http")).toBe("HTTP");
+    expect(getConnectionTypeLabel("sse")).toBe("SSE");
+  });
+
+  it("uppercases unknown types instead of dropping them", () => {
+    expect(getConnectionTypeLabel("custom")).toBe("CUSTOM");
+  });
+});
+
+describe("extractItemsFromResponse", () => {
+  it("returns an empty array for nullish responses", () => {
+    expect(extractItemsFromResponse(null)).toEqual([]);
+    expect(extractItemsFromResponse(undefined)).toEqual([]);
+  });
+
+  it("returns direct array responses as-is", () => {
+    expect(extractItemsFromResponse([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("extracts the first array field from an object response", () => {
+    expect(extractItemsFromResponse({ total: 2, items: [1, 2] })).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it("returns an empty array when the object has no array field", () => {
+    expect(extractItemsFromResponse({ total: 2 })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Source
Missing unit test coverage (Source 3, Option A) — `apps/mesh/src/web/utils/registry-utils.ts` had no test file at all.

## Why
`inferRegistryListToolName`, `flattenPaginatedItems`, `getConnectionTypeLabel`, and `extractItemsFromResponse` are pure, branch-heavy helpers used across registry/store code paths, but had zero coverage. This locks in their current behavior (well-known vs. private registry detection, both paginated-page shapes, unknown connection types, empty/nullish responses) so future refactors don't silently change it.

## Testing
Run: `bun test apps/mesh/src/web/utils/registry-utils.test.ts`

Locally I ran:
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` (pre-existing, unrelated `use-stick-to-bottom` module errors only — not touched by this change)
- `bun test apps/mesh/src/web/utils/registry-utils.test.ts` — 14 pass

Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `inferRegistryListToolName`, `flattenPaginatedItems`, `getConnectionTypeLabel`, and `extractItemsFromResponse` in `apps/mesh/src/web/utils/registry-utils.ts` to improve coverage and prevent regressions. Verifies well-known vs. private registry detection, both paginated page shapes, unknown connection types, and nullish/object responses.

<sup>Written for commit 153e9282b919baf3a611050fa728cb490488c0ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

