### PR TITLE
fix(typegen): prevent await on generated client hanging forever

### DIFF
--- a/packages/typegen/src/runtime.test.ts
+++ b/packages/typegen/src/runtime.test.ts
@@ -123,6 +123,16 @@ describe("createMeshClient", () => {
     expect(mockConnect).toHaveBeenCalledTimes(2);
   });
 
+  test("is not treated as a thenable (await would otherwise hang forever)", () => {
+    type Tools = { TOOL: { input: Record<string, never>; output: unknown } };
+    const client = createMeshClient<Tools>(
+      { mcpId: "vmc_test", apiKey: "sk" },
+      deps,
+    );
+
+    expect(client.then).toBeUndefined();
+  });
+
   test("builds URL with correct mcpId and baseUrl", async () => {
     type Tools = { TOOL: { input: Record<string, never>; output: unknown } };
 

--- a/packages/typegen/src/runtime.ts
+++ b/packages/typegen/src/runtime.ts
@@ -58,6 +58,12 @@ export function createMeshClient<T extends ToolMap>(
 
   return new Proxy({} as MeshClient<T>, {
     get(_target, toolName: string) {
+      // Without this, `await createMeshClient(...)` treats the proxy as a
+      // thenable (since `.then` resolves to a function), calls it as
+      // `then(resolve, reject)`, and — since that call is really a tool
+      // invocation that never touches `resolve`/`reject` — the await hangs
+      // forever instead of resolving to the client.
+      if (toolName === "then") return undefined;
       if (toolName === "close") {
         return async () => {
           if (connectPromise) {


### PR DESCRIPTION
## Source
Bug found reading `packages/typegen/src/runtime.ts` (the `@decocms/typegen` public SDK runtime — this is code shipped to and used directly by external consumers who generate a typed client for their MCP).

## Why
`createMeshClient()` returns a `Proxy` whose `get` trap answers *any* property name with an async function (used to build per-tool call methods). That includes `"then"`. So `await createMeshClient(...)` — a very plausible mistake, since every other factory in this codebase is async and awaited — makes JS treat the returned proxy as a thenable: it calls `client.then(resolve, reject)`, which is really just a tool invocation named `"then"` that never touches `resolve`/`reject`. The `await` never settles and the caller hangs forever with no error.

## Failure scenario + regression test
`await client` (or `Promise.resolve(client)`) on the proxy returned by `createMeshClient()` hangs indefinitely instead of resolving. Regression test added in `packages/typegen/src/runtime.test.ts` ("is not treated as a thenable...") asserts `client.then` is `undefined`; it fails on current `main` (returns an `AsyncFunction`) and passes after the fix.

## Fix
Special-case `toolName === "then"` in the `get` trap to return `undefined`, so JS's `await`/`Promise.resolve` machinery doesn't mistake the proxy for a thenable.

## Verify
```
bun test packages/typegen/src/runtime.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` (in `packages/typegen`) — passes
- `bun test packages/typegen/src/runtime.test.ts` — 8/8 pass

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang when `await createMeshClient(...)` from `@decocms/typegen` is called. The generated client proxy was treated as a thenable, causing the await to never resolve.

- **Bug Fixes**
  - Special-case `"then"` in the Proxy `get` trap to return `undefined`, so the client isn’t seen as a thenable.
  - Added a regression test asserting `client.then` is `undefined`.

<sup>Written for commit 042eeb8dc26b67f37b9d10a29252d886e908e616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

