### PR TITLE
feat(sandbox): bump sandbox image to node 26

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -308,7 +308,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.11.6",
+      "version": "1.12.0",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/std": "workspace:*",

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,7 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.9.4: default studio-sandbox image tag bumped to 1.12.0 (Node.js 26).
 # 0.9.3: opt-in HPA for the warm pool (warmPool.autoscaling.*, default off) —
 # scales SandboxWarmPool via its native scale subresource. No default metric
 # ships; requires warmPool.enabled + at least one metrics entry. Additive; no
@@ -31,7 +32,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.3
+version: 0.9.4
 # appVersion tracks the studio-sandbox image version (image.tag default).
-appVersion: "0.5.7"
+appVersion: "1.12.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -40,7 +40,7 @@ image:
   # instead of silently moving with `:latest`. Bump in lockstep with
   # packages/sandbox/package.json — release-studio-sandbox.yaml tags
   # images using that version. NEVER set this to "latest" in prod.
-  tag: "1.6.1"
+  tag: "1.12.0"
   # Override to Never on local kind clusters that load via `kind load`.
   pullPolicy: IfNotPresent
 

--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -2,6 +2,7 @@
 FROM oven/bun:1.3.14-debian
 
 ARG NODE_MAJOR=26
+ARG COREPACK_VERSION=0.35.0
 ARG DENO_VERSION=v1.46.3
 
 # `locales` + generated `en_US.UTF-8` is load-bearing: repos using
@@ -18,6 +19,9 @@ RUN apt-get update \
   && curl -fsSL https://deno.land/install.sh \
        | DENO_INSTALL=/opt/deno sh -s -- -y "${DENO_VERSION}" \
   && ln -s /opt/deno/bin/deno /usr/local/bin/deno \
+  # NodeSource's Node 26 packages no longer ship Corepack.
+  && (command -v corepack >/dev/null 2>&1 \
+       || npm install --global "corepack@${COREPACK_VERSION}") \
   && corepack enable \
   # Corepack fetches the tarballs from npm under the hood; if cloudflare
   # closes the TLS socket mid-stream (UND_ERR_SOCKET in undici) the build

--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -1,7 +1,7 @@
 # Build: docker build -t studio-sandbox:local -f packages/sandbox/image/Dockerfile packages/sandbox
 FROM oven/bun:1.3.14-debian
 
-ARG NODE_MAJOR=22
+ARG NODE_MAJOR=26
 ARG DENO_VERSION=v1.46.3
 
 # `locales` + generated `en_US.UTF-8` is load-bearing: repos using

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.11.6",
+  "version": "1.12.0",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps the sandbox image NodeSource major from 22 to 26.
- Publishes the next sandbox image version as 1.12.0.
- Updates sandbox-env chart defaults to image tag/appVersion 1.12.0 and chart version 0.9.4.

## Test Plan
- bun run --cwd=packages/sandbox check
- bun test packages/sandbox/daemon/probe.test.ts packages/sandbox/daemon/validate.test.ts packages/sandbox/server/provider/agent-sandbox/client.test.ts
- helm lint deploy/helm/sandbox-env --set envName=test --set mesh.namespace=deco-studio --set mesh.serviceAccountName=studio --set mesh.serviceName=studio --set mesh.servicePort=80
- helm template sandbox-env-test deploy/helm/sandbox-env --set envName=test --set mesh.namespace=deco-studio --set mesh.serviceAccountName=studio --set mesh.serviceName=studio --set mesh.servicePort=80 | rg "ghcr.io/decocms/studio/studio-sandbox:1.12.0"
- git diff --check

## Notes
- Local Docker image build was not run because this sandbox does not have docker, podman, or nerdctl installed. CI docker-smoke should validate the actual image build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the sandbox image to Node.js 26 and release `@decocms/sandbox` 1.12.0; updates `sandbox-env` defaults to use the new image and chart 0.9.4. Also installs Corepack since Node 26 packages no longer include it.

- **Dependencies**
  - Set `NODE_MAJOR=26` in the sandbox Dockerfile.
  - Install and enable `corepack` (`COREPACK_VERSION=0.35.0`) for Node 26 images.
  - Bump `@decocms/sandbox` to `1.12.0`.
  - Update `sandbox-env` chart to `0.9.4` with `appVersion: 1.12.0` and default image tag `1.12.0`.

<sup>Written for commit 55b20ec895caf973be4f4894e0c94702b3a3c8fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

