### PR TITLE
fix(sandbox): reinstall pre-push branch-protection hook after install

### DIFF
--- a/packages/sandbox/daemon/setup/orchestrator.test.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Broadcaster } from "../events/broadcast";
 import type { BranchStatusMonitor } from "../git/branch-status";
+import { installProtectedBranchHook } from "../git/protect-branch";
 import { LifecycleManager } from "../lifecycle/manager";
 import type { LifecycleState } from "../events/types";
 import { SetupOrchestrator } from "./orchestrator";
@@ -726,4 +733,75 @@ describe("SetupOrchestrator lifecycle wedge fixes", () => {
       cleanup();
     }
   });
+});
+
+describe("SetupOrchestrator install-step branch protection", () => {
+  // A repo's own postinstall/prepare script (lefthook, husky, ...) can
+  // overwrite .git/hooks/pre-push during `bun install`, silently dropping the
+  // hook that blocks pushing to main/master from a sandbox. stepInstall must
+  // reinstall it after a real install runs.
+  it("reinstalls the pre-push hook after an install script clobbers it", async () => {
+    const { dir, cleanup } = tempRoot();
+    try {
+      const repoDir = join(dir, "repo");
+      mkdirSync(repoDir);
+      installProtectedBranchHook(repoDir);
+      const hookPath = join(repoDir, ".git", "hooks", "pre-push");
+
+      // A separate script file avoids shell/JSON quoting entirely.
+      writeFileSync(
+        join(repoDir, "clobber-hook.js"),
+        `require("fs").writeFileSync(${JSON.stringify(hookPath)}, "#!/bin/sh\\nexit 0\\n")`,
+      );
+      writeFileSync(
+        join(repoDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox-fixture",
+          scripts: { postinstall: "node clobber-hook.js" },
+        }),
+      );
+
+      const broadcaster = new Broadcaster(1024);
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir },
+        store: {
+          read: () => ({
+            application: { packageManager: { name: "bun" } },
+            runtimePathPrefix: "",
+          }),
+        } as never,
+        taskManager: {
+          spawn: async () => ({ id: "t1" }),
+          killByLogName: () => 0,
+          waitForLogNamesIdle: async () => {},
+          onTaskExit: () => () => {},
+        } as never,
+        setStatus: () => {},
+        getStatus: () => ({ state: "running" as const }),
+        broadcaster,
+        installState: { isInstalledFor: () => false, mark: () => {} } as never,
+        logsDir: dir,
+        lifecycle: new LifecycleManager({ broadcaster }),
+        branchStatus: makeMonitorStub(),
+      });
+
+      orchestrator.handle({
+        kind: "pm-change",
+        from: undefined,
+        to: { name: "bun" },
+      });
+
+      const deadline = Date.now() + 15_000;
+      while (orchestrator.isRunning() || orchestrator.pendingCount() > 0) {
+        if (Date.now() > deadline) throw new Error("orchestrator hung");
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      expect(readFileSync(hookPath, "utf-8")).toContain(
+        "not allowed from a sandbox",
+      );
+    } finally {
+      cleanup();
+    }
+  }, 20_000);
 });

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -414,6 +414,17 @@ export class SetupOrchestrator {
       return false;
     }
     this.markInstallSucceeded(config);
+    // Install scripts (postinstall/prepare — lefthook, husky, etc.) can
+    // overwrite .git/hooks/pre-push; reinstall so branch protection survives.
+    if (config.repoDir) {
+      try {
+        installProtectedBranchHook(config.repoDir);
+      } catch (e) {
+        this.chunk(
+          `\r\n[orchestrator] warning: could not reinstall protected-branch hook: ${(e as Error).message}\r\n`,
+        );
+      }
+    }
     // Don't publish the golden yet — defer to publishPendingGolden(), which
     // the probe's `running` transition calls once the dev server is confirmed
     // healthy. Publishing only from a boot that actually came up prevents a


### PR DESCRIPTION
## Source
A bug found while reading recently-changed sandbox daemon code (`packages/sandbox/daemon/git/protect-branch.ts`, `packages/sandbox/daemon/setup/orchestrator.ts`).

## Why a maintainer wants this
`installProtectedBranchHook()` writes a `pre-push` hook that blocks pushing to `main`/`master` from a sandbox — the guard that stops an agent (or a buggy publish flow) from pushing straight to the protected branch. It only runs once, during `gitSetup()`, *before* `stepInstall()` runs the target repo's own install command (`npm install` / `bun install` / etc.).

## Failure scenario
Any target repo whose `package.json` has a `postinstall`/`prepare` script that (re)installs its own git hooks — `lefthook install`, `husky install`, `husky`, `pre-commit install`, etc., all common in the JS ecosystem — will overwrite `.git/hooks/pre-push` during that install step, silently removing Studio's branch-protection hook with no re-check afterward. From that point on, a push to `main`/`master` from the sandbox succeeds instead of being rejected.

Verified locally: a `package.json` with a `postinstall` script that rewrites `.git/hooks/pre-push` overwrites it during a real (offline, dependency-free) `bun install` in well under a second.

## Fix
Reinstall the hook right after a real install completes successfully in `stepInstall()`, so branch protection survives whatever the repo's own install scripts did to `.git/hooks`.

## Regression test
`packages/sandbox/daemon/setup/orchestrator.test.ts` — "reinstalls the pre-push hook after an install script clobbers it". Installs the hook, drives a real `pm-change` → install step against a fixture repo whose `postinstall` overwrites the hook, and asserts the hook is restored afterward. Confirmed this test fails on the pre-fix code (hook stays clobbered) and passes after the fix.

## Verify
```
bun test packages/sandbox/daemon/setup/orchestrator.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/sandbox`
- `bun test packages/sandbox/daemon/setup/orchestrator.test.ts` (12/12 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reinstalls the `pre-push` branch-protection hook right after a successful install so postinstall tools don’t clobber it. Keeps sandbox pushes to `main`/`master` blocked as intended.

- **Bug Fixes**
  - Reinstalls the hook in `SetupOrchestrator.stepInstall()` after real installs complete.
  - Emits a warning if reinstall fails without breaking the boot.
  - Adds a regression test that simulates a postinstall overwrite and verifies the hook is restored.

<sup>Written for commit 73befdda06d1ff46d2362cd60aec7dec9a89917b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

