### PR TITLE
feat(sandbox-env): opt-in HPA for warm pool via native scale subresource

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,10 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.9.3: opt-in HPA for the warm pool (warmPool.autoscaling.*, default off) —
+# scales SandboxWarmPool via its native scale subresource. No default metric
+# ships; requires warmPool.enabled + at least one metrics entry. Additive; no
+# change unless enabled.
 # 0.9.2: opt-in golden node_modules reflink cache (depsCache.golden, default
 # off) — sets GOLDEN_CACHE_ENABLED so the daemon reflink-restores a cached
 # node_modules and skips install. Additive; no change unless enabled. (The
@@ -27,7 +31,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.2
+version: 0.9.3
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.5.7"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -146,6 +146,28 @@ atomic and gives a pointer to the right install command.
 {{- end }}
 {{- end }}
 
+{{/*
+Validate warmPool.autoscaling before rendering the HPA. Two failure modes
+worth catching at template time rather than letting the API server reject
+(or silently no-op) them:
+  - autoscaling.enabled with warmPool.enabled=false: there's no
+    SandboxWarmPool object for the HPA to target.
+  - autoscaling.enabled with an empty metrics list: an HPA with no metrics
+    can't compute a desired replica count, so it would just sit idle at
+    minReplicas forever — this chart ships no default metric (see
+    sandbox-warmpool-hpa.yaml), so the operator must supply one.
+*/}}
+{{- define "sandbox-env.validateWarmPoolAutoscaling" -}}
+{{- if .Values.warmPool.autoscaling.enabled }}
+{{- if not .Values.warmPool.enabled }}
+{{- fail "sandbox-env: warmPool.autoscaling.enabled=true requires warmPool.enabled=true (there's no SandboxWarmPool to scale otherwise)." -}}
+{{- end }}
+{{- if eq (len .Values.warmPool.autoscaling.metrics) 0 }}
+{{- fail "sandbox-env: warmPool.autoscaling.enabled=true requires at least one entry in warmPool.autoscaling.metrics — this chart ships no default metric. See values.yaml for an example External-metric entry." -}}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "sandbox-env.housekeeperName" -}}
 {{- printf "sandbox-housekeeper-%s" (include "sandbox-env.envName" .) -}}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-warmpool-hpa.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-warmpool-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.warmPool.enabled .Values.warmPool.autoscaling.enabled }}
+# Scales the SandboxWarmPool via its native scale subresource (see
+# sandbox-operator/crds/agent-sandbox-crds.yaml: spec.versions[].subresources.scale,
+# specReplicasPath=.spec.replicas). Off by default — warmPool.size stays a
+# fixed number until you opt in here.
+#
+# BYO metrics: idle warm pods have no CPU/memory signal worth scaling on, so
+# this chart doesn't ship a default metric. Point warmPool.autoscaling.metrics
+# at whatever signals pool pressure in your cluster (e.g. a Prometheus
+# External/Object metric on claim-creation rate or pending-claim count via
+# the Prometheus adapter). See validations.yaml for the enforced minimum.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "sandbox-env.sandboxName" . }}
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.sandboxLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions.agents.x-k8s.io/v1alpha1
+    kind: SandboxWarmPool
+    name: {{ include "sandbox-env.sandboxName" . }}
+  minReplicas: {{ .Values.warmPool.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.warmPool.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.warmPool.autoscaling.metrics | nindent 4 }}
+  {{- with .Values.warmPool.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/sandbox-env/templates/validations.yaml
+++ b/deploy/helm/sandbox-env/templates/validations.yaml
@@ -10,6 +10,7 @@ still land in agent-sandbox-system regardless. The release namespace
 only really matters for Helm's own bookkeeping.
 */ -}}
 {{- include "sandbox-env.validatePreviewGateway" . -}}
+{{- include "sandbox-env.validateWarmPoolAutoscaling" . -}}
 {{- /* Force envName validation to run at template time even when no
 resource references it directly (pure-validation render). Discard the
 return value into a local so it doesn't leak into the rendered YAML. */ -}}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -286,6 +286,30 @@ warmPool:
   enabled: false
   size: 0
 
+  # Optional: scale `size` dynamically via a HorizontalPodAutoscaler
+  # targeting the SandboxWarmPool's native scale subresource (kubectl scale
+  # works too — this just automates it). Off by default; has no effect
+  # unless warmPool.enabled is also true. See templates/sandbox-warmpool-hpa.yaml.
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    # Required when enabled=true — no default metric ships (see
+    # sandbox-warmpool-hpa.yaml for why). Raw autoscaling/v2 `metrics` entries,
+    # e.g.:
+    # metrics:
+    #   - type: External
+    #     external:
+    #       metric:
+    #         name: sandbox_pending_claims
+    #       target:
+    #         type: AverageValue
+    #         averageValue: "2"
+    metrics: []
+    # Optional autoscaling/v2 `behavior` block (scale-up/down stabilization
+    # windows, policies). Left empty = cluster defaults.
+    behavior: {}
+
 # ── preview URL gateway (optional) ─────────────────────────────────────
 # Wildcard preview-URL ingress. Renders an Istio Gateway (HTTPS, terminates
 # `*.<domain>`) + a cert-manager Certificate. Per-claim HTTPRoutes are NOT


### PR DESCRIPTION
## Summary
- Adds `deploy/helm/sandbox-env/templates/sandbox-warmpool-hpa.yaml`, an off-by-default HorizontalPodAutoscaler targeting the `SandboxWarmPool`'s native scale subresource (`spec.replicas` / `status.replicas` / `status.selector`, already vendored in `sandbox-operator/crds/agent-sandbox-crds.yaml`).
- New `warmPool.autoscaling` values block: `enabled`, `minReplicas`, `maxReplicas`, `metrics` (BYO — no default metric shipped, since idle warm pods have no CPU/memory signal worth scaling on), `behavior`.
- Template-time validation (mirrors the existing `previewGateway` pattern): fails if `autoscaling.enabled=true` without `warmPool.enabled=true`, or with an empty `metrics` list.
- Chart bumped 0.9.2 → 0.9.3 (additive, no behavior change unless opted in).

## Test plan
- [x] `helm lint .` passes
- [x] `helm template` with autoscaling off → no HPA rendered
- [x] `helm template` with `autoscaling.enabled=true` + `warmPool.enabled=false` → fails with the expected message
- [x] `helm template` with `autoscaling.enabled=true` + empty `metrics` → fails with the expected message
- [x] `helm template` fully configured (External metric example) → HPA renders correctly against the `SandboxWarmPool` scale subresource
- [ ] Not deployed to any cluster — opt-in only, no cluster currently sets `warmPool.autoscaling.enabled`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in HorizontalPodAutoscaler to scale the warm pool via the `SandboxWarmPool` native scale subresource. Off by default; bring your own metrics to drive scaling.

- **New Features**
  - Added `sandbox-warmpool-hpa.yaml` to create an autoscaling/v2 HPA targeting `SandboxWarmPool` `spec.replicas`.
  - New `warmPool.autoscaling` values: `enabled`, `minReplicas`, `maxReplicas`, `metrics` (required), `behavior`.
  - Template-time validation: requires `warmPool.enabled=true` and at least one `metrics` entry when autoscaling is enabled.
  - No default metric ships (idle warm pods lack CPU/memory signals); use an External/Object metric.
  - Chart version bumped to 0.9.3; no changes unless enabled.

<sup>Written for commit ff3e847445ff4eeb0ff016d384381feb4238aa52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

