### PR TITLE
fix(storage): stop OOM-killing studio-worker on large thread-message parts

### DIFF
--- a/apps/mesh/src/storage/thread-message-parts.test.ts
+++ b/apps/mesh/src/storage/thread-message-parts.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "bun:test";
+import { serializePayload } from "./thread-message-parts";
+
+describe("serializePayload", () => {
+  it("passes small payloads through as-is", () => {
+    const payload = { type: "text", text: "hello" };
+    expect(serializePayload(payload)).toBe(JSON.stringify(payload));
+  });
+
+  it("stores large-but-legitimate payloads in full (no data loss)", () => {
+    const big = { type: "tool-result", output: "x".repeat(2_000_000) };
+    expect(serializePayload(big)).toBe(JSON.stringify(big));
+  });
+
+  it("only circuit-breaks truly pathological payload sizes", () => {
+    const pathological = {
+      type: "tool-result",
+      output: "x".repeat(60_000_000),
+    };
+    const out = JSON.parse(serializePayload(pathological));
+    expect(out.truncated).toBe(true);
+    expect(out.originalBytes).toBeGreaterThan(50_000_000);
+  });
+});

--- a/apps/mesh/src/storage/thread-message-parts.test.ts
+++ b/apps/mesh/src/storage/thread-message-parts.test.ts
@@ -12,13 +12,19 @@ describe("serializePayload", () => {
     expect(serializePayload(big)).toBe(JSON.stringify(big));
   });
 
-  it("only circuit-breaks truly pathological payload sizes", () => {
+  it("circuit-breaks a single oversized string without stringifying it", () => {
     const pathological = {
       type: "tool-result",
       output: "x".repeat(60_000_000),
     };
     const out = JSON.parse(serializePayload(pathological));
     expect(out.truncated).toBe(true);
-    expect(out.originalBytes).toBeGreaterThan(50_000_000);
+  });
+
+  it("circuit-breaks many small strings that sum past the cap", () => {
+    const chunks = Array.from({ length: 1000 }, () => "x".repeat(60_000));
+    const pathological = { type: "tool-result", output: chunks }; // 60MB total
+    const out = JSON.parse(serializePayload(pathological));
+    expect(out.truncated).toBe(true);
   });
 });

--- a/apps/mesh/src/storage/thread-message-parts.ts
+++ b/apps/mesh/src/storage/thread-message-parts.ts
@@ -9,9 +9,13 @@ import type { Database, ThreadMessage } from "./types";
 
 // Last-resort circuit breaker only — legitimate tool output (a large file
 // read, a big stdout capture) is stored in full. A single part this size
-// (>50MB serialized) is almost certainly a runaway/erroneous payload, not
-// real content worth keeping.
+// is almost certainly a runaway/erroneous payload, not real content worth
+// keeping.
 const MAX_PART_PAYLOAD_BYTES = 50_000_000;
+
+// Bounds the size-estimate traversal itself: a deeply-nested-but-small
+// object shouldn't be able to turn the probe into its own stall.
+const MAX_ESTIMATE_NODES = 100_000;
 
 // A synchronous loop over many/large parts' JSON.stringify calls can block
 // the event loop long enough to starve health probes and stall the whole
@@ -19,15 +23,43 @@ const MAX_PART_PAYLOAD_BYTES = 50_000_000;
 // every few parts instead of doing the whole batch in one synchronous pass.
 const SERIALIZE_YIELD_EVERY = 25;
 
+/**
+ * Upper-bound the payload's serialized size WITHOUT calling JSON.stringify.
+ * A string's `.length` is O(1) (no copy) — it's the escaping/copying that
+ * JSON.stringify does which is expensive, not knowing the size. Bails out
+ * (returns Infinity) the moment the running total clears `budget`, so an
+ * oversized payload never pays for its own full serialization just to be
+ * measured and discarded.
+ */
+function estimatePayloadBytes(value: unknown, budget: number): number {
+  let total = 0;
+  let nodes = 0;
+  const stack: unknown[] = [value];
+  while (stack.length > 0) {
+    if (total > budget || ++nodes > MAX_ESTIMATE_NODES) return Infinity;
+    const v = stack.pop();
+    if (typeof v === "string") {
+      total += v.length; // UTF-16 units — a fine over-estimate of UTF-8 bytes
+    } else if (Array.isArray(v)) {
+      for (const item of v) stack.push(item);
+    } else if (v !== null && typeof v === "object") {
+      for (const item of Object.values(v)) stack.push(item);
+    }
+  }
+  return total;
+}
+
 export function serializePayload(payload: unknown): string {
-  const serialized = JSON.stringify(payload);
-  const bytes = Buffer.byteLength(serialized, "utf8");
-  if (bytes <= MAX_PART_PAYLOAD_BYTES) return serialized;
-  return JSON.stringify({
-    truncated: true,
-    reason: "payload exceeds max stored size",
-    originalBytes: bytes,
-  });
+  if (
+    estimatePayloadBytes(payload, MAX_PART_PAYLOAD_BYTES) >
+    MAX_PART_PAYLOAD_BYTES
+  ) {
+    return JSON.stringify({
+      truncated: true,
+      reason: "payload exceeds max stored size",
+    });
+  }
+  return JSON.stringify(payload);
 }
 
 export class SqlThreadMessagePartStorage {

--- a/apps/mesh/src/storage/thread-message-parts.ts
+++ b/apps/mesh/src/storage/thread-message-parts.ts
@@ -1,3 +1,4 @@
+import { sleep } from "@decocms/std";
 import type { Kysely } from "kysely";
 import {
   foldParts,
@@ -6,10 +7,33 @@ import {
 } from "./fold-parts";
 import type { Database, ThreadMessage } from "./types";
 
+// Last-resort circuit breaker only — legitimate tool output (a large file
+// read, a big stdout capture) is stored in full. A single part this size
+// (>50MB serialized) is almost certainly a runaway/erroneous payload, not
+// real content worth keeping.
+const MAX_PART_PAYLOAD_BYTES = 50_000_000;
+
+// A synchronous loop over many/large parts' JSON.stringify calls can block
+// the event loop long enough to starve health probes and stall the whole
+// worker — this has happened in production. Yield back to the event loop
+// every few parts instead of doing the whole batch in one synchronous pass.
+const SERIALIZE_YIELD_EVERY = 25;
+
+export function serializePayload(payload: unknown): string {
+  const serialized = JSON.stringify(payload);
+  const bytes = Buffer.byteLength(serialized, "utf8");
+  if (bytes <= MAX_PART_PAYLOAD_BYTES) return serialized;
+  return JSON.stringify({
+    truncated: true,
+    reason: "payload exceeds max stored size",
+    originalBytes: bytes,
+  });
+}
+
 export class SqlThreadMessagePartStorage {
   constructor(private db: Kysely<Database>) {}
 
-  private serializeParts(parts: ThreadMessagePart[]): {
+  private async serializeParts(parts: ThreadMessagePart[]): Promise<{
     rows: Array<{
       id: string;
       seq: number;
@@ -25,7 +49,7 @@ export class SqlThreadMessagePartStorage {
       created_at: string;
     }>;
     partsById: Map<string, ThreadMessagePart>;
-  } {
+  }> {
     const seen = new Set<string>();
     const rows: Array<{
       id: string;
@@ -42,7 +66,8 @@ export class SqlThreadMessagePartStorage {
       created_at: string;
     }> = [];
     const partsById = new Map<string, ThreadMessagePart>();
-    for (const p of parts) {
+    for (let i = 0; i < parts.length; i++) {
+      const p = parts[i]!;
       if (seen.has(p.id)) continue; // can't affect same row twice in one INSERT
       seen.add(p.id);
       partsById.set(p.id, p);
@@ -55,11 +80,12 @@ export class SqlThreadMessagePartStorage {
         message_id: p.message_id,
         role: p.role,
         kind: p.kind,
-        payload: JSON.stringify(p.payload),
+        payload: serializePayload(p.payload),
         payload_ref: p.payload_ref ?? null,
-        metadata: p.metadata != null ? JSON.stringify(p.metadata) : null,
+        metadata: p.metadata != null ? serializePayload(p.metadata) : null,
         created_at: p.created_at,
       });
+      if ((i + 1) % SERIALIZE_YIELD_EVERY === 0) await sleep(0);
     }
     return { rows, partsById };
   }
@@ -67,7 +93,7 @@ export class SqlThreadMessagePartStorage {
   /** Idempotent append; rows are immutable (ON CONFLICT (id) DO NOTHING). */
   async appendParts(parts: ThreadMessagePart[]): Promise<ThreadMessagePart[]> {
     if (parts.length === 0) return [];
-    const { rows, partsById } = this.serializeParts(parts);
+    const { rows, partsById } = await this.serializeParts(parts);
     const inserted = await this.db
       .insertInto("thread_message_parts")
       .values(rows)
@@ -90,7 +116,7 @@ export class SqlThreadMessagePartStorage {
     messageId: string,
     parts: ThreadMessagePart[],
   ): Promise<ThreadMessagePart[]> {
-    const { rows } = this.serializeParts(parts);
+    const { rows } = await this.serializeParts(parts);
     await this.db.transaction().execute(async (trx) => {
       const existing = await trx
         .selectFrom("thread_message_parts")


### PR DESCRIPTION
## Summary
- Traced last night's deco-studio-worker restart storm (55 restarts/24h, one pod OOMKilled 40x over ~3h) to `SqlThreadMessagePartStorage.serializeParts`: it `JSON.stringify`s every thread-message part synchronously, with no yielding and no size bound, whenever a run flushes parts (e.g. a large tool result / file read comes through).
- `serializeParts` now yields to the event loop every 25 parts during a batch instead of doing the whole flush in one synchronous pass.
- Added a 50MB per-payload circuit breaker as a last resort for truly pathological sizes only — normal large tool output (big file reads, big stdout) is still stored in full, not dropped.
- This gap has existed unguarded since the stream-of-record feature was dark-shipped (`d54b94ca9`, June 7) — not a recent regression, just not exercised hard enough to surface until now.

## Testing
- `bun test apps/mesh/src/storage/thread-message-parts.test.ts`
- `bun run --cwd=apps/mesh check`
- `bun run fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OOM kills and event-loop stalls in the studio worker when flushing large thread-message parts by yielding during serialization and adding a per-payload size guard that estimates size without stringifying.

- **Bug Fixes**
  - Yield to the event loop every 25 parts in serializeParts to avoid long synchronous JSON.stringify loops.
  - Add a 50MB per-payload circuit breaker that estimates size via a cheap traversal and skips JSON.stringify for oversized payloads.
  - Bound the size estimator to avoid deep-input stalls.
  - Use serializePayload for both payload and metadata fields.
  - Preserve normal large tool outputs in full; add tests for small, large, and pathological cases.

<sup>Written for commit 7fd361b9845e020b274491edb9942978637e8c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

