### PR TITLE
feat(web): add optional GitHub companion to commerce onboarding

### DIFF
--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -84,6 +84,18 @@ export const KEYS = {
     ] as const,
   commerceDiscoveryCompanionGscSites: (orgId: string, connectionId: string) =>
     ["commerce-discovery", "companion-gsc-sites", orgId, connectionId] as const,
+  // GitHub repo picker: the org's accessible repos (listed via the companion
+  // connection) plus the currently-selected repo (from Commerce Discovery state).
+  commerceDiscoveryCompanionGithubRepos: (
+    orgId: string,
+    connectionId: string,
+  ) =>
+    [
+      "commerce-discovery",
+      "companion-github-repos",
+      orgId,
+      connectionId,
+    ] as const,
   // Per-(org, siteUrl) connection status from commerce-discovery — the single
   // source of truth for "Conectado" across both lanes (OAuth + shared-SA).
   commerceDiscoveryConnectionStatus: (orgId: string, siteUrl: string) =>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
@@ -1,0 +1,255 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@deco/ui/components/form.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { DialogFooter } from "@deco/ui/components/dialog.tsx";
+import { KEYS } from "@/web/lib/query-keys";
+import { fetchGithubInstallations } from "@/web/lib/github-installations";
+import { unwrapToolResult } from "../companions-core.ts";
+import { SelectableList } from "./selectable-list.tsx";
+import { LoadingIndicator } from "../loading-indicator.tsx";
+import type { CompanionFormProps } from "./types.ts";
+
+const schema = z.object({
+  githubRepo: z.string().min(1, "Selecione um repositório"),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface GithubSearchRepo {
+  full_name: string;
+  updated_at?: string;
+}
+
+async function listAccessibleRepos(
+  selfCallTool: (req: {
+    name: string;
+    arguments: Record<string, unknown>;
+  }) => Promise<unknown>,
+  companionCallTool: (req: {
+    name: string;
+    arguments: Record<string, unknown>;
+  }) => Promise<unknown>,
+  connectionId: string,
+): Promise<string[]> {
+  const { installations } = await fetchGithubInstallations(
+    selfCallTool,
+    connectionId,
+  );
+  const perAccount = await Promise.all(
+    installations.map(async (inst) => {
+      const qualifier = inst.type === "User" ? "user" : "org";
+      const result = await companionCallTool({
+        name: "search_repositories",
+        arguments: {
+          query: `${qualifier}:${inst.login}`,
+          page: 1,
+          perPage: 50,
+        },
+      });
+      const content = (result as { content?: Array<{ text?: string }> })
+        .content?.[0]?.text;
+      if (!content) return [] as GithubSearchRepo[];
+      try {
+        const parsed = JSON.parse(content) as { items?: GithubSearchRepo[] };
+        return parsed.items ?? [];
+      } catch {
+        return [] as GithubSearchRepo[];
+      }
+    }),
+  );
+  const byName = new Map<string, GithubSearchRepo>();
+  for (const repo of perAccount.flat()) {
+    if (repo.full_name && !byName.has(repo.full_name)) {
+      byName.set(repo.full_name, repo);
+    }
+  }
+  return Array.from(byName.values())
+    .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
+    .map((repo) => repo.full_name);
+}
+
+export function GitHubConfigForm({
+  connectionId,
+  companionClient,
+  selfClient,
+  org,
+  onDone,
+  onIsPendingChange,
+}: CompanionFormProps) {
+  const queryClient = useQueryClient();
+  // The repo is stored on the Commerce Discovery connection's state
+  // (github_repo, owner/name) — the field the repo-audit skill reads at run
+  // time — not on the GitHub companion connection like GA4/GSC config values.
+  const cdConnectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+
+  const dataQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryCompanionGithubRepos(org.id, connectionId),
+    queryFn: async () => {
+      const [repos, cdGet] = await Promise.all([
+        listAccessibleRepos(
+          (req) => selfClient.callTool(req),
+          (req) => companionClient.callTool(req),
+          connectionId,
+        ),
+        selfClient.callTool({
+          name: "COLLECTION_CONNECTIONS_GET",
+          arguments: { id: cdConnectionId },
+        }),
+      ]);
+      const state =
+        unwrapToolResult<{
+          item: {
+            configuration_state?: Record<string, unknown> | null;
+          } | null;
+        }>(cdGet).item?.configuration_state ?? null;
+      const selectedRepo =
+        typeof state?.github_repo === "string" ? state.github_repo : "";
+      return { repos, selectedRepo };
+    },
+  });
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { githubRepo: "" },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async (githubRepo: string) => {
+      const cdGet = await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_GET",
+        arguments: { id: cdConnectionId },
+      });
+      const currentState =
+        unwrapToolResult<{
+          item: {
+            configuration_state?: Record<string, unknown> | null;
+          } | null;
+        }>(cdGet).item?.configuration_state ?? null;
+      const merged = { ...(currentState ?? {}), github_repo: githubRepo };
+      await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_UPDATE",
+        arguments: {
+          id: cdConnectionId,
+          data: { configuration_state: merged },
+        },
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryConnection(org.id, cdConnectionId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryCompanionConnectionsPrefix(org.id),
+      });
+      onDone();
+    },
+  });
+
+  const isPending = saveMutation.isPending;
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- notify parent of save pending state
+  useEffect(() => {
+    onIsPendingChange?.(isPending);
+  }, [isPending, onIsPendingChange]);
+
+  const handleSubmit = form.handleSubmit(async (data) => {
+    saveMutation.mutate(data.githubRepo);
+  });
+
+  if (dataQuery.isLoading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <LoadingIndicator label="Carregando repositórios..." />
+      </div>
+    );
+  }
+
+  if (dataQuery.isError) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-destructive">
+          Não foi possível carregar os repositórios do GitHub.
+        </p>
+      </div>
+    );
+  }
+
+  const repos = dataQuery.data?.repos ?? [];
+  const selectedRepo = dataQuery.data?.selectedRepo ?? "";
+
+  if (repos.length === 0) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Nenhum repositório acessível foi encontrado nesta conexão do GitHub.
+        </p>
+      </div>
+    );
+  }
+
+  if (selectedRepo && form.getValues("githubRepo") !== selectedRepo) {
+    form.setValue("githubRepo", selectedRepo);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Form {...form}>
+        <FormField
+          control={form.control}
+          name="githubRepo"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <SelectableList
+                  options={repos.map((fullName) => ({
+                    value: fullName,
+                    label: fullName,
+                  }))}
+                  value={field.value}
+                  onChange={field.onChange}
+                  disabled={isPending}
+                  ariaLabel="Repositório"
+                  searchPlaceholder="Buscar repositório..."
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </Form>
+
+      {saveMutation.error && (
+        <p role="alert" className="text-sm text-destructive">
+          {saveMutation.error instanceof Error
+            ? saveMutation.error.message
+            : "Não foi possível salvar a configuração"}
+        </p>
+      )}
+
+      <DialogFooter className="pt-4">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onDone}
+          disabled={isPending}
+        >
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Salvando..." : "Salvar"}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/registry.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/registry.ts
@@ -1,10 +1,12 @@
 import { VtexConfigForm } from "./vtex-config-form.tsx";
 import { GoogleAnalyticsConfigForm } from "./google-analytics-config-form.tsx";
 import { GoogleSearchConsoleConfigForm } from "./google-search-console-config-form.tsx";
+import { GitHubConfigForm } from "./github-config-form.tsx";
 import type { CompanionFormComponent } from "./types.ts";
 
 export const COMPANION_CONFIG_FORMS: Record<string, CompanionFormComponent> = {
   vtex: VtexConfigForm,
   "google-analytics": GoogleAnalyticsConfigForm,
   "google-search-console": GoogleSearchConsoleConfigForm,
+  github: GitHubConfigForm,
 };

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions.ts
@@ -31,4 +31,9 @@ export const COMMERCE_COMPANION_MCPS: Record<string, CompanionCopy> = {
     area: "Busca",
     headline: "O tráfego de busca que você deixa na mesa.",
   },
+  github: {
+    registryAppId: "deco/mcp-github",
+    area: "Engenharia",
+    headline: "A saúde da entrega de código por trás da sua loja.",
+  },
 };


### PR DESCRIPTION
## Summary

Adds **GitHub** as an optional data-source companion on the commerce diagnostic onboarding screen (`/commerce-onboarding`), reusing the existing companion OAuth flow (`deco/mcp-github`) — same design and behavior as GA4 / GSC / VTEX. Connecting is **never required**, so a client who doesn't want to share their code never blocks the analysis.

## Changes

- **`companions.ts`** — register the `github` companion card (area "Engenharia"). Not added to `PROVIDER_BY_BINDING_TYPE`, so it stays on the OAuth lane (plain "Conectar" button), reusing `authenticateAndPersistOAuth`.
- **`companion-forms/github-config-form.tsx`** *(new)* — post-connect repo picker: lists the org's repos via `GITHUB_LIST_USER_ORGS` + `search_repositories`, and saves the chosen `owner/name` as `github_repo` on the **Commerce Discovery** connection's `configuration_state` — the field the `repo-audit` skill reads at run time.
- **`companion-forms/registry.ts`** — register the form.
- **`query-keys.ts`** — query key for the repo picker.

## How it works

The card is **schema-driven**: it surfaces once Commerce Discovery declares the `github` binding. When the client connects, the binding `{ __type:"github", value:<connId> }` is written to the CD connection's `configuration_state`; commerce-skills then leases the client's token server-side and the `repo-audit` skill reads the repo — no token ever reaches the browser session.

## Companion PR (required)

Depends on **decocms/commerce-discovery#203**, which declares the `github` binding (so the card appears) and leases the token server-side for the skill. Merge that first.

## Testing

- `tsc --noEmit` clean for the changed files; `oxlint` clean.
- Not exercised in a running app (local native deps don't build in this env) — worth a manual pass: connect GitHub on the onboarding screen → pick a repo → confirm `github` + `github_repo` land in the CD connection's `configuration_state`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional GitHub companion to commerce onboarding using the existing OAuth flow (`deco/mcp-github`); after connecting, users pick a repo saved as `github_repo` on the Commerce Discovery connection for the `repo-audit` skill.

- **New Features**
  - Registered the `github` companion card (OAuth lane, surfaces when the `github` binding is declared).
  - Added `GitHubConfigForm` to pick a repo; lists accessible repos via `search_repositories`.
  - Added a query key for the repo picker and registered the form.

- **Dependencies**
  - Requires `decocms/commerce-discovery#203` to declare the `github` binding and lease the token server-side. Merge that first.

<sup>Written for commit 9538d0e3ad792fdaff201efd2fe8b28015da9f89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

