### PR TITLE
fix(commerce-onboarding): close sidebar when navigating to discovery app

### DIFF
--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -36,9 +36,8 @@ import {
   SidebarTriggerButton,
 } from "@/web/layouts/shell-controls";
 import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { ShellRouteLoading } from "@/web/layouts/shell-route-loading";
-
-const SIDEBAR_OPEN_STORAGE_KEY = "sidebar.open";
 
 function RouteFallback() {
   return <ShellRouteLoading />;
@@ -47,7 +46,7 @@ function RouteFallback() {
 export default function OrgShellLayout() {
   const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useLocalStorage<boolean>(
-    SIDEBAR_OPEN_STORAGE_KEY,
+    LOCALSTORAGE_KEYS.sidebarOpen(),
     false,
   );
   const { width, wrapperRef, onStartResize, resetWidth } = useSidebarResize();


### PR DESCRIPTION
## What is this contribution about?

The sidebar was not closing when the user navigated to the commerce discovery MCP app. The root cause was a localStorage key mismatch: the commerce onboarding wrote `false` to `LOCALSTORAGE_KEYS.sidebarOpen()` (`"mesh:sidebar-open"`), but the sidebar layout read from a local constant `"sidebar.open"` — so the write had no effect. This fixes it by making the sidebar layout use the canonical `LOCALSTORAGE_KEYS.sidebarOpen()` key.

## Screenshots/Demonstration

No visual change beyond the sidebar now correctly closing on navigation to the discovery app.

## How to Test

1. Go through the commerce onboarding flow with a valid site URL.
2. Click "Ver relatório completo" to open the report.
3. Expected outcome: the sidebar is closed when the discovery MCP app opens.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar not closing when opening the discovery MCP app. The layout now reads `LOCALSTORAGE_KEYS.sidebarOpen()` (canonical `mesh:sidebar-open`) instead of `sidebar.open`, keeping state in sync with commerce onboarding.

<sup>Written for commit eccfa238133e80da586d5b9009917ec7ffd1b22e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

