### PR TITLE
feat(sidebar): ui cleanup — sentence case, agents first, mobile tabs, Library panel tab

### DIFF
--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -15,6 +15,18 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* Prevent iOS from zooming on input focus */
+  input,
+  select,
+  textarea {
+    font-size: max(1rem, 16px);
+  }
+  /* Larger base text on mobile — text-sm (0.875rem) → ~16px instead of 14px */
+  @media (max-width: 768px) {
+    html {
+      font-size: 18.3px;
+    }
+  }
   svg {
     stroke-width: 1.75;
   }

--- a/apps/mesh/src/web/components/sidebar/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/index.tsx
@@ -1,7 +1,6 @@
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { useProjectSidebarItems } from "@/web/hooks/use-project-sidebar-items";
 import { Suspense } from "react";
-import { Separator } from "@deco/ui/components/separator.tsx";
 import { NavigationSidebar } from "./navigation";
 import { MobileNavigationSidebar } from "./navigation-mobile";
 import { SidebarInboxFooter } from "./footer/inbox";
@@ -27,15 +26,7 @@ export function StudioSidebar() {
         footer={<SidebarInboxFooter />}
         additionalContent={
           <ErrorBoundary>
-            <Suspense
-              fallback={
-                <>
-                  <Separator className="mb-2" />
-                  <TaskGroupsSkeleton />
-                </>
-              }
-            >
-              <Separator className="mb-2" />
+            <Suspense fallback={<TaskGroupsSkeleton />}>
               <TaskGroupsList />
             </Suspense>
           </ErrorBoundary>
@@ -56,15 +47,7 @@ export function StudioSidebarMobile({ onClose }: { onClose: () => void }) {
         footer={<SidebarInboxFooterMobile />}
         additionalContent={
           <ErrorBoundary>
-            <Suspense
-              fallback={
-                <>
-                  <Separator className="mb-2" />
-                  <TaskGroupsSkeleton />
-                </>
-              }
-            >
-              <Separator className="mb-2" />
+            <Suspense fallback={<TaskGroupsSkeleton />}>
               <TaskGroupsList onNavigate={onClose} />
             </Suspense>
           </ErrorBoundary>

--- a/apps/mesh/src/web/components/sidebar/task-groups/scroll-fade.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/scroll-fade.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { cn } from "@deco/ui/lib/utils.ts";
+
+/**
+ * Wraps a scrollable area and shows a bottom fade when there is more content
+ * below the visible viewport. Uses a ref callback for the initial check so no
+ * useEffect is needed.
+ */
+export function ScrollFade({
+  className,
+  wrapperClassName,
+  children,
+}: {
+  className?: string;
+  wrapperClassName?: string;
+  children: React.ReactNode;
+}) {
+  const [hasMore, setHasMore] = useState(false);
+
+  const checkOverflow = (el: HTMLDivElement | null) => {
+    if (!el) return;
+    setHasMore(el.scrollHeight > el.clientHeight + 1);
+  };
+
+  const onScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    setHasMore(el.scrollHeight - el.scrollTop > el.clientHeight + 1);
+  };
+
+  return (
+    <div className={cn("relative", wrapperClassName)}>
+      <div ref={checkOverflow} onScroll={onScroll} className={className}>
+        {children}
+      </div>
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute right-0 bottom-0 left-0 h-10 bg-gradient-to-t from-sidebar to-transparent transition-opacity duration-150",
+          hasMore ? "opacity-100" : "opacity-0",
+        )}
+      />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sidebar/task-groups/sidebar-section-header.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/sidebar-section-header.tsx
@@ -32,7 +32,7 @@ export function SidebarSectionHeader({
         aria-expanded={open}
         aria-controls={controlsId}
         onClick={onToggle}
-        className="flex flex-1 min-w-0 items-center gap-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80 hover:text-foreground transition-colors focus-visible:outline-none"
+        className="flex flex-1 min-w-0 items-center gap-1 text-sm font-medium text-muted-foreground/80 hover:text-foreground transition-colors focus-visible:outline-none"
       >
         {open ? (
           <ChevronDown size={12} className="shrink-0" />
@@ -48,7 +48,7 @@ export function SidebarSectionHeader({
         <button
           type="button"
           onClick={action.onClick}
-          className="shrink-0 flex items-center gap-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60 hover:text-foreground opacity-0 group-hover/section:opacity-100 focus-visible:opacity-100 transition-opacity focus-visible:outline-none"
+          className="shrink-0 flex items-center gap-0.5 text-sm font-medium text-muted-foreground/60 hover:text-foreground opacity-0 group-hover/section:opacity-100 focus-visible:opacity-100 transition-opacity focus-visible:outline-none"
         >
           {action.label}
           {action.icon}

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { ScrollFade } from "./scroll-fade";
 import {
   Activity,
   Edit05,
@@ -27,7 +28,7 @@ import {
   useVirtualMCPActions,
   useVirtualMCPs,
 } from "@decocms/mesh-sdk";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
 import { authClient } from "@/web/lib/auth-client";
 import {
   useThreadActions,
@@ -35,6 +36,7 @@ import {
 } from "@/web/components/chat/store/hooks";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { GlobalSearchDialog } from "@/web/layouts/tasks-panel/global-search-dialog";
+import { TaskRow } from "@/web/layouts/tasks-panel/task-row";
 import { track } from "@/web/lib/posthog-client";
 import type { Task } from "@/web/components/chat/task/types";
 import {
@@ -64,6 +66,12 @@ import { SidebarSectionHeader } from "./sidebar-section-header";
 import type { SidebarFilters } from "./next-page-offset";
 import { buildGroupThreadCounts } from "./next-page-offset";
 import { useSidebarGroupOrder } from "./use-sidebar-group-order";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@deco/ui/components/tabs.tsx";
 
 type TypeFilter = "all" | "manual" | "automation";
 type GroupBy = "flat" | "status";
@@ -144,6 +152,10 @@ export function TaskGroupsList({
   const params = useParams({ strict: false }) as {
     taskId?: string;
   };
+  const pathname = useRouterState({
+    select: (s) => s.location.pathname,
+  });
+  const isOnHome = pathname === `/${org.slug}` || pathname === `/${org.slug}/`;
   const activeTaskId = params.taskId ?? null;
   const activeAgentId =
     allThreads.find((t) => t.id === activeTaskId)?.virtual_mcp_id ?? null;
@@ -300,7 +312,13 @@ export function TaskGroupsList({
 
   // Click an agent → open its most recent thread; if it has none, start a new
   // one (which also adds it to the personal sidebar order).
+  // Decopilot is the product home — clicking it navigates to /$org directly.
   const handleOpenAgent = async (virtualMcpId: string) => {
+    if (virtualMcpId === decopilotId) {
+      closeAfterNavigation();
+      navigate({ to: "/$org", params: { org: org.slug } });
+      return;
+    }
     const loaded = myThreadsAll.find((t) => t.virtual_mcp_id === virtualMcpId);
     if (loaded) {
       track("sidebar_agent_opened", {
@@ -407,7 +425,10 @@ export function TaskGroupsList({
     group: (typeof agentGroups)[number],
   ): AgentRowProps => ({
     virtualMcpId: group.virtualMcpId,
-    isActive: activeAgentId === group.virtualMcpId,
+    isActive:
+      group.virtualMcpId === decopilotId
+        ? isOnHome
+        : activeAgentId === group.virtualMcpId,
     threadCount: agentThreadCounts.get(group.virtualMcpId) ?? 0,
     onOpen: handleOpenAgent,
     onNewTask: handleNewInGroup,
@@ -465,6 +486,139 @@ export function TaskGroupsList({
           />
         </SidebarMenu>
       </>
+    );
+  }
+
+  if (isMobile) {
+    const hasTeamThreads = teamThreads.length > 0;
+    return (
+      <div className="flex flex-col h-full min-h-0">
+        <SyncSidebarAgentGroupsEmpty value={agentGroups.length === 0} />
+        <div className="shrink-0 px-1 h-10 flex items-center justify-between">
+          <div className="flex items-center gap-0.5">
+            <ToolbarIconButton
+              aria-label="Search threads"
+              onClick={() => {
+                track("tasks_panel_search_opened");
+                setSearchEverOpened(true);
+                setSearchOpen(true);
+              }}
+            >
+              <SearchSm size={16} />
+            </ToolbarIconButton>
+            <ToolbarIconButton
+              aria-label={
+                groupBy === "flat" ? "Group by status" : "Show as flat list"
+              }
+              title={groupBy === "flat" ? "Flat list" : "Grouped by status"}
+              onClick={() => {
+                const next: GroupBy = groupBy === "flat" ? "status" : "flat";
+                track("tasks_panel_group_by_changed", { to_value: next });
+                setGroupBy(next);
+              }}
+            >
+              {groupBy === "flat" ? (
+                <Rows01 size={16} />
+              ) : (
+                <Activity size={16} />
+              )}
+            </ToolbarIconButton>
+          </div>
+          <ToolbarIconButton
+            aria-label="New thread"
+            title="New thread"
+            onClick={() => void handleNewThread()}
+          >
+            <Edit05 size={16} />
+          </ToolbarIconButton>
+        </div>
+        <Tabs
+          defaultValue="agents"
+          variant="pill"
+          className="flex flex-col flex-1 min-h-0 gap-0"
+        >
+          <TabsList
+            variant="pill"
+            className="shrink-0 mx-1 mb-2 w-[calc(100%-0.5rem)]"
+          >
+            <TabsTrigger variant="pill" value="agents">
+              Agents
+            </TabsTrigger>
+            <TabsTrigger variant="pill" value="my-threads">
+              My threads
+            </TabsTrigger>
+            {hasTeamThreads && (
+              <TabsTrigger variant="pill" value="team-threads">
+                Team
+              </TabsTrigger>
+            )}
+          </TabsList>
+          <TabsContent
+            value="agents"
+            className="flex-1 min-h-0 mt-1 flex flex-col"
+          >
+            <ScrollFade
+              wrapperClassName="flex-1 min-h-0"
+              className="flex flex-col gap-0.5 overflow-y-auto overscroll-contain px-1 h-full"
+            >
+              <SortableAgentRows
+                groups={agentGroups}
+                orderScope={orderScope}
+                decopilotId={decopilotId}
+                orgPinnedIds={orgPinnedIds}
+                onReorder={() => setLocalOrderRevision((n) => n + 1)}
+                renderGroup={buildAgentRowProps}
+              />
+            </ScrollFade>
+          </TabsContent>
+          <TabsContent
+            value="my-threads"
+            className="flex-1 min-h-0 mt-1 flex flex-col"
+          >
+            <ScrollFade
+              wrapperClassName="flex-1 min-h-0"
+              className="flex flex-col gap-0.5 overflow-y-auto overscroll-contain px-1 h-full"
+            >
+              <MyThreadsSection
+                threads={myThreads}
+                groupBy={groupBy}
+                activeTaskId={activeTaskId}
+                onSelectTask={handleSelectTask}
+                onArchiveTask={handleArchive}
+                filters={filters}
+                hasMore={hasMore}
+                isFetchingMore={isFetchingMore}
+                onLoadMore={() => void fetchNextPage()}
+              />
+            </ScrollFade>
+          </TabsContent>
+          {hasTeamThreads && (
+            <TabsContent
+              value="team-threads"
+              className="flex-1 min-h-0 mt-1 flex flex-col"
+            >
+              <ScrollFade
+                wrapperClassName="flex-1 min-h-0"
+                className="flex flex-col gap-0.5 overflow-y-auto overscroll-contain px-1 h-full"
+              >
+                {teamThreads.slice(0, 8).map((task) => (
+                  <TaskRow
+                    key={task.id}
+                    task={task}
+                    isActive={activeTaskId === task.id}
+                    onClick={() => handleSelectTask(task)}
+                    showAutomationBadge={Boolean(task.trigger_id)}
+                    showAgentIcon
+                  />
+                ))}
+              </ScrollFade>
+            </TabsContent>
+          )}
+        </Tabs>
+        {searchEverOpened && (
+          <GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
+        )}
+      </div>
     );
   }
 
@@ -550,6 +704,34 @@ export function TaskGroupsList({
         </ToolbarIconButton>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain flex flex-col gap-0.5 -mr-2 pr-2">
+        <SidebarSectionHeader
+          label="Agents"
+          open={agentsOpen}
+          onToggle={() => setAgentsOpen((v) => !v)}
+          count={agentGroups.length}
+          controlsId="sidebar-section-agents"
+          actionSlot={<BrowseAgentsButton compact />}
+        />
+        <div
+          id="sidebar-section-agents"
+          aria-hidden={!agentsOpen}
+          className="grid transition-[grid-template-rows] duration-200 ease-out"
+          style={{ gridTemplateRows: agentsOpen ? "1fr" : "0fr" }}
+        >
+          <div className="overflow-hidden">
+            <ScrollFade className="flex flex-col gap-0.5 max-h-[35vh] overflow-y-auto overscroll-contain">
+              <SortableAgentRows
+                groups={agentGroups}
+                orderScope={orderScope}
+                decopilotId={decopilotId}
+                orgPinnedIds={orgPinnedIds}
+                onReorder={() => setLocalOrderRevision((n) => n + 1)}
+                renderGroup={buildAgentRowProps}
+              />
+            </ScrollFade>
+          </div>
+        </div>
+        <div className="mx-2 my-2 border-b" />
         <TeamThreadsSection
           threads={teamThreads}
           activeTaskId={activeTaskId}
@@ -563,45 +745,28 @@ export function TaskGroupsList({
           count={myThreads.length}
           controlsId="sidebar-section-my-threads"
         />
-        {myThreadsOpen && (
-          <div
-            id="sidebar-section-my-threads"
-            className="flex flex-col gap-0.5"
-          >
-            <MyThreadsSection
-              threads={myThreads}
-              groupBy={groupBy}
-              activeTaskId={activeTaskId}
-              onSelectTask={handleSelectTask}
-              onArchiveTask={handleArchive}
-              filters={filters}
-              hasMore={hasMore}
-              isFetchingMore={isFetchingMore}
-              onLoadMore={() => void fetchNextPage()}
-            />
+        <div
+          id="sidebar-section-my-threads"
+          aria-hidden={!myThreadsOpen}
+          className="grid transition-[grid-template-rows] duration-200 ease-out"
+          style={{ gridTemplateRows: myThreadsOpen ? "1fr" : "0fr" }}
+        >
+          <div className="overflow-hidden">
+            <ScrollFade className="flex flex-col gap-0.5 max-h-[40vh] overflow-y-auto overscroll-contain">
+              <MyThreadsSection
+                threads={myThreads}
+                groupBy={groupBy}
+                activeTaskId={activeTaskId}
+                onSelectTask={handleSelectTask}
+                onArchiveTask={handleArchive}
+                filters={filters}
+                hasMore={hasMore}
+                isFetchingMore={isFetchingMore}
+                onLoadMore={() => void fetchNextPage()}
+              />
+            </ScrollFade>
           </div>
-        )}
-        <div className="mx-2 my-2 border-b" />
-        <SidebarSectionHeader
-          label="Agents"
-          open={agentsOpen}
-          onToggle={() => setAgentsOpen((v) => !v)}
-          count={agentGroups.length}
-          controlsId="sidebar-section-agents"
-          actionSlot={<BrowseAgentsButton compact />}
-        />
-        {agentsOpen && (
-          <div id="sidebar-section-agents" className="flex flex-col gap-0.5">
-            <SortableAgentRows
-              groups={agentGroups}
-              orderScope={orderScope}
-              decopilotId={decopilotId}
-              orgPinnedIds={orgPinnedIds}
-              onReorder={() => setLocalOrderRevision((n) => n + 1)}
-              renderGroup={buildAgentRowProps}
-            />
-          </div>
-        )}
+        </div>
       </div>
       {searchEverOpened && (
         <GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />

--- a/apps/mesh/src/web/components/sidebar/task-groups/team-threads-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/team-threads-section.tsx
@@ -6,6 +6,7 @@ import { TaskRow } from "@/web/layouts/tasks-panel/task-row";
 import { track } from "@/web/lib/posthog-client";
 import type { Task } from "@/web/components/chat/task/types";
 import { SidebarSectionHeader } from "./sidebar-section-header";
+import { ScrollFade } from "./scroll-fade";
 
 /** How many teammate threads to preview inline before deferring to "See all". */
 const TEAM_PREVIEW_LIMIT = 8;
@@ -64,33 +65,37 @@ export function TeamThreadsSection({
           onClick: seeAll,
         }}
       />
-      {open && (
-        <div
-          id="sidebar-section-team-threads"
-          className="flex flex-col gap-0.5"
-        >
-          {preview.map((task) => (
-            <TaskRow
-              key={task.id}
-              task={task}
-              isActive={activeTaskId === task.id}
-              onClick={() => onSelectTask(task)}
-              showAutomationBadge={Boolean(task.trigger_id)}
-              showAgentIcon
-            />
-          ))}
-          {hasOverflow && (
-            <button
-              type="button"
-              onClick={seeAll}
-              className="flex items-center gap-1 px-2 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-accent/60 hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-            >
-              <span>See all {threads.length} team threads</span>
-              <ArrowNarrowRight size={12} />
-            </button>
-          )}
+      <div
+        id="sidebar-section-team-threads"
+        aria-hidden={!open}
+        className="grid transition-[grid-template-rows] duration-200 ease-out"
+        style={{ gridTemplateRows: open ? "1fr" : "0fr" }}
+      >
+        <div className="overflow-hidden">
+          <ScrollFade className="flex flex-col gap-0.5 max-h-[30vh] overflow-y-auto overscroll-contain">
+            {preview.map((task) => (
+              <TaskRow
+                key={task.id}
+                task={task}
+                isActive={activeTaskId === task.id}
+                onClick={() => onSelectTask(task)}
+                showAutomationBadge={Boolean(task.trigger_id)}
+                showAgentIcon
+              />
+            ))}
+            {hasOverflow && (
+              <button
+                type="button"
+                onClick={seeAll}
+                className="flex items-center gap-1 px-2 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-accent/60 hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              >
+                <span>See all {threads.length} team threads</span>
+                <ArrowNarrowRight size={12} />
+              </button>
+            )}
+          </ScrollFade>
         </div>
-      )}
+      </div>
     </>
   );
 }

--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -1,50 +1,19 @@
 import { useProjectContext } from "@decocms/mesh-sdk";
-import type {
-  NavigationSidebarItem,
-  SidebarSection,
-} from "@/web/components/sidebar/types";
-import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { Folder, Home01 } from "@untitledui/icons";
+import type { SidebarSection } from "@/web/components/sidebar/types";
+import { useSidebar } from "@deco/ui/components/sidebar.tsx";
 import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarMenu,
-  useSidebar,
 } from "@deco/ui/components/sidebar.tsx";
 import { BrowseAgentsButton } from "@/web/components/sidebar/browse-agents-button";
 
 export function useProjectSidebarItems(): SidebarSection[] {
-  const { org } = useProjectContext();
-  const navigate = useNavigate();
-  const routerState = useRouterState();
-  const pathname = routerState.location.pathname;
-  const slug = org.slug;
+  const { org: _org } = useProjectContext();
   const { state, isMobile } = useSidebar();
   const isCollapsed = !isMobile && state === "collapsed";
 
-  const homeItem: NavigationSidebarItem = {
-    key: "home",
-    label: "Home",
-    icon: <Home01 className="size-4!" />,
-    isActive: pathname === `/${slug}` || pathname === `/${slug}/`,
-    onClick: () => {
-      navigate({ to: "/$org", params: { org: slug } });
-    },
-  };
-
-  const filesItem: NavigationSidebarItem = {
-    key: "files",
-    label: "Library",
-    icon: <Folder className="size-4!" />,
-    isActive: pathname.startsWith(`/${slug}/files`),
-    onClick: () => {
-      navigate({ to: "/$org/files", params: { org: slug } });
-    },
-  };
-
-  const sections: SidebarSection[] = [
-    { type: "items", items: [homeItem, filesItem] },
-  ];
+  const sections: SidebarSection[] = [];
 
   if (isCollapsed) {
     sections.push({

--- a/apps/mesh/src/web/layouts/library/index.tsx
+++ b/apps/mesh/src/web/layouts/library/index.tsx
@@ -603,7 +603,16 @@ function VolumeView({
   );
 }
 
-function LibraryPage() {
+export function LibraryPage({
+  onOpenFile: onOpenFileOverride,
+  onOpenSkill: onOpenSkillOverride,
+  onOpenBrand: onOpenBrandOverride,
+}: {
+  /** Override file-open behaviour (e.g. open as a panel tab instead of ?preview=). */
+  onOpenFile?: (previewPath: string) => void;
+  onOpenSkill?: (skillPath: string) => void;
+  onOpenBrand?: (brandPath: string) => void;
+} = {}) {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -644,10 +653,15 @@ function LibraryPage() {
         [kind]: value,
       }),
     });
-  const onOpenFile = (previewPath: string) =>
-    openPreview("preview", previewPath);
-  const onOpenSkill = (skillPath: string) => openPreview("skill", skillPath);
-  const onOpenBrand = (brandPath: string) => openPreview("brand", brandPath);
+  const onOpenFile =
+    onOpenFileOverride ??
+    ((previewPath: string) => openPreview("preview", previewPath));
+  const onOpenSkill =
+    onOpenSkillOverride ??
+    ((skillPath: string) => openPreview("skill", skillPath));
+  const onOpenBrand =
+    onOpenBrandOverride ??
+    ((brandPath: string) => openPreview("brand", brandPath));
 
   // Global file search — cross-volume, so it lives above the browse
   // location and stays visible while inside any folder.

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -19,6 +19,7 @@ import { AutomationsListTab } from "./automations-list-tab";
 import { FileTab } from "./file-tab";
 import { DeckTab } from "./deck-tab";
 import { LibraryFileTab } from "./library-file-tab";
+import { LibraryTab } from "./library-tab";
 import { MainPanelLoading } from "./main-panel-loading";
 import {
   isLegacySettingsTab,
@@ -79,6 +80,9 @@ function TabBody({
   }
   if (activeTab === "content") {
     return <ContentTab virtualMcpId={virtualMcpId} />;
+  }
+  if (activeTab === "files") {
+    return <LibraryTab />;
   }
   if (automationTabParsed) {
     return <AutomationTab tabId={activeTab} />;

--- a/apps/mesh/src/web/layouts/main-panel-tabs/library-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/library-tab.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { LibraryPage } from "@/web/layouts/library";
+import { SkillPreviewDialog } from "@/web/layouts/library/skill-preview";
+import { BrandPreviewDialog } from "@/web/layouts/library/brand-preview";
+import { formatLibraryFileTabId } from "./tab-id";
+
+export function LibraryTab() {
+  const navigate = useNavigate();
+  const [openSkill, setOpenSkill] = useState<string | null>(null);
+  const [openBrand, setOpenBrand] = useState<string | null>(null);
+
+  const openAsTab = (tabId: string) =>
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, main: tabId }),
+      replace: true,
+    });
+
+  return (
+    <div className="flex flex-col h-full min-h-0 overflow-hidden">
+      <LibraryPage
+        onOpenFile={(path) => openAsTab(formatLibraryFileTabId(path))}
+        onOpenSkill={setOpenSkill}
+        onOpenBrand={setOpenBrand}
+      />
+      {openSkill && (
+        <SkillPreviewDialog
+          key={openSkill}
+          skillPath={openSkill}
+          onClose={() => setOpenSkill(null)}
+        />
+      )}
+      {openBrand && (
+        <BrandPreviewDialog
+          key={openBrand}
+          brandPath={openBrand}
+          onClose={() => setOpenBrand(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/resolve-tab-icon.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/resolve-tab-icon.ts
@@ -1,6 +1,7 @@
 import type { ComponentType, SVGProps } from "react";
 import {
   Edit05,
+  Folder,
   GitBranch01,
   Globe01,
   LayoutAlt04,
@@ -22,7 +23,8 @@ export type SystemTabId =
   | "automations"
   | "preview"
   | "content"
-  | "git";
+  | "git"
+  | "files";
 
 export const SYSTEM_TAB_ICONS: Record<SystemTabId, IconComponent> = {
   settings: LayoutAlt04,
@@ -30,6 +32,7 @@ export const SYSTEM_TAB_ICONS: Record<SystemTabId, IconComponent> = {
   preview: Globe01,
   content: Edit05,
   git: GitBranch01,
+  files: Folder,
 };
 
 type ConnectionLike = { id: string; icon: string | null };

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
@@ -144,6 +144,48 @@ export function parseLibraryFileTabId(
   }
 }
 
+export interface LibrarySkillTabParsed {
+  path: string;
+}
+
+export function formatLibrarySkillTabId(path: string): string {
+  return `library-skill:${encodeURIComponent(path)}`;
+}
+
+export function parseLibrarySkillTabId(
+  tabId: string | undefined,
+): LibrarySkillTabParsed | null {
+  if (!tabId || !tabId.startsWith("library-skill:")) return null;
+  const encoded = tabId.slice("library-skill:".length);
+  if (!encoded) return null;
+  try {
+    return { path: decodeURIComponent(encoded) };
+  } catch {
+    return null;
+  }
+}
+
+export interface LibraryBrandTabParsed {
+  path: string;
+}
+
+export function formatLibraryBrandTabId(path: string): string {
+  return `library-brand:${encodeURIComponent(path)}`;
+}
+
+export function parseLibraryBrandTabId(
+  tabId: string | undefined,
+): LibraryBrandTabParsed | null {
+  if (!tabId || !tabId.startsWith("library-brand:")) return null;
+  const encoded = tabId.slice("library-brand:".length);
+  if (!encoded) return null;
+  try {
+    return { path: decodeURIComponent(encoded) };
+  } catch {
+    return null;
+  }
+}
+
 export const FIXED_SYSTEM_TABS = [
   "settings",
   "automations",
@@ -169,7 +211,9 @@ export function isPerThreadTab(tabId: string): boolean {
     tabId.startsWith("automation:") ||
     tabId.startsWith("file:") ||
     tabId.startsWith("deck:") ||
-    tabId.startsWith("library-file:")
+    tabId.startsWith("library-file:") ||
+    tabId.startsWith("library-skill:") ||
+    tabId.startsWith("library-brand:")
   );
 }
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -312,6 +312,7 @@ export function useMainPanelTabs(ctx: {
     systemTabs.push({ id: "settings", title: "Settings" });
   }
   systemTabs.push({ id: "automations", title: "Automations" });
+  systemTabs.push({ id: "files", title: "Library" });
 
   // Merge pinned views + per-task expanded tools into a single list keyed
   // by the pinned-view tab id. Pinned views win on dedupe so the


### PR DESCRIPTION
## Summary

- Section headers drop uppercase/tracking-wider, bumped to `text-sm` to match thread row titles
- Agents section moved above My threads; Home and Library nav items removed
- Decopilot row navigates to `/$org` (home) and highlights as active on that route
- Separator above task list removed (was there to separate the now-removed nav items)
- Accordion open/close uses `grid-template-rows` CSS transition to eliminate CLS
- Per-accordion `max-h` cap with `ScrollFade` (bottom fade gradient appears when content overflows)
- Mobile: accordions replaced with pill tabs (Agents / My threads / Team)
- Mobile: `html` base font bumped to 18.3px so `text-sm` renders at ~16px
- Library added as a permanent right-panel tab (Folder icon, always visible)
- File clicks in the Library tab open as `library-file:` panel tabs; skills/brands open as dialogs

## Test plan

- [ ] Sidebar section headers render in sentence case, same size as thread rows
- [ ] Agents section appears above My threads on desktop
- [ ] Clicking Decopilot navigates to org home; row highlights when on home route
- [ ] Opening/closing accordion sections has no layout shift
- [ ] Expanding many agents doesn't push My threads off screen (capped + scrollable)
- [ ] Bottom fade appears when accordion content overflows, disappears at scroll end
- [ ] Mobile shows pill tabs; content scrolls within each tab without overflowing footer
- [ ] Library tab appears in top-right tab bar on all agent/thread views
- [ ] Clicking a file in Library tab opens it as a side panel tab
- [ ] Clicking a skill in Library tab opens the skill modal dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the sidebar UI for clearer navigation and less layout shift. Agents come first, mobile gets tabs, and Library is now a permanent right-panel tab.

- **New Features**
  - Agents moved above My threads; removed Home and Library items from the sidebar
  - Decopilot row navigates to `/$org` and shows as active on the home route
  - Accordions animate with no CLS via grid-template-rows; sections capped with `ScrollFade` showing a bottom fade on overflow
  - Mobile: pill tabs (Agents / My threads / Team), larger base font (~16px for `text-sm`), and 16px+ inputs to prevent iOS zoom
  - Library: added always-visible right-panel tab (Folder icon); files open as `library-file:` tabs; skills/brands open as dialogs

<sup>Written for commit 68702bc83a85f6938fe78e8971176d65ba52d1ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

